### PR TITLE
Rename VAOS list and detail pages

### DIFF
--- a/src/applications/vaos/components/PendingAppointmentListItem.jsx
+++ b/src/applications/vaos/components/PendingAppointmentListItem.jsx
@@ -13,7 +13,7 @@ function formatDate(date) {
   return parsedDate.format('MMMM D, YYYY');
 }
 
-export default function PendingAppointment({ appointment }) {
+export default function PendingAppointmentListItem({ appointment }) {
   const isCommunityCare = !!appointment.ccAppointmentRequest;
 
   return (

--- a/src/applications/vaos/containers/ConfirmedAppointmentDetailPage.jsx
+++ b/src/applications/vaos/containers/ConfirmedAppointmentDetailPage.jsx
@@ -13,7 +13,7 @@ import {
   getAppointmentDateTime,
 } from '../utils/appointment';
 
-export class ConfirmedAppointmentPage extends React.Component {
+export class ConfirmedAppointmentDetailPage extends React.Component {
   componentDidMount() {
     this.props.fetchConfirmedAppointments();
     focusElement('h1');
@@ -61,7 +61,7 @@ export class ConfirmedAppointmentPage extends React.Component {
   }
 }
 
-ConfirmedAppointmentPage.propTypes = {
+ConfirmedAppointmentDetailPage.propTypes = {
   appointment: PropTypes.object,
   status: PropTypes.string.isRequired,
 };
@@ -80,4 +80,4 @@ const mapDispatchToProps = {
 export default connect(
   mapStateToProps,
   mapDispatchToProps,
-)(ConfirmedAppointmentPage);
+)(ConfirmedAppointmentDetailPage);

--- a/src/applications/vaos/containers/ConfirmedAppointmentListPage.jsx
+++ b/src/applications/vaos/containers/ConfirmedAppointmentListPage.jsx
@@ -7,7 +7,7 @@ import ConfirmedAppointmentListItem from '../components/ConfirmedAppointmentList
 import { FETCH_STATUS } from '../utils/constants';
 import { getAppointmentId } from '../utils/appointment';
 
-export class ConfirmedAppointmentsListPage extends React.Component {
+export class ConfirmedAppointmentListPage extends React.Component {
   componentDidMount() {
     this.props.fetchConfirmedAppointments();
     focusElement('h1');
@@ -58,4 +58,4 @@ const mapDispatchToProps = {
 export default connect(
   mapStateToProps,
   mapDispatchToProps,
-)(ConfirmedAppointmentsListPage);
+)(ConfirmedAppointmentListPage);

--- a/src/applications/vaos/containers/PendingAppointmentDetailPage.jsx
+++ b/src/applications/vaos/containers/PendingAppointmentDetailPage.jsx
@@ -21,7 +21,7 @@ function formatDate(date) {
   return parsedDate.format('MMMM D, YYYY');
 }
 
-export class PendingAppointmentPage extends React.Component {
+export class PendingAppointmentDetailPage extends React.Component {
   componentDidMount() {
     this.props.fetchPendingAppointments();
     focusElement('h1');
@@ -121,7 +121,7 @@ export class PendingAppointmentPage extends React.Component {
   }
 }
 
-PendingAppointmentPage.propTypes = {
+PendingAppointmentDetailPage.propTypes = {
   appointment: PropTypes.object,
   status: PropTypes.string.isRequired,
 };
@@ -140,4 +140,4 @@ const mapDispatchToProps = {
 export default connect(
   mapStateToProps,
   mapDispatchToProps,
-)(PendingAppointmentPage);
+)(PendingAppointmentDetailPage);

--- a/src/applications/vaos/containers/PendingAppointmentListPage.jsx
+++ b/src/applications/vaos/containers/PendingAppointmentListPage.jsx
@@ -4,10 +4,10 @@ import { connect } from 'react-redux';
 import LoadingIndicator from '@department-of-veterans-affairs/formation-react/LoadingIndicator';
 import { focusElement } from 'platform/utilities/ui';
 import { fetchPendingAppointments } from '../actions/appointments';
-import PendingAppointment from '../components/PendingAppointment';
+import PendingAppointmentListItem from '../components/PendingAppointmentListItem';
 import { FETCH_STATUS } from '../utils/constants';
 
-export class PendingAppointmentsPage extends React.Component {
+export class PendingAppointmentListPage extends React.Component {
   componentDidMount() {
     this.props.fetchPendingAppointments();
     focusElement('h1');
@@ -31,7 +31,7 @@ export class PendingAppointmentsPage extends React.Component {
             {status === FETCH_STATUS.succeeded && (
               <ul className="usa-unstyled-list">
                 {appointments.map(appt => (
-                  <PendingAppointment
+                  <PendingAppointmentListItem
                     key={appt.appointmentRequestId}
                     appointment={appt}
                   />
@@ -59,4 +59,4 @@ const mapDispatchToProps = {
 export default connect(
   mapStateToProps,
   mapDispatchToProps,
-)(PendingAppointmentsPage);
+)(PendingAppointmentListPage);

--- a/src/applications/vaos/routes.jsx
+++ b/src/applications/vaos/routes.jsx
@@ -6,10 +6,10 @@ import AppointmentListsPage from './containers/AppointmentListsPage';
 // import TypeOfAppointmentPage from './containers/TypeOfAppointmentPage';
 import TypeOfCarePage from './containers/TypeOfCarePage';
 import CommunityCareProviderPage from './containers/CommunityCareProviderPage';
-import PendingAppointmentsPage from './containers/PendingAppointmentsPage';
-import PendingAppointmentPage from './containers/PendingAppointmentPage';
-import ConfirmedAppointmentPage from './containers/ConfirmedAppointmentPage';
-import ConfirmedAppointmentsListPage from './containers/ConfirmedAppointmentsListPage';
+import PendingAppointmentListPage from './containers/PendingAppointmentListPage';
+import PendingAppointmentDetailPage from './containers/PendingAppointmentDetailPage';
+import ConfirmedAppointmentDetailPage from './containers/ConfirmedAppointmentDetailPage';
+import ConfirmedAppointmentListPage from './containers/ConfirmedAppointmentListPage';
 import ContactInfoPage from './containers/ContactInfoPage';
 
 const routes = (
@@ -24,15 +24,18 @@ const routes = (
       />
     </Route>
     <Route path="appointments" component={AppointmentListsPage} />
-    <Route path="appointments/pending" component={PendingAppointmentsPage} />
-    <Route path="appointments/pending/:id" component={PendingAppointmentPage} />
+    <Route path="appointments/pending" component={PendingAppointmentListPage} />
+    <Route
+      path="appointments/pending/:id"
+      component={PendingAppointmentDetailPage}
+    />
     <Route
       path="appointments/confirmed/:id"
-      component={ConfirmedAppointmentPage}
+      component={ConfirmedAppointmentDetailPage}
     />
     <Route
       path="appointments/confirmed"
-      component={ConfirmedAppointmentsListPage}
+      component={ConfirmedAppointmentListPage}
     />
   </Route>
 );

--- a/src/applications/vaos/tests/components/PendingAppointmentListItem.unit.spec.jsx
+++ b/src/applications/vaos/tests/components/PendingAppointmentListItem.unit.spec.jsx
@@ -2,9 +2,9 @@ import React from 'react';
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
 
-import PendingAppointment from '../../components/PendingAppointment';
+import PendingAppointmentListItem from '../../components/PendingAppointmentListItem';
 
-describe('VAOS <PendingAppointment>', () => {
+describe('VAOS <PendingAppointmentListItem>', () => {
   it('should render pending VA appointment item', () => {
     const appointment = {
       appointmentType: 'Testing',
@@ -18,7 +18,9 @@ describe('VAOS <PendingAppointment>', () => {
       },
       appointmentRequestId: 'guid',
     };
-    const tree = shallow(<PendingAppointment appointment={appointment} />);
+    const tree = shallow(
+      <PendingAppointmentListItem appointment={appointment} />,
+    );
 
     expect(tree.find('h2').text()).to.equal(appointment.appointmentType);
     expect(
@@ -58,7 +60,9 @@ describe('VAOS <PendingAppointment>', () => {
         preferredState: 'NH',
       },
     };
-    const tree = shallow(<PendingAppointment appointment={appointment} />);
+    const tree = shallow(
+      <PendingAppointmentListItem appointment={appointment} />,
+    );
 
     expect(tree.find('h2').text()).to.equal(appointment.appointmentType);
     expect(

--- a/src/applications/vaos/tests/containers/ConfirmedAppointmentDetailPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/containers/ConfirmedAppointmentDetailPage.unit.spec.jsx
@@ -3,9 +3,9 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import { shallow } from 'enzyme';
 
-import { ConfirmedAppointmentPage } from '../../containers/ConfirmedAppointmentPage';
+import { ConfirmedAppointmentDetailPage } from '../../containers/ConfirmedAppointmentDetailPage';
 
-describe('VAOS <ConfirmedAppointmentPage>', () => {
+describe('VAOS <ConfirmedAppointmentDetailPage>', () => {
   describe('VA appointment', () => {
     const appointment = {
       startDate: '2019-08-16T18:57:00',
@@ -23,7 +23,7 @@ describe('VAOS <ConfirmedAppointmentPage>', () => {
     it('should render a loading indicator', () => {
       const fetchConfirmedAppointments = sinon.spy();
       const tree = shallow(
-        <ConfirmedAppointmentPage
+        <ConfirmedAppointmentDetailPage
           fetchConfirmedAppointments={fetchConfirmedAppointments}
           status="loading"
         />,
@@ -37,7 +37,7 @@ describe('VAOS <ConfirmedAppointmentPage>', () => {
     it('should render confirmed appointment', () => {
       const fetchConfirmedAppointments = sinon.spy();
       const tree = shallow(
-        <ConfirmedAppointmentPage
+        <ConfirmedAppointmentDetailPage
           fetchConfirmedAppointments={fetchConfirmedAppointments}
           appointment={appointment}
           status="succeeded"

--- a/src/applications/vaos/tests/containers/ConfirmedAppointmentListPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/containers/ConfirmedAppointmentListPage.unit.spec.jsx
@@ -3,13 +3,13 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import { shallow } from 'enzyme';
 
-import { ConfirmedAppointmentsListPage } from '../../containers/ConfirmedAppointmentsListPage';
+import { ConfirmedAppointmentListPage } from '../../containers/ConfirmedAppointmentListPage';
 
-describe('VAOS <ConfirmedAppointmentsListPage>', () => {
+describe('VAOS <ConfirmedAppointmentListPage>', () => {
   it('should render a loading indicator', () => {
     const fetchConfirmedAppointments = sinon.spy();
     const form = shallow(
-      <ConfirmedAppointmentsListPage
+      <ConfirmedAppointmentListPage
         fetchConfirmedAppointments={fetchConfirmedAppointments}
         status="loading"
       />,
@@ -25,7 +25,7 @@ describe('VAOS <ConfirmedAppointmentsListPage>', () => {
     const appointments = [{}, {}];
 
     const form = shallow(
-      <ConfirmedAppointmentsListPage
+      <ConfirmedAppointmentListPage
         fetchConfirmedAppointments={fetchConfirmedAppointments}
         status="succeeded"
         appointments={appointments}

--- a/src/applications/vaos/tests/containers/PendingAppointmentDetailPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/containers/PendingAppointmentDetailPage.unit.spec.jsx
@@ -3,13 +3,13 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import { shallow } from 'enzyme';
 
-import { PendingAppointmentPage } from '../../containers/PendingAppointmentPage';
+import { PendingAppointmentDetailPage } from '../../containers/PendingAppointmentDetailPage';
 
-describe('VAOS <PendingAppointmentPage>', () => {
+describe('VAOS <PendingAppointmentDetailPage>', () => {
   it('should render a loading indicator', () => {
     const fetchPendingAppointments = sinon.spy();
     const tree = shallow(
-      <PendingAppointmentPage
+      <PendingAppointmentDetailPage
         fetchPendingAppointments={fetchPendingAppointments}
         status="loading"
       />,
@@ -30,7 +30,7 @@ describe('VAOS <PendingAppointmentPage>', () => {
       phoneNumber: '555 555-5555',
     };
     const tree = shallow(
-      <PendingAppointmentPage
+      <PendingAppointmentDetailPage
         fetchPendingAppointments={fetchPendingAppointments}
         appointment={appointment}
         status="succeeded"
@@ -54,7 +54,7 @@ describe('VAOS <PendingAppointmentPage>', () => {
       phoneNumber: '555 555-5555',
     };
     const tree = shallow(
-      <PendingAppointmentPage
+      <PendingAppointmentDetailPage
         fetchPendingAppointments={fetchPendingAppointments}
         appointment={appointment}
         status="succeeded"
@@ -75,7 +75,7 @@ describe('VAOS <PendingAppointmentPage>', () => {
       phoneNumber: '555 555-5555',
     };
     const tree = shallow(
-      <PendingAppointmentPage
+      <PendingAppointmentDetailPage
         fetchPendingAppointments={fetchPendingAppointments}
         appointment={appointment}
         status="succeeded"

--- a/src/applications/vaos/tests/containers/PendingAppointmentListPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/containers/PendingAppointmentListPage.unit.spec.jsx
@@ -3,13 +3,13 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import { shallow } from 'enzyme';
 
-import { PendingAppointmentsPage } from '../../containers/PendingAppointmentsPage';
+import { PendingAppointmentListPage } from '../../containers/PendingAppointmentListPage';
 
-describe('VAOS <PendingAppointmentsPage>', () => {
+describe('VAOS <PendingAppointmentListPage>', () => {
   it('should render a loading indicator', () => {
     const fetchPendingAppointments = sinon.spy();
     const form = shallow(
-      <PendingAppointmentsPage
+      <PendingAppointmentListPage
         fetchPendingAppointments={fetchPendingAppointments}
         status="loading"
       />,
@@ -24,7 +24,7 @@ describe('VAOS <PendingAppointmentsPage>', () => {
     const fetchPendingAppointments = sinon.spy();
     const appointments = [{}, {}];
     const form = shallow(
-      <PendingAppointmentsPage
+      <PendingAppointmentListPage
         fetchPendingAppointments={fetchPendingAppointments}
         status="succeeded"
         appointments={appointments}
@@ -33,7 +33,7 @@ describe('VAOS <PendingAppointmentsPage>', () => {
 
     expect(fetchPendingAppointments.called).to.be.true;
     expect(form.find('LoadingIndicator').exists()).to.be.false;
-    expect(form.find('PendingAppointment').length).to.equal(2);
+    expect(form.find('PendingAppointmentListItem').length).to.equal(2);
     form.unmount();
   });
 });


### PR DESCRIPTION
## Description
We named some components in a confusing way, this updates them to follow the convention we decided upon, which is to have `ListPage` and `DetailPage` suffixes.

## Testing done
Local and unit tests

## Acceptance criteria
- [x] Pages renamed to our agreed upon format

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
