### PR TITLE
Stop missing query flags from breaking builds

### DIFF
--- a/jenkins/common.groovy
+++ b/jenkins/common.groovy
@@ -192,7 +192,7 @@ def build(String ref, dockerContainer, String assetSource, String envName, Boole
 
       // Find any missing query flags in the log
       if (envName == 'vagovprod') {
-	findMissingQueryFlags(buildLog)
+        findMissingQueryFlags(buildLog)
       }
 
       sh "cd /application && echo \"${buildDetails}\" > build/${envName}/BUILD.txt"

--- a/jenkins/common.groovy
+++ b/jenkins/common.groovy
@@ -139,7 +139,7 @@ def setup() {
  * dockerContainer.inside() context so buildLog can point to the right file.
  */
 def findMissingQueryFlags(String buildLog) {
-  def missingFlags = sh(returnStdout: true, script: "sed -nr 's/Could not find query flag (.+)\\..+/\1/p' ${buildLog}")
+  def missingFlags = sh(returnStdout: true, script: "sed -nr 's/Could not find query flag (.+)\\..+/\1/p' ${buildLog} | sort | uniq")
   if (missingFlags) {
     slackSend message: "Missing query flags found in the ${envName} build on `${env.BRANCH_NAME}`. The following will flags be considered false:\n${missingFlags}",
       color: 'warning',

--- a/jenkins/common.groovy
+++ b/jenkins/common.groovy
@@ -138,7 +138,7 @@ def setup() {
  * NOTE: This function is meant to be called from within the
  * dockerContainer.inside() context so buildLog can point to the right file.
  */
-def findMissingQueryFlags(String buildLog) {
+def findMissingQueryFlags(String buildLog, String envName) {
   def missingFlags = sh(returnStdout: true, script: "sed -nr 's/Could not find query flag (.+)\\..+/\1/p' ${buildLog} | sort | uniq")
   if (missingFlags) {
     slackSend message: "Missing query flags found in the ${envName} build on `${env.BRANCH_NAME}`. The following will flags be considered false:\n${missingFlags}",
@@ -192,7 +192,7 @@ def build(String ref, dockerContainer, String assetSource, String envName, Boole
 
       // Find any missing query flags in the log
       if (envName == 'vagovprod') {
-        findMissingQueryFlags(buildLog)
+        findMissingQueryFlags(buildLog, envName)
       }
 
       sh "cd /application && echo \"${buildDetails}\" > build/${envName}/BUILD.txt"

--- a/jenkins/common.groovy
+++ b/jenkins/common.groovy
@@ -145,7 +145,7 @@ def findMissingQueryFlags(String buildLog, String envName) {
     slackSend message: "Missing query flags found in the ${envName} build on `${env.BRANCH_NAME}`. The following will flags be considered false:\n${missingFlags}",
       color: 'warning',
       failOnError: true,
-      channel: 'cms-ci'
+      channel: 'cms-engineering'
   }
 }
 
@@ -171,7 +171,7 @@ def checkForBrokenLinks(String buildLogPath, String envName) {
     slackSend message: "${linkCount - 1} broken links found in the ${envName} build on `${env.BRANCH_NAME}`\n${env.RUN_DISPLAY_URL}".stripMargin(),
       color: 'danger',
       failOnError: true,
-      channel: 'cms-general'
+      channel: 'cms-engineering'
 
     // Only break the build if broken links are found in master
     if (IS_PROD_BRANCH) {

--- a/jenkins/common.groovy
+++ b/jenkins/common.groovy
@@ -146,6 +146,8 @@ def findMissingQueryFlags(String buildLog, String envName) {
       color: 'warning',
       failOnError: true,
       channel: 'cms-ci'
+  }
+}
 
 def checkForBrokenLinks(String buildLogPath, String envName) {
   // Look for broken links

--- a/jenkins/common.groovy
+++ b/jenkins/common.groovy
@@ -139,8 +139,8 @@ def setup() {
  * NOTE: This function is meant to be called from within the
  * dockerContainer.inside() context so buildLog can point to the right file.
  */
-def findMissingQueryFlags(String buildLog, String envName) {
-  def missingFlags = sh(returnStdout: true, script: "sed -nr 's/Could not find query flag (.+)\\..+/\1/p' ${buildLog} | sort | uniq")
+def findMissingQueryFlags(String buildLogPath, String envName) {
+  def missingFlags = sh(returnStdout: true, script: "sed -nr 's/Could not find query flag (.+)\\..+/\1/p' ${buildLogPath} | sort | uniq")
   if (missingFlags) {
     slackSend message: "Missing query flags found in the ${envName} build on `${env.BRANCH_NAME}`. The following will flags be considered false:\n${missingFlags}",
       color: 'warning',
@@ -200,7 +200,7 @@ def build(String ref, dockerContainer, String assetSource, String envName, Boole
 
       // Find any missing query flags in the log
       if (envName == 'vagovprod') {
-        findMissingQueryFlags(buildLog, envName)
+        findMissingQueryFlags(buildLogPath, envName)
       }
 
       sh "cd /application && echo \"${buildDetails}\" > build/${envName}/BUILD.txt"

--- a/src/site/stages/build/drupal/load-saved-flags.js
+++ b/src/site/stages/build/drupal/load-saved-flags.js
@@ -30,7 +30,7 @@ function useFlags(rawFlags) {
       if (!ignoreList.includes(prop.toString())) {
         // eslint-disable-next-line no-console
         console.error(
-          `Could not find feature flag ${prop.toString()}. This could be a typo or the feature flag wasn't returned from Drupal.`,
+          `Could not find query flag ${prop.toString()}. This could be a typo or the feature flag wasn't returned from Drupal.`,
         );
       }
 

--- a/src/site/stages/build/drupal/load-saved-flags.js
+++ b/src/site/stages/build/drupal/load-saved-flags.js
@@ -1,6 +1,5 @@
 const path = require('path');
 const fs = require('fs-extra');
-const ENVIRONMENTS = require('../../../constants/environments');
 
 /**
  * Takes an object of CMS feature flags, puts them in a Proxy which
@@ -12,7 +11,7 @@ const ENVIRONMENTS = require('../../../constants/environments');
  * @return {Proxy} - A Proxy containing all the feature flags; throws
  *                   an error if a flag is called without existing
  */
-function useFlags(rawFlags, buildType) {
+function useFlags(rawFlags) {
   const p = new Proxy(rawFlags, {
     get(obj, prop) {
       if (prop in obj) {
@@ -28,11 +27,9 @@ function useFlags(rawFlags, buildType) {
         'inspect',
         'Symbol(Symbol.iterator)',
       ];
-      if (
-        !ignoreList.includes(prop.toString()) &&
-        buildType !== ENVIRONMENTS.LOCALHOST // Don't fail a localhost build for missing query flags
-      ) {
-        throw new ReferenceError(
+      if (!ignoreList.includes(prop.toString())) {
+        // eslint-disable-next-line no-console
+        console.error(
           `Could not find feature flag ${prop.toString()}. This could be a typo or the feature flag wasn't returned from Drupal.`,
         );
       }
@@ -60,12 +57,12 @@ function useFlags(rawFlags, buildType) {
  * Not having a failsafe allows for better visibility into any potential
  * error messages and prevents the upload of a cache without feature flags.
  */
-function loadFeatureFlags(cacheDirectory, buildType) {
+function loadFeatureFlags(cacheDirectory) {
   const featureFlagFile = path.join(cacheDirectory, 'feature-flags.json');
   const rawFlags = fs.readJsonSync(featureFlagFile);
 
   // eslint-disable-next-line react-hooks/rules-of-hooks
-  return useFlags(rawFlags, buildType);
+  return useFlags(rawFlags);
 }
 
 module.exports = { loadFeatureFlags, useFlags };

--- a/src/site/stages/build/drupal/load-saved-flags.js
+++ b/src/site/stages/build/drupal/load-saved-flags.js
@@ -3,7 +3,7 @@ const fs = require('fs-extra');
 
 /**
  * Takes an object of CMS feature flags, puts them in a Proxy which
- * throws an error if one is used without being defined, and assigns
+ * logs an error if one is used without being defined, and assigns
  * that to global.cmsFeatureFlags.
  *
  * Returns the Proxy.
@@ -20,7 +20,7 @@ function useFlags(rawFlags) {
       // Not sure where this was getting called, but V8 does some
       // complicated things under the hood.
       // https://www.mattzeunert.com/2016/07/20/proxy-symbol-tostring.html
-      // TL;DR: V8 calls some things we don't want to throw up on.
+      // TL;DR: V8 calls some things we don't need to mention
       const ignoreList = [
         'Symbol(Symbol.toStringTag)',
         'Symbol(nodejs.util.inspect.custom)',
@@ -34,8 +34,6 @@ function useFlags(rawFlags) {
         );
       }
 
-      // If we get this far, I guess we make sure we don't mess up
-      // the expected behavior
       return obj[prop];
     },
   });

--- a/src/site/stages/build/options.js
+++ b/src/site/stages/build/options.js
@@ -192,9 +192,8 @@ async function setUpFeatureFlags(options) {
 
   logDrupal(`Drupal feature flags:\n${JSON.stringify(rawFlags, null, 2)}`);
 
-  const buildType = options.buildtype;
   // eslint-disable-next-line react-hooks/rules-of-hooks
-  const proxiedFlags = useFlags(rawFlags, buildType);
+  const proxiedFlags = useFlags(rawFlags);
 
   Object.assign(options, {
     cmsFeatureFlags: proxiedFlags,


### PR DESCRIPTION
## Description
As outlined in https://github.com/department-of-veterans-affairs/va.gov-team/issues/1583, we want to stop missing feature flags from within CMS from breaking `vets-website` builds. Instead, what we'll do is automatically notify the CMS team when we encounter feature flags that are missing, but consider them false in the meantime.

## Testing done
1) Remove / rename a query flag in the prod CMS
2) Rebuild this branch
3) Wait for the notification to #dev_null
4) Restore the query flag in the prod CMS

Ethan and I tested this. The missing feature flag does _not_ break the build. At the time, though, there were broken links preventing us from getting the notification for the missing feature flags. ([The PR](https://github.com/department-of-veterans-affairs/vets-website/pull/10693) to stop broken links from breaking the build wasn't merged yet.)

## Screenshots
N/A

## Acceptance criteria
- [x] Missing query flags don't break any builds

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
