### PR TITLE
Add VAOS type of care page

### DIFF
--- a/src/applications/vaos/components/TypeOfCareField.jsx
+++ b/src/applications/vaos/components/TypeOfCareField.jsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { TYPES_OF_CARE } from '../utils/constants';
+
+function RadioWidget({ option, checked, onChange, id }) {
+  return (
+    <div className="form-radio-buttons">
+      <input
+        type="radio"
+        checked={checked}
+        id={`${id}_${option.id}`}
+        name={`${id}`}
+        value={option.id}
+        onChange={_ => onChange(option.id)}
+      />
+      <label htmlFor={`${id}_${option.id}`}>{option.name}</label>
+    </div>
+  );
+}
+
+const PRIMARY_CARE = TYPES_OF_CARE.filter(care => care.group === 'primary');
+const MENTAL_HEALTH = TYPES_OF_CARE.filter(
+  care => care.group === 'mentalHealth',
+);
+const SPECIALTY = TYPES_OF_CARE.filter(care => care.group === 'specialty');
+
+export default function TypeOfCareField({ formData, onChange, idSchema }) {
+  return (
+    <div>
+      <fieldset>
+        <legend className="vads-u-color--base vads-u-font-family--serif vads-u-padding-bottom--0 vads-u-padding-top--3">
+          Primary care
+        </legend>
+        Including PAC Team, express care clinic, and primary care appointments
+        with clinical pharmacists.
+        {PRIMARY_CARE.map(care => (
+          <RadioWidget
+            key={care.id}
+            id={idSchema.$id}
+            option={care}
+            checked={care.id === formData}
+            onChange={onChange}
+          />
+        ))}
+      </fieldset>
+      <fieldset>
+        <legend className="vads-u-color--base vads-u-font-family--serif vads-u-padding-bottom--0 vads-u-padding-top--3">
+          Mental and behavioral health
+        </legend>
+        Including outpatient mental health and social services
+        {MENTAL_HEALTH.map(care => (
+          <RadioWidget
+            key={care.id}
+            id={idSchema.$id}
+            option={care}
+            checked={care.id === formData}
+            onChange={onChange}
+          />
+        ))}
+      </fieldset>
+      <fieldset>
+        <legend className="vads-u-color--base vads-u-font-family--serif vads-u-padding-bottom--0 vads-u-padding-top--3">
+          Specialty care
+        </legend>
+        Including hearing aid support and some other types of specialty care
+        {SPECIALTY.map(care => (
+          <RadioWidget
+            key={care.id}
+            id={idSchema.$id}
+            option={care}
+            checked={care.id === formData}
+            onChange={onChange}
+          />
+        ))}
+      </fieldset>
+    </div>
+  );
+}

--- a/src/applications/vaos/containers/TypeOfCarePage.jsx
+++ b/src/applications/vaos/containers/TypeOfCarePage.jsx
@@ -4,6 +4,7 @@ import { openFormPage, updateFormData } from '../actions/newAppointment.js';
 import SchemaForm from 'platform/forms-system/src/js/components/SchemaForm';
 import ProgressButton from 'platform/forms-system/src/js/components/ProgressButton';
 import { TYPES_OF_CARE } from '../utils/constants';
+import TypeOfCareField from '../components/TypeOfCareField';
 
 const initialSchema = {
   type: 'object',
@@ -19,30 +20,9 @@ const initialSchema = {
 const uiSchema = {
   typeOfCareId: {
     'ui:title': 'What type of care do you need?',
-    'ui:widget': 'radio',
+    'ui:field': TypeOfCareField,
     'ui:options': {
-      labels: {
-        provider: (
-          <>
-            <span className="vads-u-display--block vads-u-font-size--lg vads-u-font-weight--bold">
-              Provider
-            </span>
-            <span className="vads-u-display--block vads-u-font-size--sm">
-              Choose a doctor or care team
-            </span>
-          </>
-        ),
-        typeOfCare: (
-          <>
-            <span className="vads-u-display--block vads-u-font-size--lg vads-u-font-weight--bold">
-              Type of care
-            </span>
-            <span className="vads-u-display--block vads-u-font-size--sm">
-              Choose a specific type of care, like audiology or primary care
-            </span>
-          </>
-        ),
-      },
+      hideLabelText: true,
     },
   },
 };
@@ -67,7 +47,9 @@ export class TypeOfCarePage extends React.Component {
 
     return (
       <div>
-        <h1 className="vads-u-font-size--h2">Choose the type of care you need</h1>
+        <h1 className="vads-u-font-size--h2">
+          Choose the type of care you need
+        </h1>
         <SchemaForm
           name="Type of care"
           title="Type of care"

--- a/src/applications/vaos/containers/TypeOfCarePage.jsx
+++ b/src/applications/vaos/containers/TypeOfCarePage.jsx
@@ -3,21 +3,22 @@ import { connect } from 'react-redux';
 import { openFormPage, updateFormData } from '../actions/newAppointment.js';
 import SchemaForm from 'platform/forms-system/src/js/components/SchemaForm';
 import ProgressButton from 'platform/forms-system/src/js/components/ProgressButton';
+import { TYPES_OF_CARE } from '../utils/constants';
 
 const initialSchema = {
   type: 'object',
-  required: ['typeOfAppointment'],
+  required: ['typeOfCareId'],
   properties: {
-    typeOfAppointment: {
+    typeOfCareId: {
       type: 'string',
-      enum: ['provider', 'typeOfCare'],
+      enum: TYPES_OF_CARE.map(care => care.id || care.ccId),
     },
   },
 };
 
 const uiSchema = {
-  typeOfAppointment: {
-    'ui:title': 'How would you like to make an appointment?',
+  typeOfCareId: {
+    'ui:title': 'What type of care do you need?',
     'ui:widget': 'radio',
     'ui:options': {
       labels: {
@@ -46,9 +47,9 @@ const uiSchema = {
   },
 };
 
-const pageKey = 'type-appointment';
+const pageKey = 'type-of-care';
 
-export class TypeOfAppointmentPage extends React.Component {
+export class TypeOfCarePage extends React.Component {
   componentDidMount() {
     this.props.openFormPage(pageKey, uiSchema, initialSchema);
   }
@@ -58,17 +59,18 @@ export class TypeOfAppointmentPage extends React.Component {
   };
 
   goForward = () => {
-    this.props.router.push('/new-appointment/type-of-care');
+    this.props.router.push('/new-appointment/contact-info');
   };
 
   render() {
     const { schema, data } = this.props;
 
     return (
-      <div className="vaos-form__appt-type">
+      <div>
+        <h1 className="vads-u-font-size--h2">Choose the type of care you need</h1>
         <SchemaForm
-          name="Type of appointment"
-          title="Type of appointment"
+          name="Type of care"
+          title="Type of care"
           schema={schema || initialSchema}
           uiSchema={uiSchema}
           onSubmit={this.goForward}
@@ -116,4 +118,4 @@ const mapDispatchToProps = {
 export default connect(
   mapStateToProps,
   mapDispatchToProps,
-)(TypeOfAppointmentPage);
+)(TypeOfCarePage);

--- a/src/applications/vaos/routes.jsx
+++ b/src/applications/vaos/routes.jsx
@@ -3,6 +3,7 @@ import { Route, IndexRoute } from 'react-router';
 import LandingPage from './components/LandingPage';
 import NewAppointmentLayout from './components/NewAppointmentLayout';
 import TypeOfAppointmentPage from './containers/TypeOfAppointmentPage';
+import TypeOfCarePage from './containers/TypeOfCarePage';
 import ContactInfoPage from './containers/ContactInfoPage';
 
 const routes = (
@@ -10,6 +11,7 @@ const routes = (
     <IndexRoute component={LandingPage} />
     <Route path="new-appointment" component={NewAppointmentLayout}>
       <IndexRoute component={TypeOfAppointmentPage} />
+      <Route path="type-of-care" component={TypeOfCarePage} />
       <Route path="contact-info" component={ContactInfoPage} />
     </Route>
   </Route>

--- a/src/applications/vaos/routes.jsx
+++ b/src/applications/vaos/routes.jsx
@@ -3,7 +3,7 @@ import { Route, IndexRoute } from 'react-router';
 import LandingPage from './components/LandingPage';
 import NewAppointmentLayout from './components/NewAppointmentLayout';
 import AppointmentListsPage from './containers/AppointmentListsPage';
-import TypeOfAppointmentPage from './containers/TypeOfAppointmentPage';
+// import TypeOfAppointmentPage from './containers/TypeOfAppointmentPage';
 import TypeOfCarePage from './containers/TypeOfCarePage';
 import PendingAppointmentsPage from './containers/PendingAppointmentsPage';
 import ContactInfoPage from './containers/ContactInfoPage';
@@ -12,8 +12,7 @@ const routes = (
   <Route path="/">
     <IndexRoute component={LandingPage} />
     <Route path="new-appointment" component={NewAppointmentLayout}>
-      <IndexRoute component={TypeOfAppointmentPage} />
-      <Route path="type-of-care" component={TypeOfCarePage} />
+      <IndexRoute component={TypeOfCarePage} />
       <Route path="contact-info" component={ContactInfoPage} />
     </Route>
     <Route path="appointments" component={AppointmentListsPage} />

--- a/src/applications/vaos/tests/containers/TypeOfCarePage.unit.spec.jsx
+++ b/src/applications/vaos/tests/containers/TypeOfCarePage.unit.spec.jsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { mount } from 'enzyme';
+
+import { selectRadio } from 'platform/testing/unit/schemaform-utils.jsx';
+import { TypeOfCarePage } from '../../containers/TypeOfCarePage';
+
+describe('VAOS <TypeOfCarePage>', () => {
+  it('should render', () => {
+    const openFormPage = sinon.spy();
+    const updateFormData = sinon.spy();
+
+    const form = mount(
+      <TypeOfCarePage
+        openFormPage={openFormPage}
+        updateFormData={updateFormData}
+        data={{}}
+      />,
+    );
+
+    expect(form.find('fieldset').length).to.equal(3);
+    expect(form.find('input').length).to.equal(14);
+    form.unmount();
+  });
+
+  it('should not submit empty form', () => {
+    const openFormPage = sinon.spy();
+    const router = {
+      push: sinon.spy(),
+    };
+
+    const form = mount(
+      <TypeOfCarePage openFormPage={openFormPage} router={router} data={{}} />,
+    );
+
+    form.find('form').simulate('submit');
+
+    expect(form.find('.usa-input-error').length).to.equal(1);
+    expect(router.push.called).to.be.false;
+    form.unmount();
+  });
+
+  it('should call updateFormData after change', () => {
+    const openFormPage = sinon.spy();
+    const updateFormData = sinon.spy();
+    const router = {
+      push: sinon.spy(),
+    };
+
+    const form = mount(
+      <TypeOfCarePage
+        openFormPage={openFormPage}
+        updateFormData={updateFormData}
+        router={router}
+        data={{}}
+      />,
+    );
+
+    selectRadio(form, 'root_typeOfCareId', '323');
+
+    expect(updateFormData.firstCall.args[2].typeOfCareId).to.equal('323');
+    form.unmount();
+  });
+
+  it('should submit with valid data', () => {
+    const openFormPage = sinon.spy();
+    const router = {
+      push: sinon.spy(),
+    };
+
+    const form = mount(
+      <TypeOfCarePage
+        openFormPage={openFormPage}
+        router={router}
+        data={{ typeOfCareId: '323' }}
+      />,
+    );
+
+    form.find('form').simulate('submit');
+
+    expect(form.find('.usa-input-error').length).to.equal(0);
+    expect(router.push.called).to.be.true;
+    form.unmount();
+  });
+});

--- a/src/applications/vaos/utils/constants.js
+++ b/src/applications/vaos/utils/constants.js
@@ -61,7 +61,7 @@ export const TYPES_OF_CARE = [
   },
   {
     id: '407',
-    name: 'Ophthalmology',
+    name: 'Opthalmology',
     group: 'specialty',
   },
   {
@@ -71,6 +71,7 @@ export const TYPES_OF_CARE = [
     ccId: 'CCOPT',
   },
   {
+    id: 'tbd',
     name: 'Podiatry',
     ccId: 'CCPOD',
     group: 'specialty',

--- a/src/applications/vaos/utils/constants.js
+++ b/src/applications/vaos/utils/constants.js
@@ -1,0 +1,76 @@
+export const TYPES_OF_CARE = [
+  {
+    id: '323',
+    name: 'Primary care',
+    group: 'primary',
+    ccId: 'CCPRMYRTNE',
+  },
+  {
+    id: '160',
+    name: 'Clinical pharmacy primary care',
+    group: 'primary',
+  },
+  {
+    id: 'CR1',
+    name: 'Express care clinic',
+    group: 'primary',
+  },
+  {
+    id: '502',
+    name: 'Outpatient mental health',
+    group: 'mentalHealth',
+  },
+  {
+    id: '125',
+    name: 'Social work',
+    group: 'mentalHealth',
+  },
+  {
+    id: '211',
+    name: 'Amputation care',
+    group: 'specialty',
+  },
+  {
+    id: '203',
+    name: 'Audiology and speech',
+    group: 'specialty',
+    ccId: ['CCAUDHEAR', 'CCAUDRTNE'],
+  },
+  {
+    id: '349',
+    name: 'CPAP clinic',
+    group: 'specialty',
+  },
+  {
+    id: '372',
+    name: 'MOVE! weight management program',
+    group: 'specialty',
+  },
+  {
+    id: '123',
+    name: 'Nutrition and food',
+    group: 'specialty',
+    ccId: 'CCNUTRN',
+  },
+  {
+    id: '407',
+    name: 'Ophthalmology',
+    group: 'specialty',
+  },
+  {
+    id: '408',
+    name: 'Optometry',
+    group: 'specialty',
+    ccId: 'CCOPT',
+  },
+  {
+    name: 'Podiatry',
+    ccId: 'CCPOD',
+    group: 'specialty',
+  },
+  {
+    id: '143',
+    name: 'Sleep medicine and home sleep testing',
+    group: 'specialty',
+  },
+];


### PR DESCRIPTION
## Description
This adds a page where you can choose the type of care. The grouping here isn't well supported by the form system, so it's a custom field. How validation is supposed to look is an open question, it probably has some a11y issues right now.

## Testing done
Local testing, unit tests

## Screenshots
![Screen Shot 2019-09-11 at 4 17 25 PM](https://user-images.githubusercontent.com/634932/64731692-aa1e7980-d4af-11e9-9758-6b0acfe31c45.png)



## Acceptance criteria
- [x] Choose between types of care
- [x] Types of care are grouped

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
