### PR TITLE
Update copy on CreateWizard widget

### DIFF
--- a/src/applications/disability-benefits/wizard/createWizard.jsx
+++ b/src/applications/disability-benefits/wizard/createWizard.jsx
@@ -25,7 +25,7 @@ export default function createDisabilityIncreaseApplicationStatus(
             stayAfterDelete
             applyRender={() => (
               <div itemScope itemType="http://schema.org/Question">
-                <h2 itemProp="name">How do I file my claim online?</h2>
+                <h2 itemProp="name">Can I file my claim online?</h2>
                 <div
                   itemProp="acceptedAnswer"
                   itemScope

--- a/src/applications/disability-benefits/wizard/createWizard.jsx
+++ b/src/applications/disability-benefits/wizard/createWizard.jsx
@@ -4,17 +4,14 @@ import { Provider } from 'react-redux';
 import { VA_FORM_IDS } from 'platform/forms/constants';
 
 const disabilityForms = new Set([VA_FORM_IDS.FORM_21_526EZ]);
-
 export default function createDisabilityIncreaseApplicationStatus(
   store,
   widgetType,
 ) {
   const root = document.querySelector(`[data-widget-type="${widgetType}"]`);
   if (root) {
-    import(
-      /* webpackChunkName: "disability-application-status" */
-      './wizard-entry'
-    ).then(module => {
+    import(/* webpackChunkName: "disability-application-status" */
+    './wizard-entry').then(module => {
       const { ApplicationStatus, Wizard, pages } = module.default;
       ReactDOM.render(
         <Provider store={store}>

--- a/src/applications/disability-benefits/wizard/createWizard.jsx
+++ b/src/applications/disability-benefits/wizard/createWizard.jsx
@@ -4,6 +4,7 @@ import { Provider } from 'react-redux';
 import { VA_FORM_IDS } from 'platform/forms/constants';
 
 const disabilityForms = new Set([VA_FORM_IDS.FORM_21_526EZ]);
+
 export default function createDisabilityIncreaseApplicationStatus(
   store,
   widgetType,

--- a/src/applications/disability-benefits/wizard/createWizard.jsx
+++ b/src/applications/disability-benefits/wizard/createWizard.jsx
@@ -11,8 +11,10 @@ export default function createDisabilityIncreaseApplicationStatus(
 ) {
   const root = document.querySelector(`[data-widget-type="${widgetType}"]`);
   if (root) {
-    import(/* webpackChunkName: "disability-application-status" */
-    './wizard-entry').then(module => {
+    import(
+      /* webpackChunkName: "disability-application-status" */
+      './wizard-entry'
+    ).then(module => {
       const { ApplicationStatus, Wizard, pages } = module.default;
       ReactDOM.render(
         <Provider store={store}>
@@ -25,18 +27,21 @@ export default function createDisabilityIncreaseApplicationStatus(
             stayAfterDelete
             applyRender={() => (
               <div itemScope itemType="http://schema.org/Question">
-                <h2 itemProp="name">How do I file my claim?</h2>
+                <h2 itemProp="name">How do I file my claim online?</h2>
                 <div
                   itemProp="acceptedAnswer"
                   itemScope
                   itemType="http://schema.org/Answer"
                 >
                   <div itemProp="text">
-                    <p>You can file online right now.</p>
+                    <p>
+                      It depends on your situation. Answer a few questions, and
+                      we&apos;ll guide you to the right place.
+                    </p>
                     <Wizard
                       pages={pages}
                       expander
-                      buttonText="File a disability compensation claim"
+                      buttonText="Let's get started"
                     />
                   </div>
                 </div>

--- a/src/applications/disability-benefits/wizard/pages/disagree-file-claim.jsx
+++ b/src/applications/disability-benefits/wizard/pages/disagree-file-claim.jsx
@@ -5,8 +5,9 @@ import { pageNames } from './pageList';
 const alertContent = (
   <>
     <p>
-      If you disagree with a VA decision that you received more than a year ago,
-      you can file a Supplemental Claim.
+      If you disagree with a VA decision we made over a year ago, you need to
+      file a Supplemental Claim (VA Form 20-0995). You shouldn&apos;t file a
+      disability claim.
     </p>
     <a href="/decision-reviews/supplemental-claim/">
       Find out how to file a Supplemental Claim


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/2608

This PR changes the copy to the CreateWizard React widget.

## Testing done
Tested locally.

## Screenshots
![image](https://user-images.githubusercontent.com/12773166/67250150-4a18dc80-f438-11e9-8aee-d95e47fb0618.png)

## Acceptance criteria
- [x] Inside widget. Change H2 to: Can I file my claim online?
- [x] Inside widget. Change instruction text to: It depends on your situation. Answer a few questions, and we'll guide you to the right place.
- [x] Inside widget. Change button text to: Let's get started
- [ ] Outside widget, on body copy. Change the H3 "You can also file..." to H2 "What other ways can I file my disability claim?" And add extra spacing, so the expanded/user filled out REACT component doesn't flow right into body copy. (**Question: I think this needs to be updated on the CMS. @ncksllvn Could you confirm when you get a chance?**)

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
