### PR TITLE
VAGOV-5902: Remove link if URL field is empty.

### DIFF
--- a/src/site/components/administration-hub-rail.drupal.liquid
+++ b/src/site/components/administration-hub-rail.drupal.liquid
@@ -3,10 +3,12 @@
         {% assign accordionId = administration.entityBundle | append: administration.entityId  %}
         <button class="usa-accordion-button usa-accordion-button-dark rail-heading" aria-expanded="true" aria-controls="{{ accordionId }}">Connect with us</button>
         <div id="{{ accordionId }}" class="usa-accordion-content" aria-hidden="false">
-            <h4 class="va-nav-linkslist-list">
-                <a href="{{ administration.fieldLink.url.path }}"
-                  onclick="recordEvent({ 'event': 'nav-hub-rail', 'nav-path': 'Connect with us' });">{{ administration.name }}</a>
-            </h4>
+            {% if administration.fieldLink.url.path %}
+              <h4 class="va-nav-linkslist-list">
+                  <a href="{{ administration.fieldLink.url.path }}"
+                    onclick="recordEvent({ 'event': 'nav-hub-rail', 'nav-path': 'Connect with us' });">{{ administration.name }}</a>
+              </h4>
+            {% endif %}
 
             <section>
                 <h4>Get updates</h4>


### PR DESCRIPTION
## Description
On the family member and service member pages, there should be no link to an administration under "Connect with us". 

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
