### PR TITLE
Fix missing Cumulative Post-9/11 active duty service Dropdown on Landing Page

### DIFF
--- a/src/applications/gi/components/search/EligibilityForm.jsx
+++ b/src/applications/gi/components/search/EligibilityForm.jsx
@@ -212,6 +212,7 @@ export class EligibilityForm extends React.Component {
 }
 
 const mapStateToProps = state => ({
+  ...state.eligibility,
   isLoggedIn: isLoggedIn(state),
 });
 


### PR DESCRIPTION
## Description
https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/vets.gov-team/19819

## Testing done
Dev tested

## Screenshots
![image](https://user-images.githubusercontent.com/48804654/67228925-42d9da80-f408-11e9-954a-0d1ef6d27293.png)


## Acceptance criteria
- [ ] Cumulative Post/9-11 question is returned to Landing Page. 

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
