### PR TITLE
Show "unavailable" modal if type of care is Podiatry and CC ineligible

### DIFF
--- a/src/applications/vaos/actions/newAppointment.js
+++ b/src/applications/vaos/actions/newAppointment.js
@@ -1,6 +1,6 @@
 import * as Sentry from '@sentry/browser';
 import newAppointmentFlow from '../newAppointmentFlow';
-import { getTypeOfCare, getNewAppointment } from '../utils/selectors';
+import { getTypeOfCare } from '../utils/selectors';
 import moment from 'moment';
 import {
   getSystemIdentifiers,
@@ -98,7 +98,7 @@ export function showTypeOfCareUnavailableModal() {
   return (dispatch, getState) =>
     dispatch({
       type: FORM_SHOW_TYPE_OF_CARE_UNAVAILABLE_MODAL,
-      typeOfCare: getTypeOfCare(getNewAppointment(getState()).data),
+      typeOfCare: getTypeOfCare(getState().newAppointment.data),
     });
 }
 

--- a/src/applications/vaos/actions/newAppointment.js
+++ b/src/applications/vaos/actions/newAppointment.js
@@ -1,6 +1,6 @@
 import * as Sentry from '@sentry/browser';
 import newAppointmentFlow from '../newAppointmentFlow';
-import { getTypeOfCare } from '../utils/selectors';
+import { getTypeOfCare, getNewAppointment } from '../utils/selectors';
 import moment from 'moment';
 import {
   getSystemIdentifiers,
@@ -55,6 +55,10 @@ export const FORM_SCHEDULE_APPOINTMENT_PAGE_OPENED =
   'newAppointment/FORM_SCHEDULE_APPOINTMENT_PAGE_OPENED';
 export const FORM_SCHEDULE_APPOINTMENT_PAGE_OPENED_SUCCEEDED =
   'newAppointment/FORM_SCHEDULE_APPOINTMENT_PAGE_OPENED_SUCCEEDED';
+export const FORM_SHOW_TYPE_OF_CARE_UNAVAILABLE_MODAL =
+  'newAppointment/FORM_SHOW_TYPE_OF_CARE_UNAVAILABLE_MODAL';
+export const FORM_HIDE_TYPE_OF_CARE_UNAVAILABLE_MODAL =
+  'newAppointment/FORM_HIDE_TYPE_OF_CARE_UNAVAILABLE_MODAL';
 export const FORM_REASON_FOR_APPOINTMENT_CHANGED =
   'newAppointment/FORM_REASON_FOR_APPOINTMENT_CHANGED';
 export const FORM_PAGE_COMMUNITY_CARE_PREFS_OPEN =
@@ -87,6 +91,20 @@ export function updateCCEnabledSystems(ccEnabledSystems) {
   return {
     type: FORM_VA_SYSTEM_UPDATE_CC_ENABLED_SYSTEMS,
     ccEnabledSystems,
+  };
+}
+
+export function showTypeOfCareUnavailableModal() {
+  return (dispatch, getState) =>
+    dispatch({
+      type: FORM_SHOW_TYPE_OF_CARE_UNAVAILABLE_MODAL,
+      typeOfCare: getTypeOfCare(getNewAppointment(getState()).data),
+    });
+}
+
+export function hideTypeOfCareUnavailableModal() {
+  return {
+    type: FORM_HIDE_TYPE_OF_CARE_UNAVAILABLE_MODAL,
   };
 }
 

--- a/src/applications/vaos/actions/newAppointment.js
+++ b/src/applications/vaos/actions/newAppointment.js
@@ -13,7 +13,11 @@ import {
   getPreferences,
   updatePreferences,
 } from '../api';
-import { FLOW_TYPES, REASON_MAX_CHARS } from '../utils/constants';
+import {
+  FACILITY_TYPES,
+  FLOW_TYPES,
+  REASON_MAX_CHARS,
+} from '../utils/constants';
 import {
   transformFormToVARequest,
   transformFormToCCRequest,
@@ -379,7 +383,9 @@ export function submitAppointmentOrRequest(router) {
         let requestBody;
         let requestData;
 
-        if (newAppointment.data.facilityType === 'communityCare') {
+        if (
+          newAppointment.data.facilityType === FACILITY_TYPES.COMMUNITY_CARE
+        ) {
           requestBody = transformFormToCCRequest(getState());
           requestData = await submitRequest('cc', requestBody);
         } else {

--- a/src/applications/vaos/actions/newAppointment.js
+++ b/src/applications/vaos/actions/newAppointment.js
@@ -101,11 +101,9 @@ export function updateCCEnabledSystems(ccEnabledSystems) {
 }
 
 export function showTypeOfCareUnavailableModal() {
-  return (dispatch, getState) =>
-    dispatch({
-      type: FORM_SHOW_TYPE_OF_CARE_UNAVAILABLE_MODAL,
-      typeOfCare: getTypeOfCare(getState().newAppointment.data),
-    });
+  return {
+    type: FORM_SHOW_TYPE_OF_CARE_UNAVAILABLE_MODAL,
+  };
 }
 
 export function hideTypeOfCareUnavailableModal() {

--- a/src/applications/vaos/api/index.js
+++ b/src/applications/vaos/api/index.js
@@ -183,7 +183,7 @@ export function getCommunityCare() {
   return new Promise(resolve => {
     setTimeout(() => {
       resolve({
-        isEligible: true,
+        isEligible: false,
         reason: 'User is within x miles of facility',
         effectiveDate: '2017-10-08T23:35:12-05:00',
       });

--- a/src/applications/vaos/api/index.js
+++ b/src/applications/vaos/api/index.js
@@ -183,7 +183,7 @@ export function getCommunityCare() {
   return new Promise(resolve => {
     setTimeout(() => {
       resolve({
-        isEligible: false,
+        isEligible: true,
         reason: 'User is within x miles of facility',
         effectiveDate: '2017-10-08T23:35:12-05:00',
       });

--- a/src/applications/vaos/components/ConfirmationRequestInfo.jsx
+++ b/src/applications/vaos/components/ConfirmationRequestInfo.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import moment from 'moment';
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 import { getTypeOfCare } from '../utils/selectors';
-import { PURPOSE_TEXT } from '../utils/constants';
+import { FACILITY_TYPES, PURPOSE_TEXT } from '../utils/constants';
 
 function formatBestTime(bestTime) {
   const times = [];
@@ -28,7 +28,7 @@ function formatBestTime(bestTime) {
 }
 
 export default function ConfirmationRequestInfo({ data, facility }) {
-  const isCommunityCare = data.facilityType === 'communityCare';
+  const isCommunityCare = data.facilityType === FACILITY_TYPES.COMMUNITY_CARE;
   const isVideoVisit = data.visitType === 'telehealth';
 
   return (

--- a/src/applications/vaos/components/TypeOfCareUnavailableModal.jsx
+++ b/src/applications/vaos/components/TypeOfCareUnavailableModal.jsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Modal from '@department-of-veterans-affairs/formation-react/Modal';
+
+const TypeOfCareUnavailableModal = ({ onClose, showModal, typeOfCare }) => {
+  if (!showModal) {
+    return null;
+  }
+
+  return (
+    <Modal
+      id="toc-modal"
+      status="warning"
+      visible
+      onClose={onClose}
+      title={`You canʼt schedule a ${typeOfCare} appointment right now`}
+    >
+      At this time, {`${typeOfCare.toLowerCase()}`} appointments can only be
+      scheduled online for Community Care appointments. To schedule a podiatry
+      appointment at a VA facility, please call your local VA medical center, or
+      use the{' '}
+      <a href="/find-locations">
+        locator tool to find your nearest VA medical facility
+      </a>
+      .
+      <button
+        onClick={onClose}
+        className="vads-u-display--block vads-u-margin-top--2p5"
+      >
+        Ok
+      </button>
+    </Modal>
+  );
+};
+
+TypeOfCareUnavailableModal.propTypes = {
+  onClose: PropTypes.func.isRequired,
+  showModal: PropTypes.bool,
+  typeOfCare: PropTypes.string.isRequired,
+};
+
+export default TypeOfCareUnavailableModal;

--- a/src/applications/vaos/components/TypeOfCareUnavailableModal.jsx
+++ b/src/applications/vaos/components/TypeOfCareUnavailableModal.jsx
@@ -19,7 +19,7 @@ const TypeOfCareUnavailableModal = ({ onClose, showModal, typeOfCare }) => {
       scheduled online for Community Care appointments. To schedule a podiatry
       appointment at a VA facility, please call your local VA medical center, or
       use the{' '}
-      <a href="/find-locations">
+      <a target="_blank" rel="noopener noreferrer" href="/find-locations">
         locator tool to find your nearest VA medical facility
       </a>
       .

--- a/src/applications/vaos/components/review/ReviewRequestInfo.jsx
+++ b/src/applications/vaos/components/review/ReviewRequestInfo.jsx
@@ -1,12 +1,13 @@
 import React from 'react';
 import { getTypeOfCare } from '../../utils/selectors';
+import { FACILITY_TYPES } from '../../utils/constants';
 import TypeOfAppointmentSection from './TypeOfAppointmentSection';
 import VAAppointmentSection from './VAAppointmentSection';
 import CommunityCareSection from './CommunityCareSection';
 
 export default function ReviewRequestInfo({ data }) {
-  const isCommunityCare = data.facilityType === 'communityCare';
-  const isVAAppointment = data.facilityType === 'vamc';
+  const isCommunityCare = data.facilityType === FACILITY_TYPES.COMMUNITY_CARE;
+  const isVAAppointment = data.facilityType === FACILITY_TYPES.VAMC;
 
   return (
     <div>

--- a/src/applications/vaos/components/review/TypeOfAppointmentSection.jsx
+++ b/src/applications/vaos/components/review/TypeOfAppointmentSection.jsx
@@ -1,13 +1,14 @@
 import React from 'react';
+import { FACILITY_TYPES } from '../../utils/constants';
 
 export default function TypeOfAppointmentSection(props) {
-  if (props.data.facilityType === 'communityCare') {
+  if (props.data.facilityType === FACILITY_TYPES.COMMUNITY_CARE) {
     return (
       <h2 className="usa-alert-heading vads-u-padding-top--1">
         Community care appointment
       </h2>
     );
-  } else if (props.data.facilityType !== 'communityCare') {
+  } else if (props.data.facilityType !== FACILITY_TYPES.COMMUNITY_CARE) {
     return (
       <h2 className="usa-alert-heading vads-u-padding-top--1">
         VA appointment

--- a/src/applications/vaos/containers/TypeOfCarePage.jsx
+++ b/src/applications/vaos/containers/TypeOfCarePage.jsx
@@ -10,13 +10,16 @@ import {
 import { TYPES_OF_CARE, DIRECT_SCHEDULE_TYPES } from '../utils/constants';
 import { getLongTermAppointmentHistory } from '../api';
 import FormButtons from '../components/FormButtons';
+import TypeOfCareUnavailableModal from '../components/TypeOfCareUnavailableModal';
 import {
   openFormPage,
   updateFormData,
   routeToNextAppointmentPage,
   routeToPreviousAppointmentPage,
+  showTypeOfCareUnavailableModal,
+  hideTypeOfCareUnavailableModal,
 } from '../actions/newAppointment.js';
-import { getFormPageInfo } from '../utils/selectors';
+import { getFormPageInfo, getNewAppointment } from '../utils/selectors';
 
 const sortedCare = TYPES_OF_CARE.sort(
   (careA, careB) => (careA.name > careB.name ? 1 : -1),
@@ -98,7 +101,12 @@ export class TypeOfCarePage extends React.Component {
   };
 
   render() {
-    const { schema, data, pageChangeInProgress } = this.props;
+    const {
+      schema,
+      data,
+      pageChangeInProgress,
+      showToCUnavailableModal,
+    } = this.props;
 
     return (
       <div>
@@ -119,6 +127,11 @@ export class TypeOfCarePage extends React.Component {
             pageChangeInProgress={pageChangeInProgress}
           />
         </SchemaForm>
+        <TypeOfCareUnavailableModal
+          typeOfCare="Podiatry"
+          showModal={showToCUnavailableModal}
+          onClose={this.props.hideTypeOfCareUnavailableModal}
+        />
       </div>
     );
   }
@@ -126,11 +139,14 @@ export class TypeOfCarePage extends React.Component {
 
 function mapStateToProps(state) {
   const formPageInfo = getFormPageInfo(state, pageKey);
+  const newAppointment = getNewAppointment(state);
+
   return {
     ...formPageInfo,
     emailAddress: selectVet360EmailAddress(state),
     homePhone: selectVet360HomePhoneString(state),
     mobilePhone: selectVet360MobilePhoneString(state),
+    showToCUnavailableModal: newAppointment.showTypeOfCareUnavailableModal,
   };
 }
 
@@ -139,6 +155,8 @@ const mapDispatchToProps = {
   updateFormData,
   routeToNextAppointmentPage,
   routeToPreviousAppointmentPage,
+  showTypeOfCareUnavailableModal,
+  hideTypeOfCareUnavailableModal,
 };
 
 export default connect(

--- a/src/applications/vaos/containers/TypeOfFacilityPage.jsx
+++ b/src/applications/vaos/containers/TypeOfFacilityPage.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import SchemaForm from 'platform/forms-system/src/js/components/SchemaForm';
 import FormButtons from '../components/FormButtons';
+import { FACILITY_TYPES } from '../utils/constants';
 import {
   openFormPage,
   updateFormData,
@@ -16,7 +17,7 @@ const initialSchema = {
   properties: {
     facilityType: {
       type: 'string',
-      enum: ['vamc', 'communityCare'],
+      enum: Object.keys(FACILITY_TYPES).map(key => FACILITY_TYPES[key]),
     },
   },
 };
@@ -28,7 +29,7 @@ const uiSchema = {
     'ui:widget': 'radio',
     'ui:options': {
       labels: {
-        vamc: (
+        [FACILITY_TYPES.VAMC]: (
           <>
             <span className="vads-u-display--block vads-u-font-size--lg vads-u-font-weight--bold">
               VA medical center or clinic
@@ -38,7 +39,7 @@ const uiSchema = {
             </span>
           </>
         ),
-        communityCare: (
+        [FACILITY_TYPES.COMMUNITY_CARE]: (
           <>
             <span className="vads-u-display--block vads-u-font-size--lg vads-u-font-weight--bold">
               Community care facility

--- a/src/applications/vaos/newAppointmentFlow.js
+++ b/src/applications/vaos/newAppointmentFlow.js
@@ -181,8 +181,7 @@ export default {
       // Return to typeOFFacility page if facility is CC enabled
       if (
         getFormData(state).facilityType &&
-        getNewAppointment(state).ccEnabledSystems?.length > 0 &&
-        !isPodiatry(state)
+        getNewAppointment(state).ccEnabledSystems?.length > 0
       ) {
         nextState = 'typeOfFacility';
       }
@@ -222,6 +221,10 @@ export default {
       return 'reasonForAppointment';
     },
     previous(state) {
+      if (isPodiatry(state)) {
+        return 'typeOfCare';
+      }
+
       if (isCCFacility(state)) {
         return 'typeOfFacility';
       }

--- a/src/applications/vaos/newAppointmentFlow.js
+++ b/src/applications/vaos/newAppointmentFlow.js
@@ -181,7 +181,8 @@ export default {
       // Return to typeOFFacility page if facility is CC enabled
       if (
         getFormData(state).facilityType &&
-        getNewAppointment(state).ccEnabledSystems?.length > 0
+        getNewAppointment(state).ccEnabledSystems?.length > 0 &&
+        !isPodiatry(state)
       ) {
         nextState = 'typeOfFacility';
       }

--- a/src/applications/vaos/newAppointmentFlow.js
+++ b/src/applications/vaos/newAppointmentFlow.js
@@ -90,7 +90,7 @@ export default {
             }
           }
 
-          // If podiatry and ineligible for CC, show modal
+          // If no CC enabled systems and toc is podiatry, show modal
           if (isPodiatry(state)) {
             dispatch(showTypeOfCareUnavailableModal());
             return 'typeOfCare';

--- a/src/applications/vaos/newAppointmentFlow.js
+++ b/src/applications/vaos/newAppointmentFlow.js
@@ -13,6 +13,7 @@ import {
   getSitesSupportingVAR,
 } from './api';
 import {
+  showTypeOfCareUnavailableModal,
   startDirectScheduleFlow,
   startRequestAppointmentFlow,
   updateFacilityType,
@@ -22,6 +23,7 @@ import { hasEligibleClinics } from './utils/eligibility';
 
 const AUDIOLOGY = '203';
 const SLEEP_CARE = 'SLEEP';
+const PODIATRY = 'tbd-podiatry';
 
 function isCCAudiology(state) {
   return (
@@ -43,6 +45,10 @@ function isCCFacility(state) {
 
 function isSleepCare(state) {
   return getFormData(state).typeOfCareId === SLEEP_CARE;
+}
+
+function isPodiatry(state) {
+  return getFormData(state).typeOfCareId === PODIATRY;
 }
 
 export default {
@@ -82,6 +88,12 @@ export default {
             if (data.isEligible) {
               return 'typeOfFacility';
             }
+          }
+
+          // If podiatry and ineligible for CC, show modal
+          if (isPodiatry(state)) {
+            dispatch(showTypeOfCareUnavailableModal());
+            return 'typeOfCare';
           }
 
           dispatch(updateFacilityType('vaFacility'));

--- a/src/applications/vaos/newAppointmentFlow.js
+++ b/src/applications/vaos/newAppointmentFlow.js
@@ -5,7 +5,7 @@ import {
   getEligibilityStatus,
   getClinicsForChosenFacility,
 } from './utils/selectors';
-import { TYPES_OF_CARE, FLOW_TYPES } from './utils/constants';
+import { FACILITY_TYPES, FLOW_TYPES, TYPES_OF_CARE } from './utils/constants';
 import {
   getCommunityCare,
   getSystemIdentifiers,
@@ -27,7 +27,7 @@ const PODIATRY = 'tbd-podiatry';
 
 function isCCAudiology(state) {
   return (
-    getFormData(state).facilityType === 'communityCare' &&
+    getFormData(state).facilityType === FACILITY_TYPES.COMMUNITY_CARE &&
     getFormData(state).typeOfCareId === AUDIOLOGY
   );
 }
@@ -40,7 +40,7 @@ function isCommunityCare(state) {
 }
 
 function isCCFacility(state) {
-  return getFormData(state).facilityType === 'communityCare';
+  return getFormData(state).facilityType === FACILITY_TYPES.COMMUNITY_CARE;
 }
 
 function isSleepCare(state) {
@@ -86,6 +86,11 @@ export default {
             );
 
             if (data.isEligible) {
+              // If CC enabled systems and toc is podiatry, skip typeOfFacility
+              if (isPodiatry(state)) {
+                dispatch(updateFacilityType(FACILITY_TYPES.COMMUNITY_CARE));
+                return 'requestDateTime';
+              }
               return 'typeOfFacility';
             }
           }
@@ -96,7 +101,8 @@ export default {
             return 'typeOfCare';
           }
 
-          dispatch(updateFacilityType('vaFacility'));
+          dispatch(updateFacilityType(FACILITY_TYPES.VAMC));
+          return 'vaFacility';
         } catch (e) {
           return 'vaFacility';
         }

--- a/src/applications/vaos/reducers/newAppointment.js
+++ b/src/applications/vaos/reducers/newAppointment.js
@@ -181,7 +181,6 @@ export default function formReducer(state = initialState, action) {
       return {
         ...state,
         showTypeOfCareUnavailableModal: true,
-        typeOfCare: action.typeOfCare,
         pageChangeInProgress: false,
       };
     }
@@ -189,7 +188,6 @@ export default function formReducer(state = initialState, action) {
       return {
         ...state,
         showTypeOfCareUnavailableModal: false,
-        typeOfCare: null,
       };
     }
     case FORM_UPDATE_FACILITY_TYPE: {

--- a/src/applications/vaos/reducers/newAppointment.js
+++ b/src/applications/vaos/reducers/newAppointment.js
@@ -32,6 +32,8 @@ import {
   FORM_CLINIC_PAGE_OPENED_SUCCEEDED,
   FORM_SCHEDULE_APPOINTMENT_PAGE_OPENED,
   FORM_SCHEDULE_APPOINTMENT_PAGE_OPENED_SUCCEEDED,
+  FORM_SHOW_TYPE_OF_CARE_UNAVAILABLE_MODAL,
+  FORM_HIDE_TYPE_OF_CARE_UNAVAILABLE_MODAL,
   FORM_REASON_FOR_APPOINTMENT_CHANGED,
   FORM_PAGE_COMMUNITY_CARE_PREFS_OPEN,
   FORM_PAGE_COMMUNITY_CARE_PREFS_OPEN_SUCCEEDED,
@@ -172,6 +174,21 @@ export default function formReducer(state = initialState, action) {
       return {
         ...state,
         pageChangeInProgress: false,
+      };
+    }
+    case FORM_SHOW_TYPE_OF_CARE_UNAVAILABLE_MODAL: {
+      return {
+        ...state,
+        showTypeOfCareUnavailableModal: true,
+        typeOfCare: action.typeOfCare,
+        pageChangeInProgress: false,
+      };
+    }
+    case FORM_HIDE_TYPE_OF_CARE_UNAVAILABLE_MODAL: {
+      return {
+        ...state,
+        showTypeOfCareUnavailableModal: false,
+        typeOfCare: null,
       };
     }
     case FORM_UPDATE_FACILITY_TYPE: {

--- a/src/applications/vaos/tests/actions/newAppointment.unit.spec.js
+++ b/src/applications/vaos/tests/actions/newAppointment.unit.spec.js
@@ -36,7 +36,11 @@ import systems from '../../api/facilities.json';
 import systemIdentifiers from '../../api/systems.json';
 import facilities983 from '../../api/facilities_983.json';
 import clinics from '../../api/clinicList983.json';
-import { REASON_MAX_CHARS, FLOW_TYPES } from '../../utils/constants';
+import {
+  FACILITY_TYPES,
+  FLOW_TYPES,
+  REASON_MAX_CHARS,
+} from '../../utils/constants';
 
 const testFlow = {
   page1: {
@@ -507,7 +511,7 @@ describe('VAOS newAppointment actions', () => {
           data: {
             communityCareSystemId: '983',
             typeOfCareId: '323',
-            facilityType: 'communityCare',
+            facilityType: FACILITY_TYPES.COMMUNITY_CARE,
             reasonForAppointment: 'routine-follow-up',
             calendarData: {
               selectedDates: [],

--- a/src/applications/vaos/tests/components/TypeOfAppointmentSection.unit.spec.jsx
+++ b/src/applications/vaos/tests/components/TypeOfAppointmentSection.unit.spec.jsx
@@ -1,12 +1,13 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import { expect } from 'chai';
+import { FACILITY_TYPES } from '../../utils/constants';
 
 import TypeOfAppointmentSection from '../../components/review/TypeOfAppointmentSection';
 
 describe('VAOS <TypeOfAppointmentSection>', () => {
   it('should render heading', () => {
-    const data = { facilityType: 'communityCare' };
+    const data = { facilityType: FACILITY_TYPES.COMMUNITY_CARE };
     const tree = shallow(<TypeOfAppointmentSection data={data} />);
 
     expect(tree.find('h2').text()).to.equal('Community care appointment');

--- a/src/applications/vaos/tests/components/TypeOfCareUnavailableModal.unit.spec.jsx
+++ b/src/applications/vaos/tests/components/TypeOfCareUnavailableModal.unit.spec.jsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+
+import TypeOfCareUnavailableModal from '../../components/TypeOfCareUnavailableModal';
+
+const typeOfCare = 'Podiatry';
+
+describe('VAOS <TypeOfCareUnavailableModal>', () => {
+  it('should not render modal if showCancelModal is false', () => {
+    const tree = shallow(
+      <TypeOfCareUnavailableModal showModal={false} typeOfCare={typeOfCare} />,
+    );
+
+    expect(tree.text()).to.equal('');
+    tree.unmount();
+  });
+
+  it('should render confirmation modal', () => {
+    const tree = shallow(
+      <TypeOfCareUnavailableModal showModal typeOfCare={typeOfCare} />,
+    );
+
+    const modal = tree.find('Modal');
+    expect(modal.exists()).to.be.true;
+    expect(modal.props().title).to.equal(
+      'You canʼt schedule a Podiatry appointment right now',
+    );
+    expect(
+      tree
+        .find('Modal')
+        .find('button')
+        .prop('children'),
+    ).to.equal('Ok');
+
+    tree.unmount();
+  });
+});

--- a/src/applications/vaos/tests/containers/TypeOfFacilityPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/containers/TypeOfFacilityPage.unit.spec.jsx
@@ -5,6 +5,7 @@ import { mount } from 'enzyme';
 
 import { selectRadio } from 'platform/testing/unit/schemaform-utils.jsx';
 import { TypeOfFacilityPage } from '../../containers/TypeOfFacilityPage';
+import { FACILITY_TYPES } from '../../utils/constants';
 
 describe('VAOS <TypeOfFacilityPage>', () => {
   it('should render', () => {
@@ -60,10 +61,10 @@ describe('VAOS <TypeOfFacilityPage>', () => {
       />,
     );
 
-    selectRadio(form, 'root_facilityType', 'communityCare');
+    selectRadio(form, 'root_facilityType', FACILITY_TYPES.COMMUNITY_CARE);
 
     expect(updateFormData.firstCall.args[2].facilityType).to.equal(
-      'communityCare',
+      FACILITY_TYPES.COMMUNITY_CARE,
     );
     form.unmount();
   });
@@ -76,7 +77,7 @@ describe('VAOS <TypeOfFacilityPage>', () => {
       <TypeOfFacilityPage
         openFormPage={openFormPage}
         routeToNextAppointmentPage={routeToNextAppointmentPage}
-        data={{ facilityType: 'communityCare' }}
+        data={{ facilityType: FACILITY_TYPES.COMMUNITY_CARE }}
       />,
     );
 

--- a/src/applications/vaos/tests/newAppointmentFlow.unit.spec.js
+++ b/src/applications/vaos/tests/newAppointmentFlow.unit.spec.js
@@ -154,6 +154,7 @@ describe('VAOS newAppointmentFlow', () => {
       );
       expect(nextState).to.equal('requestDateTime');
     });
+
     it('should return to type of care page if none of user Systems is cc enabled', () => {
       const state = {
         ...defaultState,
@@ -171,6 +172,7 @@ describe('VAOS newAppointmentFlow', () => {
       const nextState = newAppointmentFlow.vaFacility.previous(state);
       expect(nextState).to.equal('typeOfCare');
     });
+
     it('should return to typeOfFacility if user is CC eligible ', () => {
       const state = {
         ...defaultState,
@@ -361,6 +363,11 @@ describe('VAOS newAppointmentFlow', () => {
   });
   describe('type of care page', () => {
     it('next should be vaFacility page if no CC support', async () => {
+      mockFetch();
+      setFetchJSONResponse(global.fetch, {
+        data: [{ attributes: { assigningAuthority: 'dfn-000' } }],
+      });
+
       const state = {
         newAppointment: {
           data: {
@@ -375,6 +382,29 @@ describe('VAOS newAppointmentFlow', () => {
         dispatch,
       );
       expect(nextState).to.equal('vaFacility');
+      resetFetch();
+    });
+
+    it('next should stay on typeOfCare page if no CC support and typeOfCare is podiatry', async () => {
+      mockFetch();
+      setFetchJSONResponse(global.fetch, {
+        data: [{ attributes: { assigningAuthority: 'dfn-000' } }],
+      });
+      const state = {
+        newAppointment: {
+          data: {
+            typeOfCareId: 'tbd-podiatry',
+          },
+        },
+      };
+
+      const dispatch = sinon.spy();
+      const nextState = await newAppointmentFlow.typeOfCare.next(
+        state,
+        dispatch,
+      );
+      expect(nextState).to.equal('typeOfCare');
+      resetFetch();
     });
 
     it('should choose Sleep care page', async () => {

--- a/src/applications/vaos/tests/newAppointmentFlow.unit.spec.js
+++ b/src/applications/vaos/tests/newAppointmentFlow.unit.spec.js
@@ -11,7 +11,7 @@ import past from '../api/past.json';
 import systems from '../api/systems.json';
 
 import newAppointmentFlow from '../newAppointmentFlow';
-import { FLOW_TYPES } from '../utils/constants';
+import { FACILITY_TYPES, FLOW_TYPES } from '../utils/constants';
 
 describe('VAOS newAppointmentFlow', () => {
   describe('type of appointment page', () => {
@@ -26,7 +26,7 @@ describe('VAOS newAppointmentFlow', () => {
       const state = {
         newAppointment: {
           data: {
-            facilityType: 'communityCare',
+            facilityType: FACILITY_TYPES.COMMUNITY_CARE,
             typeOfCareId: '203',
           },
         },
@@ -40,7 +40,7 @@ describe('VAOS newAppointmentFlow', () => {
       const state = {
         newAppointment: {
           data: {
-            facilityType: 'communityCare',
+            facilityType: FACILITY_TYPES.COMMUNITY_CARE,
             typeOfCareId: '320',
           },
         },
@@ -54,7 +54,7 @@ describe('VAOS newAppointmentFlow', () => {
       const state = {
         newAppointment: {
           data: {
-            facilityType: 'communityCare',
+            facilityType: FACILITY_TYPES.COMMUNITY_CARE,
             typeOfCareId: '203',
           },
         },
@@ -164,7 +164,7 @@ describe('VAOS newAppointmentFlow', () => {
             typeOfCareId: '323',
             vaSystem: '983',
             vaFacility: '983',
-            facilityType: 'vamc',
+            facilityType: FACILITY_TYPES.VAMC,
           },
           hasCCEnabledSystems: false,
         },
@@ -182,7 +182,7 @@ describe('VAOS newAppointmentFlow', () => {
             typeOfCareId: '323',
             vaSystem: '983',
             vaFacility: '983',
-            facilityType: 'vamc',
+            facilityType: FACILITY_TYPES.VAMC,
           },
           ccEnabledSystems: ['983'],
         },
@@ -197,7 +197,7 @@ describe('VAOS newAppointmentFlow', () => {
       const state = {
         newAppointment: {
           data: {
-            facilityType: 'communityCare',
+            facilityType: FACILITY_TYPES.COMMUNITY_CARE,
           },
         },
       };
@@ -210,7 +210,7 @@ describe('VAOS newAppointmentFlow', () => {
       const state = {
         newAppointment: {
           data: {
-            facilityType: 'vamc',
+            facilityType: FACILITY_TYPES.VAMC,
           },
         },
       };
@@ -223,7 +223,7 @@ describe('VAOS newAppointmentFlow', () => {
       const state = {
         newAppointment: {
           data: {
-            facilityType: 'communityCare',
+            facilityType: FACILITY_TYPES.COMMUNITY_CARE,
           },
         },
       };
@@ -236,7 +236,7 @@ describe('VAOS newAppointmentFlow', () => {
       const state = {
         newAppointment: {
           data: {
-            facilityType: 'vamc',
+            facilityType: FACILITY_TYPES.VAMC,
           },
         },
       };
@@ -295,7 +295,7 @@ describe('VAOS newAppointmentFlow', () => {
       const state = {
         newAppointment: {
           data: {
-            facilityType: 'vamc',
+            facilityType: FACILITY_TYPES.VAMC,
           },
         },
       };
@@ -308,7 +308,7 @@ describe('VAOS newAppointmentFlow', () => {
       const state = {
         newAppointment: {
           data: {
-            facilityType: 'communityCare',
+            facilityType: FACILITY_TYPES.COMMUNITY_CARE,
           },
         },
       };
@@ -321,7 +321,7 @@ describe('VAOS newAppointmentFlow', () => {
       const state = {
         newAppointment: {
           data: {
-            facilityType: 'communityCare',
+            facilityType: FACILITY_TYPES.COMMUNITY_CARE,
           },
           flowType: FLOW_TYPES.DIRECT,
         },
@@ -335,7 +335,7 @@ describe('VAOS newAppointmentFlow', () => {
       const state = {
         newAppointment: {
           data: {
-            facilityType: 'vamc',
+            facilityType: FACILITY_TYPES.VAMC,
           },
           flowType: FLOW_TYPES.DIRECT,
         },
@@ -350,7 +350,7 @@ describe('VAOS newAppointmentFlow', () => {
       const state = {
         newAppointment: {
           data: {
-            facilityType: 'vamc',
+            facilityType: FACILITY_TYPES.VAMC,
           },
           flowType: FLOW_TYPES.REQUEST,
         },
@@ -407,6 +407,26 @@ describe('VAOS newAppointmentFlow', () => {
       resetFetch();
     });
 
+    it('next should go to requestDateTime page if CC support and typeOfCare is podiatry', async () => {
+      mockFetch();
+      setFetchJSONResponse(global.fetch, systems);
+      const state = {
+        newAppointment: {
+          data: {
+            typeOfCareId: 'tbd-podiatry',
+          },
+        },
+      };
+
+      const dispatch = sinon.spy();
+      const nextState = await newAppointmentFlow.typeOfCare.next(
+        state,
+        dispatch,
+      );
+      expect(nextState).to.equal('requestDateTime');
+      resetFetch();
+    });
+
     it('should choose Sleep care page', async () => {
       const state = {
         newAppointment: {
@@ -456,7 +476,7 @@ describe('VAOS newAppointmentFlow', () => {
       const state = {
         newAppointment: {
           data: {
-            facilityType: 'communityCare',
+            facilityType: FACILITY_TYPES.COMMUNITY_CARE,
             typeOfCareId: '203',
           },
         },
@@ -481,7 +501,7 @@ describe('VAOS newAppointmentFlow', () => {
       const state = {
         newAppointment: {
           data: {
-            facilityType: 'communityCare',
+            facilityType: FACILITY_TYPES.COMMUNITY_CARE,
           },
         },
       };

--- a/src/applications/vaos/tests/newAppointmentFlow.unit.spec.js
+++ b/src/applications/vaos/tests/newAppointmentFlow.unit.spec.js
@@ -362,7 +362,7 @@ describe('VAOS newAppointmentFlow', () => {
     });
   });
   describe('type of care page', () => {
-    it('next should be vaFacility page if no CC support', async () => {
+    it('next should be vaFacility page if no systems have CC support', async () => {
       mockFetch();
       setFetchJSONResponse(global.fetch, {
         data: [{ attributes: { assigningAuthority: 'dfn-000' } }],

--- a/src/applications/vaos/tests/reducers/newAppointment.unit.spec.js
+++ b/src/applications/vaos/tests/reducers/newAppointment.unit.spec.js
@@ -19,6 +19,8 @@ import {
   FORM_SUBMIT,
   FORM_SUBMIT_SUCCEEDED,
   FORM_SUBMIT_FAILED,
+  FORM_SHOW_TYPE_OF_CARE_UNAVAILABLE_MODAL,
+  FORM_HIDE_TYPE_OF_CARE_UNAVAILABLE_MODAL,
 } from '../../actions/newAppointment';
 
 import systems from '../../api/facilities.json';
@@ -600,5 +602,33 @@ describe('VAOS reducer: newAppointment', () => {
       const newState = newAppointmentReducer({}, action);
       expect(newState.submitStatus).to.equal(FETCH_STATUS.failed);
     });
+  });
+
+  it('should set ToC modal to show', () => {
+    const currentState = {
+      data: {},
+      pageChangeInProgress: true,
+    };
+    const action = {
+      type: FORM_SHOW_TYPE_OF_CARE_UNAVAILABLE_MODAL,
+    };
+
+    const newState = newAppointmentReducer(currentState, action);
+
+    expect(newState.pageChangeInProgress).to.be.false;
+    expect(newState.showTypeOfCareUnavailableModal).to.be.true;
+  });
+
+  it('should set ToC modal to hidden', () => {
+    const currentState = {
+      data: {},
+    };
+    const action = {
+      type: FORM_HIDE_TYPE_OF_CARE_UNAVAILABLE_MODAL,
+    };
+
+    const newState = newAppointmentReducer(currentState, action);
+
+    expect(newState.showTypeOfCareUnavailableModal).to.be.false;
   });
 });

--- a/src/applications/vaos/tests/utils/selectors.unit.spec.js
+++ b/src/applications/vaos/tests/utils/selectors.unit.spec.js
@@ -192,6 +192,24 @@ describe('VAOS selectors', () => {
       const typeOfCare = getTypeOfCare(data);
       expect(typeOfCare.id).to.equal('CCAUDHEAR');
     });
+
+    it('get podiatry type of care', () => {
+      const data = {
+        typeOfCareId: 'tbd-podiatry',
+      };
+
+      const typeOfCare = getTypeOfCare(data);
+      expect(typeOfCare.name).to.equal('Podiatry');
+    });
+
+    it('get pharmacy type of care', () => {
+      const data = {
+        typeOfCareId: '160',
+      };
+
+      const typeOfCare = getTypeOfCare(data);
+      expect(typeOfCare.name).to.equal('Pharmacy');
+    });
   });
 
   describe('getClinicsForChosenFacility', () => {

--- a/src/applications/vaos/tests/utils/selectors.unit.spec.js
+++ b/src/applications/vaos/tests/utils/selectors.unit.spec.js
@@ -1,19 +1,62 @@
 import { expect } from 'chai';
 
 import {
-  selectPendingAppointment,
-  selectConfirmedAppointment,
-  getFormPageInfo,
   getChosenClinicInfo,
-  getTypeOfCare,
-  getClinicsForChosenFacility,
+  getChosenFacilityInfo,
   getClinicPageInfo,
+  getClinicsForChosenFacility,
   getDateTimeSelect,
-  getReasonForAppointment,
+  getFlowType,
+  getFormData,
+  getFormPageInfo,
+  getNewAppointment,
   getPreferredDate,
+  getReasonForAppointment,
+  getTypeOfCare,
+  selectConfirmedAppointment,
+  selectPendingAppointment,
 } from '../../utils/selectors';
 
 describe('VAOS selectors', () => {
+  describe('getNewAppointment', () => {
+    it('should return newAppointment state', () => {
+      const state = {
+        appointment: {},
+        newAppointment: {
+          typeOfCareId: '123',
+        },
+      };
+      const newAppointment = getNewAppointment(state);
+      expect(newAppointment).to.equal(state.newAppointment);
+    });
+  });
+
+  describe('getFormData', () => {
+    it('should return newAppointment.data', () => {
+      const state = {
+        appointment: {},
+        newAppointment: {
+          data: { typeOfCareId: '123' },
+        },
+      };
+      const formData = getFormData(state);
+      expect(formData).to.equal(state.newAppointment.data);
+    });
+  });
+
+  describe('getFlowType', () => {
+    it('should return newAppointment state', () => {
+      const state = {
+        appointment: {},
+        newAppointment: {
+          data: { typeOfCareId: '123' },
+          flowType: 'DIRECT',
+        },
+      };
+      expect(getFlowType(state)).to.equal('DIRECT');
+    });
+  });
+
   describe('selectPendingAppointment', () => {
     it('should return appt matching id', () => {
       const state = {
@@ -62,6 +105,7 @@ describe('VAOS selectors', () => {
       expect(appt).to.be.null;
     });
   });
+
   describe('getFormPageInfo', () => {
     it('should return info needed for form pages', () => {
       const state = {
@@ -80,6 +124,34 @@ describe('VAOS selectors', () => {
       );
       expect(pageInfo.data).to.equal(state.newAppointment.data);
       expect(pageInfo.schema).to.equal(state.newAppointment.pages.testPage);
+    });
+  });
+
+  describe('getChosenFacilityInfo', () => {
+    it('should return a stored facility object', () => {
+      const state = {
+        newAppointment: {
+          data: {
+            typeOfCareId: '323',
+            clinicId: '124',
+            vaSystem: '123',
+            vaFacility: '983',
+          },
+          facilities: {
+            '323_123': [
+              {
+                institution: {
+                  institutionCode: '983',
+                },
+              },
+            ],
+          },
+        },
+      };
+
+      expect(getChosenFacilityInfo(state)).to.equal(
+        state.newAppointment.facilities['323_123'][0],
+      );
     });
   });
 

--- a/src/applications/vaos/utils/constants.js
+++ b/src/applications/vaos/utils/constants.js
@@ -131,6 +131,11 @@ export const TYPES_OF_SLEEP_CARE = [
   },
 ];
 
+export const FACILITY_TYPES = {
+  VAMC: 'vamc',
+  COMMUNITY_CARE: 'communityCare',
+};
+
 export const LANGUAGES = [
   {
     id: 'english',

--- a/src/applications/vaos/utils/constants.js
+++ b/src/applications/vaos/utils/constants.js
@@ -108,7 +108,7 @@ export const TYPES_OF_CARE = [
     ccId: 'CCOPT',
   },
   {
-    id: 'tbd',
+    id: 'tbd-podiatry',
     name: 'Podiatry',
     ccId: 'CCPOD',
     group: 'specialty',

--- a/src/applications/vaos/utils/selectors.js
+++ b/src/applications/vaos/utils/selectors.js
@@ -4,6 +4,7 @@ import { getAppointmentId } from './appointment';
 import { isEligible } from './eligibility';
 import { getTimezoneAbbrBySystemId } from './timezone';
 import {
+  FACILITY_TYPES,
   TYPES_OF_CARE,
   AUDIOLOGY_TYPES_OF_CARE,
   TYPES_OF_SLEEP_CARE,
@@ -52,7 +53,7 @@ export function getTypeOfCare(data) {
 
   if (
     data.typeOfCareId === AUDIOLOGY &&
-    data.facilityType === 'communityCare'
+    data.facilityType === FACILITY_TYPES.COMMUNITY_CARE
   ) {
     return AUDIOLOGY_TYPES_OF_CARE.find(care => care.id === data.audiologyType);
   }


### PR DESCRIPTION
## Description
The VA does not currently support online scheduling podiatry appointments (but will in a few months). However, podiatry is still eligible within CC care, so should be selectable from the Type of Care page. 

When a veteran selects podiatry but is then not community care eligible, we need to show them a modal asking them to go back and make a new selection (or maybe call their VA?), so that they can continue booking their appointment.

Conversely, if user chooses podiatry and **does** have CC enabled systems, skip Type Of Facility page since VAMC is not an option.

Added a modal that has a dynamic type of care in case we need to reuse this at some point.

## Testing done 
Local and unit


## Screenshots
![image](https://user-images.githubusercontent.com/786704/69483886-b7c27a80-0de1-11ea-8555-7721931639b1.png)


## Acceptance criteria
- [ ] If user has no CC enabled systems and chooses podiatry, show modal
- [ ] If user chooses podiatry and **does** have CC enabled systems, skip Type Of Facility page

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the Pre-Launch Checklist
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] A link has been provided to the VSA-QA Test Plan ticket \[use the VSA-QA Test Plan Issue Template to create the ticket within va.gov-team repo].
- [ ] A link has been provided to the VSA-QA Test-Request ticket \[issue-template coming soon].
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
