### PR TITLE
pass credentials in fetch request

### DIFF
--- a/src/platform/utilities/feature-toggles/flipper-client.js
+++ b/src/platform/utilities/feature-toggles/flipper-client.js
@@ -18,7 +18,9 @@ function FlipperClient({
   const _subscriberCallbacks = [];
 
   const _fetchToggleValues = async () => {
-    const response = await fetch(`${host}${toggleValuesPath}`);
+    const response = await fetch(`${host}${toggleValuesPath}`, {
+      credentials: 'include',
+    });
     if (!response.ok) {
       const errorMessage = `Failed to fetch toggle values with status ${
         response.status


### PR DESCRIPTION
## Description
- pass credentials when fetching toggle values 

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
