### PR TITLE
Add page.json to test cms export data

### DIFF
--- a/src/site/stages/build/process-cms-exports/graphql-cms-export-differences/node.md
+++ b/src/site/stages/build/process-cms-exports/graphql-cms-export-differences/node.md
@@ -10,21 +10,22 @@ CMS export returned **774** records.
 
 ## `target_id`s:
 
-- `health_care_region_detail_page`
 - `documentation_page`
-- `event`
 - `event_listing`
-- `press_release`
-- `office`
-- `outreach_asset` (e.g. `Publication`)
-- `person_profile` (e.g. `Staff profile`)
-- `news_story`
-- `support_service`
-- `health_care_region_page` (e.g. `VAMC system`)
+- `event`
 - `full_width_banner_alert` (e.g. `VAMC system banner alert with situational updates`)
 - `health_care_local_facility` (e.g. `VAMC facility`)
 - `health_care_local_health_service` (e.g. `VAMC facility health service`)
+- `health_care_region_detail_page`
+- `health_care_region_page` (e.g. `VAMC system`)
+- `news_story`
+- `office`
+- `outreach_asset` (e.g. `Publication`)
+- `page`
+- `person_profile` (e.g. `Staff profile`)
+- `press_release`
 - `regional_health_care_service_des` (e.g. `VAMC system health service`)
+- `support_service`
 - `vamc_operating_status_and_alerts` (e.g. `VAMC system operating status`)
 
 ## All standard key-value pairs:
@@ -105,6 +106,18 @@ CMS export returned **774** records.
   - `field_description` | Text (plain)
   - `field_meta_tags` | Meta tags
   - `field_meta_title` | Text (plain)
+- target_id: `page`
+  - `field_administration`
+  - `field_alert`
+  - `field_content_block`
+  - `field_description`
+  - `field_featured_content`
+  - `field_intro_text`
+  - `field_meta_tags`
+  - `field_meta_title`
+  - `field_page_last_built`
+  - `field_plainlanguage_date`
+  - `field_related_links`
 - target_id: `outreach_asset` (e.g. `Publication`)
   - `field_administration` | Entity reference
   - `field_administration` | Entity reference

--- a/src/site/stages/build/process-cms-exports/tests/entities/index.js
+++ b/src/site/stages/build/process-cms-exports/tests/entities/index.js
@@ -26,6 +26,7 @@ module.exports = {
     news_story: require('./node/news_story.json'),
     office: require('./node/office.json'),
     outreach_asset: require('./node/outreach_asset.json'),
+    page: require('./node/page.json'),
     person_profile: require('./node/person_profile.json'),
     press_release: require('./node/press_release.json'),
     regional_health_care_service_des: require('./node/regional_health_care_service_des.json'),

--- a/src/site/stages/build/process-cms-exports/tests/entities/node/page.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node/page.json
@@ -1,0 +1,134 @@
+{
+  "uuid": [
+      {
+          "value": "01f07d8a-fb30-4ce1-b0e9-9be3d564542d"
+      }
+  ],
+  "langcode": [
+      {
+          "value": "en"
+      }
+  ],
+  "type": [
+      {
+          "target_id": "page",
+          "target_type": "node_type",
+          "target_uuid": "d4860e9e-588d-474c-8d59-550fb61c5c8c"
+      }
+  ],
+  "revision_timestamp": [
+      {
+          "value": "2019-09-24T22:22:26+00:00",
+          "format": "Y-m-d\\TH:i:sP"
+      }
+  ],
+  "revision_uid": [
+      {
+          "target_type": "user",
+          "target_uuid": "e62ded06-1de9-4617-bd70-595036edc7ee"
+      }
+  ],
+  "revision_log": [],
+  "status": [
+      {
+          "value": true
+      }
+  ],
+  "title": [
+      {
+          "value": "Principles of Excellence program"
+      }
+  ],
+  "uid": [
+      {
+          "target_type": "user",
+          "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+      }
+  ],
+  "created": [
+      {
+          "value": "2019-09-04T14:38:40+00:00",
+          "format": "Y-m-d\\TH:i:sP"
+      }
+  ],
+  "changed": [
+      {
+          "value": "2019-09-24T22:22:26+00:00",
+          "format": "Y-m-d\\TH:i:sP"
+      }
+  ],
+  "promote": [
+      {
+          "value": false
+      }
+  ],
+  "sticky": [
+      {
+          "value": false
+      }
+  ],
+  "default_langcode": [
+      {
+          "value": true
+      }
+  ],
+  "revision_translation_affected": [
+      {
+          "value": true
+      }
+  ],
+  "moderation_state": [
+      {
+          "value": "published"
+      }
+  ],
+  "path": [
+      {
+          "alias": "\/education\/choosing-a-school\/principles-of-excellence",
+          "langcode": "en",
+          "pathauto": 0
+      }
+  ],
+  "menu_link": [],
+  "field_administration": [
+      {
+          "target_type": "taxonomy_term",
+          "target_uuid": "43901d82-efe9-4dc0-a581-71e081516651"
+      }
+  ],
+  "field_alert": [],
+  "field_content_block": [
+      {
+          "target_type": "paragraph",
+          "target_uuid": "b9fe6ba2-f4cb-4d97-99f1-0d9654e1e125"
+      }
+  ],
+  "field_description": [
+      {
+          "value": "Learn about guidelines for programs that receive federal funding through programs like the GI Bill. Some foreign schools, high schools, internships, residencies, and apprenticeships don't have to follow these guidelines."
+      }
+  ],
+  "field_featured_content": [],
+  "field_intro_text": [
+      {
+          "value": "<p>The Principles of Excellence program requires schools that get federal funding through programs such as the GI Bill to follow certain guidelines. Learn about these guidelines.<\/p>"
+      }
+  ],
+  "field_meta_tags": [],
+  "field_meta_title": [
+      {
+          "value": "Principles Of Excellence Program | Veterans Affairs"
+      }
+  ],
+  "field_page_last_built": [
+      {
+          "value": "2019-10-16T15:00:22"
+      }
+  ],
+  "field_plainlanguage_date": [
+      {
+          "value": "2016-12-05"
+      }
+  ],
+  "field_related_links": []
+}


### PR DESCRIPTION
## Description
This PR adds `page.json` test CMS export data. The `target_id` `page` of the entity `node` was not covered in [this Google spreadsheet](https://docs.google.com/spreadsheets/d/1vL8rqLqcEVfESnJJK_GWQ7nf3BPe4SSevYYblisBTOI/edit#gid=858986005).

## Testing done
N/A

## Screenshots
N/A

## Acceptance criteria
- [x] Adds `page.json` to the `node` entity test data.
- [x] Adds `page` `target_id` documentation to the `node` entity docs.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
