### PR TITLE
VAGOV-6263: Fixing ie11 image display issue.

### DIFF
--- a/src/applications/static-pages/sass/modules/_m-facilities.scss
+++ b/src/applications/static-pages/sass/modules/_m-facilities.scss
@@ -261,17 +261,12 @@ $duo-tone-lighten: #000;
 }
 
 .bio-image {
-  height: 178px;
-  width: 144px;
-  object-fit: cover;
+  max-height: 178px;
 }
 
 .person-profile-detail-page-image {
-  height: 227px;
-  width: 176px;
-  object-fit: cover;
+  max-height: 227px;
 }
-
 
 .va-facility-page {
   .va-address-block {


### PR DESCRIPTION
## Description
Updates two classes to have max-height treatment (only)

## Testing done
Visual

## Screenshot
@cvalarida - Left side is ie11, right is firefox. Note how the left hand side is stretched / distorted as object-fit property is not recognized by ie11. 
![image](https://user-images.githubusercontent.com/2404547/68962112-d8675080-07a1-11ea-96ac-6360bc5357f6.png)
