### PR TITLE
Update cms export build test

### DIFF
--- a/script/test-cms-export.js
+++ b/script/test-cms-export.js
@@ -57,9 +57,11 @@ if (nodeName) {
 
   // eslint-disable-next-line no-console
   console.log('Number of files:', modifiedEntities.length);
-  // eslint-disable-next-line no-console
-  console.log(
-    `Node ${printIndex || 0}:`,
-    JSON.stringify(modifiedEntities[printIndex || 0], null, 2),
-  );
+  if (printIndex) {
+    // eslint-disable-next-line no-console
+    console.log(
+      `Node ${printIndex}:`,
+      JSON.stringify(modifiedEntities[printIndex || 0], null, 2),
+    );
+  }
 }

--- a/script/test-cms-export.js
+++ b/script/test-cms-export.js
@@ -17,7 +17,7 @@ const {
 const optionDefinitions = [
   { name: 'count', alias: 'c', type: Number },
   { name: 'node', alias: 'n', type: String },
-  { name: 'print', alias: 'p', type: Number, defaultValue: 0 },
+  { name: 'print', alias: 'p', type: Number },
 ];
 
 const { count, node: nodeName, print: printIndex } = commandLineArgs(
@@ -57,7 +57,7 @@ if (nodeName) {
 
   // eslint-disable-next-line no-console
   console.log('Number of files:', modifiedEntities.length);
-  if (printIndex) {
+  if (printIndex !== undefined) {
     // eslint-disable-next-line no-console
     console.log(
       `Node ${printIndex}:`,

--- a/script/test-cms-export.js
+++ b/script/test-cms-export.js
@@ -17,7 +17,7 @@ const {
 const optionDefinitions = [
   { name: 'count', alias: 'c', type: Number },
   { name: 'node', alias: 'n', type: String },
-  { name: 'print', alias: 'p', type: Number },
+  { name: 'print', alias: 'p', type: Number, defaultValue: 0 },
 ];
 
 const { count, node: nodeName, print: printIndex } = commandLineArgs(
@@ -61,7 +61,7 @@ if (nodeName) {
     // eslint-disable-next-line no-console
     console.log(
       `Node ${printIndex}:`,
-      JSON.stringify(modifiedEntities[printIndex || 0], null, 2),
+      JSON.stringify(modifiedEntities[printIndex], null, 2),
     );
   }
 }

--- a/script/test-cms-export.js
+++ b/script/test-cms-export.js
@@ -1,4 +1,6 @@
 // Dependencies
+const assert = require('assert');
+const commandLineArgs = require('command-line-args');
 const { map } = require('lodash');
 // Relative
 const {
@@ -12,19 +14,52 @@ const {
   readEntity,
 } = require('../src/site/stages/build/process-cms-exports/helpers');
 
-const fileNames = readAllNodeNames();
-const entities = map(fileNames, entityDetails =>
-  readEntity(contentDir, ...entityDetails),
+const optionDefinitions = [
+  { name: 'count', alias: 'c', type: Number },
+  { name: 'node', alias: 'n', type: String },
+  { name: 'print', alias: 'p', type: Number },
+];
+
+const { count, node: nodeName, print: printIndex } = commandLineArgs(
+  optionDefinitions,
 );
 
-// Assemble all the nodes
-// const modifiedEntities = map(entities, entity => assembleEntityTree(entity));
+if (nodeName) {
+  const nodeNamePieces = nodeName.split('.').slice(0, 2);
+  assert(
+    nodeNamePieces.length === 2,
+    'Node needs to be the filename of an entity. E.g. node.<uuid>.json',
+  );
 
-// Assemble only the first node for debugging
-const modifiedEntities = map([entities[0]], entity =>
-  assembleEntityTree(entity),
-);
+  const node = assembleEntityTree(readEntity(contentDir, ...nodeNamePieces));
+  // eslint-disable-next-line no-console
+  console.log(JSON.stringify(node, null, 2));
+} else {
+  // Make sure the printIndex is valid if passed
+  if (printIndex) {
+    if (count)
+      assert(
+        printIndex < count,
+        `Print index (${printIndex}) must be less than node count (${count}) to point to a valid node.`,
+      );
+    assert(printIndex >= 0, `Print index (${printIndex}) must be >= 0`);
+  }
 
-// eslint-disable-next-line
-console.log('Number of files:', modifiedEntities.length);
-// console.log('First node:', JSON.stringify(modifiedEntities[0], null, 2));
+  const fileNames = readAllNodeNames();
+  const entities = map(fileNames, entityDetails =>
+    readEntity(contentDir, ...entityDetails),
+  );
+
+  const modifiedEntities = map(
+    entities.slice(0, count || entities.length),
+    entity => assembleEntityTree(entity),
+  );
+
+  // eslint-disable-next-line no-console
+  console.log('Number of files:', modifiedEntities.length);
+  // eslint-disable-next-line no-console
+  console.log(
+    `Node ${printIndex || 0}:`,
+    JSON.stringify(modifiedEntities[printIndex || 0], null, 2),
+  );
+}


### PR DESCRIPTION
## Description
Adds command line options to the helper script `yarn build:content:test`

- `--count` `-c` Builds only that many nodes
- `--print` `-p` Prints out the Nth node
- `--node` `-n` Builds a specific entity
  - Despite the name, we can use this to build more than just node entities

## Testing done
Made sure it all worked manually.

## Screenshots
Specifying a count without printing:
![image](https://user-images.githubusercontent.com/12970166/69092714-d8658b80-0a01-11ea-905f-c799ef38c13a.png)
Specifying a count with printing:
![image](https://user-images.githubusercontent.com/12970166/69092754-ed421f00-0a01-11ea-8f22-ce2a47003fbf.png)
Specifying a specific entity:
![image](https://user-images.githubusercontent.com/12970166/69092781-01861c00-0a02-11ea-9547-99808449b033.png)