### PR TITLE
add no-proxy check to eslint rules

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -29,7 +29,7 @@
     // Override airbnb style.
     "camelcase": [2, { "properties": "always" }],
     "va-enzyme/unmount": 2,
-    "fp/no-proxy": 2,
+    "fp/no-proxy": 2, // IE 11 has not polyfill for Proxy 
     "func-names": 2,
     "import/no-extraneous-dependencies": 0,
     "no-console": 2,

--- a/.eslintrc
+++ b/.eslintrc
@@ -10,7 +10,7 @@
       "babel-module": {}
     }
   },
-  "plugins": ["mocha", "jest", "va-enzyme", "react-hooks"],
+  "plugins": ["mocha", "jest", "va-enzyme", "react-hooks", "fp"],
   "extends": ["airbnb", "plugin:prettier/recommended"],
   "env": {
     "browser": true,
@@ -29,6 +29,7 @@
     // Override airbnb style.
     "camelcase": [2, { "properties": "always" }],
     "va-enzyme/unmount": 2,
+    "fp/no-proxy": 2,
     "func-names": 2,
     "import/no-extraneous-dependencies": 0,
     "no-console": 2,

--- a/package.json
+++ b/package.json
@@ -140,6 +140,7 @@
     "eslint-config-airbnb": "^15.1.0",
     "eslint-config-prettier": "^3.1.0",
     "eslint-import-resolver-babel-module": "^5.0.1",
+    "eslint-plugin-fp": "^2.3.0",
     "eslint-plugin-import": "^2.14.0",
     "eslint-plugin-jest": "^21.26.1",
     "eslint-plugin-jsx-a11y": "5.1",

--- a/src/site/stages/build/drupal/load-saved-flags.js
+++ b/src/site/stages/build/drupal/load-saved-flags.js
@@ -13,6 +13,7 @@ const fs = require('fs-extra');
  *                   an error if a flag is called without existing
  */
 function useFlags(rawFlags, shouldLog = true) {
+  // eslint-disable-next-line fp/no-proxy
   const p = new Proxy(rawFlags, {
     get(obj, prop) {
       if (prop in obj) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3286,6 +3286,13 @@ create-error-class@^3.0.0:
   dependencies:
     capture-stack-trace "^1.0.0"
 
+create-eslint-index@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/create-eslint-index/-/create-eslint-index-1.0.0.tgz#d954372d86d5792fcd67e9f2b791b1ab162411bb"
+  integrity sha1-2VQ3LYbVeS/NZ+nyt5GxqxYkEbs=
+  dependencies:
+    lodash.get "^4.3.0"
+
 create-hash@^1.1.0, create-hash@^1.1.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/create-hash/-/create-hash-1.1.2.tgz#51210062d7bb7479f6c65bb41a92208b1d61abad"
@@ -4456,6 +4463,14 @@ escope@^3.6.0:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
+eslint-ast-utils@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-ast-utils/-/eslint-ast-utils-1.1.0.tgz#3d58ba557801cfb1c941d68131ee9f8c34bd1586"
+  integrity sha512-otzzTim2/1+lVrlH19EfQQJEhVJSu0zOb9ygb3iapN6UlyaDtyRq4b5U1FuW0v1lRa9Fp/GJyHkSwm6NqABgCA==
+  dependencies:
+    lodash.get "^4.4.2"
+    lodash.zip "^4.2.0"
+
 eslint-config-airbnb-base@^11.3.0:
   version "11.3.1"
   resolved "https://registry.yarnpkg.com/eslint-config-airbnb-base/-/eslint-config-airbnb-base-11.3.1.tgz#c0ab108c9beed503cb999e4c60f4ef98eda0ed30"
@@ -4494,6 +4509,16 @@ eslint-module-utils@^2.2.0:
   dependencies:
     debug "^2.6.8"
     pkg-dir "^1.0.0"
+
+eslint-plugin-fp@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-fp/-/eslint-plugin-fp-2.3.0.tgz#376d2a108710e981980bdc3875e3b9920da0489c"
+  integrity sha1-N20qEIcQ6YGYC9w4deO5kg2gSJw=
+  dependencies:
+    create-eslint-index "^1.0.0"
+    eslint-ast-utils "^1.0.0"
+    lodash "^4.13.1"
+    req-all "^0.1.0"
 
 eslint-plugin-import@^2.14.0:
   version "2.14.0"
@@ -8309,7 +8334,7 @@ lodash.get@^3.7.0:
     lodash._baseget "^3.0.0"
     lodash._topath "^3.0.0"
 
-lodash.get@^4.4.2:
+lodash.get@^4.3.0, lodash.get@^4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
 
@@ -8460,6 +8485,11 @@ lodash.topath@^4.5.2:
 lodash.uniq@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
+
+lodash.zip@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/lodash.zip/-/lodash.zip-4.2.0.tgz#ec6662e4896408ed4ab6c542a3990b72cc080020"
+  integrity sha1-7GZi5IlkCO1KtsVCo5kLcswIACA=
 
 "lodash@>=3.5 <5", lodash@^4.0.0, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.2, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.3.0, lodash@^4.6.1:
   version "4.17.15"
@@ -11627,6 +11657,11 @@ replace-ext@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/replace-ext/-/replace-ext-1.0.0.tgz#de63128373fcbf7c3ccfa4de5a480c45a67958eb"
   integrity sha1-3mMSg3P8v3w8z6TeWkgMRaZ5WOs=
+
+req-all@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/req-all/-/req-all-0.1.0.tgz#130051e2ace58a02eacbfc9d448577a736a9273a"
+  integrity sha1-EwBR4qzligLqy/ydRIV3pzapJzo=
 
 request-promise-core@1.1.1:
   version "1.1.1"


### PR DESCRIPTION
## Description

- added new eslint to prohibit to use of Proxy
- added exception to build script plugin 

## Testing done


## Screenshots
<img width="628" alt="Screen Shot 2019-10-07 at 4 10 27 PM" src="https://user-images.githubusercontent.com/4998130/66352621-31c79e80-e91d-11e9-9421-142178c6dbd5.png">


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
