### PR TITLE
fixes broken link on MVIError (#9936)

### DIFF
--- a/src/applications/personalization/profile360/components/MVIError.jsx
+++ b/src/applications/personalization/profile360/components/MVIError.jsx
@@ -22,7 +22,7 @@ export default function MVIError({ facilitiesClick }) {
       </p>
 
       <p>
-        <a href={facilityLocator} onClick={facilitiesClick}>
+        <a href={facilityLocator.rootUrl} onClick={facilitiesClick}>
           Find your nearest VA Medical Center
         </a>
       </p>


### PR DESCRIPTION
_Content below copied from https://github.com/department-of-veterans-affairs/vets-website/pull/9936 which was merged into this `cmonaghan-fix-mvi-error-link` feature branch because it came from a forked repo._

## Description
This fixes a broken on the `/profile` page when a user's information cannot be matched to veteran records. Currently, the link points to `[Object object]`. This pull request updates the link to point at a valid url path.

## Testing done
in progress

## Screenshots
Unable to replicate locally without stubbed authentication to access the user profile page.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
