### PR TITLE
Update README.md and Added `npm lint:js:changed:fix`

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Once you have the site set up locally, these are some common commands you might 
 | run all linters                          | `npm run lint`                           |
 | run only javascript linter               | `npm run lint:js`                        |
 | run only sass linter                     | `npm run lint:sass`                      |
-| run lint on JS and fixed anything that changed | `npm run lint:js:changed:fix`      |
+| run lint on JS and fix anything that changed | `npm run lint:js:changed:fix`      |
 | run automated accessibility tests        | `npm run build && npm run test:accessibility` |
 | run visual regression testing            | Start the site. Generate your baseline image set using `npm run test:visual:baseline`. Make your changes. Then run `npm run test:visual`.  |
 | test for broken links                    | Build the site. Broken Link Checking is done via a Metalsmith plugin during build. Note that it only runs on *build* not watch. |

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Once you have the site set up locally, these are some common commands you might 
 | run all linters                          | `npm run lint`                           |
 | run only javascript linter               | `npm run lint:js`                        |
 | run only sass linter                     | `npm run lint:sass`                      |
+| run lint on JS and fixed anything that changed | `npm run lint:js:changed:fix`      |
 | run automated accessibility tests        | `npm run build && npm run test:accessibility` |
 | run visual regression testing            | Start the site. Generate your baseline image set using `npm run test:visual:baseline`. Make your changes. Then run `npm run test:visual`.  |
 | test for broken links                    | Build the site. Broken Link Checking is done via a Metalsmith plugin during build. Note that it only runs on *build* not watch. |


### PR DESCRIPTION
## Description
As a developer I should be able to understand the commands that can be run on our codebase from our documentation so that I don't get frustrated and have to find someone and ask them.

We don't have in our documentation the fact that you can run `npm run lint:js:changed:fix` and it will fix lint errors. This is critical to know so that these errors don't have to be manually fixed or fixed with a plugin everytime.

## Testing done
N/A

## Acceptance criteria
- [x] `npm run Added lint:js:changed:fix` shows up in our main README.md

