### PR TITLE
VAGOV-5670: Remove space between buttons in mobile state.

### DIFF
--- a/src/platform/site-wide/sass/shame.scss
+++ b/src/platform/site-wide/sass/shame.scss
@@ -560,3 +560,13 @@ img[data-srcset] {
 .usa-accordion-bordered > ul li ul {
     list-style: square;
 }
+
+.no-left-button-right-radius-treatment {
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+.no-right-button-left-radius-treatment {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+}

--- a/src/site/facilities/facilities_events_toggle.drupal.liquid
+++ b/src/site/facilities/facilities_events_toggle.drupal.liquid
@@ -9,11 +9,43 @@
         vads-u-flex-direction--row
         medium-screen:vads-u-align-items--flex-start">
                 {% if url contains 'past-events' %}
-                        <a role="button" href="{{ url | remove_first: 'past-events' }}" class="vads-u-flex--1 usa-button usa-button-secondary vads-u-font-weight--normal vads-u-padding--1p5">Upcoming events</a>
-                        <a role="button" href="{{ url }}" class="vads-u-margin-top--0 half-em-bottom-margin vads-u-flex--1 usa-button vads-u-font-weight--normal vads-u-padding--1p5">Past events</a>
+                        <a role="button" href="{{ url | remove_first: 'past-events' }}" class="
+                        vads-u-flex--1
+                        vads-u-margin-right--0
+                        usa-button
+                        usa-button-secondary
+                        vads-u-font-weight--normal
+                        no-left-button-right-radius-treatment
+                        vads-u-padding--1p5"
+                        >Upcoming events</a>
+                        <a role="button" href="{{ url }}" class="
+                        vads-u-margin-top--0
+                        half-em-bottom-margin
+                        vads-u-flex--1
+                        usa-button
+                        vads-u-font-weight--normal
+                        no-right-button-left-radius-treatment
+                        vads-u-padding--1p5"
+                        >Past events</a>
                 {% else %}
-                        <a role="button" href="{{ url }}" class="vads-u-flex--1 usa-button vads-u-font-weight--normal vads-u-padding--1p5">Upcoming events</a>
-                        <a role="button" href="{{ url }}/past-events" class="vads-u-margin-top--0 half-em-bottom-margin vads-u-flex--1 usa-button usa-button-secondary vads-u-font-weight--normal vads-u-padding--1p5">Past events</a>
+                        <a role="button" href="{{ url }}" class="
+                        vads-u-flex--1
+                        vads-u-margin-right--0
+                        usa-button
+                        vads-u-font-weight--normal
+                        no-left-button-right-radius-treatment
+                        vads-u-padding--1p5"
+                        >Upcoming events</a>
+                        <a role="button" href="{{ url }}/past-events" class="
+                        vads-u-margin-top--0
+                        half-em-bottom-margin
+                        vads-u-flex--1
+                        usa-button
+                        usa-button-secondary
+                        vads-u-font-weight--normal
+                        no-right-button-left-radius-treatment
+                        vads-u-padding--1p5"
+                        >Past events</a>
                 {% endif %}
         </div>
 </div>


### PR DESCRIPTION
## Description
pittsburgh-health-care/events/ buttons shouldn't have space between them in mobile states.

## Testing done
Visual

## Screenshots
![Screenshot from 2019-09-10 10-52-25](https://user-images.githubusercontent.com/2404547/64624853-43b72f80-d3b9-11e9-9d6d-51c996922c70.png)