### PR TITLE
Remove content from warning

### DIFF
--- a/src/applications/disability-benefits/wizard/pages/disagree-file-claim.jsx
+++ b/src/applications/disability-benefits/wizard/pages/disagree-file-claim.jsx
@@ -6,8 +6,7 @@ const alertContent = (
   <>
     <p>
       If you disagree with a VA decision we made over a year ago, you need to
-      file a Supplemental Claim (VA Form 20-0995). You shouldn&apos;t file a
-      disability claim.
+      file a Supplemental Claim (VA Form 20-0995).
     </p>
     <a href="/decision-reviews/supplemental-claim/">
       Find out how to file a Supplemental Claim


### PR DESCRIPTION
## Description

The supplement gating includes a warning to the veteran that they should not file a disability claim. This removes that sentence

## Testing done

Local unit tests

## Screenshots

![Screen Shot 2019-11-04 at 10 29 06 AM](https://user-images.githubusercontent.com/136959/68138334-00c39500-feee-11e9-8161-5cf6f8540ca3.png)

## Acceptance criteria
- [ ] Content removed

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
