### PR TITLE
Connect cancel appts api in VAOS

### DIFF
--- a/src/applications/vaos/actions/appointments.js
+++ b/src/applications/vaos/actions/appointments.js
@@ -1,6 +1,7 @@
 import moment from 'moment';
 import * as Sentry from '@sentry/browser';
 import { FETCH_STATUS } from '../utils/constants';
+import { getMomentConfirmedDate } from '../utils/appointment';
 
 import {
   getConfirmedAppointments,
@@ -154,7 +155,7 @@ export function confirmCancelAppointment() {
         });
       } else {
         const cancelData = {
-          appointmentTime: moment(appointment.startDate).format(
+          appointmentTime: getMomentConfirmedDate(appointment).format(
             'MM/DD/YYYY HH:mm:ss',
           ),
           clinicId: appointment.clinicId,

--- a/src/applications/vaos/api/index.js
+++ b/src/applications/vaos/api/index.js
@@ -347,14 +347,19 @@ export function getCancelReasons(systemId) {
   );
 }
 
-// PUT /vaos/appointments
-// eslint-disable-next-line no-unused-vars
 export function updateAppointment(appt) {
-  return new Promise(resolve => {
-    setTimeout(() => {
-      resolve();
-    }, 500);
-  });
+  let promise;
+  if (environment.isLocalhost()) {
+    promise = Promise.resolve();
+  } else {
+    promise = apiRequest(`/vaos/appointments/cancel`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(appt),
+    });
+  }
+
+  return promise;
 }
 
 // PUT /vaos/requests

--- a/src/applications/vaos/api/index.js
+++ b/src/applications/vaos/api/index.js
@@ -336,7 +336,7 @@ export function getAvailableSlots() {
 
 export function getCancelReasons(systemId) {
   let promise;
-  if (environment.isLocalhost()) {
+  if (USE_MOCK_DATA) {
     promise = import('./cancel_reasons.json').then(
       module => (module.default ? module.default : module),
     );
@@ -351,7 +351,7 @@ export function getCancelReasons(systemId) {
 
 export function updateAppointment(appt) {
   let promise;
-  if (environment.isLocalhost()) {
+  if (USE_MOCK_DATA) {
     promise = Promise.resolve();
   } else {
     promise = apiRequest(`/vaos/appointments/cancel`, {

--- a/src/applications/vaos/tests/e2e/vaos-helpers.js
+++ b/src/applications/vaos/tests/e2e/vaos-helpers.js
@@ -48,6 +48,11 @@ function initAppointmentListMock(token) {
     value: requests,
   });
   mock(token, {
+    path: '/v0/vaos/appointments/cancel',
+    verb: 'put',
+    value: '',
+  });
+  mock(token, {
     path: '/v0/vaos/facilities/983/cancel_reasons',
     verb: 'get',
     value: cancelReasons,


### PR DESCRIPTION
## Description
This hooks up the cancel PUT for appointments (not requests).

## Testing done 
Local and unit testing

## Acceptance criteria
- [x] Cancel makes an actual call for appts

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [ ] A link has been provided to the Pre-Launch Checklist
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] A link has been provided to the VSA-QA Test Plan ticket \[use the VSA-QA Test Plan Issue Template to create the ticket within va.gov-team repo].
- [ ] A link has been provided to the VSA-QA Test-Request ticket \[issue-template coming soon].
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
