### PR TITLE
Update HLR intro page to match design

### DIFF
--- a/src/applications/disability-benefits/996/components/IntroductionPage.jsx
+++ b/src/applications/disability-benefits/996/components/IntroductionPage.jsx
@@ -62,7 +62,7 @@ class IntroductionPage extends React.Component {
     const isLoggedIn = user.login?.currentlyLoggedIn;
 
     return (
-      <div id="form0996" className="schemaform-intro" role="presentation">
+      <article id="form0996" className="schemaform-intro">
         <FormTitle title="Request a Higher-Level Review" />
         <p>Equal to VA Form 20-0996 (Higher-Level Review).</p>
         {isLoggedIn && this.state.isInLegacySystem ? (
@@ -83,23 +83,104 @@ class IntroductionPage extends React.Component {
                 Please complete the 20-0996 form to apply for Higher-Level
                 Review.
               </SaveInProgressIntro>
-              <br />
-              {/* TODO: Remove inline style after I figure out why
-                .omb-info--container has a left padding */}
-              <div
-                className="omb-info--container"
-                style={{ paddingLeft: '0px' }}
-              >
-                <OMBInfo
-                  resBurden={15}
-                  ombNumber="2900-0862"
-                  expDate="02/28/2022"
-                />
-              </div>
             </CallToActionWidget>
+            <p>
+              After you click the button to start the Higher-Level Review
+              application, you'll need to opt out (withdraw) from the old
+              appeals process. This switch triggers us to formally withdraw your
+              claim or appeal from the old appeal system and process it under
+              the new system. Once you opt in to the new appeals process, the
+              decision is permanent and you can't return to the old appeals
+              process.
+            </p>
+            <aside className="process schemaform-process">
+              <h4>
+                Follow the steps below to apply for Request a Higher-Level
+                Review.
+              </h4>
+              <br />
+              <ol>
+                <li className="process-step list-one">
+                  <h5>Prepare</h5>
+                  <h6>To fill out this application, you’ll need your:</h6>
+                  <ul>
+                    <li>Primary address</li>
+                    <li>Decisions that you want to be reviewed</li>
+                    <li>Representative's contact information (optional)</li>
+                  </ul>
+                  <p>
+                    <strong>
+                      What if I need help filling out my application?
+                    </strong>
+                  </p>
+                  <p>
+                    If you need help requesting a Higher-Level Review, you can
+                    contact a VA regional office and ask to speak to a
+                    counselor. To find the nearest regional office, please call{' '}
+                    <a href="tel:1-800-827-1000">800-827-1000</a>.
+                  </p>
+                  <p>
+                    An accredited representative, like a Veterans Service
+                    Officer (VSO), can help you fill out your claim.
+                  </p>
+                  <a href="/decision-reviews/get-help-with-review-request">
+                    Get help requesting a Higher-Level Review
+                  </a>
+                  .
+                </li>
+                <li className="process-step list-two">
+                  <h5>Apply</h5>
+                  <p>
+                    Complete this Request for Higher-Level Review form. After
+                    submitting the form, you’ll get a confirmation message. You
+                    can print this form for your records.
+                  </p>
+                </li>
+                <li className="process-step list-three">
+                  <h5>VA Review</h5>
+                  <p>
+                    Our goal for completing a Higher-Level Review is 125 days. A
+                    review might take longer if we need to get records or
+                    schedule a new exam to correct the error.
+                  </p>
+                </li>
+                <li className="process-step list-four">
+                  <h5>Decision</h5>
+                  <p>
+                    Once we’ve processed your claim, you’ll get a notice in the
+                    mail with our decision.
+                  </p>
+                </li>
+              </ol>
+            </aside>
+            <CallToActionWidget appId="higher-level-review">
+              <SaveInProgressIntro
+                formId={this.props.route.formConfig.formId}
+                prefillEnabled={this.props.route.formConfig.prefillEnabled}
+                messages={this.props.route.formConfig.savedFormMessages}
+                pageList={this.props.route.pageList}
+                startText="Start the Request for a Higher-Level Review"
+              >
+                Please complete the 20-0996 form to apply for Higher-Level
+                Review.
+              </SaveInProgressIntro>
+            </CallToActionWidget>
+            {/* TODO: Remove inline style after I figure out why
+              .omb-info--container has a left padding */}
+            <div
+              className="omb-info--container"
+              style={{ paddingLeft: '0px' }}
+              role="presentation"
+            >
+              <OMBInfo
+                resBurden={15}
+                ombNumber="2900-0862"
+                expDate="02/28/2022"
+              />
+            </div>
           </>
         )}
-      </div>
+      </article>
     );
   }
 }

--- a/src/applications/disability-benefits/996/sass/0996-higher-level-review.scss
+++ b/src/applications/disability-benefits/996/sass/0996-higher-level-review.scss
@@ -12,6 +12,10 @@
   white-space: nowrap;
 }
 
+#form0996 {
+  padding: 0 0 2rem 0;
+}
+
 /* Fix margins around the form back & continue buttons */
 .input-section,
 .row.form-progress-buttons {

--- a/src/applications/disability-benefits/996/tests/components/IntroductionPage.unit.spec.jsx
+++ b/src/applications/disability-benefits/996/tests/components/IntroductionPage.unit.spec.jsx
@@ -71,7 +71,7 @@ describe('IntroductionPage', () => {
     const tree = shallow(<IntroductionPage {...defaultProps} />);
 
     const callToActionWidget = tree.find('Connect(CallToActionWidget)');
-    expect(callToActionWidget.length).to.equal(1);
+    expect(callToActionWidget.length).to.equal(2);
     expect(callToActionWidget.first().props().appId).to.equal(
       'higher-level-review',
     );


### PR DESCRIPTION
## Description

In the previous iteration of the Higher-Level Review form, the subway map was added to the design. This PR adds this to the introduction page.

## Testing done

Local unit tests

## Screenshots

<details>
<summary>Before</summary>

<!-- leave a blank line above -->
![](https://user-images.githubusercontent.com/136959/67050711-cfca1e80-f0fe-11e9-98bd-9613478b2f3a.png)
</details>

<details>
<summary>After</summary>

<!-- leave a blank line above -->
![](https://user-images.githubusercontent.com/136959/67050768-f8eaaf00-f0fe-11e9-912e-4c95d73c2b8a.png)
</details>

## Acceptance criteria
- [ ] Content matches design
- [ ] Passing unit tests

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
