### PR TITLE
bradl3yC 3176 address validation

### DIFF
--- a/src/platform/user/profile/vet360/containers/AddressValidationModal.jsx
+++ b/src/platform/user/profile/vet360/containers/AddressValidationModal.jsx
@@ -1,0 +1,184 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import Modal from '@department-of-veterans-affairs/formation-react/Modal';
+import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
+import { selectCurrentlyOpenEditModal } from '../selectors';
+import { openModal, createTransaction } from '../actions';
+
+import * as VET360 from '../constants';
+
+class AddressValidationModal extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      selectedOption: '',
+      address: {},
+    };
+  }
+  onChangeHandler = address => event => {
+    this.setState({ selectedOption: event.target.name, address });
+  };
+
+  onSubmit = () => {
+    const { validationKey } = this.props;
+    const { address } = this.state;
+    const payload = { ...address, validationKey };
+
+    const method = payload.id ? 'PUT' : 'POST';
+
+    this.props.createTransaction(
+      VET360.API_ROUTES.ADDRESSES,
+      method,
+      this.props.fieldName,
+      payload,
+      this.props.analyticsSectionName,
+    );
+  };
+
+  renderWarningText = () => {
+    const { addressValidationError } = this.props;
+
+    return addressValidationError
+      ? 'We’re sorry. It looks like the address you entered isn’t valid.  Please edit your address'
+      : 'We’re sorry. It looks like the address you entered isn’t valid.  Please enter your address again or choose a suggested address below';
+  };
+
+  renderPrimaryButton = () => {
+    const {
+      addressValidationError,
+      addressValidationType,
+      validationKey,
+    } = this.props;
+
+    if (addressValidationError && !validationKey) {
+      return (
+        <button
+          className="usa-button-primary"
+          onClick={() => this.props.openModal(addressValidationType)}
+        >
+          Edit Address
+        </button>
+      );
+    }
+
+    return <button className="usa-button-primary">Continue</button>;
+  };
+
+  renderAddressOption = (address, id = 'userEntered') => {
+    const { validationKey } = this.props;
+    const {
+      addressLine1,
+      addressLine2,
+      addressLine3,
+      city,
+      stateCode,
+      zipCode,
+    } = address;
+
+    const isOptionDisabled = id === 'userEntered' && !validationKey;
+
+    return (
+      <div key={id}>
+        <input
+          style={{ zIndex: '1' }}
+          type="radio"
+          name={id}
+          disabled={isOptionDisabled}
+          checked={this.state.selectedOption === id}
+          onClick={this.onChangeHandler(address)}
+        />
+        <label
+          htmlFor={id}
+          className="vads-u-margin-top--2 vads-u-display--flex vads-u-align-items--center"
+        >
+          <div className="vads-u-display--flex vads-u-flex-direction--column">
+            {addressLine1 && <span>{addressLine1}</span>}
+            {addressLine2 && <span>{addressLine2}</span>}
+            {addressLine3 && <span>{addressLine3}</span>}
+            <span>{` ${city}, ${stateCode} ${zipCode}`}</span>
+          </div>
+        </label>
+      </div>
+    );
+  };
+
+  render() {
+    const {
+      closeModal,
+      isAddressValidationModalVisible,
+      addressValidationType,
+      suggestedAddresses,
+      userEnteredAddress,
+    } = this.props;
+
+    const shouldShowSuggestions = suggestedAddresses.length > 0;
+
+    const addressFromUser =
+      userEnteredAddress?.[`${addressValidationType}`]?.value || {};
+
+    return (
+      <Modal
+        title={
+          addressValidationType.includes('mailing')
+            ? 'Edit mailing address'
+            : 'Edit home address'
+        }
+        id="address-validation-warning"
+        onClose={closeModal}
+        visible={isAddressValidationModalVisible}
+      >
+        <AlertBox
+          className="vads-u-margin-bottom--1"
+          status="warning"
+          headline="Your address update isn't valid"
+        >
+          <p>{this.renderWarningText()}</p>
+        </AlertBox>
+        <form onSubmit={this.onSubmit}>
+          <span className="vads-u-font-weight--bold">You entered:</span>
+          {this.renderAddressOption(addressFromUser)}
+          {shouldShowSuggestions && (
+            <span className="vads-u-font-weight--bold">
+              Suggested Addresses:
+            </span>
+          )}
+          {shouldShowSuggestions &&
+            suggestedAddresses.map((address, index) =>
+              this.renderAddressOption(address, String(index)),
+            )}
+          {this.renderPrimaryButton()}
+          <button className="usa-button-secondary" onClick={closeModal}>
+            Cancel
+          </button>
+        </form>
+      </Modal>
+    );
+  }
+}
+
+const mapStateToProps = state => {
+  const addressValidationType = state.vet360.addressValidationType;
+
+  return {
+    analyticsSectionName: VET360.ANALYTICS_FIELD_MAP[addressValidationType],
+    isAddressValidationModalVisible:
+      selectCurrentlyOpenEditModal(state) === 'addressValidation',
+    addressValidationError: state.vet360.addressValidationError,
+    suggestedAddresses: state.vet360.suggestedAddresses,
+    addressValidationType,
+    userEnteredAddress: state.vet360.formFields,
+    validationKey: state.vet360.validationKey,
+  };
+};
+
+const mapDispatchToProps = dispatch => ({
+  closeModal: () => dispatch(openModal(null)),
+  openModal: modalName => dispatch(openModal(modalName)),
+  createTransaction,
+});
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(AddressValidationModal);

--- a/src/platform/user/profile/vet360/containers/InitializeVet360ID.jsx
+++ b/src/platform/user/profile/vet360/containers/InitializeVet360ID.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
+import AddressValidationModal from './AddressValidationModal';
+import environment from 'platform/utilities/environment';
 
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 
@@ -62,7 +64,12 @@ class InitializeVet360ID extends React.Component {
   render() {
     switch (this.props.status) {
       case VET360_INITIALIZATION_STATUS.INITIALIZED:
-        return <div>{this.props.children}</div>;
+        return (
+          <div>
+            {!environment.isProduction() && <AddressValidationModal />}
+            {this.props.children}
+          </div>
+        );
 
       case VET360_INITIALIZATION_STATUS.INITIALIZATION_FAILURE:
         return (

--- a/src/platform/user/profile/vet360/containers/Vet360ProfileField.jsx
+++ b/src/platform/user/profile/vet360/containers/Vet360ProfileField.jsx
@@ -7,6 +7,7 @@ import recordEvent from 'platform/monitoring/record-event';
 import * as VET360 from '../constants';
 
 import { isPendingTransaction } from '../util/transactions';
+import environment from 'platform/utilities/environment';
 
 import {
   createTransaction,
@@ -14,6 +15,7 @@ import {
   clearTransactionRequest,
   updateFormField,
   openModal,
+  validateAddress,
 } from '../actions';
 
 import {
@@ -96,6 +98,20 @@ class Vet360ProfileField extends React.Component {
     }
 
     const method = payload.id ? 'PUT' : 'POST';
+
+    if (
+      this.props.fieldName.toLowerCase().includes('address') &&
+      !environment.isProduction()
+    ) {
+      this.props.validateAddress(
+        this.props.apiRoute,
+        method,
+        this.props.fieldName,
+        payload,
+        this.props.analyticsSectionName,
+      );
+      return;
+    }
 
     this.props.createTransaction(
       this.props.apiRoute,
@@ -231,6 +247,7 @@ const mapDispatchToProps = {
   openModal,
   createTransaction,
   updateFormField,
+  validateAddress,
 };
 
 /**

--- a/src/platform/user/profile/vet360/reducers/index.js
+++ b/src/platform/user/profile/vet360/reducers/index.js
@@ -11,6 +11,8 @@ import {
   VET360_TRANSACTION_UPDATE_REQUESTED,
   VET360_TRANSACTION_UPDATE_FAILED,
   VET360_CLEAR_TRANSACTION_STATUS,
+  ADDRESS_VALIDATION_CONFIRM,
+  ADDRESS_VALIDATION_ERROR,
 } from '../actions';
 
 import { isFailedTransaction } from '../util/transactions';
@@ -25,6 +27,10 @@ const initialState = {
     mostRecentErroredTransactionId: '',
   },
   transactionStatus: '',
+  addressValidationType: '',
+  suggestedAddresses: [],
+  addressValidationError: false,
+  validationKey: '',
 };
 
 export default function vet360(state = initialState, action) {
@@ -183,6 +189,23 @@ export default function vet360(state = initialState, action) {
 
     case OPEN_MODAL:
       return { ...state, modal: action.modal };
+
+    case ADDRESS_VALIDATION_CONFIRM:
+      return {
+        ...state,
+        addressValidationType: action.addressValidationType,
+        suggestedAddresses: action.suggestedAddresses,
+        modal: 'addressValidation',
+        validationKey: action.validationKey,
+      };
+
+    case ADDRESS_VALIDATION_ERROR:
+      return {
+        ...state,
+        addressValidationError: action.addressValidationError,
+        addressValidationType: action.addressValidationType,
+        modal: 'addressValidation',
+      };
 
     default:
       return state;

--- a/src/platform/user/profile/vet360/tests/containers/AddressValidationModal.unit.spec.jsx
+++ b/src/platform/user/profile/vet360/tests/containers/AddressValidationModal.unit.spec.jsx
@@ -1,0 +1,191 @@
+import React from 'react';
+import enzyme from 'enzyme';
+import { expect } from 'chai';
+import AddressValidationModal from '../../containers/AddressValidationModal';
+
+describe('<AddressValidationModal/>', () => {
+  const fakeStore = {
+    getState: () => ({
+      vet360: {
+        modal: 'addressValidation',
+        formFields: {
+          mailingAddress: {
+            value: {
+              addressLine1: '1493 Martin Luther King Rd',
+              addressLine2: '',
+              addressLine3: '',
+              addressPou: 'CORRESPONDENCE',
+              addressType: 'DOMESTIC',
+              city: 'Fulton',
+              countryName: 'United States',
+              id: 123,
+              internationalPostalCode: null,
+              province: null,
+              stateCode: 'NY',
+              zipCode: '97062',
+            },
+          },
+        },
+        isAddressValidationModalVisible: true,
+        addressValidationError: false,
+        suggestedAddresses: [
+          {
+            addressLine1: '12345 1st Ave',
+            addressLine2: '',
+            addressLine3: '',
+            city: 'Tampa',
+            stateCode: 'FL',
+            zipCode: '12346',
+            addressMetaData: {
+              confidenceScore: 100.0,
+              addressType: 'Domestic',
+              deliveryPointValidation: 'CONFIRMED',
+              residentialDeliveryIndicator: 'MIXED',
+            },
+          },
+          {
+            addressLine1: '22222 1st Ave',
+            addressLine2: '',
+            addressLine3: '',
+            city: 'Saint Petersburg',
+            stateCode: 'FL',
+            zipCode: '55555',
+            addressMetaData: {
+              confidenceScore: 100.0,
+              addressType: 'Domestic',
+              deliveryPointValidation: 'CONFIRMED',
+              residentialDeliveryIndicator: 'MIXED',
+            },
+          },
+        ],
+        addressValidationType: 'mailingAddress',
+        userEnteredAddress: {},
+        validationKey: 1234,
+      },
+    }),
+    subscribe: () => {},
+    dispatch: () => {},
+  };
+
+  it('validate render', () => {
+    const component = enzyme.mount(
+      <AddressValidationModal store={fakeStore} />,
+    );
+    expect(component.exists('AddressValidationModal')).to.equal(true);
+    expect(component.exists('Modal')).to.equal(true);
+    component.unmount();
+  });
+
+  it('renders alert box', () => {
+    const component = enzyme.mount(
+      <AddressValidationModal store={fakeStore} />,
+    );
+
+    expect(component.exists('AlertBox')).to.equal(true);
+    component.unmount();
+  });
+
+  it('renders correct buttons', () => {
+    const component = enzyme.mount(
+      <AddressValidationModal store={fakeStore} />,
+    );
+
+    expect(component.find('.usa-button-primary').text()).to.equal('Continue');
+    expect(component.find('.usa-button-secondary').text()).to.equal('Cancel');
+    component.unmount();
+  });
+
+  it('renders correct buttons', () => {
+    const newFakeStore = {
+      getState: () => ({
+        vet360: {
+          modal: 'addressValidation',
+          formFields: {
+            mailingAddress: {
+              value: {
+                addressLine1: '1493 Martin Luther King Rd',
+                addressLine2: '',
+                addressLine3: '',
+                addressPou: 'CORRESPONDENCE',
+                addressType: 'DOMESTIC',
+                city: 'Fulton',
+                countryName: 'United States',
+                id: 123,
+                internationalPostalCode: null,
+                province: null,
+                stateCode: 'NY',
+                zipCode: '97062',
+              },
+            },
+          },
+          isAddressValidationModalVisible: true,
+          addressValidationError: true,
+          suggestedAddresses: [],
+          addressValidationType: 'mailingAddress',
+          userEnteredAddress: {},
+          validationKey: null,
+        },
+      }),
+      subscribe: () => {},
+      dispatch: () => {},
+    };
+
+    const component = enzyme.mount(
+      <AddressValidationModal store={newFakeStore} />,
+    );
+
+    expect(component.find('.usa-button-primary').text()).to.equal(
+      'Edit Address',
+    );
+    expect(component.find('.usa-button-secondary').text()).to.equal('Cancel');
+    component.unmount();
+  });
+
+  it('validates inputs', () => {
+    const component = enzyme.mount(
+      <AddressValidationModal store={fakeStore} />,
+    );
+
+    expect(
+      component
+        .find('label')
+        .at(0)
+        .text(),
+    ).to.equal('1493 Martin Luther King Rd Fulton, NY 97062');
+
+    expect(
+      component
+        .find('label')
+        .at(1)
+        .text(),
+    ).to.equal('12345 1st Ave Tampa, FL 12346');
+
+    expect(
+      component
+        .find('label')
+        .at(2)
+        .text(),
+    ).to.equal('22222 1st Ave Saint Petersburg, FL 55555');
+    component.unmount();
+  });
+
+  it('validates headings', () => {
+    const component = enzyme.mount(
+      <AddressValidationModal store={fakeStore} />,
+    );
+
+    expect(
+      component
+        .find('h3')
+        .at(0)
+        .text(),
+    ).to.equal('Edit mailing address');
+    expect(
+      component
+        .find('h3')
+        .at(1)
+        .text(),
+    ).to.equal("Your address update isn't valid");
+    component.unmount();
+  });
+});

--- a/src/platform/user/profile/vet360/tests/reducers/index.unit.spec.js
+++ b/src/platform/user/profile/vet360/tests/reducers/index.unit.spec.js
@@ -281,4 +281,36 @@ describe('vet360 reducer', () => {
 
     expect(state.modal).to.eql('modalName');
   });
+
+  it('should update addressValidation on confirm', () => {
+    const state = vet360(
+      {},
+      {
+        type: 'ADDRESS_VALIDATION_CONFIRM',
+        addressValidationType: 'mailingAddress',
+        suggestedAddresses: [],
+        modal: 'addressValidation',
+        validationKey: 123456,
+      },
+    );
+    expect(state.modal).to.eql('addressValidation');
+    expect(state.addressValidationType).to.eql('mailingAddress');
+    expect(state.suggestedAddresses).to.eql([]);
+    expect(state.validationKey).to.eql(123456);
+  });
+
+  it('should update addressValidation on error', () => {
+    const state = vet360(
+      {},
+      {
+        type: 'ADDRESS_VALIDATION_ERROR',
+        addressValidationError: true,
+        addressValidationType: 'mailingAddress',
+        modal: 'addressValidation',
+      },
+    );
+    expect(state.modal).to.eql('addressValidation');
+    expect(state.addressValidationError).to.eql(true);
+    expect(state.addressValidationType).to.eql('mailingAddress');
+  });
 });

--- a/src/platform/user/profile/vet360/util/local-vet360.js
+++ b/src/platform/user/profile/vet360/util/local-vet360.js
@@ -198,4 +198,37 @@ export default {
       },
     };
   },
+  addressValidationSuccess(address) {
+    return {
+      addresses: [
+        {
+          ...address,
+          addressLine2: '',
+          addressLine3: '',
+          city: 'Tampa',
+          stateCode: 'FL',
+          addressMetaData: {
+            confidenceScore: 100.0,
+            addressType: 'Domestic',
+            deliveryPointValidation: 'CONFIRMED',
+            residentialDeliveryIndicator: 'MIXED',
+          },
+        },
+        {
+          ...address,
+          addressLine2: '',
+          addressLine3: '',
+          city: 'Saint Petersburg',
+          stateCode: 'FL',
+          addressMetaData: {
+            confidenceScore: 100.0,
+            addressType: 'Domestic',
+            deliveryPointValidation: 'CONFIRMED',
+            residentialDeliveryIndicator: 'MIXED',
+          },
+        },
+      ],
+      validationKey: 1007944671,
+    };
+  },
 };


### PR DESCRIPTION
## Description
The purpose of this Feature is to give the user the option to either edit the address they entered or select from multiple addresses returned from the address validation API.  If a validation key is present, and the user wishes to confirm their entered address, the validation key will be included with the payload to the save/update API.

## Testing done
Added unit tests for reducer / component

## Screenshots
![Screen Shot 2019-11-19 at 1 48 36 PM](https://user-images.githubusercontent.com/6165421/69176207-52b21080-0ad3-11ea-8da7-9c97579a7702.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
