### PR TITLE
Filter tome-sync export

### DIFF
--- a/src/site/stages/build/page-builder/filters.js
+++ b/src/site/stages/build/page-builder/filters.js
@@ -2,6 +2,7 @@
  * When reading through entity properties, ignore these.
  */
 const blackList = new Set([
+  'uuid',
   'type',
   'revision_uid',
   'revision_user',
@@ -30,7 +31,6 @@ const blackList = new Set([
 ]);
 
 const ignoredPageProps = [
-  'uuid',
   'revision_timestamp',
   'revision_log',
   'field_plainlanguage_date',

--- a/src/site/stages/build/page-builder/filters.js
+++ b/src/site/stages/build/page-builder/filters.js
@@ -51,10 +51,32 @@ const ignoredPromoProps = [
   'field_owner',
 ];
 
+const ignoredParagraphProps = ['behavior_settings', 'created'];
+
+/* eslint-disable camelcase */
 const ignoreMap = {
   page: ignoredPageProps,
   promo: ignoredPromoProps,
+  alert: ignoredParagraphProps,
+  collapsible_panel: ignoredParagraphProps,
+  collapsible_panel_item: ignoredParagraphProps,
+  downloadable_file: ignoredParagraphProps,
+  expandable_text: ignoredParagraphProps,
+  health_care_local_facility_servi: ignoredParagraphProps,
+  link_teaser: ignoredParagraphProps,
+  list_of_link_teasers: ignoredParagraphProps,
+  media: ignoredParagraphProps,
+  number_callout: ignoredParagraphProps,
+  process: ignoredParagraphProps,
+  q_a: ignoredParagraphProps,
+  q_a_section: ignoredParagraphProps,
+  react_widget: ignoredParagraphProps,
+  spanish_translation_summary: ignoredParagraphProps,
+  staff_profile: ignoredParagraphProps,
+  table: ignoredParagraphProps,
+  wysiwyg: ignoredParagraphProps,
 };
+/* eslint-enable camelcase */
 
 function getFilterType(contentModelType) {
   return new Set(ignoreMap[contentModelType]);

--- a/src/site/stages/build/page-builder/filters.js
+++ b/src/site/stages/build/page-builder/filters.js
@@ -15,6 +15,10 @@ const blackList = new Set([
   'vid',
   'access_scheme',
   'bundle',
+  'langcode',
+  'status',
+  'default_langcode',
+  'revision_translation_affected',
   // Temporarily ignore the following properties because they were
   // causing circular references. Once we get reader functions based
   // on individual node / entity types, we can remove these from here.
@@ -27,17 +31,13 @@ const blackList = new Set([
 
 const ignoredPageProps = [
   'uuid',
-  'langcode',
   'revision_timestamp',
   'revision_uuid',
   'revision_log',
-  'status',
   'field_plainlanguage_date',
   'promote',
   'created',
   'sticky',
-  'default_langcode',
-  'revision_translation_affected',
 ];
 
 function getFilterType(contentModelType) {

--- a/src/site/stages/build/page-builder/filters.js
+++ b/src/site/stages/build/page-builder/filters.js
@@ -51,19 +51,13 @@ const ignoredPromoProps = [
   'field_owner',
 ];
 
+const ignoreMap = {
+  page: ignoredPageProps,
+  promo: ignoredPromoProps,
+};
+
 function getFilterType(contentModelType) {
-  let ignoredProps = [];
-  switch (contentModelType) {
-    case 'page':
-      ignoredProps = ignoredPageProps;
-      break;
-    case 'promo':
-      ignoredProps = ignoredPromoProps;
-      break;
-    default:
-      break;
-  }
-  return new Set(ignoredProps);
+  return new Set(ignoreMap[contentModelType]);
 }
 
 /**

--- a/src/site/stages/build/page-builder/filters.js
+++ b/src/site/stages/build/page-builder/filters.js
@@ -32,7 +32,6 @@ const blackList = new Set([
 const ignoredPageProps = [
   'uuid',
   'revision_timestamp',
-  'revision_uuid',
   'revision_log',
   'field_plainlanguage_date',
   'promote',

--- a/src/site/stages/build/page-builder/filters.js
+++ b/src/site/stages/build/page-builder/filters.js
@@ -40,11 +40,25 @@ const ignoredPageProps = [
   'sticky',
 ];
 
+const ignoredPromoProps = [
+  'revision_created',
+  'revision_log',
+  'changed',
+  'reusable',
+  'moderation_state',
+  'field_image',
+  'field_instructions',
+  'field_owner',
+];
+
 function getFilterType(contentModelType) {
   let ignoredProps = [];
   switch (contentModelType) {
     case 'page':
       ignoredProps = ignoredPageProps;
+      break;
+    case 'promo':
+      ignoredProps = ignoredPromoProps;
       break;
     default:
       break;

--- a/src/site/stages/build/page-builder/filters.js
+++ b/src/site/stages/build/page-builder/filters.js
@@ -1,0 +1,81 @@
+/**
+ * When reading through entity properties, ignore these.
+ */
+const blackList = new Set([
+  'type',
+  'revision_uid',
+  'revision_user',
+  'user_id',
+  'items',
+  'owner_id',
+  'parent',
+  'role_id',
+  'roles',
+  'uid',
+  'vid',
+  'access_scheme',
+  'bundle',
+  // Temporarily ignore the following properties because they were
+  // causing circular references. Once we get reader functions based
+  // on individual node / entity types, we can remove these from here.
+  // See the jsdoc on getEntityProperties for more information.
+  'field_facility_location',
+  'field_regional_health_service',
+  'field_region_page',
+  'field_office',
+]);
+
+const ignoredPageProps = [
+  'uuid',
+  'langcode',
+  'revision_timestamp',
+  'revision_uuid',
+  'revision_log',
+  'status',
+  'field_plainlanguage_date',
+  'promote',
+  'created',
+  'sticky',
+  'default_langcode',
+  'revision_translation_affected',
+];
+
+function getFilterType(contentModelType) {
+  let ignoredProps = [];
+  switch (contentModelType) {
+    case 'page':
+      ignoredProps = ignoredPageProps;
+      break;
+    default:
+      break;
+  }
+  return new Set(ignoredProps);
+}
+
+/**
+ * Takes the entity type and entity contents before any data
+ * transformation and returns a new entity with only the desired
+ * properties based on the content model type.
+ *
+ * @param {String} contentModelType - The type of content model.
+ * @param {Object} entity - The contents of the entity itself before
+ *                          reference expansion and property
+ *                          transformation.
+ *
+ * @return {Object} - The entity with only the desired properties
+ *                    for the specific content model type.
+ */
+function getFilteredEntity(contentModelType, entity) {
+  // TODO: Filter properties based on content model type
+  const entityTypeFilter = getFilterType(contentModelType);
+  const entityFilter = new Set([...blackList, ...entityTypeFilter]);
+  return Object.keys(entity).reduce((newEntity, key) => {
+    // eslint-disable-next-line no-param-reassign
+    if (!entityFilter.has(key)) newEntity[key] = entity[key];
+    return newEntity;
+  }, {});
+}
+
+module.exports = {
+  getFilteredEntity,
+};

--- a/src/site/stages/build/page-builder/helpers.js
+++ b/src/site/stages/build/page-builder/helpers.js
@@ -37,7 +37,7 @@ const blackList = new Set([
   'field_office',
 ]);
 
-const pageFilter = new Set([
+const ignoredPageProps = [
   'langcode',
   'revision_timestamp',
   'revision_uuid',
@@ -48,18 +48,18 @@ const pageFilter = new Set([
   'created',
   'default_langcode',
   'revision_translation_affected',
-]);
+];
 
 function getFilterType(contentModelType) {
-  let entityFilter = new Set();
+  let ignoredProps = [];
   switch (contentModelType) {
     case 'page':
-      entityFilter = pageFilter;
+      ignoredProps = ignoredPageProps;
       break;
     default:
       break;
   }
-  return entityFilter;
+  return new Set(ignoredProps);
 }
 
 /**

--- a/src/site/stages/build/page-builder/helpers.js
+++ b/src/site/stages/build/page-builder/helpers.js
@@ -1,5 +1,6 @@
 const fs = require('fs');
 const path = require('path');
+const { getFilteredEntity } = require('./filters');
 
 /**
  * This assumes the tome-sync output is sibling to the vets-website
@@ -9,60 +10,6 @@ const contentDir = path.join(
   __dirname,
   '../../../../../../tome-sync-output/content/',
 );
-
-/**
- * When reading through entity properties, ignore these.
- */
-const blackList = new Set([
-  'type',
-  'revision_uid',
-  'revision_user',
-  'user_id',
-  'items',
-  'owner_id',
-  'parent',
-  'role_id',
-  'roles',
-  'uid',
-  'vid',
-  'access_scheme',
-  'bundle',
-  // Temporarily ignore the following properties because they were
-  // causing circular references. Once we get reader functions based
-  // on individual node / entity types, we can remove these from here.
-  // See the jsdoc on getEntityProperties for more information.
-  'field_facility_location',
-  'field_regional_health_service',
-  'field_region_page',
-  'field_office',
-]);
-
-const ignoredPageProps = [
-  'uuid',
-  'langcode',
-  'revision_timestamp',
-  'revision_uuid',
-  'revision_log',
-  'status',
-  'field_plainlanguage_date',
-  'promote',
-  'created',
-  'sticky',
-  'default_langcode',
-  'revision_translation_affected',
-];
-
-function getFilterType(contentModelType) {
-  let ignoredProps = [];
-  switch (contentModelType) {
-    case 'page':
-      ignoredProps = ignoredPageProps;
-      break;
-    default:
-      break;
-  }
-  return new Set(ignoredProps);
-}
 
 /**
  * Get the content model type of an entity. This is used for
@@ -80,30 +27,6 @@ function getFilterType(contentModelType) {
  */
 function getContentModelType(entityType, entity) {
   return entity.type ? entity.type[0].target_id : entityType;
-}
-
-/**
- * Takes the entity type and entity contents before any data
- * transformation and returns a new entity with only the desired
- * properties based on the content model type.
- *
- * @param {String} contentModelType - The type of content model.
- * @param {Object} entity - The contents of the entity itself before
- *                          reference expansion and property
- *                          transformation.
- *
- * @return {Object} - The entity with only the desired properties
- *                    for the specific content model type.
- */
-function getFilteredEntity(contentModelType, entity) {
-  // TODO: Filter properties based on content model type
-  const entityTypeFilter = getFilterType(contentModelType);
-  const entityFilter = new Set([...blackList, ...entityTypeFilter]);
-  return Object.keys(entity).reduce((newEntity, key) => {
-    // eslint-disable-next-line no-param-reassign
-    if (!entityFilter.has(key)) newEntity[key] = entity[key];
-    return newEntity;
-  }, {});
 }
 
 /**

--- a/src/site/stages/build/page-builder/helpers.js
+++ b/src/site/stages/build/page-builder/helpers.js
@@ -38,6 +38,7 @@ const blackList = new Set([
 ]);
 
 const ignoredPageProps = [
+  'uuid',
   'langcode',
   'revision_timestamp',
   'revision_uuid',
@@ -46,6 +47,7 @@ const ignoredPageProps = [
   'field_plainlanguage_date',
   'promote',
   'created',
+  'sticky',
   'default_langcode',
   'revision_translation_affected',
 ];

--- a/src/site/stages/build/page-builder/helpers.js
+++ b/src/site/stages/build/page-builder/helpers.js
@@ -37,6 +37,31 @@ const blackList = new Set([
   'field_office',
 ]);
 
+const pageFilter = new Set([
+  'langcode',
+  'revision_timestamp',
+  'revision_uuid',
+  'revision_log',
+  'status',
+  'field_plainlanguage_date',
+  'promote',
+  'created',
+  'default_langcode',
+  'revision_translation_affected',
+]);
+
+function getFilterType(contentModelType) {
+  let entityFilter = new Set();
+  switch (contentModelType) {
+    case 'page':
+      entityFilter = pageFilter;
+      break;
+    default:
+      break;
+  }
+  return entityFilter;
+}
+
 /**
  * Get the content model type of an entity. This is used for
  * determining how to handle specific entities. For example, in some
@@ -70,9 +95,11 @@ function getContentModelType(entityType, entity) {
  */
 function getFilteredEntity(contentModelType, entity) {
   // TODO: Filter properties based on content model type
+  const entityTypeFilter = getFilterType(contentModelType);
+  const entityFilter = new Set([...blackList, ...entityTypeFilter]);
   return Object.keys(entity).reduce((newEntity, key) => {
     // eslint-disable-next-line no-param-reassign
-    if (!blackList.has(key)) newEntity[key] = entity[key];
+    if (!entityFilter.has(key)) newEntity[key] = entity[key];
     return newEntity;
   }, {});
 }


### PR DESCRIPTION
## Description

The tome-sync export contains lots of key/value pairs that we don't care about.  This PR establishes a strategy for filtering out the properties that we don't want & then passing the subset onto the transformation stage.

More PRs will likely follow this one to add more whitelists/blacklists for each of the numerous subtypes.  At the moment this contains the blacklist for the following subtypes:

- `page` - subtype of `node`
- `promo` - subtype of `block_content`
- All subtypes of `paragraph`
  - `rg "target_id" paragraph.*.json | sed -E 's/.*: "(.*)".*/\1/' | sort | uniq -c`
  ```
     14 alert
     62 collapsible_panel
    266 collapsible_panel_item
    156 downloadable_file
      9 expandable_text
     43 health_care_local_facility_servi
   1075 link_teaser
    209 list_of_link_teasers
     10 media
     15 number_callout
     49 process
    971 q_a
    296 q_a_section
     27 react_widget
      2 spanish_translation_summary
     62 staff_profile
    137 table
   1359 wysiwyg
  ```

(Part of https://github.com/department-of-veterans-affairs/va.gov-team/issues/2697)

## Testing done

Manual so far - comparing JSON from `pages.json` to the files that tome-sync gives us.  Using [this PR](https://github.com/department-of-veterans-affairs/vets-website/pull/10939) for some guidance.

<!--

## Screenshots

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs

-->
