### PR TITLE
Screenreader fix for IE11

### DIFF
--- a/src/platform/forms-system/src/js/components/FieldTemplate.jsx
+++ b/src/platform/forms-system/src/js/components/FieldTemplate.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import _ from 'lodash/fp'; // eslint-disable-line no-restricted-imports
 import classNames from 'classnames';
+import environment from 'platform/utilities/environment';
 
 /*
  * This is the template for each field (which in the schema library means label + widget)
@@ -46,11 +47,26 @@ export default function FieldTemplate(props) {
   let errorSpanId;
   let errorSpan;
   let errorClass;
+  let errorStyle = 'none';
   if (hasErrors) {
     errorClass = isDateField ? 'input-error-date' : 'usa-input-error';
     errorSpanId = `${id}-error-message`;
+    errorStyle = 'block';
     errorSpan = (
       <span className="usa-input-error-message" role="alert" id={errorSpanId}>
+        <span className="sr-only">Error</span> {rawErrors[0]}
+      </span>
+    );
+  }
+
+  if (!environment.isProduction()) {
+    errorSpan = (
+      <span
+        style={{ display: errorStyle }}
+        className="usa-input-error-message"
+        role="alert"
+        id={errorSpanId}
+      >
         <span className="sr-only">Error</span> {rawErrors[0]}
       </span>
     );

--- a/src/platform/forms-system/src/js/components/FieldTemplate.jsx
+++ b/src/platform/forms-system/src/js/components/FieldTemplate.jsx
@@ -59,7 +59,7 @@ export default function FieldTemplate(props) {
     );
   }
 
-  if (!environment.isProduction()) {
+  if (environment.isStaging()) {
     errorSpan = (
       <span
         style={{ display: errorStyle }}


### PR DESCRIPTION
## Description
Current implementation seems to be stable only on Firefox and Chrome. Implementation was changed to use css style display attribute instead. Both implementations worked seamless in Firefox and Chrome locally but needs further testing in IE11

## Testing done
Testing passes locally. Needs additional IE11 testing.

## Screenshots
N/A

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
