### PR TITLE
[PromoBanner] Open VeteransDayProclamation in a new tab

### DIFF
--- a/package.json
+++ b/package.json
@@ -225,7 +225,7 @@
   "private": true,
   "dependencies": {
     "@department-of-veterans-affairs/formation": "^6.8.0",
-    "@department-of-veterans-affairs/formation-react": "^4.10.2",
+    "@department-of-veterans-affairs/formation-react": "^4.10.3",
     "@department-of-veterans-affairs/react-jsonschema-form": "^1.0.0",
     "@fortawesome/fontawesome-free": "^5.6.3",
     "blob-polyfill": "^2.0.20171115",

--- a/src/platform/site-wide/announcements/components/VeteransDayProclamation.jsx
+++ b/src/platform/site-wide/announcements/components/VeteransDayProclamation.jsx
@@ -8,6 +8,7 @@ export default function VeteransDayProclamation({ dismiss }) {
     <PromoBanner
       type={PROMO_BANNER_TYPES.announcement}
       onClose={dismiss}
+      target="_blank"
       href="https://www.va.gov/opa/vetsday/docs/National_Veterans_and_Military_Families_Month_Proclamation_2019.pdf"
       text="Read President Donald Trump's proclamation celebrating National Veterans and Military Families Month"
     />

--- a/yarn.lock
+++ b/yarn.lock
@@ -706,10 +706,10 @@
     lodash "^4.17.11"
     to-fast-properties "^2.0.0"
 
-"@department-of-veterans-affairs/formation-react@^4.10.2":
-  version "4.10.2"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/formation-react/-/formation-react-4.10.2.tgz#a6009bb0ac0b0e0953220212da11893b9a730753"
-  integrity sha512-C8zjwft8hJGcifDvAcD43PoNxBpLEOSlBEJknSLN86V4EYeIcVBZUQyELX2gfLcIZLLPkuUBIkLCbtDfPk8DBA==
+"@department-of-veterans-affairs/formation-react@^4.10.3":
+  version "4.10.3"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/formation-react/-/formation-react-4.10.3.tgz#7b66ea9cae7b373b547d8201fcfcc5b977bdd781"
+  integrity sha512-ozYSByIQgUhqkXAA27CACm/JOcjJl9NczjB0mDF0+T/0ZTS70thjL8VcF9VlHNj0oe3WPfPhqzJ7afnWA1cDxw==
   dependencies:
     classnames "^2.2.6"
     lodash "^4.17.15"


### PR DESCRIPTION
## Description
This PR modifies the latest PromoBanner to open its link in a new tab instead of current, because it links to a PDF.  It also updates Formation because Formation needed to add support for this case.

## Testing done
- Opened the site locally
- Clicked the PromoBanner
- Confirmed that the PromoBanner disappears and that the link opens in a new tab

## Screenshots
![image](https://user-images.githubusercontent.com/1915775/68408367-34532900-0153-11ea-8c76-1344e3795147.png)


## Acceptance criteria
- [ ] PromoBanner link opens in a new tab

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
