### PR TITLE
Double-escape the back-reference

### DIFF
--- a/jenkins/common.groovy
+++ b/jenkins/common.groovy
@@ -140,7 +140,7 @@ def setup() {
  * dockerContainer.inside() context so buildLog can point to the right file.
  */
 def findMissingQueryFlags(String buildLogPath, String envName) {
-  def missingFlags = sh(returnStdout: true, script: "sed -nr 's/Could not find query flag (.+)\\..+/\1/p' ${buildLogPath} | sort | uniq")
+  def missingFlags = sh(returnStdout: true, script: "sed -nr 's/Could not find query flag (.+)\\..+/\\1/p' ${buildLogPath} | sort | uniq")
   if (missingFlags) {
     slackSend message: "Missing query flags found in the ${envName} build on `${env.BRANCH_NAME}`. The following will flags be considered false:\n${missingFlags}",
       color: 'warning',


### PR DESCRIPTION
## Description
Looks like this was broken because of a Groovy -> Shell escaping issue. I double-escaped the first backslash, but not the second. :man_facepalming: 

## Testing done
None. :grimacing: :see_no_evil: 

## Screenshots
![image](https://user-images.githubusercontent.com/12970166/64984695-35b15500-d878-11e9-9aea-a1708de30907.png)
Note how it doesn't give the back-reference in the `sed` command. Groovy must have interpreted the `\1` as a single character before passing it to the `sh` command.