### PR TITLE
Revert "Call build with named parameters and hope for the best (#10813)"

### DIFF
--- a/Jenkinsfile.content
+++ b/Jenkinsfile.content
@@ -26,14 +26,7 @@ node('vetsgov-general-purpose') {
   dockerContainer = commonStages.setup()
 
   stage("Build") {
-    commonStages.build(
-      ref: ref,
-      dockerContainer: dockerContainer,
-      assetSource: ref,
-      envName: params.env,
-      useCache: false,
-      contentOnlyBuild: true
-    )
+    commonStages.build(ref, dockerContainer, ref, params.env, false, true)
   }
 
   stage("Prearchive") {

--- a/jenkins/common.groovy
+++ b/jenkins/common.groovy
@@ -221,14 +221,7 @@ def buildAll(String ref, dockerContainer, Boolean contentOnlyBuild) {
         def envName = VAGOV_BUILDTYPES.get(i)
         builds[envName] = {
           try {
-            build(
-	      ref: ref,
-	      dockerContainer: dockerContainer,
-	      assetSource: assetSource,
-	      envName: envName,
-	      useCache: false,
-	      contentOnlyBuild: contentOnlyBuild
-	    )
+            build(ref, dockerContainer, assetSource, envName, false, contentOnlyBuild)
             envUsedCache[envName] = false
           } catch (error) {
             // We're not using the cache for content only builds, because requesting


### PR DESCRIPTION
This reverts commit 132ff1372ca0d134456aaaa725a3a7f2e0c067ae.

## Description
Reverts https://github.com/department-of-veterans-affairs/vets-website/pull/10813/files

I was hoping that would solve the content-only build problem, but it turns out it didn't. http://jenkins.vfs.va.gov/job/builds/job/vets-website-content-vagovprod/105/console still failed, but now with
```
WARNING: Unknown parameter(s) found for class type 'org.jenkinsci.plugins.workflow.support.steps.build.BuildTriggerStep': assetSource,contentOnlyBuild,dockerContainer,envName,ref,useCache
```

I don't know why not. I'm very confused.

## Testing done
:man_shrugging: 