### PR TITLE
[CMS Build] Generate heading IDs using page context, rather than globally.

### DIFF
--- a/src/site/stages/build/plugins/add-id-to-subheadings.js
+++ b/src/site/stages/build/plugins/add-id-to-subheadings.js
@@ -2,11 +2,7 @@
  * Add unique ID to H2s and H3s that aren't in WYSIWYG or accordion buttons
  */
 
-const usedHeaders = [];
-
-let currentId = 1;
-
-function createUniqueId(headingEl, usedHeaders, currentHeaderId) {
+function createUniqueId(headingEl, headingOptions) {
   const headingString = headingEl.text();
   const length = 30;
   let anchor = headingString
@@ -17,17 +13,11 @@ function createUniqueId(headingEl, usedHeaders, currentHeaderId) {
     .replace(/-+$/, '')
     .substring(0, length);
 
-  if (usedHeaders.includes(anchor)) {
-
-    anchor = `${anchor}-${++currentHeaderId}`;
-
-    if (usedHeaders.includes(anchor)) {
-      console.log(usedHeaders)
-      console.log(anchor)
-      throw new Error('WTF')
-    }
+  if (headingOptions.previousHeadings.includes(anchor)) {
+    anchor += `-${headingOptions.getHeadingId()}`;
   }
-  usedHeaders.push(anchor);
+
+  headingOptions.previousHeadings.push(anchor);
   return anchor;
 }
 
@@ -41,11 +31,15 @@ function generateHeadingIds() {
         const { dom } = file;
         const tableOfContents = dom('#table-of-contents ul');
 
-        const
-        const usedHeaders = [];
-        let currentHeaderId = 0;
+        const headingOptions = {
+          previousHeadings: [],
+          previousId: 0,
+          getHeadingId() {
+            return ++this.previousId;
+          },
+        };
 
-        dom('h2, h3').each((i, el) => {
+        dom('h2, h3').each((index, el) => {
           const heading = dom(el);
           const parent = heading.parents();
           const isInAccordionButton = parent.hasClass('usa-accordion-button');
@@ -53,7 +47,7 @@ function generateHeadingIds() {
 
           // skip heading if it already has an id and skip heading if it's in an accordion button
           if (!heading.attr('id') && !isInAccordionButton) {
-            const headingID = createUniqueId(heading, usedHeaders, currentHeaderId);
+            const headingID = createUniqueId(heading, headingOptions);
             heading.attr('id', headingID);
             idAdded = true;
           }

--- a/src/site/stages/build/plugins/add-id-to-subheadings.js
+++ b/src/site/stages/build/plugins/add-id-to-subheadings.js
@@ -6,7 +6,7 @@ const usedHeaders = [];
 
 let currentId = 1;
 
-function createUniqueId(headingEl) {
+function createUniqueId(headingEl, usedHeaders, currentHeaderId) {
   const headingString = headingEl.text();
   const length = 30;
   let anchor = headingString
@@ -18,9 +18,13 @@ function createUniqueId(headingEl) {
     .substring(0, length);
 
   if (usedHeaders.includes(anchor)) {
-    if (!usedHeaders.includes(`${anchor}-${currentId}`)) {
-      anchor = `${anchor}-${currentId}`;
-      currentId++;
+
+    anchor = `${anchor}-${++currentHeaderId}`;
+
+    if (usedHeaders.includes(anchor)) {
+      console.log(usedHeaders)
+      console.log(anchor)
+      throw new Error('WTF')
     }
   }
   usedHeaders.push(anchor);
@@ -36,6 +40,11 @@ function generateHeadingIds() {
       if (fileName.endsWith('html')) {
         const { dom } = file;
         const tableOfContents = dom('#table-of-contents ul');
+
+        const
+        const usedHeaders = [];
+        let currentHeaderId = 0;
+
         dom('h2, h3').each((i, el) => {
           const heading = dom(el);
           const parent = heading.parents();
@@ -44,7 +53,7 @@ function generateHeadingIds() {
 
           // skip heading if it already has an id and skip heading if it's in an accordion button
           if (!heading.attr('id') && !isInAccordionButton) {
-            const headingID = createUniqueId(heading);
+            const headingID = createUniqueId(heading, usedHeaders, currentHeaderId);
             heading.attr('id', headingID);
             idAdded = true;
           }
@@ -62,7 +71,7 @@ function generateHeadingIds() {
                   <a href="#${heading.attr(
                     'id',
                   )}" class="vads-u-text-decoration--none">
-                    <i class="fas fa-arrow-down va-c-font-size--xs vads-u-margin-right--1"></i> 
+                    <i class="fas fa-arrow-down va-c-font-size--xs vads-u-margin-right--1"></i>
                     ${heading.text()}
                   </a>
                 </li>`,


### PR DESCRIPTION
## Description
We currently generate ID attributes for all h2 and h3 headings so that we can create jump links to them. We use the text of the heading to generate the ID. Sometimes, there is more than one heading containing the same text. In those cases, we append an integer, so that the heading ID is unique.

However, we currently generate those integers taking into account all of the headings in the entire site. For example, if Page A has a heading that says `More info`, and Page B has a heading that says `More info`, then Page B's heading ID will have an integer appended so that it's unique. Page A's would be `more-info`, while Page B's would be `more-info-1`.

The issue with this is -

1. It's unnecessary for Page B to be concerned about Page A's headings
1. The heading IDs generated on the Preview Server don't align with the live website, because the Preview Server only builds a single page and doesn't know what the headings are across the rest of the website
1. The page order of our build is dynamic, as are the content of the pages. Generating these integers globally means that if Page A removes its heading `More Info`, then Page B's heading ID would be changed from `more-info-1` to `more-info`, breaking any jump links to that heading, even though Page B didn't actually change.

### Ticket 
https://github.com/department-of-veterans-affairs/va.gov-team/issues/1625

## Testing done
- Locally testing, throwing errors if certain conditions occur

## Screenshots
Shows HTML output for /pittsburgh-health-care/locations/hj-heinz/. Notice the integers appended to the IDs were generated only in the scope of the page.

![image](https://user-images.githubusercontent.com/1915775/65993523-6c35c500-e45f-11e9-8458-7441a6541bb4.png)

## Acceptance criteria
- [x] Heading IDs are generated only in the scope of that page alone

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
