### PR TITLE
SCO: Add right panel content to SCO Skeleton page #19908

### DIFF
--- a/src/site/includes/education-sco.html
+++ b/src/site/includes/education-sco.html
@@ -1,10 +1,7 @@
 {% comment %}
 =====================
-Level 2 Index (Merger)
+Education SCO (Merger)
 =====================
-
-Used for index pages in top-level paths (e.g. hubpages /health-care/index.html)
-
 {% endcomment %}
 
 <main>

--- a/src/site/includes/education-sco.html
+++ b/src/site/includes/education-sco.html
@@ -35,6 +35,8 @@ Used for index pages in top-level paths (e.g. hubpages /health-care/index.html)
             {% include "src/site/components/merger-crosslinks.html" %}
           {% endif %}
 
+          {% include "src/site/includes/last-update.html" %}
+
         </article>
       </div>
 


### PR DESCRIPTION
## Description
Adding lastupdate property use to education-sco template

https://github.com/department-of-veterans-affairs/vets.gov-team/issues/19908

value won't display until after https://github.com/department-of-veterans-affairs/vagov-content/pull/577 has been merged in

## Testing done
- local testing

## Screenshots


## Acceptance criteria
- [ ] "Last updated: Month Day, Year" appears below "Other resources to support your students"

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
