### PR TITLE
temporarily hide the MessagingWidget

### DIFF
--- a/src/applications/personalization/dashboard/components/ManageYourVAHealthCare.jsx
+++ b/src/applications/personalization/dashboard/components/ManageYourVAHealthCare.jsx
@@ -12,7 +12,7 @@ import {
   renderWidgetDowntimeNotification,
 } from '../helpers';
 
-import MessagingWidget from '../containers/MessagingWidget';
+// import MessagingWidget from '../containers/MessagingWidget';
 import PrescriptionsWidget from '../containers/PrescriptionsWidget';
 import ESRError, { ESR_ERROR_TYPES } from './ESRError';
 
@@ -84,7 +84,8 @@ const ManageYourVAHealthCare = ({
       isVisible={isEnrolledInHealthCare}
       className="background-color-only"
     />
-    <DowntimeNotification
+    {/* hide the messaging widget until this is resolved https://github.com/department-of-veterans-affairs/va.gov-team/issues/3271 */}
+    {/* <DowntimeNotification
       appTitle="messaging"
       dependencies={[externalServices.mvi, externalServices.mhv]}
       render={renderWidgetDowntimeNotification(
@@ -93,7 +94,7 @@ const ManageYourVAHealthCare = ({
       )}
     >
       <MessagingWidget />
-    </DowntimeNotification>
+    </DowntimeNotification> */}
 
     <DowntimeNotification
       appTitle="rx"


### PR DESCRIPTION
## Description
We got word that this bug (https://github.com/department-of-veterans-affairs/va.gov-team/issues/3271) is also affecting the messaging widget. Seems like removing it until we figure this out is the best course of action.

## Testing done
Local

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs