### PR TITLE
Add content repo installation to vets-website scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "nightwatch": "nightwatch -c config/nightwatch.js",
     "nightwatch-sauce": "nightwatch -c config/nightwatch-sauce.js",
     "nightwatch-visual": "node src/platform/testing/visual-regression/index.js",
+    "install-repos": "./script/install-repos.sh",
     "postinstall": "npm rebuild node-sass",
     "reset:env": "./script/reset-environment.sh",
     "security-check": "node ./script/security-check.js",

--- a/script/install-repos.sh
+++ b/script/install-repos.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+if [ ! -d ../vagov-content ]; then
+  git clone https://github.com/department-of-veterans-affairs/vagov-content.git ../vagov-content
+else
+  echo "Repo vagov-content already cloned."
+fi
+
+# @TODO: if these are not needed anymore, remove.
+# git clone git@github.com:department-of-veterans-affairs/vets-json-schema.git
+# git clone git@github.com:department-of-veterans-affairs/veteran-facing-services-tools.git
+# git clone git@github.com:department-of-veterans-affairs/vets-api.git
+# git clone git@github.com:department-of-veterans-affairs/vets-api-mockdata.git


### PR DESCRIPTION
## Description
Carries over the work from https://github.com/department-of-veterans-affairs/vets-website/pull/10270 to allow automatically installing the vets-content repo.

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
