### PR TITLE
Prefill email on contact info page

### DIFF
--- a/src/applications/vaos/actions/newAppointment.js
+++ b/src/applications/vaos/actions/newAppointment.js
@@ -1,7 +1,12 @@
 import * as Sentry from '@sentry/browser';
+import moment from 'moment';
+import {
+  selectVet360EmailAddress,
+  selectVet360HomePhoneString,
+  selectVet360MobilePhoneString,
+} from 'platform/user/selectors';
 import newAppointmentFlow from '../newAppointmentFlow';
 import { getTypeOfCare } from '../utils/selectors';
-import moment from 'moment';
 import {
   getSystemIdentifiers,
   getSystemDetails,
@@ -25,6 +30,8 @@ import { getEligibilityData } from '../utils/eligibility';
 
 export const FORM_DATA_UPDATED = 'newAppointment/FORM_DATA_UPDATED';
 export const FORM_PAGE_OPENED = 'newAppointment/FORM_PAGE_OPENED';
+export const FORM_TYPE_OF_CARE_PAGE_OPENED =
+  'newAppointment/TYPE_OF_CARE_PAGE_OPENED';
 export const FORM_PAGE_CHANGE_STARTED =
   'newAppointment/FORM_PAGE_CHANGE_STARTED';
 export const FORM_PAGE_CHANGE_COMPLETED =
@@ -107,6 +114,25 @@ export function startDirectScheduleFlow(appointments) {
 export function startRequestAppointmentFlow() {
   return {
     type: START_REQUEST_APPOINTMENT_FLOW,
+  };
+}
+
+export function openTypeOfCarePage(page, uiSchema, schema) {
+  return (dispatch, getState) => {
+    const state = getState();
+    const email = selectVet360EmailAddress(state);
+    const homePhone = selectVet360HomePhoneString(state);
+    const mobilePhone = selectVet360MobilePhoneString(state);
+
+    const phoneNumber = mobilePhone || homePhone;
+    dispatch({
+      type: FORM_TYPE_OF_CARE_PAGE_OPENED,
+      page,
+      uiSchema,
+      schema,
+      email,
+      phoneNumber,
+    });
   };
 }
 

--- a/src/applications/vaos/containers/TypeOfCarePage.jsx
+++ b/src/applications/vaos/containers/TypeOfCarePage.jsx
@@ -1,17 +1,12 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import SchemaForm from 'platform/forms-system/src/js/components/SchemaForm';
-import {
-  selectVet360EmailAddress,
-  selectVet360HomePhoneString,
-  selectVet360MobilePhoneString,
-} from 'platform/user/selectors';
 
-import { TYPES_OF_CARE, DIRECT_SCHEDULE_TYPES } from '../utils/constants';
+import { TYPES_OF_CARE } from '../utils/constants';
 import { getLongTermAppointmentHistory } from '../api';
 import FormButtons from '../components/FormButtons';
 import {
-  openFormPage,
+  openTypeOfCarePage,
   updateFormData,
   routeToNextAppointmentPage,
   routeToPreviousAppointmentPage,
@@ -48,45 +43,17 @@ const pageKey = 'typeOfCare';
 
 export class TypeOfCarePage extends React.Component {
   componentDidMount() {
-    this.props.openFormPage(pageKey, uiSchema, initialSchema);
-    this.prefillContactInfo();
+    this.props.openTypeOfCarePage(pageKey, uiSchema, initialSchema);
   }
 
   onChange = newData => {
     // When someone chooses a type of care that can be direct scheduled,
     // kick off the past appointments fetch, which takes a while
-    if (DIRECT_SCHEDULE_TYPES.has(newData.typeOfCareId)) {
-      // This could get called multiple times, but the function is memoized
-      // and returns the previous promise if it eixsts
-      getLongTermAppointmentHistory();
-    }
+    // This could get called multiple times, but the function is memoized
+    // and returns the previous promise if it eixsts
+    getLongTermAppointmentHistory();
 
     this.props.updateFormData(pageKey, uiSchema, newData);
-  };
-
-  prefillContactInfo = () => {
-    const phoneNumber = this.props.mobilePhone || this.props.homePhone;
-    // only prefill the phone number if it isn't already set. So if the user has
-    // explicitly set a phone number and then gone back to the start of the New
-    // Appointment flow (without a hard refresh), this prefill won't rerun,
-    // overwriting what they have manually entered
-    if (phoneNumber && !this.props.data.phoneNumber) {
-      this.props.updateFormData(pageKey, uiSchema, {
-        ...this.props.data,
-        phoneNumber,
-      });
-    }
-    // The following is disabled since we don't yet have email address on the
-    // Contact Info page.. When it's enabled it'll be best to refactor this
-    // function to make a single call to updateFormData rather than one for
-    // phone number and one for email address.
-    // // only prefill the email address if it isn't already set
-    // if (this.props.emailAddress && !this.props.data.emailAddress) {
-    //   this.props.updateFormData(pageKey, uiSchema, {
-    //     ...this.props.data,
-    //     emailAddress: this.props.emailAddress,
-    //   });
-    // }
   };
 
   goBack = () => {
@@ -125,17 +92,11 @@ export class TypeOfCarePage extends React.Component {
 }
 
 function mapStateToProps(state) {
-  const formPageInfo = getFormPageInfo(state, pageKey);
-  return {
-    ...formPageInfo,
-    emailAddress: selectVet360EmailAddress(state),
-    homePhone: selectVet360HomePhoneString(state),
-    mobilePhone: selectVet360MobilePhoneString(state),
-  };
+  return getFormPageInfo(state, pageKey);
 }
 
 const mapDispatchToProps = {
-  openFormPage,
+  openTypeOfCarePage,
   updateFormData,
   routeToNextAppointmentPage,
   routeToPreviousAppointmentPage,

--- a/src/applications/vaos/reducers/newAppointment.js
+++ b/src/applications/vaos/reducers/newAppointment.js
@@ -38,6 +38,7 @@ import {
   FORM_SUBMIT,
   FORM_SUBMIT_FAILED,
   FORM_SUBMIT_SUCCEEDED,
+  FORM_TYPE_OF_CARE_PAGE_OPENED,
 } from '../actions/newAppointment';
 
 import {
@@ -172,6 +173,28 @@ export default function formReducer(state = initialState, action) {
       return {
         ...state,
         pageChangeInProgress: false,
+      };
+    }
+    case FORM_TYPE_OF_CARE_PAGE_OPENED: {
+      const prefilledData = {
+        ...state.data,
+        phoneNumber: state.data.phoneNumber || action.phoneNumber,
+        email: state.data.email || action.email,
+      };
+
+      const { data, schema } = setupFormData(
+        prefilledData,
+        action.schema,
+        action.uiSchema,
+      );
+
+      return {
+        ...state,
+        data,
+        pages: {
+          ...state.pages,
+          [action.page]: schema,
+        },
       };
     }
     case FORM_UPDATE_FACILITY_TYPE: {

--- a/src/applications/vaos/tests/actions/newAppointment.unit.spec.js
+++ b/src/applications/vaos/tests/actions/newAppointment.unit.spec.js
@@ -12,6 +12,7 @@ import {
   openFacilityPage,
   updateFacilityPageData,
   updateReasonForAppointmentData,
+  openTypeOfCarePage,
   openClinicPage,
   openCommunityCarePreferencesPage,
   submitAppointmentOrRequest,
@@ -31,6 +32,7 @@ import {
   FORM_PAGE_COMMUNITY_CARE_PREFS_OPEN_SUCCEEDED,
   FORM_SUBMIT,
   FORM_SUBMIT_SUCCEEDED,
+  FORM_TYPE_OF_CARE_PAGE_OPENED,
 } from '../../actions/newAppointment';
 import systems from '../../api/facilities.json';
 import systemIdentifiers from '../../api/systems.json';
@@ -522,5 +524,34 @@ describe('VAOS newAppointment actions', () => {
       expect(dispatch.secondCall.args[0].type).to.equal(FORM_SUBMIT_SUCCEEDED);
       expect(router.push.called).to.be.true;
     });
+  });
+  it('should open type of care page and pull contact info to prefill', () => {
+    const state = {
+      user: {
+        profile: {
+          vet360: {
+            email: {
+              emailAddress: 'test@va.gov',
+            },
+            homePhone: {
+              areaCode: '503',
+              extension: '0000',
+              phoneNumber: '2222222',
+            },
+          },
+        },
+      },
+    };
+    const getState = () => state;
+    const dispatch = sinon.spy();
+
+    const thunk = openTypeOfCarePage('typeOfCare', {}, {});
+    thunk(dispatch, getState);
+
+    expect(dispatch.firstCall.args[0].type).to.equal(
+      FORM_TYPE_OF_CARE_PAGE_OPENED,
+    );
+    expect(dispatch.firstCall.args[0].phoneNumber).to.equal('5032222222');
+    expect(dispatch.firstCall.args[0].email).to.equal('test@va.gov');
   });
 });

--- a/src/applications/vaos/tests/containers/TypeOfCarePage.unit.spec.jsx
+++ b/src/applications/vaos/tests/containers/TypeOfCarePage.unit.spec.jsx
@@ -14,12 +14,12 @@ import { TypeOfCarePage } from '../../containers/TypeOfCarePage';
 
 describe('VAOS <TypeOfCarePage>', () => {
   it('should render', () => {
-    const openFormPage = sinon.spy();
+    const openTypeOfCarePage = sinon.spy();
     const updateFormData = sinon.spy();
 
     const form = mount(
       <TypeOfCarePage
-        openFormPage={openFormPage}
+        openTypeOfCarePage={openTypeOfCarePage}
         updateFormData={updateFormData}
         data={{}}
       />,
@@ -31,13 +31,17 @@ describe('VAOS <TypeOfCarePage>', () => {
   });
 
   it('should not submit empty form', () => {
-    const openFormPage = sinon.spy();
+    const openTypeOfCarePage = sinon.spy();
     const router = {
       push: sinon.spy(),
     };
 
     const form = mount(
-      <TypeOfCarePage openFormPage={openFormPage} router={router} data={{}} />,
+      <TypeOfCarePage
+        openTypeOfCarePage={openTypeOfCarePage}
+        router={router}
+        data={{}}
+      />,
     );
 
     form.find('form').simulate('submit');
@@ -50,7 +54,7 @@ describe('VAOS <TypeOfCarePage>', () => {
   it('should call updateFormData after change', () => {
     mockFetch();
     setFetchJSONResponse(global.fetch, { data: [] });
-    const openFormPage = sinon.spy();
+    const openTypeOfCarePage = sinon.spy();
     const updateFormData = sinon.spy();
     const router = {
       push: sinon.spy(),
@@ -58,7 +62,7 @@ describe('VAOS <TypeOfCarePage>', () => {
 
     const form = mount(
       <TypeOfCarePage
-        openFormPage={openFormPage}
+        openTypeOfCarePage={openTypeOfCarePage}
         updateFormData={updateFormData}
         router={router}
         data={{}}
@@ -73,12 +77,12 @@ describe('VAOS <TypeOfCarePage>', () => {
   });
 
   it('should submit with valid data', () => {
-    const openFormPage = sinon.spy();
+    const openTypeOfCarePage = sinon.spy();
     const routeToNextAppointmentPage = sinon.spy();
 
     const form = mount(
       <TypeOfCarePage
-        openFormPage={openFormPage}
+        openTypeOfCarePage={openTypeOfCarePage}
         routeToNextAppointmentPage={routeToNextAppointmentPage}
         data={{ typeOfCareId: '323' }}
       />,
@@ -91,13 +95,13 @@ describe('VAOS <TypeOfCarePage>', () => {
     form.unmount();
   });
 
-  it('should list type of care in alphabeticl order', () => {
-    const openFormPage = sinon.spy();
+  it('should list type of care in alphabetical order', () => {
+    const openTypeOfCarePage = sinon.spy();
     const updateFormData = sinon.spy();
 
     const form = mount(
       <TypeOfCarePage
-        openFormPage={openFormPage}
+        openTypeOfCarePage={openTypeOfCarePage}
         updateFormData={updateFormData}
         data={{}}
       />,

--- a/src/applications/vaos/tests/reducers/newAppointment.unit.spec.js
+++ b/src/applications/vaos/tests/reducers/newAppointment.unit.spec.js
@@ -19,6 +19,7 @@ import {
   FORM_SUBMIT,
   FORM_SUBMIT_SUCCEEDED,
   FORM_SUBMIT_FAILED,
+  FORM_TYPE_OF_CARE_PAGE_OPENED,
 } from '../../actions/newAppointment';
 
 import systems from '../../api/facilities.json';
@@ -600,5 +601,28 @@ describe('VAOS reducer: newAppointment', () => {
       const newState = newAppointmentReducer({}, action);
       expect(newState.submitStatus).to.equal(FETCH_STATUS.failed);
     });
+  });
+  it('should open the type of care page and prefill contact info', () => {
+    const currentState = {
+      data: {},
+      pages: {},
+    };
+    const action = {
+      type: FORM_TYPE_OF_CARE_PAGE_OPENED,
+      page: 'test',
+      schema: {
+        type: 'object',
+        properties: {},
+      },
+      uiSchema: {},
+      phoneNumber: '123456789',
+      email: 'test@va.gov',
+    };
+
+    const newState = newAppointmentReducer(currentState, action);
+
+    expect(newState.pages.test).not.to.be.undefined;
+    expect(newState.data.phoneNumber).to.equal(action.phoneNumber);
+    expect(newState.data.email).to.equal(action.email);
   });
 });


### PR DESCRIPTION
## Description
This adds email prefilling to the VAOS contact page. I've also refactored this some to move the logic out of the component and into an action/reducer, since it's not really related to the type of care page, it's just triggered there.

## Testing done 
Local and unit testing

## Screenshots
![Screen Shot 2019-11-22 at 3 47 27 PM](https://user-images.githubusercontent.com/634932/69459274-682b7280-0d3f-11ea-8d0c-7d77fe30e8de.png)

## Acceptance criteria
- [ ] Phone and email are prefilled

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the Pre-Launch Checklist
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] A link has been provided to the VSA-QA Test Plan ticket \[use the VSA-QA Test Plan Issue Template to create the ticket within va.gov-team repo].
- [ ] A link has been provided to the VSA-QA Test-Request ticket \[issue-template coming soon].
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
