### PR TITLE
Fix the build script argument threading to pull the latest content

### DIFF
--- a/jenkins/build.sh
+++ b/jenkins/build.sh
@@ -21,7 +21,7 @@ do
       drupalAddress="${2}"
       shift 2
       ;;
-    --pullDrupal)
+    --pull-drupal)
       pullDrupal="${1}"
       shift
       ;;


### PR DESCRIPTION
## Description
Turns out I messed this up in #10592. :disappointed: 

The `build()` function in `common.groovy` passes the `--pull-drupal` flag to the shell script, but it was looking for `--pullDrupal`.

## Testing done
Tested that this worked locally.

## Screenshots
![image](https://user-images.githubusercontent.com/12970166/64645767-70277780-d3ca-11e9-8311-36ce89a0d479.png)
Note how the `--pull-drupal` flag is passed to the `node` command now.

## Acceptance criteria
- [x] The CMS is used when `--pull-drupal` is passed to the `jenkins/build.sh` script

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
