### PR TITLE
Underline selected nav items that do not have children

### DIFF
--- a/src/platform/site-wide/sass/modules/_m-side-nav.scss
+++ b/src/platform/site-wide/sass/modules/_m-side-nav.scss
@@ -77,7 +77,7 @@
     &.selected {
       color: $color-gray-dark;
 
-      &.va-sidenav-item-label-duplicate {
+      &.va-sidenav-item-label-underlined {
         text-decoration: underline;
       }
     }

--- a/src/platform/site-wide/side-nav/components/DuplicateLineLabel.js
+++ b/src/platform/site-wide/side-nav/components/DuplicateLineLabel.js
@@ -36,11 +36,13 @@ const DuplicateLineLabel = ({ depth, item }) => {
     <>
       <div className="line" />
       <a
-        className={classNames({
-          'va-sidenav-item-label': true,
-          'va-sidenav-item-label-underlined': true,
-          selected: isSelected,
-        })}
+        className={classNames(
+          'va-sidenav-item-label',
+          'va-sidenav-item-label-underlined',
+          {
+            selected: isSelected,
+          },
+        )}
         href={href}
         rel="noopener noreferrer"
       >

--- a/src/platform/site-wide/side-nav/components/DuplicateLineLabel.js
+++ b/src/platform/site-wide/side-nav/components/DuplicateLineLabel.js
@@ -38,7 +38,7 @@ const DuplicateLineLabel = ({ depth, item }) => {
       <a
         className={classNames({
           'va-sidenav-item-label': true,
-          'va-sidenav-item-label-duplicate': true,
+          'va-sidenav-item-label-underlined': true,
           selected: isSelected,
         })}
         href={href}

--- a/src/platform/site-wide/side-nav/components/ExpandCollapseIcon.js
+++ b/src/platform/site-wide/side-nav/components/ExpandCollapseIcon.js
@@ -22,8 +22,7 @@ const ExpandCollapseButton = ({ depth, item }) => {
   return (
     <span className="va-sidenav-toggle-expand">
       <i
-        className={classNames({
-          fa: true,
+        className={classNames('fa', {
           'fa-chevron-up': expanded,
           'fa-chevron-down': !expanded,
         })}

--- a/src/platform/site-wide/side-nav/components/NavItemRow.js
+++ b/src/platform/site-wide/side-nav/components/NavItemRow.js
@@ -49,6 +49,7 @@ const NavItemRow = ({ depth, item, toggleItemExpanded }) => {
     <a
       className={classNames({
         'va-sidenav-item-label': true,
+        'va-sidenav-item-label-underlined': true,
         selected: isSelected,
       })}
       rel="noopener noreferrer"

--- a/src/platform/site-wide/side-nav/components/NavItemRow.js
+++ b/src/platform/site-wide/side-nav/components/NavItemRow.js
@@ -28,11 +28,15 @@ const NavItemRow = ({ depth, item, toggleItemExpanded }) => {
     return (
       <button
         aria-label={label}
-        className={classNames({
-          'va-sidenav-item-label': true,
-          'va-sidenav-item-label-bold': isFirstLevel,
-          selected: isSelected,
-        })}
+        className={classNames(
+          'va-sidenav-item-label',
+          'va-sidenav-item-label',
+          'va-sidenav-item-label-underlined',
+          {
+            'va-sidenav-item-label-bold': isFirstLevel,
+            selected: isSelected,
+          },
+        )}
         onClick={toggleItemExpanded(id)}
         style={{ paddingLeft: indentation }}
       >
@@ -47,11 +51,14 @@ const NavItemRow = ({ depth, item, toggleItemExpanded }) => {
 
   return (
     <a
-      className={classNames({
-        'va-sidenav-item-label': true,
-        'va-sidenav-item-label-underlined': true,
-        selected: isSelected,
-      })}
+      className={classNames(
+        'va-sidenav-item-label',
+        'va-sidenav-item-label',
+        'va-sidenav-item-label-underlined',
+        {
+          selected: isSelected,
+        },
+      )}
       rel="noopener noreferrer"
       href={href}
       style={{ paddingLeft: indentation }}


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/3574

**Current Behavior:** Selected nav items that do not have children are not underlined.

**Desired Behavior:** Selected nav items that do not have children are underlined.

This PR adds the desired behavior.

## Testing done 
Locally.

## Screenshots
![image](https://user-images.githubusercontent.com/12773166/69349809-6e89f380-0c46-11ea-9836-95c44574f189.png)

## Acceptance criteria
- [x] Selected nav items with no children are underlined.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the Pre-Launch Checklist
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] A link has been provided to the VSA-QA Test Plan ticket \[use the VSA-QA Test Plan Issue Template to create the ticket within va.gov-team repo].
- [x] A link has been provided to the VSA-QA Test-Request ticket \[issue-template coming soon].
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
