### PR TITLE
Change target of link

### DIFF
--- a/src/applications/personalization/profile360/containers/PaymentInformation.jsx
+++ b/src/applications/personalization/profile360/containers/PaymentInformation.jsx
@@ -60,7 +60,7 @@ const AdditionalInfos = props => (
           Go to eBenefits to change your information
         </a>
         <br />
-        <a href="/change-direct-deposit/#mail-phone">
+        <a href="/change-direct-deposit/#are-there-other-ways-to-change">
           Find out how to change your information by mail or phone
         </a>
       </AdditionalInfo>


### PR DESCRIPTION
## Description
Changes the link target ID of the "how to change your information" link in the Direct Deposit section of the Profile page

## Testing done
Local, confirmed that the link goes directly to the desired `h2` on the target page

## Screenshots
![link](https://user-images.githubusercontent.com/20728956/64551055-18fda600-d2e9-11e9-8d1d-1b5cf04ca736.gif)


## Acceptance criteria
- [x] When clicking the "how to change your information" link the page should scroll directly to the correct section of the page.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs