### PR TITLE
fix styling issues when screen size is at 481 pixels width

### DIFF
--- a/src/applications/gi/components/search/LandingPageTypeOfInstitutionFilter.jsx
+++ b/src/applications/gi/components/search/LandingPageTypeOfInstitutionFilter.jsx
@@ -26,7 +26,7 @@ class LandingPageTypeOfInstitutionFilter extends React.Component {
     ];
     if (this.props.displayVetTecOption) {
       const vetTecLabel = (
-        <span className="vads-u-padding-top--1 vads-u-margin-left--0p5 learnMoreLabel">
+        <span className="vads-u-padding-top--1 vads-u-margin-left--0p5">
           {' '}
           <button
             aria-label={ariaLabels.learnMore.vetTecProgram}

--- a/src/applications/gi/sass/partials/_gi-search-page.scss
+++ b/src/applications/gi/sass/partials/_gi-search-page.scss
@@ -39,7 +39,7 @@
   .filter-button,
   .results-button {
     display: none;
-
+    width: 100%;
     @include media-maxwidth($small-screen) {
       display: block;
     }


### PR DESCRIPTION
## Description
https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/vets.gov-team/19991

https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/vets.gov-team/19990

1) Removed unnecessary css class that was causing styling issues on learn more label. 
2) Set filter button width to 100%.

## Testing done 
\[Provide link to QA Test Plan ticket (issue-template coming soon) for the relevant product/feature.
List the new/update unit-test(s) & e2e-test\(s) that have been successfully run before open this PR.
Also, if UI-testable (i.e., testable manually on Staging by QA, either via the browser or REST API-client), provide link to QA test-request ticket \[issue-template coming soon].]

See [VSA QA Process](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/vsa/teams/qa/vsa-qa-process.md) for more info on Engineering/QA collaboration/engagement.


## Screenshots
<img width="403" alt="Screen Shot 2019-11-19 at 10 26 54 AM" src="https://user-images.githubusercontent.com/48804654/69160221-356f4900-0ab7-11ea-8119-7a7ebc193eb6.png">

<img width="600" alt="Screen Shot 2019-11-19 at 11 03 38 AM" src="https://user-images.githubusercontent.com/48804654/69163481-466e8900-0abc-11ea-8655-c050d90e100c.png">

## Acceptance criteria
- [x] Fix learn more button position.
- [x] Fix filter button size.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the Pre-Launch Checklist
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] A link has been provided to the VSA-QA Test Plan ticket \[use the VSA-QA Test Plan Issue Template to create the ticket within va.gov-team repo].
- [ ] A link has been provided to the VSA-QA Test-Request ticket \[issue-template coming soon].
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
