### PR TITLE
Add VAOS page breadcrumbs

### DIFF
--- a/src/applications/vaos/components/Breadcrumbs.jsx
+++ b/src/applications/vaos/components/Breadcrumbs.jsx
@@ -3,15 +3,6 @@ import { Link } from 'react-router';
 import Breadcrumbs from '@department-of-veterans-affairs/formation-react/Breadcrumbs';
 
 export default function VAOSBreadcrumbs({ children }) {
-  const crumbs = [];
-
-  if (children?.length === undefined) {
-    const childArr = React.Children.toArray(children);
-    crumbs.push(childArr);
-  } else if (children) {
-    crumbs.push(...children);
-  }
-
   return (
     <Breadcrumbs customClasses="new-grid">
       <a href="/" key="home">
@@ -23,7 +14,7 @@ export default function VAOSBreadcrumbs({ children }) {
       <Link to="/" key="vaos-home">
         VA Online Scheduling
       </Link>
-      {crumbs}
+      {children}
     </Breadcrumbs>
   );
 }

--- a/src/applications/vaos/components/Breadcrumbs.jsx
+++ b/src/applications/vaos/components/Breadcrumbs.jsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { Link } from 'react-router';
+import Breadcrumbs from '@department-of-veterans-affairs/formation-react/Breadcrumbs';
+
+export default class VAOSBreadcrumbs extends React.Component {
+  renderBreadcrumbs = childNodes => {
+    const crumbs = [
+      <a href="/" key="home">
+        Home
+      </a>,
+      <a href="/health-care" key="health-care">
+        Health care
+      </a>,
+      <Link to="/" key="vaos-home">
+        VA Online Scheduling
+      </Link>,
+    ];
+
+    if (childNodes) {
+      if (childNodes.length === undefined) {
+        const childArr = React.Children.toArray(childNodes);
+        crumbs.push(childArr);
+      } else {
+        crumbs.push(...childNodes);
+      }
+    }
+
+    return crumbs;
+  };
+
+  render() {
+    return (
+      <Breadcrumbs customClasses="new-grid">
+        {this.renderBreadcrumbs(this.props.children)}
+      </Breadcrumbs>
+    );
+  }
+}

--- a/src/applications/vaos/components/Breadcrumbs.jsx
+++ b/src/applications/vaos/components/Breadcrumbs.jsx
@@ -2,37 +2,28 @@ import React from 'react';
 import { Link } from 'react-router';
 import Breadcrumbs from '@department-of-veterans-affairs/formation-react/Breadcrumbs';
 
-export default class VAOSBreadcrumbs extends React.Component {
-  renderBreadcrumbs = childNodes => {
-    const crumbs = [
+export default function VAOSBreadcrumbs({ children }) {
+  const crumbs = [];
+
+  if (children?.length === undefined) {
+    const childArr = React.Children.toArray(children);
+    crumbs.push(childArr);
+  } else if (children) {
+    crumbs.push(...children);
+  }
+
+  return (
+    <Breadcrumbs customClasses="new-grid">
       <a href="/" key="home">
         Home
-      </a>,
+      </a>
       <a href="/health-care" key="health-care">
         Health care
-      </a>,
+      </a>
       <Link to="/" key="vaos-home">
         VA Online Scheduling
-      </Link>,
-    ];
-
-    if (childNodes) {
-      if (childNodes.length === undefined) {
-        const childArr = React.Children.toArray(childNodes);
-        crumbs.push(childArr);
-      } else {
-        crumbs.push(...childNodes);
-      }
-    }
-
-    return crumbs;
-  };
-
-  render() {
-    return (
-      <Breadcrumbs customClasses="new-grid">
-        {this.renderBreadcrumbs(this.props.children)}
-      </Breadcrumbs>
-    );
-  }
+      </Link>
+      {crumbs}
+    </Breadcrumbs>
+  );
 }

--- a/src/applications/vaos/components/LandingPage.jsx
+++ b/src/applications/vaos/components/LandingPage.jsx
@@ -1,9 +1,11 @@
 import React from 'react';
 import { Link } from 'react-router';
+import Breadcrumbs from './Breadcrumbs';
 
 export default function LandingPage() {
   return (
     <div className="vads-l-grid-container vads-u-padding-x--2p5 large-screen:vads-u-padding-x--0 vads-u-padding-bottom--2p5">
+      <Breadcrumbs />
       <div className="vads-l-row">
         <div className="vads-l-col--12 medium-screen:vads-l-col--8 vads-u-margin-bottom--4">
           <div>

--- a/src/applications/vaos/components/NewAppointmentLayout.jsx
+++ b/src/applications/vaos/components/NewAppointmentLayout.jsx
@@ -1,8 +1,13 @@
 import React from 'react';
+import { Link } from 'react-router';
+import Breadcrumbs from './Breadcrumbs';
 
 export default function NewAppointmentLayout({ children }) {
   return (
     <div className="vads-l-grid-container vads-u-padding-x--2p5 large-screen:vads-u-padding-x--0 vads-u-padding-bottom--2">
+      <Breadcrumbs>
+        <Link to="new-appointment">New appointment</Link>
+      </Breadcrumbs>
       <div className="vads-l-row">
         <div className="vads-l-col--12 medium-screen:vads-l-col--8">
           <h1 className="vaos-form__title vaos-u-margin-bottom--1 vads-u-font-size--sm vads-u-font-weight--normal vads-u-font-family--sans">

--- a/src/applications/vaos/containers/AppointmentListsPage.jsx
+++ b/src/applications/vaos/containers/AppointmentListsPage.jsx
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import { Link } from 'react-router';
 import { focusElement } from 'platform/utilities/ui';
 import LoadingIndicator from '@department-of-veterans-affairs/formation-react/LoadingIndicator';
+import Breadcrumbs from '../components/Breadcrumbs';
 
 import {
   fetchConfirmedAppointments,
@@ -32,6 +33,9 @@ export class AppointmentListsPage extends Component {
 
     return (
       <div className="vads-l-grid-container vads-u-padding-x--2p5 large-screen:vads-u-padding-x--0 vads-u-padding-bottom--2p5">
+        <Breadcrumbs>
+          <Link to="appointments">Your appointments</Link>
+        </Breadcrumbs>
         <div className="vads-l-row">
           <div className="vads-l-col--12 medium-screen:vads-l-col--8 vads-u-margin-bottom--4">
             <h1>Your Appointments</h1>

--- a/src/applications/vaos/containers/ConfirmedAppointmentPage.jsx
+++ b/src/applications/vaos/containers/ConfirmedAppointmentPage.jsx
@@ -9,6 +9,7 @@ import { fetchConfirmedAppointments } from '../actions/appointments';
 import { FETCH_STATUS, PURPOSE_TEXT } from '../utils/constants';
 import { selectConfirmedAppointment } from '../utils/selectors';
 import { formatTimeToCall } from '../utils/formatters';
+import Breadcrumbs from '../components/Breadcrumbs';
 
 function formatDate(date) {
   const parsedDate = moment(date, 'MM/DD/YYYY hh:mm:ss');
@@ -37,6 +38,11 @@ export class ConfirmedAppointmentPage extends React.Component {
 
     return (
       <div className="vads-l-grid-container vads-u-padding-x--2p5 large-screen:vads-u-padding-x--0 vads-u-padding-bottom--2p5">
+        <Breadcrumbs>
+          <Link to="appointments">Your appointments</Link>
+          <Link to="appointments/confirmed">Confirmed appointments</Link>
+          <Link to="appointments/confirmed">Appointment detail</Link>
+        </Breadcrumbs>
         <div className="vads-l-row">
           <div className="vads-l-col--12 medium-screen:vads-l-col--8 vads-u-margin-bottom--4">
             <Link to="appointments/confirmed">

--- a/src/applications/vaos/containers/ConfirmedAppointmentsListPage.jsx
+++ b/src/applications/vaos/containers/ConfirmedAppointmentsListPage.jsx
@@ -1,10 +1,12 @@
 import React from 'react';
+import { Link } from 'react-router';
 import { connect } from 'react-redux';
 import LoadingIndicator from '@department-of-veterans-affairs/formation-react/LoadingIndicator';
 import { focusElement } from 'platform/utilities/ui';
 import { fetchConfirmedAppointments } from '../actions/appointments';
 import ConfirmedAppointmentListItem from '../components/ConfirmedAppointmentListItem';
 import { FETCH_STATUS } from '../utils/constants';
+import Breadcrumbs from '../components/Breadcrumbs';
 
 export class ConfirmedAppointmentsListPage extends React.Component {
   componentDidMount() {
@@ -16,6 +18,10 @@ export class ConfirmedAppointmentsListPage extends React.Component {
 
     return (
       <div className="vads-l-grid-container vads-u-padding-x--2p5 large-screen:vads-u-padding-x--0 vads-u-padding-bottom--2p5">
+        <Breadcrumbs>
+          <Link to="appointments">Your appointments</Link>
+          <Link to="appointments/confirmed">Confirmed appointments</Link>
+        </Breadcrumbs>
         <div className="vads-l-row">
           <div className="vads-l-col--12 medium-screen:vads-l-col--8 vads-u-margin-bottom--4">
             <div>

--- a/src/applications/vaos/containers/PendingAppointmentPage.jsx
+++ b/src/applications/vaos/containers/PendingAppointmentPage.jsx
@@ -10,6 +10,7 @@ import { fetchPendingAppointments } from '../actions/appointments';
 import { FETCH_STATUS, TIME_TEXT, PURPOSE_TEXT } from '../utils/constants';
 import { selectPendingAppointment } from '../utils/selectors';
 import { formatTimeToCall } from '../utils/formatters';
+import Breadcrumbs from '../components/Breadcrumbs';
 
 function formatDate(date) {
   const parsedDate = moment(date, 'MM/DD/YYYY');
@@ -32,6 +33,11 @@ export class PendingAppointmentPage extends React.Component {
 
     return (
       <div className="vads-l-grid-container vads-u-padding-x--2p5 large-screen:vads-u-padding-x--0 vads-u-padding-bottom--2p5">
+        <Breadcrumbs>
+          <Link to="appointments">Your appointments</Link>
+          <Link to="appointments/pending">Pending appointments</Link>
+          <Link to="appointments/pending">Appointment details</Link>
+        </Breadcrumbs>
         <div className="vads-l-row">
           <div className="vads-l-col--12 medium-screen:vads-l-col--8 vads-u-margin-bottom--4">
             <Link to="appointments/pending">

--- a/src/applications/vaos/containers/PendingAppointmentsPage.jsx
+++ b/src/applications/vaos/containers/PendingAppointmentsPage.jsx
@@ -6,6 +6,7 @@ import { focusElement } from 'platform/utilities/ui';
 import { fetchPendingAppointments } from '../actions/appointments';
 import PendingAppointment from '../components/PendingAppointment';
 import { FETCH_STATUS } from '../utils/constants';
+import Breadcrumbs from '../components/Breadcrumbs';
 
 export class PendingAppointmentsPage extends React.Component {
   componentDidMount() {
@@ -17,6 +18,10 @@ export class PendingAppointmentsPage extends React.Component {
 
     return (
       <div className="vads-l-grid-container vads-u-padding-x--2p5 large-screen:vads-u-padding-x--0 vads-u-padding-bottom--2p5">
+        <Breadcrumbs>
+          <Link to="appointments">Your appointments</Link>
+          <Link to="appointments/pending">Pending appointments</Link>
+        </Breadcrumbs>
         <div className="vads-l-row">
           <div className="vads-l-col--12 medium-screen:vads-l-col--8 vads-u-margin-bottom--4">
             <Link to="appointments">

--- a/src/applications/vaos/tests/components/Breadcrumbs.unit.spec.jsx
+++ b/src/applications/vaos/tests/components/Breadcrumbs.unit.spec.jsx
@@ -5,7 +5,16 @@ import { shallow } from 'enzyme';
 import Breadcrumbs from '../../components/Breadcrumbs';
 
 describe('VAOS <Breadcrumbs>', () => {
-  it('should render first two items', () => {
+  it('should render with no child items', () => {
+    const tree = shallow(<Breadcrumbs />);
+
+    const items = tree.find('a');
+    expect(items.at(0).props().href).to.equal('/');
+    expect(items.at(1).props().href).to.equal('/health-care');
+
+    tree.unmount();
+  });
+  it('should render with child item', () => {
     const tree = shallow(
       <Breadcrumbs>
         <a href="#">Testing</a>

--- a/src/applications/vaos/tests/components/Breadcrumbs.unit.spec.jsx
+++ b/src/applications/vaos/tests/components/Breadcrumbs.unit.spec.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+
+import Breadcrumbs from '../../components/Breadcrumbs';
+
+describe('VAOS <Breadcrumbs>', () => {
+  it('should render first two items', () => {
+    const tree = shallow(
+      <Breadcrumbs>
+        <a href="#">Testing</a>
+      </Breadcrumbs>,
+    );
+
+    const items = tree.find('a');
+    expect(items.at(0).props().href).to.equal('/');
+    expect(items.at(1).props().href).to.equal('/health-care');
+    expect(items.at(2).props().href).to.equal('#');
+    expect(items.at(2).text()).to.equal('Testing');
+
+    tree.unmount();
+  });
+});


### PR DESCRIPTION
## Description
We lost our static breadcrumbs with some recent platform changes, this creates new ones that follow the pages in the React app, like with the claim status app. Copy will very likely change in the future.

## Testing done
Tested locally and wrote unit test

## Screenshots
![Screen Shot 2019-09-18 at 3 08 08 PM](https://user-images.githubusercontent.com/634932/65178161-25d77380-da26-11e9-91f3-5c3488288f3c.png)
![Screen Shot 2019-09-18 at 3 08 02 PM](https://user-images.githubusercontent.com/634932/65178162-25d77380-da26-11e9-9862-94b38591a19b.png)


## Acceptance criteria
- [x] Breadcrumbs show up on all our pages with the right path

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
