### PR TITLE
[Facility Locator] Change search result headings to proper heading tag

### DIFF
--- a/src/applications/facility-locator/components/search-results/LocationInfoBlock.jsx
+++ b/src/applications/facility-locator/components/search-results/LocationInfoBlock.jsx
@@ -16,7 +16,7 @@ const LocationInfoBlock = ({ location }) => {
       {isProvider ? (
         <span>
           <Link to={`provider/${location.id}`}>
-            <h5>{name}</h5>
+            <h2 className="vads-u-font-size--h5">{name}</h2>
           </Link>
           {location.attributes.orgName && (
             <h6>{location.attributes.orgName}</h6>
@@ -26,7 +26,7 @@ const LocationInfoBlock = ({ location }) => {
       ) : (
         <span>
           <Link to={`facility/${location.id}`}>
-            <h5>{name}</h5>
+            <h2 className="vads-u-font-size--h5">{name}</h2>
           </Link>
           <FacilityTypeDescription location={location} />
         </span>

--- a/src/applications/facility-locator/tests/00-required.e2e.spec.js
+++ b/src/applications/facility-locator/tests/00-required.e2e.spec.js
@@ -25,7 +25,7 @@ module.exports = E2eHelpers.createE2eTest(client => {
   // check detail pages
   client
     .waitForElementVisible('.facility-result a h2', Timeouts.slow)
-    .click('.facility-result a h5')
+    .click('.facility-result a h2')
     .waitForElementVisible('.all-details', Timeouts.slow)
     .axeCheck('.main');
 

--- a/src/applications/facility-locator/tests/00-required.e2e.spec.js
+++ b/src/applications/facility-locator/tests/00-required.e2e.spec.js
@@ -24,7 +24,7 @@ module.exports = E2eHelpers.createE2eTest(client => {
 
   // check detail pages
   client
-    .waitForElementVisible('.facility-result a h5', Timeouts.slow)
+    .waitForElementVisible('.facility-result a h2', Timeouts.slow)
     .click('.facility-result a h5')
     .waitForElementVisible('.all-details', Timeouts.slow)
     .axeCheck('.main');

--- a/src/applications/facility-locator/tests/02-breadcrumbs.e2e.spec.js
+++ b/src/applications/facility-locator/tests/02-breadcrumbs.e2e.spec.js
@@ -41,8 +41,8 @@ module.exports = E2eHelpers.createE2eTest(client => {
 
   // check detail page with ID pattern letters_, letter, digits
   client
-    .waitForElementVisible('.facility-result a h5', Timeouts.slow)
-    .click('.facility-result a h5')
+    .waitForElementVisible('.facility-result a h2', Timeouts.slow)
+    .click('.facility-result a h2')
     .waitForElementVisible('.all-details', Timeouts.slow, false);
 
   client.waitForElementVisible('a[aria-current="page"', Timeouts.normal);


### PR DESCRIPTION
## Description
This PR changes the heading tags used on Facility Locator search result items to H2s to fix an accessibility issue.

Ticket - https://github.com/department-of-veterans-affairs/va.gov-team/issues/483

## Testing done
- Performed search and inspected tag to make sure H2 was rendered
- Compared local result with Staging to make sure there are no visual changes

## Screenshots
![image](https://user-images.githubusercontent.com/1915775/65634399-20d96d80-dfac-11e9-97aa-da252f4b1d98.png)


## Acceptance criteria
- [x] Proper heading tag is used

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
