### PR TITLE
Remove GI Bill Benefits tool availability note

### DIFF
--- a/src/applications/post-911-gib-status/containers/IntroPageSummary.jsx
+++ b/src/applications/post-911-gib-status/containers/IntroPageSummary.jsx
@@ -20,10 +20,6 @@ export default function IntroPageSummary() {
         </p>
       </div>
       <CallToActionWidget appId="gi-bill-benefits" />
-      <p>
-        <strong>Note:</strong> This tool is available Sunday through Friday,
-        6:00 a.m. to 10:00 p.m. ET, and Saturday 6:00 a.m. to 7:00 p.m. ET.
-      </p>
       <h2 itemProp="name">Am I eligible to use this tool?</h2>
       <div
         itemProp="acceptedAnswer"


### PR DESCRIPTION
## Description

Remove repetitive content in GI Bill Benefits tool. See https://github.com/department-of-veterans-affairs/va.gov-team/issues/1713

The second part of issue 1713, remove the troubleshooting wizard, appears to have already been done.

And the additional note by @peggygannon concerning https://github.com/department-of-veterans-affairs/vets.gov-team/issues/18742 has already been completed.

## Testing done

Unit tests. I was unable to get the GI Benefits tool to execute locally as it was showing as offline. 

![Screen Shot 2019-09-17 at 11 27 04 AM](https://user-images.githubusercontent.com/136959/65060764-1c72dc00-d93e-11e9-96cb-ee948005be9c.png)

And the same content is not available at `http://localhost:3001/gi-bill-comparison-tool/`.

## Screenshots

None available

## Acceptance criteria
- [ ] GI Bill tool availability note has been removed

## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
