### PR TITLE
Add build-content command

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "apps": "./script/app-list.sh",
     "analyze": "webpack-bundle-analyzer build/vagovprod/generated/stats.json",
     "build": "node --max-old-space-size=4096 script/build.js",
+    "build-content": "node src/site/stages/build/tome-sync-page-builder.js",
     "build-webpack": "NODE_OPTIONS=--max-old-space-size=4096 webpack --config config/standalone-webpack.config.js",
     "build-analyze": "NODE_ENV=production npm run build -- --buildtype vagovprod --analyzer; npm run analyze",
     "fetch-drupal-cache": "node script/drupal-aws-cache.js --fetch",


### PR DESCRIPTION
## Description
Adds a command to run the tome-sync page builder. Later, we can use this to pipe it into the build process without disturbing the current build until we're ready.

## Testing done
![image](https://user-images.githubusercontent.com/12970166/67905625-37d12980-fb2f-11e9-82cb-0bfea08e7c84.png)