### PR TITLE
Update VET TEC program search result housing amount

### DIFF
--- a/src/applications/gi/components/vet-tec/VetTecProgramSearchResult.jsx
+++ b/src/applications/gi/components/vet-tec/VetTecProgramSearchResult.jsx
@@ -71,7 +71,7 @@ class VetTecProgramSearchResult extends React.Component {
                       Housing <span>(monthly):</span>
                       <div className="programHousingAllowance">
                         {`${formatCurrency(
-                          constants.AVGDODBAH,
+                          constants.AVGDODBAH / 2,
                         )} - ${formatCurrency(dodBah)}`}
                       </div>
                     </h4>

--- a/src/applications/gi/components/vet-tec/VetTecProgramSearchResult.jsx
+++ b/src/applications/gi/components/vet-tec/VetTecProgramSearchResult.jsx
@@ -6,7 +6,7 @@ import { renderPreferredProviderFlag } from '../../utils/render';
 
 class VetTecProgramSearchResult extends React.Component {
   render() {
-    const { version, result } = this.props;
+    const { version, result, constants } = this.props;
     const {
       facilityCode,
       description,
@@ -16,11 +16,8 @@ class VetTecProgramSearchResult extends React.Component {
       country,
       tuitionAmount,
       lengthInWeeks,
-      vaBah,
       dodBah,
     } = result;
-
-    const housing = Math.min(dodBah, vaBah);
 
     const linkTo = {
       pathname: `profile/${facilityCode}/${description}`,
@@ -32,7 +29,7 @@ class VetTecProgramSearchResult extends React.Component {
         <div className="outer">
           <div className="inner">
             <div className="row">
-              <div className="small-12 usa-width-seven-twelfths medium-7 columns">
+              <div className="small-12 medium-6 columns">
                 <h2>
                   <Link to={linkTo}>{description}</Link>
                 </h2>
@@ -45,7 +42,7 @@ class VetTecProgramSearchResult extends React.Component {
                   </p>
                 </div>
               </div>
-              <div className="small-12 usa-width-five-twelfths medium-5 columns estimated-benefits">
+              <div className="small-12 medium-6 columns estimated-benefits">
                 {renderPreferredProviderFlag(this.props.result)}
                 <h3 className="vads-u-padding-top--1p5">
                   You may be eligible for up to:
@@ -73,7 +70,9 @@ class VetTecProgramSearchResult extends React.Component {
                       />
                       Housing <span>(monthly):</span>
                       <div className="programHousingAllowance">
-                        {formatCurrency(housing)}
+                        {`${formatCurrency(
+                          constants.AVGDODBAH,
+                        )} - ${formatCurrency(dodBah)}`}
                       </div>
                     </h4>
                   </div>

--- a/src/applications/gi/containers/SearchPage.jsx
+++ b/src/applications/gi/containers/SearchPage.jsx
@@ -208,6 +208,7 @@ export class SearchPage extends React.Component {
                     version={this.props.location.query.version}
                     key={`${result.facilityCode}-${result.description}`}
                     result={result}
+                    constants={this.props.constants}
                   />
                 );
               }
@@ -346,6 +347,7 @@ SearchPage.defaultProps = {};
 
 const mapStateToProps = state => ({
   autocomplete: state.autocomplete,
+  constants: state.constants.constants,
   filters: state.filters,
   search: state.search,
   eligibility: state.eligibility,

--- a/src/applications/gi/tests/components/VetTecProgramSearchResult.unit.spec.jsx
+++ b/src/applications/gi/tests/components/VetTecProgramSearchResult.unit.spec.jsx
@@ -46,9 +46,9 @@ describe('<VetTecProgramSearchResult>', () => {
       formatCurrency(defaultProps.result.tuitionAmount),
     );
     expect(wrapper.find('.programHousingAllowance').text()).to.eq(
-      `${formatCurrency(defaultProps.constants.AVGDODBAH)} - ${formatCurrency(
-        defaultProps.result.dodBah,
-      )}`,
+      `${formatCurrency(
+        defaultProps.constants.AVGDODBAH / 2,
+      )} - ${formatCurrency(defaultProps.result.dodBah)}`,
     );
     expect(wrapper.find('.info-flag').text()).to.eq('2 weeks');
     expect(wrapper.find('.preferred-flag')).to.have.lengthOf(0);

--- a/src/applications/gi/tests/components/VetTecProgramSearchResult.unit.spec.jsx
+++ b/src/applications/gi/tests/components/VetTecProgramSearchResult.unit.spec.jsx
@@ -18,7 +18,9 @@ const defaultProps = {
     programType: 'NCD',
     state: 'IL',
     tuitionAmount: 10000,
-    vaBah: 1998,
+  },
+  constants: {
+    AVGDODBAH: 1000,
   },
 };
 
@@ -44,29 +46,18 @@ describe('<VetTecProgramSearchResult>', () => {
       formatCurrency(defaultProps.result.tuitionAmount),
     );
     expect(wrapper.find('.programHousingAllowance').text()).to.eq(
-      formatCurrency(defaultProps.result.dodBah),
+      `${formatCurrency(defaultProps.constants.AVGDODBAH)} - ${formatCurrency(
+        defaultProps.result.dodBah,
+      )}`,
     );
     expect(wrapper.find('.info-flag').text()).to.eq('2 weeks');
     expect(wrapper.find('.preferred-flag')).to.have.lengthOf(0);
     wrapper.unmount();
   });
 
-  it('should display lowest housing allowance provider', () => {
-    const props = {
-      result: {
-        ...defaultProps.result,
-        vaBah: 500,
-      },
-    };
-    const wrapper = mount(<VetTecProgramSearchResult {...props} />);
-    expect(wrapper.find('.programHousingAllowance').text()).to.eq(
-      formatCurrency(500),
-    );
-    wrapper.unmount();
-  });
-
   it('should display preferred provider', () => {
     const props = {
+      ...defaultProps,
       result: {
         ...defaultProps.result,
         preferredProvider: true,


### PR DESCRIPTION
## Description
Update the VET TEC program search results to display the estimated housing allowance as a range instead of the lower of the VA and DOD rate.

https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/vets.gov-team/19867

## Testing done
Tested locally and QA review

## Screenshots
![image](https://user-images.githubusercontent.com/41960449/67970778-ee8de200-fbe1-11e9-803d-f6f91284243d.png)


## Acceptance criteria
- [x] The length in hours in the bottom left of the card is replaced with the length in weeks.
- [x] The housing rate always displays: $[dod national average] - $[dod housing amount].

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
