### PR TITLE
19704: Phone number information not displaying extension/when no phone number is provided displays a dash

### DIFF
--- a/src/applications/gi/components/vet-tec/VetTecScoContact.jsx
+++ b/src/applications/gi/components/vet-tec/VetTecScoContact.jsx
@@ -14,13 +14,19 @@ export const VetTecScoContact = (sco, header) => {
             <div>
               <a href={`mailto:${sco.email}`}>{sco.email}</a>
             </div>
-            <div>
-              <a href={`tel:+1${`${sco.phoneAreaCode}-${sco.phoneNumber}`}`}>
-                {sco.phoneAreaCode}
-                {'-'}
-                {sco.phoneNumber}
-              </a>
-            </div>
+            {sco.phoneAreaCode &&
+              sco.phoneNumber && (
+                <div>
+                  <a
+                    href={`tel:+1${`${sco.phoneAreaCode}-${sco.phoneNumber}`}`}
+                  >
+                    {sco.phoneAreaCode}
+                    {'-'}
+                    {sco.phoneNumber}
+                  </a>
+                  {sco.phoneExtension && ` ext. ${sco.phoneExtension}`}
+                </div>
+              )}
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Description
When viewing SCO information, when no phone number is provided in the school certifying officials csv, it displays as a dash on the contact details page.

https://github.com/department-of-veterans-affairs/vets.gov-team/issues/19704#event-2640622548

## Testing done
Unit, E2E, and Manual testing passes locally

## Screenshots
![image](https://user-images.githubusercontent.com/48804834/65070950-9ebdc900-d95b-11e9-9404-3680a2472245.png)

## Acceptance criteria
- [x] Correct bug

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
