### PR TITLE
Report more info to GA when payment info save failures occur

### DIFF
--- a/src/applications/personalization/profile360/actions/paymentInformation.js
+++ b/src/applications/personalization/profile360/actions/paymentInformation.js
@@ -94,8 +94,9 @@ export function savePaymentInformation(fields) {
     // };
 
     if (response.error || response.errors) {
-      const eventData = createEventDataObjectWithErrors(response.errors);
-      recordEvent(eventData);
+      const errors = response?.error?.errors || [];
+      const analyticsData = createEventDataObjectWithErrors(errors);
+      recordEvent(analyticsData);
       dispatch({
         type: PAYMENT_INFORMATION_SAVE_FAILED,
         response,

--- a/src/applications/personalization/profile360/actions/paymentInformation.js
+++ b/src/applications/personalization/profile360/actions/paymentInformation.js
@@ -1,4 +1,4 @@
-import { getData } from '../util';
+import { getData, createEventDataObjectWithErrors } from '../util';
 import recordEvent from 'platform/monitoring/record-event';
 
 export const PAYMENT_INFORMATION_FETCH_STARTED =
@@ -94,11 +94,8 @@ export function savePaymentInformation(fields) {
     // };
 
     if (response.error || response.errors) {
-      recordEvent({
-        event: 'profile-edit-failure',
-        'profile-action': 'save-failure',
-        'profile-section': 'direct-deposit-information',
-      });
+      const eventData = createEventDataObjectWithErrors(response.errors);
+      recordEvent(eventData);
       dispatch({
         type: PAYMENT_INFORMATION_SAVE_FAILED,
         response,

--- a/src/applications/personalization/profile360/actions/paymentInformation.js
+++ b/src/applications/personalization/profile360/actions/paymentInformation.js
@@ -1,4 +1,4 @@
-import { getData, createEventDataObjectWithErrors } from '../util';
+import { getData, createDirectDepositAnalyticsDataObject } from '../util';
 import recordEvent from 'platform/monitoring/record-event';
 
 export const PAYMENT_INFORMATION_FETCH_STARTED =
@@ -95,7 +95,7 @@ export function savePaymentInformation(fields) {
 
     if (response.error || response.errors) {
       const errors = response?.error?.errors || [];
-      const analyticsData = createEventDataObjectWithErrors(errors);
+      const analyticsData = createDirectDepositAnalyticsDataObject(errors);
       recordEvent(analyticsData);
       dispatch({
         type: PAYMENT_INFORMATION_SAVE_FAILED,

--- a/src/applications/personalization/profile360/components/PaymentInformationEditModalError.jsx
+++ b/src/applications/personalization/profile360/components/PaymentInformationEditModalError.jsx
@@ -1,15 +1,13 @@
 import React from 'react';
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 
-// possible values for the `key` property on error messages we get from the server
-const ACCOUNT_FLAGGED_FOR_FRAUD_KEY = 'cnp.payment.flashes.on.record.message';
-const GENERIC_ERROR_KEY = 'cnp.payment.generic.error.message';
-const INVALID_ROUTING_NUMBER_KEY =
-  'payment.accountRoutingNumber.invalidCheckSum';
-const PAYMENT_RESTRICTIONS_PRESENT_KEY =
-  'payment.restriction.indicators.present';
-const ROUTING_NUMBER_FLAGGED_FOR_FRAUD_KEY =
-  'cnp.payment.routing.number.fraud.message';
+import {
+  hasFlaggedForFraudError,
+  hasInvalidAddressError,
+  hasInvalidHomePhoneNumberError,
+  hasInvalidRoutingNumberError,
+  hasInvalidWorkPhoneNumberError,
+} from '../util';
 
 function FlaggedAccount() {
   return (
@@ -88,77 +86,6 @@ function UpdatePhoneNumberError({ closeModal, phoneNumberType = 'home' }) {
       and fill in this required information.
     </p>
   );
-}
-
-function hasErrorMessageKey(errors, errorKey) {
-  return errors.some(err =>
-    err.meta.messages.some(message => message.key === errorKey),
-  );
-}
-
-function hasErrorMessageText(errors, errorText) {
-  return errors.some(err =>
-    err.meta.messages.some(message =>
-      message.text.toLowerCase().includes(errorText.toLowerCase()),
-    ),
-  );
-}
-
-function hasFlaggedForFraudError(errors) {
-  return (
-    hasErrorMessageKey(errors, ACCOUNT_FLAGGED_FOR_FRAUD_KEY) ||
-    hasErrorMessageKey(errors, PAYMENT_RESTRICTIONS_PRESENT_KEY) ||
-    hasErrorMessageKey(errors, ROUTING_NUMBER_FLAGGED_FOR_FRAUD_KEY)
-  );
-}
-
-function hasInvalidRoutingNumberError(errors) {
-  let result = false;
-  if (hasErrorMessageKey(errors, INVALID_ROUTING_NUMBER_KEY)) {
-    result = true;
-  }
-  if (
-    hasErrorMessageKey(errors, GENERIC_ERROR_KEY) &&
-    hasErrorMessageText(errors, 'Invalid Routing Number')
-  ) {
-    result = true;
-  }
-  return result;
-}
-
-function hasInvalidAddressError(errors) {
-  let result = false;
-  if (
-    hasErrorMessageKey(errors, GENERIC_ERROR_KEY) &&
-    hasErrorMessageText(errors, 'address update')
-  ) {
-    result = true;
-  }
-  return result;
-}
-
-function hasInvalidHomePhoneNumberError(errors) {
-  let result = false;
-  if (
-    hasErrorMessageKey(errors, GENERIC_ERROR_KEY) &&
-    (hasErrorMessageText(errors, 'night phone number') ||
-      hasErrorMessageText(errors, 'night area number'))
-  ) {
-    result = true;
-  }
-  return result;
-}
-
-function hasInvalidWorkPhoneNumberError(errors) {
-  let result = false;
-  if (
-    hasErrorMessageKey(errors, GENERIC_ERROR_KEY) &&
-    (hasErrorMessageText(errors, 'day phone number') ||
-      hasErrorMessageText(errors, 'day area number'))
-  ) {
-    result = true;
-  }
-  return result;
 }
 
 export default function PaymentInformationEditModalError({

--- a/src/applications/personalization/profile360/tests/util/index.unit.spec.js
+++ b/src/applications/personalization/profile360/tests/util/index.unit.spec.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 
-import { createEventDataObjectWithErrors } from '../../util';
+import { createDirectDepositAnalyticsDataObject } from '../../util';
 
 describe('profile utils', () => {
   const defaultDataObject = {
@@ -29,15 +29,15 @@ describe('profile utils', () => {
   };
   describe('createEventDataObjectWithErrors', () => {
     it('returns the correct data when passed nothing', () => {
-      const eventDataObject = createEventDataObjectWithErrors();
+      const eventDataObject = createDirectDepositAnalyticsDataObject();
       expect(eventDataObject).to.deep.equal(defaultDataObject);
     });
     it('returns the correct data when passed nothing', () => {
-      const eventDataObject = createEventDataObjectWithErrors([]);
+      const eventDataObject = createDirectDepositAnalyticsDataObject([]);
       expect(eventDataObject).to.deep.equal(defaultDataObject);
     });
     it('returns the correct data when a bad address error is passed', () => {
-      const eventDataObject = createEventDataObjectWithErrors([
+      const eventDataObject = createDirectDepositAnalyticsDataObject([
         {
           title: 'Unprocessable Entity',
           detail: 'One or more unprocessable user payment properties',
@@ -59,7 +59,7 @@ describe('profile utils', () => {
       expect(eventDataObject).to.deep.equal(badAddressDataObject);
     });
     it('returns the correct data when a work phone number error is passed', () => {
-      const eventDataObject = createEventDataObjectWithErrors([
+      const eventDataObject = createDirectDepositAnalyticsDataObject([
         {
           title: 'Unprocessable Entity',
           detail: 'One or more unprocessable user payment properties',
@@ -81,7 +81,7 @@ describe('profile utils', () => {
       expect(eventDataObject).to.deep.equal(badWorkPhoneDataObject);
     });
     it('returns the correct data when a day phone number error is passed', () => {
-      const eventDataObject = createEventDataObjectWithErrors([
+      const eventDataObject = createDirectDepositAnalyticsDataObject([
         {
           title: 'Unprocessable Entity',
           detail: 'One or more unprocessable user payment properties',

--- a/src/applications/personalization/profile360/tests/util/index.unit.spec.js
+++ b/src/applications/personalization/profile360/tests/util/index.unit.spec.js
@@ -1,0 +1,106 @@
+import { expect } from 'chai';
+
+import { createEventDataObjectWithErrors } from '../../util';
+
+describe('profile utils', () => {
+  const defaultDataObject = {
+    event: 'profile-edit-failure',
+    'profile-action': 'save-failure',
+    'profile-section': 'direct-deposit-information',
+    'error-key': 'other-error',
+  };
+  const badAddressDataObject = {
+    event: 'profile-edit-failure',
+    'profile-action': 'save-failure',
+    'profile-section': 'direct-deposit-information',
+    'error-key': 'mailing-address-error',
+  };
+  const badHomePhoneDataObject = {
+    event: 'profile-edit-failure',
+    'profile-action': 'save-failure',
+    'profile-section': 'direct-deposit-information',
+    'error-key': 'home-phone-error',
+  };
+  const badWorkPhoneDataObject = {
+    event: 'profile-edit-failure',
+    'profile-action': 'save-failure',
+    'profile-section': 'direct-deposit-information',
+    'error-key': 'work-phone-error',
+  };
+  describe('createEventDataObjectWithErrors', () => {
+    it('returns the correct data when passed nothing', () => {
+      const eventDataObject = createEventDataObjectWithErrors();
+      expect(eventDataObject).to.deep.equal(defaultDataObject);
+    });
+    it('returns the correct data when passed nothing', () => {
+      const eventDataObject = createEventDataObjectWithErrors([]);
+      expect(eventDataObject).to.deep.equal(defaultDataObject);
+    });
+    it('returns the correct data when a bad address error is passed', () => {
+      const eventDataObject = createEventDataObjectWithErrors([
+        {
+          title: 'Unprocessable Entity',
+          detail: 'One or more unprocessable user payment properties',
+          code: '126',
+          source: 'EVSS::PPIU::Service',
+          status: '422',
+          meta: {
+            messages: [
+              {
+                key: 'cnp.payment.generic.error.message',
+                severity: 'ERROR',
+                text:
+                  'Generic CnP payment update error. Update response: Update Failed: Required field not entered for mailing address update',
+              },
+            ],
+          },
+        },
+      ]);
+      expect(eventDataObject).to.deep.equal(badAddressDataObject);
+    });
+    it('returns the correct data when a work phone number error is passed', () => {
+      const eventDataObject = createEventDataObjectWithErrors([
+        {
+          title: 'Unprocessable Entity',
+          detail: 'One or more unprocessable user payment properties',
+          code: '126',
+          source: 'EVSS::PPIU::Service',
+          status: '422',
+          meta: {
+            messages: [
+              {
+                key: 'cnp.payment.generic.error.message',
+                severity: 'ERROR',
+                text:
+                  'Generic CnP payment update error. Update response: Update Failed: Day phone number is invalid, must be 7 digits',
+              },
+            ],
+          },
+        },
+      ]);
+      expect(eventDataObject).to.deep.equal(badWorkPhoneDataObject);
+    });
+    it('returns the correct data when a day phone number error is passed', () => {
+      const eventDataObject = createEventDataObjectWithErrors([
+        {
+          title: 'Unprocessable Entity',
+          detail: 'One or more unprocessable user payment properties',
+          code: '126',
+          source: 'EVSS::PPIU::Service',
+          status: '422',
+          meta: {
+            messages: [
+              {
+                key: 'cnp.payment.generic.error.message',
+                severity: 'ERROR',
+                text:
+                  'Generic CnP payment update error. Update response: Update Failed: Night area number is invalid, must be 3 digits',
+              },
+            ],
+          },
+        },
+      ]);
+      expect(eventDataObject).to.deep.equal(badHomePhoneDataObject);
+    });
+  });
+});

--- a/src/applications/personalization/profile360/util/index.js
+++ b/src/applications/personalization/profile360/util/index.js
@@ -99,7 +99,7 @@ export function hasInvalidWorkPhoneNumberError(errors) {
 // function when an errors occurs while trying to save/update a user's direct
 // deposit payment information. The value of the `error-key` prop will change
 // depending on the content of the `errors` array.
-export function createEventDataObjectWithErrors(errors) {
+export function createDirectDepositAnalyticsDataObject(errors) {
   const key = 'error-key';
   const eventDataObject = {
     event: 'profile-edit-failure',

--- a/src/applications/personalization/profile360/util/index.js
+++ b/src/applications/personalization/profile360/util/index.js
@@ -98,7 +98,7 @@ export function hasInvalidWorkPhoneNumberError(errors) {
 // Helper that creates and returns an object to pass to the recordEvent()
 // function. The value of the `error-key` prop will change depending on the
 // content of the `errors` array.
-export function createEventDataObjectWithErrors(errors = []) {
+export function createEventDataObjectWithErrors(errors) {
   const key = 'error-key';
   const eventDataObject = {
     event: 'profile-edit-failure',

--- a/src/applications/personalization/profile360/util/index.js
+++ b/src/applications/personalization/profile360/util/index.js
@@ -10,6 +10,11 @@ const PAYMENT_RESTRICTIONS_PRESENT_KEY =
 const ROUTING_NUMBER_FLAGGED_FOR_FRAUD_KEY =
   'cnp.payment.routing.number.fraud.message';
 
+const GA_ERROR_KEY_BAD_ADDRESS = 'mailing-address-error';
+const GA_ERROR_KEY_BAD_HOME_PHONE = 'home-phone-error';
+const GA_ERROR_KEY_BAD_WORK_PHONE = 'work-phone-error';
+const GA_ERROR_KEY_DEFAULT = 'other-error';
+
 export async function getData(apiRoute, options) {
   try {
     const response = await apiRequest(apiRoute, options);
@@ -94,14 +99,21 @@ export function hasInvalidWorkPhoneNumberError(errors) {
 // function. The value of the `error-key` prop will change depending on the
 // content of the `errors` array.
 export function createEventDataObjectWithErrors(errors = []) {
-  const value = {
+  const key = 'error-key';
+  const eventDataObject = {
     event: 'profile-edit-failure',
     'profile-action': 'save-failure',
     'profile-section': 'direct-deposit-information',
-    'error-key': 'other-error',
+    [key]: GA_ERROR_KEY_DEFAULT,
   };
   if (errors && errors.length) {
-    value['error-key'] = 'blah';
+    if (hasInvalidAddressError(errors)) {
+      eventDataObject[key] = GA_ERROR_KEY_BAD_ADDRESS;
+    } else if (hasInvalidHomePhoneNumberError(errors)) {
+      eventDataObject[key] = GA_ERROR_KEY_BAD_HOME_PHONE;
+    } else if (hasInvalidWorkPhoneNumberError(errors)) {
+      eventDataObject[key] = GA_ERROR_KEY_BAD_WORK_PHONE;
+    }
   }
-  return value;
+  return eventDataObject;
 }

--- a/src/applications/personalization/profile360/util/index.js
+++ b/src/applications/personalization/profile360/util/index.js
@@ -1,5 +1,15 @@
 import { apiRequest } from 'platform/utilities/api';
 
+// possible values for the `key` property on error messages we get from the server
+const ACCOUNT_FLAGGED_FOR_FRAUD_KEY = 'cnp.payment.flashes.on.record.message';
+const GENERIC_ERROR_KEY = 'cnp.payment.generic.error.message';
+const INVALID_ROUTING_NUMBER_KEY =
+  'payment.accountRoutingNumber.invalidCheckSum';
+const PAYMENT_RESTRICTIONS_PRESENT_KEY =
+  'payment.restriction.indicators.present';
+const ROUTING_NUMBER_FLAGGED_FOR_FRAUD_KEY =
+  'cnp.payment.routing.number.fraud.message';
+
 export async function getData(apiRoute, options) {
   try {
     const response = await apiRequest(apiRoute, options);
@@ -7,4 +17,91 @@ export async function getData(apiRoute, options) {
   } catch (error) {
     return { error };
   }
+}
+
+function hasErrorMessageKey(errors, errorKey) {
+  return errors.some(err =>
+    err.meta.messages.some(message => message.key === errorKey),
+  );
+}
+
+function hasErrorMessageText(errors, errorText) {
+  return errors.some(err =>
+    err.meta.messages.some(message =>
+      message.text.toLowerCase().includes(errorText.toLowerCase()),
+    ),
+  );
+}
+
+export function hasFlaggedForFraudError(errors) {
+  return (
+    hasErrorMessageKey(errors, ACCOUNT_FLAGGED_FOR_FRAUD_KEY) ||
+    hasErrorMessageKey(errors, PAYMENT_RESTRICTIONS_PRESENT_KEY) ||
+    hasErrorMessageKey(errors, ROUTING_NUMBER_FLAGGED_FOR_FRAUD_KEY)
+  );
+}
+
+export function hasInvalidRoutingNumberError(errors) {
+  let result = false;
+  if (hasErrorMessageKey(errors, INVALID_ROUTING_NUMBER_KEY)) {
+    result = true;
+  }
+  if (
+    hasErrorMessageKey(errors, GENERIC_ERROR_KEY) &&
+    hasErrorMessageText(errors, 'Invalid Routing Number')
+  ) {
+    result = true;
+  }
+  return result;
+}
+
+export function hasInvalidAddressError(errors) {
+  let result = false;
+  if (
+    hasErrorMessageKey(errors, GENERIC_ERROR_KEY) &&
+    hasErrorMessageText(errors, 'address update')
+  ) {
+    result = true;
+  }
+  return result;
+}
+
+export function hasInvalidHomePhoneNumberError(errors) {
+  let result = false;
+  if (
+    hasErrorMessageKey(errors, GENERIC_ERROR_KEY) &&
+    (hasErrorMessageText(errors, 'night phone number') ||
+      hasErrorMessageText(errors, 'night area number'))
+  ) {
+    result = true;
+  }
+  return result;
+}
+
+export function hasInvalidWorkPhoneNumberError(errors) {
+  let result = false;
+  if (
+    hasErrorMessageKey(errors, GENERIC_ERROR_KEY) &&
+    (hasErrorMessageText(errors, 'day phone number') ||
+      hasErrorMessageText(errors, 'day area number'))
+  ) {
+    result = true;
+  }
+  return result;
+}
+
+// Helper that creates and returns an object to pass to the recordEvent()
+// function. The value of the `error-key` prop will change depending on the
+// content of the `errors` array.
+export function createEventDataObjectWithErrors(errors = []) {
+  const value = {
+    event: 'profile-edit-failure',
+    'profile-action': 'save-failure',
+    'profile-section': 'direct-deposit-information',
+    'error-key': 'other-error',
+  };
+  if (errors && errors.length) {
+    value['error-key'] = 'blah';
+  }
+  return value;
 }

--- a/src/applications/personalization/profile360/util/index.js
+++ b/src/applications/personalization/profile360/util/index.js
@@ -96,8 +96,9 @@ export function hasInvalidWorkPhoneNumberError(errors) {
 }
 
 // Helper that creates and returns an object to pass to the recordEvent()
-// function. The value of the `error-key` prop will change depending on the
-// content of the `errors` array.
+// function when an errors occurs while trying to save/update a user's direct
+// deposit payment information. The value of the `error-key` prop will change
+// depending on the content of the `errors` array.
 export function createEventDataObjectWithErrors(errors) {
   const key = 'error-key';
   const eventDataObject = {


### PR DESCRIPTION
## Description
The bulk of this work is simply adding a new helper function that's called by `paymentInformation` actions when an error occurs. But since that function relied on some code that already existed in the PaymentInformationEditModalError.jsx component, I moved the relevant logic to common helpers.

## Testing done
- [x] Local + unit tests for the new helper
- [ ] I'll follow this up with a PR to improve the test coverage of the Payment Info actions, to make sure that `recordEvent()` is called correctly when payment info saves succeed or fail.

## Screenshots
N/A

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs