### PR TITLE
Squash all newlines in broken links CSV

### DIFF
--- a/src/site/stages/build/plugins/check-broken-links/helpers/getErrorOutput.js
+++ b/src/site/stages/build/plugins/check-broken-links/helpers/getErrorOutput.js
@@ -14,7 +14,7 @@ function getErrorOutput(brokenPages) {
   const csvBody = brokenPages
     .map(brokenPage =>
       brokenPage.linkErrors
-        .map(link => `${brokenPage.path},${link.html.replace('\n', '')}`)
+        .map(link => `${brokenPage.path},${link.html.replace(/\n/g, '')}`)
         .join('\n'),
     )
     .join('\n');


### PR DESCRIPTION
## Description
Like it says on the tin, this is supposed to squash _all_ newlines in the CSV output, not just the first.

### Background
I noticed the broken link Slack notification count didn't match the count given by the link checker. (See this [Jenkins log](http://jenkins.vfs.va.gov/blue/rest/organizations/jenkins/pipelines/testing/pipelines/vets-website/branches/cms-cache-fix-cv/runs/2/nodes/94/steps/112/log/?start=0) (245) and [this Slack notification](https://dsva.slack.com/archives/CDJQ0JCE4/p1568668259012700) (211).) The difference was quite a bit. After investigating, I found the CSV had multi-line values for `Broken link`. This is because the `link.html` contained HTML with nested elements which contained blank lines, and the `.replace()` I had before was a string, which means it [only replaces the first instance](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace).

Once it squashes all the newlines, it the `sed` command that looks for the broken link CSV will grab the whole thing since there won't be a random empty line smack in the middle of the CSV block.