### PR TITLE
Add update-robots build plugin

### DIFF
--- a/src/site/stages/build/index.js
+++ b/src/site/stages/build/index.js
@@ -15,29 +15,30 @@ const getOptions = require('./options');
 const registerLiquidFilters = require('../../filters/liquid');
 const { getDrupalContent } = require('./drupal/metalsmith-drupal');
 const addDrupalPrefix = require('./plugins/add-drupal-prefix');
-const createBuildSettings = require('./plugins/create-build-settings');
-const createRedirects = require('./plugins/create-redirects');
-const createSitemaps = require('./plugins/create-sitemaps');
-const updateExternalLinks = require('./plugins/update-external-links');
-const createEnvironmentFilter = require('./plugins/create-environment-filter');
 const addNonceToScripts = require('./plugins/add-nonce-to-scripts');
-const leftRailNavResetLevels = require('./plugins/left-rail-nav-reset-levels');
-const checkBrokenLinks = require('./plugins/check-broken-links');
-const rewriteVaDomains = require('./plugins/rewrite-va-domains');
-const rewriteDrupalPages = require('./plugins/rewrite-drupal-pages');
-const createDrupalDebugPage = require('./plugins/create-drupal-debug');
-const configureAssets = require('./plugins/configure-assets');
+const addSubheadingsIds = require('./plugins/add-id-to-subheadings');
 const applyFragments = require('./plugins/apply-fragments');
+const checkBrokenLinks = require('./plugins/check-broken-links');
 const checkCollections = require('./plugins/check-collections');
+const checkForCMSUrls = require('./plugins/check-cms-urls');
+const configureAssets = require('./plugins/configure-assets');
+const createBuildSettings = require('./plugins/create-build-settings');
+const createDrupalDebugPage = require('./plugins/create-drupal-debug');
+const createEnvironmentFilter = require('./plugins/create-environment-filter');
 const createFeatureToggles = require('./plugins/create-feature-toggles');
 const createHeaderFooter = require('./plugins/create-header-footer');
-const createReactPages = require('./plugins/create-react-pages');
-const downloadDrupalAssets = require('./plugins/download-drupal-assets');
-const checkForCMSUrls = require('./plugins/check-cms-urls');
 const createOutreachAssetsData = require('./plugins/create-outreach-assets-data');
-const addSubheadingsIds = require('./plugins/add-id-to-subheadings');
+const createReactPages = require('./plugins/create-react-pages');
+const createRedirects = require('./plugins/create-redirects');
+const createSitemaps = require('./plugins/create-sitemaps');
+const downloadDrupalAssets = require('./plugins/download-drupal-assets');
+const leftRailNavResetLevels = require('./plugins/left-rail-nav-reset-levels');
 const parseHtml = require('./plugins/parse-html');
 const replaceContentsWithDom = require('./plugins/replace-contents-with-dom');
+const rewriteDrupalPages = require('./plugins/rewrite-drupal-pages');
+const rewriteVaDomains = require('./plugins/rewrite-va-domains');
+const updateExternalLinks = require('./plugins/update-external-links');
+const updateRobots = require('./plugins/update-robots');
 
 function defaultBuild(BUILD_OPTIONS) {
   const smith = Metalsmith(__dirname); // eslint-disable-line new-cap
@@ -213,6 +214,7 @@ function defaultBuild(BUILD_OPTIONS) {
 
   smith.use(createSitemaps(BUILD_OPTIONS), 'Create sitemap');
   smith.use(createRedirects(BUILD_OPTIONS), 'Create redirects');
+  smith.use(updateRobots(BUILD_OPTIONS), 'Update robots.txt');
   smith.use(checkForCMSUrls(BUILD_OPTIONS), 'Check for CMS URLs');
 
   /**

--- a/src/site/stages/build/plugins/update-robots.js
+++ b/src/site/stages/build/plugins/update-robots.js
@@ -1,0 +1,26 @@
+// Dependencies
+const ENVIRONMENTS = require('../../../constants/environments');
+
+function updateRobots(buildOptions) {
+  // Use the default robots.txt file on production.
+  if (buildOptions.buildtype === ENVIRONMENTS.VAGOVPROD) {
+    // eslint-disable-next-line
+    console.log('Using the production robots.txt');
+    return () => {};
+  }
+
+  return (files, smith, done) => {
+    // Derive the robots file.
+    const robots = files['robots.txt'];
+
+    // Update the robots.txt contents to disallow crawlers.
+    robots.contents = new Buffer('User-agent: *\nDisallow: /\n');
+
+    // eslint-disable-next-line
+    console.log('Using the non-production robots.txt');
+
+    done();
+  };
+}
+
+module.exports = updateRobots;

--- a/src/site/stages/build/plugins/update-robots.js
+++ b/src/site/stages/build/plugins/update-robots.js
@@ -9,7 +9,7 @@ function updateRobots(buildOptions) {
     return () => {};
   }
 
-  return (files, smith, done) => {
+  return files => {
     // Derive the robots file.
     const robots = files['robots.txt'];
 
@@ -18,8 +18,6 @@ function updateRobots(buildOptions) {
 
     // eslint-disable-next-line
     console.log('Using the non-production robots.txt');
-
-    done();
   };
 }
 


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/1258

**Current Behavior:** Google and other search engines crawl non-production environments.

**Expected Behavior:** Google and other search engines **cannot** crawl non-production environments.

This PR implements the expected behavior by updating the `robots.txt` file based on the environment.

## Testing done
I tested locally. (View screenshot below)

## Screenshots
![image](https://user-images.githubusercontent.com/12773166/65975911-5c0cee00-e43d-11e9-8913-23726179e276.png)

## Acceptance criteria
- [x] Robots are instructed to not index non-production environments.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
