### PR TITLE
Kelsonic 2278 sidenav

### DIFF
--- a/src/platform/site-wide/index.js
+++ b/src/platform/site-wide/index.js
@@ -10,6 +10,7 @@ import './wysiwyg-analytics-setup';
 import addMenuListeners from './accessible-menus';
 import startUserNavWidget from './user-nav';
 import startMegaMenuWidget from './mega-menu';
+import startSideNav from './side-nav';
 import startMetrics from '../monitoring/frontend-metrics';
 import startMobileMenuButton from './mobile-menu-button';
 import startAnnouncementWidget from './announcements';
@@ -50,6 +51,7 @@ export default function startSitewideComponents(commonStore) {
   startUserNavWidget(commonStore);
   startAnnouncementWidget(commonStore);
   startMegaMenuWidget(window.VetsGov.headerFooter.megaMenuData, commonStore);
+  startSideNav(window.sideNav, commonStore);
   startMobileMenuButton(commonStore);
   startVAFooter(
     window.VetsGov.headerFooter.footerData,

--- a/src/platform/site-wide/sass/modules/_m-side-nav.scss
+++ b/src/platform/site-wide/sass/modules/_m-side-nav.scss
@@ -1,0 +1,92 @@
+.va-sidenav {
+  background: $color-white;
+  border: 1px solid $color-gray-lighter;
+  border-radius: 5px;
+  display: flex;
+  flex-direction: column;
+  padding: 10px 0;
+  margin: 0 20px 0 0;
+
+  li {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  ul {
+    display: flex;
+    flex-direction: column;
+    margin: 0;
+    padding: 0;
+  }
+
+  a, button {
+    background: none;
+    border-radius: none;
+    color: $color-gray-dark;
+    font-size: 15px;
+    font-weight: bold;
+    letter-spacing: 0.3px;
+    line-height: 1.5;
+    margin: 0;
+    padding: 0;
+    text-align: left;
+    text-decoration: none;
+    text-transform: uppercase;
+  }
+
+  .fa {
+    color: $color-primary;
+  }
+
+  .line {
+    background: $color-gray-lighter;
+    height: 1px;
+    margin: 10px 23px;
+  }
+
+  .va-sidenav-toggle-expand {
+    align-items: center;
+    background: $color-gray-lightest;
+    border-radius: 4px;
+    color: $color-primary;
+    display: flex;
+    height: 24px;
+    justify-content: center;
+    width: 24px;
+  }
+
+  .va-sidenav-item-label {
+    align-items: center;
+    border-radius: 0;
+    display: flex;
+    justify-content: space-between;
+    padding: 10px 23px;
+    transition: background 0.5s ease;
+    width: 100%;
+
+    &.selected {
+      a, button {
+        color: $color-gray-dark;
+      }
+
+      &.va-sidenav-item-label-duplicate {
+        text-decoration: underline;
+      }
+    }
+
+    &:hover {
+      background: #f8f8f8; // I could not find the color in our design utilities.
+    }
+  }
+
+  .va-sidenav-level-2 {
+    a, button {
+      color: $color-primary;
+      font-weight: normal;
+      letter-spacing: 0;
+      line-height: 1.38;
+      text-transform: none;
+    }
+  }
+}

--- a/src/platform/site-wide/sass/style.scss
+++ b/src/platform/site-wide/sass/style.scss
@@ -27,5 +27,6 @@
 @import "modules/m-homepage";
 @import "modules/m-veteran-banner";
 @import "modules/m-cta-widget";
+@import "modules/m-side-nav";
 
 @import "shame";

--- a/src/platform/site-wide/side-nav/components/SideNav.js
+++ b/src/platform/site-wide/side-nav/components/SideNav.js
@@ -1,0 +1,166 @@
+// Dependencies
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+import { find, filter, get, startsWith, map, orderBy } from 'lodash';
+
+class SideNav extends Component {
+  static propTypes = {
+    navItemsLookup: PropTypes.object.isRequired,
+  };
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      navItemsLookup: props.navItemsLookup,
+    };
+  }
+
+  toggleItemExpanded = id => () => {
+    const { navItemsLookup } = this.state;
+
+    // Derive the nav item and its properties.
+    const navItem = get(navItemsLookup, `[${id}]`);
+    const hasChildren = get(navItem, 'hasChildren');
+    const expanded = get(navItem, 'expanded');
+
+    // Escape early if the nav item has no children.
+    if (!hasChildren) {
+      return;
+    }
+
+    // Flip the item's expanded property.
+    this.setState({
+      navItemsLookup: {
+        ...navItemsLookup,
+        [id]: {
+          ...navItemsLookup[id],
+          expanded: !expanded,
+        },
+      },
+    });
+  };
+
+  renderChildItems = (parentID, depth) => {
+    const { toggleItemExpanded } = this;
+    const { navItemsLookup } = this.state;
+
+    // Derive the items to render.
+    const filteredNavItems = filter(
+      navItemsLookup,
+      item => item.parentID === parentID,
+    );
+
+    // Sort the items by `order`.
+    const sortedNavItems = orderBy(filteredNavItems, 'order', 'asc');
+
+    return map(sortedNavItems, (item, index) => {
+      // Derive the item properties.
+      const expanded = get(item, 'expanded');
+      const hasChildren = get(item, 'hasChildren', false);
+      const href = get(item, 'href');
+      const id = get(item, 'id');
+      const label = get(item, 'label', '');
+
+      // Derive if the nav item is selected and the selected class.
+      const isSelected = startsWith(window.location.pathname, href);
+
+      // Derive the depth booleans.
+      const isFirstLevel = depth === 1;
+      const isSecondLevel = depth === 2;
+      const isDeeperThanSecondLevel = depth >= 2;
+
+      // Caclculate the indentation for the child items.
+      const indentation = isDeeperThanSecondLevel ? 20 * (depth - 1) : 20;
+
+      // Determine if we should show a line at the end.
+      const showLine = isFirstLevel && index !== sortedNavItems.length - 1;
+
+      // Derive the label element.
+      const labelElement = href ? (
+        <a
+          className="va-sidenav-item-label-text"
+          href={href}
+          rel="noopener noreferrer"
+        >
+          {label}
+        </a>
+      ) : (
+        <div className="va-sidenav-item-label-text">{label}</div>
+      );
+
+      return (
+        <li className={`va-sidenav-level-${depth}`} key={id}>
+          <button
+            aria-label={label}
+            className={classNames({
+              'va-sidenav-item-label': true,
+              selected: isSelected,
+            })}
+            onClick={toggleItemExpanded(id)}
+            style={{ paddingLeft: indentation }}
+          >
+            {/* Label */}
+            {labelElement}
+
+            {/* Expand/Collapse Button */}
+            {hasChildren && isDeeperThanSecondLevel && (
+              <button
+                aria-label={`Expand "${label}"`}
+                className="va-sidenav-toggle-expand"
+              >
+                <i
+                  className={classNames({
+                    fa: true,
+                    'fa-chevron-down': expanded,
+                    'fa-chevron-up': !expanded,
+                  })}
+                />
+              </button>
+            )}
+          </button>
+
+          {/* Duplicate Line + Label when Expanded */}
+          {expanded && isSecondLevel && (
+            <>
+              <div className="line" />
+              <div
+                className={classNames({
+                  'va-sidenav-item-label': true,
+                  'va-sidenav-item-label-duplicate': true,
+                  selected: isSelected,
+                })}
+              >
+                {labelElement}
+              </div>
+            </>
+          )}
+
+          {/* Child Items */}
+          {expanded && <ul>{this.renderChildItems(id, depth + 1)}</ul>}
+
+          {/* Ending Line */}
+          {showLine && <div className="line" />}
+        </li>
+      );
+    });
+  };
+
+  render() {
+    const { renderChildItems } = this;
+    const { navItemsLookup } = this.props;
+
+    // Derive the parent-most nav item. This is O(n), which isn't great but I'm assuming there won't be 1000s of side nav items.
+    const parentMostNavItem = find(navItemsLookup, item => !item.parentID);
+    const parentMostID = get(parentMostNavItem, 'id');
+
+    return (
+      <ul className="usa-width-one-fourth va-sidenav">
+        {/* Render all the items recursively. */}
+        {renderChildItems(parentMostID, 1)}
+      </ul>
+    );
+  }
+}
+
+export default SideNav;

--- a/src/platform/site-wide/side-nav/components/SideNav.js
+++ b/src/platform/site-wide/side-nav/components/SideNav.js
@@ -156,6 +156,11 @@ class SideNav extends Component {
     const parentMostNavItem = find(navItemsLookup, item => !item.parentID);
     const parentMostID = get(parentMostNavItem, 'id');
 
+    // Escape early if we have no nav items to render.
+    if (!parentMostID) {
+      return null;
+    }
+
     return (
       <ul className="usa-width-one-fourth va-sidenav">
         {/* Render all the items recursively. */}

--- a/src/platform/site-wide/side-nav/components/SideNav.js
+++ b/src/platform/site-wide/side-nav/components/SideNav.js
@@ -104,37 +104,39 @@ class SideNav extends Component {
             {labelElement}
 
             {/* Expand/Collapse Button */}
-            {hasChildren && isDeeperThanSecondLevel && (
-              <button
-                aria-label={`Expand "${label}"`}
-                className="va-sidenav-toggle-expand"
-              >
-                <i
-                  className={classNames({
-                    fa: true,
-                    'fa-chevron-down': expanded,
-                    'fa-chevron-up': !expanded,
-                  })}
-                />
-              </button>
-            )}
+            {hasChildren &&
+              isDeeperThanSecondLevel && (
+                <button
+                  aria-label={`Expand "${label}"`}
+                  className="va-sidenav-toggle-expand"
+                >
+                  <i
+                    className={classNames({
+                      fa: true,
+                      'fa-chevron-down': expanded,
+                      'fa-chevron-up': !expanded,
+                    })}
+                  />
+                </button>
+              )}
           </button>
 
           {/* Duplicate Line + Label when Expanded */}
-          {expanded && isSecondLevel && (
-            <>
-              <div className="line" />
-              <div
-                className={classNames({
-                  'va-sidenav-item-label': true,
-                  'va-sidenav-item-label-duplicate': true,
-                  selected: isSelected,
-                })}
-              >
-                {labelElement}
-              </div>
-            </>
-          )}
+          {expanded &&
+            isSecondLevel && (
+              <>
+                <div className="line" />
+                <div
+                  className={classNames({
+                    'va-sidenav-item-label': true,
+                    'va-sidenav-item-label-duplicate': true,
+                    selected: isSelected,
+                  })}
+                >
+                  {labelElement}
+                </div>
+              </>
+            )}
 
           {/* Child Items */}
           {expanded && <ul>{this.renderChildItems(id, depth + 1)}</ul>}

--- a/src/platform/site-wide/side-nav/helpers.js
+++ b/src/platform/site-wide/side-nav/helpers.js
@@ -1,0 +1,93 @@
+// Dependencies
+import { each, get, uniqueId, isEmpty } from 'lodash';
+
+/* Recursive function that derives `navItems` and `navItemsLookup` for `normalizeSideNavData`.
+  @param {Object}, options:
+  {
+    items: array,
+    parentID: string,
+    navItemsLookup: object,
+  }
+  @returns {Object}, navItemsLookup is keyed off `id`.
+*/
+const deriveNavItemsLookup = options => {
+  // Derive the properties from options.
+  const items = get(options, 'items', []);
+  const parentID = get(options, 'parentID');
+  let navItemsLookup = get(options, 'navItemsLookup', {});
+
+  each(items, (item, index) => {
+    // Derive item properties.
+    const description = get(item, 'description', '');
+    const expanded = get(item, 'expanded', false);
+    const href = get(item, 'url.path', '');
+    const id = uniqueId();
+    const label = get(item, 'label', '');
+    const nestedItems = get(item, 'links');
+
+    // Construct the formatted item.
+    const formattedItem = {
+      description,
+      expanded,
+      hasChildren: !isEmpty(nestedItems),
+      href,
+      id,
+      label,
+      order: index,
+      parentID,
+    };
+
+    // Always add the item to our lookup table keyed off by ID.
+    navItemsLookup[id] = formattedItem;
+
+    // Update our navItemsLookup with the nested items if the option is passed.
+    if (!isEmpty(nestedItems)) {
+      const nestedNavItemsLookup = deriveNavItemsLookup({
+        items: nestedItems,
+        navItemsLookup,
+        parentID: id,
+      });
+
+      // Update our navItemsLookup with the nested items.
+      navItemsLookup = {
+        ...navItemsLookup,
+        ...nestedNavItemsLookup,
+      };
+    }
+  });
+
+  return navItemsLookup;
+};
+
+/* `normalizeSideNavData` returns normalized SideNav data.
+  @param {Object} data, will likely look like:
+  {
+    description: string,
+    links: arrayOf(
+      {
+        description: string,
+        expanded: bool,
+        label: string,
+        links: array, (... and so on)
+        url: {
+          path: string,
+        }),
+      }),
+    ),
+    name: string,
+  }
+
+  @returns {Object}, navItemsLookup keyed off by `id`.
+*/
+export const normalizeSideNavData = data => {
+  // Derive properties we need from data.
+  const items = get(data, 'links');
+
+  // Derive a nav items array and a lookup table.
+  const navItemsLookup = deriveNavItemsLookup({
+    items,
+    navItemsLookup: {},
+  });
+
+  return navItemsLookup;
+};

--- a/src/platform/site-wide/side-nav/helpers.js
+++ b/src/platform/site-wide/side-nav/helpers.js
@@ -19,7 +19,6 @@ const deriveNavItemsLookup = options => {
   each(items, (item, index) => {
     // Derive item properties.
     const description = get(item, 'description', '');
-    const expanded = get(item, 'expanded', false);
     const href = get(item, 'url.path', '');
     const id = uniqueId();
     const label = get(item, 'label', '');
@@ -28,7 +27,7 @@ const deriveNavItemsLookup = options => {
     // Construct the formatted item.
     const formattedItem = {
       description,
-      expanded,
+      expanded: false,
       hasChildren: !isEmpty(nestedItems),
       href,
       id,

--- a/src/platform/site-wide/side-nav/index.js
+++ b/src/platform/site-wide/side-nav/index.js
@@ -1,0 +1,25 @@
+// Dependencies
+import React from 'react';
+// Relative
+import startReactApp from '../../startup/react';
+import SideNav from './components/SideNav';
+import { normalizeSideNavData } from './helpers';
+
+// Are you looking for where this is used?
+// Search for `<div data-widget-type="side-nav"></div>` to find all the places
+// this React widget is used.
+export default data => {
+  // Derive the root element to place the SideNav.
+  const root = document.querySelector(`[data-widget-type="side-nav"]`);
+
+  // Escape early if there is no root element found.
+  if (!root) {
+    return;
+  }
+
+  // Normalize the data before we pass it to the SideNav.
+  const navItemsLookup = normalizeSideNavData(data);
+
+  // Create the SideNav.
+  startReactApp(<SideNav navItemsLookup={navItemsLookup} />, root);
+};

--- a/src/platform/site-wide/side-nav/tests/components/SideNav.unit.spec.js
+++ b/src/platform/site-wide/side-nav/tests/components/SideNav.unit.spec.js
@@ -47,13 +47,13 @@ describe('<SideNav>', () => {
 
   it('should not render when there are no nav items to show', () => {
     const wrapper = shallow(<SideNav />);
-    expect(wrapper.find('SideNav').length).to.equal(0);
+    expect(wrapper.type()).to.equal(null);
     wrapper.unmount();
   });
 
   it('should render when there are nav items', () => {
     const wrapper = shallow(<SideNav {...defaultProps} />);
-    expect(wrapper.find('SideNav').length).to.equal(1);
+    expect(wrapper.type()).to.not.equal(null);
     wrapper.unmount();
   });
 });

--- a/src/platform/site-wide/side-nav/tests/components/SideNav.unit.spec.js
+++ b/src/platform/site-wide/side-nav/tests/components/SideNav.unit.spec.js
@@ -1,0 +1,59 @@
+// Dependencies
+import React from 'react';
+import { shallow } from 'enzyme';
+import { expect } from 'chai';
+// Relative
+import SideNav from '../../components/SideNav';
+
+describe('<SideNav>', () => {
+  const defaultProps = {
+    navItemsLookup: {
+      '00c9a1ff-3550-4f54-9239-c769fc6edab1': {
+        description: 'Some description',
+        expanded: false,
+        hasChildren: true,
+        href: '/pittsburgh-health-care',
+        id: '00c9a1ff-3550-4f54-9239-c769fc6edab1',
+        label: 'Location',
+        order: 0,
+        parentID: '8e5668a6-90d9-4913-bc9f-c8f6788d7a2e',
+      },
+      '8e5668a6-90d9-4913-bc9f-c8f6788d7a2e': {
+        description: 'Some description',
+        expanded: false,
+        hasChildren: false,
+        href: '/pittsburgh-health-care/location',
+        id: '8e5668a6-90d9-4913-bc9f-c8f6788d7a2e',
+        label: 'Pittsburgh Health Care',
+        order: 0,
+        parentID: undefined,
+      },
+    },
+  };
+
+  const oldWindow = global.window;
+
+  beforeEach(() => {
+    global.window = {
+      location: {
+        pathname: '/',
+      },
+    };
+  });
+
+  afterEach(() => {
+    global.window = oldWindow;
+  });
+
+  it('should not render when there are no nav items to show', () => {
+    const wrapper = shallow(<SideNav />);
+    expect(wrapper.find('SideNav').length).to.equal(0);
+    wrapper.unmount();
+  });
+
+  it('should render when there are nav items', () => {
+    const wrapper = shallow(<SideNav {...defaultProps} />);
+    expect(wrapper.find('SideNav').length).to.equal(1);
+    wrapper.unmount();
+  });
+});

--- a/src/site/navigation/facility_no_drupal_page_sidebar_nav.drupal.liquid
+++ b/src/site/navigation/facility_no_drupal_page_sidebar_nav.drupal.liquid
@@ -5,110 +5,114 @@
 
     For an example of how to make a string look like this, look at in `src/site/layouts/person_profile.drupal.liquid` where sidebarData is being assigned.
 {% endcomment %}
-<nav id="va-detailpage-sidebar" data-drupal-sidebar class="va-c-facility-sidebar usa-width-one-fourth va-sidebarnav">
-    <div>
-        <button class="va-btn-close-icon va-sidebarnav-close" type="button" aria-label="Close this menu"></button>
-
-        {% assign deepLinksObj = sidebarData | jsonToObj %}
-        <div class="left-side-nav-title">
-            <h4>{{ deepLinksObj.link.label }}</h4>
-        </div>
-
-        {% assign depth = deepLinksObj.depth  %}
-        {% assign deepLinks = deepLinksObj.link.links %}
-
-        {% if depth <= 2 %}
-            <ul class="usa-accordion">
-                {% for link in deepLinksObj.link.links %}
-                    <li>
-
-                        {% assign isRoot = entityUrl.path | isRootPage %}
-                        {% assign expanded = false %}
-                        {% assign activeItem = path | prepend: "/" %}
-
-                        {% if forloop.first == true and isRoot == true and isInAbout == false %}
-                            {% assign expanded = true %}
-                        {% endif %}
-
-                        <button class="usa-accordion-button"
-                                aria-expanded="{{ expanded }}"
-                                aria-controls="a{{ forloop.index }}">
-                            {{ link.label }}
-                        </button>
-                        <div id="a{{ forloop.index }}" class="usa-accordion-content" aria-hidden="false">
-                            {% assign listSize = link.links | size %}
-                            {% if listSize > 0 %}
-                                <ul class="usa-sidenav-list">
-                                    {% for link in link.links %}
-                                        <li {% if entityUrl.path contains link.url.path %} class="active-level" {% endif %}>
-                                            <a {% if entityUrl.path contains link.url.path %} class="usa-current" {% endif %}
-                                                    href="{{ link.url.path }}" onClick="recordEvent({ event: 'nav-sidenav' });">{{ link.label }}</a>
-                                            {% assign subListSize = link.links | size %}
-                                            {% if subListSize > 0 %}
-                                                <ul class="usa-sidenav-sub_list">
-                                                    {% for link in link.links %}
-                                                        {% assign subSubListSize = link.links | size %}
-                                                        {% if subSubListSize > 0 %}
-                                                            <li {% if entityUrl.path contains link.url.path %} class="active-level" {% endif %}>
-                                                                <a {% if entityUrl.path == link.url.path %} class="usa-current" {% endif %}
-                                                                        href="{{ link.url.path }}" onClick="recordEvent({ event: 'nav-sidenav' });">{{ link.label }}</a>
-                                                                <ul class="usa-sidenav-sub_list">
-                                                                    {% for link in link.links %}
-                                                                        <li>
-                                                                            <a {% if entityUrl.path == link.url.path %} class="usa-current" {% endif %}
-                                                                                    href="{{ link.url.path }}" onClick="recordEvent({ event: 'nav-sidenav' });">{{ link.label }}</a>
-                                                                        </li>
-                                                                    {% endfor %}
-                                                                </ul>
-                                                            </li>
-                                                        {% else %}
-                                                            <li>
-                                                                <a {% if entityUrl.path contains link.url.path %} class="usa-current" {% endif %}
-                                                                        href="{{ link.url.path }}" onClick="recordEvent({ event: 'nav-sidenav' });">{{ link.label }}</a>
-                                                            </li>
-                                                        {% endif %}
-                                                    {% endfor %}
-                                                </ul>
-                                            {% endif %}
-                                        </li>
-                                    {% endfor %}
-                                </ul>
-                            {% endif %}
-                        </div>
-                    </li>
-                {% endfor %}
-            </ul>
-        {% else %}
-            <div class="sidenav-previous-page">
-                <a href="{{ deepLinksObj.parent.url.path }}">{{ deepLinksObj.parent.label }}</a>
-            </div>
-
-            <ul class="usa-sidenav-list">
-                {% for link in deepLinks %}
-                <li {% if entityUrl.path == link.url.path %} class="active-level" {% endif %}>
-                    <a {% if entityUrl.path == link.url.path %} class="usa-current" {% endif %}
-                            href="{{ link.url.path }}" onClick="recordEvent({ event: 'nav-sidenav' });">{{ link.label }}</a>
-                    {% if link.links.length %}
-                        <ul class="usa-sidenav-sub_list">
-                            {% for link in link.links %}
-                                <li>
-                                    <a {% if entityUrl.path == link.url.path %} class="usa-current" {% endif %}
-                                            href="{{ link.url.path }}" onClick="recordEvent({ event: 'nav-sidenav' });">{{ link.label }}</a>
-                                </li>
-                            {% endfor %}
-                        </ul>
-                        </li>
-                    {% else %}
-                        </li>
-                    {% endif %}
-                {% endfor %}
-            </ul>
-        {% endif %}
-    </div>
-</nav>
 
 {% if buildtype != 'vagovprod' %}
-    <script>
-      console.info('Context specific sidebar data recursive:', {{ sidebarData }});
+    <script type="text/javascript">
+      window.sideNav = {{ sidebarData | json }};
     </script>
+
+    {% comment %} React Widget located in `src/platform/site-wide/side-nav` {% endcomment %}
+    <div data-widget-type="side-nav"></div>
+{% else %}
+    <nav id="va-detailpage-sidebar" data-drupal-sidebar class="va-c-facility-sidebar usa-width-one-fourth va-sidebarnav">
+        <div>
+            <button class="va-btn-close-icon va-sidebarnav-close" type="button" aria-label="Close this menu"></button>
+
+            {% assign deepLinksObj = sidebarData | jsonToObj %}
+            <div class="left-side-nav-title">
+                <h4>{{ deepLinksObj.link.label }}</h4>
+            </div>
+
+            {% assign depth = deepLinksObj.depth  %}
+            {% assign deepLinks = deepLinksObj.link.links %}
+
+            {% if depth <= 2 %}
+                <ul class="usa-accordion">
+                    {% for link in deepLinksObj.link.links %}
+                        <li>
+
+                            {% assign isRoot = entityUrl.path | isRootPage %}
+                            {% assign expanded = false %}
+                            {% assign activeItem = path | prepend: "/" %}
+
+                            {% if forloop.first == true and isRoot == true and isInAbout == false %}
+                                {% assign expanded = true %}
+                            {% endif %}
+
+                            <button class="usa-accordion-button"
+                                    aria-expanded="{{ expanded }}"
+                                    aria-controls="a{{ forloop.index }}">
+                                {{ link.label }}
+                            </button>
+                            <div id="a{{ forloop.index }}" class="usa-accordion-content" aria-hidden="false">
+                                {% assign listSize = link.links | size %}
+                                {% if listSize > 0 %}
+                                    <ul class="usa-sidenav-list">
+                                        {% for link in link.links %}
+                                            <li {% if entityUrl.path contains link.url.path %} class="active-level" {% endif %}>
+                                                <a {% if entityUrl.path contains link.url.path %} class="usa-current" {% endif %}
+                                                        href="{{ link.url.path }}" onClick="recordEvent({ event: 'nav-sidenav' });">{{ link.label }}</a>
+                                                {% assign subListSize = link.links | size %}
+                                                {% if subListSize > 0 %}
+                                                    <ul class="usa-sidenav-sub_list">
+                                                        {% for link in link.links %}
+                                                            {% assign subSubListSize = link.links | size %}
+                                                            {% if subSubListSize > 0 %}
+                                                                <li {% if entityUrl.path contains link.url.path %} class="active-level" {% endif %}>
+                                                                    <a {% if entityUrl.path == link.url.path %} class="usa-current" {% endif %}
+                                                                            href="{{ link.url.path }}" onClick="recordEvent({ event: 'nav-sidenav' });">{{ link.label }}</a>
+                                                                    <ul class="usa-sidenav-sub_list">
+                                                                        {% for link in link.links %}
+                                                                            <li>
+                                                                                <a {% if entityUrl.path == link.url.path %} class="usa-current" {% endif %}
+                                                                                        href="{{ link.url.path }}" onClick="recordEvent({ event: 'nav-sidenav' });">{{ link.label }}</a>
+                                                                            </li>
+                                                                        {% endfor %}
+                                                                    </ul>
+                                                                </li>
+                                                            {% else %}
+                                                                <li>
+                                                                    <a {% if entityUrl.path contains link.url.path %} class="usa-current" {% endif %}
+                                                                            href="{{ link.url.path }}" onClick="recordEvent({ event: 'nav-sidenav' });">{{ link.label }}</a>
+                                                                </li>
+                                                            {% endif %}
+                                                        {% endfor %}
+                                                    </ul>
+                                                {% endif %}
+                                            </li>
+                                        {% endfor %}
+                                    </ul>
+                                {% endif %}
+                            </div>
+                        </li>
+                    {% endfor %}
+                </ul>
+            {% else %}
+                <div class="sidenav-previous-page">
+                    <a href="{{ deepLinksObj.parent.url.path }}">{{ deepLinksObj.parent.label }}</a>
+                </div>
+
+                <ul class="usa-sidenav-list">
+                    {% for link in deepLinks %}
+                    <li {% if entityUrl.path == link.url.path %} class="active-level" {% endif %}>
+                        <a {% if entityUrl.path == link.url.path %} class="usa-current" {% endif %}
+                                href="{{ link.url.path }}" onClick="recordEvent({ event: 'nav-sidenav' });">{{ link.label }}</a>
+                        {% if link.links.length %}
+                            <ul class="usa-sidenav-sub_list">
+                                {% for link in link.links %}
+                                    <li>
+                                        <a {% if entityUrl.path == link.url.path %} class="usa-current" {% endif %}
+                                                href="{{ link.url.path }}" onClick="recordEvent({ event: 'nav-sidenav' });">{{ link.label }}</a>
+                                    </li>
+                                {% endfor %}
+                            </ul>
+                            </li>
+                        {% else %}
+                            </li>
+                        {% endif %}
+                    {% endfor %}
+                </ul>
+            {% endif %}
+        </div>
+    </nav>
 {% endif %}

--- a/src/site/navigation/facility_sidebar_nav.drupal.liquid
+++ b/src/site/navigation/facility_sidebar_nav.drupal.liquid
@@ -10,110 +10,114 @@
 {% assign isInAbout = aboutMenu | isAboutItem: entityUrl.path %}
 {% assign deepLinks = deepLinksObj.link.links %}
 
-<nav id="va-detailpage-sidebar" {% if depth != 1 %} data-drupal-sidebar {% endif %} class="va-c-facility-sidebar usa-width-one-fourth va-sidebarnav">
-    <div>
-        <button class="va-btn-close-icon va-sidebarnav-close" type="button" aria-label="Close this menu"></button>
-
-        {% for rootLink in sidebarData.links %}
-            {% if forloop.first == true %}
-                <div class="left-side-nav-title">
-                    <h4>{{ rootLink.label }}</h4>
-                </div>
-
-            {% if depth <= 2 %}
-                <ul class="usa-accordion">
-                    {% for link in rootLink.links %}
-                        <li>
-
-
-                            {% assign expanded = false %}
-                            {% assign activeItem = path | prepend: "/" %}
-
-                            {% if forloop.first == true and depth == 1 %}
-                                {% assign expanded = true %}
-                            {% endif %}
-
-                            <button class="usa-accordion-button"
-                                    aria-expanded="{{ expanded }}"
-                                    aria-controls="a{{ forloop.index }}">
-                                {{ link.label }}
-                            </button>
-                            <div id="a{{ forloop.index }}" class="usa-accordion-content" aria-hidden="{{ expanded == false}}">
-                                {% assign listSize = link.links | size %}
-                                {% if listSize > 0 %}
-                                    <ul class="usa-sidenav-list">
-                                        {% for link in link.links %}
-                                            <li {% if entityUrl.path contains link.url.path %} class="active-level" {% endif %}>
-                                                <a {% if entityUrl.path contains link.url.path %} class="usa-current" {% endif %}
-                                                        href="{{ link.url.path }}" onClick="recordEvent({ event: 'nav-sidenav' });">{{ link.label }}</a>
-                                                {% assign subListSize = link.links | size %}
-                                                {% if subListSize > 0 %}
-                                                    <ul class="usa-sidenav-sub_list">
-                                                        {% for link in link.links %}
-                                                            {% assign subSubListSize = link.links | size %}
-                                                            {% if subSubListSize > 0 %}
-                                                                <li {% if entityUrl.path contains link.url.path %} class="active-level" {% endif %}>
-                                                                    <a {% if entityUrl.path == link.url.path %} class="usa-current" {% endif %}
-                                                                            href="{{ link.url.path }}" onClick="recordEvent({ event: 'nav-sidenav' });">{{ link.label }}</a>
-                                                                    <ul class="usa-sidenav-sub_list">
-                                                                        {% for link in link.links %}
-                                                                            <li>
-                                                                                <a {% if entityUrl.path == link.url.path %} class="usa-current" {% endif %}
-                                                                                        href="{{ link.url.path }}" onClick="recordEvent({ event: 'nav-sidenav' });">{{ link.label }}</a>
-                                                                            </li>
-                                                                        {% endfor %}
-                                                                    </ul>
-                                                                </li>
-                                                            {% else %}
-                                                                <li>
-                                                                    <a {% if entityUrl.path contains link.url.path %} class="usa-current" {% endif %}
-                                                                            href="{{ link.url.path }}" onClick="recordEvent({ event: 'nav-sidenav' });">{{ link.label }}</a>
-                                                                </li>
-                                                            {% endif %}
-                                                        {% endfor %}
-                                                    </ul>
-                                                {% endif %}
-                                            </li>
-                                        {% endfor %}
-                                    </ul>
-                                {% endif %}
-                            </div>
-                        </li>
-                    {% endfor %}
-                </ul>
-            {% else %}
-                <div class="sidenav-previous-page">
-                    <a href="{{ deepLinksObj.parent.url.path }}">{{ deepLinksObj.parent.label }}</a>
-                </div>
-
-                <ul class="usa-sidenav-list">
-                    {% for link in deepLinksObj.parent.links %}
-                    <li {% if entityUrl.path == link.url.path %} class="active-level" {% endif %}>
-                        <a {% if entityUrl.path == link.url.path %} class="usa-current" {% endif %}
-                                href="{{ link.url.path }}" onClick="recordEvent({ event: 'nav-sidenav' });">{{ link.label }}</a>
-                        {% if link.links.length %}
-                            <ul class="usa-sidenav-sub_list">
-                                {% for link in link.links %}
-                                    <li>
-                                        <a {% if entityUrl.path == link.url.path %} class="usa-current" {% endif %}
-                                                href="{{ link.url.path }}" onClick="recordEvent({ event: 'nav-sidenav' });">{{ link.label }}</a>
-                                    </li>
-                                {% endfor %}
-                            </ul>
-                            </li>
-                        {% else %}
-                            </li>
-                        {% endif %}
-                    {% endfor %}
-                </ul>
-            {% endif %}
-        {% endif %}
-    {% endfor %}
-    </div>
-</nav>
-
 {% if buildtype != 'vagovprod' %}
-    <script>
-      console.info('Context specific sidebar data recursive:', {{ sidebarData.links | findCurrentPathDepthRecursive: entityUrl.path }});
+    <script type="text/javascript">
+      window.sideNav = {{ sidebarData | json }};
     </script>
+
+    {% comment %} React Widget located in `src/platform/site-wide/side-nav` {% endcomment %}
+    <div data-widget-type="side-nav"></div>
+{% else %}
+    {% comment %} Legacy sidebar nav {% endcomment %}
+    <nav id="va-detailpage-sidebar" {% if depth != 1 %} data-drupal-sidebar {% endif %} class="va-c-facility-sidebar usa-width-one-fourth va-sidebarnav">
+        <div>
+            <button class="va-btn-close-icon va-sidebarnav-close" type="button" aria-label="Close this menu"></button>
+
+            {% for rootLink in sidebarData.links %}
+                {% if forloop.first == true %}
+                    <div class="left-side-nav-title">
+                        <h4>{{ rootLink.label }}</h4>
+                    </div>
+
+                {% if depth <= 2 %}
+                    <ul class="usa-accordion">
+                        {% for link in rootLink.links %}
+                            <li>
+
+
+                                {% assign expanded = false %}
+                                {% assign activeItem = path | prepend: "/" %}
+
+                                {% if forloop.first == true and depth == 1 %}
+                                    {% assign expanded = true %}
+                                {% endif %}
+
+                                <button class="usa-accordion-button"
+                                        aria-expanded="{{ expanded }}"
+                                        aria-controls="a{{ forloop.index }}">
+                                    {{ link.label }}
+                                </button>
+                                <div id="a{{ forloop.index }}" class="usa-accordion-content" aria-hidden="{{ expanded == false}}">
+                                    {% assign listSize = link.links | size %}
+                                    {% if listSize > 0 %}
+                                        <ul class="usa-sidenav-list">
+                                            {% for link in link.links %}
+                                                <li {% if entityUrl.path contains link.url.path %} class="active-level" {% endif %}>
+                                                    <a {% if entityUrl.path contains link.url.path %} class="usa-current" {% endif %}
+                                                            href="{{ link.url.path }}" onClick="recordEvent({ event: 'nav-sidenav' });">{{ link.label }}</a>
+                                                    {% assign subListSize = link.links | size %}
+                                                    {% if subListSize > 0 %}
+                                                        <ul class="usa-sidenav-sub_list">
+                                                            {% for link in link.links %}
+                                                                {% assign subSubListSize = link.links | size %}
+                                                                {% if subSubListSize > 0 %}
+                                                                    <li {% if entityUrl.path contains link.url.path %} class="active-level" {% endif %}>
+                                                                        <a {% if entityUrl.path == link.url.path %} class="usa-current" {% endif %}
+                                                                                href="{{ link.url.path }}" onClick="recordEvent({ event: 'nav-sidenav' });">{{ link.label }}</a>
+                                                                        <ul class="usa-sidenav-sub_list">
+                                                                            {% for link in link.links %}
+                                                                                <li>
+                                                                                    <a {% if entityUrl.path == link.url.path %} class="usa-current" {% endif %}
+                                                                                            href="{{ link.url.path }}" onClick="recordEvent({ event: 'nav-sidenav' });">{{ link.label }}</a>
+                                                                                </li>
+                                                                            {% endfor %}
+                                                                        </ul>
+                                                                    </li>
+                                                                {% else %}
+                                                                    <li>
+                                                                        <a {% if entityUrl.path contains link.url.path %} class="usa-current" {% endif %}
+                                                                                href="{{ link.url.path }}" onClick="recordEvent({ event: 'nav-sidenav' });">{{ link.label }}</a>
+                                                                    </li>
+                                                                {% endif %}
+                                                            {% endfor %}
+                                                        </ul>
+                                                    {% endif %}
+                                                </li>
+                                            {% endfor %}
+                                        </ul>
+                                    {% endif %}
+                                </div>
+                            </li>
+                        {% endfor %}
+                    </ul>
+                {% else %}
+                    <div class="sidenav-previous-page">
+                        <a href="{{ deepLinksObj.parent.url.path }}">{{ deepLinksObj.parent.label }}</a>
+                    </div>
+
+                    <ul class="usa-sidenav-list">
+                        {% for link in deepLinksObj.parent.links %}
+                        <li {% if entityUrl.path == link.url.path %} class="active-level" {% endif %}>
+                            <a {% if entityUrl.path == link.url.path %} class="usa-current" {% endif %}
+                                    href="{{ link.url.path }}" onClick="recordEvent({ event: 'nav-sidenav' });">{{ link.label }}</a>
+                            {% if link.links.length %}
+                                <ul class="usa-sidenav-sub_list">
+                                    {% for link in link.links %}
+                                        <li>
+                                            <a {% if entityUrl.path == link.url.path %} class="usa-current" {% endif %}
+                                                    href="{{ link.url.path }}" onClick="recordEvent({ event: 'nav-sidenav' });">{{ link.label }}</a>
+                                        </li>
+                                    {% endfor %}
+                                </ul>
+                                </li>
+                            {% else %}
+                                </li>
+                            {% endif %}
+                        {% endfor %}
+                    </ul>
+                {% endif %}
+            {% endif %}
+        {% endfor %}
+        </div>
+    </nav>
 {% endif %}

--- a/src/site/navigation/sidebar_nav.drupal.liquid
+++ b/src/site/navigation/sidebar_nav.drupal.liquid
@@ -1,110 +1,113 @@
-<nav id="va-detailpage-sidebar" data-drupal-sidebar="true" class="va-drupal-sidebarnav usa-width-one-fourth va-sidebarnav">
-    <div>
+{% if buildtype != 'vagovprod' %}
+    <script type="text/javascript">
+      window.sideNav = {{ sidebarData | json }};
+    </script>
 
-        <button class="va-btn-close-icon va-sidebarnav-close" type="button" aria-label="Close this menu"></button>
+    {% comment %} React Widget located in `src/platform/site-wide/side-nav` {% endcomment %}
+    <div data-widget-type="side-nav"></div>
+{% else %}
+    <nav id="va-detailpage-sidebar" data-drupal-sidebar="true" class="va-drupal-sidebarnav usa-width-one-fourth va-sidebarnav">
+        <div>
 
-        {% for link in sidebar.links %}
-            {% if forloop.first == true %}
-                <div class="left-side-nav-title">
-                    <i class="icon-small white hub-icon-{{ fieldTitleIcon }} hub-background-{{ fieldTitleIcon }}"></i>
-                    <h4>{{ link.label }}</h4>
-                </div>
+            <button class="va-btn-close-icon va-sidebarnav-close" type="button" aria-label="Close this menu"></button>
 
-                {% assign deepLinksString = link.links | findCurrentPathDepth: entityUrl.path %}
-                {% assign deepLinksObj = deepLinksString | jsonToObj %}
-                {% assign depth = deepLinksObj.depth  %}
-                {% assign deepLinks = deepLinksObj.links %}
+            {% for link in sidebar.links %}
+                {% if forloop.first == true %}
+                    <div class="left-side-nav-title">
+                        <i class="icon-small white hub-icon-{{ fieldTitleIcon }} hub-background-{{ fieldTitleIcon }}"></i>
+                        <h4>{{ link.label }}</h4>
+                    </div>
 
-                {% if depth <= 2 %}
-                    <ul class="usa-accordion">
-                    {% for link in link.links %}
-                        <li>
-                            <button class="usa-accordion-button"
-                                    {% if deepLinksString == "false" and forloop.first == true %}
-                                        aria-expanded="true"
-                                    {% else %}
-                                        aria-expanded="false"
+                    {% assign deepLinksString = link.links | findCurrentPathDepth: entityUrl.path %}
+                    {% assign deepLinksObj = deepLinksString | jsonToObj %}
+                    {% assign depth = deepLinksObj.depth  %}
+                    {% assign deepLinks = deepLinksObj.links %}
+
+                    {% if depth <= 2 %}
+                        <ul class="usa-accordion">
+                        {% for link in link.links %}
+                            <li>
+                                <button class="usa-accordion-button"
+                                        {% if deepLinksString == "false" and forloop.first == true %}
+                                            aria-expanded="true"
+                                        {% else %}
+                                            aria-expanded="false"
+                                        {% endif %}
+                                        aria-controls="a{{ forloop.index }}">
+                                    {{ link.label }}
+                                </button>
+                                <div id="a{{ forloop.index }}" class="usa-accordion-content" aria-hidden="false">
+                                    {% assign listSize = link.links | size %}
+                                    {% if listSize > 0 %}
+                                        <ul class="usa-sidenav-list">
+                                            {% for link in link.links %}
+                                                <li {% if link.url.path contains entityUrl.path %} class="active-level" {% endif %}>
+                                                    <a {% if entityUrl.path == link.url.path %} class="usa-current" {% endif %}
+                                                            href="{{ link.url.path }}" onClick="recordEvent({ event: 'nav-sidenav' });">{{ link.label }}</a>
+                                                    {% assign subListSize = link.links | size %}
+                                                    {% if subListSize > 0 %}
+                                                        <ul class="usa-sidenav-sub_list">
+                                                            {% for link in link.links %}
+                                                                {% assign subSubListSize = link.links | size %}
+                                                                {% if subSubListSize > 0 %}
+                                                                    <li {% if entityUrl.path contains link.url.path %} class="active-level" {% endif %}>
+                                                                        <a {% if entityUrl.path == link.url.path %} class="usa-current" {% endif %}
+                                                                                href="{{ link.url.path }}" onClick="recordEvent({ event: 'nav-sidenav' });">{{ link.label }}</a>
+                                                                        <ul class="usa-sidenav-sub_list">
+                                                                            {% for link in link.links %}
+                                                                                <li>
+                                                                                    <a {% if entityUrl.path == link.url.path %} class="usa-current" {% endif %}
+                                                                                            href="{{ link.url.path }}" onClick="recordEvent({ event: 'nav-sidenav' });">{{ link.label }}</a>
+                                                                                </li>
+                                                                            {% endfor %}
+                                                                        </ul>
+                                                                    </li>
+                                                                {% else %}
+                                                                    <li>
+                                                                        <a {% if entityUrl.path == link.url.path %} class="usa-current" {% endif %}
+                                                                                href="{{ link.url.path }}" onClick="recordEvent({ event: 'nav-sidenav' });">{{ link.label }}</a>
+                                                                    </li>
+                                                                {% endif %}
+                                                            {% endfor %}
+                                                        </ul>
+                                                    {% endif %}
+                                                </li>
+                                            {% endfor %}
+                                        </ul>
                                     {% endif %}
-                                    aria-controls="a{{ forloop.index }}">
-                                {{ link.label }}
-                            </button>
-                            <div id="a{{ forloop.index }}" class="usa-accordion-content" aria-hidden="false">
-                                {% assign listSize = link.links | size %}
-                                {% if listSize > 0 %}
-                                    <ul class="usa-sidenav-list">
+                                </div>
+                            </li>
+                        {% endfor %}
+                    </ul>
+                {% else %}
+                    <div class="sidenav-previous-page">
+                        <a href="{{ deepLinks.url.path }}">{{ deepLinks.label }}</a>
+                    </div>
+                    <ul class="usa-sidenav-list">
+                        {% for link in deepLinks.links %}
+                            <li {% if entityUrl.path == link.url.path %} class="active-level" {% endif %}>
+                                <a {% if entityUrl.path == link.url.path %} class="usa-current" {% endif %}
+                                        href="{{ link.url.path }}" onClick="recordEvent({ event: 'nav-sidenav' });">{{ link.label }}</a>
+                                {% if link.links.length %}
+                                    <ul class="usa-sidenav-sub_list">
                                         {% for link in link.links %}
-                                            <li {% if link.url.path contains entityUrl.path %} class="active-level" {% endif %}>
+                                            <li>
                                                 <a {% if entityUrl.path == link.url.path %} class="usa-current" {% endif %}
                                                         href="{{ link.url.path }}" onClick="recordEvent({ event: 'nav-sidenav' });">{{ link.label }}</a>
-                                                {% assign subListSize = link.links | size %}
-                                                {% if subListSize > 0 %}
-                                                    <ul class="usa-sidenav-sub_list">
-                                                        {% for link in link.links %}
-                                                            {% assign subSubListSize = link.links | size %}
-                                                            {% if subSubListSize > 0 %}
-                                                                <li {% if entityUrl.path contains link.url.path %} class="active-level" {% endif %}>
-                                                                    <a {% if entityUrl.path == link.url.path %} class="usa-current" {% endif %}
-                                                                            href="{{ link.url.path }}" onClick="recordEvent({ event: 'nav-sidenav' });">{{ link.label }}</a>
-                                                                    <ul class="usa-sidenav-sub_list">
-                                                                        {% for link in link.links %}
-                                                                            <li>
-                                                                                <a {% if entityUrl.path == link.url.path %} class="usa-current" {% endif %}
-                                                                                        href="{{ link.url.path }}" onClick="recordEvent({ event: 'nav-sidenav' });">{{ link.label }}</a>
-                                                                            </li>
-                                                                        {% endfor %}
-                                                                    </ul>
-                                                                </li>
-                                                            {% else %}
-                                                                <li>
-                                                                    <a {% if entityUrl.path == link.url.path %} class="usa-current" {% endif %}
-                                                                            href="{{ link.url.path }}" onClick="recordEvent({ event: 'nav-sidenav' });">{{ link.label }}</a>
-                                                                </li>
-                                                            {% endif %}
-                                                        {% endfor %}
-                                                    </ul>
-                                                {% endif %}
                                             </li>
                                         {% endfor %}
                                     </ul>
+                            </li>
+                                {% else %}
+                            </li>
                                 {% endif %}
-                            </div>
-                        </li>
-                    {% endfor %}
-                </ul>
-            {% else %}
-                <div class="sidenav-previous-page">
-                    <a href="{{ deepLinks.url.path }}">{{ deepLinks.label }}</a>
-                </div>
-                <ul class="usa-sidenav-list">
-                    {% for link in deepLinks.links %}
-                        <li {% if entityUrl.path == link.url.path %} class="active-level" {% endif %}>
-                            <a {% if entityUrl.path == link.url.path %} class="usa-current" {% endif %}
-                                    href="{{ link.url.path }}" onClick="recordEvent({ event: 'nav-sidenav' });">{{ link.label }}</a>
-                            {% if link.links.length %}
-                                <ul class="usa-sidenav-sub_list">
-                                    {% for link in link.links %}
-                                        <li>
-                                            <a {% if entityUrl.path == link.url.path %} class="usa-current" {% endif %}
-                                                    href="{{ link.url.path }}" onClick="recordEvent({ event: 'nav-sidenav' });">{{ link.label }}</a>
-                                        </li>
-                                    {% endfor %}
-                                </ul>
-                        </li>
-                            {% else %}
-                        </li>
-                            {% endif %}
-                    {% endfor %}
-                </ul>
-
-                {% if buildtype != 'vagovprod' %}
-                    <script>
-                        console.info('Context specific sidebar data:', {{ deepLinksString }});
-                    </script>
+                        {% endfor %}
+                    </ul>
                 {% endif %}
             {% endif %}
-        {% endif %}
 
-        {% endfor %}
+            {% endfor %}
 
-    </div>
-</nav>
+        </div>
+    </nav>
+{% endif %}


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/2278

**Current Behavior:** The side nav on staging.va.gov/pittsburgh-health-care looks like:

![image](https://user-images.githubusercontent.com/12773166/66652242-3b922000-ec03-11e9-942b-09aabbc499ac.png)

**Desired Behavior:** The side nav should look like:

![image](https://user-images.githubusercontent.com/12773166/66652271-56fd2b00-ec03-11e9-8848-1befa2be0a92.png)

This PR implements the above behavior by abstracting out the SideNav into a separate React component instead of the previous Liquid implementation.

## Testing done
Tested locally.

## Screenshots
![image](https://user-images.githubusercontent.com/12773166/66654909-3041f300-ec09-11e9-9eb3-875ebbfd59ab.png)

![image](https://user-images.githubusercontent.com/12773166/66654883-228c6d80-ec09-11e9-9220-e9151c9e44be.png)

## Acceptance criteria
- [ ] Implement new navigation on Pittsburgh section of the website according to designs
- [x] Implement behind feature flag so that it can be tested in Staging prior to being promoted to Production.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
