### PR TITLE
Added fetchTotalDisabilityRating to props

### DIFF
--- a/src/applications/personalization/rated-disabilities/containers/RatedDisabilitiesApp.jsx
+++ b/src/applications/personalization/rated-disabilities/containers/RatedDisabilitiesApp.jsx
@@ -29,6 +29,7 @@ class RatedDisabilitiesApp extends React.Component {
               fetchRatedDisabilities={this.props.fetchRatedDisabilities}
               ratedDisabilities={ratedDisabilities}
               user={this.props.user}
+              fetchTotalDisabilityRating={this.props.fetchTotalDisabilityRating}
               totalDisabilityRating={this.props.totalDisabilityRating}
               loading={this.props.loading}
               error={this.props.error}


### PR DESCRIPTION
## Description
Rated Disabilities is throwing an error in staging because fetchTotalDisabilityRating needs to be passed as a prop to RatedDisabilityView.

## Acceptance criteria
- [x] fetchTotalDisabilityRating added to props
- [x] rated disabilities page now loads

