### PR TITLE
BAH 116 Content Updates 19916 and 19917

### DIFF
--- a/src/applications/gi/components/content/AdditionalResources.jsx
+++ b/src/applications/gi/components/content/AdditionalResources.jsx
@@ -43,7 +43,7 @@ export const AdditionalResourcesLinks = () => (
 
 const AdditionalResources = () => (
   <div className="additional-resources usa-width-one-third medium-4 small-12 column">
-    <h4 className="highlight">Additional Resources</h4>
+    <h4 className="highlight">Additional resources</h4>
     <AdditionalResourcesLinks />
   </div>
 );

--- a/src/applications/gi/components/heading/GiBillBreadcrumbs.jsx
+++ b/src/applications/gi/components/heading/GiBillBreadcrumbs.jsx
@@ -19,7 +19,7 @@ export default function GiBillBreadcrumbs({
       Home
     </a>,
     <a href="/education/" key="education">
-      Education and Training
+      Education and training
     </a>,
     <Link to={root} key="main">
       GI Bill® Comparison Tool
@@ -36,7 +36,7 @@ export default function GiBillBreadcrumbs({
         to={{ pathname: 'search', query: searchQuery }}
         key="search-results"
       >
-        Search Results
+        Search results
       </Link>,
     );
   }
@@ -44,7 +44,7 @@ export default function GiBillBreadcrumbs({
   if (onProfilePage) {
     crumbs.push(
       <Link to={`profile/${facilityCode}`} key="result-detail">
-        School Details
+        School details
       </Link>,
     );
   }

--- a/src/applications/gi/components/search/EligibilityForm.jsx
+++ b/src/applications/gi/components/search/EligibilityForm.jsx
@@ -42,7 +42,7 @@ export class EligibilityForm extends React.Component {
       <div className="eligibility-form">
         <h2>Your eligibility</h2>
         <Dropdown
-          label="What is your military status?"
+          label="What's your military status?"
           name="militaryStatus"
           options={[
             { value: 'veteran', label: 'Veteran' },
@@ -55,7 +55,7 @@ export class EligibilityForm extends React.Component {
             { value: 'child', label: 'Child' },
           ]}
           value={this.props.militaryStatus}
-          alt="What is your military status?"
+          alt="What's your military status?"
           visible
           onChange={this.props.eligibilityChange}
         />
@@ -134,14 +134,14 @@ export class EligibilityForm extends React.Component {
         )}
         <Dropdown
           label={this.renderLearnMoreLabel({
-            text: 'Cumulative Post-9/11 active duty service',
+            text: 'Cumulative Post-9/11 active-duty service',
             modal: 'cumulativeService',
             ariaLabel: ariaLabels.learnMore.post911Chapter33,
           })}
           name="cumulativeService"
           options={this.cumulativeServiceOptions()}
           value={this.props.cumulativeService}
-          alt="Cumulative Post-9/11 active duty service"
+          alt="Cumulative Post-9/11 active-duty service"
           visible={this.props.giBillChapter === '33'}
           onChange={this.props.eligibilityChange}
         />

--- a/src/applications/gi/components/vet-tec/VetTecAdditionalResources.jsx
+++ b/src/applications/gi/components/vet-tec/VetTecAdditionalResources.jsx
@@ -70,7 +70,7 @@ const VetTecAdditionalResources = () => (
       {renderVetTecLogo(classNames('vettec-logo'))}
     </div>
     <h2 className="highlight vettec-additional-resources-header vads-u-font-size--h4">
-      Additional Resources
+      Additional resources
     </h2>
     <VetTecAdditionalResourcesLinks />
   </div>


### PR DESCRIPTION
## Description

#### 19916: 
As a developer, I need to update the Comparison Tool Landing Page Content so that it meets DSVA standards.

https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/vets.gov-team/19916

#### 19917: 
As a developer, I need to update the breadcrumbs in the Comparison Tool so that they match DSVA styling patterns.

https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/vets.gov-team/19917

## Testing done
Manual, Unit, and E2E Tests pass locally

## Screenshots

#### 19916: 
![Screen Shot 2019-11-12 at 10 39 13 AM](https://user-images.githubusercontent.com/48804834/68687961-fe8bb700-053b-11ea-8a94-e4668aa114e1.png)

#### 19917:
![Screen Shot 2019-11-12 at 10 36 47 AM](https://user-images.githubusercontent.com/48804834/68687847-d0a67280-053b-11ea-94de-55022182ab8a.png)
![Screen Shot 2019-11-12 at 10 36 26 AM](https://user-images.githubusercontent.com/48804834/68687921-eb78e700-053b-11ea-83dc-7b2007cbcfbb.png)


## Acceptance criteria
#### 19916: 
- [x] The question text "What is your military status?" is replaced with: "What's your military status?"
- [x] The question text "Cumulative Post-9/11 active duty service" is replaced with: "Cumulative Post-9/11 active-duty service"

#### 19917:
- [x] "Education and Training" in the Comparison Tool Breadcrumb is replaced with "Education and training" on the following pages:
  - Landing page
  - Search Results
  - VET TEC Search Results
  - School Details
  - VET TEC Provider Details

- [x] "Search Results" in the Comparison Tool Breadcrumb is replaced with "Search Results" on the following pages:
  - Search Results
  - VET TEC Search Results
  - School Details
  - VET TEC Provider Details

- [x] "School Details" in the Comparison Tool Breadcrumb is replaced with "School details" on the following pages:
  - School Details
  - VET TEC Provider Details


- [x] "Additional Resources" in the Comparison Tool is replaced with "Additional resources" no the following pages:
  - VET TEC Provider Details
  - School Details 


## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
