### PR TITLE
19959: CT 116: [Chrome & Safari] Link goes to next line when URL is too long

### DIFF
--- a/src/applications/gi/components/vet-tec/VetTecHeadingSummary.jsx
+++ b/src/applications/gi/components/vet-tec/VetTecHeadingSummary.jsx
@@ -10,11 +10,16 @@ import { ariaLabels } from '../../constants';
 const IconWithInfo = ({ icon, iconClassName, children, present }) => {
   if (!present) return null;
   return (
-    <p className="icon-with-info">
-      <i className={`fa fa-${icon} ${iconClassName}`} />
-      &nbsp;
-      {children}
-    </p>
+    <div className="icon-with-info vads-l-grid-container vads-u-padding-x--0">
+      <div className="vads-l-row vads-u-padding-x--0 vads-u-padding-bottom--1p5">
+        <div className="vads-l-col--1">
+          <i className={`fa fa-${icon} ${iconClassName}`} />
+        </div>
+        <div className="text-column vads-l-col--11 vads-u-padding-left--1">
+          {children}
+        </div>
+      </div>
+    </div>
   );
 };
 

--- a/src/applications/gi/sass/partials/_gi-profile-page.scss
+++ b/src/applications/gi/sass/partials/_gi-profile-page.scss
@@ -38,7 +38,9 @@
   }
 
   .icon-with-info {
-    margin-top: 0;
+    .text-column {
+      overflow-wrap: break-word;
+    }
   }
 
   button.usa-accordion-button {


### PR DESCRIPTION
## Description
https://www.galvanize.com/campuses/los-angeles drops below icon since the link is too long.

https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/vets.gov-team/19959

## Testing done
Manual, unit, and E2E testing passes locally. Local approval by BAH UX team.

## Screenshots
<img width="1207" alt="Screen Shot 2019-11-13 at 11 03 42 AM" src="https://user-images.githubusercontent.com/48804834/68782220-06645d80-0607-11ea-8927-fb6782932a4a.png">


## Acceptance criteria
- [x] Issue is resolved

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
