### PR TITLE
Build pipeline html parsing cv

### DIFF
--- a/src/site/stages/build/index.js
+++ b/src/site/stages/build/index.js
@@ -37,7 +37,7 @@ const checkForCMSUrls = require('./plugins/check-cms-urls');
 const createOutreachAssetsData = require('./plugins/create-outreach-assets-data');
 const addSubheadingsIds = require('./plugins/add-id-to-subheadings');
 const parseHtml = require('./plugins/parse-html');
-const outputHtml = require('./plugins/output-html');
+const replaceContentsWithDom = require('./plugins/replace-contents-with-dom');
 
 function defaultBuild(BUILD_OPTIONS) {
   const smith = Metalsmith(__dirname); // eslint-disable-line new-cap
@@ -222,7 +222,7 @@ function defaultBuild(BUILD_OPTIONS) {
    * the content is modified directly between those two plugins, any
    * changes will be overwritten during the outputHtml step.
    */
-  smith.use(parseHtml, 'Parse HTML');
+  smith.use(parseHtml, 'Parse HTML files');
   /**
    * Add nonce attribute with substition string to all inline script tags
    * Convert onclick event handles into nonced script tags
@@ -231,7 +231,7 @@ function defaultBuild(BUILD_OPTIONS) {
   smith.use(updateExternalLinks(BUILD_OPTIONS), 'Update external links');
   smith.use(addSubheadingsIds(BUILD_OPTIONS), 'Add IDs to subheadings');
   smith.use(checkBrokenLinks(BUILD_OPTIONS), 'Check for broken links');
-  smith.use(outputHtml, 'Save the changes from parsedContent');
+  smith.use(replaceContentsWithDom, 'Save the changes from the modified DOM');
 
   /* eslint-disable no-console */
   smith.build(err => {

--- a/src/site/stages/build/index.js
+++ b/src/site/stages/build/index.js
@@ -222,10 +222,10 @@ function defaultBuild(BUILD_OPTIONS) {
    * changes will be overwritten during the outputHtml step.
    */
   smith.use(parseHtml, 'Parse HTML');
-  /*
-  Add nonce attribute with substition string to all inline script tags
-  Convert onclick event handles into nonced script tags
-  */
+  /**
+   * Add nonce attribute with substition string to all inline script tags
+   * Convert onclick event handles into nonced script tags
+   */
   smith.use(addNonceToScripts, 'Add nonce to script tags');
   smith.use(updateExternalLinks(BUILD_OPTIONS), 'Update external links');
   smith.use(addSubheadingsIds(BUILD_OPTIONS), 'Add IDs to subheadings');

--- a/src/site/stages/build/index.js
+++ b/src/site/stages/build/index.js
@@ -37,6 +37,7 @@ const checkForCMSUrls = require('./plugins/check-cms-urls');
 const createOutreachAssetsData = require('./plugins/create-outreach-assets-data');
 const addSubheadingsIds = require('./plugins/add-id-to-subheadings');
 const parseHtml = require('./plugins/parse-html');
+const outputHtml = require('./plugins/output-html');
 
 function defaultBuild(BUILD_OPTIONS) {
   const smith = Metalsmith(__dirname); // eslint-disable-line new-cap
@@ -230,7 +231,7 @@ function defaultBuild(BUILD_OPTIONS) {
   smith.use(updateExternalLinks(BUILD_OPTIONS), 'Update external links');
   smith.use(addSubheadingsIds(BUILD_OPTIONS), 'Add IDs to subheadings');
   smith.use(checkBrokenLinks(BUILD_OPTIONS), 'Check for broken links');
-  // smith.use(outputHtml, 'Save the changes from parsedContent');
+  smith.use(outputHtml, 'Save the changes from parsedContent');
 
   /* eslint-disable no-console */
   smith.build(err => {

--- a/src/site/stages/build/plugins/add-id-to-subheadings.js
+++ b/src/site/stages/build/plugins/add-id-to-subheadings.js
@@ -34,10 +34,10 @@ function generateHeadingIds() {
       let idAdded = false;
 
       if (fileName.endsWith('html')) {
-        const doc = file.parsedContent;
-        const tableOfContents = doc('#table-of-contents ul');
-        doc('h2, h3').each((i, el) => {
-          const heading = doc(el);
+        const { dom } = file;
+        const tableOfContents = dom('#table-of-contents ul');
+        dom('h2, h3').each((i, el) => {
+          const heading = dom(el);
           const parent = heading.parents();
           const isInAccordionButton = parent.hasClass('usa-accordion-button');
           const isInAccordion = parent.hasClass('usa-accordion-content');

--- a/src/site/stages/build/plugins/add-id-to-subheadings.js
+++ b/src/site/stages/build/plugins/add-id-to-subheadings.js
@@ -72,7 +72,7 @@ function generateHeadingIds() {
         });
 
         if (idAdded) {
-          file.contents = new Buffer(doc.html());
+          file.modified = true;
         }
       }
     }

--- a/src/site/stages/build/plugins/add-id-to-subheadings.js
+++ b/src/site/stages/build/plugins/add-id-to-subheadings.js
@@ -2,8 +2,6 @@
  * Add unique ID to H2s and H3s that aren't in WYSIWYG or accordion buttons
  */
 
-const cheerio = require('cheerio');
-
 const usedHeaders = [];
 
 let currentId = 1;
@@ -36,7 +34,7 @@ function generateHeadingIds() {
       let idAdded = false;
 
       if (fileName.endsWith('html')) {
-        const doc = cheerio.load(file.contents);
+        const doc = file.parsedContent;
         const tableOfContents = doc('#table-of-contents ul');
         doc('h2, h3').each((i, el) => {
           const heading = doc(el);

--- a/src/site/stages/build/plugins/add-nonce-to-scripts.js
+++ b/src/site/stages/build/plugins/add-nonce-to-scripts.js
@@ -31,10 +31,10 @@ module.exports = (files, metalsmith, done) => {
     const clickHandlers = [];
     dom('[onclick]').each((index, onClickEl) => {
       const o = dom(onClickEl);
-      if (o.attr('id') === '') {
+      if (!o.attr('id')) {
         o.attr('id', generateNewId(ids)); // eslint-disable-line no-param-reassign
       }
-      const id = o.id;
+      const id = o.attr('id');
       const onclick = o.attr('onclick');
 
       clickHandlers.push(

--- a/src/site/stages/build/plugins/add-nonce-to-scripts.js
+++ b/src/site/stages/build/plugins/add-nonce-to-scripts.js
@@ -1,4 +1,4 @@
-const jsdom = require('jsdom');
+/* eslint-disable no-param-reassign */
 const path = require('path');
 
 const CSP_NONCE = '**CSP_NONCE**';
@@ -19,39 +19,41 @@ module.exports = (files, metalsmith, done) => {
   Object.keys(files).forEach(file => {
     if (path.extname(file) !== '.html') return;
 
-    const data = files[file];
-    const dom = new jsdom.JSDOM(data.contents.toString());
-    dom.window.document.querySelectorAll('script').forEach(scriptEl => {
-      if (scriptEl.textContent !== '') {
-        scriptEl.setAttribute('nonce', CSP_NONCE);
+    // const dom = new jsdom.JSDOM(data.contents.toString());
+    const dom = files[file].parsedContent;
+    dom('script').each((index, scriptEl) => {
+      const s = dom(scriptEl);
+      if (s.text() !== '') {
+        s.attr('nonce', CSP_NONCE);
       }
     });
     const ids = new Set();
     const clickHandlers = [];
-    dom.window.document.querySelectorAll('[onclick]').forEach(onclickEl => {
-      if (onclickEl.id === '') {
-        onclickEl.id = generateNewId(ids); // eslint-disable-line no-param-reassign
+    dom('[onclick]').each((index, onClickEl) => {
+      const o = dom(onClickEl);
+      if (o.attr('id') === '') {
+        o.attr('id', generateNewId(ids)); // eslint-disable-line no-param-reassign
       }
-      const id = onclickEl.id;
-      const onclick = onclickEl.getAttribute('onclick');
+      const id = o.id;
+      const onclick = o.attr('onclick');
 
       clickHandlers.push(
         `document.getElementById('${id}').addEventListener('click', function(ev) { ${onclick} });`,
       );
-      onclickEl.removeAttribute('onclick');
+      o.attr('onclick', null);
     });
 
-    const newScript = dom.window.document.createElement('script');
-    newScript.setAttribute('nonce', CSP_NONCE);
-    newScript.textContent = `
+    const scriptTag = `
+     <script>
       (function() {
         ${clickHandlers.join('\n')}
-      })();`;
+      })();
+     </script>`;
+    const newScript = dom(scriptTag);
+    newScript.attr('nonce', CSP_NONCE);
 
-    dom.window.document.body.appendChild(newScript);
-    data.contents = new Buffer(dom.serialize());
-    dom.window.close();
-    files[file] = data; // eslint-disable-line no-param-reassign
+    dom('body').append(newScript);
+    files[file].contents = new Buffer(dom.html());
   });
   done();
 };

--- a/src/site/stages/build/plugins/add-nonce-to-scripts.js
+++ b/src/site/stages/build/plugins/add-nonce-to-scripts.js
@@ -19,7 +19,7 @@ module.exports = (files, metalsmith, done) => {
   Object.keys(files).forEach(fileName => {
     if (path.extname(fileName) !== '.html') return;
 
-    const dom = files[fileName].parsedContent;
+    const { dom } = files[fileName];
     dom('script').each((index, scriptEl) => {
       const s = dom(scriptEl);
       // Only add nonce to inline scripts

--- a/src/site/stages/build/plugins/add-nonce-to-scripts.js
+++ b/src/site/stages/build/plugins/add-nonce-to-scripts.js
@@ -53,7 +53,7 @@ module.exports = (files, metalsmith, done) => {
     newScript.attr('nonce', CSP_NONCE);
 
     dom('body').append(newScript);
-    files[fileName].contents = new Buffer(dom.html());
+    files[fileName].modified = true;
   });
   done();
 };

--- a/src/site/stages/build/plugins/add-nonce-to-scripts.js
+++ b/src/site/stages/build/plugins/add-nonce-to-scripts.js
@@ -16,14 +16,14 @@ function generateNewId(existingIds) {
 }
 
 module.exports = (files, metalsmith, done) => {
-  Object.keys(files).forEach(file => {
-    if (path.extname(file) !== '.html') return;
+  Object.keys(files).forEach(fileName => {
+    if (path.extname(fileName) !== '.html') return;
 
-    // const dom = new jsdom.JSDOM(data.contents.toString());
-    const dom = files[file].parsedContent;
+    const dom = files[fileName].parsedContent;
     dom('script').each((index, scriptEl) => {
       const s = dom(scriptEl);
-      if (s.text() !== '') {
+      // Only add nonce to inline scripts
+      if (!s.attr('src')) {
         s.attr('nonce', CSP_NONCE);
       }
     });
@@ -53,7 +53,7 @@ module.exports = (files, metalsmith, done) => {
     newScript.attr('nonce', CSP_NONCE);
 
     dom('body').append(newScript);
-    files[file].contents = new Buffer(dom.html());
+    files[fileName].contents = new Buffer(dom.html());
   });
   done();
 };

--- a/src/site/stages/build/plugins/check-broken-links/helpers/getBrokenLinks.js
+++ b/src/site/stages/build/plugins/check-broken-links/helpers/getBrokenLinks.js
@@ -8,7 +8,7 @@ const _isBrokenLink = require('./isBrokenLink');
  * @param {Set<string>} allPaths The paths of all files in the website. Used to confirm the existence of a file.
  */
 function getBrokenLinks(file, allPaths, isBrokenLink = _isBrokenLink) {
-  const $ = cheerio.load(file.contents);
+  const $ = file.parsedContent;
   const elements = $('a, img');
   const currentPath = file.path;
 

--- a/src/site/stages/build/plugins/check-broken-links/helpers/getBrokenLinks.js
+++ b/src/site/stages/build/plugins/check-broken-links/helpers/getBrokenLinks.js
@@ -8,7 +8,7 @@ const _isBrokenLink = require('./isBrokenLink');
  * @param {Set<string>} allPaths The paths of all files in the website. Used to confirm the existence of a file.
  */
 function getBrokenLinks(file, allPaths, isBrokenLink = _isBrokenLink) {
-  const $ = file.parsedContent;
+  const $ = file.dom;
   const elements = $('a, img');
   const currentPath = file.path;
 

--- a/src/site/stages/build/plugins/check-broken-links/tests/helpers/getBrokenLinks.unit.spec.js
+++ b/src/site/stages/build/plugins/check-broken-links/tests/helpers/getBrokenLinks.unit.spec.js
@@ -1,5 +1,6 @@
 const { expect } = require('chai');
 const sinon = require('sinon');
+const cheerio = require('cheerio');
 
 const getBrokenLinks = require('../../helpers/getBrokenLinks');
 
@@ -8,53 +9,41 @@ const img = '<img src="/another-link.png">';
 const span = '<span>Not a link</span>';
 const anchorWithoutHref = '<a>Link</a>';
 
+const getFile = tag => {
+  const contents = `<div>${anchor}${tag}</div>`;
+  return {
+    path: '/health-care',
+    contents,
+    parsedContent: cheerio.load(contents),
+  };
+};
+
 describe('getBrokenLinks', () => {
+  const detectAllLinksBroken = sinon.stub().returns(true);
+  const detectAllLinksOkay = sinon.stub().returns(false);
+
   it('finds broken links', () => {
-    const file = {
-      path: '/health-care',
-      contents: `<div>${anchor}${img}</div>`,
-    };
-
-    const detectAllLinksBroken = sinon.stub().returns(true);
-    const linkErrors = getBrokenLinks(file, [], detectAllLinksBroken);
-
+    const linkErrors = getBrokenLinks(getFile(img), [], detectAllLinksBroken);
     expect(linkErrors).to.have.lengthOf(2);
   });
 
   it('does not detect non-links as a link', () => {
-    const file = {
-      path: '/health-care',
-      contents: `<div>${anchor}${span}</div>`,
-    };
-
-    const detectAllLinksBroken = sinon.stub().returns(true);
-    const linkErrors = getBrokenLinks(file, [], detectAllLinksBroken);
-
+    const linkErrors = getBrokenLinks(getFile(span), [], detectAllLinksBroken);
     expect(linkErrors).to.have.lengthOf(1);
     expect(linkErrors[0].html).to.be.equal(anchor);
   });
 
   it('does not detect valid links as broken', () => {
-    const file = {
-      path: '/health-care',
-      contents: `<div>${anchor}${img}</div>`,
-    };
-
-    const detectAllLinksOkay = sinon.stub().returns(false);
-    const linkErrors = getBrokenLinks(file, [], detectAllLinksOkay);
-
+    const linkErrors = getBrokenLinks(getFile(img), [], detectAllLinksOkay);
     expect(linkErrors).to.have.lengthOf(0);
   });
 
   it('skips anchors without an HREF attribute', () => {
-    const file = {
-      path: '/health-care',
-      contents: `<div>${anchorWithoutHref}</div>`,
-    };
-
-    const detectAllLinksBroken = sinon.stub().returns(true);
-    const linkErrors = getBrokenLinks(file, [], detectAllLinksBroken);
-
+    const linkErrors = getBrokenLinks(
+      getFile(anchorWithoutHref),
+      [],
+      detectAllLinksBroken,
+    );
     expect(linkErrors).to.have.lengthOf(0);
   });
 });

--- a/src/site/stages/build/plugins/check-broken-links/tests/helpers/getBrokenLinks.unit.spec.js
+++ b/src/site/stages/build/plugins/check-broken-links/tests/helpers/getBrokenLinks.unit.spec.js
@@ -14,7 +14,7 @@ const getFile = tag => {
   return {
     path: '/health-care',
     contents,
-    parsedContent: cheerio.load(contents),
+    dom: cheerio.load(contents),
   };
 };
 

--- a/src/site/stages/build/plugins/check-broken-links/tests/helpers/getBrokenLinks.unit.spec.js
+++ b/src/site/stages/build/plugins/check-broken-links/tests/helpers/getBrokenLinks.unit.spec.js
@@ -44,6 +44,6 @@ describe('getBrokenLinks', () => {
       [],
       detectAllLinksBroken,
     );
-    expect(linkErrors).to.have.lengthOf(0);
+    expect(linkErrors).to.have.lengthOf(1);
   });
 });

--- a/src/site/stages/build/plugins/output-html.js
+++ b/src/site/stages/build/plugins/output-html.js
@@ -3,8 +3,8 @@
 const outputHtml = files => {
   for (const fileName of Object.keys(files)) {
     const file = files[fileName];
-    if (file.parsedContent && file.modified) {
-      file.contents = new Buffer(file.parsedContent.html());
+    if (file.dom && file.modified) {
+      file.contents = new Buffer(file.dom.html());
     }
   }
 };

--- a/src/site/stages/build/plugins/output-html.js
+++ b/src/site/stages/build/plugins/output-html.js
@@ -1,0 +1,12 @@
+/* eslint-disable no-param-reassign */
+
+const outputHtml = files => {
+  for (const fileName of Object.keys(files)) {
+    const file = files[fileName];
+    if (file.parsedContent && file.modified) {
+      file.contents = new Buffer(file.parsedContent.html());
+    }
+  }
+};
+
+module.exports = outputHtml;

--- a/src/site/stages/build/plugins/parse-html.js
+++ b/src/site/stages/build/plugins/parse-html.js
@@ -5,7 +5,7 @@ const cheerio = require('cheerio');
 const parseHtml = files => {
   for (const fileName of Object.keys(files)) {
     if (path.extname(fileName) === '.html') {
-      files[fileName].parsedContent = cheerio.load(files[fileName].contents);
+      files[fileName].dom = cheerio.load(files[fileName].contents);
     }
   }
 };

--- a/src/site/stages/build/plugins/parse-html.js
+++ b/src/site/stages/build/plugins/parse-html.js
@@ -1,0 +1,13 @@
+/* eslint-disable no-param-reassign */
+const path = require('path');
+const cheerio = require('cheerio');
+
+const parseHtml = files => {
+  for (const fileName of Object.keys(files)) {
+    if (path.extname(fileName) === '.html') {
+      files[fileName].parsedContent = cheerio.load(files[fileName].contents);
+    }
+  }
+};
+
+module.exports = parseHtml;

--- a/src/site/stages/build/plugins/replace-contents-with-dom.js
+++ b/src/site/stages/build/plugins/replace-contents-with-dom.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-param-reassign */
 
-const outputHtml = files => {
+const replaceContentsWithDom = files => {
   for (const fileName of Object.keys(files)) {
     const file = files[fileName];
     if (file.dom && file.modified) {
@@ -9,4 +9,4 @@ const outputHtml = files => {
   }
 };
 
-module.exports = outputHtml;
+module.exports = replaceContentsWithDom;

--- a/src/site/stages/build/plugins/update-external-links.js
+++ b/src/site/stages/build/plugins/update-external-links.js
@@ -1,6 +1,4 @@
 /* eslint-disable no-param-reassign */
-const cheerio = require('cheerio');
-
 const newTabDomains = [
   'myhealth.va.gov',
   'ebenefits.va.gov',
@@ -28,7 +26,7 @@ function updateExternalLinks() {
       let linkUpdated = false;
 
       if (fileName.endsWith('html')) {
-        const doc = cheerio.load(file.contents);
+        const doc = file.parsedContent;
         doc('a[href^="http"]').each((i, el) => {
           const link = doc(el);
           const relAttr = link.attr('rel');

--- a/src/site/stages/build/plugins/update-external-links.js
+++ b/src/site/stages/build/plugins/update-external-links.js
@@ -66,7 +66,7 @@ function updateExternalLinks() {
         });
 
         if (linkUpdated) {
-          file.contents = new Buffer(doc.html());
+          file.modified = true;
         }
       }
     }

--- a/src/site/stages/build/plugins/update-external-links.js
+++ b/src/site/stages/build/plugins/update-external-links.js
@@ -26,9 +26,9 @@ function updateExternalLinks() {
       let linkUpdated = false;
 
       if (fileName.endsWith('html')) {
-        const doc = file.parsedContent;
-        doc('a[href^="http"]').each((i, el) => {
-          const link = doc(el);
+        const { dom } = file;
+        dom('a[href^="http"]').each((i, el) => {
+          const link = dom(el);
           const relAttr = link.attr('rel');
           const targetAttr = link.attr('target');
           const hrefAttr = link.attr('href') || '';


### PR DESCRIPTION
## Description
This PR speeds up the Metalsmith build by parsing all HTML files only once.
- Adds a plugin to the Metalsmith pipeline that parses out all the html files
- Passes that parsed object along with each Metalsmith file
- Modifies the four plugins that were each individually parsing the files to use the new `parsedContent`
- Modifies those plugins to also _not_ write to `file.contents`, but instead add a `modified` flag when they would normally have written
- Adds a plugin that rewrites `file.contents` one time for each file that has the `modified` flag

## Testing done
Our Metalsmith build adds random IDs to elements with an `[onclick]` handler. This means we can't just checksum the build output to ensure that nothing has changed.

My testing process was like this:
**Test the nonce script plugin**
1) Build
2) Output a list of MD5 checksums for every file in the build
    - `find build/localhost/ -type f -exec md5sum {} + | awk '{print $2 "  " $1}' | sort > first-build`
3) Build again
4) Output another list of MD5 checksums into a new file
    - `find build/localhost/ -type f -exec md5sum {} + | awk '{print $2 "  " $1}' | sort > second-build`
5) `diff`ed the two to see which files changed
6) Check the differences; this shows the files that have changed by the nonce script plugin
7) Modify the build pipeline
8) Output another list of MD5 checksums into another new file
    - `find build/localhost/ -type f -exec md5sum {} + | awk '{print $2 "  " $1}' | sort > after-modification`
9) Diff the output
    - Unfortunately, this shows a _lot_ more modifications because the nonce script plugin now uses Cheerio instead of JSDOM, so the formatting is somewhat different
    ![image](https://user-images.githubusercontent.com/12970166/65629421-2755ee00-df88-11e9-989f-2f82e67293f6.png)
10) Check files that are expected to be different (from step 6)
    - The expected differences show up
    - `nonce` is added to inline scripts and not to scripts with a `src` attribute

**Check the update links plugin**
This one adds `rel="noopener"`.
1) Build the baseline
2) `mv build/localhost build/localhost-before`
3) Make the modifications
4) Check the count on the build before modification
    - `find build/localhost-before/ -name '*.html' -exec grep 'noopener' {} + | wc -l`
    - 1504
5) Check the count on the build after modification
    - `find build/localhost/ -name '*.html' -exec grep 'noopener' {} + | wc -l`
    - 1504

**Check the IDs**
1) Modify the plugin to output the files which were modified
2) Build
3) Open a file from the list of modified files
4) Find an `h2` or `h3` and ensure that the IDs are there
    - From what I could tell, they are

**Check the broken links plugin**
I had broken links locally for missing PDFs. After modifying the build, those same broken links were still reported.

**Reordering the plugins**
While testing, I found that a couple problems with keeping the previous plugin order:
- Parsing before the nonce plugin resulted in an error where the Drupal debug page created a new HTML file that wasn't parsed
- Putting the "redirect va.gov links" plugin before one that used `parsedContent` overrode the results of those redirects because the changes weren't made in the parsed content, just `file.contents`
With that in mind, I grouped all the plugins that require the parsed content together.

## Screenshots
![image](https://user-images.githubusercontent.com/12970166/65632946-c7634580-df8f-11e9-8ec8-003f34863974.png)

## Acceptance criteria
- [x] The HTML files are parsed only once
- [x] All the plugins still function as expected
- [x] The result of the other plugins is not affected
