### PR TITLE
VAGOV-megamenu: add e2e tests for launch of data-driven megamenu

### DIFF
--- a/src/platform/testing/e2e/megamenu/megamenu.e2e.spec.js
+++ b/src/platform/testing/e2e/megamenu/megamenu.e2e.spec.js
@@ -1,8 +1,7 @@
-const Header = require('./megamenu');
+const Megamenu = require('./megamenu');
 const E2eHelpers = require('../helpers');
-// const Timeouts = require('../../testing/e2e/timeouts');
 
 module.exports = E2eHelpers.createE2eTest(client => {
-  Header.testDataDrivenHeader(client, '/');
+  Megamenu.testDataDrivenMegamenu(client, '/');
   client.end();
 });

--- a/src/platform/testing/e2e/megamenu/megamenu.e2e.spec.js
+++ b/src/platform/testing/e2e/megamenu/megamenu.e2e.spec.js
@@ -1,0 +1,8 @@
+const Header = require('./megamenu');
+const E2eHelpers = require('../helpers');
+// const Timeouts = require('../../testing/e2e/timeouts');
+
+module.exports = E2eHelpers.createE2eTest(client => {
+  Header.testDataDrivenHeader(client, '/');
+  client.end();
+});

--- a/src/platform/testing/e2e/megamenu/megamenu.js
+++ b/src/platform/testing/e2e/megamenu/megamenu.js
@@ -1,0 +1,305 @@
+const E2eHelpers = require('../helpers');
+const Timeouts = require('../timeouts');
+
+function testDataDrivenMegamenu(client, path) {
+  const appURL = `${E2eHelpers.baseUrl}${path}`;
+
+  client.openUrl(appURL).waitForElementVisible('body', Timeouts.normal);
+
+  client
+    .waitForElementVisible('#vetnav-menu', Timeouts.normal)
+    .elements('css selector', '#vetnav-menu li', results => {
+      client.expect(results.value.length).to.equal(4);
+    })
+    .click('.va-modal-close')
+    .elements(
+      'css selector',
+      '#vetnav-va-benefits-and-health-care',
+      results => {
+        client.expect(results.value.length).to.equal(1);
+      },
+    );
+
+  // Click on "VA Benefits and Health Care" nav button
+  client.click('button[aria-controls="vetnav-va-benefits-and-health-care"]');
+
+  // VA Benefits and Health Care top level links
+  client
+    .elements(
+      'css selector',
+      '#vetnav-va-benefits-and-health-care > ul > li',
+      results => {
+        client.expect(results.value.length).to.equal(11);
+      },
+    )
+
+    // Health care
+    .elements(
+      'css selector',
+      '#vetnav-health-care-ms .column-one ul > li.mm-link-container',
+      results => {
+        client.expect(results.value.length).to.equal(4);
+      },
+    )
+    .elements(
+      'css selector',
+      '#vetnav-health-care-ms .column-two ul > li.mm-link-container',
+      results => {
+        client.expect(results.value.length).to.equal(5);
+      },
+    )
+    .expect.element('#vetnav-health-care-ms .panel-bottom-link')
+    .text.to.equal('View all in health care');
+
+  // Disability links
+  client
+    .click(
+      'css selector',
+      '#vetnav-va-benefits-and-health-care > ul li:nth-child(2) button',
+    )
+    .elements(
+      'css selector',
+      '#vetnav-disability-ms .column-one > ul > li.mm-link-container',
+      results => {
+        client.expect(results.value.length).to.equal(3);
+      },
+    )
+    .elements(
+      'css selector',
+      '#vetnav-disability-ms .column-two > ul > li.mm-link-container',
+      results => {
+        client.expect(results.value.length).to.equal(5);
+      },
+    )
+    .expect.element('#vetnav-disability-ms .panel-bottom-link')
+    .text.to.equal('View all in disability');
+
+  // Education and training links
+  client
+    .click(
+      'css selector',
+      '#vetnav-va-benefits-and-health-care > ul li:nth-child(3) button',
+    )
+    .elements(
+      'css selector',
+      '#vetnav-education-and-training-ms .column-one > ul > li.mm-link-container',
+      results => {
+        client.expect(results.value.length).to.equal(5);
+      },
+    )
+    .elements(
+      'css selector',
+      '#vetnav-education-and-training-ms .column-two > ul > li.mm-link-container',
+      results => {
+        client.expect(results.value.length).to.equal(5);
+      },
+    )
+    .expect.element('#vetnav-education-and-training-ms .panel-bottom-link')
+    .text.to.equal('View all in education');
+
+  // Careers and employment links
+  client
+    .click(
+      'css selector',
+      '#vetnav-va-benefits-and-health-care > ul li:nth-child(4) button',
+    )
+    .elements(
+      'css selector',
+      '#vetnav-careers-and-employment-ms .column-one > ul > li.mm-link-container',
+      results => {
+        client.expect(results.value.length).to.equal(3);
+      },
+    )
+    .elements(
+      'css selector',
+      '#vetnav-careers-and-employment-ms .column-two > ul > li.mm-link-container',
+      results => {
+        client.expect(results.value.length).to.equal(5);
+      },
+    )
+    .expect.element('#vetnav-careers-and-employment-ms .panel-bottom-link')
+    .text.to.equal('View all in careers and employment');
+
+  // Pension links
+  client
+    .click(
+      'css selector',
+      '#vetnav-va-benefits-and-health-care > ul li:nth-child(5) button',
+    )
+    .elements(
+      'css selector',
+      '#vetnav-pension-ms .column-one > ul > li.mm-link-container',
+      results => {
+        client.expect(results.value.length).to.equal(5);
+      },
+    )
+    .elements(
+      'css selector',
+      '#vetnav-pension-ms .column-two > ul > li.mm-link-container',
+      results => {
+        client.expect(results.value.length).to.equal(4);
+      },
+    )
+    .expect.element('#vetnav-pension-ms .panel-bottom-link')
+    .text.to.equal('View all in pension');
+
+  // Housing assistance links
+  client
+    .click(
+      'css selector',
+      '#vetnav-va-benefits-and-health-care > ul li:nth-child(6) button',
+    )
+    .elements(
+      'css selector',
+      '#vetnav-housing-assistance-ms .column-one > ul > li.mm-link-container',
+      results => {
+        client.expect(results.value.length).to.equal(3);
+      },
+    )
+    .elements(
+      'css selector',
+      '#vetnav-housing-assistance-ms .column-two > ul > li.mm-link-container',
+      results => {
+        client.expect(results.value.length).to.equal(3);
+      },
+    )
+    .expect.element('#vetnav-housing-assistance-ms .panel-bottom-link')
+    .text.to.equal('View all in housing assistance');
+
+  // Life insurance links
+  client
+    .click(
+      'css selector',
+      '#vetnav-va-benefits-and-health-care > ul li:nth-child(7) button',
+    )
+    .elements(
+      'css selector',
+      '#vetnav-life-insurance-ms .column-one > ul > li.mm-link-container',
+      results => {
+        client.expect(results.value.length).to.equal(3);
+      },
+    )
+    .elements(
+      'css selector',
+      '#vetnav-life-insurance-ms .column-two > ul > li.mm-link-container',
+      results => {
+        client.expect(results.value.length).to.equal(4);
+      },
+    )
+    .expect.element('#vetnav-life-insurance-ms .panel-bottom-link')
+    .text.to.equal('View all in life insurance');
+
+  // Burials and memorials links
+  client
+    .click(
+      'css selector',
+      '#vetnav-va-benefits-and-health-care > ul li:nth-child(8) button',
+    )
+    .elements(
+      'css selector',
+      '#vetnav-burials-and-memorials-ms .column-one > ul > li.mm-link-container',
+      results => {
+        client.expect(results.value.length).to.equal(5);
+      },
+    )
+    .elements(
+      'css selector',
+      '#vetnav-burials-and-memorials-ms .column-two > ul > li.mm-link-container',
+      results => {
+        client.expect(results.value.length).to.equal(4);
+      },
+    )
+    .expect.element('#vetnav-burials-and-memorials-ms .panel-bottom-link')
+    .text.to.equal('View all in burials and memorials');
+
+  // Records links
+  client
+    .click(
+      'css selector',
+      '#vetnav-va-benefits-and-health-care > ul li:nth-child(9) button',
+    )
+    .elements(
+      'css selector',
+      '#vetnav-records-ms .column-one > ul > li.mm-link-container',
+      results => {
+        client.expect(results.value.length).to.equal(4);
+      },
+    )
+    .elements(
+      'css selector',
+      '#vetnav-records-ms .column-two > ul > li.mm-link-container',
+      results => {
+        client.expect(results.value.length).to.equal(5);
+      },
+    )
+    .expect.element('#vetnav-records-ms .panel-bottom-link')
+    .text.to.equal('View all in records');
+
+  client.expect
+    .element('#vetnav-va-benefits-and-health-care > ul li:nth-child(10) a')
+    .text.to.equal('Service member benefits');
+
+  client.expect
+    .element('#vetnav-va-benefits-and-health-care > ul li:nth-child(11) a')
+    .text.to.equal('Family member benefits');
+
+  // Click on "About VA" nav button
+  client.click('button[aria-controls="vetnav-about-va"]');
+
+  // About VA nav
+  client.elements(
+    'css selector',
+    '#vetnav-about-va > ul .vetnav-panel--submenu',
+    results => {
+      client.expect(results.value.length).to.equal(4);
+    },
+  );
+
+  // About VA links column one
+  client.expect
+    .element('#vetnav-main-column-header')
+    .text.to.equal('VA organizations');
+
+  client.elements(
+    'css selector',
+    '#vetnav-main-column-col li.mm-link-container',
+    results => {
+      client.expect(results.value.length).to.equal(7);
+    },
+  );
+
+  // About VA links column two
+  client.expect
+    .element('#vetnav-column-one-header')
+    .text.to.equal('Innovation at VA');
+
+  client.elements(
+    'css selector',
+    '#vetnav-column-one-col li.mm-link-container',
+    results => {
+      client.expect(results.value.length).to.equal(8);
+    },
+  );
+
+  // About VA links column two
+  client.expect
+    .element('#vetnav-column-two-header')
+    .text.to.equal('Learn about VA');
+
+  client.elements(
+    'css selector',
+    '#vetnav-column-two-col li.mm-link-container',
+    results => {
+      client.expect(results.value.length).to.equal(6);
+    },
+  );
+
+  // Find a VA Location
+  client.expect
+    .element('#vetnav-menu > li:last-child a')
+    .text.to.equal('Find a VA Location');
+}
+
+module.exports = {
+  testDataDrivenHeader: testDataDrivenMegamenu,
+};

--- a/src/platform/testing/e2e/megamenu/megamenu.js
+++ b/src/platform/testing/e2e/megamenu/megamenu.js
@@ -301,5 +301,5 @@ function testDataDrivenMegamenu(client, path) {
 }
 
 module.exports = {
-  testDataDrivenHeader: testDataDrivenMegamenu,
+  testDataDrivenMegamenu,
 };

--- a/src/site/stages/build/plugins/create-header-footer.js
+++ b/src/site/stages/build/plugins/create-header-footer.js
@@ -1,8 +1,6 @@
 const fs = require('fs-extra');
 const path = require('path');
 const yaml = require('js-yaml');
-const assert = require('assert');
-const ENVIRONMENTS = require('../../../constants/environments');
 
 const footerData = require('../../../../platform/static-data/footer-links.json');
 
@@ -77,11 +75,6 @@ function loadFromVagovContent(buildOptions, metalsmith) {
 }
 
 function createHeaderFooterData(buildOptions) {
-  const shouldConfirmDrupalMenuOkay = [
-    ENVIRONMENTS.VAGOVPROD,
-    ENVIRONMENTS.VAGOVSTAGING,
-  ].includes(buildOptions.buildtype);
-
   return (files, metalsmith, done) => {
     const megaMenuFromVagovContent = loadFromVagovContent(
       buildOptions,
@@ -96,22 +89,6 @@ function createHeaderFooterData(buildOptions) {
         buildOptions,
         buildOptions.drupalData,
       );
-
-      if (shouldConfirmDrupalMenuOkay) {
-        // eslint-disable-next-line no-console
-        console.log(JSON.stringify(megaMenuFromDrupal, null, 4));
-
-        // This assertion ensures that the Drupal-generated
-        // menu data structure is identical to the vagov-content-generated
-        // menu structure while we launch and QA the Drupal-powered
-        // megaMenu header. The assertion should be removed once
-        // we are confident that Drupal reliably generates the menu data.
-        assert.deepStrictEqual(
-          megaMenuFromDrupal,
-          megaMenuFromVagovContent,
-          'The Drupal data aligns with that from vagov-content.',
-        );
-      }
 
       megaMenuData = megaMenuFromDrupal;
     }


### PR DESCRIPTION
## Description
adds a few e2e tests for the data-driven megamenu. it mostly checks for link counts and header title text

## Testing done
e2e tests

## Screenshots
![image](https://user-images.githubusercontent.com/19178435/65480491-890e3f00-de46-11e9-8d27-c6f8ae11e7dc.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
