### PR TITLE
Fix styling issue to before selector for checkbox label

### DIFF
--- a/src/applications/gi/components/Checkbox.jsx
+++ b/src/applications/gi/components/Checkbox.jsx
@@ -79,7 +79,9 @@ class Checkbox extends React.Component {
         />
         <label
           className={
-            this.props.errorMessage ? 'usa-input-error-label gi-checkbox-label' : 'gi-checkbox-label'
+            this.props.errorMessage
+              ? 'usa-input-error-label gi-checkbox-label'
+              : 'gi-checkbox-label'
           }
           name={`${this.props.name}-label`}
           htmlFor={this.inputId}

--- a/src/applications/gi/components/Checkbox.jsx
+++ b/src/applications/gi/components/Checkbox.jsx
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import _ from 'lodash';
+import classNames from 'classnames';
 
 import ToolTip from './ToolTip';
 
@@ -34,7 +35,8 @@ class Checkbox extends React.Component {
     // Calculate error state.
     let errorSpan = '';
     let errorSpanId = undefined;
-    if (this.props.errorMessage) {
+    const hasErrors = !!this.props.errorMessage;
+    if (hasErrors) {
       errorSpanId = `${this.inputId}-error-message`;
       errorSpan = (
         <span className="usa-input-error-message" role="alert" id={errorSpanId}>
@@ -60,13 +62,10 @@ class Checkbox extends React.Component {
       requiredSpan = <span className="form-required-span">*</span>;
     }
 
-    let className = `form-checkbox${
-      this.props.errorMessage ? ' usa-input-error' : ''
-    }`;
+    let className = `form-checkbox${hasErrors ? ' usa-input-error' : ''}`;
     if (!_.isUndefined(this.props.className)) {
       className = `${className} ${this.props.className}`;
     }
-
     return (
       <div className={className}>
         <input
@@ -78,11 +77,9 @@ class Checkbox extends React.Component {
           onChange={this.handleChange}
         />
         <label
-          className={
-            this.props.errorMessage
-              ? 'usa-input-error-label gi-checkbox-label'
-              : 'gi-checkbox-label'
-          }
+          className={classNames('gi-checkbox-label', {
+            'usa-input-error-label': hasErrors,
+          })}
           name={`${this.props.name}-label`}
           htmlFor={this.inputId}
         >

--- a/src/applications/gi/components/Checkbox.jsx
+++ b/src/applications/gi/components/Checkbox.jsx
@@ -79,7 +79,7 @@ class Checkbox extends React.Component {
         />
         <label
           className={
-            this.props.errorMessage ? 'usa-input-error-label' : undefined
+            this.props.errorMessage ? 'usa-input-error-label gi-checkbox-label' : 'gi-checkbox-label'
           }
           name={`${this.props.name}-label`}
           htmlFor={this.inputId}

--- a/src/applications/gi/components/CheckboxGroup.jsx
+++ b/src/applications/gi/components/CheckboxGroup.jsx
@@ -34,6 +34,7 @@ class CheckboxGroup extends React.Component {
             aria-labelledby={`${this.inputId}-legend ${name}-${index}-label`}
           />
           <label
+            className="gi-checkbox-label"
             id={`${name}-${index}-label`}
             name={`${name}-label`}
             htmlFor={`${this.inputId}-${index}`}

--- a/src/applications/gi/sass/partials/_gi-search-page.scss
+++ b/src/applications/gi/sass/partials/_gi-search-page.scss
@@ -177,4 +177,7 @@
       margin-bottom: 1.333em;
     }
   }
+  .gi-checkbox-label:before {
+    box-shadow: 0 0 0 2px #ffffff, 0 0 0 3px #757575;
+  }
 }

--- a/src/applications/gi/sass/partials/_gi-search-page.scss
+++ b/src/applications/gi/sass/partials/_gi-search-page.scss
@@ -178,6 +178,6 @@
     }
   }
   .gi-checkbox-label:before {
-    box-shadow: 0 0 0 2px #ffffff, 0 0 0 3px #757575;
+    box-shadow: 0 0 0 2px white, 0 0 0 3px $color-gray-medium;
   }
 }


### PR DESCRIPTION
## Description
https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/vets.gov-team/19962

This fixes the  GIDS checkboxes losing their labels' ::before selector's styling when you zoom out  in Safari. With this change, the checkbox will retain visibility when you zoom out to 75%. 

## Testing done 
\[Provide link to QA Test Plan ticket (issue-template coming soon) for the relevant product/feature.
List the new/update unit-test(s) & e2e-test\(s) that have been successfully run before open this PR.
Also, if UI-testable (i.e., testable manually on Staging by QA, either via the browser or REST API-client), provide link to QA test-request ticket \[issue-template coming soon].]

See [VSA QA Process](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/vsa/teams/qa/vsa-qa-process.md) for more info on Engineering/QA collaboration/engagement.


## Screenshots
Before Fix:
<img width="855" alt="Screen Shot 2019-11-22 at 11 34 37 AM" src="https://user-images.githubusercontent.com/48804654/69663116-98328880-1053-11ea-9926-9ae8f1d09be1.png">

After FIx:
![image](https://user-images.githubusercontent.com/48804654/69663155-af717600-1053-11ea-9b82-5d4ae6eb6dc6.png)


## Acceptance criteria
- [x] Checkboxes should remain despite zoom.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the Pre-Launch Checklist
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] A link has been provided to the VSA-QA Test Plan ticket \[use the VSA-QA Test Plan Issue Template to create the ticket within va.gov-team repo].
- [ ] A link has been provided to the VSA-QA Test-Request ticket \[issue-template coming soon].
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
