### PR TITLE
updated renderLearnMore method to handle aria-label text

### DIFF
--- a/src/applications/gi/components/search/EligibilityForm.jsx
+++ b/src/applications/gi/components/search/EligibilityForm.jsx
@@ -23,11 +23,11 @@ export class EligibilityForm extends React.Component {
     { value: 'purple heart', label: 'Purple Heart Service: 100%' },
   ];
 
-  renderLearnMoreLabel = ({ text, modal, learnMoreMessage }) =>
+  renderLearnMoreLabel = ({ text, modal, ariaLabel }) =>
     renderLearnMoreLabel({
       text,
       modal,
-      learnMoreMessage,
+      ariaLabel,
       showModal: this.props.showModal,
       component: this,
     });
@@ -70,7 +70,7 @@ export class EligibilityForm extends React.Component {
           label={this.renderLearnMoreLabel({
             text: 'Which GI Bill benefit do you want to use?',
             modal: 'giBillChapter',
-            learnMoreMessage: 'Learn more about GI Bill benefits',
+            ariaLabel: 'Learn more about GI Bill benefits',
           })}
           name="giBillChapter"
           options={[
@@ -125,8 +125,8 @@ export class EligibilityForm extends React.Component {
           label={this.renderLearnMoreLabel({
             text: 'Cumulative Post-9/11 active duty service',
             modal: 'cumulativeService',
-            learnMoreMessage:
-              '“Learn more about cumulative Post-9/11 active duty service”',
+            ariaLabel:
+              'Learn more about cumulative Post-9/11 active duty service',
           })}
           name="cumulativeService"
           options={this.cumulativeServiceOptions()}

--- a/src/applications/gi/components/search/EligibilityForm.jsx
+++ b/src/applications/gi/components/search/EligibilityForm.jsx
@@ -23,10 +23,11 @@ export class EligibilityForm extends React.Component {
     { value: 'purple heart', label: 'Purple Heart Service: 100%' },
   ];
 
-  renderLearnMoreLabel = ({ text, modal }) =>
+  renderLearnMoreLabel = ({ text, modal, learnMoreMessage }) =>
     renderLearnMoreLabel({
       text,
       modal,
+      learnMoreMessage,
       showModal: this.props.showModal,
       component: this,
     });
@@ -69,6 +70,7 @@ export class EligibilityForm extends React.Component {
           label={this.renderLearnMoreLabel({
             text: 'Which GI Bill benefit do you want to use?',
             modal: 'giBillChapter',
+            learnMoreMessage: 'Learn more about GI Bill benefits',
           })}
           name="giBillChapter"
           options={[
@@ -123,6 +125,8 @@ export class EligibilityForm extends React.Component {
           label={this.renderLearnMoreLabel({
             text: 'Cumulative Post-9/11 active duty service',
             modal: 'cumulativeService',
+            learnMoreMessage:
+              '“Learn more about cumulative Post-9/11 active duty service”',
           })}
           name="cumulativeService"
           options={this.cumulativeServiceOptions()}

--- a/src/applications/gi/components/vet-tec/VetTecCalculatorForm.jsx
+++ b/src/applications/gi/components/vet-tec/VetTecCalculatorForm.jsx
@@ -28,7 +28,7 @@ class VetTecCalculatorForm extends React.Component {
         Scholarships (excluding Pell)
       </label>{' '}
       <button
-        aria-label="scholarships (excluding Pell) learn more"
+        aria-label="Learn more about scholarships (excluding Pell)"
         type="button"
         className="va-button-link learn-more-button"
         onClick={() => onShowModal('scholarships')}
@@ -56,7 +56,7 @@ class VetTecCalculatorForm extends React.Component {
         Tuition and fees for program
       </label>{' '}
       <button
-        aria-label="tuition and fees learn more"
+        aria-label="Learn more about tuition and fees"
         type="button"
         className="va-button-link learn-more-button"
         onClick={() => onShowModal('tuitionAndFees')}

--- a/src/applications/gi/utils/render.jsx
+++ b/src/applications/gi/utils/render.jsx
@@ -36,14 +36,14 @@ export const renderPreferredProviderFlag = result => {
 export const renderLearnMoreLabel = ({
   text,
   modal,
-  learnMoreMessage,
+  ariaLabel,
   showModal,
   component,
 }) => (
   <span>
     {text}{' '}
     <button
-      aria-label={learnMoreMessage}
+      aria-label={ariaLabel}
       type="button"
       className="va-button-link learn-more-button"
       onClick={showModal.bind(component, modal)}

--- a/src/applications/gi/utils/render.jsx
+++ b/src/applications/gi/utils/render.jsx
@@ -33,10 +33,17 @@ export const renderPreferredProviderFlag = result => {
   );
 };
 
-export const renderLearnMoreLabel = ({ text, modal, showModal, component }) => (
+export const renderLearnMoreLabel = ({
+  text,
+  modal,
+  learnMoreMessage,
+  showModal,
+  component,
+}) => (
   <span>
     {text}{' '}
     <button
+      aria-label={learnMoreMessage}
       type="button"
       className="va-button-link learn-more-button"
       onClick={showModal.bind(component, modal)}


### PR DESCRIPTION
## Description
The `Learn more` buttons rely on proximity to a label or heading to answer the question "Learn more about what?". This can be improved for assistive devices and screen readers by adding aria-label attributes to the buttons. 

https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/1252

## Testing done
1. Test done locally on mac using apple voice over with Safari, Chrome and Firefox.
2. Testing done Locally on Windows VM using NVDA, JAWS with Chrome, Firefox, Internet explorer and edge. 

## Screenshots


## Acceptance criteria
- [x]As a screen reader user, I want to hear contextual aria-labels read aloud. This text could sound like "Learn more about GI Bill benefits" or "Learn more about cumulative Post-9/11 active duty service".
- [x] The text "Learn more" should be included in each aria-label, ideally as the first text. 

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
