### PR TITLE
[Facility Locator] Use new CareSite Phone attribute for providers

### DIFF
--- a/src/applications/facility-locator/components/search-results/LocationPhoneLink.jsx
+++ b/src/applications/facility-locator/components/search-results/LocationPhoneLink.jsx
@@ -36,7 +36,7 @@ const LocationPhoneLink = ({ location }) => {
   const isProvider = location.type === LocationType.CC_PROVIDER;
 
   if (isProvider) {
-    const { phone } = location.attributes;
+    const { caresitePhone: phone } = location.attributes;
     return (
       <div>
         {renderPhoneNumber(


### PR DESCRIPTION
## Description
PPMS data has two sets of phone numbers - one from a Provider DB and another from a data source called CareSite. The API has been updated to include both per this, https://github.com/department-of-veterans-affairs/vets-api/pull/3278.

The CareSite data is much more reliable at this time (most providers currently have empty data for phone numbers), so I'm updating the Community Cares Provider component of the Facility Locator to use that instead. 

Ticket - https://github.com/department-of-veterans-affairs/va.gov-team/issues/993

## Testing done
Local using the mock API

## Screenshots
![image](https://user-images.githubusercontent.com/1915775/64875298-cdb20300-d61a-11e9-8204-149a2b399de6.png)


## Acceptance criteria
- [x] Community Cares providers have phone numbers

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
