### PR TITLE
20019: SCO: Update page with Design/UAT feedback items

### DIFF
--- a/src/applications/static-pages/school-resources/ScoAnnouncementsWidget.jsx
+++ b/src/applications/static-pages/school-resources/ScoAnnouncementsWidget.jsx
@@ -47,24 +47,31 @@ export default class ScoAnnouncementsWidget extends React.Component {
   };
 
   renderAnnouncements = () => {
-    const announcements = this.props.announcements
-      .filter(this.shouldDisplay)
-      .sort(this.eventComparer)
-      .map((announcement, index) => {
-        const displayDate = moment(announcement.date).format('M/D/YYYY');
-        const content = `${displayDate} — ${announcement.name}`;
-        return (
-          <li key={index} className="hub-page-link-list__item">
-            {announcement.url ? (
-              <a href={announcement.url} onClick={this.recordClickEvent}>
-                <b>{content}</b>
-              </a>
-            ) : (
-              <b>{content}</b>
-            )}
-          </li>
-        );
-      });
+    const announcements =
+      this.props.announcements &&
+      this.props.announcements.filter(this.shouldDisplay).length > 0 ? (
+        this.props.announcements
+          .filter(this.shouldDisplay)
+          .sort(this.eventComparer)
+          .map((announcement, index) => {
+            const displayDate = moment(announcement.date).format('M/D/YYYY');
+            const content = `${displayDate} — ${announcement.name}`;
+            return (
+              <li key={index} className="hub-page-link-list__item">
+                {announcement.url ? (
+                  <a href={announcement.url} onClick={this.recordClickEvent}>
+                    <b>{content}</b>
+                  </a>
+                ) : (
+                  <b>{content}</b>
+                )}
+              </li>
+            );
+          })
+      ) : (
+        <p>No new announcements are available at this time.</p>
+      );
+
     return <ul className="va-nav-linkslist-list">{announcements}</ul>;
   };
 
@@ -80,7 +87,7 @@ export default class ScoAnnouncementsWidget extends React.Component {
             href="https://benefits.va.gov/gibill/index.asp"
             className="vads-u-text-decoration--none"
           >
-            See past updates...
+            See past announcements...
           </a>
         </p>
       </div>

--- a/src/applications/static-pages/school-resources/ScoEventsWidget.jsx
+++ b/src/applications/static-pages/school-resources/ScoEventsWidget.jsx
@@ -68,27 +68,33 @@ export default class ScoEventsWidget extends React.Component {
   };
 
   renderEvents = () => {
-    const scoEvents = this.props.scoEvents
-      .filter(this.shouldDisplay)
-      .sort(this.eventComparer)
-      .map((scoEvent, index) => (
-        <li key={index} className="hub-page-link-list__item">
-          <a href={scoEvent.url} className="no-external-icon">
-            <span className="hub-page-link-list__header">
-              {`${scoEvent.name}`}
-            </span>
-            <img
-              className="all-link-arrow"
-              src="/img/arrow-right-blue.svg"
-              alt="right-arrow"
-            />
-          </a>
-          <br />
-          <span style={{ color: '#5B616B' }}>
-            <b>{`${this.displayDate(scoEvent)} — ${scoEvent.location}`}</b>
-          </span>
-        </li>
-      ));
+    const scoEvents =
+      this.props.scoEvents &&
+      this.props.scoEvents.filter(this.shouldDisplay).length > 0 ? (
+        this.props.scoEvents
+          .filter(this.shouldDisplay)
+          .sort(this.eventComparer)
+          .map((scoEvent, index) => (
+            <li key={index} className="hub-page-link-list__item">
+              <a href={scoEvent.url} className="no-external-icon">
+                <span className="hub-page-link-list__header">
+                  {`${scoEvent.name}`}
+                </span>
+                <img
+                  className="all-link-arrow"
+                  src="/img/arrow-right-blue.svg"
+                  alt="right-arrow"
+                />
+              </a>
+              <br />
+              <span style={{ color: '#5B616B' }}>
+                <b>{`${this.displayDate(scoEvent)} — ${scoEvent.location}`}</b>
+              </span>
+            </li>
+          ))
+      ) : (
+        <p>No new events are available at this time.</p>
+      );
     return (
       <ul id="get" className="hub-page-link-list">
         {scoEvents}


### PR DESCRIPTION
## Description
As a developer, I need to update the SCO page with items that were uncovered during the DSVA design review and found by the customer during UAT so that the page contains accurate information the reflects DSVA design standards. 

This pull request is specifically to address the announcements and events widgets on the School administrators page to add a message when no announcements or events are present.

https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/vets.gov-team/20019

## Testing done
Manual, unit, and e2e tests pass locally

## Screenshots
![image](https://user-images.githubusercontent.com/48804834/69735469-bacdab80-10fe-11ea-8cae-8002dfdd3e8e.png)


## Acceptance criteria
- [x] The following items on the "Design Review Modifications" tab of supporting artifact # 1 are addressed:9, 33, 34, 35

- [x] The following items on "Client Modifications" tab are resolved:3, 4, 5, 6, 8, 10, 11, 12, 13, 15, 16,

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
