### PR TITLE
Calendar updates

### DIFF
--- a/src/applications/vaos/components/DateTimeRequestField.jsx
+++ b/src/applications/vaos/components/DateTimeRequestField.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import CalendarWidget from './calendar/CalendarWidget';
+import moment from 'moment';
 
 const DateTimeRequestField = ({ onChange, formData }) => (
   <CalendarWidget
@@ -8,6 +9,12 @@ const DateTimeRequestField = ({ onChange, formData }) => (
     multiSelect
     maxSelections={3}
     onChange={onChange}
+    minDate={moment()
+      .add(5, 'days')
+      .format('YYYY-MM-DD')}
+    maxDate={moment()
+      .add(395, 'days')
+      .format('YYYY-MM-DD')}
     currentlySelectedDate={formData?.currentlySelectedDate}
     selectedDates={formData?.selectedDates}
     additionalOptions={{

--- a/src/applications/vaos/components/DateTimeSelectField.jsx
+++ b/src/applications/vaos/components/DateTimeSelectField.jsx
@@ -31,18 +31,25 @@ class DateTimeSelectField extends Component {
 
     return (
       <CalendarWidget
-        monthsToShowAtOnce={2}
-        maxSelections={1}
-        availableDates={formContext?.availableDates}
-        currentlySelectedDate={currentlySelectedDate}
-        selectedDates={selectedDates}
         additionalOptions={{
           fieldName: 'datetime',
           required: true,
           maxSelections: 1,
           getOptionsByDate: this.getOptionsByDate,
         }}
+        availableDates={formContext?.availableDates}
+        currentlySelectedDate={currentlySelectedDate}
+        maxSelections={1}
+        minDate={moment()
+          .add(1, 'days')
+          .format('YYYY-MM-DD')}
+        maxDate={moment()
+          .add(395, 'days')
+          .format('YYYY-MM-DD')}
+        monthsToShowAtOnce={2}
         onChange={this.props.onChange}
+        selectedDates={selectedDates}
+        startMonth={formContext?.preferredDate}
       />
     );
   }

--- a/src/applications/vaos/components/DateTimeSelectField.jsx
+++ b/src/applications/vaos/components/DateTimeSelectField.jsx
@@ -31,24 +31,24 @@ class DateTimeSelectField extends Component {
 
     return (
       <CalendarWidget
+        monthsToShowAtOnce={2}
+        maxSelections={1}
+        availableDates={formContext?.availableDates}
+        currentlySelectedDate={currentlySelectedDate}
+        selectedDates={selectedDates}
         additionalOptions={{
           fieldName: 'datetime',
           required: true,
           maxSelections: 1,
           getOptionsByDate: this.getOptionsByDate,
         }}
-        availableDates={formContext?.availableDates}
-        currentlySelectedDate={currentlySelectedDate}
-        maxSelections={1}
+        onChange={this.props.onChange}
         minDate={moment()
           .add(1, 'days')
           .format('YYYY-MM-DD')}
         maxDate={moment()
           .add(395, 'days')
           .format('YYYY-MM-DD')}
-        monthsToShowAtOnce={2}
-        onChange={this.props.onChange}
-        selectedDates={selectedDates}
         startMonth={formContext?.preferredDate}
       />
     );

--- a/src/applications/vaos/components/calendar/CalendarRow.jsx
+++ b/src/applications/vaos/components/calendar/CalendarRow.jsx
@@ -47,7 +47,7 @@ export default class CalendarRow extends Component {
       disabled = true;
     }
 
-    // If maxDate provided, disable dates after minDate
+    // If maxDate provided, disable dates after maxDate
     if (
       maxDate &&
       moment(maxDate).isValid() &&

--- a/src/applications/vaos/components/calendar/CalendarRow.jsx
+++ b/src/applications/vaos/components/calendar/CalendarRow.jsx
@@ -18,23 +18,44 @@ export default class CalendarRow extends Component {
     getSelectedDateOptions: PropTypes.func,
     handleSelectDate: PropTypes.func.isRequired,
     handleSelectOption: PropTypes.func,
+    minDate: PropTypes.string,
+    maxDate: PropTypes.string,
     optionsError: PropTypes.string,
     rowNumber: PropTypes.number.isRequired,
     selectedDates: PropTypes.array,
   };
 
   isCellDisabled = date => {
-    // If user provides an array of availableDates, disable dates that are not
-    // in the array.  Otherwise, assume all dates >= today are valid
-    const { availableDates } = this.props;
+    const { availableDates, minDate, maxDate } = this.props;
     let disabled = false;
 
+    // If user provides an array of availableDates, disable dates that are not
+    // in the array.
     if (
       (Array.isArray(availableDates) && !availableDates.includes(date)) ||
       moment(date).isBefore(moment().format('YYYY-MM-DD'))
     ) {
       disabled = true;
     }
+
+    // If minDate provided, disable dates before minDate
+    if (
+      minDate &&
+      moment(minDate).isValid() &&
+      moment(date).isBefore(moment(minDate))
+    ) {
+      disabled = true;
+    }
+
+    // If maxDate provided, disable dates after minDate
+    if (
+      maxDate &&
+      moment(maxDate).isValid() &&
+      moment(date).isAfter(moment(maxDate))
+    ) {
+      disabled = true;
+    }
+
     return disabled;
   };
 

--- a/src/applications/vaos/components/calendar/CalendarWidget.jsx
+++ b/src/applications/vaos/components/calendar/CalendarWidget.jsx
@@ -86,8 +86,8 @@ export default class CalendarWidget extends Component {
         sortedDates = sortedDates.filter(d => {
           const momentDate = moment(d);
           return (
-            momentDate.isSameOrAfter(moment(minDate), 'days') &&
-            momentDate.isSameOrBefore(moment(maxDate), 'days')
+            momentDate.isSameOrAfter(moment(minDate), 'day') &&
+            momentDate.isSameOrBefore(moment(maxDate), 'day')
           );
         });
       }

--- a/src/applications/vaos/components/calendar/CalendarWidget.jsx
+++ b/src/applications/vaos/components/calendar/CalendarWidget.jsx
@@ -73,24 +73,35 @@ export default class CalendarWidget extends Component {
   getMaxMonth = () => {
     const { availableDates, minDate, maxDate } = this.props;
     if (Array.isArray(availableDates) && availableDates.length) {
-      // sort available dates and filter those that are out of minDate/maxDate range
-      const sortedArray = this.sortDates(availableDates).filter(d => {
-        const momentDate = moment(d);
-        return (
-          momentDate.isSameOrAfter(moment(minDate), 'days') &&
-          momentDate.isSameOrBefore(moment(maxDate), 'days')
-        );
-      });
+      // sort available dates
+      let sortedDates = this.sortDates(availableDates);
+
+      if (
+        minDate &&
+        moment(minDate).isValid() &&
+        maxDate &&
+        moment(maxDate).isValid()
+      ) {
+        // filter those that are out of minDate/maxDate range
+        sortedDates = sortedDates.filter(d => {
+          const momentDate = moment(d);
+          return (
+            momentDate.isSameOrAfter(moment(minDate), 'days') &&
+            momentDate.isSameOrBefore(moment(maxDate), 'days')
+          );
+        });
+      }
+
       const lastAvailableDateMonth = moment(
-        sortedArray[sortedArray.length - 1],
+        sortedDates[sortedDates.length - 1],
       ).format('YYYYMM');
 
       return lastAvailableDateMonth;
     }
 
-    // If no available dates array provided, set max to 45 days from now
+    // If no available dates array provided, set max to 90 days from now
     return moment()
-      .add(395, 'days')
+      .add(90, 'days')
       .format('YYYYMM');
   };
 

--- a/src/applications/vaos/components/calendar/CalendarWidget.jsx
+++ b/src/applications/vaos/components/calendar/CalendarWidget.jsx
@@ -288,23 +288,34 @@ export default class CalendarWidget extends Component {
     );
   };
 
-  renderWeeks = month =>
-    getCalendarWeeks(month).map((week, index) => (
+  renderWeeks = month => {
+    const {
+      availableDates,
+      additionalOptions,
+      selectedDates,
+      currentlySelectedDate,
+      minDate,
+      maxDate,
+    } = this.props;
+    return getCalendarWeeks(month).map((week, index) => (
       <CalendarRow
         key={`row-${index}`}
         cells={week}
-        availableDates={this.props.availableDates}
+        availableDates={availableDates}
+        minDate={minDate}
+        maxDate={maxDate}
         rowNumber={index}
-        additionalOptions={this.props.additionalOptions}
+        additionalOptions={additionalOptions}
         handleSelectDate={this.handleSelectDate}
         handleSelectOption={this.handleSelectOption}
-        selectedDates={this.props.selectedDates || []}
-        currentlySelectedDate={this.props.currentlySelectedDate}
+        selectedDates={selectedDates || []}
+        currentlySelectedDate={currentlySelectedDate}
         optionsError={
           this.state.currentRowIndex === index ? this.state.optionsError : null
         }
       />
     ));
+  };
 
   renderMonth = (month, index) => {
     const { months, currentDate, maxMonth } = this.state;

--- a/src/applications/vaos/components/calendar/CalendarWidget.jsx
+++ b/src/applications/vaos/components/calendar/CalendarWidget.jsx
@@ -308,6 +308,7 @@ export default class CalendarWidget extends Component {
       minDate,
       maxDate,
     } = this.props;
+
     return getCalendarWeeks(month).map((week, index) => (
       <CalendarRow
         key={`row-${index}`}

--- a/src/applications/vaos/components/calendar/CalendarWidget.jsx
+++ b/src/applications/vaos/components/calendar/CalendarWidget.jsx
@@ -227,12 +227,12 @@ export default class CalendarWidget extends Component {
       this.handleMultiSelect(date, currentRowIndex);
     } else {
       if (date !== currentlySelectedDate) {
-        selectedDates = !additionalOptions?.required
-          ? [{ date }]
-          : selectedDates;
+        if (!additionalOptions?.required) {
+          selectedDates = [{ date }];
+        }
         currentlySelectedDate = date;
       } else {
-        selectedDates = [];
+        selectedDates = selectedDates.filter(d => d.date !== date);
         currentlySelectedDate = null;
       }
       this.setState(

--- a/src/applications/vaos/containers/DateTimeSelectPage.jsx
+++ b/src/applications/vaos/containers/DateTimeSelectPage.jsx
@@ -128,7 +128,7 @@ export class DateTimeSelectPage extends React.Component {
           onChange={newData => {
             this.props.updateFormData(pageKey, uiSchema, newData);
           }}
-          formContext={{ availableSlots, availableDates }}
+          formContext={{ availableSlots, availableDates, preferredDate }}
           data={data}
         >
           <FormButtons

--- a/src/applications/vaos/tests/components/calendar/CalendarWidget.unit.spec.jsx
+++ b/src/applications/vaos/tests/components/calendar/CalendarWidget.unit.spec.jsx
@@ -15,4 +15,19 @@ describe('VAOS <CalendarWidget>', () => {
     expect(weekdayHeaders.length).to.equal(2);
     tree.unmount();
   });
+
+  it('should display the same month as startMonth', () => {
+    const tree = shallow(
+      <CalendarWidget monthsToShowAtOnce={2} startMonth="2019-11-20" />,
+    );
+
+    expect(
+      tree
+        .find('h2')
+        .at(0)
+        .text(),
+    ).to.equal('November 2019');
+
+    tree.unmount();
+  });
 });


### PR DESCRIPTION
## Description
- Currently, if a user has a datetime selected and they click on another day, their selection is cleared, even before they've selected a time or am/pm.  The selection should remain until the user chooses a time or am/pm.
- The first month displayed should be the same month that the user selects for their preferred date (wait time)
- Min/max dates should be set
  - Direct schedule:
    - No same day scheduling
    - Max day is 395 days out
  - Requests
    - No requests within 5 days
    - Max day is 395 days out

## Testing done 
Local and unit


## Acceptance criteria
- [ ] Datetime selection should remain until the user chooses a time or am/pm.
- [ ] For direct schedule, the first month shown should be the same month the user chose on the wait time (preferred date) screen
- [ ] Calendar widget shoudl accept min and max days

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the Pre-Launch Checklist
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] A link has been provided to the VSA-QA Test Plan ticket \[use the VSA-QA Test Plan Issue Template to create the ticket within va.gov-team repo].
- [ ] A link has been provided to the VSA-QA Test-Request ticket \[issue-template coming soon].
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
