### PR TITLE
[CMS] Fix for validation not working for Preview Server

### DIFF
--- a/src/site/stages/build/plugins/process-entry-names.js
+++ b/src/site/stages/build/plugins/process-entry-names.js
@@ -88,7 +88,12 @@ function processEntryNames(buildOptions) {
         const hashedEntryName = entryNamesDictionary.get(entryName);
         const entryExists = files[hashedEntryName.slice(1)];
 
-        if (!buildOptions.watch && !entryExists) {
+        if (
+          !buildOptions.watch &&
+          !buildOptions.isPreviewServer &&
+          !buildOptions.entry &&
+          !entryExists
+        ) {
           throw new Error(`Entry Name "${entryName}" was not found.`);
         }
 


### PR DESCRIPTION
## Description
This is a follow-up to https://github.com/department-of-veterans-affairs/vets-website/pull/10935.

After merging, I found that the validation I added failed during these commands -

`npm run preview` - The preview server doesn't work with this validation
`npm run build -- --entry=some-bundle` - If the entry flag is passed, we shouldn't throw errors for bundles not existing.

## Testing done
Local testing of these commands

## Screenshots
N/A

## Acceptance criteria
- [ ] Commands work again

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
