### PR TITLE
3025 add downtime notification to rd

### DIFF
--- a/src/applications/personalization/rated-disabilities/containers/RatedDisabilitiesApp.jsx
+++ b/src/applications/personalization/rated-disabilities/containers/RatedDisabilitiesApp.jsx
@@ -2,9 +2,10 @@ import React from 'react';
 import { connect } from 'react-redux';
 
 import backendServices from 'platform/user/profile/constants/backendServices';
+import DowntimeNotification, {
+  externalServices,
+} from 'platform/monitoring/DowntimeNotification';
 import { fetchRatedDisabilities, fetchTotalDisabilityRating } from '../actions';
-
-// Wonder if we can put RD data in platform...
 import RequiredLoginView from 'platform/user/authorization/components/RequiredLoginView';
 import RatedDisabilityView from '../components/RatedDisabilityView';
 
@@ -24,14 +25,19 @@ class RatedDisabilitiesApp extends React.Component {
           loginUrl={this.props.loginUrl}
           verifyUrl={this.props.verifyUrl}
         >
-          <RatedDisabilityView
-            fetchRatedDisabilities={this.props.fetchRatedDisabilities}
-            ratedDisabilities={ratedDisabilities}
-            user={this.props.user}
-            totalDisabilityRating={this.props.totalDisabilityRating}
-            loading={this.props.loading}
-            error={this.props.error}
-          />
+          <DowntimeNotification
+            appTitle="Rated Disabilities"
+            dependencies={[externalServices.evss]}
+          >
+            <RatedDisabilityView
+              fetchRatedDisabilities={this.props.fetchRatedDisabilities}
+              ratedDisabilities={ratedDisabilities}
+              user={this.props.user}
+              totalDisabilityRating={this.props.totalDisabilityRating}
+              loading={this.props.loading}
+              error={this.props.error}
+            />
+          </DowntimeNotification>
         </RequiredLoginView>
       </>
     );


### PR DESCRIPTION
## Description
The rated disabilities application should implement the `DowntimeNotification` component so users know when they are experiencing downtime. 

## Testing done
- [x] local

## Acceptance criteria
- [x] DowntimeNotification has been added to the rated disabilities application

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
