### PR TITLE
[Disability Rating Calc] Clear calculated rating after rating input is changed

### DIFF
--- a/src/applications/disability-benefits/disability-rating-calculator/components/CalculatedDisabilityRating.jsx
+++ b/src/applications/disability-benefits/disability-rating-calculator/components/CalculatedDisabilityRating.jsx
@@ -12,12 +12,20 @@ class CalculatedDisabilityRating extends React.Component {
   }
 
   componentDidUpdate(previousProps) {
-    if (previousProps.calculatedRating !== this.props.calculatedRating) {
+    const formWasSubmitted =
+      this.props.calculatedRating &&
+      previousProps.calculatedRating !== this.props.calculatedRating;
+
+    if (formWasSubmitted) {
       focusElement(this.resultsRef.current);
     }
   }
 
   render() {
+    const { calculatedRating } = this.props;
+
+    const placeholder = '--';
+
     return (
       <div className="vads-u-margin-top--1">
         <div
@@ -30,12 +38,12 @@ class CalculatedDisabilityRating extends React.Component {
             className="vads-u-font-size--2xl vads-u-line-height--1"
             data-e2e="combined-rating"
           >
-            {this.props.calculatedRating.rounded}%
+            {calculatedRating ? calculatedRating.rounded : placeholder}%
           </div>
         </div>
         <p>
           <strong>Note:</strong> The actual combined value of your disability
-          ratings is {this.props.calculatedRating.exact}
+          ratings is {calculatedRating ? calculatedRating.exact : placeholder}
           %.
         </p>
         <p>

--- a/src/applications/disability-benefits/disability-rating-calculator/components/CalculatedDisabilityRating.jsx
+++ b/src/applications/disability-benefits/disability-rating-calculator/components/CalculatedDisabilityRating.jsx
@@ -23,7 +23,6 @@ class CalculatedDisabilityRating extends React.Component {
 
   render() {
     const { calculatedRating } = this.props;
-
     const placeholder = '--';
 
     return (

--- a/src/applications/disability-benefits/disability-rating-calculator/components/DisabilityRatingCalculator.jsx
+++ b/src/applications/disability-benefits/disability-rating-calculator/components/DisabilityRatingCalculator.jsx
@@ -53,9 +53,18 @@ export default class DisabilityRatingCalculator extends React.Component {
   };
 
   handleDisabilityChange = (index, updatedRow) => {
-    const disabilities = this.state.disabilities;
+    const { disabilities, calculatedRating } = this.state;
+
+    const previousRowValue = disabilities[index];
+
     disabilities[index] = updatedRow;
-    this.setState({ disabilities });
+
+    const ratingChanged = previousRowValue.rating !== updatedRow.rating;
+
+    this.setState({
+      disabilities,
+      calculatedRating: ratingChanged ? null : calculatedRating,
+    });
   };
 
   handleSubmit = () => {

--- a/src/applications/disability-benefits/disability-rating-calculator/utils/helpers.js
+++ b/src/applications/disability-benefits/disability-rating-calculator/utils/helpers.js
@@ -10,14 +10,14 @@ export function getRatingErrorMessage(rating) {
   if (isBeyondMax) {
     return {
       title: '100% is the maximum disability rating',
-      body: 'You can’t receive a combined rating of more than 100%.',
+      body: 'You can’t receive a combined disability rating of more than 100%.',
     };
   }
 
   if (!isFactorOfTen || isBelowMin) {
     return {
       title: 'Enter a valid rating',
-      body: 'Disability ratings are given in 10% increments, from 0 to 100.',
+      body: 'Disability ratings are given in 10% increments.',
     };
   }
 


### PR DESCRIPTION
## Description
This pull request edits the disability rating calculator to clarify when the results are stale, so that if a user inputs some ratings, submits, then changes a rating input, the calculated disability rating value in the results is replaced with a `--`, because it's misleading.

Ticket - https://github.com/department-of-veterans-affairs/va.gov-team/issues/731

## Testing done
1. Visit `/disability/about-disability-ratings-beta/`
1. Typing some rating values into the calculator
1. Submit the form
1. Observe the calculated rating
1. Changed a rating input 
1. Observe that the calculated rating is replaced with `--`

## Screenshots
![image](https://user-images.githubusercontent.com/1915775/65638816-ef18d480-dfb4-11e9-94d7-3efa5de7bde3.png)


## Acceptance criteria
- [x] Calculated rating now reflects when its value is stale

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
