### PR TITLE
VAGOV-6254: Decorative image should have empty alt tag.

### DIFF
--- a/src/site/layouts/health_care_region_page.drupal.liquid
+++ b/src/site/layouts/health_care_region_page.drupal.liquid
@@ -144,7 +144,7 @@ Example data:
 
           <div
             class="duotone darken lighten medium-screen:vads-u-margin-bottom--0p5">
-            <img src="{{ image.derivative.url }}" alt="{{ image.alt }}"
+            <img src="{{ image.derivative.url }}" alt=""
               title="{{ image.title }}" width="100%">
           </div>
 


### PR DESCRIPTION
## Description

Decorative images on VAMC system landing page should have an empty `<img alt="">` tag. 

https://va-gov.atlassian.net/browse/VAGOV-6254

## Screenshots

![VA_Pittsburgh_Health_Care___Veterans_Affairs](https://user-images.githubusercontent.com/643678/68682825-be283b00-0533-11ea-8330-af021b8f383f.jpg)

## Acceptance criteria
- [ ]

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
