### PR TITLE
Broken links don't cause feature branch builds to fail

### DIFF
--- a/jenkins/common.groovy
+++ b/jenkins/common.groovy
@@ -156,7 +156,7 @@ def checkForBrokenLinks(String buildLogPath, String envName) {
       channel: 'cms-general'
 
     // Only break the build if broken links are found in master
-    if (isDeployable()) {
+    if (IS_PROD_BRANCH) {
       throw new Exception('Broken links found')
     }
   } else {

--- a/jenkins/common.groovy
+++ b/jenkins/common.groovy
@@ -176,7 +176,9 @@ def build(String ref, dockerContainer, String assetSource, String envName, Boole
 
       sh "cd /application && jenkins/build.sh --envName ${envName} --assetSource ${assetSource} --drupalAddress ${drupalAddress} ${drupalMode} --buildLog ${buildLogPath}"
 
-      handleBrokenLinks(buildLogPath, envName, csvFileName)
+      if (envName == 'vagovprod') {
+	handleBrokenLinks(buildLogPath, envName, csvFileName)
+      }
 
       sh "cd /application && echo \"${buildDetails}\" > build/${envName}/BUILD.txt"
     }

--- a/jenkins/common.groovy
+++ b/jenkins/common.groovy
@@ -150,7 +150,7 @@ def checkForBrokenLinks(String buildLogPath, String envName) {
 
     // Until slackUploadFile works...
     def linkCount = sh(returnStdout: true, script: "cd /application && wc -l ${csvFileName} | cut -d ' ' -f1") as Integer
-    slackSend message: "@here ${linkCount - 1} broken links found in the ${envName} build on `${env.BRANCH_NAME}`\n${env.RUN_DISPLAY_URL}".stripMargin(),
+    slackSend message: "${linkCount - 1} broken links found in the ${envName} build on `${env.BRANCH_NAME}`\n${env.RUN_DISPLAY_URL}".stripMargin(),
       color: 'danger',
       failOnError: true,
       channel: 'cms-general'

--- a/jenkins/common.groovy
+++ b/jenkins/common.groovy
@@ -153,7 +153,7 @@ def checkForBrokenLinks(String buildLogPath, String envName) {
     slackSend message: "@here ${linkCount - 1} broken links found in the ${envName} build on `${env.BRANCH_NAME}`\n${env.RUN_DISPLAY_URL}".stripMargin(),
       color: 'danger',
       failOnError: true,
-      channel: 'cms-ci'
+      channel: 'cms-general'
 
     // Only break the build if broken links are found in master
     if (isDeployable()) {

--- a/jenkins/common.groovy
+++ b/jenkins/common.groovy
@@ -131,7 +131,7 @@ def setup() {
   }
 }
 
-def handleBrokenLinks(String buildLogPath, String envName, String csvFileName) {
+def handleBrokenLinks(String buildLogPath, String envName) {
   // Look for broken links
   def csvFileName = "${envName}-broken-links.csv" // For use within the docker container
   def csvFile = "${WORKSPACE}/vets-website/${csvFileName}" // For use outside of the docker context
@@ -177,7 +177,7 @@ def build(String ref, dockerContainer, String assetSource, String envName, Boole
       sh "cd /application && jenkins/build.sh --envName ${envName} --assetSource ${assetSource} --drupalAddress ${drupalAddress} ${drupalMode} --buildLog ${buildLogPath}"
 
       if (envName == 'vagovprod') {
-	handleBrokenLinks(buildLogPath, envName, csvFileName)
+	handleBrokenLinks(buildLogPath, envName)
       }
 
       sh "cd /application && echo \"${buildDetails}\" > build/${envName}/BUILD.txt"

--- a/jenkins/common.groovy
+++ b/jenkins/common.groovy
@@ -153,7 +153,7 @@ def checkForBrokenLinks(String buildLogPath, String envName) {
     slackSend message: "@here ${linkCount - 1} broken links found in the ${envName} build on `${env.BRANCH_NAME}`\n${env.RUN_DISPLAY_URL}".stripMargin(),
       color: 'danger',
       failOnError: true,
-      channel: 'cms-general'
+      channel: 'cms-ci'
 
     // Only break the build if broken links are found in master
     if (isDeployable()) {

--- a/jenkins/common.groovy
+++ b/jenkins/common.groovy
@@ -131,6 +131,36 @@ def setup() {
   }
 }
 
+def handleBrokenLinks(String buildLogPath, String envName, String csvFileName) {
+  // Look for broken links
+  def csvFileName = "${envName}-broken-links.csv" // For use within the docker container
+  def csvFile = "${WORKSPACE}/vets-website/${csvFileName}" // For use outside of the docker context
+
+  // Ensure the file isn't there if we had to rebuild
+  if (fileExists(csvFile)) {
+    sh "rm /application/${csvFileName}"
+  }
+
+  // Output a csv file with the broken links
+  sh "cd /application && jenkins/glean-broken-links.sh ${buildLogPath} ${csvFileName}"
+  if (fileExists(csvFile)) {
+    echo "Found broken links; notifying the Slack channel."
+    // TODO: Move this slackUploadFile to cacheDrupalContent and update the echo statement above
+    // slackUploadFile(filePath: csvFile, channel: 'dev_null', failOnError: true, initialComment: "Found broken links in the ${envName} build on `${env.BRANCH_NAME}`.")
+
+    // Until slackUploadFile works...
+    def linkCount = sh(returnStdout: true, script: "cd /application && wc -l ${csvFileName} | cut -d ' ' -f1") as Integer
+    slackSend message: "@here ${linkCount - 1} broken links found in the ${envName} build on `${env.BRANCH_NAME}`\n${env.RUN_DISPLAY_URL}".stripMargin(),
+      color: 'danger',
+      failOnError: true,
+      channel: 'cms-ci'
+
+    // TODO: Throw an error if broken links are found && isDeployable && envName === 'vagovprod'
+  } else {
+    echo "Did not find broken links."
+  }
+}
+
 def build(String ref, dockerContainer, String assetSource, String envName, Boolean useCache) {
   def buildDetails = buildDetails(envName, ref)
   def drupalAddress = DRUPAL_ADDRESSES.get(envName)
@@ -139,39 +169,11 @@ def build(String ref, dockerContainer, String assetSource, String envName, Boole
 
   withCredentials([usernamePassword(credentialsId:  "${drupalCred}", usernameVariable: 'DRUPAL_USERNAME', passwordVariable: 'DRUPAL_PASSWORD')]) {
     dockerContainer.inside(DOCKER_ARGS) {
-      def buildLog = "/application/${envName}-build.log"
+      def buildLogPath = "/application/${envName}-build.log"
 
-      try {
-	sh "cd /application && jenkins/build.sh --envName ${envName} --assetSource ${assetSource} --drupalAddress ${drupalAddress} ${drupalMode} --buildLog ${buildLog}"
-      } catch (error) {
-	// Look for broken links
-	def csvFileName = "${envName}-broken-links.csv" // For use within the docker container
-	def csvFile = "${WORKSPACE}/vets-website/${csvFileName}" // For use outside of the docker context
+      sh "cd /application && jenkins/build.sh --envName ${envName} --assetSource ${assetSource} --drupalAddress ${drupalAddress} ${drupalMode} --buildLog ${buildLogPath}"
 
-	// Ensure the file isn't there if we had to rebuild
-	if (fileExists(csvFile)) {
-	  sh "rm /application/${csvFileName}"
-	}
-
-	// Output a csv file with the broken links
-	sh "cd /application && jenkins/glean-broken-links.sh ${buildLog} ${csvFileName}"
-	if (fileExists(csvFile)) {
-	  echo "Found broken links; notifying the Slack channel."
-	  // TODO: Move this slackUploadFile to cacheDrupalContent and update the echo statement above
-	  // slackUploadFile(filePath: csvFile, channel: 'dev_null', failOnError: true, initialComment: "Found broken links in the ${envName} build on `${env.BRANCH_NAME}`.")
-
-	  // Until slackUploadFile works...
-	  def linkCount = sh(returnStdout: true, script: "cd /application && wc -l ${csvFileName} | cut -d ' ' -f1") as Integer
-	  slackSend message: "@here ${linkCount - 1} broken links found in the ${envName} build on `${env.BRANCH_NAME}`\n${env.RUN_DISPLAY_URL}".stripMargin(),
-	    color: 'danger',
-	    failOnError: true,
-	    channel: 'cms-ci'
-	} else {
-	  echo "Did not find broken links."
-	}
-
-	throw error
-      }
+      handleBrokenLinks(buildLogPath, envName, csvFileName)
 
       sh "cd /application && echo \"${buildDetails}\" > build/${envName}/BUILD.txt"
     }

--- a/jenkins/common.groovy
+++ b/jenkins/common.groovy
@@ -155,7 +155,10 @@ def handleBrokenLinks(String buildLogPath, String envName, String csvFileName) {
       failOnError: true,
       channel: 'cms-ci'
 
-    // TODO: Throw an error if broken links are found && isDeployable && envName === 'vagovprod'
+    // Only break the build if broken links are found in master
+    if (isDeployable()) {
+      throw new Exception('Broken links found')
+    }
   } else {
     echo "Did not find broken links."
   }

--- a/jenkins/common.groovy
+++ b/jenkins/common.groovy
@@ -131,7 +131,7 @@ def setup() {
   }
 }
 
-def handleBrokenLinks(String buildLogPath, String envName) {
+def checkForBrokenLinks(String buildLogPath, String envName) {
   // Look for broken links
   def csvFileName = "${envName}-broken-links.csv" // For use within the docker container
   def csvFile = "${WORKSPACE}/vets-website/${csvFileName}" // For use outside of the docker context
@@ -177,7 +177,7 @@ def build(String ref, dockerContainer, String assetSource, String envName, Boole
       sh "cd /application && jenkins/build.sh --envName ${envName} --assetSource ${assetSource} --drupalAddress ${drupalAddress} ${drupalMode} --buildLog ${buildLogPath}"
 
       if (envName == 'vagovprod') {
-	handleBrokenLinks(buildLogPath, envName)
+	checkForBrokenLinks(buildLogPath, envName)
       }
 
       sh "cd /application && echo \"${buildDetails}\" > build/${envName}/BUILD.txt"

--- a/src/site/layouts/page.drupal.liquid
+++ b/src/site/layouts/page.drupal.liquid
@@ -5,8 +5,6 @@
 <div id="content" class="interior">
   <main class="va-l-detail-page">
     <div class="usa-grid usa-grid-full">
-      {% comment %} Adding a broken link to test sending the broken links in a file to Slack {% endcomment %}
-      <a href="I am broken">This link left intentionally broken in page.drupal.liquid</a>
 
     {% include 'src/site/navigation/sidebar_nav.drupal.liquid' with sidebar %}
 

--- a/src/site/layouts/page.drupal.liquid
+++ b/src/site/layouts/page.drupal.liquid
@@ -5,6 +5,8 @@
 <div id="content" class="interior">
   <main class="va-l-detail-page">
     <div class="usa-grid usa-grid-full">
+      {% comment %} Adding a broken link to test sending the broken links in a file to Slack {% endcomment %}
+      <a href="I am broken">This link left intentionally broken in page.drupal.liquid</a>
 
     {% include 'src/site/navigation/sidebar_nav.drupal.liquid' with sidebar %}
 

--- a/src/site/stages/build/index.js
+++ b/src/site/stages/build/index.js
@@ -169,7 +169,7 @@ function defaultBuild(BUILD_OPTIONS) {
 
   smith.use(createSitemaps(BUILD_OPTIONS));
   smith.use(createRedirects(BUILD_OPTIONS));
-  smith.use(checkBrokenLinks(BUILD_OPTIONS));
+  smith.use(checkBrokenLinks());
   smith.use(checkForCMSUrls(BUILD_OPTIONS));
 
   /* eslint-disable no-console */

--- a/src/site/stages/build/plugins/check-broken-links/index.js
+++ b/src/site/stages/build/plugins/check-broken-links/index.js
@@ -2,8 +2,6 @@
 
 const path = require('path');
 
-const ENVIRONMENTS = require('../../../../constants/environments');
-
 const _getBrokenLinks = require('./helpers/getBrokenLinks');
 const _applyIgnoredRoutes = require('./helpers/applyIgnoredRoutes');
 const _getErrorOutput = require('./helpers/getErrorOutput');
@@ -12,7 +10,6 @@ const _getErrorOutput = require('./helpers/getErrorOutput');
  * Metalsmith middleware for verifying HREF/SRC values in HTML files are valid file references.
  */
 function getMiddleware(
-  buildOptions,
   getBrokenLinks = _getBrokenLinks,
   applyIgnoredRoutes = _applyIgnoredRoutes,
   getErrorOutput = _getErrorOutput,
@@ -48,10 +45,6 @@ function getMiddleware(
     if (brokenPages.length > 0) {
       const errorOutput = getErrorOutput(brokenPages);
 
-      if (buildOptions.buildtype === ENVIRONMENTS.VAGOVPROD) {
-        done(errorOutput);
-        return;
-      }
       console.log(errorOutput);
     }
 

--- a/src/site/stages/build/plugins/check-broken-links/tests/index.unit.spec.js
+++ b/src/site/stages/build/plugins/check-broken-links/tests/index.unit.spec.js
@@ -3,11 +3,8 @@
 const { expect } = require('chai');
 const sinon = require('sinon');
 
-const ENVIRONMENTS = require('../../../../../constants/environments');
-
 const checkBrokenLinks = require('../index');
 
-const buildOptions = {};
 const getBrokenLinks = sinon.stub();
 const applyIgnoredRoutes = sinon.stub();
 const getErrorOutput = sinon.stub();
@@ -21,7 +18,6 @@ const files = {
 const done = sinon.stub();
 
 const middleware = checkBrokenLinks(
-  buildOptions,
   getBrokenLinks,
   applyIgnoredRoutes,
   getErrorOutput,
@@ -49,7 +45,6 @@ describe('build/check-broken-links', () => {
   });
 
   beforeEach(() => {
-    buildOptions.buildtype = ENVIRONMENTS.LOCALHOST;
     console.log.reset();
     getBrokenLinks.resetHistory();
     applyIgnoredRoutes.resetHistory();
@@ -101,26 +96,13 @@ describe('build/check-broken-links', () => {
     expect(getErrorOutput.called).to.be.true;
   });
 
-  it('logs errors and calls done without arguments on non-production environments', () => {
+  it('logs errors and calls done without arguments', () => {
     setBrokenLinksPerPage(0);
     setTotalBrokenPages(5);
     setErrorOutput('broken links!');
-
-    buildOptions.buildtype = ENVIRONMENTS.VAGOVSTAGING;
 
     middleware(files, null, done);
     expect(console.log.firstCall.args[0]).to.be.equal('broken links!');
     expect(done.firstCall.args[0]).to.be.undefined;
-  });
-
-  it('calls done with errors on the production environment', () => {
-    setBrokenLinksPerPage(0);
-    setTotalBrokenPages(5);
-    setErrorOutput('broken links!');
-
-    buildOptions.buildtype = ENVIRONMENTS.VAGOVPROD;
-
-    middleware(files, null, done);
-    expect(done.firstCall.args[0]).to.be.equal('broken links!');
   });
 });


### PR DESCRIPTION
## Description
The PR causes broken links to _not_ break the builds of feature branches. This should still break the master builds if there are broken links, however.

## Testing done
Tested that it doesn't break feature branch builds by inserting a broken link in `pages.drupal.liquid`.
- Check out [this build](http://jenkins.vfs.va.gov/blue/organizations/jenkins/testing%2Fvets-website/detail/broken-links-notifications-only-cv/3/pipeline/94) and the corresponding [slack notification](https://dsva.slack.com/archives/CLLM968CB/p1567807349061400)

I don't know how to test that it _does_ break the master branch build. I'm open to suggestions.

## Screenshots
N/A

## Acceptance criteria
- [x] Feature branches aren't halted by broken links
- [x] A notification is still sent to slack for broken prod links when found in feature branch builds
- [ ] The master branch's build _is_ broken when a broken link is introduced
    - Still need to test this somehow

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
