### PR TITLE
Cancel requests, in addition to appointments

### DIFF
--- a/src/applications/vaos/api/index.js
+++ b/src/applications/vaos/api/index.js
@@ -228,3 +228,13 @@ export function updateAppointment(appt) {
     }, 500);
   });
 }
+
+// PUT /vaos/requests
+// eslint-disable-next-line no-unused-vars
+export function updateRequest(appt) {
+  return new Promise(resolve => {
+    setTimeout(() => {
+      resolve();
+    }, 500);
+  });
+}

--- a/src/applications/vaos/tests/actions/appointments.unit.spec.js
+++ b/src/applications/vaos/tests/actions/appointments.unit.spec.js
@@ -159,6 +159,27 @@ describe('VAOS actions: appointments', () => {
       });
     });
 
+    it('should cancel request', async () => {
+      const state = {
+        appointments: {
+          appointmentToCancel: {
+            status: 'Booked',
+          },
+        },
+      };
+      const dispatch = sinon.spy();
+      const thunk = confirmCancelAppointment();
+
+      await thunk(dispatch, () => state);
+
+      expect(dispatch.firstCall.args[0].type).to.equal(
+        CANCEL_APPOINTMENT_CONFIRMED,
+      );
+      expect(dispatch.secondCall.args[0]).to.deep.equal({
+        type: CANCEL_APPOINTMENT_CONFIRMED_SUCCEEDED,
+      });
+    });
+
     it('should send fail action if cancel fails', async () => {
       const state = {
         appointments: {


### PR DESCRIPTION
## Description
We need to be able to cancel requests as well as appointments, this adds code to skip the cancel reasons and update a request object instead of sending an appointment cancellation request.

## Testing done
Unit testing

## Acceptance criteria
- [ ] Detects requests and cancels those appropriately

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
