### PR TITLE
Change URL of FOIA link

### DIFF
--- a/src/platform/static-data/footer-links.json
+++ b/src/platform/static-data/footer-links.json
@@ -238,7 +238,7 @@
   },
   {
     "column": "bottom_rail",
-    "href": "https://www.oprm.va.gov/foia/",
+    "href": "https://www.va.gov/foia/",
     "order": 7,
     "target": null,
     "title": "Freedom of Information Act (FOIA)"


### PR DESCRIPTION
## Description
Make simple change to the target URL of the FOIA link in the site's main footer

## Testing done
local

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs