### PR TITLE
Prevent undefined JS error in Review accordion

### DIFF
--- a/src/platform/forms-system/src/js/review/ReviewCollapsibleChapter.jsx
+++ b/src/platform/forms-system/src/js/review/ReviewCollapsibleChapter.jsx
@@ -69,7 +69,7 @@ export default class ReviewCollapsibleChapter extends React.Component {
 
   shouldHideExpandedPageTitle = (expandedPages, chapterTitle, pageTitle) =>
     expandedPages.length === 1 &&
-    chapterTitle.toLowerCase() === pageTitle.toLowerCase();
+    (chapterTitle || '').toLowerCase() === pageTitle.toLowerCase();
 
   render() {
     let pageContent = null;
@@ -146,7 +146,7 @@ export default class ReviewCollapsibleChapter extends React.Component {
             const classes = classNames('form-review-panel-page', {
               'schemaform-review-page-warning': !viewedPages.has(fullPageKey),
             });
-            const title = page.reviewTitle || page.title;
+            const title = page.reviewTitle || page.title || '';
 
             return (
               <div key={`${fullPageKey}`} className={classes}>
@@ -252,7 +252,7 @@ export default class ReviewCollapsibleChapter extends React.Component {
                 aria-controls={`collapsible-${this.id}`}
                 onClick={this.props.toggleButtonClicked}
               >
-                {chapterTitle}
+                {chapterTitle || ''}
               </button>
               {showUnviewedPageWarning && (
                 <span className="schemaform-review-chapter-warning-icon" />


### PR DESCRIPTION
## Description

On various forms, expanding the review accordion will cause a JS error: `Uncaught TypeError: Cannot read property 'toLowerCase' of undefined`

See https://github.com/department-of-veterans-affairs/va.gov-team/issues/2523 for details.

## Testing done

Local unit tests

## Screenshots

![](https://user-images.githubusercontent.com/136959/66953628-84434200-f024-11e9-9b39-88fba7acabf5.gif)

## Acceptance criteria
- [ ] Accordions open & content is visible.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
