### PR TITLE
Add confirmed appointment page

### DIFF
--- a/src/applications/vaos/actions/confirmed.json
+++ b/src/applications/vaos/actions/confirmed.json
@@ -13,9 +13,10 @@
   },
   "dateTime": "2019-08-29T12:00:00Z",
   "reason": "Routine/Follow-up",
-  "type": "Office Visit",
+  "type": "Hematology (Internal Medicine), Medical Oncology, Internal Medicine",
+  "visitType": "Office Visit",
   "contactNumber": "+1-908-477-1720",
-  "preferredContactTime": "evening",
+  "preferredContactTime": ["Morning"],
   "status": "booked",
   "pactTeam": {
     "teamSid": "1400018881",

--- a/src/applications/vaos/actions/confirmed.json
+++ b/src/applications/vaos/actions/confirmed.json
@@ -1,29 +1,900 @@
-[{
-  "id": "123",
-  "facilityId": "888",
-  "facility": {
-    "id": "888",
-    "name": "Washington VA Medical Center",
-    "type": "VAMC",
-    "address": "50 Irving St NW",
-    "city": "Washington",
-    "state": "DC",
-    "directScheduleEnabled": true,
-    "parentSiteCode": 688
+{
+  "lastAccessDate": "09/04/2019 20:52:01",
+  "selfUri": "https://var-resources-v4.sqa.svc.cluster.local/var/VeteranAppointmentRequestService/v4/rest/appointment-service/patient/ICN/1012845331V153043/appointments?endDate=09%2F04%2F2019&startDate=05%2F07%2F2019&_=1567630368746",
+  "selfLink": {
+    "rel": "self",
+    "href": "https://var-resources-v4.sqa.svc.cluster.local/var/VeteranAppointmentRequestService/v4/rest/appointment-service/patient/ICN/1012845331V153043/appointments?endDate=09%2F04%2F2019&startDate=05%2F07%2F2019&_=1567630368746",
+    "objectType": "AtomLink"
   },
-  "dateTime": "2019-08-29T12:00:00Z",
-  "reason": "Routine/Follow-up",
-  "type": "Hematology (Internal Medicine), Medical Oncology, Internal Medicine",
-  "visitType": "Office Visit",
-  "contactNumber": "+1-908-477-1720",
-  "preferredContactTime": ["Morning"],
-  "status": "booked",
-  "pactTeam": {
-    "teamSid": "1400018881",
-    "teamName": "Green-four",
-    "staff": [{
-      "name": "McBride, Samantha M",
-      "title": "Registered Nurse (RN)"
-    }]
-  }
-}]
+  "empty": false,
+  "appointmentRequests": [{
+    "dataIdentifier": {
+      "uniqueId": "8a48912a6cab0202016cd3afd3ef008a",
+      "systemId": "var"
+    },
+    "patientIdentifier": {
+      "uniqueId": "1012845331V153043",
+      "assigningAuthority": "ICN"
+    },
+    "surrogateIdentifier": {},
+    "lastUpdatedDate": "08/27/2019 12:16:19",
+    "optionDate1": "09/11/2019",
+    "optionTime1": "AM",
+    "optionDate2": "09/12/2019",
+    "optionTime2": "AM",
+    "optionDate3": "No Date Selected",
+    "optionTime3": "No Time Selected",
+    "status": "Booked",
+    "appointmentType": "Primary Care",
+    "visitType": "Office Visit",
+    "facility": {
+      "name": "CHYSHR-Cheyenne VA Medical Center",
+      "facilityCode": "983",
+      "state": "WY",
+      "city": "Cheyenne",
+      "parentSiteCode": "983",
+      "objectType": "Facility",
+      "link": []
+    },
+    "email": "samatha.girla@va.gov",
+    "textMessagingAllowed": false,
+    "phoneNumber": "(703) 652-0000",
+    "purposeOfVisit": "New Issue",
+    "providerId": "0",
+    "secondRequest": false,
+    "secondRequestSubmitted": false,
+    "patient": {
+      "displayName": "MORRISON, JUDY",
+      "firstName": "JUDY",
+      "lastName": "MORRISON",
+      "dateOfBirth": "Apr 01, 1953",
+      "patientIdentifier": {
+        "uniqueId": "1259897978"
+      },
+      "ssn": "796061976",
+      "inpatient": false,
+      "textMessagingAllowed": false,
+      "id": "1259897978",
+      "objectType": "Patient",
+      "link": []
+    },
+    "bestTimetoCall": ["Morning"],
+    "appointmentRequestDetailCode": [{
+      "appointmentRequestDetailCodeId": "8a48e8b56cd0144c016cd44afc0a00e7",
+      "createdDate": "08/27/2019 12:16:19",
+      "detailCode": {
+        "code": "DETCODE12",
+        "providerMessage": "Booked on alternate date.",
+        "veteranMessage": "Your appointment has been booked at a time other than your original request.  Please use the Appointments feature on the previous screen to see more information on this and other appointments at VA healthcare facilities.",
+        "objectType": "VARDetailCode",
+        "link": []
+      },
+      "userId": "1013004612",
+      "objectType": "VARAppointmentRequestDetailCode",
+      "link": []
+    }],
+    "hasVeteranNewMessage": true,
+    "hasProviderNewMessage": false,
+    "providerSeenAppointmentRequest": true,
+    "requestedPhoneCall": false,
+    "bookedApptDateTime": "09/11/2019 10:00:00",
+    "typeOfCareId": "323",
+    "friendlyLocationName": "CHYSHR-Cheyenne VA Medical Center",
+    "patientId": "1259897978",
+    "appointmentRequestId": "8a48912a6cab0202016cd3afd3ef008a",
+    "date": "2019-08-27T09:26:51.000+0000",
+    "assigningAuthority": "ICN",
+    "uniqueId": "8a48912a6cab0202016cd3afd3ef008a",
+    "systemId": "var",
+    "objectType": "VARAppointmentRequest",
+    "selfUri": "/var/VeteranAppointmentRequestService/v4/rest/appointment-service/patient/ICN/1012845331V153043/appointments/system/var/id/8a48912a6cab0202016cd3afd3ef008a",
+    "selfLink": {
+      "rel": "self",
+      "href": "/var/VeteranAppointmentRequestService/v4/rest/appointment-service/patient/ICN/1012845331V153043/appointments/system/var/id/8a48912a6cab0202016cd3afd3ef008a",
+      "objectType": "AtomLink"
+    },
+    "link": [{
+      "rel": "self",
+      "href": "/var/VeteranAppointmentRequestService/v4/rest/appointment-service/patient/ICN/1012845331V153043/appointments/system/var/id/8a48912a6cab0202016cd3afd3ef008a",
+      "objectType": "AtomLink"
+    }, {
+      "rel": "related",
+      "title": "appointment-request-messages",
+      "href": "/var/VeteranAppointmentRequestService/v4/rest/appointment-service/patient/ICN/1012845331V153043/appointment-requests/system/var/id/8a48912a6cab0202016cd3afd3ef008a/messages",
+      "objectType": "AtomLink"
+    }, {
+      "rel": "related",
+      "title": "appointment-request-new-message-flag",
+      "href": "/var/VeteranAppointmentRequestService/v4/rest/appointment-service/patient/ICN/1012845331V153043/appointment-requests/system/var/id/8a48912a6cab0202016cd3afd3ef008a/messages/read",
+      "objectType": "AtomLink"
+    }, {
+      "rel": "related",
+      "title": "appointment-request-provider-seen-flag",
+      "href": "/var/VeteranAppointmentRequestService/v4/rest/appointment-service/patient/ICN/1012845331V153043/appointment-requests/system/var/id/8a48912a6cab0202016cd3afd3ef008a/appointment/provider-read",
+      "objectType": "AtomLink"
+    }],
+    "createdDate": "08/27/2019 09:26:51"
+  }, {
+    "dataIdentifier": {
+      "uniqueId": "8a48912a6cab0202016cb4fcaa8b0038",
+      "systemId": "var"
+    },
+    "patientIdentifier": {
+      "uniqueId": "1012845331V153043",
+      "assigningAuthority": "ICN"
+    },
+    "surrogateIdentifier": {},
+    "lastUpdatedDate": "08/21/2019 12:22:33",
+    "optionDate1": "08/30/2019",
+    "optionTime1": "AM",
+    "optionDate2": "No Date Selected",
+    "optionTime2": "No Time Selected",
+    "optionDate3": "No Date Selected",
+    "optionTime3": "No Time Selected",
+    "status": "Submitted",
+    "appointmentType": "Primary Care",
+    "visitType": "Office Visit",
+    "facility": {
+      "name": "DAYTSHR -Dayton VA Medical Center",
+      "facilityCode": "984",
+      "state": "OH",
+      "city": "Dayton",
+      "parentSiteCode": "984",
+      "objectType": "Facility",
+      "link": []
+    },
+    "email": "Vilasini.reddy@va.gov",
+    "textMessagingAllowed": false,
+    "phoneNumber": "(777) 777-7777",
+    "purposeOfVisit": "Other",
+    "otherPurposeOfVisit": "Testing",
+    "providerId": "0",
+    "secondRequest": false,
+    "secondRequestSubmitted": false,
+    "patient": {
+      "displayName": "MORRISON, JUDY",
+      "firstName": "JUDY",
+      "lastName": "MORRISON",
+      "dateOfBirth": "Apr 01, 1953",
+      "patientIdentifier": {
+        "uniqueId": "1259897978"
+      },
+      "ssn": "796061976",
+      "inpatient": false,
+      "textMessagingAllowed": false,
+      "id": "1259897978",
+      "objectType": "Patient",
+      "link": []
+    },
+    "bestTimetoCall": ["Morning"],
+    "appointmentRequestDetailCode": [],
+    "hasVeteranNewMessage": true,
+    "hasProviderNewMessage": false,
+    "providerSeenAppointmentRequest": true,
+    "requestedPhoneCall": false,
+    "typeOfCareId": "323",
+    "friendlyLocationName": "DAYTSHR -Dayton VA Medical Center name2",
+    "patientId": "1259897978",
+    "appointmentRequestId": "8a48912a6cab0202016cb4fcaa8b0038",
+    "date": "2019-08-21T12:22:33.252+0000",
+    "assigningAuthority": "ICN",
+    "uniqueId": "8a48912a6cab0202016cb4fcaa8b0038",
+    "systemId": "var",
+    "objectType": "VARAppointmentRequest",
+    "selfUri": "/var/VeteranAppointmentRequestService/v4/rest/appointment-service/patient/ICN/1012845331V153043/appointments/system/var/id/8a48912a6cab0202016cb4fcaa8b0038",
+    "selfLink": {
+      "rel": "self",
+      "href": "/var/VeteranAppointmentRequestService/v4/rest/appointment-service/patient/ICN/1012845331V153043/appointments/system/var/id/8a48912a6cab0202016cb4fcaa8b0038",
+      "objectType": "AtomLink"
+    },
+    "link": [{
+      "rel": "self",
+      "href": "/var/VeteranAppointmentRequestService/v4/rest/appointment-service/patient/ICN/1012845331V153043/appointments/system/var/id/8a48912a6cab0202016cb4fcaa8b0038",
+      "objectType": "AtomLink"
+    }, {
+      "rel": "related",
+      "title": "appointment-request-messages",
+      "href": "/var/VeteranAppointmentRequestService/v4/rest/appointment-service/patient/ICN/1012845331V153043/appointment-requests/system/var/id/8a48912a6cab0202016cb4fcaa8b0038/messages",
+      "objectType": "AtomLink"
+    }, {
+      "rel": "related",
+      "title": "appointment-request-new-message-flag",
+      "href": "/var/VeteranAppointmentRequestService/v4/rest/appointment-service/patient/ICN/1012845331V153043/appointment-requests/system/var/id/8a48912a6cab0202016cb4fcaa8b0038/messages/read",
+      "objectType": "AtomLink"
+    }, {
+      "rel": "related",
+      "title": "appointment-request-provider-seen-flag",
+      "href": "/var/VeteranAppointmentRequestService/v4/rest/appointment-service/patient/ICN/1012845331V153043/appointment-requests/system/var/id/8a48912a6cab0202016cb4fcaa8b0038/appointment/provider-read",
+      "objectType": "AtomLink"
+    }],
+    "createdDate": "08/21/2019 12:22:33"
+  }, {
+    "dataIdentifier": {
+      "uniqueId": "8a48912a6c2409b9016c9a9afff101ee",
+      "systemId": "var"
+    },
+    "patientIdentifier": {
+      "uniqueId": "1012845331V153043",
+      "assigningAuthority": "ICN"
+    },
+    "surrogateIdentifier": {},
+    "lastUpdatedDate": "08/16/2019 13:14:16",
+    "optionDate1": "08/21/2019",
+    "optionTime1": "AM",
+    "optionDate2": "No Date Selected",
+    "optionTime2": "No Time Selected",
+    "optionDate3": "No Date Selected",
+    "optionTime3": "No Time Selected",
+    "status": "Cancelled",
+    "appointmentType": "Outpatient Mental Health",
+    "visitType": "Office Visit",
+    "facility": {
+      "name": "CHYSHR-Cheyenne VA Medical Center",
+      "facilityCode": "983",
+      "state": "WY",
+      "city": "Cheyenne",
+      "parentSiteCode": "983",
+      "objectType": "Facility",
+      "link": []
+    },
+    "email": "samatha.girla@va.gov",
+    "textMessagingAllowed": false,
+    "phoneNumber": "(703) 652-0000",
+    "purposeOfVisit": "New Issue",
+    "providerId": "0",
+    "secondRequest": false,
+    "secondRequestSubmitted": false,
+    "patient": {
+      "displayName": "MORRISON, JUDY",
+      "firstName": "JUDY",
+      "lastName": "MORRISON",
+      "dateOfBirth": "Apr 01, 1953",
+      "patientIdentifier": {
+        "uniqueId": "1259897978"
+      },
+      "ssn": "796061976",
+      "inpatient": false,
+      "textMessagingAllowed": false,
+      "id": "1259897978",
+      "objectType": "Patient",
+      "link": []
+    },
+    "bestTimetoCall": ["Morning"],
+    "appointmentRequestDetailCode": [{
+      "appointmentRequestDetailCodeId": "8a48e78f6c8bfe02016c9bda173c005c",
+      "createdDate": "08/16/2019 13:14:16",
+      "detailCode": {
+        "code": "DETCODE22",
+        "providerMessage": "Cancelled - Cancelled at Veteran Request",
+        "veteranMessage": "Your appointment request has been cancelled at your request.",
+        "objectType": "VARDetailCode",
+        "link": []
+      },
+      "userId": "1013004612",
+      "objectType": "VARAppointmentRequestDetailCode",
+      "link": []
+    }],
+    "hasVeteranNewMessage": true,
+    "hasProviderNewMessage": false,
+    "providerSeenAppointmentRequest": true,
+    "requestedPhoneCall": false,
+    "typeOfCareId": "502",
+    "friendlyLocationName": "CHYSHR-Cheyenne VA Medical Center",
+    "patientId": "1259897978",
+    "appointmentRequestId": "8a48912a6c2409b9016c9a9afff101ee",
+    "date": "2019-08-16T07:25:44.000+0000",
+    "assigningAuthority": "ICN",
+    "uniqueId": "8a48912a6c2409b9016c9a9afff101ee",
+    "systemId": "var",
+    "objectType": "VARAppointmentRequest",
+    "selfUri": "/var/VeteranAppointmentRequestService/v4/rest/appointment-service/patient/ICN/1012845331V153043/appointments/system/var/id/8a48912a6c2409b9016c9a9afff101ee",
+    "selfLink": {
+      "rel": "self",
+      "href": "/var/VeteranAppointmentRequestService/v4/rest/appointment-service/patient/ICN/1012845331V153043/appointments/system/var/id/8a48912a6c2409b9016c9a9afff101ee",
+      "objectType": "AtomLink"
+    },
+    "link": [{
+      "rel": "self",
+      "href": "/var/VeteranAppointmentRequestService/v4/rest/appointment-service/patient/ICN/1012845331V153043/appointments/system/var/id/8a48912a6c2409b9016c9a9afff101ee",
+      "objectType": "AtomLink"
+    }, {
+      "rel": "related",
+      "title": "appointment-request-messages",
+      "href": "/var/VeteranAppointmentRequestService/v4/rest/appointment-service/patient/ICN/1012845331V153043/appointment-requests/system/var/id/8a48912a6c2409b9016c9a9afff101ee/messages",
+      "objectType": "AtomLink"
+    }, {
+      "rel": "related",
+      "title": "appointment-request-new-message-flag",
+      "href": "/var/VeteranAppointmentRequestService/v4/rest/appointment-service/patient/ICN/1012845331V153043/appointment-requests/system/var/id/8a48912a6c2409b9016c9a9afff101ee/messages/read",
+      "objectType": "AtomLink"
+    }, {
+      "rel": "related",
+      "title": "appointment-request-provider-seen-flag",
+      "href": "/var/VeteranAppointmentRequestService/v4/rest/appointment-service/patient/ICN/1012845331V153043/appointment-requests/system/var/id/8a48912a6c2409b9016c9a9afff101ee/appointment/provider-read",
+      "objectType": "AtomLink"
+    }],
+    "createdDate": "08/16/2019 07:25:44"
+  }, {
+    "dataIdentifier": {
+      "uniqueId": "8a48e79e6c8c2187016c9bbde3ee002d",
+      "systemId": "var"
+    },
+    "patientIdentifier": {
+      "uniqueId": "1012845331V153043",
+      "assigningAuthority": "ICN"
+    },
+    "surrogateIdentifier": {},
+    "lastUpdatedDate": "08/16/2019 12:58:41",
+    "optionDate1": "08/16/2019",
+    "optionTime1": "PM",
+    "optionDate2": "No Date Selected",
+    "optionTime2": "No Time Selected",
+    "optionDate3": "No Date Selected",
+    "optionTime3": "No Time Selected",
+    "status": "Booked",
+    "appointmentType": "Express Care",
+    "visitType": "Express Care",
+    "facility": {
+      "name": "CHYSHR-Cheyenne VA Medical Center",
+      "facilityCode": "983",
+      "state": "WY",
+      "city": "Cheyenne",
+      "parentSiteCode": "983",
+      "objectType": "Facility",
+      "link": []
+    },
+    "email": "samatha.girla@va.gov",
+    "textMessagingAllowed": false,
+    "phoneNumber": "(321) 321-3211",
+    "purposeOfVisit": "Express Care Request",
+    "providerId": "0",
+    "secondRequest": false,
+    "secondRequestSubmitted": false,
+    "patient": {
+      "displayName": "MORRISON, JUDY",
+      "firstName": "JUDY",
+      "lastName": "MORRISON",
+      "dateOfBirth": "Apr 01, 1953",
+      "patientIdentifier": {
+        "uniqueId": "1259897978"
+      },
+      "ssn": "796061976",
+      "inpatient": false,
+      "textMessagingAllowed": false,
+      "id": "1259897978",
+      "objectType": "Patient",
+      "link": []
+    },
+    "bestTimetoCall": ["Morning"],
+    "appointmentRequestDetailCode": [{
+      "appointmentRequestDetailCodeId": "8a48e78f6c8bfe02016c9bcbd2700049",
+      "createdDate": "08/16/2019 12:58:41",
+      "detailCode": {
+        "code": "DETCODE1",
+        "providerMessage": "Made on requested date",
+        "veteranMessage": "Your appointment was booked based upon your request for an appointment on %s %s.  Please use the Appointments feature on the previous screen to see more information on this and other appointments booked at VA healthcare facilities.",
+        "objectType": "VARDetailCode",
+        "link": []
+      },
+      "userId": "1013004612",
+      "objectType": "VARAppointmentRequestDetailCode",
+      "link": []
+    }, {
+      "appointmentRequestDetailCodeId": "8a48e79e6c8c2187016c9bc19de80035",
+      "createdDate": "08/16/2019 12:47:32",
+      "detailCode": {
+        "code": "DETCODE8",
+        "providerMessage": "Cancelled by Veteran - Pending",
+        "veteranMessage": "Your request to cancel this appointment request has been sent.",
+        "objectType": "VARDetailCode",
+        "link": []
+      },
+      "userId": "1012845331V153043",
+      "objectType": "VARAppointmentRequestDetailCode",
+      "link": []
+    }],
+    "hasVeteranNewMessage": true,
+    "hasProviderNewMessage": false,
+    "providerSeenAppointmentRequest": true,
+    "requestedPhoneCall": false,
+    "bookedApptDateTime": "08/16/2019 18:57:00",
+    "typeOfCareId": "CR1",
+    "reasonForVisit": "Headache",
+    "additionalInformation": "test",
+    "friendlyLocationName": "CHYSHR-Cheyenne VA Medical Center",
+    "patientId": "1259897978",
+    "appointmentRequestId": "8a48e79e6c8c2187016c9bbde3ee002d",
+    "date": "2019-08-16T12:43:28.000+0000",
+    "assigningAuthority": "ICN",
+    "uniqueId": "8a48e79e6c8c2187016c9bbde3ee002d",
+    "systemId": "var",
+    "objectType": "VARAppointmentRequest",
+    "selfUri": "/var/VeteranAppointmentRequestService/v4/rest/appointment-service/patient/ICN/1012845331V153043/appointments/system/var/id/8a48e79e6c8c2187016c9bbde3ee002d",
+    "selfLink": {
+      "rel": "self",
+      "href": "/var/VeteranAppointmentRequestService/v4/rest/appointment-service/patient/ICN/1012845331V153043/appointments/system/var/id/8a48e79e6c8c2187016c9bbde3ee002d",
+      "objectType": "AtomLink"
+    },
+    "link": [{
+      "rel": "self",
+      "href": "/var/VeteranAppointmentRequestService/v4/rest/appointment-service/patient/ICN/1012845331V153043/appointments/system/var/id/8a48e79e6c8c2187016c9bbde3ee002d",
+      "objectType": "AtomLink"
+    }, {
+      "rel": "related",
+      "title": "appointment-request-messages",
+      "href": "/var/VeteranAppointmentRequestService/v4/rest/appointment-service/patient/ICN/1012845331V153043/appointment-requests/system/var/id/8a48e79e6c8c2187016c9bbde3ee002d/messages",
+      "objectType": "AtomLink"
+    }, {
+      "rel": "related",
+      "title": "appointment-request-new-message-flag",
+      "href": "/var/VeteranAppointmentRequestService/v4/rest/appointment-service/patient/ICN/1012845331V153043/appointment-requests/system/var/id/8a48e79e6c8c2187016c9bbde3ee002d/messages/read",
+      "objectType": "AtomLink"
+    }, {
+      "rel": "related",
+      "title": "appointment-request-provider-seen-flag",
+      "href": "/var/VeteranAppointmentRequestService/v4/rest/appointment-service/patient/ICN/1012845331V153043/appointment-requests/system/var/id/8a48e79e6c8c2187016c9bbde3ee002d/appointment/provider-read",
+      "objectType": "AtomLink"
+    }],
+    "createdDate": "08/16/2019 12:43:28"
+  }, {
+    "dataIdentifier": {
+      "uniqueId": "8a48dea06c84a667016c867b1ac00011",
+      "systemId": "var"
+    },
+    "patientIdentifier": {
+      "uniqueId": "1012845331V153043",
+      "assigningAuthority": "ICN"
+    },
+    "surrogateIdentifier": {},
+    "lastUpdatedDate": "08/12/2019 09:38:30",
+    "optionDate1": "08/19/2019",
+    "optionTime1": "AM",
+    "optionDate2": "No Date Selected",
+    "optionTime2": "No Time Selected",
+    "optionDate3": "No Date Selected",
+    "optionTime3": "No Time Selected",
+    "status": "Submitted",
+    "appointmentType": "Audiology (hearing aid support)",
+    "visitType": "Office Visit",
+    "facility": {
+      "name": "CHYSHR-Cheyenne VA Medical Center",
+      "facilityCode": "983",
+      "state": "WY",
+      "city": "Cheyenne",
+      "parentSiteCode": "983",
+      "objectType": "Facility",
+      "link": []
+    },
+    "email": "samatha.girla@va.gov",
+    "textMessagingAllowed": false,
+    "phoneNumber": "(732) 476-0990",
+    "purposeOfVisit": "routine-follow-up",
+    "providerId": "0",
+    "secondRequest": false,
+    "secondRequestSubmitted": false,
+    "patient": {
+      "displayName": "MORRISON, JUDY",
+      "firstName": "JUDY",
+      "lastName": "MORRISON",
+      "dateOfBirth": "Apr 01, 1953",
+      "patientIdentifier": {
+        "uniqueId": "1259897978"
+      },
+      "ssn": "796061976",
+      "inpatient": false,
+      "textMessagingAllowed": false,
+      "id": "1259897978",
+      "objectType": "Patient",
+      "link": []
+    },
+    "bestTimetoCall": ["Afternoon", "Evening", "Morning"],
+    "appointmentRequestDetailCode": [],
+    "hasVeteranNewMessage": true,
+    "hasProviderNewMessage": false,
+    "providerSeenAppointmentRequest": true,
+    "requestedPhoneCall": false,
+    "typeOfCareId": "CCAUDHEAR",
+    "friendlyLocationName": "CHYSHR-Cheyenne VA Medical Center",
+    "ccAppointmentRequest": {
+      "dataIdentifier": {},
+      "patientIdentifier": {},
+      "surrogateIdentifier": {},
+      "hasVeteranNewMessage": false,
+      "preferredZipCode": "20171",
+      "preferredState": "VA",
+      "preferredCity": "hernodon",
+      "preferredLanguage": "English",
+      "distanceWillingToTravel": 10,
+      "distanceEligible": false,
+      "officeHours": ["Weekdays"],
+      "preferredProviders": [],
+      "objectType": "CCAppointmentRequest",
+      "link": []
+    },
+    "patientId": "1259897978",
+    "appointmentRequestId": "8a48dea06c84a667016c867b1ac00011",
+    "date": "2019-08-12T09:38:30.376+0000",
+    "assigningAuthority": "ICN",
+    "uniqueId": "8a48dea06c84a667016c867b1ac00011",
+    "systemId": "var",
+    "objectType": "VARAppointmentRequest",
+    "selfUri": "/var/VeteranAppointmentRequestService/v4/rest/appointment-service/patient/ICN/1012845331V153043/appointments/system/var/id/8a48dea06c84a667016c867b1ac00011",
+    "selfLink": {
+      "rel": "self",
+      "href": "/var/VeteranAppointmentRequestService/v4/rest/appointment-service/patient/ICN/1012845331V153043/appointments/system/var/id/8a48dea06c84a667016c867b1ac00011",
+      "objectType": "AtomLink"
+    },
+    "link": [{
+      "rel": "self",
+      "href": "/var/VeteranAppointmentRequestService/v4/rest/appointment-service/patient/ICN/1012845331V153043/appointments/system/var/id/8a48dea06c84a667016c867b1ac00011",
+      "objectType": "AtomLink"
+    }, {
+      "rel": "related",
+      "title": "appointment-request-messages",
+      "href": "/var/VeteranAppointmentRequestService/v4/rest/appointment-service/patient/ICN/1012845331V153043/appointment-requests/system/var/id/8a48dea06c84a667016c867b1ac00011/messages",
+      "objectType": "AtomLink"
+    }, {
+      "rel": "related",
+      "title": "appointment-request-new-message-flag",
+      "href": "/var/VeteranAppointmentRequestService/v4/rest/appointment-service/patient/ICN/1012845331V153043/appointment-requests/system/var/id/8a48dea06c84a667016c867b1ac00011/messages/read",
+      "objectType": "AtomLink"
+    }, {
+      "rel": "related",
+      "title": "appointment-request-provider-seen-flag",
+      "href": "/var/VeteranAppointmentRequestService/v4/rest/appointment-service/patient/ICN/1012845331V153043/appointment-requests/system/var/id/8a48dea06c84a667016c867b1ac00011/appointment/provider-read",
+      "objectType": "AtomLink"
+    }],
+    "createdDate": "08/12/2019 09:38:30"
+  }, {
+    "dataIdentifier": {
+      "uniqueId": "8a48912a6c2409b9016c7212651a01cc",
+      "systemId": "var"
+    },
+    "patientIdentifier": {
+      "uniqueId": "1012845331V153043",
+      "assigningAuthority": "ICN"
+    },
+    "surrogateIdentifier": {},
+    "lastUpdatedDate": "08/08/2019 12:04:07",
+    "optionDate1": "08/14/2019",
+    "optionTime1": "AM",
+    "optionDate2": "No Date Selected",
+    "optionTime2": "No Time Selected",
+    "optionDate3": "No Date Selected",
+    "optionTime3": "No Time Selected",
+    "status": "Booked",
+    "appointmentType": "Primary Care",
+    "visitType": "Office Visit",
+    "facility": {
+      "name": "CHYSHR-Fort Collins VA Clinic",
+      "facilityCode": "983GC",
+      "state": "CO",
+      "city": "Fort Collins",
+      "parentSiteCode": "983",
+      "objectType": "Facility",
+      "link": []
+    },
+    "email": "samatha.girla@va.gov",
+    "textMessagingAllowed": false,
+    "phoneNumber": "(703) 652-0000",
+    "purposeOfVisit": "New Issue",
+    "providerId": "0",
+    "secondRequest": false,
+    "secondRequestSubmitted": false,
+    "patient": {
+      "displayName": "MORRISON, JUDY",
+      "firstName": "JUDY",
+      "lastName": "MORRISON",
+      "dateOfBirth": "Apr 01, 1953",
+      "patientIdentifier": {
+        "uniqueId": "1259897978"
+      },
+      "ssn": "796061976",
+      "inpatient": false,
+      "textMessagingAllowed": false,
+      "id": "1259897978",
+      "objectType": "Patient",
+      "link": []
+    },
+    "bestTimetoCall": ["Morning"],
+    "appointmentRequestDetailCode": [{
+      "appointmentRequestDetailCodeId": "8a4894d36c71e4b7016c7266fcf3005a",
+      "createdDate": "08/08/2019 12:04:07",
+      "detailCode": {
+        "code": "DETCODE1",
+        "providerMessage": "Made on requested date",
+        "veteranMessage": "Your appointment was booked based upon your request for an appointment on %s %s.  Please use the Appointments feature on the previous screen to see more information on this and other appointments booked at VA healthcare facilities.",
+        "objectType": "VARDetailCode",
+        "link": []
+      },
+      "userId": "1013118126",
+      "objectType": "VARAppointmentRequestDetailCode",
+      "link": []
+    }],
+    "hasVeteranNewMessage": true,
+    "hasProviderNewMessage": false,
+    "providerSeenAppointmentRequest": true,
+    "requestedPhoneCall": false,
+    "bookedApptDateTime": "08/12/2019 12:20:00",
+    "typeOfCareId": "323",
+    "friendlyLocationName": "CHYSHR-Fort Collins VA Clinic",
+    "patientId": "1259897978",
+    "appointmentRequestId": "8a48912a6c2409b9016c7212651a01cc",
+    "date": "2019-08-08T10:31:43.000+0000",
+    "assigningAuthority": "ICN",
+    "uniqueId": "8a48912a6c2409b9016c7212651a01cc",
+    "systemId": "var",
+    "objectType": "VARAppointmentRequest",
+    "selfUri": "/var/VeteranAppointmentRequestService/v4/rest/appointment-service/patient/ICN/1012845331V153043/appointments/system/var/id/8a48912a6c2409b9016c7212651a01cc",
+    "selfLink": {
+      "rel": "self",
+      "href": "/var/VeteranAppointmentRequestService/v4/rest/appointment-service/patient/ICN/1012845331V153043/appointments/system/var/id/8a48912a6c2409b9016c7212651a01cc",
+      "objectType": "AtomLink"
+    },
+    "link": [{
+      "rel": "self",
+      "href": "/var/VeteranAppointmentRequestService/v4/rest/appointment-service/patient/ICN/1012845331V153043/appointments/system/var/id/8a48912a6c2409b9016c7212651a01cc",
+      "objectType": "AtomLink"
+    }, {
+      "rel": "related",
+      "title": "appointment-request-messages",
+      "href": "/var/VeteranAppointmentRequestService/v4/rest/appointment-service/patient/ICN/1012845331V153043/appointment-requests/system/var/id/8a48912a6c2409b9016c7212651a01cc/messages",
+      "objectType": "AtomLink"
+    }, {
+      "rel": "related",
+      "title": "appointment-request-new-message-flag",
+      "href": "/var/VeteranAppointmentRequestService/v4/rest/appointment-service/patient/ICN/1012845331V153043/appointment-requests/system/var/id/8a48912a6c2409b9016c7212651a01cc/messages/read",
+      "objectType": "AtomLink"
+    }, {
+      "rel": "related",
+      "title": "appointment-request-provider-seen-flag",
+      "href": "/var/VeteranAppointmentRequestService/v4/rest/appointment-service/patient/ICN/1012845331V153043/appointment-requests/system/var/id/8a48912a6c2409b9016c7212651a01cc/appointment/provider-read",
+      "objectType": "AtomLink"
+    }],
+    "createdDate": "08/08/2019 10:31:43"
+  }, {
+    "dataIdentifier": {
+      "uniqueId": "8a48912a6c2409b9016c720da97c01c5",
+      "systemId": "var"
+    },
+    "patientIdentifier": {
+      "uniqueId": "1012845331V153043",
+      "assigningAuthority": "ICN"
+    },
+    "surrogateIdentifier": {},
+    "lastUpdatedDate": "08/08/2019 11:36:34",
+    "optionDate1": "08/08/2019",
+    "optionTime1": "PM",
+    "optionDate2": "No Date Selected",
+    "optionTime2": "No Time Selected",
+    "optionDate3": "No Date Selected",
+    "optionTime3": "No Time Selected",
+    "status": "Booked",
+    "appointmentType": "Express Care",
+    "visitType": "Express Care",
+    "facility": {
+      "name": "CHYSHR-Cheyenne VA Medical Center",
+      "facilityCode": "983",
+      "state": "WY",
+      "city": "Cheyenne",
+      "parentSiteCode": "983",
+      "objectType": "Facility",
+      "link": []
+    },
+    "email": "samatha.girla@va.gov",
+    "textMessagingAllowed": false,
+    "phoneNumber": "(703) 652-0000",
+    "purposeOfVisit": "Express Care Request",
+    "providerId": "0",
+    "secondRequest": false,
+    "secondRequestSubmitted": false,
+    "patient": {
+      "displayName": "MORRISON, JUDY",
+      "firstName": "JUDY",
+      "lastName": "MORRISON",
+      "dateOfBirth": "Apr 01, 1953",
+      "patientIdentifier": {
+        "uniqueId": "1259897978"
+      },
+      "ssn": "796061976",
+      "inpatient": false,
+      "textMessagingAllowed": false,
+      "id": "1259897978",
+      "objectType": "Patient",
+      "link": []
+    },
+    "bestTimetoCall": ["Morning"],
+    "appointmentRequestDetailCode": [{
+      "appointmentRequestDetailCodeId": "8a4894d36c71e4b7016c724dc16b0042",
+      "createdDate": "08/08/2019 11:36:34",
+      "detailCode": {
+        "code": "DETCODE1",
+        "providerMessage": "Made on requested date",
+        "veteranMessage": "Your appointment was booked based upon your request for an appointment on %s %s.  Please use the Appointments feature on the previous screen to see more information on this and other appointments booked at VA healthcare facilities.",
+        "objectType": "VARDetailCode",
+        "link": []
+      },
+      "userId": "1013118126",
+      "objectType": "VARAppointmentRequestDetailCode",
+      "link": []
+    }],
+    "hasVeteranNewMessage": true,
+    "hasProviderNewMessage": false,
+    "providerSeenAppointmentRequest": false,
+    "requestedPhoneCall": false,
+    "bookedApptDateTime": "08/08/2019 12:35:00",
+    "typeOfCareId": "CR1",
+    "reasonForVisit": "Headache",
+    "additionalInformation": "test",
+    "friendlyLocationName": "CHYSHR-Cheyenne VA Medical Center",
+    "patientId": "1259897978",
+    "appointmentRequestId": "8a48912a6c2409b9016c720da97c01c5",
+    "date": "2019-08-08T10:26:33.000+0000",
+    "assigningAuthority": "ICN",
+    "uniqueId": "8a48912a6c2409b9016c720da97c01c5",
+    "systemId": "var",
+    "objectType": "VARAppointmentRequest",
+    "selfUri": "/var/VeteranAppointmentRequestService/v4/rest/appointment-service/patient/ICN/1012845331V153043/appointments/system/var/id/8a48912a6c2409b9016c720da97c01c5",
+    "selfLink": {
+      "rel": "self",
+      "href": "/var/VeteranAppointmentRequestService/v4/rest/appointment-service/patient/ICN/1012845331V153043/appointments/system/var/id/8a48912a6c2409b9016c720da97c01c5",
+      "objectType": "AtomLink"
+    },
+    "link": [{
+      "rel": "self",
+      "href": "/var/VeteranAppointmentRequestService/v4/rest/appointment-service/patient/ICN/1012845331V153043/appointments/system/var/id/8a48912a6c2409b9016c720da97c01c5",
+      "objectType": "AtomLink"
+    }, {
+      "rel": "related",
+      "title": "appointment-request-messages",
+      "href": "/var/VeteranAppointmentRequestService/v4/rest/appointment-service/patient/ICN/1012845331V153043/appointment-requests/system/var/id/8a48912a6c2409b9016c720da97c01c5/messages",
+      "objectType": "AtomLink"
+    }, {
+      "rel": "related",
+      "title": "appointment-request-new-message-flag",
+      "href": "/var/VeteranAppointmentRequestService/v4/rest/appointment-service/patient/ICN/1012845331V153043/appointment-requests/system/var/id/8a48912a6c2409b9016c720da97c01c5/messages/read",
+      "objectType": "AtomLink"
+    }, {
+      "rel": "related",
+      "title": "appointment-request-provider-seen-flag",
+      "href": "/var/VeteranAppointmentRequestService/v4/rest/appointment-service/patient/ICN/1012845331V153043/appointment-requests/system/var/id/8a48912a6c2409b9016c720da97c01c5/appointment/provider-read",
+      "objectType": "AtomLink"
+    }],
+    "createdDate": "08/08/2019 10:26:33"
+  }, {
+    "dataIdentifier": {
+      "uniqueId": "8a48912a6c2409b9016c525a4d490190",
+      "systemId": "var"
+    },
+    "patientIdentifier": {
+      "uniqueId": "1012845331V153043",
+      "assigningAuthority": "ICN"
+    },
+    "surrogateIdentifier": {},
+    "lastUpdatedDate": "08/06/2019 06:53:03",
+    "optionDate1": "08/13/2019",
+    "optionTime1": "AM",
+    "optionDate2": "No Date Selected",
+    "optionTime2": "No Time Selected",
+    "optionDate3": "No Date Selected",
+    "optionTime3": "No Time Selected",
+    "status": "Cancelled",
+    "appointmentType": "Audiology (hearing aid support)",
+    "visitType": "Office Visit",
+    "facility": {
+      "name": "CHYSHR-Cheyenne VA Medical Center",
+      "facilityCode": "983",
+      "state": "WY",
+      "city": "Cheyenne",
+      "parentSiteCode": "983",
+      "objectType": "Facility",
+      "link": []
+    },
+    "email": "samatha.girla@va.gov",
+    "textMessagingAllowed": false,
+    "phoneNumber": "(703) 652-0000",
+    "purposeOfVisit": "routine-follow-up",
+    "providerId": "0",
+    "providerOption": "Call before booking appointment",
+    "secondRequest": false,
+    "secondRequestSubmitted": false,
+    "patient": {
+      "displayName": "MORRISON, JUDY",
+      "firstName": "JUDY",
+      "lastName": "MORRISON",
+      "dateOfBirth": "Apr 01, 1953",
+      "patientIdentifier": {
+        "uniqueId": "1259897978"
+      },
+      "ssn": "796061976",
+      "inpatient": false,
+      "textMessagingAllowed": false,
+      "id": "1259897978",
+      "objectType": "Patient",
+      "link": []
+    },
+    "bestTimetoCall": ["Afternoon", "Evening"],
+    "appointmentRequestDetailCode": [{
+      "appointmentRequestDetailCodeId": "8a48912a6c2409b9016c66fd7afb01a7",
+      "createdDate": "08/06/2019 06:53:03",
+      "detailCode": {
+        "code": "DETCODE8",
+        "providerMessage": "Cancelled by Veteran - Pending",
+        "veteranMessage": "Your request to cancel this appointment request has been sent.",
+        "objectType": "VARDetailCode",
+        "link": []
+      },
+      "userId": "1012845331V153043",
+      "objectType": "VARAppointmentRequestDetailCode",
+      "link": []
+    }, {
+      "appointmentRequestDetailCodeId": "8a48912a6c2409b9016c66fd7afb01a7",
+      "createdDate": "08/06/2019 06:53:03",
+      "detailCode": {
+        "code": "DETCODE8",
+        "providerMessage": "Cancelled by Veteran - Pending",
+        "veteranMessage": "Your request to cancel this appointment request has been sent.",
+        "objectType": "VARDetailCode",
+        "link": []
+      },
+      "userId": "1012845331V153043",
+      "objectType": "VARAppointmentRequestDetailCode",
+      "link": []
+    }],
+    "hasVeteranNewMessage": true,
+    "hasProviderNewMessage": false,
+    "providerSeenAppointmentRequest": true,
+    "requestedPhoneCall": true,
+    "typeOfCareId": "CCAUDHEAR",
+    "friendlyLocationName": "CHYSHR-Cheyenne VA Medical Center",
+    "ccAppointmentRequest": {
+      "dataIdentifier": {},
+      "patientIdentifier": {},
+      "surrogateIdentifier": {},
+      "hasVeteranNewMessage": false,
+      "preferredState": "VA",
+      "preferredCity": "hhhhh",
+      "preferredLanguage": "English",
+      "distanceWillingToTravel": 50,
+      "distanceEligible": false,
+      "officeHours": ["Weekdays"],
+      "preferredProviders": [],
+      "objectType": "CCAppointmentRequest",
+      "link": []
+    },
+    "patientId": "1259897978",
+    "appointmentRequestId": "8a48912a6c2409b9016c525a4d490190",
+    "date": "2019-08-02T06:42:25.000+0000",
+    "assigningAuthority": "ICN",
+    "uniqueId": "8a48912a6c2409b9016c525a4d490190",
+    "systemId": "var",
+    "objectType": "VARAppointmentRequest",
+    "selfUri": "/var/VeteranAppointmentRequestService/v4/rest/appointment-service/patient/ICN/1012845331V153043/appointments/system/var/id/8a48912a6c2409b9016c525a4d490190",
+    "selfLink": {
+      "rel": "self",
+      "href": "/var/VeteranAppointmentRequestService/v4/rest/appointment-service/patient/ICN/1012845331V153043/appointments/system/var/id/8a48912a6c2409b9016c525a4d490190",
+      "objectType": "AtomLink"
+    },
+    "link": [{
+      "rel": "self",
+      "href": "/var/VeteranAppointmentRequestService/v4/rest/appointment-service/patient/ICN/1012845331V153043/appointments/system/var/id/8a48912a6c2409b9016c525a4d490190",
+      "objectType": "AtomLink"
+    }, {
+      "rel": "related",
+      "title": "appointment-request-messages",
+      "href": "/var/VeteranAppointmentRequestService/v4/rest/appointment-service/patient/ICN/1012845331V153043/appointment-requests/system/var/id/8a48912a6c2409b9016c525a4d490190/messages",
+      "objectType": "AtomLink"
+    }, {
+      "rel": "related",
+      "title": "appointment-request-new-message-flag",
+      "href": "/var/VeteranAppointmentRequestService/v4/rest/appointment-service/patient/ICN/1012845331V153043/appointment-requests/system/var/id/8a48912a6c2409b9016c525a4d490190/messages/read",
+      "objectType": "AtomLink"
+    }, {
+      "rel": "related",
+      "title": "appointment-request-provider-seen-flag",
+      "href": "/var/VeteranAppointmentRequestService/v4/rest/appointment-service/patient/ICN/1012845331V153043/appointment-requests/system/var/id/8a48912a6c2409b9016c525a4d490190/appointment/provider-read",
+      "objectType": "AtomLink"
+    }],
+    "createdDate": "08/02/2019 06:42:25"
+  }]
+}

--- a/src/applications/vaos/containers/ConfirmedAppointmentPage.jsx
+++ b/src/applications/vaos/containers/ConfirmedAppointmentPage.jsx
@@ -11,7 +11,7 @@ import { selectConfirmedAppointment } from '../utils/selectors';
 import { formatTimeToCall } from '../utils/formatters';
 
 function formatDate(date) {
-  const parsedDate = moment(date);
+  const parsedDate = moment(date, 'MM/DD/YYYY hh:mm:ss');
 
   if (!parsedDate.isValid()) {
     return '';
@@ -31,8 +31,8 @@ export class ConfirmedAppointmentPage extends React.Component {
   render() {
     const { appointment, status } = this.props;
 
-    const formattedDateTime = appointment?.dateTime
-      ? formatDate(appointment.dateTime)
+    const formattedDateTime = appointment?.bookedApptDateTime
+      ? formatDate(appointment.bookedApptDateTime)
       : {};
 
     return (
@@ -50,7 +50,7 @@ export class ConfirmedAppointmentPage extends React.Component {
             )}
             {status === FETCH_STATUS.succeeded && (
               <>
-                <h2>{appointment.type}</h2>
+                <h2>{appointment.appointmentType}</h2>
                 <div className="vads-u-display--flex vads-u-margin-bottom--2">
                   <div className="vads-u-flex--1">
                     <>
@@ -70,7 +70,7 @@ export class ConfirmedAppointmentPage extends React.Component {
                       Purpose
                     </h3>
                     {PURPOSE_TEXT[appointment.purposeOfVisit] ||
-                      appointment.reason}
+                      appointment.reasonForVisit}
                     <h3 className="vaos-appts__block-label vads-u-margin-top--2">
                       Type
                     </h3>
@@ -78,8 +78,8 @@ export class ConfirmedAppointmentPage extends React.Component {
                     <h3 className="vaos-appts__block-label vads-u-margin-top--2">
                       My contact number
                     </h3>
-                    {appointment.contactNumber}, in the{' '}
-                    {formatTimeToCall(appointment.preferredContactTime)}
+                    {appointment.phoneNumber}, in the{' '}
+                    {formatTimeToCall(appointment.bestTimetoCall)}
                   </div>
                 </div>
                 <Link to="appointments/confirmed">

--- a/src/applications/vaos/containers/ConfirmedAppointmentPage.jsx
+++ b/src/applications/vaos/containers/ConfirmedAppointmentPage.jsx
@@ -1,0 +1,116 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Link } from 'react-router';
+import { connect } from 'react-redux';
+import moment from 'moment';
+import LoadingIndicator from '@department-of-veterans-affairs/formation-react/LoadingIndicator';
+import { focusElement } from 'platform/utilities/ui';
+import { fetchConfirmedAppointments } from '../actions/appointments';
+import { FETCH_STATUS, PURPOSE_TEXT } from '../utils/constants';
+import { selectConfirmedAppointment } from '../utils/selectors';
+import { formatTimeToCall } from '../utils/formatters';
+
+function formatDate(date) {
+  const parsedDate = moment(date);
+
+  if (!parsedDate.isValid()) {
+    return '';
+  }
+
+  return {
+    date: parsedDate.format('MMMM D, YYYY'),
+    time: parsedDate.format('h:mm a'),
+  };
+}
+
+export class ConfirmedAppointmentPage extends React.Component {
+  componentDidMount() {
+    this.props.fetchConfirmedAppointments();
+    focusElement('h1');
+  }
+  render() {
+    const { appointment, status } = this.props;
+
+    const formattedDateTime = appointment?.dateTime
+      ? formatDate(appointment.dateTime)
+      : '';
+
+    return (
+      <div className="vads-l-grid-container vads-u-padding-x--2p5 large-screen:vads-u-padding-x--0 vads-u-padding-bottom--2p5">
+        <div className="vads-l-row">
+          <div className="vads-l-col--12 medium-screen:vads-l-col--8 vads-u-margin-bottom--4">
+            <Link to="appointments/confirmed">
+              <i className="fas fa-angle-left" /> Back
+            </Link>
+            <h1 className="vads-u-margin-bottom--4 vads-u-margin-top--1">
+              Appointment details
+            </h1>
+            {status === FETCH_STATUS.loading && (
+              <LoadingIndicator message="Loading appointment" />
+            )}
+            {status === FETCH_STATUS.succeeded && (
+              <>
+                <h2>{appointment.type}</h2>
+                <div className="vads-u-display--flex vads-u-margin-bottom--2">
+                  <div className="vads-u-flex--1">
+                    <>
+                      <h3 className="vaos-appts__block-label">Where</h3>
+                      {appointment.friendlyLocationName ||
+                        appointment.facility.name}
+                      <br />
+                      {appointment.facility.city}, {appointment.facility.state}
+                    </>
+                    <h3 className="vaos-appts__block-label vads-u-margin-top--2">
+                      When
+                    </h3>
+                    {formattedDateTime.date}
+                    <br />
+                    {formattedDateTime.time}
+                    <h3 className="vaos-appts__block-label vads-u-margin-top--2">
+                      Purpose
+                    </h3>
+                    {PURPOSE_TEXT[appointment.purposeOfVisit] ||
+                      appointment.reason}
+                    <h3 className="vaos-appts__block-label vads-u-margin-top--2">
+                      Type
+                    </h3>
+                    {appointment.visitType}
+                    <h3 className="vaos-appts__block-label vads-u-margin-top--2">
+                      My contact number
+                    </h3>
+                    {appointment.contactNumber}, in the{' '}
+                    {formatTimeToCall(appointment.preferredContactTime)}
+                  </div>
+                </div>
+                <Link to="appointments/pending">
+                  <i className="fas fa-angle-left" /> Back
+                </Link>
+              </>
+            )}
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
+
+ConfirmedAppointmentPage.propTypes = {
+  appointment: PropTypes.object,
+  status: PropTypes.string.isRequired,
+};
+
+function mapStateToProps(state, ownProps) {
+  return {
+    appointment: selectConfirmedAppointment(state, ownProps.params.id),
+    status: state.appointments.confirmedStatus,
+  };
+}
+
+const mapDispatchToProps = {
+  fetchConfirmedAppointments,
+};
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(ConfirmedAppointmentPage);

--- a/src/applications/vaos/containers/ConfirmedAppointmentPage.jsx
+++ b/src/applications/vaos/containers/ConfirmedAppointmentPage.jsx
@@ -33,7 +33,7 @@ export class ConfirmedAppointmentPage extends React.Component {
 
     const formattedDateTime = appointment?.dateTime
       ? formatDate(appointment.dateTime)
-      : '';
+      : {};
 
     return (
       <div className="vads-l-grid-container vads-u-padding-x--2p5 large-screen:vads-u-padding-x--0 vads-u-padding-bottom--2p5">

--- a/src/applications/vaos/containers/ConfirmedAppointmentPage.jsx
+++ b/src/applications/vaos/containers/ConfirmedAppointmentPage.jsx
@@ -82,7 +82,7 @@ export class ConfirmedAppointmentPage extends React.Component {
                     {formatTimeToCall(appointment.preferredContactTime)}
                   </div>
                 </div>
-                <Link to="appointments/pending">
+                <Link to="appointments/confirmed">
                   <i className="fas fa-angle-left" /> Back
                 </Link>
               </>

--- a/src/applications/vaos/containers/PendingAppointmentPage.jsx
+++ b/src/applications/vaos/containers/PendingAppointmentPage.jsx
@@ -9,6 +9,7 @@ import { focusElement } from 'platform/utilities/ui';
 import { fetchPendingAppointments } from '../actions/appointments';
 import { FETCH_STATUS, TIME_TEXT, PURPOSE_TEXT } from '../utils/constants';
 import { selectPendingAppointment } from '../utils/selectors';
+import { formatTimeToCall } from '../utils/formatters';
 
 function formatDate(date) {
   const parsedDate = moment(date, 'MM/DD/YYYY');
@@ -18,16 +19,6 @@ function formatDate(date) {
   }
 
   return parsedDate.format('MMMM D, YYYY');
-}
-
-function formatTimeToCall(timeToCall) {
-  if (timeToCall.length === 1) {
-    return timeToCall[0].toLowerCase();
-  } else if (timeToCall.length === 2) {
-    return `${timeToCall[0].toLowerCase()} or ${timeToCall[1].toLowerCase()}`;
-  }
-
-  return `${timeToCall[0].toLowerCase()}, ${timeToCall[1].toLowerCase()}, or ${timeToCall[2].toLowerCase()}`;
 }
 
 export class PendingAppointmentPage extends React.Component {

--- a/src/applications/vaos/reducers/appointments.js
+++ b/src/applications/vaos/reducers/appointments.js
@@ -11,6 +11,7 @@ import {
 } from '../actions/appointments';
 
 import { FETCH_STATUS } from '../utils/constants';
+import moment from 'moment';
 
 const initialState = {
   confirmed: null,
@@ -28,12 +29,25 @@ export default function appointmentsReducer(state = initialState, action) {
         ...state,
         confirmedStatus: FETCH_STATUS.loading,
       };
-    case FETCH_CONFIRMED_APPOINTMENTS_SUCCEEDED:
+    case FETCH_CONFIRMED_APPOINTMENTS_SUCCEEDED: {
+      const confirmed = action.data.appointmentRequests.filter(
+        req => req.status === 'Booked',
+      );
+      confirmed.sort((a, b) => {
+        const date1 = moment(a.bookedApptDateTime, 'MM/DD/YYYY HH:mm:ss');
+        const date2 = moment(b.bookedApptDateTime, 'MM/DD/YYYY HH:mm:ss');
+        if (date1.isValid() && date2.isValid()) {
+          return date1.isBefore(date2) ? -1 : 1;
+        }
+
+        return 0;
+      });
       return {
         ...state,
         confirmedStatus: FETCH_STATUS.succeeded,
-        confirmed: action.data,
+        confirmed,
       };
+    }
     case FETCH_CONFIRMED_APPOINTMENTS_FAILED:
       return {
         ...state,

--- a/src/applications/vaos/routes.jsx
+++ b/src/applications/vaos/routes.jsx
@@ -7,6 +7,7 @@ import AppointmentListsPage from './containers/AppointmentListsPage';
 import TypeOfCarePage from './containers/TypeOfCarePage';
 import PendingAppointmentsPage from './containers/PendingAppointmentsPage';
 import PendingAppointmentPage from './containers/PendingAppointmentPage';
+import ConfirmedAppointmentPage from './containers/ConfirmedAppointmentPage';
 import ContactInfoPage from './containers/ContactInfoPage';
 
 const routes = (
@@ -17,6 +18,10 @@ const routes = (
       <Route path="contact-info" component={ContactInfoPage} />
     </Route>
     <Route path="appointments" component={AppointmentListsPage} />
+    <Route
+      path="appointments/confirmed/:id"
+      component={ConfirmedAppointmentPage}
+    />
     <Route path="appointments/pending" component={PendingAppointmentsPage} />
     <Route path="appointments/pending/:id" component={PendingAppointmentPage} />
   </Route>

--- a/src/applications/vaos/tests/containers/ConfirmedAppointmentPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/containers/ConfirmedAppointmentPage.unit.spec.jsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { shallow } from 'enzyme';
+
+import { ConfirmedAppointmentPage } from '../../containers/ConfirmedAppointmentPage';
+
+const appointment = {
+  type: 'Primary Care',
+  facility: {
+    name: 'John Hopkins Medical Center',
+  },
+  dateTime: '2019-08-29T12:00:00Z',
+  preferredContactTime: ['Morning'],
+  contactNumber: '555 555-5555',
+};
+
+describe('VAOS <ConfirmedAppointmentPage>', () => {
+  it('should render a loading indicator', () => {
+    const fetchConfirmedAppointments = sinon.spy();
+    const tree = shallow(
+      <ConfirmedAppointmentPage
+        fetchConfirmedAppointments={fetchConfirmedAppointments}
+        status="loading"
+      />,
+    );
+
+    expect(tree.find('LoadingIndicator').exists()).to.be.true;
+    expect(fetchConfirmedAppointments.called).to.be.true;
+    tree.unmount();
+  });
+
+  it('should render confirmed appointment', () => {
+    const fetchConfirmedAppointments = sinon.spy();
+    const tree = shallow(
+      <ConfirmedAppointmentPage
+        fetchConfirmedAppointments={fetchConfirmedAppointments}
+        appointment={appointment}
+        status="succeeded"
+      />,
+    );
+
+    expect(fetchConfirmedAppointments.called).to.be.true;
+    expect(tree.find('LoadingIndicator').exists()).to.be.false;
+    expect(tree.text()).to.contain(appointment.type);
+    expect(tree.text()).to.contain('555 555-5555, in the morning');
+    tree.unmount();
+  });
+
+  it('should render contact info morning and afternoon text', () => {
+    appointment.preferredContactTime = ['Morning', 'Afternoon'];
+    const fetchConfirmedAppointments = sinon.spy();
+    const tree = shallow(
+      <ConfirmedAppointmentPage
+        fetchConfirmedAppointments={fetchConfirmedAppointments}
+        appointment={appointment}
+        status="succeeded"
+      />,
+    );
+
+    expect(tree.text()).to.contain('555 555-5555, in the morning or afternoon');
+    tree.unmount();
+  });
+
+  it('should render contact info morning, afternoon, and evening text', () => {
+    appointment.preferredContactTime = ['Morning', 'Afternoon', 'Evening'];
+    const fetchConfirmedAppointments = sinon.spy();
+    const tree = shallow(
+      <ConfirmedAppointmentPage
+        fetchConfirmedAppointments={fetchConfirmedAppointments}
+        appointment={appointment}
+        status="succeeded"
+      />,
+    );
+
+    expect(tree.text()).to.contain(
+      '555 555-5555, in the morning, afternoon, or evening',
+    );
+    tree.unmount();
+  });
+});

--- a/src/applications/vaos/tests/containers/ConfirmedAppointmentPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/containers/ConfirmedAppointmentPage.unit.spec.jsx
@@ -6,13 +6,13 @@ import { shallow } from 'enzyme';
 import { ConfirmedAppointmentPage } from '../../containers/ConfirmedAppointmentPage';
 
 const appointment = {
-  type: 'Primary Care',
+  appointmentType: 'Primary Care',
   facility: {
     name: 'John Hopkins Medical Center',
   },
-  dateTime: '2019-08-29T12:00:00Z',
-  preferredContactTime: ['Morning'],
-  contactNumber: '555 555-5555',
+  bookedApptDateTime: '08/16/2019 18:57:00',
+  bestTimetoCall: ['Morning'],
+  phoneNumber: '555 555-5555',
 };
 
 describe('VAOS <ConfirmedAppointmentPage>', () => {
@@ -42,13 +42,13 @@ describe('VAOS <ConfirmedAppointmentPage>', () => {
 
     expect(fetchConfirmedAppointments.called).to.be.true;
     expect(tree.find('LoadingIndicator').exists()).to.be.false;
-    expect(tree.text()).to.contain(appointment.type);
+    expect(tree.text()).to.contain(appointment.appointmentType);
     expect(tree.text()).to.contain('555 555-5555, in the morning');
     tree.unmount();
   });
 
   it('should render contact info morning and afternoon text', () => {
-    appointment.preferredContactTime = ['Morning', 'Afternoon'];
+    appointment.bestTimetoCall = ['Morning', 'Afternoon'];
     const fetchConfirmedAppointments = sinon.spy();
     const tree = shallow(
       <ConfirmedAppointmentPage
@@ -63,7 +63,7 @@ describe('VAOS <ConfirmedAppointmentPage>', () => {
   });
 
   it('should render contact info morning, afternoon, and evening text', () => {
-    appointment.preferredContactTime = ['Morning', 'Afternoon', 'Evening'];
+    appointment.bestTimetoCall = ['Morning', 'Afternoon', 'Evening'];
     const fetchConfirmedAppointments = sinon.spy();
     const tree = shallow(
       <ConfirmedAppointmentPage

--- a/src/applications/vaos/tests/reducers/appointments.unit.spec.js
+++ b/src/applications/vaos/tests/reducers/appointments.unit.spec.js
@@ -50,7 +50,12 @@ describe('VAOS reducer: appointments', () => {
   it('should populate confirmed with appointments with FETCH_CONFIRMED_APPOINTMENTS_SUCCEDED', () => {
     const action = {
       type: FETCH_CONFIRMED_APPOINTMENTS_SUCCEEDED,
-      data: [{ id: 1 }, { id: 2 }],
+      data: {
+        appointmentRequests: [
+          { id: 1, status: 'Booked' },
+          { id: 2, status: 'Booked' },
+        ],
+      },
     };
 
     const newState = appointmentsReducer(initialState, action);

--- a/src/applications/vaos/utils/formatters.js
+++ b/src/applications/vaos/utils/formatters.js
@@ -1,0 +1,9 @@
+export function formatTimeToCall(timeToCall) {
+  if (timeToCall.length === 1) {
+    return timeToCall[0].toLowerCase();
+  } else if (timeToCall.length === 2) {
+    return `${timeToCall[0].toLowerCase()} or ${timeToCall[1].toLowerCase()}`;
+  }
+
+  return `${timeToCall[0].toLowerCase()}, ${timeToCall[1].toLowerCase()}, or ${timeToCall[2].toLowerCase()}`;
+}

--- a/src/applications/vaos/utils/selectors.js
+++ b/src/applications/vaos/utils/selectors.js
@@ -1,3 +1,7 @@
+export function selectConfirmedAppointment(state, id) {
+  return state.appointments?.confirmed?.find(appt => appt.id === id) || null;
+}
+
 export function selectPendingAppointment(state, id) {
   return (
     state.appointments?.pending?.find(appt => appt.uniqueId === id) || null

--- a/src/applications/vaos/utils/selectors.js
+++ b/src/applications/vaos/utils/selectors.js
@@ -1,5 +1,7 @@
 export function selectConfirmedAppointment(state, id) {
-  return state.appointments?.confirmed?.find(appt => appt.id === id) || null;
+  return (
+    state.appointments?.confirmed?.find(appt => appt.uniqueId === id) || null
+  );
 }
 
 export function selectPendingAppointment(state, id) {

--- a/src/applications/vaos/utils/selectors.js
+++ b/src/applications/vaos/utils/selectors.js
@@ -1,11 +1,11 @@
 export function selectConfirmedAppointment(state, id) {
   return (
-    state.appointments?.confirmed?.find(appt => appt.uniqueId === id) || null
+    state.appointments?.confirmed?.find?.(appt => appt.uniqueId === id) || null
   );
 }
 
 export function selectPendingAppointment(state, id) {
   return (
-    state.appointments?.pending?.find(appt => appt.uniqueId === id) || null
+    state.appointments?.pending?.find?.(appt => appt.uniqueId === id) || null
   );
 }


### PR DESCRIPTION
## Description
Confirmed appointment detail page.  Will supplant mock data with betamocks data from API once complete.

Latest design does not have this page. Used `<PendingAppointmentPage/>` and previous mockup as a model since the design is very similar.  

## Testing done
Tested locally, unit tests

## Screenshots
![image](https://user-images.githubusercontent.com/786704/64743811-36cc3600-d4b6-11e9-8e35-c043267669ce.png)



## Acceptance criteria
- [ ] Confirmed appointment details are present

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs