### PR TITLE
Fix silly mistake on VAOS pending page

### DIFF
--- a/src/applications/vaos/containers/PendingAppointmentPage.jsx
+++ b/src/applications/vaos/containers/PendingAppointmentPage.jsx
@@ -137,7 +137,7 @@ PendingAppointmentPage.propTypes = {
 
 function mapStateToProps(state, ownProps) {
   return {
-    appointment: selectPendingAppointment(state, ownProps.id),
+    appointment: selectPendingAppointment(state, ownProps.params.id),
     status: state.appointments.pendingStatus,
   };
 }


### PR DESCRIPTION
## Description
Missed a thing in my last commit

## Testing done
Local testing

## Acceptance criteria
- [x] Pending appt detail page opens again

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
