### PR TITLE
Set reason max characters to 100 if flow type is request

### DIFF
--- a/src/applications/vaos/actions/newAppointment.js
+++ b/src/applications/vaos/actions/newAppointment.js
@@ -8,7 +8,7 @@ import {
   getFacilityInfo,
   getAvailableSlots,
 } from '../api';
-import { FLOW_TYPES } from '../utils/constants';
+import { FLOW_TYPES, REASON_MAX_CHARS } from '../utils/constants';
 
 import { getEligibilityData } from '../utils/eligibility';
 
@@ -50,8 +50,6 @@ export const FORM_PAGE_COMMUNITY_CARE_PREFS_OPEN =
   'newAppointment/FORM_PAGE_COMMUNITY_CARE_PREFS_OPEN';
 export const FORM_PAGE_COMMUNITY_CARE_PREFS_OPEN_SUCCEEDED =
   'newAppointment/FORM_PAGE_COMMUNITY_CARE_PREFS_OPEN_SUCCEEDED';
-
-export const REASON_MAX_CHAR_DEFAULT = 150;
 
 export function openFormPage(page, uiSchema, schema) {
   return {
@@ -210,15 +208,21 @@ export function updateFacilityPageData(page, uiSchema, data) {
 }
 
 export function updateReasonForAppointmentData(page, uiSchema, data) {
-  return async dispatch => {
+  return async (dispatch, getState) => {
+    const newAppointment = getState().newAppointment;
+    const reasonMaxChars =
+      newAppointment.flowType === FLOW_TYPES.DIRECT
+        ? REASON_MAX_CHARS.direct
+        : REASON_MAX_CHARS.request;
+
     let reasonAdditionalInfo = data.reasonAdditionalInfo;
     let remainingCharacters =
-      REASON_MAX_CHAR_DEFAULT - data.reasonForAppointment.length - 1;
+      reasonMaxChars - data.reasonForAppointment.length - 1;
 
     if (reasonAdditionalInfo) {
       // Max length for reason
       const maxTextAreaLength =
-        REASON_MAX_CHAR_DEFAULT - data.reasonForAppointment.length - 1;
+        reasonMaxChars - data.reasonForAppointment.length - 1;
       reasonAdditionalInfo = reasonAdditionalInfo.substr(0, maxTextAreaLength);
       remainingCharacters = maxTextAreaLength - reasonAdditionalInfo.length;
     }

--- a/src/applications/vaos/reducers/newAppointment.js
+++ b/src/applications/vaos/reducers/newAppointment.js
@@ -33,12 +33,11 @@ import {
   FORM_SCHEDULE_APPOINTMENT_PAGE_OPENED,
   FORM_SCHEDULE_APPOINTMENT_PAGE_OPENED_SUCCEEDED,
   FORM_REASON_FOR_APPOINTMENT_UPDATE_REMAINING_CHAR,
-  REASON_MAX_CHAR_DEFAULT,
   FORM_PAGE_COMMUNITY_CARE_PREFS_OPEN,
   FORM_PAGE_COMMUNITY_CARE_PREFS_OPEN_SUCCEEDED,
 } from '../actions/newAppointment';
 
-import { FLOW_TYPES } from '../utils/constants';
+import { FLOW_TYPES, REASON_MAX_CHARS } from '../utils/constants';
 
 import { getTypeOfCare } from '../utils/selectors';
 
@@ -56,7 +55,6 @@ const initialState = {
   loadingEligibility: false,
   loadingFacilityDetails: false,
   pastAppointments: null,
-  reasonRemainingChar: REASON_MAX_CHAR_DEFAULT,
 };
 
 function getFacilities(state, typeOfCareId, vaSystem) {
@@ -356,11 +354,13 @@ export default function formReducer(state = initialState, action) {
         ...state,
         pastAppointments: action.appointments,
         flowType: FLOW_TYPES.DIRECT,
+        reasonRemainingChar: REASON_MAX_CHARS.direct,
       };
     case START_REQUEST_APPOINTMENT_FLOW:
       return {
         ...state,
         flowType: FLOW_TYPES.REQUEST,
+        reasonRemainingChar: REASON_MAX_CHARS.request,
       };
     case FORM_CLINIC_PAGE_OPENED: {
       return {

--- a/src/applications/vaos/tests/actions/newAppointment.unit.spec.js
+++ b/src/applications/vaos/tests/actions/newAppointment.unit.spec.js
@@ -26,13 +26,13 @@ import {
   FORM_CLINIC_PAGE_OPENED,
   FORM_CLINIC_PAGE_OPENED_SUCCEEDED,
   FORM_REASON_FOR_APPOINTMENT_UPDATE_REMAINING_CHAR,
-  REASON_MAX_CHAR_DEFAULT,
   FORM_PAGE_COMMUNITY_CARE_PREFS_OPEN,
   FORM_PAGE_COMMUNITY_CARE_PREFS_OPEN_SUCCEEDED,
 } from '../../actions/newAppointment';
 import systems from '../../api/facilities.json';
 import systemIdentifiers from '../../api/systems.json';
 import facilities983 from '../../api/facilities_983.json';
+import { REASON_MAX_CHARS, FLOW_TYPES } from '../../utils/constants';
 
 const testFlow = {
   page1: {
@@ -354,9 +354,15 @@ describe('VAOS newAppointment actions', () => {
   });
 
   describe('reasonForAppointment', () => {
-    it('update values and calculates remaining characters for additional info', async () => {
-      const reasonForAppointment = 'new-issue';
-      const reasonAdditionalInfo = 'test';
+    const reasonForAppointment = 'new-issue';
+    const reasonAdditionalInfo = 'test';
+
+    it('update values and calculates remaining characters for direct schedule reason', async () => {
+      const state = {
+        newAppointment: {
+          flowType: FLOW_TYPES.DIRECT,
+        },
+      };
 
       const dispatch = sinon.spy();
       const thunk = updateReasonForAppointmentData(
@@ -367,17 +373,45 @@ describe('VAOS newAppointment actions', () => {
           reasonAdditionalInfo,
         },
       );
-      await thunk(dispatch);
+
+      await thunk(dispatch, () => state);
+
       expect(dispatch.firstCall.args[0].type).to.equal(
         FORM_REASON_FOR_APPOINTMENT_UPDATE_REMAINING_CHAR,
       );
       expect(dispatch.firstCall.args[0].remainingCharacters).to.equal(
-        REASON_MAX_CHAR_DEFAULT -
+        REASON_MAX_CHARS.direct -
           reasonForAppointment.length -
           1 -
           reasonAdditionalInfo.length,
       );
       expect(dispatch.secondCall.args[0].type).to.equal(FORM_DATA_UPDATED);
+    });
+
+    it('update values and calculates remaining characters for request message', async () => {
+      const state = {
+        newAppointment: {
+          flowType: FLOW_TYPES.REQUEST,
+        },
+      };
+
+      const dispatch = sinon.spy();
+      const thunk = updateReasonForAppointmentData(
+        'reasonForAppointment',
+        {},
+        {
+          reasonForAppointment,
+          reasonAdditionalInfo,
+        },
+      );
+
+      await thunk(dispatch, () => state);
+      expect(dispatch.firstCall.args[0].remainingCharacters).to.equal(
+        REASON_MAX_CHARS.request -
+          reasonForAppointment.length -
+          1 -
+          reasonAdditionalInfo.length,
+      );
     });
   });
   describe('openCommunityCarePreferencesPage', () => {

--- a/src/applications/vaos/utils/constants.js
+++ b/src/applications/vaos/utils/constants.js
@@ -224,6 +224,11 @@ export const DISTANCES = [
   },
 ];
 
+export const REASON_MAX_CHARS = {
+  request: 100,
+  direct: 150,
+};
+
 export const DISABLED_LIMIT_VALUE = 0;
 export const PRIMARY_CARE = '323';
 export const MENTAL_HEALTH = '502';


### PR DESCRIPTION
## Description
Schedule Manager & legacy VAOS restrict messages to scheduling clerks to 100 characters. Our current UI allows 150 - mainly because the UI for 'reason for appointment' in the direct schedule flow allows (and should continue to allow) 150 characters, and it was built before the messaging feature was integrated into it.

## Testing done
Local and unit

## Acceptance criteria
- [ ] When direct scheduling, veterans see 150 chars (minus the selected radio option) as the 'reason for appointment' character limit
- [ ] When requesting, veterans see 100 chars (minus the selected radio option) as the 'reason for appointment' character limit (though this is technically the 'submit a message to the scheduling clerk' question)


## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
