### PR TITLE
VAGOV-5766: Revert breadcrumb casing rule.

### DIFF
--- a/src/site/includes/breadcrumbs.drupal.liquid
+++ b/src/site/includes/breadcrumbs.drupal.liquid
@@ -2,13 +2,7 @@
   <ul class="row va-nav-breadcrumbs-list columns" id="va-breadcrumbs-list">
     {% for crumb in entityUrl.breadcrumb %}
         {% if forloop.last == true %}
-            <li><a aria-current="page" href="/{{ path }}">
-            {% if path == "pittsburgh-health-care" %}
-                {{ crumb.text }}
-            {% else %}
-                {{ crumb.text | downcase | capitalize }}
-            {% endif %}
-            </a></li>
+            <li><a aria-current="page" href="/{{ path }}">{{ crumb.text }}</a></li>
         {% elsif crumb.url.path %}
             {% if crumb.url.path == '/' %}
                 <li>


### PR DESCRIPTION
## Description
https://github.com/department-of-veterans-affairs/vets-website/pull/10695/commits/8b8363950570acf9c4b165b779c8838a4747aa79 caused breadcrumbs to downcase sitewide for all drupal-powered pages. 

This reverts one of those changes. 

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
