### PR TITLE
Prevent JS error on staging

### DIFF
--- a/src/platform/forms-system/src/js/components/FieldTemplate.jsx
+++ b/src/platform/forms-system/src/js/components/FieldTemplate.jsx
@@ -67,7 +67,7 @@ export default function FieldTemplate(props) {
         role="alert"
         id={errorSpanId}
       >
-        <span className="sr-only">Error</span> {rawErrors[0]}
+        <span className="sr-only">Error</span> {hasErrors && rawErrors[0]}
       </span>
     );
   }


### PR DESCRIPTION
## Description

There is a JS error on staging (only), that is preventing users from filling in forms.

> breadcrumbs.js:58 TypeError: Cannot read property '0' of undefined
    at E (FieldTemplate.jsx:70)
    at Yo (react-dom.production.min.js:150)
    at Ci (react-dom.production.min.js:166)
    at Li (react-dom.production.min.js:179)
    at Ka (react-dom.production.min.js:232)
    at Ga (react-dom.production.min.js:233)
    at ju (react-dom.production.min.js:249)
    at Cu (react-dom.production.min.js:248)
    at Uu (react-dom.production.min.js:251)
    at On (react-dom.production.min.js:85)
    at HTMLFormElement.r (helpers.js:70)

This error prevents applying for health care & education benefits and completing step 3 of the 526EZ form (as far as I know)

Duplicate this issue by _not_ logging in and going to https://staging.va.gov/health-care/apply/application/id-form and completing that first page. Proceeding to the second page will cause the error and prevent content from rendering on the page.

Related to [this PR](https://github.com/department-of-veterans-affairs/vets-website/pull/10875#pullrequestreview-300718567).

Also, see [this disccusion in Slack](https://dsva.slack.com/archives/CBU0KDSB1/p1570802221045500). Thanks Trevor!

## Testing done

Unable to test this fix in a local environment

## Screenshots

![Screen Shot 2019-10-11 at 9 03 33 AM](https://user-images.githubusercontent.com/136959/66661718-130f2380-ec0d-11e9-95dd-a1db53df4c5b.png)

## Acceptance criteria
- [ ] Previous JS error is prevented & content can be seen.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
