### PR TITLE
Remove pittsburgh beta banner for now

### DIFF
--- a/src/site/includes/header.html
+++ b/src/site/includes/header.html
@@ -68,7 +68,7 @@
   {% include "src/site/includes/top-nav.html" %}
 {% endif %}
 
-{% include "src/site/blocks/pittsburgh-beta-banner.liquid" %}
+<!-- {% include "src/site/blocks/pittsburgh-beta-banner.liquid" %} -->
 
 {% if path == '' or path == '/' %}
   <div id="homepage-banner">

--- a/src/site/includes/header.html
+++ b/src/site/includes/header.html
@@ -68,13 +68,13 @@
   {% include "src/site/includes/top-nav.html" %}
 {% endif %}
 
-<!-- {% include "src/site/blocks/pittsburgh-beta-banner.liquid" %} -->
+{% if buildtype == 'vagovprod' %}
+  {% include "src/site/blocks/pittsburgh-beta-banner.liquid" %}
+{% endif %}
 
 {% if path == '' or path == '/' %}
   <div id="homepage-banner">
-    <!--
-      Rendered from vets-website/src/applications/static-pages/renderHomepageBanner.js
-    -->
+    <!-- Rendered from vets-website/src/applications/static-pages/renderHomepageBanner.js -->
   </div>
 {% endif %}
 


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/3725

**Current Behavior:** The beta banner shows [here](http://localhost:3001/pittsburgh-health-care/).

**Desired Behavior:** The beta banner does not exist [here](http://localhost:3001/pittsburgh-health-care/).

This PR implements the above behavior.

## Testing done
Locally.

## Screenshots
![image](https://user-images.githubusercontent.com/12773166/69667732-8d302600-105c-11ea-93bc-eb43c4974681.png)

## Acceptance criteria
- [x] Remove beta banner for now [here](http://localhost:3001/pittsburgh-health-care/)

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
