### PR TITLE
GIBCT: Accordion Header Font is Incorrect on the Profile Page #19923

### DIFF
--- a/src/applications/gi/components/AccordionItem.jsx
+++ b/src/applications/gi/components/AccordionItem.jsx
@@ -27,7 +27,9 @@ class AccordionItem extends React.Component {
             aria-expanded={expanded}
             aria-controls={this.id}
           >
-            <span className="accordion-button-text">{this.props.button}</span>
+            <span className="vads-u-font-family--serif accordion-button-text">
+              {this.props.button}
+            </span>
           </button>
         </h2>
         <div

--- a/src/applications/gi/sass/partials/_gi-profile-page.scss
+++ b/src/applications/gi/sass/partials/_gi-profile-page.scss
@@ -10,7 +10,6 @@
 
   .accordion-button-text {
     font-size: 1.35em;
-    font-family: 'bitter', serif;
   }
 
   h2.accordion-button-wrapper {

--- a/src/applications/gi/sass/partials/_gi-profile-page.scss
+++ b/src/applications/gi/sass/partials/_gi-profile-page.scss
@@ -10,6 +10,7 @@
 
   .accordion-button-text {
     font-size: 1.35em;
+    font-family: 'bitter', serif;
   }
 
   h2.accordion-button-wrapper {
@@ -43,6 +44,8 @@
 
   button.usa-accordion-button {
     text-align: left;
+    margin-top: 0.208em;
+    margin-bottom: 0.208em;
   }
 
   .calculate-your-benefits {


### PR DESCRIPTION
## Description
On the institution profile page, each section is divided into collapsable accordions. The headers of these sections should be in Bitter typeface but have changed to Sans Serif. This is present on all comparison tool profile pages including VET TEC.

https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/vets.gov-team/19923

## Testing done
Local Testing

## Screenshots
![Screen Shot 2019-11-07 at 10 53 22 AM](https://user-images.githubusercontent.com/50601724/68404621-d91e3800-014c-11ea-8014-c7673835cb35.png)


## Acceptance criteria
- [x] Font is updated to Bitter with serif typeface
- [x] Accordion button is 59px high

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
