### PR TITLE
Add noindex meta tag on non-prod envs

### DIFF
--- a/src/site/includes/header.html
+++ b/src/site/includes/header.html
@@ -12,6 +12,10 @@
 <meta name="MobileOptimized" content="320">
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
+  {% if buildtype != 'vagovprod' %}
+  <meta name="robots" content="noindex">
+  {% endif %}
+
 {% if drupalTags %}
   {% include "src/site/includes/metatags.drupal.liquid" %}
 {% else %}


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/1258

**Current Behavior:** Google and other search engines crawl non-production environments.

**Expected Behavior:** Google and other search engines **cannot** crawl non-production environments.

This PR implements the expected behavior by using `<meta name="robots" content="noindex">`, which is definitely respected by Google and is very likely to be [respected by Bing](https://www.bing.com/webmaster/help/which-robots-metatags-does-bing-support-5198d240) and [respected by Yahoo](https://en.wikipedia.org/wiki/Noindex).

## Testing done
I tested locally. (View screenshot below)

## Screenshots
![image](https://user-images.githubusercontent.com/12773166/65727105-cd871e00-e084-11e9-9178-8956e99423f0.png)


## Acceptance criteria
- [x] Robots are instructed to not index non-production environments.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
