### PR TITLE
Stop focusing searchResultTitle ref on componentDidUpdate

### DIFF
--- a/src/applications/facility-locator/components/ResultsList.jsx
+++ b/src/applications/facility-locator/components/ResultsList.jsx
@@ -10,7 +10,6 @@ import Pagination from '@department-of-veterans-affairs/formation-react/Paginati
 import { facilityTypes } from '../config';
 
 import { distBetween } from '../utils/facilityDistance';
-import { setFocus } from '../utils/helpers';
 
 import { updateSearchQuery, searchWithBounds } from '../actions';
 
@@ -24,17 +23,12 @@ class ResultsList extends Component {
     super(props);
     this.searchResultTitle = React.createRef();
   }
+
   shouldComponentUpdate(nextProps) {
     return (
       nextProps.results !== this.props.results ||
       nextProps.inProgress !== this.props.inProgress
     );
-  }
-
-  componentDidUpdate() {
-    if (this.searchResultTitle.current) {
-      setFocus(this.searchResultTitle.current);
-    }
   }
 
   handlePageSelect = page => {
@@ -86,10 +80,7 @@ class ResultsList extends Component {
         const timedOut = error.find(err => TIMEOUTS.has(err.code));
         if (timedOut) {
           return (
-            <div
-              className="search-result-title facility-result"
-              ref={this.searchResultTitle}
-            >
+            <div className="search-result-title facility-result">
               <p>
                 We’re sorry. We couldn’t complete your request. We’re aware of
                 this problem, and we’re working to fix it as soon as possible.
@@ -117,10 +108,7 @@ class ResultsList extends Component {
       }
 
       return (
-        <div
-          className="search-result-title facility-result"
-          ref={this.searchResultTitle}
-        >
+        <div className="search-result-title facility-result">
           <p>We’re sorry. We couldn’t complete your request.</p>
           <p>
             Please try again in a few minutes. Or, if you need care right away
@@ -146,10 +134,7 @@ class ResultsList extends Component {
     if (!results || results.length < 1) {
       if (this.props.facilityTypeName === facilityTypes.cc_provider) {
         return (
-          <div
-            className="search-result-title facility-result"
-            ref={this.searchResultTitle}
-          >
+          <div className="search-result-title facility-result">
             We didn't find any facilities near you. <br />
             <strong>To try again, please enter a different:</strong>
             <ul className="vads-u-margin-y--1p5">
@@ -167,10 +152,7 @@ class ResultsList extends Component {
         );
       }
       return (
-        <div
-          className="search-result-title facility-result"
-          ref={this.searchResultTitle}
-        >
+        <div className="search-result-title facility-result">
           No facilities found. Please try entering a different search term
           (Street, City, State or Zip) and click search to find facilities.
         </div>
@@ -194,7 +176,7 @@ class ResultsList extends Component {
 
     return (
       <div>
-        <p className="search-result-title" ref={this.searchResultTitle}>
+        <p className="search-result-title">
           {`${totalEntries} results for ${facilityTypeName} near `}
           <strong>“{context}”</strong>
         </p>


### PR DESCRIPTION
## Description
**Issue**: https://github.com/department-of-veterans-affairs/va.gov-team/issues/490

**Current behavior**: is that when a user is focused on the map and presses either `+` or `-`, it zooms the user in/out and when the new results come in **we focus on the results**.

**Expected behavior**: is that when a user is focused on the map and presses either `+` or `-`, it zooms the user in/out and when the new results come in **focus stays on the map**.

This PR implements the expected behavior mentioned above.

## Testing done
I tested locally only. I would upload video snippets of before and after but GitHub isn't letting me upload .mp4s 😭My steps to test it were as follows:

1. Open http://localhost:3001/find-locations.
2. Open https://www.va.gov/find-locations.
3. Click on map in both windows.
4. Open dev tools and type `$0` to confirm the map node is focused in both windows.
5. Focused on the map, I pressed `-` (step 8 I pressed `+`).
6. In https://www.va.gov/find-locations I observed the focus was on the results title. I repeated step 4 to confirm the results title was focused.
7. In http://localhost:3001/find-locations I observed no change in focus. I repeated step 4 to confirm the map was focused.
8. Repeat steps 5-8.

## Screenshots
N/A -- Wish I could have uploaded .mp4s!

## Acceptance criteria
- [x] As a keyboard user, I would like the map to retain focus when I press an arrow key, or any other keyboard shortcut. The number of results should update as before, but the yellow focus halo should stay on the map.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
