### PR TITLE
Prefill phone number in VAOS contact page

### DIFF
--- a/src/applications/vaos/containers/ContactInfoPage.jsx
+++ b/src/applications/vaos/containers/ContactInfoPage.jsx
@@ -2,11 +2,6 @@ import React from 'react';
 import { connect } from 'react-redux';
 import SchemaForm from 'platform/forms-system/src/js/components/SchemaForm';
 import phoneUI from 'platform/forms-system/src/js/definitions/phone';
-import {
-  selectVet360EmailAddress,
-  selectVet360HomePhoneString,
-  selectVet360MobilePhoneString,
-} from 'platform/user/selectors';
 import FormButtons from '../components/FormButtons';
 
 import {
@@ -75,39 +70,7 @@ const pageKey = 'contactInfo';
 export class ContactInfoPage extends React.Component {
   componentDidMount() {
     this.props.openFormPage(pageKey, uiSchema, initialSchema);
-    this.prefillForm();
   }
-
-  componentDidUpdate(prevProps) {
-    if (
-      (!prevProps.homePhone && this.props.homePhone) ||
-      (!prevProps.mobilePhone && this.props.mobilePhone) ||
-      (!prevProps.emailAddress && this.props.emailAddress)
-    ) {
-      this.prefillForm();
-    }
-  }
-
-  prefillForm = () => {
-    const phoneNumber = this.props.mobilePhone || this.props.homePhone;
-    // only prefill the phone number if it isn't already set
-    if (phoneNumber && !this.props.data.phoneNumber) {
-      this.props.updateFormData(pageKey, uiSchema, {
-        ...this.props.data,
-        phoneNumber,
-      });
-    }
-    // The following is disabled since we don't yet have email address on this page.
-    // When it's enabled it'll be best to refactor this to make a single call to
-    // updateFormData.
-    // // only prefill the email address if it isn't already set
-    // if (this.props.emailAddress && !this.props.data.emailAddress) {
-    //   this.props.updateFormData(pageKey, uiSchema, {
-    //     ...this.props.data,
-    //     emailAddress: this.props.emailAddress,
-    //   });
-    // }
-  };
 
   goBack = () => {
     this.props.routeToPreviousAppointmentPage(this.props.router, pageKey);
@@ -142,13 +105,7 @@ export class ContactInfoPage extends React.Component {
 }
 
 function mapStateToProps(state) {
-  const formPageInfo = getFormPageInfo(state, pageKey);
-  return {
-    ...formPageInfo,
-    emailAddress: selectVet360EmailAddress(state),
-    homePhone: selectVet360HomePhoneString(state),
-    mobilePhone: selectVet360MobilePhoneString(state),
-  };
+  return getFormPageInfo(state, pageKey);
 }
 
 const mapDispatchToProps = {

--- a/src/applications/vaos/containers/ContactInfoPage.jsx
+++ b/src/applications/vaos/containers/ContactInfoPage.jsx
@@ -2,6 +2,11 @@ import React from 'react';
 import { connect } from 'react-redux';
 import SchemaForm from 'platform/forms-system/src/js/components/SchemaForm';
 import phoneUI from 'platform/forms-system/src/js/definitions/phone';
+import {
+  selectVet360EmailAddress,
+  selectVet360HomePhoneString,
+  selectVet360MobilePhoneString,
+} from 'platform/user/selectors';
 import FormButtons from '../components/FormButtons';
 
 import {
@@ -18,7 +23,7 @@ const initialSchema = {
   properties: {
     phoneNumber: {
       type: 'string',
-      minLength: 10,
+      pattern: '^[0-9]{10}$',
     },
     bestTimeToCall: {
       type: 'object',
@@ -70,7 +75,39 @@ const pageKey = 'contactInfo';
 export class ContactInfoPage extends React.Component {
   componentDidMount() {
     this.props.openFormPage(pageKey, uiSchema, initialSchema);
+    this.prefillForm();
   }
+
+  componentDidUpdate(prevProps) {
+    if (
+      (!prevProps.homePhone && this.props.homePhone) ||
+      (!prevProps.mobilePhone && this.props.mobilePhone) ||
+      (!prevProps.emailAddress && this.props.emailAddress)
+    ) {
+      this.prefillForm();
+    }
+  }
+
+  prefillForm = () => {
+    const phoneNumber = this.props.mobilePhone || this.props.homePhone;
+    // only prefill the phone number if it isn't already set
+    if (phoneNumber && !this.props.data.phoneNumber) {
+      this.props.updateFormData(pageKey, uiSchema, {
+        ...this.props.data,
+        phoneNumber,
+      });
+    }
+    // The following is disabled since we don't yet have email address on this page.
+    // When it's enabled it'll be best to refactor this to make a single call to
+    // updateFormData.
+    // // only prefill the email address if it isn't already set
+    // if (this.props.emailAddress && !this.props.data.emailAddress) {
+    //   this.props.updateFormData(pageKey, uiSchema, {
+    //     ...this.props.data,
+    //     emailAddress: this.props.emailAddress,
+    //   });
+    // }
+  };
 
   goBack = () => {
     this.props.routeToPreviousAppointmentPage(this.props.router, pageKey);
@@ -105,7 +142,13 @@ export class ContactInfoPage extends React.Component {
 }
 
 function mapStateToProps(state) {
-  return getFormPageInfo(state, pageKey);
+  const formPageInfo = getFormPageInfo(state, pageKey);
+  return {
+    ...formPageInfo,
+    emailAddress: selectVet360EmailAddress(state),
+    homePhone: selectVet360HomePhoneString(state),
+    mobilePhone: selectVet360MobilePhoneString(state),
+  };
 }
 
 const mapDispatchToProps = {

--- a/src/applications/vaos/containers/TypeOfCarePage.jsx
+++ b/src/applications/vaos/containers/TypeOfCarePage.jsx
@@ -1,6 +1,11 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import SchemaForm from 'platform/forms-system/src/js/components/SchemaForm';
+import {
+  selectVet360EmailAddress,
+  selectVet360HomePhoneString,
+  selectVet360MobilePhoneString,
+} from 'platform/user/selectors';
 
 import { TYPES_OF_CARE, DIRECT_SCHEDULE_TYPES } from '../utils/constants';
 import { getPastAppointments } from '../api';
@@ -40,6 +45,7 @@ const pageKey = 'typeOfCare';
 export class TypeOfCarePage extends React.Component {
   componentDidMount() {
     this.props.openFormPage(pageKey, uiSchema, initialSchema);
+    this.prefillContactInfo();
   }
 
   onChange = newData => {
@@ -52,6 +58,31 @@ export class TypeOfCarePage extends React.Component {
     }
 
     this.props.updateFormData(pageKey, uiSchema, newData);
+  };
+
+  prefillContactInfo = () => {
+    const phoneNumber = this.props.mobilePhone || this.props.homePhone;
+    // only prefill the phone number if it isn't already set. So if the user has
+    // explicitly set a phone number and then gone back to the start of the New
+    // Appointment flow (without a hard refresh), this prefill won't rerun,
+    // overwriting what they have manually entered
+    if (phoneNumber && !this.props.data.phoneNumber) {
+      this.props.updateFormData(pageKey, uiSchema, {
+        ...this.props.data,
+        phoneNumber,
+      });
+    }
+    // The following is disabled since we don't yet have email address on the
+    // Contact Info page.. When it's enabled it'll be best to refactor this
+    // function to make a single call to updateFormData rather than one for
+    // phone number and one for email address.
+    // // only prefill the email address if it isn't already set
+    // if (this.props.emailAddress && !this.props.data.emailAddress) {
+    //   this.props.updateFormData(pageKey, uiSchema, {
+    //     ...this.props.data,
+    //     emailAddress: this.props.emailAddress,
+    //   });
+    // }
   };
 
   goBack = () => {
@@ -90,7 +121,13 @@ export class TypeOfCarePage extends React.Component {
 }
 
 function mapStateToProps(state) {
-  return getFormPageInfo(state, pageKey);
+  const formPageInfo = getFormPageInfo(state, pageKey);
+  return {
+    ...formPageInfo,
+    emailAddress: selectVet360EmailAddress(state),
+    homePhone: selectVet360HomePhoneString(state),
+    mobilePhone: selectVet360MobilePhoneString(state),
+  };
 }
 
 const mapDispatchToProps = {

--- a/src/applications/vaos/sass/vaos.scss
+++ b/src/applications/vaos/sass/vaos.scss
@@ -58,7 +58,7 @@
 .vaos-calendar__weekday {
   width: 20%;
 }
-    
+
 
 .vaos-calendar__calendar-day {
   border-radius: 5px;
@@ -89,7 +89,7 @@
     background-color: $color-primary;
     border-color: $color-primary;
     color: $color-white;
-    
+
     .vaos-calendar__cell-selected-triangle {
       display: block;
       height: 20px;
@@ -140,8 +140,8 @@
   border-radius: 5px;
   padding: 8px 0;
   margin: 8px;
-  
-  
+
+
   input[type="radio"], input[type="checkbox"] {
     width: unset;
   }

--- a/src/platform/forms-system/src/js/widgets/PhoneNumberWidget.jsx
+++ b/src/platform/forms-system/src/js/widgets/PhoneNumberWidget.jsx
@@ -11,11 +11,7 @@ export default class PhoneNumberWidget extends React.Component {
     super(props);
     this.state = { val: props.value };
   }
-  componentDidUpdate(previousProps) {
-    if (previousProps.value !== this.props.value) {
-      this.handleChange(this.props.value);
-    }
-  }
+
   handleChange = val => {
     let stripped;
     if (val) {

--- a/src/platform/forms-system/src/js/widgets/PhoneNumberWidget.jsx
+++ b/src/platform/forms-system/src/js/widgets/PhoneNumberWidget.jsx
@@ -10,6 +10,11 @@ export default class PhoneNumberWidget extends React.Component {
     super(props);
     this.state = { val: props.value };
   }
+  componentDidUpdate(previousProps) {
+    if (previousProps.value !== this.props.value) {
+      this.handleChange(this.props.value);
+    }
+  }
   handleChange = val => {
     let stripped;
     if (val) {

--- a/src/platform/forms-system/src/js/widgets/PhoneNumberWidget.jsx
+++ b/src/platform/forms-system/src/js/widgets/PhoneNumberWidget.jsx
@@ -2,8 +2,9 @@ import React from 'react';
 import TextWidget from './TextWidget';
 
 /*
- * Handles removing dashes from SSNs by keeping the user input in local state
- * and saving the transformed version instead
+ * Handles removing dashes, parentheses, and the letter `x` from phone numbers
+ * by keeping the user input in local state and saving the transformed version
+ * instead
  */
 export default class PhoneNumberWidget extends React.Component {
   constructor(props) {

--- a/src/platform/user/selectors.js
+++ b/src/platform/user/selectors.js
@@ -15,7 +15,8 @@ export const selectVet360EmailAddress = state =>
 const createPhoneNumberStringFromData = (phoneNumberData = {}) => {
   const areaCode = phoneNumberData.areaCode || '';
   const phoneNumber = phoneNumberData.phoneNumber || '';
-  // in some test data the extension is set to '0000'
+  // in some test data the extension is set to '0000' and we want to treat that
+  // as a null extension
   const extension =
     phoneNumberData.extension === '0000'
       ? undefined

--- a/src/platform/user/selectors.js
+++ b/src/platform/user/selectors.js
@@ -9,6 +9,27 @@ export const isLOA3 = state => selectProfile(state).loa.current === 3;
 export const isLOA1 = state => selectProfile(state).loa.current === 1;
 export const isMultifactorEnabled = state => selectProfile(state).multifactor;
 export const selectAvailableServices = state => selectProfile(state).services;
+export const selectVet360 = state => selectProfile(state).vet360;
+export const selectVet360EmailAddress = state =>
+  selectVet360(state)?.email?.emailAddress;
+const createPhoneNumberStringFromData = (phoneNumberData = {}) => {
+  const areaCode = phoneNumberData.areaCode || '';
+  const phoneNumber = phoneNumberData.phoneNumber || '';
+  // in some test data the extension is set to '0000'
+  const extension =
+    phoneNumberData.extension === '0000'
+      ? undefined
+      : phoneNumberData.extension;
+  return `${areaCode}${phoneNumber}${extension ? `x${extension}` : ''}`;
+};
+export const selectVet360MobilePhone = state =>
+  selectVet360(state)?.mobilePhone;
+export const selectVet360MobilePhoneString = state =>
+  createPhoneNumberStringFromData(selectVet360MobilePhone(state));
+export const selectVet360HomePhone = state => selectVet360(state)?.homePhone;
+export const selectVet360HomePhoneString = state =>
+  createPhoneNumberStringFromData(selectVet360HomePhone(state));
+
 export function createIsServiceAvailableSelector(service) {
   return state => selectAvailableServices(state).includes(service);
 }

--- a/src/platform/user/tests/selectors.unit.spec.js
+++ b/src/platform/user/tests/selectors.unit.spec.js
@@ -1,0 +1,247 @@
+import { expect } from 'chai';
+import * as selectors from '../selectors';
+
+describe('user selectors', () => {
+  describe('selectVet360', () => {
+    it('pulls out the state.profile.vet360 data', () => {
+      const state = {
+        user: {
+          profile: {
+            vet360: {
+              email: {
+                emailAddress: '123@va.com',
+              },
+            },
+          },
+        },
+      };
+      expect(selectors.selectVet360(state)).to.deep.equal(
+        state.user.profile.vet360,
+      );
+    });
+    it('returns undefined if there is not vet360 on the profile', () => {
+      const state = {
+        user: {
+          profile: {},
+        },
+      };
+      expect(selectors.selectVet360(state)).to.be.undefined;
+    });
+  });
+
+  describe('selectVet360EmailAddress', () => {
+    it('pulls out the state.profile.vet360.emailAddress', () => {
+      const state = {
+        user: {
+          profile: {
+            vet360: {
+              email: {
+                createdAt: '2019-10-11T12:42:14.000Z',
+                emailAddress: 'testertester2@mail.com',
+                effectiveEndDate: null,
+                effectiveStartDate: '2019-10-11T12:41:06.000Z',
+                id: 70619,
+                sourceDate: '2019-10-11T12:41:06.000Z',
+                sourceSystemUser: null,
+                transactionId: '5fda71d0-7e4c-468c-aee7-21c16405ca1f',
+                updatedAt: '2019-10-11T12:42:14.000Z',
+                vet360Id: '139281',
+              },
+            },
+          },
+        },
+      };
+      expect(selectors.selectVet360EmailAddress(state)).to.equal(
+        state.user.profile.vet360.email.emailAddress,
+      );
+    });
+    it('returns undefined if there is no vet360 on the profile', () => {
+      const state = {
+        user: {
+          profile: {},
+        },
+      };
+      expect(selectors.selectVet360EmailAddress(state)).to.be.undefined;
+    });
+    it('returns undefined if there is no email', () => {
+      const state = {
+        user: {
+          profile: {
+            vet360: {},
+          },
+        },
+      };
+      expect(selectors.selectVet360EmailAddress(state)).to.be.undefined;
+    });
+  });
+
+  describe('phone number selectors', () => {
+    const phoneNumberData = {
+      areaCode: '415',
+      countryCode: '1',
+      createdAt: '2019-10-22T13:39:19.000Z',
+      extension: null,
+      effectiveEndDate: null,
+      effectiveStartDate: '2019-10-22T13:41:02.000Z',
+      id: 82709,
+      isInternational: false,
+      isTextable: null,
+      isTextPermitted: null,
+      isTty: null,
+      isVoicemailable: null,
+      phoneNumber: '8453210',
+      phoneType: 'MOBILE',
+      sourceDate: '2019-10-22T13:41:02.000Z',
+      sourceSystemUser: null,
+      transactionId: '5d83b4cd-da19-42fd-8c90-40382c4b61cb',
+      updatedAt: '2019-10-22T13:41:03.000Z',
+      vet360Id: '139281',
+    };
+
+    describe('selectVet360MobilePhone', () => {
+      it('pulls out the state.profile.vet360.mobilePhone data object', () => {
+        const state = {
+          user: {
+            profile: {
+              vet360: {
+                mobilePhone: phoneNumberData,
+              },
+            },
+          },
+        };
+        expect(selectors.selectVet360MobilePhone(state)).to.deep.equal(
+          state.user.profile.vet360.mobilePhone,
+        );
+      });
+      it('returns undefined if there is no vet360 on the profile', () => {
+        const state = {
+          user: {
+            profile: {},
+          },
+        };
+        expect(selectors.selectVet360MobilePhone(state)).to.be.undefined;
+      });
+      it('returns undefined if there is no mobile phone', () => {
+        const state = {
+          user: {
+            profile: {
+              vet360: {},
+            },
+          },
+        };
+        expect(selectors.selectVet360MobilePhone(state)).to.be.undefined;
+      });
+    });
+
+    describe('selectVet360MobilePhoneString', () => {
+      it('pulls out the mobile phone number as a single string if it exists', () => {
+        const state = {
+          user: {
+            profile: {
+              vet360: {
+                mobilePhone: phoneNumberData,
+              },
+            },
+          },
+        };
+        expect(selectors.selectVet360MobilePhoneString(state)).to.equal(
+          '4158453210',
+        );
+      });
+      it('properly handles phone numbers with an extension', () => {
+        const state = {
+          user: {
+            profile: {
+              vet360: {
+                mobilePhone: { ...phoneNumberData, extension: '1234' },
+              },
+            },
+          },
+        };
+        expect(selectors.selectVet360MobilePhoneString(state)).to.equal(
+          '4158453210x1234',
+        );
+      });
+      it('properly handles phone numbers with an extension of "0000"', () => {
+        const state = {
+          user: {
+            profile: {
+              vet360: {
+                mobilePhone: { ...phoneNumberData, extension: '0000' },
+              },
+            },
+          },
+        };
+        expect(selectors.selectVet360MobilePhoneString(state)).to.equal(
+          '4158453210',
+        );
+      });
+    });
+
+    describe('selectVet360HomePhone', () => {
+      it('pulls out the state.profile.vet360.homePhone data object', () => {
+        const state = {
+          user: {
+            profile: {
+              vet360: {
+                homePhone: phoneNumberData,
+              },
+            },
+          },
+        };
+        expect(selectors.selectVet360HomePhone(state)).to.deep.equal(
+          state.user.profile.vet360.homePhone,
+        );
+      });
+      it('returns undefined if there is no vet360 on the profile', () => {
+        const state = {
+          user: {
+            profile: {},
+          },
+        };
+        expect(selectors.selectVet360HomePhone(state)).to.be.undefined;
+      });
+      it('returns undefined if there is no mobile phone', () => {
+        const state = {
+          user: {
+            profile: {
+              vet360: {},
+            },
+          },
+        };
+        expect(selectors.selectVet360HomePhone(state)).to.be.undefined;
+      });
+    });
+
+    describe('selectVet360HomePhoneString', () => {
+      it('pulls out the home phone number as a single string if it exists', () => {
+        const state = {
+          user: {
+            profile: {
+              vet360: {
+                homePhone: phoneNumberData,
+              },
+            },
+          },
+        };
+        expect(selectors.selectVet360HomePhoneString(state)).to.equal(
+          '4158453210',
+        );
+      });
+      it('properly handles phone numbers with an extension', () => {
+        const state = {
+          user: {
+            profile: {
+              vet360: {
+                homePhone: { ...phoneNumberData, extension: '1234' },
+              },
+            },
+          },
+        };
+        expect(selectors.selectVet360HomePhoneString(state)).to.equal(
+          '4158453210x1234',
+        );
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Description
**You can test this with user 37 locally.**

This PR prefills the phone number in the Contact Page in the VAOS appointment flow. 

Also:
- adds new vet360 Redux selectors

## Testing done
Local

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs