### PR TITLE
CT 116 Estimate your benefits NVDA bug #19948

### DIFF
--- a/src/applications/gi/components/vet-tec/VetTecCalculator.jsx
+++ b/src/applications/gi/components/vet-tec/VetTecCalculator.jsx
@@ -209,7 +209,7 @@ export class VetTecCalculator extends React.Component {
         <div className="usa-width-one-half medium-6 columns vads-u-padding--0">
           <div className=" your-estimated-benefits">
             <h3>Your estimated benefits</h3>
-            <div className="programs-label">
+            <div className="program-name">
               {this.props.calculator.vetTecProgramName}
             </div>
             {this.renderTuitionSection(outputs, showModal)}

--- a/src/applications/gi/components/vet-tec/VetTecCalculator.jsx
+++ b/src/applications/gi/components/vet-tec/VetTecCalculator.jsx
@@ -209,7 +209,9 @@ export class VetTecCalculator extends React.Component {
         <div className="usa-width-one-half medium-6 columns vads-u-padding--0">
           <div className=" your-estimated-benefits">
             <h3>Your estimated benefits</h3>
-            <i>{this.props.calculator.vetTecProgramName}</i>
+            <div className="programs-label">
+              {this.props.calculator.vetTecProgramName}
+            </div>
             {this.renderTuitionSection(outputs, showModal)}
             <hr />
             {this.renderHousingSection(outputs, showModal)}

--- a/src/applications/gi/sass/partials/_gi-profile-page.scss
+++ b/src/applications/gi/sass/partials/_gi-profile-page.scss
@@ -94,6 +94,10 @@
     }
   }
 
+  .programs-label {
+    font-style: italic;
+  }
+
   .total-paid-to-you {
     .calculator-result {
       margin-top: 1.6rem;

--- a/src/applications/gi/sass/partials/_gi-profile-page.scss
+++ b/src/applications/gi/sass/partials/_gi-profile-page.scss
@@ -94,7 +94,7 @@
     }
   }
 
-  .programs-label {
+  .program-name {
     font-style: italic;
   }
 


### PR DESCRIPTION
## Description
After selecting a program from the search results page, a user is given the option to switch to a different program from the same provider on the profile page. When a new program is selected, the information in the "Estimate your benefits" box is updated. When using NVDA to read the information in the Estimate your benefits box, the original program name is still read.

https://github.com/department-of-veterans-affairs/vets.gov-team/issues/19948

## Testing done
Windows VM with NVDA

## Screenshots


## Acceptance criteria
- [x] Programs speaks correct program name in "estimate you benefits"

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
