### PR TITLE
1651: GIBCT® Colmery 107 - Learn more button needs an aria-label for context

### DIFF
--- a/src/applications/gi/components/profile/CalculatorForm.jsx
+++ b/src/applications/gi/components/profile/CalculatorForm.jsx
@@ -628,6 +628,8 @@ class CalculatorForm extends React.Component {
             <span>
               {'Where will you take the majority of your classes? '}
               <button
+                aria-live="polite"
+                aria-atomic="true"
                 type="button"
                 className="va-button-link learn-more-button"
                 onClick={onShowModal.bind(
@@ -635,6 +637,9 @@ class CalculatorForm extends React.Component {
                   'calcBeneficiaryLocationQuestion',
                 )}
               >
+                <span className="sr-only">
+                  Learn more about the location-based housing allowance
+                </span>
                 (Learn more)
               </button>
             </span>


### PR DESCRIPTION
## Description
The Learn more buttons rely on proximity to a label or heading to answer the question "Learn more about what?". This can be improved for assistive devices and screen readers by adding aria-label attributes to the buttons. Example screenshots attached.

https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/1651

## Testing done
Local testing passes

## Screenshots
N/A

## Acceptance criteria
- [x] As a screen reader user, I want to hear a contextual aria-label read aloud. This text could sound like "Learn more about where you will take the majority of your classes" or "Learn more about locations for taking classes".

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
