### PR TITLE
Update VAOS list page headers and add CC provider

### DIFF
--- a/src/applications/vaos/api/requests.json
+++ b/src/applications/vaos/api/requests.json
@@ -3,6 +3,137 @@
     {
       "attributes": {
         "dataIdentifier": {
+          "uniqueId": "8a4886886e4c8e22016e6613216d001f",
+          "systemId": "var"
+        },
+        "patientIdentifier": {
+          "uniqueId": "1012845331V153043",
+          "assigningAuthority": "ICN"
+        },
+        "surrogateIdentifier": {},
+        "lastUpdatedDate": "11/13/2019 11:42:40",
+        "optionDate1": "11/21/2019",
+        "optionTime1": "AM",
+        "optionDate2": "No Date Selected",
+        "optionTime2": "No Time Selected",
+        "optionDate3": "No Date Selected",
+        "optionTime3": "No Time Selected",
+        "status": "Submitted",
+        "appointmentType": "Audiology (hearing aid support)",
+        "visitType": "Office Visit",
+        "facility": {
+          "name": "CHYSHR-CHEYENNE VAMC",
+          "type": "M&ROC",
+          "facilityCode": "983",
+          "state": "WY",
+          "city": "CHEYENNE",
+          "address": "2360 EAST PERSHING BLVD",
+          "parentSiteCode": "983",
+          "objectType": "Facility",
+          "link": []
+        },
+        "email": "Vilasini.reddy@va.gov",
+        "textMessagingAllowed": false,
+        "phoneNumber": "(555) 555-5555",
+        "purposeOfVisit": "routine-follow-up",
+        "providerId": "0",
+        "secondRequest": false,
+        "secondRequestSubmitted": false,
+        "patient": {
+          "displayName": "MORRISON, JUDY",
+          "firstName": "JUDY",
+          "lastName": "MORRISON",
+          "dateOfBirth": "Apr 01, 1953",
+          "patientIdentifier": {
+            "uniqueId": "1259897978"
+          },
+          "ssn": "796061976",
+          "inpatient": false,
+          "textMessagingAllowed": false,
+          "id": "1259897978",
+          "objectType": "Patient",
+          "link": []
+        },
+        "bestTimetoCall": ["Afternoon", "Evening", "Morning"],
+        "appointmentRequestDetailCode": [],
+        "hasVeteranNewMessage": false,
+        "hasProviderNewMessage": false,
+        "providerSeenAppointmentRequest": false,
+        "requestedPhoneCall": false,
+        "typeOfCareId": "CCAUDHEAR",
+        "friendlyLocationName": "CHYSHR-Cheyenne VA Medical Center- RR",
+        "ccAppointmentRequest": {
+          "dataIdentifier": {},
+          "patientIdentifier": {},
+          "surrogateIdentifier": {},
+          "hasVeteranNewMessage": false,
+          "preferredState": "AK",
+          "preferredCity": "sadfasdf",
+          "preferredLanguage": "English",
+          "distanceWillingToTravel": 10,
+          "distanceEligible": false,
+          "officeHours": ["Weekdays"],
+          "preferredProviders": [
+            {
+              "firstName": "Test",
+              "lastName": "User",
+              "practiceName": "Some practice",
+              "address": {
+                "zipCode": "01060"
+              },
+              "preferredOrder": 0,
+              "providerZipCode": "01060",
+              "objectType": "Provider",
+              "link": []
+            }
+          ],
+          "objectType": "CCAppointmentRequest",
+          "link": []
+        },
+        "appointmentRequestId": "8a4886886e4c8e22016e6613216d001f",
+        "patientId": "1259897978",
+        "date": "2019-11-13T11:42:40.033+0000",
+        "uniqueId": "8a4886886e4c8e22016e6613216d001f",
+        "assigningAuthority": "ICN",
+        "systemId": "var",
+        "selfUri": "/var/VeteranAppointmentRequestService/v4/rest/appointment-service/patient/ICN/1012845331V153043/appointments/system/var/id/8a4886886e4c8e22016e6613216d001f",
+        "selfLink": {
+          "rel": "self",
+          "href": "/var/VeteranAppointmentRequestService/v4/rest/appointment-service/patient/ICN/1012845331V153043/appointments/system/var/id/8a4886886e4c8e22016e6613216d001f",
+          "objectType": "AtomLink"
+        },
+        "objectType": "VARAppointmentRequest",
+        "link": [
+          {
+            "rel": "self",
+            "href": "/var/VeteranAppointmentRequestService/v4/rest/appointment-service/patient/ICN/1012845331V153043/appointments/system/var/id/8a4886886e4c8e22016e6613216d001f",
+            "objectType": "AtomLink"
+          },
+          {
+            "rel": "related",
+            "title": "appointment-request-messages",
+            "href": "/var/VeteranAppointmentRequestService/v4/rest/appointment-service/patient/ICN/1012845331V153043/appointment-requests/system/var/id/8a4886886e4c8e22016e6613216d001f/messages",
+            "objectType": "AtomLink"
+          },
+          {
+            "rel": "related",
+            "title": "appointment-request-new-message-flag",
+            "href": "/var/VeteranAppointmentRequestService/v4/rest/appointment-service/patient/ICN/1012845331V153043/appointment-requests/system/var/id/8a4886886e4c8e22016e6613216d001f/messages/read",
+            "objectType": "AtomLink"
+          },
+          {
+            "rel": "related",
+            "title": "appointment-request-provider-seen-flag",
+            "href": "/var/VeteranAppointmentRequestService/v4/rest/appointment-service/patient/ICN/1012845331V153043/appointment-requests/system/var/id/8a4886886e4c8e22016e6613216d001f/appointment/provider-read",
+            "objectType": "AtomLink"
+          }
+        ],
+        "createdDate": "11/13/2019 11:42:40"
+      }
+    },
+    {
+      "attributes": {
+        "dataIdentifier": {
           "uniqueId": "8a48912a6cab0202016cd3afd3ef008a",
           "systemId": "var"
         },

--- a/src/applications/vaos/components/AppointmentRequestListItem.jsx
+++ b/src/applications/vaos/components/AppointmentRequestListItem.jsx
@@ -29,6 +29,7 @@ export default class AppointmentRequestListItem extends React.Component {
     } = this.props;
     const { showMore } = this.state;
     const canceled = appointment.status === 'Cancelled';
+    const isCommunityCare = !!appointment.ccAppointmentRequest;
 
     return (
       <li
@@ -43,10 +44,7 @@ export default class AppointmentRequestListItem extends React.Component {
               <i className="fas fa-exclamation-triangle vads-u-color--warning-message" />
             )}
             <span className="vads-u-font-weight--bold vads-u-display--inline-block">
-              <h2
-                id={`card-${index}`}
-                className="vaos-appts__status-text vads-u-font-size--base vads-u-font-family--sans"
-              >
+              <div className="vaos-appts__status-text vads-u-font-size--base vads-u-font-family--sans">
                 {canceled ? (
                   'Canceled'
                 ) : (
@@ -54,12 +52,12 @@ export default class AppointmentRequestListItem extends React.Component {
                     <span className="vads-u-font-weight--bold vads-u-display--inline-block vads-u-margin-right--0p5">
                       Pending
                     </span>
-                    <span className="vads-u-font-weight--normal">
-                      Date and time to be determined
+                    <span className="vads-u-display--none medium-screen:vads-u-display--block vads-u-font-weight--normal">
+                      - The time and date are still to be determined.
                     </span>
                   </>
                 )}
-              </h2>
+              </div>
             </span>
           </div>
 
@@ -75,18 +73,42 @@ export default class AppointmentRequestListItem extends React.Component {
             </div>
           )}
         </div>
-        <div className="vads-u-flex--1 vads-u-margin-y--1p5">
-          <span className="vads-u-font-weight--bold">
-            {titleCase(appointment.appointmentType)} appointment
-          </span>
-        </div>
+        <h2
+          id={`card-${index}`}
+          className="vads-u-font-size--h3 vads-u-margin-y--2"
+        >
+          {titleCase(appointment.appointmentType)} appointment{' '}
+          {isCommunityCare && '- Community Care'}
+        </h2>
         <div className="vads-u-flex--1 vads-u-margin-bottom--2">
-          <dl className="vads-u-margin--0">
-            <dt className="vads-u-font-weight--bold">
-              {getClinicName(appointment)}
-            </dt>
-            <dd>{getAppointmentLocation(appointment)}</dd>
-          </dl>
+          {!isCommunityCare && (
+            <dl className="vads-u-margin--0">
+              <dt className="vads-u-font-weight--bold">
+                {getClinicName(appointment)}
+              </dt>
+              <dd>{getAppointmentLocation(appointment)}</dd>
+            </dl>
+          )}
+          {isCommunityCare && (
+            <dl className="vads-u-margin--0">
+              <dt className="vads-u-font-weight--bold">Preferred providers</dt>
+              <dd>
+                <ul className="usa-unstyled-list">
+                  {appointment.ccAppointmentRequest.preferredProviders.map(
+                    provider => (
+                      <li key={`${provider.firstName} ${provider.lastName}`}>
+                        {provider.practiceName}
+                        <br />
+                        {provider.firstName} {provider.lastName}
+                      </li>
+                    ),
+                  )}
+                  {!appointment.ccAppointmentRequest?.preferredProviders?.[0] &&
+                    'Not specified'}
+                </ul>
+              </dd>
+            </dl>
+          )}
         </div>
         <hr className="vads-u-margin--0 vads-u-margin-top--1p5" />
         {showMore ? (

--- a/src/applications/vaos/components/AppointmentRequestListItem.jsx
+++ b/src/applications/vaos/components/AppointmentRequestListItem.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {
   titleCase,
-  getClinicName,
+  getLocationHeader,
   getAppointmentLocation,
   getRequestDateOptions,
   getRequestTimeToCall,
@@ -90,34 +90,12 @@ export default class AppointmentRequestListItem extends React.Component {
           {titleCase(appointment.appointmentType)} appointment
         </h2>
         <div className="vads-u-flex--1 vads-u-margin-bottom--2">
-          {type === APPOINTMENT_TYPES.request && (
-            <dl className="vads-u-margin--0">
-              <dt className="vads-u-font-weight--bold">
-                {getClinicName(appointment)}
-              </dt>
-              <dd>{getAppointmentLocation(appointment)}</dd>
-            </dl>
-          )}
-          {type === APPOINTMENT_TYPES.ccRequest && (
-            <dl className="vads-u-margin--0">
-              <dt className="vads-u-font-weight--bold">Preferred providers</dt>
-              <dd>
-                <ul className="usa-unstyled-list">
-                  {appointment.ccAppointmentRequest.preferredProviders.map(
-                    provider => (
-                      <li key={`${provider.firstName} ${provider.lastName}`}>
-                        {provider.practiceName}
-                        <br />
-                        {provider.firstName} {provider.lastName}
-                      </li>
-                    ),
-                  )}
-                  {!appointment.ccAppointmentRequest?.preferredProviders?.[0] &&
-                    'Not specified'}
-                </ul>
-              </dd>
-            </dl>
-          )}
+          <dl className="vads-u-margin--0">
+            <dt className="vads-u-font-weight--bold">
+              {getLocationHeader(appointment)}
+            </dt>
+            <dd>{getAppointmentLocation(appointment)}</dd>
+          </dl>
         </div>
         <hr className="vads-u-margin--0 vads-u-margin-top--1p5" />
         {showMore ? (

--- a/src/applications/vaos/components/AppointmentRequestListItem.jsx
+++ b/src/applications/vaos/components/AppointmentRequestListItem.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {
-  titleCase,
   getLocationHeader,
   getAppointmentLocation,
   getRequestDateOptions,
@@ -87,7 +86,7 @@ export default class AppointmentRequestListItem extends React.Component {
           id={`card-${index}`}
           className="vads-u-font-size--h3 vads-u-margin-top--0 vads-u-margin-bottom--2"
         >
-          {titleCase(appointment.appointmentType)} appointment
+          {appointment.appointmentType} appointment
         </h2>
         <div className="vads-u-flex--1 vads-u-margin-bottom--2">
           <dl className="vads-u-margin--0">

--- a/src/applications/vaos/components/AppointmentRequestListItem.jsx
+++ b/src/applications/vaos/components/AppointmentRequestListItem.jsx
@@ -7,6 +7,7 @@ import {
   getRequestDateOptions,
   getRequestTimeToCall,
 } from '../utils/appointment';
+import { APPOINTMENT_TYPES } from '../utils/constants';
 
 export default class AppointmentRequestListItem extends React.Component {
   static propTypes = {
@@ -26,10 +27,10 @@ export default class AppointmentRequestListItem extends React.Component {
       index,
       cancelAppointment,
       showCancelButton,
+      type,
     } = this.props;
     const { showMore } = this.state;
     const canceled = appointment.status === 'Cancelled';
-    const isCommunityCare = !!appointment.ccAppointmentRequest;
 
     return (
       <li
@@ -37,23 +38,23 @@ export default class AppointmentRequestListItem extends React.Component {
         className="vaos-appts__list-item vads-u-background-color--gray-lightest vads-u-padding--2p5 vads-u-margin-bottom--3"
       >
         <div className="vads-u-display--flex vads-u-justify-content--space-between">
-          <div className="vaos-appts__status vads-u-flex--1">
+          <div className="vaos-appts__status vads-u-padding-right--1">
             {canceled ? (
               <i className="fas fa-exclamation-circle vads-u-color--secondary-dark" />
             ) : (
               <i className="fas fa-exclamation-triangle vads-u-color--warning-message" />
             )}
+          </div>
+          <div className="vaos-appts__status vads-u-flex--1">
             <span className="vads-u-font-weight--bold vads-u-display--inline-block">
               <div className="vaos-appts__status-text vads-u-font-size--base vads-u-font-family--sans">
                 {canceled ? (
                   'Canceled'
                 ) : (
                   <>
-                    <span className="vads-u-font-weight--bold vads-u-display--inline-block vads-u-margin-right--0p5">
-                      Pending
-                    </span>
-                    <span className="vads-u-display--none medium-screen:vads-u-display--block vads-u-font-weight--normal">
-                      - The time and date are still to be determined.
+                    <strong>Pending -</strong>{' '}
+                    <span className="vads-u-font-weight--normal">
+                      The time and date are still to be determined.
                     </span>
                   </>
                 )}
@@ -73,15 +74,23 @@ export default class AppointmentRequestListItem extends React.Component {
             </div>
           )}
         </div>
+        <div className="vaos-form__title vads-u-margin-top--1 vads-u-font-size--sm vads-u-font-weight--normal vads-u-font-family--sans">
+          {type === APPOINTMENT_TYPES.ccRequest && 'Community Care'}
+          {type === APPOINTMENT_TYPES.request &&
+            appointment.visitType !== 'Telehealth' &&
+            'VA Facility'}
+          {type === APPOINTMENT_TYPES.request &&
+            appointment.visitType === 'Telehealth' &&
+            'VA Video Connect'}
+        </div>
         <h2
           id={`card-${index}`}
-          className="vads-u-font-size--h3 vads-u-margin-y--2"
+          className="vads-u-font-size--h3 vads-u-margin-top--0 vads-u-margin-bottom--2"
         >
-          {titleCase(appointment.appointmentType)} appointment{' '}
-          {isCommunityCare && '- Community Care'}
+          {titleCase(appointment.appointmentType)} appointment
         </h2>
         <div className="vads-u-flex--1 vads-u-margin-bottom--2">
-          {!isCommunityCare && (
+          {type === APPOINTMENT_TYPES.request && (
             <dl className="vads-u-margin--0">
               <dt className="vads-u-font-weight--bold">
                 {getClinicName(appointment)}
@@ -89,7 +98,7 @@ export default class AppointmentRequestListItem extends React.Component {
               <dd>{getAppointmentLocation(appointment)}</dd>
             </dl>
           )}
-          {isCommunityCare && (
+          {type === APPOINTMENT_TYPES.ccRequest && (
             <dl className="vads-u-margin--0">
               <dt className="vads-u-font-weight--bold">Preferred providers</dt>
               <dd>

--- a/src/applications/vaos/components/ConfirmedAppointmentListItem.jsx
+++ b/src/applications/vaos/components/ConfirmedAppointmentListItem.jsx
@@ -1,12 +1,10 @@
 import React from 'react';
 import {
   getClinicName,
-  getAppointmentTitle,
   getAppointmentLocation,
   getAppointmentDate,
   getAppointmentDateTime,
   isVideoVisit,
-  isCommunityCare,
 } from '../utils/appointment';
 import {
   CANCELLED_APPOINTMENT_SET,
@@ -69,18 +67,18 @@ export default function ConfirmedAppointmentListItem({
           </button>
         )}
       </div>
-      <h2 className="vaos-appts__date-time vads-u-font-size--lg vads-u-margin-y--2">
+      <div className="vaos-form__title vads-u-margin-top--1 vads-u-font-size--sm vads-u-font-weight--normal vads-u-font-family--sans">
+        {type === APPOINTMENT_TYPES.ccAppointment && 'Community Care'}
+        {type === APPOINTMENT_TYPES.vaAppointment &&
+          !isVideoVisit(appointment) &&
+          'VA Facility'}
+        {type === APPOINTMENT_TYPES.vaAppointment &&
+          isVideoVisit(appointment) &&
+          'VA Video Connect'}
+      </div>
+      <h2 className="vaos-appts__date-time vads-u-font-size--lg vads-u-margin-bottom--2">
         {getAppointmentDateTime(appointment)}
       </h2>
-
-      {isCommunityCare(appointment) || isVideoVisit(appointment) ? (
-        <div className="vads-u-font-weight--bold vads-u-margin-bottom--1">
-          <dl>
-            <dt>{getAppointmentTitle(appointment)}</dt>
-            <dd />
-          </dl>
-        </div>
-      ) : null}
 
       <div className="vaos-appts__split-section">
         <div className="vads-u-flex--1">

--- a/src/applications/vaos/components/ConfirmedAppointmentListItem.jsx
+++ b/src/applications/vaos/components/ConfirmedAppointmentListItem.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import {
-  getClinicName,
+  getLocationHeader,
   getAppointmentLocation,
   getAppointmentDate,
   getAppointmentDateTime,
@@ -87,7 +87,7 @@ export default function ConfirmedAppointmentListItem({
           ) : (
             <dl className="vads-u-margin--0">
               <dt className="vads-u-font-weight--bold">
-                {getClinicName(appointment)}
+                {getLocationHeader(appointment)}
               </dt>
               <dd>{getAppointmentLocation(appointment)}</dd>
             </dl>

--- a/src/applications/vaos/components/ConfirmedAppointmentListItem.jsx
+++ b/src/applications/vaos/components/ConfirmedAppointmentListItem.jsx
@@ -69,7 +69,7 @@ export default function ConfirmedAppointmentListItem({
           </button>
         )}
       </div>
-      <h2 className="vaos-appts__date-time vads-u-font-size--lg">
+      <h2 className="vaos-appts__date-time vads-u-font-size--lg vads-u-margin-y--2">
         {getAppointmentDateTime(appointment)}
       </h2>
 

--- a/src/applications/vaos/containers/AppointmentsPage.jsx
+++ b/src/applications/vaos/containers/AppointmentsPage.jsx
@@ -53,12 +53,14 @@ export class AppointmentsPage extends Component {
             const type = getAppointmentType(appt);
 
             switch (type) {
+              case APPOINTMENT_TYPES.ccRequest:
               case APPOINTMENT_TYPES.request:
                 return (
                   <AppointmentRequestListItem
                     key={index}
                     index={index}
                     appointment={appt}
+                    type={type}
                     showCancelButton={showCancelButton}
                     cancelAppointment={this.props.cancelAppointment}
                   />

--- a/src/applications/vaos/sass/vaos.scss
+++ b/src/applications/vaos/sass/vaos.scss
@@ -18,16 +18,6 @@
   }
 }
 
-// .vaos-appts__status-text {
-//   display: flex;
-//   margin: 0 0 0 8px;
-//
-//   @media (max-width: $small-screen) {
-//     margin-top: -4px;
-//     flex-direction: column;
-//   }
-// }
-
 .vaos-appts__cancel-btn {
   @media (max-width: $small-screen) {
     max-width: 90px;

--- a/src/applications/vaos/sass/vaos.scss
+++ b/src/applications/vaos/sass/vaos.scss
@@ -18,15 +18,15 @@
   }
 }
 
-.vaos-appts__status-text {
-  display: flex;
-  margin: 0 0 0 8px;
-
-  @media (max-width: $small-screen) {
-    margin-top: -4px;
-    flex-direction: column;
-  }
-}
+// .vaos-appts__status-text {
+//   display: flex;
+//   margin: 0 0 0 8px;
+//
+//   @media (max-width: $small-screen) {
+//     margin-top: -4px;
+//     flex-direction: column;
+//   }
+// }
 
 .vaos-appts__cancel-btn {
   @media (max-width: $small-screen) {

--- a/src/applications/vaos/tests/components/AppointmentRequestListItem.unit.spec.jsx
+++ b/src/applications/vaos/tests/components/AppointmentRequestListItem.unit.spec.jsx
@@ -27,13 +27,10 @@ describe('VAOS <AppointmentRequestListItem>', () => {
       <AppointmentRequestListItem appointment={appointment} showCancelButton />,
     );
 
-    const statusSpans = tree.find('h2 > span');
-    expect(statusSpans.at(0).text()).to.equal('Pending');
-    expect(statusSpans.at(1).text()).to.equal('Date and time to be determined');
+    expect(tree.text()).to.contain('Pending');
+    expect(tree.text()).to.contain('time and date are still to be determined');
 
-    expect(
-      tree.find('div.vads-u-flex--1.vads-u-margin-y--1p5 > span').text(),
-    ).to.equal('Testing appointment');
+    expect(tree.text()).to.contain('Testing appointment');
 
     expect(tree.find('.usa-button-secondary').text()).to.equal('Cancel');
 
@@ -72,11 +69,11 @@ describe('VAOS <AppointmentRequestListItem>', () => {
       <AppointmentRequestListItem appointment={appointment} />,
     );
 
-    expect(tree.find('h2').text()).to.equal('Canceled');
+    expect(tree.text()).to.contain('Canceled');
 
-    expect(
-      tree.find('div.vads-u-flex--1.vads-u-margin-y--1p5 > span').text(),
-    ).to.equal('Audiology (hearing Aid Support) appointment');
+    expect(tree.text()).to.contain(
+      'Audiology (hearing Aid Support) appointment',
+    );
 
     expect(tree.find('.usa-button-secondary').length).to.equal(0);
     tree.unmount();

--- a/src/applications/vaos/tests/components/AppointmentRequestListItem.unit.spec.jsx
+++ b/src/applications/vaos/tests/components/AppointmentRequestListItem.unit.spec.jsx
@@ -3,6 +3,7 @@ import { expect } from 'chai';
 import { shallow } from 'enzyme';
 
 import AppointmentRequestListItem from '../../components/AppointmentRequestListItem';
+import { APPOINTMENT_TYPES } from '../../utils/constants';
 
 describe('VAOS <AppointmentRequestListItem>', () => {
   it('should render pending VA appointment request', () => {
@@ -24,12 +25,17 @@ describe('VAOS <AppointmentRequestListItem>', () => {
       appointmentRequestId: 'guid',
     };
     const tree = shallow(
-      <AppointmentRequestListItem appointment={appointment} showCancelButton />,
+      <AppointmentRequestListItem
+        appointment={appointment}
+        showCancelButton
+        type={APPOINTMENT_TYPES.request}
+      />,
     );
 
     expect(tree.text()).to.contain('Pending');
     expect(tree.text()).to.contain('time and date are still to be determined');
 
+    expect(tree.text()).to.contain('VA Facility');
     expect(tree.text()).to.contain('Testing appointment');
 
     expect(tree.find('.usa-button-secondary').text()).to.equal('Cancel');
@@ -66,7 +72,10 @@ describe('VAOS <AppointmentRequestListItem>', () => {
       appointmentRequestId: 'guid',
     };
     const tree = shallow(
-      <AppointmentRequestListItem appointment={appointment} />,
+      <AppointmentRequestListItem
+        appointment={appointment}
+        type={APPOINTMENT_TYPES.request}
+      />,
     );
 
     expect(tree.text()).to.contain('Canceled');
@@ -76,6 +85,67 @@ describe('VAOS <AppointmentRequestListItem>', () => {
     );
 
     expect(tree.find('.usa-button-secondary').length).to.equal(0);
+    tree.unmount();
+  });
+
+  it('should render pending CC appointment request', () => {
+    const appointment = {
+      appointmentType: 'Testing',
+      optionDate1: '05/22/2019',
+      optionTime1: 'PM',
+      optionDate2: '05/23/2019',
+      optionTime2: 'AM',
+      typeOfCareId: '1',
+      friendlyLocationName: 'Some location',
+      status: 'Submitted',
+      bestTimetoCall: ['Morning'],
+      facility: {
+        city: 'Northampton',
+        state: 'MA',
+        facilityCode: '983',
+      },
+      appointmentRequestId: 'guid',
+      ccAppointmentRequest: {
+        preferredProviders: [
+          {
+            firstName: 'Jane',
+            lastName: 'Doe',
+            practiceName: 'Test Practice',
+          },
+        ],
+      },
+    };
+    const tree = shallow(
+      <AppointmentRequestListItem
+        appointment={appointment}
+        showCancelButton
+        type={APPOINTMENT_TYPES.ccRequest}
+      />,
+    );
+
+    expect(tree.text()).to.contain('Pending');
+    expect(tree.text()).to.contain('time and date are still to be determined');
+
+    expect(tree.text()).to.contain('Testing appointment');
+    expect(tree.text()).to.contain('Community Care');
+    expect(tree.text()).to.contain('Test Practice');
+    expect(tree.text()).to.contain('Jane Doe');
+
+    expect(tree.find('.usa-button-secondary').text()).to.equal('Cancel');
+
+    const toggleExpand = tree.find('.vaos-appts__expand-link');
+    toggleExpand.simulate('click');
+
+    const preferredDates = tree.find('.vaos-appts__preferred-dates li');
+
+    expect(preferredDates.at(0).text()).to.equal(
+      'Wed, May 22, 2019 in the afternoon',
+    );
+
+    expect(preferredDates.at(1).text()).to.equal(
+      'Thu, May 23, 2019 in the morning',
+    );
+
     tree.unmount();
   });
 });

--- a/src/applications/vaos/utils/appointment.jsx
+++ b/src/applications/vaos/utils/appointment.jsx
@@ -9,7 +9,9 @@ import {
 } from './timezone';
 
 export function getAppointmentType(appt) {
-  if (appt.optionDate1) {
+  if (appt.optionDate1 && appt.ccAppointmentRequest?.preferredProviders) {
+    return APPOINTMENT_TYPES.ccRequest;
+  } else if (appt.optionDate1) {
     return APPOINTMENT_TYPES.request;
   } else if (appt.appointmentRequestId) {
     return APPOINTMENT_TYPES.ccAppointment;

--- a/src/applications/vaos/utils/appointment.jsx
+++ b/src/applications/vaos/utils/appointment.jsx
@@ -64,12 +64,14 @@ export function titleCase(str) {
     .join(' ');
 }
 
-export function getClinicName(appt) {
+export function getLocationHeader(appt) {
   const type = getAppointmentType(appt);
 
   switch (type) {
     case APPOINTMENT_TYPES.ccAppointment:
       return appt.providerPractice;
+    case APPOINTMENT_TYPES.ccRequest:
+      return 'Preferred provider';
     case APPOINTMENT_TYPES.request:
       return appt.friendlyLocationName || appt.facility.name;
     default:
@@ -104,8 +106,26 @@ export function getAppointmentLocation(appt) {
     );
   }
 
+  if (type === APPOINTMENT_TYPES.ccRequest) {
+    if (!appt.ccAppointmentRequest?.preferredProviders?.[0]) {
+      return 'Not specified';
+    }
+
+    return (
+      <ul className="usa-unstyled-list">
+        {appt.ccAppointmentRequest.preferredProviders.map(provider => (
+          <li key={`${provider.firstName} ${provider.lastName}`}>
+            {provider.practiceName}
+            <br />
+            {provider.firstName} {provider.lastName}
+          </li>
+        ))}
+      </ul>
+    );
+  }
+
   const facilityId =
-    type === APPOINTMENT_TYPES.request
+    type === APPOINTMENT_TYPES.request || type === APPOINTMENT_TYPES.ccRequest
       ? appt.facility.facilityCode
       : appt.facilityId;
 
@@ -151,6 +171,7 @@ export function getAppointmentTimezoneAbbreviation(appt) {
   switch (type) {
     case APPOINTMENT_TYPES.ccAppointment:
       return stripDST(appt?.timeZone?.split(' ')?.[1]);
+    case APPOINTMENT_TYPES.ccRequest:
     case APPOINTMENT_TYPES.request:
       return getTimezoneAbbrBySystemId(appt?.facility?.facilityCode);
     case APPOINTMENT_TYPES.vaAppointment:
@@ -260,8 +281,12 @@ export function filterFutureRequests(request, today) {
 }
 
 export function sortFutureList(a, b) {
-  const aIsRequest = getAppointmentType(a) === APPOINTMENT_TYPES.request;
-  const bIsRequest = getAppointmentType(b) === APPOINTMENT_TYPES.request;
+  const aIsRequest =
+    getAppointmentType(a) === APPOINTMENT_TYPES.request ||
+    getAppointmentType(a) === APPOINTMENT_TYPES.ccRequest;
+  const bIsRequest =
+    getAppointmentType(b) === APPOINTMENT_TYPES.request ||
+    getAppointmentType(b) === APPOINTMENT_TYPES.ccRequest;
 
   const aDate = aIsRequest
     ? getMomentRequestOptionDate(a.optionDate1)

--- a/src/applications/vaos/utils/constants.js
+++ b/src/applications/vaos/utils/constants.js
@@ -9,6 +9,7 @@ export const APPOINTMENT_TYPES = {
   vaAppointment: 'vaAppointment',
   ccAppointment: 'ccAppointment',
   request: 'request',
+  ccRequest: 'ccRequest',
 };
 
 export const TIME_TEXT = {


### PR DESCRIPTION
## Description
Ryan has some tweaks to the headers shown for different card types. I've also updated the list to include the CC provider when its relevant.

## Testing done
Local and unit testing

## Screenshots
![Screen Shot 2019-11-13 at 4 51 12 PM](https://user-images.githubusercontent.com/634932/68809458-f74ad300-0639-11ea-8e85-e81bfb5a2532.png)
![Screen Shot 2019-11-13 at 5 20 33 PM](https://user-images.githubusercontent.com/634932/68809459-f74ad300-0639-11ea-9277-d0effe2a0c49.png)

## Acceptance criteria
- [ ] Cards have header

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
