### PR TITLE
Kelsonic 3575 remove sidenav on events news releases and stories subpages

### DIFF
--- a/src/site/layouts/event.drupal.liquid
+++ b/src/site/layouts/event.drupal.liquid
@@ -104,13 +104,147 @@ Example data:
 {% endif %}
 <div class="interior" id="content">
   <main class="va-l-detail-page va-facility-page">
-    <div class="usa-grid usa-grid-full">
-      {% if entityUrl.path contains "/outreach-and-events" %}
-        {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with sidebarData = outreachSidebar %}
-      {% else %}
-        {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with sidebarData = facilitySidebar %}
-      {% endif %}
-      <div class="usa-width-three-fourths">
+
+    {% comment %} On prod, show the SideNav. {% endcomment %}
+    {% if buildtype == 'vagovprod' %}
+      <div class="usa-grid usa-grid-full">
+        {% comment %} SideNav {% endcomment %}
+        {% if entityUrl.path contains "/outreach-and-events" %}
+          {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with sidebarData = outreachSidebar %}
+        {% else %}
+          {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with sidebarData = facilitySidebar %}
+        {% endif %}
+
+        {% comment %} Content {% endcomment %}
+        <div class="usa-width-three-fourths">
+          {% include "src/site/components/navigation-sidebar-trigger.html" with menuId = "va-detailpage-sidebar" %}
+          {% if !entityPublished %}
+          <div class="usa-alert usa-alert-info">
+            <div class="usa-alert-body">
+              <p class="usa-alert-text">You are viewing a draft.</p>
+            </div>
+          </div>
+          {% endif %}
+
+          <article aria-labelledby="article-heading" role="region"class="usa-content">
+            <div class="usa-grid usa-grid-full">
+              <h1 id="article-heading" class="{% if fieldMedia %}vads-u-margin-bottom--4{% else %}vads-u-margin-bottom--2{% endif %}">{{ title }}</h1>
+              {% if fieldMedia %}
+                  <img class="event-detail-img vads-u-margin-bottom--3 medium-screen:vads-u-margin-bottom--4" alt="{{fieldMedia.entity.image.alt}}"
+                    src="{{fieldMedia.entity.image.derivative.url}}" />
+              {% endif %}
+              <div class="va-introtext">
+                <p class="vads-u-margin-top--0 vads-u-margin-bottom--1 medium-screen:vads-u-margin-bottom--4">{{ fieldDescription }}</p>
+              </div>
+
+              <div class="usa-width-one-half vads-u-margin-bottom--2p5 medium-screen:vads-u-margin-bottom--0">
+                {% assign facility = fieldFacilityLocation.entity %}
+                <dl class="va-c-event-info">
+                  <dt class="vads-u-font-weight--bold when-where-width vads-u-margin-right--2">When</dt>
+                  <dd>
+                    {% if date_type == "start_date_only" %}
+                    <span>{{ start_date_no_time }}</span><br>
+                    <span>{{ start_time }}</span>
+                    {% else %}
+                    {% if date_type == "same_day" %}
+                    <span>{{ start_date_no_time }}</span><br>
+                    <span>{{ start_time }}
+                      –
+                      {{ end_time }}</span>
+                    {% else %}
+                    <span>{{ start_date_full }}
+                      –</span><br>
+                    <span>{{ end_date_full }}</span>
+                    {% endif %}
+                    {% endif %}
+                    <span> ET</span>
+                  </dd>
+                </dl>
+
+                {% if fieldFacilityLocation or fieldAddress.addressLine1 %}
+                <dl class="va-c-event-info">
+                  <dt class="vads-u-font-weight--bold when-where-width vads-u-margin-right--2">Where</dt>
+                  <dd>
+                    {% if facility %}
+                    <p class="vads-u-margin--0">
+                      <a
+                        href="{{ facility.entityUrl.path }}">{{ facility.title }}</a>
+                    </p>
+                    <p class="vads-u-margin--0">{{ fieldLocationHumanreadable }}
+                    </p>
+                    {% else %}
+                        {% if fieldAddress.addressLine1 %}
+                          <p class="vads-u-margin--0">{{ fieldAddress.addressLine1 }}</p>
+                        {% endif %}
+                        {% if fieldAddress.addressLine2 %}
+                          <p class="vads-u-margin--0">{{ fieldAddress.addressLine2 }}</p>
+                        {% endif %}
+                        <p class="vads-u-margin--0">
+                          {% if fieldAddress.locality %}
+                              {{ fieldAddress.locality }}
+                          {% endif %}
+                          {% if fieldAddress.administrativeArea %}
+                          , {{ fieldAddress.administrativeArea }}
+                          {% endif %}
+                        </p>
+                    {% endif %}
+                  </dd>
+
+                </dl>
+                {% endif %}
+
+                  {% if fieldEventCost %}
+                      <dl class="va-c-event-info">
+                        <dt class="vads-u-font-weight--bold vads-u-margin-right--2">Cost</dt>
+                        <dd>
+                          <span>{{ fieldEventCost }}</span>
+                        </dd>
+                      </dl>
+                  {% endif %}
+
+                  <div class="registration vads-u-margin-top--4 vads-u-margin-bottom--3 medium-screen:vads-u-margin-bottom--1">
+                      <p class="vads-u-font-weight--bold vads-u-margin-top--0 vads-u-margin-bottom--1">Registration</p>
+                      {% if start_timestamp < current_timestamp %}
+                          <p class="vads-u-margin--0 vads-u-color--secondary vads-u-font-weight--bold">This event already happened.</p>
+                      {% else %}
+                          {% if fieldLink %}
+                              <p class="vads-u-margin--0"><a
+                                          href="{{ fieldLink.url.path }}"><button class="vads-u-margin--0">{{fieldEventCta | listValue | capitalize}}</button></a>
+                              </p>
+                          {% endif %}
+                          {% if fieldAdditionalInformationAbo %}
+                              <p class="vads-u-margin--0">{{ fieldAdditionalInformationAbo.processed | outputLinks }}</p>
+                          {% endif %}
+
+                      {% endif %}
+                  </div>
+              </div>
+
+                  <div class="usa-width-one-half va-c-event-share vads-u-margin-bottom--1">
+                      {% include "src/site/includes/social-share.drupal.liquid" %}
+                  </div>
+              </div>
+
+            <div class="usa-grid usa-grid-full">
+              <div class="event-description">
+                {{ fieldBody.processed }}
+              </div>
+            </div>
+              {% assign index = entityUrl.breadcrumb.length | minus: 2 %}
+            <a onClick="recordEvent({ event: 'nav-secondary-button-click' });" href="{{ entityUrl.breadcrumb | getValueFromArrayObjPath: index, 'url.path' }}">See all events</a>
+          </article>
+
+          <div class="last-updated usa-content">
+            Last updated:
+            <time
+              datetime="{{ changed | dateFromUnix: 'YYYY-MM-DD'}}">{{ changed | humanizeTimestamp }}</time>
+          </div>
+        </div>
+      </div>
+
+    {% comment %} On non-prod environments, do not show the SideNav. {% endcomment %}
+    {% else %}
+      <div class="usa-grid usa-grid-full">
         {% include "src/site/components/navigation-sidebar-trigger.html" with menuId = "va-detailpage-sidebar" %}
         {% if !entityPublished %}
         <div class="usa-alert usa-alert-info">
@@ -234,7 +368,7 @@ Example data:
             datetime="{{ changed | dateFromUnix: 'YYYY-MM-DD'}}">{{ changed | humanizeTimestamp }}</time>
         </div>
       </div>
-    </div>
+    {% end %}
   </main>
 </div>
 {% include "src/site/includes/footer.html" %}

--- a/src/site/layouts/event.drupal.liquid
+++ b/src/site/layouts/event.drupal.liquid
@@ -368,7 +368,7 @@ Example data:
             datetime="{{ changed | dateFromUnix: 'YYYY-MM-DD'}}">{{ changed | humanizeTimestamp }}</time>
         </div>
       </div>
-    {% end %}
+    {% endif %}
   </main>
 </div>
 {% include "src/site/includes/footer.html" %}

--- a/src/site/layouts/news_story.drupal.liquid
+++ b/src/site/layouts/news_story.drupal.liquid
@@ -61,9 +61,13 @@ Example data:
 {% include "src/site/includes/breadcrumbs.drupal.liquid" %}
 <div id="content" class="interior">
     <main class="va-l-detail-page va-facility-page">
+        {% comment %} On prod environments, show the SideNav. {% endcomment %}
         {% if buildtype == 'vagovprod' %}
             <div class="usa-grid usa-grid-full">
+                {% comment %} SideNav {% endcomment %}
                 {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with sidebarData = facilitySidebar %}
+
+                {% comment %} Content {% endcomment %}
                 <div class="usa-width-three-fourths">
                     {% include "src/site/components/navigation-sidebar-trigger.html" with menuId = "va-detailpage-sidebar" %}
                     {% if !entityPublished %}
@@ -101,6 +105,8 @@ Example data:
                     </article>
                 </div>
             </div>
+
+        {% comment %} On non-prod environments, do not show the SideNav. {% endcomment %}
         {% else %}
             <div class="usa-grid usa-grid-full">
                 {% include "src/site/components/navigation-sidebar-trigger.html" with menuId = "va-detailpage-sidebar" %}

--- a/src/site/layouts/news_story.drupal.liquid
+++ b/src/site/layouts/news_story.drupal.liquid
@@ -61,9 +61,48 @@ Example data:
 {% include "src/site/includes/breadcrumbs.drupal.liquid" %}
 <div id="content" class="interior">
     <main class="va-l-detail-page va-facility-page">
-        <div class="usa-grid usa-grid-full">
-            {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with sidebarData = facilitySidebar %}
-            <div class="usa-width-three-fourths">
+        {% if buildtype == 'vagovprod' %}
+            <div class="usa-grid usa-grid-full">
+                {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with sidebarData = facilitySidebar %}
+                <div class="usa-width-three-fourths">
+                    {% include "src/site/components/navigation-sidebar-trigger.html" with menuId = "va-detailpage-sidebar" %}
+                    {% if !entityPublished %}
+                        <div class="usa-alert usa-alert-info" >
+                            <div class="usa-alert-body">
+                                <p class="usa-alert-text">You are viewing a draft.</p>
+                            </div>
+                        </div>
+                    {% endif %}
+
+                    <article class="usa-content">
+                        <h1>{{ title }}</h1>
+                        {% assign image = fieldMedia.entity.image %}
+                        <img class="story-detail-img {% if fieldImageCaption == empty %}vads-u-margin-bottom--2p5{% else %}vads-u-margin-bottom--1{% endif %}" src="{{ image.derivative.url }}" alt="{{ image.alt }}" title="{{ image.title }}" width="100%">
+                        <div class="vads-u-font-size--sm vads-u-margin-bottom--2p5">{{ fieldImageCaption }}</div>
+                        {% if fieldAuthor != empty and fieldAuthor.entity != empty %}
+                            {% assign author = fieldAuthor.entity %}
+                            <div class="authored-by-line vads-u-margin-bottom--0p5 vads-u-font-weight--bold">By {{ author.title }}{% if author.fieldDescription != empty %}, {{ author.fieldDescription }} {% endif %}</div>
+                        {% endif %}
+                        <div class="created-line vads-u-margin-bottom--2p5">
+                            <time datetime="{{ created | dateFromUnix: 'YYYY-MM-DD'}}">{{ created | humanizeTimestamp }}</time>
+                        </div>
+
+                        {% include "src/site/facilities/story_social_share.drupal.liquid" %}
+
+                        <div class="usa-grid usa-grid-full vads-u-margin-bottom--2">
+                            <div class="va-introtext">
+                                <p>{{ fieldIntroText }}</p>
+                            </div>
+                            <div class="full-story">
+                                {{ fieldFullStory.processed }}
+                            </div>
+                        </div>
+                        <a onClick="recordEvent({ event: 'nav-secondary-button-click' });" class="vads-u-display--block vads-u-margin-bottom--7" href="{{ fieldOffice.entity.entityUrl.path }}/stories">See all stories</a>
+                    </article>
+                </div>
+            </div>
+        {% else %}
+            <div class="usa-grid usa-grid-full">
                 {% include "src/site/components/navigation-sidebar-trigger.html" with menuId = "va-detailpage-sidebar" %}
                 {% if !entityPublished %}
                     <div class="usa-alert usa-alert-info" >
@@ -99,7 +138,7 @@ Example data:
                     <a onClick="recordEvent({ event: 'nav-secondary-button-click' });" class="vads-u-display--block vads-u-margin-bottom--7" href="{{ fieldOffice.entity.entityUrl.path }}/stories">See all stories</a>
                 </article>
             </div>
-        </div>
+        {% end %}
     </main>
 </div>
 {% include "src/site/includes/footer.html" %}

--- a/src/site/layouts/news_story.drupal.liquid
+++ b/src/site/layouts/news_story.drupal.liquid
@@ -138,7 +138,7 @@ Example data:
                     <a onClick="recordEvent({ event: 'nav-secondary-button-click' });" class="vads-u-display--block vads-u-margin-bottom--7" href="{{ fieldOffice.entity.entityUrl.path }}/stories">See all stories</a>
                 </article>
             </div>
-        {% end %}
+        {% endif %}
     </main>
 </div>
 {% include "src/site/includes/footer.html" %}

--- a/src/site/layouts/press_release.drupal.liquid
+++ b/src/site/layouts/press_release.drupal.liquid
@@ -97,9 +97,79 @@
 {% include "src/site/includes/breadcrumbs.drupal.liquid" %}
 <div id="content" class="interior">
     <main class="va-l-detail-page va-facility-page">
-        <div class="usa-grid usa-grid-full">
-            {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with sidebarData = facilitySidebar %}
-            <div class="usa-width-three-fourths">
+        {% if buildtype == 'vagovprod' %}
+            <div class="usa-grid usa-grid-full">
+                {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with sidebarData = facilitySidebar %}
+                <div class="usa-width-three-fourths">
+                    {% include "src/site/components/navigation-sidebar-trigger.html" with menuId = "va-detailpage-sidebar" %}
+                    <article class="usa-content">
+                        <section class="vads-u-margin-bottom--5">
+                            <h1 class="vads-u-margin-bottom--2p5">{{ title }}</h1>
+                            <p class="vads-u-margin-bottom--0p5">PRESS RELEASE</p>
+                            <p class="vads-u-font-weight--bold vads-u-margin-bottom--3 vads-u-margin-top--0">{{ fieldReleaseDate.value | formatDate: 'MMMM D, YYYY' }}</p>
+                            <div>
+                                <button type="button" class="vads-u-margin-right--4 va-button-link" onclick="window.print(); return false;"><i class="fa fa-print vads-u-padding-right--1"></i>Print</button>
+                                {% if fieldPdfVersion != empty %}
+                                    <a href="{{ fieldPdfVersion.entity.fieldDocument.entity.url }}" download><i class="fa fa-download vads-u-padding-right--1"></i>Download press release (PDF)</a>
+                                {% endif %}
+                            </div>
+                            <p class="va-introtext vads-u-font-size--lg vads-u-margin-top--3">{{ fieldAddress.locality }}, {{ fieldAddress.administrativeArea }} — {{ fieldIntroText }}</p>
+                            <div>{{ fieldPressReleaseFulltext.processed }}</div>
+                        </section>
+
+                        {% assign anyContacts = fieldPressReleaseContact.length %}
+                        {% if anyContacts > 0 %}
+                            <section class="vads-u-margin-bottom--6">
+                                <div class="vads-u-font-weight--bold">Media contacts</div>
+                                {% for contact in fieldPressReleaseContact %}
+                                    {% assign c = contact.entity %}
+                                    {% if c != empty %}
+                                        <div>
+                                            <p class="vads-u-margin-top--1 vads-u-margin-bottom--0">{{ c.title }}{% if c.fieldDescription != empty %}, {{ c.fieldDescription }} {% endif %}</p>
+                                            <p class="vads-u-margin-top--1 vads-u-margin-bottom--0">{{ c.fieldPhoneNumber }}</p>
+                                            {% if c.fieldEmailAddress != empty %}
+                                                <p class="vads-u-margin-top--1 vads-u-margin-bottom--0"><a href="mailto:{{ c.fieldEmailAddress }}">{{ c.fieldEmailAddress }}</a></p>
+                                            {% endif %}
+                                        </div>
+                                    {% endif %}
+                                {% endfor %}
+                            </section>
+                        {%  endif %}
+
+                        {% assign anyDownloads = fieldPressReleaseDownloads.length %}
+                        {% if anyDownloads > 0 %}
+                            <section class="vads-u-margin-bottom--6">
+                                <div class="vads-u-font-weight--bold vads-u-margin-bottom--1">Download media assets</div>
+                                {% for asset in fieldPressReleaseDownloads %}
+                                    {% assign a = asset.entity %}
+                                    <ul class="vads-u-margin-bottom--1 usa-unstyled-list">
+                                        <li class="vads-u-margin-bottom--1">
+                                            {% case a.entityBundle %}
+                                            {% when 'document' %}
+                                                <a href="{{ a.fieldDocument.entity.url }}" download>{{ a.name }}</a>
+                                            {% when a.entityBundle === 'image' %}
+                                                <a href="{{ a.image.url }}" download>{{ a.name }}</a>
+                                            {% when a.entityBundle === 'video' %}
+                                                <a href="{{ a.fieldMediaVideoEmbedField }}">{{ a.name }}</a>
+                                            {%  endcase %}
+                                        </li>
+                                    </ul>
+                                {% endfor %}
+                            </section>
+                        {%  endif %}
+
+                        <section class="vads-u-margin-bottom--6 vads-u-text-align--center">###</section>
+
+                        <section class="vads-u-margin-bottom--3">
+                            {{ fieldOffice.entity.fieldPressReleaseBlurb.processed }}
+                        </section>
+                        {% assign index = entityUrl.breadcrumb.length | minus: 2 %}
+                        <a onClick="recordEvent({ event: 'nav-secondary-button-click' });" href="{{ entityUrl.breadcrumb | getValueFromArrayObjPath: index, 'url.path' }}">See all news releases</a>
+                    </article>
+                </div>
+            </div>
+        {% else %}
+            <div class="usa-grid usa-grid-full">
                 {% include "src/site/components/navigation-sidebar-trigger.html" with menuId = "va-detailpage-sidebar" %}
                 <article class="usa-content">
                     <section class="vads-u-margin-bottom--5">
@@ -166,7 +236,7 @@
                     <a onClick="recordEvent({ event: 'nav-secondary-button-click' });" href="{{ entityUrl.breadcrumb | getValueFromArrayObjPath: index, 'url.path' }}">See all news releases</a>
                 </article>
             </div>
-        </div>
+        {% endif %}
     </main>
 </div>
 {% include "src/site/includes/footer.html" %}

--- a/src/site/layouts/press_release.drupal.liquid
+++ b/src/site/layouts/press_release.drupal.liquid
@@ -97,9 +97,13 @@
 {% include "src/site/includes/breadcrumbs.drupal.liquid" %}
 <div id="content" class="interior">
     <main class="va-l-detail-page va-facility-page">
+        {% comment %} On prod, show the SideNav. {% endcomment %}
         {% if buildtype == 'vagovprod' %}
             <div class="usa-grid usa-grid-full">
+                {% comment %} SideNav {% endcomment %}
                 {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with sidebarData = facilitySidebar %}
+
+                {% comment %} Content {% endcomment %}
                 <div class="usa-width-three-fourths">
                     {% include "src/site/components/navigation-sidebar-trigger.html" with menuId = "va-detailpage-sidebar" %}
                     <article class="usa-content">
@@ -168,6 +172,8 @@
                     </article>
                 </div>
             </div>
+
+        {% comment %} On non-prod environments, do not show the SideNav. {% endcomment %}
         {% else %}
             <div class="usa-grid usa-grid-full">
                 {% include "src/site/components/navigation-sidebar-trigger.html" with menuId = "va-detailpage-sidebar" %}


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/3575

**Current Behavior:** `Events`, `News Releases`, and `Stories` sub pages have the SideNav.

**Desired Behavior:** `Events`, `News Releases`, and `Stories` sub pages do not have the SideNav.

## Testing done
Locally.

## Screenshots
News Releases:
![image](https://user-images.githubusercontent.com/12773166/69356041-d2b1b500-0c50-11ea-886f-a1ffd33a8a2b.png)

Events:
![image](https://user-images.githubusercontent.com/12773166/69356078-de9d7700-0c50-11ea-818c-663dac112b6e.png)

Stories:
![image](https://user-images.githubusercontent.com/12773166/69356120-efe68380-0c50-11ea-91ea-dc9ca821c69d.png)

## Acceptance criteria
- [x] Remove SideNav on `Events` subpages.
- [x] Remove SideNav on `News Releases` subpages.
- [x] Remove SideNav on `Stories` subpages.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the Pre-Launch Checklist
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] A link has been provided to the VSA-QA Test Plan ticket \[use the VSA-QA Test Plan Issue Template to create the ticket within va.gov-team repo].
- [x] A link has been provided to the VSA-QA Test-Request ticket \[issue-template coming soon].
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
