### PR TITLE
Prevent phone numbers from wrapping

### DIFF
--- a/src/applications/personalization/profile360/components/PaymentInformationEditModalError.jsx
+++ b/src/applications/personalization/profile360/components/PaymentInformationEditModalError.jsx
@@ -14,9 +14,10 @@ function FlaggedAccount() {
         security issue.
       </p>
       <p>
-        If you have any questions, please call us at 800-827-1000 (TTY:
-        800-829-4833). We’re here Monday through Friday, 8:00 a.m. to 9:00 p.m.
-        ET.
+        If you have any questions, please call us at{' '}
+        <span className="no-wrap">800-827-1000</span> (TTY:
+        <span className="no-wrap">800-829-4833</span>
+        ). We’re here Monday through Friday, 8:00 a.m. to 9:00 p.m. ET.
       </p>
     </>
   );

--- a/src/applications/personalization/profile360/containers/PaymentInformation.jsx
+++ b/src/applications/personalization/profile360/containers/PaymentInformation.jsx
@@ -217,8 +217,10 @@ class PaymentInformation extends React.Component {
           {directDepositIsSetUp && (
             <p>
               <strong>Note:</strong> If you think you’ve been the victim of bank
-              fraud, please call us at 800-827-1000 (TTY: 800-829-4833). We’re
-              here Monday through Friday, 8:00 a.m. to 9:00 p.m.
+              fraud, please call us at{' '}
+              <span className="no-wrap">800-827-1000</span> (TTY:{' '}
+              <span className="no-wrap">800-829-4833</span>
+              ). We’re here Monday through Friday, 8:00 a.m. to 9:00 p.m.
             </p>
           )}
 

--- a/src/applications/personalization/profile360/sass/profile-360.scss
+++ b/src/applications/personalization/profile360/sass/profile-360.scss
@@ -70,3 +70,7 @@ input.usa-only-phone {
     margin: 0;
   }
 }
+
+.no-wrap {
+  white-space: nowrap;
+}

--- a/src/platform/forms/sass/_m-schemaform.scss
+++ b/src/platform/forms/sass/_m-schemaform.scss
@@ -298,7 +298,7 @@ fieldset.schemaform-field-template {
   font-weight: bold;
   text-decoration: none;
   margin: 0.5em 0;
-  word-break: keep-all;
+  white-space: nowrap;
 }
 
 //duplicated/renamed from claims-status.scss


### PR DESCRIPTION
## Description
Phone numbers should not break across multiple lines. This PR fixes it in the Direct Deposit feature as well as updates an existing class that was supposed to fix this issue months ago.

## Testing done
Local

## Screenshots
See the non-wrapping phone number in the below screenshots
<img width="402" alt="Screen Shot 2019-09-06 at 10 41 17 AM" src="https://user-images.githubusercontent.com/20728956/64449672-58cc4f80-d095-11e9-8732-61c1fad134b4.png">
<img width="644" alt="Screen Shot 2019-09-06 at 10 35 04 AM" src="https://user-images.githubusercontent.com/20728956/64449685-5e299a00-d095-11e9-9602-4771be2b2c0c.png">

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs