### PR TITLE
[Due on 11/22/19] [Redirects] Implement redirects to /school-administrators

### DIFF
--- a/src/applications/proxy-rewrite/redirects/disabilityRedirects.json
+++ b/src/applications/proxy-rewrite/redirects/disabilityRedirects.json
@@ -183,5 +183,20 @@
     "domain": "www.benefits.va.gov",
     "src": "/compensation/claimexam.asp",
     "dest": "/disability/va-claim-exam/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/gibill/school_resources.asp",
+    "dest": "/school-administrators"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/gibill/school_training_resources.asp",
+    "dest": "/school-administrators"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/gibill/resources/education_resources/school_certifying_officials/sco_info.asp",
+    "dest": "/school-administrators"
   }
 ]


### PR DESCRIPTION
## Description
This PR implements the client-side redirects as outlined by https://github.com/department-of-veterans-affairs/va.gov-team/issues/3145.

https://github.com/department-of-veterans-affairs/va.gov-team/issues/3611

## Testing done 
There isn't a clear way to test this locally, but fortunately, it's just a static JSON file.

## Screenshots
N/A

## Acceptance criteria
- [x] Pages on benefits.va.gov are redirected to /school-administrators

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [ ] A link has been provided to the Pre-Launch Checklist
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] A link has been provided to the VSA-QA Test Plan ticket \[use the VSA-QA Test Plan Issue Template to create the ticket within va.gov-team repo].
- [ ] A link has been provided to the VSA-QA Test-Request ticket \[issue-template coming soon].
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
