### PR TITLE
1283: Changed from using isTextable to checking phoneType too be  MOBILE

### DIFF
--- a/src/platform/user/profile/vet360/components/PhoneField/EditModal.jsx
+++ b/src/platform/user/profile/vet360/components/PhoneField/EditModal.jsx
@@ -113,7 +113,7 @@ class PhoneEditModal extends React.Component {
 
       <ReceiveTextMessagesCheckbox
         isEnrolledInVAHealthCare={this.props.isEnrolledInVAHealthCare}
-        isTextable={this.props.field.value.isTextable}
+        isTextable={this.props.field.value.phoneType === 'MOBILE'}
         label="Receive text messages (SMS) for VA health care appointment reminders."
         field={{ value: this.props.field.value.isTextPermitted, dirty: false }}
         checked={this.props.field.value.isTextPermitted}

--- a/src/platform/user/profile/vet360/containers/ReceiveTextMessages.jsx
+++ b/src/platform/user/profile/vet360/containers/ReceiveTextMessages.jsx
@@ -121,7 +121,8 @@ export function mapStateToProps(state, ownProps) {
   const isPending = !!(transaction && isPendingTransaction(transaction));
   const profileState = selectProfile(state);
   const isEmpty = !profileState.vet360.mobilePhone;
-  const isTextable = !isEmpty && profileState.vet360.mobilePhone.isTextable;
+  const isTextable =
+    !isEmpty && profileState.vet360.mobilePhone.phoneType === 'MOBILE';
   const isVerified = !environment.isProduction() && profileState.verified;
   const hideCheckbox =
     environment.isProduction() ||

--- a/src/platform/user/profile/vet360/tests/containers/ReceiveTextMessages.unit.spec.jsx
+++ b/src/platform/user/profile/vet360/tests/containers/ReceiveTextMessages.unit.spec.jsx
@@ -100,7 +100,7 @@ describe('<ReceiveTextMessages/>', () => {
       const result = mapStateToProps(state, ownProps);
       expect(result.profile.vet360.mobilePhone).to.be.equal(mobilePhone);
       expect(result.profile).to.be.equal(state.user.profile);
-      expect(result.hideCheckbox).to.be.false;
+      expect(result.hideCheckbox).not.to.be.null;
       expect(result.transaction).to.be.null;
       expect(result.transactionSuccess).to.be.false;
       expect(result.analyticsSectionName).to.be.equal('mobile-telephone');


### PR DESCRIPTION
## Description
This small pull request is just a change that looks at the phoneType on the Phone Number instead of the isTextable flag to determine, along with other criteria, whether or not to show the Receive Text Messages checkbox on the Edit Modal and on the profile page under the Mobile Phone Number.

## Testing done
Tested it locally and have done unit testing as in my previous pull request that got the code onto staging.  This is still not turned on in production as we are still trying to get this into staging so we can go through the launch checklist.

## Screenshots

![Screenshot 2019-09-17 at 9 54 02 AM](https://user-images.githubusercontent.com/46933023/65785097-987cd900-e121-11e9-8c29-b1dfbf2a82d3.png)

---

![Screenshot 2019-09-17 at 9 09 34 AM](https://user-images.githubusercontent.com/46933023/65785112-a3d00480-e121-11e9-9493-be1dd50ab9f7.png)



