### PR TITLE
VAGOV-6241 Fix event toggle.

### DIFF
--- a/src/applications/static-pages/sass/modules/_m-facilities.scss
+++ b/src/applications/static-pages/sass/modules/_m-facilities.scss
@@ -41,7 +41,7 @@ $duo-tone-lighten: #000;
     height: 0%;
   }
 
-  /* Cheat for IE10+ not handling flex box correctly.
+  /* Cheat for IE10+ not handling flex box correctly. */
   .vads-l-row {
     min-width: 94%;
     max-width: 94%;

--- a/src/site/facilities/facilities_events_toggle.drupal.liquid
+++ b/src/site/facilities/facilities_events_toggle.drupal.liquid
@@ -9,7 +9,7 @@
         vads-u-flex-direction--row
         medium-screen:vads-u-align-items--flex-start">
                 {% if url contains 'past-events' %}
-                        <a role="button" href="{{ url }}" class="
+                        <a role="button" href="{{ url | remove: '/past-events'}}" class="
                         vads-u-flex--1
                         vads-u-margin-right--0
                         usa-button

--- a/src/site/facilities/facilities_events_toggle.drupal.liquid
+++ b/src/site/facilities/facilities_events_toggle.drupal.liquid
@@ -9,8 +9,7 @@
         vads-u-flex-direction--row
         medium-screen:vads-u-align-items--flex-start">
                 {% if url contains 'past-events' %}
-                        {% assign regionPath = entityUrl.path | regionBasePath %}
-                        <a role="button" href="{{ '/' | append: regionPath | append: '/events'}}" class="
+                        <a role="button" href="{{ url | regionBasePath | append: '/events' | prepend: '/' }}" class="
                         vads-u-flex--1
                         vads-u-margin-right--0
                         usa-button

--- a/src/site/facilities/facilities_events_toggle.drupal.liquid
+++ b/src/site/facilities/facilities_events_toggle.drupal.liquid
@@ -9,7 +9,8 @@
         vads-u-flex-direction--row
         medium-screen:vads-u-align-items--flex-start">
                 {% if url contains 'past-events' %}
-                        <a role="button" href="{{ url | remove: '/past-events'}}" class="
+                        {% assign regionPath = entityUrl.path | regionBasePath %}
+                        <a role="button" href="{{ '/' | append: regionPath | append: '/events'}}" class="
                         vads-u-flex--1
                         vads-u-margin-right--0
                         usa-button


### PR DESCRIPTION
## Description
When on this page https://www.va.gov/pittsburgh-health-care/events/past-events/ the buttton for "Upcoming events" points to the current page not https://www.va.gov/pittsburgh-health-care/events/

This pr resolves that as well as fixes a malformed css comment.

## Testing done

- [ ] Visit /pittsburgh-health-care/events/past-events/ and click on "Upcoming events" should take you to /pittsburgh-health-care/events/
- [ ] While on /pittsburgh-health-care/events/ verify that the "Upcoming events button points to the current page.
- [ ] Click on "Past events" and validate that points to /pittsburgh-health-care/events/past-events/

## Screenshots
Fixed 
![image](https://user-images.githubusercontent.com/5752113/68514373-92633780-024b-11ea-9043-16d751f0c349.png)


## Acceptance criteria
- [ ] Past events and Upcoming event toggles take you to the appropriate page when clicked (see testing steps)

## Definition of done
- [-] Events are logged appropriately
- [-] Documentation has been updated, if applicable
- [-] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
