### PR TITLE
Send time part of date for confirmed va appts

### DIFF
--- a/src/applications/vaos/actions/appointments.js
+++ b/src/applications/vaos/actions/appointments.js
@@ -70,21 +70,24 @@ export function fetchFutureAppointments() {
         const data = await Promise.all([
           getConfirmedAppointments(
             'va',
-            moment().toISOString(),
             moment()
-              .add(4, 'months')
+              .startOf('day')
+              .toISOString(),
+            moment()
+              .startOf('day')
+              .add(120, 'days')
               .toISOString(),
           ),
           getConfirmedAppointments(
             'cc',
             moment().format('YYYY-MM-DD'),
             moment()
-              .add(4, 'months')
+              .add(120, 'days')
               .format('YYYY-MM-DD'),
           ),
           getPendingAppointments(
             moment()
-              .subtract(4, 'months')
+              .subtract(30, 'days')
               .format('YYYY-MM-DD'),
             moment().format('YYYY-MM-DD'),
           ),

--- a/src/applications/vaos/actions/appointments.js
+++ b/src/applications/vaos/actions/appointments.js
@@ -70,10 +70,10 @@ export function fetchFutureAppointments() {
         const data = await Promise.all([
           getConfirmedAppointments(
             'va',
-            moment().format('YYYY-MM-DD'),
+            moment().toISOString(),
             moment()
               .add(4, 'months')
-              .format('YYYY-MM-DD'),
+              .toISOString(),
           ),
           getConfirmedAppointments(
             'cc',


### PR DESCRIPTION
## Description
We should send a time that matches what legacy VAOS is doing

## Testing done
Local testing

## Acceptance criteria
- [ ] Time is set to start of day, sent in UTC

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
