### PR TITLE
[CMS Preview Server] Mark getOptions as async

### DIFF
--- a/script/preview.js
+++ b/script/preview.js
@@ -94,7 +94,7 @@ app.get('/health', (req, res) => {
 
 app.get('/preview', async (req, res, next) => {
   try {
-    const smith = createPipieline({
+    const smith = await createPipieline({
       ...options,
       port: process.env.PORT || 3001,
     });
@@ -151,7 +151,7 @@ app.get('/preview', async (req, res, next) => {
       }
 
       res.send(`
-        <p>This page isn't ready to be previewed yet. 
+        <p>This page isn't ready to be previewed yet.
           This may mean development is still in progress or that there's an issue with the preview server.
         </p>
       `);

--- a/src/site/stages/preview/index.js
+++ b/src/site/stages/preview/index.js
@@ -21,8 +21,8 @@ const applyFragments = require('../build/plugins/apply-fragments');
 const addAssetHashes = require('../build/plugins/add-asset-hashes');
 const addSubheadingsIds = require('../build/plugins/add-id-to-subheadings');
 
-function createPipeline(options) {
-  const BUILD_OPTIONS = getOptions(options);
+async function createPipeline(options) {
+  const BUILD_OPTIONS = await getOptions(options);
   const smith = Metalsmith(__dirname); // eslint-disable-line new-cap
   const isDevBuild = [environments.LOCALHOST, environments.VAGOVDEV].includes(
     BUILD_OPTIONS.buildtype,

--- a/src/site/stages/preview/index.js
+++ b/src/site/stages/preview/index.js
@@ -20,6 +20,7 @@ const rewriteAWSUrls = require('../build/plugins/rewrite-cms-aws-urls');
 const applyFragments = require('../build/plugins/apply-fragments');
 const addAssetHashes = require('../build/plugins/add-asset-hashes');
 const addSubheadingsIds = require('../build/plugins/add-id-to-subheadings');
+const createFeatureToggles = require('../build/plugins/create-feature-toggles');
 
 async function createPipeline(options) {
   const BUILD_OPTIONS = await getOptions(options);
@@ -91,6 +92,8 @@ async function createPipeline(options) {
       ],
     }),
   );
+
+  smith.use(createFeatureToggles(BUILD_OPTIONS));
 
   smith.use(
     navigation({


### PR DESCRIPTION
## Description
Now that CMS feature flags are embedded into basically every aspect of our stack, we have to mark the function for gathering build arguments as `async`, because it needs to load the CMS feature flags. The CMS Preview Server wasn't updated during that work, so it's now broken. This PR fixes it.

## Testing done
Started the preview server locally
Navigated to http://localhost:3001/preview?nodeId=77

## Screenshots

### Before
![image](https://user-images.githubusercontent.com/1915775/64351036-a2e6ff80-cfc7-11e9-8c91-5adc60eddb19.png)

### After
![image](https://user-images.githubusercontent.com/1915775/64352017-4e448400-cfc9-11e9-8a53-9444dc7531ee.png)


## Acceptance criteria
- [x] Content writers can preview their work

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
