### PR TITLE
Skip visit type page for DS

### DIFF
--- a/src/applications/vaos/newAppointmentFlow.js
+++ b/src/applications/vaos/newAppointmentFlow.js
@@ -208,7 +208,10 @@ export default {
   reasonForAppointment: {
     url: '/new-appointment/reason-appointment',
     next(state) {
-      if (isCCFacility(state)) {
+      if (
+        isCCFacility(state) ||
+        getNewAppointment(state).flowType === FLOW_TYPES.DIRECT
+      ) {
         return 'contactInfo';
       }
 
@@ -229,7 +232,6 @@ export default {
   visitType: {
     url: '/new-appointment/choose-visit-type',
     previous: 'reasonForAppointment',
-    // Update this when reasonForAppointment is merged
     next: 'contactInfo',
   },
   appointmentTime: {
@@ -243,6 +245,10 @@ export default {
     previous(state) {
       if (isCCFacility(state)) {
         return 'ccPreferences';
+      }
+
+      if (getNewAppointment(state).flowType === FLOW_TYPES.DIRECT) {
+        return 'reasonForAppointment';
       }
 
       return 'visitType';


### PR DESCRIPTION
## Description
We should skip the visit type page for direct scheduling, because you only direct schedule office visits.

## Testing done
Local testing

## Acceptance criteria
- [ ] visitType page is skipped for DS

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
