### PR TITLE
remove "add" state for Direct Deposit

### DIFF
--- a/src/applications/personalization/profile360/containers/PaymentInformation.jsx
+++ b/src/applications/personalization/profile360/containers/PaymentInformation.jsx
@@ -144,83 +144,66 @@ class PaymentInformation extends React.Component {
     });
   };
 
-  renderSetupButton(label, gaProfileSection) {
-    return (
-      <button
-        className="va-button-link"
-        onClick={() => this.handleLinkClick('add', gaProfileSection)}
-      >{`Please add your ${label}`}</button>
-    );
-  }
-
   render() {
-    if (!this.props.isEligible) {
-      return null;
-    }
-
-    if (this.props.isLoading) {
-      return <LoadingIndicator message="Loading payment information..." />;
-    }
-
-    const { paymentInformation } = this.props;
+    const {
+      isEligible,
+      isLoading,
+      multifactorEnabled,
+      paymentInformation,
+    } = this.props;
     const directDepositIsSetUp =
       paymentInformation &&
       get('responses[0].paymentAccount.accountNumber', paymentInformation);
 
     let content = null;
 
-    if (!this.props.multifactorEnabled) {
+    if (!isEligible) {
+      return content;
+    }
+
+    if (isLoading) {
+      return <LoadingIndicator message="Loading payment information..." />;
+    }
+
+    if (!multifactorEnabled) {
       content = <PaymentInformation2FARequired />;
     } else if (paymentInformation.error) {
       content = <LoadFail information="payment" />;
+    } else if (!directDepositIsSetUp) {
+      // we might eventually want to return some helpful contenct explaining how
+      // a vet could go about setting up direct deposit
+      return null;
     } else {
-      const paymentAccount = paymentInformation.responses[0].paymentAccount;
-
-      content = (
-        <>
-          <div className="vet360-profile-field">
-            <ProfileFieldHeading
-              onEditClick={
-                directDepositIsSetUp &&
-                (() => this.handleLinkClick('edit', 'bank-name'))
-              }
-            >
-              Bank name
-            </ProfileFieldHeading>
-            {directDepositIsSetUp
-              ? paymentAccount.financialInstitutionName
-              : this.renderSetupButton('bank name', 'bank-name')}
-          </div>
-          <div className="vet360-profile-field">
-            <ProfileFieldHeading
-              onEditClick={
-                directDepositIsSetUp &&
-                (() => this.handleLinkClick('edit', 'account-number'))
-              }
-            >
-              Account number
-            </ProfileFieldHeading>
-            {directDepositIsSetUp
-              ? paymentAccount.accountNumber
-              : this.renderSetupButton('account number', 'account-number')}
-          </div>
-          <div className="vet360-profile-field">
-            <ProfileFieldHeading
-              onEditClick={
-                directDepositIsSetUp &&
-                (() => this.handleLinkClick('edit', 'account-type'))
-              }
-            >
-              Account type
-            </ProfileFieldHeading>
-            {directDepositIsSetUp
-              ? paymentAccount.accountType
-              : this.renderSetupButton(
-                  'account type (checking or savings)',
-                  'account-type',
-                )}
-          </div>
-          {directDepositIsSetUp && (
+      const paymentAccount = paymentInformation?.responses[0]?.paymentAccount;
+      if (paymentAccount) {
+        content = (
+          <>
+            <div className="vet360-profile-field">
+              <ProfileFieldHeading
+                onEditClick={() => this.handleLinkClick('edit', 'bank-name')}
+              >
+                Bank name
+              </ProfileFieldHeading>
+              {paymentAccount.financialInstitutionName}
+            </div>
+            <div className="vet360-profile-field">
+              <ProfileFieldHeading
+                onEditClick={() =>
+                  this.handleLinkClick('edit', 'account-number')
+                }
+              >
+                Account number
+              </ProfileFieldHeading>
+              {paymentAccount.accountNumber}
+            </div>
+            <div className="vet360-profile-field">
+              <ProfileFieldHeading
+                onEditClick={() => this.handleLinkClick('edit', 'account-type')}
+              >
+                Account type
+              </ProfileFieldHeading>
+              {paymentAccount.accountType}
+            </div>
             <p>
               <strong>Note:</strong> If you think you’ve been the victim of bank
               fraud, please call us at{' '}
@@ -228,19 +211,19 @@ class PaymentInformation extends React.Component {
               <span className="no-wrap">800-829-4833</span>
               ). We’re here Monday through Friday, 8:00 a.m. to 9:00 p.m.
             </p>
-          )}
 
-          <PaymentInformationEditModal
-            onClose={this.props.editModalToggled}
-            onSubmit={this.handleDirectDepositUpdateSubmit}
-            isEditing={this.props.paymentInformationUiState.isEditing}
-            isSaving={this.props.paymentInformationUiState.isSaving}
-            fields={this.props.paymentInformationUiState.editModalForm}
-            editModalFieldChanged={this.props.editModalFieldChanged}
-            responseError={this.props.paymentInformationUiState.responseError}
-          />
-        </>
-      );
+            <PaymentInformationEditModal
+              onClose={this.props.editModalToggled}
+              onSubmit={this.handleDirectDepositUpdateSubmit}
+              isEditing={this.props.paymentInformationUiState.isEditing}
+              isSaving={this.props.paymentInformationUiState.isSaving}
+              fields={this.props.paymentInformationUiState.editModalForm}
+              editModalFieldChanged={this.props.editModalFieldChanged}
+              responseError={this.props.paymentInformationUiState.responseError}
+            />
+          </>
+        );
+      }
     }
 
     return (

--- a/src/applications/personalization/profile360/containers/PaymentInformation.jsx
+++ b/src/applications/personalization/profile360/containers/PaymentInformation.jsx
@@ -175,55 +175,51 @@ class PaymentInformation extends React.Component {
       return null;
     } else {
       const paymentAccount = paymentInformation?.responses[0]?.paymentAccount;
-      if (paymentAccount) {
-        content = (
-          <>
-            <div className="vet360-profile-field">
-              <ProfileFieldHeading
-                onEditClick={() => this.handleLinkClick('edit', 'bank-name')}
-              >
-                Bank name
-              </ProfileFieldHeading>
-              {paymentAccount.financialInstitutionName}
-            </div>
-            <div className="vet360-profile-field">
-              <ProfileFieldHeading
-                onEditClick={() =>
-                  this.handleLinkClick('edit', 'account-number')
-                }
-              >
-                Account number
-              </ProfileFieldHeading>
-              {paymentAccount.accountNumber}
-            </div>
-            <div className="vet360-profile-field">
-              <ProfileFieldHeading
-                onEditClick={() => this.handleLinkClick('edit', 'account-type')}
-              >
-                Account type
-              </ProfileFieldHeading>
-              {paymentAccount.accountType}
-            </div>
-            <p>
-              <strong>Note:</strong> If you think you’ve been the victim of bank
-              fraud, please call us at{' '}
-              <span className="no-wrap">800-827-1000</span> (TTY:{' '}
-              <span className="no-wrap">800-829-4833</span>
-              ). We’re here Monday through Friday, 8:00 a.m. to 9:00 p.m.
-            </p>
+      content = (
+        <>
+          <div className="vet360-profile-field">
+            <ProfileFieldHeading
+              onEditClick={() => this.handleLinkClick('edit', 'bank-name')}
+            >
+              Bank name
+            </ProfileFieldHeading>
+            {paymentAccount.financialInstitutionName}
+          </div>
+          <div className="vet360-profile-field">
+            <ProfileFieldHeading
+              onEditClick={() => this.handleLinkClick('edit', 'account-number')}
+            >
+              Account number
+            </ProfileFieldHeading>
+            {paymentAccount.accountNumber}
+          </div>
+          <div className="vet360-profile-field">
+            <ProfileFieldHeading
+              onEditClick={() => this.handleLinkClick('edit', 'account-type')}
+            >
+              Account type
+            </ProfileFieldHeading>
+            {paymentAccount.accountType}
+          </div>
+          <p>
+            <strong>Note:</strong> If you think you’ve been the victim of bank
+            fraud, please call us at{' '}
+            <span className="no-wrap">800-827-1000</span> (TTY:{' '}
+            <span className="no-wrap">800-829-4833</span>
+            ). We’re here Monday through Friday, 8:00 a.m. to 9:00 p.m.
+          </p>
 
-            <PaymentInformationEditModal
-              onClose={this.props.editModalToggled}
-              onSubmit={this.handleDirectDepositUpdateSubmit}
-              isEditing={this.props.paymentInformationUiState.isEditing}
-              isSaving={this.props.paymentInformationUiState.isSaving}
-              fields={this.props.paymentInformationUiState.editModalForm}
-              editModalFieldChanged={this.props.editModalFieldChanged}
-              responseError={this.props.paymentInformationUiState.responseError}
-            />
-          </>
-        );
-      }
+          <PaymentInformationEditModal
+            onClose={this.props.editModalToggled}
+            onSubmit={this.handleDirectDepositUpdateSubmit}
+            isEditing={this.props.paymentInformationUiState.isEditing}
+            isSaving={this.props.paymentInformationUiState.isSaving}
+            fields={this.props.paymentInformationUiState.editModalForm}
+            editModalFieldChanged={this.props.editModalFieldChanged}
+            responseError={this.props.paymentInformationUiState.responseError}
+          />
+        </>
+      );
     }
 
     return (

--- a/src/applications/personalization/profile360/tests/containers/PaymentInformation.unit.spec.jsx
+++ b/src/applications/personalization/profile360/tests/containers/PaymentInformation.unit.spec.jsx
@@ -56,6 +56,34 @@ describe('<PaymentInformation/>', () => {
     wrapper.unmount();
   });
 
+  it('does not render if the user has not previously set up direct deposit', () => {
+    const fetchPaymentInformation = sinon.spy();
+    const props = {
+      ...defaultProps,
+      fetchPaymentInformation,
+      paymentInformation: {
+        responses: [],
+      },
+    };
+    const wrapper = shallow(<PaymentInformation {...props} />);
+    expect(wrapper.text()).to.be.empty;
+    expect(fetchPaymentInformation.called).to.be.true;
+    wrapper.unmount();
+  });
+
+  it('renders nothing if the accountNumber is empty', () => {
+    const props = set(
+      'paymentInformation.responses[0].paymentAccount.accountNumber',
+      '',
+      defaultProps,
+    );
+    const wrapper = shallow(<PaymentInformation {...props} />);
+
+    expect(wrapper.text()).to.be.empty;
+
+    wrapper.unmount();
+  });
+
   it('renders a prompt to enable 2FA is the user does not have it enabled already', () => {
     const props = { ...defaultProps, multifactorEnabled: false };
     const wrapper = shallow(<PaymentInformation {...props} />);
@@ -67,28 +95,6 @@ describe('<PaymentInformation/>', () => {
     const props = set('paymentInformation', { error: {} }, defaultProps);
     const wrapper = shallow(<PaymentInformation {...props} />);
     expect(wrapper.find('LoadFail')).to.have.lengthOf(1);
-    wrapper.unmount();
-  });
-
-  it('renders the correct content if the accountNumber is empty', () => {
-    const props = set(
-      'paymentInformation.responses[0].paymentAccount.accountNumber',
-      '',
-      defaultProps,
-    );
-    const wrapper = shallow(<PaymentInformation {...props} />);
-
-    expect(wrapper.find(DowntimeNotification)).to.have.lengthOf(1);
-    expect(wrapper.find(PaymentInformationEditModal)).to.have.lengthOf(1);
-    const profileFieldHeadings = wrapper.find(ProfileFieldHeading);
-    profileFieldHeadings.forEach(node => {
-      expect(node.props().onEditClick).to.equal('');
-    });
-    wrapper.find('.vet360-profile-field').forEach(node => {
-      expect(node.text()).to.contain('Please add your');
-    });
-    expect(wrapper.find('p')).to.have.length(0);
-
     wrapper.unmount();
   });
 


### PR DESCRIPTION
## Description
We only want to allow users to edit their bank info if they already have bank info set, as described in the linked issue

## Testing done
Updated the existing tests to reflect the changes in functionality and added an additional test

## Screenshots
N/A

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs