### PR TITLE
[TeamSite] Fix for MegaMenu style issue

### DIFF
--- a/src/applications/proxy-rewrite/sass/consolidated-patches.scss
+++ b/src/applications/proxy-rewrite/sass/consolidated-patches.scss
@@ -105,10 +105,6 @@ header.merger {
 
         .mm-link-container {
           width: 220px;
-
-          .vetnav-level2 {
-            line-height: 1em;
-          }
         }
 
         &.column-one {
@@ -129,6 +125,12 @@ header.merger {
       .panel-bottom-link {
         width: 657px;
       }
+    }
+  }
+
+  @include media($medium-screen) {
+    .vetnav-panel .mm-link-container .vetnav-level2 {
+      line-height: 1em;
     }
   }
 

--- a/src/applications/proxy-rewrite/sass/consolidated-patches.scss
+++ b/src/applications/proxy-rewrite/sass/consolidated-patches.scss
@@ -105,6 +105,10 @@ header.merger {
 
         .mm-link-container {
           width: 220px;
+
+          .vetnav-level2 {
+            line-height: 1em;
+          }
         }
 
         &.column-one {


### PR DESCRIPTION
## Description
The bottom two items of our MegaMenu - the `Service member benefits` and `Family member benefits` - render differently than the items above them. This is a fix for that.

Ticket - https://github.com/department-of-veterans-affairs/va.gov-team/issues/1946

## Testing done
- `npm run watch -- --local-proxy-rewrite --entry=proxy-rewrite`
- Navigated to `http://localhost:3001/?target=https://www.va.gov/health/`
- Observed that the menu looks okay

## Screenshots
It looks bad on medium and large screens. The fix here applies to both.

### Bad
![image](https://user-images.githubusercontent.com/1915775/68894718-d8aa1200-06f5-11ea-94fe-468e9814e5e5.png)

### Fixed
![image](https://user-images.githubusercontent.com/1915775/68894702-ce881380-06f5-11ea-9d7e-2c5f9dd1c427.png)


## Acceptance criteria
- [ ] MegaMenu looks okay on TeamSite pages

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
