### PR TITLE
[TeamSite] Fix MegaMenu style bug on benefits.va.gov

### DIFF
--- a/src/applications/proxy-rewrite/sass/consolidated-patches.scss
+++ b/src/applications/proxy-rewrite/sass/consolidated-patches.scss
@@ -131,6 +131,7 @@ header.merger {
   @include media($medium-screen) {
     .vetnav-panel .mm-link-container .vetnav-level2 {
       line-height: 1em;
+      font-family: $font-sans;
     }
   }
 


### PR DESCRIPTION
## Description
The PR fixes the font-family issue in the MegaMenu on benefits.va.gov. Who would have thought that injecting a website header into an external site would lead to weird edge cases?

Ticket - https://github.com/department-of-veterans-affairs/va.gov-team/issues/1946

## Testing done 
- `npm run watch -- --local-proxy-rewrite --entry=proxy-rewrite`
- navigate to `http://localhost:3001/?target=https://benefits.va.gov/benefits/`
- observe menu is fixed


## Screenshots

### issue
![image](https://user-images.githubusercontent.com/1915775/69179159-0ec20a00-0ad9-11ea-99f3-2b1b88926ee9.png)

### Fixed locally
![image](https://user-images.githubusercontent.com/1915775/69179182-1681ae80-0ad9-11ea-8bd8-0123e96e4352.png)


## Acceptance criteria
- [x] Menu looks okay on benefits.va.gov

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [ ] A link has been provided to the Pre-Launch Checklist
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] A link has been provided to the VSA-QA Test Plan ticket \[use the VSA-QA Test Plan Issue Template to create the ticket within va.gov-team repo].
- [ ] A link has been provided to the VSA-QA Test-Request ticket \[issue-template coming soon].
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
