### PR TITLE
Revert "3416 - Add QA/testing step(s)/info to PR-template. (#11094)"

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,25 +1,17 @@
 ## Description
 
 
-## Testing done 
-\[Provide link to QA Test Plan ticket (issue-template coming soon) for the relevant product/feature.
-List the new/update unit-test(s) & e2e-test\(s) that have been successfully run before open this PR.
-Also, if UI-testable (i.e., testable manually on Staging by QA, either via the browser or REST API-client), provide link to QA test-request ticket \[issue-template coming soon].]
-
-See [VSA QA Process](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/vsa/teams/qa/vsa-qa-process.md) for more info on Engineering/QA collaboration/engagement.
+## Testing done
 
 
 ## Screenshots
 
 
 ## Acceptance criteria
-- [ ] 
+- [ ]
 
 ## Definition of done
 - [ ] Events are logged appropriately
 - [ ] Documentation has been updated, if applicable
-- [ ] A link has been provided to the Pre-Launch Checklist
 - [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
-- [ ] A link has been provided to the VSA-QA Test Plan ticket \[use the VSA-QA Test Plan Issue Template to create the ticket within va.gov-team repo].
-- [ ] A link has been provided to the VSA-QA Test-Request ticket \[issue-template coming soon].
 - [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs


### PR DESCRIPTION
[3651](https://github.com/department-of-veterans-affairs/va.gov-team/issues/3651) - This reverts commit 4029c747be8bb000808a9a62da11d869e9104713.

## Description
Per @jcosta-gcio, the recent PR-template changes made via [3416](https://github.com/department-of-veterans-affairs/va.gov-team/issues/3416) need to be rolled back, as they are impacting PRs made by non-VSA teams.  The changes were meant only for VSA PRs.

## Acceptance criteria
- [ ] PR approved by @jcosta-gcio 

## Definition of done
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
