### PR TITLE
Add aria labels to 526 form locations missing them

### DIFF
--- a/src/applications/disability-benefits/all-claims/pages/addDisabilities.js
+++ b/src/applications/disability-benefits/all-claims/pages/addDisabilities.js
@@ -73,6 +73,9 @@ export const uiSchema = {
       'view:descriptionInfo': {
         'ui:description': descriptionInfo,
       },
+      'ui:options': {
+        ariaLabelForEditButtonOnReview: 'Edit New condition',
+      },
     },
   },
   // This object only shows up when the user tries to continue without claiming either a rated or new condition

--- a/src/applications/disability-benefits/all-claims/pages/militaryHistory.js
+++ b/src/applications/disability-benefits/all-claims/pages/militaryHistory.js
@@ -42,6 +42,9 @@ export const uiSchema = {
           'ui:title': 'Branch of service',
         },
         dateRange: dateRangeUISchema,
+        'ui:options': {
+          ariaLabelForEditButtonOnReview: 'Edit Military service history',
+        },
       },
     },
   },

--- a/src/platform/forms-system/src/js/fields/ArrayField.jsx
+++ b/src/platform/forms-system/src/js/fields/ArrayField.jsx
@@ -310,6 +310,7 @@ export default class ArrayField extends React.Component {
                               <button
                                 className="float-left"
                                 onClick={() => this.handleUpdate(index)}
+                                aria-label={`Update ${title}`}
                               >
                                 Update
                               </button>

--- a/src/platform/forms-system/src/js/fields/ArrayField.jsx
+++ b/src/platform/forms-system/src/js/fields/ArrayField.jsx
@@ -320,6 +320,7 @@ export default class ArrayField extends React.Component {
                               className="usa-button-secondary float-right"
                               type="button"
                               onClick={() => this.handleRemove(index)}
+                              aria-label={`Remove ${title}`}
                             >
                               Remove
                             </button>
@@ -341,6 +342,7 @@ export default class ArrayField extends React.Component {
                   <button
                     className="usa-button-secondary edit-button"
                     onClick={() => this.handleEdit(index)}
+                    aria-label={`Edit ${title}`}
                   >
                     Edit
                   </button>

--- a/src/platform/forms-system/src/js/fields/ArrayField.jsx
+++ b/src/platform/forms-system/src/js/fields/ArrayField.jsx
@@ -321,7 +321,6 @@ export default class ArrayField extends React.Component {
                               className="usa-button-secondary float-right"
                               type="button"
                               onClick={() => this.handleRemove(index)}
-                              aria-label={`Remove ${title}`}
                             >
                               Remove
                             </button>

--- a/src/platform/forms-system/src/js/fields/FileField.jsx
+++ b/src/platform/forms-system/src/js/fields/FileField.jsx
@@ -246,6 +246,7 @@ export default class FileField extends React.Component {
                 id={`${idSchema.$id}_add_label`}
                 htmlFor={idSchema.$id}
                 className="usa-button usa-button-secondary"
+                aria-label={uiSchema['ui:title'] || schema.title}
               >
                 <span
                   role="button"

--- a/src/platform/forms-system/src/js/fields/FileField.jsx
+++ b/src/platform/forms-system/src/js/fields/FileField.jsx
@@ -162,6 +162,7 @@ export default class FileField extends React.Component {
                         onClick={() => {
                           this.cancelUpload(index);
                         }}
+                        aria-label="Cancel Upload"
                       >
                         Cancel
                       </button>
@@ -246,7 +247,6 @@ export default class FileField extends React.Component {
                 id={`${idSchema.$id}_add_label`}
                 htmlFor={idSchema.$id}
                 className="usa-button usa-button-secondary"
-                aria-label={uiSchema['ui:title'] || schema.title}
               >
                 <span
                   role="button"
@@ -257,6 +257,7 @@ export default class FileField extends React.Component {
                     }
                   }}
                   tabIndex="0"
+                  aria-label={uiSchema['ui:title'] || schema.title}
                 >
                   {buttonText}
                 </span>

--- a/src/platform/forms-system/src/js/review/ArrayField.jsx
+++ b/src/platform/forms-system/src/js/review/ArrayField.jsx
@@ -270,7 +270,6 @@ class ArrayField extends React.Component {
                                 type="button"
                                 className="usa-button-secondary float-right"
                                 onClick={() => this.handleRemove(index)}
-                                aria-label={`Remove ${uiOptions.itemName}`}
                               >
                                 Remove
                               </button>

--- a/src/platform/forms-system/src/js/review/ArrayField.jsx
+++ b/src/platform/forms-system/src/js/review/ArrayField.jsx
@@ -270,6 +270,7 @@ class ArrayField extends React.Component {
                                 type="button"
                                 className="usa-button-secondary float-right"
                                 onClick={() => this.handleRemove(index)}
+                                aria-label={`Remove ${uiOptions.itemName}`}
                               >
                                 Remove
                               </button>


### PR DESCRIPTION
## Description
Some of the UI controls for editing and removing sections of content don't have aria-labels. This leaves screen reader users to find headings or other related text when determining what action they are taking. This adds aria labels to the specified locations in the connected issue.

## Definition of done
- [ ] Specified locations are properly labeled with aria labels
