### PR TITLE
Facility Locator should display the hours of operation information sent through the API, rather than interpreting the data

### DIFF
--- a/src/applications/facility-locator/components/LocationHours.jsx
+++ b/src/applications/facility-locator/components/LocationHours.jsx
@@ -30,46 +30,60 @@ const LocationHours = ({ location }) => {
       <h4 className="highlight">Hours of Operation</h4>
 
       {/* Sunday */}
-      <div className="row">
-        <div className="small-6 columns">Sunday:</div>
-        <div className="small-6 columns">{sunday}</div>
-      </div>
+      {sunday && (
+        <div className="row">
+          <div className="small-6 columns">Sunday:</div>
+          <div className="small-6 columns">{sunday}</div>
+        </div>
+      )}
 
       {/* Monday */}
-      <div className="row">
-        <div className="small-6 columns">Monday:</div>
-        <div className="small-6 columns">{monday}</div>
-      </div>
+      {monday && (
+        <div className="row">
+          <div className="small-6 columns">Monday:</div>
+          <div className="small-6 columns">{monday}</div>
+        </div>
+      )}
 
       {/* Tuesday */}
-      <div className="row">
-        <div className="small-6 columns">Tuesday:</div>
-        <div className="small-6 columns">{tuesday}</div>
-      </div>
+      {tuesday && (
+        <div className="row">
+          <div className="small-6 columns">Tuesday:</div>
+          <div className="small-6 columns">{tuesday}</div>
+        </div>
+      )}
 
       {/* Wednesday */}
-      <div className="row">
-        <div className="small-6 columns">Wednesday:</div>
-        <div className="small-6 columns">{wednesday}</div>
-      </div>
+      {wednesday && (
+        <div className="row">
+          <div className="small-6 columns">Wednesday:</div>
+          <div className="small-6 columns">{wednesday}</div>
+        </div>
+      )}
 
       {/* Thursday */}
-      <div className="row">
-        <div className="small-6 columns">Thursday:</div>
-        <div className="small-6 columns">{thursday}</div>
-      </div>
+      {thursday && (
+        <div className="row">
+          <div className="small-6 columns">Thursday:</div>
+          <div className="small-6 columns">{thursday}</div>
+        </div>
+      )}
 
       {/* Friday */}
-      <div className="row">
-        <div className="small-6 columns">Friday:</div>
-        <div className="small-6 columns">{friday}</div>
-      </div>
+      {friday && (
+        <div className="row">
+          <div className="small-6 columns">Friday:</div>
+          <div className="small-6 columns">{friday}</div>
+        </div>
+      )}
 
       {/* Saturday */}
-      <div className="row">
-        <div className="small-6 columns">Saturday:</div>
-        <div className="small-6 columns">{saturday}</div>
-      </div>
+      {saturday && (
+        <div className="row">
+          <div className="small-6 columns">Saturday:</div>
+          <div className="small-6 columns">{saturday}</div>
+        </div>
+      )}
 
       {isVetCenter && (
         <p>

--- a/src/applications/facility-locator/tests/helpers.unit.spec.js
+++ b/src/applications/facility-locator/tests/helpers.unit.spec.js
@@ -187,9 +187,9 @@ describe('Validate ID Strings for Breadcrumb', () => {
     expect(result).to.eq(expected);
   });
 
-  it('formatOperatingHours should return "N/A" if a time is invalid', () => {
-    const operatingHours = '00AM-30PM';
-    const expected = 'N/A - N/A';
+  it('formatOperatingHours should return the original string a time is invalid', () => {
+    const operatingHours = 'By Appointment only';
+    const expected = 'By Appointment only';
 
     const result = formatOperatingHours(operatingHours);
 

--- a/src/applications/facility-locator/utils/helpers.js
+++ b/src/applications/facility-locator/utils/helpers.js
@@ -114,7 +114,8 @@ export const validateIdString = (urlObj, urlPrefixString) => {
  * @returns {String} Formatted operating hours, like '8:00am - 5:00pm' or 'All Day', etc.
  *
  */
-export const formatOperatingHours = (operatingHours = 'N/A - N/A') => {
+export const formatOperatingHours = operatingHours => {
+  if (!operatingHours) return operatingHours;
   // Remove all whitespace.
   const sanitizedOperatingHours = replace(operatingHours, ' ', '');
 
@@ -151,14 +152,12 @@ export const formatOperatingHours = (operatingHours = 'N/A - N/A') => {
   }
 
   // Derive the formatted operating hours.
-  let formattedOperatingHours = `${formattedOpeningHour} - ${formattedClosingHour}`;
+  const formattedOperatingHours = `${formattedOpeningHour} - ${formattedClosingHour}`;
 
-  // Swap 'Invalid date' with 'N/A' for legibility.
-  formattedOperatingHours = replace(
-    formattedOperatingHours,
-    /Invalid date/g,
-    'N/A',
-  );
+  // Return original string if invalid date.
+  if (formattedOperatingHours.search(/Invalid date/i) === 0) {
+    return operatingHours;
+  }
 
   // Return the formatted operating hours.
   return formattedOperatingHours;


### PR DESCRIPTION
## Description
Issue: https://github.com/department-of-veterans-affairs/va.gov-team/issues/2405

## Testing done
Locally.

## Screenshots

## Acceptance criteria
- [x] Facility Locator should display the hours of operation information sent through the API, rather than interpreting the data.

Acceptance Criteria
If the Facility reports hours as "24/7", the Facility Detail page should display 24/7
If the Facility reports "Sunrise-Sunset", the Facility Detail page should display "Sunrise-Sunset" 
If the API does not contain information for the hours of operation, the Facility Detail page should not display that area of content.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
