### PR TITLE
bradl3yC 3723 Add callTransaction if only 1 address

### DIFF
--- a/src/platform/user/profile/vet360/actions/transactions.js
+++ b/src/platform/user/profile/vet360/actions/transactions.js
@@ -203,6 +203,11 @@ export const validateAddress = (
           address.addressMetaData.confidenceScore >= 80,
       )
       .map(address => address.address);
+    const payloadWithSuggestedAddress = {
+      ...suggestedAddresses[0],
+      id: payload?.id,
+    };
+    // If multiple suggestions, present them to the modal
     if (suggestedAddresses.length > 1) {
       return dispatch({
         type: ADDRESS_VALIDATION_CONFIRM,
@@ -216,7 +221,7 @@ export const validateAddress = (
         route,
         method,
         fieldName,
-        payload,
+        payloadWithSuggestedAddress,
         analyticsSectionName,
       ),
     );


### PR DESCRIPTION
## Description
During the initial creation of address validation modal, there was an assumption that vet360 save/update address endpoint would, on some level, validate the address and if there was 1 possible confirmed/deliverable address returned with a high confidence score, it would save that address.  During testing of address validation modal, it doesn't seem like that was happening.  The transaction was returning an error state.  This code will take that single returned address and pass that on as the payload to the save / update endpoint as opposed to the user entered address.

## Testing done 
\[Provide link to QA Test Plan ticket (issue-template coming soon) for the relevant product/feature.
List the new/update unit-test(s) & e2e-test\(s) that have been successfully run before open this PR.
Also, if UI-testable (i.e., testable manually on Staging by QA, either via the browser or REST API-client), provide link to QA test-request ticket \[issue-template coming soon].]

See [VSA QA Process](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/vsa/teams/qa/vsa-qa-process.md) for more info on Engineering/QA collaboration/engagement.


## Screenshots


## Acceptance criteria
- [ ] 

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the Pre-Launch Checklist
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] A link has been provided to the VSA-QA Test Plan ticket \[use the VSA-QA Test Plan Issue Template to create the ticket within va.gov-team repo].
- [ ] A link has been provided to the VSA-QA Test-Request ticket \[issue-template coming soon].
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
