### PR TITLE
2442 Added text alert preference to transaction pending message

### DIFF
--- a/src/platform/user/profile/vet360/components/base/TransactionPending.jsx
+++ b/src/platform/user/profile/vet360/components/base/TransactionPending.jsx
@@ -27,6 +27,16 @@ export default class Vet360TransactionPending extends React.Component {
       </span>
     );
 
+    if (this.props.title.toLowerCase() === 'mobile phone number') {
+      content = (
+        <span>
+          We’re working on saving your new {this.props.title.toLowerCase()} and
+          text alert preference. They will show on your profile once they've
+          been updated.
+        </span>
+      );
+    }
+
     if (this.props.method === 'DELETE') {
       content = (
         <span>

--- a/src/platform/user/profile/vet360/components/base/TransactionPending.jsx
+++ b/src/platform/user/profile/vet360/components/base/TransactionPending.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import environment from 'platform/utilities/environment';
+
 export default class Vet360TransactionPending extends React.Component {
   static propTypes = {
     title: PropTypes.string,
@@ -27,7 +29,10 @@ export default class Vet360TransactionPending extends React.Component {
       </span>
     );
 
-    if (this.props.title.toLowerCase() === 'mobile phone number') {
+    if (
+      !environment.isProduction() &&
+      this.props.title.toLowerCase() === 'mobile phone number'
+    ) {
       content = (
         <span>
           We’re working on saving your new {this.props.title.toLowerCase()} and


### PR DESCRIPTION
# Description

After a 508 review was conducted it was determined that the Transaction Pending message for the Mobile Phone number should be changed to include text about the alert changing as well.

## Testing done

Local testing performed.

## Screenshots

![Screenshot 2019-10-21 at 11 01 27 AM](https://user-images.githubusercontent.com/46933023/67219548-44020c00-f3f6-11e9-839a-d935d3e0a2ff.png)

