### PR TITLE
Minor copy updates in markdown files

### DIFF
--- a/src/site/stages/build/drupal/graphql-tome-differences/file.md
+++ b/src/site/stages/build/drupal/graphql-tome-differences/file.md
@@ -6,7 +6,7 @@ Tome returned **606** records.
 
 `"url": "https://dev.cms.va.gov/sites/default/files/styles/large/public/video_thumbnails/qRYoUL6BNdc.jpg?itok=mutTJ3Cb"`
 
-We have the URL above, we just don't have the query param `?itok=mutTJ3Cb` and I'm not sure if that's different or the same for each public video thumbnail.
+We have the URL above, we just don't have the query param `?itok=mutTJ3Cb` and it's not certain if that's different or the same for each public video thumbnail.
 
 If it's different, then we are missing it in the Tome data.
 

--- a/src/site/stages/build/drupal/graphql-tome-differences/menu_link_content.md
+++ b/src/site/stages/build/drupal/graphql-tome-differences/menu_link_content.md
@@ -7,7 +7,7 @@ Tome returned **786** records.
 1. `"url": { "path": "/burials-memorials/plan-a-burial" },`
 1. The whole `links` key-value pair and its nested properties.
 
-**WARNING:** The above missing properties makes me think that the **Example GraphQL response below may not be a match for the Example Tome data.**
+**WARNING:** The above missing properties indicate that the **Example GraphQL response below may not be a match for the Example Tome data.**
 
 ## All standard key-value pairs:
 

--- a/src/site/stages/build/drupal/graphql-tome-differences/node.md
+++ b/src/site/stages/build/drupal/graphql-tome-differences/node.md
@@ -2,7 +2,6 @@
 
 Tome returned **774** records.
 
-
 ## Missing properties in Tome:
 
 1. `"entityId": "1000",`


### PR DESCRIPTION
## Description
Updates the documentation on GraphQL response vs `tome-sync` data to conform to [these best practices](https://department-of-veterans-affairs.github.io/veteran-facing-services-tools/documentation-guide/documentation-style-guide) by not using the first-person.

## Testing done
N/A

## Screenshots
N/A

## Acceptance criteria
- [x] Updates documentation to conform to [these best practices](https://department-of-veterans-affairs.github.io/veteran-facing-services-tools/documentation-guide/documentation-style-guide).

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
