### PR TITLE
Improve HLR unit tests

### DIFF
--- a/src/applications/disability-benefits/996/helpers.js
+++ b/src/applications/disability-benefits/996/helpers.js
@@ -31,3 +31,7 @@ export const addXMonths = numberOfMonths =>
   moment()
     .add(numberOfMonths, 'months')
     .format('YYYY-MM-DD');
+
+// testing
+export const $ = (selector, DOM) => DOM.querySelector(selector);
+export const $$ = (selector, DOM) => DOM.querySelectorAll(selector);


### PR DESCRIPTION
## Description

Unit tests for form 0996 (Higher-Level Review) were using `setTimeout`s to check if a form was progressing. This PR uses sinon to check that a submit was called instead of using a `setTimeout` which was causing build errors.

See https://github.com/department-of-veterans-affairs/va.gov-team/issues/2963

## Testing done

Global unit tests

## Acceptance criteria
- [ ] Unit tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
