### PR TITLE
Move createMetaTag out into helper file

### DIFF
--- a/src/site/stages/build/process-cms-exports/transformers/helpers.js
+++ b/src/site/stages/build/process-cms-exports/transformers/helpers.js
@@ -11,6 +11,15 @@ function getDrupalValue(arr) {
   return null;
 }
 
+function createMetaTag(type, key, value) {
+  return {
+    type,
+    key,
+    value,
+  };
+}
+
 module.exports = {
   getDrupalValue,
+  createMetaTag,
 };

--- a/src/site/stages/build/process-cms-exports/transformers/page.js
+++ b/src/site/stages/build/process-cms-exports/transformers/page.js
@@ -1,13 +1,5 @@
 const { flatten, isEmpty } = require('lodash');
-const { getDrupalValue } = require('./helpers');
-
-function createMetaTag(type, key, value) {
-  return {
-    type,
-    key,
-    value,
-  };
-}
+const { getDrupalValue, createMetaTag } = require('./helpers');
 
 function pageTransform(entity) {
   const transformed = entity;


### PR DESCRIPTION
## Description

This is a <sup>tiny</sup> PR that should help us avoid merge conflicts as we continue to build out the transformers.

Multiple entityTypes besides 'node-page' will need to have metatags, so it would be better if the simple helper function to create them lived elsewhere.

## Testing done

N/A

## Screenshots
N/A