### PR TITLE
Video link in appointment details

### DIFF
--- a/src/applications/vaos/actions/confirmed.json
+++ b/src/applications/vaos/actions/confirmed.json
@@ -1,24 +1,21 @@
 {
-  "vaAppointments": [
-    {
+  "vaAppointments": [{
       "startDate": "2019-09-11T15:00:00Z",
       "clinicId": "455",
       "facilityId": "983",
       "patientIcn": "1012845331V153043",
-      "vdsAppointments": [
-        {
-          "appointmentLength": "60",
-          "appointmentTime": "2019-09-11T15:00:00Z",
-          "clinic": {
-            "name": "CASSIDY PC",
-            "askForCheckIn": false,
-            "facilityCode": "983"
-          },
-          "patientId": "7216691",
-          "type": "REGULAR",
-          "currentStatus": "NO ACTION TAKEN/TODAY"
-        }
-      ]
+      "vdsAppointments": [{
+        "appointmentLength": "60",
+        "appointmentTime": "2019-09-11T15:00:00Z",
+        "clinic": {
+          "name": "CASSIDY PC",
+          "askForCheckIn": false,
+          "facilityCode": "983"
+        },
+        "patientId": "7216691",
+        "type": "REGULAR",
+        "currentStatus": "NO ACTION TAKEN/TODAY"
+      }]
     },
     {
       "startDate": "2019-09-11T16:00:00Z",
@@ -26,197 +23,182 @@
       "clinicFriendlyName": "WHEATLAND AUDIOLOGY",
       "facilityId": "983",
       "patientIcn": "1012845331V153043",
-      "vdsAppointments": [
-        {
-          "appointmentLength": "60",
-          "appointmentTime": "2019-09-11T16:00:00Z",
-          "clinic": {
-            "name": "C&P BEV AUDIO FTC1",
-            "askForCheckIn": false,
-            "facilityCode": "983"
-          },
-          "patientId": "7216691",
-          "type": "REGULAR",
-          "currentStatus": "NO ACTION TAKEN/TODAY",
-          "bookingNote": "Test"
-        }
-      ]
+      "vdsAppointments": [{
+        "appointmentLength": "60",
+        "appointmentTime": "2019-09-11T16:00:00Z",
+        "clinic": {
+          "name": "C&P BEV AUDIO FTC1",
+          "askForCheckIn": false,
+          "facilityCode": "983"
+        },
+        "patientId": "7216691",
+        "type": "REGULAR",
+        "currentStatus": "NO ACTION TAKEN/TODAY",
+        "bookingNote": "Test"
+      }]
     },
     {
-      "startDate": "2019-11-22T13:35:00Z",
+      "startDate": "2019-10-03T06:40:00Z",
       "facilityId": "983",
       "patientIcn": "1012845331V153043",
-      "vvsAppointments": [
-        {
-          "id": "250afc0b-8551-4a79-bbc9-cf5cdd6575c2",
-          "appointmentKind": "ADHOC",
-          "sourceSystem": "SM",
-          "dateTime": "2019-11-22T13:35:00Z",
-          "duration": 20,
-          "status": {
-            "description": "F",
-            "code": "FUTURE"
-          },
-          "schedulingRequestType": "NEXT_AVAILABLE_APPT",
-          "type": "REGULAR",
-          "bookingNotes": "Testing for >90 days",
-          "instructionsOther": false,
-          "patients": {
-            "patient": [
-              {
-                "id": {
-                  "assigningAuthority": "ICN",
-                  "uniqueId": "1012845331V153043"
-                },
-                "name": {
-                  "firstName": "JUDY",
-                  "lastName": "MORRISON"
-                },
-                "contactInformation": {
-                  "mobile": "7036520000",
-                  "preferredEmail": "fake@va.gov"
-                },
-                "location": {
-                  "type": "NonVA",
-                  "facility": {
-                    "name": "CHEYENNE VAMC",
-                    "siteCode": "983",
-                    "timeZone": "10"
-                  }
-                },
-                "patientAppointment": true,
-                "virtualMeetingRoom": {
-                  "conference": "VVC1012210",
-                  "pin": "4790493668#",
-                  "url": "https://care2.evn.va.gov/vvc-app/?join=1&media=1&escalate=1&conference=VVC1012210@care2.evn.va.gov&pin=4790493668#"
-                }
+      "vvsAppointments": [{
+        "id": "250afc0b-8551-4a79-bbc9-cf5cdd6575c2",
+        "appointmentKind": "ADHOC",
+        "sourceSystem": "SM",
+        "dateTime": "2019-10-03T06:40:00Z",
+        "duration": 20,
+        "status": {
+          "description": "F",
+          "code": "FUTURE"
+        },
+        "schedulingRequestType": "NEXT_AVAILABLE_APPT",
+        "type": "REGULAR",
+        "bookingNotes": "Testing for >90 days",
+        "instructionsOther": false,
+        "patients": {
+          "patient": [{
+            "id": {
+              "assigningAuthority": "ICN",
+              "uniqueId": "1012845331V153043"
+            },
+            "name": {
+              "firstName": "JUDY",
+              "lastName": "MORRISON"
+            },
+            "contactInformation": {
+              "mobile": "7036520000",
+              "preferredEmail": "fake@va.gov"
+            },
+            "location": {
+              "type": "NonVA",
+              "facility": {
+                "name": "CHEYENNE VAMC",
+                "siteCode": "983",
+                "timeZone": "10"
               }
-            ]
-          },
-          "providers": {
-            "provider": [
-              {
-                "name": {
-                  "firstName": "Jane",
-                  "lastName": "Doe"
-                },
-                "id": {
-                  "assigningAuthority": "DFN-983",
-                  "uniqueId": "7216691"
-                },
-                "contactInformation": {
-                  "mobile": "6767676767",
-                  "preferredEmail": "fake@va.gov",
-                  "timeZone": "10"
-                },
-                "location": {
-                  "type": "VA",
-                  "facility": {
-                    "name": "CHEYENNE VAMC",
-                    "siteCode": "983",
-                    "timeZone": "10"
-                  }
-                },
-                "virtualMeetingRoom": {
-                  "conference": "VVC1012210",
-                  "pin": "3527890#",
-                  "url": "https://care2.evn.va.gov/vvc-app/?name=Reddy%2CVilasini&join=1&media=1&escalate=1&conference=VVC1012210@care2.evn.va.gov&pin=3527890#"
-                }
+            },
+            "patientAppointment": true,
+            "virtualMeetingRoom": {
+              "conference": "VVC1012210",
+              "pin": "4790493668#",
+              "url": "https://care2.evn.va.gov/vvc-app/?join=1&media=1&escalate=1&conference=VVC1012210@care2.evn.va.gov&pin=4790493668#"
+            }
+          }]
+        },
+        "providers": {
+          "provider": [{
+            "name": {
+              "firstName": "Jane",
+              "lastName": "Doe"
+            },
+            "id": {
+              "assigningAuthority": "DFN-983",
+              "uniqueId": "7216691"
+            },
+            "contactInformation": {
+              "mobile": "6767676767",
+              "preferredEmail": "fake@va.gov",
+              "timeZone": "10"
+            },
+            "location": {
+              "type": "VA",
+              "facility": {
+                "name": "CHEYENNE VAMC",
+                "siteCode": "983",
+                "timeZone": "10"
               }
-            ]
-          }
+            },
+            "virtualMeetingRoom": {
+              "conference": "VVC1012210",
+              "pin": "3527890#",
+              "url": "https://care2.evn.va.gov/vvc-app/?name=Reddy%2CVilasini&join=1&media=1&escalate=1&conference=VVC1012210@care2.evn.va.gov&pin=3527890#"
+            }
+          }]
         }
-      ]
+      }]
     },
     {
       "startDate": "2019-11-25T15:17:00Z",
       "facilityId": "983",
       "patientIcn": "1012845331V153043",
-      "vvsAppointments": [
-        {
-          "id": "8a74bdfa-0e66-4848-87f5-0d9bb413ae6d",
-          "appointmentKind": "ADHOC",
-          "sourceSystem": "SM",
-          "dateTime": "2019-11-25T15:17:00Z",
-          "duration": 20,
-          "status": {
-            "description": "F",
-            "code": "FUTURE"
-          },
-          "schedulingRequestType": "NEXT_AVAILABLE_APPT",
-          "type": "REGULAR",
-          "bookingNotes": "T+90 Testing",
-          "instructionsOther": false,
-          "patients": {
-            "patient": [
-              {
-                "id": {
-                  "assigningAuthority": "ICN",
-                  "uniqueId": "1012845331V153043"
-                },
-                "name": {
-                  "firstName": "JUDY",
-                  "lastName": "MORRISON"
-                },
-                "contactInformation": {
-                  "mobile": "7036520000",
-                  "preferredEmail": "fake@va.gov"
-                },
-                "location": {
-                  "type": "NonVA",
-                  "facility": {
-                    "name": "CHEYENNE VAMC",
-                    "siteCode": "983",
-                    "timeZone": "10"
-                  }
-                },
-                "patientAppointment": true,
-                "virtualMeetingRoom": {
-                  "conference": "VVC8275247",
-                  "pin": "3242949390#",
-                  "url": "https://care2.evn.va.gov/vvc-app/?join=1&media=1&escalate=1&conference=VVC8275247@care2.evn.va.gov&pin=3242949390#"
-                }
+      "vvsAppointments": [{
+        "id": "8a74bdfa-0e66-4848-87f5-0d9bb413ae6d",
+        "appointmentKind": "ADHOC",
+        "sourceSystem": "SM",
+        "dateTime": "2019-11-25T15:17:00Z",
+        "duration": 20,
+        "status": {
+          "description": "F",
+          "code": "FUTURE"
+        },
+        "schedulingRequestType": "NEXT_AVAILABLE_APPT",
+        "type": "REGULAR",
+        "bookingNotes": "T+90 Testing",
+        "instructionsOther": false,
+        "patients": {
+          "patient": [{
+            "id": {
+              "assigningAuthority": "ICN",
+              "uniqueId": "1012845331V153043"
+            },
+            "name": {
+              "firstName": "JUDY",
+              "lastName": "MORRISON"
+            },
+            "contactInformation": {
+              "mobile": "7036520000",
+              "preferredEmail": "fake@va.gov"
+            },
+            "location": {
+              "type": "NonVA",
+              "facility": {
+                "name": "CHEYENNE VAMC",
+                "siteCode": "983",
+                "timeZone": "10"
               }
-            ]
-          },
-          "providers": {
-            "provider": [
-              {
-                "name": {
-                  "firstName": "Test T+90",
-                  "lastName": "Test"
-                },
-                "id": {
-                  "assigningAuthority": "DFN-983",
-                  "uniqueId": "7216691"
-                },
-                "contactInformation": {
-                  "mobile": "8888888888",
-                  "preferredEmail": "fake@va.gov",
-                  "timeZone": "10"
-                },
-                "location": {
-                  "type": "VA",
-                  "facility": {
-                    "name": "CHEYENNE VAMC",
-                    "siteCode": "983",
-                    "timeZone": "10"
-                  }
-                },
-                "virtualMeetingRoom": {
-                  "conference": "VVC8275247",
-                  "pin": "7172705#",
-                  "url": "https://care2.evn.va.gov/vvc-app/?name=Test%2CTest+T%2B90&join=1&media=1&escalate=1&conference=VVC8275247@care2.evn.va.gov&pin=7172705#"
-                }
+            },
+            "patientAppointment": true,
+            "virtualMeetingRoom": {
+              "conference": "VVC8275247",
+              "pin": "3242949390#",
+              "url": "https://care2.evn.va.gov/vvc-app/?join=1&media=1&escalate=1&conference=VVC8275247@care2.evn.va.gov&pin=3242949390#"
+            }
+          }]
+        },
+        "providers": {
+          "provider": [{
+            "name": {
+              "firstName": "Test T+90",
+              "lastName": "Test"
+            },
+            "id": {
+              "assigningAuthority": "DFN-983",
+              "uniqueId": "7216691"
+            },
+            "contactInformation": {
+              "mobile": "8888888888",
+              "preferredEmail": "fake@va.gov",
+              "timeZone": "10"
+            },
+            "location": {
+              "type": "VA",
+              "facility": {
+                "name": "CHEYENNE VAMC",
+                "siteCode": "983",
+                "timeZone": "10"
               }
-            ]
-          }
+            },
+            "virtualMeetingRoom": {
+              "conference": "VVC8275247",
+              "pin": "7172705#",
+              "url": "https://care2.evn.va.gov/vvc-app/?name=Test%2CTest+T%2B90&join=1&media=1&escalate=1&conference=VVC8275247@care2.evn.va.gov&pin=7172705#"
+            }
+          }]
         }
-      ]
+      }]
     }
   ],
-  "ccAppointments": [
-    {
+  "ccAppointments": [{
       "appointmentRequestId": "8a4885896a22f88f016a2c8834b1005d",
       "patientIdentifier": {
         "uniqueId": "1012845331V153043",

--- a/src/applications/vaos/actions/confirmed.json
+++ b/src/applications/vaos/actions/confirmed.json
@@ -1,21 +1,24 @@
 {
-  "vaAppointments": [{
+  "vaAppointments": [
+    {
       "startDate": "2019-09-11T15:00:00Z",
       "clinicId": "455",
       "facilityId": "983",
       "patientIcn": "1012845331V153043",
-      "vdsAppointments": [{
-        "appointmentLength": "60",
-        "appointmentTime": "2019-09-11T15:00:00Z",
-        "clinic": {
-          "name": "CASSIDY PC",
-          "askForCheckIn": false,
-          "facilityCode": "983"
-        },
-        "patientId": "7216691",
-        "type": "REGULAR",
-        "currentStatus": "NO ACTION TAKEN/TODAY"
-      }]
+      "vdsAppointments": [
+        {
+          "appointmentLength": "60",
+          "appointmentTime": "2019-09-11T15:00:00Z",
+          "clinic": {
+            "name": "CASSIDY PC",
+            "askForCheckIn": false,
+            "facilityCode": "983"
+          },
+          "patientId": "7216691",
+          "type": "REGULAR",
+          "currentStatus": "NO ACTION TAKEN/TODAY"
+        }
+      ]
     },
     {
       "startDate": "2019-09-11T16:00:00Z",
@@ -23,182 +26,197 @@
       "clinicFriendlyName": "WHEATLAND AUDIOLOGY",
       "facilityId": "983",
       "patientIcn": "1012845331V153043",
-      "vdsAppointments": [{
-        "appointmentLength": "60",
-        "appointmentTime": "2019-09-11T16:00:00Z",
-        "clinic": {
-          "name": "C&P BEV AUDIO FTC1",
-          "askForCheckIn": false,
-          "facilityCode": "983"
-        },
-        "patientId": "7216691",
-        "type": "REGULAR",
-        "currentStatus": "NO ACTION TAKEN/TODAY",
-        "bookingNote": "Test"
-      }]
+      "vdsAppointments": [
+        {
+          "appointmentLength": "60",
+          "appointmentTime": "2019-09-11T16:00:00Z",
+          "clinic": {
+            "name": "C&P BEV AUDIO FTC1",
+            "askForCheckIn": false,
+            "facilityCode": "983"
+          },
+          "patientId": "7216691",
+          "type": "REGULAR",
+          "currentStatus": "NO ACTION TAKEN/TODAY",
+          "bookingNote": "Test"
+        }
+      ]
     },
     {
       "startDate": "2019-11-22T13:35:00Z",
       "facilityId": "983",
       "patientIcn": "1012845331V153043",
-      "vvsAppointments": [{
-        "id": "250afc0b-8551-4a79-bbc9-cf5cdd6575c2",
-        "appointmentKind": "ADHOC",
-        "sourceSystem": "SM",
-        "dateTime": "2019-11-22T13:35:00Z",
-        "duration": 20,
-        "status": {
-          "description": "F",
-          "code": "FUTURE"
-        },
-        "schedulingRequestType": "NEXT_AVAILABLE_APPT",
-        "type": "REGULAR",
-        "bookingNotes": "Testing for >90 days",
-        "instructionsOther": false,
-        "patients": {
-          "patient": [{
-            "id": {
-              "assigningAuthority": "ICN",
-              "uniqueId": "1012845331V153043"
-            },
-            "name": {
-              "firstName": "JUDY",
-              "lastName": "MORRISON"
-            },
-            "contactInformation": {
-              "mobile": "7036520000",
-              "preferredEmail": "fake@va.gov"
-            },
-            "location": {
-              "type": "NonVA",
-              "facility": {
-                "name": "CHEYENNE VAMC",
-                "siteCode": "983",
-                "timeZone": "10"
+      "vvsAppointments": [
+        {
+          "id": "250afc0b-8551-4a79-bbc9-cf5cdd6575c2",
+          "appointmentKind": "ADHOC",
+          "sourceSystem": "SM",
+          "dateTime": "2019-11-22T13:35:00Z",
+          "duration": 20,
+          "status": {
+            "description": "F",
+            "code": "FUTURE"
+          },
+          "schedulingRequestType": "NEXT_AVAILABLE_APPT",
+          "type": "REGULAR",
+          "bookingNotes": "Testing for >90 days",
+          "instructionsOther": false,
+          "patients": {
+            "patient": [
+              {
+                "id": {
+                  "assigningAuthority": "ICN",
+                  "uniqueId": "1012845331V153043"
+                },
+                "name": {
+                  "firstName": "JUDY",
+                  "lastName": "MORRISON"
+                },
+                "contactInformation": {
+                  "mobile": "7036520000",
+                  "preferredEmail": "fake@va.gov"
+                },
+                "location": {
+                  "type": "NonVA",
+                  "facility": {
+                    "name": "CHEYENNE VAMC",
+                    "siteCode": "983",
+                    "timeZone": "10"
+                  }
+                },
+                "patientAppointment": true,
+                "virtualMeetingRoom": {
+                  "conference": "VVC1012210",
+                  "pin": "4790493668#",
+                  "url": "https://care2.evn.va.gov/vvc-app/?join=1&media=1&escalate=1&conference=VVC1012210@care2.evn.va.gov&pin=4790493668#"
+                }
               }
-            },
-            "patientAppointment": true,
-            "virtualMeetingRoom": {
-              "conference": "VVC1012210",
-              "pin": "4790493668#",
-              "url": "https://care2.evn.va.gov/vvc-app/?join=1&media=1&escalate=1&conference=VVC1012210@care2.evn.va.gov&pin=4790493668#"
-            }
-          }]
-        },
-        "providers": {
-          "provider": [{
-            "name": {
-              "firstName": "Jane",
-              "lastName": "Doe"
-            },
-            "id": {
-              "assigningAuthority": "DFN-983",
-              "uniqueId": "7216691"
-            },
-            "contactInformation": {
-              "mobile": "6767676767",
-              "preferredEmail": "fake@va.gov",
-              "timeZone": "10"
-            },
-            "location": {
-              "type": "VA",
-              "facility": {
-                "name": "CHEYENNE VAMC",
-                "siteCode": "983",
-                "timeZone": "10"
+            ]
+          },
+          "providers": {
+            "provider": [
+              {
+                "name": {
+                  "firstName": "Jane",
+                  "lastName": "Doe"
+                },
+                "id": {
+                  "assigningAuthority": "DFN-983",
+                  "uniqueId": "7216691"
+                },
+                "contactInformation": {
+                  "mobile": "6767676767",
+                  "preferredEmail": "fake@va.gov",
+                  "timeZone": "10"
+                },
+                "location": {
+                  "type": "VA",
+                  "facility": {
+                    "name": "CHEYENNE VAMC",
+                    "siteCode": "983",
+                    "timeZone": "10"
+                  }
+                },
+                "virtualMeetingRoom": {
+                  "conference": "VVC1012210",
+                  "pin": "3527890#",
+                  "url": "https://care2.evn.va.gov/vvc-app/?name=Reddy%2CVilasini&join=1&media=1&escalate=1&conference=VVC1012210@care2.evn.va.gov&pin=3527890#"
+                }
               }
-            },
-            "virtualMeetingRoom": {
-              "conference": "VVC1012210",
-              "pin": "3527890#",
-              "url": "https://care2.evn.va.gov/vvc-app/?name=Reddy%2CVilasini&join=1&media=1&escalate=1&conference=VVC1012210@care2.evn.va.gov&pin=3527890#"
-            }
-          }]
+            ]
+          }
         }
-      }]
+      ]
     },
     {
       "startDate": "2019-11-25T15:17:00Z",
       "facilityId": "983",
       "patientIcn": "1012845331V153043",
-      "vvsAppointments": [{
-        "id": "8a74bdfa-0e66-4848-87f5-0d9bb413ae6d",
-        "appointmentKind": "MOBILE_GFE",
-        "sourceSystem": "SM",
-        "dateTime": "2019-11-25T15:17:00Z",
-        "duration": 20,
-        "status": {
-          "description": "F",
-          "code": "FUTURE"
-        },
-        "schedulingRequestType": "NEXT_AVAILABLE_APPT",
-        "type": "REGULAR",
-        "bookingNotes": "T+90 Testing",
-        "instructionsOther": false,
-        "patients": {
-          "patient": [{
-            "id": {
-              "assigningAuthority": "ICN",
-              "uniqueId": "1012845331V153043"
-            },
-            "name": {
-              "firstName": "JUDY",
-              "lastName": "MORRISON"
-            },
-            "contactInformation": {
-              "mobile": "7036520000",
-              "preferredEmail": "fake@va.gov"
-            },
-            "location": {
-              "type": "NonVA",
-              "facility": {
-                "name": "CHEYENNE VAMC",
-                "siteCode": "983",
-                "timeZone": "10"
+      "vvsAppointments": [
+        {
+          "id": "8a74bdfa-0e66-4848-87f5-0d9bb413ae6d",
+          "appointmentKind": "ADHOC",
+          "sourceSystem": "SM",
+          "dateTime": "2019-11-25T15:17:00Z",
+          "duration": 20,
+          "status": {
+            "description": "F",
+            "code": "FUTURE"
+          },
+          "schedulingRequestType": "NEXT_AVAILABLE_APPT",
+          "type": "REGULAR",
+          "bookingNotes": "T+90 Testing",
+          "instructionsOther": false,
+          "patients": {
+            "patient": [
+              {
+                "id": {
+                  "assigningAuthority": "ICN",
+                  "uniqueId": "1012845331V153043"
+                },
+                "name": {
+                  "firstName": "JUDY",
+                  "lastName": "MORRISON"
+                },
+                "contactInformation": {
+                  "mobile": "7036520000",
+                  "preferredEmail": "fake@va.gov"
+                },
+                "location": {
+                  "type": "NonVA",
+                  "facility": {
+                    "name": "CHEYENNE VAMC",
+                    "siteCode": "983",
+                    "timeZone": "10"
+                  }
+                },
+                "patientAppointment": true,
+                "virtualMeetingRoom": {
+                  "conference": "VVC8275247",
+                  "pin": "3242949390#",
+                  "url": "https://care2.evn.va.gov/vvc-app/?join=1&media=1&escalate=1&conference=VVC8275247@care2.evn.va.gov&pin=3242949390#"
+                }
               }
-            },
-            "patientAppointment": true,
-            "virtualMeetingRoom": {
-              "conference": "VVC8275247",
-              "pin": "3242949390#",
-              "url": "https://care2.evn.va.gov/vvc-app/?join=1&media=1&escalate=1&conference=VVC8275247@care2.evn.va.gov&pin=3242949390#"
-            }
-          }]
-        },
-        "providers": {
-          "provider": [{
-            "name": {
-              "firstName": "Test T+90",
-              "lastName": "Test"
-            },
-            "id": {
-              "assigningAuthority": "DFN-983",
-              "uniqueId": "7216691"
-            },
-            "contactInformation": {
-              "mobile": "8888888888",
-              "preferredEmail": "fake@va.gov",
-              "timeZone": "10"
-            },
-            "location": {
-              "type": "VA",
-              "facility": {
-                "name": "CHEYENNE VAMC",
-                "siteCode": "983",
-                "timeZone": "10"
+            ]
+          },
+          "providers": {
+            "provider": [
+              {
+                "name": {
+                  "firstName": "Test T+90",
+                  "lastName": "Test"
+                },
+                "id": {
+                  "assigningAuthority": "DFN-983",
+                  "uniqueId": "7216691"
+                },
+                "contactInformation": {
+                  "mobile": "8888888888",
+                  "preferredEmail": "fake@va.gov",
+                  "timeZone": "10"
+                },
+                "location": {
+                  "type": "VA",
+                  "facility": {
+                    "name": "CHEYENNE VAMC",
+                    "siteCode": "983",
+                    "timeZone": "10"
+                  }
+                },
+                "virtualMeetingRoom": {
+                  "conference": "VVC8275247",
+                  "pin": "7172705#",
+                  "url": "https://care2.evn.va.gov/vvc-app/?name=Test%2CTest+T%2B90&join=1&media=1&escalate=1&conference=VVC8275247@care2.evn.va.gov&pin=7172705#"
+                }
               }
-            },
-            "virtualMeetingRoom": {
-              "conference": "VVC8275247",
-              "pin": "7172705#",
-              "url": "https://care2.evn.va.gov/vvc-app/?name=Test%2CTest+T%2B90&join=1&media=1&escalate=1&conference=VVC8275247@care2.evn.va.gov&pin=7172705#"
-            }
-          }]
+            ]
+          }
         }
-      }]
+      ]
     }
   ],
-  "ccAppointments": [{
+  "ccAppointments": [
+    {
       "appointmentRequestId": "8a4885896a22f88f016a2c8834b1005d",
       "patientIdentifier": {
         "uniqueId": "1012845331V153043",

--- a/src/applications/vaos/actions/confirmed.json
+++ b/src/applications/vaos/actions/confirmed.json
@@ -38,14 +38,14 @@
       }]
     },
     {
-      "startDate": "2019-10-03T06:40:00Z",
+      "startDate": "2019-11-22T13:35:00Z",
       "facilityId": "983",
       "patientIcn": "1012845331V153043",
       "vvsAppointments": [{
         "id": "250afc0b-8551-4a79-bbc9-cf5cdd6575c2",
         "appointmentKind": "ADHOC",
         "sourceSystem": "SM",
-        "dateTime": "2019-10-03T06:40:00Z",
+        "dateTime": "2019-11-22T13:35:00Z",
         "duration": 20,
         "status": {
           "description": "F",

--- a/src/applications/vaos/actions/confirmed.json
+++ b/src/applications/vaos/actions/confirmed.json
@@ -1,21 +1,24 @@
 {
-  "vaAppointments": [{
+  "vaAppointments": [
+    {
       "startDate": "2019-09-11T15:00:00Z",
       "clinicId": "455",
       "facilityId": "983",
       "patientIcn": "1012845331V153043",
-      "vdsAppointments": [{
-        "appointmentLength": "60",
-        "appointmentTime": "2019-09-11T15:00:00Z",
-        "clinic": {
-          "name": "CASSIDY PC",
-          "askForCheckIn": false,
-          "facilityCode": "983"
-        },
-        "patientId": "7216691",
-        "type": "REGULAR",
-        "currentStatus": "NO ACTION TAKEN/TODAY"
-      }]
+      "vdsAppointments": [
+        {
+          "appointmentLength": "60",
+          "appointmentTime": "2019-09-11T15:00:00Z",
+          "clinic": {
+            "name": "CASSIDY PC",
+            "askForCheckIn": false,
+            "facilityCode": "983"
+          },
+          "patientId": "7216691",
+          "type": "REGULAR",
+          "currentStatus": "NO ACTION TAKEN/TODAY"
+        }
+      ]
     },
     {
       "startDate": "2019-09-11T16:00:00Z",
@@ -23,182 +26,197 @@
       "clinicFriendlyName": "WHEATLAND AUDIOLOGY",
       "facilityId": "983",
       "patientIcn": "1012845331V153043",
-      "vdsAppointments": [{
-        "appointmentLength": "60",
-        "appointmentTime": "2019-09-11T16:00:00Z",
-        "clinic": {
-          "name": "C&P BEV AUDIO FTC1",
-          "askForCheckIn": false,
-          "facilityCode": "983"
-        },
-        "patientId": "7216691",
-        "type": "REGULAR",
-        "currentStatus": "NO ACTION TAKEN/TODAY",
-        "bookingNote": "Test"
-      }]
+      "vdsAppointments": [
+        {
+          "appointmentLength": "60",
+          "appointmentTime": "2019-09-11T16:00:00Z",
+          "clinic": {
+            "name": "C&P BEV AUDIO FTC1",
+            "askForCheckIn": false,
+            "facilityCode": "983"
+          },
+          "patientId": "7216691",
+          "type": "REGULAR",
+          "currentStatus": "NO ACTION TAKEN/TODAY",
+          "bookingNote": "Test"
+        }
+      ]
     },
     {
       "startDate": "2019-11-22T13:35:00Z",
       "facilityId": "983",
       "patientIcn": "1012845331V153043",
-      "vvsAppointments": [{
-        "id": "250afc0b-8551-4a79-bbc9-cf5cdd6575c2",
-        "appointmentKind": "ADHOC",
-        "sourceSystem": "SM",
-        "dateTime": "2019-11-22T13:35:00Z",
-        "duration": 20,
-        "status": {
-          "description": "F",
-          "code": "FUTURE"
-        },
-        "schedulingRequestType": "NEXT_AVAILABLE_APPT",
-        "type": "REGULAR",
-        "bookingNotes": "Testing for >90 days",
-        "instructionsOther": false,
-        "patients": {
-          "patient": [{
-            "id": {
-              "assigningAuthority": "ICN",
-              "uniqueId": "1012845331V153043"
-            },
-            "name": {
-              "firstName": "JUDY",
-              "lastName": "MORRISON"
-            },
-            "contactInformation": {
-              "mobile": "7036520000",
-              "preferredEmail": "fake@va.gov"
-            },
-            "location": {
-              "type": "NonVA",
-              "facility": {
-                "name": "CHEYENNE VAMC",
-                "siteCode": "983",
-                "timeZone": "10"
+      "vvsAppointments": [
+        {
+          "id": "250afc0b-8551-4a79-bbc9-cf5cdd6575c2",
+          "appointmentKind": "ADHOC",
+          "sourceSystem": "SM",
+          "dateTime": "2019-11-22T13:35:00Z",
+          "duration": 20,
+          "status": {
+            "description": "F",
+            "code": "FUTURE"
+          },
+          "schedulingRequestType": "NEXT_AVAILABLE_APPT",
+          "type": "REGULAR",
+          "bookingNotes": "Testing for >90 days",
+          "instructionsOther": false,
+          "patients": {
+            "patient": [
+              {
+                "id": {
+                  "assigningAuthority": "ICN",
+                  "uniqueId": "1012845331V153043"
+                },
+                "name": {
+                  "firstName": "JUDY",
+                  "lastName": "MORRISON"
+                },
+                "contactInformation": {
+                  "mobile": "7036520000",
+                  "preferredEmail": "fake@va.gov"
+                },
+                "location": {
+                  "type": "NonVA",
+                  "facility": {
+                    "name": "CHEYENNE VAMC",
+                    "siteCode": "983",
+                    "timeZone": "10"
+                  }
+                },
+                "patientAppointment": true,
+                "virtualMeetingRoom": {
+                  "conference": "VVC1012210",
+                  "pin": "4790493668#",
+                  "url": "https://care2.evn.va.gov/vvc-app/?join=1&media=1&escalate=1&conference=VVC1012210@care2.evn.va.gov&pin=4790493668#"
+                }
               }
-            },
-            "patientAppointment": true,
-            "virtualMeetingRoom": {
-              "conference": "VVC1012210",
-              "pin": "4790493668#",
-              "url": "https://care2.evn.va.gov/vvc-app/?join=1&media=1&escalate=1&conference=VVC1012210@care2.evn.va.gov&pin=4790493668#"
-            }
-          }]
-        },
-        "providers": {
-          "provider": [{
-            "name": {
-              "firstName": "Jane",
-              "lastName": "Doe"
-            },
-            "id": {
-              "assigningAuthority": "DFN-983",
-              "uniqueId": "7216691"
-            },
-            "contactInformation": {
-              "mobile": "6767676767",
-              "preferredEmail": "fake@va.gov",
-              "timeZone": "10"
-            },
-            "location": {
-              "type": "VA",
-              "facility": {
-                "name": "CHEYENNE VAMC",
-                "siteCode": "983",
-                "timeZone": "10"
+            ]
+          },
+          "providers": {
+            "provider": [
+              {
+                "name": {
+                  "firstName": "Jane",
+                  "lastName": "Doe"
+                },
+                "id": {
+                  "assigningAuthority": "DFN-983",
+                  "uniqueId": "7216691"
+                },
+                "contactInformation": {
+                  "mobile": "6767676767",
+                  "preferredEmail": "fake@va.gov",
+                  "timeZone": "10"
+                },
+                "location": {
+                  "type": "VA",
+                  "facility": {
+                    "name": "CHEYENNE VAMC",
+                    "siteCode": "983",
+                    "timeZone": "10"
+                  }
+                },
+                "virtualMeetingRoom": {
+                  "conference": "VVC1012210",
+                  "pin": "3527890#",
+                  "url": "https://care2.evn.va.gov/vvc-app/?name=Reddy%2CVilasini&join=1&media=1&escalate=1&conference=VVC1012210@care2.evn.va.gov&pin=3527890#"
+                }
               }
-            },
-            "virtualMeetingRoom": {
-              "conference": "VVC1012210",
-              "pin": "3527890#",
-              "url": "https://care2.evn.va.gov/vvc-app/?name=Reddy%2CVilasini&join=1&media=1&escalate=1&conference=VVC1012210@care2.evn.va.gov&pin=3527890#"
-            }
-          }]
+            ]
+          }
         }
-      }]
+      ]
     },
     {
       "startDate": "2019-11-25T15:17:00Z",
       "facilityId": "983",
       "patientIcn": "1012845331V153043",
-      "vvsAppointments": [{
-        "id": "8a74bdfa-0e66-4848-87f5-0d9bb413ae6d",
-        "appointmentKind": "ADHOC",
-        "sourceSystem": "SM",
-        "dateTime": "2019-11-25T15:17:00Z",
-        "duration": 20,
-        "status": {
-          "description": "F",
-          "code": "FUTURE"
-        },
-        "schedulingRequestType": "NEXT_AVAILABLE_APPT",
-        "type": "REGULAR",
-        "bookingNotes": "T+90 Testing",
-        "instructionsOther": false,
-        "patients": {
-          "patient": [{
-            "id": {
-              "assigningAuthority": "ICN",
-              "uniqueId": "1012845331V153043"
-            },
-            "name": {
-              "firstName": "JUDY",
-              "lastName": "MORRISON"
-            },
-            "contactInformation": {
-              "mobile": "7036520000",
-              "preferredEmail": "fake@va.gov"
-            },
-            "location": {
-              "type": "NonVA",
-              "facility": {
-                "name": "CHEYENNE VAMC",
-                "siteCode": "983",
-                "timeZone": "10"
+      "vvsAppointments": [
+        {
+          "id": "8a74bdfa-0e66-4848-87f5-0d9bb413ae6d",
+          "appointmentKind": "ADHOC",
+          "sourceSystem": "SM",
+          "dateTime": "2019-11-25T15:17:00Z",
+          "duration": 20,
+          "status": {
+            "description": "F",
+            "code": "FUTURE"
+          },
+          "schedulingRequestType": "NEXT_AVAILABLE_APPT",
+          "type": "REGULAR",
+          "bookingNotes": "T+90 Testing",
+          "instructionsOther": false,
+          "patients": {
+            "patient": [
+              {
+                "id": {
+                  "assigningAuthority": "ICN",
+                  "uniqueId": "1012845331V153043"
+                },
+                "name": {
+                  "firstName": "JUDY",
+                  "lastName": "MORRISON"
+                },
+                "contactInformation": {
+                  "mobile": "7036520000",
+                  "preferredEmail": "fake@va.gov"
+                },
+                "location": {
+                  "type": "NonVA",
+                  "facility": {
+                    "name": "CHEYENNE VAMC",
+                    "siteCode": "983",
+                    "timeZone": "10"
+                  }
+                },
+                "patientAppointment": true,
+                "virtualMeetingRoom": {
+                  "conference": "VVC8275247",
+                  "pin": "3242949390#",
+                  "url": "https://care2.evn.va.gov/vvc-app/?join=1&media=1&escalate=1&conference=VVC8275247@care2.evn.va.gov&pin=3242949390#"
+                }
               }
-            },
-            "patientAppointment": true,
-            "virtualMeetingRoom": {
-              "conference": "VVC8275247",
-              "pin": "3242949390#",
-              "url": "https://care2.evn.va.gov/vvc-app/?join=1&media=1&escalate=1&conference=VVC8275247@care2.evn.va.gov&pin=3242949390#"
-            }
-          }]
-        },
-        "providers": {
-          "provider": [{
-            "name": {
-              "firstName": "Test T+90",
-              "lastName": "Test"
-            },
-            "id": {
-              "assigningAuthority": "DFN-983",
-              "uniqueId": "7216691"
-            },
-            "contactInformation": {
-              "mobile": "8888888888",
-              "preferredEmail": "fake@va.gov",
-              "timeZone": "10"
-            },
-            "location": {
-              "type": "VA",
-              "facility": {
-                "name": "CHEYENNE VAMC",
-                "siteCode": "983",
-                "timeZone": "10"
+            ]
+          },
+          "providers": {
+            "provider": [
+              {
+                "name": {
+                  "firstName": "Test T+90",
+                  "lastName": "Test"
+                },
+                "id": {
+                  "assigningAuthority": "DFN-983",
+                  "uniqueId": "7216691"
+                },
+                "contactInformation": {
+                  "mobile": "8888888888",
+                  "preferredEmail": "fake@va.gov",
+                  "timeZone": "10"
+                },
+                "location": {
+                  "type": "VA",
+                  "facility": {
+                    "name": "CHEYENNE VAMC",
+                    "siteCode": "983",
+                    "timeZone": "10"
+                  }
+                },
+                "virtualMeetingRoom": {
+                  "conference": "VVC8275247",
+                  "pin": "7172705#",
+                  "url": "https://care2.evn.va.gov/vvc-app/?name=Test%2CTest+T%2B90&join=1&media=1&escalate=1&conference=VVC8275247@care2.evn.va.gov&pin=7172705#"
+                }
               }
-            },
-            "virtualMeetingRoom": {
-              "conference": "VVC8275247",
-              "pin": "7172705#",
-              "url": "https://care2.evn.va.gov/vvc-app/?name=Test%2CTest+T%2B90&join=1&media=1&escalate=1&conference=VVC8275247@care2.evn.va.gov&pin=7172705#"
-            }
-          }]
+            ]
+          }
         }
-      }]
+      ]
     }
   ],
-  "ccAppointments": [{
+  "ccAppointments": [
+    {
       "appointmentRequestId": "8a4885896a22f88f016a2c8834b1005d",
       "patientIdentifier": {
         "uniqueId": "1012845331V153043",

--- a/src/applications/vaos/actions/confirmed.json
+++ b/src/applications/vaos/actions/confirmed.json
@@ -1,24 +1,21 @@
 {
-  "vaAppointments": [
-    {
+  "vaAppointments": [{
       "startDate": "2019-09-11T15:00:00Z",
       "clinicId": "455",
       "facilityId": "983",
       "patientIcn": "1012845331V153043",
-      "vdsAppointments": [
-        {
-          "appointmentLength": "60",
-          "appointmentTime": "2019-09-11T15:00:00Z",
-          "clinic": {
-            "name": "CASSIDY PC",
-            "askForCheckIn": false,
-            "facilityCode": "983"
-          },
-          "patientId": "7216691",
-          "type": "REGULAR",
-          "currentStatus": "NO ACTION TAKEN/TODAY"
-        }
-      ]
+      "vdsAppointments": [{
+        "appointmentLength": "60",
+        "appointmentTime": "2019-09-11T15:00:00Z",
+        "clinic": {
+          "name": "CASSIDY PC",
+          "askForCheckIn": false,
+          "facilityCode": "983"
+        },
+        "patientId": "7216691",
+        "type": "REGULAR",
+        "currentStatus": "NO ACTION TAKEN/TODAY"
+      }]
     },
     {
       "startDate": "2019-09-11T16:00:00Z",
@@ -26,197 +23,182 @@
       "clinicFriendlyName": "WHEATLAND AUDIOLOGY",
       "facilityId": "983",
       "patientIcn": "1012845331V153043",
-      "vdsAppointments": [
-        {
-          "appointmentLength": "60",
-          "appointmentTime": "2019-09-11T16:00:00Z",
-          "clinic": {
-            "name": "C&P BEV AUDIO FTC1",
-            "askForCheckIn": false,
-            "facilityCode": "983"
-          },
-          "patientId": "7216691",
-          "type": "REGULAR",
-          "currentStatus": "NO ACTION TAKEN/TODAY",
-          "bookingNote": "Test"
-        }
-      ]
+      "vdsAppointments": [{
+        "appointmentLength": "60",
+        "appointmentTime": "2019-09-11T16:00:00Z",
+        "clinic": {
+          "name": "C&P BEV AUDIO FTC1",
+          "askForCheckIn": false,
+          "facilityCode": "983"
+        },
+        "patientId": "7216691",
+        "type": "REGULAR",
+        "currentStatus": "NO ACTION TAKEN/TODAY",
+        "bookingNote": "Test"
+      }]
     },
     {
       "startDate": "2019-11-22T13:35:00Z",
       "facilityId": "983",
       "patientIcn": "1012845331V153043",
-      "vvsAppointments": [
-        {
-          "id": "250afc0b-8551-4a79-bbc9-cf5cdd6575c2",
-          "appointmentKind": "ADHOC",
-          "sourceSystem": "SM",
-          "dateTime": "2019-11-22T13:35:00Z",
-          "duration": 20,
-          "status": {
-            "description": "F",
-            "code": "FUTURE"
-          },
-          "schedulingRequestType": "NEXT_AVAILABLE_APPT",
-          "type": "REGULAR",
-          "bookingNotes": "Testing for >90 days",
-          "instructionsOther": false,
-          "patients": {
-            "patient": [
-              {
-                "id": {
-                  "assigningAuthority": "ICN",
-                  "uniqueId": "1012845331V153043"
-                },
-                "name": {
-                  "firstName": "JUDY",
-                  "lastName": "MORRISON"
-                },
-                "contactInformation": {
-                  "mobile": "7036520000",
-                  "preferredEmail": "fake@va.gov"
-                },
-                "location": {
-                  "type": "NonVA",
-                  "facility": {
-                    "name": "CHEYENNE VAMC",
-                    "siteCode": "983",
-                    "timeZone": "10"
-                  }
-                },
-                "patientAppointment": true,
-                "virtualMeetingRoom": {
-                  "conference": "VVC1012210",
-                  "pin": "4790493668#",
-                  "url": "https://care2.evn.va.gov/vvc-app/?join=1&media=1&escalate=1&conference=VVC1012210@care2.evn.va.gov&pin=4790493668#"
-                }
+      "vvsAppointments": [{
+        "id": "250afc0b-8551-4a79-bbc9-cf5cdd6575c2",
+        "appointmentKind": "ADHOC",
+        "sourceSystem": "SM",
+        "dateTime": "2019-11-22T13:35:00Z",
+        "duration": 20,
+        "status": {
+          "description": "F",
+          "code": "FUTURE"
+        },
+        "schedulingRequestType": "NEXT_AVAILABLE_APPT",
+        "type": "REGULAR",
+        "bookingNotes": "Testing for >90 days",
+        "instructionsOther": false,
+        "patients": {
+          "patient": [{
+            "id": {
+              "assigningAuthority": "ICN",
+              "uniqueId": "1012845331V153043"
+            },
+            "name": {
+              "firstName": "JUDY",
+              "lastName": "MORRISON"
+            },
+            "contactInformation": {
+              "mobile": "7036520000",
+              "preferredEmail": "fake@va.gov"
+            },
+            "location": {
+              "type": "NonVA",
+              "facility": {
+                "name": "CHEYENNE VAMC",
+                "siteCode": "983",
+                "timeZone": "10"
               }
-            ]
-          },
-          "providers": {
-            "provider": [
-              {
-                "name": {
-                  "firstName": "Jane",
-                  "lastName": "Doe"
-                },
-                "id": {
-                  "assigningAuthority": "DFN-983",
-                  "uniqueId": "7216691"
-                },
-                "contactInformation": {
-                  "mobile": "6767676767",
-                  "preferredEmail": "fake@va.gov",
-                  "timeZone": "10"
-                },
-                "location": {
-                  "type": "VA",
-                  "facility": {
-                    "name": "CHEYENNE VAMC",
-                    "siteCode": "983",
-                    "timeZone": "10"
-                  }
-                },
-                "virtualMeetingRoom": {
-                  "conference": "VVC1012210",
-                  "pin": "3527890#",
-                  "url": "https://care2.evn.va.gov/vvc-app/?name=Reddy%2CVilasini&join=1&media=1&escalate=1&conference=VVC1012210@care2.evn.va.gov&pin=3527890#"
-                }
+            },
+            "patientAppointment": true,
+            "virtualMeetingRoom": {
+              "conference": "VVC1012210",
+              "pin": "4790493668#",
+              "url": "https://care2.evn.va.gov/vvc-app/?join=1&media=1&escalate=1&conference=VVC1012210@care2.evn.va.gov&pin=4790493668#"
+            }
+          }]
+        },
+        "providers": {
+          "provider": [{
+            "name": {
+              "firstName": "Jane",
+              "lastName": "Doe"
+            },
+            "id": {
+              "assigningAuthority": "DFN-983",
+              "uniqueId": "7216691"
+            },
+            "contactInformation": {
+              "mobile": "6767676767",
+              "preferredEmail": "fake@va.gov",
+              "timeZone": "10"
+            },
+            "location": {
+              "type": "VA",
+              "facility": {
+                "name": "CHEYENNE VAMC",
+                "siteCode": "983",
+                "timeZone": "10"
               }
-            ]
-          }
+            },
+            "virtualMeetingRoom": {
+              "conference": "VVC1012210",
+              "pin": "3527890#",
+              "url": "https://care2.evn.va.gov/vvc-app/?name=Reddy%2CVilasini&join=1&media=1&escalate=1&conference=VVC1012210@care2.evn.va.gov&pin=3527890#"
+            }
+          }]
         }
-      ]
+      }]
     },
     {
       "startDate": "2019-11-25T15:17:00Z",
       "facilityId": "983",
       "patientIcn": "1012845331V153043",
-      "vvsAppointments": [
-        {
-          "id": "8a74bdfa-0e66-4848-87f5-0d9bb413ae6d",
-          "appointmentKind": "ADHOC",
-          "sourceSystem": "SM",
-          "dateTime": "2019-11-25T15:17:00Z",
-          "duration": 20,
-          "status": {
-            "description": "F",
-            "code": "FUTURE"
-          },
-          "schedulingRequestType": "NEXT_AVAILABLE_APPT",
-          "type": "REGULAR",
-          "bookingNotes": "T+90 Testing",
-          "instructionsOther": false,
-          "patients": {
-            "patient": [
-              {
-                "id": {
-                  "assigningAuthority": "ICN",
-                  "uniqueId": "1012845331V153043"
-                },
-                "name": {
-                  "firstName": "JUDY",
-                  "lastName": "MORRISON"
-                },
-                "contactInformation": {
-                  "mobile": "7036520000",
-                  "preferredEmail": "fake@va.gov"
-                },
-                "location": {
-                  "type": "NonVA",
-                  "facility": {
-                    "name": "CHEYENNE VAMC",
-                    "siteCode": "983",
-                    "timeZone": "10"
-                  }
-                },
-                "patientAppointment": true,
-                "virtualMeetingRoom": {
-                  "conference": "VVC8275247",
-                  "pin": "3242949390#",
-                  "url": "https://care2.evn.va.gov/vvc-app/?join=1&media=1&escalate=1&conference=VVC8275247@care2.evn.va.gov&pin=3242949390#"
-                }
+      "vvsAppointments": [{
+        "id": "8a74bdfa-0e66-4848-87f5-0d9bb413ae6d",
+        "appointmentKind": "MOBILE_GFE",
+        "sourceSystem": "SM",
+        "dateTime": "2019-11-25T15:17:00Z",
+        "duration": 20,
+        "status": {
+          "description": "F",
+          "code": "FUTURE"
+        },
+        "schedulingRequestType": "NEXT_AVAILABLE_APPT",
+        "type": "REGULAR",
+        "bookingNotes": "T+90 Testing",
+        "instructionsOther": false,
+        "patients": {
+          "patient": [{
+            "id": {
+              "assigningAuthority": "ICN",
+              "uniqueId": "1012845331V153043"
+            },
+            "name": {
+              "firstName": "JUDY",
+              "lastName": "MORRISON"
+            },
+            "contactInformation": {
+              "mobile": "7036520000",
+              "preferredEmail": "fake@va.gov"
+            },
+            "location": {
+              "type": "NonVA",
+              "facility": {
+                "name": "CHEYENNE VAMC",
+                "siteCode": "983",
+                "timeZone": "10"
               }
-            ]
-          },
-          "providers": {
-            "provider": [
-              {
-                "name": {
-                  "firstName": "Test T+90",
-                  "lastName": "Test"
-                },
-                "id": {
-                  "assigningAuthority": "DFN-983",
-                  "uniqueId": "7216691"
-                },
-                "contactInformation": {
-                  "mobile": "8888888888",
-                  "preferredEmail": "fake@va.gov",
-                  "timeZone": "10"
-                },
-                "location": {
-                  "type": "VA",
-                  "facility": {
-                    "name": "CHEYENNE VAMC",
-                    "siteCode": "983",
-                    "timeZone": "10"
-                  }
-                },
-                "virtualMeetingRoom": {
-                  "conference": "VVC8275247",
-                  "pin": "7172705#",
-                  "url": "https://care2.evn.va.gov/vvc-app/?name=Test%2CTest+T%2B90&join=1&media=1&escalate=1&conference=VVC8275247@care2.evn.va.gov&pin=7172705#"
-                }
+            },
+            "patientAppointment": true,
+            "virtualMeetingRoom": {
+              "conference": "VVC8275247",
+              "pin": "3242949390#",
+              "url": "https://care2.evn.va.gov/vvc-app/?join=1&media=1&escalate=1&conference=VVC8275247@care2.evn.va.gov&pin=3242949390#"
+            }
+          }]
+        },
+        "providers": {
+          "provider": [{
+            "name": {
+              "firstName": "Test T+90",
+              "lastName": "Test"
+            },
+            "id": {
+              "assigningAuthority": "DFN-983",
+              "uniqueId": "7216691"
+            },
+            "contactInformation": {
+              "mobile": "8888888888",
+              "preferredEmail": "fake@va.gov",
+              "timeZone": "10"
+            },
+            "location": {
+              "type": "VA",
+              "facility": {
+                "name": "CHEYENNE VAMC",
+                "siteCode": "983",
+                "timeZone": "10"
               }
-            ]
-          }
+            },
+            "virtualMeetingRoom": {
+              "conference": "VVC8275247",
+              "pin": "7172705#",
+              "url": "https://care2.evn.va.gov/vvc-app/?name=Test%2CTest+T%2B90&join=1&media=1&escalate=1&conference=VVC8275247@care2.evn.va.gov&pin=7172705#"
+            }
+          }]
         }
-      ]
+      }]
     }
   ],
-  "ccAppointments": [
-    {
+  "ccAppointments": [{
       "appointmentRequestId": "8a4885896a22f88f016a2c8834b1005d",
       "patientIdentifier": {
         "uniqueId": "1012845331V153043",

--- a/src/applications/vaos/components/ConfirmedAppointmentListItem.jsx
+++ b/src/applications/vaos/components/ConfirmedAppointmentListItem.jsx
@@ -32,7 +32,7 @@ export default function ConfirmedAppointmentListItem({ appointment }) {
           {isVideoVisit(appointment) ? (
             <VideoVisitLink appointment={appointment} />
           ) : (
-            <>{getAppointmentLocation(appointment)}</>
+            getAppointmentLocation(appointment)
           )}
         </div>
       </div>

--- a/src/applications/vaos/components/ConfirmedAppointmentListItem.jsx
+++ b/src/applications/vaos/components/ConfirmedAppointmentListItem.jsx
@@ -1,13 +1,26 @@
 import React from 'react';
 import { Link } from 'react-router';
+import moment from 'moment';
 import {
   getAppointmentId,
   getAppointmentTitle,
   getAppointmentLocation,
   getAppointmentDateTime,
+  isVideoVisit,
+  getVideoVisitLink,
 } from '../utils/appointment';
 
 export default function ConfirmedAppointmentListItem({ appointment }) {
+  const videoLink = isVideoVisit(appointment) && getVideoVisitLink(appointment);
+  let disableVideoLink = true;
+
+  if (videoLink) {
+    const now = moment();
+    const apptTime = moment(appointment.startDate);
+    const diff = apptTime.diff(now, 'minutes');
+    disableVideoLink = diff < 0 || diff > 30;
+  }
+
   return (
     <li className="vads-u-border-left--5px vads-u-border-color--green vads-u-background-color--gray-lightest vads-u-padding--2 vads-u-margin-bottom--3">
       <h2 className="vads-u-margin--0 vads-u-margin-bottom--2p5 vads-u-font-size--md">
@@ -27,7 +40,27 @@ export default function ConfirmedAppointmentListItem({ appointment }) {
             {' '}
             Where{' '}
           </h3>
-          {getAppointmentLocation(appointment)}
+          {videoLink ? (
+            <>
+              <a
+                href={videoLink}
+                target="_blank"
+                rel="noopener noreferrer"
+                className={`vaos-appts__video-link usa-button ${
+                  disableVideoLink ? 'usa-button-disabled' : ''
+                }`}
+              >
+                Join meeting
+              </a>
+              {disableVideoLink && (
+                <span className="vads-u-display--block">
+                  You can join 30 minutes prior to your appointment
+                </span>
+              )}
+            </>
+          ) : (
+            <>{getAppointmentLocation(appointment)}</>
+          )}
         </div>
       </div>
       <Link

--- a/src/applications/vaos/components/ConfirmedAppointmentListItem.jsx
+++ b/src/applications/vaos/components/ConfirmedAppointmentListItem.jsx
@@ -1,26 +1,15 @@
 import React from 'react';
 import { Link } from 'react-router';
-import moment from 'moment';
 import {
   getAppointmentId,
   getAppointmentTitle,
   getAppointmentLocation,
   getAppointmentDateTime,
   isVideoVisit,
-  getVideoVisitLink,
 } from '../utils/appointment';
+import VideoVisitLink from './VideoVisitLink';
 
 export default function ConfirmedAppointmentListItem({ appointment }) {
-  const videoLink = isVideoVisit(appointment) && getVideoVisitLink(appointment);
-  let disableVideoLink = true;
-
-  if (videoLink) {
-    const now = moment();
-    const apptTime = moment(appointment.startDate);
-    const diff = apptTime.diff(now, 'minutes');
-    disableVideoLink = diff < 0 || diff > 30;
-  }
-
   return (
     <li className="vads-u-border-left--5px vads-u-border-color--green vads-u-background-color--gray-lightest vads-u-padding--2 vads-u-margin-bottom--3">
       <h2 className="vads-u-margin--0 vads-u-margin-bottom--2p5 vads-u-font-size--md">
@@ -40,24 +29,8 @@ export default function ConfirmedAppointmentListItem({ appointment }) {
             {' '}
             Where{' '}
           </h3>
-          {videoLink ? (
-            <>
-              <a
-                href={videoLink}
-                target="_blank"
-                rel="noopener noreferrer"
-                className={`vaos-appts__video-link usa-button ${
-                  disableVideoLink ? 'usa-button-disabled' : ''
-                }`}
-              >
-                Join meeting
-              </a>
-              {disableVideoLink && (
-                <span className="vads-u-display--block">
-                  You can join 30 minutes prior to your appointment
-                </span>
-              )}
-            </>
+          {isVideoVisit(appointment) ? (
+            <VideoVisitLink appointment={appointment} />
           ) : (
             <>{getAppointmentLocation(appointment)}</>
           )}

--- a/src/applications/vaos/components/VideoVisitLink.jsx
+++ b/src/applications/vaos/components/VideoVisitLink.jsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import moment from 'moment';
+import { getVideoVisitLink } from '../utils/appointment';
+
+const VideoVisitLink = ({ appointment }) => {
+  const videoLink = getVideoVisitLink(appointment);
+  let disableVideoLink = true;
+
+  if (videoLink) {
+    const now = moment();
+    const apptTime = moment(appointment.startDate);
+    const diff = apptTime.diff(now, 'minutes');
+    disableVideoLink = diff < 0 || diff > 30;
+  }
+
+  return (
+    <div className="vads-u-display--block">
+      <a
+        href={videoLink}
+        target="_blank"
+        rel="noopener noreferrer"
+        className={`vaos-appts__video-link usa-button ${
+          disableVideoLink ? 'usa-button-disabled' : ''
+        }`}
+      >
+        Join meeting
+      </a>
+      {disableVideoLink && (
+        <span className="vads-u-display--block">
+          You can join 30 minutes prior to your appointment
+        </span>
+      )}
+    </div>
+  );
+};
+
+VideoVisitLink.propTypes = {
+  appointment: PropTypes.object.isRequired,
+};
+
+export default VideoVisitLink;

--- a/src/applications/vaos/components/VideoVisitLink.jsx
+++ b/src/applications/vaos/components/VideoVisitLink.jsx
@@ -6,9 +6,7 @@ import { getVideoVisitLink, isGFEVideoVisit } from '../utils/appointment';
 const VideoVisitLink = ({ appointment }) => {
   if (isGFEVideoVisit(appointment)) {
     return (
-      <span className="vads-u-display--block">
-        Join the video session from the device provided by the VA.
-      </span>
+      <span>Join the video session from the device provided by the VA.</span>
     );
   }
 
@@ -44,9 +42,7 @@ const VideoVisitLink = ({ appointment }) => {
     );
   }
 
-  return (
-    <div className="vads-u-display--block">Video visit link unavailable</div>
-  );
+  return <span>Video visit link unavailable</span>;
 };
 
 VideoVisitLink.propTypes = {

--- a/src/applications/vaos/components/VideoVisitLink.jsx
+++ b/src/applications/vaos/components/VideoVisitLink.jsx
@@ -16,10 +16,9 @@ const VideoVisitLink = ({ appointment }) => {
     const now = moment();
     const apptTime = moment(appointment.startDate);
     const diff = apptTime.diff(now, 'minutes');
-    let disableVideoLink = true;
 
     // Button is enabled 30 minutes prior to start time, until 4 hours after start time
-    disableVideoLink = diff < -30 || diff > 240;
+    const disableVideoLink = diff < -30 || diff > 240;
 
     return (
       <div className="vads-u-display--block">

--- a/src/applications/vaos/components/VideoVisitLink.jsx
+++ b/src/applications/vaos/components/VideoVisitLink.jsx
@@ -1,9 +1,17 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import moment from 'moment';
-import { getVideoVisitLink } from '../utils/appointment';
+import { getVideoVisitLink, isGFEVideoVisit } from '../utils/appointment';
 
 const VideoVisitLink = ({ appointment }) => {
+  if (isGFEVideoVisit(appointment)) {
+    return (
+      <span className="vads-u-display--block">
+        Join the video session from the device provided by the VA.
+      </span>
+    );
+  }
+
   const videoLink = getVideoVisitLink(appointment);
   let disableVideoLink = true;
 
@@ -11,27 +19,34 @@ const VideoVisitLink = ({ appointment }) => {
     const now = moment();
     const apptTime = moment(appointment.startDate);
     const diff = apptTime.diff(now, 'minutes');
-    disableVideoLink = diff < 0 || diff > 30;
+
+    // Button is enabled 30 minutes prior to start time, until 4 hours after start time
+    disableVideoLink = diff < -30 || diff > 240;
+
+    return (
+      <div className="vads-u-display--block">
+        <a
+          href={videoLink}
+          target="_blank"
+          rel="noopener noreferrer"
+          className={`vaos-appts__video-link usa-button${
+            disableVideoLink ? ' usa-button-disabled' : ''
+          }`}
+        >
+          Join meeting
+        </a>
+        {disableVideoLink && (
+          <span className="vads-u-display--block">
+            You can join 30 minutes prior to your appointment
+          </span>
+        )}
+        )}
+      </div>
+    );
   }
 
   return (
-    <div className="vads-u-display--block">
-      <a
-        href={videoLink}
-        target="_blank"
-        rel="noopener noreferrer"
-        className={`vaos-appts__video-link usa-button ${
-          disableVideoLink ? 'usa-button-disabled' : ''
-        }`}
-      >
-        Join meeting
-      </a>
-      {disableVideoLink && (
-        <span className="vads-u-display--block">
-          You can join 30 minutes prior to your appointment
-        </span>
-      )}
-    </div>
+    <div className="vads-u-display--block">Video visit link unavailable</div>
   );
 };
 

--- a/src/applications/vaos/components/VideoVisitLink.jsx
+++ b/src/applications/vaos/components/VideoVisitLink.jsx
@@ -13,12 +13,12 @@ const VideoVisitLink = ({ appointment }) => {
   }
 
   const videoLink = getVideoVisitLink(appointment);
-  let disableVideoLink = true;
 
   if (videoLink) {
     const now = moment();
     const apptTime = moment(appointment.startDate);
     const diff = apptTime.diff(now, 'minutes');
+    let disableVideoLink = true;
 
     // Button is enabled 30 minutes prior to start time, until 4 hours after start time
     disableVideoLink = diff < -30 || diff > 240;
@@ -39,7 +39,6 @@ const VideoVisitLink = ({ appointment }) => {
           <span className="vads-u-display--block">
             You can join 30 minutes prior to your appointment
           </span>
-        )}
         )}
       </div>
     );

--- a/src/applications/vaos/containers/ConfirmedAppointmentDetailPage.jsx
+++ b/src/applications/vaos/containers/ConfirmedAppointmentDetailPage.jsx
@@ -8,10 +8,12 @@ import { fetchConfirmedAppointments } from '../actions/appointments';
 import { FETCH_STATUS } from '../utils/constants';
 import { selectConfirmedAppointment } from '../utils/selectors';
 import Breadcrumbs from '../components/Breadcrumbs';
+import VideoVisitLink from '../components/VideoVisitLink';
 import {
   getAppointmentTitle,
   getAppointmentLocation,
   getAppointmentDateTime,
+  isVideoVisit,
 } from '../utils/appointment';
 
 export class ConfirmedAppointmentDetailPage extends React.Component {
@@ -48,6 +50,9 @@ export class ConfirmedAppointmentDetailPage extends React.Component {
                     <>
                       <h3 className="vaos-appts__block-label">Where</h3>
                       {getAppointmentLocation(appointment)}
+                      {isVideoVisit(appointment) && (
+                        <VideoVisitLink appointment={appointment} />
+                      )}
                     </>
                     <h3 className="vaos-appts__block-label vads-u-margin-top--2">
                       When

--- a/src/applications/vaos/containers/ConfirmedAppointmentDetailPage.jsx
+++ b/src/applications/vaos/containers/ConfirmedAppointmentDetailPage.jsx
@@ -47,13 +47,12 @@ export class ConfirmedAppointmentDetailPage extends React.Component {
                 <h2>{getAppointmentTitle(appointment)}</h2>
                 <div className="vads-u-display--flex vads-u-margin-bottom--2">
                   <div className="vads-u-flex--1">
-                    <>
-                      <h3 className="vaos-appts__block-label">Where</h3>
-                      {getAppointmentLocation(appointment)}
-                      {isVideoVisit(appointment) && (
-                        <VideoVisitLink appointment={appointment} />
-                      )}
-                    </>
+                    <h3 className="vaos-appts__block-label">Where</h3>
+                    {isVideoVisit(appointment) ? (
+                      <VideoVisitLink appointment={appointment} />
+                    ) : (
+                      getAppointmentLocation(appointment)
+                    )}
                     <h3 className="vaos-appts__block-label vads-u-margin-top--2">
                       When
                     </h3>

--- a/src/applications/vaos/tests/components/ConfirmedAppointmentListItem.unit.spec.jsx
+++ b/src/applications/vaos/tests/components/ConfirmedAppointmentListItem.unit.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
+import moment from 'moment';
 
 import ConfirmedAppointmentListItem from '../../components/ConfirmedAppointmentListItem';
 
@@ -72,6 +73,57 @@ describe('VA Confirmed Appointment', () => {
         `appointments/confirmed/va-234-456-2019-04-05T10:00:00`,
       );
     });
+  });
+});
+
+describe('Video visit', () => {
+  const apptTime = moment()
+    .add(20, 'minutes')
+    .format();
+
+  const url =
+    'https://care2.evn.va.gov/vvc-app/?join=1&media=1&escalate=1&conference=VVC1012210@care2.evn.va.gov&pin=4790493668#';
+  const appointment = {
+    startDate: apptTime,
+    facilityId: '234',
+    clinicId: '456',
+    vvsAppointments: [
+      {
+        patients: {
+          patient: [
+            {
+              virtualMeetingRoom: {
+                url,
+              },
+            },
+          ],
+        },
+      },
+    ],
+  };
+
+  let tree = shallow(
+    <ConfirmedAppointmentListItem appointment={appointment} />,
+  );
+
+  it('should contain link to appointment detail page', () => {
+    const videoLink = tree.find('.vaos-appts__video-link');
+    expect(videoLink.length).to.equal(1);
+    expect(videoLink.at(0).props().href).to.equal(url);
+  });
+
+  it('should enable video link if appointment if appointment is within 30 minutes', () => {
+    expect(tree.find('.usa-button-disabled').length).to.equal(0);
+  });
+
+  it('should disable video link if appointment is over 30 min away', () => {
+    appointment.startDate = moment()
+      .add(40, 'minutes')
+      .format();
+
+    tree = shallow(<ConfirmedAppointmentListItem appointment={appointment} />);
+    expect(tree.find('.usa-button-disabled').length).to.equal(1);
+    tree.unmount();
   });
 });
 

--- a/src/applications/vaos/tests/components/ConfirmedAppointmentListItem.unit.spec.jsx
+++ b/src/applications/vaos/tests/components/ConfirmedAppointmentListItem.unit.spec.jsx
@@ -102,28 +102,12 @@ describe('Video visit', () => {
     ],
   };
 
-  let tree = shallow(
+  const tree = shallow(
     <ConfirmedAppointmentListItem appointment={appointment} />,
   );
 
-  it('should contain link to appointment detail page', () => {
-    const videoLink = tree.find('.vaos-appts__video-link');
-    expect(videoLink.length).to.equal(1);
-    expect(videoLink.at(0).props().href).to.equal(url);
-  });
-
-  it('should enable video link if appointment if appointment is within 30 minutes', () => {
-    expect(tree.find('.usa-button-disabled').length).to.equal(0);
-  });
-
-  it('should disable video link if appointment is over 30 min away', () => {
-    appointment.startDate = moment()
-      .add(40, 'minutes')
-      .format();
-
-    tree = shallow(<ConfirmedAppointmentListItem appointment={appointment} />);
-    expect(tree.find('.usa-button-disabled').length).to.equal(1);
-    tree.unmount();
+  it('should contain link to video conference', () => {
+    expect(tree.find('VideoVisitLink').length).to.equal(1);
   });
 });
 

--- a/src/applications/vaos/tests/components/VideoVisitLink.unit.spec.jsx
+++ b/src/applications/vaos/tests/components/VideoVisitLink.unit.spec.jsx
@@ -31,25 +31,49 @@ describe('Video visit', () => {
     ],
   };
 
-  let tree = shallow(<VideoVisitLink appointment={appointment} />);
-
+  // console.log(tree.debug());
   it('should display link button', () => {
-    const linkButton = tree.find('.vaos-appts__video-link');
-    expect(linkButton.length).to.equal(1);
+    const tree = shallow(<VideoVisitLink appointment={appointment} />);
+    expect(tree.exists('.usa-button')).to.equal(true);
+    tree.unmount();
   });
 
-  it('should enable video link if appointment if appointment is within 30 minutes', () => {
-    const linkButton = tree.find('.usa-button-disabled');
-    expect(linkButton.length).to.equal(0);
+  it('should enable video link if appointment if appointment has started and is less than 240 min passed', () => {
+    const tree = shallow(<VideoVisitLink appointment={appointment} />);
+    expect(tree.exists('.usa-button')).to.equal(true);
+    expect(tree.exists('.usa-button-disabled')).to.equal(false);
+    tree.unmount();
   });
 
-  it('should disable video link if appointment is over 30 min away', () => {
+  it('should enable video link if appointment is less than 30 minutes away', () => {
     appointment.startDate = moment()
-      .add(40, 'minutes')
+      .add(-20, 'minutes')
       .format();
 
-    tree = shallow(<VideoVisitLink appointment={appointment} />);
-    expect(tree.find('.usa-button-disabled').length).to.equal(1);
+    const tree = shallow(<VideoVisitLink appointment={appointment} />);
+    expect(tree.exists('.usa-button')).to.equal(true);
+    expect(tree.exists('.usa-button-disabled')).to.equal(false);
+    tree.unmount();
+  });
+
+  it('should disable video link if appointment is over 4 hours away', () => {
+    appointment.startDate = moment()
+      .add(245, 'minutes')
+      .format();
+
+    const tree = shallow(<VideoVisitLink appointment={appointment} />);
+    expect(tree.exists('.usa-button')).to.equal(true);
+    expect(tree.exists('.usa-button-disabled')).to.equal(true);
+    tree.unmount();
+  });
+
+  it('should only display a message if it is a MOBILE_GFE appointment', () => {
+    const gfeAppt = { ...appointment, appointmentKind: 'MOBILE_GFE' };
+    const tree = shallow(<VideoVisitLink appointment={gfeAppt} />);
+    expect(tree.exists('.usa-button')).to.equal(false);
+    expect(tree.find('span.vads-u-display--block').text()).to.equal(
+      'Join the video session from the device provided by the VA.',
+    );
     tree.unmount();
   });
 });

--- a/src/applications/vaos/tests/components/VideoVisitLink.unit.spec.jsx
+++ b/src/applications/vaos/tests/components/VideoVisitLink.unit.spec.jsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+import moment from 'moment';
+
+import VideoVisitLink from '../../components/VideoVisitLink';
+
+describe('Video visit', () => {
+  const apptTime = moment()
+    .add(20, 'minutes')
+    .format();
+
+  const url =
+    'https://care2.evn.va.gov/vvc-app/?join=1&media=1&escalate=1&conference=VVC1012210@care2.evn.va.gov&pin=4790493668#';
+  const appointment = {
+    startDate: apptTime,
+    facilityId: '234',
+    clinicId: '456',
+    vvsAppointments: [
+      {
+        patients: {
+          patient: [
+            {
+              virtualMeetingRoom: {
+                url,
+              },
+            },
+          ],
+        },
+      },
+    ],
+  };
+
+  let tree = shallow(<VideoVisitLink appointment={appointment} />);
+
+  it('should display link button', () => {
+    const linkButton = tree.find('.vaos-appts__video-link');
+    expect(linkButton.length).to.equal(1);
+  });
+
+  it('should enable video link if appointment if appointment is within 30 minutes', () => {
+    const linkButton = tree.find('.usa-button-disabled');
+    expect(linkButton.length).to.equal(0);
+  });
+
+  it('should disable video link if appointment is over 30 min away', () => {
+    appointment.startDate = moment()
+      .add(40, 'minutes')
+      .format();
+
+    tree = shallow(<VideoVisitLink appointment={appointment} />);
+    expect(tree.find('.usa-button-disabled').length).to.equal(1);
+    tree.unmount();
+  });
+});

--- a/src/applications/vaos/tests/components/VideoVisitLink.unit.spec.jsx
+++ b/src/applications/vaos/tests/components/VideoVisitLink.unit.spec.jsx
@@ -78,7 +78,7 @@ describe('Video visit', () => {
     };
     const tree = shallow(<VideoVisitLink appointment={gfeAppt} />);
     expect(tree.exists('.usa-button')).to.equal(false);
-    expect(tree.find('span.vads-u-display--block').text()).to.equal(
+    expect(tree.find('span').text()).to.equal(
       'Join the video session from the device provided by the VA.',
     );
     tree.unmount();

--- a/src/applications/vaos/tests/components/VideoVisitLink.unit.spec.jsx
+++ b/src/applications/vaos/tests/components/VideoVisitLink.unit.spec.jsx
@@ -68,7 +68,14 @@ describe('Video visit', () => {
   });
 
   it('should only display a message if it is a MOBILE_GFE appointment', () => {
-    const gfeAppt = { ...appointment, appointmentKind: 'MOBILE_GFE' };
+    const gfeAppt = {
+      ...appointment,
+      vvsAppointments: [
+        {
+          appointmentKind: 'MOBILE_GFE',
+        },
+      ],
+    };
     const tree = shallow(<VideoVisitLink appointment={gfeAppt} />);
     expect(tree.exists('.usa-button')).to.equal(false);
     expect(tree.find('span.vads-u-display--block').text()).to.equal(

--- a/src/applications/vaos/utils/appointment.jsx
+++ b/src/applications/vaos/utils/appointment.jsx
@@ -20,6 +20,10 @@ export function isVideoVisit(appt) {
   return !!appt.vvsAppointments;
 }
 
+export function getVideoVisitLink(appt) {
+  return appt.vvsAppointments[0]?.patients?.patient[0]?.virtualMeetingRoom?.url;
+}
+
 function getStagingId(facilityId) {
   if (!environment.isProduction() && facilityId.startsWith('983')) {
     return facilityId.replace('983', '442');

--- a/src/applications/vaos/utils/appointment.jsx
+++ b/src/applications/vaos/utils/appointment.jsx
@@ -16,12 +16,12 @@ export function isCommunityCare(appt) {
   return !!appt.appointmentRequestId;
 }
 
-export function isVideoVisit(appt) {
-  return !!appt.vvsAppointments || appt.appointmentKind === 'MOBILE_GFE';
-}
-
 export function isGFEVideoVisit(appt) {
   return appt.vvsAppointments[0]?.appointmentKind === 'MOBILE_GFE';
+}
+
+export function isVideoVisit(appt) {
+  return !!appt.vvsAppointments || isGFEVideoVisit(appt);
 }
 
 export function getVideoVisitLink(appt) {

--- a/src/applications/vaos/utils/appointment.jsx
+++ b/src/applications/vaos/utils/appointment.jsx
@@ -17,7 +17,11 @@ export function isCommunityCare(appt) {
 }
 
 export function isVideoVisit(appt) {
-  return !!appt.vvsAppointments;
+  return !!appt.vvsAppointments || appt.appointmentKind === 'MOBILE_GFE';
+}
+
+export function isGFEVideoVisit(appt) {
+  return appt.appointmentKind === 'MOBILE_GFE';
 }
 
 export function getVideoVisitLink(appt) {

--- a/src/applications/vaos/utils/appointment.jsx
+++ b/src/applications/vaos/utils/appointment.jsx
@@ -21,7 +21,7 @@ export function isVideoVisit(appt) {
 }
 
 export function isGFEVideoVisit(appt) {
-  return appt.appointmentKind === 'MOBILE_GFE';
+  return appt.vvsAppointments[0]?.appointmentKind === 'MOBILE_GFE';
 }
 
 export function getVideoVisitLink(appt) {

--- a/src/applications/vaos/utils/appointment.jsx
+++ b/src/applications/vaos/utils/appointment.jsx
@@ -17,7 +17,7 @@ export function isCommunityCare(appt) {
 }
 
 export function isGFEVideoVisit(appt) {
-  return appt.vvsAppointments[0]?.appointmentKind === 'MOBILE_GFE';
+  return appt.vvsAppointments?.[0]?.appointmentKind === 'MOBILE_GFE';
 }
 
 export function isVideoVisit(appt) {
@@ -25,7 +25,8 @@ export function isVideoVisit(appt) {
 }
 
 export function getVideoVisitLink(appt) {
-  return appt.vvsAppointments[0]?.patients?.patient[0]?.virtualMeetingRoom?.url;
+  return appt.vvsAppointments?.[0]?.patients?.patient[0]?.virtualMeetingRoom
+    ?.url;
 }
 
 function getStagingId(facilityId) {


### PR DESCRIPTION
# Description
- Button is enabled 30 minutes prior to start time, until 4 hours after start time
- There is one type of video appointment, MOBILE_GFE, which does not display a link, it displays a message that you should join the session using the device provided to you
   - There's no time window for this message

**Note:** design for confirmed appointments list has not yet been updated to match new mock ups.

## Testing done
Local and unit

## Screenshots
![image](https://user-images.githubusercontent.com/786704/66103950-10a52d80-e56c-11e9-9645-88cb7e422766.png)
![image](https://user-images.githubusercontent.com/786704/66105718-076a8f80-e571-11e9-8fc5-7bad7dc969f9.png)


## Acceptance criteria
- [ ] Video link in telehealth-type appointment details
- [ ] Veterans are able to click link to connect directly to their appointment within x time of appointment

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
