### PR TITLE
Check early if the hashed entry name exists

### DIFF
--- a/src/site/stages/build/plugins/process-entry-names.js
+++ b/src/site/stages/build/plugins/process-entry-names.js
@@ -87,11 +87,8 @@ function processEntryNames(buildOptions) {
         const entryName = $el.data('entryName');
         const attribute = $el.is('script') ? 'src' : 'href';
 
-        // Derive the hashed entry name and make sure it exists.
-        const hashedEntryName = entryNamesDictionary.get(entryName);
-        if (!hashedEntryName) {
-          throw new Error(`Entry Name "${entryName}" was not found.`);
-        }
+        // Derive the hashed entry name.
+        const hashedEntryName = entryNamesDictionary.get(entryName) || [];
 
         // Ensure we have valid options and that the entry exists.
         const entryExists = files[hashedEntryName.slice(1)];

--- a/src/site/stages/build/plugins/process-entry-names.js
+++ b/src/site/stages/build/plugins/process-entry-names.js
@@ -82,12 +82,19 @@ function processEntryNames(buildOptions) {
       if (!dom) continue;
 
       dom('script[data-entry-name],link[data-entry-name]').each((index, el) => {
+        // Derive the element properties.
         const $el = dom(el);
         const entryName = $el.data('entryName');
         const attribute = $el.is('script') ? 'src' : 'href';
-        const hashedEntryName = entryNamesDictionary.get(entryName);
-        const entryExists = files[hashedEntryName.slice(1)];
 
+        // Derive the hashed entry name and make sure it exists.
+        const hashedEntryName = entryNamesDictionary.get(entryName);
+        if (!hashedEntryName) {
+          throw new Error(`Entry Name "${entryName}" was not found.`);
+        }
+
+        // Ensure we have valid options and that the entry exists.
+        const entryExists = files[hashedEntryName.slice(1)];
         if (
           !buildOptions.watch &&
           !buildOptions.isPreviewServer &&
@@ -97,6 +104,7 @@ function processEntryNames(buildOptions) {
           throw new Error(`Entry Name "${entryName}" was not found.`);
         }
 
+        // Link the element to the hashed entry name.
         $el.attr(attribute, hashedEntryName);
         file.modified = true;
       });


### PR DESCRIPTION
## Description
This PR is a quick fix for the following runtime error that was being thrown in Jenkins:
![Screen Shot 2019-10-25 at 9 48 24 AM](https://user-images.githubusercontent.com/12773166/67584698-2f868200-f71c-11e9-8aa6-cd04cec24af4.png)

This issue derives from this line of code here that was merged in: https://github.com/department-of-veterans-affairs/vets-website/pull/10935/files#diff-d27e34ec55c7f073b93e4073f9e13d0cR89

## Testing done
Ran `yarn build` locally afterwards with no issues.

## Screenshots
^^

## Acceptance criteria
- [x] Fixes the runtime error on Jenkins.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
