### PR TITLE
Kelsonic 488 community care placeholder

### DIFF
--- a/src/applications/facility-locator/components/ServiceTypeAhead.jsx
+++ b/src/applications/facility-locator/components/ServiceTypeAhead.jsx
@@ -84,6 +84,7 @@ class ServiceTypeAhead extends Component {
             </label>
             <span id="service-typeahead">
               <input
+                className="service-type-ahead-input"
                 {...getInputProps({
                   placeholder: 'Like primary care, cardiology',
                 })}

--- a/src/applications/facility-locator/sass/facility-locator.scss
+++ b/src/applications/facility-locator/sass/facility-locator.scss
@@ -743,3 +743,17 @@ $color-info-bubble-text: #818a8d;
 .va-nav-breadcrumbs:focus {
   outline: 0;
 }
+
+.service-type-ahead-input:focus {
+  &::-webkit-input-placeholder {
+    color: #5b616b;
+  }
+
+  &::-moz-placeholder {
+    color: #5b616b;
+  }
+
+  &::-ms-input-placeholder {
+    color: #5b616b;
+  }
+}

--- a/src/applications/facility-locator/sass/facility-locator.scss
+++ b/src/applications/facility-locator/sass/facility-locator.scss
@@ -1,8 +1,8 @@
-@import "~@department-of-veterans-affairs/formation/sass/shared-variables";
-@import "~@department-of-veterans-affairs/formation/sass/modules/va-pagination";
+@import '~@department-of-veterans-affairs/formation/sass/shared-variables';
+@import '~@department-of-veterans-affairs/formation/sass/modules/va-pagination';
 // @import "~react-tabs/style/react-tabs.scss";
-@import "~leaflet/dist/leaflet.css";
-@import "~react-tabs/style/react-tabs";
+@import '~leaflet/dist/leaflet.css';
+@import '~react-tabs/style/react-tabs';
 
 // TODO: These colors are not close enough to anything that already exists in
 // Formation. Perhaps the design should be reevaluated to see if Formation
@@ -11,7 +11,6 @@ $color-info-bubble-border: #6495a3;
 $color-info-bubble-text: #818a8d;
 
 .facility-locator {
-
   // TODO(css): Fix when #content .section h* is fixed
   .highlight {
     margin-bottom: 0.5em !important;
@@ -121,7 +120,7 @@ $color-info-bubble-text: #818a8d;
     }
   }
 
-  .facility-result+.facility-result {
+  .facility-result + .facility-result {
     border-top: solid 3px $color-gray-lightest;
   }
 
@@ -171,7 +170,7 @@ $color-info-bubble-text: #818a8d;
     }
   }
 
-  .react-tabs [role=tab][aria-selected=true] {
+  .react-tabs [role='tab'][aria-selected='true'] {
     border-left-color: $color-black;
     border-right-color: $color-black;
   }
@@ -180,7 +179,7 @@ $color-info-bubble-text: #818a8d;
     padding: 0;
   }
 
-  .react-tabs__tab+.react-tabs__tab {
+  .react-tabs__tab + .react-tabs__tab {
     border-left: none;
   }
 
@@ -216,22 +215,22 @@ $color-info-bubble-text: #818a8d;
       width: 230px;
       height: 39px;
       margin: 0.5em 0.5em 0.5em 0;
-      background: url("/img/icons/fa-male-lt-grey.svg") repeat-x left center;
+      background: url('/img/icons/fa-male-lt-grey.svg') repeat-x left center;
     }
 
     .fl-stats-bar-inner {
       display: block;
-      content: "&nbsp;";
+      content: '&nbsp;';
       height: 100%;
       margin: 0;
     }
 
     .fl-stats-bar-inner.grey {
-      background: url("/img/icons/fa-male-dk-grey.svg") repeat-x left center;
+      background: url('/img/icons/fa-male-dk-grey.svg') repeat-x left center;
     }
 
     .fl-stats-bar-inner.blue {
-      background: url("/img/icons/fa-male-blue.svg") repeat-x left center;
+      background: url('/img/icons/fa-male-blue.svg') repeat-x left center;
     }
   }
 
@@ -240,7 +239,7 @@ $color-info-bubble-text: #818a8d;
     border-top: none;
   }
 
-  .mobile-search-result+.mobile-search-result {
+  .mobile-search-result + .mobile-search-result {
     border-top: solid 1px $color-gray-light;
   }
 
@@ -261,31 +260,31 @@ $color-info-bubble-text: #818a8d;
   }
 
   .benefits-icon {
-    background-image: url("/img/icons/benefits-pin.svg");
+    background-image: url('/img/icons/benefits-pin.svg');
     background-repeat: no-repeat;
     background-size: contain;
   }
 
   .cemetery-icon {
-    background-image: url("/img/icons/cemetery-pin.svg");
+    background-image: url('/img/icons/cemetery-pin.svg');
     background-repeat: no-repeat;
     background-size: contain;
   }
 
   .health-icon {
-    background-image: url("/img/icons/health-pin.svg");
+    background-image: url('/img/icons/health-pin.svg');
     background-repeat: no-repeat;
     background-size: contain;
   }
 
   .cc-provider-icon {
-    background-image: url("/img/icons/cc-provider-pin.svg");
+    background-image: url('/img/icons/cc-provider-pin.svg');
     background-repeat: no-repeat;
     background-size: contain;
   }
 
   .vet-center-icon {
-    background-image: url("/img/icons/vet-centers-pin.svg");
+    background-image: url('/img/icons/vet-centers-pin.svg');
     background-repeat: no-repeat;
     background-size: contain;
   }
@@ -298,18 +297,19 @@ $color-info-bubble-text: #818a8d;
     padding-top: 3px;
     width: 32px;
     z-index: 999;
-    background: url("/img/icons/map-pin.svg") no-repeat center center;
+    background: url('/img/icons/map-pin.svg') no-repeat center center;
     background-size: contain;
     color: $color-white;
   }
 
   .current-position-icon {
-    background: url("/img/icons/current-location-pin.svg") no-repeat center center;
+    background: url('/img/icons/current-location-pin.svg') no-repeat center
+      center;
     background-size: contain;
   }
 
   .clearfix {
-    content: "";
+    content: '';
     display: block;
     clear: both;
   }
@@ -345,12 +345,11 @@ $color-info-bubble-text: #818a8d;
         background: $color-gray-lightest;
       }
 
-      input[type=submit] {
+      input[type='submit'] {
         padding: 0 1rem;
         margin-top: 2.5rem;
       }
     }
-
   }
 
   .mb2 {
@@ -359,7 +358,7 @@ $color-info-bubble-text: #818a8d;
 
   //TODO(css): Make this less specific
   #content .section h4 {
-    padding: 0 0 .25em 0;
+    padding: 0 0 0.25em 0;
   }
 
   hr.light {
@@ -419,8 +418,8 @@ $color-info-bubble-text: #818a8d;
       text-decoration: underline;
 
       &:after {
-        font: normal normal normal 1em "Font Awesome 5 Free";
-        content: "\F078";
+        font: normal normal normal 1em 'Font Awesome 5 Free';
+        content: '\F078';
         text-decoration: none;
         display: inline-block;
         padding: 0 0.5em;
@@ -429,7 +428,7 @@ $color-info-bubble-text: #818a8d;
 
       &.expanded {
         &:after {
-          content: "\F077";
+          content: '\F077';
         }
       }
     }
@@ -645,13 +644,14 @@ $color-info-bubble-text: #818a8d;
   margin-bottom: 0;
 }
 
-.cc-info-link:hover, .cc-info-link:active {
+.cc-info-link:hover,
+.cc-info-link:active {
   background-color: transparent;
 }
 
 .cc-info-link-icon {
   margin: 0 !important;
-  font-size: 2.0rem !important;
+  font-size: 2rem !important;
   vertical-align: -0.2rem;
   cursor: pointer;
 }
@@ -669,7 +669,8 @@ $color-info-bubble-text: #818a8d;
   font-weight: normal;
   font-size: 130%;
 }
-.cc-info-close-btn:hover, .cc-info-close-btn:active {
+.cc-info-close-btn:hover,
+.cc-info-close-btn:active {
   background-color: transparent;
 }
 
@@ -680,7 +681,6 @@ $color-info-bubble-text: #818a8d;
 #urgent-care-link {
   font-weight: bold;
 }
-
 
 #infoBubble {
   background-color: $color-aqua-lightest;
@@ -704,7 +704,6 @@ $color-info-bubble-text: #818a8d;
     cursor: pointer;
     color: $color-info-bubble-text;
   }
-
 
   h6 {
     font-size: 1.6rem !important;


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/488

**Current Behavior:** On focus of the `service-type-ahead-input` input field, the placeholder text color is transparent.

**Desired Behavior:** On focus of the `service-type-ahead-input` input field, the placeholder text color is #5b616b.

This PR implements the above desired behavior, **but only for the `service-type-ahead-input` input field**.

## Testing done
Tested locally.

## Screenshots
### Before
![image](https://user-images.githubusercontent.com/12773166/66224747-ae037d00-e6a4-11e9-9561-e4ea04535f89.png)

### After
![image](https://user-images.githubusercontent.com/12773166/66224715-9a581680-e6a4-11e9-941f-fcc0b5ba98fa.png)

## Acceptance criteria
- [x] [As a user, I want the type of things I can search for like "primary care" or "cardiology" to be available anytime. This text should not disappear when the Service Type input receives or loses keyboard focus.](https://github.com/department-of-veterans-affairs/va.gov-team/issues/488)

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
