### PR TITLE
Insert ul tag with sublist class after "Specialty care" item

### DIFF
--- a/src/applications/facility-locator/components/AppointmentInfo.jsx
+++ b/src/applications/facility-locator/components/AppointmentInfo.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
 import { get, some, pull, startCase } from 'lodash';
 import classNames from 'classnames';
 import moment from 'moment';
@@ -112,26 +112,30 @@ export default class AppointmentInfo extends Component {
           ),
         );
 
-      return [
-        <li key="specialty-care">Specialty care:</li>,
-        firstThree.map(k =>
-          renderStat(
-            startCase(k.replace(/([A-Z])/g, ' $1')),
-            healthAccessAttrs[k][existing ? 'established' : 'new'],
-            true,
-          ),
-        ),
-        lastToEnd.length > 0 && renderMoreTimes(),
-        <li key="show-more" className="show-more">
-          <button
-            onClick={onClick}
-            className={seeMoreClasses}
-            aria-expanded={this.state[showHideKey] ? 'true' : 'false'}
-          >
-            See {this.state[showHideKey] ? 'less' : 'more'}
-          </button>
-        </li>,
-      ];
+      return (
+        <Fragment>
+          <li key="specialty-care">Specialty care:</li>
+          <ul className="sublist">
+            {firstThree.map(k =>
+              renderStat(
+                startCase(k.replace(/([A-Z])/g, ' $1')),
+                healthAccessAttrs[k][existing ? 'established' : 'new'],
+                true,
+              ),
+            )}
+            {lastToEnd.length > 0 && renderMoreTimes()}
+            <li key="show-more" className="show-more">
+              <button
+                onClick={onClick}
+                className={seeMoreClasses}
+                aria-expanded={this.state[showHideKey] ? 'true' : 'false'}
+              >
+                See {this.state[showHideKey] ? 'less' : 'more'}
+              </button>
+            </li>
+          </ul>
+        </Fragment>
+      );
     };
 
     return (

--- a/src/applications/facility-locator/sass/facility-locator.scss
+++ b/src/applications/facility-locator/sass/facility-locator.scss
@@ -407,6 +407,10 @@ $color-info-bubble-text: #818a8d;
   .facility-detail {
     padding: 0 1.5rem;
 
+    ul.sublist {
+      padding-left: 0;
+    }
+
     li.sublist {
       margin-left: 1.5em;
     }


### PR DESCRIPTION
## Description
The facility detail views sometimes have second-level lists that use CSS to indent them instead of nesting an `<ul>` inside the `<li>`. These lists were flagged as SC 1.3.1 issues. Screenshots attached below. This is the PR related to [this issue](https://github.com/department-of-veterans-affairs/va.gov-team/issues/484).

## Testing done
I only tested locally as I do not know how to test on staging, yet.

## Screenshots
### Before
<img width="250" alt="before" src="https://user-images.githubusercontent.com/12773166/65276083-05c2b580-daf5-11e9-8452-079f8918017a.png">
<img width="689" alt="before" src="https://user-images.githubusercontent.com/12773166/65276278-63570200-daf5-11e9-88eb-51f45320555f.png">


### After
<img width="270" alt="Screen Shot 2019-09-19 at 3 47 39 PM" src="https://user-images.githubusercontent.com/12773166/65275999-dd3abb80-daf4-11e9-87d7-94f19298ebe4.png">
<img width="708" alt="after" src="https://user-images.githubusercontent.com/12773166/65276297-694ce300-daf5-11e9-831e-0178e845d21d.png">


## Acceptance criteria
- [ ] As an assistive device user, I want to hear the lists announced as proper nested lists, instead of one large list.
- [x] As a user with a level of visual acuity, I do not want to see any visual changes in the application.

## Definition of done
- [ ] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
