### PR TITLE
Refactor capitalizeEachWord and re-enable logging

### DIFF
--- a/src/applications/disability-benefits/526EZ/helpers.jsx
+++ b/src/applications/disability-benefits/526EZ/helpers.jsx
@@ -303,13 +303,13 @@ export const supportingEvidenceOrientation = (
 
 export const disabilityNameTitle = ({ formData }) => (
   <legend className="schemaform-block-title schemaform-title-underline">
-    {capitalizeEachWord(formData.name)}
+    {typeof formData.name === 'string' ? capitalizeEachWord(formData.name) : 'Unknown Condition'}
   </legend>
 );
 
 export const facilityDescription = ({ formData }) => (
   <p>
-    Please tell us where VA treated you for {capitalizeEachWord(formData.name)}{' '}
+    Please tell us where VA treated you for {typeof formData.name === 'string' ? capitalizeEachWord(formData.name) : 'Unknown Condition'}{' '}
     <strong>after you got your disability rating</strong>.
   </p>
 );
@@ -317,7 +317,7 @@ export const facilityDescription = ({ formData }) => (
 export const vaMedicalRecordsIntro = ({ formData }) => (
   <p>
     First we’ll ask you about your VA medical records that show your{' '}
-    {capitalizeEachWord(formData.name)} has gotten worse.
+    {typeof formData.name === 'string' ? capitalizeEachWord(formData.name) : 'Unknown Condition'} has gotten worse.
   </p>
 );
 
@@ -325,7 +325,7 @@ export const privateRecordsChoice = ({ formData }) => (
   <div>
     <h4>About private medical records</h4>
     <p>
-      You said you were treated for {capitalizeEachWord(formData.name)} by a
+      You said you were treated for {typeof formData.name === 'string' ? capitalizeEachWord(formData.name) : 'Unknown Condition'} by a
       private doctor. If you have your private medical records, you can upload
       them to your application. If you want us to get them for you, you’ll need
       to authorize their release.
@@ -339,7 +339,7 @@ export const privateMedicalRecordsIntro = ({ formData }) => (
   <p>
     {firstOrNowString(formData['view:selectableEvidenceTypes'])} we’ll ask you
     about your private medical records that show your{' '}
-    {capitalizeEachWord(formData.name)} has gotten worse.
+    {typeof formData.name === 'string' ? capitalizeEachWord(formData.name) : 'Unknown Condition'} has gotten worse.
   </p>
 );
 
@@ -694,7 +694,7 @@ const evidenceTypesDescription = disabilityName => (
 
 export const getEvidenceTypesDescription = (form, index) => {
   const { name } = form.disabilities[index];
-  return evidenceTypesDescription(capitalizeEachWord(name));
+  return evidenceTypesDescription(typeof name === 'string' ? capitalizeEachWord(name) : 'Unknown Condition');
 };
 
 /**

--- a/src/applications/disability-benefits/526EZ/helpers.jsx
+++ b/src/applications/disability-benefits/526EZ/helpers.jsx
@@ -26,6 +26,7 @@ import {
   VA_FORM4142_URL,
   SERVICE_CONNECTION_TYPES,
   disabilityActionTypes,
+  NULL_CONDITION_STRING
 } from '../all-claims/constants';
 
 /**
@@ -303,13 +304,13 @@ export const supportingEvidenceOrientation = (
 
 export const disabilityNameTitle = ({ formData }) => (
   <legend className="schemaform-block-title schemaform-title-underline">
-    {typeof formData.name === 'string' ? capitalizeEachWord(formData.name) : 'Unknown Condition'}
+    {typeof formData.name === 'string' ? capitalizeEachWord(formData.name) : NULL_CONDITION_STRING}
   </legend>
 );
 
 export const facilityDescription = ({ formData }) => (
   <p>
-    Please tell us where VA treated you for {typeof formData.name === 'string' ? capitalizeEachWord(formData.name) : 'Unknown Condition'}{' '}
+    Please tell us where VA treated you for {typeof formData.name === 'string' ? capitalizeEachWord(formData.name) : NULL_CONDITION_STRING}{' '}
     <strong>after you got your disability rating</strong>.
   </p>
 );
@@ -317,7 +318,7 @@ export const facilityDescription = ({ formData }) => (
 export const vaMedicalRecordsIntro = ({ formData }) => (
   <p>
     First we’ll ask you about your VA medical records that show your{' '}
-    {typeof formData.name === 'string' ? capitalizeEachWord(formData.name) : 'Unknown Condition'} has gotten worse.
+    {typeof formData.name === 'string' ? capitalizeEachWord(formData.name) : NULL_CONDITION_STRING} has gotten worse.
   </p>
 );
 
@@ -325,7 +326,7 @@ export const privateRecordsChoice = ({ formData }) => (
   <div>
     <h4>About private medical records</h4>
     <p>
-      You said you were treated for {typeof formData.name === 'string' ? capitalizeEachWord(formData.name) : 'Unknown Condition'} by a
+      You said you were treated for {typeof formData.name === 'string' ? capitalizeEachWord(formData.name) : NULL_CONDITION_STRING} by a
       private doctor. If you have your private medical records, you can upload
       them to your application. If you want us to get them for you, you’ll need
       to authorize their release.
@@ -339,7 +340,7 @@ export const privateMedicalRecordsIntro = ({ formData }) => (
   <p>
     {firstOrNowString(formData['view:selectableEvidenceTypes'])} we’ll ask you
     about your private medical records that show your{' '}
-    {typeof formData.name === 'string' ? capitalizeEachWord(formData.name) : 'Unknown Condition'} has gotten worse.
+    {typeof formData.name === 'string' ? capitalizeEachWord(formData.name) : NULL_CONDITION_STRING} has gotten worse.
   </p>
 );
 
@@ -694,7 +695,7 @@ const evidenceTypesDescription = disabilityName => (
 
 export const getEvidenceTypesDescription = (form, index) => {
   const { name } = form.disabilities[index];
-  return evidenceTypesDescription(typeof name === 'string' ? capitalizeEachWord(name) : 'Unknown Condition');
+  return evidenceTypesDescription(typeof name === 'string' ? capitalizeEachWord(name) : NULL_CONDITION_STRING);
 };
 
 /**

--- a/src/applications/disability-benefits/all-claims/components/NewDisability.jsx
+++ b/src/applications/disability-benefits/all-claims/components/NewDisability.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { capitalizeEachWord } from '../utils';
+import { NULL_CONDITION_STRING } from '../constants';
 
 export default function NewDisability({ formData }) {
-  return <div>{typeof formData.condition === 'string' ? capitalizeEachWord(formData.condition) : 'Unknown Condition'}</div>;
+  return <div>{typeof formData.condition === 'string' ? capitalizeEachWord(formData.condition) : NULL_CONDITION_STRING}</div>;
 }

--- a/src/applications/disability-benefits/all-claims/components/NewDisability.jsx
+++ b/src/applications/disability-benefits/all-claims/components/NewDisability.jsx
@@ -2,5 +2,5 @@ import React from 'react';
 import { capitalizeEachWord } from '../utils';
 
 export default function NewDisability({ formData }) {
-  return <div>{capitalizeEachWord(formData.condition)}</div>;
+  return <div>{typeof formData.condition === 'string' ? capitalizeEachWord(formData.condition) : 'Unknown Condition'}</div>;
 }

--- a/src/applications/disability-benefits/all-claims/config/form.js
+++ b/src/applications/disability-benefits/all-claims/config/form.js
@@ -303,7 +303,7 @@ const formConfig = {
           schema: { type: 'object', properties: {} },
         },
         newDisabilityFollowUp: {
-          title: formData => capitalizeEachWord(formData.condition),
+          title: formData => typeof formData.condition === 'string' ? capitalizeEachWord(formData.condition) : 'Unknown Condition',
           depends: hasNewDisabilities,
           path: 'new-disabilities/follow-up/:index',
           showPagePerItem: true,
@@ -328,7 +328,7 @@ const formConfig = {
         },
         // 781/a - 1. REVIEW INTRODUCTION PAGE
         newPTSDFollowUp: {
-          title: formData => capitalizeEachWord(formData.condition),
+          title: formData => typeof formData.condition === 'string' ? capitalizeEachWord(formData.condition) : 'Unknown Condition',
           path: 'new-disabilities/ptsd-intro',
           depends: hasNewPtsdDisability,
           uiSchema: newPTSDFollowUp.uiSchema,

--- a/src/applications/disability-benefits/all-claims/config/form.js
+++ b/src/applications/disability-benefits/all-claims/config/form.js
@@ -114,7 +114,10 @@ import { createFormConfig781, createFormConfig781a } from './781';
 
 import createformConfig8940 from './8940';
 
-import { PTSD_INCIDENT_ITERATION } from '../constants';
+import { 
+  PTSD_INCIDENT_ITERATION, 
+  NULL_CONDITION_STRING 
+} from '../constants';
 
 import migrations from '../migrations';
 
@@ -303,7 +306,7 @@ const formConfig = {
           schema: { type: 'object', properties: {} },
         },
         newDisabilityFollowUp: {
-          title: formData => typeof formData.condition === 'string' ? capitalizeEachWord(formData.condition) : 'Unknown Condition',
+          title: formData => typeof formData.condition === 'string' ? capitalizeEachWord(formData.condition) : NULL_CONDITION_STRING,
           depends: hasNewDisabilities,
           path: 'new-disabilities/follow-up/:index',
           showPagePerItem: true,
@@ -328,7 +331,7 @@ const formConfig = {
         },
         // 781/a - 1. REVIEW INTRODUCTION PAGE
         newPTSDFollowUp: {
-          title: formData => typeof formData.condition === 'string' ? capitalizeEachWord(formData.condition) : 'Unknown Condition',
+          title: formData => typeof formData.condition === 'string' ? capitalizeEachWord(formData.condition) : NULL_CONDITION_STRING,
           path: 'new-disabilities/ptsd-intro',
           depends: hasNewPtsdDisability,
           uiSchema: newPTSDFollowUp.uiSchema,

--- a/src/applications/disability-benefits/all-claims/constants.js
+++ b/src/applications/disability-benefits/all-claims/constants.js
@@ -307,3 +307,5 @@ export const ANALYTICS_EVENTS = {
       'Disability - Form 21-0781a - PTSD Secondary Sources - Which should I choose',
   },
 };
+
+export const NULL_CONDITION_STRING = 'Unknown Condition';

--- a/src/applications/disability-benefits/all-claims/content/confirmation-page.jsx
+++ b/src/applications/disability-benefits/all-claims/content/confirmation-page.jsx
@@ -9,6 +9,8 @@ import {
   errorMessage,
 } from '../content/confirmation-poll';
 
+import { NULL_CONDITION_STRING } from '../constants';
+
 const template = (props, title, content, submissionMessage, messageType) => {
   const { fullName, disabilities, submittedAt } = props;
   const { first, last, middle, suffix } = fullName;
@@ -73,7 +75,7 @@ const template = (props, title, content, submissionMessage, messageType) => {
           <br />
           <ul className="disability-list">
             {disabilities.map((disability, i) => (
-              <li key={i}>{typeof disability === 'string' ? capitalizeEachWord(disability) : 'Unknown Condition'}</li>
+              <li key={i}>{typeof disability === 'string' ? capitalizeEachWord(disability) : NULL_CONDITION_STRING}</li>
             ))}
           </ul>
           {submissionMessage}

--- a/src/applications/disability-benefits/all-claims/content/confirmation-page.jsx
+++ b/src/applications/disability-benefits/all-claims/content/confirmation-page.jsx
@@ -73,7 +73,7 @@ const template = (props, title, content, submissionMessage, messageType) => {
           <br />
           <ul className="disability-list">
             {disabilities.map((disability, i) => (
-              <li key={i}>{capitalizeEachWord(disability)}</li>
+              <li key={i}>{typeof disability === 'string' ? capitalizeEachWord(disability) : 'Unknown Condition'}</li>
             ))}
           </ul>
           {submissionMessage}

--- a/src/applications/disability-benefits/all-claims/content/newDisabilityFollowUp.jsx
+++ b/src/applications/disability-benefits/all-claims/content/newDisabilityFollowUp.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import Modal from '@department-of-veterans-affairs/formation-react/Modal';
 import { capitalizeEachWord } from '../utils';
+import { NULL_CONDITION_STRING } from '../constants';
 
 export class CauseTitle extends React.Component {
   constructor(props) {
@@ -47,6 +48,6 @@ export class CauseTitle extends React.Component {
 
 export const disabilityNameTitle = ({ formData }) => (
   <legend className="schemaform-block-title schemaform-title-underline">
-    {typeof formData.condition === 'string' ? capitalizeEachWord(formData.condition) : 'Unknown Condition'}
+    {typeof formData.condition === 'string' ? capitalizeEachWord(formData.condition) : NULL_CONDITION_STRING}
   </legend>
 );

--- a/src/applications/disability-benefits/all-claims/content/newDisabilityFollowUp.jsx
+++ b/src/applications/disability-benefits/all-claims/content/newDisabilityFollowUp.jsx
@@ -47,6 +47,6 @@ export class CauseTitle extends React.Component {
 
 export const disabilityNameTitle = ({ formData }) => (
   <legend className="schemaform-block-title schemaform-title-underline">
-    {capitalizeEachWord(formData.condition)}
+    {typeof formData.condition === 'string' ? capitalizeEachWord(formData.condition) : 'Unknown Condition'}
   </legend>
 );

--- a/src/applications/disability-benefits/all-claims/content/ratedDisabilities.jsx
+++ b/src/applications/disability-benefits/all-claims/content/ratedDisabilities.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 import { capitalizeEachWord } from '../utils';
+import { NULL_CONDITION_STRING } from '../constants';
 
 /**
  * @typedef {Object} Disability
@@ -16,7 +17,7 @@ export const disabilityOption = ({ name, ratingPercentage }) => {
 
   return (
     <div>
-      <h4>{typeof name === 'string' ? capitalizeEachWord(name) : 'Unknown Condition'}</h4>
+      <h4>{typeof name === 'string' ? capitalizeEachWord(name) : NULL_CONDITION_STRING}</h4>
       {showRatingPercentage && (
         <p>
           Current rating: <strong>{ratingPercentage}%</strong>

--- a/src/applications/disability-benefits/all-claims/content/ratedDisabilities.jsx
+++ b/src/applications/disability-benefits/all-claims/content/ratedDisabilities.jsx
@@ -16,7 +16,7 @@ export const disabilityOption = ({ name, ratingPercentage }) => {
 
   return (
     <div>
-      <h4>{capitalizeEachWord(name)}</h4>
+      <h4>{typeof name === 'string' ? capitalizeEachWord(name) : 'Unknown Condition'}</h4>
       {showRatingPercentage && (
         <p>
           Current rating: <strong>{ratingPercentage}%</strong>

--- a/src/applications/disability-benefits/all-claims/content/summaryOfDisabilities.jsx
+++ b/src/applications/disability-benefits/all-claims/content/summaryOfDisabilities.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { capitalizeEachWord, isDisabilityPtsd } from '../utils';
 import { ptsdTypeEnum } from './ptsdTypeInfo';
+import { NULL_CONDITION_STRING } from '../constants';
 
 const mapDisabilityName = (disabilityName, formData, index) => {
   if (isDisabilityPtsd(disabilityName)) {
@@ -30,13 +31,13 @@ export const SummaryOfDisabilitiesDescription = ({ formData }) => {
     ? ratedDisabilities
         .filter(disability => disability['view:selected'])
         .map((disability) => {
-          return typeof disability.name === 'string' ? capitalizeEachWord(disability.name) : 'Unknown Condition';
+          return typeof disability.name === 'string' ? capitalizeEachWord(disability.name) : NULL_CONDITION_STRING;
         })
     : [];
   const newDisabilityNames =
     newDisabilities && formData['view:newDisabilities']
       ? newDisabilities.map((disability) => {
-          return typeof disability.condition === 'string' ? capitalizeEachWord(disability.condition) : 'Unknown Condition';
+          return typeof disability.condition === 'string' ? capitalizeEachWord(disability.condition) : NULL_CONDITION_STRING;
         })
       : [];
   const selectedDisabilitiesList = ratedDisabilityNames

--- a/src/applications/disability-benefits/all-claims/content/summaryOfDisabilities.jsx
+++ b/src/applications/disability-benefits/all-claims/content/summaryOfDisabilities.jsx
@@ -29,13 +29,15 @@ export const SummaryOfDisabilitiesDescription = ({ formData }) => {
   const ratedDisabilityNames = ratedDisabilities
     ? ratedDisabilities
         .filter(disability => disability['view:selected'])
-        .map(disability => capitalizeEachWord(disability.name))
+        .map((disability) => {
+          return typeof disability.name === 'string' ? capitalizeEachWord(disability.name) : 'Unknown Condition';
+        })
     : [];
   const newDisabilityNames =
     newDisabilities && formData['view:newDisabilities']
-      ? newDisabilities.map(disability =>
-          capitalizeEachWord(disability.condition),
-        )
+      ? newDisabilities.map((disability) => {
+          return typeof disability.condition === 'string' ? capitalizeEachWord(disability.condition) : 'Unknown Condition';
+        })
       : [];
   const selectedDisabilitiesList = ratedDisabilityNames
     .concat(newDisabilityNames)

--- a/src/applications/disability-benefits/all-claims/pages/newDisabilityFollowUp.js
+++ b/src/applications/disability-benefits/all-claims/pages/newDisabilityFollowUp.js
@@ -12,6 +12,8 @@ import {
 
 import { validateLength } from '../../../../platform/forms/validations';
 
+import { NULL_CONDITION_STRING } from '../constants';
+
 const {
   cause,
   causedByDisability,
@@ -32,12 +34,12 @@ const getDisabilitiesList = createSelector(
     const newDisabilitiesWithoutCurrent = newDisabilities
       .filter((item, index) => index !== currentIndex)
       .map((item) => {
-        return typeof item.condition === 'string' ? capitalizeEachWord(item.condition) : 'Unknown Condition';
+        return typeof item.condition === 'string' ? capitalizeEachWord(item.condition) : NULL_CONDITION_STRING;
       });
 
     return ratedDisabilities
       .map((disability) => {
-        return typeof disability.name === 'string' ? capitalizeEachWord(disability.name) : 'Unknown Condition'
+        return typeof disability.name === 'string' ? capitalizeEachWord(disability.name) : NULL_CONDITION_STRING
       })
       .concat(newDisabilitiesWithoutCurrent);
   },

--- a/src/applications/disability-benefits/all-claims/pages/newDisabilityFollowUp.js
+++ b/src/applications/disability-benefits/all-claims/pages/newDisabilityFollowUp.js
@@ -31,10 +31,14 @@ const getDisabilitiesList = createSelector(
   (ratedDisabilities = [], newDisabilities = [], currentIndex) => {
     const newDisabilitiesWithoutCurrent = newDisabilities
       .filter((item, index) => index !== currentIndex)
-      .map(item => capitalizeEachWord(item.condition));
+      .map((item) => {
+        return typeof item.condition === 'string' ? capitalizeEachWord(item.condition) : 'Unknown Condition';
+      });
 
     return ratedDisabilities
-      .map(disability => capitalizeEachWord(disability.name))
+      .map((disability) => {
+        return typeof disability.name === 'string' ? capitalizeEachWord(disability.name) : 'Unknown Condition'
+      })
       .concat(newDisabilitiesWithoutCurrent);
   },
 );

--- a/src/applications/disability-benefits/all-claims/tests/utils.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/utils.unit.spec.jsx
@@ -173,14 +173,14 @@ describe('526 helpers', () => {
         ['some "quote" disability', 'Some "Quote" Disability'],
       ].forEach(pair => expect(capitalizeEachWord(pair[0])).to.equal(pair[1]));
     });
-    it('should return Unknown Condition with undefined name', () => {
-      expect(capitalizeEachWord()).to.equal('Unknown Condition');
+    it('should return null with undefined name', () => {
+      expect(capitalizeEachWord()).to.equal(null);
     });
-    it('should return Unknown Condition when input is empty string', () => {
-      expect(capitalizeEachWord('')).to.equal('Unknown Condition');
+    it('should return null when input is empty string', () => {
+      expect(capitalizeEachWord('')).to.equal(null);
     });
-    it('should return Unknown Condition when name is not a string', () => {
-      expect(capitalizeEachWord(249481)).to.equal('Unknown Condition');
+    it('should return null when name is not a string', () => {
+      expect(capitalizeEachWord(249481)).to.equal(null);
     });
   });
 

--- a/src/applications/disability-benefits/all-claims/utils.jsx
+++ b/src/applications/disability-benefits/all-claims/utils.jsx
@@ -165,14 +165,12 @@ export const capitalizeEachWord = name => {
   }
 
   if (typeof name !== 'string') {
-    // Sentry.captureMessage(
-    //   `form_526_v1 / form_526_v2: capitalizeEachWord requires 'name' argument of type 'string' but got ${typeof name}`,
-    // );
+    Sentry.captureMessage(
+      `form_526_v1 / form_526_v2: capitalizeEachWord requires 'name' argument of type 'string' but got ${typeof name}`,
+    );
   }
 
-  // TODO: Refactor this out; the function name doesn't imply that it
-  // would return a completely unrelated string
-  return 'Unknown Condition';
+  return null;
 };
 
 export const hasForwardingAddress = formData =>
@@ -222,7 +220,7 @@ export const disabilityIsSelected = disability => disability['view:selected'];
 export const sippableId = str => (str || 'blank').toLowerCase();
 
 const createCheckboxSchema = (schema, disabilityName) => {
-  const capitalizedDisabilityName = capitalizeEachWord(disabilityName);
+  const capitalizedDisabilityName = typeof disabilityName === 'string' ? capitalizeEachWord(disabilityName) : 'Unknown Condition';
   return _.set(
     // As an array like this to prevent periods in the name being interpreted as nested objects
     [sippableId(disabilityName)],

--- a/src/applications/disability-benefits/all-claims/utils.jsx
+++ b/src/applications/disability-benefits/all-claims/utils.jsx
@@ -35,6 +35,7 @@ import {
   USA,
   TYPO_THRESHOLD,
   itfStatuses,
+  NULL_CONDITION_STRING
 } from './constants';
 
 /**
@@ -155,7 +156,7 @@ const capitalizeWord = word => {
 
 /**
  * Takes a string and returns the same string with every word capitalized. If no valid
- * string is given as input, returns 'Unknown Condition' and logs to Sentry.
+ * string is given as input, returns NULL_CONDITION_STRING and logs to Sentry.
  * @param {string} name the lower-case name of a disability
  * @returns {string} the input name, but with all words capitalized
  */
@@ -220,7 +221,7 @@ export const disabilityIsSelected = disability => disability['view:selected'];
 export const sippableId = str => (str || 'blank').toLowerCase();
 
 const createCheckboxSchema = (schema, disabilityName) => {
-  const capitalizedDisabilityName = typeof disabilityName === 'string' ? capitalizeEachWord(disabilityName) : 'Unknown Condition';
+  const capitalizedDisabilityName = typeof disabilityName === 'string' ? capitalizeEachWord(disabilityName) : NULL_CONDITION_STRING;
   return _.set(
     // As an array like this to prevent periods in the name being interpreted as nested objects
     [sippableId(disabilityName)],


### PR DESCRIPTION
Refactor capitalizeEachWord to not return an unrelated string when a non-string is supplied and also re-enable the logging to Sentry for this non-supplied string error.

## Description
capitalizeEachWord was logging a message to Sentry each time a non-string was passed into the function. This spawned https://github.com/department-of-veterans-affairs/va.gov-team/issues/1365. This message was logging frequently throughout the 526 form if a user entered a blank condition because capitalizeEachWord was called each time the condition was shown. At some point, this logging message was commented out, so this story (1365) pivoted to being about re-enabling this logging message and reworking capitalizeEachWord and the places it is used to no longer cause the message to be logged as frequently. The function was also reworked to no longer return an unrelated string, but rather return null if a non-string is provided. 

## Testing done
Test were modified and re-run.

## Acceptance criteria
- [ ] Re-enable Sentry logging for capitalizeEachWord
- [ ] Refactor capitalizeEachWord to not return an unrelated string when a non-string is provided