### PR TITLE
3540: GIBCT Section 116 - Benefit amounts wrap to two lines when zoomed above 300%

### DIFF
--- a/src/applications/gi/components/vet-tec/VetTecCalculator.jsx
+++ b/src/applications/gi/components/vet-tec/VetTecCalculator.jsx
@@ -73,7 +73,9 @@ export class VetTecCalculator extends React.Component {
           <h4 className="vads-u-font-size--h5">Tuition & fees:</h4>
         </div>
         <div className="small-6 columns vads-u-text-align--right">
-          <h5>{outputs.vetTecTuitionFees}</h5>
+          <h5 className="estimated-benefit-values">
+            {outputs.vetTecTuitionFees}
+          </h5>
         </div>
       </div>
       {this.renderScholarshipBenefitSection(outputs)}
@@ -92,7 +94,9 @@ export class VetTecCalculator extends React.Component {
           </div>
         </div>
         <div className="small-4 columns vads-u-text-align--right">
-          <div>{outputs.vaPaysToProvider}</div>
+          <div className="estimated-benefit-values">
+            {outputs.vaPaysToProvider}
+          </div>
         </div>
       </div>
       <div className={this.indentVaPaysToProvider()}>
@@ -101,7 +105,9 @@ export class VetTecCalculator extends React.Component {
             <div>Upon enrollment in program (25%):</div>
           </div>
           <div className="small-3 xsmall-screen:small-2 vads-u-text-align--right columns value">
-            <div>{outputs.quarterVetTecPayment}</div>
+            <div className="estimated-benefit-values">
+              {outputs.quarterVetTecPayment}
+            </div>
           </div>
         </div>
         <div className="row vads-u-margin-top--0p5 small-screen:vads-u-padding-right--7">
@@ -109,7 +115,9 @@ export class VetTecCalculator extends React.Component {
             <div>Upon completion of program (25%):</div>
           </div>
           <div className="small-3 xsmall-screen:small-2 vads-u-text-align--right columns value">
-            <div>{outputs.quarterVetTecPayment}</div>
+            <div className="estimated-benefit-values">
+              {outputs.quarterVetTecPayment}
+            </div>
           </div>
         </div>
         <div className="row vads-u-margin-top--0p5 small-screen:vads-u-padding-right--7">
@@ -117,7 +125,9 @@ export class VetTecCalculator extends React.Component {
             <div>Upon employment (50%):</div>
           </div>
           <div className="small-3 xsmall-screen:small-2 vads-u-text-align--right columns value">
-            <div>{outputs.halfVetTecPayment}</div>
+            <div className="estimated-benefit-values">
+              {outputs.halfVetTecPayment}
+            </div>
           </div>
         </div>
       </div>
@@ -128,7 +138,7 @@ export class VetTecCalculator extends React.Component {
           </h4>
         </div>
         <div className="small-6 columns vads-u-text-align--right">
-          <h5 className="vads-u-font-family--sans">
+          <h5 className="vads-u-font-family--sans estimated-benefit-values">
             {outputs.outOfPocketTuitionFees}
           </h5>
         </div>

--- a/src/applications/gi/sass/partials/_gi-profile-page.scss
+++ b/src/applications/gi/sass/partials/_gi-profile-page.scss
@@ -174,6 +174,10 @@
     }
   }
 
+  .estimated-benefit-values {
+    white-space: nowrap;
+  }
+
   .contact-heading {
     vertical-align: top;
     margin: 0;


### PR DESCRIPTION
## Description
The Your Estimated Benefits module text starts to wrap unexpectedly when I zoom my layout greater than 300% at 1280px width. Screenshot attached below.

https://github.com/department-of-veterans-affairs/va.gov-team/issues/3540

## Testing done 
Manual, unit, and E2E testing passes locally

## Screenshots
<img width="1220" alt="Screen Shot 2019-11-19 at 11 58 26 AM" src="https://user-images.githubusercontent.com/48804834/69168058-f72c5680-0ac3-11ea-86c3-d4af5875e05f.png">


## Acceptance criteria
- [ ] As a user who prefers to zoom my desktop layout, I want to see the Your Estimated Benefits module display text correctly up to 400% zoom.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [ ] A link has been provided to the Pre-Launch Checklist
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] A link has been provided to the VSA-QA Test Plan ticket \[use the VSA-QA Test Plan Issue Template to create the ticket within va.gov-team repo].
- [ ] A link has been provided to the VSA-QA Test-Request ticket \[issue-template coming soon].
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
