### PR TITLE
Make the preview server query params case insensitive

### DIFF
--- a/script/preview.js
+++ b/script/preview.js
@@ -84,6 +84,23 @@ if (process.env.SENTRY_DSN) {
   app.use(Raven.requestHandler());
 }
 
+/**
+ * Make the query params case-insensitive.
+ */
+app.use((req, res, next) => {
+  // eslint-disable-next-line fp/no-proxy
+  req.query = new Proxy(req.query, {
+    get: (target, name) =>
+      target[
+        Object.keys(target).find(
+          key => key.toLowerCase() === name.toLowerCase(),
+        )
+      ],
+  });
+
+  next();
+});
+
 // eslint-disable-next-line no-unused-vars
 app.get('/error', (req, res) => {
   throw new Error('fake error');


### PR DESCRIPTION
## Problem statement
Content editors and other folks manually typing in the `nodeId` query param pretty regularly type in variations such as `nodeID` which don't work. The error it throws is confusing, and catching the problem can be tricky.

## Description
This PR uses an express middleware to replace req.query with a Proxy to case-desensitize (to coin a phrase) the query params.

## Testing done
Manually checked that it worked.

## Screenshots
### Capital `nodeID`
![capital nodeID](https://user-images.githubusercontent.com/12970166/68802287-80e6aa80-0612-11ea-840d-012e86e55515.png)
### Lowercase `nodeid`
![image](https://user-images.githubusercontent.com/12970166/68802306-87752200-0612-11ea-8de4-7f36e66991c4.png)

## Acceptance criteria
- [x] The preview server's `nodeId` query param is case insensitive
