### PR TITLE
Vagov 1330 trigger information must be a button keyboard focusable

### DIFF
--- a/src/applications/personalization/profile360/containers/PaymentInformation.jsx
+++ b/src/applications/personalization/profile360/containers/PaymentInformation.jsx
@@ -143,7 +143,8 @@ class PaymentInformation extends React.Component {
 
   renderSetupButton(label, gaProfileSection) {
     return (
-      <button className="va-button-link"
+      <button
+        className="va-button-link"
         onClick={() => this.handleLinkClick('add', gaProfileSection)}
       >{`Please add your ${label}`}</button>
     );

--- a/src/applications/personalization/profile360/containers/PaymentInformation.jsx
+++ b/src/applications/personalization/profile360/containers/PaymentInformation.jsx
@@ -177,39 +177,39 @@ class PaymentInformation extends React.Component {
           <div className="vet360-profile-field">
             <ProfileFieldHeading
               onEditClick={
-                !directDepositIsSetUp &&
+                directDepositIsSetUp &&
                 (() => this.handleLinkClick('edit', 'bank-name'))
               }
             >
               Bank name
             </ProfileFieldHeading>
-            {!directDepositIsSetUp
+            {directDepositIsSetUp
               ? paymentAccount.financialInstitutionName
               : this.renderSetupButton('bank name', 'bank-name')}
           </div>
           <div className="vet360-profile-field">
             <ProfileFieldHeading
               onEditClick={
-                !directDepositIsSetUp &&
+                directDepositIsSetUp &&
                 (() => this.handleLinkClick('edit', 'account-number'))
               }
             >
               Account number
             </ProfileFieldHeading>
-            {!directDepositIsSetUp
+            {directDepositIsSetUp
               ? paymentAccount.accountNumber
               : this.renderSetupButton('account number', 'account-number')}
           </div>
           <div className="vet360-profile-field">
             <ProfileFieldHeading
               onEditClick={
-                !directDepositIsSetUp &&
+                directDepositIsSetUp &&
                 (() => this.handleLinkClick('edit', 'account-type'))
               }
             >
               Account type
             </ProfileFieldHeading>
-            {!directDepositIsSetUp
+            {directDepositIsSetUp
               ? paymentAccount.accountType
               : this.renderSetupButton(
                   'account type (checking or savings)',

--- a/src/applications/personalization/profile360/containers/PaymentInformation.jsx
+++ b/src/applications/personalization/profile360/containers/PaymentInformation.jsx
@@ -143,9 +143,9 @@ class PaymentInformation extends React.Component {
 
   renderSetupButton(label, gaProfileSection) {
     return (
-      <a
+      <button className="va-button-link"
         onClick={() => this.handleLinkClick('add', gaProfileSection)}
-      >{`Please add your ${label}`}</a>
+      >{`Please add your ${label}`}</button>
     );
   }
 
@@ -177,39 +177,39 @@ class PaymentInformation extends React.Component {
           <div className="vet360-profile-field">
             <ProfileFieldHeading
               onEditClick={
-                directDepositIsSetUp &&
+                !directDepositIsSetUp &&
                 (() => this.handleLinkClick('edit', 'bank-name'))
               }
             >
               Bank name
             </ProfileFieldHeading>
-            {directDepositIsSetUp
+            {!directDepositIsSetUp
               ? paymentAccount.financialInstitutionName
               : this.renderSetupButton('bank name', 'bank-name')}
           </div>
           <div className="vet360-profile-field">
             <ProfileFieldHeading
               onEditClick={
-                directDepositIsSetUp &&
+                !directDepositIsSetUp &&
                 (() => this.handleLinkClick('edit', 'account-number'))
               }
             >
               Account number
             </ProfileFieldHeading>
-            {directDepositIsSetUp
+            {!directDepositIsSetUp
               ? paymentAccount.accountNumber
               : this.renderSetupButton('account number', 'account-number')}
           </div>
           <div className="vet360-profile-field">
             <ProfileFieldHeading
               onEditClick={
-                directDepositIsSetUp &&
+                !directDepositIsSetUp &&
                 (() => this.handleLinkClick('edit', 'account-type'))
               }
             >
               Account type
             </ProfileFieldHeading>
-            {directDepositIsSetUp
+            {!directDepositIsSetUp
               ? paymentAccount.accountType
               : this.renderSetupButton(
                   'account type (checking or savings)',

--- a/src/applications/personalization/profile360/sass/profile-360.scss
+++ b/src/applications/personalization/profile360/sass/profile-360.scss
@@ -70,11 +70,13 @@ input.usa-only-phone {
     margin: 0;
   }
 }
-.vads-u-width--auto{
+[type="submit"].vads-u-width--auto {
   width: 100% !important;
 }
-@media screen and (min-width:768px){
-  .vads-u-width--auto{
+
+@include media($medium-screen) {
+  [type="submit"].vads-u-width--auto {
     width: auto !important;
   }
 }
+

--- a/src/applications/personalization/profile360/sass/profile-360.scss
+++ b/src/applications/personalization/profile360/sass/profile-360.scss
@@ -70,3 +70,11 @@ input.usa-only-phone {
     margin: 0;
   }
 }
+.vads-u-width--auto{
+  width: 100% !important;
+}
+@media screen and (min-width:768px){
+  .vads-u-width--auto{
+    width: auto !important;
+  }
+}

--- a/src/applications/personalization/profile360/sass/profile-360.scss
+++ b/src/applications/personalization/profile360/sass/profile-360.scss
@@ -70,13 +70,3 @@ input.usa-only-phone {
     margin: 0;
   }
 }
-[type="submit"].vads-u-width--auto {
-  width: 100% !important;
-}
-
-@include media($medium-screen) {
-  [type="submit"].vads-u-width--auto {
-    width: auto !important;
-  }
-}
-

--- a/yarn.lock
+++ b/yarn.lock
@@ -8808,6 +8808,7 @@ metalsmith-date-in-filename@^0.0.14:
 metalsmith-filenames@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/metalsmith-filenames/-/metalsmith-filenames-1.0.0.tgz#df4e69f246b8325bb9189e0273d2ee70899d00de"
+  integrity sha1-305p8ka4Mlu5GJ4Cc9LucImdAN4=
 
 metalsmith-in-place@^1.4.4:
   version "1.4.4"


### PR DESCRIPTION
## Description
<!-- This is a detailed description of the issue. It should include a restatement of the title, and provide more background information. -->
The `<a>` tags to open the modal for entering direct deposit information are not keyboard focusable. They should be `<button>` tags and have some specific requirements for keyboard navigation. Screenshot attached below.
## Testing done
Was able to use the keyboard to open and close the modal and stay on the same clickable button
## Screenshots
<img width="1269" alt="Your_Profile___Veterans_Affairs_and_Updating_Docker" src="https://user-images.githubusercontent.com/875558/64364370-adfa5980-cfe0-11e9-9d0d-8acc18b32bee.png">

## Acceptance criteria
- [ ]

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
