### PR TITLE
Small logging correction

### DIFF
--- a/src/site/stages/build/drupal/metalsmith-drupal.js
+++ b/src/site/stages/build/drupal/metalsmith-drupal.js
@@ -125,7 +125,7 @@ async function loadDrupal(buildOptions) {
   if (!isDrupalAvailableInCache) {
     log(`Drupal content unavailable in local cache: ${drupalCache}`);
   } else {
-    log(`Drupal content loaded from local cache: ${drupalCache}`);
+    log(`Drupal content cache found: ${drupalCache}`);
   }
 
   if (shouldPull) {


### PR DESCRIPTION
## Description
I just noticed that one of the logs was saying that the content was loaded from the cache when it, in fact, has not yet. I updated this to say that the cache _exists_ instead.

## Testing done
None.

## Screenshots
N/A

## Acceptance criteria
- [x] The log states the the cache is found, not that it's being used

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
