### PR TITLE
Fix unit test for video visit link

### DIFF
--- a/src/applications/vaos/tests/components/VideoVisitLink.unit.spec.jsx
+++ b/src/applications/vaos/tests/components/VideoVisitLink.unit.spec.jsx
@@ -46,22 +46,28 @@ describe('Video visit', () => {
   });
 
   it('should enable video link if appointment is less than 30 minutes away', () => {
-    appointment.startDate = moment()
-      .add(-20, 'minutes')
-      .format();
+    const pastAppointment = {
+      ...appointment,
+      startDate: moment()
+        .add(-20, 'minutes')
+        .format(),
+    };
 
-    const tree = shallow(<VideoVisitLink appointment={appointment} />);
+    const tree = shallow(<VideoVisitLink appointment={pastAppointment} />);
     expect(tree.exists('.usa-button')).to.equal(true);
     expect(tree.exists('.usa-button-disabled')).to.equal(false);
     tree.unmount();
   });
 
   it('should disable video link if appointment is over 4 hours away', () => {
-    appointment.startDate = moment()
-      .add(245, 'minutes')
-      .format();
+    const futureAppointment = {
+      ...appointment,
+      startDate: moment()
+        .add(245, 'minutes')
+        .format(),
+    };
 
-    const tree = shallow(<VideoVisitLink appointment={appointment} />);
+    const tree = shallow(<VideoVisitLink appointment={futureAppointment} />);
     expect(tree.exists('.usa-button')).to.equal(true);
     expect(tree.exists('.usa-button-disabled')).to.equal(true);
     tree.unmount();


### PR DESCRIPTION
## Description
Video visit link unit tests are causing failures sometimes on master build. Multiple tests in thie file were using the same appointment object, which would sometimes cause conflicts.  Modified the tests that were changing the data to create a copy of the appointment using spread operator to prevent this conflict.

## Testing done
Tested locally

## Acceptance criteria
- [ ] `src/applications/vaos/tests/components/VideoVisitLink.unit.spec.jsx` does not cause faultures

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
