### PR TITLE
VAGOV-6250 ie fix duotone

### DIFF
--- a/src/applications/static-pages/sass/modules/_m-facilities.scss
+++ b/src/applications/static-pages/sass/modules/_m-facilities.scss
@@ -34,6 +34,22 @@ $duo-tone-lighten: #000;
   mix-blend-mode: screen;
 }
 
+@media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+  /* Cheat to restrict to IE10+ CSS styles. */
+  .duotone::before, .duotone::after {
+    width: 0%;
+    height: 0%;
+  }
+}
+
+@supports (-ms-ime-align: auto) {
+  /* Cheat to restrict to IE Edge CSS styles. */
+  .duotone::before, .duotone::after {
+    width: 0%;
+    height: 0%;
+  }
+}
+
 .usa-accordion > ul li ul.usa-unstyled-list,
 .usa-accordion-bordered > ul li ul.usa-unstyled-list {
   list-style: none;


### PR DESCRIPTION
## Description
IE and Edge do not support the duotone effect and the image gets overlayed by the failed image overlay causing the image to appear completely black.  The desired effect is that on all other browsers the image  placed on the System page will be duo-toned to blue and black and on IE 10+ and Edge, the image will just appear normal, without the blue.
Issue: https://github.com/department-of-veterans-affairs/vets-website/issues/11023

## Testing done
Local was built on linux machine.   Examined in Chrome and Firefox  (works as expected).
Copied generated css to a file and moved it to Windows machine and replaced the live CSS with the locally generated CSS and confirmed that in both IE11 and Edge, the image shows without blue.

## Screenshots
Local no longer builds  /pittsburgh-health-care/   I do no think that is related to this css change.   The css does get correctly compiled.   
Chrome:
![image](https://user-images.githubusercontent.com/5752113/68402684-ba6a7200-0149-11ea-8980-21fca875678a.png)
Firefox: 
![image](https://user-images.githubusercontent.com/5752113/68402769-d8d06d80-0149-11ea-93b7-db9903df20be.png)

IE   - NOTE: THe stacking of the buttons beneath the image is unrelated to the changes made.  It is a side effect of using a saved version of the html from IE
![image](https://user-images.githubusercontent.com/5752113/68403461-f8b46100-014a-11ea-9bb4-822ececec023.png)


Edge NOTE: THe stacking of the buttons beneath the image is unrelated to the changes made.  It is a side effect of using a saved version of the html from IE
![image](https://user-images.githubusercontent.com/5752113/68403402-e1757380-014a-11ea-9478-4e4e7b4ed69d.png)

## Acceptance criteria
- [ ] Visiting /pittsburgh-health-care/ in Firefox shows the blue toned image of the facility
- [ ] Visiting /pittsburgh-health-care/ in Chrome shows the blue toned image of the facility
- [ ] Visiting /pittsburgh-health-care/ in Internet Explorer10 or higher shows the  image of the facility with no blue tone.
- [ ] Visiting /pittsburgh-health-care/ in Windows Edge or higher shows the  image of the facility with no blue tone.

## Definition of done
- [-] Events are logged appropriately
- [-] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
      https://github.com/department-of-veterans-affairs/vets-website/issues/11023
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
