### PR TITLE
Kelsonic 2577 update expanded sidenav logic

### DIFF
--- a/src/platform/site-wide/sass/modules/_m-side-nav.scss
+++ b/src/platform/site-wide/sass/modules/_m-side-nav.scss
@@ -45,6 +45,21 @@
     margin: 10px 23px;
   }
 
+  .va-sidenav-item-label-text {
+    background: none;
+    border-radius: none;
+    color: $color-gray-dark;
+    font-size: 15px;
+    font-weight: bold;
+    letter-spacing: 0.3px;
+    line-height: 1.5;
+    margin: 0;
+    padding: 0;
+    text-align: left;
+    text-decoration: none;
+    text-transform: uppercase;
+  }
+
   .va-sidenav-toggle-expand {
     align-items: center;
     background: $color-gray-lightest;

--- a/src/platform/site-wide/side-nav/components/SideNav.js
+++ b/src/platform/site-wide/side-nav/components/SideNav.js
@@ -2,7 +2,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { find, filter, get, startsWith, map, orderBy } from 'lodash';
+import { find, filter, get, map, orderBy } from 'lodash';
 
 class SideNav extends Component {
   static propTypes = {
@@ -60,10 +60,8 @@ class SideNav extends Component {
       const hasChildren = get(item, 'hasChildren', false);
       const href = get(item, 'href');
       const id = get(item, 'id');
+      const isSelected = get(item, 'isSelected');
       const label = get(item, 'label', '');
-
-      // Derive if the nav item is selected and the selected class.
-      const isSelected = startsWith(window.location.pathname, href);
 
       // Derive the depth booleans.
       const isFirstLevel = depth === 1;
@@ -104,39 +102,37 @@ class SideNav extends Component {
             {labelElement}
 
             {/* Expand/Collapse Button */}
-            {hasChildren &&
-              isDeeperThanSecondLevel && (
-                <button
-                  aria-label={`Expand "${label}"`}
-                  className="va-sidenav-toggle-expand"
-                >
-                  <i
-                    className={classNames({
-                      fa: true,
-                      'fa-chevron-down': expanded,
-                      'fa-chevron-up': !expanded,
-                    })}
-                  />
-                </button>
-              )}
+            {hasChildren && isDeeperThanSecondLevel && (
+              <button
+                aria-label={`Expand "${label}"`}
+                className="va-sidenav-toggle-expand"
+              >
+                <i
+                  className={classNames({
+                    fa: true,
+                    'fa-chevron-down': expanded,
+                    'fa-chevron-up': !expanded,
+                  })}
+                />
+              </button>
+            )}
           </button>
 
           {/* Duplicate Line + Label when Expanded */}
-          {expanded &&
-            isSecondLevel && (
-              <>
-                <div className="line" />
-                <div
-                  className={classNames({
-                    'va-sidenav-item-label': true,
-                    'va-sidenav-item-label-duplicate': true,
-                    selected: isSelected,
-                  })}
-                >
-                  {labelElement}
-                </div>
-              </>
-            )}
+          {expanded && isSecondLevel && (
+            <>
+              <div className="line" />
+              <div
+                className={classNames({
+                  'va-sidenav-item-label': true,
+                  'va-sidenav-item-label-duplicate': true,
+                  selected: isSelected,
+                })}
+              >
+                {labelElement}
+              </div>
+            </>
+          )}
 
           {/* Child Items */}
           {expanded && <ul>{this.renderChildItems(id, depth + 1)}</ul>}

--- a/src/platform/site-wide/side-nav/components/SideNav.js
+++ b/src/platform/site-wide/side-nav/components/SideNav.js
@@ -6,7 +6,18 @@ import { find, filter, get, map, orderBy } from 'lodash';
 
 class SideNav extends Component {
   static propTypes = {
-    navItemsLookup: PropTypes.object.isRequired,
+    navItemsLookup: PropTypes.objectOf(PropTypes.shape({
+      depth: PropTypes.number.isRequired,
+      description: PropTypes.string,
+      expanded: PropTypes.bool.isRequired,
+      hasChildren: PropTypes.bool.isRequired,
+      href: PropTypes.string,
+      id: PropTypes.string.isRequired,
+      label: PropTypes.string.isRequired,
+      order: PropTypes.number.isRequired,
+      parentID: PropTypes.string.isRequired,
+      isSelected: PropTypes.bool.isRequired,
+    })).isRequired,
   };
 
   constructor(props) {

--- a/src/platform/site-wide/side-nav/components/SideNav.js
+++ b/src/platform/site-wide/side-nav/components/SideNav.js
@@ -92,7 +92,7 @@ class SideNav extends Component {
       // Derive the label element.
       const labelElement = href ? (
         <a
-          className="va-sidenav-item-label-text"
+          className="va-sidenav-item-label-link"
           href={href}
           rel="noopener noreferrer"
         >
@@ -104,7 +104,7 @@ class SideNav extends Component {
 
       return (
         <li className={`va-sidenav-level-${depth}`} key={id}>
-          <button
+          <div
             aria-label={label}
             className={classNames({
               'va-sidenav-item-label': true,
@@ -132,7 +132,7 @@ class SideNav extends Component {
                   />
                 </button>
               )}
-          </button>
+          </div>
 
           {/* Duplicate Line + Label when Expanded */}
           {expanded &&

--- a/src/platform/site-wide/side-nav/components/SideNav.js
+++ b/src/platform/site-wide/side-nav/components/SideNav.js
@@ -6,18 +6,20 @@ import { find, filter, get, map, orderBy } from 'lodash';
 
 class SideNav extends Component {
   static propTypes = {
-    navItemsLookup: PropTypes.objectOf(PropTypes.shape({
-      depth: PropTypes.number.isRequired,
-      description: PropTypes.string,
-      expanded: PropTypes.bool.isRequired,
-      hasChildren: PropTypes.bool.isRequired,
-      href: PropTypes.string,
-      id: PropTypes.string.isRequired,
-      label: PropTypes.string.isRequired,
-      order: PropTypes.number.isRequired,
-      parentID: PropTypes.string.isRequired,
-      isSelected: PropTypes.bool.isRequired,
-    })).isRequired,
+    navItemsLookup: PropTypes.objectOf(
+      PropTypes.shape({
+        depth: PropTypes.number.isRequired,
+        description: PropTypes.string,
+        expanded: PropTypes.bool.isRequired,
+        hasChildren: PropTypes.bool.isRequired,
+        href: PropTypes.string,
+        id: PropTypes.string.isRequired,
+        label: PropTypes.string.isRequired,
+        order: PropTypes.number.isRequired,
+        parentID: PropTypes.string.isRequired,
+        isSelected: PropTypes.bool.isRequired,
+      }),
+    ).isRequired,
   };
 
   constructor(props) {

--- a/src/platform/site-wide/side-nav/components/SideNav.js
+++ b/src/platform/site-wide/side-nav/components/SideNav.js
@@ -102,37 +102,39 @@ class SideNav extends Component {
             {labelElement}
 
             {/* Expand/Collapse Button */}
-            {hasChildren && isDeeperThanSecondLevel && (
-              <button
-                aria-label={`Expand "${label}"`}
-                className="va-sidenav-toggle-expand"
-              >
-                <i
-                  className={classNames({
-                    fa: true,
-                    'fa-chevron-down': expanded,
-                    'fa-chevron-up': !expanded,
-                  })}
-                />
-              </button>
-            )}
+            {hasChildren &&
+              isDeeperThanSecondLevel && (
+                <button
+                  aria-label={`Expand "${label}"`}
+                  className="va-sidenav-toggle-expand"
+                >
+                  <i
+                    className={classNames({
+                      fa: true,
+                      'fa-chevron-down': expanded,
+                      'fa-chevron-up': !expanded,
+                    })}
+                  />
+                </button>
+              )}
           </button>
 
           {/* Duplicate Line + Label when Expanded */}
-          {expanded && isSecondLevel && (
-            <>
-              <div className="line" />
-              <div
-                className={classNames({
-                  'va-sidenav-item-label': true,
-                  'va-sidenav-item-label-duplicate': true,
-                  selected: isSelected,
-                })}
-              >
-                {labelElement}
-              </div>
-            </>
-          )}
+          {expanded &&
+            isSecondLevel && (
+              <>
+                <div className="line" />
+                <div
+                  className={classNames({
+                    'va-sidenav-item-label': true,
+                    'va-sidenav-item-label-duplicate': true,
+                    selected: isSelected,
+                  })}
+                >
+                  {labelElement}
+                </div>
+              </>
+            )}
 
           {/* Child Items */}
           {expanded && <ul>{this.renderChildItems(id, depth + 1)}</ul>}

--- a/src/platform/site-wide/side-nav/components/SideNav.js
+++ b/src/platform/site-wide/side-nav/components/SideNav.js
@@ -23,9 +23,13 @@ class SideNav extends Component {
     const navItem = get(navItemsLookup, `[${id}]`);
     const hasChildren = get(navItem, 'hasChildren');
     const expanded = get(navItem, 'expanded');
+    const depth = get(navItem, 'depth');
 
-    // Escape early if the nav item has no children.
-    if (!hasChildren) {
+    // Determine if the nav item is top-level.
+    const isTopNavItem = depth < 2;
+
+    // Escape early if the item has no children or is not collapsible.
+    if (!hasChildren || isTopNavItem) {
       return;
     }
 

--- a/src/platform/site-wide/side-nav/helpers.js
+++ b/src/platform/site-wide/side-nav/helpers.js
@@ -1,5 +1,5 @@
 // Dependencies
-import { each, get, uniqueId, isEmpty, trimEnd } from 'lodash';
+import { each, get, uniqueId, isEmpty, set, trimEnd } from 'lodash';
 
 /* Recursive function that expands all `parentID`s.
   @param {Object}, options:
@@ -25,7 +25,7 @@ const expandParentIDs = options => {
   }
 
   // Update the nav item to expanded.
-  navItem.expanded = true;
+  set(navItem, 'expanded', true);
 
   // Stop recursing if we went through all the parents.
   if (!parentID) {

--- a/src/platform/site-wide/side-nav/helpers.js
+++ b/src/platform/site-wide/side-nav/helpers.js
@@ -1,5 +1,40 @@
 // Dependencies
-import { each, get, uniqueId, isEmpty } from 'lodash';
+import { each, get, uniqueId, isEmpty, trimEnd } from 'lodash';
+
+/* Recursive function that expands all `parentID`s.
+  @param {Object}, options:
+  {
+    navItemID: string,
+    navItemsLookup: object,
+  }
+  @returns {Object}, navItemsLookup is keyed off `id`.
+*/
+const expandParentIDs = options => {
+  // Derive the properties from options.
+  const navItemID = get(options, 'navItemID');
+  const navItemsLookup = get(options, 'navItemsLookup', {});
+
+  // Derive the nav item properties.
+  const navItem = get(navItemsLookup, `[${navItemID}]`);
+  const expanded = get(navItem, 'expanded');
+  const parentID = get(navItem, 'parentID');
+
+  // Stop recursing if the item is already expanded.
+  if (expanded) {
+    return navItemsLookup;
+  }
+
+  // Update the nav item to expanded.
+  navItem.expanded = true;
+
+  // Stop recursing if we went through all the parents.
+  if (!parentID) {
+    return navItemsLookup;
+  }
+
+  // Continue recursively expanding all parentIDs.
+  return expandParentIDs({ navItemID: parentID, navItemsLookup });
+};
 
 /* Recursive function that derives `navItems` and `navItemsLookup` for `normalizeSideNavData`.
   @param {Object}, options:
@@ -12,9 +47,13 @@ import { each, get, uniqueId, isEmpty } from 'lodash';
 */
 const deriveNavItemsLookup = options => {
   // Derive the properties from options.
+  const depth = get(options, 'depth', 0);
   const items = get(options, 'items', []);
   const parentID = get(options, 'parentID');
   let navItemsLookup = get(options, 'navItemsLookup', {});
+
+  // Determine if the nav items are top-level.
+  const isTopNavItem = depth < 2;
 
   each(items, (item, index) => {
     // Derive item properties.
@@ -24,24 +63,38 @@ const deriveNavItemsLookup = options => {
     const label = get(item, 'label', '');
     const nestedItems = get(item, 'links');
 
+    // Derive the current path.
+    const pathname = trimEnd(window.location.pathname, '/');
+
+    // Derive if the item is selected.
+    const isSelected = pathname === href;
+
     // Construct the formatted item.
     const formattedItem = {
+      depth,
       description,
-      expanded: false,
+      expanded: isTopNavItem || isSelected,
       hasChildren: !isEmpty(nestedItems),
       href,
       id,
       label,
       order: index,
       parentID,
+      isSelected,
     };
 
     // Always add the item to our lookup table keyed off by ID.
     navItemsLookup[id] = formattedItem;
 
+    // Expand all of the nav item's parents if it's selected.
+    if (isSelected) {
+      navItemsLookup = expandParentIDs({ navItemID: parentID, navItemsLookup });
+    }
+
     // Update our navItemsLookup with the nested items if the option is passed.
     if (!isEmpty(nestedItems)) {
       const nestedNavItemsLookup = deriveNavItemsLookup({
+        depth: depth + 1,
         items: nestedItems,
         navItemsLookup,
         parentID: id,

--- a/src/site/navigation/sidebar_nav.drupal.liquid
+++ b/src/site/navigation/sidebar_nav.drupal.liquid
@@ -1,113 +1,104 @@
-{% if buildtype != 'vagovprod' %}
-    <script type="text/javascript">
-      window.sideNav = {{ sidebarData | json }};
-    </script>
+<nav id="va-detailpage-sidebar" data-drupal-sidebar="true" class="va-drupal-sidebarnav usa-width-one-fourth va-sidebarnav">
+    <div>
 
-    {% comment %} React Widget located in `src/platform/site-wide/side-nav` {% endcomment %}
-    <div data-widget-type="side-nav"></div>
-{% else %}
-    <nav id="va-detailpage-sidebar" data-drupal-sidebar="true" class="va-drupal-sidebarnav usa-width-one-fourth va-sidebarnav">
-        <div>
+        <button class="va-btn-close-icon va-sidebarnav-close" type="button" aria-label="Close this menu"></button>
 
-            <button class="va-btn-close-icon va-sidebarnav-close" type="button" aria-label="Close this menu"></button>
+        {% for link in sidebar.links %}
+            {% if forloop.first == true %}
+                <div class="left-side-nav-title">
+                    <i class="icon-small white hub-icon-{{ fieldTitleIcon }} hub-background-{{ fieldTitleIcon }}"></i>
+                    <h4>{{ link.label }}</h4>
+                </div>
 
-            {% for link in sidebar.links %}
-                {% if forloop.first == true %}
-                    <div class="left-side-nav-title">
-                        <i class="icon-small white hub-icon-{{ fieldTitleIcon }} hub-background-{{ fieldTitleIcon }}"></i>
-                        <h4>{{ link.label }}</h4>
-                    </div>
+                {% assign deepLinksString = link.links | findCurrentPathDepth: entityUrl.path %}
+                {% assign deepLinksObj = deepLinksString | jsonToObj %}
+                {% assign depth = deepLinksObj.depth  %}
+                {% assign deepLinks = deepLinksObj.links %}
 
-                    {% assign deepLinksString = link.links | findCurrentPathDepth: entityUrl.path %}
-                    {% assign deepLinksObj = deepLinksString | jsonToObj %}
-                    {% assign depth = deepLinksObj.depth  %}
-                    {% assign deepLinks = deepLinksObj.links %}
-
-                    {% if depth <= 2 %}
-                        <ul class="usa-accordion">
-                        {% for link in link.links %}
-                            <li>
-                                <button class="usa-accordion-button"
-                                        {% if deepLinksString == "false" and forloop.first == true %}
-                                            aria-expanded="true"
-                                        {% else %}
-                                            aria-expanded="false"
-                                        {% endif %}
-                                        aria-controls="a{{ forloop.index }}">
-                                    {{ link.label }}
-                                </button>
-                                <div id="a{{ forloop.index }}" class="usa-accordion-content" aria-hidden="false">
-                                    {% assign listSize = link.links | size %}
-                                    {% if listSize > 0 %}
-                                        <ul class="usa-sidenav-list">
-                                            {% for link in link.links %}
-                                                <li {% if link.url.path contains entityUrl.path %} class="active-level" {% endif %}>
-                                                    <a {% if entityUrl.path == link.url.path %} class="usa-current" {% endif %}
-                                                            href="{{ link.url.path }}" onClick="recordEvent({ event: 'nav-sidenav' });">{{ link.label }}</a>
-                                                    {% assign subListSize = link.links | size %}
-                                                    {% if subListSize > 0 %}
-                                                        <ul class="usa-sidenav-sub_list">
-                                                            {% for link in link.links %}
-                                                                {% assign subSubListSize = link.links | size %}
-                                                                {% if subSubListSize > 0 %}
-                                                                    <li {% if entityUrl.path contains link.url.path %} class="active-level" {% endif %}>
-                                                                        <a {% if entityUrl.path == link.url.path %} class="usa-current" {% endif %}
-                                                                                href="{{ link.url.path }}" onClick="recordEvent({ event: 'nav-sidenav' });">{{ link.label }}</a>
-                                                                        <ul class="usa-sidenav-sub_list">
-                                                                            {% for link in link.links %}
-                                                                                <li>
-                                                                                    <a {% if entityUrl.path == link.url.path %} class="usa-current" {% endif %}
-                                                                                            href="{{ link.url.path }}" onClick="recordEvent({ event: 'nav-sidenav' });">{{ link.label }}</a>
-                                                                                </li>
-                                                                            {% endfor %}
-                                                                        </ul>
-                                                                    </li>
-                                                                {% else %}
-                                                                    <li>
-                                                                        <a {% if entityUrl.path == link.url.path %} class="usa-current" {% endif %}
-                                                                                href="{{ link.url.path }}" onClick="recordEvent({ event: 'nav-sidenav' });">{{ link.label }}</a>
-                                                                    </li>
-                                                                {% endif %}
-                                                            {% endfor %}
-                                                        </ul>
-                                                    {% endif %}
-                                                </li>
-                                            {% endfor %}
-                                        </ul>
+                {% if depth <= 2 %}
+                    <ul class="usa-accordion">
+                    {% for link in link.links %}
+                        <li>
+                            <button class="usa-accordion-button"
+                                    {% if deepLinksString == "false" and forloop.first == true %}
+                                        aria-expanded="true"
+                                    {% else %}
+                                        aria-expanded="false"
                                     {% endif %}
-                                </div>
-                            </li>
-                        {% endfor %}
-                    </ul>
-                {% else %}
-                    <div class="sidenav-previous-page">
-                        <a href="{{ deepLinks.url.path }}">{{ deepLinks.label }}</a>
-                    </div>
-                    <ul class="usa-sidenav-list">
-                        {% for link in deepLinks.links %}
-                            <li {% if entityUrl.path == link.url.path %} class="active-level" {% endif %}>
-                                <a {% if entityUrl.path == link.url.path %} class="usa-current" {% endif %}
-                                        href="{{ link.url.path }}" onClick="recordEvent({ event: 'nav-sidenav' });">{{ link.label }}</a>
-                                {% if link.links.length %}
-                                    <ul class="usa-sidenav-sub_list">
+                                    aria-controls="a{{ forloop.index }}">
+                                {{ link.label }}
+                            </button>
+                            <div id="a{{ forloop.index }}" class="usa-accordion-content" aria-hidden="false">
+                                {% assign listSize = link.links | size %}
+                                {% if listSize > 0 %}
+                                    <ul class="usa-sidenav-list">
                                         {% for link in link.links %}
-                                            <li>
+                                            <li {% if link.url.path contains entityUrl.path %} class="active-level" {% endif %}>
                                                 <a {% if entityUrl.path == link.url.path %} class="usa-current" {% endif %}
                                                         href="{{ link.url.path }}" onClick="recordEvent({ event: 'nav-sidenav' });">{{ link.label }}</a>
+                                                {% assign subListSize = link.links | size %}
+                                                {% if subListSize > 0 %}
+                                                    <ul class="usa-sidenav-sub_list">
+                                                        {% for link in link.links %}
+                                                            {% assign subSubListSize = link.links | size %}
+                                                            {% if subSubListSize > 0 %}
+                                                                <li {% if entityUrl.path contains link.url.path %} class="active-level" {% endif %}>
+                                                                    <a {% if entityUrl.path == link.url.path %} class="usa-current" {% endif %}
+                                                                            href="{{ link.url.path }}" onClick="recordEvent({ event: 'nav-sidenav' });">{{ link.label }}</a>
+                                                                    <ul class="usa-sidenav-sub_list">
+                                                                        {% for link in link.links %}
+                                                                            <li>
+                                                                                <a {% if entityUrl.path == link.url.path %} class="usa-current" {% endif %}
+                                                                                        href="{{ link.url.path }}" onClick="recordEvent({ event: 'nav-sidenav' });">{{ link.label }}</a>
+                                                                            </li>
+                                                                        {% endfor %}
+                                                                    </ul>
+                                                                </li>
+                                                            {% else %}
+                                                                <li>
+                                                                    <a {% if entityUrl.path == link.url.path %} class="usa-current" {% endif %}
+                                                                            href="{{ link.url.path }}" onClick="recordEvent({ event: 'nav-sidenav' });">{{ link.label }}</a>
+                                                                </li>
+                                                            {% endif %}
+                                                        {% endfor %}
+                                                    </ul>
+                                                {% endif %}
                                             </li>
                                         {% endfor %}
                                     </ul>
-                            </li>
-                                {% else %}
-                            </li>
                                 {% endif %}
-                        {% endfor %}
-                    </ul>
-                {% endif %}
+                            </div>
+                        </li>
+                    {% endfor %}
+                </ul>
+            {% else %}
+                <div class="sidenav-previous-page">
+                    <a href="{{ deepLinks.url.path }}">{{ deepLinks.label }}</a>
+                </div>
+                <ul class="usa-sidenav-list">
+                    {% for link in deepLinks.links %}
+                        <li {% if entityUrl.path == link.url.path %} class="active-level" {% endif %}>
+                            <a {% if entityUrl.path == link.url.path %} class="usa-current" {% endif %}
+                                    href="{{ link.url.path }}" onClick="recordEvent({ event: 'nav-sidenav' });">{{ link.label }}</a>
+                            {% if link.links.length %}
+                                <ul class="usa-sidenav-sub_list">
+                                    {% for link in link.links %}
+                                        <li>
+                                            <a {% if entityUrl.path == link.url.path %} class="usa-current" {% endif %}
+                                                    href="{{ link.url.path }}" onClick="recordEvent({ event: 'nav-sidenav' });">{{ link.label }}</a>
+                                        </li>
+                                    {% endfor %}
+                                </ul>
+                        </li>
+                            {% else %}
+                        </li>
+                            {% endif %}
+                    {% endfor %}
+                </ul>
             {% endif %}
+        {% endif %}
 
-            {% endfor %}
+        {% endfor %}
 
-        </div>
-    </nav>
-{% endif %}
+    </div>
+</nav>


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/2577

**Current Behavior:** On non-prod envs, the SideNav items are not by default expanded/collapsed based on the current `window.location.pathname`.

**Desired Behavior:** On non-prod envs, a selected SideNav item should have a black font and all parent nav items should be expanded.

## Testing done
Tested locally at http://localhost:3001/pittsburgh-health-care/locations/pittsburgh-va-medical-center-university-drive and a few other routes.

## Screenshots
![image](https://user-images.githubusercontent.com/12773166/67249713-a7139300-f436-11e9-912a-592f70f302ef.png)

## Acceptance criteria
- [x] Update Expanded Logic to not rely on original data source
- [x] Remove new SideNav from pages other than `/pittsburgh-health-care/**`

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
