### PR TITLE
Remove home from breadcrumbs

### DIFF
--- a/src/site/includes/breadcrumbs.drupal.liquid
+++ b/src/site/includes/breadcrumbs.drupal.liquid
@@ -4,11 +4,7 @@
         {% if forloop.last == true %}
             <li><a aria-current="page" href="/{{ path }}">{{ crumb.text }}</a></li>
         {% elsif crumb.url.path %}
-            {% if crumb.url.path == '/' %}
-                <li>
-                    <a href="{{ crumb.url.path }}" onClick="recordEvent({ event: 'nav-breadcrumb', 'nav-breadcrumb-section': 'home' });">{{ crumb.text }}</a>
-                </li>
-            {% else %}
+            {% if crumb.url.path != '/' %}
                 <li><a href="{{ crumb.url.path }}">{{ crumb.text }}</a></li>
             {% endif %}
         {% endif %}


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/3572

**Current Behavior:** Home is included in the breadcrumbs.

**Desired Behavior:** Home is not included in the breadcrumbs.

This PR implements the desired behavior.

## Testing done 
Locally.

## Screenshots
![image](https://user-images.githubusercontent.com/12773166/69351509-71d2ae80-0c49-11ea-9197-169e12ef7d4d.png)


## Acceptance criteria
- [x]"Home" is not included in breadcrumbs.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the Pre-Launch Checklist
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] A link has been provided to the VSA-QA Test Plan ticket \[use the VSA-QA Test Plan Issue Template to create the ticket within va.gov-team repo].
- [x] A link has been provided to the VSA-QA Test-Request ticket \[issue-template coming soon].
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
