### PR TITLE
[CMS Preview Server] Remove the "featureToggles" plugin

### DIFF
--- a/src/site/stages/preview/index.js
+++ b/src/site/stages/preview/index.js
@@ -20,7 +20,6 @@ const rewriteAWSUrls = require('../build/plugins/rewrite-cms-aws-urls');
 const applyFragments = require('../build/plugins/apply-fragments');
 const addAssetHashes = require('../build/plugins/add-asset-hashes');
 const addSubheadingsIds = require('../build/plugins/add-id-to-subheadings');
-const createFeatureToggles = require('../build/plugins/create-feature-toggles');
 
 async function createPipeline(options) {
   const BUILD_OPTIONS = await getOptions(options);
@@ -41,6 +40,7 @@ async function createPipeline(options) {
   smith.metadata({
     buildtype: BUILD_OPTIONS.buildtype,
     hostUrl: BUILD_OPTIONS.hostUrl,
+    featureToggles: '{}',
   });
 
   smith.use(createEnvironmentFilter(BUILD_OPTIONS));
@@ -92,8 +92,6 @@ async function createPipeline(options) {
       ],
     }),
   );
-
-  smith.use(createFeatureToggles(BUILD_OPTIONS));
 
   smith.use(
     navigation({


### PR DESCRIPTION
## Description
The Preview Server is failing with the following output. It appears that the address "https://api.va.gov/v0/feature_toggles?features=facilityLocatorShowCommunityCares" is not accessible from inside the VPC. This PR removes that plugin.

```
(node:7) UnhandledPromiseRejectionWarning: Error: createFeatureToggles failed: request to https://api.va.gov/v0/feature_toggles?features=facilityLocatorShowCommunityCares failed, reason: connect ETIMEDOUT 152.133
.104.23:443
    at Ware.<anonymous> (/home/node/src/site/stages/build/plugins/create-feature-toggles.js:24:15)
```

Ticket - https://github.com/department-of-veterans-affairs/va.gov-team/issues/1606

## Testing done
Started the preview server locally. Can't really test this fully, since it's unique to the VA network.

## Screenshots
N/A

## Acceptance criteria
- [x] Preview Server works 

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
