### PR TITLE
Fixed Zipcode validation bug

### DIFF
--- a/src/applications/gi/components/profile/CalculatorForm.jsx
+++ b/src/applications/gi/components/profile/CalculatorForm.jsx
@@ -612,8 +612,7 @@ class CalculatorForm extends React.Component {
             name="beneficiaryZIPCode"
             field={{ value: inputs.beneficiaryZIP }}
             onValueChange={this.handleBeneficiaryZIPCodeChanged}
-            type="number"
-            max="5"
+            charMax={5}
           />
           <p>
             <strong>{inputs.housingAllowanceCity}</strong>

--- a/src/applications/gi/components/profile/CalculatorForm.jsx
+++ b/src/applications/gi/components/profile/CalculatorForm.jsx
@@ -612,6 +612,8 @@ class CalculatorForm extends React.Component {
             name="beneficiaryZIPCode"
             field={{ value: inputs.beneficiaryZIP }}
             onValueChange={this.handleBeneficiaryZIPCodeChanged}
+            type="number"
+            max="5"
           />
           <p>
             <strong>{inputs.housingAllowanceCity}</strong>

--- a/src/applications/gi/reducers/calculator.js
+++ b/src/applications/gi/reducers/calculator.js
@@ -228,7 +228,10 @@ export default function(state = INITIAL_STATE, action) {
 
       let beneficiaryZIPError;
 
-      if (!beneficiaryZIPRegExTester.exec(beneficiaryZIP)) {
+      if (
+        !beneficiaryZIPRegExTester.exec(beneficiaryZIP) &&
+        beneficiaryZIP !== ''
+      ) {
         beneficiaryZIPError = 'ZIP Code must be a five digit number';
       } else {
         beneficiaryZIPError = '';

--- a/src/applications/gi/reducers/calculator.js
+++ b/src/applications/gi/reducers/calculator.js
@@ -230,9 +230,8 @@ export default function(state = INITIAL_STATE, action) {
       let beneficiaryZIPError;
 
       if (
-        (beneficiaryZIP !== '' &&
-          !beneficiaryZIPRegExTester.exec(beneficiaryZIP)) ||
-        beneficiaryZIP.length > 5
+        beneficiaryZIP !== '' &&
+        !beneficiaryZIPRegExTester.exec(beneficiaryZIP)
       ) {
         beneficiaryZIPError = 'ZIP Code must be a five digit number';
       } else {

--- a/src/applications/gi/reducers/calculator.js
+++ b/src/applications/gi/reducers/calculator.js
@@ -10,7 +10,6 @@ import {
   FETCH_PROFILE_SUCCEEDED,
 } from '../actions';
 
-const beneficiaryZIPRegExTester = /^\d{1,5}$|^\d{1,5}-\d{4}$/;
 const INITIAL_STATE = {
   beneficiaryLocationQuestion: 'yes',
   beneficiaryZIP: '',
@@ -228,10 +227,7 @@ export default function(state = INITIAL_STATE, action) {
 
       let beneficiaryZIPError;
 
-      if (
-        beneficiaryZIP !== '' &&
-        !beneficiaryZIPRegExTester.exec(beneficiaryZIP)
-      ) {
+      if (beneficiaryZIP.length > 5) {
         beneficiaryZIPError = 'ZIP Code must be a five digit number';
       } else {
         beneficiaryZIPError = '';

--- a/src/applications/gi/reducers/calculator.js
+++ b/src/applications/gi/reducers/calculator.js
@@ -10,6 +10,8 @@ import {
   FETCH_PROFILE_SUCCEEDED,
 } from '../actions';
 
+const beneficiaryZIPRegExTester = /^\d{1,5}$/;
+
 const INITIAL_STATE = {
   beneficiaryLocationQuestion: 'yes',
   beneficiaryZIP: '',
@@ -227,7 +229,11 @@ export default function(state = INITIAL_STATE, action) {
 
       let beneficiaryZIPError;
 
-      if (beneficiaryZIP.length > 5) {
+      if (
+        (beneficiaryZIP !== '' &&
+          !beneficiaryZIPRegExTester.exec(beneficiaryZIP)) ||
+        beneficiaryZIP.length > 5
+      ) {
         beneficiaryZIPError = 'ZIP Code must be a five digit number';
       } else {
         beneficiaryZIPError = '';

--- a/src/applications/gi/reducers/calculator.js
+++ b/src/applications/gi/reducers/calculator.js
@@ -10,7 +10,7 @@ import {
   FETCH_PROFILE_SUCCEEDED,
 } from '../actions';
 
-const beneficiaryZIPRegExTester = /\b\d{1,5}\b/;
+const beneficiaryZIPRegExTester = /^\d{1,5}$|^\d{1,5}-\d{4}$/;
 const INITIAL_STATE = {
   beneficiaryLocationQuestion: 'yes',
   beneficiaryZIP: '',

--- a/src/applications/gi/reducers/calculator.js
+++ b/src/applications/gi/reducers/calculator.js
@@ -229,8 +229,8 @@ export default function(state = INITIAL_STATE, action) {
       let beneficiaryZIPError;
 
       if (
-        !beneficiaryZIPRegExTester.exec(beneficiaryZIP) &&
-        beneficiaryZIP !== ''
+        beneficiaryZIP !== '' &&
+        !beneficiaryZIPRegExTester.exec(beneficiaryZIP)
       ) {
         beneficiaryZIPError = 'ZIP Code must be a five digit number';
       } else {


### PR DESCRIPTION
## Description
On a school profile page, a user is able to select if they will be attending class at the school's main campus or at another location. When the user indicates that they will be taking classes at an "other" location, a field appears in which the user will enter a postal code. Currently, the field will appear accompanied by an error message before the user makes an entry. The field also accepts letters and special characters, but should only accept numbers.

https://github.com/department-of-veterans-affairs/vets.gov-team/issues/19650

## Testing done
Local Testing

## Screenshots
![ezgif-3-afcb73f3cfbc](https://user-images.githubusercontent.com/50601724/64427347-ad140700-d076-11e9-8962-06727672585f.gif)


## Acceptance criteria
- [x] Zip code validation error only displays when bad input is entered

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
