### PR TITLE
Make vet profile email inputs use type="email"

### DIFF
--- a/src/platform/user/profile/vet360/components/EmailField/EditModal.jsx
+++ b/src/platform/user/profile/vet360/components/EmailField/EditModal.jsx
@@ -27,6 +27,7 @@ export default class EditEmailModal extends React.Component {
       autoFocus
       label="Email Address"
       name="email"
+      type="email"
       field={{ value: this.props.field.value.emailAddress, dirty: false }}
       errorMessage={this.props.field.validations.emailAddress}
       onValueChange={this.onChange}


### PR DESCRIPTION
## Description

For accessibility considerations, this PR is switching the vet profile email input to an input of type "email".

In the process of fulfilling the associated ticket, email inputs in other forms were verified to also be using an email type of input.

## Testing done

Local unit tests

## Screenshots

<details>
<summary>Changed to `type="email"`</summary>

<!-- leave a blank line above -->
![Screen Shot 2019-11-08 at 3 28 01 PM](https://user-images.githubusercontent.com/136959/68512015-d13dc100-023c-11ea-8615-38f4d8ed7d7d.png)
</details>

## Acceptance criteria

- [ ] Use type="email" on all email inputs to improve accessibility

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
