### PR TITLE
2317 Adding new Google Analytics codes for Notifications

### DIFF
--- a/src/platform/user/profile/vet360/constants/index.js
+++ b/src/platform/user/profile/vet360/constants/index.js
@@ -73,6 +73,8 @@ export const ANALYTICS_FIELD_MAP = {
   email: 'email',
   mailingAddress: 'mailing-address',
   residentialAddress: 'home-address',
+  smsOptin: 'sms-optin',
+  smsOptout: 'sms-optout',
 };
 
 export const API_ROUTES = {

--- a/src/platform/user/profile/vet360/containers/ReceiveTextMessages.jsx
+++ b/src/platform/user/profile/vet360/containers/ReceiveTextMessages.jsx
@@ -98,8 +98,8 @@ class ReceiveTextMessages extends React.Component {
             checked={!!this.props.profile.vet360.mobilePhone.isTextPermitted}
             label={
               <span>
-                Send me text message (SMS) reminders for my VA health care
-                appointments
+                Please check the box if you want to receive text message (SMS)
+                reminders for my VA health care appointments
               </span>
             }
             onValueChange={this.onChange}

--- a/src/platform/user/profile/vet360/containers/ReceiveTextMessages.jsx
+++ b/src/platform/user/profile/vet360/containers/ReceiveTextMessages.jsx
@@ -55,12 +55,13 @@ class ReceiveTextMessages extends React.Component {
     const payload = this.props.profile.vet360.mobilePhone;
     payload.isTextPermitted = event;
     const method = payload.id ? 'PUT' : 'POST';
+    const smsAction = payload.isTextPermitted ? 'smsOptin' : 'smsOptout';
     this.props.createTransaction(
       this.props.apiRoute,
       method,
       this.props.fieldName,
       payload,
-      this.props.analyticsSectionName,
+      VET360.ANALYTICS_FIELD_MAP[smsAction],
     );
   };
 
@@ -142,7 +143,6 @@ export function mapStateToProps(state, ownProps) {
     isVerified,
     transaction,
     transactionSuccess,
-    analyticsSectionName: VET360.ANALYTICS_FIELD_MAP[fieldName],
     apiRoute: VET360.API_ROUTES.TELEPHONES,
   };
 }

--- a/src/platform/user/profile/vet360/tests/containers/ReceiveTextMessages.unit.spec.jsx
+++ b/src/platform/user/profile/vet360/tests/containers/ReceiveTextMessages.unit.spec.jsx
@@ -103,7 +103,6 @@ describe('<ReceiveTextMessages/>', () => {
       expect(result.hideCheckbox).not.to.be.null;
       expect(result.transaction).to.be.null;
       expect(result.transactionSuccess).to.be.false;
-      expect(result.analyticsSectionName).to.be.equal('mobile-telephone');
       expect(result.apiRoute).to.be.equal('/profile/telephones');
     });
     it('returns hideCheckbox as true when user is not enrolled in va healthcare', () => {


### PR DESCRIPTION
## Description

Additional fields to the Google Analytics field map for opting into receiving SMS text notifications and opting out of SMS text notifications.  Updated the transaction to use the correct one depending on the value being set on the checkbox.

## Testing

Local testing was done to ensure proper value being pulled from the ANALYTICS_FIELD_MAP.
