### PR TITLE
My VA Benefits screen is reading a lot of data to some assistive devices on content load

### DIFF
--- a/src/applications/personalization/preferences/containers/PreferencesWidget.jsx
+++ b/src/applications/personalization/preferences/containers/PreferencesWidget.jsx
@@ -250,7 +250,7 @@ class PreferencesWidget extends React.Component {
             />
           )}
         </ReactCSSTransitionGroup>
-        <div aria-live="polite">{this.renderContent()}</div>
+        <div>{this.renderContent()}</div>
       </div>
     );
   }

--- a/src/applications/personalization/preferences/containers/PreferencesWidget.jsx
+++ b/src/applications/personalization/preferences/containers/PreferencesWidget.jsx
@@ -250,7 +250,7 @@ class PreferencesWidget extends React.Component {
             />
           )}
         </ReactCSSTransitionGroup>
-        <div>{this.renderContent()}</div>
+        {this.renderContent()}
       </div>
     );
   }


### PR DESCRIPTION
## Description
The My VA benefits are wrapped in a div with an `aria-live="polite"` attribute. Some screen readers are reading the alert message and all of the benefits a veteran is signed up for on first load. This is a lot of information to parse, and should be dialed back to just read the important alert messages on load. Screenshot attached below.

## Testing done
Used voice over on Mac to verify this fix is implemented. 

## Screenshots


## Acceptance criteria
- [ ] As a screen reader user, I want to hear relevant alerts read out (such as homelessness, or if my healthcare application was rejected) when my benefits load.
- [ ] I do not want to hear all of the benefits I've signed up for read when the benefits load.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
