### PR TITLE
Build VAOS page in production

### DIFF
--- a/src/applications/vaos/manifest.json
+++ b/src/applications/vaos/manifest.json
@@ -3,9 +3,9 @@
   "entryFile": "./vaos-entry",
   "entryName": "vaos",
   "rootUrl": "/health-care/schedule-view-va-appointments/appointments",
-  "production": false,
+  "production": true,
   "template": {
-    "vagovprod": false,
+    "vagovprod": true,
     "layout": "page-react.html"
   }
 }


### PR DESCRIPTION
## Description
This allows the VAOS app and page to be enabled in production. The app itself is behind a feature flag, so this does not release the app to anyone.

## Acceptance criteria
- [ ] App builds in prod

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
