### PR TITLE
Fix back button issue when user is not CC eligible

### DIFF
--- a/src/applications/vaos/actions/newAppointment.js
+++ b/src/applications/vaos/actions/newAppointment.js
@@ -74,6 +74,8 @@ export const FORM_PAGE_COMMUNITY_CARE_PREFS_OPEN_SUCCEEDED =
 export const FORM_SUBMIT = 'newAppointment/FORM_SUBMIT';
 export const FORM_SUBMIT_SUCCEEDED = 'newAppointment/FORM_SUBMIT_SUCCEEDED';
 export const FORM_SUBMIT_FAILED = 'newAppointment/FORM_SUBMIT_FAILED';
+export const FORM_UPDATE_CC_ELIGIBILITY =
+  'newAppointment/FORM_UPDATE_CC_ELIGIBILITY';
 
 export function openFormPage(page, uiSchema, schema) {
   return {
@@ -367,6 +369,13 @@ export function openCommunityCarePreferencesPage(page, uiSchema, schema) {
       schema,
       systems,
     });
+  };
+}
+
+export function updateCCEligibility(isEligible) {
+  return {
+    type: FORM_UPDATE_CC_ELIGIBILITY,
+    isEligible,
   };
 }
 

--- a/src/applications/vaos/api/index.js
+++ b/src/applications/vaos/api/index.js
@@ -185,7 +185,7 @@ export function getCommunityCare() {
   return new Promise(resolve => {
     setTimeout(() => {
       resolve({
-        isEligible: true,
+        isEligible: false,
         reason: 'User is within x miles of facility',
         effectiveDate: '2017-10-08T23:35:12-05:00',
       });

--- a/src/applications/vaos/api/index.js
+++ b/src/applications/vaos/api/index.js
@@ -185,7 +185,7 @@ export function getCommunityCare() {
   return new Promise(resolve => {
     setTimeout(() => {
       resolve({
-        isEligible: false,
+        isEligible: true,
         reason: 'User is within x miles of facility',
         effectiveDate: '2017-10-08T23:35:12-05:00',
       });

--- a/src/applications/vaos/newAppointmentFlow.js
+++ b/src/applications/vaos/newAppointmentFlow.js
@@ -18,6 +18,7 @@ import {
   startRequestAppointmentFlow,
   updateFacilityType,
   updateCCEnabledSystems,
+  updateCCEligibility,
 } from './actions/newAppointment';
 import { hasEligibleClinics } from './utils/eligibility';
 
@@ -41,6 +42,10 @@ function isCommunityCare(state) {
 
 function isCCFacility(state) {
   return getFormData(state).facilityType === FACILITY_TYPES.COMMUNITY_CARE;
+}
+
+function isCCEligible(state) {
+  return getNewAppointment(state).isCCEligible;
 }
 
 function isSleepCare(state) {
@@ -86,6 +91,7 @@ export default {
             );
 
             if (data.isEligible) {
+              dispatch(updateCCEligibility(data.isEligible));
               // If CC enabled systems and toc is podiatry, skip typeOfFacility
               if (isPodiatry(state)) {
                 dispatch(updateFacilityType(FACILITY_TYPES.COMMUNITY_CARE));
@@ -178,13 +184,10 @@ export default {
     previous(state) {
       let nextState = 'typeOfCare';
 
-      // Return to typeOFFacility page if facility is CC enabled
-      if (
-        getFormData(state).facilityType &&
-        getNewAppointment(state).ccEnabledSystems?.length > 0
-      ) {
+      if (isCCEligible(state)) {
         nextState = 'typeOfFacility';
       }
+
       return nextState;
     },
   },

--- a/src/applications/vaos/newAppointmentFlow.js
+++ b/src/applications/vaos/newAppointmentFlow.js
@@ -90,8 +90,9 @@ export default {
               '/vaos/community-care/eligibility',
             );
 
+            dispatch(updateCCEligibility(data.isEligible));
+
             if (data.isEligible) {
-              dispatch(updateCCEligibility(data.isEligible));
               // If CC enabled systems and toc is podiatry, skip typeOfFacility
               if (isPodiatry(state)) {
                 dispatch(updateFacilityType(FACILITY_TYPES.COMMUNITY_CARE));

--- a/src/applications/vaos/reducers/newAppointment.js
+++ b/src/applications/vaos/reducers/newAppointment.js
@@ -40,6 +40,7 @@ import {
   FORM_SUBMIT,
   FORM_SUBMIT_FAILED,
   FORM_SUBMIT_SUCCEEDED,
+  FORM_UPDATE_CC_ELIGIBILITY,
 } from '../actions/newAppointment';
 
 import {
@@ -67,6 +68,7 @@ const initialState = {
   pastAppointments: null,
   availableSlots: null,
   submitStatus: FETCH_STATUS.notStarted,
+  isCCEligible: false,
 };
 
 function getFacilities(state, typeOfCareId, vaSystem) {
@@ -590,6 +592,12 @@ export default function formReducer(state = initialState, action) {
         ...state,
         submitStatus: FETCH_STATUS.failed,
       };
+    case FORM_UPDATE_CC_ELIGIBILITY: {
+      return {
+        ...state,
+        isCCEligible: action.isEligible,
+      };
+    }
     default:
       return state;
   }

--- a/src/applications/vaos/tests/newAppointmentFlow.unit.spec.js
+++ b/src/applications/vaos/tests/newAppointmentFlow.unit.spec.js
@@ -185,11 +185,32 @@ describe('VAOS newAppointmentFlow', () => {
             facilityType: FACILITY_TYPES.VAMC,
           },
           ccEnabledSystems: ['983'],
+          isCCEligible: true,
         },
       };
 
       const nextState = newAppointmentFlow.vaFacility.previous(state);
       expect(nextState).to.equal('typeOfFacility');
+    });
+
+    it('should return to typeOfCare if user is not CC eligible ', () => {
+      const state = {
+        ...defaultState,
+        newAppointment: {
+          ...defaultState.newAppointment,
+          data: {
+            typeOfCareId: '323',
+            vaSystem: '983',
+            vaFacility: '983',
+            facilityType: FACILITY_TYPES.VAMC,
+          },
+          ccEnabledSystems: ['983'],
+          isCCEligible: false,
+        },
+      };
+
+      const nextState = newAppointmentFlow.vaFacility.previous(state);
+      expect(nextState).to.equal('typeOfCare');
     });
   });
   describe('request date/time page', () => {


### PR DESCRIPTION
## Description
We should go back to the type of care page if a user isn't eligible for CC and they're on the VA facility page. Currently, we send them back to the facility type page, because they have CC enabled systems. In order to do that, I need to save the eligibility status in the Redux store, so that we don't have to fetch it again when a user goes back a page.

## Testing done
Local testing

## Acceptance criteria
- [ ] Go back to type of care page from facility page if not CC eligible

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
