### PR TITLE
[PromoBanner] Change key to show all users

### DIFF
--- a/src/platform/site-wide/announcements/config/index.js
+++ b/src/platform/site-wide/announcements/config/index.js
@@ -29,7 +29,7 @@ const config = {
       component: WelcomeToNewVAModal,
     },
     {
-      name: 'veterans-day-proclamation',
+      name: 'veterans-day-proclamation-edited',
       paths: /^\/$/,
       component: VeteransDayProclamation,
     },


### PR DESCRIPTION
## Description
This PR changes the key for the latest PromoBanner so that users see the latest PromoBannner content, even if they dismissed it previously.

## Testing done


## Screenshots
N/A

## Acceptance criteria
- [ ] PromoBanner doesn't require cache refresh to see latest content

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
