### PR TITLE
Remove "(optional)" text from street address labels

### DIFF
--- a/src/applications/disability-benefits/all-claims/utils.jsx
+++ b/src/applications/disability-benefits/all-claims/utils.jsx
@@ -391,13 +391,13 @@ export const addressUISchema = (
       },
     },
     addressLine2: {
-      'ui:title': 'Street address (optional)',
+      'ui:title': 'Street address',
       'ui:errorMessages': {
         pattern: 'Please fill in a valid address',
       },
     },
     addressLine3: {
-      'ui:title': 'Street address (optional)',
+      'ui:title': 'Street address',
       'ui:errorMessages': {
         pattern: 'Please fill in a valid address',
       },

--- a/src/applications/letters/components/Address.jsx
+++ b/src/applications/letters/components/Address.jsx
@@ -99,7 +99,7 @@ class Address extends React.Component {
         />
         <ErrorableTextInput
           errorMessage={errorMessages.addressTwo}
-          label="Street address (optional)"
+          label="Street address"
           name="addressTwo"
           autocomplete="address-line2"
           charMax={35}
@@ -109,7 +109,7 @@ class Address extends React.Component {
         />
         <ErrorableTextInput
           errorMessage={errorMessages.addressThree}
-          label="Street address (optional)"
+          label="Street address"
           name="addressThree"
           autocomplete="address-line3"
           charMax={35}

--- a/src/platform/user/profile/vet360/components/AddressField/AddressForm.jsx
+++ b/src/platform/user/profile/vet360/components/AddressField/AddressForm.jsx
@@ -71,7 +71,7 @@ class Address extends React.Component {
           onBlur={() => this.props.onBlur('addressLine1')}
         />
         <ErrorableTextInput
-          label="Street address (optional)"
+          label="Street address"
           name="addressLine2"
           autocomplete="address-line2"
           charMax={100}
@@ -80,7 +80,7 @@ class Address extends React.Component {
           onBlur={() => this.props.onBlur('addressLine2')}
         />
         <ErrorableTextInput
-          label="Street address (optional)"
+          label="Street address"
           name="addressLine3"
           autocomplete="address-line3"
           charMax={100}


### PR DESCRIPTION
## Description

As per [issue #2292](https://github.com/department-of-veterans-affairs/va.gov-team/issues/2292) and [this slack discussion](https://dsva.slack.com/archives/C0NGDDXME/p1570051496075200), we're removing the "(optional)" portion of the street address label globally to make all forms consistent.

## Testing done

Local unit tests

## Screenshots

![Screen Shot 2019-10-07 at 12 20 22 PM](https://user-images.githubusercontent.com/136959/66333721-2b292f00-e8fd-11e9-8077-3b421f2273a1.png)

## Acceptance criteria
- [ ] "(optional)" text removed.
- [ ] Content reviewed

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
