### PR TITLE
Escape DOM selector for focused element

### DIFF
--- a/src/platform/forms-system/src/js/review/ReviewCollapsibleChapter.jsx
+++ b/src/platform/forms-system/src/js/review/ReviewCollapsibleChapter.jsx
@@ -35,7 +35,7 @@ export default class ReviewCollapsibleChapter extends React.Component {
   }
 
   focusOnPage(key) {
-    const pageDiv = document.querySelector(`#${key}`);
+    const pageDiv = document.querySelector(`#${key.replace(/:/g, '\\:')}`);
     focusElement(pageDiv);
   }
 

--- a/src/platform/forms-system/test/js/review/ReviewCollapsibleChapter.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/review/ReviewCollapsibleChapter.unit.spec.jsx
@@ -84,6 +84,46 @@ describe('<ReviewCollapsibleChapter>', () => {
     expect(onEdit.calledWith('test', true, 0)).to.be.true;
   });
 
+  it('should handle editing of view:keys', () => {
+    const onEdit = sinon.spy();
+    const pages = [
+      {
+        title: '',
+        pageKey: 'view:test',
+      },
+    ];
+    const chapterKey = 'view:test';
+    const chapter = {};
+    const form = {
+      pages: {
+        'view:test': {
+          title: '',
+          schema: {
+            properties: {},
+          },
+          uiSchema: {},
+          editMode: false,
+        },
+      },
+      data: {},
+    };
+
+    const tree = SkinDeep.shallowRender(
+      <ReviewCollapsibleChapter
+        viewedPages={new Set()}
+        onEdit={onEdit}
+        expandedPages={pages}
+        chapterKey={chapterKey}
+        chapterFormConfig={chapter}
+        form={form}
+      />,
+    );
+
+    tree.getMountedInstance().handleEdit('view:test', true);
+
+    expect(onEdit.calledWith('view:test', true)).to.be.true;
+  });
+
   it('should display a page for each item for an array page', () => {
     const onEdit = sinon.spy();
     const pages = [


### PR DESCRIPTION
## Description

Prevent invalid selector error when `focusOnPage` is called after editing a block on the review page. This PR escapes the colon (`:`) used to target the schema keys that start with `view:`.

Even after fixing this error, there still remains an **accessibility problem**. Basically, the function being fixed by this PR doesn't target anything (that I know of) on the page. After clicking on the "Edit" button, the focus should move to the first form element within the block being edited. Luckily the hidden Edit button retains focus, so pressing tab moves focus to the next focusable element. This doesn't seem ideal so I started a discussion in [Slack](https://dsva.slack.com/archives/C5HP4GN3F/p1574455877431900).

## Testing done

* Added a test to cover the case of having a `view:` prefix in the selector.

## Screenshots

After the "Edit" is clicked, the focus is not moved. But you can <kbd>Tab</kbd> to the next focusable element.

![](https://user-images.githubusercontent.com/136959/69449181-e37d2c00-0d1f-11ea-9bbb-b187b266d5d8.gif)

## Acceptance criteria
- [x] No JS error reporting an invalid selector
- [ ] Move focus to the first form element inside the page being edited (to be considered)

## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
