### PR TITLE
fix abbreviation of Armed Forces Pacific

### DIFF
--- a/src/platform/forms/address/data/states.json
+++ b/src/platform/forms/address/data/states.json
@@ -62,5 +62,5 @@
   "PI": "Virgin Island",
   "AA": "Armed Forces Americas (AA)",
   "AE": "Armed Forces Europe (AE)",
-  "AP": "Armed Forces Pacific (AE)"
+  "AP": "Armed Forces Pacific (AP)"
 }


### PR DESCRIPTION
## Description
Fix abbreviation of Armed Forces Pacific from `AE` to `AP`. Addresses this bit I had missed in the original ticket (thanks for the catch, @lihanli):

> First, the "state" drop down in the edit mailing address pop up lists Armed Forces Pacific as AE when it is supposed to be AP.

## Testing done
Local

## Screenshots
![image](https://user-images.githubusercontent.com/20728956/64890865-60579f80-d625-11e9-9d90-8bf3e842ffd2.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs