### PR TITLE
VAGOV-6033: Replacing react facility data with cms data.

### DIFF
--- a/src/site/includes/facilityListing.drupal.liquid
+++ b/src/site/includes/facilityListing.drupal.liquid
@@ -1,0 +1,36 @@
+<div
+  class="region-list usa-width-one-whole vads-u-display--flex vads-u-flex-direction--column small-screen:vads-u-flex-direction--row facility vads-u-margin-bottom--4 medium-screen:vads-u-margin-bottom--5">
+  <section class="region-grid vads-u-margin-right--2">
+    <h3
+      class="vads-u-margin-bottom--1 vads-u-margin-top--0 vads-u-font-size--md medium-screen:vads-u-font-size--lg">
+      <a href="{{entity.entityUrl.path}}">{{entity.title}}</a> </h3> <div
+        class="vads-u-margin-bottom--1">
+        <address class="vads-u-margin-bottom--0">
+          <div>{{entity.fieldAddress.addressLine1}}</div>
+          <div>{{entity.fieldAddress.locality}},
+            {{entity.fieldAddress.administrativeArea}}
+            {{entity.fieldAddress.postalCode}}</div>
+        </address>
+        <div><a
+            href="https://maps.google.com?saddr=Current+Location&amp;daddr={{entity.fieldAddress.addressLine1}}, {{entity.fieldAddress.locality}}, {{entity.fieldAddress.administrativeArea}} {{entity.fieldAddress.postalCode}}"
+            target="_blank" rel="noopener noreferrer">Directions</a></div>
+</div>
+<div class="vads-u-margin-bottom--0">
+  <div class="main-phone vads-u-margin-bottom--1"><strong>Main phone:
+    </strong><a
+      href="tel:{{entity.fieldPhoneNumber}}">{{entity.fieldPhoneNumber}}</a>
+  </div>
+  <div class="mental-health-clinic-phone"><strong>Mental health clinic:
+    </strong><a
+      href="tel:{{entity.fieldMentalHealthPhone}}">{{entity.fieldMentalHealthPhone}}</a>
+  </div>
+</div>
+</section>
+<section
+  class="region-grid usa-width-one-half vads-u-order--first small-screen:vads-u-order--initial vads-u-margin-bottom--2">
+  <a href="{{entity.entityUrl.path}}" aria-label="{{entity.fieldMedia.entity.image.alt}}"><img
+      class="region-img"
+      src="{{entity.fieldMedia.entity.image.derivative.url}}"
+      alt="{{entity.fieldMedia.entity.image.alt}}"></a>
+</section>
+</div>

--- a/src/site/layouts/health_care_local_facility.drupal.liquid
+++ b/src/site/layouts/health_care_local_facility.drupal.liquid
@@ -1,81 +1,211 @@
 {% comment %}
-    {
-    "entityUrl": {
-    "path": "/pittsburgh-health-care/locations/university-drive-campus"
-    },
-    "entityBundle": "health_care_local_facility",
-    "title": "Pittsburgh VA Medical Center-University Drive",
-    "fieldFacilityLocatorApiId": "vha_646",
-    "fieldNicknameForThisFacility": "University Drive Medical Center",
-    "fieldIntroText": "Get directions and parking information, prepare for your visit, or make an appointment.\r\n\r\n\r\nOur Pittsburgh University Drive campus provides primary and specialty health services including hearing care, dermatology, eye care, cardiac surgery and oncology referral centers, and more.\r\n",
-    "fieldLocationServices": [
-    {
-    "entity": {
-    "fieldTitle": "Transportation services and schedules (sample)",
-    "fieldWysiwyg": {
-    "processed": "<p>THIS IS SAMPLE CONTENT AND NEEDS TO BE UPDATED FROM THE COPY DECK. <br /><br />\nThere are several forms of transportation that you can choose from to travel to one of the VA Pittsburgh medical facilities:</p>\n\n<ul><li><a href=\"#\">Heinz Shuttle</a> – free shuttle service between Heinz and University Drive</li>\n\t<li>Shuttle Plus – free shuttle service between University Drive and Fisher House, Research Office Building (ROB) and Federal Building</li>\n\t<li>DAV vans – complete van schedule from all of our spoke hospitals</li>\n\t<li>Mass transit – Port Authority of Allegheny County and ACCESS Transportation</li>\n\t<li>Para Transit Service (p.r.n.) – (412) 824-2181 or 800-860-8222</li>\n\t<li><a href=\"#\">Yellow Cab</a> – (412) 321-8100/8112</li>\n\t<li><a href=\"#\">Veterans Taxi</a> – (412) 481-VETS (8387)</li>\n\t<li>Transcare ambulance – (412) 373-0200</li>\n\t<li>Pittsburgh International Airport</li>\n\t<li>Greyhound Bus lines</li>\n\t<li>Amtrak</li>\n</ul><p>Note: For a complete guide to the VA hospital shuttle and van service, refer to the <a href=\"#\">transportation resource guide</a>.</p>"
-    }
-    }
-    },
-    {
-    "entity": {
-    "fieldTitle": "Visitor hours and information (sample content)",
-    "fieldWysiwyg": {
-    "processed": "<p>THIS IS SAMPLE CONTENT AND NEEDS TO BE UPDATED FROM THE COPY DECK. </p>\n\n<p>We encourage you to visit when most convenient for you and the patient. There are no set visitor hours for most departments. Exceptions are listed below:</p>\n\n<h4>Medical, surgical, and hospice wards</h4>\n\n<p>24 hours a day, 7 days a week</p>\n\n<h4>Behavioral health inpatient wards</h4>\n\n<p>1:00 p.m. – 2:00 p.m. and 6:00 p.m. -7:30 p.m., 7 days a week</p>\n\n<h4>Critical care</h4>\n\n<p>Visiting hours will be individualized to meet the needs of the patient, family and caregivers.</p>\n\n<h4>Post-anesthesia recovery</h4>\n\n<p>Generally, visitors are not permitted. In certain circumstances, the doctor or nurse may make an exception.</p>\n\n<h4>General visitor policies</h4>\n\n<ul><li>Children under the age of 16 must be directly supervised by an adult, and bedside visits are limited to 15 minutes. </li>\n\t<li>Children under the ages of 16 are not permitted in the dialysis unit due to infection control and safety reasons. </li>\n</ul><p>See full visitor policies [make a link to another page containing the remaining bullets.]<br />\n </p>"
-    }
-    }
-    },
-    {
-    "entity": {
-    "fieldTitle": "Lodging for patients and families (sample)",
-    "fieldWysiwyg": {
-    "processed": "<p>THIS IS SAMPLE CONTENT AND NEEDS TO BE UPDATED FROM THE COPY DECK. </p>\n\n<p dir=\"ltr\">Visitors are not permitted to stay overnight in the medical center. Many local accommodations are available for Veterans and their families.</p>\n\n<p dir=\"ltr\">Veterans and family members may be eligible for the following:</p>\n\n<ul><li dir=\"ltr\">\n\t<p dir=\"ltr\"><a href=\"https://www.pittsburgh.va.gov/services/hoptel-program.asp\">Hoptel and lodging program</a> – Our Hoptel program provides temporary overnight lodging to eligible Veterans for outpatient medical procedures. For more information call 412-360-6233, or visit the <a href=\"https://www.pittsburgh.va.gov/services/hoptel-program.asp\">website</a>.</p>\n\t</li>\n\t<li dir=\"ltr\">\n\t<p dir=\"ltr\"><a href=\"https://www.pittsburghfisherhouse.org/\">Fisher House</a> – The 10-bedroom Pittsburgh Fisher House provides a place for visiting families to stay, free of charge, while their loved ones receive inpatient medical care. For more information call 412-360-2032, or visit the <a href=\"https://www.pittsburghfisherhouse.org/\">Fisher House website</a>.</p>\n\t</li>\n\t<li dir=\"ltr\">\n\t<p dir=\"ltr\"><a href=\"https://www.familyhouse.org/\">Family House</a> – Family House provides a special home away from home for patients and/or families who must travel to Pittsburgh for treatment of serious or life-threatening illnesses. Family House has four locations in the area. For more information call 412-647-7777, or visit the <a href=\"https://www.familyhouse.org/\">Family House website</a>.</p>\n\t</li>\n\t<li dir=\"ltr\">\n\t<p dir=\"ltr\"><a href=\"http://www.visitpittsburgh.com/\">Visit Pittsburgh</a> – the official tourism and promotion agency for Pittsburgh and Allegheny County, also has up-to-date listings for area hotels, activities, events, festivals, transportation, sports, restaurants, cultural attractions, shops and more.</p>\n\t</li>\n\t<li dir=\"ltr\">\n\t<p dir=\"ltr\">Nearby hotels – There are many nearby hotels to choose from. When booking your reservations, be sure to ask for the hospital rate. Many hotels have shuttle service to VA hospitals. Please check with the hotel you’re staying at.</p>\n\n\t<ul><li dir=\"ltr\">\n\t\t<p dir=\"ltr\"><a href=\"https://www.marriott.com/hotels/travel/pitok-courtyard-pittsburgh-shadyside\">Courtyard by Marriott, Shadyside</a> <br />\n\t\t412-683-3113 or 800-228-9290</p>\n\t\t</li>\n\t\t<li dir=\"ltr\">\n\t\t<p dir=\"ltr\"><a href=\"http://hamptoninn3.hilton.com/en/hotels/pennsylvania/hampton-inn-pittsburgh-university-medical-center-PITOKHX/index.html\">Hampton Inn, University Center</a> <br />\n\t\t412-329-4969 or 800-426-7866</p>\n\t\t</li>\n\t\t<li dir=\"ltr\">\n\t\t<p dir=\"ltr\"><a href=\"http://hiltongardeninn3.hilton.com/en/hotels/pennsylvania/hilton-garden-inn-pittsburgh-university-place-PITUCGI/index.html\">Hilton Garden Inn</a> <br />\n\t\t412-683-2040 or 877-782-9444</p>\n\t\t</li>\n\t\t<li dir=\"ltr\">\n\t\t<p dir=\"ltr\"><a href=\"http://www.qualityinn.com/hotel-pittsburgh-pennsylvania-PA369\">Quality Inn, University Center</a> <br />\n\t\t412-683-6100 or 877-424-6423</p>\n\t\t</li>\n\t\t<li dir=\"ltr\">\n\t\t<p dir=\"ltr\"><a href=\"https://www.marriott.com/hotels/travel/pitro-residence-inn-pittsburgh-university-medical-center/\">Residence Inn by Marriott, Oakland</a> <br />\n\t\t412-621-2200 or 800-513-8766</p>\n\t\t</li>\n\t\t<li dir=\"ltr\">\n\t\t<p dir=\"ltr\"><a href=\"https://www.marriott.com/hotels/travel/pitrd-residence-inn-pittsburgh-oakland-university-place/\">Residence Inn by Marriott, Oakland/University Place</a><br />\n\t\t 412-621-5600</p>\n\t\t</li>\n\t</ul></li>\n</ul><p><a href=\"http://www.shadysideinn.com/\">Shadyside Inn All Suites Hotel</a><br />\n412-441-4444 or 800-767-8483</p>"
-    }
-    }
-    },
-    {
-    "entity": {
-    "fieldTitle": "Parking (sample content)",
-    "fieldWysiwyg": {
-    "processed": "<p>THIS IS SAMPLE CONTENT AND NEEDS TO BE UPDATED FROM THE COPY DECK. </p>\n\n<p>University Drive campus facility map<br />\nRefer to the following map for parking locations.<br />\n[add map here]</p>"
-    }
-    }
-    },
-    {
-    "entity": {
-    "fieldTitle": "Campus and building maps (sample content)",
-    "fieldWysiwyg": {
-    "processed": "<p>THIS IS SAMPLE CONTENT AND NEEDS TO BE UPDATED FROM THE COPY DECK. </p>\n\n<p>University Drive campus facility map<br />\nUse the following maps to help you get around the campus.<br />\n[add map here, https://www.pittsburgh.va.gov/about/UD-facility-map.asp]</p>\n\n<p>Building floor plans</p>\n\n<p>First floor<br />\nIncludes outpatient behavioral health and primary care offices<br />\n(Download floor plan, PDF, 540KB)<br />\n[add map here, https://www.pittsburgh.va.gov/about/CB-floorplans.asp]<br />\nSecond floor<br />\nIncludes audiology and speech pathology, chapel, education, library, and public affairs offices<br />\n(Download floor plan, PDF, 540KB)<br />\n[add map here, https://www.pittsburgh.va.gov/about/CB-floorplans.asp]</p>"
-    }
-    }
-    },
-    {
-    "entity": {
-    "fieldTitle": "Cafeteria, shops, and other retail (sample content)",
-    "fieldWysiwyg": {
-    "processed": "<p>THIS IS SAMPLE CONTENT AND NEEDS TO BE UPDATED FROM THE COPY DECK. </p>\n\n<p>Veterans Canteen Service (VCS) Patriot Café<br />\nLocated on the ground floor, the Café is open Monday through Friday from 7:00 a.m. to 3:30 p.m. They serve hot and cold entrees, beverages and desserts. </p>\n\n<p>VCS Patriot Brew (Starbucks®) Coffee<br />\nLocated on the first floor to the right of Release of Information. It is open Monday through Friday from 6:30 a.m. to 7:00 p.m. and from 8:00 a.m. to 3:30 p.m. on Saturday. It is closed on Sunday. They serve a variety of pastries, light sandwiches and beverages.</p>\n\n<p>VCS Patriot Store<br />\nLocated on the ground floor, the Patriot Store offers a full-service retail store with such products as electronics, cosmetics, toiletries, and clothing. Items may be purchased tax-free. The retail store is open Monday through Friday from 7:00 a.m. to 7:00 p.m., Saturday from 9:00 a.m. to 3:30 p.m. and Sunday from 8:30 a.m. to 2:00 p.m.</p>\n\n<p>Vending areas<br />\nVending machines are located throughout the hospital.<br />\n </p>"
-    }
-    }
-    }
-    ],
-    "fieldMainLocation": true,
-    "fieldMedia": {
-    "entity": {
-    "image": {
-    "alt": "The entrance to the Pittsburgh VA Medical Center--University Drive",
-    "title": "",
-    "derivative": {
-    "url": "http://dev.va.agile6.com/sites/default/files/styles/3_2_medium_thumbnail/public/2019-02/university-drive-consolidation-building2.jpg?itok=qK823DFr",
-    "width": 480,
-    "height": 330
-    },
-    "entityUrl": {
-    "path": "/pittsburgh-health-care/locations/university-drive-campus"
-    }
-    }
-    }
-    }
-    }
+{
+"entityUrl": {
+"path": "/pittsburgh-health-care/locations/university-drive-campus"
+},
+"entityBundle": "health_care_local_facility",
+"title": "Pittsburgh VA Medical Center-University Drive",
+"fieldFacilityLocatorApiId": "vha_646",
+"fieldNicknameForThisFacility": "University Drive Medical Center",
+"fieldIntroText": "Get directions and parking information, prepare for your
+visit, or make an appointment.\r\n\r\n\r\nOur Pittsburgh University Drive campus
+provides primary and specialty health services including hearing care,
+dermatology, eye care, cardiac surgery and oncology referral centers, and
+more.\r\n",
+"fieldLocationServices": [
+{
+"entity": {
+"fieldTitle": "Transportation services and schedules (sample)",
+"fieldWysiwyg": {
+"processed": "<p>THIS IS SAMPLE CONTENT AND NEEDS TO BE UPDATED FROM THE COPY
+  DECK. <br /><br />\nThere are several forms of transportation that you can
+  choose from to travel to one of the VA Pittsburgh medical facilities:</p>\n\n
+<ul>
+  <li><a href=\"#\">Heinz Shuttle</a> – free shuttle service between Heinz and
+    University Drive</li>\n\t<li>Shuttle Plus – free shuttle service between
+    University Drive and Fisher House, Research Office Building (ROB) and
+    Federal Building</li>\n\t<li>DAV vans – complete van schedule from all of
+    our spoke hospitals</li>\n\t<li>Mass transit – Port Authority of Allegheny
+    County and ACCESS Transportation</li>\n\t<li>Para Transit Service (p.r.n.) –
+    (412) 824-2181 or 800-860-8222</li>\n\t<li><a href=\"#\">Yellow Cab</a> –
+    (412) 321-8100/8112</li>\n\t<li><a href=\"#\">Veterans Taxi</a> – (412)
+    481-VETS (8387)</li>\n\t<li>Transcare ambulance – (412) 373-0200</li>\n\t
+  <li>Pittsburgh International Airport</li>\n\t<li>Greyhound Bus lines</li>\n\t
+  <li>Amtrak</li>\n
+</ul>
+<p>Note: For a complete guide to the VA hospital shuttle and van service, refer
+  to the <a href=\"#\">transportation resource guide</a>.</p>"
+}
+}
+},
+{
+"entity": {
+"fieldTitle": "Visitor hours and information (sample content)",
+"fieldWysiwyg": {
+"processed": "<p>THIS IS SAMPLE CONTENT AND NEEDS TO BE UPDATED FROM THE COPY
+  DECK. </p>\n\n<p>We encourage you to visit when most convenient for you and
+  the patient. There are no set visitor hours for most departments. Exceptions
+  are listed below:</p>\n\n<h4>Medical, surgical, and hospice wards</h4>\n\n<p>
+  24 hours a day, 7 days a week</p>\n\n<h4>Behavioral health inpatient wards
+</h4>\n\n<p>1:00 p.m. – 2:00 p.m. and 6:00 p.m. -7:30 p.m., 7 days a week</p>
+\n\n<h4>Critical care</h4>\n\n<p>Visiting hours will be individualized to meet
+  the needs of the patient, family and caregivers.</p>\n\n<h4>Post-anesthesia
+  recovery</h4>\n\n<p>Generally, visitors are not permitted. In certain
+  circumstances, the doctor or nurse may make an exception.</p>\n\n<h4>General
+  visitor policies</h4>\n\n<ul>
+  <li>Children under the age of 16 must be directly supervised by an adult, and
+    bedside visits are limited to 15 minutes. </li>\n\t<li>Children under the
+    ages of 16 are not permitted in the dialysis unit due to infection control
+    and safety reasons. </li>\n
+</ul>
+<p>See full visitor policies [make a link to another page containing the
+  remaining bullets.]<br />\n </p>"
+}
+}
+},
+{
+"entity": {
+"fieldTitle": "Lodging for patients and families (sample)",
+"fieldWysiwyg": {
+"processed": "<p>THIS IS SAMPLE CONTENT AND NEEDS TO BE UPDATED FROM THE COPY
+  DECK. </p>\n\n<p dir=\"ltr\">Visitors are not permitted to stay overnight in
+  the medical center. Many local accommodations are available for Veterans and
+  their families.</p>\n\n<p dir=\"ltr\">Veterans and family members may be
+  eligible for the following:</p>\n\n<ul>
+  <li dir=\"ltr\">\n\t<p dir=\"ltr\"><a
+        href=\"https://www.pittsburgh.va.gov/services/hoptel-program.asp\">Hoptel
+        and lodging program</a> – Our Hoptel program provides temporary
+        overnight lodging to eligible Veterans for outpatient medical
+        procedures. For more information call 412-360-6233, or visit the <a
+        href=\"https://www.pittsburgh.va.gov/services/hoptel-program.asp\">website
+        </a>. </p>\n\t </li>\n\t <li dir=\"ltr\">\n\t<p dir=\"ltr\"><a
+            href=\"https://www.pittsburghfisherhouse.org/\">Fisher House</a> –
+            The 10-bedroom Pittsburgh Fisher House provides a place for visiting
+            families to stay, free of charge, while their loved ones receive
+            inpatient medical care. For more information call 412-360-2032, or
+            visit the <a href=\"https://www.pittsburghfisherhouse.org/\">Fisher
+            House website</a>. </p>\n\t </li>\n\t <li dir=\"ltr\">\n\t<p
+              dir=\"ltr\"><a href=\"https://www.familyhouse.org/\">Family
+                House</a> – Family House provides a special home away from home
+                for patients and/or families who must travel to Pittsburgh for
+                treatment of serious or life-threatening illnesses. Family House
+                has four locations in the area. For more information call
+                412-647-7777, or visit the <a
+                href=\"https://www.familyhouse.org/\">Family House website</a>.
+                </p>\n\t </li>\n\t <li dir=\"ltr\">\n\t<p dir=\"ltr\"><a
+                    href=\"http://www.visitpittsburgh.com/\">Visit
+                    Pittsburgh</a> – the official tourism and promotion agency
+                    for Pittsburgh and Allegheny County, also has up-to-date
+                    listings for area hotels, activities, events, festivals,
+                    transportation, sports, restaurants, cultural attractions,
+                    shops and more.</p>\n\t </li>\n\t <li dir=\"ltr\">\n\t<p
+                      dir=\"ltr\">Nearby hotels – There are many nearby hotels
+                      to choose from. When booking your reservations, be sure to
+                      ask for the hospital rate. Many hotels have shuttle
+                      service to VA hospitals. Please check with the hotel
+                      you’re staying at.</p>\n\n\t<ul>
+                      <li dir=\"ltr\">\n\t\t<p dir=\"ltr\"><a
+                            href=\"https://www.marriott.com/hotels/travel/pitok-courtyard-pittsburgh-shadyside\">Courtyard
+                            by Marriott, Shadyside</a>  <br />\n\t\t412-683-3113
+                          or 800-228-9290</p>\n\t\t</li>\n\t\t<li dir=\"ltr\">
+                        \n\t\t<p dir=\"ltr\"><a
+                            href=\"http://hamptoninn3.hilton.com/en/hotels/pennsylvania/hampton-inn-pittsburgh-university-medical-center-PITOKHX/index.html\">Hampton
+                            Inn, University Center</a>  <br />\n\t\t412-329-4969
+                          or 800-426-7866</p>\n\t\t</li>\n\t\t<li dir=\"ltr\">
+                        \n\t\t<p dir=\"ltr\"><a
+                            href=\"http://hiltongardeninn3.hilton.com/en/hotels/pennsylvania/hilton-garden-inn-pittsburgh-university-place-PITUCGI/index.html\">Hilton
+                            Garden Inn</a>  <br />\n\t\t412-683-2040 or
+                          877-782-9444</p>\n\t\t</li>\n\t\t<li dir=\"ltr\">
+                        \n\t\t<p dir=\"ltr\"><a
+                            href=\"http://www.qualityinn.com/hotel-pittsburgh-pennsylvania-PA369\">Quality
+                            Inn, University Center</a>  <br />\n\t\t412-683-6100
+                          or 877-424-6423</p>\n\t\t</li>\n\t\t<li dir=\"ltr\">
+                        \n\t\t<p dir=\"ltr\"><a
+                            href=\"https://www.marriott.com/hotels/travel/pitro-residence-inn-pittsburgh-university-medical-center/\">Residence
+                            Inn by Marriott, Oakland</a> 
+                            <br />\n\t\t412-621-2200 or 800-513-8766</p>\n\t\t
+                      </li>\n\t\t<li dir=\"ltr\">\n\t\t<p dir=\"ltr\"><a
+                            href=\"https://www.marriott.com/hotels/travel/pitrd-residence-inn-pittsburgh-oakland-university-place/\">Residence
+                            Inn by Marriott, Oakland/University Place</a>
+                            <br />\n\t\t 412-621-5600</p>\n\t\t</li>\n\t
+                    </ul>
+  </li>\n
+</ul>
+<p><a href=\"http://www.shadysideinn.com/\">Shadyside Inn All Suites Hotel</a>
+    <br />\n412-441-4444 or 800-767-8483</p>"
+}
+}
+},
+{
+"entity": {
+"fieldTitle": "Parking (sample content)",
+"fieldWysiwyg": {
+"processed": "<p>THIS IS SAMPLE CONTENT AND NEEDS TO BE UPDATED FROM THE COPY
+  DECK. </p>\n\n<p>University Drive campus facility map<br />\nRefer to the
+  following map for parking locations.<br />\n[add map here]</p>"
+}
+}
+},
+{
+"entity": {
+"fieldTitle": "Campus and building maps (sample content)",
+"fieldWysiwyg": {
+"processed": "<p>THIS IS SAMPLE CONTENT AND NEEDS TO BE UPDATED FROM THE COPY
+  DECK. </p>\n\n<p>University Drive campus facility map<br />\nUse the following
+  maps to help you get around the campus.<br />\n[add map here,
+  https://www.pittsburgh.va.gov/about/UD-facility-map.asp]</p>\n\n<p>Building
+  floor plans</p>\n\n<p>First floor<br />\nIncludes outpatient behavioral health
+  and primary care offices<br />\n(Download floor plan, PDF, 540KB)<br />\n[add
+  map here, https://www.pittsburgh.va.gov/about/CB-floorplans.asp]<br />\nSecond
+  floor<br />\nIncludes audiology and speech pathology, chapel, education,
+  library, and public affairs offices<br />\n(Download floor plan, PDF,
+  540KB)<br />\n[add map here,
+  https://www.pittsburgh.va.gov/about/CB-floorplans.asp]</p>"
+}
+}
+},
+{
+"entity": {
+"fieldTitle": "Cafeteria, shops, and other retail (sample content)",
+"fieldWysiwyg": {
+"processed": "<p>THIS IS SAMPLE CONTENT AND NEEDS TO BE UPDATED FROM THE COPY
+  DECK. </p>\n\n<p>Veterans Canteen Service (VCS) Patriot Café<br />\nLocated on
+  the ground floor, the Café is open Monday through Friday from 7:00 a.m. to
+  3:30 p.m. They serve hot and cold entrees, beverages and desserts. </p>\n\n<p>
+  VCS Patriot Brew (Starbucks®) Coffee<br />\nLocated on the first floor to the
+  right of Release of Information. It is open Monday through Friday from 6:30
+  a.m. to 7:00 p.m. and from 8:00 a.m. to 3:30 p.m. on Saturday. It is closed on
+  Sunday. They serve a variety of pastries, light sandwiches and beverages.</p>
+\n\n<p>VCS Patriot Store<br />\nLocated on the ground floor, the Patriot Store
+  offers a full-service retail store with such products as electronics,
+  cosmetics, toiletries, and clothing. Items may be purchased tax-free. The
+  retail store is open Monday through Friday from 7:00 a.m. to 7:00 p.m.,
+  Saturday from 9:00 a.m. to 3:30 p.m. and Sunday from 8:30 a.m. to 2:00 p.m.
+</p>\n\n<p>Vending areas<br />\nVending machines are located throughout the
+  hospital.<br />\n </p>"
+}
+}
+}
+],
+"fieldMainLocation": true,
+"fieldMedia": {
+"entity": {
+"image": {
+"alt": "The entrance to the Pittsburgh VA Medical Center--University Drive",
+"title": "",
+"derivative": {
+"url":
+"http://dev.va.agile6.com/sites/default/files/styles/3_2_medium_thumbnail/public/2019-02/university-drive-consolidation-building2.jpg?itok=qK823DFr",
+"width": 480,
+"height": 330
+},
+"entityUrl": {
+"path": "/pittsburgh-health-care/locations/university-drive-campus"
+}
+}
+}
+}
+}
 {% endcomment %}
 
 {% include "src/site/includes/header.html" with drupalTags = true %}
@@ -87,117 +217,202 @@
     <div class="usa-grid usa-grid-full">
       {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with sidebarData = facilitySidebar %}
       <div class="usa-width-three-fourths">
-          {% include "src/site/components/navigation-sidebar-trigger.html" with menuId = "va-detailpage-sidebar" %}
-          {% if !entityPublished %}
-          <div class="usa-alert usa-alert-info">
-            <div class="usa-alert-body">
-              <p class="usa-alert-text">You are viewing a draft.</p>
-            </div>
+        {% include "src/site/components/navigation-sidebar-trigger.html" with menuId = "va-detailpage-sidebar" %}
+        {% if !entityPublished %}
+        <div class="usa-alert usa-alert-info">
+          <div class="usa-alert-body">
+            <p class="usa-alert-text">You are viewing a draft.</p>
           </div>
+        </div>
         {% endif %}
 
         <article class="usa-content va-l-facility-detail">
           {% if title != empty %}
-            <h1>{{ title }}</h1>
+          <h1>{{ title }}</h1>
           {% endif %}
 
           {% if fieldIntroText != empty %}
-            <div class="va-introtext">
-              <p>{{ fieldIntroText }}</p>
-            </div>
+          <div class="va-introtext">
+            <p>{{ fieldIntroText }}</p>
+          </div>
           {% endif %}
 
-          <div class="usa-grid usa-grid-full vads-u-margin-y--1p5 vads-u-margin-bottom--6">{% assign basePath = entityUrl.path | regionBasePath %}
-              {% include "src/site/facilities/facilities_health_services_buttons.drupal.liquid" with path = basePath %}</div>
+          <div
+            class="usa-grid usa-grid-full vads-u-margin-y--1p5 vads-u-margin-bottom--6">
+            {% assign basePath = entityUrl.path | regionBasePath %}
+            {% include "src/site/facilities/facilities_health_services_buttons.drupal.liquid" with path = basePath %}
+          </div>
 
-            <section id="table-of-contents" class="vads-u-margin-bottom--5">
-                <h2 class="vads-u-margin-bottom--2 vads-u-font-size--lg">On this page</h2>
-                <ul class="usa-unstyled-list"></ul>
-            </section>
+          <section id="table-of-contents" class="vads-u-margin-bottom--5">
+            <h2 class="vads-u-margin-bottom--2 vads-u-font-size--lg">On this
+              page</h2>
+            <ul class="usa-unstyled-list"></ul>
+          </section>
 
-          <h2 class="vads-u-line-height--1 vads-u-margin-bottom--3">Location and contact information</h2>
-          <div class="region-list usa-grid usa-grid-full vads-u-display--flex vads-u-flex-direction--column small-screen:vads-u-flex-direction--row facility vads-u-margin-bottom--2p5 vads-u-margin-bottom--4">
-            <!-- facility details from api -->
-            <div class="usa-width-two-thirds vads-u-display--block vads-u-width--full">
-              <div data-widget-type="facility-detail" data-facility="{{ fieldFacilityLocatorApiId | widgetFacilityDetail | escape }}"></div>
+          <h2 class="vads-u-line-height--1 vads-u-margin-bottom--3">Location and
+            contact information</h2>
+          <div
+            class="region-list usa-grid usa-grid-full vads-u-display--flex vads-u-flex-direction--column small-screen:vads-u-flex-direction--row facility vads-u-margin-bottom--2p5 vads-u-margin-bottom--4">
+
+
+            <div
+              class="usa-width-two-thirds vads-u-display--block vads-u-width--full">
+              <div>
+                <div class="vads-c-facility-detail">
+                  <section class="vads-facility-detail">
+                    <h3
+                      class="vads-u-font-size--lg vads-u-margin-top--0 vads-u-line-height--1 vads-u-margin-bottom--1">
+                      Address
+                    </h3>
+                    <div class="vads-u-margin-bottom--3">
+                      <div>{{fieldAddress.addressLine1}}</div>
+                      {{fieldAddress.locality}},
+                      {{fieldAddress.administrativeArea}}
+                      {{fieldAddress.postalCode}}
+                      <div><a
+                          href="https://maps.google.com?saddr=Current+Location&daddr={{fieldAddress.addressLine1}}, {{fieldAddress.locality}}, {{fieldAddress.postalCode}}"
+                          target="_blank"
+                          rel="noopener noreferrer">Directions</a>
+                      </div>
+                    </div>
+                    <h3
+                      class="vads-u-font-size--lg vads-u-margin-top--0 vads-u-line-height--1 vads-u-margin-bottom--1">
+                      Phone numbers
+                    </h3>
+                    <div class="vads-u-margin-bottom--0">
+                      <div class="main-phone vads-u-margin-bottom--1">
+                        <strong>Main phone:
+                        </strong><a
+                          href="tel:{{fieldPhoneNumber}}">{{fieldPhoneNumber}}</a>
+                      </div>
+                      <div class="mental-health-clinic-phone"><strong>Mental
+                          health clinic:
+                        </strong><a
+                          href="tel:{{fieldMentalHealthPhone}}">{{fieldMentalHealthPhone}}</a>
+                      </div>
+                    </div>
+                    <div class="vads-u-margin-bottom--0">
+                      <div class="clinicalhours">
+                        <h3
+                          class="vads-u-margin-top--2p5 vads-u-margin-bottom--1">
+                          Clinical hours
+                        </h3>
+                        <div
+                          class="vads-u-display--flex vads-u-flex-direction--column small-screen:vads-u-flex-direction--row vads-u-margin-bottom--0">
+                          <ul
+                            class="vads-u-flex--1 va-c-facility-hours-list vads-u-margin-top--0 vads-u-margin-bottom--1 small-screen:vads-u-margin-bottom--0 vads-u-margin-right--3">
+                            {% for hours in fieldFacilityHours.value limit:5 %}
+                            <li><b class="abbrv-day">{{hours.0}}:</b>
+                              {{hours.1}}
+                            </li>
+                            {% endfor %}
+                          </ul>
+                          <ul
+                            class="vads-u-flex--1 va-c-facility-hours-list vads-u-margin-top--0 'vads-u-margin-bottom--0">
+                            {% for hours in fieldFacilityHours.value offset:5 limit:2 %}
+                            <li><b class="abbrv-day">{{hours.0}}:</b>
+                              {{hours.1}}
+                            </li>
+                            {% endfor %} </ul>
+                        </div>
+                      </div>
+                    </div>
+                  </section>
+                </div>
+              </div>
             </div>
 
-              <div class="usa-width-one-third inline-table-helper vads-u-order--first small-screen:vads-u-order--initial vads-u-margin-bottom--2 vads-u-margin-left--auto facility">
-                <!-- facility image -->
-                {% if fieldMedia.entity.image != empty %}
-                  {% assign image = fieldMedia.entity.image %}
-                  <a href="#" rel="noopener noreferrer" target="_blank" id="google-map-link-image">
-                    <img class="facility-img" src="{{ image.derivative.url }}" alt="{{ image.alt }}" title="{{ image.title }}" width="{{ image.derivative.width }}" height="{{ image.derivative.height }}"/>
-                  </a>
-                {% endif %}
-                <div data-widget-type="facility-map" data-facility="{{ fieldFacilityLocatorApiId | widgetFacilityDetail | escape }}"></div>
+
+            <div
+              class="usa-width-one-third inline-table-helper vads-u-order--first small-screen:vads-u-order--initial vads-u-margin-bottom--2 vads-u-margin-left--auto facility">
+              <!-- facility image -->
+              {% if fieldMedia.entity.image != empty %}
+              {% assign image = fieldMedia.entity.image %}
+              <a href="#" rel="noopener noreferrer" target="_blank"
+                id="google-map-link-image">
+                <img class="facility-img" src="{{ image.derivative.url }}"
+                  alt="{{ image.alt }}" title="{{ image.title }}"
+                  width="{{ image.derivative.width }}"
+                  height="{{ image.derivative.height }}" />
+              </a>
+              {% endif %}
+              <div data-widget-type="facility-map"
+                data-facility="{{ fieldFacilityLocatorApiId | widgetFacilityDetail | escape }}">
               </div>
+            </div>
           </div>
 
           <!-- Location services section -->
           {% capture difference %}
-            {{ fieldLocationServices | size | minus:1 }}
+          {{ fieldLocationServices | size | minus:1 }}
           {% endcapture %}
           {% unless difference contains '-' %}
-            <div class="vads-u-margin-bottom--4">
-                <h2 id="prepare-for-your-visit" class="vads-u-margin-top--0 vads-u-font-size--lg small-screen:vads-u-font-size--xl vads-u-margin-bottom--2">Prepare for your visit</h2>
-                <div class="usa-accordion-bordered">
-                  <ul class="usa-unstyled-list">
-                    {% for accordionItem in fieldLocationServices %}
-                      {% assign item = accordionItem.entity %}
-                      <li class="vads-u-margin-bottom--1">
-                        <button class="usa-accordion-button usa-button-unstyled vads-u-padding-y--2 vads-u-padding-left--2p5 vads-u-line-height--4
-" aria-expanded="false" aria-controls="{{ item.entityBundle }}-{{ item.entityId }}">
-                          {{ item.fieldTitle }}
-                        </button>
-                        <div id="{{ item.entityBundle }}-{{ item.entityId }}" class="usa-accordion-content" aria-hidden="true">
-                          {% include "src/site/paragraphs/wysiwyg.drupal.liquid" entity = item %}
-                        </div>
-                      </li>
-                    {% endfor %}
-                  </ul>
-                </div>
+          <div class="vads-u-margin-bottom--4">
+            <h2 id="prepare-for-your-visit"
+              class="vads-u-margin-top--0 vads-u-font-size--lg small-screen:vads-u-font-size--xl vads-u-margin-bottom--2">
+              Prepare for your visit</h2>
+            <div class="usa-accordion-bordered">
+              <ul class="usa-unstyled-list">
+                {% for accordionItem in fieldLocationServices %}
+                {% assign item = accordionItem.entity %}
+                <li class="vads-u-margin-bottom--1">
+                  <button class="usa-accordion-button usa-button-unstyled vads-u-padding-y--2 vads-u-padding-left--2p5 vads-u-line-height--4
+" aria-expanded="false"
+                    aria-controls="{{ item.entityBundle }}-{{ item.entityId }}">
+                    {{ item.fieldTitle }}
+                  </button>
+                  <div id="{{ item.entityBundle }}-{{ item.entityId }}"
+                    class="usa-accordion-content" aria-hidden="true">
+                    {% include "src/site/paragraphs/wysiwyg.drupal.liquid" entity = item %}
+                  </div>
+                </li>
+                {% endfor %}
+              </ul>
             </div>
+          </div>
           {% endunless %}
 
-            <!-- List of links section -->
-            {% if fieldRegionPage.entity.fieldRelatedLinks != empty %}
-                {% include "src/site/paragraphs/list_of_link_teasers_facility.drupal.liquid" with paragraph = fieldRegionPage.entity.fieldRelatedLinks.entity %}
+          <!-- List of links section -->
+          {% if fieldRegionPage.entity.fieldRelatedLinks != empty %}
+          {% include "src/site/paragraphs/list_of_link_teasers_facility.drupal.liquid" with paragraph = fieldRegionPage.entity.fieldRelatedLinks.entity %}
+          {% endif %}
+
+          <!-- Local Health Services -->
+          {% if fieldLocalHealthCareService != empty and fieldLocalHealthCareService.length %}
+          <h2 id="health-care-offered-here"
+            class="vads-u-font-size--xl vads-u-margin-top--5">Health care
+            services offered here</h2>
+          <section class="local-health-services" id="local-health-services">
+
+            {% assign localHealthServices = fieldLocalHealthCareService | sortObjectsBy: 'entity.fieldRegionalHealthService.entity.fieldServiceNameAndDescripti.entity.name' %}
+            {% for localService in localHealthServices %}
+            {% assign localHealthService = localService.entity | featureFieldRegionalHealthService %}
+            {% if localHealthService != empty %}
+            {% include "src/site/facilities/facility_health_service.drupal.liquid" with healthService = localHealthService localServiceDescription = localService.entity.fieldBody.processed fieldFacilityLocatorApiId = fieldFacilityLocatorApiId %}
             {% endif %}
+            {% endfor %}
+          </section>
+          {% endif %}
 
-            <!-- Local Health Services -->
-            {% if fieldLocalHealthCareService != empty and fieldLocalHealthCareService.length %}
-                <h2 id="health-care-offered-here" class="vads-u-font-size--xl vads-u-margin-top--5">Health care services offered here</h2>
-                <section class="local-health-services" id="local-health-services">
-
-                    {% assign localHealthServices = fieldLocalHealthCareService | sortObjectsBy: 'entity.fieldRegionalHealthService.entity.fieldServiceNameAndDescripti.entity.name' %}
-                    {% for localService in localHealthServices %}
-                        {% assign localHealthService = localService.entity | featureFieldRegionalHealthService %}
-                        {% if localHealthService != empty %}
-                            {% include "src/site/facilities/facility_health_service.drupal.liquid" with healthService = localHealthService localServiceDescription = localService.entity.fieldBody.processed fieldFacilityLocatorApiId = fieldFacilityLocatorApiId %}
-                        {% endif %}
-                    {% endfor %}
-                </section>
-            {% endif %}
-
-            <h2
-                    id="our-patient-satisfaction-scores"
-                    class="vads-u-margin-top--4 vads-u-font-size--lg small-screen:vads-u-font-size--xl"
-            >
-                Veteran satisfaction with appointment wait times at this location
-            </h2>
-            <div data-widget-type="facility-patient-satisfaction-scores" data-facility="{{ fieldFacilityLocatorApiId | widgetFacilityDetail | escape }}"></div>
+          <h2 id="our-patient-satisfaction-scores"
+            class="vads-u-margin-top--4 vads-u-font-size--lg small-screen:vads-u-font-size--xl">
+            Veteran satisfaction with appointment wait times at this location
+          </h2>
+          <div data-widget-type="facility-patient-satisfaction-scores"
+            data-facility="{{ fieldFacilityLocatorApiId | widgetFacilityDetail | escape }}">
+          </div>
 
 
-            <!-- Social Links -->
-            {% if fieldFacebook != empty || fieldFlickr != empty || fieldInstagram != empty || fieldTwitter != empty || fieldEmailSubscription != empty || (fieldLinks != empty and fieldLinks.length)%}
-                {% include "src/site/facilities/facility_social_links.drupal.liquid" with regionNickname = fieldRegionPage.entity.fieldNicknameForThisFacility %}
-            {% endif %}
+          <!-- Social Links -->
+          {% if fieldFacebook != empty || fieldFlickr != empty || fieldInstagram != empty || fieldTwitter != empty || fieldEmailSubscription != empty || (fieldLinks != empty and fieldLinks.length)%}
+          {% include "src/site/facilities/facility_social_links.drupal.liquid" with regionNickname = fieldRegionPage.entity.fieldNicknameForThisFacility %}
+          {% endif %}
 
         </article>
         <div class="last-updated usa-content">
           Last updated:
-          <time datetime="{{ changed | dateFromUnix: 'YYYY-MM-DD'}}">{{ changed | humanizeTimestamp }}</time>
+          <time
+            datetime="{{ changed | dateFromUnix: 'YYYY-MM-DD'}}">{{ changed | humanizeTimestamp }}</time>
         </div>
       </div>
     </div>

--- a/src/site/layouts/health_care_region_locations_page.drupal.liquid
+++ b/src/site/layouts/health_care_region_locations_page.drupal.liquid
@@ -4,33 +4,45 @@
 {% include "src/site/includes/breadcrumbs.drupal.liquid" %}
 <div id="content" class="interior">
     <main class="va-l-detail-page va-facility-page">
-    <div class="usa-grid usa-grid-full">
-        {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with sidebarData = facilitySidebar %}
-        <div class="usa-width-three-fourths">
-            {% include "src/site/components/navigation-sidebar-trigger.html" with menuId = "va-detailpage-sidebar" %}
+        <div class="usa-grid usa-grid-full">
+            {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with sidebarData = facilitySidebar %}
+            <div class="usa-width-three-fourths">
+                {% include "src/site/components/navigation-sidebar-trigger.html" with menuId = "va-detailpage-sidebar" %}
 
-            <article class="usa-content">
-                <h1 class="vads-u-margin-bottom--2">Locations</h1>
-                <div class="va-introtext vads-u-margin-bottom--0">
-                    {{ fieldLocationsIntroBlurb.processed }}
-                </div>
-                <div class="usa-grid usa-grid-full vads-u-margin-y--1p5">{% assign basePath = entityUrl.path | regionBasePath %}
-                    {% include "src/site/facilities/main_buttons.drupal.liquid" with path = basePath %}</div>
-                <section class="locations clearfix">
-                    <h2 id="main-locations" class="vads-u-font-size--xl vads-u-margin-top--3 medium-screen:vads-u-margin-top--5 vads-u-margin-bottom--2p5 medium-screen:vads-u-margin-bottom--3">Main locations</h2>
-                    <div data-widget-type="facility-locations-list" data-facilities="{{ mainFacilities.entities | widgetFacilitiesList | escape }}"></div>
-                    <h2 id="community-clinic-locations" class="medium-screen:vads-u-margin-bottom--4">Health clinic locations</h2>
-                    <div data-widget-type="facility-locations-list" data-facilities="{{ otherFacilities.entities | widgetFacilitiesList | escape }}"></div>
-
-                    {% if fieldOtherVaLocations != empty and fieldOtherVaLocations.length %}
-                        <h2 id="other-nearby-va-locations" class="medium-screen:vads-u-margin-bottom--4">Other nearby VA locations</h2>
-                        <div data-widget-type="other-facility-locations-list" data-facilities="{{ fieldOtherVaLocations }}"></div>
-                    {% endif %}
-                </section>
-            </article>
+                <article class="usa-content">
+                    <h1 class="vads-u-margin-bottom--2">Locations</h1>
+                    <div class="va-introtext vads-u-margin-bottom--0">
+                        {{ fieldLocationsIntroBlurb.processed }}
+                    </div>
+                    <div class="usa-grid usa-grid-full vads-u-margin-y--1p5">
+                        {% assign basePath = entityUrl.path | regionBasePath %}
+                        {% include "src/site/facilities/main_buttons.drupal.liquid" with path = basePath %}
+                    </div>
+                    <section class="locations clearfix">
+                        <h2 id="main-locations"
+                            class="vads-u-font-size--xl vads-u-margin-top--3 medium-screen:vads-u-margin-top--5 vads-u-margin-bottom--2p5 medium-screen:vads-u-margin-bottom--3">
+                            Main locations</h2>
+                        {% for main in mainFacilities.entities %}
+                        {% include 'src/site/includes/facilityListing.drupal.liquid' with entity = main %}
+                        {% endfor %}
+                        <h2 id="community-clinic-locations"
+                            class="medium-screen:vads-u-margin-bottom--4">Health
+                            clinic locations</h2>
+                        {% for other in otherFacilities.entities %}
+                        {% include 'src/site/includes/facilityListing.drupal.liquid' with entity = other %}
+                        {% endfor %}
+                        {% if fieldOtherVaLocations != empty and fieldOtherVaLocations.length %}
+                        <h2 id="other-nearby-va-locations"
+                            class="medium-screen:vads-u-margin-bottom--4">Other
+                            nearby VA locations</h2>
+                        <div data-widget-type="other-facility-locations-list"
+                            data-facilities="{{ fieldOtherVaLocations }}"></div>
+                        {% endif %}
+                    </section>
+                </article>
+            </div>
         </div>
-    </div>
-  </main>
+    </main>
 </div>
 {% include "src/site/includes/footer.html" %}
 {% include "src/site/includes/debug.drupal.liquid" %}

--- a/src/site/layouts/health_care_region_page.drupal.liquid
+++ b/src/site/layouts/health_care_region_page.drupal.liquid
@@ -1,122 +1,123 @@
 {% comment %}
 Example data:
 "entityUrl": {
-  "breadcrumb": [
-    {
-      "url": {
-        "path": "/",
-        "routed": true
-      },
-      "text": "Home"
-    }
-  ],
-  "path": "/pittsburgh-health-care"
+"breadcrumb": [
+{
+"url": {
+"path": "/",
+"routed": true
+},
+"text": "Home"
+}
+],
+"path": "/pittsburgh-health-care"
 },
 "entityId": "83",
 "entityBundle": "health_care_region_page",
 "entityPublished": true,
 "title": "Pittsburgh Health Care System",
 "fieldMedia": {
-  "entity": {
-    "image": {
-      "alt": "U Drive",
-      "title": "",
-      "derivative": {
-        "url": "http://vagovcms.lndo.site/sites/default/files/styles/crop_2_1/public/2019-02/university-drive-consolidation-building2.jpg?itok=Gb4BrUjw",
-        "width": 480,
-        "height": 330
-      }
-    }
-  }
+"entity": {
+"image": {
+"alt": "U Drive",
+"title": "",
+"derivative": {
+"url":
+"http://vagovcms.lndo.site/sites/default/files/styles/crop_2_1/public/2019-02/university-drive-consolidation-building2.jpg?itok=Gb4BrUjw",
+"width": 480,
+"height": 330
+}
+}
+}
 },
 "fieldIntroText": "Lorem ipsum dolor sit amet, consectetur adipiscing elit....
 "fieldRelatedLinks": {
-  "entity": {
-    "parentFieldName": "field_related_links",
-    "fieldTitle": "Popular in Pittsburgh",
-    "fieldVaParagraphs": [
-      {
-        "entity": {
-          "fieldLink": {
-            "uri": "internal:#",
-            "title": "Phone Directory",
-            "options": null
-          },
-          "fieldLinkSummary": null
-        }
-      },
-      {
-        "entity": {
-          "fieldLink": {
-            "uri": "internal:#",
-            "title": "Billing and insurance",
-            "options": null
-          },
-          "fieldLinkSummary": null
-        }
-      },
-      {
-        "entity": {
-          "fieldLink": {
-            "uri": "internal:#",
-            "title": "Patient advocates",
-            "options": null
-          },
-          "fieldLinkSummary": null
-        }
-      },
-      {
-        "entity": {
-          "fieldLink": {
-            "uri": "internal:#",
-            "title": "Library",
-            "options": null
-          },
-          "fieldLinkSummary": null
-        }
-      }
-    ]
-  }
+"entity": {
+"parentFieldName": "field_related_links",
+"fieldTitle": "Popular in Pittsburgh",
+"fieldVaParagraphs": [
+{
+"entity": {
+"fieldLink": {
+"uri": "internal:#",
+"title": "Phone Directory",
+"options": null
+},
+"fieldLinkSummary": null
+}
+},
+{
+"entity": {
+"fieldLink": {
+"uri": "internal:#",
+"title": "Billing and insurance",
+"options": null
+},
+"fieldLinkSummary": null
+}
+},
+{
+"entity": {
+"fieldLink": {
+"uri": "internal:#",
+"title": "Patient advocates",
+"options": null
+},
+"fieldLinkSummary": null
+}
+},
+{
+"entity": {
+"fieldLink": {
+"uri": "internal:#",
+"title": "Library",
+"options": null
+},
+"fieldLinkSummary": null
+}
+}
+]
+}
 },
 "localFacilities": {
-  "entities": [
-    {
-      "title": "Fayette County VA Clinic",
-      "fieldFacilityLocatorApiId": "vha_646ge"
-    },
-    {
-      "title": "H. John Heinz III Department of Veterans Affairs Medical Center",
-      "fieldFacilityLocatorApiId": "vha_646A4"
-    },
-    {
-      "title": "Pittsburgh VA Medical Center-University Drive",
-      "fieldFacilityLocatorApiId": "vha_646"
-    },
-    {
-      "title": "Washington County VA Clinic",
-      "fieldFacilityLocatorApiId": "vha_646gd"
-    }
-  ]
+"entities": [
+{
+"title": "Fayette County VA Clinic",
+"fieldFacilityLocatorApiId": "vha_646ge"
+},
+{
+"title": "H. John Heinz III Department of Veterans Affairs Medical Center",
+"fieldFacilityLocatorApiId": "vha_646A4"
+},
+{
+"title": "Pittsburgh VA Medical Center-University Drive",
+"fieldFacilityLocatorApiId": "vha_646"
+},
+{
+"title": "Washington County VA Clinic",
+"fieldFacilityLocatorApiId": "vha_646gd"
+}
+]
 },
 "newsStoryTeasers": {
-  "entities": [
-    {
-      "title": "Test Story",
-      "fieldIntroText": "This is a story",
-      "fieldMedia": null,
-      "entityUrl": {
-        "path": "/test-story"
-      }
-    },
-    {
-      "title": "Test Story 2",
-      "fieldIntroText": null,
-      "fieldMedia": null,
-      "entityUrl": {
-        "path": "/test-story-2"
-      }
-    }
-  ]
+"entities": [
+{
+"title": "Test Story",
+"fieldIntroText": "This is a story",
+"fieldMedia": null,
+"entityUrl": {
+"path": "/test-story"
+}
+},
+{
+"title": "Test Story 2",
+"fieldIntroText": null,
+"fieldMedia": null,
+"entityUrl": {
+"path": "/test-story-2"
+}
+}
+]
 }
 {% endcomment %}
 {% include "src/site/includes/header.html" with drupalTags = true %}
@@ -126,130 +127,187 @@ Example data:
 <div id="content" class="interior">
   <main class="va-l-detail-page va-facility-page">
     <div class="usa-grid usa-grid-full">
-    {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with sidebarData = facilitySidebar %}
-    <div class="usa-width-three-fourths">
+      {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with sidebarData = facilitySidebar %}
+      <div class="usa-width-three-fourths">
         {% include "src/site/components/navigation-sidebar-trigger.html" with menuId = "va-detailpage-sidebar" %}
         {% if !entityPublished %}
-        <div class="usa-alert usa-alert-info" >
+        <div class="usa-alert usa-alert-info">
           <div class="usa-alert-body">
             <p class="usa-alert-text">You are viewing a draft.</p>
           </div>
         </div>
-      {% endif %}
+        {% endif %}
 
-      <article class="usa-content">
-        <h1>{{ title }}</h1>
-        {% assign image = fieldMedia.entity.image %}
+        <article class="usa-content">
+          <h1>{{ title }}</h1>
+          {% assign image = fieldMedia.entity.image %}
 
-        <div class="duotone darken lighten medium-screen:vads-u-margin-bottom--0p5">
-          <img src="{{ image.derivative.url }}" alt="{{ image.alt }}" title="{{ image.title }}" width="100%">
-        </div>
+          <div
+            class="duotone darken lighten medium-screen:vads-u-margin-bottom--0p5">
+            <img src="{{ image.derivative.url }}" alt="{{ image.alt }}"
+              title="{{ image.title }}" width="100%">
+          </div>
 
-        <div class="usa-grid usa-grid-full vads-u-margin-top--0 vads-u-margin-bottom--3">{% assign basePath = entityUrl.path | regionBasePath %}
-            {% include "src/site/facilities/main_buttons.drupal.liquid" with path = basePath %}</div>
+          <div
+            class="usa-grid usa-grid-full vads-u-margin-top--0 vads-u-margin-bottom--3">
+            {% assign basePath = entityUrl.path | regionBasePath %}
+            {% include "src/site/facilities/main_buttons.drupal.liquid" with path = basePath %}
+          </div>
 
-        {% if fieldIntroText != empty %}
+          {% if fieldIntroText != empty %}
           <div class="va-introtext">
             <p class="vads-u-margin-bottom--0">{{ fieldIntroText }}</p>
           </div>
-        {% endif %}
+          {% endif %}
 
-        <section>
-          <h2 class="vads-u-font-size--xl vads-u-margin-top--3 medium-screen:vads-u-margin-top--5 medium-screen:vads-u-margin-bottom--2p5">Locations</h2>
-          <div data-widget-type="basic-facility-locations-list" data-facilities="{{ mainFacilities.entities | widgetFacilitiesList | escape }}" data-path="{{ entityUrl.path }}"></div>
-          <a onClick="recordEvent({ event: 'nav-secondary-button-click' });" class="usa-button usa-button-secondary vads-facility-hub-button vads-u-width--full medium-screen:vads-u-width--auto vads-u-font-size--md" href="{{ entityUrl.path }}/locations">
-            See all locations <i class="fa fa-chevron-right va-l-font-size--12px">&nbsp;</i>
-          </a>
-        </section>
+          <section>
+            <h2
+              class="vads-u-font-size--xl vads-u-margin-top--3 medium-screen:vads-u-margin-top--5 medium-screen:vads-u-margin-bottom--2p5">
+              Locations</h2>
+            {% for main in mainFacilities.entities %}
+            {% include 'src/site/includes/facilityListing.drupal.liquid' with entity = main %}
+            {% endfor %} <a
+              onClick="recordEvent({ event: 'nav-secondary-button-click' });"
+              class="usa-button usa-button-secondary vads-facility-hub-button vads-u-width--full medium-screen:vads-u-width--auto vads-u-font-size--md"
+              href="{{ entityUrl.path }}/locations">
+              See all locations <i
+                class="fa fa-chevron-right va-l-font-size--12px">&nbsp;</i>
+            </a>
+          </section>
 
-        <!-- "Manage your health online" section -->
-        <section>
-          <h3>Manage your health online</h3>
-          <div class="vads-u-display--flex medium-screen:vads-u-flex-direction--row vads-u-flex-direction--column">
-            <div class="vads-u-margin-right--0 medium-screen:vads-u-margin-right--3">
-              <div class="vads-facility-hub-cta">
-                <a onClick="recordEvent({ event: 'cta-hub-link-click' });" href="/health-care/refill-track-prescriptions/" class="vads-u-height--full vads-u-width--full">
-                  <i class=" fa fa-prescription-bottle vads-facility-hub-cta-circle">&nbsp;</i>
-                  <span class="vads-facility-hub-cta-label">Refill and track your prescriptions<i class="fa fa-chevron-right vads-facility-hub-cta-arrow">&nbsp;</i></span>
-                </a>
+          <!-- "Manage your health online" section -->
+          <section>
+            <h3>Manage your health online</h3>
+            <div
+              class="vads-u-display--flex medium-screen:vads-u-flex-direction--row vads-u-flex-direction--column">
+              <div
+                class="vads-u-margin-right--0 medium-screen:vads-u-margin-right--3">
+                <div class="vads-facility-hub-cta">
+                  <a onClick="recordEvent({ event: 'cta-hub-link-click' });"
+                    href="/health-care/refill-track-prescriptions/"
+                    class="vads-u-height--full vads-u-width--full">
+                    <i
+                      class=" fa fa-prescription-bottle vads-facility-hub-cta-circle">&nbsp;</i>
+                    <span class="vads-facility-hub-cta-label">Refill and track
+                      your prescriptions<i
+                        class="fa fa-chevron-right vads-facility-hub-cta-arrow">&nbsp;</i></span>
+                  </a>
+                </div>
+                <div class="vads-facility-hub-cta">
+                  <a onClick="recordEvent({ event: 'cta-hub-link-click' });"
+                    href="/health-care/secure-messaging/"
+                    class="vads-u-height--full vads-u-width--full">
+                    <i
+                      class="far fa-comments vads-facility-hub-cta-circle">&nbsp;</i>
+                    <span class="vads-facility-hub-cta-label">Send a secure
+                      message to your health care team<i
+                        class="fa fa-chevron-right vads-facility-hub-cta-arrow">&nbsp;</i></span>
+                  </a>
+                </div>
+                <div
+                  class="vads-facility-hub-cta vads-u-border-color--primary-alt-light medium-screen:vads-u-border-bottom--1px">
+
+                  <a onClick="recordEvent({ event: 'cta-hub-link-click' });"
+                    href="/health-care/schedule-view-va-appointments/"
+                    class="vads-u-height--full vads-u-width--full">
+                    <i
+                      class="far fa-calendar-check vads-facility-hub-cta-circle">&nbsp;</i>
+                    <span class="vads-facility-hub-cta-label">Schedule and view
+                      your appointments<i
+                        class="fa fa-chevron-right vads-facility-hub-cta-arrow">&nbsp;</i></span>
+                  </a>
+                </div>
               </div>
-              <div class="vads-facility-hub-cta">
-                <a onClick="recordEvent({ event: 'cta-hub-link-click' });" href="/health-care/secure-messaging/" class="vads-u-height--full vads-u-width--full">
-                  <i class="far fa-comments vads-facility-hub-cta-circle">&nbsp;</i>
-                  <span class="vads-facility-hub-cta-label">Send a secure message to your health care team<i class="fa fa-chevron-right vads-facility-hub-cta-arrow">&nbsp;</i></span>
-                </a>
-              </div>
-              <div class="vads-facility-hub-cta vads-u-border-color--primary-alt-light medium-screen:vads-u-border-bottom--1px">
-
-                <a onClick="recordEvent({ event: 'cta-hub-link-click' });" href="/health-care/schedule-view-va-appointments/" class="vads-u-height--full vads-u-width--full">
-                  <i class="far fa-calendar-check vads-facility-hub-cta-circle">&nbsp;</i>
-                  <span class="vads-facility-hub-cta-label">Schedule and view your appointments<i class="fa fa-chevron-right vads-facility-hub-cta-arrow">&nbsp;</i></span>
-                </a>
+              <div>
+                <div class="vads-facility-hub-cta">
+                  <a onClick="recordEvent({ event: 'cta-hub-link-click' });"
+                    href="/health-care/get-medical-records/"
+                    class="vads-u-height--full vads-u-width--full">
+                    <i
+                      class="fa fa-file-medical vads-facility-hub-cta-circle">&nbsp;</i>
+                    <span class="vads-facility-hub-cta-label">Download your VA
+                      medical records (Blue Button)<i
+                        class="fa fa-chevron-right vads-facility-hub-cta-arrow">&nbsp;</i></span>
+                  </a>
+                </div>
+                <div class="vads-facility-hub-cta">
+                  <a onClick="recordEvent({ event: 'cta-hub-link-click' });"
+                    href="/health-care/view-test-and-lab-results/"
+                    class="vads-u-height--full vads-u-width--full">
+                    <i
+                      class="fa fa-clipboard-list vads-facility-hub-cta-circle">&nbsp;</i>
+                    <span class="vads-facility-hub-cta-label">View your lab and
+                      test results<i
+                        class="fa fa-chevron-right vads-facility-hub-cta-arrow">&nbsp;</i></span>
+                  </a>
+                </div>
+                <div
+                  class="vads-facility-hub-cta vads-facility-hub-cta-last-line vads-u-border-top--1px vads-u-border-color--primary-alt-light">
+                  <a onClick="recordEvent({ event: 'cta-hub-link-click' });"
+                    href="/health-care/order-hearing-aid-batteries-prosthetic-socks/"
+                    class="vads-u-height--full vads-u-width--full">
+                    <i
+                      class="fa fa-deaf vads-facility-hub-cta-circle">&nbsp;</i>
+                    <span class="vads-facility-hub-cta-label">Order hearing aid
+                      batteries and prosthetic socks<i
+                        class="fa fa-chevron-right vads-facility-hub-cta-arrow">&nbsp;</i></span>
+                  </a>
+                </div>
               </div>
             </div>
-            <div>
-              <div class="vads-facility-hub-cta">
-                <a onClick="recordEvent({ event: 'cta-hub-link-click' });" href="/health-care/get-medical-records/" class="vads-u-height--full vads-u-width--full">
-                  <i class="fa fa-file-medical vads-facility-hub-cta-circle">&nbsp;</i>
-                  <span class="vads-facility-hub-cta-label">Download your VA medical records (Blue Button)<i class="fa fa-chevron-right vads-facility-hub-cta-arrow">&nbsp;</i></span>
-                </a>
-              </div>
-              <div class="vads-facility-hub-cta">
-                <a onClick="recordEvent({ event: 'cta-hub-link-click' });" href="/health-care/view-test-and-lab-results/" class="vads-u-height--full vads-u-width--full">
-                  <i class="fa fa-clipboard-list vads-facility-hub-cta-circle">&nbsp;</i>
-                  <span class="vads-facility-hub-cta-label">View your lab and test results<i class="fa fa-chevron-right vads-facility-hub-cta-arrow">&nbsp;</i></span>
-                </a>
-              </div>
-              <div class="vads-facility-hub-cta vads-facility-hub-cta-last-line vads-u-border-top--1px vads-u-border-color--primary-alt-light">
-                <a onClick="recordEvent({ event: 'cta-hub-link-click' });" href="/health-care/order-hearing-aid-batteries-prosthetic-socks/" class="vads-u-height--full vads-u-width--full">
-                  <i class="fa fa-deaf vads-facility-hub-cta-circle">&nbsp;</i>
-                  <span class="vads-facility-hub-cta-label">Order hearing aid batteries and prosthetic socks<i class="fa fa-chevron-right vads-facility-hub-cta-arrow">&nbsp;</i></span>
-                </a>
-              </div>
-            </div>
+          </section>
+
+
+          <!-- List of links section -->
+          <div class="vads-u-margin-top--5">
+            {% include "src/site/paragraphs/list_of_link_teasers_facility.drupal.liquid" with paragraph = fieldRelatedLinks.entity %}
           </div>
-        </section>
-
-
-        <!-- List of links section -->
-        <div class="vads-u-margin-top--5">
-          {% include "src/site/paragraphs/list_of_link_teasers_facility.drupal.liquid" with paragraph = fieldRelatedLinks.entity %}
-        </div>
 
           <!-- Stories -->
-        <section>
-          <h2 class="vads-u-margin-bottom--3 medium-screen:vads-u-margin-top--5">Stories</h2>
-          {% for story in newsStoryTeasers.entities %}
+          <section>
+            <h2
+              class="vads-u-margin-bottom--3 medium-screen:vads-u-margin-top--5">
+              Stories</h2>
+            {% for story in newsStoryTeasers.entities %}
             {% include "src/site/teasers/news_story.drupal.liquid" with node = story %}
-          {% endfor %}
-          <a onClick="recordEvent({ event: 'nav-secondary-button-click' });" class="usa-button usa-button-secondary vads-facility-hub-button vads-u-width--full medium-screen:vads-u-width--auto vads-u-font-size--md vads-u-margin--0" href="{{ entityUrl.path }}/stories">
-            See all stories <i class="fa fa-chevron-right va-l-font-size--12px"></i>
-          </a>
-        </section>
+            {% endfor %}
+            <a onClick="recordEvent({ event: 'nav-secondary-button-click' });"
+              class="usa-button usa-button-secondary vads-facility-hub-button vads-u-width--full medium-screen:vads-u-width--auto vads-u-font-size--md vads-u-margin--0"
+              href="{{ entityUrl.path }}/stories">
+              See all stories <i
+                class="fa fa-chevron-right va-l-font-size--12px"></i>
+            </a>
+          </section>
 
-        <!-- Events -->
-        <section>
-          <h2 class="vads-u-margin-top--4 vads-u-margin-bottom--2 medium-screen:vads-u-margin-bottom--2p5">Events</h2>
-          <div class="usa-grid usa-grid-full region-list vads-u-margin-bottom--2 vads-u-display--flex vads-u-flex-direction--column small-screen:vads-u-flex-direction--row">
-          {% for event in eventTeasers.entities %}
-            <div class="region-grid event">
-            {% include "src/site/teasers/event.drupal.liquid" with node = event %}
+          <!-- Events -->
+          <section>
+            <h2
+              class="vads-u-margin-top--4 vads-u-margin-bottom--2 medium-screen:vads-u-margin-bottom--2p5">
+              Events</h2>
+            <div
+              class="usa-grid usa-grid-full region-list vads-u-margin-bottom--2 vads-u-display--flex vads-u-flex-direction--column small-screen:vads-u-flex-direction--row">
+              {% for event in eventTeasers.entities %}
+              <div class="region-grid event">
+                {% include "src/site/teasers/event.drupal.liquid" with node = event %}
+              </div>
+              {% endfor %}
             </div>
-          {% endfor %}
-          </div>
-          <a onClick="recordEvent({ event: 'nav-secondary-button-click' });" class="usa-button usa-button-secondary vads-facility-hub-button vads-u-width--full medium-screen:vads-u-width--auto vads-u-font-size--md vads-u-margin--0" href="{{ entityUrl.path }}/events">
-            See all events <i class="fa fa-chevron-right va-l-font-size--12px"></i>
-          </a>
-        </section>
+            <a onClick="recordEvent({ event: 'nav-secondary-button-click' });"
+              class="usa-button usa-button-secondary vads-facility-hub-button vads-u-width--full medium-screen:vads-u-width--auto vads-u-font-size--md vads-u-margin--0"
+              href="{{ entityUrl.path }}/events">
+              See all events <i
+                class="fa fa-chevron-right va-l-font-size--12px"></i>
+            </a>
+          </section>
 
-        <!-- Social Links -->
-        {% if fieldFacebook != empty || fieldFlickr != empty || fieldInstagram != empty || fieldTwitter != empty || fieldEmailSubscription != empty %}
+          <!-- Social Links -->
+          {% if fieldFacebook != empty || fieldFlickr != empty || fieldInstagram != empty || fieldTwitter != empty || fieldEmailSubscription != empty %}
           {% include "src/site/facilities/facility_social_links.drupal.liquid" with regionNickname = fieldNicknameForThisFacility %}
-        {% endif %}
+          {% endif %}
 
-    </article>
+        </article>
+      </div>
     </div>
-  </div>
-</main>
-{% include "src/site/includes/footer.html" %}
-{% include "src/site/includes/debug.drupal.liquid" %}
+  </main>
+  {% include "src/site/includes/footer.html" %}
+  {% include "src/site/includes/debug.drupal.liquid" %}

--- a/src/site/stages/build/drupal/graphql/facilities-fragments/healthCareLocalFacility.node.graphql.js
+++ b/src/site/stages/build/drupal/graphql/facilities-fragments/healthCareLocalFacility.node.graphql.js
@@ -37,6 +37,17 @@ const FACILITIES_RESULTS = `
           }
         }
       }
+    fieldAddress {
+      addressLine1
+      locality
+      administrativeArea
+      postalCode
+    }
+    fieldPhoneNumber
+    fieldMentalHealthPhone
+    fieldFacilityHours {
+      value
+    }
       fieldMainLocation
       fieldMedia {
         entity {

--- a/src/site/stages/build/drupal/graphql/healthCareLocalFacilityPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/healthCareLocalFacilityPage.graphql.js
@@ -21,6 +21,17 @@ module.exports = `
         }
       }
     }
+    fieldAddress {
+      addressLine1
+      locality
+      administrativeArea
+      postalCode
+    }
+    fieldPhoneNumber
+    fieldMentalHealthPhone
+    fieldFacilityHours {
+      value
+    }
     fieldMainLocation
     fieldMedia {
       entity {


### PR DESCRIPTION
## Description
**Replaces react facility data widgets with cms data in facility templates. The following fields are now coming from cms, and are plugged into liquid (as opposed to grabbing from api, and outputting via react widget).**
- Facility title 
- Address
- Phone numbers
- Hours

## Screenshots of pages where output will now come from cms
![image](https://user-images.githubusercontent.com/2404547/67119520-58a39180-f1b5-11e9-957f-af5e5ecba809.png)
![image](https://user-images.githubusercontent.com/2404547/67119532-5f320900-f1b5-11e9-8ec3-f7b3a284e7a7.png)

## Testing done
Visual