### PR TITLE
19869: VETTEC Profile page header is missing data

### DIFF
--- a/src/applications/gi/components/vet-tec/VetTecHeadingSummary.jsx
+++ b/src/applications/gi/components/vet-tec/VetTecHeadingSummary.jsx
@@ -40,9 +40,11 @@ export const VetTecHeadingSummary = ({ institution, showModal }) => {
   );
 
   const addressPresent = formattedAddress !== ''; // if locationInfo returns a blank string, icon should not show
-  const providerWebsitePresent = firstProgram.providerWebsite !== '';
+  const providerWebsitePresent =
+    firstProgram.providerWebsite && firstProgram.providerWebsite !== '';
   const phonePresent = providerPhone !== '';
-  const schoolLocalePresent = firstProgram.schoolLocale !== '';
+  const schoolLocalePresent =
+    firstProgram.schoolLocale && firstProgram.schoolLocale !== '';
 
   return (
     <div className="heading row">


### PR DESCRIPTION
## Description
The Vet Tec profile page should contain a website, phone number, and locale for the institution. This information comes from the EduProgram file. Currently, this information is not being displayed.

Example profile page:
https://staging.va.gov/gi-bill-comparison-tool/profile/2V000105

https://github.com/department-of-veterans-affairs/vets.gov-team/issues/19869

## Testing done
Testing passes locally

## Screenshots
![image](https://user-images.githubusercontent.com/48804834/67789591-996b9800-fa4a-11e9-962c-2fca9a132a5e.png)
Tested using the program files from GIDS staging

## Acceptance criteria
- [x] Issue corrected

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
