### PR TITLE
1640 - GIBCT Screenreader bug - School Location table

### DIFF
--- a/src/applications/gi/components/profile/SchoolLocations.jsx
+++ b/src/applications/gi/components/profile/SchoolLocations.jsx
@@ -189,8 +189,13 @@ export class SchoolLocations extends React.Component {
         <span>
           Below are locations for {main.institution.institution}. The housing
           estimates shown here are based on a full-time student taking in-person
-          classes. Select a link to view a location and calculate the benefits
-          you’d receive there.
+          classes.&nbsp;
+          {main.branches.length > 0 && ( // only displayed when branches exist
+            <span>
+              Select a link to view a location and calculate the benefits you’d
+              receive there.
+            </span>
+          )}
         </span>
         {this.renderFacilityMapTable(main)}
         {this.renderViewMore(main)}

--- a/src/applications/gi/components/profile/SchoolLocations.jsx
+++ b/src/applications/gi/components/profile/SchoolLocations.jsx
@@ -75,7 +75,7 @@ export class SchoolLocations extends React.Component {
       physicalZip,
     } = institution;
     const nameLabel = this.institutionIsBeingViewed(facilityCode) ? (
-      <h6>{name}</h6>
+      <p className="main-campus-name">{name}</p>
     ) : (
       name
     );
@@ -152,15 +152,9 @@ export class SchoolLocations extends React.Component {
       <table>
         <thead>
           <tr>
-            <th>
-              <h4>School Name</h4>
-            </th>
-            <th>
-              <h4>Location</h4>
-            </th>
-            <th>
-              <h4>Estimated housing</h4>
-            </th>
+            <th>School Name</th>
+            <th>Location</th>
+            <th>Estimated housing</th>
           </tr>
         </thead>
         <tbody>

--- a/src/applications/gi/components/profile/SchoolLocations.jsx
+++ b/src/applications/gi/components/profile/SchoolLocations.jsx
@@ -75,7 +75,7 @@ export class SchoolLocations extends React.Component {
       physicalZip,
     } = institution;
     const nameLabel = this.institutionIsBeingViewed(facilityCode) ? (
-      <p className="main-campus-name">{name}</p>
+      <p className="schoolName">{name}</p>
     ) : (
       name
     );

--- a/src/applications/gi/sass/partials/_gi-profile-page.scss
+++ b/src/applications/gi/sass/partials/_gi-profile-page.scss
@@ -258,7 +258,7 @@
       vertical-align: top;
     }
 
-    .main-campus-name {
+    .schoolName {
       margin-bottom: 0em;
       margin-top: 0em;
       font-weight: bold;

--- a/src/applications/gi/sass/partials/_gi-profile-page.scss
+++ b/src/applications/gi/sass/partials/_gi-profile-page.scss
@@ -232,16 +232,22 @@
   .school-locations {
     table {
       border: hidden;
-      margin-top: 0em;
-      margin-bottom: 0em;
+      margin-top: 1.5em;
+      margin-bottom: 0.5em;
     }
 
     th {
       border: hidden;
       background: none;
       white-space: nowrap;
-      padding-bottom: 0em;
+      padding-bottom: 0.5em;
       padding-top: 0em;
+      clear: both;
+      font-weight: 700;
+      font-family: Bitter, Georgia, Cambria, Times New Roman, Times, serif;
+      line-height: 1.5;
+      margin-bottom: 0.5em;
+      margin-top: 1.5em;
     }
 
     td {
@@ -250,10 +256,12 @@
       padding-top: 0em;
       padding-bottom: 0em;
       vertical-align: top;
+    }
 
-      h6 {
-        margin-top: 0em;
-      }
+    .main-campus-name {
+      margin-bottom: 0em;
+      margin-top: 0em;
+      font-weight: bold;
     }
 
     .location-cell {


### PR DESCRIPTION
## Description
The school locations table doesn't announce itself properly to Safari + VoiceOver, and has some invalid HTML. It would be good to refactor this table for assistive device users. Screenshot and code sample below.

As a user, I want the table instructions to match the table, and links be provided if necessary. The sentence mentioning the links in the table has been given conditional rendering logic and will only be displayed when branches exist under the current institution. 

https://github.com/department-of-veterans-affairs/va.gov-team/issues/1640

https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/1646

## Testing done
Confirmed locally in UI, via Chrome browser, Apple VoiceOver and Axe accessibility plugin. 

## Screenshots
Errors on page before fix:
<img width="1379" alt="Screen Shot 2019-09-10 at 11 50 23 AM" src="https://user-images.githubusercontent.com/52166695/64630048-4c603380-d3c2-11e9-9d38-4332c06cf3a4.png">

Screenreader and Axe util now approve:
<img width="1043" alt="Screen Shot 2019-09-10 at 11 51 14 AM" src="https://user-images.githubusercontent.com/52166695/64630072-571ac880-d3c2-11e9-817a-6c0c44184ad5.png">

## Acceptance criteria
- [x] As a VoiceOver user, I want to hear the column header and cell announced properly.
- [x] As a user, I do not want the visual layout to change when the HTML is refactored.

- [x] As a user, I want the table instructions to match the table, and links be provided if necessary.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
