### PR TITLE
[Facility Locator] Fix for Community Cares option missing on mobile

### DIFF
--- a/src/applications/facility-locator/containers/VAMap.jsx
+++ b/src/applications/facility-locator/containers/VAMap.jsx
@@ -461,7 +461,7 @@ class VAMap extends Component {
   renderMobileView = () => {
     const coords = this.props.currentQuery.position;
     const position = [coords.latitude, coords.longitude];
-    const { currentQuery, selectedResult } = this.props;
+    const { currentQuery, selectedResult, showCommunityCares } = this.props;
     const facilityLocatorMarkers = this.renderFacilityMarkers();
     const externalLink =
       currentQuery.facilityType === LocationType.CC_PROVIDER
@@ -474,6 +474,7 @@ class VAMap extends Component {
             currentQuery={currentQuery}
             onChange={this.props.updateSearchQuery}
             onSubmit={this.handleSearch}
+            showCommunityCares={showCommunityCares}
             isMobile
           />
           <Tabs onSelect={this.centerMap}>


### PR DESCRIPTION
## Description
The mobile view on Facility Locator isn't passing the Community Cares feature flag to the `Search for` dropdown. This causes that feature flag to default to `undefined`, with the result of that being to not render the Community Cares option.

## Testing done
On Prod, used the React tools to change the `showCommunityCares` property to true, and confirmed that the Community Cares option is rendered in the dropdown.

## Screenshots

### Current issue
![image](https://user-images.githubusercontent.com/1915775/65180500-00009d80-da2b-11e9-9e23-a5c676ab7f7e.png)

### Fixed
Used React tools to manually change the `showCommunityCares` property to true - 
![image](https://user-images.githubusercontent.com/1915775/65180703-80bf9980-da2b-11e9-975c-fc8a9aa88450.png)

## Acceptance criteria
- [x] Community Cares option is shown in the Facility Locator dropdown on mobile

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
    - https://dsva.slack.com/archives/C52CL1PKQ/p1568834042082700
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
