### PR TITLE
Feature/2842 remove nutrition from cc eligible care types remove podiatry from vaos

### DIFF
--- a/src/applications/vaos/newAppointmentFlow.js
+++ b/src/applications/vaos/newAppointmentFlow.js
@@ -9,6 +9,7 @@ import { hasEligibleClinics } from './utils/eligibility';
 
 const AUDIOLOGY = '203';
 const SLEEP_CARE = 'SLEEP';
+const NUTRITION_FOOD = '123';
 
 function isCCAudiology(state) {
   return (
@@ -26,6 +27,10 @@ function isCommunityCare(state) {
 
 function isSleepCare(state) {
   return getFormData(state).typeOfCareId === SLEEP_CARE;
+}
+
+function isNutrition(state) {
+  return getFormData(state).typeOfCareId === NUTRITION_FOOD;
 }
 
 export default {
@@ -46,6 +51,8 @@ export default {
 
       if (isSleepCare(state)) {
         nextState = 'typeOfSleepCare';
+      } else if (isNutrition(state)) {
+        nextState = 'vaFacility';
       } else if (isCommunityCare(state)) {
         try {
           const data = await getCommunityCare(

--- a/src/applications/vaos/tests/containers/TypeOfCarePage.unit.spec.jsx
+++ b/src/applications/vaos/tests/containers/TypeOfCarePage.unit.spec.jsx
@@ -20,7 +20,7 @@ describe('VAOS <TypeOfCarePage>', () => {
     );
 
     expect(form.find('fieldset').length).to.equal(3);
-    expect(form.find('input').length).to.equal(12);
+    expect(form.find('input').length).to.equal(11);
     form.unmount();
   });
 

--- a/src/applications/vaos/tests/newAppointmentFlow.unit.spec.js
+++ b/src/applications/vaos/tests/newAppointmentFlow.unit.spec.js
@@ -233,6 +233,18 @@ describe('VAOS newAppointmentFlow', () => {
       const nextState = await newAppointmentFlow.typeOfCare.next(state);
       expect(nextState).to.equal('typeOfFacility');
     });
+    it('should choose VA Facility page', async () => {
+      const state = {
+        newAppointment: {
+          data: {
+            typeOfCareId: '123',
+          },
+        },
+      };
+
+      const nextState = await newAppointmentFlow.typeOfCare.next(state);
+      expect(nextState).to.equal('vaFacility');
+    });
   });
   describe('ccProvider page', () => {
     it('should return to type of facility page', () => {

--- a/src/applications/vaos/utils/constants.js
+++ b/src/applications/vaos/utils/constants.js
@@ -57,12 +57,6 @@ export const TYPES_OF_CARE = [
     group: 'specialty',
   },
   {
-    id: '123',
-    name: 'Nutrition and food',
-    group: 'specialty',
-    ccId: 'CCNUTRN',
-  },
-  {
     id: '407',
     name: 'Opthamology',
     group: 'specialty',
@@ -72,12 +66,6 @@ export const TYPES_OF_CARE = [
     name: 'Optometry',
     group: 'specialty',
     ccId: 'CCOPT',
-  },
-  {
-    id: 'tbd',
-    name: 'Podiatry',
-    ccId: 'CCPOD',
-    group: 'specialty',
   },
   {
     id: 'SLEEP',

--- a/src/applications/vaos/utils/constants.js
+++ b/src/applications/vaos/utils/constants.js
@@ -57,6 +57,12 @@ export const TYPES_OF_CARE = [
     group: 'specialty',
   },
   {
+    id: '123',
+    name: 'Nutrition and food',
+    group: 'specialty',
+    ccId: 'CCNUTRN',
+  },
+  {
     id: '407',
     name: 'Opthamology',
     group: 'specialty',


### PR DESCRIPTION
## Description
Nutrition and Podiatry should not be eligible for Community Care at this time. Additionally, 'podiatry' is not supported for online scheduling at the VA at all. We need to remove them from the respective lists so that they don't trigger the VA / CC Choice page or let veterans pick an option that isn't available.

## Testing done
Yes

## Screenshots
![image](https://user-images.githubusercontent.com/3587066/68216907-4f813580-ffa7-11e9-9304-e97d06db5eaf.png)

## Acceptance criteria
- [ ] Clicking on nutrition does not give veteran CC option
- [ ] VAOS does not include a podiatry option in the type of care list

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
