### PR TITLE
2313 update rd e2e

### DIFF
--- a/src/applications/personalization/rated-disabilities/tests/e2e/ratedDisabilitiesError.e2e.spec.js
+++ b/src/applications/personalization/rated-disabilities/tests/e2e/ratedDisabilitiesError.e2e.spec.js
@@ -8,12 +8,12 @@ const Timeouts = require('platform/testing/e2e/timeouts');
 function runRatedDisabilitiesTest(browser) {
   browser.assert.containsText(
     '.usa-alert-heading',
-    'No disability rating found',
+    'We’re sorry. Something went wrong on our end',
   );
   browser.assert.visible('.usa-alert-text');
   browser.assert.containsText(
     '.usa-alert-text p:nth-of-type(1)',
-    "We are sorry. We can't find a disability rating matched with the name, date of birth, and social secuity number you provided in our Veteran records.",
+    'Please refresh this page or check back later. You can also sign out of VA.gov and try signing back into this page.',
   );
 }
 

--- a/src/applications/personalization/rated-disabilities/tests/e2e/ratedDisabilitiesSuccess.e2e.spec.js
+++ b/src/applications/personalization/rated-disabilities/tests/e2e/ratedDisabilitiesSuccess.e2e.spec.js
@@ -19,14 +19,14 @@ function runRatedDisabilitiesTest(browser) {
   );
 }
 
-function generateTableData(token) {
+function generateData(token) {
   return Mock(token, SuccessMockData);
 }
 
 function begin(browser) {
   browser.perform(done => {
     const token = Auth.getUserToken();
-    generateTableData(token).then(() => {
+    generateData(token).then(() => {
       Auth.logIn(
         token,
         browser,

--- a/src/applications/personalization/rated-disabilities/tests/e2e/ratedDisabilitiesSuccess.e2e.spec.js
+++ b/src/applications/personalization/rated-disabilities/tests/e2e/ratedDisabilitiesSuccess.e2e.spec.js
@@ -7,11 +7,16 @@ const Timeouts = require('platform/testing/e2e/timeouts');
 
 function runRatedDisabilitiesTest(browser) {
   browser.assert.containsText(
-    '.vads-u-font-size--h3',
-    'Your rated disabilities',
+    '.vads-u-font-family--sans.vads-u-margin-y--1',
+    'Individual disability ratings',
   );
-  browser.assert.visible('.va-sortable-table');
-  browser.assert.containsText('td:nth-of-type(1)', 'Diabetes mellitus0');
+  browser.assert.visible(
+    '.vads-u-font-weight--bold.vads-u-margin-top--0p25.vads-u-margin-bottom--0.vads-u-margin-x--0.vads-u-font-size--base',
+  );
+  browser.assert.containsText(
+    'p.vads-u-font-weight--bold.vads-u-margin-top--0p25.vads-u-margin-bottom--0.vads-u-margin-x--0.vads-u-font-size--base:nth-of-type(1)',
+    'Diabetes mellitus0',
+  );
 }
 
 function generateTableData(token) {
@@ -27,7 +32,10 @@ function begin(browser) {
         browser,
         '/disability/check-disability-rating/rating',
         3,
-      ).waitForElementVisible('.vads-u-font-size--h3', Timeouts.verySlow);
+      ).waitForElementVisible(
+        '.vads-u-font-family--sans.vads-u-margin-y--1',
+        Timeouts.verySlow,
+      );
     });
     browser.pause(Timeouts.slow);
     runRatedDisabilitiesTest(browser);


### PR DESCRIPTION
## Description
This is an update to the e2e tests for rated disabilities since designs had diverged from original tests a while ago. 

## Testing done
- local

## Screenshots
<img width="761" alt="Screen Shot 2019-11-15 at 11 28 53 AM" src="https://user-images.githubusercontent.com/15097156/68962859-24fb5d80-079b-11ea-8bdd-fafd2048c2a1.png">


## Acceptance criteria
- [x] all e2e tests pass.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
