### PR TITLE
Add --drupal-fail-fast flag

### DIFF
--- a/src/site/stages/build/drupal/metalsmith-drupal.js
+++ b/src/site/stages/build/drupal/metalsmith-drupal.js
@@ -217,7 +217,10 @@ function getDrupalContent(buildOptions) {
       buildOptions.drupalError = drupalData;
       log(err.stack);
       log('Failed to pipe Drupal content into Metalsmith!');
-      if (buildOptions.buildtype !== ENVIRONMENTS.LOCALHOST) {
+      if (
+        buildOptions.buildtype !== ENVIRONMENTS.LOCALHOST ||
+        buildOptions['drupal-fail-fast']
+      ) {
         done(err);
       } else {
         done();

--- a/src/site/stages/build/index.js
+++ b/src/site/stages/build/index.js
@@ -168,7 +168,7 @@ function defaultBuild(BUILD_OPTIONS) {
 
   smith.use(createSitemaps(BUILD_OPTIONS));
   smith.use(createRedirects(BUILD_OPTIONS));
-  smith.use(checkBrokenLinks());
+  smith.use(checkBrokenLinks(BUILD_OPTIONS));
   smith.use(checkForCMSUrls(BUILD_OPTIONS));
 
   /* eslint-disable no-console */

--- a/src/site/stages/build/options.js
+++ b/src/site/stages/build/options.js
@@ -31,6 +31,7 @@ const COMMAND_LINE_OPTIONS_DEFINITIONS = [
   { name: 'asset-source', type: String, defaultValue: assetSources.LOCAL },
   { name: 'content-directory', type: String, defaultValue: defaultContentDir },
   { name: 'pull-drupal', type: Boolean, defaultValue: false },
+  { name: 'drupal-fail-fast', type: Boolean, defaultValue: false },
   {
     name: 'drupal-address',
     type: String,

--- a/src/site/stages/build/plugins/check-broken-links/index.js
+++ b/src/site/stages/build/plugins/check-broken-links/index.js
@@ -10,6 +10,7 @@ const _getErrorOutput = require('./helpers/getErrorOutput');
  * Metalsmith middleware for verifying HREF/SRC values in HTML files are valid file references.
  */
 function getMiddleware(
+  buildOptions,
   getBrokenLinks = _getBrokenLinks,
   applyIgnoredRoutes = _applyIgnoredRoutes,
   getErrorOutput = _getErrorOutput,
@@ -44,6 +45,11 @@ function getMiddleware(
 
     if (brokenPages.length > 0) {
       const errorOutput = getErrorOutput(brokenPages);
+
+      if (buildOptions['drupal-fail-fast']) {
+        done(errorOutput);
+        return;
+      }
 
       console.log(errorOutput);
     }

--- a/src/site/stages/build/plugins/check-broken-links/tests/index.unit.spec.js
+++ b/src/site/stages/build/plugins/check-broken-links/tests/index.unit.spec.js
@@ -5,6 +5,7 @@ const sinon = require('sinon');
 
 const checkBrokenLinks = require('../index');
 
+const buildOptions = {};
 const getBrokenLinks = sinon.stub();
 const applyIgnoredRoutes = sinon.stub();
 const getErrorOutput = sinon.stub();
@@ -18,6 +19,7 @@ const files = {
 const done = sinon.stub();
 
 const middleware = checkBrokenLinks(
+  buildOptions,
   getBrokenLinks,
   applyIgnoredRoutes,
   getErrorOutput,
@@ -45,6 +47,7 @@ describe('build/check-broken-links', () => {
   });
 
   beforeEach(() => {
+    buildOptions['drupal-fail-fast'] = false;
     console.log.reset();
     getBrokenLinks.resetHistory();
     applyIgnoredRoutes.resetHistory();
@@ -104,5 +107,16 @@ describe('build/check-broken-links', () => {
     middleware(files, null, done);
     expect(console.log.firstCall.args[0]).to.be.equal('broken links!');
     expect(done.firstCall.args[0]).to.be.undefined;
+  });
+
+  it('logs errors and calls done without arguments', () => {
+    setBrokenLinksPerPage(0);
+    setTotalBrokenPages(5);
+    setErrorOutput('broken links!');
+
+    buildOptions['drupal-fail-fast'] = true;
+
+    middleware(files, null, done);
+    expect(done.firstCall.args[0]).to.equal('broken links!');
   });
 });


### PR DESCRIPTION
## Description
When the `--drupal-fail-fast` flag is passed to the Metalsmith build process, some safety mechanisms are ignored and the build fails.

## Testing done
- I threw an error in the `getDrupalContent` return function
  - `yarn watch --pull-drupal` outputted the error, but continued building
  - `yarn watch --pull-drupal --drupal-fail-fast` caught the error and then threw it again to break to the build
- Letting `yarn watch --pull-drupal --drupal-fail-fast` finish locally results in some broken links, which break the build

## Screenshots
N/A

## Acceptance criteria
The build with the `--drupal-fail-fast` flag will fail when:
- [x] We fail to fetch the feature flags
  - This should already happen since we're not wrapping any of that in a `try .. catch`
- [x] Any error thrown when getting the Drupal content
- [x] Broken links are found

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
