### PR TITLE
Add 'Community Care Preferences' page

### DIFF
--- a/src/applications/vaos/containers/CommunityCarePreferencesPage.jsx
+++ b/src/applications/vaos/containers/CommunityCarePreferencesPage.jsx
@@ -1,0 +1,111 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import SchemaForm from 'platform/forms-system/src/js/components/SchemaForm';
+import FormButtons from '../components/FormButtons';
+import {
+  openFormPage,
+  updateFormData,
+  routeToNextAppointmentPage,
+  routeToPreviousAppointmentPage,
+} from '../actions/newAppointment.js';
+import { getFormPageInfo } from '../utils/selectors';
+import { LANGUAGES } from './../utils/constants';
+
+const initialSchema = {
+  type: 'object',
+  required: ['distanceWillingToTravel', 'preferredLanguage'],
+  properties: {
+    distanceWillingToTravel: {
+      type: 'string',
+      enum: ['25', '50', '50 or more'],
+    },
+    preferredLanguage: {
+      type: 'string',
+      enum: LANGUAGES.map(l => l.value),
+    },
+  },
+};
+
+const uiSchema = {
+  distanceWillingToTravel: {
+    'ui:title': 'How many miles are you willing to travel for an appointment?',
+    'ui:widget': 'radio',
+    'ui:options': {
+      labels: {
+        25: 'Up to 25 miles',
+        50: '25 to 50 miles',
+        '50 or more': 'Farther than 50 miles',
+      },
+    },
+  },
+  preferredLanguage: {
+    'ui:title': 'Select your preferred language',
+    'ui:options': {
+      labels: LANGUAGES.reduce((allLanguages, language) => {
+        const result = { ...allLanguages };
+        result[language] = language.text;
+        return result;
+      }),
+    },
+  },
+};
+
+const pageKey = 'ccPreferences';
+
+export class CommunityCarePreferencesPage extends React.Component {
+  componentDidMount() {
+    this.props.openFormPage(pageKey, uiSchema, initialSchema);
+  }
+
+  goBack = () => {
+    this.props.routeToPreviousAppointmentPage(this.props.router, pageKey);
+  };
+
+  goForward = () => {
+    this.props.routeToNextAppointmentPage(this.props.router, pageKey);
+  };
+
+  render() {
+    const { schema, data, pageChangeInProgress } = this.props;
+
+    return (
+      <div>
+        <h1 className="vads-u-font-size--h2">
+          Share your community care provider preferences (2/2)
+        </h1>
+        <SchemaForm
+          name="Community care preferences"
+          title="Community care preferences"
+          schema={schema || initialSchema}
+          uiSchema={uiSchema}
+          onSubmit={this.goForward}
+          onChange={newData =>
+            this.props.updateFormData(pageKey, uiSchema, newData)
+          }
+          data={data}
+        >
+          <FormButtons
+            onBack={this.goBack}
+            pageChangeInProgress={pageChangeInProgress}
+          />
+        </SchemaForm>
+      </div>
+    );
+  }
+}
+
+function mapStateToProps(state) {
+  return getFormPageInfo(state, pageKey);
+}
+
+const mapDispatchToProps = {
+  openFormPage,
+  updateFormData,
+  routeToNextAppointmentPage,
+  routeToPreviousAppointmentPage,
+};
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(CommunityCarePreferencesPage);

--- a/src/applications/vaos/newAppointmentFlow.js
+++ b/src/applications/vaos/newAppointmentFlow.js
@@ -53,7 +53,7 @@ export default {
   },
   ccProvider: {
     url: '/new-appointment/community-care-provider',
-    next: 'contactInfo',
+    next: 'ccPreferences',
     previous(state) {
       if (isCCAudiology(state)) {
         return 'audiologyCareType';
@@ -61,6 +61,11 @@ export default {
 
       return 'typeOfFacility';
     },
+  },
+  ccPreferences: {
+    url: '/new-appointment/community-care-preferences',
+    next: 'contactInfo',
+    previous: 'ccProvider',
   },
   vaFacility: {
     url: '/new-appointment/va-facility',

--- a/src/applications/vaos/routes.jsx
+++ b/src/applications/vaos/routes.jsx
@@ -6,6 +6,7 @@ import AppointmentListsPage from './containers/AppointmentListsPage';
 // import TypeOfAppointmentPage from './containers/TypeOfAppointmentPage';
 import TypeOfCarePage from './containers/TypeOfCarePage';
 import CommunityCareProviderPage from './containers/CommunityCareProviderPage';
+import CommunityCarePreferencesPage from './containers/CommunityCarePreferencesPage';
 import PendingAppointmentListPage from './containers/PendingAppointmentListPage';
 import PendingAppointmentDetailPage from './containers/PendingAppointmentDetailPage';
 import ConfirmedAppointmentDetailPage from './containers/ConfirmedAppointmentDetailPage';
@@ -30,6 +31,10 @@ const routes = (
         component={CommunityCareProviderPage}
       />
       <Route path="va-facility" component={VAFacilityPage} />
+      <Route
+        path="community-care-preferences"
+        component={CommunityCarePreferencesPage}
+      />
     </Route>
     <Route path="appointments" component={AppointmentListsPage} />
     <Route path="appointments/pending" component={PendingAppointmentListPage} />

--- a/src/applications/vaos/tests/containers/CommunityCarePreferencesPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/containers/CommunityCarePreferencesPage.unit.spec.jsx
@@ -1,0 +1,101 @@
+import React from 'react';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { mount } from 'enzyme';
+
+import { selectRadio } from 'platform/testing/unit/schemaform-utils.jsx';
+import { CommunityCarePreferencesPage } from '../../containers/CommunityCarePreferencesPage';
+
+describe('VAOS <CommunityCarePreferencesPage>', () => {
+  it('should render', () => {
+    const openFormPage = sinon.spy();
+    const updateFormData = sinon.spy();
+
+    const form = mount(
+      <CommunityCarePreferencesPage
+        openFormPage={openFormPage}
+        updateFormData={updateFormData}
+        data={{}}
+      />,
+    );
+
+    expect(form.find('input').length).to.equal(3);
+    form.unmount();
+  });
+
+  it('should not submit empty form', () => {
+    const openFormPage = sinon.spy();
+    const router = {
+      push: sinon.spy(),
+    };
+
+    const form = mount(
+      <CommunityCarePreferencesPage
+        openFormPage={openFormPage}
+        router={router}
+        data={{}}
+      />,
+    );
+
+    form.find('form').simulate('submit');
+
+    expect(form.find('.usa-input-error').length).to.equal(2);
+    expect(router.push.called).to.be.false;
+    form.unmount();
+  });
+
+  it('should call updateFormData after change', () => {
+    const openFormPage = sinon.spy();
+    const updateFormData = sinon.spy();
+    const router = {
+      push: sinon.spy(),
+    };
+
+    const form = mount(
+      <CommunityCarePreferencesPage
+        openFormPage={openFormPage}
+        updateFormData={updateFormData}
+        router={router}
+        data={{}}
+      />,
+    );
+
+    selectRadio(form, 'root_distanceWillingToTravel', '25');
+
+    const language = form.find('select#root_preferredLanguage');
+
+    expect(updateFormData.firstCall.args[2].distanceWillingToTravel).to.equal(
+      '25',
+    );
+
+    language.simulate('change', {
+      target: {
+        value: 'Chinese',
+      },
+    });
+
+    expect(updateFormData.secondCall.args[2].preferredLanguage).to.equal(
+      'Chinese',
+    );
+    form.unmount();
+  });
+
+  it('should submit with valid data', () => {
+    const openFormPage = sinon.spy();
+    const routeToNextAppointmentPage = sinon.spy();
+
+    const form = mount(
+      <CommunityCarePreferencesPage
+        openFormPage={openFormPage}
+        routeToNextAppointmentPage={routeToNextAppointmentPage}
+        data={{ distanceWillingToTravel: '25', preferredLanguage: 'English' }}
+      />,
+    );
+
+    form.find('form').simulate('submit');
+
+    expect(form.find('.usa-input-error').length).to.equal(0);
+    expect(routeToNextAppointmentPage.called).to.be.true;
+    form.unmount();
+  });
+});

--- a/src/applications/vaos/utils/constants.js
+++ b/src/applications/vaos/utils/constants.js
@@ -96,6 +96,69 @@ export const TYPES_OF_CARE = [
   },
 ];
 
+export const LANGUAGES = [
+  {
+    id: 'english',
+    text: 'English',
+    value: 'English',
+  },
+  {
+    id: 'chinese',
+    text: 'Chinese',
+    value: 'Chinese',
+  },
+  {
+    id: 'french',
+    text: 'French',
+    value: 'French',
+  },
+  {
+    id: 'german',
+    text: 'German',
+    value: 'German',
+  },
+  {
+    id: 'italian)',
+    text: 'Italian',
+    value: 'Italian',
+  },
+  {
+    id: 'korean',
+    text: 'Korean',
+    value: 'Korean',
+  },
+  {
+    id: 'portuguese',
+    text: 'Portuguese',
+    value: 'Portuguese',
+  },
+  {
+    id: 'russian',
+    text: 'Russian',
+    value: 'Russian',
+  },
+  {
+    id: 'spanish',
+    text: 'Spanish',
+    value: 'Spanish',
+  },
+  {
+    id: 'tagalog',
+    text: 'Tagalog (Filipino)',
+    value: 'Tagalog (Filipino)',
+  },
+  {
+    id: 'vietnamese',
+    text: 'Vietnamese',
+    value: 'Vietnamese',
+  },
+  {
+    id: 'other',
+    text: 'Other',
+    value: 'Other',
+  },
+];
+
 export const CANCELLED_APPOINTMENT_SET = new Set([
   'NO-SHOW',
   'CANCELLED BY CLINIC',


### PR DESCRIPTION
## Description
Add 'Community Care Provider Preferences' page where user can indicate how far they are willing to drive for an appointment and what language they'd prefer the appointment to be in, so that they can get scheduled for community care at a location that's reachable for them and that can speak the language with which they most comfortable.

Languages were copied from `veteran-appointment-requests/app/modules/community-care-request/new-appointment-request-question/preferred-provider/preferences/preferred-provider.json` in legacy `var-web` project. Will ask Marcy or Shawn if there is a reason these specific languages are in the app.  Unsure whether `id` or `value` is being passed in request

## Testing done
Local and unit test

## Screenshots
![image](https://user-images.githubusercontent.com/786704/65662623-90ba1900-dfe9-11e9-83c8-d2e944bb5012.png)


## Acceptance criteria
- [ ] User can select distance options as well as language preference

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
