### PR TITLE
removed prod flag

### DIFF
--- a/src/applications/gi/containers/Modals.jsx
+++ b/src/applications/gi/containers/Modals.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { connect } from 'react-redux';
 import * as actions from '../actions';
 import Modal from '@department-of-veterans-affairs/formation-react/Modal';
-import environment from 'platform/utilities/environment';
 
 export class Modals extends React.Component {
   calcBeneficiaryLocationQuestionContent = () => (
@@ -559,8 +558,7 @@ export class Modals extends React.Component {
         onClose={this.props.hideModal}
         visible={this.shouldDisplayModal('stemIndicator')}
       >
-        {environment.isProduction() && <h3>STEM</h3>}
-        {!environment.isProduction() && <h3>The Rogers STEM Scholarship</h3>}
+        <h3>The Rogers STEM Scholarship</h3>
         <div>
           <p>
             The Edith Nourse Rogers STEM Scholarship provides up to 9 months of
@@ -573,19 +571,14 @@ export class Modals extends React.Component {
             degree and are getting a teaching certification.
           </p>
           <p>
-            {environment.isProduction() &&
-              'To learn more about the STEM Scholarship,'}{' '}
-            {!environment.isProduction() &&
-              'To learn more about this scholarship,'}{' '}
+            To learn more about this scholarship,{' '}
             <a
               href="https://benefits.va.gov/gibill/fgib/stem.asp"
               target="_blank"
               rel="noopener noreferrer"
             >
               {' '}
-              {environment.isProduction() && 'visit the VBA STEM website'}
-              {!environment.isProduction() &&
-                'visit the Rogers STEM Scholarship website'}
+              visit the Rogers STEM Scholarship website
             </a>
             .
           </p>


### PR DESCRIPTION
## Description
This issue lifts the production flags for the functionality originally implemented in the following stories: 
https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/vets.gov-team/19658

## Original
- story 19506 https://github.com/department-of-veterans-affairs/vets.gov-team/issues/19506
And the following PRs: 
- PR 10597 https://github.com/department-of-veterans-affairs/vets-website/pull/10597

## Testing
Local Testing

## Acceptance Criteria: 
- [x] Prod Flag removed

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs

