### PR TITLE
Make TTY a tel link in PTSD help pages

### DIFF
--- a/src/applications/disability-benefits/all-claims/content/incidentSupport.jsx
+++ b/src/applications/disability-benefits/all-claims/content/incidentSupport.jsx
@@ -30,6 +30,9 @@ export const incidentSupportText = (
         Send a text message to <a href="sms:838255">838255</a>.
       </li>
     </ul>
-    <p>If you have hearing loss, please call TTY at 800-799-4889.</p>
+    <p>
+      If you have hearing loss, please call TTY at{' '}
+      <a href="tel:1-800-799-4889">800-799-4889.</a>
+    </p>
   </div>
 );

--- a/src/applications/disability-benefits/all-claims/content/incidentSupport.jsx
+++ b/src/applications/disability-benefits/all-claims/content/incidentSupport.jsx
@@ -32,7 +32,7 @@ export const incidentSupportText = (
     </ul>
     <p>
       If you have hearing loss, please call TTY at{' '}
-      <a href="tel:1-800-799-4889">800-799-4889.</a>
+      <a href="tel:1-800-799-4889">800-799-4889</a>.
     </p>
   </div>
 );

--- a/src/applications/disability-benefits/all-claims/content/newPTSDFollowUp.jsx
+++ b/src/applications/disability-benefits/all-claims/content/newPTSDFollowUp.jsx
@@ -37,7 +37,10 @@ export const introExplanationText = (
         Send a text message to <a href="sms:838255">838255</a>.
       </li>
     </ul>
-    <p>If you have hearing loss, please call TTY at 800-799-4889.</p>
+    <p>
+      If you have hearing loss, please call TTY at{' '}
+      <a href="tel:1-800-799-4889">800-799-4889.</a>
+    </p>
   </div>
 );
 

--- a/src/applications/disability-benefits/all-claims/content/newPTSDFollowUp.jsx
+++ b/src/applications/disability-benefits/all-claims/content/newPTSDFollowUp.jsx
@@ -39,7 +39,7 @@ export const introExplanationText = (
     </ul>
     <p>
       If you have hearing loss, please call TTY at{' '}
-      <a href="tel:1-800-799-4889">800-799-4889.</a>
+      <a href="tel:1-800-799-4889">800-799-4889</a>.
     </p>
   </div>
 );


### PR DESCRIPTION
## Description
On the PTSD help pages within the 526 form, the TTY phone number for hearing loss was simply text on the page. This has been updated to be a tel link.

## Screenshots
![PTSD_526](https://user-images.githubusercontent.com/53942725/67099793-8f18e680-f18c-11e9-85c4-10bb96da813a.PNG)
***Period is now located outside of the tel link

## Acceptance criteria
- [ ] Hearing loss phone number is now a tel link in the 526 form