### PR TITLE
Add VAOS Community Care provider page

### DIFF
--- a/src/applications/vaos/containers/CommunityCareProviderPage.jsx
+++ b/src/applications/vaos/containers/CommunityCareProviderPage.jsx
@@ -14,15 +14,18 @@ import { getFormPageInfo } from '../utils/selectors';
 
 const initialSchema = {
   type: 'object',
-  required: ['phoneNumber'],
+  required: ['hasCommunityCareProvider'],
   properties: {
     hasCommunityCareProvider: {
       type: 'boolean',
     },
     communityCareProviders: {
       type: 'array',
+      maxItems: 3,
+      minItems: 1,
       items: {
         type: 'object',
+        required: ['firstName', 'lastName', 'phone'],
         properties: {
           practiceName: {
             type: 'string',
@@ -35,6 +38,7 @@ const initialSchema = {
           },
           phone: {
             type: 'string',
+            minLength: 10,
           },
         },
       },
@@ -55,25 +59,33 @@ const uiSchema = {
   },
   communityCareProviders: {
     'ui:title': 'Community Care provider',
+    'ui:required': data => data.hasCommunityCareProvider,
     'ui:options': {
       expandUnder: 'hasCommunityCareProvider',
-      viewField: ({ formData }) => <div>{formData.practiceName}</div>,
+      viewField: ({ formData }) => (
+        <div>
+          <strong>
+            {formData.firstName} {formData.lastName}
+          </strong>
+          <br />
+          {formData.phone}
+          <br />
+          {formData.practiceName}
+        </div>
+      ),
       itemName: 'Community Care provider',
     },
     items: {
-      'ui:options': {
-        expandUnder: 'hasCommunityCareProvider',
-      },
       practiceName: {
         'ui:title': 'Practice name',
       },
       firstName: {
-        'ui:title': 'Provider first name',
+        'ui:title': 'First name',
       },
       lastName: {
-        'ui:title': 'Provider last name',
+        'ui:title': 'Last name',
       },
-      phone: phoneUI('Provider phone number'),
+      phone: phoneUI(),
     },
   },
 };

--- a/src/applications/vaos/containers/CommunityCareProviderPage.jsx
+++ b/src/applications/vaos/containers/CommunityCareProviderPage.jsx
@@ -1,0 +1,141 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import SchemaForm from 'platform/forms-system/src/js/components/SchemaForm';
+import phoneUI from 'platform/forms-system/src/js/definitions/phone';
+import FormButtons from '../components/FormButtons';
+
+import {
+  openFormPage,
+  updateFormData,
+  routeToNextAppointmentPage,
+  routeToPreviousAppointmentPage,
+} from '../actions/newAppointment.js';
+import { getFormPageInfo } from '../utils/selectors';
+
+const initialSchema = {
+  type: 'object',
+  required: ['phoneNumber'],
+  properties: {
+    hasCommunityCareProvider: {
+      type: 'boolean',
+    },
+    communityCareProviders: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          practiceName: {
+            type: 'string',
+          },
+          firstName: {
+            type: 'string',
+          },
+          lastName: {
+            type: 'string',
+          },
+          phone: {
+            type: 'string',
+          },
+        },
+      },
+    },
+  },
+};
+
+const uiSchema = {
+  hasCommunityCareProvider: {
+    'ui:widget': 'yesNo',
+    'ui:title':
+      'Do you have a preferred Community Care provider? You may specify up to three providers',
+    'ui:options': {
+      labels: {
+        N: "No/I don't know",
+      },
+    },
+  },
+  communityCareProviders: {
+    'ui:title': 'Community Care provider',
+    'ui:options': {
+      expandUnder: 'hasCommunityCareProvider',
+      viewField: ({ formData }) => <div>{formData.practiceName}</div>,
+      itemName: 'Community Care provider',
+    },
+    items: {
+      'ui:options': {
+        expandUnder: 'hasCommunityCareProvider',
+      },
+      practiceName: {
+        'ui:title': 'Practice name',
+      },
+      firstName: {
+        'ui:title': 'Provider first name',
+      },
+      lastName: {
+        'ui:title': 'Provider last name',
+      },
+      phone: phoneUI('Provider phone number'),
+    },
+  },
+};
+
+const pageKey = 'ccProvider';
+
+export class CommunityCareProviderPage extends React.Component {
+  componentDidMount() {
+    this.props.openFormPage(pageKey, uiSchema, initialSchema);
+  }
+
+  goBack = () => {
+    this.props.routeToPreviousAppointmentPage(this.props.router, pageKey);
+  };
+
+  goForward = () => {
+    this.props.routeToNextAppointmentPage(this.props.router, pageKey);
+  };
+
+  render() {
+    const { schema, data, pageChangeInProgress } = this.props;
+
+    return (
+      <>
+        <h1 className="vads-u-font-size--h2">
+          Share your community care provider preferences (1/2)
+        </h1>
+        {!!schema && (
+          <SchemaForm
+            name="ccProvider"
+            title="Community Care provider"
+            schema={schema}
+            uiSchema={uiSchema}
+            onSubmit={this.goForward}
+            onChange={newData =>
+              this.props.updateFormData(pageKey, uiSchema, newData)
+            }
+            data={data}
+          >
+            <FormButtons
+              onBack={this.goBack}
+              pageChangeInProgress={pageChangeInProgress}
+            />
+          </SchemaForm>
+        )}
+      </>
+    );
+  }
+}
+
+function mapStateToProps(state) {
+  return getFormPageInfo(state, pageKey);
+}
+
+const mapDispatchToProps = {
+  openFormPage,
+  updateFormData,
+  routeToNextAppointmentPage,
+  routeToPreviousAppointmentPage,
+};
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(CommunityCareProviderPage);

--- a/src/applications/vaos/newAppointmentFlow.js
+++ b/src/applications/vaos/newAppointmentFlow.js
@@ -45,4 +45,9 @@ export default {
     },
     previous: 'typeOfCare',
   },
+  ccProvider: {
+    url: '/new-appointment/community-care-provider',
+    next: 'home',
+    previous: 'contactInfo',
+  },
 };

--- a/src/applications/vaos/reducers/newAppointment.js
+++ b/src/applications/vaos/reducers/newAppointment.js
@@ -1,3 +1,4 @@
+import { getDefaultFormState } from '@department-of-veterans-affairs/react-jsonschema-form/lib/utils';
 import {
   updateSchemaAndData,
   updateItemsSchema,
@@ -19,10 +20,11 @@ const initialState = {
 export default function formReducer(state = initialState, action) {
   switch (action.type) {
     case FORM_PAGE_OPENED: {
+      const schemaWithItemsCorrected = updateItemsSchema(action.schema);
       const { data, schema } = updateSchemaAndData(
-        updateItemsSchema(action.schema),
+        schemaWithItemsCorrected,
         action.uiSchema,
-        state.data,
+        getDefaultFormState(schemaWithItemsCorrected, action.data, {}),
       );
 
       return {

--- a/src/applications/vaos/reducers/newAppointment.js
+++ b/src/applications/vaos/reducers/newAppointment.js
@@ -1,4 +1,8 @@
-import { updateSchemaAndData } from 'platform/forms-system/src/js/state/helpers';
+import {
+  updateSchemaAndData,
+  updateItemsSchema,
+} from 'platform/forms-system/src/js/state/helpers';
+
 import {
   FORM_DATA_UPDATED,
   FORM_PAGE_OPENED,
@@ -16,7 +20,7 @@ export default function formReducer(state = initialState, action) {
   switch (action.type) {
     case FORM_PAGE_OPENED: {
       const { data, schema } = updateSchemaAndData(
-        action.schema,
+        updateItemsSchema(action.schema),
         action.uiSchema,
         state.data,
       );

--- a/src/applications/vaos/routes.jsx
+++ b/src/applications/vaos/routes.jsx
@@ -5,6 +5,7 @@ import NewAppointmentLayout from './components/NewAppointmentLayout';
 import AppointmentListsPage from './containers/AppointmentListsPage';
 // import TypeOfAppointmentPage from './containers/TypeOfAppointmentPage';
 import TypeOfCarePage from './containers/TypeOfCarePage';
+import CommunityCareProviderPage from './containers/CommunityCareProviderPage';
 import PendingAppointmentsPage from './containers/PendingAppointmentsPage';
 import PendingAppointmentPage from './containers/PendingAppointmentPage';
 import ConfirmedAppointmentPage from './containers/ConfirmedAppointmentPage';
@@ -16,6 +17,10 @@ const routes = (
     <Route path="new-appointment" component={NewAppointmentLayout}>
       <IndexRoute component={TypeOfCarePage} />
       <Route path="contact-info" component={ContactInfoPage} />
+      <Route
+        path="community-care-provider"
+        component={CommunityCareProviderPage}
+      />
     </Route>
     <Route path="appointments" component={AppointmentListsPage} />
     <Route

--- a/src/applications/vaos/tests/containers/CommunityCareProviderPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/containers/CommunityCareProviderPage.unit.spec.jsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { mount } from 'enzyme';
+
+import { selectRadio } from 'platform/testing/unit/schemaform-utils.jsx';
+import useFormPageTester from '../useFormPageTester';
+
+import { CommunityCareProviderPage } from '../../containers/CommunityCareProviderPage';
+
+function CommunityCareProviderPageTester(props) {
+  const formProps = useFormPageTester(props.data);
+  return <CommunityCareProviderPage {...props} {...formProps} />;
+}
+
+describe('VAOS <CommunityCareProviderPage>', () => {
+  it('should render', () => {
+    const form = mount(<CommunityCareProviderPageTester />);
+
+    expect(form.find('input').length).to.equal(2);
+    form.unmount();
+  });
+
+  it('should render provider fields', () => {
+    const form = mount(
+      <CommunityCareProviderPageTester
+        data={{ hasCommunityCareProvider: true }}
+      />,
+    );
+
+    expect(form.find('input').length).to.equal(6);
+    form.unmount();
+  });
+
+  it('should not submit empty form', () => {
+    const routeToNextAppointmentPage = sinon.spy();
+
+    const form = mount(
+      <CommunityCareProviderPageTester
+        routeToNextAppointmentPage={routeToNextAppointmentPage}
+      />,
+    );
+
+    form.find('form').simulate('submit');
+
+    expect(form.find('.usa-input-error').length).to.equal(1);
+    expect(routeToNextAppointmentPage.called).to.be.false;
+    form.unmount();
+  });
+
+  it('should update data after change', () => {
+    const form = mount(<CommunityCareProviderPageTester />);
+
+    selectRadio(form, 'root_hasCommunityCareProvider', 'Y');
+
+    expect(form.find('#root_hasCommunityCareProviderYes').getDOMNode().checked)
+      .to.be.true;
+    form.unmount();
+  });
+
+  it('should submit with valid data', () => {
+    const routeToNextAppointmentPage = sinon.spy();
+
+    const form = mount(
+      <CommunityCareProviderPageTester
+        data={{ hasCommunityCareProvider: false }}
+        routeToNextAppointmentPage={routeToNextAppointmentPage}
+      />,
+    );
+
+    form.find('form').simulate('submit');
+
+    expect(form.find('.usa-input-error').length).to.equal(0);
+    expect(routeToNextAppointmentPage.called).to.be.true;
+    form.unmount();
+  });
+});

--- a/src/applications/vaos/tests/useFormPageTester.js
+++ b/src/applications/vaos/tests/useFormPageTester.js
@@ -1,0 +1,34 @@
+import { useState } from 'react';
+import { getDefaultFormState } from '@department-of-veterans-affairs/react-jsonschema-form/lib/utils';
+import {
+  updateSchemaAndData,
+  updateItemsSchema,
+} from 'platform/forms-system/src/js/state/helpers';
+
+export default function useFormPageTester(initialData) {
+  const [dataAndSchema, setDataAndSchema] = useState({
+    schema: null,
+    data: initialData,
+  });
+
+  function openFormPage(page, uiSchema, schema) {
+    const schemaWithItemsCorrected = updateItemsSchema(schema);
+    setDataAndSchema(
+      updateSchemaAndData(
+        schemaWithItemsCorrected,
+        uiSchema,
+        getDefaultFormState(schemaWithItemsCorrected, dataAndSchema.data, {}),
+      ),
+    );
+  }
+
+  function updateFormData(page, uiSchema, data) {
+    setDataAndSchema(updateSchemaAndData(dataAndSchema.schema, uiSchema, data));
+  }
+
+  return {
+    ...dataAndSchema,
+    openFormPage,
+    updateFormData,
+  };
+}


### PR DESCRIPTION
## Description
This adds the community care provider info page.

I skipped the address, which is in the prototype, because it sounded like there was some uncertainty there and addresses are a pain. I will create a ticket to keep track of it.

## Testing done
Local and unit testing

## Screenshots
![Screen Shot 2019-09-18 at 1 43 30 PM](https://user-images.githubusercontent.com/634932/65172056-52858e00-da1a-11e9-9198-48a713cfb749.png)


## Acceptance criteria
- [x] You can see a yes/no choice and CC provider fields when you choose Yes

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
