### PR TITLE
Update TypeOfAppointment to use newAppointmentFlow actions

### DIFF
--- a/src/applications/vaos/containers/TypeOfAppointmentPage.jsx
+++ b/src/applications/vaos/containers/TypeOfAppointmentPage.jsx
@@ -1,6 +1,11 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import { openFormPage, updateFormData } from '../actions/newAppointment.js';
+import {
+  openFormPage,
+  updateFormData,
+  routeToNextAppointmentPage,
+  routeToPreviousAppointmentPage,
+} from '../actions/newAppointment.js';
 import SchemaForm from 'platform/forms-system/src/js/components/SchemaForm';
 import ProgressButton from 'platform/forms-system/src/js/components/ProgressButton';
 
@@ -46,7 +51,7 @@ const uiSchema = {
   },
 };
 
-const pageKey = 'type-appointment';
+const pageKey = 'typeOfAppointment';
 
 export class TypeOfAppointmentPage extends React.Component {
   componentDidMount() {
@@ -54,11 +59,11 @@ export class TypeOfAppointmentPage extends React.Component {
   }
 
   goBack = () => {
-    this.props.router.push('/');
+    this.props.routeToPreviousAppointmentPage(this.props.router, pageKey);
   };
 
   goForward = () => {
-    this.props.router.push('/new-appointment/type-of-care');
+    this.props.routeToNextAppointmentPage(this.props.router, pageKey);
   };
 
   render() {
@@ -111,6 +116,8 @@ function mapStateToProps(state) {
 const mapDispatchToProps = {
   openFormPage,
   updateFormData,
+  routeToPreviousAppointmentPage,
+  routeToNextAppointmentPage,
 };
 
 export default connect(

--- a/src/applications/vaos/newAppointmentFlow.js
+++ b/src/applications/vaos/newAppointmentFlow.js
@@ -13,6 +13,13 @@ export default {
   home: {
     url: '/',
   },
+  typeOfAppointment: {
+    url: '/new-appointment',
+    // Temporary stub for typeOfAppointment which will eventually be first step
+    // Next will direct to type of care or provider once both flows are complete
+    next: 'typeOfFacility',
+    previous: 'home',
+  },
   typeOfCare: {
     url: '/new-appointment',
     next: 'typeOfFacility',

--- a/src/applications/vaos/tests/containers/TypeOfAppointmentPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/containers/TypeOfAppointmentPage.unit.spec.jsx
@@ -77,7 +77,6 @@ describe('VAOS <TypeOfAppointmentPage>', () => {
     );
 
     form.find('form').simulate('submit');
-
     expect(form.find('.usa-input-error').length).to.equal(0);
     form.unmount();
   });

--- a/src/applications/vaos/tests/containers/TypeOfAppointmentPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/containers/TypeOfAppointmentPage.unit.spec.jsx
@@ -47,15 +47,11 @@ describe('VAOS <TypeOfAppointmentPage>', () => {
   it('should call updateFormData after change', () => {
     const openFormPage = sinon.spy();
     const updateFormData = sinon.spy();
-    const router = {
-      push: sinon.spy(),
-    };
 
     const form = mount(
       <TypeOfAppointmentPage
         openFormPage={openFormPage}
         updateFormData={updateFormData}
-        router={router}
         data={{}}
       />,
     );
@@ -70,14 +66,12 @@ describe('VAOS <TypeOfAppointmentPage>', () => {
 
   it('should submit with valid data', () => {
     const openFormPage = sinon.spy();
-    const router = {
-      push: sinon.spy(),
-    };
+    const routeToNextAppointmentPage = sinon.spy();
 
     const form = mount(
       <TypeOfAppointmentPage
         openFormPage={openFormPage}
-        router={router}
+        routeToNextAppointmentPage={routeToNextAppointmentPage}
         data={{ typeOfAppointment: 'provider' }}
       />,
     );
@@ -85,7 +79,6 @@ describe('VAOS <TypeOfAppointmentPage>', () => {
     form.find('form').simulate('submit');
 
     expect(form.find('.usa-input-error').length).to.equal(0);
-    expect(router.push.called).to.be.true;
     form.unmount();
   });
 });

--- a/src/applications/vaos/tests/newAppointmentFlow.unit.spec.js
+++ b/src/applications/vaos/tests/newAppointmentFlow.unit.spec.js
@@ -3,6 +3,13 @@ import { expect } from 'chai';
 import newAppointmentFlow from '../newAppointmentFlow';
 
 describe('VAOS newAppointmentFlow', () => {
+  describe('type of appointment page', () => {
+    expect(newAppointmentFlow.typeOfAppointment.next).to.equal(
+      'typeOfFacility',
+    );
+    expect(newAppointmentFlow.typeOfAppointment.previous).to.equal('home');
+  });
+
   describe('type of facility page', () => {
     it('next should choose audiology decision page if CC and audiology chosen', () => {
       const state = {


### PR DESCRIPTION
## Description
Update TypeOfAppointment to use newAppointmentFlow actions for next and previous buttons

## Testing done
Local testing


## Acceptance criteria
- [ ] `goBack()` and `goForward()` are using updated actions for navigation

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
