### PR TITLE
RE: Fix: If a phone number does not exist, the prompt to call should be hidden

### DIFF
--- a/src/applications/facility-locator/containers/FacilityDetail.jsx
+++ b/src/applications/facility-locator/containers/FacilityDetail.jsx
@@ -67,12 +67,13 @@ class FacilityDetail extends Component {
         <div>
           <LocationDirectionsLink location={facility} />
         </div>
-        {phone && (
-          <p className="p1">
-            Planning to visit? Please call first as information on this page may
-            change.
-          </p>
-        )}
+        {phone &&
+          phone.main && (
+            <p className="p1">
+              Planning to visit? Please call first as information on this page
+              change.
+            </p>
+          )}
       </div>
     );
   }


### PR DESCRIPTION
## Description
Original Fix :https://github.com/department-of-veterans-affairs/vets-website/pull/11143

The safety check has to be in the main phone number

