### PR TITLE
Remove onClick handler in footer

### DIFF
--- a/src/platform/site-wide/va-footer/components/MobileLinks.jsx
+++ b/src/platform/site-wide/va-footer/components/MobileLinks.jsx
@@ -12,7 +12,6 @@ export default function MobileLinks({ links, visible }) {
       <ul className="usa-accordion va-footer-accordion">
         <li>
           <button
-            onClick={() => recordEvent({ event: 'nav-jumplink-click' })}
             className="usa-button-unstyled usa-accordion-button va-footer-button"
             aria-controls="veteran-contact"
             itemProp="name"

--- a/src/platform/site-wide/va-footer/components/MobileLinks.jsx
+++ b/src/platform/site-wide/va-footer/components/MobileLinks.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import recordEvent from '../../../../platform/monitoring/record-event';
 
 import { FOOTER_COLUMNS } from '../helpers';
 


### PR DESCRIPTION
## Description

Remove problematic `onClick` from the mobile view contact footer accordion.

The `onClick` was preventing the expansion of the footer. After some discussion in Slack, the decision was to remove it and work on the tracking later.

ref: https://github.com/department-of-veterans-affairs/va.gov-team/issues/2799

## Testing done

Local unit tests

## Screenshots

![contact](https://user-images.githubusercontent.com/136959/67962970-dc08ae00-fbcb-11e9-80cc-0381f3b884a3.gif)

## Acceptance criteria
- [ ] Contact accordion expanding as intended

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
