### PR TITLE
VAGOV-6245: Downsize leadership headshots to 480.

### DIFF
--- a/src/site/stages/build/drupal/graphql/bioPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/bioPage.graphql.js
@@ -4,8 +4,6 @@
  */
 const entityElementsFromPages = require('./entityElementsForPages.graphql');
 
-const { cmsFeatureFlags } = global;
-
 module.exports = `
  fragment bioPage on NodePersonProfile {
   ${entityElementsFromPages}
@@ -35,10 +33,10 @@ module.exports = `
           alt
           title
           url
-          ${
-            cmsFeatureFlags.FEATURE_IMAGE_STYLE_23
-              ? 'derivative(style: _23MEDIUMTHUMBNAIL) {url width height}'
-              : 'derivative(style: CROP32) {url width height}'
+          derivative(style: _23MEDIUMTHUMBNAIL) {
+            url
+            width
+            height
           }
         }
       }

--- a/src/site/stages/build/drupal/graphql/facilities-fragments/healthCareRegionStaffBios.node.graphql.js
+++ b/src/site/stages/build/drupal/graphql/facilities-fragments/healthCareRegionStaffBios.node.graphql.js
@@ -1,8 +1,6 @@
 /**
  * Associated person profiles on the healthcare region node
  */
-const { cmsFeatureFlags } = global;
-
 const PERSON_PROFILE_RESULTS = `
   entity {
     ... on NodePersonProfile {
@@ -29,10 +27,10 @@ const PERSON_PROFILE_RESULTS = `
               alt
               title
               url
-              ${
-                cmsFeatureFlags.FEATURE_IMAGE_STYLE_23
-                  ? 'derivative(style: _23MEDIUMTHUMBNAIL) {url width height}'
-                  : 'derivative(style: CROP32) {url width height}'
+              derivative(style: _23MEDIUMTHUMBNAIL) {
+                url
+                width
+                height
               }
             }
           }


### PR DESCRIPTION
## Description

https://va-gov.atlassian.net/browse/VAGOV-6245?utm_medium=referral-external&utm_source=jira-slack&utm_term=

www.va.gov/pittsburgh-health-care/leadership/ is serving original sized images, because a feature flag is set to false. we don't need that flag anymore, we want to use the 2x3 thumbnails.

## Testing done


## Screenshots


## Acceptance criteria
- [ ] 

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
