### PR TITLE
[COGNITION]: GIBCT Section 116 - Add screen reader only text for the benefit breakdowns by time #3537

### DIFF
--- a/src/applications/gi/components/vet-tec/VetTecCalculator.jsx
+++ b/src/applications/gi/components/vet-tec/VetTecCalculator.jsx
@@ -99,8 +99,9 @@ export class VetTecCalculator extends React.Component {
         <div className="row vads-u-margin-top--0p5 small-screen:vads-u-padding-right--7">
           <div className="small-9 small-screen:small-9 columns">
             <div>
-              Upon enrollment in program{' '}
-              <span className="sr-only">V A pays to provider</span> (25%):
+              <span>Upon enrollment in program</span>
+              <span className="sr-only">VA pays to provider</span>
+              <span>(25%):</span>
             </div>
           </div>
           <div className="small-3 xsmall-screen:small-2 vads-u-text-align--right columns value">
@@ -111,7 +112,7 @@ export class VetTecCalculator extends React.Component {
           <div className="small-9 small-screen:small-9 columns">
             <div>
               Upon completion of program{' '}
-              <span className="sr-only">V A pays to provider</span>
+              <span className="sr-only">VA pays to provider</span>
               (25%):
             </div>
           </div>
@@ -123,7 +124,7 @@ export class VetTecCalculator extends React.Component {
           <div className="small-9 small-screen:small-9 columns">
             <div>
               Upon employment{' '}
-              <span className="sr-only">V A pays to provider</span>
+              <span className="sr-only">VA pays to provider</span>
               (50%):
             </div>
           </div>

--- a/src/applications/gi/components/vet-tec/VetTecCalculator.jsx
+++ b/src/applications/gi/components/vet-tec/VetTecCalculator.jsx
@@ -99,9 +99,9 @@ export class VetTecCalculator extends React.Component {
         <div className="row vads-u-margin-top--0p5 small-screen:vads-u-padding-right--7">
           <div className="small-9 small-screen:small-9 columns">
             <div>
-              <span>Upon enrollment in program</span>
+              Upon enrollment in program{' '}
               <span className="sr-only">VA pays to provider</span>
-              <span>(25%):</span>
+              (25%):
             </div>
           </div>
           <div className="small-3 xsmall-screen:small-2 vads-u-text-align--right columns value">

--- a/src/applications/gi/components/vet-tec/VetTecCalculator.jsx
+++ b/src/applications/gi/components/vet-tec/VetTecCalculator.jsx
@@ -98,7 +98,10 @@ export class VetTecCalculator extends React.Component {
       <div className={this.indentVaPaysToProvider()}>
         <div className="row vads-u-margin-top--0p5 small-screen:vads-u-padding-right--7">
           <div className="small-9 small-screen:small-9 columns">
-            <div>Upon enrollment in program (25%):</div>
+            <div>
+              Upon enrollment in program{' '}
+              <span className="sr-only">V A pays to provider</span> (25%):
+            </div>
           </div>
           <div className="small-3 xsmall-screen:small-2 vads-u-text-align--right columns value">
             <div>{outputs.quarterVetTecPayment}</div>
@@ -106,7 +109,11 @@ export class VetTecCalculator extends React.Component {
         </div>
         <div className="row vads-u-margin-top--0p5 small-screen:vads-u-padding-right--7">
           <div className="small-9 small-screen:small-9 columns">
-            <div>Upon completion of program (25%):</div>
+            <div>
+              Upon completion of program{' '}
+              <span className="sr-only">V A pays to provider</span>
+              (25%):
+            </div>
           </div>
           <div className="small-3 xsmall-screen:small-2 vads-u-text-align--right columns value">
             <div>{outputs.quarterVetTecPayment}</div>
@@ -114,7 +121,11 @@ export class VetTecCalculator extends React.Component {
         </div>
         <div className="row vads-u-margin-top--0p5 small-screen:vads-u-padding-right--7">
           <div className="small-9 small-screen:small-9 columns">
-            <div>Upon employment (50%):</div>
+            <div>
+              Upon employment{' '}
+              <span className="sr-only">V A pays to provider</span>
+              (50%):
+            </div>
           </div>
           <div className="small-3 xsmall-screen:small-2 vads-u-text-align--right columns value">
             <div>{outputs.halfVetTecPayment}</div>


### PR DESCRIPTION
## Description
The VET TEC benefits that VA pays upon enrollment, upon completion, and upon employment could include some screen reader only text for assistive technology users. As I was listening to the read outs this morning, it wasn't clear to me what the 25%, 25%, and 50% were referring to. I had to go back and figure out the VA pays out amount above was the entire amount, and these were the breakouts. 

Context is now provided for your estimated benefits section

https://github.com/department-of-veterans-affairs/va.gov-team/issues/3537

## Testing done 
\[Provide link to QA Test Plan ticket (issue-template coming soon) for the relevant product/feature.
List the new/update unit-test(s) & e2e-test\(s) that have been successfully run before open this PR.
Also, if UI-testable (i.e., testable manually on Staging by QA, either via the browser or REST API-client), provide link to QA test-request ticket \[issue-template coming soon].]

See [VSA QA Process](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/vsa/teams/qa/vsa-qa-process.md) for more info on Engineering/QA collaboration/engagement.


## Screenshots


## Acceptance criteria
- [x] Context is provided for your estimated benefits section

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the Pre-Launch Checklist
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] A link has been provided to the VSA-QA Test Plan ticket \[use the VSA-QA Test Plan Issue Template to create the ticket within va.gov-team repo].
- [x] A link has been provided to the VSA-QA Test-Request ticket \[issue-template coming soon].
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
