### PR TITLE
Fix: If a phone number does not exist, the prompt to call should be hidden

### DIFF
--- a/src/applications/facility-locator/containers/FacilityDetail.jsx
+++ b/src/applications/facility-locator/containers/FacilityDetail.jsx
@@ -43,8 +43,8 @@ class FacilityDetail extends Component {
 
   renderFacilityInfo() {
     const { facility } = this.props;
-    const { name, website } = facility.attributes;
 
+    const { name, website, phone } = facility.attributes;
     return (
       <div>
         <h1>{name}</h1>
@@ -67,10 +67,12 @@ class FacilityDetail extends Component {
         <div>
           <LocationDirectionsLink location={facility} />
         </div>
-        <p className="p1">
-          Planning to visit? Please call first as information on this page may
-          change.
-        </p>
+        {phone && (
+          <p className="p1">
+            Planning to visit? Please call first as information on this page may
+            change.
+          </p>
+        )}
       </div>
     );
   }


### PR DESCRIPTION
## Description
Issue: https://github.com/department-of-veterans-affairs/va.gov-team/issues/2700

## Testing done
Locally.

## Acceptance criteria
- [x] If a phone number does not exist, the prompt to call should be hidden.


## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
