### PR TITLE
removing hashing from webfonts

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -121,8 +121,9 @@ const configGenerator = (buildOptions, apps) => {
           use: {
             loader: 'url-loader',
             options: {
-              limit: 10000,
+              limit: 7000,
               mimetype: 'application/font-woff',
+              name: '[name].[ext]',
             },
           },
         },


### PR DESCRIPTION
## Description
Hashing webfonts is not necessary since webfonts never change their content and they're wasting cache. By not caching them every time they page loads, it will actually improve the loading speed.

## Testing done
Locally done

## Screenshots
![Build - Regular](https://user-images.githubusercontent.com/55560129/69669790-899e9e00-1060-11ea-9bf0-40599e72e84b.png)


![Build Regular](https://user-images.githubusercontent.com/55560129/69669635-3a586d80-1060-11ea-80cb-7ea292a62ccd.png)

