### PR TITLE
Feature/2043 update type of care list

### DIFF
--- a/src/applications/vaos/components/TypeOfCareField.jsx
+++ b/src/applications/vaos/components/TypeOfCareField.jsx
@@ -12,16 +12,23 @@ function RadioWidget({ option, checked, onChange, id }) {
         value={option.id}
         onChange={_ => onChange(option.id)}
       />
-      <label htmlFor={`${id}_${option.id}`}>{option.name}</label>
+      <label htmlFor={`${id}_${option.id}`}>
+        {option.name}{' '}
+        {option.id === '203' ? '(including hearing aid support)' : ''}
+      </label>
     </div>
   );
 }
 
-const PRIMARY_CARE = TYPES_OF_CARE.filter(care => care.group === 'primary');
+const PRIMARY_CARE = TYPES_OF_CARE.filter(
+  care => care.group === 'primary' && care.id !== 'CR1',
+);
 const MENTAL_HEALTH = TYPES_OF_CARE.filter(
   care => care.group === 'mentalHealth',
 );
-const SPECIALTY = TYPES_OF_CARE.filter(care => care.group === 'specialty');
+const SPECIALTY = TYPES_OF_CARE.filter(
+  care => care.group === 'specialty' && care.id !== '349',
+);
 
 export default function TypeOfCareField({ formData, onChange, idSchema }) {
   return (
@@ -46,7 +53,6 @@ export default function TypeOfCareField({ formData, onChange, idSchema }) {
         <legend className="vads-u-color--base vads-u-font-family--serif vads-u-padding-bottom--0 vads-u-padding-top--3">
           Mental and behavioral health
         </legend>
-        Including outpatient mental health and social services
         {MENTAL_HEALTH.map(care => (
           <RadioWidget
             key={care.id}
@@ -61,7 +67,6 @@ export default function TypeOfCareField({ formData, onChange, idSchema }) {
         <legend className="vads-u-color--base vads-u-font-family--serif vads-u-padding-bottom--0 vads-u-padding-top--3">
           Specialty care
         </legend>
-        Including hearing aid support and some other types of specialty care
         {SPECIALTY.map(care => (
           <RadioWidget
             key={care.id}

--- a/src/applications/vaos/components/TypeOfCareField.jsx
+++ b/src/applications/vaos/components/TypeOfCareField.jsx
@@ -12,23 +12,16 @@ function RadioWidget({ option, checked, onChange, id }) {
         value={option.id}
         onChange={_ => onChange(option.id)}
       />
-      <label htmlFor={`${id}_${option.id}`}>
-        {option.name}{' '}
-        {option.id === '203' ? '(including hearing aid support)' : ''}
-      </label>
+      <label htmlFor={`${id}_${option.id}`}>{option.name}</label>
     </div>
   );
 }
 
-const PRIMARY_CARE = TYPES_OF_CARE.filter(
-  care => care.group === 'primary' && care.id !== 'CR1',
-);
+const PRIMARY_CARE = TYPES_OF_CARE.filter(care => care.group === 'primary');
 const MENTAL_HEALTH = TYPES_OF_CARE.filter(
   care => care.group === 'mentalHealth',
 );
-const SPECIALTY = TYPES_OF_CARE.filter(
-  care => care.group === 'specialty' && care.id !== '349',
-);
+const SPECIALTY = TYPES_OF_CARE.filter(care => care.group === 'specialty');
 
 export default function TypeOfCareField({ formData, onChange, idSchema }) {
   return (

--- a/src/applications/vaos/containers/TypeOfSleepCarePage.jsx
+++ b/src/applications/vaos/containers/TypeOfSleepCarePage.jsx
@@ -18,7 +18,8 @@ const initialSchema = {
   properties: {
     typeOfSleepCareId: {
       type: 'string',
-      enum: TYPES_OF_SLEEP_CARE,
+      enum: TYPES_OF_SLEEP_CARE.map(care => care.id),
+      enumNames: TYPES_OF_SLEEP_CARE.map(care => care.name),
     },
   },
 };

--- a/src/applications/vaos/containers/TypeOfSleepCarePage.jsx
+++ b/src/applications/vaos/containers/TypeOfSleepCarePage.jsx
@@ -1,0 +1,94 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import SchemaForm from 'platform/forms-system/src/js/components/SchemaForm';
+
+import { TYPES_OF_SLEEP_CARE } from '../utils/constants';
+import FormButtons from '../components/FormButtons';
+import {
+  openFormPage,
+  updateFormData,
+  routeToNextAppointmentPage,
+  routeToPreviousAppointmentPage,
+} from '../actions/newAppointment.js';
+import { getFormPageInfo } from '../utils/selectors';
+
+const initialSchema = {
+  type: 'object',
+  required: ['typeOfSleepCareId'],
+  properties: {
+    typeOfSleepCareId: {
+      type: 'string',
+      enum: TYPES_OF_SLEEP_CARE,
+    },
+  },
+};
+
+const uiSchema = {
+  typeOfSleepCareId: {
+    'ui:widget': 'radio',
+    'ui:options': {
+      hideLabelText: true,
+      labels: {},
+    },
+  },
+};
+
+const pageKey = 'typeOfSleepCare';
+
+export class TypeOfSleepCarePage extends React.Component {
+  componentDidMount() {
+    this.props.openFormPage(pageKey, uiSchema, initialSchema);
+  }
+
+  goBack = () => {
+    this.props.routeToPreviousAppointmentPage(this.props.router, pageKey);
+  };
+
+  goForward = () => {
+    this.props.routeToNextAppointmentPage(this.props.router, pageKey);
+  };
+
+  render() {
+    const { schema, data, pageChangeInProgress } = this.props;
+
+    return (
+      <div>
+        <h1 className="vads-u-font-size--h2">
+          Choose the type of sleep care you need
+        </h1>
+        <SchemaForm
+          name="Type of sleep care"
+          title="Type of sleep care"
+          schema={schema || initialSchema}
+          uiSchema={uiSchema}
+          onSubmit={this.goForward}
+          onChange={newData =>
+            this.props.updateFormData(pageKey, uiSchema, newData)
+          }
+          data={data}
+        >
+          <FormButtons
+            onBack={this.goBack}
+            pageChangeInProgress={pageChangeInProgress}
+          />
+        </SchemaForm>
+      </div>
+    );
+  }
+}
+
+function mapStateToProps(state) {
+  return getFormPageInfo(state, pageKey);
+}
+
+const mapDispatchToProps = {
+  openFormPage,
+  updateFormData,
+  routeToNextAppointmentPage,
+  routeToPreviousAppointmentPage,
+};
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(TypeOfSleepCarePage);

--- a/src/applications/vaos/newAppointmentFlow.js
+++ b/src/applications/vaos/newAppointmentFlow.js
@@ -1,6 +1,7 @@
 import { getFormData } from './utils/selectors';
 
 const AUDIOLOGY = '203';
+const SLEEP_CARE = '143';
 
 function isCCAudiology(state) {
   return (
@@ -15,7 +16,13 @@ export default {
   },
   typeOfCare: {
     url: '/new-appointment',
-    next: 'typeOfFacility',
+    next(state) {
+      if (getFormData(state).typeOfCareId === SLEEP_CARE) {
+        return 'typeOfSleepCare';
+      }
+      return 'typeOfFacility';
+    },
+
     // async next(state) {
     //   try {
     //     const data = await apiRequest('/vaos/community-care/eligibility');
@@ -44,6 +51,11 @@ export default {
 
       return 'vaFacility';
     },
+    previous: 'typeOfCare',
+  },
+  typeOfSleepCare: {
+    url: '/new-appointment/choose-sleep-care',
+    next: 'typeOfFacility',
     previous: 'typeOfCare',
   },
   audiologyCareType: {

--- a/src/applications/vaos/routes.jsx
+++ b/src/applications/vaos/routes.jsx
@@ -16,6 +16,7 @@ import TypeOfFacilityPage from './containers/TypeOfFacilityPage';
 import ContactInfoPage from './containers/ContactInfoPage';
 import VAFacilityPage from './containers/VAFacilityPage';
 import TypeOfVisitPage from './containers/TypeOfVisitPage';
+import TypeOfSleepCarePage from './containers/TypeOfSleepCarePage';
 
 const routes = (
   <Route path="/">
@@ -26,6 +27,7 @@ const routes = (
       <Route path="contact-info" component={ContactInfoPage} />
       <Route path="choose-facility-type" component={TypeOfFacilityPage} />
       <Route path="choose-visit-type" component={TypeOfVisitPage} />
+      <Route path="choose-sleep-care" component={TypeOfSleepCarePage} />
       <Route path="audiology" component={TypeOfAudiologyCarePage} />
       <Route
         path="community-care-provider"

--- a/src/applications/vaos/tests/containers/TypeOfCarePage.unit.spec.jsx
+++ b/src/applications/vaos/tests/containers/TypeOfCarePage.unit.spec.jsx
@@ -20,7 +20,7 @@ describe('VAOS <TypeOfCarePage>', () => {
     );
 
     expect(form.find('fieldset').length).to.equal(3);
-    expect(form.find('input').length).to.equal(14);
+    expect(form.find('input').length).to.equal(12);
     form.unmount();
   });
 

--- a/src/applications/vaos/tests/containers/TypeOfSleepCarePage.unit.spec.jsx
+++ b/src/applications/vaos/tests/containers/TypeOfSleepCarePage.unit.spec.jsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { mount } from 'enzyme';
+
+import { selectRadio } from 'platform/testing/unit/schemaform-utils.jsx';
+import { TypeOfSleepCarePage } from '../../containers/TypeOfSleepCarePage';
+
+describe('VAOS <TypeOfSleepCarePage>', () => {
+  it('should render', () => {
+    const openFormPage = sinon.spy();
+    const updateFormData = sinon.spy();
+
+    const form = mount(
+      <TypeOfSleepCarePage
+        openFormPage={openFormPage}
+        updateFormData={updateFormData}
+        data={{}}
+      />,
+    );
+
+    expect(form.find('fieldset').length).to.equal(1);
+    expect(form.find('input').length).to.equal(2);
+    form.unmount();
+  });
+
+  it('should not submit empty form', () => {
+    const openFormPage = sinon.spy();
+    const router = {
+      push: sinon.spy(),
+    };
+
+    const form = mount(
+      <TypeOfSleepCarePage
+        openFormPage={openFormPage}
+        router={router}
+        data={{}}
+      />,
+    );
+
+    form.find('form').simulate('submit');
+
+    expect(form.find('.usa-input-error').length).to.equal(1);
+    expect(router.push.called).to.be.false;
+    form.unmount();
+  });
+
+  it('should call updateFormData after change', () => {
+    const openFormPage = sinon.spy();
+    const updateFormData = sinon.spy();
+    const router = {
+      push: sinon.spy(),
+    };
+
+    const form = mount(
+      <TypeOfSleepCarePage
+        openFormPage={openFormPage}
+        updateFormData={updateFormData}
+        router={router}
+        data={{}}
+      />,
+    );
+
+    selectRadio(form, 'root_typeOfSleepCareId', 'CPAP');
+
+    expect(updateFormData.firstCall.args[2].typeOfSleepCareId).to.equal('CPAP');
+    form.unmount();
+  });
+
+  it('should submit with valid data', () => {
+    const openFormPage = sinon.spy();
+    const routeToNextAppointmentPage = sinon.spy();
+
+    const form = mount(
+      <TypeOfSleepCarePage
+        openFormPage={openFormPage}
+        routeToNextAppointmentPage={routeToNextAppointmentPage}
+        data={{ typeOfSleepCareId: 'CPAP' }}
+      />,
+    );
+
+    form.find('form').simulate('submit');
+
+    expect(form.find('.usa-input-error').length).to.equal(0);
+    expect(routeToNextAppointmentPage.called).to.be.true;
+    form.unmount();
+  });
+});

--- a/src/applications/vaos/tests/containers/TypeOfSleepCarePage.unit.spec.jsx
+++ b/src/applications/vaos/tests/containers/TypeOfSleepCarePage.unit.spec.jsx
@@ -61,9 +61,9 @@ describe('VAOS <TypeOfSleepCarePage>', () => {
       />,
     );
 
-    selectRadio(form, 'root_typeOfSleepCareId', 'CPAP');
+    selectRadio(form, 'root_typeOfSleepCareId', '349');
 
-    expect(updateFormData.firstCall.args[2].typeOfSleepCareId).to.equal('CPAP');
+    expect(updateFormData.firstCall.args[2].typeOfSleepCareId).to.equal('349');
     form.unmount();
   });
 
@@ -75,7 +75,7 @@ describe('VAOS <TypeOfSleepCarePage>', () => {
       <TypeOfSleepCarePage
         openFormPage={openFormPage}
         routeToNextAppointmentPage={routeToNextAppointmentPage}
-        data={{ typeOfSleepCareId: 'CPAP' }}
+        data={{ typeOfSleepCareId: '349' }}
       />,
     );
 

--- a/src/applications/vaos/utils/constants.js
+++ b/src/applications/vaos/utils/constants.js
@@ -31,11 +31,6 @@ export const TYPES_OF_CARE = [
     group: 'primary',
   },
   {
-    id: 'CR1',
-    name: 'Express care clinic',
-    group: 'primary',
-  },
-  {
     id: '502',
     name: 'Mental health',
     group: 'mentalHealth',
@@ -52,14 +47,9 @@ export const TYPES_OF_CARE = [
   },
   {
     id: '203',
-    name: 'Audiology and speech',
+    name: 'Audiology and speech (including hearing aid support)',
     group: 'specialty',
     ccId: ['CCAUDHEAR', 'CCAUDRTNE'],
-  },
-  {
-    id: '349',
-    name: 'CPAP clinic',
-    group: 'specialty',
   },
   {
     id: '372',
@@ -96,7 +86,16 @@ export const TYPES_OF_CARE = [
   },
 ];
 
-export const TYPES_OF_SLEEP_CARE = ['CPAP', 'Home sleep study'];
+export const TYPES_OF_SLEEP_CARE = [
+  {
+    id: '349',
+    name: 'CPAP',
+  },
+  {
+    id: '143',
+    name: 'Home sleep study',
+  },
+];
 
 export const LANGUAGES = [
   {

--- a/src/applications/vaos/utils/constants.js
+++ b/src/applications/vaos/utils/constants.js
@@ -27,7 +27,7 @@ export const TYPES_OF_CARE = [
   },
   {
     id: '160',
-    name: 'Clinical pharmacy primary care',
+    name: 'Pharmacy',
     group: 'primary',
   },
   {
@@ -37,7 +37,7 @@ export const TYPES_OF_CARE = [
   },
   {
     id: '502',
-    name: 'Outpatient mental health',
+    name: 'Mental health',
     group: 'mentalHealth',
   },
   {
@@ -91,10 +91,12 @@ export const TYPES_OF_CARE = [
   },
   {
     id: '143',
-    name: 'Sleep medicine and home sleep testing',
+    name: 'Sleep medicine',
     group: 'specialty',
   },
 ];
+
+export const TYPES_OF_SLEEP_CARE = ['CPAP', 'Home sleep study'];
 
 export const LANGUAGES = [
   {


### PR DESCRIPTION
## Description
The type of care options for veterans need to be updated to clarify the sleep medicine options for veterans (based on feedback) and to remove express care since MVP will not handle these.

Sleep medicine option should show a follow up page (like what we do with audiology)

## Testing done
Unit tested

## Screenshots
![Screen Shot 2019-10-02 at 10 11 38 AM](https://user-images.githubusercontent.com/3587066/66056769-40691c80-e4fd-11e9-8fe8-02ab5a70982b.png)
![Screen Shot 2019-10-02 at 10 10 48 AM](https://user-images.githubusercontent.com/3587066/66056798-4bbc4800-e4fd-11e9-84d2-f924d0f5dde4.png)

## Acceptance criteria
- [ ] Type of Care page does not include Express Care
- [ ] Type of Care page includes 'Sleep Medicine' option
- [ ] Type of Care page does not include CPAP or home sleep study options
- [ ] If 'Sleep Medicine' option chosen, veteran gets follow up page that asks them to choose between CPAP and home sleep study options
- [ ] Veteran does not get sleep medicine follow-up page if they don't select 'sleep medicine' from the type of care list
- [ ] '(including hearing aid support)' is next to audiology option (not in bold)
- [ ] Subbheaders gone for mental health & specialty care
- [ ] 'Outpatient mental health' just reads 'Mental health'

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
