### PR TITLE
Lazy load mock data, fix cancel flow

### DIFF
--- a/src/applications/vaos/actions/appointments.js
+++ b/src/applications/vaos/actions/appointments.js
@@ -101,7 +101,7 @@ export function cancelAppointment(appointment) {
   };
 }
 
-const BOOKED_REQUEST = 'Booked';
+const SUBMITTED_REQUEST = 'Submitted';
 const CANCELLED_REQUEST = 'Cancelled';
 export function confirmCancelAppointment() {
   return async (dispatch, getState) => {
@@ -112,7 +112,7 @@ export function confirmCancelAppointment() {
 
       const appointment = getState().appointments.appointmentToCancel;
 
-      if (appointment.status === BOOKED_REQUEST) {
+      if (appointment.status === SUBMITTED_REQUEST) {
         await updateRequest({
           ...appointment,
           status: CANCELLED_REQUEST,

--- a/src/applications/vaos/api/index.js
+++ b/src/applications/vaos/api/index.js
@@ -2,18 +2,6 @@ import moment from 'moment';
 import { apiRequest } from 'platform/utilities/api';
 import environment from 'platform/utilities/environment';
 
-// Mock Data
-import slots from './slots.json';
-
-import mockFacilityData from './facilities.json';
-import mockFacility983Data from './facilities_983.json';
-import mockFacility984Data from './facilities_984.json';
-
-import mockClinicList from './clinicList983.json';
-import mockPACT from './pact.json';
-import mockCancelReasons from './cancel_reasons.json';
-import sitesSupportingVAR from './sites-supporting-var.json';
-
 // This wil go away once we stop mocking api calls
 const TEST_TIMEOUT = navigator.userAgent === 'node.js' ? 1 : null;
 function getStagingId(facilityId) {
@@ -134,7 +122,9 @@ export const getSystemIdentifiers = (() => {
 export function getSystemDetails(systemIds) {
   return new Promise(resolve => {
     setTimeout(() => {
-      resolve(mockFacilityData);
+      import('./facilities.json').then(module =>
+        resolve(module.default ? module.default : module),
+      );
     }, TEST_TIMEOUT || 1000);
   });
 }
@@ -145,9 +135,13 @@ export function getFacilitiesBySystemAndTypeOfCare(systemId, typeOfCareId) {
   return new Promise(resolve => {
     setTimeout(() => {
       if (systemId === '984') {
-        resolve(mockFacility984Data);
+        import('./facilities_984.json').then(module =>
+          resolve(module.default ? module.default : module),
+        );
       } else {
-        resolve(mockFacility983Data);
+        import('./facilities_983.json').then(module =>
+          resolve(module.default ? module.default : module),
+        );
       }
     }, TEST_TIMEOUT || 1000);
   });
@@ -206,7 +200,9 @@ export function getClinics(facilityId, typeOfCareId) {
   return new Promise(resolve => {
     setTimeout(() => {
       if (facilityId.includes('983')) {
-        resolve(mockClinicList);
+        import('./clinicList983.json').then(module =>
+          resolve(module.default ? module.default : module),
+        );
       } else {
         resolve([]);
       }
@@ -220,7 +216,9 @@ export function getPacTeam(systemId) {
   return new Promise(resolve => {
     setTimeout(() => {
       if (systemId === '983') {
-        resolve(mockPACT);
+        import('./pact.json').then(module =>
+          resolve(module.default ? module.default : module),
+        );
       } else {
         resolve([]);
       }
@@ -258,7 +256,9 @@ export function getFacilityInfo(facilityId) {
 export function getSitesSupportingVAR() {
   return new Promise(resolve => {
     setTimeout(() => {
-      resolve(sitesSupportingVAR);
+      import('./sites-supporting-var.json').then(module =>
+        resolve(module.default ? module.default : module),
+      );
     }, TEST_TIMEOUT || 1500);
   });
 }
@@ -266,7 +266,9 @@ export function getSitesSupportingVAR() {
 export function getAvailableSlots() {
   return new Promise(resolve => {
     setTimeout(() => {
-      resolve(slots);
+      import('./slots.json').then(module =>
+        resolve(module.default ? module.default : module),
+      );
     }, 500);
   });
 }
@@ -276,7 +278,9 @@ export function getAvailableSlots() {
 export function getCancelReasons(systemId) {
   return new Promise(resolve => {
     setTimeout(() => {
-      resolve(mockCancelReasons.cancelReasonsList);
+      import('./cancel_reasons.json').then(module =>
+        resolve((module.default ? module.default : module).cancelReasonsList),
+      );
     }, 500);
   });
 }

--- a/src/applications/vaos/components/CancelAppointmentModal.jsx
+++ b/src/applications/vaos/components/CancelAppointmentModal.jsx
@@ -69,6 +69,43 @@ export default class CancelAppointmentModal extends React.Component {
       );
     }
 
+    if (
+      !!appointmentToCancel.appointmentRequestId &&
+      cancelAppointmentStatus === FETCH_STATUS.failed
+    ) {
+      return (
+        <Modal
+          id="cancelAppt"
+          status="error"
+          visible
+          onClose={onClose}
+          title="We could not cancel this appointment"
+        >
+          Something went wrong when we tried to cancel your request.
+          <h4>What you can do</h4>
+          It may have just been a blip and you can try again.
+          <p>
+            <button onClick={onConfirm} className="va-button-link">
+              Try to cancel again
+            </button>
+          </p>
+          <p>
+            But you should probably{' '}
+            <a
+              target="_blank"
+              rel="noopener noreferrer"
+              href={`/find-locations/facility/vha_${getStagingId(
+                appointmentToCancel.facility?.facilityCode,
+              )}`}
+            >
+              contact the facility by phone
+            </a>
+            .
+          </p>
+        </Modal>
+      );
+    }
+
     if (cancelAppointmentStatus === FETCH_STATUS.failed) {
       return (
         <Modal

--- a/src/applications/vaos/reducers/appointments.js
+++ b/src/applications/vaos/reducers/appointments.js
@@ -22,16 +22,14 @@ import { FETCH_STATUS } from '../utils/constants';
 const initialState = {
   future: null,
   futureStatus: FETCH_STATUS.notStarted,
-  confirmed: null,
-  confirmedStatus: FETCH_STATUS.notStarted,
-  pending: null,
-  pendingStatus: FETCH_STATUS.notStarted,
   past: null,
   pastStatus: FETCH_STATUS.notStarted,
   showCancelModal: false,
   cancelAppointmentStatus: FETCH_STATUS.notStarted,
   appointmentToCancel: null,
 };
+
+const BOOKED_REQUEST = 'Booked';
 
 export default function appointmentsReducer(state = initialState, action) {
   switch (action.type) {
@@ -47,7 +45,11 @@ export default function appointmentsReducer(state = initialState, action) {
         ...ccAppointments.filter(appt =>
           filterFutureConfirmedAppointments(appt, action.today),
         ),
-        ...requests.filter(req => filterFutureRequests(req, action.today)),
+        ...requests.filter(
+          req =>
+            req.status !== BOOKED_REQUEST &&
+            filterFutureRequests(req, action.today),
+        ),
       ];
 
       futureAppointments.sort(sortFutureList);
@@ -95,13 +97,13 @@ export default function appointmentsReducer(state = initialState, action) {
         cancelAppointmentStatus: FETCH_STATUS.loading,
       };
     case CANCEL_APPOINTMENT_CONFIRMED_SUCCEEDED: {
-      const confirmed = state.confirmed.filter(
+      const future = state.future.filter(
         appt => appt !== state.appointmentToCancel,
       );
       return {
         ...state,
         showCancelModal: true,
-        confirmed,
+        future,
         cancelAppointmentStatus: FETCH_STATUS.succeeded,
       };
     }

--- a/src/applications/vaos/tests/actions/appointments.unit.spec.js
+++ b/src/applications/vaos/tests/actions/appointments.unit.spec.js
@@ -119,7 +119,7 @@ describe('VAOS actions: appointments', () => {
       const state = {
         appointments: {
           appointmentToCancel: {
-            status: 'Booked',
+            status: 'Submitted',
           },
         },
       };

--- a/src/applications/vaos/tests/reducers/appointments.unit.spec.js
+++ b/src/applications/vaos/tests/reducers/appointments.unit.spec.js
@@ -127,14 +127,14 @@ describe('VAOS reducer: appointments', () => {
       const appt = {};
       const state = {
         ...initialState,
-        confirmed: [appt],
+        future: [appt],
         appointmentToCancel: appt,
       };
       const newState = appointmentsReducer(state, action);
 
       expect(newState.showCancelModal).to.be.true;
       expect(newState.cancelAppointmentStatus).to.equal(FETCH_STATUS.succeeded);
-      expect(newState.confirmed.length).to.equal(0);
+      expect(newState.future.length).to.equal(0);
     });
 
     it('should set status to failed', () => {


### PR DESCRIPTION
## Description
This moves our mock data into separate chunks, so that we don't bloat the main bundle. It also fixes some filtering and cancellation issues.

## Testing done
Local and unit testing

## Acceptance criteria
- [ ] App works the same, but you can cancel without errors
- [ ] We don't show Booked requests

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
