### PR TITLE
Change nav item color to dark grey on hover

### DIFF
--- a/src/platform/site-wide/sass/modules/_m-side-nav.scss
+++ b/src/platform/site-wide/sass/modules/_m-side-nav.scss
@@ -102,6 +102,11 @@
       letter-spacing: 0;
       line-height: 1.38;
       text-transform: none;
+      transition: color 0.5s ease;
+
+      &:hover {
+        color: $color-gray-dark;
+      }
     }
   }
 }


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/3576

**Current Behavior:** On nav item hover, the nav item color stays the same.

**Desired Behavior:** On nav item hover, the nav item color should turn to dark grey.

This PR implements the desired behavior.

## Testing done 
Locally.

## Screenshots
![image](https://user-images.githubusercontent.com/12773166/69347523-9ecf9300-0c42-11ea-8959-5e28879b7bc5.png)

## Acceptance criteria
- [x] Change color to dark grey on nav item hover.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the Pre-Launch Checklist
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] A link has been provided to the VSA-QA Test Plan ticket \[use the VSA-QA Test Plan Issue Template to create the ticket within va.gov-team repo].
- [x] A link has been provided to the VSA-QA Test-Request ticket \[issue-template coming soon].
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
