### PR TITLE
adding EVSS endpoint directly to see what response data structure is

### DIFF
--- a/src/applications/personalization/rated-disabilities/actions/index.js
+++ b/src/applications/personalization/rated-disabilities/actions/index.js
@@ -31,8 +31,9 @@ export function fetchRatedDisabilities() {
 
 export function fetchTotalDisabilityRating() {
   return async dispatch => {
-    const response = await getData(
-      '/disability_compensation_form/rated_disabilities',
+    // Attempt to hit EVSS directly to view response data structure
+    const response = fetch(
+      'https://int.ebenefits.va.gov:444/VONAPP2/wss-common-services-web-11.6/rest/ratingInfoService/11.6/findRatingInfoPID',
     );
 
     if (response.errors) {


### PR DESCRIPTION
## Description
Original ticket - https://github.com/department-of-veterans-affairs/va.gov-team/issues/2488

So far our backend engineer has been unable to hit the EVSS endpoint needed for our work because it does not work from her GFE. In an attempt to simply see what the data structure from the EVSS endpoint looks like, and to see if we can get some type of response, we are going to try to hit the EVSS endpoint directly and just see what response we get in Staging. 

## Testing done
Unit tests for the reducer code will be included in a separate branch

## Screenshots
N/A

## Acceptance criteria
- [x] Direct EVSS end point fetch is being performed in Staging

## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
