### PR TITLE
Add codeclimate config file based on server settings

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,39 @@
+version: "2"         # required to adjust maintainability checks
+checks:
+  argument-count:
+    enabled: false
+  complex-logic:
+    enabled: false
+  file-lines:
+    enabled: false
+  method-complexity:
+    enabled: false
+  method-count:
+    enabled: false
+  method-lines:
+    enabled: false
+  nested-control-flow:
+    enabled: false
+  return-statements:
+    enabled: false
+  similar-code:
+    enabled: false
+  identical-code:
+    enabled: false
+plugins:
+  eslint:
+    enabled: false
+exclude_patterns:
+- 'config/'
+- 'db/'
+- 'dist/'
+- 'features/'
+- '**/node_modules/'
+- 'script/'
+- '**/spec/'
+- '**/test/'
+- '**/tests/'
+- 'Tests/'
+- '**/vendor/'
+- '**/*_test.go'
+- '**/*.d.ts'

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,11 +1,11 @@
 version: "2"         # required to adjust maintainability checks
 checks:
   argument-count:
-    enabled: false
+    enabled: true
   complex-logic:
-    enabled: false
+    enabled: true
   file-lines:
-    enabled: false
+    enabled: true
   method-complexity:
     enabled: false
   method-count:
@@ -17,12 +17,12 @@ checks:
   return-statements:
     enabled: false
   similar-code:
-    enabled: false
+    enabled: true
   identical-code:
-    enabled: false
+    enabled: true
 plugins:
   eslint:
-    enabled: false
+    enabled: true
 exclude_patterns:
 - 'config/'
 - 'db/'

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,11 +1,11 @@
 version: "2"         # required to adjust maintainability checks
 checks:
   argument-count:
-    enabled: true
+    enabled: false
   complex-logic:
-    enabled: true
+    enabled: false
   file-lines:
-    enabled: true
+    enabled: false
   method-complexity:
     enabled: false
   method-count:
@@ -17,12 +17,12 @@ checks:
   return-statements:
     enabled: false
   similar-code:
-    enabled: true
+    enabled: false
   identical-code:
-    enabled: true
+    enabled: false
 plugins:
   eslint:
-    enabled: true
+    enabled: false
 exclude_patterns:
 - 'config/'
 - 'db/'


### PR DESCRIPTION
## Description
CodeClimate config is possible directly in the application instead of on the server. All of the current config on CodeClimate.com has been moved into the `yml` file so it can be controlled without needing a GitHub admin.

## Testing done
Verified on codeclimate.
Added a new setting in local file, verified that codeclimate ran the codeclimate.yml settings successfully.

## Screenshots
N/A

## Acceptance criteria
- [x] Similar results for CodeClimate runs

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs