### PR TITLE
Filter tome-sync export using whitelist

### DIFF
--- a/src/site/stages/build/page-builder/filters.js
+++ b/src/site/stages/build/page-builder/filters.js
@@ -3,7 +3,7 @@
  */
 
 const whitelists = {
-  global: ['title', 'changed'],
+  global: ['title'],
   page: [
     'field_intro_text',
     'field_description',

--- a/src/site/stages/build/page-builder/filters.js
+++ b/src/site/stages/build/page-builder/filters.js
@@ -78,7 +78,7 @@ const ignoreMap = {
 /* eslint-enable camelcase */
 
 function getFilterType(contentModelType) {
-  return new Set(ignoreMap[contentModelType]);
+  return ignoreMap[contentModelType] || [];
 }
 
 /**

--- a/src/site/stages/build/page-builder/filters.js
+++ b/src/site/stages/build/page-builder/filters.js
@@ -16,14 +16,16 @@ const whitelists = {
   ],
 };
 
+const missingFilters = new Set();
+
 function getFilterType(contentModelType) {
-  let whitelist = whitelists[contentModelType];
-  if (!whitelist) {
+  const whitelist = whitelists[contentModelType];
+  if (!whitelist && !missingFilters.has(contentModelType)) {
+    missingFilters.add(contentModelType);
     // eslint-disable-next-line no-console
     console.warn(`No filter for target_id ${contentModelType}`);
-    whitelist = [];
   }
-  return whitelist;
+  return whitelist || [];
 }
 
 /**

--- a/src/site/stages/build/page-builder/filters.js
+++ b/src/site/stages/build/page-builder/filters.js
@@ -1,84 +1,29 @@
 /**
  * When reading through entity properties, ignore these.
  */
-const blackList = new Set([
-  'uuid',
-  'type',
-  'revision_uid',
-  'revision_user',
-  'user_id',
-  'items',
-  'owner_id',
-  'parent',
-  'role_id',
-  'roles',
-  'uid',
-  'vid',
-  'access_scheme',
-  'bundle',
-  'langcode',
-  'status',
-  'default_langcode',
-  'revision_translation_affected',
-  // Temporarily ignore the following properties because they were
-  // causing circular references. Once we get reader functions based
-  // on individual node / entity types, we can remove these from here.
-  // See the jsdoc on getEntityProperties for more information.
-  'field_facility_location',
-  'field_regional_health_service',
-  'field_region_page',
-  'field_office',
-]);
 
-const ignoredPageProps = [
-  'revision_timestamp',
-  'revision_log',
-  'field_plainlanguage_date',
-  'promote',
-  'created',
-  'sticky',
-];
-
-const ignoredPromoProps = [
-  'revision_created',
-  'revision_log',
-  'changed',
-  'reusable',
-  'moderation_state',
-  'field_image',
-  'field_instructions',
-  'field_owner',
-];
-
-const ignoredParagraphProps = ['behavior_settings', 'created'];
-
-/* eslint-disable camelcase */
-const ignoreMap = {
-  page: ignoredPageProps,
-  promo: ignoredPromoProps,
-  alert: ignoredParagraphProps,
-  collapsible_panel: ignoredParagraphProps,
-  collapsible_panel_item: ignoredParagraphProps,
-  downloadable_file: ignoredParagraphProps,
-  expandable_text: ignoredParagraphProps,
-  health_care_local_facility_servi: ignoredParagraphProps,
-  link_teaser: ignoredParagraphProps,
-  list_of_link_teasers: ignoredParagraphProps,
-  media: ignoredParagraphProps,
-  number_callout: ignoredParagraphProps,
-  process: ignoredParagraphProps,
-  q_a: ignoredParagraphProps,
-  q_a_section: ignoredParagraphProps,
-  react_widget: ignoredParagraphProps,
-  spanish_translation_summary: ignoredParagraphProps,
-  staff_profile: ignoredParagraphProps,
-  table: ignoredParagraphProps,
-  wysiwyg: ignoredParagraphProps,
+const whitelists = {
+  global: ['title', 'changed'],
+  page: [
+    'field_intro_text',
+    'field_description',
+    'field_featured_content',
+    'field_content_block',
+    'field_alert',
+    'field_related_links',
+    'field_administration',
+    'field_page_last_built',
+  ],
 };
-/* eslint-enable camelcase */
 
 function getFilterType(contentModelType) {
-  return ignoreMap[contentModelType] || [];
+  let whitelist = whitelists[contentModelType];
+  if (!whitelist) {
+    // eslint-disable-next-line no-console
+    console.warn(`No filter for target_id ${contentModelType}`);
+    whitelist = [];
+  }
+  return whitelist;
 }
 
 /**
@@ -97,10 +42,10 @@ function getFilterType(contentModelType) {
 function getFilteredEntity(contentModelType, entity) {
   // TODO: Filter properties based on content model type
   const entityTypeFilter = getFilterType(contentModelType);
-  const entityFilter = new Set([...blackList, ...entityTypeFilter]);
+  const entityFilter = new Set([...whitelists.global, ...entityTypeFilter]);
   return Object.keys(entity).reduce((newEntity, key) => {
     // eslint-disable-next-line no-param-reassign
-    if (!entityFilter.has(key)) newEntity[key] = entity[key];
+    if (entityFilter.has(key)) newEntity[key] = entity[key];
     return newEntity;
   }, {});
 }


### PR DESCRIPTION
## Description

This is a follow-up to #10959 

Our initial approach was to use a blacklist to filter things, but we eventually decided that a whitelist would be better since it would explicitly state the things we want.  This PR switches over to that new strategy and starts it off with a filter for the `page` target_id.

It includes a warning message anytime the script encounters a `target_id` that it doesn't have a whitelist for:

```
No filter for target_id taxonomy_term
```

## Testing done

All manual for now.

## Screenshots

![image](https://user-images.githubusercontent.com/2008881/67707754-4cb78c80-f978-11e9-97b9-20c1460fb099.png)


This screenshot is of a slightly modified version of the script to work on only one file and to output the contents at the end.  We see 7 occurrences where there wasn't a filter identified for the `target_id`:

- 4 for `field_content_block`
- 1 each for:
  - `field_related_links`
  - `field_featured_content`
  - `field_administration`


Modifying the script again so that it `log`s instead of `warn`s, I used the following command to reveal the missing filters that will need to be added (and how often they occur):

> `node tome-sync-page-builder.js | sed -E 's/.*target_id / /' | sort | uniq -c`

```
     21  alert
     20  collapsible_panel
      6  documentation_page
     17  event
      1  event_listing
      7  health_care_local_facility
     94  health_care_local_health_service
     51  health_care_region_detail_page
      1  health_care_region_page
     11  landing_page
    114  list_of_link_teasers
     22  news_story
      2  office
    176  outreach_asset
     77  person_profile
     19  press_release
      4  process
      1  publication_listing
    179  q_a
    286  q_a_section
     16  react_widget
     52  regional_health_care_service_des
      2  spanish_translation_summary
     16  support_service
     25  table
    221  taxonomy_term
    209  wysiwyg
```

As of right now we have 27 filters to add.

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
