### PR TITLE
19706: GIBCT: School Locations Table not shown on iPad

### DIFF
--- a/src/applications/gi/sass/partials/_gi-profile-page.scss
+++ b/src/applications/gi/sass/partials/_gi-profile-page.scss
@@ -290,7 +290,7 @@
     }
   }
 
-  @include media-maxwidth($medium-screen) {
+  @include media-maxwidth($medium-screen - 1) {
     .locations-table {
       display: none;
     }


### PR DESCRIPTION
## Description
When viewing the profile page for a school with branches or extensions, a table is shown including all of the locations. A user should be able to see this information on any device. When using an iPad, this table is not shown.

Using an iPad or Chrome's responsive tool, access https://www.va.gov/gi-bill-comparison-tool/profile/11806124

The table indicating all locations for the University of Mississippi should be shown, but is not.

Originating Issue: https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/vets.gov-team/19706

## Testing done
Unit, E2E, and manual tests pass locally

## Screenshots
![image](https://user-images.githubusercontent.com/48804834/65179864-a8adfd80-da29-11e9-921d-2f851a5251c6.png)


## Acceptance criteria
- [x] School Locations Table is displayed on screens 768px wide.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
