### PR TITLE
VAGOV-5832: default timezone for events is EST

### DIFF
--- a/src/site/layouts/event.drupal.liquid
+++ b/src/site/layouts/event.drupal.liquid
@@ -76,14 +76,19 @@ Example data:
 {% include "src/site/includes/preview-edit.drupal.liquid" %}
 {% include "src/site/includes/breadcrumbs.drupal.liquid" %}
 
-{% assign start_date_no_time = fieldDate.value | timeZone: uid.entity.timezone, "dddd, MMM D" %}
-{% assign end_date_no_time = fieldDate.endValue | timeZone: uid.entity.timezone, "dddd, MMM D" %}
+{% assign timezone = "EST" %}
+{% if uid.entity.timezone != empty %}
+  {% assign timezone = uid.entity.timezone %}
+{% endif %}
 
-{% assign start_time = fieldDate.value | timeZone: uid.entity.timezone, "h:mm A" %}
-{% assign end_time = fieldDate.endValue | timeZone: uid.entity.timezone, "h:mm A" %}
+{% assign start_date_no_time = fieldDate.value | timeZone: timezone, "dddd, MMM D" %}
+{% assign end_date_no_time = fieldDate.endValue | timeZone: timezone, "dddd, MMM D" %}
 
-{% assign start_date_full = fieldDate.value | timeZone: uid.entity.timezone, "dddd, MMM D, h:mm A" %}
-{% assign end_date_full = fieldDate.endValue | timeZone: uid.entity.timezone, "dddd, MMM D, h:mm A" %}
+{% assign start_time = fieldDate.value | timeZone: timezone, "h:mm A" %}
+{% assign end_time = fieldDate.endValue | timeZone: timezone, "h:mm A" %}
+
+{% assign start_date_full = fieldDate.value | timeZone: timezone, "dddd, MMM D, h:mm A" %}
+{% assign end_date_full = fieldDate.endValue | timeZone: timezone, "dddd, MMM D, h:mm A" %}
 
 {% assign start_timestamp = fieldDate.value | unixFromDate %}
 {% assign current_timestamp = fieldDate.value | currentUnixFromDate %}

--- a/src/site/teasers/event.drupal.liquid
+++ b/src/site/teasers/event.drupal.liquid
@@ -27,14 +27,19 @@ Example data:
 {% endcomment %}
 {% if node != empty %}
 
-    {% assign start_date_no_time = node.fieldDate.value | timeZone: node.uid.entity.timezone, "dddd, MMM D" %}
-    {% assign end_date_no_time = node.fieldDate.endValue | timeZone: node.uid.entity.timezone , "dddd, MMM D" %}
+    {% assign timezone = "EST" %}
+    {% if node.uid.entity.timezone != empty %}
+        {% assign timezone = uid.entity.timezone %}
+    {% endif %}
 
-    {% assign start_time = node.fieldDate.value | timeZone: node.uid.entity.timezone, "h:mm A" %}
-    {% assign end_time = node.fieldDate.endValue | timeZone: node.uid.entity.timezone, "h:mm A" %}
+    {% assign start_date_no_time = node.fieldDate.value | timeZone: timezone, "dddd, MMM D" %}
+    {% assign end_date_no_time = node.fieldDate.endValue | timeZone: timezone , "dddd, MMM D" %}
 
-    {% assign start_date_full = node.fieldDate.value | timeZone: node.uid.entity.timezone, "dddd, MMM D, h:mm A" %}
-    {% assign end_date_full = node.fieldDate.endValue | timeZone: node.uid.entity.timezone, "dddd, MMM D, h:mm A" %}
+    {% assign start_time = node.fieldDate.value | timeZone: timezone, "h:mm A" %}
+    {% assign end_time = node.fieldDate.endValue | timeZone: timezone, "h:mm A" %}
+
+    {% assign start_date_full = node.fieldDate.value | timeZone: timezone, "dddd, MMM D, h:mm A" %}
+    {% assign end_date_full = node.fieldDate.endValue | timeZone: timezone, "dddd, MMM D, h:mm A" %}
 
     {% if node.fieldDate.value != empty and node.fieldDate.endValue == empty %}
         {% assign date_type = "start_date_only" %}

--- a/src/site/teasers/event_featured.drupal.liquid
+++ b/src/site/teasers/event_featured.drupal.liquid
@@ -28,14 +28,19 @@ views",
 {% endcomment %}
 {% if node != empty %}
 
-{% assign start_date_no_time = node.fieldDate.value | timeZone: node.uid.entity.timezone, "dddd, MMM D" %}
-{% assign end_date_no_time = node.fieldDate.endValue | timeZone: node.uid.entity.timezone , "dddd, MMM D" %}
+  {% assign timezone = "EST" %}
+  {% if node.uid.entity.timezone != empty %}
+    {% assign timezone = uid.entity.timezone %}
+  {% endif %}
 
-{% assign start_time = node.fieldDate.value | timeZone: node.uid.entity.timezone, "h:mm A" %}
-{% assign end_time = node.fieldDate.endValue | timeZone: node.uid.entity.timezone, "h:mm A" %}
+{% assign start_date_no_time = node.fieldDate.value | timeZone: timezone, "dddd, MMM D" %}
+{% assign end_date_no_time = node.fieldDate.endValue | timeZone: timezone , "dddd, MMM D" %}
 
-{% assign start_date_full = node.fieldDate.value | timeZone: node.uid.entity.timezone, "dddd, MMM D, h:mm A" %}
-{% assign end_date_full = node.fieldDate.endValue | timeZone: node.uid.entity.timezone, "dddd, MMM D, h:mm A" %}
+{% assign start_time = node.fieldDate.value | timeZone: timezone, "h:mm A" %}
+{% assign end_time = node.fieldDate.endValue | timeZone: timezone, "h:mm A" %}
+
+{% assign start_date_full = node.fieldDate.value | timeZone: timezone, "dddd, MMM D, h:mm A" %}
+{% assign end_date_full = node.fieldDate.endValue | timeZone: timezone, "dddd, MMM D, h:mm A" %}
 
 {% if node.fieldDate.value != empty and node.fieldDate.endValue == empty %}
 {% assign date_type = "start_date_only" %}


### PR DESCRIPTION
## Description
sets the default timezone for events as EST in the event templates if the `uid` timezone field is not populated

## Testing done
locally with staging data

## Screenshots
when this happens
![image](https://user-images.githubusercontent.com/19178435/64663155-c06cfc80-d3ff-11e9-8b52-8e6003be4fda.png)
 default the timezone to EST
![image](https://user-images.githubusercontent.com/19178435/64663138-b2b77700-d3ff-11e9-8c4e-8a1131dbec6a.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
