### PR TITLE
validation message for school search field

### DIFF
--- a/src/applications/gi/components/search/KeywordSearch.jsx
+++ b/src/applications/gi/components/search/KeywordSearch.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { debounce } from 'lodash';
-import recordEvent from '../../../../platform/monitoring/record-event';
+import recordEvent from 'platform/monitoring/record-event';
 import Downshift from 'downshift';
 import classNames from 'classnames';
 import { WAIT_INTERVAL } from '../../constants';
@@ -20,7 +20,7 @@ export class KeywordSearch extends React.Component {
     const { onFilterChange, autocomplete } = this.props;
     if ((e.which || e.keyCode) === 13) {
       e.target.blur();
-      onFilterChange('name', autocomplete.searchTerm);
+      onFilterChange(autocomplete.searchTerm);
     }
   };
 
@@ -52,7 +52,7 @@ export class KeywordSearch extends React.Component {
       event: 'gibct-autosuggest',
       'gibct-autosuggest-value': searchQuery,
     });
-    this.props.onFilterChange('name', searchQuery);
+    this.props.onFilterChange(searchQuery);
   };
 
   render() {

--- a/src/applications/gi/components/search/KeywordSearch.jsx
+++ b/src/applications/gi/components/search/KeywordSearch.jsx
@@ -39,6 +39,7 @@ export class KeywordSearch extends React.Component {
       this.props.onUpdateAutocompleteSearchTerm(searchQuery);
       this.handleFetchSuggestion({ searchQuery });
     }
+    this.props.validateSearchQuery(searchQuery);
   };
 
   handleFetchSuggestion({ value }) {
@@ -58,19 +59,14 @@ export class KeywordSearch extends React.Component {
     const { suggestions, searchTerm } = this.props.autocomplete;
     let errorSpan = '';
     let errorSpanId = undefined;
-    const searchClassName = this.props.searchErrorMessage
-      ? ' usa-input-error'
-      : 'keyword-search';
-
-    const searchLabelClassName = this.props.searchErrorMessage
-      ? 'usa-input-error-label'
-      : 'institution-search-label';
-
-    if (this.props.searchErrorMessage && this.props.searchErrorMessage !== '') {
+    let searchClassName = 'keyword-search';
+    if (this.props.searchError) {
+      searchClassName = 'usa-input-error';
       errorSpanId = `${this.inputId}-error-message`;
       errorSpan = (
         <span className="usa-input-error-message" role="alert" id={errorSpanId}>
-          <span className="sr-only">Error</span> {this.props.searchErrorMessage}
+          <span className="sr-only">Error</span>
+          Please enter a city, school, or employer name.
         </span>
       );
     }
@@ -101,13 +97,13 @@ export class KeywordSearch extends React.Component {
             highlightedIndex,
             selectedItem,
           }) => (
-            <div className={searchLabelClassName}>
+            <div>
               <input
                 {...getInputProps({
                   type: 'text',
                   onChange: this.handleChange,
                   onKeyUp: this.handleKeyUp,
-                  'aria-labelledby': { searchLabelClassName },
+                  'aria-labelledby': 'institution-search-label',
                 })}
               />
               {isOpen && (
@@ -148,7 +144,8 @@ KeywordSearch.propTypes = {
   onFetchAutocompleteSuggestions: PropTypes.func,
   onFilterChange: PropTypes.func,
   onUpdateAutocompleteSearchTerm: PropTypes.func,
-  searchErrorMessage: PropTypes.string,
+  searchError: PropTypes.bool,
+  validateSearchQuery: PropTypes.func,
 };
 
 export default KeywordSearch;

--- a/src/applications/gi/components/search/KeywordSearch.jsx
+++ b/src/applications/gi/components/search/KeywordSearch.jsx
@@ -58,13 +58,15 @@ export class KeywordSearch extends React.Component {
   render() {
     const { suggestions, searchTerm } = this.props.autocomplete;
     let errorSpan = '';
-    let errorSpanId = undefined;
     let searchClassName = 'keyword-search';
     if (this.props.searchError) {
       searchClassName = 'usa-input-error';
-      errorSpanId = `${this.inputId}-error-message`;
       errorSpan = (
-        <span className="usa-input-error-message" role="alert" id={errorSpanId}>
+        <span
+          className="usa-input-error-message"
+          role="alert"
+          id="search-error-message"
+        >
           <span className="sr-only">Error</span>
           Please enter a city, school, or employer name.
         </span>

--- a/src/applications/gi/components/search/KeywordSearch.jsx
+++ b/src/applications/gi/components/search/KeywordSearch.jsx
@@ -138,6 +138,7 @@ export class KeywordSearch extends React.Component {
 KeywordSearch.defaultProps = {
   label: 'Enter a city, school or employer name',
   onFilterChange: () => {},
+  validateSearchQuery: () => {},
 };
 
 KeywordSearch.propTypes = {

--- a/src/applications/gi/components/search/KeywordSearch.jsx
+++ b/src/applications/gi/components/search/KeywordSearch.jsx
@@ -56,8 +56,26 @@ export class KeywordSearch extends React.Component {
 
   render() {
     const { suggestions, searchTerm } = this.props.autocomplete;
+    let errorSpan = '';
+    let errorSpanId = undefined;
+    const searchClassName = this.props.searchErrorMessage
+      ? ' usa-input-error'
+      : 'keyword-search';
+
+    const searchLabelClassName = this.props.searchErrorMessage
+      ? 'usa-input-error-label'
+      : 'institution-search-label';
+
+    if (this.props.searchErrorMessage && this.props.searchErrorMessage !== '') {
+      errorSpanId = `${this.inputId}-error-message`;
+      errorSpan = (
+        <span className="usa-input-error-message" role="alert" id={errorSpanId}>
+          <span className="sr-only">Error</span> {this.props.searchErrorMessage}
+        </span>
+      );
+    }
     return (
-      <div className="keyword-search">
+      <div className={searchClassName}>
         <label
           id="institution-search-label"
           className="institution-search-label"
@@ -65,6 +83,7 @@ export class KeywordSearch extends React.Component {
         >
           {this.props.label}
         </label>
+        {errorSpan}
         <Downshift
           inputValue={searchTerm}
           onSelect={item => this.handleSuggestionSelected(item)}
@@ -82,13 +101,13 @@ export class KeywordSearch extends React.Component {
             highlightedIndex,
             selectedItem,
           }) => (
-            <div>
+            <div className={searchLabelClassName}>
               <input
                 {...getInputProps({
                   type: 'text',
                   onChange: this.handleChange,
                   onKeyUp: this.handleKeyUp,
-                  'aria-labelledby': 'institution-search-label',
+                  'aria-labelledby': { searchLabelClassName },
                 })}
               />
               {isOpen && (
@@ -129,6 +148,7 @@ KeywordSearch.propTypes = {
   onFetchAutocompleteSuggestions: PropTypes.func,
   onFilterChange: PropTypes.func,
   onUpdateAutocompleteSearchTerm: PropTypes.func,
+  searchErrorMessage: PropTypes.string,
 };
 
 export default KeywordSearch;

--- a/src/applications/gi/containers/LandingPage.jsx
+++ b/src/applications/gi/containers/LandingPage.jsx
@@ -36,26 +36,17 @@ export class LandingPage extends React.Component {
 
   handleSubmit = event => {
     event.preventDefault();
-    this.handleFilterChange('name', this.props.autocomplete.searchTerm);
+    this.handleFilterChange(this.props.autocomplete.searchTerm);
   };
 
-  handleFilterChange = (field, value) => {
+  handleFilterChange = value => {
     // Only search upon blur, keyUp, suggestion selection
     // if the search term is not empty.
-    if (isVetTecSelected(this.props.filters)) {
-      this.setState({
-        searchError: false,
-      });
+    this.setState({
+      searchError: !(isVetTecSelected(this.props.filters) || value),
+    });
+    if (isVetTecSelected(this.props.filters) || value) {
       this.search(value);
-    } else if (value) {
-      this.setState({
-        searchError: false,
-      });
-      this.search(value);
-    } else {
-      this.setState({
-        searchError: true,
-      });
     }
   };
 
@@ -128,15 +119,9 @@ export class LandingPage extends React.Component {
   };
 
   validateSearchQuery = searchQuery => {
-    if (searchQuery === '') {
-      this.setState({
-        searchError: true,
-      });
-    } else {
-      this.setState({
-        searchError: false,
-      });
-    }
+    this.setState({
+      searchError: searchQuery === '',
+    });
   };
 
   render() {

--- a/src/applications/gi/containers/LandingPage.jsx
+++ b/src/applications/gi/containers/LandingPage.jsx
@@ -27,7 +27,7 @@ export class LandingPage extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      searchError: '',
+      searchError: false,
     };
   }
   componentDidMount() {
@@ -36,26 +36,26 @@ export class LandingPage extends React.Component {
 
   handleSubmit = event => {
     event.preventDefault();
-    if (
-      this.props.filters.category === 'vettec' ||
-      this.props.autocomplete.searchTerm
-    ) {
-      this.setState({ searchError: '' });
-      this.handleFilterChange('name', this.props.autocomplete.searchTerm);
-    } else {
-      this.setState({
-        searchError: 'Please enter a city, school, or employer name.',
-      });
-    }
+    this.handleFilterChange('name', this.props.autocomplete.searchTerm);
   };
 
   handleFilterChange = (field, value) => {
     // Only search upon blur, keyUp, suggestion selection
     // if the search term is not empty.
     if (isVetTecSelected(this.props.filters)) {
+      this.setState({
+        searchError: false,
+      });
       this.search(value);
     } else if (value) {
+      this.setState({
+        searchError: false,
+      });
       this.search(value);
+    } else {
+      this.setState({
+        searchError: true,
+      });
     }
   };
 
@@ -95,7 +95,6 @@ export class LandingPage extends React.Component {
 
       if (filters.vetTecProvider) {
         this.props.updateAutocompleteSearchTerm('');
-        this.setState({ searchError: '' });
       }
     }
     filters[field] = value;
@@ -128,9 +127,19 @@ export class LandingPage extends React.Component {
     this.props.eligibilityChange(e);
   };
 
-  render() {
-    const errorMessage = this.state.searchError;
+  validateSearchQuery = searchQuery => {
+    if (searchQuery === '') {
+      this.setState({
+        searchError: true,
+      });
+    } else {
+      this.setState({
+        searchError: false,
+      });
+    }
+  };
 
+  render() {
     return (
       <span className="landing-page">
         <div className="row">
@@ -172,7 +181,8 @@ export class LandingPage extends React.Component {
                   onUpdateAutocompleteSearchTerm={
                     this.props.updateAutocompleteSearchTerm
                   }
-                  searchErrorMessage={errorMessage}
+                  searchError={this.state.searchError}
+                  validateSearchQuery={this.validateSearchQuery}
                 />
               )}
               <button

--- a/src/applications/gi/containers/LandingPage.jsx
+++ b/src/applications/gi/containers/LandingPage.jsx
@@ -24,13 +24,29 @@ import { isVetTecSelected } from '../utils/helpers';
 import recordEvent from 'platform/monitoring/record-event';
 
 export class LandingPage extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      searchError: '',
+    };
+  }
   componentDidMount() {
     this.props.setPageTitle(`GI Bill® Comparison Tool: VA.gov`);
   }
 
   handleSubmit = event => {
     event.preventDefault();
-    this.handleFilterChange('name', this.props.autocomplete.searchTerm);
+    if (
+      this.props.filters.category === 'vettec' ||
+      this.props.autocomplete.searchTerm
+    ) {
+      this.setState({ searchError: '' });
+      this.handleFilterChange('name', this.props.autocomplete.searchTerm);
+    } else {
+      this.setState({
+        searchError: 'Please enter a city, school, or employer name.',
+      });
+    }
   };
 
   handleFilterChange = (field, value) => {
@@ -79,6 +95,7 @@ export class LandingPage extends React.Component {
 
       if (filters.vetTecProvider) {
         this.props.updateAutocompleteSearchTerm('');
+        this.setState({ searchError: '' });
       }
     }
     filters[field] = value;
@@ -112,6 +129,8 @@ export class LandingPage extends React.Component {
   };
 
   render() {
+    const errorMessage = this.state.searchError;
+
     return (
       <span className="landing-page">
         <div className="row">
@@ -153,6 +172,7 @@ export class LandingPage extends React.Component {
                   onUpdateAutocompleteSearchTerm={
                     this.props.updateAutocompleteSearchTerm
                   }
+                  searchErrorMessage={errorMessage}
                 />
               )}
               <button

--- a/src/applications/gi/tests/components/KeywordSearch.unit.spec.jsx
+++ b/src/applications/gi/tests/components/KeywordSearch.unit.spec.jsx
@@ -29,6 +29,7 @@ describe('<KeywordSearch>', () => {
 
   it('should open suggestion list when input is filled with text', () => {
     const onChange = sinon.spy();
+    const validateSearchQuery = sinon.spy();
     const tree = mount(
       <KeywordSearch
         label="test"
@@ -42,6 +43,7 @@ describe('<KeywordSearch>', () => {
         onFetchAutocompleteSuggestions={() => {}}
         onFilterChange={() => {}}
         onUpdateAutocompleteSearchTerm={() => {}}
+        validateSearchQuery={validateSearchQuery}
       />,
     );
 
@@ -58,6 +60,7 @@ describe('<KeywordSearch>', () => {
   it('should call on select when an suggestion is selected', () => {
     const onChange = sinon.spy();
     const onFilterChange = sinon.spy();
+    const validateSearchQuery = sinon.spy();
     const tree = mount(
       <KeywordSearch
         label="test"
@@ -71,6 +74,7 @@ describe('<KeywordSearch>', () => {
         onFetchAutocompleteSuggestions={() => {}}
         onFilterChange={onFilterChange}
         onUpdateAutocompleteSearchTerm={() => {}}
+        validateSearchQuery={validateSearchQuery}
       />,
     );
 

--- a/src/applications/gi/tests/components/KeywordSearch.unit.spec.jsx
+++ b/src/applications/gi/tests/components/KeywordSearch.unit.spec.jsx
@@ -85,7 +85,7 @@ describe('<KeywordSearch>', () => {
     const suggestions = tree.find('.suggestion');
     suggestions.at(1).simulate('click');
     expect(onFilterChange.called).to.be.true;
-    expect(onFilterChange.args[0]).to.deep.equal(['name', 'item2']);
+    expect(onFilterChange.args[0]).to.deep.equal(['item2']);
     tree.unmount();
   });
 });


### PR DESCRIPTION
## Description
https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/2381

## Testing done
Developer locally tested.

## Screenshots
<img width="836" alt="Screen Shot 2019-10-15 at 10 38 19 AM" src="https://user-images.githubusercontent.com/48804654/66842463-4e755f00-ef39-11e9-8fe1-0dab9126c8be.png">

## Acceptance criteria
- [ ] As a screen reader user, I want to hear an error message read out when I press `Search Schools` without entering a term like "University of Mississippi" in the search field.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
