### PR TITLE
Allow eligible users to set up Direct Deposit

### DIFF
--- a/src/applications/personalization/profile360/components/ProfileView.jsx
+++ b/src/applications/personalization/profile360/components/ProfileView.jsx
@@ -22,7 +22,8 @@ import IdentityVerification from './IdentityVerification';
 import MVIError from './MVIError';
 
 import {
-  directDepositIsSetUp as directDepositIsSetUpSelector,
+  directDepositIsSetUp,
+  directDepositAddressIsSetUp,
   profileShowDirectDeposit,
   profileShowReceiveTextNotifications,
 } from 'applications/personalization/profile360/selectors';
@@ -89,8 +90,8 @@ class ProfileView extends React.Component {
       fetchPersonalInformation,
       profile: { hero, personalInformation, militaryInformation },
       downtimeData: { appTitle },
-      directDepositIsSetUp,
       showDirectDepositFeature,
+      showDirectDepositLink,
       showReceiveTextNotifications,
     } = this.props;
 
@@ -118,7 +119,7 @@ class ProfileView extends React.Component {
               />
               <ProfileTOC
                 militaryInformation={militaryInformation}
-                showDirectDepositLink={directDepositIsSetUp}
+                showDirectDepositLink={showDirectDepositLink}
               />
               <div id="contact-information" />
               <ContactInformation
@@ -193,8 +194,9 @@ class ProfileView extends React.Component {
 
 function mapStateToProps(state) {
   return {
-    directDepositIsSetUp: directDepositIsSetUpSelector(state),
     showDirectDepositFeature: profileShowDirectDeposit(state),
+    showDirectDepositLink:
+      directDepositIsSetUp(state) || directDepositAddressIsSetUp(state),
     showReceiveTextNotifications: profileShowReceiveTextNotifications(state),
   };
 }

--- a/src/applications/personalization/profile360/containers/PaymentInformation.jsx
+++ b/src/applications/personalization/profile360/containers/PaymentInformation.jsx
@@ -30,6 +30,7 @@ import {
 } from '../actions/paymentInformation';
 import {
   directDepositAccountInformation,
+  directDepositAddressIsSetUp,
   directDepositInformation,
   directDepositIsSetUp as directDepositIsSetUpSelector,
 } from '../selectors';
@@ -148,19 +149,28 @@ class PaymentInformation extends React.Component {
     });
   };
 
+  renderSetupButton(label, gaProfileSection) {
+    return (
+      <button
+        className="va-button-link"
+        onClick={() => this.handleLinkClick('add', gaProfileSection)}
+      >{`Please add your ${label}`}</button>
+    );
+  }
+
   render() {
     const {
       directDepositIsSetUp,
-      isEligible,
       isLoading,
       multifactorEnabled,
       paymentInformation,
       paymentAccount,
+      shouldShowDirectDeposit,
     } = this.props;
 
     let content = null;
 
-    if (!isEligible) {
+    if (!shouldShowDirectDeposit) {
       return content;
     }
 
@@ -172,44 +182,62 @@ class PaymentInformation extends React.Component {
       content = <PaymentInformation2FARequired />;
     } else if (paymentInformation.error) {
       content = <LoadFail information="payment" />;
-    } else if (!directDepositIsSetUp) {
-      return null;
     } else {
       content = (
         <>
           <div className="vet360-profile-field">
             <ProfileFieldHeading
-              onEditClick={() => this.handleLinkClick('edit', 'bank-name')}
+              onEditClick={
+                directDepositIsSetUp &&
+                (() => this.handleLinkClick('edit', 'bank-name'))
+              }
             >
               Bank name
             </ProfileFieldHeading>
-            {paymentAccount.financialInstitutionName}
+            {directDepositIsSetUp
+              ? paymentAccount.financialInstitutionName
+              : this.renderSetupButton('bank name', 'bank-name')}
           </div>
           <div className="vet360-profile-field">
             <ProfileFieldHeading
-              onEditClick={() => this.handleLinkClick('edit', 'account-number')}
+              onEditClick={
+                directDepositIsSetUp &&
+                (() => this.handleLinkClick('edit', 'account-number'))
+              }
             >
               Account number
             </ProfileFieldHeading>
-            {paymentAccount.accountNumber}
+            {directDepositIsSetUp
+              ? paymentAccount.accountNumber
+              : this.renderSetupButton('account number', 'account-number')}
           </div>
           <div className="vet360-profile-field">
             <ProfileFieldHeading
-              onEditClick={() => this.handleLinkClick('edit', 'account-type')}
+              onEditClick={
+                directDepositIsSetUp &&
+                (() => this.handleLinkClick('edit', 'account-type'))
+              }
             >
               Account type
             </ProfileFieldHeading>
-            {paymentAccount.accountType}
+            {directDepositIsSetUp
+              ? paymentAccount.accountType
+              : this.renderSetupButton(
+                  'account type (checking or savings)',
+                  'account-type',
+                )}
           </div>
-          <p>
-            <strong>Note:</strong> If you think you’ve been the victim of bank
-            fraud, please call us at{' '}
-            <a href="tel:1-800-827-1000" className="no-wrap">
-              800-827-1000
-            </a>{' '}
-            (TTY: <span className="no-wrap">800-829-4833</span>
-            ). We’re here Monday through Friday, 8:00 a.m. to 9:00 p.m.
-          </p>
+          {directDepositIsSetUp && (
+            <p>
+              <strong>Note:</strong> If you think you’ve been the victim of bank
+              fraud, please call us at{' '}
+              <a href="tel:1-800-827-1000" className="no-wrap">
+                800-827-1000
+              </a>{' '}
+              (TTY: <span className="no-wrap">800-829-4833</span>
+              ). We’re here Monday through Friday, 8:00 a.m. to 9:00 p.m.
+            </p>
+          )}
 
           <PaymentInformationEditModal
             onClose={this.props.editModalToggled}
@@ -247,18 +275,27 @@ const isEvssAvailable = createIsServiceAvailableSelector(
   backendServices.EVSS_CLAIMS,
 );
 
-const mapStateToProps = state => ({
-  directDepositIsSetUp: directDepositIsSetUpSelector(state),
-  multifactorEnabled: isMultifactorEnabled(state),
-  isEligible: isEvssAvailable(state),
-  isLoading:
-    isEvssAvailable(state) &&
-    isMultifactorEnabled(state) &&
-    !directDepositInformation(state),
-  paymentAccount: directDepositAccountInformation(state),
-  paymentInformation: directDepositInformation(state),
-  paymentInformationUiState: state.vaProfile.paymentInformationUiState,
-});
+const mapStateToProps = state => {
+  const directDepositIsSetUp = directDepositIsSetUpSelector(state);
+  const isEligible = isEvssAvailable(state);
+  const isEligibleToSignUp = directDepositAddressIsSetUp(state);
+
+  return {
+    directDepositIsSetUp,
+    isEligible,
+    isEligibleToSignUp,
+    isLoading:
+      isEligible &&
+      isMultifactorEnabled(state) &&
+      !directDepositInformation(state),
+    multifactorEnabled: isMultifactorEnabled(state),
+    paymentAccount: directDepositAccountInformation(state),
+    paymentInformation: directDepositInformation(state),
+    paymentInformationUiState: state.vaProfile.paymentInformationUiState,
+    shouldShowDirectDeposit:
+      isEligible && (directDepositIsSetUp || isEligibleToSignUp),
+  };
+};
 
 const mapDispatchToProps = {
   fetchPaymentInformation,

--- a/src/applications/personalization/profile360/selectors.js
+++ b/src/applications/personalization/profile360/selectors.js
@@ -15,3 +15,15 @@ export const directDepositAccountInformation = state =>
 
 export const directDepositIsSetUp = state =>
   !!directDepositAccountInformation(state)?.accountNumber;
+
+export const directDepositAddressInfomation = state =>
+  directDepositInformation(state)?.responses[0]?.paymentAddress;
+
+export const directDepositAddressIsSetUp = state => {
+  const addressInfo = directDepositAddressInfomation(state);
+  return !!(
+    addressInfo?.addressOne &&
+    addressInfo?.city &&
+    addressInfo?.stateCode
+  );
+};

--- a/src/applications/personalization/profile360/selectors.js
+++ b/src/applications/personalization/profile360/selectors.js
@@ -16,11 +16,11 @@ export const directDepositAccountInformation = state =>
 export const directDepositIsSetUp = state =>
   !!directDepositAccountInformation(state)?.accountNumber;
 
-export const directDepositAddressInfomation = state =>
+export const directDepositAddressInformation = state =>
   directDepositInformation(state)?.responses[0]?.paymentAddress;
 
 export const directDepositAddressIsSetUp = state => {
-  const addressInfo = directDepositAddressInfomation(state);
+  const addressInfo = directDepositAddressInformation(state);
   return !!(
     addressInfo?.addressOne &&
     addressInfo?.city &&

--- a/src/applications/personalization/profile360/tests/containers/PaymentInformation.unit.spec.jsx
+++ b/src/applications/personalization/profile360/tests/containers/PaymentInformation.unit.spec.jsx
@@ -22,6 +22,7 @@ describe('<PaymentInformation/>', () => {
     multifactorEnabled: true,
     isLoading: false,
     isEligible: true,
+    isEligibleToSignUp: true,
     fetchPaymentInformation() {},
     savePaymentInformation() {},
     editModalToggled() {},
@@ -38,6 +39,7 @@ describe('<PaymentInformation/>', () => {
         },
       ],
     },
+    shouldShowDirectDeposit: true,
   };
 
   it('renders', () => {
@@ -52,6 +54,7 @@ describe('<PaymentInformation/>', () => {
       ...defaultProps,
       fetchPaymentInformation,
       isEligible: false,
+      shouldShowDirectDeposit: false,
     };
     const wrapper = shallow(<PaymentInformation {...props} />);
     expect(wrapper.text()).to.be.empty;
@@ -59,14 +62,22 @@ describe('<PaymentInformation/>', () => {
     wrapper.unmount();
   });
 
-  it('renders nothing if the user has not already set up direct deposit', () => {
+  it('renders the correct content if the user is eligible for direct deposit but has not yet set it up', () => {
     const props = {
       ...defaultProps,
       directDepositIsSetUp: false,
     };
     const wrapper = shallow(<PaymentInformation {...props} />);
 
-    expect(wrapper.text()).to.be.empty;
+    // expect(wrapper.text()).to.be.empty;
+    const profileFieldHeadings = wrapper.find(ProfileFieldHeading);
+    profileFieldHeadings.forEach(node => {
+      expect(node.props().onEditClick).to.be.false;
+    });
+    wrapper.find('.vet360-profile-field').forEach(node => {
+      expect(node.text()).to.contain('Please add your');
+    });
+    expect(wrapper.find('p')).to.have.length(0);
 
     wrapper.unmount();
   });

--- a/src/applications/personalization/profile360/tests/selectors.unit.spec.js
+++ b/src/applications/personalization/profile360/tests/selectors.unit.spec.js
@@ -70,4 +70,42 @@ describe('profile360 selectors', () => {
       expect(selectors.directDepositIsSetUp(state)).to.be.false;
     });
   });
+
+  describe('directDepositAddressIsSetUp selector', () => {
+    let state;
+    beforeEach(() => {
+      state = {
+        vaProfile: {
+          paymentInformation: {
+            responses: [
+              {
+                paymentAddress: {
+                  addressOne: '123 Main',
+                  city: 'San Francisco',
+                  stateCode: 'CA',
+                },
+              },
+            ],
+          },
+        },
+      };
+    });
+    it('returns `true` if there is a street, city, and state set on the payment info payment address', () => {
+      expect(selectors.directDepositAddressIsSetUp(state)).to.be.true;
+    });
+    it('returns `false` if the street address is missing', () => {
+      state.vaProfile.paymentInformation.responses[0].paymentAddress.addressOne =
+        '';
+      expect(selectors.directDepositAddressIsSetUp(state)).to.be.false;
+    });
+    it('returns `false` if the city is missing', () => {
+      state.vaProfile.paymentInformation.responses[0].paymentAddress.city = '';
+      expect(selectors.directDepositAddressIsSetUp(state)).to.be.false;
+    });
+    it('returns `false` if the state is missing', () => {
+      state.vaProfile.paymentInformation.responses[0].paymentAddress.stateCode =
+        '';
+      expect(selectors.directDepositAddressIsSetUp(state)).to.be.false;
+    });
+  });
 });


### PR DESCRIPTION
## Description
This change allows users to sign up for Direct Deposit if they have a valid payment address on file. We are treating the existence of a payment address as an indication that they currently receive compensation via paper checks therefor are eligible to sign up for DD. This should provide feature parity with the existing functionality on the eBenefits site.

The changes to the render logic is simply a reversion of this PR which removed it: https://github.com/department-of-veterans-affairs/vets-website/pull/10977

## Testing done 
Local + updated unit tests. Also confirmed that the Direct Deposit jump link at the top of the profile appears when the Direct Deposit component is visible and it does not appear when the DD component is not visible.

## Screenshots
**When DD is not set up yet**
![image](https://user-images.githubusercontent.com/20728956/69166431-0f8e7800-0aa8-11ea-8257-e099172e3944.png)

**When DD is set up**
![image](https://user-images.githubusercontent.com/20728956/69166463-1d43fd80-0aa8-11ea-9400-fd5b67bb8d4a.png)

## Acceptance criteria
- [ ] 

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the Pre-Launch Checklist
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] A link has been provided to the VSA-QA Test Plan ticket \[use the VSA-QA Test Plan Issue Template to create the ticket within va.gov-team repo].
- [ ] A link has been provided to the VSA-QA Test-Request ticket \[issue-template coming soon].
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs