### PR TITLE
Add error bad contact info error messages

### DIFF
--- a/src/applications/personalization/profile360/actions/paymentInformation.js
+++ b/src/applications/personalization/profile360/actions/paymentInformation.js
@@ -84,7 +84,7 @@ export function savePaymentInformation(fields) {
     //               key: 'cnp.payment.generic.error.message',
     //               severity: 'ERROR',
     //               text:
-    //                 'Generic CnP payment update error. Update response: Update Failed: Required field not entered for phone number update',
+    //                 'Generic CnP payment update error. Update response: Update Failed: Night area number is invalid, must be 3 digits',
     //             },
     //           ],
     //         },

--- a/src/applications/personalization/profile360/actions/paymentInformation.js
+++ b/src/applications/personalization/profile360/actions/paymentInformation.js
@@ -68,6 +68,31 @@ export function savePaymentInformation(fields) {
       apiRequestOptions,
     );
 
+    // Leaving this here for the time being while we wrap up the error handling
+    // const response = {
+    //   error: {
+    //     errors: [
+    //       {
+    //         title: 'Unprocessable Entity',
+    //         detail: 'One or more unprocessable user payment properties',
+    //         code: '126',
+    //         source: 'EVSS::PPIU::Service',
+    //         status: '422',
+    //         meta: {
+    //           messages: [
+    //             {
+    //               key: 'cnp.payment.generic.error.message',
+    //               severity: 'ERROR',
+    //               text:
+    //                 'Generic CnP payment update error. Update response: Update Failed: Required field not entered for phone number update',
+    //             },
+    //           ],
+    //         },
+    //       },
+    //     ],
+    //   },
+    // };
+
     if (response.error || response.errors) {
       recordEvent({
         event: 'profile-edit-failure',

--- a/src/applications/personalization/profile360/components/PaymentInformationEditModal.jsx
+++ b/src/applications/personalization/profile360/components/PaymentInformationEditModal.jsx
@@ -121,6 +121,7 @@ class PaymentInformationEditModal extends React.Component {
           {!!this.props.responseError && (
             <PaymentInformationEditModalError
               responseError={this.props.responseError}
+              closeModal={this.props.onClose}
             />
           )}
         </div>

--- a/src/applications/personalization/profile360/components/PaymentInformationEditModalError.jsx
+++ b/src/applications/personalization/profile360/components/PaymentInformationEditModalError.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 
+// possible values for the `key` property on error messages we get from the server
 const ACCOUNT_FLAGGED_FOR_FRAUD_KEY = 'cnp.payment.flashes.on.record.message';
 const INVALID_ROUTING_NUMBER_KEY =
   'payment.accountRoutingNumber.invalidCheckSum';
@@ -89,7 +90,7 @@ function hasErrorMessageKey(errors, errorKey) {
 function hasErrorMessageText(errors, errorText) {
   return errors.some(err =>
     err.meta.messages.some(message =>
-      message.text.toLowerCase().includes(errorText),
+      message.text.toLowerCase().includes(errorText.toLowerCase()),
     ),
   );
 }
@@ -99,7 +100,17 @@ function hasFlaggedForFraudError(errors) {
 }
 
 function hasInvalidRoutingNumberError(errors) {
-  return hasErrorMessageKey(errors, INVALID_ROUTING_NUMBER_KEY);
+  let result = false;
+  if (hasErrorMessageKey(errors, INVALID_ROUTING_NUMBER_KEY)) {
+    result = true;
+  }
+  if (
+    hasErrorMessageKey(errors, GENERIC_ERROR_KEY) &&
+    hasErrorMessageText(errors, 'Invalid Routing Number')
+  ) {
+    result = true;
+  }
+  return result;
 }
 
 function hasInvalidAddressError(errors) {

--- a/src/applications/personalization/profile360/components/PaymentInformationEditModalError.jsx
+++ b/src/applications/personalization/profile360/components/PaymentInformationEditModalError.jsx
@@ -50,16 +50,17 @@ function GenericError() {
 function UpdateAddressError({ closeModal }) {
   return (
     <p>
-      Update your home and mailing addresses in your{' '}
+      We’re sorry. We couldn’t update your direct deposit bank information
+      because your address is missing or invalid. Please go back to{' '}
       <a
         href="/profile/#contact-information"
         onClick={() => {
           closeModal();
         }}
       >
-        profile
+        your profile
       </a>{' '}
-      and try again.
+      and fill in this required information.
     </p>
   );
 }
@@ -67,16 +68,18 @@ function UpdateAddressError({ closeModal }) {
 function UpdatePhoneNumberError({ closeModal, phoneNumberType = 'home' }) {
   return (
     <p>
-      Update your {phoneNumberType} phone number in your{' '}
+      We’re sorry. We couldn’t update your direct deposit bank information
+      because your {phoneNumberType} phone number is missing or invalid. Please
+      go back to{' '}
       <a
         href="/profile/#contact-information"
         onClick={() => {
           closeModal();
         }}
       >
-        profile
+        your profile
       </a>{' '}
-      and try again.
+      and fill in this required information.
     </p>
   );
 }
@@ -181,7 +184,11 @@ export default function PaymentInformationEditModalError({
   }
 
   return (
-    <AlertBox status="error" isVisible>
+    <AlertBox
+      status="error"
+      headline="We couldn’t update your bank information"
+      isVisible
+    >
       {content}
     </AlertBox>
   );

--- a/src/applications/personalization/profile360/tests/components/PaymentInformationEditModalError.unit.spec.jsx
+++ b/src/applications/personalization/profile360/tests/components/PaymentInformationEditModalError.unit.spec.jsx
@@ -227,19 +227,19 @@ describe('<PaymentInformationEditModalError />', () => {
       />,
     );
     expect(wrapper.html()).to.contain(
-      'Update your home and mailing addresses in your <a href="/profile/#contact-information">profile</a> and try again.',
+      'We’re sorry. We couldn’t update your direct deposit bank information because your address is missing or invalid. Please go back to <a href="/profile/#contact-information">your profile</a> and fill in this required information.',
     );
     wrapper.unmount();
   });
 
-  it('renders the bad home phone number error messages', () => {
+  it('renders the bad phone number error messages', () => {
     let wrapper = shallow(
       <PaymentInformationEditModalError
         responseError={{ error: badWorkPhoneNumberError }}
       />,
     );
     expect(wrapper.html()).to.contain(
-      'Update your work phone number in your <a href="/profile/#contact-information">profile</a> and try again.',
+      'We’re sorry. We couldn’t update your direct deposit bank information because your work phone number is missing or invalid. Please go back to <a href="/profile/#contact-information">your profile</a> and fill in this required information.',
     );
     wrapper.unmount();
 
@@ -249,7 +249,7 @@ describe('<PaymentInformationEditModalError />', () => {
       />,
     );
     expect(wrapper.html()).to.contain(
-      'Update your home phone number in your <a href="/profile/#contact-information">profile</a> and try again.',
+      'We’re sorry. We couldn’t update your direct deposit bank information because your home phone number is missing or invalid. Please go back to <a href="/profile/#contact-information">your profile</a> and fill in this required information.',
     );
     wrapper.unmount();
   });

--- a/src/applications/personalization/profile360/tests/components/PaymentInformationEditModalError.unit.spec.jsx
+++ b/src/applications/personalization/profile360/tests/components/PaymentInformationEditModalError.unit.spec.jsx
@@ -45,7 +45,7 @@ describe('<PaymentInformationEditModalError />', () => {
       },
     ],
   };
-  const genericError = {
+  const badWorkPhoneNumberError = {
     errors: [
       {
         title: 'Unprocessable Entity',
@@ -60,6 +60,68 @@ describe('<PaymentInformationEditModalError />', () => {
               severity: 'ERROR',
               text:
                 'Generic CnP payment update error. Update response: Update Failed: Day phone number is invalid, must be 7 digits',
+            },
+          ],
+        },
+      },
+    ],
+  };
+  const badHomeAreaCodeError = {
+    errors: [
+      {
+        title: 'Unprocessable Entity',
+        detail: 'One or more unprocessable user payment properties',
+        code: '126',
+        source: 'EVSS::PPIU::Service',
+        status: '422',
+        meta: {
+          messages: [
+            {
+              key: 'cnp.payment.generic.error.message',
+              severity: 'ERROR',
+              text:
+                'Generic CnP payment update error. Update response: Update Failed: Night area number is invalid, must be 3 digits',
+            },
+          ],
+        },
+      },
+    ],
+  };
+  const badAddressError = {
+    errors: [
+      {
+        title: 'Unprocessable Entity',
+        detail: 'One or more unprocessable user payment properties',
+        code: '126',
+        source: 'EVSS::PPIU::Service',
+        status: '422',
+        meta: {
+          messages: [
+            {
+              key: 'cnp.payment.generic.error.message',
+              severity: 'ERROR',
+              text:
+                'Generic CnP payment update error. Update response: Update Failed: Required field not entered for mailing address update',
+            },
+          ],
+        },
+      },
+    ],
+  };
+  const genericError = {
+    errors: [
+      {
+        title: 'Unprocessable Entity',
+        detail: 'One or more unprocessable user payment properties',
+        code: '126',
+        source: 'EVSS::PPIU::Service',
+        status: '422',
+        meta: {
+          messages: [
+            {
+              key: 'cnp.payment.generic.error.message',
+              severity: 'ERROR',
+              text: 'This is a generic error that we do not recognize.',
             },
           ],
         },
@@ -91,7 +153,7 @@ describe('<PaymentInformationEditModalError />', () => {
     wrapper.unmount();
   });
 
-  it('renders the default error', () => {
+  it('renders the default error when it gets an unrecognized error message', () => {
     const wrapper = shallow(
       <PaymentInformationEditModalError
         responseError={{ error: genericError }}
@@ -103,7 +165,7 @@ describe('<PaymentInformationEditModalError />', () => {
     wrapper.unmount();
   });
 
-  it('renders the invalid routing numaber error', () => {
+  it('renders the invalid routing number error', () => {
     const wrapper = shallow(
       <PaymentInformationEditModalError
         responseError={{ error: checksumError }}
@@ -123,6 +185,40 @@ describe('<PaymentInformationEditModalError />', () => {
     );
     expect(wrapper.html()).to.contain(
       'We’re sorry. You can’t change your direct deposit information right now because we’ve locked your account. We do this to protect your bank account information and prevent fraud when we think there may be a security issue.',
+    );
+    wrapper.unmount();
+  });
+
+  it('renders an error message prompting the user to update their address', () => {
+    const wrapper = shallow(
+      <PaymentInformationEditModalError
+        responseError={{ error: badAddressError }}
+      />,
+    );
+    expect(wrapper.html()).to.contain(
+      'Update your home and mailing addresses in your <a href="/profile/#contact-information">profile</a> and try again.',
+    );
+    wrapper.unmount();
+  });
+
+  it('renders the bad home phone number error messages', () => {
+    let wrapper = shallow(
+      <PaymentInformationEditModalError
+        responseError={{ error: badWorkPhoneNumberError }}
+      />,
+    );
+    expect(wrapper.html()).to.contain(
+      'Update your work phone number in your <a href="/profile/#contact-information">profile</a> and try again.',
+    );
+    wrapper.unmount();
+
+    wrapper = shallow(
+      <PaymentInformationEditModalError
+        responseError={{ error: badHomeAreaCodeError }}
+      />,
+    );
+    expect(wrapper.html()).to.contain(
+      'Update your home phone number in your <a href="/profile/#contact-information">profile</a> and try again.',
     );
     wrapper.unmount();
   });

--- a/src/applications/personalization/profile360/tests/components/PaymentInformationEditModalError.unit.spec.jsx
+++ b/src/applications/personalization/profile360/tests/components/PaymentInformationEditModalError.unit.spec.jsx
@@ -25,6 +25,27 @@ describe('<PaymentInformationEditModalError />', () => {
       },
     ],
   };
+  const invalidRoutingNumberError = {
+    errors: [
+      {
+        code: '126',
+        detail: 'One or more unprocessable user payment properties',
+        meta: {
+          messages: [
+            {
+              key: 'cnp.payment.generic.error.message',
+              severity: 'ERROR',
+              text:
+                'Generic CnP payment update error. Update response: Update Failed: Invalid Routing Number',
+            },
+          ],
+        },
+        source: 'EVSS::PPIU::Service',
+        status: '422',
+        title: 'Unprocessable Entity',
+      },
+    ],
+  };
   const accountFlaggedError = {
     errors: [
       {
@@ -166,9 +187,19 @@ describe('<PaymentInformationEditModalError />', () => {
   });
 
   it('renders the invalid routing number error', () => {
-    const wrapper = shallow(
+    let wrapper = shallow(
       <PaymentInformationEditModalError
         responseError={{ error: checksumError }}
+      />,
+    );
+    expect(wrapper.html()).to.contain(
+      'We couldn’t find a bank linked to this routing number. Please check your bank’s 9-digit routing number and enter it again.',
+    );
+    wrapper.unmount();
+
+    wrapper = shallow(
+      <PaymentInformationEditModalError
+        responseError={{ error: invalidRoutingNumberError }}
       />,
     );
     expect(wrapper.html()).to.contain(


### PR DESCRIPTION
**ON HOLD:** The actual content/copy of the error messages will be updated when content has had a chance to craft better messages

## Description
Adds error messages for bad contact info. And provide a link from the error message to the profile so the user can quickly update the bad data in their profile.

## Testing done
Local

## Screenshots
Example error message in place:
![image](https://user-images.githubusercontent.com/20728956/66944071-4f71c380-f001-11e9-95b9-0b8390da6731.png)


## Acceptance criteria
- [x] Handles errors related to bad phone numbers or addresses

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
