### PR TITLE
Do not render duplicate label + line when the nav item !hasChildren

### DIFF
--- a/src/platform/site-wide/side-nav/components/DuplicateLineLabel.js
+++ b/src/platform/site-wide/side-nav/components/DuplicateLineLabel.js
@@ -10,14 +10,25 @@ import LabelText from './LabelText';
 const DuplicateLineLabel = ({ depth, item }) => {
   // Derive the item properties.
   const expanded = get(item, 'expanded');
+  const hasChildren = get(item, 'hasChildren');
   const href = get(item, 'href');
   const isSelected = get(item, 'isSelected');
 
   // Determine if the nav item is 2nd level.
   const isSecondLevel = depth === 2;
 
-  // Do not render if we are collapsed or if the nav item is not 2nd level.
-  if (!expanded || !isSecondLevel) {
+  // Do not render if we are collapsed.
+  if (!expanded) {
+    return null;
+  }
+
+  // Do not render if the nav item is not 2nd level.
+  if (!isSecondLevel) {
+    return null;
+  }
+
+  // Do not render if the nav item has no children.
+  if (!hasChildren) {
     return null;
   }
 


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/3569

**Current Behavior:** When a selected nav item does _not_ have children, it shows a duplicate label and an extra line.

**Desired Behavior:** When a selected nav item does _not_ have children, it does not show a duplicate label and an extra line.

## Testing done 
Locally.

## Screenshots
![image](https://user-images.githubusercontent.com/12773166/69350562-c7a65700-0c47-11ea-8b84-0e254d54ed4c.png)

## Acceptance criteria
- [x] When a selected nav item does _not_ have children, it does not show a duplicate label and an extra line.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the Pre-Launch Checklist
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] A link has been provided to the VSA-QA Test Plan ticket \[use the VSA-QA Test Plan Issue Template to create the ticket within va.gov-team repo].
- [x] A link has been provided to the VSA-QA Test-Request ticket \[issue-template coming soon].
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
