### PR TITLE
remove the cookie gating and release va.gv header to oprm.va.gov

### DIFF
--- a/src/applications/proxy-rewrite/proxy-rewrite-whitelist.json
+++ b/src/applications/proxy-rewrite/proxy-rewrite-whitelist.json
@@ -18,7 +18,7 @@
     {
         "hostname": "www.oprm.va.gov",
         "pathnameBeginning": "/",
-        "cookieOnly": true 
+        "cookieOnly": false 
     },
     {
         "hostname": "www.telehealth.va.gov",


### PR DESCRIPTION
## Description
- teamsite admin confirmed that testing is complete for oprm.va.gov to display va.gov header 

## Testing done
- testing was done as part of previous ticket

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
