### PR TITLE
SCO: Create Skeleton of SCO Resource Page in Github #19835

### DIFF
--- a/src/site/includes/education-sco.html
+++ b/src/site/includes/education-sco.html
@@ -1,0 +1,67 @@
+{% comment %}
+=====================
+Level 2 Index (Merger)
+=====================
+
+Used for index pages in top-level paths (e.g. hubpages /health-care/index.html)
+
+{% endcomment %}
+
+<main>
+    <div class="vads-l-grid-container large-screen:vads-u-padding-x--0">
+      <div class="vads-l-row medium-screen:vads-u-margin-x--neg2p5">
+         <div class="vads-l-col--12 medium-screen:vads-u-padding-x--2p5 medium-screen:vads-l-col--8">
+        <article class="new-grid">
+          <div class="medium-screen:vads-u-display--flex">
+            {% if hub != empty %}
+            <div class="hub-main-icon vads-u-margin-right--1p5 vads-u-margin-top--1">
+              <i class="icon-large white hub-icon-{{hub}} hub-background-{{hub}}"></i>
+            </div>
+            {% endif %}
+            <div class="hub-main-title">
+              <h1>
+              {{ heading }}
+              </h1>
+            </div>
+          </div>
+          {{ contents }}
+
+          {% if hublinks != empty %}
+            {% include "src/site/components/hub-page-link-list.html" %}
+          {% endif %}
+
+
+          {% if crosslinks != empty %}
+            {% include "src/site/components/merger-crosslinks.html" %}
+          {% endif %}
+
+        </article>
+      </div>
+
+      <div class="vads-l-col--12 medium-screen:vads-u-padding-x--2p5 medium-screen:vads-l-col--4" id="hub-rail">
+
+        {% if administration != empty %}
+          {% include "src/site/components/merger-administration.html" %}
+        {% endif %}
+
+        {% if promo != empty %}
+          {% include "src/site/components/merger-promo.html" %}
+        {% endif %}
+
+        {% if social != empty %}
+          {% include "src/site/components/merger-social.html" %}
+        {% endif %}
+
+        {% if mobile != empty %}
+          {% include "src/site/components/merger-mobile.html" %}
+        {% endif %}
+
+      </div>
+
+    </div>
+  </div>
+
+
+  {% include "src/site/includes/veteran-banner.html" %}
+  {% include "src/site/includes/social-accordion.html" %}
+</main>

--- a/src/site/layouts/page-breadcrumbs.html
+++ b/src/site/layouts/page-breadcrumbs.html
@@ -32,6 +32,10 @@
 
     {% when 'topic-landing' %}
       {% include "src/site/includes/topic-landing.html" %}
+
+    {% when 'education-sco' %}
+      {% include "src/site/includes/education-sco.html" %}
+
   {% else %}
     {{ contents }}
   {% endcase %}


### PR DESCRIPTION
## Description
As a developer, I need to create a skeleton of the new SCO resource page in source control with all current prototype sections so that multiple developers can work on the page at once.

https://github.com/department-of-veterans-affairs/vets.gov-team/issues/19835

## Testing done
- local testing

## Screenshots


## Acceptance criteria
- [ ] The new SCO Resource page has two content areas:
     - A main content area (about 2/3 width)
     - A right panel content area (about 1/3 width)
- [ ] The new SCO Resource page main content area has the following placeholder sections:
     - Introduction
     - Announcements
     - Training and guides
     - Upcoming events
     - Policies and procedures
     - Resources to support students
- [ ] Each section of the main content area is separated by a HR
- [ ] The new SCO Resource page right panel content area has the following placeholder sections:
     - SCO Handbook
     - Ask questions
     - Average processing times
     - Connect with us

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
