### PR TITLE
Implement expiration dates into announcement configs

### DIFF
--- a/src/platform/site-wide/announcements/config/index.js
+++ b/src/platform/site-wide/announcements/config/index.js
@@ -32,6 +32,7 @@ const config = {
       name: 'veterans-day-proclamation-edited',
       paths: /^\/$/,
       component: VeteransDayProclamation,
+      expiresAt: '2019-11-12',
     },
     {
       name: 'find-benefits-intro',

--- a/src/platform/site-wide/announcements/config/index.js
+++ b/src/platform/site-wide/announcements/config/index.js
@@ -32,7 +32,7 @@ const config = {
       name: 'veterans-day-proclamation-edited',
       paths: /^\/$/,
       component: VeteransDayProclamation,
-      disabled: true,
+      expiresAt: '2019-11-12',
     },
     {
       name: 'find-benefits-intro',

--- a/src/platform/site-wide/announcements/config/index.js
+++ b/src/platform/site-wide/announcements/config/index.js
@@ -32,6 +32,7 @@ const config = {
       name: 'veterans-day-proclamation-edited',
       paths: /^\/$/,
       component: VeteransDayProclamation,
+      disabled: true,
     },
     {
       name: 'find-benefits-intro',

--- a/src/platform/site-wide/announcements/selectors.js
+++ b/src/platform/site-wide/announcements/selectors.js
@@ -1,4 +1,14 @@
 import _config from './config';
+import moment from 'moment';
+
+function isExpiredAnnouncement(announcement) {
+  if (!announcement.expiresAt) return true;
+
+  const expirationDate = moment(announcement.expiresAt);
+  const isExpired = moment().isSameOrAfter(expirationDate);
+
+  return !isExpired;
+}
 
 export function selectAnnouncement(
   state,
@@ -11,6 +21,7 @@ export function selectAnnouncement(
   if (announcements.isInitialized) {
     announcement = config.announcements
       .filter(a => !a.disabled)
+      .filter(isExpiredAnnouncement)
       .filter(a => !announcements.dismissed.includes(a.name))
       .find(a => a.paths.test(path));
   }

--- a/src/platform/site-wide/announcements/tests/selectors.unit.spec.js
+++ b/src/platform/site-wide/announcements/tests/selectors.unit.spec.js
@@ -44,6 +44,11 @@ describe('selectAnnouncement', () => {
           name: 'dummy6',
           paths: /^(\/some-route-6\/)$/,
         },
+        {
+          name: 'dummy7',
+          paths: /^(\/unique-route\/)$/,
+          expiresAt: '2019-11-11',
+        },
       ],
     };
   });
@@ -105,5 +110,15 @@ describe('selectAnnouncement', () => {
       'dummy6',
       '"disabled dummy6" preceded "dummy6" but was ignored because of the disabled flag.',
     );
+  });
+
+  it('filters our expired announcements', () => {
+    const result = selectors.selectAnnouncement(
+      state,
+      config,
+      '/unique-route/',
+    );
+
+    expect(result).to.be.undefined;
   });
 });


### PR DESCRIPTION
## Description
This PR unpublishes the banner for the Veterans Day message using a new `expiresAt` property for announcements. That banner has to go down between 12 AM ET and 7 AM ET, November 12th. 

## Testing done
Added a unit test

## Screenshots
N/A

## Acceptance criteria
- [ ] PromoBanner is gone

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
