### PR TITLE
Filtering and temporary error message on VAOS appointment list

### DIFF
--- a/src/applications/vaos/actions/appointments.js
+++ b/src/applications/vaos/actions/appointments.js
@@ -58,6 +58,7 @@ export function fetchFutureAppointments() {
         dispatch({
           type: FETCH_FUTURE_APPOINTMENTS_SUCCEEDED,
           data,
+          today: moment(),
         });
       } catch (error) {
         Sentry.captureException(error);

--- a/src/applications/vaos/api/confirmed_cc.json
+++ b/src/applications/vaos/api/confirmed_cc.json
@@ -16,7 +16,7 @@
           "zipCode": "32826"
         },
         "instructionsToVeteran": "Please arrive 15 minutes ahead of appointment.",
-        "appointmentTime": "12/25/2019 13:30:00",
+        "appointmentTime": "01/25/2019 13:30:00",
         "timeZone": "-04:00 EDT"
       }
     },

--- a/src/applications/vaos/containers/AppointmentsPage.jsx
+++ b/src/applications/vaos/containers/AppointmentsPage.jsx
@@ -3,6 +3,7 @@ import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router';
 import LoadingIndicator from '@department-of-veterans-affairs/formation-react/LoadingIndicator';
+import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 import Breadcrumbs from '../components/Breadcrumbs';
 import ConfirmedAppointmentListItem from '../components/ConfirmedAppointmentListItem';
 import AppointmentRequestListItem from '../components/AppointmentRequestListItem';
@@ -31,7 +32,8 @@ export class AppointmentsPage extends Component {
     let content;
 
     const loading = futureStatus === FETCH_STATUS.loading;
-    const hasAppointments = FETCH_STATUS.succeeded && future?.length > 0;
+    const hasAppointments =
+      futureStatus === FETCH_STATUS.succeeded && future?.length > 0;
 
     if (loading) {
       content = (
@@ -40,37 +42,48 @@ export class AppointmentsPage extends Component {
         </div>
       );
     } else if (hasAppointments) {
-      content = future.map((appt, index) => {
-        const type = getAppointmentType(appt);
+      content = (
+        <ul className="usa-unstyled-list">
+          {future.map((appt, index) => {
+            const type = getAppointmentType(appt);
 
-        switch (type) {
-          case APPOINTMENT_TYPES.request:
-            return (
-              <AppointmentRequestListItem
-                key={index}
-                index={index}
-                appointment={appt}
-                cancelAppointment={this.props.cancelAppointment}
-              />
-            );
-          case APPOINTMENT_TYPES.ccAppointment:
-          case APPOINTMENT_TYPES.vaAppointment:
-            return (
-              <ConfirmedAppointmentListItem
-                key={index}
-                index={index}
-                appointment={appt}
-                type={type}
-                cancelAppointment={this.props.cancelAppointment}
-              />
-            );
-          default:
-            return null;
-        }
-      });
+            switch (type) {
+              case APPOINTMENT_TYPES.request:
+                return (
+                  <AppointmentRequestListItem
+                    key={index}
+                    index={index}
+                    appointment={appt}
+                    cancelAppointment={this.props.cancelAppointment}
+                  />
+                );
+              case APPOINTMENT_TYPES.ccAppointment:
+              case APPOINTMENT_TYPES.vaAppointment:
+                return (
+                  <ConfirmedAppointmentListItem
+                    key={index}
+                    index={index}
+                    appointment={appt}
+                    type={type}
+                    cancelAppointment={this.props.cancelAppointment}
+                  />
+                );
+              default:
+                return null;
+            }
+          })}
+        </ul>
+      );
+    } else if (futureStatus === FETCH_STATUS.failed) {
+      content = (
+        <AlertBox status="error" headline="We're sorry, something went wrong">
+          We're having trouble getting your upcoming appointments. Please try
+          again later.
+        </AlertBox>
+      );
     } else {
       content = (
-        <li className="vads-u-margin-bottom--2 vads-u-background-color--gray-lightest vads-u-padding--2 vads-u-margin-bottom--3">
+        <div className="vads-u-margin-bottom--2 vads-u-background-color--gray-lightest vads-u-padding--2 vads-u-margin-bottom--3">
           <h2 className="vads-u-margin--0 vads-u-margin-bottom--2p5 vads-u-font-size--md">
             You don’t have any appointments.
           </h2>
@@ -90,7 +103,7 @@ export class AppointmentsPage extends Component {
               Schedule an appointment
             </button>
           </Link>
-        </li>
+        </div>
       );
     }
 
@@ -117,7 +130,7 @@ export class AppointmentsPage extends Component {
             <h2 className="vads-u-font-size--h3 vads-u-margin-bottom--2">
               Upcoming appointments
             </h2>
-            <ul className="usa-unstyled-list">{content}</ul>
+            {content}
           </div>
         </div>
         <CancelAppointmentModal

--- a/src/applications/vaos/containers/AppointmentsPage.jsx
+++ b/src/applications/vaos/containers/AppointmentsPage.jsx
@@ -76,7 +76,10 @@ export class AppointmentsPage extends Component {
       );
     } else if (futureStatus === FETCH_STATUS.failed) {
       content = (
-        <AlertBox status="error" headline="We're sorry, something went wrong">
+        <AlertBox
+          status="error"
+          headline="We're sorry. We've run into a problem"
+        >
           We're having trouble getting your upcoming appointments. Please try
           again later.
         </AlertBox>

--- a/src/applications/vaos/containers/RegistrationCheck.jsx
+++ b/src/applications/vaos/containers/RegistrationCheck.jsx
@@ -17,7 +17,11 @@ export class RegistrationCheck extends React.Component {
     const { status, isEnrolled, hasRegisteredSystems, children } = this.props;
 
     if (status === FETCH_STATUS.loading || status === FETCH_STATUS.notStarted) {
-      return <LoadingIndicator message="Check your VA registration" />;
+      return (
+        <div className="vads-u-margin-y--5">
+          <LoadingIndicator message="Looking for VA health care registrations" />
+        </div>
+      );
     }
 
     if (

--- a/src/applications/vaos/reducers/appointments.js
+++ b/src/applications/vaos/reducers/appointments.js
@@ -12,7 +12,11 @@ import {
   CANCEL_APPOINTMENT_CLOSED,
 } from '../actions/appointments';
 
-import { filterFutureRequests, sortFutureList } from '../utils/appointment';
+import {
+  filterFutureRequests,
+  filterFutureConfirmedAppointments,
+  sortFutureList,
+} from '../utils/appointment';
 import { FETCH_STATUS } from '../utils/constants';
 
 const initialState = {
@@ -40,8 +44,12 @@ export default function appointmentsReducer(state = initialState, action) {
       const [vaAppointments, ccAppointments, requests] = action.data;
       const futureAppointments = [
         ...vaAppointments,
-        ...ccAppointments,
-        ...requests.appointmentRequests.filter(filterFutureRequests),
+        ...ccAppointments.filter(appt =>
+          filterFutureConfirmedAppointments(appt, action.today),
+        ),
+        ...requests.appointmentRequests.filter(req =>
+          filterFutureRequests(req, action.today),
+        ),
       ];
 
       futureAppointments.sort(sortFutureList);

--- a/src/applications/vaos/utils/appointment.jsx
+++ b/src/applications/vaos/utils/appointment.jsx
@@ -3,8 +3,6 @@ import moment from 'moment';
 import environment from 'platform/utilities/environment';
 import { APPOINTMENT_TYPES, TIME_TEXT } from './constants';
 
-const today = moment();
-
 export function getAppointmentType(appt) {
   if (appt.optionDate1) {
     return APPOINTMENT_TYPES.request;
@@ -30,12 +28,12 @@ export function parseRequestDate(optionDate) {
   return moment(optionDate, 'MM/DD/YYYY');
 }
 
-export function filterFutureConfirmedAppointments(appt) {
+export function filterFutureConfirmedAppointments(appt, today) {
   const date = parseVAorCCDate(appt);
   return date.isValid() && date.isAfter(today);
 }
 
-export function filterFutureRequests(request) {
+export function filterFutureRequests(request, today) {
   const optionDate1 = moment(request.optionDate1, 'MM/DD/YYYY');
   const optionDate2 = moment(request.optionDate2, 'MM/DD/YYYY');
   const optionDate3 = moment(request.optionDate3, 'MM/DD/YYYY');


### PR DESCRIPTION
## Description
We're showing the no appointments message when there are errors, which is misleading. We don't have real error message copy, but this temporary message will at least be accurate.

Additionally, I've added back the future date filtering for CC appointments, because they ignore the dates we send to the service.

I've also adjusted the message for another spinner to be clearer.

## Testing done
Local testing

## Screenshots
![Screen Shot 2019-11-08 at 3 31 42 PM](https://user-images.githubusercontent.com/634932/68508935-bddf2580-023d-11ea-8e08-8f1b70aac6ca.png)


## Acceptance criteria
- [ ] Get an error message when there are service errors.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
