### PR TITLE
Remove bottom margin for empty form pages

### DIFF
--- a/src/platform/forms-system/src/js/review/ReviewCollapsibleChapter.jsx
+++ b/src/platform/forms-system/src/js/review/ReviewCollapsibleChapter.jsx
@@ -145,6 +145,9 @@ export default class ReviewCollapsibleChapter extends React.Component {
 
             const classes = classNames('form-review-panel-page', {
               'schemaform-review-page-warning': !viewedPages.has(fullPageKey),
+              // Remove bottom margin when the div content is empty
+              'vads-u-margin-bottom--0':
+                !pageSchema && arrayFields.length === 0,
             });
             const title = page.reviewTitle || page.title || '';
 


### PR DESCRIPTION
## Description

This PR removes the bottom margin from empty review components.

When a form contains presentational content within a page of a chapter, it gets rendered as an empty block in the review form. This empty section has a 5rem bottom margin applied

![](https://user-images.githubusercontent.com/136959/69259547-0d99e700-0b84-11ea-832c-c9ff97820a22.png)

## Testing done 

Local unit tests.

## Screenshots

![Screen Shot 2019-11-21 at 9 19 34 AM](https://user-images.githubusercontent.com/136959/69350944-1b14a700-0c40-11ea-810f-61e2708a734b.png)

## Acceptance criteria
- [ ] Excessive gaps within the review page content is removed

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
