### PR TITLE
[Development] [SCREENREADER] Add descriptive error messages to all forms

### DIFF
--- a/src/applications/burials/config/form.js
+++ b/src/applications/burials/config/form.js
@@ -37,6 +37,7 @@ import { VA_FORM_IDS } from 'platform/forms/constants';
 import * as address from 'platform/forms/definitions/address';
 import FullNameField from 'platform/forms-system/src/js/fields/FullNameField';
 import phoneUI from 'platform/forms-system/src/js/definitions/phone';
+import emailUI from 'platform/forms-system/src/js/definitions/email';
 import ssnUI from 'platform/forms-system/src/js/definitions/ssn';
 import currentOrPastDateUI from 'platform/forms-system/src/js/definitions/currentOrPastDate';
 import toursOfDutyUI from '../definitions/toursOfDuty';
@@ -566,9 +567,7 @@ const formConfig = {
               validateCentralMailPostalCode,
               address.uiSchema('Address'),
             ),
-            claimantEmail: {
-              'ui:title': 'Email address',
-            },
+            claimantEmail: emailUI(),
             claimantPhone: phoneUI('Phone number'),
           },
           schema: {

--- a/src/applications/disability-benefits/526EZ/config/form.js
+++ b/src/applications/disability-benefits/526EZ/config/form.js
@@ -7,6 +7,7 @@ import fullSchema526EZ from 'vets-json-schema/dist/21-526EZ-schema.json';
 
 import submitFormFor from '../../all-claims/config/submitForm';
 
+import phoneUI from 'platform/forms-system/src/js/definitions/phone';
 import fileUploadUI from 'platform/forms-system/src/js/definitions/file';
 import dateRangeUI from 'platform/forms-system/src/js/definitions/dateRange';
 import { uiSchema as autoSuggestUiSchema } from 'platform/forms-system/src/js/definitions/autosuggest';
@@ -87,8 +88,6 @@ import { requireOneSelected, isInPast } from '../validations';
 import { hasMonthYear } from '../../all-claims/validations';
 
 import { validateBooleanGroup } from 'platform/forms-system/src/js/validation';
-import PhoneNumberWidget from 'platform/forms-system/src/js/widgets/PhoneNumberWidget';
-import PhoneNumberReviewWidget from 'platform/forms-system/src/js/review/PhoneNumberWidget';
 
 const {
   treatments,
@@ -263,21 +262,11 @@ const formConfig = {
                       _.get('veteran.homelessness.isHomeless', formData, '') ===
                       true,
                   },
-                  primaryPhone: {
-                    'ui:title': 'Phone number',
-                    'ui:widget': PhoneNumberWidget,
-                    'ui:reviewWidget': PhoneNumberReviewWidget,
-                    'ui:options': {
-                      widgetClassNames: 'va-input-medium-large',
-                    },
-                    'ui:errorMessages': {
-                      pattern:
-                        'Phone numbers must be 10 digits (dashes allowed)',
-                    },
+                  primaryPhone: merge(phoneUI('Phone number'), {
                     'ui:required': formData =>
                       _.get('veteran.homelessness.isHomeless', formData, '') ===
                       true,
-                  },
+                  }),
                 },
               },
             },

--- a/src/applications/disability-benefits/526EZ/pages/primaryAddress.js
+++ b/src/applications/disability-benefits/526EZ/pages/primaryAddress.js
@@ -4,8 +4,8 @@ import fullSchema526EZ from 'vets-json-schema/dist/21-526EZ-schema.json';
 // import fullSchema526EZ from '/path/vets-json-schema/dist/21-526EZ-schema.json';
 
 import dateUI from 'platform/forms-system/src/js/definitions/date';
-import PhoneNumberWidget from 'platform/forms-system/src/js/widgets/PhoneNumberWidget';
-import PhoneNumberReviewWidget from 'platform/forms-system/src/js/review/PhoneNumberWidget';
+import phoneUI from 'platform/forms-system/src/js/definitions/phone';
+import emailUI from 'platform/forms-system/src/js/definitions/email';
 
 import ReviewCardField from '../../all-claims/components/ReviewCardField';
 import { ForwardingAddressViewField } from '../helpers';
@@ -39,23 +39,8 @@ export const uiSchema = {
       'ui:options': {
         viewComponent: phoneEmailViewField,
       },
-      primaryPhone: {
-        'ui:title': 'Phone number',
-        'ui:widget': PhoneNumberWidget,
-        'ui:reviewWidget': PhoneNumberReviewWidget,
-        'ui:errorMessages': {
-          pattern: 'Phone numbers must be 10 digits (dashes allowed)',
-        },
-        'ui:options': {
-          widgetClassNames: 'va-input-medium-large',
-        },
-      },
-      emailAddress: {
-        'ui:title': 'Email address',
-        'ui:errorMessages': {
-          pattern: 'The email you enter should be in this format x@x.xx',
-        },
-      },
+      primaryPhone: phoneUI('Phone number'),
+      emailAddress: emailUI(),
     },
     mailingAddress: addressUISchema(
       'veteran.mailingAddress',
@@ -85,6 +70,9 @@ export const uiSchema = {
         },
         effectiveDate: _.merge({}, dateUI('Effective date'), {
           'ui:required': hasForwardingAddress,
+          'ui:errorMessages': {
+            required: 'Please enter an effective date',
+          },
         }),
         country: {
           'ui:required': hasForwardingAddress,

--- a/src/applications/disability-benefits/686/config/form.js
+++ b/src/applications/disability-benefits/686/config/form.js
@@ -313,7 +313,7 @@ function createAddressUISchemaForKey(key, isRequiredCallback = () => true) {
         isMilitaryAddress(get(`${insertRealIndexInKey(key, index)}`, formData)),
       'ui:errorMessages': {
         pattern: 'Please enter a valid post office',
-        required: 'Please enter a post officeAs ',
+        required: 'Please enter a post office ',
       },
       'ui:options': {
         hideIf: (formData, index) =>

--- a/src/applications/disability-benefits/686/config/form.js
+++ b/src/applications/disability-benefits/686/config/form.js
@@ -279,7 +279,7 @@ function createAddressUISchemaForKey(key, isRequiredCallback = () => true) {
       'ui:title': 'Street',
       'ui:required': isRequiredCallback,
       'ui:errorMessages': {
-        required: 'Please fill in a valid street address',
+        required: 'Please enter a street address',
       },
     },
     street2: {
@@ -291,11 +291,17 @@ function createAddressUISchemaForKey(key, isRequiredCallback = () => true) {
     city: {
       'ui:title': 'City',
       'ui:required': isRequiredCallback,
+      'ui:errorMessages': {
+        required: 'Please enter a city',
+      },
     },
     state: {
       'ui:title': 'State',
       'ui:required': (formData, index) =>
         isDomesticAddress(get(`${insertRealIndexInKey(key, index)}`, formData)),
+      'ui:errorMessages': {
+        required: 'Please enter a state',
+      },
       'ui:options': {
         hideIf: (formData, index) =>
           !isUSAAddress(get(`${insertRealIndexInKey(key, index)}`, formData)),
@@ -305,6 +311,10 @@ function createAddressUISchemaForKey(key, isRequiredCallback = () => true) {
       'ui:title': 'Post Office',
       'ui:required': (formData, index) =>
         isMilitaryAddress(get(`${insertRealIndexInKey(key, index)}`, formData)),
+      'ui:errorMessages': {
+        pattern: 'Please enter a valid post office',
+        required: 'Please enter a post officeAs ',
+      },
       'ui:options': {
         hideIf: (formData, index) =>
           isNotMilitaryAddress(
@@ -316,6 +326,10 @@ function createAddressUISchemaForKey(key, isRequiredCallback = () => true) {
       'ui:title': 'Postal Type',
       'ui:required': (formData, index) =>
         isMilitaryAddress(get(`${insertRealIndexInKey(key, index)}`, formData)),
+      'ui:errorMessages': {
+        pattern: 'Please enter a valid postal type',
+        required: 'Please enter a postal type',
+      },
       'ui:options': {
         hideIf: (formData, index) =>
           isNotMilitaryAddress(
@@ -328,8 +342,8 @@ function createAddressUISchemaForKey(key, isRequiredCallback = () => true) {
       'ui:required': (formData, index) =>
         isUSAAddress(get(`${insertRealIndexInKey(key, index)}`, formData)),
       'ui:errorMessages': {
-        pattern: 'Please fill in a valid postal code',
-        required: 'Please fill in a valid postal code',
+        pattern: 'Please enter a valid postal code',
+        required: 'Please enter a postal code',
       },
     },
   };

--- a/src/applications/disability-benefits/996/constants.js
+++ b/src/applications/disability-benefits/996/constants.js
@@ -14,12 +14,6 @@ export const errorMessages = {
     'Please sign in again to continue your request for Higher-Level Review',
   optOutCheckbox:
     'You need to opt out of the old appeals process to continue with your request',
-  phone: 'Please enter a phone number',
-  email: 'Please enter an email address',
-  address1: 'Please enter a street address',
-  city: 'Please enter a city',
-  state: 'Please enter a state',
-  zipCode: 'Please enter a valid postal code',
   forwardStartDate: 'Please select a date',
   startDateInPast: 'Start date must be in the future',
   endDateInPast: 'End date must be in the future',
@@ -34,9 +28,8 @@ export const errorMessages = {
 };
 
 export const patternMessages = {
-  phone: 'Please enter your 10-digit phone number (with or without dashes)',
-  email: 'Please enter your email address using this format: X@X.com',
-  representativePhone: 'Phone numbers must be 10 digits (dashes allowed)',
+  representativePhone:
+    'Please enter a 10-digit phone number (with or without dashes)',
 };
 
 export const NULL_CONDITION_STRING = 'Unknown Condition';

--- a/src/applications/disability-benefits/996/pages/contactInformation.js
+++ b/src/applications/disability-benefits/996/pages/contactInformation.js
@@ -1,11 +1,9 @@
-import merge from 'lodash/merge';
-
 // import fullSchema from 'vets-json-schema/dist/20-0996-schema.json';
 import fullSchema from '../20-0996-schema.json';
 
 // import dateRangeUI from 'platform/forms-system/src/js/definitions/dateRange';
-import PhoneNumberWidget from 'platform/forms-system/src/js/widgets/PhoneNumberWidget';
-import PhoneNumberReviewWidget from 'platform/forms-system/src/js/review/PhoneNumberWidget';
+import phoneUI from 'platform/forms-system/src/js/definitions/phone';
+import emailUI from 'platform/forms-system/src/js/definitions/email';
 
 import ReviewCardField from '../../all-claims/components/ReviewCardField';
 import { addressUISchema } from '../../all-claims/utils';
@@ -15,9 +13,9 @@ import {
   phoneEmailViewField,
 } from '../../all-claims/content/contactInformation';
 
-import { errorMessages, patternMessages } from '../constants';
-
 /*
+import { errorMessages } from '../constants';
+
 import { hasForwardingAddress, forwardingCountryIsUSA } from '../helpers';
 import {
   ForwardingAddressViewField,
@@ -49,59 +47,10 @@ const contactInfo = {
       'ui:options': {
         viewComponent: phoneEmailViewField,
       },
-      phone: {
-        'ui:title': 'Phone number',
-        'ui:widget': PhoneNumberWidget,
-        'ui:reviewWidget': PhoneNumberReviewWidget,
-        'ui:errorMessages': {
-          pattern: patternMessages.phone,
-          required: errorMessages.phone,
-        },
-        'ui:options': {
-          widgetClassNames: 'va-input-medium-large',
-          inputType: 'tel',
-        },
-      },
-      emailAddress: {
-        'ui:title': 'Email address',
-        'ui:errorMessages': {
-          pattern: patternMessages.email,
-          required: errorMessages.email,
-        },
-        'ui:options': {
-          inputType: 'email',
-        },
-      },
+      phone: phoneUI('Phone number'),
+      emailAddress: emailUI(),
     },
-    mailingAddress: merge(
-      addressUISchema('mailingAddress', 'Mailing address', true),
-      {
-        addressLine1: {
-          'ui:errorMessages': {
-            pattern: errorMessages.address1,
-            required: errorMessages.address1,
-          },
-        },
-        city: {
-          'ui:errorMessages': {
-            pattern: errorMessages.city,
-            required: errorMessages.city,
-          },
-        },
-        state: {
-          'ui:errorMessages': {
-            pattern: errorMessages.state,
-            required: errorMessages.state,
-          },
-        },
-        zipCode: {
-          'ui:errorMessages': {
-            pattern: errorMessages.zipCode,
-            required: errorMessages.zipCode,
-          },
-        },
-      },
-    ),
+    mailingAddress: addressUISchema('mailingAddress', 'Mailing address', true),
     /*
     'view:hasForwardingAddress': {
       'ui:title': forwardingAddressCheckboxLabel,
@@ -121,7 +70,6 @@ const contactInfo = {
           'country',
           'addressLine1',
           'addressLine2',
-          'addressLine3',
           'city',
           'state',
           'zipCode',
@@ -153,33 +101,17 @@ const contactInfo = {
         },
         addressLine1: {
           'ui:required': hasForwardingAddress,
-          'ui:errorMessages': {
-            pattern: errorMessages.address1,
-            required: errorMessages.address1,
-          },
         },
         city: {
           'ui:required': hasForwardingAddress,
-          'ui:errorMessages': {
-            pattern: errorMessages.city,
-            required: errorMessages.city,
-          },
         },
         state: {
           'ui:required': formData =>
             hasForwardingAddress(formData) && forwardingCountryIsUSA(formData),
-          'ui:errorMessages': {
-            pattern: errorMessages.state,
-            required: errorMessages.state,
-          },
         },
         zipCode: {
           'ui:required': formData =>
             hasForwardingAddress(formData) && forwardingCountryIsUSA(formData),
-          'ui:errorMessages': {
-            pattern: errorMessages.zipCode,
-            required: errorMessages.zipCode,
-          },
         },
       },
     ),

--- a/src/applications/disability-benefits/all-claims/pages/claimType.jsx
+++ b/src/applications/disability-benefits/all-claims/pages/claimType.jsx
@@ -13,8 +13,8 @@ export const uiSchema = {
     },
     'ui:validations': [validateBooleanGroup],
     'ui:errorMessages': {
-      atLeastOne: 'Please select at least one',
-      required: 'Please select at least one',
+      atLeastOne: 'Please select at least one type',
+      required: 'Please select at least one type',
     },
     'view:claimingNew': {
       'ui:title': 'A new condition',

--- a/src/applications/disability-benefits/all-claims/pages/contactInformation.js
+++ b/src/applications/disability-benefits/all-claims/pages/contactInformation.js
@@ -3,8 +3,8 @@
 import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json';
 // import dateUI from 'platform/forms-system/src/js/definitions/date';
 // import dateRangeUI from 'platform/forms-system/src/js/definitions/dateRange';
-import PhoneNumberWidget from 'platform/forms-system/src/js/widgets/PhoneNumberWidget';
-import PhoneNumberReviewWidget from 'platform/forms-system/src/js/review/PhoneNumberWidget';
+import phoneUI from 'platform/forms-system/src/js/definitions/phone';
+import emailUI from 'platform/forms-system/src/js/definitions/email';
 
 import ReviewCardField from '../components/ReviewCardField';
 
@@ -41,23 +41,8 @@ export const uiSchema = {
     'ui:options': {
       viewComponent: phoneEmailViewField,
     },
-    primaryPhone: {
-      'ui:title': 'Phone number',
-      'ui:widget': PhoneNumberWidget,
-      'ui:reviewWidget': PhoneNumberReviewWidget,
-      'ui:errorMessages': {
-        pattern: 'Phone numbers must be 10 digits (dashes allowed)',
-      },
-      'ui:options': {
-        widgetClassNames: 'va-input-medium-large',
-      },
-    },
-    emailAddress: {
-      'ui:title': 'Email address',
-      'ui:errorMessages': {
-        pattern: 'The email you enter should be in this format x@x.xx',
-      },
-    },
+    primaryPhone: phoneUI('Phone number'),
+    emailAddress: emailUI(),
   },
   mailingAddress: addressUISchema(
     ADDRESS_PATHS.mailingAddress,

--- a/src/applications/disability-benefits/all-claims/utils.jsx
+++ b/src/applications/disability-benefits/all-claims/utils.jsx
@@ -388,19 +388,20 @@ export const addressUISchema = (
     addressLine1: {
       'ui:title': 'Street address',
       'ui:errorMessages': {
-        pattern: 'Please fill in a valid address',
+        pattern: 'Please enter a valid street address',
+        required: 'Please enter a street address',
       },
     },
     addressLine2: {
       'ui:title': 'Street address',
       'ui:errorMessages': {
-        pattern: 'Please fill in a valid address',
+        pattern: 'Please enter a valid street address',
       },
     },
     addressLine3: {
       'ui:title': 'Street address',
       'ui:errorMessages': {
-        pattern: 'Please fill in a valid address',
+        pattern: 'Please enter a valid street address',
       },
     },
     city: {
@@ -413,7 +414,8 @@ export const addressUISchema = (
         },
       ],
       'ui:errorMessages': {
-        pattern: 'Please fill in a valid city',
+        pattern: 'Please enter a valid city',
+        required: 'Please enter a city',
       },
     },
     state: {
@@ -438,6 +440,10 @@ export const addressUISchema = (
           validator: validateMilitaryState,
         },
       ],
+      'ui:errorMessages': {
+        pattern: 'Please enter a valid state',
+        required: 'Please enter a state',
+      },
     },
     zipCode: {
       'ui:title': 'Postal code',
@@ -447,7 +453,9 @@ export const addressUISchema = (
         _.get(`${pathWithIndex(addressPath, index)}.country`, formData, '') ===
           USA,
       'ui:errorMessages': {
-        pattern: 'Please enter a valid 5- or 9-digit ZIP code (dashes allowed)',
+        required: 'Please enter a postal code',
+        pattern:
+          'Please enter a valid 5- or 9-digit postal code (dashes allowed)',
       },
       'ui:options': {
         widgetClassNames: 'va-input-medium-large',

--- a/src/applications/disability-benefits/all-claims/validations.js
+++ b/src/applications/disability-benefits/all-claims/validations.js
@@ -32,7 +32,7 @@ export function isValidZIP(value) {
 export function validateZIP(errors, zip) {
   if (zip && !isValidZIP(zip)) {
     errors.addError(
-      'Please enter a valid 5 or 9 digit Postal code (dashes allowed)',
+      'Please enter a valid 5- or 9-digit postal code (dashes allowed)',
     );
   }
 }

--- a/src/applications/edu-benefits/0994/pages/applicantInformation.js
+++ b/src/applications/edu-benefits/0994/pages/applicantInformation.js
@@ -15,26 +15,12 @@ const {
 
 export const uiSchema = {
   'ui:description': ApplicantDescription,
-  applicantFullName: {
-    ...fullNameUI,
-    first: {
-      ...fullNameUI.first,
-      'ui:errorMessages': {
-        pattern: 'Please provide a response',
-      },
-    },
-    last: {
-      ...fullNameUI.last,
-      'ui:errorMessages': {
-        pattern: 'Please provide a response',
-      },
-    },
-  },
+  applicantFullName: fullNameUI,
   applicantSocialSecurityNumber: ssnUI,
   dateOfBirth: {
     ...currentOrPastDateUI('Date of birth'),
     'ui:errorMessages': {
-      pattern: 'Please provide a valid date',
+      required: 'Please provide a valid date',
       futureDate: 'Please provide a valid date',
     },
   },

--- a/src/applications/edu-benefits/0994/pages/contactInformation.js
+++ b/src/applications/edu-benefits/0994/pages/contactInformation.js
@@ -1,8 +1,8 @@
 import _ from 'lodash';
 import fullSchema from 'vets-json-schema/dist/22-0994-schema.json';
 import ReviewCardField from '../../components/ReviewCardField';
-import PhoneNumberWidget from 'platform/forms-system/src/js/widgets/PhoneNumberWidget';
-import PhoneNumberReviewWidget from 'platform/forms-system/src/js/review/PhoneNumberWidget';
+import phoneUI from 'platform/forms-system/src/js/definitions/phone';
+import emailUI from 'platform/forms-system/src/js/definitions/email';
 import { AddressViewField } from '../components/AddressViewField';
 import { PhoneEmailViewField } from '../components/PhoneEmailViewField';
 
@@ -14,7 +14,7 @@ import {
 import {
   uiSchema as addressUISchema,
   schema as addressSchema,
-} from '../../../../platform/forms/definitions/address';
+} from 'platform/forms/definitions/address';
 
 const { emailAddress, dayTimePhone, nightTimePhone } = fullSchema.properties;
 
@@ -48,34 +48,9 @@ export const uiSchema = {
       viewComponent: PhoneEmailViewField,
     },
     saveClickTrackEvent: { event: 'edu-0994-personal-information-saved' },
-    dayTimePhone: {
-      'ui:title': 'Phone number',
-      'ui:widget': PhoneNumberWidget,
-      'ui:reviewWidget': PhoneNumberReviewWidget,
-      'ui:errorMessages': {
-        pattern: 'Phone numbers must be 10 digits (dashes allowed)',
-      },
-      'ui:options': {
-        widgetClassNames: 'va-input-medium-large',
-      },
-    },
-    nightTimePhone: {
-      'ui:title': 'Alternate Phone number',
-      'ui:widget': PhoneNumberWidget,
-      'ui:reviewWidget': PhoneNumberReviewWidget,
-      'ui:errorMessages': {
-        pattern: 'Phone numbers must be 10 digits (dashes allowed)',
-      },
-      'ui:options': {
-        widgetClassNames: 'va-input-medium-large',
-      },
-    },
-    emailAddress: {
-      'ui:title': 'Email address',
-      'ui:errorMessages': {
-        pattern: 'The email you enter should be in this format x@x.xx',
-      },
-    },
+    dayTimePhone: phoneUI('Phone number'),
+    nightTimePhone: phoneUI('Alternate Phone number'),
+    emailAddress: emailUI(),
   },
   mailingAddress: {
     ...addressUiSchema,
@@ -89,9 +64,6 @@ export const uiSchema = {
     street: {
       ...addressUiSchema.street,
       'ui:title': 'Street address',
-      'ui:errorMessages': {
-        pattern: 'Please provide a response',
-      },
     },
     street2: {
       ...addressUiSchema.street2,
@@ -101,12 +73,7 @@ export const uiSchema = {
       ...addressUiSchema.street3,
       'ui:title': 'Street address (line 3)',
     },
-    city: {
-      ...addressUiSchema.city,
-      'ui:errorMessages': {
-        pattern: 'Please provide a response',
-      },
-    },
+    city: addressUiSchema.city,
   },
   'view:contactInfoNote': {
     'ui:description': contactInfoNote,

--- a/src/applications/edu-benefits/feedback-tool/config/form.js
+++ b/src/applications/edu-benefits/feedback-tool/config/form.js
@@ -3,6 +3,7 @@ import React from 'react';
 import fullSchema from 'vets-json-schema/dist/FEEDBACK-TOOL-schema.json';
 import dateRangeUI from 'platform/forms-system/src/js/definitions/dateRange';
 import phoneUI from 'platform/forms-system/src/js/definitions/phone';
+import emailUI from 'platform/forms-system/src/js/definitions/email';
 import { validateBooleanGroup } from 'platform/forms-system/src/js/validation';
 
 import FormFooter from 'platform/forms/components/FormFooter';
@@ -209,13 +210,12 @@ const formConfig = {
                 expandUnderClassNames: 'schemaform-expandUnder',
               },
             },
-            anonymousEmail: {
-              'ui:title': 'Email',
+            anonymousEmail: _.merge(emailUI('Email'), {
               'ui:options': {
                 expandUnder: 'onBehalfOf',
                 expandUnderCondition: anonymous,
               },
-            },
+            }),
           },
           schema: {
             type: 'object',
@@ -368,20 +368,10 @@ const formConfig = {
                 'email',
               ),
             ],
-            applicantEmail: {
-              'ui:title': 'Email address',
-              'ui:errorMessages': {
-                pattern: 'Please put your email in this format x@x.xxx',
-                required: 'Please put your email in this format x@x.xxx',
-              },
-            },
-            'view:applicantEmailConfirmation': {
-              'ui:title': 'Re-enter email address',
-              'ui:errorMessages': {
-                pattern: 'Please put your email in this format x@x.xxx',
-                required: 'Please put your email in this format x@x.xxx',
-              },
-            },
+            applicantEmail: emailUI(),
+            'view:applicantEmailConfirmation': emailUI(
+              'Re-enter email address',
+            ),
             phone: phoneUI('Phone number'),
           },
           schema: {

--- a/src/applications/edu-benefits/pages/contactInformation.js
+++ b/src/applications/edu-benefits/pages/contactInformation.js
@@ -9,6 +9,7 @@ import { preferredContactMethodLabels } from '../utils/labels';
 const { preferredContactMethod } = schemaDefinitions;
 
 import phoneUI from 'platform/forms-system/src/js/definitions/phone';
+import emailUI from 'platform/forms-system/src/js/definitions/email';
 import * as address from '../../../platform/forms/definitions/address';
 
 export default function createContactInformationPage(
@@ -36,15 +37,12 @@ export default function createContactInformationPage(
         'ui:description':
           'Please enter as much contact information as possible so we can get in touch with you, if necessary.',
         'ui:validations': [validateMatch('email', 'view:confirmEmail')],
-        email: {
-          'ui:title': 'Email address',
-        },
-        'view:confirmEmail': {
-          'ui:title': 'Re-enter email address',
+        email: emailUI(),
+        'view:confirmEmail': _.merge(emailUI('Re-enter email address'), {
           'ui:options': {
             hideOnReview: true,
           },
-        },
+        }),
         homePhone: _.assign(phoneUI('Primary telephone number'), {
           'ui:required': form => form.preferredContactMethod === 'phone',
         }),

--- a/src/applications/hca/config/form.js
+++ b/src/applications/hca/config/form.js
@@ -6,6 +6,7 @@ import { VA_FORM_IDS } from 'platform/forms/constants';
 import { validateMatch } from 'platform/forms-system/src/js/validation';
 import { createUSAStateLabels } from 'platform/forms-system/src/js/helpers';
 import phoneUI from 'platform/forms-system/src/js/definitions/phone';
+import emailUI from 'platform/forms-system/src/js/definitions/email';
 import {
   schema as addressSchema,
   uiSchema as addressUI,
@@ -431,18 +432,8 @@ const formConfig = {
             'ui:validations': [
               validateMatch('email', 'view:emailConfirmation'),
             ],
-            email: {
-              'ui:title': 'Email address',
-              'ui:errorMessages': {
-                pattern: 'Please put your email in this format x@x.xxx',
-              },
-            },
-            'view:emailConfirmation': {
-              'ui:title': 'Re-enter email address',
-              'ui:errorMessages': {
-                pattern: 'Please enter a valid email address',
-              },
-            },
+            email: emailUI(),
+            'view:emailConfirmation': emailUI('Re-enter email address'),
             homePhone: phoneUI('Home telephone number'),
             mobilePhone: phoneUI('Mobile telephone number'),
           },

--- a/src/applications/hca/helpers.jsx
+++ b/src/applications/hca/helpers.jsx
@@ -507,13 +507,13 @@ export const idFormUiSchema = {
   firstName: {
     'ui:title': 'First name',
     'ui:errorMessages': {
-      required: 'Please enter your first name.',
+      required: 'Please enter a first name.',
     },
   },
   lastName: {
     'ui:title': 'Last name',
     'ui:errorMessages': {
-      required: 'Please enter your last name.',
+      required: 'Please enter a last name.',
     },
   },
   dob: {
@@ -526,13 +526,12 @@ export const idFormUiSchema = {
   ssn: {
     ...ssnUI,
     'ui:errorMessages': {
-      required:
-        'Please enter your Social Security number in this format: XXX-XX-XXXX.',
+      required: 'Please enter a Social Security number',
       // NOTE: this `pattern` message is ignored because the pattern
       // validation error message is hard coded in the validation function:
       // https://github.com/usds/us-forms-system/blob/db029cb4f18362870d420e3eee5b71be98004e5e/src/js/validation.js#L231
       pattern:
-        'Please enter your Social Security number in this format: XXX-XX-XXXX.',
+        'Please enter a Social Security number in this format: XXX-XX-XXXX.',
     },
   },
 };

--- a/src/applications/personalization/profile360/util/paymentInformation.js
+++ b/src/applications/personalization/profile360/util/paymentInformation.js
@@ -1,20 +1,20 @@
 export function getRoutingNumberErrorMessage(routingNumber) {
   if (!routingNumber.match(/^\d{9}$/)) {
-    return 'Please enter your bank’s 9-digit routing number.';
+    return 'Please enter the bank’s 9-digit routing number.';
   }
   return null;
 }
 
 export function getAccountNumberErrorMessage(accountNumber) {
   if (!accountNumber.match(/^\d{1,17}$/)) {
-    return 'Please enter your account number.';
+    return 'Please enter an account number.';
   }
   return null;
 }
 
 export function getAccountTypeErrorMessage(accountType) {
   if (!accountType) {
-    return 'Please select the type that best describes your account.';
+    return 'Please select the type that best describes the account.';
   }
   return null;
 }

--- a/src/applications/pre-need/config/form.jsx
+++ b/src/applications/pre-need/config/form.jsx
@@ -14,6 +14,7 @@ import dateRangeUI from 'platform/forms-system/src/js/definitions/dateRange';
 import fileUploadUI from 'platform/forms-system/src/js/definitions/file';
 import fullNameUI from 'platform/forms/definitions/fullName';
 import phoneUI from 'platform/forms-system/src/js/definitions/phone';
+import emailUI from 'platform/forms-system/src/js/definitions/email';
 
 import applicantDescription from 'platform/forms/components/ApplicantDescription';
 
@@ -668,12 +669,7 @@ const formConfig = {
                   'ui:description': contactInfoDescription,
                 },
                 phoneNumber: phoneUI('Primary telephone number'),
-                email: {
-                  'ui:title': 'Email address',
-                  'ui:errorMessages': {
-                    pattern: 'Please enter a valid email address',
-                  },
-                },
+                email: emailUI(),
               },
             },
           },

--- a/src/applications/veteran-id-card/containers/EmailCapture.jsx
+++ b/src/applications/veteran-id-card/containers/EmailCapture.jsx
@@ -47,7 +47,7 @@ class EmailCapture extends React.Component {
           </p>
           <p>
             We want to engage you in the application process quickly and will be
-            sending specific instructions on how to proceed. Please enter your
+            sending specific instructions on how to proceed. Please enter an
             email address below. We'll only use it to contact you about
             continuing the Veteran ID Card application process.{' '}
             <a href="/privacy-policy/">See our privacy policy</a>

--- a/src/applications/vic-v2/config/form.js
+++ b/src/applications/vic-v2/config/form.js
@@ -21,6 +21,7 @@ import ssnUI from 'platform/forms-system/src/js/definitions/ssn';
 import * as addressDefinition from '../definitions/address';
 import currentOrPastDateUI from 'platform/forms-system/src/js/definitions/currentOrPastDate';
 import phoneUI from 'platform/forms-system/src/js/definitions/phone';
+import emailUI from 'platform/forms-system/src/js/definitions/email';
 import fileUploadUI from 'platform/forms-system/src/js/definitions/file';
 import { genderLabels } from 'platform/static-data/labels';
 import { validateMatch } from 'platform/forms-system/src/js/validation';
@@ -149,15 +150,12 @@ const formConfig = {
           path: 'contact-information',
           title: 'Contact information',
           uiSchema: {
-            email: {
-              'ui:title': 'Email address',
-            },
-            'view:confirmEmail': {
-              'ui:title': 'Re-enter email address',
+            email: emailUI(),
+            'view:confirmEmail': _.merge(emailUI('Re-enter email address'), {
               'ui:options': {
                 hideOnReview: true,
               },
-            },
+            }),
             phone: phoneUI('Phone number'),
             'ui:validations': [validateMatch('email', 'view:confirmEmail')],
           },

--- a/src/applications/vre/chapter31/config/form.js
+++ b/src/applications/vre/chapter31/config/form.js
@@ -5,6 +5,7 @@ import fullSchema31 from 'vets-json-schema/dist/28-1900-schema.json';
 import * as address from '../../../../platform/forms/definitions/address';
 import currencyUI from 'platform/forms-system/src/js/definitions/currency';
 import phoneUI from 'platform/forms-system/src/js/definitions/phone';
+import emailUI from 'platform/forms-system/src/js/definitions/email';
 import DD214Description from '../components/DD214Description';
 import IntroductionPage from '../components/IntroductionPage';
 import ConfirmationPage from '../containers/ConfirmationPage';
@@ -391,15 +392,12 @@ const formConfig = {
           uiSchema: {
             daytimePhone: phoneUI('Daytime phone number'),
             eveningPhone: phoneUI('Evening phone number'),
-            email: {
-              'ui:title': 'Email address',
-            },
-            'view:confirmEmail': {
-              'ui:title': 'Re-enter email address',
+            email: emailUI(),
+            'view:confirmEmail': _.merge(emailUI('Re-enter email address'), {
               'ui:options': {
                 hideOnReview: true,
               },
-            },
+            }),
             'ui:validations': [validateMatch('email', 'view:confirmEmail')],
           },
           schema: {

--- a/src/applications/vre/chapter36/config/form.js
+++ b/src/applications/vre/chapter36/config/form.js
@@ -16,6 +16,7 @@ import dateRangeUI from 'platform/forms-system/src/js/definitions/dateRange';
 import currentOrPastDateUI from 'platform/forms-system/src/js/definitions/currentOrPastDate';
 import fullNameUI from '../../../../platform/forms/definitions/fullName';
 import phoneUI from 'platform/forms-system/src/js/definitions/phone';
+import emailUI from 'platform/forms-system/src/js/definitions/email';
 import ssnUI from 'platform/forms-system/src/js/definitions/ssn';
 import { validateMatch } from 'platform/forms-system/src/js/validation';
 import { externalServices } from 'platform/monitoring/DowntimeNotification';
@@ -466,15 +467,12 @@ const formConfig = {
               'Primary phone number where a message can be left',
             ),
             applicantOtherPhone: phoneUI('Other phone number'),
-            applicantEmail: {
-              'ui:title': 'Email address',
-            },
-            'view:confirmEmail': {
-              'ui:title': 'Re-enter email address',
+            applicantEmail: emailUI(),
+            'view:confirmEmail': _.merge(emailUI('Re-enter email address'), {
               'ui:options': {
                 hideOnReview: true,
               },
-            },
+            }),
             'ui:validations': [
               validateMatch('applicantEmail', 'view:confirmEmail'),
             ],

--- a/src/platform/forms-system/src/js/definitions/address.js
+++ b/src/platform/forms-system/src/js/definitions/address.js
@@ -276,6 +276,9 @@ export function uiSchema(
     },
     street: {
       'ui:title': 'Street',
+      'ui:errorMessages': {
+        required: 'Please enter a street address',
+      },
     },
     street2: {
       'ui:title': 'Line 2',
@@ -285,12 +288,24 @@ export function uiSchema(
     },
     city: {
       'ui:title': 'City',
+      'ui:errorMessages': {
+        required: 'Please enter a city',
+      },
     },
-    state: {},
+    state: {
+      'ui:errorMessages': {
+        required: 'Please enter a state',
+      },
+    },
     postalCode: {
       'ui:title': 'Postal code',
       'ui:options': {
         widgetClassNames: 'usa-input-medium',
+      },
+      'ui:errorMessages': {
+        required: 'Please enter a postal code',
+        pattern:
+          'Please enter a valid 5- or 9-digit postal code (dashes allowed)',
       },
     },
   };

--- a/src/platform/forms-system/src/js/definitions/autosuggest.js
+++ b/src/platform/forms-system/src/js/definitions/autosuggest.js
@@ -36,7 +36,7 @@ export function uiSchema(label, getOptions, options = {}) {
       'ui:field': AutosuggestField,
       'ui:validations': validations,
       'ui:errorMessages': {
-        type: 'Please select an option from the suggestions',
+        required: 'Please select an option from the suggestions',
       },
       'ui:options': {
         showFieldLabel: 'label',

--- a/src/platform/forms-system/src/js/definitions/bankAccount.js
+++ b/src/platform/forms-system/src/js/definitions/bankAccount.js
@@ -20,6 +20,7 @@ const uiSchema = {
     'ui:validations': [validateRoutingNumber],
     'ui:errorMessages': {
       pattern: 'Please enter a valid nine digit routing number',
+      required: 'Please enter a routing number',
     },
   },
 };

--- a/src/platform/forms-system/src/js/definitions/currency.js
+++ b/src/platform/forms-system/src/js/definitions/currency.js
@@ -10,7 +10,8 @@ export default function uiSchema(title) {
       classNames: 'schemaform-currency-input',
     },
     'ui:errorMessages': {
-      type: 'Please enter a valid dollar amount',
+      pattern: 'Please enter a valid dollar amount',
+      required: 'Please enter an amount',
     },
   };
 }

--- a/src/platform/forms-system/src/js/definitions/currentOrPastDate.js
+++ b/src/platform/forms-system/src/js/definitions/currentOrPastDate.js
@@ -6,7 +6,8 @@ export default function uiSchema(title = 'Date') {
     'ui:widget': 'date',
     'ui:validations': [validateCurrentOrPastDate],
     'ui:errorMessages': {
-      pattern: 'Please provide a valid current or past date',
+      pattern: 'Please enter a valid current or past date',
+      required: 'Please enter a date',
     },
   };
 }

--- a/src/platform/forms-system/src/js/definitions/currentOrPastMonthYear.js
+++ b/src/platform/forms-system/src/js/definitions/currentOrPastMonthYear.js
@@ -6,7 +6,8 @@ export default function uiSchema(title = 'Date') {
   return _.assign(monthYearUI(title), {
     'ui:validations': [validateCurrentOrPastMonthYear],
     'ui:errorMessages': {
-      pattern: 'Please provide a valid current or past date',
+      pattern: 'Please enter a valid current or past date',
+      required: 'Please enter a date',
     },
   });
 }

--- a/src/platform/forms-system/src/js/definitions/date.js
+++ b/src/platform/forms-system/src/js/definitions/date.js
@@ -6,7 +6,8 @@ export default function uiSchema(title = 'Date') {
     'ui:widget': 'date',
     'ui:validations': [validateDate],
     'ui:errorMessages': {
-      pattern: 'Please provide a valid date',
+      pattern: 'Please enter a valid date',
+      required: 'Please enter a date',
     },
   };
 }

--- a/src/platform/forms-system/src/js/definitions/dateRange.js
+++ b/src/platform/forms-system/src/js/definitions/dateRange.js
@@ -10,6 +10,7 @@ export default function uiSchema(
     'ui:validations': [validateDateRange],
     'ui:errorMessages': {
       pattern: rangeError,
+      required: 'Please enter a date',
     },
     from: dateUI(from),
     to: dateUI(to),

--- a/src/platform/forms-system/src/js/definitions/email.js
+++ b/src/platform/forms-system/src/js/definitions/email.js
@@ -1,0 +1,18 @@
+/*
+ * Email uiSchema
+ *
+ * @param {string} title - The field label, defaults to "Email address"
+ */
+export default function uiSchema(title = 'Email address') {
+  return {
+    'ui:title': title,
+    'ui:errorMessages': {
+      pattern: 'Please enter an email address using this format: X@X.com',
+      required: 'Please enter an email address',
+    },
+    'ui:options': {
+      widgetClassNames: 'va-input-medium-large',
+      inputType: 'email',
+    },
+  };
+}

--- a/src/platform/forms-system/src/js/definitions/fullName.js
+++ b/src/platform/forms-system/src/js/definitions/fullName.js
@@ -1,9 +1,15 @@
 const uiSchema = {
   first: {
     'ui:title': 'First name',
+    'ui:errorMessages': {
+      required: 'Please enter a first name',
+    },
   },
   last: {
     'ui:title': 'Last name',
+    'ui:errorMessages': {
+      required: 'Please enter a last name',
+    },
   },
   middle: {
     'ui:title': 'Middle name',

--- a/src/platform/forms-system/src/js/definitions/monthYear.js
+++ b/src/platform/forms-system/src/js/definitions/monthYear.js
@@ -9,7 +9,8 @@ export default function uiSchema(title = 'Date') {
     },
     'ui:validations': [validateMonthYear],
     'ui:errorMessages': {
-      pattern: 'Please provide a valid date',
+      pattern: 'Please enter a valid month and year',
+      required: 'Please enter a date',
     },
   };
 }

--- a/src/platform/forms-system/src/js/definitions/monthYearRange.js
+++ b/src/platform/forms-system/src/js/definitions/monthYearRange.js
@@ -10,6 +10,7 @@ export default function uiSchema(
     'ui:validations': [validateDateRange],
     'ui:errorMessages': {
       pattern: rangeError,
+      required: 'Please enter a date',
     },
     from: monthYearUI(from),
     to: monthYearUI(to),

--- a/src/platform/forms-system/src/js/definitions/personId.js
+++ b/src/platform/forms-system/src/js/definitions/personId.js
@@ -37,6 +37,7 @@ export function uiSchema(
       'ui:title': 'VA file number',
       'ui:errorMessages': {
         pattern: 'Your VA file number must be between 7 to 9 digits',
+        required: 'Please enter a VA file number',
       },
       'ui:options': {
         expandUnder: 'view:noSSN',

--- a/src/platform/forms-system/src/js/definitions/phone.js
+++ b/src/platform/forms-system/src/js/definitions/phone.js
@@ -12,10 +12,11 @@ export default function uiSchema(title = 'Phone') {
     'ui:reviewWidget': PhoneNumberReviewWidget,
     'ui:title': title,
     'ui:errorMessages': {
-      pattern: 'Phone numbers must be 10 digits',
+      pattern: 'Please enter a 10-digit phone number (with or without dashes)',
+      required: 'Please enter a phone number',
     },
     'ui:options': {
-      widgetClassNames: 'home-phone va-input-medium-large',
+      widgetClassNames: 'va-input-medium-large',
       inputType: 'tel',
     },
   };

--- a/src/platform/forms-system/src/js/definitions/ssn.js
+++ b/src/platform/forms-system/src/js/definitions/ssn.js
@@ -12,6 +12,7 @@ const uiSchema = {
   'ui:validations': [validateSSN],
   'ui:errorMessages': {
     pattern: 'Please enter a valid 9 digit SSN (dashes allowed)',
+    required: 'Please enter a SSN',
   },
 };
 

--- a/src/platform/forms-system/src/js/definitions/year.js
+++ b/src/platform/forms-system/src/js/definitions/year.js
@@ -6,7 +6,8 @@ const uiSchema = {
   'ui:reviewWidget': ReviewWidget.TextWidget,
   'ui:validations': [validateCurrentOrPastYear],
   'ui:errorMessages': {
-    type: 'Please provide a valid year',
+    pattern: 'Please enter a valid year',
+    required: 'Please enter a year',
   },
   'ui:options': {
     widgetClassNames: 'usa-input-medium',

--- a/src/platform/forms/definitions/address.js
+++ b/src/platform/forms/definitions/address.js
@@ -278,6 +278,9 @@ export function uiSchema(
     },
     street: {
       'ui:title': 'Street',
+      'ui:errorMessages': {
+        required: 'Please enter a street address',
+      },
     },
     street2: {
       'ui:title': 'Line 2',
@@ -287,12 +290,22 @@ export function uiSchema(
     },
     city: {
       'ui:title': 'City',
+      'ui:errorMessages': {
+        required: 'Please enter a city',
+      },
     },
-    state: {},
+    state: {
+      'ui:errorMessages': {
+        required: 'Please enter a state',
+      },
+    },
     postalCode: {
       'ui:title': 'Postal code',
       'ui:options': {
         widgetClassNames: 'usa-input-medium',
+      },
+      'ui:errorMessages': {
+        required: 'Please enter a postal code',
       },
     },
   };

--- a/src/platform/forms/definitions/bankAccount.js
+++ b/src/platform/forms/definitions/bankAccount.js
@@ -32,6 +32,7 @@ const uiSchema = {
     'ui:validations': [validateRoutingNumber],
     'ui:errorMessages': {
       pattern: 'Please enter a valid nine digit routing number',
+      required: 'Please enter a routing number',
     },
   },
 };

--- a/src/platform/forms/definitions/fullName.js
+++ b/src/platform/forms/definitions/fullName.js
@@ -10,9 +10,15 @@ const uiSchema = {
   'ui:validations': [validateName],
   first: {
     'ui:title': 'First name',
+    'ui:errorMessages': {
+      required: 'Please enter a first name',
+    },
   },
   last: {
     'ui:title': 'Last name',
+    'ui:errorMessages': {
+      required: 'Please enter a last name',
+    },
   },
   middle: {
     'ui:title': 'Middle name',

--- a/src/platform/forms/definitions/personId.js
+++ b/src/platform/forms/definitions/personId.js
@@ -36,6 +36,7 @@ export function uiSchema(
       'ui:title': 'VA file number',
       'ui:errorMessages': {
         pattern: 'Your VA file number must be between 7 to 9 digits',
+        required: 'Please enter a VA file number',
       },
       'ui:options': {
         expandUnder: 'view:noSSN',

--- a/src/platform/forms/pages/applicantInformation.jsx
+++ b/src/platform/forms/pages/applicantInformation.jsx
@@ -55,6 +55,7 @@ export default function applicantInformation(schema, options) {
           {
             'ui:errorMessages': {
               pattern: 'Please provide a valid date',
+              required: 'Please enter a date',
               futureDate: 'Please provide a valid date',
             },
           },

--- a/src/platform/user/profile/vet360/components/EmailField/EmailField.jsx
+++ b/src/platform/user/profile/vet360/components/EmailField/EmailField.jsx
@@ -30,7 +30,7 @@ export default class EmailField extends React.Component {
       emailAddress:
         email && isValidEmail(email)
           ? ''
-          : 'Please enter your email address again, following a standard format like name@domain.com.',
+          : 'Please enter the email address again, using this format: X@X.com',
     };
   }
 


### PR DESCRIPTION
## Description

Replace the generic "Please provide a response" with more concise error messages for screen readers needed for better 508 accessibility.

The following changes have been made:

- Added default _pattern & error messages_ to most of the definitions in the same platform folder, including:
  - Address
  - Date
  - Phone
  - Full Name
- Replaced "your" with "a" or "the" in messages because the user entering the information may be the veteran's representative.
- Created a common `email` uiSchema definition in the `platform/forms-system/src/definitions` folder and applied it to numerous forms
- Some changes of "zip" to "postal" may have been included. See https://github.com/department-of-veterans-affairs/va.gov-team/issues/5452

## Testing done

Unit tests

## Screenshots

<details>
<summary>Required error message examples from the HLR form</summary>

<!-- leave a blank line above -->
![](https://user-images.githubusercontent.com/136959/73694499-c3fa6c00-469d-11ea-9f03-61cdec72a366.png)
</details>
<details>
<summary>Pattern error messages from the HLR form</summary>

<!-- leave a blank line above -->
![Screen Shot 2020-02-03 at 4 15 21 PM](https://user-images.githubusercontent.com/136959/73695842-92cf6b00-46a0-11ea-9731-1d00b9ec1cf7.png)
</details>

## Acceptance criteria
- [ ] Appropriately detailed pattern & error messages are shown for the screen reader.

## Definition of done
- [ ] Descriptive error messages added to required inputs.
- [ ] Descriptive pattern error messages added to required inputs.
- [ ] Address forwarding address effective date error message (currently disabled in forms).