### PR TITLE
Update VAOS dashboard landing page

### DIFF
--- a/src/applications/vaos/components/LandingPage.jsx
+++ b/src/applications/vaos/components/LandingPage.jsx
@@ -13,9 +13,6 @@ export default function LandingPage() {
         <div className="vads-l-col--12 medium-screen:vads-l-col--8 vads-u-margin-bottom--4">
           <div>
             <h1>VA Appointments</h1>
-            <h2 className="vads-u-font-size--sm vads-u-font-family--sans vads-u-font-weight--normal">
-              Get started
-            </h2>
             <ul className="usa-unstyled-list">
               <li className="vads-u-border-top--1px vads-u-border-color--gray-lighter">
                 <Link
@@ -47,7 +44,7 @@ export default function LandingPage() {
                   </div>
                   <div className="vads-u-flex--1">
                     <h3 className="vads-u-margin-top--0 vads-u-margin-bottom--0p5 vads-u-font-size--lg">
-                      View your appointments
+                      View or cancel appointments
                     </h3>
                     View confirmed, pending, or past appointments
                   </div>

--- a/src/applications/vaos/tests/components/LandingPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/components/LandingPage.unit.spec.jsx
@@ -21,7 +21,7 @@ describe('VAOS <LandingPage>', () => {
         .find('a')
         .at(1)
         .text(),
-    ).to.contain('View your appointments');
+    ).to.contain('View or cancel appointments');
 
     tree.unmount();
   });


### PR DESCRIPTION
## Description
Removed 'Get Started' and update subheader with 'View or cancel appointment' 

## Testing done
local unit test

## Screenshots
![image](https://user-images.githubusercontent.com/54327023/67806275-ed857500-fa68-11e9-9cf7-eb5ac328ebcc.png)


## Acceptance criteria
- [ ] shows user where to view or cancel appt

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
