### PR TITLE
19964: Lowercase two letters based off of feedback

### DIFF
--- a/src/applications/static-pages/school-resources/ScoEventsWidget.jsx
+++ b/src/applications/static-pages/school-resources/ScoEventsWidget.jsx
@@ -95,11 +95,11 @@ export default class ScoEventsWidget extends React.Component {
         <p>
           See full list of{' '}
           <a href="https://www.benefits.va.gov/gibill/resources/education_resources/school_certifying_officials/conferences_and_events.asp">
-            Conferences and Events
+            Conferences and events
           </a>{' '}
           |{' '}
           <a href="https://www.benefits.va.gov/gibill/resources/education_resources/school_certifying_officials/presentations.asp">
-            Training Webinars
+            Training webinars
           </a>{' '}
         </p>
       </div>


### PR DESCRIPTION
## Description
As a developer, I need to update the SCO page content based on DSVA feedback so that it meets DSVA standards and design practices.

Changes just to lowercase `events` and `webinars`.

https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/vets.gov-team/19964

## Testing done
Manual, unit, and E2E tests pass locally

## Screenshots
![Screen Shot 2019-11-15 at 10 36 57 AM](https://user-images.githubusercontent.com/48804834/68955391-eb732400-0793-11ea-96be-914e82d10502.png)


## Acceptance criteria
- [x] Both words are lowercased

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
