### PR TITLE
Kelsonic 2556 update sidenav width

### DIFF
--- a/src/platform/site-wide/sass/modules/_m-side-nav.scss
+++ b/src/platform/site-wide/sass/modules/_m-side-nav.scss
@@ -5,7 +5,11 @@
   display: flex;
   flex-direction: column;
   padding: 10px 0;
-  margin: 0 20px 0 0;
+  margin: 0;
+
+  &:last-child {
+    margin-right: 20px;
+  }
 
   li {
     list-style: none;

--- a/src/platform/site-wide/side-nav/components/SideNav.js
+++ b/src/platform/site-wide/side-nav/components/SideNav.js
@@ -85,7 +85,7 @@ class SideNav extends Component {
     }
 
     return (
-      <ul className="usa-width-one-fourth va-sidenav">
+      <ul className="usa-width-one-third va-sidenav">
         {/* Render all the items recursively. */}
         {renderChildItems(parentMostID, 1)}
       </ul>

--- a/src/site/layouts/bios_page.drupal.liquid
+++ b/src/site/layouts/bios_page.drupal.liquid
@@ -43,7 +43,7 @@
 
             {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with sidebarData = facilitySidebar %}
 
-            <div class="usa-width-three-fourths">
+            <div class="usa-width-two-thirds">
                 {% include "src/site/components/navigation-sidebar-trigger.html" with menuId = "va-detailpage-sidebar" %}
                 <article class="usa-content">
                     <h1 class="vads-u-margin-bottom--3">Our leadership team</h1>

--- a/src/site/layouts/event.drupal.liquid
+++ b/src/site/layouts/event.drupal.liquid
@@ -110,7 +110,7 @@ Example data:
       {% else %}
         {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with sidebarData = facilitySidebar %}
       {% endif %}
-      <div class="usa-width-three-fourths">
+      <div class="usa-width-two-thirds">
         {% include "src/site/components/navigation-sidebar-trigger.html" with menuId = "va-detailpage-sidebar" %}
         {% if !entityPublished %}
         <div class="usa-alert usa-alert-info">

--- a/src/site/layouts/event_listing.drupal.liquid
+++ b/src/site/layouts/event_listing.drupal.liquid
@@ -7,7 +7,7 @@
   <main class="va-l-detail-page va-facility-page">
     <div class="usa-grid usa-grid-full">
       {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with sidebarData = outreachSidebar %}
-      <div class="usa-width-three-fourths">
+      <div class="usa-width-two-thirds">
         {% include "src/site/components/navigation-sidebar-trigger.html" with menuId = "va-detailpage-sidebar" %}
         {% if !entityPublished %}
         <div class="usa-alert usa-alert-info">

--- a/src/site/layouts/events_page.drupal.liquid
+++ b/src/site/layouts/events_page.drupal.liquid
@@ -52,7 +52,7 @@ Example data:
   <main class="va-l-detail-page va-facility-page">
     <div class="usa-grid usa-grid-full">
       {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with sidebarData = facilitySidebar %}
-      <div class="usa-width-three-fourths">
+      <div class="usa-width-two-thirds">
         {% include "src/site/components/navigation-sidebar-trigger.html" with menuId = "va-detailpage-sidebar" %}
         <article class="usa-content">
           <h1>Events</h1>

--- a/src/site/layouts/health_care_facility_status.drupal.liquid
+++ b/src/site/layouts/health_care_facility_status.drupal.liquid
@@ -6,7 +6,7 @@
     <main class="va-l-detail-page va-facility-page">
         <div class="usa-grid usa-grid-full">
             {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with sidebarData = facilitySidebar %}
-            <div class="usa-width-three-fourths">
+            <div class="usa-width-two-thirds">
                 {% include "src/site/components/navigation-sidebar-trigger.html" with menuId = "va-detailpage-sidebar" %}
 
                 <article class="usa-content">

--- a/src/site/layouts/health_care_local_facility.drupal.liquid
+++ b/src/site/layouts/health_care_local_facility.drupal.liquid
@@ -216,7 +216,7 @@ more.\r\n",
   <main class="va-l-detail-page va-facility-page">
     <div class="usa-grid usa-grid-full">
       {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with sidebarData = facilitySidebar %}
-      <div class="usa-width-three-fourths">
+      <div class="usa-width-two-thirds">
         {% include "src/site/components/navigation-sidebar-trigger.html" with menuId = "va-detailpage-sidebar" %}
         {% if !entityPublished %}
         <div class="usa-alert usa-alert-info">

--- a/src/site/layouts/health_care_region_detail_page.drupal.liquid
+++ b/src/site/layouts/health_care_region_detail_page.drupal.liquid
@@ -10,7 +10,7 @@
       {% else %}
         {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with sidebarData = facilitySidebar %}
       {% endif %}
-      <div class="usa-width-three-fourths">
+      <div class="usa-width-two-thirds">
        {% include "src/site/components/navigation-sidebar-trigger.html" with menuId = "va-detailpage-sidebar" %}
         <article aria-labelledby="article-heading" role="region" class="usa-content">
           <h1 id="article-heading">{{ title }}</h1>

--- a/src/site/layouts/health_care_region_health_services_page.drupal.liquid
+++ b/src/site/layouts/health_care_region_health_services_page.drupal.liquid
@@ -6,7 +6,7 @@
     <main class="va-l-detail-page va-facility-page">
     <div class="usa-grid usa-grid-full">
         {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with sidebarData = facilitySidebar %}
-        <div class="usa-width-three-fourths">
+        <div class="usa-width-two-thirds">
             {% include "src/site/components/navigation-sidebar-trigger.html" with menuId = "va-detailpage-sidebar" %}
             <article class="usa-content">
                 <h1 class="vads-u-margin-bottom--1 medium-screen:vads-u-margin-bottom--2">Health services</h1>

--- a/src/site/layouts/health_care_region_locations_page.drupal.liquid
+++ b/src/site/layouts/health_care_region_locations_page.drupal.liquid
@@ -6,7 +6,7 @@
     <main class="va-l-detail-page va-facility-page">
         <div class="usa-grid usa-grid-full">
             {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with sidebarData = facilitySidebar %}
-            <div class="usa-width-three-fourths">
+            <div class="usa-width-two-thirds">
                 {% include "src/site/components/navigation-sidebar-trigger.html" with menuId = "va-detailpage-sidebar" %}
 
                 <article class="usa-content">

--- a/src/site/layouts/health_care_region_page.drupal.liquid
+++ b/src/site/layouts/health_care_region_page.drupal.liquid
@@ -128,7 +128,7 @@ Example data:
   <main class="va-l-detail-page va-facility-page">
     <div class="usa-grid usa-grid-full">
       {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with sidebarData = facilitySidebar %}
-      <div class="usa-width-three-fourths">
+      <div class="usa-width-two-thirds">
         {% include "src/site/components/navigation-sidebar-trigger.html" with menuId = "va-detailpage-sidebar" %}
         {% if !entityPublished %}
         <div class="usa-alert usa-alert-info">

--- a/src/site/layouts/news_stories_page.drupal.liquid
+++ b/src/site/layouts/news_stories_page.drupal.liquid
@@ -53,7 +53,7 @@ Example data:
   <main class="va-l-detail-page va-facility-page">
     <div class="usa-grid usa-grid-full">
       {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with sidebarData = facilitySidebar %}
-      <div class="usa-width-three-fourths">
+      <div class="usa-width-two-thirds">
        {% include "src/site/components/navigation-sidebar-trigger.html" with menuId = "va-detailpage-sidebar" %}
         <article class="usa-content">
           <h1>Stories</h1>

--- a/src/site/layouts/news_story.drupal.liquid
+++ b/src/site/layouts/news_story.drupal.liquid
@@ -63,7 +63,7 @@ Example data:
     <main class="va-l-detail-page va-facility-page">
         <div class="usa-grid usa-grid-full">
             {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with sidebarData = facilitySidebar %}
-            <div class="usa-width-three-fourths">
+            <div class="usa-width-two-thirds">
                 {% include "src/site/components/navigation-sidebar-trigger.html" with menuId = "va-detailpage-sidebar" %}
                 {% if !entityPublished %}
                     <div class="usa-alert usa-alert-info" >

--- a/src/site/layouts/office.drupal.liquid
+++ b/src/site/layouts/office.drupal.liquid
@@ -8,7 +8,7 @@
   <main class="va-l-detail-page">
     <div class="usa-grid usa-grid-full">
       {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with sidebarData = outreachSidebar %}
-      <div class="usa-width-three-fourths">
+      <div class="usa-width-two-thirds">
         {% include "src/site/components/navigation-sidebar-trigger.html" with menuId = "va-detailpage-sidebar" %}
         {% if !entityPublished %}
         <div class="usa-alert usa-alert-info">

--- a/src/site/layouts/press_release.drupal.liquid
+++ b/src/site/layouts/press_release.drupal.liquid
@@ -99,7 +99,7 @@
     <main class="va-l-detail-page va-facility-page">
         <div class="usa-grid usa-grid-full">
             {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with sidebarData = facilitySidebar %}
-            <div class="usa-width-three-fourths">
+            <div class="usa-width-two-thirds">
                 {% include "src/site/components/navigation-sidebar-trigger.html" with menuId = "va-detailpage-sidebar" %}
                 <article class="usa-content">
                     <section class="vads-u-margin-bottom--5">

--- a/src/site/layouts/press_releases_page.drupal.liquid
+++ b/src/site/layouts/press_releases_page.drupal.liquid
@@ -50,7 +50,7 @@ Example data:
 
       {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with sidebarData = facilitySidebar %}
 
-      <div class="usa-width-three-fourths">
+      <div class="usa-width-two-thirds">
        {% include "src/site/components/navigation-sidebar-trigger.html" with menuId = "va-detailpage-sidebar" %}
         <article class="usa-content">
           <h1 class="vads-u-margin-bottom--5">News releases</h1>

--- a/src/site/layouts/publication_listing.drupal.liquid
+++ b/src/site/layouts/publication_listing.drupal.liquid
@@ -8,7 +8,7 @@
   <main class="va-l-detail-page va-facility-page">
     <div class="usa-grid usa-grid-full">
       {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with sidebarData = outreachSidebar %}
-      <div class="usa-width-three-fourths">
+      <div class="usa-width-two-thirds">
         {% include "src/site/components/navigation-sidebar-trigger.html" with menuId = "va-detailpage-sidebar" %}
         {% if !entityPublished %}
         <div class="usa-alert usa-alert-info">

--- a/src/site/layouts/vamc_operating_status_and_alerts.drupal.liquid
+++ b/src/site/layouts/vamc_operating_status_and_alerts.drupal.liquid
@@ -6,7 +6,7 @@
     <main class="va-l-detail-page va-facility-page">
         <div class="usa-grid usa-grid-full">
             {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with sidebarData = facilitySidebar %}
-            <div class="usa-width-three-fourths">
+            <div class="usa-width-two-thirds">
                 {% include "src/site/components/navigation-sidebar-trigger.html" with menuId = "va-detailpage-sidebar" %}
 
                 <article class="usa-content">


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/2556

**Current Behavior:** The SideNav is 1/4 and the content is 3/4s.
![image](https://user-images.githubusercontent.com/12773166/69345040-6b8b0500-0c3e-11ea-9ef0-cd44e9ac2f7f.png)

**Desired Behavior:** The SideNav is 1/3 and the content is 2/3s.
![image](https://user-images.githubusercontent.com/12773166/69345080-852c4c80-0c3e-11ea-8f06-fe9dbf4a08ae.png)

**WARNING:** This PR will affect the current SideNav and not just the new SideNav. This will likely want to be merged once the new SideNav is going to production.

## Testing done 
Locally, clicked through each page. If you are reviewing this, please be sure to pull down the branch and navigate to [http://localhost:3001/pittsburgh-health-care/](http://localhost:3001/pittsburgh-health-care/) and click on each nav item to ensure the width is calculated correctly.

## Screenshots
See above.

## Acceptance criteria
- [x] SideNav is 1/3 width.
- [x] SideNav is 2/3 width.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the Pre-Launch Checklist
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] A link has been provided to the VSA-QA Test Plan ticket \[use the VSA-QA Test Plan Issue Template to create the ticket within va.gov-team repo].
- [x] A link has been provided to the VSA-QA Test-Request ticket \[issue-template coming soon].
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
