### PR TITLE
Recurse with child in assembleEntityTree

### DIFF
--- a/script/test-cms-export.js
+++ b/script/test-cms-export.js
@@ -13,3 +13,4 @@ const modifiedEntities = map(entities, entity => assembleEntityTree(entity));
 
 // eslint-disable-next-line
 console.log('Number of files:', modifiedEntities.length);
+// console.log('First node:', modifiedEntities[0]);

--- a/src/site/stages/build/process-cms-exports/index.js
+++ b/src/site/stages/build/process-cms-exports/index.js
@@ -2,7 +2,7 @@ const chalk = require('chalk');
 
 const { getFilteredEntity } = require('./filters');
 const { transformEntity } = require('./transform');
-const { toId } = require('./helpers');
+const { toId, readEntity } = require('./helpers');
 
 const validateEntity = require('./schema-validation');
 
@@ -55,8 +55,7 @@ const assembleEntityTree = (entity, parents = []) => {
         // We found a reference! Override it with the expanded entity.
         if (targetUuid && targetType) {
           filteredEntity[key][index] = assembleEntityTree(
-            targetType,
-            targetUuid,
+            readEntity(targetType, targetUuid),
             parents.concat([toId(entity)]),
           );
         }


### PR DESCRIPTION
## Description
We changed up how `assembleEntityTree` was called without changing the recursive call. :grimacing: 
With this, we'll call `assembleEntityTree` with the child entity.

## Testing done
Tested locally.

## Screenshots
N/A

## Acceptance criteria
- [ ] `assembleEntityTree` is called with the expected parameters
