### PR TITLE
VAGOV-5999: Adding operating status page logic.

### DIFF
--- a/src/platform/site-wide/sass/shame.scss
+++ b/src/platform/site-wide/sass/shame.scss
@@ -579,19 +579,3 @@ img[data-srcset] {
 .operating-status-title {
   margin: auto;
 }
-
-.operating-status-info {
-  min-height: 70px;
-  padding: 10px 0;
-  .normal-hours {
-    margin-top: 14px;
-    display: block
-  }
-}
-
-.emergency-resources {
-  h3 {
-    margin-top: 1.5em;
-    margin-bottom: 1em;
-  }
-}

--- a/src/platform/site-wide/sass/shame.scss
+++ b/src/platform/site-wide/sass/shame.scss
@@ -571,3 +571,27 @@ img[data-srcset] {
   border-top-left-radius: 0;
   border-bottom-left-radius: 0;
 }
+
+.no-p-bottom-margin p {
+  margin-bottom: 0;
+}
+
+.operating-status-title {
+  margin: auto;
+}
+
+.operating-status-info {
+  min-height: 70px;
+  padding: 10px 0;
+  .normal-hours {
+    margin-top: 14px;
+    display: block
+  }
+}
+
+.emergency-resources {
+  h3 {
+    margin-top: 1.5em;
+    margin-bottom: 1em;
+  }
+}

--- a/src/site/components/situation_updates.drupal.liquid
+++ b/src/site/components/situation_updates.drupal.liquid
@@ -1,0 +1,22 @@
+<section id="situation-updates" class="situation-updates clearfix">
+  <h2>Situation updates and information</h2>
+  {% for situation in fieldBannerAlert %}
+  {% for update in situation.entity.fieldSituationUpdates %}
+  <div class="usa-alert background-color-only vads-u-padding-y--1p5">
+    <h3 class="vads-u-margin-top--0">
+      Situation update
+    </h3>
+    <div class="vads-u-margin-bottom--0 no-p-bottom-margin">
+      <h4 class="vads-u-margin-top--1 vads-u-margin-bottom--2">
+        {{update.entity.fieldDateAndTime.date | timeZone: "America/New_York", "dddd, MMM D, h:mm A"}}
+        ET</h4>
+      {{update.entity.fieldWysiwyg.processed}}
+    </div>
+  </div>
+  {% endfor %}
+  {% if situation.entity.fieldBannerAlertSituationinfo.processed %}
+  <h3 class="vads-u-margin-top--3">Situation info</h3>
+  {{situation.entity.fieldBannerAlertSituationinfo.processed}}
+  {% endif %}
+  {% endfor %}
+</section>

--- a/src/site/layouts/vamc_operating_status_and_alerts.drupal.liquid
+++ b/src/site/layouts/vamc_operating_status_and_alerts.drupal.liquid
@@ -87,7 +87,7 @@
                                         href="{{status.entity.entityUrl.path}}">{{ status.entity.title }}</a>
                                 </div>
                                 <div class="vads-l-col--6">
-                                    <div class="operating-status-info">
+                                    <div class="operating-status-info vads-u-padding-y--1p5 vads-u-padding-x--0">
                                         {% if status.entity.fieldOperatingStatusFacility == 'notice' %}
                                         <span
                                             class="operating-status usa-alert usa-alert-info background-color-only vads-u-margin-top--0 vads-u-padding--1p5">
@@ -97,7 +97,7 @@
                                         </span>
                                         {% elsif status.entity.fieldOperatingStatusFacility == 'normal' %}
                                         <span
-                                            class="operating-status normal-hours">
+                                            class="operating-status normal-hours vads-u-margin-top--2 vads-u-display--block">
                                             Normal services and hours
                                         </span>
                                         {% elsif status.entity.fieldOperatingStatusFacility == 'limited' %}
@@ -138,7 +138,7 @@
                         <div>{{ fieldOperatingStatusEmergInf.value }}</div>
                         {% endif %}
                         {% if fieldLinks.0.uri %}
-                        <h3>Local emergency resources</h3>
+                        <h3 class="vads-u-margin-top--3 vads-u-margin-bottom--2 ">Local emergency resources</h3>
                         {% for link in fieldLinks %}
                         <p><a href="{{ link.uri }}">{{ link.title }}</a></p>
                         {% endfor %}

--- a/src/site/layouts/vamc_operating_status_and_alerts.drupal.liquid
+++ b/src/site/layouts/vamc_operating_status_and_alerts.drupal.liquid
@@ -1,0 +1,155 @@
+{% include "src/site/includes/header.html" with drupalTags = true %}
+{% include "src/site/includes/alerts.drupal.liquid" %}
+{% include "src/site/includes/preview-edit.drupal.liquid" %}
+{% include "src/site/includes/breadcrumbs.drupal.liquid" %}
+<div id="content" class="interior">
+    <main class="va-l-detail-page va-facility-page">
+        <div class="usa-grid usa-grid-full">
+            {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with sidebarData = facilitySidebar %}
+            <div class="usa-width-three-fourths">
+                {% include "src/site/components/navigation-sidebar-trigger.html" with menuId = "va-detailpage-sidebar" %}
+
+                <article class="usa-content">
+                    <h1 class="vads-u-margin-bottom--2">Operating status</h1>
+                    <div class="va-introtext vads-u-margin-bottom--0">
+                        Check the latest operating status of services and
+                        facility hours for {{facilitySidebar.name}}
+                    </div>
+                    {% if fieldOffice.entity.fieldLinkFacilityEmergList.url.path %}
+                    <div class="usa-grid usa-grid-full vads-u-margin-y--1p5">
+                        <div class="vads-l-row">
+                            <div class="vads-u-margin-right--2p5">
+                                <a class="vads-u-padding-x--5 usa-button vads-u-margin-top--1 vads-u-margin--0 vads-u-width--full vads-u-font-size--md"
+                                    href="{{fieldOffice.entity.fieldLinkFacilityEmergList.url.path}}">Subscribe
+                                    to emergency notifications</a>
+                            </div>
+                        </div>
+                    </div>
+                    {% endif %}
+                    <section class="table-of-contents"
+                        class="vads-u-margin-bottom--5">
+                        <h2 class="vads-u-margin-bottom--2 vads-u-font-size--lg"
+                            id="on-this-page">On this
+                            page</h2>
+                        <ul class="usa-unstyled-list">
+                            {% if fieldBannerAlert.0.entity %}
+                            <li class="vads-u-margin-bottom--2">
+                                <a href="#situation-updates"
+                                    onclick="recordEvent({ event: 'nav-jumplink-click' });"
+                                    class="vads-u-display--flex vads-u-text-decoration--none">
+                                    <i
+                                        class="fas fa-arrow-down va-c-font-size--xs vads-u-margin-top--1 vads-u-margin-right--1"></i>
+                                    Situation updates and information
+                                </a>
+                            </li>
+                            {% endif %}
+                            <li class="vads-u-margin-bottom--2">
+                                <a href="#operating-statuses"
+                                    onclick="recordEvent({ event: 'nav-jumplink-click' });"
+                                    class="vads-u-display--flex vads-u-text-decoration--none">
+                                    <i
+                                        class="fas fa-arrow-down va-c-font-size--xs vads-u-margin-top--1 vads-u-margin-right--1"></i>
+                                    Facility operating statuses
+                                </a>
+                            </li>
+                            {% if fieldLink.0.uri or fieldOperatingStatusEmergInf.value %}
+                            <li class="vads-u-margin-bottom--2">
+                                <a href="#emergency-resources"
+                                    onclick="recordEvent({ event: 'nav-jumplink-click' });"
+                                    class="vads-u-display--flex vads-u-text-decoration--none">
+                                    <i
+                                        class="fas fa-arrow-down va-c-font-size--xs vads-u-margin-top--1 vads-u-margin-right--1"></i>
+                                    Emergency resources
+                                </a>
+                            </li>
+                            {% endif %}
+                        </ul>
+                    </section>
+
+                    {% if fieldBannerAlert.0.entity %}
+                    {% include "src/site/components/situation_updates.drupal.liquid" with fieldBannerAlert %}
+                    {% endif %}
+
+
+
+                    {% if fieldFacilityOperatingStatus.0.entity %}
+                    <section id="operating-statuses"
+                        class="operating-statuses clearfix">
+                        <h2>Facility operating statuses</h2>
+                        <div
+                            class="vads-l-grid-container vads-u-padding-x--0 vads-l-row vads-u-border-bottom--1px vads-u-border-color--gray-light">
+                            {% for status in fieldFacilityOperatingStatus %}
+                            <div
+                                class="vads-l-row vads-u-border-top--1px vads-u-border-color--gray-light">
+                                <div
+                                    class="vads-l-col--6 vads-u-display--flex operating-status-title">
+                                    <a class="vads-u-font-weight--bold"
+                                        href="{{status.entity.entityUrl.path}}">{{ status.entity.title }}</a>
+                                </div>
+                                <div class="vads-l-col--6">
+                                    <div class="operating-status-info">
+                                        {% if status.entity.fieldOperatingStatusFacility == 'notice' %}
+                                        <span
+                                            class="operating-status usa-alert usa-alert-info background-color-only vads-u-margin-top--0 vads-u-padding--1p5">
+                                            <i class="fa fa-info-circle"
+                                                aria-hidden="true"></i> Facility
+                                            notice
+                                        </span>
+                                        {% elsif status.entity.fieldOperatingStatusFacility == 'normal' %}
+                                        <span
+                                            class="operating-status normal-hours">
+                                            Normal services and hours
+                                        </span>
+                                        {% elsif status.entity.fieldOperatingStatusFacility == 'limited' %}
+                                        <span
+                                            class="operating-status usa-alert usa-alert-warning background-color-only vads-u-margin-top--0 vads-u-padding--1p5">
+                                            <i class="fa fa-exclamation-triangle"
+                                                aria-hidden="true"></i> Limited
+                                            services and hours
+                                        </span>
+                                        {% elsif status.entity.fieldOperatingStatusFacility == 'closed' %}
+                                        <span
+                                            class="operating-status usa-alert usa-alert-error background-color-only vads-u-margin-top--0 vads-u-padding--1p5">
+                                            <i class="fa fa-exclamation-circle"
+                                                aria-hidden="true"></i> Facility
+                                            Closed
+                                        </span>
+                                        {% endif %}
+
+                                        {% if status.entity.fieldOperatingStatusMoreInfo %}
+                                        <div class="vads-u-margin-top--1p5">
+                                            {{ status.entity.fieldOperatingStatusMoreInfo }}
+                                        </div>
+                                        {% endif %}
+                                    </div>
+                                </div>
+                            </div>
+                            {% endfor %}
+                        </div>
+                    </section>
+                    {% endif %}
+
+                    {% if fieldLink.0.uri or fieldOperatingStatusEmergInf.value %}
+                    <section id="emergency-resources"
+                        class="emergency-resources clearfix">
+                        <h2>Emergency information</h2>
+
+                        {% if fieldOperatingStatusEmergInf.value %}
+                        <div>{{ fieldOperatingStatusEmergInf.value }}</div>
+                        {% endif %}
+                        {% if fieldLinks.0.uri %}
+                        <h3>Local emergency resources</h3>
+                        {% for link in fieldLinks %}
+                        <p><a href="{{ link.uri }}">{{ link.title }}</a></p>
+                        {% endfor %}
+                        {% endif %}
+                    </section>
+                    {% endif %}
+
+                </article>
+            </div>
+        </div>
+    </main>
+</div>
+{% include "src/site/includes/footer.html" %}
+{% include "src/site/includes/debug.drupal.liquid" %}

--- a/src/site/stages/build/drupal/graphql/GetAllPages.graphql.js
+++ b/src/site/stages/build/drupal/graphql/GetAllPages.graphql.js
@@ -5,6 +5,7 @@ const healthCareRegionPage = require('./healthCareRegionPage.graphql');
 const healthCareLocalFacilityPage = require('./healthCareLocalFacilityPage.graphql');
 const healthCareRegionDetailPage = require('./healthCareRegionDetailPage.graphql');
 const pressReleasePage = require('./pressReleasePage.graphql');
+const vamcOperatingStatusAndAlerts = require('./vamcOperatingStatusAndAlerts.graphql');
 const fragments = require('./fragments.graphql');
 const newsStoryPage = require('./newStoryPage.graphql');
 const sidebarQuery = require('./navigation-fragments/sidebar.nav.graphql');
@@ -44,6 +45,7 @@ module.exports = `
   ${healthCareLocalFacilityPage}
   ${healthCareRegionDetailPage}
   ${pressReleasePage}
+  ${vamcOperatingStatusAndAlerts}
   ${newsStoryPage}
   ${eventPage}
   ${officePage}
@@ -64,6 +66,7 @@ module.exports = `
         ... healthCareLocalFacilityPage
         ... healthCareRegionDetailPage
         ... pressReleasePage
+        ... vamcOperatingStatusAndAlerts
         ... newsStoryPage
         ... eventPage
         ... officePage

--- a/src/site/stages/build/drupal/graphql/GetLatestPageById.graphql.js
+++ b/src/site/stages/build/drupal/graphql/GetLatestPageById.graphql.js
@@ -7,6 +7,7 @@ const healthCareLocalFacilityPage = require('./healthCareLocalFacilityPage.graph
 const healthCareRegionDetailPage = require('./healthCareRegionDetailPage.graphql');
 const newsStoryPage = require('./newStoryPage.graphql');
 const pressReleasePage = require('./pressReleasePage.graphql');
+const vamcOperatingStatusAndAlerts = require('./vamcOperatingStatusAndAlerts.graphql');
 const sidebarQuery = require('./navigation-fragments/sidebar.nav.graphql');
 const facilitySidebarQuery = require('./navigation-fragments/facilitySidebar.nav.graphql');
 const bioPage = require('./bioPage.graphql');
@@ -38,6 +39,7 @@ module.exports = `
   ${healthCareLocalFacilityPage}
   ${healthCareRegionDetailPage}
   ${pressReleasePage}
+  ${vamcOperatingStatusAndAlerts}
   ${newsStoryPage}
   ${eventPage}
   ${bioPage}
@@ -56,6 +58,7 @@ module.exports = `
         ... healthCareRegionDetailPage
         ... newsStoryPage
         ... pressReleasePage
+        ... vamcOperatingStatusAndAlerts
         ... eventPage
         ... bioPage
       }

--- a/src/site/stages/build/drupal/graphql/vamcOperatingStatusAndAlerts.graphql.js
+++ b/src/site/stages/build/drupal/graphql/vamcOperatingStatusAndAlerts.graphql.js
@@ -1,0 +1,67 @@
+const entityElementsFromPages = require('./entityElementsForPages.graphql');
+
+module.exports = `
+  fragment vamcOperatingStatusAndAlerts on NodeVamcOperatingStatusAndAlerts {
+    ${entityElementsFromPages}
+    title
+    nid
+    fieldOffice {
+      entity {
+        ... on NodeHealthCareRegionPage {
+          fieldLinkFacilityEmergList {
+            url {
+              path
+              routed
+            }
+          }
+        }
+      }
+    }
+    fieldLinks {
+      uri
+      title
+    }
+    fieldOperatingStatusEmergInf {
+      value
+    }
+    fieldFacilityOperatingStatus {
+      entity {
+        ... on NodeHealthCareLocalFacility {
+          title
+          entityUrl {
+            path
+            routed
+          }
+          fieldOperatingStatusFacility
+          fieldOperatingStatusMoreInfo
+        }
+      }
+    }
+    fieldBannerAlert {
+      entity {
+        ... on NodeFullWidthBannerAlert {
+          title
+          fieldBannerAlertSituationinfo {
+            processed
+          }
+          fieldSituationUpdates {
+            entity {
+              ... on ParagraphSituationUpdate {
+                fieldDateAndTime {
+                  date
+                  value
+                }
+                fieldWysiwyg {
+                  processed
+                }
+              }
+            }
+          }
+          fieldBody {
+            processed
+          }
+        }
+      }
+    }
+  }
+`;

--- a/src/site/stages/build/drupal/page.js
+++ b/src/site/stages/build/drupal/page.js
@@ -261,6 +261,7 @@ function compilePage(page, contentData) {
       );
       break;
     case 'health_care_local_facility':
+    case 'vamc_operating_status_and_alerts':
       pageCompiled = Object.assign(
         {},
         page,


### PR DESCRIPTION
## Description
Outputs operating status node data from drupal, here: `pittsburgh-health-care/operating-status/`

## Testing done
Visual

## Screenshots
![image](https://user-images.githubusercontent.com/2404547/67597336-f14b8b80-f738-11e9-8781-66f6752915a5.png)
![image](https://user-images.githubusercontent.com/2404547/67597348-f6103f80-f738-11e9-8f75-07d8f634adda.png)
![image](https://user-images.githubusercontent.com/2404547/67597362-fad4f380-f738-11e9-902c-7479163be1d1.png)

## Dependencies prior to merge / release to prod
- [ ] Requires https://github.com/department-of-veterans-affairs/va.gov-cms/pull/665/files merge and release to prod