### PR TITLE
Update appointment list filtering and sorting

### DIFF
--- a/src/applications/vaos/reducers/appointments.js
+++ b/src/applications/vaos/reducers/appointments.js
@@ -16,8 +16,8 @@ import {
 import {
   filterFutureConfirmedAppointments,
   filterFutureRequests,
-  sortFutureConfirmedList,
-  sortFutureRequestsList,
+  sortFutureConfirmedAppointments,
+  sortFutureRequests,
   sortMessages,
 } from '../utils/appointment';
 import { FETCH_STATUS } from '../utils/constants';
@@ -46,11 +46,11 @@ export default function appointmentsReducer(state = initialState, action) {
 
       const confirmedFilteredAndSorted = [...vaAppointments, ...ccAppointments]
         .filter(appt => filterFutureConfirmedAppointments(appt, action.today))
-        .sort(sortFutureConfirmedList);
+        .sort(sortFutureConfirmedAppointments);
 
       const requestsFilteredAndSorted = [
         ...requests.filter(req => filterFutureRequests(req, action.today)),
-      ].sort(sortFutureRequestsList);
+      ].sort(sortFutureRequests);
 
       return {
         ...state,

--- a/src/applications/vaos/reducers/appointments.js
+++ b/src/applications/vaos/reducers/appointments.js
@@ -14,7 +14,7 @@ import {
 } from '../actions/appointments';
 
 import {
-  filterFutureConfirmedList,
+  filterFutureConfirmedAppointments,
   filterFutureRequests,
   sortFutureConfirmedList,
   sortFutureRequestsList,
@@ -34,8 +34,6 @@ const initialState = {
   requestMessages: {},
 };
 
-const BOOKED_REQUEST = 'Booked';
-
 export default function appointmentsReducer(state = initialState, action) {
   switch (action.type) {
     case FETCH_FUTURE_APPOINTMENTS:
@@ -46,19 +44,18 @@ export default function appointmentsReducer(state = initialState, action) {
     case FETCH_FUTURE_APPOINTMENTS_SUCCEEDED: {
       const [vaAppointments, ccAppointments, requests] = action.data;
 
-      const confirmedSorted = [...vaAppointments, ...ccAppointments]
-        .filter(appt => filterFutureConfirmedList(appt, action.today))
+      const confirmedFilteredAndSorted = [...vaAppointments, ...ccAppointments]
+        .filter(appt => filterFutureConfirmedAppointments(appt, action.today))
         .sort(sortFutureConfirmedList);
 
-      const requestsSorted = [
-        ...requests.filter(
-          req =>
-            req.status !== BOOKED_REQUEST &&
-            filterFutureRequests(req, action.today),
-        ),
+      const requestsFilteredAndSorted = [
+        ...requests.filter(req => filterFutureRequests(req, action.today)),
       ].sort(sortFutureRequestsList);
 
-      const future = [...confirmedSorted, ...requestsSorted];
+      const future = [
+        ...confirmedFilteredAndSorted,
+        ...requestsFilteredAndSorted,
+      ];
 
       return {
         ...state,

--- a/src/applications/vaos/reducers/appointments.js
+++ b/src/applications/vaos/reducers/appointments.js
@@ -52,14 +52,9 @@ export default function appointmentsReducer(state = initialState, action) {
         ...requests.filter(req => filterFutureRequests(req, action.today)),
       ].sort(sortFutureRequestsList);
 
-      const future = [
-        ...confirmedFilteredAndSorted,
-        ...requestsFilteredAndSorted,
-      ];
-
       return {
         ...state,
-        future,
+        future: [...confirmedFilteredAndSorted, ...requestsFilteredAndSorted],
         futureStatus: FETCH_STATUS.succeeded,
       };
     }

--- a/src/applications/vaos/reducers/appointments.js
+++ b/src/applications/vaos/reducers/appointments.js
@@ -14,9 +14,10 @@ import {
 } from '../actions/appointments';
 
 import {
+  filterFutureConfirmedList,
   filterFutureRequests,
-  filterFutureConfirmedAppointments,
-  sortFutureList,
+  sortFutureConfirmedList,
+  sortFutureRequestsList,
   sortMessages,
 } from '../utils/appointment';
 import { FETCH_STATUS } from '../utils/constants';
@@ -44,23 +45,24 @@ export default function appointmentsReducer(state = initialState, action) {
       };
     case FETCH_FUTURE_APPOINTMENTS_SUCCEEDED: {
       const [vaAppointments, ccAppointments, requests] = action.data;
-      const futureAppointments = [
-        ...vaAppointments,
-        ...ccAppointments.filter(appt =>
-          filterFutureConfirmedAppointments(appt, action.today),
-        ),
+
+      const confirmedSorted = [...vaAppointments, ...ccAppointments]
+        .filter(appt => filterFutureConfirmedList(appt, action.today))
+        .sort(sortFutureConfirmedList);
+
+      const requestsSorted = [
         ...requests.filter(
           req =>
             req.status !== BOOKED_REQUEST &&
             filterFutureRequests(req, action.today),
         ),
-      ];
+      ].sort(sortFutureRequestsList);
 
-      futureAppointments.sort(sortFutureList);
+      const future = [...confirmedSorted, ...requestsSorted];
 
       return {
         ...state,
-        future: futureAppointments,
+        future,
         futureStatus: FETCH_STATUS.succeeded,
       };
     }

--- a/src/applications/vaos/tests/reducers/appointments.unit.spec.js
+++ b/src/applications/vaos/tests/reducers/appointments.unit.spec.js
@@ -12,6 +12,7 @@ import {
   CANCEL_APPOINTMENT_CLOSED,
   FETCH_REQUEST_MESSAGES_SUCCEEDED,
 } from '../../actions/appointments';
+import moment from 'moment';
 
 import { FETCH_STATUS } from '../../utils/constants';
 
@@ -34,6 +35,7 @@ describe('VAOS reducer: appointments', () => {
       data: [
         [
           { appointmentTime: '05/29/2099 05:30:00', appointmentRequestId: '1' },
+          // Cancelled should not show
           {
             appointmentTime: '05/29/2099 05:32:00',
             appointmentRequestId: '2',
@@ -44,14 +46,49 @@ describe('VAOS reducer: appointments', () => {
             ],
           },
         ],
-        [{ startDate: '2099-04-30T05:35:00', facilityId: '984' }],
+        [
+          { startDate: '2099-04-30T05:35:00', facilityId: '984' },
+          // appointment more than 1 hour ago should not show
+          {
+            startDate: moment()
+              .subtract(65, 'minutes')
+              .format(),
+          },
+          // appointment 30 min ago should show
+          {
+            startDate: moment()
+              .subtract(30, 'minutes')
+              .format(),
+          },
+          // video appointment less than 4 hours ago should show
+          {
+            vvsAppointments: [
+              {
+                dateTime: moment()
+                  .subtract(230, 'minutes')
+                  .format(),
+              },
+            ],
+          },
+          // video appointment more than 4 hours ago should not show
+          {
+            vvsAppointments: [
+              {
+                dateTime: moment()
+                  .subtract(245, 'minutes')
+                  .format(),
+              },
+            ],
+          },
+        ],
         [{ optionDate1: '05/29/2099' }],
       ],
+      today: moment(),
     };
 
     const newState = appointmentsReducer(initialState, action);
     expect(newState.futureStatus).to.equal(FETCH_STATUS.succeeded);
-    expect(newState.future.length).to.equal(3);
+    expect(newState.future.length).to.equal(5);
   });
 
   it('should populate requests with messages with FETCH_REQUEST_MESSAGES_SUCCEEDED', () => {

--- a/src/applications/vaos/tests/reducers/appointments.unit.spec.js
+++ b/src/applications/vaos/tests/reducers/appointments.unit.spec.js
@@ -34,19 +34,6 @@ describe('VAOS reducer: appointments', () => {
       type: FETCH_FUTURE_APPOINTMENTS_SUCCEEDED,
       data: [
         [
-          { appointmentTime: '05/29/2099 05:30:00', appointmentRequestId: '1' },
-          // Cancelled should not show
-          {
-            appointmentTime: '05/29/2099 05:32:00',
-            appointmentRequestId: '2',
-            vdsAppointments: [
-              {
-                currentStatus: 'CANCELLED BY CLINIC',
-              },
-            ],
-          },
-        ],
-        [
           { startDate: '2099-04-30T05:35:00', facilityId: '984' },
           // appointment more than 1 hour ago should not show
           {
@@ -77,6 +64,19 @@ describe('VAOS reducer: appointments', () => {
                 dateTime: moment()
                   .subtract(245, 'minutes')
                   .format(),
+              },
+            ],
+          },
+        ],
+        [
+          { appointmentTime: '05/29/2099 05:30:00', appointmentRequestId: '1' },
+          // Cancelled should not show
+          {
+            appointmentTime: '05/29/2099 05:32:00',
+            appointmentRequestId: '2',
+            vdsAppointments: [
+              {
+                currentStatus: 'CANCELLED BY CLINIC',
               },
             ],
           },

--- a/src/applications/vaos/tests/utils/appointment.unit.spec.jsx
+++ b/src/applications/vaos/tests/utils/appointment.unit.spec.jsx
@@ -1,6 +1,14 @@
 import { expect } from 'chai';
 
-import { getAppointmentId, getAppointmentTitle } from '../../utils/appointment';
+import {
+  getAppointmentId,
+  getAppointmentTitle,
+  filterFutureRequests,
+  filterFutureConfirmedAppointments,
+  sortFutureRequests,
+  sortFutureConfirmedAppointments,
+} from '../../utils/appointment';
+import moment from 'moment';
 
 describe('VAOS appointment helpers', () => {
   describe('getAppointmentId', () => {
@@ -70,5 +78,136 @@ describe('VAOS appointment helpers', () => {
       });
       expect(id).to.equal('VA visit');
     });
+  });
+
+  const now = moment();
+
+  it('should filter future confirmed appointments', () => {
+    const confirmed = [
+      { startDate: '2099-04-30T05:35:00', facilityId: '984' },
+      // appointment 30 min ago should show
+      {
+        startDate: now
+          .clone()
+          .subtract(30, 'minutes')
+          .format(),
+        facilityId: '984',
+      },
+      // appointment more than 1 hour ago should not show
+      {
+        startDate: now
+          .clone()
+          .subtract(65, 'minutes')
+          .format(),
+        facilityId: '984',
+      },
+      // video appointment less than 4 hours ago should show
+      {
+        vvsAppointments: [
+          {
+            dateTime: now
+              .clone()
+              .subtract(230, 'minutes')
+              .format(),
+          },
+        ],
+        facilityId: '984',
+      },
+      // video appointment more than 4 hours ago should not show
+      {
+        vvsAppointments: [
+          {
+            dateTime: now
+              .clone()
+              .subtract(245, 'minutes')
+              .format(),
+          },
+        ],
+        facilityId: '984',
+      },
+    ];
+
+    const filteredConfirmed = confirmed.filter(a =>
+      filterFutureConfirmedAppointments(a, now),
+    );
+    expect(filteredConfirmed.length).to.equal(3);
+  });
+
+  it('should sort future confirmed appointments', () => {
+    const confirmed = [
+      { startDate: '2099-04-30T05:35:00', facilityId: '984' },
+      { startDate: '2099-04-27T05:35:00', facilityId: '984' },
+    ];
+
+    const sorted = confirmed.sort(sortFutureConfirmedAppointments);
+    expect(sorted[0].startDate).to.equal('2099-04-27T05:35:00');
+  });
+
+  it('should filter future requests', () => {
+    const requests = [
+      {
+        status: 'Booked',
+        appointmentType: 'Primary Care',
+        optionDate1: now
+          .clone()
+          .add(2, 'days')
+          .format('MM/DD/YYYY'),
+      },
+      {
+        attributes: {
+          status: 'Submitted',
+          appointmentType: 'Primary Care',
+          optionDate1: now
+            .clone()
+            .add(-2, 'days')
+            .format('MM/DD/YYYY'),
+        },
+      },
+      {
+        status: 'Submitted',
+        appointmentType: 'Primary Care',
+        optionDate1: now
+          .clone()
+          .add(2, 'days')
+          .format('MM/DD/YYYY'),
+      },
+      {
+        status: 'Cancelled',
+        appointmentType: 'Primary Care',
+        optionDate1: now
+          .clone()
+          .add(3, 'days')
+          .format('MM/DD/YYYY'),
+      },
+    ];
+
+    const filteredRequests = requests.filter(r => filterFutureRequests(r, now));
+    expect(filteredRequests.length).to.equal(2);
+  });
+
+  it('should sort future requests', () => {
+    const requests = [
+      {
+        appointmentType: 'Primary Care',
+        optionDate1: '12/13/2019',
+      },
+      {
+        appointmentType: 'Primary Care',
+        optionDate1: '12/12/2019',
+      },
+      {
+        appointmentType: 'Audiology (hearing aid support)',
+        optionDate1: '12/12/2019',
+      },
+    ];
+
+    const sortedRequests = requests.sort(sortFutureRequests);
+    expect(sortedRequests[0].appointmentType).to.equal(
+      'Audiology (hearing aid support)',
+    );
+    expect(sortedRequests[1].appointmentType).to.equal('Primary Care');
+    expect(sortedRequests[1].optionDate1).to.equal('12/12/2019');
+    expect(sortedRequests[2].appointmentType).to.equal('Primary Care');
+    expect(sortedRequests[2].optionDate1).to.equal('12/13/2019');
   });
 });

--- a/src/applications/vaos/utils/appointment.jsx
+++ b/src/applications/vaos/utils/appointment.jsx
@@ -285,7 +285,8 @@ export function getRequestTimeToCall(appt) {
  */
 
 export function filterFutureConfirmedAppointments(appt, today) {
-  //  return appointments that are after current time +60 min, or +240 min in case of video
+  // return appointments where current time is less than appointment time
+  // +60 min or +240 min in the case of video
   const threshold = isVideoVisit(appt) ? 240 : 60;
   const apptDateTime = getMomentConfirmedDate(appt);
   return (

--- a/src/applications/vaos/utils/appointment.jsx
+++ b/src/applications/vaos/utils/appointment.jsx
@@ -323,7 +323,7 @@ export function sortFutureRequestsList(a, b) {
   }
 
   // Otherwise, return sorted alphabetically by appointmentType
-  return a.appointmenType < b.appointmentType ? -1 : 1;
+  return a.appointmentType < b.appointmentType ? -1 : 1;
 }
 
 export function sortMessages(a, b) {

--- a/src/applications/vaos/utils/appointment.jsx
+++ b/src/applications/vaos/utils/appointment.jsx
@@ -284,20 +284,7 @@ export function getRequestTimeToCall(appt) {
  * Filter and sort methods
  */
 
-export function filterFutureRequests(request, today) {
-  const optionDate1 = moment(request.optionDate1, 'MM/DD/YYYY');
-  const optionDate2 = moment(request.optionDate2, 'MM/DD/YYYY');
-  const optionDate3 = moment(request.optionDate3, 'MM/DD/YYYY');
-
-  return (
-    ['Submitted', 'Cancelled'].includes(request.status) &&
-    ((optionDate1.isValid() && optionDate1.isAfter(today)) ||
-      (optionDate2.isValid() && optionDate2.isAfter(today)) ||
-      (optionDate3.isValid() && optionDate3.isAfter(today)))
-  );
-}
-
-export function filterFutureConfirmedList(appt, today) {
+export function filterFutureConfirmedAppointments(appt, today) {
   //  return appointments that are after current time +60 min, or +240 min in case of video
   const threshold = isVideoVisit(appt) ? 240 : 60;
   const apptDateTime = getMomentConfirmedDate(appt);
@@ -309,6 +296,21 @@ export function filterFutureConfirmedList(appt, today) {
 
 export function sortFutureConfirmedList(a, b) {
   return getMomentConfirmedDate(a).isBefore(getMomentConfirmedDate(b)) ? -1 : 1;
+}
+
+export function filterFutureRequests(request, today) {
+  const optionDate1 = moment(request.optionDate1, 'MM/DD/YYYY');
+  const optionDate2 = moment(request.optionDate2, 'MM/DD/YYYY');
+  const optionDate3 = moment(request.optionDate3, 'MM/DD/YYYY');
+
+  const VALID_STATUSES = ['Submitted', 'Cancelled'];
+
+  return (
+    VALID_STATUSES.includes(request.status) &&
+    ((optionDate1.isValid() && optionDate1.isAfter(today)) ||
+      (optionDate2.isValid() && optionDate2.isAfter(today)) ||
+      (optionDate3.isValid() && optionDate3.isAfter(today)))
+  );
 }
 
 export function sortFutureRequestsList(a, b) {

--- a/src/applications/vaos/utils/appointment.jsx
+++ b/src/applications/vaos/utils/appointment.jsx
@@ -284,11 +284,6 @@ export function getRequestTimeToCall(appt) {
  * Filter and sort methods
  */
 
-export function filterFutureConfirmedAppointments(appt, today) {
-  const date = getMomentConfirmedDate(appt);
-  return date.isValid() && date.isAfter(today);
-}
-
 export function filterFutureRequests(request, today) {
   const optionDate1 = moment(request.optionDate1, 'MM/DD/YYYY');
   const optionDate2 = moment(request.optionDate2, 'MM/DD/YYYY');
@@ -302,34 +297,31 @@ export function filterFutureRequests(request, today) {
   );
 }
 
-export function sortFutureList(a, b) {
-  const aIsRequest =
-    getAppointmentType(a) === APPOINTMENT_TYPES.request ||
-    getAppointmentType(a) === APPOINTMENT_TYPES.ccRequest;
-  const bIsRequest =
-    getAppointmentType(b) === APPOINTMENT_TYPES.request ||
-    getAppointmentType(b) === APPOINTMENT_TYPES.ccRequest;
+export function filterFutureConfirmedList(appt, today) {
+  //  return appointments that are after current time +60 min, or +240 min in case of video
+  const threshold = isVideoVisit(appt) ? 240 : 60;
+  const apptDateTime = getMomentConfirmedDate(appt);
+  return (
+    apptDateTime.isValid() &&
+    apptDateTime.add(threshold, 'minutes').isAfter(today)
+  );
+}
 
-  const aDate = aIsRequest
-    ? getMomentRequestOptionDate(a.optionDate1)
-    : getMomentConfirmedDate(a);
+export function sortFutureConfirmedList(a, b) {
+  return getMomentConfirmedDate(a).isBefore(getMomentConfirmedDate(b)) ? -1 : 1;
+}
 
-  const bDate = bIsRequest
-    ? getMomentRequestOptionDate(b.optionDate1)
-    : getMomentConfirmedDate(b);
+export function sortFutureRequestsList(a, b) {
+  const aDate = getMomentRequestOptionDate(a.optionDate1);
+  const bDate = getMomentRequestOptionDate(b.optionDate1);
 
-  if (aDate.isSame(bDate)) {
-    // If same date, requests should show after confirmed
-    if (aIsRequest && !bIsRequest) {
-      return 1;
-    } else if (bIsRequest && !aIsRequest) {
-      return -1;
-    }
-
-    return 0;
+  // If appointmentType is the same, return the one with the sooner date
+  if (a.appointmentType === b.appointmentType) {
+    return aDate.isBefore(bDate) ? -1 : 1;
   }
 
-  return aDate.isBefore(bDate) ? -1 : 1;
+  // Otherwise, return sorted alphabetically by appointmentType
+  return a.appointmenType < b.appointmentType ? -1 : 1;
 }
 
 export function sortMessages(a, b) {

--- a/src/applications/vaos/utils/appointment.jsx
+++ b/src/applications/vaos/utils/appointment.jsx
@@ -295,7 +295,7 @@ export function filterFutureConfirmedAppointments(appt, today) {
   );
 }
 
-export function sortFutureConfirmedList(a, b) {
+export function sortFutureConfirmedAppointments(a, b) {
   return getMomentConfirmedDate(a).isBefore(getMomentConfirmedDate(b)) ? -1 : 1;
 }
 
@@ -314,7 +314,7 @@ export function filterFutureRequests(request, today) {
   );
 }
 
-export function sortFutureRequestsList(a, b) {
+export function sortFutureRequests(a, b) {
   const aDate = getMomentRequestOptionDate(a.optionDate1);
   const bDate = getMomentRequestOptionDate(b.optionDate1);
 


### PR DESCRIPTION
## Description
- Confirmed & cancelled upcoming appointments are sorted to the top of the unified list, with the soonest appointment sorted to the top of the confirmed appointments stack
- Requests and cancelled requests are sorted to below the confirmed appointments stack, in alphabetical order by Type Of Care.
- Past appointments are filtered out by both date and time - i.e., appointments that ENDED earlier today are not visible.
  - For regular appointments, we want to show an appointment if it is in progress, however we don't always have the duration of the appointment, so default to showing an appointment for 60 minutes after it has started
  - For video appointments, show appointment link for 4 hours after start time to duplicate legacy behavior

## Testing done 
Local and unit

## Screenshots
![image](https://user-images.githubusercontent.com/786704/69207464-b6086680-0b04-11ea-9268-6028064e9582.png)


## Acceptance criteria
- [ ] Confirmed & cancelled upcoming appointments are sorted to the top of the unified list, with the soonest appointment sorted to the top of the confirmed appointments stack
- [ ] Requests and cancelled requests are sorted to below the confirmed appointments stack, in alphabetical order by Type Of Care.
- [ ] Past appointments are filtered out by both date and time - i.e., appointments that ENDED earlier today are not visible.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the Pre-Launch Checklist
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] A link has been provided to the VSA-QA Test Plan ticket \[use the VSA-QA Test Plan Issue Template to create the ticket within va.gov-team repo].
- [ ] A link has been provided to the VSA-QA Test-Request ticket \[issue-template coming soon].
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
