### PR TITLE
Fix intermittently failing formConfig tests

### DIFF
--- a/src/platform/forms/tests/forms.unit.spec.js
+++ b/src/platform/forms/tests/forms.unit.spec.js
@@ -123,13 +123,13 @@ describe('form:', () => {
         expect(form.defaultDefinitions).to.be.an('object');
       });
 
-      if (form.introduction !== undefined) {
+      if (form.introduction) {
         it('should have introduction function', () => {
           expect(form.introduction).to.be.a('function');
         });
       }
 
-      if (form.prefillEnabled !== undefined) {
+      if (form.prefillEnabled) {
         it('should have prefillEnabled boolean', () => {
           expect(form.prefillEnabled).to.be.a('boolean');
         });

--- a/src/platform/forms/tests/forms.unit.spec.js
+++ b/src/platform/forms/tests/forms.unit.spec.js
@@ -123,13 +123,13 @@ describe('form:', () => {
         expect(form.defaultDefinitions).to.be.an('object');
       });
 
-      if (form.introduction !== 'undefined') {
+      if (form.introduction !== undefined) {
         it('should have introduction function', () => {
           expect(form.introduction).to.be.a('function');
         });
       }
 
-      if (form.prefillEnabled !== 'undefined') {
+      if (form.prefillEnabled !== undefined) {
         it('should have prefillEnabled boolean', () => {
           expect(form.prefillEnabled).to.be.a('boolean');
         });


### PR DESCRIPTION
## Description
We were still seeing these tests fail periodically. This doesn't address _why_ these form configs are sometimes `undefined`, but it should fix the intermittent failures while still catching some truly wonky `formConfig`s.

## Testing done
Tested locally

## Screenshots
N/A

## Acceptance criteria
- [x] The tests pass when the properties exist and are functions
- [x] The tests fail when the properties exist and are **not** functions