### PR TITLE
Call build with named parameters

### DIFF
--- a/Jenkinsfile.content
+++ b/Jenkinsfile.content
@@ -26,7 +26,14 @@ node('vetsgov-general-purpose') {
   dockerContainer = commonStages.setup()
 
   stage("Build") {
-    commonStages.build(ref, dockerContainer, ref, params.env, false, true)
+    commonStages.build(
+      ref: ref,
+      dockerContainer: dockerContainer,
+      assetSource: ref,
+      envName: params.env,
+      useCache: false,
+      contentOnlyBuild: true
+    )
   }
 
   stage("Prearchive") {

--- a/jenkins/common.groovy
+++ b/jenkins/common.groovy
@@ -221,7 +221,14 @@ def buildAll(String ref, dockerContainer, Boolean contentOnlyBuild) {
         def envName = VAGOV_BUILDTYPES.get(i)
         builds[envName] = {
           try {
-            build(ref, dockerContainer, assetSource, envName, false, contentOnlyBuild)
+            build(
+	      ref: ref,
+	      dockerContainer: dockerContainer,
+	      assetSource: assetSource,
+	      envName: envName,
+	      useCache: false,
+	      contentOnlyBuild: contentOnlyBuild
+	    )
             envUsedCache[envName] = false
           } catch (error) {
             // We're not using the cache for content only builds, because requesting


### PR DESCRIPTION
## Description
Gonna be honest: I don't understand why this should be necessary.

A [content-only deploy failed](http://jenkins.vfs.va.gov/job/builds/job/vets-website-content-vagovprod/103/console) with the following error:
```
java.lang.IllegalArgumentException: Expected named arguments but got [741f6c463ef7101ed7d602d1203ec87a7c3d59bc, org.jenkinsci.plugins.docker.workflow.Docker$Image@20007a84, 741f6c463ef7101ed7d602d1203ec87a7c3d59bc, vagovprod, false, true]
````
Expected named arguments. The only change made to this was [here](https://github.com/department-of-veterans-affairs/vets-website/pull/10810/files#diff-c79b85a3f1f3f199e1045f9a6c95e2abR29). Notice how it didn't expect named arguments before. :roll_eyes: 

What's more, the build for the branch that introduced that error built with `buildAll()`, which _also_ calls `build()` with that new parameter, but _it_ doesn't expect named arguments.

I don't understand why the failure happened, and I'm only hoping this fixes it.

## Testing done
I added named arguments to one of the `build` calls in `buildAll()` just to check that using named arguments works in there. (I have no way to test the command in `Jenkinsfile.content`.)