### PR TITLE
Update ReviewFieldTemplate

### DIFF
--- a/src/platform/forms-system/src/js/review/ReviewFieldTemplate.jsx
+++ b/src/platform/forms-system/src/js/review/ReviewFieldTemplate.jsx
@@ -12,8 +12,12 @@ export default function ReviewFieldTemplate(props) {
   const DescriptionField =
     typeof description === 'function' ? uiSchema['ui:description'] : null;
 
-  return schema.type === 'object' || schema.type === 'array' ? (
-    children
+  if (schema.type === 'object' || schema.type === 'array') {
+    return children;
+  }
+
+  return uiSchema?.['ui:reviewField'] ? (
+    uiSchema['ui:reviewField'](props)
   ) : (
     <div className="review-row">
       <dt>

--- a/src/platform/forms-system/test/js/review/ReviewFieldTemplate.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/review/ReviewFieldTemplate.unit.spec.jsx
@@ -66,4 +66,43 @@ describe('Schemaform ReviewFieldTemplate', () => {
     expect(tree.everySubTree('.review-row')).to.be.empty;
     expect(tree.everySubTree('.test-child')).to.not.be.empty;
   });
+  it('should render the custom reviewField', () => {
+    const uiSchema = {
+      'ui:title': 'Label',
+      'ui:description': 'Blah',
+      'ui:reviewField': () => (
+        <dl className="review-row">
+          <dt>Test</dt>
+        </dl>
+      ),
+    };
+    const tree = SkinDeep.shallowRender(
+      <ReviewFieldTemplate schema={{ type: 'string' }} uiSchema={uiSchema}>
+        <div className="test-child" />
+      </ReviewFieldTemplate>,
+    );
+
+    expect(tree.subTree('dt').text()).to.equal('Test');
+    // Children are ignored for non-string/array objects
+    expect(tree.everySubTree('.test-child').length).to.equal(0);
+  });
+  it('should render the custom reviewField & children', () => {
+    const uiSchema = {
+      'ui:title': 'Label',
+      'ui:description': 'Blah',
+      'ui:reviewField': () => (
+        <dl className="review-row">
+          <dt>Test</dt>
+        </dl>
+      ),
+    };
+    const tree = SkinDeep.shallowRender(
+      <ReviewFieldTemplate schema={{ type: 'object' }} uiSchema={uiSchema}>
+        <div className="test-child" />
+      </ReviewFieldTemplate>,
+    );
+
+    expect(tree.everySubTree('.review-row')).to.be.empty;
+    expect(tree.everySubTree('.test-child').length).to.equal(1);
+  });
 });


### PR DESCRIPTION
## Description

This PR modifies the `reviewFieldTemplate` component to allow customized review field templates

### Scenario

This update is needed for the following scenario:

* When using the [checkbox group schema](https://department-of-veterans-affairs.github.io/veteran-facing-services-tools/forms/available-features-and-usage-guidelines/#checkbox-group),
* the following review field is shown on the review application page - the key is seen on the left with its value on the right

    ![](https://user-images.githubusercontent.com/136959/68981172-3313a300-07c8-11ea-8ff5-cc114cb27411.png)

* The design I'm working with requires some custom content to be added to the left ("Representative's availability" versus "My availability") with the key name shown on the right, but only if the key's value is `true`

  ![](https://user-images.githubusercontent.com/136959/68981265-7bcb5c00-07c8-11ea-9fd3-06b463b71c65.png)

* Since each field entry is run separately, CSS will need to be used to hide the custom content on the left.

### New flow

This PR adds a new `'ui:reviewField'` entry to the `uiSchema`.

Internally, the `ReviewFieldTemplate` component (`src/platform/forms-system/src/js/review/ReviewFieldTemplate.jsx`):

* Check for any `children` passed to it in the props (a React component) and immediately returns it  if the schema type is set as an object or array - this part didn't change.
* This PR then adds a check for a `'ui:reviewField'` uiSchema entry. If it exists, the value of that entry is returned with the `props` parameter.
* If a `'ui:reviewField'` isn't found, it returns the previous content; but the `<div>` has been replaced by a `<dl>` 

The `'ui:reviewField'` is passed the following parameters (props):
* `children` - most likely undefined as the `ReviewFieldTemplate` returns this value if defined; but only if the schema type is either `object` or `array`.
* `uiSchema` - The `uiSchema` for that specific level (depth) of the form.
* `schema` - The `schema` for that specific level (depth) of the form.

## Testing done

Added unit tests for rendering of the custom template and rendering of children instead of the custom template when the schema type is either `object` or `array` (as it was done originally).

## Screenshots

N/A

## Acceptance criteria
- [ ] Unit tests passing
- [ ] Acceptable naming of the new uiSchema function

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] ~A link has been provided to the originating GitHub issue (or connected to it via ZenHub)~
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
