### PR TITLE
10857 Update isTextPermitted Checkbox Handling in Edit Modal for Mobile Phone

### DIFF
--- a/src/applications/vaos/tests/components/VideoVisitLink.unit.spec.jsx
+++ b/src/applications/vaos/tests/components/VideoVisitLink.unit.spec.jsx
@@ -46,22 +46,28 @@ describe('Video visit', () => {
   });
 
   it('should enable video link if appointment is less than 30 minutes away', () => {
-    appointment.startDate = moment()
-      .add(-20, 'minutes')
-      .format();
+    const pastAppointment = {
+      ...appointment,
+      startDate: moment()
+        .add(-20, 'minutes')
+        .format(),
+    };
 
-    const tree = shallow(<VideoVisitLink appointment={appointment} />);
+    const tree = shallow(<VideoVisitLink appointment={pastAppointment} />);
     expect(tree.exists('.usa-button')).to.equal(true);
     expect(tree.exists('.usa-button-disabled')).to.equal(false);
     tree.unmount();
   });
 
   it('should disable video link if appointment is over 4 hours away', () => {
-    appointment.startDate = moment()
-      .add(245, 'minutes')
-      .format();
+    const futureAppointment = {
+      ...appointment,
+      startDate: moment()
+        .add(245, 'minutes')
+        .format(),
+    };
 
-    const tree = shallow(<VideoVisitLink appointment={appointment} />);
+    const tree = shallow(<VideoVisitLink appointment={futureAppointment} />);
     expect(tree.exists('.usa-button')).to.equal(true);
     expect(tree.exists('.usa-button-disabled')).to.equal(true);
     tree.unmount();

--- a/src/applications/vaos/tests/components/VideoVisitLink.unit.spec.jsx
+++ b/src/applications/vaos/tests/components/VideoVisitLink.unit.spec.jsx
@@ -46,28 +46,22 @@ describe('Video visit', () => {
   });
 
   it('should enable video link if appointment is less than 30 minutes away', () => {
-    const pastAppointment = {
-      ...appointment,
-      startDate: moment()
-        .add(-20, 'minutes')
-        .format(),
-    };
+    appointment.startDate = moment()
+      .add(-20, 'minutes')
+      .format();
 
-    const tree = shallow(<VideoVisitLink appointment={pastAppointment} />);
+    const tree = shallow(<VideoVisitLink appointment={appointment} />);
     expect(tree.exists('.usa-button')).to.equal(true);
     expect(tree.exists('.usa-button-disabled')).to.equal(false);
     tree.unmount();
   });
 
   it('should disable video link if appointment is over 4 hours away', () => {
-    const futureAppointment = {
-      ...appointment,
-      startDate: moment()
-        .add(245, 'minutes')
-        .format(),
-    };
+    appointment.startDate = moment()
+      .add(245, 'minutes')
+      .format();
 
-    const tree = shallow(<VideoVisitLink appointment={futureAppointment} />);
+    const tree = shallow(<VideoVisitLink appointment={appointment} />);
     expect(tree.exists('.usa-button')).to.equal(true);
     expect(tree.exists('.usa-button-disabled')).to.equal(true);
     tree.unmount();

--- a/src/platform/user/profile/vet360/components/PhoneField/EditModal.jsx
+++ b/src/platform/user/profile/vet360/components/PhoneField/EditModal.jsx
@@ -59,6 +59,11 @@ class PhoneEditModal extends React.Component {
     this.props.onChange(newFieldValue, dirty);
   };
 
+  onCheckboxChange = event => {
+    const newFieldValue = { ...this.props.field.value, isTextPermitted: event };
+    this.props.onChange(newFieldValue, false);
+  };
+
   getInitialFormValues = () => {
     let defaultFieldValue;
 
@@ -111,9 +116,8 @@ class PhoneEditModal extends React.Component {
         isEnrolledInVAHealthCare={this.props.isEnrolledInVAHealthCare}
         isTextable={this.props.fieldName === FIELD_NAMES.MOBILE_PHONE}
         label="Send me text message (SMS) reminders for my VA health care appointments"
-        field={{ value: this.props.field.value.isTextPermitted, dirty: false }}
         checked={this.props.field.value.isTextPermitted}
-        onValueChange={this.onChange('isTextPermitted')}
+        onValueChange={this.onCheckboxChange}
       />
     </div>
   );


### PR DESCRIPTION
## Description
This update is to correct the handling of the isTextPermitted checkbox in the Edit Modal for the Mobile Phone Notifications MVP.

## Testing done
Local testing and unit testing.  It needs to be tested on staging in order to tell if it is going to work for sure.





