### PR TITLE
Ensure nested lists are accessible (axe)

### DIFF
--- a/src/applications/facility-locator/components/ProviderDetailBlock.jsx
+++ b/src/applications/facility-locator/components/ProviderDetailBlock.jsx
@@ -19,8 +19,8 @@ const ProviderDetailBlock = ({ provider }) => {
         </li>
         <li>
           <strong>Services:</strong>
+          <ProviderServiceDescription provider={provider} details />
         </li>
-        <ProviderServiceDescription provider={provider} details />
       </ul>
 
       <h4 className="highlight">Appointments</h4>

--- a/src/applications/facility-locator/components/ProviderDetailBlock.jsx
+++ b/src/applications/facility-locator/components/ProviderDetailBlock.jsx
@@ -23,11 +23,11 @@ const ProviderDetailBlock = ({ provider }) => {
         </li>
       </ul>
 
-      <h4 className="highlight">Appointments</h4>
-      <h4>Accepting new patients</h4>
+      <h3 className="highlight vads-u-font-size--h4">Appointments</h3>
+      <h3 className="vads-u-font-size--h4">Accepting new patients</h3>
       {accNewPatients ? 'Yes' : 'No'}
 
-      <h4 className="highlight">Community Care Details</h4>
+      <h3 className="highlight vads-u-font-size--h4">Community Care Details</h3>
       <ul>
         <li>
           <strong>Network:</strong> {network}

--- a/src/applications/facility-locator/components/ProviderServiceDescription.jsx
+++ b/src/applications/facility-locator/components/ProviderServiceDescription.jsx
@@ -17,7 +17,7 @@ const ProviderServiceDescription = ({ provider, details = false }) => {
     if (specialty && specialty.length < 1) return null;
 
     return (
-      <ul>
+      <ul className="vads-u-margin-top--1">
         {specialty.map(s => (
           <li key={s.name}>
             <u>{s.name}</u>: {s.desc}


### PR DESCRIPTION
## Description
The provider detail views sometimes have second-level lists that use CSS to indent them instead of nesting an `<ul>` inside the `<li>`. These lists were flagged as SC 1.3.1 issues. Screenshots attached below. This is the PR related to [this issue](https://github.com/department-of-veterans-affairs/va.gov-team/issues/2015).

## Testing done
Testing was done by using [axe accessibility's Chrome extension](https://chrome.google.com/webstore/detail/axe/lhdoppojpmngadmnindnejefpokejbdd?hl=en-US) and ensuring that the following 2 errors are resolved:
![image](https://user-images.githubusercontent.com/12773166/65640777-20939f00-dfb9-11e9-8d27-a365e7a1eda5.png)

## Screenshots
### Before
![image](https://user-images.githubusercontent.com/12773166/65640732-0b1e7500-dfb9-11e9-8241-a59fcd2b28d4.png)


### After
![image](https://user-images.githubusercontent.com/12773166/65640619-c8f53380-dfb8-11e9-9afa-812478ddb9c8.png)


## Acceptance criteria
- [x] As an assistive device user, I want to hear the lists announced as proper nested lists, instead of one large list.
- [x] As a user with a level of visual acuity, I do not want to see any visual changes in the application.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
