### PR TITLE
Flip the button arrows on the new sidenav

### DIFF
--- a/src/platform/site-wide/side-nav/components/SideNav.js
+++ b/src/platform/site-wide/side-nav/components/SideNav.js
@@ -128,8 +128,8 @@ class SideNav extends Component {
                   <i
                     className={classNames({
                       fa: true,
-                      'fa-chevron-down': expanded,
-                      'fa-chevron-up': !expanded,
+                      'fa-chevron-up': expanded,
+                      'fa-chevron-down': !expanded,
                     })}
                   />
                 </button>


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/3429

**Current Behavior:** Expanded = Down Arrow, Collapsed = Up Arrow

**Desired Behavior:** Expanded = Up Arrow, Collapsed = Down Arrow

This PR implements the desired behavior above for the new SideNav.

## Testing done
Visual confirmation [here](http://localhost:3001/pittsburgh-health-care/)

## Screenshots
![image](https://user-images.githubusercontent.com/12773166/68879751-ee104380-06d7-11ea-8087-4f383d631790.png)

## Acceptance criteria
- [x] Flip expand/collapse arrows on the new SideNav

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
