### PR TITLE
Disable form 526 forwarding address

### DIFF
--- a/src/applications/disability-benefits/all-claims/pages/contactInformation.js
+++ b/src/applications/disability-benefits/all-claims/pages/contactInformation.js
@@ -1,8 +1,8 @@
 // import _ from '../../../../platform/utilities/data';
-import merge from 'lodash/merge';
+// import merge from 'lodash/merge';
 import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json';
 // import dateUI from 'platform/forms-system/src/js/definitions/date';
-import dateRangeUI from 'platform/forms-system/src/js/definitions/dateRange';
+// import dateRangeUI from 'platform/forms-system/src/js/definitions/dateRange';
 import PhoneNumberWidget from 'platform/forms-system/src/js/widgets/PhoneNumberWidget';
 import PhoneNumberReviewWidget from 'platform/forms-system/src/js/review/PhoneNumberWidget';
 
@@ -11,16 +11,16 @@ import ReviewCardField from '../components/ReviewCardField';
 import {
   contactInfoDescription,
   contactInfoUpdateHelp,
-  forwardingAddressDescription,
-  ForwardingAddressViewField,
+  // forwardingAddressDescription,
+  // ForwardingAddressViewField,
   phoneEmailViewField,
 } from '../content/contactInformation';
 
-import { isInFuture } from '../validations';
+// import { isInFuture } from '../validations';
 
 import {
-  hasForwardingAddress,
-  forwardingCountryIsUSA,
+  // hasForwardingAddress,
+  // forwardingCountryIsUSA,
   addressUISchema,
 } from '../utils';
 
@@ -28,7 +28,7 @@ import { ADDRESS_PATHS } from '../constants';
 
 const {
   mailingAddress,
-  forwardingAddress,
+  // forwardingAddress,
   phoneAndEmail,
 } = fullSchema.properties;
 
@@ -64,60 +64,60 @@ export const uiSchema = {
     'Mailing address',
     true,
   ),
-  'view:hasForwardingAddress': {
-    'ui:title': 'My address will be changing soon.',
-  },
-  forwardingAddress: merge(
-    addressUISchema(ADDRESS_PATHS.forwardingAddress, 'Forwarding address'),
-    {
-      'ui:field': ReviewCardField,
-      'ui:subtitle': forwardingAddressDescription,
-      'ui:order': [
-        'effectiveDate',
-        'country',
-        'addressLine1',
-        'addressLine2',
-        'addressLine3',
-        'city',
-        'state',
-        'zipCode',
-      ],
-      'ui:options': {
-        viewComponent: ForwardingAddressViewField,
-        expandUnder: 'view:hasForwardingAddress',
-      },
-      effectiveDate: merge(
-        dateRangeUI(
-          'Start date',
-          'End date (optional)',
-          'End date must be after start date',
-        ),
-        {
-          from: {
-            'ui:required': hasForwardingAddress,
-            'ui:validations': [isInFuture],
-          },
-        },
-      ),
-      country: {
-        'ui:required': hasForwardingAddress,
-      },
-      addressLine1: {
-        'ui:required': hasForwardingAddress,
-      },
-      city: {
-        'ui:required': hasForwardingAddress,
-      },
-      state: {
-        'ui:required': formData =>
-          hasForwardingAddress(formData) && forwardingCountryIsUSA(formData),
-      },
-      zipCode: {
-        'ui:required': formData =>
-          hasForwardingAddress(formData) && forwardingCountryIsUSA(formData),
-      },
-    },
-  ),
+  // 'view:hasForwardingAddress': {
+  //   'ui:title': 'My address will be changing soon.',
+  // },
+  // forwardingAddress: merge(
+  //   addressUISchema(ADDRESS_PATHS.forwardingAddress, 'Forwarding address'),
+  //   {
+  //     'ui:field': ReviewCardField,
+  //     'ui:subtitle': forwardingAddressDescription,
+  //     'ui:order': [
+  //       'effectiveDate',
+  //       'country',
+  //       'addressLine1',
+  //       'addressLine2',
+  //       'addressLine3',
+  //       'city',
+  //       'state',
+  //       'zipCode',
+  //     ],
+  //     'ui:options': {
+  //       viewComponent: ForwardingAddressViewField,
+  //       expandUnder: 'view:hasForwardingAddress',
+  //     },
+  //     effectiveDate: merge(
+  //       dateRangeUI(
+  //         'Start date',
+  //         'End date (optional)',
+  //         'End date must be after start date',
+  //       ),
+  //       {
+  //         from: {
+  //           'ui:required': hasForwardingAddress,
+  //           'ui:validations': [isInFuture],
+  //         },
+  //       },
+  //     ),
+  //     country: {
+  //       'ui:required': hasForwardingAddress,
+  //     },
+  //     addressLine1: {
+  //       'ui:required': hasForwardingAddress,
+  //     },
+  //     city: {
+  //       'ui:required': hasForwardingAddress,
+  //     },
+  //     state: {
+  //       'ui:required': formData =>
+  //         hasForwardingAddress(formData) && forwardingCountryIsUSA(formData),
+  //     },
+  //     zipCode: {
+  //       'ui:required': formData =>
+  //         hasForwardingAddress(formData) && forwardingCountryIsUSA(formData),
+  //     },
+  //   },
+  // ),
   'view:contactInfoDescription': {
     'ui:description': contactInfoUpdateHelp,
   },
@@ -128,10 +128,10 @@ export const schema = {
   properties: {
     phoneAndEmail,
     mailingAddress,
-    'view:hasForwardingAddress': {
-      type: 'boolean',
-    },
-    forwardingAddress,
+    // 'view:hasForwardingAddress': {
+    //   type: 'boolean',
+    // },
+    // forwardingAddress,
     'view:contactInfoDescription': {
       type: 'object',
       properties: {},

--- a/src/applications/disability-benefits/all-claims/tests/pages/contactInformation.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/contactInformation.unit.spec.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { mount } from 'enzyme';
-import moment from 'moment';
+// import moment from 'moment';
 
 import {
   DefinitionTester, // selectCheckbox
@@ -13,9 +13,9 @@ import {
   MILITARY_STATE_VALUES,
 } from '../../../all-claims/constants';
 
-const NEXT_YEAR = moment()
-  .add(1, 'year')
-  .format('YYYY-MM-DD');
+// const NEXT_YEAR = moment()
+//   .add(1, 'year')
+//   .format('YYYY-MM-DD');
 
 describe('Disability benefits 526EZ contact information', () => {
   const {
@@ -40,7 +40,7 @@ describe('Disability benefits 526EZ contact information', () => {
     // country
     expect(form.find('select').length).to.equal(1);
     // street 1, 2, 3, city, phone, email, fwding address checkbox
-    expect(form.find('input').length).to.equal(7);
+    expect(form.find('input').length).to.equal(6);
     form.unmount();
   });
 
@@ -63,7 +63,7 @@ describe('Disability benefits 526EZ contact information', () => {
     // country, state
     expect(form.find('select').length).to.equal(2);
     // street 1, 2, 3, city, zip, phone, email, fwding address checkbox
-    expect(form.find('input').length).to.equal(8);
+    expect(form.find('input').length).to.equal(7);
     form.unmount();
   });
 
@@ -86,7 +86,7 @@ describe('Disability benefits 526EZ contact information', () => {
     // country
     expect(form.find('select').length).to.equal(1);
     // street 1, 2, 3, city, phone, email, fwding address checkbox
-    expect(form.find('input').length).to.equal(7);
+    expect(form.find('input').length).to.equal(6);
     form.unmount();
   });
 
@@ -204,203 +204,203 @@ describe('Disability benefits 526EZ contact information', () => {
     form.unmount();
   });
 
-  it('expands forwarding address fields when forwarding address checked', () => {
-    const form = mount(
-      <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
-        schema={schema}
-        data={{
-          'view:hasForwardingAddress': true,
-          mailingAddress: {
-            country: '',
-            addressLine1: '',
-          },
-          forwardingAddress: {
-            country: '',
-            addressLine1: '',
-          },
-          phoneAndEmail: {},
-        }}
-        formData={{}}
-        uiSchema={uiSchema}
-      />,
-    );
+  // it('expands forwarding address fields when forwarding address checked', () => {
+  //   const form = mount(
+  //     <DefinitionTester
+  //       definitions={formConfig.defaultDefinitions}
+  //       schema={schema}
+  //       data={{
+  //         'view:hasForwardingAddress': true,
+  //         mailingAddress: {
+  //           country: '',
+  //           addressLine1: '',
+  //         },
+  //         forwardingAddress: {
+  //           country: '',
+  //           addressLine1: '',
+  //         },
+  //         phoneAndEmail: {},
+  //       }}
+  //       formData={{}}
+  //       uiSchema={uiSchema}
+  //     />,
+  //   );
 
-    // (2 x country), 2x date month, 2x date day, country
-    expect(form.find('select').length).to.equal(6);
-    // (2 x (street 1, 2, 3, city)), phone, email, fwding address checkbox, 2x date year
-    expect(form.find('input').length).to.equal(13);
-    form.unmount();
-  });
+  //   // (2 x country), 2x date month, 2x date day, country
+  //   expect(form.find('select').length).to.equal(6);
+  //   // (2 x (street 1, 2, 3, city)), phone, email, fwding address checkbox, 2x date year
+  //   expect(form.find('input').length).to.equal(13);
+  //   form.unmount();
+  // });
 
-  it('validates that forwarding state is military type if forwarding city is military type', () => {
-    const onSubmit = sinon.spy();
-    const form = mount(
-      <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
-        schema={schema}
-        data={{
-          phoneAndEmail: {
-            primaryPhone: '1231231231',
-            emailAddress: 'a@b.co',
-          },
-          mailingAddress: {
-            country: 'USA',
-            addressLine1: '123 Any Street',
-            city: 'Anytown',
-            state: 'MI',
-            zipCode: '12345',
-          },
-          'view:hasForwardingAddress': true,
-          forwardingAddress: {
-            effectiveDate: {
-              from: NEXT_YEAR,
-            },
-            country: 'USA',
-            addressLine1: '123 Any Street',
-            city: 'APO',
-            state: 'TX',
-            zipCode: '12345',
-          },
-        }}
-        formData={{}}
-        uiSchema={uiSchema}
-        onSubmit={onSubmit}
-      />,
-    );
+  // it('validates that forwarding state is military type if forwarding city is military type', () => {
+  //   const onSubmit = sinon.spy();
+  //   const form = mount(
+  //     <DefinitionTester
+  //       definitions={formConfig.defaultDefinitions}
+  //       schema={schema}
+  //       data={{
+  //         phoneAndEmail: {
+  //           primaryPhone: '1231231231',
+  //           emailAddress: 'a@b.co',
+  //         },
+  //         mailingAddress: {
+  //           country: 'USA',
+  //           addressLine1: '123 Any Street',
+  //           city: 'Anytown',
+  //           state: 'MI',
+  //           zipCode: '12345',
+  //         },
+  //         'view:hasForwardingAddress': true,
+  //         forwardingAddress: {
+  //           effectiveDate: {
+  //             from: NEXT_YEAR,
+  //           },
+  //           country: 'USA',
+  //           addressLine1: '123 Any Street',
+  //           city: 'APO',
+  //           state: 'TX',
+  //           zipCode: '12345',
+  //         },
+  //       }}
+  //       formData={{}}
+  //       uiSchema={uiSchema}
+  //       onSubmit={onSubmit}
+  //     />,
+  //   );
 
-    form.find('form').simulate('submit');
-    expect(form.find('.usa-input-error-message').length).to.equal(1);
-    expect(onSubmit.called).to.be.false;
-    form.unmount();
-  });
+  //   form.find('form').simulate('submit');
+  //   expect(form.find('.usa-input-error-message').length).to.equal(1);
+  //   expect(onSubmit.called).to.be.false;
+  //   form.unmount();
+  // });
 
-  it('validates that forwarding city is military type if forwarding state is military type', () => {
-    const onSubmit = sinon.spy();
-    const form = mount(
-      <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
-        schema={schema}
-        data={{
-          phoneAndEmail: {
-            primaryPhone: '1231231231',
-            emailAddress: 'a@b.co',
-          },
-          mailingAddress: {
-            country: 'USA',
-            addressLine1: '123 Any Street',
-            city: 'Anytown',
-            state: 'MI',
-            zipCode: '12345',
-          },
-          'view:hasForwardingAddress': true,
-          forwardingAddress: {
-            effectiveDate: {
-              from: NEXT_YEAR,
-            },
-            country: 'USA',
-            addressLine1: '123 Any Street',
-            city: 'Anytown',
-            state: 'AA',
-            zipCode: '12345',
-          },
-        }}
-        formData={{}}
-        uiSchema={uiSchema}
-        onSubmit={onSubmit}
-      />,
-    );
+  // it('validates that forwarding city is military type if forwarding state is military type', () => {
+  //   const onSubmit = sinon.spy();
+  //   const form = mount(
+  //     <DefinitionTester
+  //       definitions={formConfig.defaultDefinitions}
+  //       schema={schema}
+  //       data={{
+  //         phoneAndEmail: {
+  //           primaryPhone: '1231231231',
+  //           emailAddress: 'a@b.co',
+  //         },
+  //         mailingAddress: {
+  //           country: 'USA',
+  //           addressLine1: '123 Any Street',
+  //           city: 'Anytown',
+  //           state: 'MI',
+  //           zipCode: '12345',
+  //         },
+  //         'view:hasForwardingAddress': true,
+  //         forwardingAddress: {
+  //           effectiveDate: {
+  //             from: NEXT_YEAR,
+  //           },
+  //           country: 'USA',
+  //           addressLine1: '123 Any Street',
+  //           city: 'Anytown',
+  //           state: 'AA',
+  //           zipCode: '12345',
+  //         },
+  //       }}
+  //       formData={{}}
+  //       uiSchema={uiSchema}
+  //       onSubmit={onSubmit}
+  //     />,
+  //   );
 
-    form.find('form').simulate('submit');
-    expect(form.find('.usa-input-error-message').length).to.equal(1);
-    expect(onSubmit.called).to.be.false;
-    form.unmount();
-  });
+  //   form.find('form').simulate('submit');
+  //   expect(form.find('.usa-input-error-message').length).to.equal(1);
+  //   expect(onSubmit.called).to.be.false;
+  //   form.unmount();
+  // });
 
-  it('validates that effective date is in the future', () => {
-    const onSubmit = sinon.spy();
-    const form = mount(
-      <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
-        schema={schema}
-        data={{
-          phoneAndEmail: {
-            primaryPhone: '1231231231',
-            emailAddress: 'a@b.co',
-          },
-          mailingAddress: {
-            country: 'USA',
-            addressLine1: '123 Any Street',
-            city: 'Anytown',
-            state: 'MI',
-            zipCode: '12345',
-          },
-          'view:hasForwardingAddress': true,
-          forwardingAddress: {
-            effectiveDate: {
-              from: '2018-10-12',
-            },
-            country: 'USA',
-            addressLine1: '123 Any Street',
-            city: 'Detroit',
-            state: 'MI',
-            zipCode: '12345',
-          },
-        }}
-        formData={{}}
-        uiSchema={uiSchema}
-        onSubmit={onSubmit}
-      />,
-    );
+  // it('validates that effective date is in the future', () => {
+  //   const onSubmit = sinon.spy();
+  //   const form = mount(
+  //     <DefinitionTester
+  //       definitions={formConfig.defaultDefinitions}
+  //       schema={schema}
+  //       data={{
+  //         phoneAndEmail: {
+  //           primaryPhone: '1231231231',
+  //           emailAddress: 'a@b.co',
+  //         },
+  //         mailingAddress: {
+  //           country: 'USA',
+  //           addressLine1: '123 Any Street',
+  //           city: 'Anytown',
+  //           state: 'MI',
+  //           zipCode: '12345',
+  //         },
+  //         'view:hasForwardingAddress': true,
+  //         forwardingAddress: {
+  //           effectiveDate: {
+  //             from: '2018-10-12',
+  //           },
+  //           country: 'USA',
+  //           addressLine1: '123 Any Street',
+  //           city: 'Detroit',
+  //           state: 'MI',
+  //           zipCode: '12345',
+  //         },
+  //       }}
+  //       formData={{}}
+  //       uiSchema={uiSchema}
+  //       onSubmit={onSubmit}
+  //     />,
+  //   );
 
-    form.find('form').simulate('submit');
-    expect(form.find('.usa-input-error-message').length).to.equal(1);
-    expect(onSubmit.called).to.be.false;
-    form.unmount();
-  });
+  //   form.find('form').simulate('submit');
+  //   expect(form.find('.usa-input-error-message').length).to.equal(1);
+  //   expect(onSubmit.called).to.be.false;
+  //   form.unmount();
+  // });
 
-  it('validates that effective end date is after start date', () => {
-    const onSubmit = sinon.spy();
-    const form = mount(
-      <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
-        schema={schema}
-        data={{
-          phoneAndEmail: {
-            primaryPhone: '1231231231',
-            emailAddress: 'a@b.co',
-          },
-          mailingAddress: {
-            country: 'USA',
-            addressLine1: '123 Any Street',
-            city: 'Anytown',
-            state: 'MI',
-            zipCode: '12345',
-          },
-          'view:hasForwardingAddress': true,
-          forwardingAddress: {
-            effectiveDate: {
-              from: '2099-10-12',
-              to: '2099-10-12',
-            },
-            country: 'USA',
-            addressLine1: '123 Any Street',
-            city: 'Detroit',
-            state: 'MI',
-            zipCode: '12345',
-          },
-        }}
-        formData={{}}
-        uiSchema={uiSchema}
-        onSubmit={onSubmit}
-      />,
-    );
+  // it('validates that effective end date is after start date', () => {
+  //   const onSubmit = sinon.spy();
+  //   const form = mount(
+  //     <DefinitionTester
+  //       definitions={formConfig.defaultDefinitions}
+  //       schema={schema}
+  //       data={{
+  //         phoneAndEmail: {
+  //           primaryPhone: '1231231231',
+  //           emailAddress: 'a@b.co',
+  //         },
+  //         mailingAddress: {
+  //           country: 'USA',
+  //           addressLine1: '123 Any Street',
+  //           city: 'Anytown',
+  //           state: 'MI',
+  //           zipCode: '12345',
+  //         },
+  //         'view:hasForwardingAddress': true,
+  //         forwardingAddress: {
+  //           effectiveDate: {
+  //             from: '2099-10-12',
+  //             to: '2099-10-12',
+  //           },
+  //           country: 'USA',
+  //           addressLine1: '123 Any Street',
+  //           city: 'Detroit',
+  //           state: 'MI',
+  //           zipCode: '12345',
+  //         },
+  //       }}
+  //       formData={{}}
+  //       uiSchema={uiSchema}
+  //       onSubmit={onSubmit}
+  //     />,
+  //   );
 
-    form.find('form').simulate('submit');
-    expect(form.find('.usa-input-error-message').length).to.equal(1);
-    expect(onSubmit.called).to.be.false;
-    form.unmount();
-  });
+  //   form.find('form').simulate('submit');
+  //   expect(form.find('.usa-input-error-message').length).to.equal(1);
+  //   expect(onSubmit.called).to.be.false;
+  //   form.unmount();
+  // });
 
   it('does not submit without required info', () => {
     const onSubmit = sinon.spy();
@@ -418,15 +418,15 @@ describe('Disability benefits 526EZ contact information', () => {
             addressLine1: '',
             city: '',
           },
-          'view:hasForwardingAddress': true,
-          forwardingAddress: {
-            effectiveDate: {
-              from: '',
-            },
-            country: '',
-            addressLine1: '',
-            city: '',
-          },
+          // 'view:hasForwardingAddress': true,
+          // forwardingAddress: {
+          //   effectiveDate: {
+          //     from: '',
+          //   },
+          //   country: '',
+          //   addressLine1: '',
+          //   city: '',
+          // },
         }}
         formData={{}}
         onSubmit={onSubmit}
@@ -435,7 +435,7 @@ describe('Disability benefits 526EZ contact information', () => {
     );
 
     form.find('form').simulate('submit');
-    expect(form.find('.usa-input-error-message').length).to.equal(9);
+    expect(form.find('.usa-input-error-message').length).to.equal(5);
     expect(onSubmit.called).to.be.false;
     form.unmount();
   });
@@ -458,17 +458,17 @@ describe('Disability benefits 526EZ contact information', () => {
             state: 'MI',
             zipCode: '12345',
           },
-          'view:hasForwardingAddress': true,
-          forwardingAddress: {
-            effectiveDate: {
-              from: NEXT_YEAR,
-            },
-            country: 'USA',
-            addressLine1: '234 Maple St.',
-            city: 'Detroit',
-            state: 'MI',
-            zipCode: '234563453',
-          },
+          // 'view:hasForwardingAddress': true,
+          // forwardingAddress: {
+          //   effectiveDate: {
+          //     from: NEXT_YEAR,
+          //   },
+          //   country: 'USA',
+          //   addressLine1: '234 Maple St.',
+          //   city: 'Detroit',
+          //   state: 'MI',
+          //   zipCode: '234563453',
+          // },
         }}
         formData={{}}
         onSubmit={onSubmit}


### PR DESCRIPTION
## Description

Disable form 526 (all-claims) forwarding address temporarily:

- Form elements commented out in schema & uiSchema
- Related tests commented out
- See [issue 3283](https://github.com/department-of-veterans-affairs/va.gov-team/issues/3283) as to why.

The following code was _not modified_:

- Main schema (on `vets-json-schema`)
- End-to-end tests; none found pertaining to the forwarding address?
- Associated utility functions

## Testing done

Local unit tests

## Screenshots

<details>
<summary>Forwarding address block removed</summary>

<!-- leave a blank line above -->
![Screen Shot 2019-11-13 at 11 23 17 AM](https://user-images.githubusercontent.com/136959/68791996-1cc2e700-0610-11ea-9670-ad4af660b7e4.png)
</details>

## Acceptance criteria
- [ ] Forwarding address is not submitted
- [ ] All unit tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
