### PR TITLE
Update CT Landing Page Announcement Content

### DIFF
--- a/src/applications/gi/components/content/BenefitNotification.jsx
+++ b/src/applications/gi/components/content/BenefitNotification.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import environment from 'platform/utilities/environment';
 
-export const StemScholarshipNotification = () => {
+export const BenefitNotification = () => {
   // prod flag for story 19656
   if (environment.isProduction())
     return (
-      <div className="stem-notification">
+      <div className="benefit-notification">
         <span className="usa-label">New</span>
         <div className="feature">
           <h4>The Edith Nourse Rogers STEM Scholarship</h4>
@@ -30,7 +30,7 @@ export const StemScholarshipNotification = () => {
       </div>
     );
   return (
-    <div className="stem-notification">
+    <div className="benefit-notification">
       <span className="usa-label">New</span>
       <div className="feature">
         <h4>Attending classes at an extension campus?</h4>
@@ -61,4 +61,4 @@ export const StemScholarshipNotification = () => {
   );
 };
 
-export default StemScholarshipNotification;
+export default BenefitNotification;

--- a/src/applications/gi/components/content/BenefitNotification.jsx
+++ b/src/applications/gi/components/content/BenefitNotification.jsx
@@ -40,7 +40,7 @@ export const BenefitNotification = () => {
           the majority of your classes.
         </p>
         <p>
-          To estimate your MHA benefit, you can go a school or employer's
+          To estimate your MHA benefit, you can go to a school or employer's
           profile page in the GI Bill Comparison Tool and answer the question
           "Where will you take the majority of your classes?"
         </p>

--- a/src/applications/gi/components/content/StemScholarshipNotification.jsx
+++ b/src/applications/gi/components/content/StemScholarshipNotification.jsx
@@ -1,34 +1,64 @@
 import React from 'react';
+import environment from 'platform/utilities/environment';
 
-export const StemScholarshipNotification = () => (
-  <div className="stem-notification">
-    <span className="usa-label">New</span>
-    <div className="feature">
-      <h4>Attending classes at an extension campus?</h4>
-      <p>
-        Under the Forever GI Bill, the Monthly Housing Allowance (MHA) is
-        calculated based on the campus location where you physically attend the
-        majority of your classes.
-      </p>
-      <p>
-        To estimate your MHA benefit, you can go a school or employer's profile
-        page in the GI Bill Comparison Tool and answer the question "Where will
-        you take the majority of your classes?"
-      </p>
-      <p>
-        To learn more about the Location-Based Housing Allowance,{' '}
-        <a
-          href="https://va.gov/education/about-gi-bill-benefits/post-9-11/#location-based107"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          {' '}
-          visit the Post-9/11 GI Bill website
-        </a>
-        .
-      </p>
+export const StemScholarshipNotification = () => {
+  // prod flag for story 19656
+  if (environment.isProduction())
+    return (
+      <div className="stem-notification">
+        <span className="usa-label">New</span>
+        <div className="feature">
+          <h4>The Edith Nourse Rogers STEM Scholarship</h4>
+          <p>
+            On August 1, 2019, VA launched the Edith Nourse Rogers STEM
+            Scholarship for students enrolled in a high-demand STEM (Science,
+            Technology, Engineering, and Math) program.
+          </p>
+          <p>
+            To learn more about this scholarship,{' '}
+            <a
+              href="https://benefits.va.gov/gibill/fgib/stem.asp"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {' '}
+              visit the Edith Nourse Rogers STEM Scholarship website
+            </a>
+            .
+          </p>
+        </div>
+      </div>
+    );
+  return (
+    <div className="stem-notification">
+      <span className="usa-label">New</span>
+      <div className="feature">
+        <h4>Attending classes at an extension campus?</h4>
+        <p>
+          Under the Forever GI Bill, the Monthly Housing Allowance (MHA) is
+          calculated based on the campus location where you physically attend
+          the majority of your classes.
+        </p>
+        <p>
+          To estimate your MHA benefit, you can go a school or employer's
+          profile page in the GI Bill Comparison Tool and answer the question
+          "Where will you take the majority of your classes?"
+        </p>
+        <p>
+          To learn more about the Location-Based Housing Allowance,{' '}
+          <a
+            href="https://va.gov/education/about-gi-bill-benefits/post-9-11/#location-based107"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            {' '}
+            visit the Post-9/11 GI Bill website
+          </a>
+          .
+        </p>
+      </div>
     </div>
-  </div>
-);
+  );
+};
 
 export default StemScholarshipNotification;

--- a/src/applications/gi/components/content/StemScholarshipNotification.jsx
+++ b/src/applications/gi/components/content/StemScholarshipNotification.jsx
@@ -4,21 +4,26 @@ export const StemScholarshipNotification = () => (
   <div className="stem-notification">
     <span className="usa-label">New</span>
     <div className="feature">
-      <h4>The Edith Nourse Rogers STEM Scholarship</h4>
+      <h4>Attending classes at an extension campus?</h4>
       <p>
-        On August 1, 2019, VA launched the Edith Nourse Rogers STEM Scholarship
-        for students enrolled in a high-demand STEM (Science, Technology,
-        Engineering, and Math) program.
+        Under the Forever GI Bill, the Monthly Housing Allowance (MHA) is
+        calculated based on the campus location where you physically attend the
+        majority of your classes.
       </p>
       <p>
-        To learn more about this scholarship,{' '}
+        To estimate your MHA benefit, you can go a school or employer's profile
+        page in the GI Bill Comparison Tool and answer the question "Where will
+        you take the majority of your classes?"
+      </p>
+      <p>
+        To learn more about the Location-Based Housing Allowance,{' '}
         <a
-          href="https://benefits.va.gov/gibill/fgib/stem.asp"
+          href="https://va.gov/education/about-gi-bill-benefits/post-9-11/#location-based107"
           target="_blank"
           rel="noopener noreferrer"
         >
           {' '}
-          visit the Edith Nourse Rogers STEM Scholarship website
+          visit the Post-9/11 GI Bill website
         </a>
         .
       </p>

--- a/src/applications/gi/containers/LandingPage.jsx
+++ b/src/applications/gi/containers/LandingPage.jsx
@@ -16,7 +16,7 @@ import {
 import VideoSidebar from '../components/content/VideoSidebar';
 import KeywordSearch from '../components/search/KeywordSearch';
 import EligibilityForm from '../components/search/EligibilityForm';
-import StemScholarshipNotification from '../components/content/StemScholarshipNotification';
+import BenefitNotification from '../components/content/BenefitNotification';
 import LandingPageTypeOfInstitutionFilter from '../components/search/LandingPageTypeOfInstitutionFilter';
 import OnlineClassesFilter from '../components/search/OnlineClassesFilter';
 import { calculateFilters } from '../selectors/search';
@@ -167,7 +167,7 @@ export class LandingPage extends React.Component {
 
           <div className="small-12 usa-width-one-third medium-4 columns">
             <VideoSidebar />
-            <StemScholarshipNotification />
+            <BenefitNotification />
           </div>
         </div>
       </span>

--- a/src/applications/gi/sass/gi.scss
+++ b/src/applications/gi/sass/gi.scss
@@ -80,7 +80,7 @@
    }
   }
 
-  .stem-notification {
+  .benefit-notification {
     padding-top: 1em;
   }
 


### PR DESCRIPTION
## Description
https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/vets.gov-team/19656

## Testing done
Dev tested.

## Screenshots
<img width="1116" alt="Screen Shot 2019-09-19 at 8 20 33 AM" src="https://user-images.githubusercontent.com/48804654/65243461-6383dd00-dab6-11e9-9808-ca4a5a5e65ac.png">


## Acceptance criteria
- [ ] The content of the current landing page notification is replaced with the content in Supporting Artifact # 2. (See link in description)

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
