### PR TITLE
Slow down polling of claims

### DIFF
--- a/src/applications/claims-status/actions/index.jsx
+++ b/src/applications/claims-status/actions/index.jsx
@@ -196,7 +196,7 @@ export function getClaimsV2(poll = pollRequest) {
         dispatch({ type: FETCH_CLAIMS_ERROR });
       },
       onSuccess: response => dispatch(fetchClaimsSuccess(response)),
-      pollingInterval: window.VetsGov.pollTimeout || 1000,
+      pollingInterval: window.VetsGov.pollTimeout || 5000,
       shouldFail: response => getSyncStatus(response) === 'FAILED',
       shouldSucceed: response => getSyncStatus(response) === 'SUCCESS',
       target: '/evss_claims_async',
@@ -255,7 +255,7 @@ export function getClaimDetail(id, router, poll = pollRequest) {
           claim: response.data,
           meta: response.meta,
         }),
-      pollingInterval: window.VetsGov.pollTimeout || 1000,
+      pollingInterval: window.VetsGov.pollTimeout || 5000,
       shouldFail: response => getSyncStatus(response) === 'FAILED',
       shouldSucceed: response => getSyncStatus(response) === 'SUCCESS',
       target: `/evss_claims_async/${id}`,


### PR DESCRIPTION
Rapid polling of the claims status endpoint is causing multiple issues. This PR hopes to slow down the polling.

https://dsva.slack.com/archives/C30LCU8S3/p1571673172048900