### PR TITLE
VAGOV-5786: Adding path filter for wysiwyg embeds.

### DIFF
--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -57,11 +57,25 @@ module.exports = function registerFilters() {
 
   liquid.filters.drupalToVaPath = content => {
     let replaced = content.replace(/href="(.*?)(png|jpg|jpeg|svg|gif)"/g, img =>
-      img.replace('sites/default/files', 'img'),
+      img
+        .replace('http://va-gov-cms.lndo.site/sites/default/files', '/img')
+        .replace('http://dev.cms.va.gov/sites/default/files', '/img')
+        .replace('http://staging.cms.va.gov/sites/default/files', '/img')
+        .replace('http://prod.cms.va.gov/sites/default/files', '/img')
+        .replace('https://prod.cms.va.gov/sites/default/files', '/img')
+        .replace('http://cms.va.gov/sites/default/files', '/img')
+        .replace('https://cms.va.gov/sites/default/files', '/img'),
     );
 
     replaced = replaced.replace(/href="(.*?)(doc|docx|pdf|txt)"/g, file =>
-      file.replace('sites/default/files', 'files'),
+      file
+        .replace('http://va-gov-cms.lndo.site/sites/default/files', '/files')
+        .replace('http://dev.cms.va.gov/sites/default/files', '/files')
+        .replace('http://staging.cms.va.gov/sites/default/files', '/files')
+        .replace('http://prod.cms.va.gov/sites/default/files', '/files')
+        .replace('https://prod.cms.va.gov/sites/default/files', '/files')
+        .replace('http://cms.va.gov/sites/default/files', '/files')
+        .replace('https://cms.va.gov/sites/default/files', '/files'),
     );
 
     return replaced;

--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -55,6 +55,18 @@ module.exports = function registerFilters() {
     return prettyTimeFormatted;
   };
 
+  liquid.filters.drupalToVaPath = content => {
+    let replaced = content.replace(/href="(.*?)(png|jpg|jpeg|svg|gif)"/g, img =>
+      img.replace('sites/default/files', 'img'),
+    );
+
+    replaced = replaced.replace(/href="(.*?)(doc|docx|pdf|txt)"/g, file =>
+      file.replace('sites/default/files', 'files'),
+    );
+
+    return replaced;
+  };
+
   liquid.filters.dateFromUnix = (dt, format) => moment.unix(dt).format(format);
 
   liquid.filters.unixFromDate = data => new Date(data).getTime();

--- a/src/site/paragraphs/wysiwyg.drupal.liquid
+++ b/src/site/paragraphs/wysiwyg.drupal.liquid
@@ -10,5 +10,5 @@
 {% endcomment %}
 
 <div class="processed-content">
-    {{ entity.fieldWysiwyg.processed }}
+    {{ entity.fieldWysiwyg.processed | drupalToVaPath }}
 </div>


### PR DESCRIPTION
## Description
When embedding media assets (files, images) in the wysiwyg, drupal file path is passed to front end build. This doesn't work, as drupal file paths don't match vets-website build file paths.
For instance, all drupal files can be found with `sites/default/files` path prefix. Vets-website files are prefixed as `files` for documents, and `img` for images. This pr adds a filter to the wysiwyg fragment that look at hrefs, and if it finds the `sites/default/files` prefix, transforms the prefix to either `files` or `img` depending on the file type found at the end of the path.

