### PR TITLE
Hide the Direct Deposit jump link if DD isn't set up

### DIFF
--- a/src/applications/personalization/profile360/components/ProfileView.jsx
+++ b/src/applications/personalization/profile360/components/ProfileView.jsx
@@ -22,18 +22,19 @@ import IdentityVerification from './IdentityVerification';
 import MVIError from './MVIError';
 
 import {
+  directDepositIsSetUp as directDepositIsSetUpSelector,
   profileShowDirectDeposit,
   profileShowReceiveTextNotifications,
 } from 'applications/personalization/profile360/selectors';
 
-const ProfileTOC = ({ militaryInformation, showDirectDeposit }) => (
+const ProfileTOC = ({ militaryInformation, showDirectDepositLink }) => (
   <>
     <h2 className="vads-u-font-size--h3">On this page</h2>
     <ul>
       <li>
         <a href="#contact-information">Contact information</a>
       </li>
-      {showDirectDeposit && <PaymentInformationTOCItem />}
+      {showDirectDepositLink && <PaymentInformationTOCItem />}
       <li>
         <a href="#personal-information">Personal information</a>
       </li>
@@ -88,7 +89,9 @@ class ProfileView extends React.Component {
       fetchPersonalInformation,
       profile: { hero, personalInformation, militaryInformation },
       downtimeData: { appTitle },
-      showDirectDeposit,
+      directDepositIsSetUp,
+      showDirectDepositFeature,
+      showReceiveTextNotifications,
     } = this.props;
 
     let content;
@@ -115,15 +118,13 @@ class ProfileView extends React.Component {
               />
               <ProfileTOC
                 militaryInformation={militaryInformation}
-                showDirectDeposit={showDirectDeposit}
+                showDirectDepositLink={directDepositIsSetUp}
               />
               <div id="contact-information" />
               <ContactInformation
-                showReceiveTextNotifications={
-                  this.props.showReceiveTextNotifications
-                }
+                showReceiveTextNotifications={showReceiveTextNotifications}
               />
-              {showDirectDeposit && (
+              {showDirectDepositFeature && (
                 <>
                   <div id="direct-deposit" />
                   <PaymentInformation />
@@ -192,7 +193,8 @@ class ProfileView extends React.Component {
 
 function mapStateToProps(state) {
   return {
-    showDirectDeposit: profileShowDirectDeposit(state),
+    directDepositIsSetUp: directDepositIsSetUpSelector(state),
+    showDirectDepositFeature: profileShowDirectDeposit(state),
     showReceiveTextNotifications: profileShowReceiveTextNotifications(state),
   };
 }

--- a/src/applications/personalization/profile360/containers/PaymentInformation.jsx
+++ b/src/applications/personalization/profile360/containers/PaymentInformation.jsx
@@ -14,7 +14,6 @@ import {
 } from 'platform/user/selectors';
 import backendServices from 'platform/user/profile/constants/backendServices';
 
-import get from 'platform/utilities/data/get';
 import recordEvent from 'platform/monitoring/record-event';
 
 import ProfileFieldHeading from 'vet360/components/base/ProfileFieldHeading';
@@ -29,6 +28,11 @@ import {
   editModalToggled,
   editModalFieldChanged,
 } from '../actions/paymentInformation';
+import {
+  directDepositAccountInformation,
+  directDepositInformation,
+  directDepositIsSetUp as directDepositIsSetUpSelector,
+} from '../selectors';
 
 const AdditionalInfos = props => (
   <>
@@ -146,14 +150,13 @@ class PaymentInformation extends React.Component {
 
   render() {
     const {
+      directDepositIsSetUp,
       isEligible,
       isLoading,
       multifactorEnabled,
       paymentInformation,
+      paymentAccount,
     } = this.props;
-    const directDepositIsSetUp =
-      paymentInformation &&
-      get('responses[0].paymentAccount.accountNumber', paymentInformation);
 
     let content = null;
 
@@ -170,11 +173,8 @@ class PaymentInformation extends React.Component {
     } else if (paymentInformation.error) {
       content = <LoadFail information="payment" />;
     } else if (!directDepositIsSetUp) {
-      // we might eventually want to return some helpful contenct explaining how
-      // a vet could go about setting up direct deposit
       return null;
     } else {
-      const paymentAccount = paymentInformation?.responses[0]?.paymentAccount;
       content = (
         <>
           <div className="vet360-profile-field">
@@ -248,13 +248,15 @@ const isEvssAvailable = createIsServiceAvailableSelector(
 );
 
 const mapStateToProps = state => ({
+  directDepositIsSetUp: directDepositIsSetUpSelector(state),
   multifactorEnabled: isMultifactorEnabled(state),
   isEligible: isEvssAvailable(state),
   isLoading:
     isEvssAvailable(state) &&
     isMultifactorEnabled(state) &&
-    !state.vaProfile.paymentInformation,
-  paymentInformation: state.vaProfile.paymentInformation,
+    !directDepositInformation(state),
+  paymentAccount: directDepositAccountInformation(state),
+  paymentInformation: directDepositInformation(state),
   paymentInformationUiState: state.vaProfile.paymentInformationUiState,
 });
 

--- a/src/applications/personalization/profile360/selectors.js
+++ b/src/applications/personalization/profile360/selectors.js
@@ -6,3 +6,12 @@ export const profileShowDirectDeposit = state =>
 
 export const profileShowReceiveTextNotifications = state =>
   toggleValues(state)[FEATURE_FLAG_NAMES.profileShowReceiveTextNotifications];
+
+export const directDepositInformation = state =>
+  state.vaProfile?.paymentInformation;
+
+export const directDepositAccountInformation = state =>
+  directDepositInformation(state)?.responses[0]?.paymentAccount;
+
+export const directDepositIsSetUp = state =>
+  !!directDepositAccountInformation(state)?.accountNumber;

--- a/src/applications/personalization/profile360/tests/containers/PaymentInformation.unit.spec.jsx
+++ b/src/applications/personalization/profile360/tests/containers/PaymentInformation.unit.spec.jsx
@@ -11,7 +11,14 @@ import PaymentInformationEditModal from '../../components/PaymentInformationEdit
 import DowntimeNotification from 'platform/monitoring/DowntimeNotification';
 
 describe('<PaymentInformation/>', () => {
+  const paymentAccount = {
+    accountNumber: '123',
+    accountType: 'Checking',
+    financialInstitutionName: 'My bank',
+    financialInstitutionRoutingNumber: '123456789',
+  };
   const defaultProps = {
+    directDepositIsSetUp: true,
     multifactorEnabled: true,
     isLoading: false,
     isEligible: true,
@@ -19,6 +26,7 @@ describe('<PaymentInformation/>', () => {
     savePaymentInformation() {},
     editModalToggled() {},
     editModalFieldChanged() {},
+    paymentAccount,
     paymentInformationUiState: {
       isEditing: false,
       isSaving: false,
@@ -26,12 +34,7 @@ describe('<PaymentInformation/>', () => {
     paymentInformation: {
       responses: [
         {
-          paymentAccount: {
-            accountNumber: '123',
-            accountType: 'Checking',
-            financialInstitutionName: 'My bank',
-            financialInstitutionRoutingNumber: '123456789',
-          },
+          paymentAccount,
         },
       ],
     },
@@ -56,27 +59,11 @@ describe('<PaymentInformation/>', () => {
     wrapper.unmount();
   });
 
-  it('does not render if the user has not previously set up direct deposit', () => {
-    const fetchPaymentInformation = sinon.spy();
+  it('renders nothing if the user has not already set up direct deposit', () => {
     const props = {
       ...defaultProps,
-      fetchPaymentInformation,
-      paymentInformation: {
-        responses: [],
-      },
+      directDepositIsSetUp: false,
     };
-    const wrapper = shallow(<PaymentInformation {...props} />);
-    expect(wrapper.text()).to.be.empty;
-    expect(fetchPaymentInformation.called).to.be.true;
-    wrapper.unmount();
-  });
-
-  it('renders nothing if the accountNumber is empty', () => {
-    const props = set(
-      'paymentInformation.responses[0].paymentAccount.accountNumber',
-      '',
-      defaultProps,
-    );
     const wrapper = shallow(<PaymentInformation {...props} />);
 
     expect(wrapper.text()).to.be.empty;

--- a/src/applications/personalization/profile360/tests/selectors.unit.spec.js
+++ b/src/applications/personalization/profile360/tests/selectors.unit.spec.js
@@ -1,33 +1,73 @@
 import { expect } from 'chai';
 import * as selectors from '../selectors';
 
-describe('profileShowDirectDeposit selector', () => {
-  it('returns `true` if the `profileShowDirectDeposit` toggle value is set to `true`', () => {
-    const state = {
-      featureToggles: {
-        profileShowDirectDeposit: true,
-      },
-    };
-    expect(selectors.profileShowDirectDeposit(state)).to.be.true;
+describe('profile360 selectors', () => {
+  describe('profileShowDirectDeposit selector', () => {
+    it('returns `true` if the `profileShowDirectDeposit` toggle value is set to `true`', () => {
+      const state = {
+        featureToggles: {
+          profileShowDirectDeposit: true,
+        },
+      };
+      expect(selectors.profileShowDirectDeposit(state)).to.be.true;
+    });
+    it('returns `false` if the `profileShowDirectDeposit` toggle value is set to `false`', () => {
+      const state = {
+        featureToggles: {
+          profileShowDirectDeposit: false,
+        },
+      };
+      expect(selectors.profileShowDirectDeposit(state)).to.be.false;
+    });
+    it('returns `undefined` if the `profileShowDirectDeposit` toggle value is not set', () => {
+      const state = {
+        featureToggles: {
+          anotherFeatureFlagID: true,
+        },
+      };
+      expect(selectors.profileShowDirectDeposit(state)).to.be.undefined;
+    });
+    it('returns `undefined` if the `featureToggles` are not set on the Redux store', () => {
+      const state = {};
+      expect(selectors.profileShowDirectDeposit(state)).to.be.undefined;
+    });
   });
-  it('returns `false` if the `profileShowDirectDeposit` toggle value is set to `false`', () => {
-    const state = {
-      featureToggles: {
-        profileShowDirectDeposit: false,
-      },
-    };
-    expect(selectors.profileShowDirectDeposit(state)).to.be.false;
-  });
-  it('returns `undefined` if the `profileShowDirectDeposit` toggle value is not set', () => {
-    const state = {
-      featureToggles: {
-        anotherFeatureFlagID: true,
-      },
-    };
-    expect(selectors.profileShowDirectDeposit(state)).to.be.undefined;
-  });
-  it('returns `undefined` if the `featureToggles` are not set on the Redux store', () => {
-    const state = {};
-    expect(selectors.profileShowDirectDeposit(state)).to.be.undefined;
+
+  describe('directDepositIsSetUp selector', () => {
+    let state;
+    beforeEach(() => {
+      state = {
+        vaProfile: {
+          paymentInformation: {
+            responses: [
+              {
+                paymentAccount: {
+                  accountType: '',
+                  financialInstitutionName: null,
+                  accountNumber: '123123123',
+                  financialInstitutionRoutingNumber: '',
+                },
+              },
+            ],
+          },
+        },
+      };
+    });
+    it('returns `true` if there is an account number set in state', () => {
+      expect(selectors.directDepositIsSetUp(state)).to.be.true;
+    });
+    it('returns `false` when vaProfile does not exist on state', () => {
+      delete state.vaProfile;
+      expect(selectors.directDepositIsSetUp(state)).to.be.false;
+    });
+    it('returns `false` when vaProfile.paymentInformation is not set on state', () => {
+      delete state.vaProfile.paymentInformation;
+      expect(selectors.directDepositIsSetUp(state)).to.be.false;
+    });
+    it('returns `false` when the account number is not set', () => {
+      state.vaProfile.paymentInformation.responses[0].paymentAccount.accountNumber =
+        '';
+      expect(selectors.directDepositIsSetUp(state)).to.be.false;
+    });
   });
 });


### PR DESCRIPTION
## Description
The purpose of this PR is to hide the "jump link" to the Direct Deposit component on the Profile if the user has not actually set up Direct Deposit. We had previously hidden the Direct Deposit component itself in this case, but the jump link was still visible and sent the user to a non-existent component if they clicked on it.

## Testing done
Local + updated the existing unit tests.

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs