### PR TITLE
[IE11 + JAWS] Colmery 107 - Too much information is being read on SELECT menu changes

### DIFF
--- a/src/applications/gi/components/profile/Calculator.jsx
+++ b/src/applications/gi/components/profile/Calculator.jsx
@@ -82,7 +82,7 @@ export class Calculator extends React.Component {
     const expanded = this.state.showCalculatorForm;
 
     return (
-      <div className="calculator-inputs">
+      <div aria-live="off" className="calculator-inputs">
         <button
           aria-expanded={expanded}
           onClick={this.toggleCalculatorForm}
@@ -92,16 +92,20 @@ export class Calculator extends React.Component {
         </button>
         <div>
           {expanded ? (
-            <CalculatorForm
-              profile={profile}
-              eligibility={this.props.eligibility}
-              eligibilityChange={this.props.eligibilityChange}
-              inputs={inputs}
-              displayedInputs={displayed}
-              onShowModal={this.props.showModal}
-              onInputChange={this.props.calculatorInputChange}
-              onBeneficiaryZIPCodeChanged={this.props.beneficiaryZIPCodeChanged}
-            />
+            <form>
+              <CalculatorForm
+                profile={profile}
+                eligibility={this.props.eligibility}
+                eligibilityChange={this.props.eligibilityChange}
+                inputs={inputs}
+                displayedInputs={displayed}
+                onShowModal={this.props.showModal}
+                onInputChange={this.props.calculatorInputChange}
+                onBeneficiaryZIPCodeChanged={
+                  this.props.beneficiaryZIPCodeChanged
+                }
+              />
+            </form>
           ) : null}
         </div>
       </div>

--- a/src/applications/gi/components/profile/Calculator.jsx
+++ b/src/applications/gi/components/profile/Calculator.jsx
@@ -52,7 +52,7 @@ export class Calculator extends React.Component {
     const expanded = this.state.showEligibilityForm;
 
     return (
-      <div className="eligibility-details">
+      <div aria-live="off" className="eligibility-details">
         <button
           aria-expanded={expanded}
           onClick={this.toggleEligibilityForm}
@@ -62,7 +62,11 @@ export class Calculator extends React.Component {
         </button>
         <div>
           {expanded ? (
-            <EligibilityForm eligibilityChange={this.props.eligibilityChange} />
+            <form>
+              <EligibilityForm
+                eligibilityChange={this.props.eligibilityChange}
+              />
+            </form>
           ) : null}
         </div>
       </div>


### PR DESCRIPTION
## Description
The 508 office noticed an issue where IE11 + JAWS will read out a lot of extra information on the program detail views when users change a `select` menu in forms mode. I was able to recreate the issue, and it only occurred with IE11, not Chrome, using JAWS.

https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/2386

## Testing done
Local testing on iOS and windows with Chrome, Firefox, Safafi, Edge and ie11

## Screenshots


## Acceptance criteria
- [x] As a JAWS user, I don't want to hear extra information read aloud when I make a choice in FORMS mode from

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
