### PR TITLE
CT 116: Update VET TEC Profile Page Content

### DIFF
--- a/src/applications/gi/components/vet-tec/VetTecApplicationProcess.jsx
+++ b/src/applications/gi/components/vet-tec/VetTecApplicationProcess.jsx
@@ -1,62 +1,100 @@
 import React from 'react';
+import environment from 'platform/utilities/environment';
 
-const VetTecApplicationProcess = () => (
-  <div
-    className={
-      'columns vads-u-margin-top--neg1p5 vads-u-margin-x--neg1p5 medium-screen:vads-l-col--10'
-    }
-  >
-    <h3 className="vads-u-font-size--h4">
-      Enrolling in VET TEC is a two-step process:
-    </h3>
-    <p>
-      First, you’ll need to apply for Veteran Employment Through Technology
-      Education Courses (VET TEC). You’ll get a Certificate of Eligibility (COE)
-      in the mail if we approve your application.
-    </p>
-    <p>
-      <a
-        href={
-          '/education/about-gi-bill-benefits/how-to-use-benefits/vettec-high-tech-program/apply-for-vettec-form-22-0994/introduction'
+class VetTecApplicationProcess extends React.Component {
+  providersWebsiteLink = () => {
+    const programs = this.props.institution.programs;
+    return programs[0].providerWebsite === null ? (
+      <p>
+        To learn more about available programs, visit the training provider's
+        website.
+      </p>
+    ) : (
+      <p>
+        To learn more about available programs,{' '}
+        <a
+          href={` https://${programs[0].providerWebsite}`}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          visit the training provider's website
+        </a>
+        .
+      </p>
+    );
+  };
+  render() {
+    return (
+      <div
+        className={
+          'columns vads-u-margin-top--neg1p5 vads-u-margin-x--neg1p5 medium-screen:vads-l-col--10'
         }
-        target="_blank"
-        rel="noopener noreferrer"
       >
-        Apply for VET TEC (VA Form 22-0994)
-      </a>
-    </p>
-    <p>
-      After you’ve been approved for VET TEC, apply to the program you’d like to
-      attend.
-    </p>
-    <p>
-      <a
-        href={
-          '/education/about-gi-bill-benefits/how-to-use-benefits/vettec-high-tech-program/'
-        }
-        target="_blank"
-        rel="noopener noreferrer"
-      >
-        Learn more about VET TEC programs
-      </a>
-    </p>
-    <h3 className="vads-u-font-size--h4">
-      Have questions about the VET TEC program or how to apply?
-    </h3>
-    <div>
-      <ul className="vet-tec-application-process-list">
-        <li>
-          Call us at 1-888-GIBILL (<a href="tel:+18884424551">1-888-442-4551</a>
-          ). We’re here Monday through Friday, 8:00a.m. to 7:00 p.m. ET. If you
-          have hearing loss, call TYY:711.
-        </li>
-        <li>
-          Or email us at{' '}
-          <a href="mailto:VETTEC.VBABUF@va.gov">VETTEC.VBABUF@va.gov</a>
-        </li>
-      </ul>
-    </div>
-  </div>
-);
-
+        <h3 className="vads-u-font-size--h4">
+          Enrolling in VET TEC is a two-step process:
+        </h3>
+        <p>
+          First, you’ll need to apply for Veteran Employment Through Technology
+          Education Courses (VET TEC). You’ll get a Certificate of Eligibility
+          (COE) in the mail if we approve your application.
+        </p>
+        <p>
+          <a
+            href={
+              '/education/about-gi-bill-benefits/how-to-use-benefits/vettec-high-tech-program/apply-for-vettec-form-22-0994/introduction'
+            }
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Apply for VET TEC (VA Form 22-0994)
+          </a>
+        </p>
+        {// PROD FLAG CT 116 STORY 19868
+        environment.isProduction() ? (
+          <p>
+            After you’ve been approved for VET TEC, apply to the program you’d
+            like to attend.
+          </p>
+        ) : (
+          <p>
+            Then, after you've been approved for VET TEC, apply to the
+            VA-approved training provider you'd like to attend.
+          </p>
+        )}
+        {environment.isProduction() ? (
+          <p>
+            <a
+              href={
+                '/education/about-gi-bill-benefits/how-to-use-benefits/vettec-high-tech-program/'
+              }
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Learn more about VET TEC programs
+            </a>
+          </p>
+        ) : (
+          this.providersWebsiteLink()
+        )}
+        <h3 className="vads-u-font-size--h4">
+          Have questions about the VET TEC program or how to apply?
+        </h3>
+        <div>
+          <ul className="vet-tec-application-process-list">
+            <li>
+              Call us at 1-888-GIBILL (
+              <a href="tel:+18884424551">1-888-442-4551</a>
+              ). We’re here Monday through Friday, 8:00a.m. to 7:00 p.m. ET. If
+              you have hearing loss, call TYY:711.
+            </li>
+            <li>
+              Or email us at{' '}
+              <a href="mailto:VETTEC.VBABUF@va.gov">VETTEC.VBABUF@va.gov</a>
+            </li>
+          </ul>
+        </div>
+      </div>
+    );
+  }
+}
 export default VetTecApplicationProcess;

--- a/src/applications/gi/components/vet-tec/VetTecApplicationProcess.jsx
+++ b/src/applications/gi/components/vet-tec/VetTecApplicationProcess.jsx
@@ -4,12 +4,19 @@ import environment from 'platform/utilities/environment';
 class VetTecApplicationProcess extends React.Component {
   providersWebsiteLink = () => {
     const programs = this.props.institution.programs;
-    return programs[0].providerWebsite === null ? (
-      <p>
-        To learn more about available programs, visit the training provider's
-        website.
-      </p>
-    ) : (
+
+    if (
+      programs[0].providerWebsite === null ||
+      programs[0].providerWebsite === ''
+    ) {
+      return (
+        <p>
+          To learn more about available programs, visit the training provider's
+          website.
+        </p>
+      );
+    }
+    return (
       <p>
         To learn more about available programs,{' '}
         <a
@@ -61,7 +68,8 @@ class VetTecApplicationProcess extends React.Component {
             VA-approved training provider you'd like to attend.
           </p>
         )}
-        {environment.isProduction() ? (
+        {// PROD FLAG CT 116 STORY 19868
+        environment.isProduction() ? (
           <p>
             <a
               href={

--- a/src/applications/gi/components/vet-tec/VetTecApplicationProcess.jsx
+++ b/src/applications/gi/components/vet-tec/VetTecApplicationProcess.jsx
@@ -20,7 +20,7 @@ class VetTecApplicationProcess extends React.Component {
       <p>
         To learn more about available programs,{' '}
         <a
-          href={` https://${programs[0].providerWebsite}`}
+          href={`https://${programs[0].providerWebsite}`}
           target="_blank"
           rel="noopener noreferrer"
         >

--- a/src/applications/gi/components/vet-tec/VetTecApprovedPrograms.jsx
+++ b/src/applications/gi/components/vet-tec/VetTecApprovedPrograms.jsx
@@ -67,7 +67,12 @@ class VetTecApprovedPrograms extends React.Component {
               </label>
             </div>
           </td>
-          <td>{`${program.lengthInHours} hours`}</td>
+          {// PROD FLAG CT 116 STORY 19868
+          environment.isProduction() ? (
+            <td>{`${program.lengthInHours} hours`}</td>
+          ) : (
+            <td>{`${program.lengthInWeeks} weeks`}</td>
+          )}
           <td>{formatCurrency(program.tuitionAmount)}</td>
         </tr>
       ));

--- a/src/applications/gi/components/vet-tec/VetTecCalculator.jsx
+++ b/src/applications/gi/components/vet-tec/VetTecCalculator.jsx
@@ -11,6 +11,7 @@ import { getCalculatedBenefits } from '../../selectors/vetTecCalculator';
 import VetTecCalculatorForm from './VetTecCalculatorForm';
 import PropTypes from 'prop-types';
 import { ariaLabels } from '../../constants';
+import environment from '../../../../platform/utilities/environment';
 
 export class VetTecCalculator extends React.Component {
   constructor(props) {
@@ -21,6 +22,10 @@ export class VetTecCalculator extends React.Component {
       scholarships: 0,
     };
   }
+  // PROD FLAG CT 116 19868
+
+  indentVaPaysToProvider = () =>
+    environment.isProduction() ? '' : 'vads-u-margin-left--2p5';
 
   renderCalculatorForm = () => {
     const {
@@ -86,7 +91,7 @@ export class VetTecCalculator extends React.Component {
           <div>{outputs.vaPaysToProvider}</div>
         </div>
       </div>
-      <div>
+      <div className={this.indentVaPaysToProvider()}>
         <div className="row vads-u-margin-top--0p5 small-screen:vads-u-padding-right--7">
           <div className="small-9 small-screen:small-9 columns">
             <div>Upon enrollment in program (25%):</div>
@@ -140,24 +145,48 @@ export class VetTecCalculator extends React.Component {
           (Learn more)
         </button>
       </div>
+      {// PROD FLAG CT 116 STORY 19868
+      environment.isProduction() ? (
+        <div>
+          <div className="row calculator-result">
+            <div className="small-8 columns">
+              <div>In person rate:</div>
+            </div>
+            <div className="small-4 columns vads-u-text-align--right small-screen:vads-u-padding-left--7">
+              <div>{`${outputs.inPersonRate}/mo`}</div>
+            </div>
+          </div>
 
-      <div className="row calculator-result">
-        <div className="small-8 columns">
-          <div>In person rate:</div>
+          <div className="row calculator-result">
+            <div className="small-8 columns">
+              <div>Online rate:</div>
+            </div>
+            <div className="small-4 columns vads-u-text-align--right small-screen:vads-u-padding-left--7">
+              <div>{`${outputs.onlineRate}/mo`}</div>
+            </div>
+          </div>
         </div>
-        <div className="small-4 columns vads-u-text-align--right small-screen:vads-u-padding-left--7">
-          <div>{outputs.inPersonRate}</div>
-        </div>
-      </div>
+      ) : (
+        <div>
+          <div className="row calculator-result">
+            <div className="small-8 columns">
+              <div>In person rate (monthly):</div>
+            </div>
+            <div className="small-4 columns vads-u-text-align--right small-screen:vads-u-padding-left--7">
+              <div>{outputs.inPersonRate}</div>
+            </div>
+          </div>
 
-      <div className="row calculator-result">
-        <div className="small-8 columns">
-          <div>Online rate:</div>
+          <div className="row calculator-result">
+            <div className="small-8 columns">
+              <div>Online rate (monthly):</div>
+            </div>
+            <div className="small-4 columns vads-u-text-align--right small-screen:vads-u-padding-left--7">
+              <div>{outputs.onlineRate}</div>
+            </div>
+          </div>
         </div>
-        <div className="small-4 columns vads-u-text-align--right small-screen:vads-u-padding-left--7">
-          <div>{outputs.onlineRate}</div>
-        </div>
-      </div>
+      )}
     </div>
   );
 

--- a/src/applications/gi/components/vet-tec/VetTecCalculator.jsx
+++ b/src/applications/gi/components/vet-tec/VetTecCalculator.jsx
@@ -11,7 +11,7 @@ import { getCalculatedBenefits } from '../../selectors/vetTecCalculator';
 import VetTecCalculatorForm from './VetTecCalculatorForm';
 import PropTypes from 'prop-types';
 import { ariaLabels } from '../../constants';
-import environment from '../../../../platform/utilities/environment';
+import environment from 'platform/utilities/environment';
 
 export class VetTecCalculator extends React.Component {
   constructor(props) {
@@ -22,10 +22,14 @@ export class VetTecCalculator extends React.Component {
       scholarships: 0,
     };
   }
+
   // PROD FLAG CT 116 19868
 
   indentVaPaysToProvider = () =>
     environment.isProduction() ? '' : 'vads-u-margin-left--2p5';
+
+  housingAllowanceClassName =
+    'small-4 columns vads-u-text-align--right small-screen:vads-u-padding-left--7';
 
   renderCalculatorForm = () => {
     const {
@@ -152,7 +156,7 @@ export class VetTecCalculator extends React.Component {
             <div className="small-8 columns">
               <div>In person rate:</div>
             </div>
-            <div className="small-4 columns vads-u-text-align--right small-screen:vads-u-padding-left--7">
+            <div className={this.housingAllowanceClassName}>
               <div>{`${outputs.inPersonRate}/mo`}</div>
             </div>
           </div>
@@ -161,7 +165,7 @@ export class VetTecCalculator extends React.Component {
             <div className="small-8 columns">
               <div>Online rate:</div>
             </div>
-            <div className="small-4 columns vads-u-text-align--right small-screen:vads-u-padding-left--7">
+            <div className={this.housingAllowanceClassName}>
               <div>{`${outputs.onlineRate}/mo`}</div>
             </div>
           </div>
@@ -172,7 +176,7 @@ export class VetTecCalculator extends React.Component {
             <div className="small-8 columns">
               <div>In person rate (monthly):</div>
             </div>
-            <div className="small-4 columns vads-u-text-align--right small-screen:vads-u-padding-left--7">
+            <div className={this.housingAllowanceClassName}>
               <div>{outputs.inPersonRate}</div>
             </div>
           </div>
@@ -181,7 +185,7 @@ export class VetTecCalculator extends React.Component {
             <div className="small-8 columns">
               <div>Online rate (monthly):</div>
             </div>
-            <div className="small-4 columns vads-u-text-align--right small-screen:vads-u-padding-left--7">
+            <div className={this.housingAllowanceClassName}>
               <div>{outputs.onlineRate}</div>
             </div>
           </div>

--- a/src/applications/gi/components/vet-tec/VetTecInstitutionProfile.jsx
+++ b/src/applications/gi/components/vet-tec/VetTecInstitutionProfile.jsx
@@ -32,7 +32,7 @@ const VetTecInstitutionProfile = ({
           <VetTecCalculator showModal={showModal} />
         </AccordionItem>
         <AccordionItem button="Application process">
-          <VetTecApplicationProcess />
+          <VetTecApplicationProcess institution={institution} />
         </AccordionItem>
         <AccordionItem button="Contact details">
           <VetTecContactInformation institution={institution} />

--- a/src/applications/gi/selectors/vetTecCalculator.js
+++ b/src/applications/gi/selectors/vetTecCalculator.js
@@ -44,7 +44,6 @@ export const getCalculatedBenefits = createSelector(
         outOfPocketFees = 0;
       }
     }
-
     return {
       outputs: {
         vetTecTuitionFees: formatCurrencyNullTBD(
@@ -55,8 +54,8 @@ export const getCalculatedBenefits = createSelector(
         quarterVetTecPayment: formatCurrencyNullTBD(quarterPaysToProviderValue),
         halfVetTecPayment: formatCurrencyNullTBD(halfPaysToProviderValue),
         outOfPocketTuitionFees: formatCurrencyNullTBD(outOfPocketFees),
-        inPersonRate: `${formatCurrency(institution.dodBah)}/mo`,
-        onlineRate: `${formatCurrency(constants.AVGDODBAH * 0.5)}/mo`,
+        inPersonRate: `${formatCurrency(institution.dodBah)}`,
+        onlineRate: `${formatCurrency(constants.AVGDODBAH * 0.5)}`,
       },
     };
   },

--- a/src/applications/gi/tests/components/VetTecComponents.unit.spec.jsx
+++ b/src/applications/gi/tests/components/VetTecComponents.unit.spec.jsx
@@ -7,6 +7,7 @@ import { VetTecScoContact } from '../../components/vet-tec/VetTecScoContact';
 import VetTecContactInformation from '../../components/vet-tec/VetTecContactInformation';
 import VetTecApprovedPrograms from '../../components/vet-tec/VetTecApprovedPrograms';
 import VetTecHeadingSummary from '../../components/vet-tec/VetTecHeadingSummary';
+import VetTecApplicationProcess from '../../components/vet-tec/VetTecApplicationProcess';
 
 const institution = {
   facilityCode: '2V000105',
@@ -88,6 +89,17 @@ describe('<VetTecContactInformation>', () => {
   it('should render', () => {
     const wrapper = shallow(
       <VetTecContactInformation institution={institution} />,
+    );
+    const vdom = wrapper.html();
+    expect(vdom).to.not.be.undefined;
+    wrapper.unmount();
+  });
+});
+
+describe('<VetTecApplicationProcess>', () => {
+  it('should render', () => {
+    const wrapper = shallow(
+      <VetTecApplicationProcess institution={institution} />,
     );
     const vdom = wrapper.html();
     expect(vdom).to.not.be.undefined;

--- a/src/applications/gi/tests/selectors/vetTecCalculator.unit.spec.js
+++ b/src/applications/gi/tests/selectors/vetTecCalculator.unit.spec.js
@@ -116,13 +116,13 @@ describe('getCalculatedBenefits', () => {
 
   it('should calculate onlineRate as AVGDODBAH constant', () => {
     expect(getCalculatedBenefits(defaultState).outputs.onlineRate).to.equal(
-      '$800/mo',
+      '$800',
     );
   });
 
   it('should correctly calculate inPersonRate', () => {
     expect(getCalculatedBenefits(defaultState).outputs.inPersonRate).to.equal(
-      '$1,800/mo',
+      '$1,800',
     );
   });
 });


### PR DESCRIPTION
## Description
As a comparison tool user, I need the VET TEC profile page to display relevant information in a user friendly manner so that I can make decisions about which provider / program I would like to attend to use my benefits.

https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/vets.gov-team/19868

## Testing done
Testing conducted using local host

## Screenshots
![Screen Shot 2019-11-01 at 9 02 13 AM](https://user-images.githubusercontent.com/50601724/68026549-6e6d8800-fc86-11e9-8179-0f823d7c03e3.png)
![Screen Shot 2019-11-01 at 9 07 32 AM](https://user-images.githubusercontent.com/50601724/68026812-1b480500-fc87-11e9-8a54-8a123a764f93.png)


## Acceptance criteria Approved Programs
- [x] In the table listing the programs, the length is displayed in weeks.
- [x] The benefits estimator indents the percentage listing descriptions.
- [x] The housing allowance includes "(monthly)" as part of the label instead of "/mo" on the amount.
## Acceptance criteria Application Process
- [x] The sentence "After you've been approved for VET TEC, apply to the program you'd like to attend." is replaced with "Then, after you've been approved for VET TEC, apply to the VA-approved training provider you'd like to attend."
- [x] The sentence link "Learn more about VET TEC programs" is replaced with the following: "To learn more about available programs, visit the training provider's website."
- [x] "visit the training provider's website" is a link to the provided website.
## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
