### PR TITLE
Fix calls to dispatchRefreshTransaction()

### DIFF
--- a/src/platform/user/profile/vet360/containers/PendingTransactionCategory.jsx
+++ b/src/platform/user/profile/vet360/containers/PendingTransactionCategory.jsx
@@ -26,7 +26,9 @@ function Vet360PendingTransactionCategory({
   }
 
   const refreshAllTransactions = () => {
-    transactions.forEach(dispatchRefreshTransaction);
+    transactions.forEach(transaction => {
+      dispatchRefreshTransaction(transaction);
+    });
   };
 
   return (


### PR DESCRIPTION
## Description
Previously we were inadvertently passing the array index and array itself to the dispatchRefreshTransaction() action creator. We only want to pass the transaction object.

## Testing done
Local

## Screenshots
N/A

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs