### PR TITLE
Remove unused babel module resolver alias

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -37,8 +37,7 @@
     ["module-resolver", {
       "root": "./src",
       "alias": {
-        "vet360": "./src/platform/user/profile/vet360",
-        "@profile360": "./src/applications/personalization/profile360"
+        "vet360": "./src/platform/user/profile/vet360"
       }
     }]
   ],


### PR DESCRIPTION
## Description
Removing a `babel-plugin-module-resolver` alias that's no longer needed. This should have been done as part of https://github.com/department-of-veterans-affairs/vets-website/pull/10791

## Testing done
existing tests

## Screenshots
n/a

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs