### PR TITLE
report more Direct Deposit save errors to Google Analytics

### DIFF
--- a/src/applications/personalization/profile360/components/PaymentInformationEditModalError.jsx
+++ b/src/applications/personalization/profile360/components/PaymentInformationEditModalError.jsx
@@ -7,6 +7,7 @@ import {
   hasInvalidHomePhoneNumberError,
   hasInvalidRoutingNumberError,
   hasInvalidWorkPhoneNumberError,
+  hasPaymentRestrictionIndicatorsError,
 } from '../util';
 
 function FlaggedAccount() {
@@ -97,7 +98,10 @@ export default function PaymentInformationEditModalError({
   if (responseError.error) {
     const { errors = [] } = responseError.error;
 
-    if (hasFlaggedForFraudError(errors)) {
+    if (
+      hasFlaggedForFraudError(errors) ||
+      hasPaymentRestrictionIndicatorsError(errors)
+    ) {
       content = <FlaggedAccount />;
     } else if (hasInvalidRoutingNumberError(errors)) {
       content = <InvalidRoutingNumber />;

--- a/src/applications/personalization/profile360/tests/util/index.unit.spec.js
+++ b/src/applications/personalization/profile360/tests/util/index.unit.spec.js
@@ -25,13 +25,13 @@ describe('profile utils', () => {
       'work-phone-error',
     );
     const flaggedForFraudDataObject = createEventDataObjectWithError(
-      'flagged-for-fraud',
+      'flagged-for-fraud-error',
     );
     const invalidRoutingNumberDataObject = createEventDataObjectWithError(
-      'invalid-routing-number',
+      'invalid-routing-number-error',
     );
     const paymentRestrictionIndicatorsDataObject = createEventDataObjectWithError(
-      'payment-restriction-indicators',
+      'payment-restriction-indicators-error',
     );
     it('returns the correct data when passed nothing', () => {
       const eventDataObject = createDirectDepositAnalyticsDataObject();

--- a/src/applications/personalization/profile360/tests/util/index.unit.spec.js
+++ b/src/applications/personalization/profile360/tests/util/index.unit.spec.js
@@ -7,36 +7,37 @@ import {
 } from '../../util';
 
 describe('profile utils', () => {
-  const defaultDataObject = {
-    event: 'profile-edit-failure',
-    'profile-action': 'save-failure',
-    'profile-section': 'direct-deposit-information',
-    'error-key': 'other-error',
-  };
-  const badAddressDataObject = {
-    event: 'profile-edit-failure',
-    'profile-action': 'save-failure',
-    'profile-section': 'direct-deposit-information',
-    'error-key': 'mailing-address-error',
-  };
-  const badHomePhoneDataObject = {
-    event: 'profile-edit-failure',
-    'profile-action': 'save-failure',
-    'profile-section': 'direct-deposit-information',
-    'error-key': 'home-phone-error',
-  };
-  const badWorkPhoneDataObject = {
-    event: 'profile-edit-failure',
-    'profile-action': 'save-failure',
-    'profile-section': 'direct-deposit-information',
-    'error-key': 'work-phone-error',
-  };
   describe('createEventDataObjectWithErrors', () => {
+    const createEventDataObjectWithError = error => ({
+      event: 'profile-edit-failure',
+      'profile-action': 'save-failure',
+      'profile-section': 'direct-deposit-information',
+      'error-key': error,
+    });
+    const defaultDataObject = createEventDataObjectWithError('other-error');
+    const badAddressDataObject = createEventDataObjectWithError(
+      'mailing-address-error',
+    );
+    const badHomePhoneDataObject = createEventDataObjectWithError(
+      'home-phone-error',
+    );
+    const badWorkPhoneDataObject = createEventDataObjectWithError(
+      'work-phone-error',
+    );
+    const flaggedForFraudDataObject = createEventDataObjectWithError(
+      'flagged-for-fraud',
+    );
+    const invalidRoutingNumberDataObject = createEventDataObjectWithError(
+      'invalid-routing-number',
+    );
+    const paymentRestrictionIndicatorsDataObject = createEventDataObjectWithError(
+      'payment-restriction-indicators',
+    );
     it('returns the correct data when passed nothing', () => {
       const eventDataObject = createDirectDepositAnalyticsDataObject();
       expect(eventDataObject).to.deep.equal(defaultDataObject);
     });
-    it('returns the correct data when passed nothing', () => {
+    it('returns the correct data when passed an empty array', () => {
       const eventDataObject = createDirectDepositAnalyticsDataObject([]);
       expect(eventDataObject).to.deep.equal(defaultDataObject);
     });
@@ -105,6 +106,113 @@ describe('profile utils', () => {
         },
       ]);
       expect(eventDataObject).to.deep.equal(badHomePhoneDataObject);
+    });
+    it('returns the correct data when a flagged for fraud error is passed', () => {
+      const eventDataObject = createDirectDepositAnalyticsDataObject([
+        {
+          title: 'Unprocessable Entity',
+          detail: 'One or more unprocessable user payment properties',
+          code: '126',
+          source: 'EVSS::PPIU::Service',
+          status: '422',
+          meta: {
+            messages: [
+              {
+                key: 'cnp.payment.routing.number.fraud.message',
+                severity: 'ERROR',
+                text: '',
+              },
+            ],
+          },
+        },
+      ]);
+      expect(eventDataObject).to.deep.equal(flaggedForFraudDataObject);
+    });
+    it('returns the correct data when a flagged for fraud error is passed', () => {
+      const eventDataObject = createDirectDepositAnalyticsDataObject([
+        {
+          title: 'Unprocessable Entity',
+          detail: 'One or more unprocessable user payment properties',
+          code: '126',
+          source: 'EVSS::PPIU::Service',
+          status: '422',
+          meta: {
+            messages: [
+              {
+                key: 'cnp.payment.flashes.on.record.message',
+                severity: 'ERROR',
+                text: '',
+              },
+            ],
+          },
+        },
+      ]);
+      expect(eventDataObject).to.deep.equal(flaggedForFraudDataObject);
+    });
+    it('returns the correct data when an invalid routing number error is passed', () => {
+      const eventDataObject = createDirectDepositAnalyticsDataObject([
+        {
+          title: 'Unprocessable Entity',
+          detail: 'One or more unprocessable user payment properties',
+          code: '126',
+          source: 'EVSS::PPIU::Service',
+          status: '422',
+          meta: {
+            messages: [
+              {
+                key: 'payment.accountRoutingNumber.invalidCheckSum',
+                severity: 'ERROR',
+                text: '',
+              },
+            ],
+          },
+        },
+      ]);
+      expect(eventDataObject).to.deep.equal(invalidRoutingNumberDataObject);
+    });
+    it('returns the correct data when an invalid routing number error is passed', () => {
+      const eventDataObject = createDirectDepositAnalyticsDataObject([
+        {
+          title: 'Unprocessable Entity',
+          detail: 'One or more unprocessable user payment properties',
+          code: '126',
+          source: 'EVSS::PPIU::Service',
+          status: '422',
+          meta: {
+            messages: [
+              {
+                key: 'cnp.payment.generic.error.message',
+                severity: 'ERROR',
+                text: 'Invalid Routing Number',
+              },
+            ],
+          },
+        },
+      ]);
+      expect(eventDataObject).to.deep.equal(invalidRoutingNumberDataObject);
+    });
+    it('returns the correct data when a payment restriction indicators error is passed', () => {
+      const eventDataObject = createDirectDepositAnalyticsDataObject([
+        {
+          title: 'Unprocessable Entity',
+          detail: 'One or more unprocessable user payment properties',
+          code: '126',
+          source: 'EVSS::PPIU::Service',
+          status: '422',
+          meta: {
+            messages: [
+              {
+                key: 'payment.restriction.indicators.present',
+                severity: 'ERROR',
+                text: '',
+              },
+            ],
+          },
+        },
+      ]);
+      expect(eventDataObject).to.deep.equal(
+        paymentRestrictionIndicatorsDataObject,
+      );
     });
   });
 

--- a/src/applications/personalization/profile360/util/index.js
+++ b/src/applications/personalization/profile360/util/index.js
@@ -13,9 +13,10 @@ const ROUTING_NUMBER_FLAGGED_FOR_FRAUD_KEY =
 const GA_ERROR_KEY_BAD_ADDRESS = 'mailing-address-error';
 const GA_ERROR_KEY_BAD_HOME_PHONE = 'home-phone-error';
 const GA_ERROR_KEY_BAD_WORK_PHONE = 'work-phone-error';
-const GA_ERROR_KEY_FLAGGED_FOR_FRAUD = 'flagged-for-fraud';
-const GA_ERROR_KEY_INVALID_ROUTING_NUMBER = 'invalid-routing-number';
-const GA_ERROR_KEY_PAYMENT_RESTRICTIONS = 'payment-restriction-indicators';
+const GA_ERROR_KEY_FLAGGED_FOR_FRAUD = 'flagged-for-fraud-error';
+const GA_ERROR_KEY_INVALID_ROUTING_NUMBER = 'invalid-routing-number-error';
+const GA_ERROR_KEY_PAYMENT_RESTRICTIONS =
+  'payment-restriction-indicators-error';
 const GA_ERROR_KEY_DEFAULT = 'other-error';
 
 export async function getData(apiRoute, options) {


### PR DESCRIPTION
## Description
This change expands the Direct Deposit save error reporting to Google Analytics. Previously we were breaking out errors related to bad phone numbers or addresses to Google Analytics. With this change we are also reporting errors related to fraud (`'flagged-for-fraud'`), bad routing number (`'invalid-routing-number'`), and when payment restriction indicators are present (`'payment-restriction-indicators'`).

## Testing done 
Unit tests

## Screenshots
N/A

## Acceptance criteria
- [ ] 

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the Pre-Launch Checklist
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] A link has been provided to the VSA-QA Test Plan ticket \[use the VSA-QA Test Plan Issue Template to create the ticket within va.gov-team repo].
- [ ] A link has been provided to the VSA-QA Test-Request ticket \[issue-template coming soon].
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs