### PR TITLE
HLR: update confirmation page

### DIFF
--- a/src/applications/disability-benefits/996/TODO.md
+++ b/src/applications/disability-benefits/996/TODO.md
@@ -38,7 +38,7 @@
 
 - [x] Build form `selectContestedIssues` in `config/form.js`
 - [ ] Get eligible issues API call?
-- [ ] Desination of "See all your issues" click?
+- [ ] Desination of "See all your issues" link?
 - [x] Add unit tests
 - [ ] Add e2e tests
 
@@ -54,16 +54,24 @@
 
 - [x] Build form `requestAnInformalConference` in `config/form.js`
 - [x] Awaiting design on "Weekday" dropdown content - remove
+- [x] Applied step 3 redesign
 - [x] Add unit tests
 - [ ] Add e2e tests
 
 ### Submit your application (Step 4)
 
-- [ ] Is there a design? This page was automaticaly added by the form builder.
+- [x] Is there a design? This page was automaticaly added by the form builder.
 - [x] Change wording to be "Review and submit your
       application", can it be changed to match the design?)
 - [x] Add privacy policy check
 - [ ] Add unit tests
+- [ ] Add e2e tests
+
+### Confirmation page
+
+- [x] Update pre-built page from design
+- [ ] Update link "after you apply" when available
+- [x] Add unit tests
 - [ ] Add e2e tests
 
 ### Swap order of intro & opt out page

--- a/src/applications/disability-benefits/996/containers/ConfirmationPage.jsx
+++ b/src/applications/disability-benefits/996/containers/ConfirmationPage.jsx
@@ -31,7 +31,7 @@ export class ConfirmationPage extends React.Component {
           Your request has been submitted
         </h3>
         <p>
-          We'll mail a letter confirming your request within{' '}
+          We’ll mail a letter confirming your request within{' '}
           <strong>5 business days</strong>.
         </p>
         <p>
@@ -72,13 +72,13 @@ export class ConfirmationPage extends React.Component {
 
         <h3>What should I do while I wait?</h3>
         <p>
-          You don't need to do anything unless VA sends you a letter asking for
+          You don’t need to do anything unless VA sends you a letter asking for
           more information. If VA schedules any exams for you, be sure not to
           miss them.
         </p>
         <p>
-          If you requested a decision review and haven't heard back from VA yet,
-          please don't request another review. Call VA at{' '}
+          If you requested a decision review and haven’t heard back from VA yet,
+          please don’t request another review. Call VA at{' '}
           <a href="tel:1-800-827-1000">800-827-1000</a>.
         </p>
         <br />

--- a/src/applications/disability-benefits/996/containers/ConfirmationPage.jsx
+++ b/src/applications/disability-benefits/996/containers/ConfirmationPage.jsx
@@ -21,26 +21,29 @@ export class ConfirmationPage extends React.Component {
   }
 
   render() {
-    const { submission, data } = this.props.form;
+    const { submission, data, formId } = this.props.form;
     const { response } = submission;
     const name = data.fullName;
 
     return (
       <div>
-        <h3 className="confirmation-page-title">Claim received</h3>
+        <h3 className="confirmation-page-title">
+          Your request has been submitted
+        </h3>
         <p>
-          We usually process claims within <strong>a week</strong>.
+          We'll mail a letter confirming your request within{' '}
+          <strong>5 business days</strong>.
         </p>
         <p>
           We may contact you for more information or documents.
           <br />
-          <i>Please print this page for your records.</i>
+          <em>Please print this page for your records.</em>
         </p>
         <div className="inset" role="presentation">
           <h4 className="vads-u-margin-top--0">
-            Higher-Level Review Claim{' '}
+            Higher-Level Review{' '}
             <span className="additional" role="presentation">
-              (Form 20-0996)
+              (Form {formId})
             </span>
           </h4>
           <span>
@@ -59,6 +62,32 @@ export class ConfirmationPage extends React.Component {
             </ul>
           )}
         </div>
+
+        <h3>After your request a decision review</h3>
+        <p>
+          When your review is complete, VA will mail you a decision packet that
+          includes details about the decision in your case. Any other questions,
+          please refer to the information <a href="#">after you apply</a>.
+        </p>
+
+        <h3>What should I do while I wait?</h3>
+        <p>
+          You don't need to do anything unless VA sends you a letter asking for
+          more information. If VA schedules any exams for you, be sure not to
+          miss them.
+        </p>
+        <p>
+          If you requested a decision review and haven't heard back from VA yet,
+          please don't request another review. Call VA at{' '}
+          <a href="tel:1-800-827-1000">800-827-1000</a>.
+        </p>
+        <br />
+        <a
+          href="/track-claims/your-claims"
+          className="usa-button usa-button-primary"
+        >
+          Track the status of your decision review
+        </a>
       </div>
     );
   }

--- a/src/applications/disability-benefits/996/sass/0996-higher-level-review.scss
+++ b/src/applications/disability-benefits/996/sass/0996-higher-level-review.scss
@@ -237,3 +237,10 @@ article[data-location="request-informal-conference"] {
     margin-top: 1em;
   }
 }
+
+/* Confirmation page */
+article[data-location="confirmation"] {
+  h1[tabindex="-1"] {
+    outline: none;
+  }
+}

--- a/src/applications/disability-benefits/996/sass/0996-higher-level-review.scss
+++ b/src/applications/disability-benefits/996/sass/0996-higher-level-review.scss
@@ -184,7 +184,7 @@ aside.process {
 article[data-location^="contested-issues/"] {
   /* Info alert icon color */
   .usa-alert-info:before {
-    color: #00a6d2;
+    color: $color-aqua-dark;
   }
 
   /* Add space above AdditionalInfo block */
@@ -209,7 +209,7 @@ article[data-location="request-informal-conference"] {
 
   /* Info alert icon color */
   .usa-alert-info:before {
-    color: #00a6d2;
+    color: $color-aqua-dark;
   }
 
   /* Remove extra spacing between form elements */

--- a/src/applications/disability-benefits/996/tests/components/ConfirmationPage.unit.spec.jsx
+++ b/src/applications/disability-benefits/996/tests/components/ConfirmationPage.unit.spec.jsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { expect } from 'chai';
+import { mount } from 'enzyme';
+import { Provider } from 'react-redux';
+
+import createCommonStore from 'platform/startup/store';
+
+import formConfig from '../../config/form';
+import initialData from '../schema/initialData';
+
+import ConfirmationPage from '../../containers/ConfirmationPage';
+import reducer from '../../reducers';
+
+const defaultStore = createCommonStore(reducer);
+
+describe('Confirmation page', () => {
+  it('should render the confirmation page', () => {
+    const tree = mount(
+      <Provider store={defaultStore}>
+        <ConfirmationPage
+          form={{
+            formId: formConfig.formId,
+            submission: {
+              response: Date.now(),
+            },
+            data: initialData,
+          }}
+        />
+      </Provider>,
+    );
+
+    const page = tree.find('ConfirmationPage');
+    expect(page.length).to.equal(1);
+
+    tree.unmount();
+  });
+});


### PR DESCRIPTION
## Description

The confirmation page, seen after the Higher-Level Review form has been submitted, has an updated design.

Design reference: https://vsateams.invisionapp.com/share/W5U21BDFTQK#/screens/393047724

## Testing done

- [x] Added confirmation page rendered unit test
- [x] All local unit test passing

## Screenshots

<details>
<summary>Confirmation page</summary>

<!-- leave a blank line above -->
![Screen Shot 2019-11-13 at 3 30 17 PM](https://user-images.githubusercontent.com/136959/68806844-50ac0580-062c-11ea-8848-d0f50da11bbf.png)
</details>

## Acceptance criteria
- [ ] Confirmation content matches design
- [ ] Unit test passing
- [ ] Meets design standards

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
