### PR TITLE
Kelsonic 3065 update docs for node entity

### DIFF
--- a/src/site/stages/build/process-cms-exports/graphql-cms-export-differences/node.md
+++ b/src/site/stages/build/process-cms-exports/graphql-cms-export-differences/node.md
@@ -10,21 +10,22 @@ CMS export returned **774** records.
 
 ## `target_id`s:
 
-- `health_care_region_detail_page`
 - `documentation_page`
-- `event`
 - `event_listing`
-- `press_release`
-- `office`
-- `outreach_asset` (e.g. `Publication`)
-- `person_profile` (e.g. `Staff profile`)
-- `news_story`
-- `support_service`
-- `health_care_region_page` (e.g. `VAMC system`)
+- `event`
 - `full_width_banner_alert` (e.g. `VAMC system banner alert with situational updates`)
 - `health_care_local_facility` (e.g. `VAMC facility`)
 - `health_care_local_health_service` (e.g. `VAMC facility health service`)
+- `health_care_region_detail_page`
+- `health_care_region_page` (e.g. `VAMC system`)
+- `news_story`
+- `office`
+- `outreach_asset` (e.g. `Publication`)
+- `page`
+- `person_profile` (e.g. `Staff profile`)
+- `press_release`
 - `regional_health_care_service_des` (e.g. `VAMC system health service`)
+- `support_service`
 - `vamc_operating_status_and_alerts` (e.g. `VAMC system operating status`)
 
 ## All standard key-value pairs:
@@ -105,6 +106,18 @@ CMS export returned **774** records.
   - `field_description` | Text (plain)
   - `field_meta_tags` | Meta tags
   - `field_meta_title` | Text (plain)
+- target_id: `page`
+  - `field_administration`
+  - `field_alert`
+  - `field_content_block`
+  - `field_description`
+  - `field_featured_content`
+  - `field_intro_text`
+  - `field_meta_tags`
+  - `field_meta_title`
+  - `field_page_last_built`
+  - `field_plainlanguage_date`
+  - `field_related_links`
 - target_id: `outreach_asset` (e.g. `Publication`)
   - `field_administration` | Entity reference
   - `field_administration` | Entity reference

--- a/src/site/stages/build/process-cms-exports/graphql-cms-export-differences/node.md
+++ b/src/site/stages/build/process-cms-exports/graphql-cms-export-differences/node.md
@@ -18,12 +18,14 @@ CMS export returned **774** records.
 - `health_care_local_health_service` (e.g. `VAMC facility health service`)
 - `health_care_region_detail_page`
 - `health_care_region_page` (e.g. `VAMC system`)
+- `landing_page`
 - `news_story`
 - `office`
 - `outreach_asset` (e.g. `Publication`)
 - `page`
 - `person_profile` (e.g. `Staff profile`)
 - `press_release`
+- `publication_listing`
 - `regional_health_care_service_des` (e.g. `VAMC system health service`)
 - `support_service`
 - `vamc_operating_status_and_alerts` (e.g. `VAMC system operating status`)
@@ -89,35 +91,29 @@ CMS export returned **774** records.
   - `field_meta_tags` | Meta tags
   - `field_meta_title` | Text (plain)
   - `field_office` | Entity reference
-- target_id: `press_release`
-  - `field_address` | Address
-  - `field_administration` | Entity reference
-  - `field_intro_text` | Text (plain, long)
-  - `field_meta_tags` | Meta tags
-  - `field_office` | Entity reference
-  - `field_pdf_version` | Entity reference
-  - `field_press_release_contact` | Entity reference
-  - `field_press_release_downloads` | Entity reference
-  - `field_press_release_fulltext` | Text (formatted, long)
-  - `field_release_date` | Date
+- target_id: `landing_page`
+  - `field_administration`
+  - `field_alert`
+  - `field_description`
+  - `field_home_page_hub_label`
+  - `field_intro_text`
+  - `field_links`
+  - `field_meta_tags`
+  - `field_meta_title`
+  - `field_page_last_built`
+  - `field_plainlanguage_date`
+  - `field_promo`
+  - `field_related_links`
+  - `field_spokes`
+  - `field_support_services`
+  - `field_teaser_text`
+  - `field_title_icon`
 - target_id: `office`
   - `field_administration` | Entity reference
   - `field_body` | Text (formatted, long)
   - `field_description` | Text (plain)
   - `field_meta_tags` | Meta tags
   - `field_meta_title` | Text (plain)
-- target_id: `page`
-  - `field_administration`
-  - `field_alert`
-  - `field_content_block`
-  - `field_description`
-  - `field_featured_content`
-  - `field_intro_text`
-  - `field_meta_tags`
-  - `field_meta_title`
-  - `field_page_last_built`
-  - `field_plainlanguage_date`
-  - `field_related_links`
 - target_id: `outreach_asset` (e.g. `Publication`)
   - `field_administration` | Entity reference
   - `field_administration` | Entity reference
@@ -132,6 +128,36 @@ CMS export returned **774** records.
   - `field_meta_title` | Text (plain)
   - `field_office` | Entity reference
   - `field_office` | Entity reference
+- target_id: `page`
+  - `field_administration`
+  - `field_alert`
+  - `field_content_block`
+  - `field_description`
+  - `field_featured_content`
+  - `field_intro_text`
+  - `field_meta_tags`
+  - `field_meta_title`
+  - `field_page_last_built`
+  - `field_plainlanguage_date`
+  - `field_related_links`
+- target_id: `press_release`
+  - `field_address` | Address
+  - `field_administration` | Entity reference
+  - `field_intro_text` | Text (plain, long)
+  - `field_meta_tags` | Meta tags
+  - `field_office` | Entity reference
+  - `field_pdf_version` | Entity reference
+  - `field_press_release_contact` | Entity reference
+  - `field_press_release_downloads` | Entity reference
+  - `field_press_release_fulltext` | Text (formatted, long)
+  - `field_release_date` | Date
+- target_id: `publication_listing`
+  - `field_administration`
+  - `field_description`
+  - `field_intro_text`
+  - `field_meta_tags`
+  - `field_meta_title`
+  - `field_office`
 - target_id: `person_profile` (e.g. `Staff profile`)
   - `field_administration` | Entity reference
   - `field_body` | Text (formatted, long)

--- a/src/site/stages/build/process-cms-exports/tests/entities/index.js
+++ b/src/site/stages/build/process-cms-exports/tests/entities/index.js
@@ -26,6 +26,7 @@ module.exports = {
     news_story: require('./node/news_story.json'),
     office: require('./node/office.json'),
     outreach_asset: require('./node/outreach_asset.json'),
+    page: require('./node/page.json'),
     person_profile: require('./node/person_profile.json'),
     press_release: require('./node/press_release.json'),
     regional_health_care_service_des: require('./node/regional_health_care_service_des.json'),

--- a/src/site/stages/build/process-cms-exports/tests/entities/node/landing_page.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node/landing_page.json
@@ -1,0 +1,196 @@
+{
+  "uuid": [
+      {
+          "value": "18ca8756-9f78-43ef-95ea-04bd106063c5"
+      }
+  ],
+  "langcode": [
+      {
+          "value": "en"
+      }
+  ],
+  "type": [
+      {
+          "target_id": "landing_page",
+          "target_type": "node_type",
+          "target_uuid": "9bf68a65-e5fb-42ab-b13e-ee905507aeac"
+      }
+  ],
+  "revision_timestamp": [
+      {
+          "value": "2019-09-24T22:59:21+00:00",
+          "format": "Y-m-d\\TH:i:sP"
+      }
+  ],
+  "revision_uid": [
+      {
+          "target_type": "user",
+          "target_uuid": "e62ded06-1de9-4617-bd70-595036edc7ee"
+      }
+  ],
+  "revision_log": [],
+  "status": [
+      {
+          "value": true
+      }
+  ],
+  "title": [
+      {
+          "value": "VA education and training benefits"
+      }
+  ],
+  "uid": [
+      {
+          "target_type": "user",
+          "target_uuid": "b02c2ff5-dfe1-4542-beec-3fd410a3f267"
+      }
+  ],
+  "created": [
+      {
+          "value": "2019-02-06T16:36:11+00:00",
+          "format": "Y-m-d\\TH:i:sP"
+      }
+  ],
+  "changed": [
+      {
+          "value": "2019-09-24T22:59:21+00:00",
+          "format": "Y-m-d\\TH:i:sP"
+      }
+  ],
+  "promote": [
+      {
+          "value": false
+      }
+  ],
+  "sticky": [
+      {
+          "value": false
+      }
+  ],
+  "default_langcode": [
+      {
+          "value": true
+      }
+  ],
+  "revision_translation_affected": [
+      {
+          "value": true
+      }
+  ],
+  "moderation_state": [
+      {
+          "value": "published"
+      }
+  ],
+  "path": [
+      {
+          "alias": "\/education",
+          "langcode": "en",
+          "pathauto": 0
+      }
+  ],
+  "menu_link": [],
+  "field_administration": [
+      {
+          "target_type": "taxonomy_term",
+          "target_uuid": "2c331a6d-b525-4f0c-8bea-4ecde41c7ef0"
+      }
+  ],
+  "field_alert": [],
+  "field_description": [
+      {
+          "value": "Find out if you're eligible and how to apply for VA education benefits for Veterans, service members, and their qualified family members. VA education and training benefits can help you pay for college tuition, find the right school or training program, get career counseling, and more."
+      }
+  ],
+  "field_home_page_hub_label": [
+      {
+          "value": "Education and training"
+      }
+  ],
+  "field_intro_text": [
+      {
+          "value": "VA education benefits help Veterans, service members, and their qualified family members with needs like paying college tuition, finding the right school or training program, and getting career counseling. Learn how to apply for and manage the education and training benefits you've earned."
+      }
+  ],
+  "field_links": [
+      {
+          "uri": "https:\/\/www.benefits.va.gov\/gibill\/school_resources.asp",
+          "title": "School administrators",
+          "options": []
+      }
+  ],
+  "field_meta_tags": [],
+  "field_meta_title": [
+      {
+          "value": "VA Education Benefits | Veterans Affairs"
+      }
+  ],
+  "field_page_last_built": [
+      {
+          "value": "2019-10-16T15:00:22"
+      }
+  ],
+  "field_plainlanguage_date": [],
+  "field_promo": [
+      {
+          "target_type": "block_content",
+          "target_uuid": "dbe0917d-f1a2-4740-871b-6a6fd3874571"
+      }
+  ],
+  "field_related_links": [
+      {
+          "target_type": "paragraph",
+          "target_uuid": "e687605c-a73c-416f-ae38-f187ffbffc55"
+      }
+  ],
+  "field_spokes": [
+      {
+          "target_type": "paragraph",
+          "target_uuid": "06f14316-25a9-45a3-b231-fb1be92044a6"
+      },
+      {
+          "target_type": "paragraph",
+          "target_uuid": "122daa48-9f64-403d-9167-2ee6974027d7"
+      },
+      {
+          "target_type": "paragraph",
+          "target_uuid": "5b080236-d03d-42c1-be21-57d966b58da2"
+      }
+  ],
+  "field_support_services": [
+      {
+          "target_type": "node",
+          "target_uuid": "f1ca55d7-9426-4139-9214-95dbbe83f90b"
+      },
+      {
+          "target_type": "node",
+          "target_uuid": "07695285-89d3-4a39-a207-3d0032370f4c"
+      },
+      {
+          "target_type": "node",
+          "target_uuid": "4b965df6-2ea0-4990-878f-8a5d0e19f504"
+      },
+      {
+          "target_type": "node",
+          "target_uuid": "c6e3d4cd-698d-406c-b2b0-cf9f93e5b7ec"
+      },
+      {
+          "target_type": "node",
+          "target_uuid": "79938f13-7be8-4ce6-92ea-35671532c645"
+      },
+      {
+          "target_type": "node",
+          "target_uuid": "f01de83a-b111-444a-b7cc-748e0faf10fd"
+      }
+  ],
+  "field_teaser_text": [
+      {
+          "value": "Apply for and manage your GI Bill and other education benefits to help pay for college and training programs."
+      }
+  ],
+  "field_title_icon": [
+      {
+          "value": "education"
+      }
+  ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node/page.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node/page.json
@@ -1,0 +1,134 @@
+{
+  "uuid": [
+      {
+          "value": "01f07d8a-fb30-4ce1-b0e9-9be3d564542d"
+      }
+  ],
+  "langcode": [
+      {
+          "value": "en"
+      }
+  ],
+  "type": [
+      {
+          "target_id": "page",
+          "target_type": "node_type",
+          "target_uuid": "d4860e9e-588d-474c-8d59-550fb61c5c8c"
+      }
+  ],
+  "revision_timestamp": [
+      {
+          "value": "2019-09-24T22:22:26+00:00",
+          "format": "Y-m-d\\TH:i:sP"
+      }
+  ],
+  "revision_uid": [
+      {
+          "target_type": "user",
+          "target_uuid": "e62ded06-1de9-4617-bd70-595036edc7ee"
+      }
+  ],
+  "revision_log": [],
+  "status": [
+      {
+          "value": true
+      }
+  ],
+  "title": [
+      {
+          "value": "Principles of Excellence program"
+      }
+  ],
+  "uid": [
+      {
+          "target_type": "user",
+          "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+      }
+  ],
+  "created": [
+      {
+          "value": "2019-09-04T14:38:40+00:00",
+          "format": "Y-m-d\\TH:i:sP"
+      }
+  ],
+  "changed": [
+      {
+          "value": "2019-09-24T22:22:26+00:00",
+          "format": "Y-m-d\\TH:i:sP"
+      }
+  ],
+  "promote": [
+      {
+          "value": false
+      }
+  ],
+  "sticky": [
+      {
+          "value": false
+      }
+  ],
+  "default_langcode": [
+      {
+          "value": true
+      }
+  ],
+  "revision_translation_affected": [
+      {
+          "value": true
+      }
+  ],
+  "moderation_state": [
+      {
+          "value": "published"
+      }
+  ],
+  "path": [
+      {
+          "alias": "\/education\/choosing-a-school\/principles-of-excellence",
+          "langcode": "en",
+          "pathauto": 0
+      }
+  ],
+  "menu_link": [],
+  "field_administration": [
+      {
+          "target_type": "taxonomy_term",
+          "target_uuid": "43901d82-efe9-4dc0-a581-71e081516651"
+      }
+  ],
+  "field_alert": [],
+  "field_content_block": [
+      {
+          "target_type": "paragraph",
+          "target_uuid": "b9fe6ba2-f4cb-4d97-99f1-0d9654e1e125"
+      }
+  ],
+  "field_description": [
+      {
+          "value": "Learn about guidelines for programs that receive federal funding through programs like the GI Bill. Some foreign schools, high schools, internships, residencies, and apprenticeships don't have to follow these guidelines."
+      }
+  ],
+  "field_featured_content": [],
+  "field_intro_text": [
+      {
+          "value": "<p>The Principles of Excellence program requires schools that get federal funding through programs such as the GI Bill to follow certain guidelines. Learn about these guidelines.<\/p>"
+      }
+  ],
+  "field_meta_tags": [],
+  "field_meta_title": [
+      {
+          "value": "Principles Of Excellence Program | Veterans Affairs"
+      }
+  ],
+  "field_page_last_built": [
+      {
+          "value": "2019-10-16T15:00:22"
+      }
+  ],
+  "field_plainlanguage_date": [
+      {
+          "value": "2016-12-05"
+      }
+  ],
+  "field_related_links": []
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node/publication_listing.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node/publication_listing.json
@@ -1,0 +1,127 @@
+{
+  "uuid": [
+      {
+          "value": "931072aa-94ed-4072-b3d4-d8735052a073"
+      }
+  ],
+  "langcode": [
+      {
+          "value": "en"
+      }
+  ],
+  "type": [
+      {
+          "target_id": "publication_listing",
+          "target_type": "node_type",
+          "target_uuid": "0e4eb7bf-c65b-4d01-af13-c6cb3e06e591"
+      }
+  ],
+  "revision_timestamp": [
+      {
+          "value": "2019-08-15T18:53:23+00:00",
+          "format": "Y-m-d\\TH:i:sP"
+      }
+  ],
+  "revision_uid": [
+      {
+          "target_type": "user",
+          "target_uuid": "fd71292f-3dc7-409d-b0e8-500204cb005a"
+      }
+  ],
+  "revision_log": [],
+  "status": [
+      {
+          "value": true
+      }
+  ],
+  "title": [
+      {
+          "value": "Outreach materials"
+      }
+  ],
+  "uid": [
+      {
+          "target_type": "user",
+          "target_uuid": "b02c2ff5-dfe1-4542-beec-3fd410a3f267"
+      }
+  ],
+  "created": [
+      {
+          "value": "2019-07-23T18:19:30+00:00",
+          "format": "Y-m-d\\TH:i:sP"
+      }
+  ],
+  "changed": [
+      {
+          "value": "2019-08-15T18:53:23+00:00",
+          "format": "Y-m-d\\TH:i:sP"
+      }
+  ],
+  "promote": [
+      {
+          "value": true
+      }
+  ],
+  "sticky": [
+      {
+          "value": false
+      }
+  ],
+  "default_langcode": [
+      {
+          "value": true
+      }
+  ],
+  "revision_translation_affected": [
+      {
+          "value": true
+      }
+  ],
+  "moderation_state": [
+      {
+          "value": "published"
+      }
+  ],
+  "path": [
+      {
+          "alias": "\/outreach-and-events\/outreach-materials",
+          "langcode": "en",
+          "pathauto": 0
+      }
+  ],
+  "menu_link": [],
+  "field_administration": [
+      {
+          "target_type": "taxonomy_term",
+          "target_uuid": "c20f3989-e93e-49bd-8c95-ad3821042a02"
+      }
+  ],
+  "field_description": [
+      {
+          "value": "Outreach materials"
+      }
+  ],
+  "field_intro_text": [
+      {
+          "value": "Use our outreach materials to help Veterans manage their journey with VA and learn about their benefits."
+      }
+  ],
+  "field_meta_tags": [
+      {
+          "value": {
+              "title": "Outreach & Events | Outreach Materials | Veterans Affairs"
+          }
+      }
+  ],
+  "field_meta_title": [
+      {
+          "value": "Outreach materials"
+      }
+  ],
+  "field_office": [
+      {
+          "target_type": "node",
+          "target_uuid": "c71e29a0-431f-44a5-ac5c-cee0c0ef0ceb"
+      }
+  ]
+}


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/3065

This PR adds the following `target_id` test files and documentation for the `node` entity:
```
landing_page,
page,
publication_listing,
```

## Testing done
N/A

## Screenshots
N/A

## Acceptance criteria
- [x] All missing `target_id`s are added to the test cms-export data.
- [x] All missing `target_id`s are documented properly.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
