### PR TITLE
removed email and phone number from SCO contact info

### DIFF
--- a/src/applications/gi/components/vet-tec/VetTecScoContact.jsx
+++ b/src/applications/gi/components/vet-tec/VetTecScoContact.jsx
@@ -3,28 +3,11 @@ import React from 'react';
 export const VetTecScoContact = sco => {
   if (sco) {
     return (
-      <div
-        key={`${sco.email}`}
-        className="vads-l-col--12 medium-screen:vads-l-col--6 large-screen:vads-l-col--4 vads-u-margin-bottom--2 sco-contact-info"
-      >
+      <div className="vads-l-col--12 medium-screen:vads-l-col--6 large-screen:vads-l-col--4 vads-u-margin-bottom--2 sco-contact-info">
         <div>
           {sco.firstName} {sco.lastName}
         </div>
         <div>{sco.title}</div>
-        <div>
-          <a href={`mailto:${sco.email}`}>{sco.email}</a>
-        </div>
-        {sco.phoneAreaCode &&
-          sco.phoneNumber && (
-            <div>
-              <a href={`tel:+1${`${sco.phoneAreaCode}-${sco.phoneNumber}`}`}>
-                {sco.phoneAreaCode}
-                {'-'}
-                {sco.phoneNumber}
-                {sco.phoneExtension && `, ext. ${sco.phoneExtension}`}
-              </a>
-            </div>
-          )}
       </div>
     );
   }

--- a/src/applications/gi/tests/components/VetTecComponents.unit.spec.jsx
+++ b/src/applications/gi/tests/components/VetTecComponents.unit.spec.jsx
@@ -81,8 +81,6 @@ describe('<VetTecScoContact>', () => {
 
     expect(wrapper.text().includes('MARTIN INDIATSI')).to.be.true;
     expect(wrapper.text().includes('SCHOOL CERTIFYING OFFICIAL')).to.be.true;
-    expect(wrapper.text().includes('VABENEFITS@GALVANIZE.COM')).to.be.true;
-    expect(wrapper.text().includes('303-749-0110')).to.be.true;
     wrapper.unmount();
   });
 });


### PR DESCRIPTION
## Description
As a developer, I need to remove the email address and phone number from the SCO contact details so that it matches the data available in WEAMS public

https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/vets.gov-team/20018

## Testing done
Local Testing conducted

## Screenshots
![Screen Shot 2019-11-26 at 12 17 38 PM](https://user-images.githubusercontent.com/50601724/69656653-eb520e80-1046-11ea-8dde-046951be31b6.png)

## Acceptance criteria
- [x] The SCO Phone number is not displayed on the VET TEC profile page.
- [x] The SCO Email address is not displayed on the VET TEC profile page.
- [x] The SCOs are displayed in alphabetical order by last name from left to right, top to bottom for each type (primary, secondary)

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
