### PR TITLE
19888: SCO: Add Announcements content and styling to SCO Skeleton page update styling for announcements

### DIFF
--- a/src/platform/site-wide/sass/shame.scss
+++ b/src/platform/site-wide/sass/shame.scss
@@ -1,7 +1,6 @@
 $medium-phone-screen: 375px;
 /* OVERRIDE */
 .merger {
-
   // Begin new-grid override
   // Overrides some default properties with a
   // class name that makes it more clear we remove
@@ -44,8 +43,8 @@ $medium-phone-screen: 375px;
   }
   $color-primary-lightest: #e1f3f8;
 
-  @import "iconography";
-  @import "modules/m-right-rail";
+  @import 'iconography';
+  @import 'modules/m-right-rail';
 
   section.usa-grid {
     padding-top: 3em;
@@ -375,16 +374,15 @@ $medium-phone-screen: 375px;
     }
   }
 
-
-
   .usa-accordion-bordered {
-    &.social, &.links {
+    &.social,
+    &.links {
       a {
         text-decoration: underline;
       }
-        .social-icon {
-          text-decoration: none;
-        }
+      .social-icon {
+        text-decoration: none;
+      }
 
       .usa-accordion-content {
         h4:first-child {
@@ -450,7 +448,7 @@ $medium-phone-screen: 375px;
 
     a {
       &::before {
-        content: " \2039 ";
+        content: ' \2039 ';
         display: inline-block;
         padding: 0 0.35em 0 0;
       }
@@ -532,20 +530,21 @@ img[data-srcset] {
   position: relative;
 }
 
-.usa-grid > :last-child, .usa-grid-full > :last-child {
+.usa-grid > :last-child,
+.usa-grid-full > :last-child {
   &.half-em-bottom-margin {
-    margin-bottom: .5em;
+    margin-bottom: 0.5em;
   }
 }
 
 .inline-table-helper {
-  display: inline-table
+  display: inline-table;
 }
 
 .va-l-detail-page {
   .usa-content {
     p {
-      margin-top: 0
+      margin-top: 0;
     }
   }
 
@@ -559,7 +558,7 @@ img[data-srcset] {
 
 .usa-accordion > ul li ul,
 .usa-accordion-bordered > ul li ul {
-    list-style: square;
+  list-style: square;
 }
 
 .no-left-button-right-radius-treatment {
@@ -570,4 +569,14 @@ img[data-srcset] {
 .no-right-button-left-radius-treatment {
   border-top-left-radius: 0;
   border-bottom-left-radius: 0;
+}
+
+.bluecard {
+  background-color: #e1f3f8;
+  padding: 0.5em;
+  margin-top: 3em;
+}
+
+.simple-link {
+  text-decoration: none;
 }

--- a/src/platform/site-wide/sass/shame.scss
+++ b/src/platform/site-wide/sass/shame.scss
@@ -571,7 +571,7 @@ img[data-srcset] {
   border-bottom-left-radius: 0;
 }
 
-.bluecard {
+.sco-card {
   background-color: #e1f3f8;
   padding: 0.5em;
   margin-top: 3em;


### PR DESCRIPTION
## Description

As a SCO, I need to be informed of announcements on the resource page so that I am made aware of any relevant news.

https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/vets.gov-team/19888


## Testing done
Manual, unit, and e2e testing passes locally


## Screenshots
![image](https://user-images.githubusercontent.com/48804834/68426055-4e9dfe80-0175-11ea-98a1-fa503a442728.png)


## Acceptance criteria
- [x] The announcements section of the new SCO Resource page matches the content, layout and design as specified in supporting artifacts 1 and 2.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
