### PR TITLE
VAGOV-6262: IE specific fix for buttons on system pages.

### DIFF
--- a/src/applications/static-pages/sass/modules/_m-facilities.scss
+++ b/src/applications/static-pages/sass/modules/_m-facilities.scss
@@ -40,6 +40,13 @@ $duo-tone-lighten: #000;
     width: 0%;
     height: 0%;
   }
+
+  /* Cheat for IE10+ not handling flex box correctly.
+  .vads-l-row {
+    min-width: 94%;
+    max-width: 94%;
+    flex-wrap: nowrap;
+  }
 }
 
 @supports (-ms-ime-align: auto) {


### PR DESCRIPTION
## Description
The Pittsburgh System page (https://www.va.gov/pittsburgh-health-care/) has a defect on IE only that causes the  last button in the row to roll onto the next line.
![image](https://user-images.githubusercontent.com/5752113/68489599-6d53d200-0215-11ea-89b4-d2fc23637728.png)

## Testing done
- [ ] Visit /pittsburgh-health-care/ in IE and validate all three buttons below the image are alligned the same row.
- [ ] Visit /pittsburgh-health-care/ in Edge and validate all three buttons below the image are alligned the same row.
- [ ] Visit /pittsburgh-health-care/ in Firefox and validate all three buttons below the image are alligned the same row.
- [ ] Visit /pittsburgh-health-care/ in Chrome and validate all three buttons below the image are aligned the same row.

## Screenshots
This PR results in this on IE
![image](https://user-images.githubusercontent.com/5752113/68489736-a9873280-0215-11ea-81ae-0d3cb7a094b7.png)

Chrome:
![image](https://user-images.githubusercontent.com/5752113/68490722-85c4ec00-0217-11ea-9aef-2efda0b7d1fa.png)


Firefox:
![image](https://user-images.githubusercontent.com/5752113/68490661-67f78700-0217-11ea-9344-611870284432.png)



## Acceptance criteria
- [ ] All three buttons on the /pittsburgh-health-care page that appear under the image should sit on the same row when visited in IE, Edge, Firefox and Crhome

## Definition of done
- [-] Events are logged appropriately
- [-] Documentation has been updated, if applicable
- [-] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
    VAGOV-6262
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
