### PR TITLE
Apply content model type

### DIFF
--- a/src/site/stages/build/process-cms-exports/index.js
+++ b/src/site/stages/build/process-cms-exports/index.js
@@ -119,6 +119,7 @@ const entityAssemblerFactory = contentDir => {
 
     // Post-transformation JSON schema validation
     const transformedEntity = transformEntity(filteredEntity);
+    transformedEntity.contentModelType = entity.contentModelType;
     const transformedErrors = validateTransformedEntity(transformedEntity);
     if (transformedErrors.length) {
       /* eslint-disable no-console */

--- a/src/site/stages/build/process-cms-exports/schemas/transformed/node-page.js
+++ b/src/site/stages/build/process-cms-exports/schemas/transformed/node-page.js
@@ -1,17 +1,14 @@
-// const { getFilter } = require('../../filters');
-
+const baseType = 'node';
+const subType = 'page';
 module.exports = {
   type: 'object',
   properties: {
-    title: {
-      type: 'string',
-    },
-    fieldIntroText: {
-      type: ['string', 'null'],
-    },
-    fieldDescription: {
-      type: ['string', 'null'],
-    },
+    contentModelType: { type: 'string', enum: [`${baseType}-${subType}`] },
+    entityType: { type: 'string', enum: [baseType] },
+    entityBundle: { type: 'string', enum: [subType] },
+    title: { type: 'string' },
+    fieldIntroText: { type: ['string', 'null'] },
+    fieldDescription: { type: ['string', 'null'] },
     fieldFeaturedContent: {
       type: 'array',
       items: {
@@ -24,9 +21,7 @@ module.exports = {
         $ref: 'Paragraph',
       },
     },
-    fieldAlert: {
-      type: ['object', 'null'],
-    },
+    fieldAlert: { type: ['object', 'null'] },
     fieldRelatedLinks: {
       type: 'array',
       items: {
@@ -46,9 +41,6 @@ module.exports = {
       },
       required: ['date'],
     },
-    entityMetaTags: {
-      $ref: 'MetaTags',
-    },
+    entityMetaTags: { $ref: 'MetaTags' },
   },
-  // required: getFilter('node-page'),
 };

--- a/src/site/stages/build/process-cms-exports/schemas/transformed/paragraph-alert.js
+++ b/src/site/stages/build/process-cms-exports/schemas/transformed/paragraph-alert.js
@@ -1,12 +1,14 @@
+const baseType = 'paragraph';
+const subType = 'alert';
 module.exports = {
   type: 'object',
   properties: {
-    contentModelType: { type: 'string', enum: ['paragraph-alert'] },
+    contentModelType: { type: 'string', enum: [`${baseType}-${subType}`] },
     entity: {
       type: 'object',
       properties: {
-        entityType: { type: 'string' },
-        entityBundle: { type: 'string' },
+        entityType: { type: 'string', enum: [baseType] },
+        entityBundle: { type: 'string', enum: [subType] },
         fieldAlertType: { type: 'string' },
         fieldAlertHeading: { type: 'string' },
         fieldVaParagraphs: {

--- a/src/site/stages/build/process-cms-exports/transformers/paragraph-alert.js
+++ b/src/site/stages/build/process-cms-exports/transformers/paragraph-alert.js
@@ -8,7 +8,6 @@ const transform = entity => {
     fieldAlertBlockReference,
   } = entity;
   return {
-    contentModelType: entity.contentModelType,
     entity: {
       entityType: 'paragraph',
       entityBundle: 'alert',


### PR DESCRIPTION
## Description
For consistency, this ensures that all transformed entities have a `contentModelType`. This shouldn't be used after we run the transformations, but it might help for debugging.

## Testing done
Made sure the tests still passed.

## Screenshots
N/A

## Acceptance criteria
- [ ] `contentModelType` is added to every transformed entity