### PR TITLE
Add pending appointment details page

### DIFF
--- a/src/applications/vaos/components/PendingAppointment.jsx
+++ b/src/applications/vaos/components/PendingAppointment.jsx
@@ -1,12 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router';
 import moment from 'moment';
-
-const timeText = {
-  AM: 'in the morning',
-  PM: 'in the afternoon',
-  'No Time Selected': '',
-};
+import { TIME_TEXT } from '../utils/constants';
 
 function formatDate(date) {
   const parsedDate = moment(date, 'MM/DD/YYYY');
@@ -28,29 +23,27 @@ export default function PendingAppointment({ appointment }) {
       </h2>
       <div className="vads-u-display--flex vads-u-flex-direction--column medium-screen:vads-u-flex-direction--row">
         <div className="vads-u-flex--1 vads-u-margin-bottom--1p5">
-          <h3 className="vads-u-margin--0 vads-u-margin-bottom--1 vads-u-font-size--base vads-u-font-family--sans">
+          <h3 className="vaos-appts__block-label">
             Preferred appointment dates:
           </h3>
           <ul className="usa-unstyled-list">
             <li className="vads-u-margin-bottom--1">
               {formatDate(appointment.optionDate1)}{' '}
-              {timeText[appointment.optionTime1]}
+              {TIME_TEXT[appointment.optionTime1]}
             </li>
             <li className="vads-u-margin-bottom--1">
               {formatDate(appointment.optionDate2)}{' '}
-              {timeText[appointment.optionTime2]}
+              {TIME_TEXT[appointment.optionTime2]}
             </li>
             <li>
               {formatDate(appointment.optionDate3)}{' '}
-              {timeText[appointment.optionTime3]}
+              {TIME_TEXT[appointment.optionTime3]}
             </li>
           </ul>
         </div>
         {!isCommunityCare && (
           <div className="vads-u-flex--1 vads-u-margin-bottom--1p5">
-            <h3 className="vads-u-margin--0 vads-u-margin-bottom--1 vads-u-font-size--base vads-u-font-family--sans">
-              Where:
-            </h3>
+            <h3 className="vaos-appts__block-label">Where:</h3>
             {appointment.friendlyLocationName || appointment.facility.name}
             <br />
             {appointment.facility.city}, {appointment.facility.state}
@@ -58,9 +51,7 @@ export default function PendingAppointment({ appointment }) {
         )}
         {isCommunityCare && (
           <div className="vads-u-flex--1 vads-u-margin-bottom--1p5">
-            <h3 className="vads-u-margin--0 vads-u-margin-bottom--1 vads-u-font-size--base vads-u-font-family--sans">
-              Preferred location:
-            </h3>
+            <h3 className="vaos-appts__block-label">Preferred location:</h3>
             {appointment.ccAppointmentRequest.preferredCity},{' '}
             {appointment.ccAppointmentRequest.preferredState}
           </div>

--- a/src/applications/vaos/containers/PendingAppointmentPage.jsx
+++ b/src/applications/vaos/containers/PendingAppointmentPage.jsx
@@ -1,0 +1,155 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Link } from 'react-router';
+import { connect } from 'react-redux';
+import moment from 'moment';
+import LoadingIndicator from '@department-of-veterans-affairs/formation-react/LoadingIndicator';
+import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
+import { focusElement } from 'platform/utilities/ui';
+import { fetchPendingAppointments } from '../actions/appointments';
+import { FETCH_STATUS, TIME_TEXT, PURPOSE_TEXT } from '../utils/constants';
+
+function formatDate(date) {
+  const parsedDate = moment(date, 'MM/DD/YYYY');
+
+  if (!parsedDate.isValid()) {
+    return '';
+  }
+
+  return parsedDate.format('MMMM D, YYYY');
+}
+
+function formatTimeToCall(timeToCall) {
+  if (timeToCall.length === 1) {
+    return timeToCall[0].toLowerCase();
+  } else if (timeToCall.length === 2) {
+    return `${timeToCall[0].toLowerCase()} or ${timeToCall[1].toLowerCase()}`;
+  }
+
+  return `${timeToCall[0].toLowerCase()}, ${timeToCall[1].toLowerCase()}, or ${timeToCall[2].toLowerCase()}`;
+}
+
+export class PendingAppointmentPage extends React.Component {
+  componentDidMount() {
+    this.props.fetchPendingAppointments();
+    focusElement('h1');
+  }
+  render() {
+    const { appointment, status } = this.props;
+    const isCommunityCare = !!appointment?.ccAppointmentRequest;
+
+    return (
+      <div className="vads-l-grid-container vads-u-padding-x--2p5 large-screen:vads-u-padding-x--0 vads-u-padding-bottom--2p5">
+        <div className="vads-l-row">
+          <div className="vads-l-col--12 medium-screen:vads-l-col--8 vads-u-margin-bottom--4">
+            <Link to="appointments/pending">
+              <i className="fas fa-angle-left" /> Back
+            </Link>
+            <h1 className="vads-u-margin-bottom--4 vads-u-margin-top--1">
+              Appointment details
+            </h1>
+            <AlertBox
+              level="2"
+              status="warning"
+              headline="You don't have a scheduled appointment yet"
+            >
+              We will call you within 48 hours to confirm and appointment time.
+            </AlertBox>
+            {status === FETCH_STATUS.loading && (
+              <LoadingIndicator message="Loading pending appointment" />
+            )}
+            {status === FETCH_STATUS.successful && (
+              <>
+                <h2>{appointment.appointmentType}</h2>
+                <div className="vads-u-display--flex vads-u-margin-bottom--2">
+                  <div className="vads-u-flex--1">
+                    {!isCommunityCare && (
+                      <>
+                        <h3 className="vaos-appts__block-label">Where</h3>
+                        {appointment.friendlyLocationName ||
+                          appointment.facility.name}
+                        <br />
+                        {appointment.facility.city},{' '}
+                        {appointment.facility.state}
+                      </>
+                    )}
+                    {isCommunityCare && (
+                      <>
+                        <h3 className="vaos-appts__block-label">
+                          Preferred location
+                        </h3>
+                        {appointment.ccAppointmentRequest.preferredCity},{' '}
+                        {appointment.ccAppointmentRequest.preferredState}
+                      </>
+                    )}
+                    <h3 className="vaos-appts__block-label vads-u-margin-top--2">
+                      Purpose
+                    </h3>
+                    {PURPOSE_TEXT[appointment.purposeOfVisit] ||
+                      appointment.purposeOfVisit}
+                    <br />
+                    {appointment.otherPurposeOfVisit}
+                    <h3 className="vaos-appts__block-label vads-u-margin-top--2">
+                      Type
+                    </h3>
+                    {appointment.visitType}
+                    <h3 className="vaos-appts__block-label vads-u-margin-top--2">
+                      Preferred appointment dates
+                    </h3>
+                    <ul className="usa-unstyled-list">
+                      <li className="vads-u-margin-bottom--1">
+                        {formatDate(appointment.optionDate1)}{' '}
+                        {TIME_TEXT[appointment.optionTime1]}
+                      </li>
+                      <li className="vads-u-margin-bottom--1">
+                        {formatDate(appointment.optionDate2)}{' '}
+                        {TIME_TEXT[appointment.optionTime2]}
+                      </li>
+                      <li>
+                        {formatDate(appointment.optionDate3)}{' '}
+                        {TIME_TEXT[appointment.optionTime3]}
+                      </li>
+                    </ul>
+                    <h3 className="vaos-appts__block-label vads-u-margin-top--2">
+                      My contact number
+                    </h3>
+                    {appointment.phoneNumber}, in the{' '}
+                    {formatTimeToCall(appointment.bestTimetoCall)}
+                  </div>
+                </div>
+                <Link to="appointments/pending">
+                  <i className="fas fa-angle-left" /> Back
+                </Link>
+              </>
+            )}
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
+
+PendingAppointmentPage.propTypes = {
+  appointment: PropTypes.object,
+  status: PropTypes.string.isRequired,
+};
+
+function mapStateToProps(state, ownProps) {
+  return {
+    appointment: state.appointments.pending
+      ? state.appointments.pending.find(
+          appt => appt.uniqueId === ownProps.params.id,
+        )
+      : null,
+    status: state.appointments.pendingStatus,
+  };
+}
+
+const mapDispatchToProps = {
+  fetchPendingAppointments,
+};
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(PendingAppointmentPage);

--- a/src/applications/vaos/reducers/appointments.js
+++ b/src/applications/vaos/reducers/appointments.js
@@ -26,7 +26,7 @@ export default function appointmentsReducer(state = initialState, action) {
     case FETCH_CONFIRMED_APPOINTMENTS:
       return {
         ...state,
-        confirmedStatus: true,
+        confirmedLoading: true,
       };
     case FETCH_CONFIRMED_APPOINTMENTS_SUCCEEDED:
       return {

--- a/src/applications/vaos/routes.jsx
+++ b/src/applications/vaos/routes.jsx
@@ -5,6 +5,7 @@ import NewAppointmentLayout from './components/NewAppointmentLayout';
 import AppointmentListsPage from './containers/AppointmentListsPage';
 import TypeOfAppointmentPage from './containers/TypeOfAppointmentPage';
 import PendingAppointmentsPage from './containers/PendingAppointmentsPage';
+import PendingAppointmentPage from './containers/PendingAppointmentPage';
 import ContactInfoPage from './containers/ContactInfoPage';
 
 const routes = (
@@ -16,6 +17,7 @@ const routes = (
     </Route>
     <Route path="appointments" component={AppointmentListsPage} />
     <Route path="appointments/pending" component={PendingAppointmentsPage} />
+    <Route path="appointments/pending/:id" component={PendingAppointmentPage} />
   </Route>
 );
 

--- a/src/applications/vaos/sass/vaos.scss
+++ b/src/applications/vaos/sass/vaos.scss
@@ -24,9 +24,9 @@
 
 .vaos-appts__block-label {
   margin: 0;
-  margin-bottom: 4px;
-  font-size: 16px;
-  font-family: Source Sans Pro,Helvetica Neue,Helvetica,Roboto,Arial,sans-serif;
+  margin-bottom: map-get($spacers, 0p5); 
+  font-size: $base-font-size;
+  font-family: $font-sans;
 }
 
 .vaos-form__title {

--- a/src/applications/vaos/sass/vaos.scss
+++ b/src/applications/vaos/sass/vaos.scss
@@ -22,6 +22,13 @@
   align-items: center;
 }
 
+.vaos-appts__block-label {
+  margin: 0;
+  margin-bottom: 4px;
+  font-size: 16px;
+  font-family: Source Sans Pro,Helvetica Neue,Helvetica,Roboto,Arial,sans-serif;
+}
+
 .vaos-form__title {
   text-transform: uppercase;
 }
@@ -35,3 +42,5 @@
     margin-top: 0.6em;
   }
 }
+
+

--- a/src/applications/vaos/tests/containers/PendingAppointmentPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/containers/PendingAppointmentPage.unit.spec.jsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { shallow } from 'enzyme';
+
+import { PendingAppointmentPage } from '../../containers/PendingAppointmentPage';
+
+describe('VAOS <PendingAppointmentPage>', () => {
+  it('should render a loading indicator', () => {
+    const fetchPendingAppointments = sinon.spy();
+    const tree = shallow(
+      <PendingAppointmentPage
+        fetchPendingAppointments={fetchPendingAppointments}
+        status="loading"
+      />,
+    );
+
+    expect(tree.find('LoadingIndicator').exists()).to.be.true;
+    expect(fetchPendingAppointments.called).to.be.true;
+    tree.unmount();
+  });
+
+  it('should render pending appointment', () => {
+    const fetchPendingAppointments = sinon.spy();
+    const appointment = {
+      appointmentType: 'Primary Care',
+      friendlyLocationName: 'Testing',
+      facility: {},
+      bestTimetoCall: ['Morning'],
+      phoneNumber: '555 555-5555',
+    };
+    const tree = shallow(
+      <PendingAppointmentPage
+        fetchPendingAppointments={fetchPendingAppointments}
+        appointment={appointment}
+        status="successful"
+      />,
+    );
+
+    expect(fetchPendingAppointments.called).to.be.true;
+    expect(tree.find('LoadingIndicator').exists()).to.be.false;
+    expect(tree.text()).to.contain(appointment.appointmentType);
+    expect(tree.text()).to.contain('555 555-5555, in the morning');
+    tree.unmount();
+  });
+});

--- a/src/applications/vaos/tests/reducers/appointments.unit.spec.js
+++ b/src/applications/vaos/tests/reducers/appointments.unit.spec.js
@@ -12,6 +12,8 @@ import {
   FETCH_PAST_APPOINTMENTS_FAILED,
 } from '../../actions/appointments';
 
+import { FETCH_STATUS } from '../../utils/constants';
+
 const initialState = {};
 
 describe('VAOS reducer: appointments', () => {
@@ -42,7 +44,7 @@ describe('VAOS reducer: appointments', () => {
 
     const newState = appointmentsReducer(initialState, action);
 
-    expect(newState.pendingLoading).to.be.true;
+    expect(newState.pendingStatus).to.equal(FETCH_STATUS.loading);
   });
 
   it('should populate confirmed with appointments with FETCH_CONFIRMED_APPOINTMENTS_SUCCEDED', () => {
@@ -70,11 +72,16 @@ describe('VAOS reducer: appointments', () => {
   it('should populate pending with appointments with FETCH_PENDING_APPOINTMENTS_SUCCEEDED', () => {
     const action = {
       type: FETCH_PENDING_APPOINTMENTS_SUCCEEDED,
-      data: { appointmentRequests: [{ id: 1, status: 'Submitted' }] },
+      data: {
+        appointmentRequests: [
+          { id: 1, status: 'Submitted' },
+          { id: 2, status: 'Booked' },
+        ],
+      },
     };
 
     const newState = appointmentsReducer(initialState, action);
-    expect(newState.pendingLoading).to.be.false;
+    expect(newState.pendingStatus).to.equal(FETCH_STATUS.successful);
     expect(newState.pending.length).to.equal(1);
   });
 
@@ -98,12 +105,12 @@ describe('VAOS reducer: appointments', () => {
     expect(newState.pastLoading).to.be.false;
   });
 
-  it('should update pendingLoading to be false when calling FETCH_CONFIRMED_APPOINTMENTS_FAILED', () => {
+  it('should update pendingStatus to be error when calling FETCH_PENDING_APPOINTMENTS_FAILED', () => {
     const action = {
       type: FETCH_PENDING_APPOINTMENTS_FAILED,
     };
     const newState = appointmentsReducer(initialState, action);
 
-    expect(newState.pendingLoading).to.be.false;
+    expect(newState.pendingStatus).to.equal(FETCH_STATUS.error);
   });
 });

--- a/src/applications/vaos/utils/constants.js
+++ b/src/applications/vaos/utils/constants.js
@@ -4,3 +4,16 @@ export const FETCH_STATUS = {
   successful: 'successful',
   error: 'error',
 };
+
+export const TIME_TEXT = {
+  AM: 'in the morning',
+  PM: 'in the afternoon',
+  'No Time Selected': '',
+};
+
+export const PURPOSE_TEXT = {
+  'routine-follow-up': 'Routine/Follow-Up',
+  'new-issue': 'New Issue',
+  'medication-concern': 'Medication Concern',
+  other: 'Other',
+};


### PR DESCRIPTION
## Description
This is the pending appointment detail page. It's missing some data that we have to get from the facilities api, which is in a separate ticket.

## Testing done
Local testing, unit tests

## Screenshots
![Screen Shot 2019-09-09 at 3 15 16 PM](https://user-images.githubusercontent.com/634932/64561614-2d599700-d319-11e9-9ded-cb72d0632b15.png)


## Acceptance criteria
- [ ] pending appointment is visible

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
