### PR TITLE
Make all phone inputs use type="tel"

### DIFF
--- a/src/platform/forms-system/src/js/widgets/PhoneNumberWidget.jsx
+++ b/src/platform/forms-system/src/js/widgets/PhoneNumberWidget.jsx
@@ -26,6 +26,7 @@ export default class PhoneNumberWidget extends React.Component {
     return (
       <TextWidget
         {...this.props}
+        inputType={'tel'}
         value={this.state.val}
         onChange={this.handleChange}
       />

--- a/src/platform/forms-system/src/js/widgets/PhoneNumberWidget.jsx
+++ b/src/platform/forms-system/src/js/widgets/PhoneNumberWidget.jsx
@@ -22,6 +22,7 @@ export default class PhoneNumberWidget extends React.Component {
       this.props.onChange(stripped);
     });
   };
+
   render() {
     return (
       <TextWidget

--- a/src/platform/forms-system/test/js/widgets/PhoneNumberWidget.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/widgets/PhoneNumberWidget.unit.spec.jsx
@@ -12,6 +12,10 @@ describe('Schemaform <PhoneNumberWidget>', () => {
     );
     expect(tree.subTree('TextWidget').props.value).to.equal('1234567890');
   });
+  it('should render a "tel" type input', () => {
+    const tree = SkinDeep.shallowRender(<PhoneNumberWidget />);
+    expect(tree.subTree('TextWidget').props.inputType).to.equal('tel');
+  });
   it('should strip spaces, (, ), -, +, and x on change', () => {
     const onChange = sinon.spy();
     const tree = SkinDeep.shallowRender(

--- a/src/platform/forms-system/test/js/widgets/PhoneNumberWidget.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/widgets/PhoneNumberWidget.unit.spec.jsx
@@ -12,10 +12,12 @@ describe('Schemaform <PhoneNumberWidget>', () => {
     );
     expect(tree.subTree('TextWidget').props.value).to.equal('1234567890');
   });
+
   it('should render a "tel" type input', () => {
     const tree = SkinDeep.shallowRender(<PhoneNumberWidget />);
     expect(tree.subTree('TextWidget').props.inputType).to.equal('tel');
   });
+
   it('should strip spaces, (, ), -, +, and x on change', () => {
     const onChange = sinon.spy();
     const tree = SkinDeep.shallowRender(
@@ -24,6 +26,7 @@ describe('Schemaform <PhoneNumberWidget>', () => {
     tree.subTree('TextWidget').props.onChange('+(154) 945-56x77');
     expect(onChange.calledWith('1549455677')).to.be.true;
   });
+
   it('should call onChange with undefined if value is blank', () => {
     const onChange = sinon.spy();
     const tree = SkinDeep.shallowRender(

--- a/src/platform/user/profile/vet360/components/PhoneField/EditModal.jsx
+++ b/src/platform/user/profile/vet360/components/PhoneField/EditModal.jsx
@@ -32,7 +32,7 @@ class PhoneTextInput extends ErrorableTextInput {
   // }
 
   render() {
-    return <ErrorableTextInput {...this.props} />;
+    return <ErrorableTextInput {...this.props} type="tel" />;
   }
 }
 


### PR DESCRIPTION
## Description

For accessibility considerations, this PR is globally switching inputs where users enter a phone number to an input of type "tel". 

## Testing done

Added a unit test to the form-systems `PhoneNumberWidget`.
All unit tests are passing

## Screenshots

<details>
<summary>Changed to `type="tel"`</summary>

<!-- leave a blank line above -->
![Screen Shot 2019-11-08 at 10 52 44 AM](https://user-images.githubusercontent.com/136959/68495518-fec34400-0215-11ea-8c13-2dde2fa71c55.png)
</details>

## Acceptance criteria
- [ ] Use type="tel" on all phone inputs to improve accessibility

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
