### PR TITLE
[Discharge Wizard] Remove sidebar

### DIFF
--- a/src/applications/discharge-wizard/DischargeWizardApp.jsx
+++ b/src/applications/discharge-wizard/DischargeWizardApp.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
 
 export default function DischargeWizardApp({ children }) {
-  return <div className="discharge-wizard">{children}</div>;
+  return <div className="row discharge-wizard">{children}</div>;
 }

--- a/src/applications/discharge-wizard/manifest.json
+++ b/src/applications/discharge-wizard/manifest.json
@@ -1,10 +1,10 @@
 {
-  "appName": "Claims Status",
+  "appName": "Discharge Wizard",
   "entryFile": "./discharge-wizard-entry.jsx",
   "entryName": "discharge-upgrade-instructions",
   "rootUrl": "/discharge-upgrade-instructions",
   "template": {
-    "layout": "page-react-sidebar.html",
+    "layout": "page-react.html",
     "title": "How To Apply For A Discharge Upgrade",
     "heading": "How to apply for a discharge upgrade",
     "display_title": "Discharge upgrade",
@@ -12,6 +12,7 @@
     "keywords": "upgrade discharge, military discharge upgrade, discharge upgrade",
     "order": 6,
     "spoke": "Get records",
-    "collection": "records"
+    "collection": "records",
+    "includeBreadcrumbs": true
   }
 }


### PR DESCRIPTION
## Description
This PR removes the sidebar from `/discharge-upgrade-instructions/` by switching it to a different layout.

https://github.com/department-of-veterans-affairs/va.gov-team/issues/2451

## Testing done
Looked at it locally 🙂 

## Screenshots
![image](https://user-images.githubusercontent.com/1915775/67886829-862afc00-fb20-11e9-8f75-667ff11a4404.png)


## Acceptance criteria
- [ ] Sidebar is gone

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
