### PR TITLE
2387: Colmery 107 - Heading H2s should wrap expand/collapse buttons

### DIFF
--- a/src/applications/gi/components/AccordionItem.jsx
+++ b/src/applications/gi/components/AccordionItem.jsx
@@ -20,14 +20,16 @@ class AccordionItem extends React.Component {
     const expanded = this.state.expanded;
     return (
       <li>
-        <button
-          onClick={this.toggle}
-          className="usa-accordion-button"
-          aria-expanded={expanded}
-          aria-controls={this.id}
-        >
-          <h2>{this.props.button}</h2>
-        </button>
+        <h2 className="accordion-button-wrapper">
+          <button
+            onClick={this.toggle}
+            className="usa-accordion-button"
+            aria-expanded={expanded}
+            aria-controls={this.id}
+          >
+            <span className="accordion-button-text">{this.props.button}</span>
+          </button>
+        </h2>
         <div
           id={this.id}
           className="usa-accordion-content"

--- a/src/applications/gi/sass/partials/_gi-profile-page.scss
+++ b/src/applications/gi/sass/partials/_gi-profile-page.scss
@@ -8,6 +8,14 @@
     margin-top: 1em;
   }
 
+  .accordion-button-text {
+    font-size: 1.35em;
+  }
+
+  h2.accordion-button-wrapper {
+    margin: 0;
+  }
+
   .link-header {
     h3,
     h4,
@@ -33,13 +41,8 @@
     margin-top: 0;
   }
 
-  li button.usa-accordion-button {
+  button.usa-accordion-button {
     text-align: left;
-
-    h2 {
-      font-size: 1.35em;
-      padding: 0;
-    }
   }
 
   .calculate-your-benefits {
@@ -48,7 +51,6 @@
     }
 
     button {
-      color: $color-primary;
       margin: 0.5em 0;
       padding: 1rem 2rem;
     }


### PR DESCRIPTION
## Description
The VA 508 office noted this as an improvement item. The large gray expand/collapse sections do not identify as headings level two in JAWS. A quick investigation showed the `<button>` elements wrapping the `<h2>` and is the likely cause of these headings being ignored. Screenshot attached.

https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/2387

## Testing done
Manual, Unit, and E2E tests pass locally

## Screenshots
N/A

## Acceptance criteria
- [x] As a screenreader user, I want the H2 headings to appear in the Headings menu and be available as virtual cursor stops when I'm navigating by heading
- [x] As a visual user, I do not want to see any style or functionality changes in the expand/collapse sections

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
