### PR TITLE
[VAOS] Add text area to 'reason for appointment page'

### DIFF
--- a/src/applications/vaos/actions/newAppointment.js
+++ b/src/applications/vaos/actions/newAppointment.js
@@ -37,6 +37,10 @@ export const FORM_SCHEDULE_APPOINTMENT_PAGE_OPENED =
   'newAppointment/FORM_SCHEDULE_APPOINTMENT_PAGE_OPENED';
 export const FORM_SCHEDULE_APPOINTMENT_PAGE_OPENED_SUCCEEDED =
   'newAppointment/FORM_SCHEDULE_APPOINTMENT_PAGE_OPENED_SUCCEEDED';
+export const FORM_REASON_FOR_APPOINTMENT_UPDATE_REMAINING_CHAR =
+  'newAppointment/FORM_REASON_FOR_APPOINTMENT_UPDATE_REMAINING_CHAR';
+
+export const REASON_MAX_CHAR_DEFAULT = 150;
 
 export function openFormPage(page, uiSchema, schema) {
   return {
@@ -176,6 +180,25 @@ export function updateFacilityPageData(page, uiSchema, data) {
   };
 }
 
+export function updateReasonForAppointmentData(page, uiSchema, data) {
+  return async dispatch => {
+    let additionalInfo = data.reasonAdditionalInfo || '';
+
+    // Max length for reason
+    const maxTextAreaLength =
+      REASON_MAX_CHAR_DEFAULT - data.reasonForAppointment.length - 1;
+    additionalInfo = additionalInfo.substr(0, maxTextAreaLength);
+
+    const remainingCharacters = maxTextAreaLength - additionalInfo.length;
+    dispatch({
+      type: FORM_REASON_FOR_APPOINTMENT_UPDATE_REMAINING_CHAR,
+      remainingCharacters,
+    });
+
+    dispatch(updateFormData(page, uiSchema, { ...data, additionalInfo }));
+  };
+}
+
 export function openClinicPage(page, uiSchema, schema) {
   return async (dispatch, getState) => {
     let facilityDetails;
@@ -245,6 +268,16 @@ export function openSelectAppointmentPage(page, uiSchema, schema) {
     });
   };
 }
+
+// export function submitDirectSchedule(page, uiSchema, schema) {
+//   // TODO: combine reason for appointment
+//   // TODO: parse selected date
+// }
+
+// export function submitAppointmentRequest(page, uiSchema, schema) {
+//   // TODO: combine reason for appointment
+//   // TODO: parse selected date into options
+// }
 
 export function routeToPageInFlow(flow, router, current, action) {
   return async (dispatch, getState) => {

--- a/src/applications/vaos/actions/newAppointment.js
+++ b/src/applications/vaos/actions/newAppointment.js
@@ -182,20 +182,20 @@ export function updateFacilityPageData(page, uiSchema, data) {
 
 export function updateReasonForAppointmentData(page, uiSchema, data) {
   return async dispatch => {
-    let additionalInfo = data.reasonAdditionalInfo || '';
+    let reasonAdditionalInfo = data.reasonAdditionalInfo || '';
 
     // Max length for reason
     const maxTextAreaLength =
       REASON_MAX_CHAR_DEFAULT - data.reasonForAppointment.length - 1;
-    additionalInfo = additionalInfo.substr(0, maxTextAreaLength);
+    reasonAdditionalInfo = reasonAdditionalInfo.substr(0, maxTextAreaLength);
 
-    const remainingCharacters = maxTextAreaLength - additionalInfo.length;
+    const remainingCharacters = maxTextAreaLength - reasonAdditionalInfo.length;
     dispatch({
       type: FORM_REASON_FOR_APPOINTMENT_UPDATE_REMAINING_CHAR,
       remainingCharacters,
     });
 
-    dispatch(updateFormData(page, uiSchema, { ...data, additionalInfo }));
+    dispatch(updateFormData(page, uiSchema, { ...data, reasonAdditionalInfo }));
   };
 }
 

--- a/src/applications/vaos/actions/newAppointment.js
+++ b/src/applications/vaos/actions/newAppointment.js
@@ -270,13 +270,13 @@ export function openSelectAppointmentPage(page, uiSchema, schema) {
 }
 
 // export function submitDirectSchedule(page, uiSchema, schema) {
-//   // TODO: combine reason for appointment
+//   // TODO: combine reasonForAppointment to be `${reasonForAppointment};${reasonAdditionalInfo}
 //   // TODO: parse selected date
 // }
 
 // export function submitAppointmentRequest(page, uiSchema, schema) {
-//   // TODO: combine reason for appointment
-//   // TODO: parse selected date into options
+//   // TODO: combine reasonForAppointment to be `${reasonForAppointment};${reasonAdditionalInfo}
+//   // TODO: parse selected date into optionTime
 // }
 
 export function routeToPageInFlow(flow, router, current, action) {

--- a/src/applications/vaos/containers/ReasonForAppointmentPage.jsx
+++ b/src/applications/vaos/containers/ReasonForAppointmentPage.jsx
@@ -2,22 +2,25 @@ import React from 'react';
 import { connect } from 'react-redux';
 import {
   openFormPage,
-  updateFormData,
+  updateReasonForAppointmentData,
   routeToNextAppointmentPage,
   routeToPreviousAppointmentPage,
 } from '../actions/newAppointment.js';
 import SchemaForm from 'platform/forms-system/src/js/components/SchemaForm';
 import FormButtons from '../components/FormButtons';
-import { getFormPageInfo } from '../utils/selectors';
+import { getReasonForAppointment } from '../utils/selectors';
 import { PURPOSE_TEXT } from '../utils/constants';
 
 const initialSchema = {
   type: 'object',
-  required: ['reasonForAppointment'],
+  required: ['reasonForAppointment', 'reasonAdditionalInfo'],
   properties: {
     reasonForAppointment: {
       type: 'string',
-      enum: ['routine-follow-up', 'new-issue', 'medication-concern'],
+      enum: ['routine-follow-up', 'new-issue', 'medication-concern', 'other'],
+    },
+    reasonAdditionalInfo: {
+      type: 'string',
     },
   },
 };
@@ -28,6 +31,14 @@ const uiSchema = {
     'ui:options': {
       hideLabelText: true,
       labels: PURPOSE_TEXT,
+    },
+  },
+  reasonAdditionalInfo: {
+    'ui:title': 'Provide additional details for your appointment.',
+    'ui:widget': 'textarea',
+    'ui:options': {
+      rows: 5,
+      hideIf: formData => !formData.reasonForAppointment,
     },
   },
 };
@@ -48,10 +59,15 @@ export class ReasonForAppointmentPage extends React.Component {
   };
 
   render() {
-    const { schema, data, pageChangeInProgress } = this.props;
+    const {
+      schema,
+      data,
+      pageChangeInProgress,
+      reasonRemainingChar,
+    } = this.props;
 
     return (
-      <div className="vaos-form__detailed-radio">
+      <div>
         <h1 className="vads-u-font-size--h2">
           Why do you want to make an
           <br /> appointment?
@@ -63,10 +79,19 @@ export class ReasonForAppointmentPage extends React.Component {
           uiSchema={uiSchema}
           onSubmit={this.goForward}
           onChange={newData =>
-            this.props.updateFormData(pageKey, uiSchema, newData)
+            this.props.updateReasonForAppointmentData(
+              pageKey,
+              uiSchema,
+              newData,
+            )
           }
           data={data}
         >
+          {data.reasonForAppointment && (
+            <div className="vads-u-font-style--italic vads-u-margin-top--neg3 vads-u-margin-bottom--2p5">
+              {reasonRemainingChar} characters remaining
+            </div>
+          )}
           <FormButtons
             onBack={this.goBack}
             pageChangeInProgress={pageChangeInProgress}
@@ -78,12 +103,12 @@ export class ReasonForAppointmentPage extends React.Component {
 }
 
 function mapStateToProps(state) {
-  return getFormPageInfo(state, pageKey);
+  return getReasonForAppointment(state, pageKey);
 }
 
 const mapDispatchToProps = {
   openFormPage,
-  updateFormData,
+  updateReasonForAppointmentData,
   routeToNextAppointmentPage,
   routeToPreviousAppointmentPage,
 };

--- a/src/applications/vaos/reducers/newAppointment.js
+++ b/src/applications/vaos/reducers/newAppointment.js
@@ -30,6 +30,7 @@ import {
   FORM_CLINIC_PAGE_OPENED_SUCCEEDED,
   FORM_SCHEDULE_APPOINTMENT_PAGE_OPENED,
   FORM_SCHEDULE_APPOINTMENT_PAGE_OPENED_SUCCEEDED,
+  FORM_REASON_FOR_APPOINTMENT_UPDATE_REMAINING_CHAR,
 } from '../actions/newAppointment';
 
 import { getTypeOfCare } from '../utils/selectors';
@@ -370,6 +371,12 @@ export default function formReducer(state = initialState, action) {
           ...state.pages,
           [action.page]: schema,
         },
+      };
+    }
+    case FORM_REASON_FOR_APPOINTMENT_UPDATE_REMAINING_CHAR: {
+      return {
+        ...state,
+        reasonRemainingChar: action.remainingCharacters,
       };
     }
     case FORM_CLINIC_PAGE_OPENED_SUCCEEDED: {

--- a/src/applications/vaos/reducers/newAppointment.js
+++ b/src/applications/vaos/reducers/newAppointment.js
@@ -31,6 +31,7 @@ import {
   FORM_SCHEDULE_APPOINTMENT_PAGE_OPENED,
   FORM_SCHEDULE_APPOINTMENT_PAGE_OPENED_SUCCEEDED,
   FORM_REASON_FOR_APPOINTMENT_UPDATE_REMAINING_CHAR,
+  REASON_MAX_CHAR_DEFAULT,
 } from '../actions/newAppointment';
 
 import { getTypeOfCare } from '../utils/selectors';
@@ -48,6 +49,7 @@ const initialState = {
   loadingEligibility: false,
   loadingFacilityDetails: false,
   pastAppointments: null,
+  reasonRemainingChar: REASON_MAX_CHAR_DEFAULT,
 };
 
 function getFacilities(state, typeOfCareId, vaSystem) {

--- a/src/applications/vaos/tests/actions/newAppointment.unit.spec.js
+++ b/src/applications/vaos/tests/actions/newAppointment.unit.spec.js
@@ -6,6 +6,7 @@ import {
   routeToPageInFlow,
   openFacilityPage,
   updateFacilityPageData,
+  updateReasonForAppointmentData,
   openClinicPage,
   FORM_DATA_UPDATED,
   FORM_PAGE_CHANGE_STARTED,
@@ -19,6 +20,8 @@ import {
   FORM_ELIGIBILITY_CHECKS_SUCCEEDED,
   FORM_CLINIC_PAGE_OPENED,
   FORM_CLINIC_PAGE_OPENED_SUCCEEDED,
+  FORM_REASON_FOR_APPOINTMENT_UPDATE_REMAINING_CHAR,
+  REASON_MAX_CHAR_DEFAULT,
 } from '../../actions/newAppointment';
 import systems from '../../api/facilities.json';
 import facilities983 from '../../api/facilities_983.json';
@@ -302,6 +305,7 @@ describe('VAOS newAppointment actions', () => {
       expect(eligibilityData.requestLimits.numberOfRequests).to.equal(0);
     });
   });
+
   describe('openClinicPage', () => {
     it('should fetch facility info', async () => {
       const dispatch = sinon.spy();
@@ -335,6 +339,34 @@ describe('VAOS newAppointment actions', () => {
         FORM_CLINIC_PAGE_OPENED_SUCCEEDED,
       );
       expect(dispatch.secondCall.args[0].facilityDetails).to.not.be.undefined;
+    });
+  });
+
+  describe('reasonForAppointment', () => {
+    it('update values and calculates remaining characters for additional info', async () => {
+      const reasonForAppointment = 'new-issue';
+      const reasonAdditionalInfo = 'test';
+
+      const dispatch = sinon.spy();
+      const thunk = updateReasonForAppointmentData(
+        'reasonForAppointment',
+        {},
+        {
+          reasonForAppointment,
+          reasonAdditionalInfo,
+        },
+      );
+      await thunk(dispatch);
+      expect(dispatch.firstCall.args[0].type).to.equal(
+        FORM_REASON_FOR_APPOINTMENT_UPDATE_REMAINING_CHAR,
+      );
+      expect(dispatch.firstCall.args[0].remainingCharacters).to.equal(
+        REASON_MAX_CHAR_DEFAULT -
+          reasonForAppointment.length -
+          1 -
+          reasonAdditionalInfo.length,
+      );
+      expect(dispatch.secondCall.args[0].type).to.equal(FORM_DATA_UPDATED);
     });
   });
 });

--- a/src/applications/vaos/tests/containers/ReasonForAppointmentPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/containers/ReasonForAppointmentPage.unit.spec.jsx
@@ -9,17 +9,18 @@ import { ReasonForAppointmentPage } from '../../containers/ReasonForAppointmentP
 describe('VAOS <ReasonForAppointmentPage>', () => {
   it('should render', () => {
     const openFormPage = sinon.spy();
-    const updateFormData = sinon.spy();
+    const updateReasonForAppointmentData = sinon.spy();
 
     const form = mount(
       <ReasonForAppointmentPage
         openFormPage={openFormPage}
-        updateFormData={updateFormData}
+        updateReasonForAppointmentData={updateReasonForAppointmentData}
         data={{}}
       />,
     );
 
-    expect(form.find('input').length).to.equal(3);
+    expect(form.find('input').length).to.equal(4);
+    expect(form.find('textarea').length).to.equal(1);
     form.unmount();
   });
 
@@ -39,14 +40,14 @@ describe('VAOS <ReasonForAppointmentPage>', () => {
 
     form.find('form').simulate('submit');
 
-    expect(form.find('.usa-input-error').length).to.equal(1);
+    expect(form.find('.usa-input-error').length).to.equal(2);
     expect(router.push.called).to.be.false;
     form.unmount();
   });
 
-  it('should call updateFormData after change', () => {
+  it('should call updateReasonForAppointmentData after change', () => {
     const openFormPage = sinon.spy();
-    const updateFormData = sinon.spy();
+    const updateReasonForAppointmentData = sinon.spy();
     const router = {
       push: sinon.spy(),
     };
@@ -54,7 +55,7 @@ describe('VAOS <ReasonForAppointmentPage>', () => {
     const form = mount(
       <ReasonForAppointmentPage
         openFormPage={openFormPage}
-        updateFormData={updateFormData}
+        updateReasonForAppointmentData={updateReasonForAppointmentData}
         router={router}
         data={{}}
       />,
@@ -62,9 +63,9 @@ describe('VAOS <ReasonForAppointmentPage>', () => {
 
     selectRadio(form, 'root_reasonForAppointment', 'routine-follow-up');
 
-    expect(updateFormData.firstCall.args[2].reasonForAppointment).to.equal(
-      'routine-follow-up',
-    );
+    expect(
+      updateReasonForAppointmentData.firstCall.args[2].reasonForAppointment,
+    ).to.equal('routine-follow-up');
     form.unmount();
   });
 
@@ -78,6 +79,7 @@ describe('VAOS <ReasonForAppointmentPage>', () => {
         routeToNextAppointmentPage={routeToNextAppointmentPage}
         data={{
           reasonForAppointment: 'routine-follow-up',
+          reasonAdditionalInfo: 'test',
         }}
       />,
     );

--- a/src/applications/vaos/tests/utils/selectors.unit.spec.js
+++ b/src/applications/vaos/tests/utils/selectors.unit.spec.js
@@ -11,7 +11,6 @@ import {
   getDateTimeSelect,
   getReasonForAppointment,
 } from '../../utils/selectors';
-import { REASON_MAX_CHAR_DEFAULT } from '../../actions/newAppointment';
 
 describe('VAOS selectors', () => {
   describe('selectPendingAppointment', () => {

--- a/src/applications/vaos/tests/utils/selectors.unit.spec.js
+++ b/src/applications/vaos/tests/utils/selectors.unit.spec.js
@@ -9,7 +9,9 @@ import {
   getClinicsForChosenFacility,
   getClinicPageInfo,
   getDateTimeSelect,
+  getReasonForAppointment,
 } from '../../utils/selectors';
+import { REASON_MAX_CHAR_DEFAULT } from '../../actions/newAppointment';
 
 describe('VAOS selectors', () => {
   describe('selectPendingAppointment', () => {
@@ -184,6 +186,29 @@ describe('VAOS selectors', () => {
       expect(data.timezone).to.equal('MDT');
       expect(data.availableDates).to.eql(['2019-10-24']);
       expect(data.availableSlots).to.eql(availableSlots);
+    });
+  });
+
+  describe('getReasonForAppointment', () => {
+    it('should return reason data and remaining characters for textarea', () => {
+      const data = {
+        reasonForAppointment: 'new-issue',
+        reasonAdditionalInfo: 'test',
+      };
+
+      const state = {
+        newAppointment: {
+          pages: {
+            reasonForAppointment: {},
+          },
+          data,
+          reasonRemainingChar: 130,
+        },
+      };
+
+      const pageInfo = getReasonForAppointment(state, 'reasonForAppointment');
+      expect(pageInfo.data).to.eql(data);
+      expect(pageInfo.reasonRemainingChar).to.equal(130);
     });
   });
 

--- a/src/applications/vaos/utils/constants.js
+++ b/src/applications/vaos/utils/constants.js
@@ -15,7 +15,7 @@ export const PURPOSE_TEXT = {
   'routine-follow-up': 'Routine/follow-up',
   'new-issue': 'New issue',
   'medication-concern': 'Medication concern',
-  other: 'Other',
+  other: 'My reason is not listed here',
 };
 
 export const TYPES_OF_CARE = [

--- a/src/applications/vaos/utils/selectors.js
+++ b/src/applications/vaos/utils/selectors.js
@@ -6,7 +6,6 @@ import {
   TYPES_OF_SLEEP_CARE,
 } from './constants';
 import moment from './moment-tz';
-import { REASON_MAX_CHAR_DEFAULT } from '../actions/newAppointment';
 
 export function selectConfirmedAppointment(state, id) {
   return (
@@ -168,12 +167,10 @@ export function getChosenClinicInfo(state) {
 
 export function getReasonForAppointment(state, pageKey) {
   const formInfo = getFormPageInfo(state, pageKey);
-  const remainingChar = getNewAppointment(state).reasonRemainingChar;
+  const reasonRemainingChar = getNewAppointment(state).reasonRemainingChar;
   return {
     ...formInfo,
-    reasonRemainingChar: !isNaN(remainingChar)
-      ? remainingChar
-      : REASON_MAX_CHAR_DEFAULT,
+    reasonRemainingChar,
   };
 }
 

--- a/src/applications/vaos/utils/selectors.js
+++ b/src/applications/vaos/utils/selectors.js
@@ -6,6 +6,7 @@ import {
   TYPES_OF_SLEEP_CARE,
 } from './constants';
 import moment from './moment-tz';
+import { REASON_MAX_CHAR_DEFAULT } from '../actions/newAppointment';
 
 export function selectConfirmedAppointment(state, id) {
   return (
@@ -163,6 +164,17 @@ export function getChosenClinicInfo(state) {
       clinic => clinic.clinicId === data.clinicId,
     ) || null
   );
+}
+
+export function getReasonForAppointment(state, pageKey) {
+  const formInfo = getFormPageInfo(state, pageKey);
+  const remainingChar = getNewAppointment(state).reasonRemainingChar;
+  return {
+    ...formInfo,
+    reasonRemainingChar: !isNaN(remainingChar)
+      ? remainingChar
+      : REASON_MAX_CHAR_DEFAULT,
+  };
 }
 
 export function getClinicsForChosenFacility(state) {


### PR DESCRIPTION
## Description
Currently, we have a textarea in the direct schedule flow where veterans can add some free text around their reason for wanting an appointment. We want to let them also be able to add the 'purpose of visit' so that a schedule groomer can glean more information about whether they are scheduled with the correct provider before their appointment.

The textarea will have a dynamic character limit depending on the selected radio button. 

## Testing done
Local and unit

## Screenshots
![image](https://user-images.githubusercontent.com/786704/67608944-5ace9880-f73f-11e9-9983-1a507542d0ba.png)


## Acceptance criteria
- [ ] Veteran must choose a 'purpose of visit' option on the 'reason for appointment' page
- [ ] Veteran must fill out the 'Provide additional details' textarea
- [ ] The new textarea starts hidden, auto-expands when 'reason for appointment' selection is made
- [ ] 'Purpose of Visit' options match options in mock
- [ ] Chosen 'Purpose of visit' selection is pre-pended to the 'reason for appointment' text in the form data that's submitted like so: `Purpose of visit: ${selection}; Veteran free text goes here.`
- [ ] If 'my reason is not listed here' is selected, veteran should describe the reason in the text area described in this ticket (we don't need yet another field for this).
- [ ] Character limit for 'reason for appointment' text area is shortened enough to make room for the longest of the 'purpose of visit' options & contextual text.  Max limit is 150.
## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
