### PR TITLE
Conditionally post 1995 as 1995s

### DIFF
--- a/src/applications/edu-benefits/1995/submitForm.js
+++ b/src/applications/edu-benefits/1995/submitForm.js
@@ -1,4 +1,5 @@
 import { submitToUrl } from 'platform/forms-system/src/js/actions';
+import environment from 'platform/utilities/environment';
 import { transformForSubmit } from 'platform/forms-system/src/js/helpers';
 
 const submitForm = (form, formConfig) => {
@@ -18,12 +19,13 @@ const submitForm = (form, formConfig) => {
     preferredContactMethod: form.data.preferredContactMethod,
   };
 
-  return submitToUrl(
-    body,
-    formConfig.submitUrl,
-    formConfig.trackingPrefix,
-    eventData,
-  );
+  const submitUrl =
+    !environment.isProduction() &&
+    form.data.isEdithNourseRogersScholarship === true
+      ? formConfig.submitUrl.replace('1995', '1995s')
+      : formConfig;
+
+  return submitToUrl(body, submitUrl, formConfig.trackingPrefix, eventData);
 };
 
 export default submitForm;

--- a/src/applications/edu-benefits/1995/submitForm.js
+++ b/src/applications/edu-benefits/1995/submitForm.js
@@ -23,7 +23,7 @@ const submitForm = (form, formConfig) => {
     !environment.isProduction() &&
     form.data.isEdithNourseRogersScholarship === true
       ? formConfig.submitUrl.replace('1995', '1995s')
-      : formConfig;
+      : formConfig.submitUrl;
 
   return submitToUrl(body, submitUrl, formConfig.trackingPrefix, eventData);
 };

--- a/src/applications/edu-benefits/tests/1995/01-all-fields.e2e.spec.js
+++ b/src/applications/edu-benefits/tests/1995/01-all-fields.e2e.spec.js
@@ -7,6 +7,7 @@ const FormsTestHelpers = require('../../../../platform/testing/e2e/form-helpers'
 
 module.exports = E2eHelpers.createE2eTest(client => {
   EduHelpers.initApplicationSubmitMock('1995');
+  EduHelpers.initApplicationSubmitMock('1995s');
 
   // Ensure introduction page renders.
   client

--- a/src/applications/edu-benefits/tests/1995/02-stem-all-fields.e2e.spec.js
+++ b/src/applications/edu-benefits/tests/1995/02-stem-all-fields.e2e.spec.js
@@ -6,7 +6,7 @@ const testData = require('./schema/e2e-maximal-test.json');
 const FormsTestHelpers = require('../../../../platform/testing/e2e/form-helpers');
 
 module.exports = E2eHelpers.createE2eTest(client => {
-  EduHelpers.initApplicationSubmitMock('1995');
+  EduHelpers.initApplicationSubmitMock('1995s');
 
   // Ensure introduction page renders.
   client
@@ -43,27 +43,28 @@ module.exports = E2eHelpers.createE2eTest(client => {
     'label[for="root_isEdithNourseRogersScholarshipYes"',
     Timeouts.slow,
   );
-  Edu1995Helpers.completeStemSelection(client);
+  Edu1995Helpers.completeStemSelectionFor1995s(client);
+  client.waitForElementVisible(
+    'label[for="root_isEnrolledStemYes"]',
+    Timeouts.slow,
+  );
+  Edu1995Helpers.completeStemEnrollmentSelection(client);
+  client.waitForElementVisible(
+    'label[for="root_isPursuingTeachingCertYes"]',
+    Timeouts.slow,
+  );
+  Edu1995Helpers.completePursuingTeachingCertSelection(client);
   client.axeCheck('.main').click('.form-progress-buttons .usa-button-primary');
   E2eHelpers.expectNavigateAwayFrom(client, '/benefits/stem');
 
-  // Service periods page.
+  // Active duty page
   client.waitForElementVisible(
-    'label[for="root_view:newServiceYes"]',
+    'label[for="root_isActiveDutyYes"]',
     Timeouts.slow,
   );
-  EduHelpers.completeServicePeriods(client, testData.data);
+  Edu1995Helpers.completeActiveDutySelection(client);
   client.axeCheck('.main').click('.form-progress-buttons .usa-button-primary');
-  E2eHelpers.expectNavigateAwayFrom(client, '/military/service');
-
-  // Military service page.
-  client.waitForElementVisible(
-    'label[for="root_view:hasServiceBefore1978Yes"]',
-    Timeouts.slow,
-  );
-  Edu1995Helpers.completeMilitaryService(client);
-  client.axeCheck('.main').click('.form-progress-buttons .usa-button-primary');
-  E2eHelpers.expectNavigateAwayFrom(client, '/military/history');
+  E2eHelpers.expectNavigateAwayFrom(client, '/benefits/stem');
 
   // New school page.
   client.waitForElementVisible(
@@ -94,15 +95,6 @@ module.exports = E2eHelpers.createE2eTest(client => {
     client,
     '/personal-information/contact-information',
   );
-
-  // Dependents page.
-  client.waitForElementVisible(
-    'label[for="root_serviceBefore1977_marriedYes"]',
-    Timeouts.slow,
-  );
-  Edu1995Helpers.completeDependents(client);
-  client.axeCheck('.main').click('.form-progress-buttons .usa-button-primary');
-  E2eHelpers.expectNavigateAwayFrom(client, '/personal-information/dependents');
 
   // Direct deposit page.
   client.waitForElementVisible(

--- a/src/applications/edu-benefits/tests/1995/edu-1995-helpers.js
+++ b/src/applications/edu-benefits/tests/1995/edu-1995-helpers.js
@@ -92,10 +92,30 @@ function completeStemSelection(client) {
   client.click('input[id="root_isEdithNourseRogersScholarshipNo"]');
 }
 
+function completeStemSelectionFor1995s(client) {
+  client.click('input[id="root_isEdithNourseRogersScholarshipYes"]');
+}
+
+function completeStemEnrollmentSelection(client) {
+  client.click('input[id="root_isEnrolledStemNo"]');
+}
+
+function completePursuingTeachingCertSelection(client) {
+  client.click('input[id="root_isPursuingTeachingCertNo"]');
+}
+
+function completeActiveDutySelection(client) {
+  client.click('input[id="root_isActiveDutyNo"]');
+}
+
 module.exports = {
   completeMilitaryService,
   completeNewSchool,
   completeOldSchool,
   completeDependents,
   completeStemSelection,
+  completeStemSelectionFor1995s,
+  completeStemEnrollmentSelection,
+  completePursuingTeachingCertSelection,
+  completeActiveDutySelection,
 };


### PR DESCRIPTION
## Description
Conditionally post 1995 form as 1995s when the user has answered "Yes" to the "Are you applying for the Edith Nourse Rogers STEM Scholarship?" question.

[19617](https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/vets.gov-team/19617) - As an EDU Team Member, I need the YTD reports to distinguish between 1995 submissions and 1995 submissions for the STEM Scholarship so I am aware of the number of STEM Scholarship applications.

## Testing done
Tested locally and QA reviewed

## Screenshots
N/A

## Acceptance criteria
- [x] New functionality is behind a prod flag

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
