### PR TITLE
URL Adjustment for View Rated Disabilities

### DIFF
--- a/src/applications/personalization/rated-disabilities/manifest.json
+++ b/src/applications/personalization/rated-disabilities/manifest.json
@@ -2,7 +2,7 @@
   "appName": "Rated Disabilities",
   "entryFile": "./rated-disabilities-entry.jsx",
   "entryName": "disability-my-rated-disabilities",
-  "rootUrl": "/disability/check-disability-rating/rating",
+  "rootUrl": "/disability/view-disability-rating/rating",
   "template": {
     "layout": "page-react.html",
     "vagovprod": false


### PR DESCRIPTION
## Description
[Original Ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/3516)

As a Veteran, I want to ensure that the url for the page I am on closely matches the feature I am interacting with and makes sense when viewing in my browser, contributing to clarity and confidence.

Adjust one word (check to view) in the following urls:

Static page URL: //www.va.gov/disability/check-disability-rating/
Report/dynamic page URL: //www.va.gov/disability/check-disability-rating/rating/

to

Static page URL: //www.va.gov/disability/view-disability-rating/
Report/dynamic page URL: //www.va.gov/disability/view-disability-rating/rating/

## Acceptance criteria
- [x] Adjusted URL 

## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
