### PR TITLE
Veterans and Military Families Month proclamation promo

### DIFF
--- a/src/platform/site-wide/announcements/components/VeteransDayProclamation.jsx
+++ b/src/platform/site-wide/announcements/components/VeteransDayProclamation.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import PromoBanner, {
+  PROMO_BANNER_TYPES,
+} from '@department-of-veterans-affairs/formation-react/PromoBanner';
+
+export default function VeteransDayProclamation({ dismiss }) {
+  return (
+    <PromoBanner
+      type={PROMO_BANNER_TYPES.announcement}
+      onClose={dismiss}
+      href="https://www.va.gov/opa/vetsday/docs/National_Veterans_and_Military_Families_Month_Proclamation_2019.pdf"
+      text="Read President Donald Trump's proclamation celebrating National Veterans and Military Families Month"
+    />
+  );
+}

--- a/src/platform/site-wide/announcements/config/index.js
+++ b/src/platform/site-wide/announcements/config/index.js
@@ -3,7 +3,7 @@ import Profile360Intro from '../components/Profile360Intro';
 import PersonalizationBanner from '../components/PersonalizationBanner';
 import VAPlusVetsModal from '../components/VAPlusVetsModal';
 import WelcomeToNewVAModal from '../components/WelcomeToNewVAModal';
-import MissionAct from '../components/MissionAct';
+import VeteransDayProclamation from '../components/VeteransDayProclamation';
 import ExploreVAModal from '../components/ExploreVAModal';
 
 const config = {
@@ -29,9 +29,9 @@ const config = {
       component: WelcomeToNewVAModal,
     },
     {
-      name: 'mission-act',
+      name: 'veterans-day-proclamation',
       paths: /^\/$/,
-      component: MissionAct,
+      component: VeteransDayProclamation,
     },
     {
       name: 'find-benefits-intro',


### PR DESCRIPTION
## Description
Replaces MISSION Act promo with Veterans and Military Families Month proclamation promo on homepage. Change requested by VA OPIA.

## Testing done
Tested locally.

## Screenshots
<img width="1201" alt="Screen Shot 2019-11-06 at 2 55 50 PM" src="https://user-images.githubusercontent.com/7645362/68333598-cea96300-00a6-11ea-985e-420774b45162.png">

## Acceptance criteria
- [x] Updated promo banner displays

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
