### PR TITLE
Remove facility address for VA appts

### DIFF
--- a/src/applications/vaos/tests/components/ConfirmedAppointmentListItem.unit.spec.jsx
+++ b/src/applications/vaos/tests/components/ConfirmedAppointmentListItem.unit.spec.jsx
@@ -83,8 +83,8 @@ describe('VAOS <ConfirmedAppointmentListItem> Regular Appointment', () => {
     );
   });
 
-  it('should show facility address', () => {
-    expect(tree.find('FacilityAddress').exists()).to.be.true;
+  it('should not show facility address', () => {
+    expect(tree.find('FacilityAddress').exists()).to.be.false;
   });
 });
 

--- a/src/applications/vaos/utils/appointment.jsx
+++ b/src/applications/vaos/utils/appointment.jsx
@@ -126,6 +126,14 @@ export function getAppointmentLocation(appt, facility) {
     );
   }
 
+  if (type === APPOINTMENT_TYPES.vaAppointment) {
+    return (
+      <a href="/find-locations" rel="noopener noreferrer" target="_blank">
+        Find facility information
+      </a>
+    );
+  }
+
   if (facility) {
     return (
       <>


### PR DESCRIPTION
## Description
We can't get an accurate facility id for VA appointments currently, so the address is wrong. This removes the address from confirmed VA appointments for now.

## Testing done 
Unit testing

## Screenshots
![Screen Shot 2019-11-20 at 10 03 31 AM](https://user-images.githubusercontent.com/634932/69250090-06bba600-0b7d-11ea-8904-ff17d5b4a1a6.png)


## Acceptance criteria
- [x] Address doesn't show up for VA facility appts

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [ ] A link has been provided to the Pre-Launch Checklist
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] A link has been provided to the VSA-QA Test Plan ticket \[use the VSA-QA Test Plan Issue Template to create the ticket within va.gov-team repo].
- [ ] A link has been provided to the VSA-QA Test-Request ticket \[issue-template coming soon].
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
