### PR TITLE
Fixed Google Analytics saving issue on Profile Failure Alert Boxes

### DIFF
--- a/src/applications/personalization/profile360/components/Hero.jsx
+++ b/src/applications/personalization/profile360/components/Hero.jsx
@@ -45,19 +45,17 @@ class HeroContent extends React.Component {
   render() {
     return (
       <div className="va-profile-hero">
-        <div className="row-padded">
-          <LoadingSection
-            isLoading={!this.props.hero}
-            message="Loading full name..."
-            render={this.renderName}
-          />
-          {this.props.militaryInformation && this.renderService()}
-          <p className="va-introtext">
-            Review your personal, military service, direct deposit, and contact
-            information—and find out how to make any needed updates or
-            corrections.
-          </p>
-        </div>
+        <LoadingSection
+          isLoading={!this.props.hero}
+          message="Loading full name..."
+          render={this.renderName}
+        />
+        {this.props.militaryInformation && this.renderService()}
+        <p className="va-introtext">
+          Review your personal, military service, direct deposit, and contact
+          information—and find out how to make any needed updates or
+          corrections.
+        </p>
       </div>
     );
   }

--- a/src/platform/user/profile/vet360/actions/transactions.js
+++ b/src/platform/user/profile/vet360/actions/transactions.js
@@ -92,7 +92,7 @@ export function refreshTransaction(
       const route = _route || `/profile/status/${transactionId}`;
       const transactionRefreshed = isVet360Configured()
         ? await apiRequest(route)
-        : await localVet360.updateTransaction(transactionId);
+        : await localVet360.updateTransactionToFailure(transactionId);
 
       if (isSuccessfulTransaction(transactionRefreshed)) {
         const forceCacheClear = true;

--- a/src/platform/user/profile/vet360/actions/transactions.js
+++ b/src/platform/user/profile/vet360/actions/transactions.js
@@ -92,7 +92,7 @@ export function refreshTransaction(
       const route = _route || `/profile/status/${transactionId}`;
       const transactionRefreshed = isVet360Configured()
         ? await apiRequest(route)
-        : await localVet360.updateTransactionToFailure(transactionId);
+        : await localVet360.updateTransaction(transactionId);
 
       if (isSuccessfulTransaction(transactionRefreshed)) {
         const forceCacheClear = true;

--- a/src/platform/user/profile/vet360/components/base/TransactionErrorBanner.jsx
+++ b/src/platform/user/profile/vet360/components/base/TransactionErrorBanner.jsx
@@ -12,16 +12,11 @@ export function GenericUpdateError(props) {
   return (
     <AlertBox
       {...props}
+      className="vads-u-margin-bottom--4"
       status="error"
-      content={
-        <div>
-          <h4>Your recent profile update didn’t save</h4>
-          <p>
-            We’re sorry. Something went wrong on our end and we couldn’t save
-            the recent updates you made to your profile. Please try again later.
-          </p>
-        </div>
-      }
+      headline="Your recent profile update didn’t save"
+      content="We’re sorry. Something went wrong on our end and we couldn’t save the
+      recent updates you made to your profile. Please try again later."
     />
   );
 }

--- a/src/platform/user/profile/vet360/components/base/TransactionErrorBanner.jsx
+++ b/src/platform/user/profile/vet360/components/base/TransactionErrorBanner.jsx
@@ -31,7 +31,7 @@ export function MVILookupFailError(props) {
             We’re sorry. We’re having trouble matching your information to our
             Veteran records, so we can’t give you access to tools for managing
             your health and benefits.
-          <a href={facilityLocator.rootUrl}>
+          <a href=${facilityLocator.rootUrl}>
             Find your nearest VA medical center
           </a>`}
     />

--- a/src/platform/user/profile/vet360/components/base/TransactionErrorBanner.jsx
+++ b/src/platform/user/profile/vet360/components/base/TransactionErrorBanner.jsx
@@ -26,22 +26,14 @@ export function MVILookupFailError(props) {
     <AlertBox
       {...props}
       status="error"
-      content={
-        <div>
-          <h4>
-            We’re having trouble matching your information to our Veteran
-            records
-          </h4>
-          <p>
+      headline="We’re having trouble matching your information to our Veteran records"
+      content={`
             We’re sorry. We’re having trouble matching your information to our
             Veteran records, so we can’t give you access to tools for managing
             your health and benefits.
-          </p>
           <a href={facilityLocator.rootUrl}>
             Find your nearest VA medical center
-          </a>
-        </div>
-      }
+          </a>`}
     />
   );
 }
@@ -51,15 +43,8 @@ export function MVIError(props) {
     <AlertBox
       {...props}
       status="error"
-      content={
-        <div>
-          <h4>We can’t access your contact information right now</h4>
-          <p>
-            We’re sorry. Something went wrong on our end. Please refresh this
-            page or try again later.
-          </p>
-        </div>
-      }
+      headline=">We can’t access your contact information right now"
+      content="We’re sorry. Something went wrong on our end. Please refresh this page or try again later."
     />
   );
 }

--- a/src/platform/user/profile/vet360/components/base/TransactionErrorBanner.jsx
+++ b/src/platform/user/profile/vet360/components/base/TransactionErrorBanner.jsx
@@ -7,7 +7,6 @@ import {
   hasMVIError,
   hasMVINotFoundError,
 } from '../../util/transactions';
-import {divIcon} from 'leaflet';
 
 export function GenericUpdateError(props) {
   return (

--- a/src/platform/user/profile/vet360/components/base/TransactionErrorBanner.jsx
+++ b/src/platform/user/profile/vet360/components/base/TransactionErrorBanner.jsx
@@ -7,6 +7,7 @@ import {
   hasMVIError,
   hasMVINotFoundError,
 } from '../../util/transactions';
+import {divIcon} from 'leaflet';
 
 export function GenericUpdateError(props) {
   return (
@@ -25,15 +26,21 @@ export function MVILookupFailError(props) {
   return (
     <AlertBox
       {...props}
+      className="vads-u-margin-bottom--4"
       status="error"
       headline="We’re having trouble matching your information to our Veteran records"
-      content={`
+      content={
+        <div>
+          <p>
             We’re sorry. We’re having trouble matching your information to our
             Veteran records, so we can’t give you access to tools for managing
             your health and benefits.
-          <a href=${facilityLocator.rootUrl}>
+          </p>
+          <a href={facilityLocator.rootUrl}>
             Find your nearest VA medical center
-          </a>`}
+          </a>
+        </div>
+      }
     />
   );
 }
@@ -42,8 +49,9 @@ export function MVIError(props) {
   return (
     <AlertBox
       {...props}
+      className="vads-u-margin-bottom--4"
       status="error"
-      headline=">We can’t access your contact information right now"
+      headline="We can’t access your contact information right now"
       content="We’re sorry. Something went wrong on our end. Please refresh this page or try again later."
     />
   );

--- a/src/platform/user/profile/vet360/containers/ProfileField.jsx
+++ b/src/platform/user/profile/vet360/containers/ProfileField.jsx
@@ -143,6 +143,7 @@ class Vet360ProfileField extends React.Component {
 
   render() {
     const {
+      analyticsSectionName,
       fieldName,
       isEditing,
       isEmpty,
@@ -177,10 +178,9 @@ class Vet360ProfileField extends React.Component {
           title={title}
           transaction={transaction}
           transactionRequest={transactionRequest}
-          refreshTransaction={this.props.refreshTransaction.bind(
-            this,
-            transaction,
-          )}
+          refreshTransaction={() =>
+            this.props.refreshTransaction(transaction, analyticsSectionName)
+          }
         >
           {isEmpty ? (
             <button


### PR DESCRIPTION
…nging the headline and content and correcting the method call in the TransactionRefreshed action

## Description
The Call Center is receiving feedback that veterans are not able to save their mailing address. Analytics-Insights wants to research how often this is occurring in order to determine the impact and resolution for the error.  

## Testing done
- \[Developer debug]: Open browser dev-tools and Watch window.dataLayer for GA/GTM events being pushed to the data-array.
- URL: [**https://staging.va.gov/profile**](https://staging.va.gov/profile)
- Login via **ID.me** as test-user 150 (**vets.gov.user+150<span>@</span>gmail.com**) \[find credentials [here](https://github.com/department-of-veterans-affairs/vets.gov-team/blob/master/Products/Identity/Login/Testing/TestAccounts.md) \(under ID.me, click Staing Users link)]. 
- On Profile page, under Contact Information, next to Mailing Address, click **Edit**.
- In the edit dialogue, change address\*.
- Observe the error-message displayed in the dialogue box.

## Screenshots
![Your_Profile___Veterans_Affairs](https://user-images.githubusercontent.com/875558/66334879-e3f46b80-e907-11e9-92e4-77af2d1bb9f1.png)

![Your_Profile___Veterans_Affairs](https://user-images.githubusercontent.com/875558/66334844-cf17d800-e907-11e9-87c9-c37ba1e71d0d.png)

## Acceptance criteria
- [ ] The Profile Save Failure was being tracked in Google Analytics but now the Profile Section is being tracked that is generating the error.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
