### PR TITLE
Fix input typeahead loses focus

### DIFF
--- a/src/applications/facility-locator/components/ServiceTypeAhead.jsx
+++ b/src/applications/facility-locator/components/ServiceTypeAhead.jsx
@@ -66,7 +66,6 @@ class ServiceTypeAhead extends Component {
             clearSelection();
           }
         }}
-        key={defaultSelectedItem || 'defaultSelectedItem'}
       >
         {({
           getInputProps,

--- a/src/applications/facility-locator/components/ServiceTypeAhead.jsx
+++ b/src/applications/facility-locator/components/ServiceTypeAhead.jsx
@@ -66,7 +66,7 @@ class ServiceTypeAhead extends Component {
             clearSelection();
           }
         }}
-        key={defaultSelectedItem}
+        key={defaultSelectedItem || 'defaultSelectedItem'}
       >
         {({
           getInputProps,


### PR DESCRIPTION
## Description
Issue: https://github.com/department-of-veterans-affairs/va.gov-team/issues/487

## Testing done
Locally.

## Acceptance criteria
- [x] As a keyboard user, I want the Service Type typeahead to retain focus until I have picked a list item. I should be able to tab into the field, pause, and start typing without focus changing.


## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs


