### PR TITLE
Update content on cancel modal

### DIFF
--- a/src/applications/vaos/api/confirmed_va.json
+++ b/src/applications/vaos/api/confirmed_va.json
@@ -4,7 +4,7 @@
       "id": "22cdc6741c00ac67b6cbf6b972d084c0",
       "type": "va_appointments",
       "attributes": {
-        "startDate": "2019-11-07T16:00:00Z",
+        "startDate": "2019-12-07T16:00:00Z",
         "clinicId": "308",
         "clinicFriendlyName": null,
         "facilityId": "983",
@@ -13,7 +13,7 @@
           {
             "bookingNote": "RP test",
             "appointmentLength": "60",
-            "appointmentTime": "2019-11-07T16:00:00Z",
+            "appointmentTime": "2019-12-07T16:00:00Z",
             "clinic": {
               "name": "CHY OPT VAR1",
               "askForCheckIn": false,

--- a/src/applications/vaos/api/index.js
+++ b/src/applications/vaos/api/index.js
@@ -349,7 +349,7 @@ export function getCancelReasons(systemId) {
 
 export function updateAppointment(appt) {
   let promise;
-  if (USE_MOCK_DATA) {
+  if (false && USE_MOCK_DATA) {
     promise = Promise.resolve();
   } else {
     promise = apiRequest(`/vaos/appointments/cancel`, {

--- a/src/applications/vaos/api/index.js
+++ b/src/applications/vaos/api/index.js
@@ -349,7 +349,7 @@ export function getCancelReasons(systemId) {
 
 export function updateAppointment(appt) {
   let promise;
-  if (false && USE_MOCK_DATA) {
+  if (USE_MOCK_DATA) {
     promise = Promise.resolve();
   } else {
     promise = apiRequest(`/vaos/appointments/cancel`, {

--- a/src/applications/vaos/components/AppointmentRequestListItem.jsx
+++ b/src/applications/vaos/components/AppointmentRequestListItem.jsx
@@ -82,7 +82,7 @@ export default class AppointmentRequestListItem extends React.Component {
           {!showCancelButton || canceled ? null : (
             <div>
               <button
-                className="usa-button-secondary vads-u-margin--0 vads-u-flex--0"
+                className="vaos-appts__cancel-btn usa-button-secondary vads-u-margin--0 vads-u-flex--0"
                 onClick={() => cancelAppointment(appointment)}
                 aria-label="Cancel appointment"
               >

--- a/src/applications/vaos/components/AppointmentRequestListItem.jsx
+++ b/src/applications/vaos/components/AppointmentRequestListItem.jsx
@@ -52,6 +52,7 @@ export default class AppointmentRequestListItem extends React.Component {
     return (
       <li
         aria-labelledby={`card-${index}`}
+        data-request-id={appointment.id}
         className="vaos-appts__list-item vads-u-background-color--gray-lightest vads-u-padding--2p5 vads-u-margin-bottom--3"
       >
         <div className="vads-u-display--flex vads-u-justify-content--space-between">

--- a/src/applications/vaos/components/CancelAppointmentModal.jsx
+++ b/src/applications/vaos/components/CancelAppointmentModal.jsx
@@ -71,10 +71,8 @@ export default class CancelAppointmentModal extends React.Component {
       );
     }
 
-    if (
-      getAppointmentType(appointmentToCancel) === APPOINTMENT_TYPES.request &&
-      cancelAppointmentStatus === FETCH_STATUS.failed
-    ) {
+    if (cancelAppointmentStatus === FETCH_STATUS.failed) {
+      const appointmentType = getAppointmentType(appointmentToCancel);
       return (
         <Modal
           id="cancelAppt"
@@ -94,56 +92,36 @@ export default class CancelAppointmentModal extends React.Component {
               </button>
               , <strong>or</strong>
             </li>
-            <li>
-              Call the medical center to cancel
-              <br />
-              {appointmentToCancel.facility.name}
-              <br />
-              {!!facility?.phone?.main && (
-                <a href={`tel:${facility.phone.main.replace(/-/g, '')}`}>
-                  {facility.phone.main}
+            {(appointmentType === APPOINTMENT_TYPES.request ||
+              appointmentType === APPOINTMENT_TYPES.ccRequest) && (
+              <li>
+                Call the medical center to cancel
+                <br />
+                {appointmentToCancel.facility.name}
+                <br />
+                {!!facility?.phone?.main && (
+                  <a href={`tel:${facility.phone.main.replace(/-/g, '')}`}>
+                    {facility.phone.main}
+                  </a>
+                )}
+              </li>
+            )}
+            {appointmentType === APPOINTMENT_TYPES.vaAppointment && (
+              <li>
+                Call the medical center to cancel
+                <br />
+                {appointmentToCancel.clinicFriendlyName ||
+                  appointmentToCancel.vdsAppointments[0].clinic.name}
+                <br />
+                <a
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  href="/find-locations"
+                >
+                  Find facility contact information
                 </a>
-              )}
-            </li>
-          </ul>
-        </Modal>
-      );
-    }
-
-    if (cancelAppointmentStatus === FETCH_STATUS.failed) {
-      return (
-        <Modal
-          id="cancelAppt"
-          status="error"
-          visible
-          onClose={onClose}
-          title="We could not cancel this appointment"
-        >
-          We’re sorry. Something went wrong when we tried to cancel this
-          appointment.
-          <h4>You can:</h4>
-          <ul>
-            <li>
-              Try to{' '}
-              <button onClick={onConfirm} className="va-button-link">
-                cancel this appointment again
-              </button>
-              , <strong>or</strong>
-            </li>
-            <li>
-              Call the medical center to cancel
-              <br />
-              {appointmentToCancel.clinicFriendlyName ||
-                appointmentToCancel.vdsAppointments[0].clinic.name}
-              <br />
-              <a
-                target="_blank"
-                rel="noopener noreferrer"
-                href="/find-locations"
-              >
-                Find facility contact information
-              </a>
-            </li>
+              </li>
+            )}
           </ul>
         </Modal>
       );

--- a/src/applications/vaos/components/CancelAppointmentModal.jsx
+++ b/src/applications/vaos/components/CancelAppointmentModal.jsx
@@ -3,8 +3,8 @@ import React from 'react';
 import LoadingButton from 'platform/site-wide/loading-button/LoadingButton';
 import Modal from '@department-of-veterans-affairs/formation-react/Modal';
 
-import { FETCH_STATUS } from '../utils/constants';
-import { getStagingId } from '../utils/appointment';
+import { FETCH_STATUS, APPOINTMENT_TYPES } from '../utils/constants';
+import { getAppointmentType } from '../utils/appointment';
 
 export default class CancelAppointmentModal extends React.Component {
   render() {
@@ -14,6 +14,7 @@ export default class CancelAppointmentModal extends React.Component {
       cancelAppointmentStatus,
       onClose,
       onConfirm,
+      facility,
     } = this.props;
 
     if (!showCancelModal) {
@@ -42,6 +43,7 @@ export default class CancelAppointmentModal extends React.Component {
               Yes, cancel this appointment
             </LoadingButton>
             <button
+              className="usa-button-secondary"
               onClick={onClose}
               disabled={cancelAppointmentStatus === FETCH_STATUS.loading}
             >
@@ -70,7 +72,7 @@ export default class CancelAppointmentModal extends React.Component {
     }
 
     if (
-      !!appointmentToCancel.appointmentRequestId &&
+      getAppointmentType(appointmentToCancel) === APPOINTMENT_TYPES.request &&
       cancelAppointmentStatus === FETCH_STATUS.failed
     ) {
       return (
@@ -79,29 +81,31 @@ export default class CancelAppointmentModal extends React.Component {
           status="error"
           visible
           onClose={onClose}
-          title="We could not cancel this appointment"
+          title="We couldn’t cancel your appointment"
         >
-          Something went wrong when we tried to cancel your request.
-          <h4>What you can do</h4>
-          It may have just been a blip and you can try again.
-          <p>
-            <button onClick={onConfirm} className="va-button-link">
-              Try to cancel again
-            </button>
-          </p>
-          <p>
-            But you should probably{' '}
-            <a
-              target="_blank"
-              rel="noopener noreferrer"
-              href={`/find-locations/facility/vha_${getStagingId(
-                appointmentToCancel.facility?.facilityCode,
-              )}`}
-            >
-              contact the facility by phone
-            </a>
-            .
-          </p>
+          We’re sorry. Something went wrong when we tried to cancel this
+          appointment.
+          <h4>You can:</h4>
+          <ul>
+            <li>
+              Try to{' '}
+              <button onClick={onConfirm} className="va-button-link">
+                cancel this appointment again
+              </button>
+              , <strong>or</strong>
+            </li>
+            <li>
+              Call the medical center to cancel
+              <br />
+              {appointmentToCancel.facility.name}
+              <br />
+              {!!facility?.phone?.main && (
+                <a href={`tel:${facility.phone.main.replace(/-/g, '')}`}>
+                  {facility.phone.main}
+                </a>
+              )}
+            </li>
+          </ul>
         </Modal>
       );
     }
@@ -115,29 +119,32 @@ export default class CancelAppointmentModal extends React.Component {
           onClose={onClose}
           title="We could not cancel this appointment"
         >
-          Something went wrong when we tried to cancel your appointment.
-          <h4>What you can do</h4>
-          It may have just been a blip and you can try again.
-          <p>
-            <button onClick={onConfirm} className="va-button-link">
-              Try to cancel again
-            </button>
-          </p>
-          <p>But you should probably contact the clinic by phone.</p>
-          <p>
-            {appointmentToCancel.clinicFriendlyName ||
-              appointmentToCancel.vdsAppointments[0].clinic.name}
-            <br />
-            <a
-              target="_blank"
-              rel="noopener noreferrer"
-              href={`/find-locations/facility/vha_${getStagingId(
-                appointmentToCancel.facilityId,
-              )}`}
-            >
-              View facility contact information
-            </a>
-          </p>
+          We’re sorry. Something went wrong when we tried to cancel this
+          appointment.
+          <h4>You can:</h4>
+          <ul>
+            <li>
+              Try to{' '}
+              <button onClick={onConfirm} className="va-button-link">
+                cancel this appointment again
+              </button>
+              , <strong>or</strong>
+            </li>
+            <li>
+              Call the medical center to cancel
+              <br />
+              {appointmentToCancel.clinicFriendlyName ||
+                appointmentToCancel.vdsAppointments[0].clinic.name}
+              <br />
+              <a
+                target="_blank"
+                rel="noopener noreferrer"
+                href="/find-locations"
+              >
+                Find facility contact information
+              </a>
+            </li>
+          </ul>
         </Modal>
       );
     }

--- a/src/applications/vaos/containers/AppointmentsPage.jsx
+++ b/src/applications/vaos/containers/AppointmentsPage.jsx
@@ -4,7 +4,6 @@ import PropTypes from 'prop-types';
 import { Link } from 'react-router';
 import LoadingIndicator from '@department-of-veterans-affairs/formation-react/LoadingIndicator';
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
-import environment from 'platform/utilities/environment';
 import Breadcrumbs from '../components/Breadcrumbs';
 import ConfirmedAppointmentListItem from '../components/ConfirmedAppointmentListItem';
 import AppointmentRequestListItem from '../components/AppointmentRequestListItem';
@@ -15,19 +14,11 @@ import {
   closeCancelAppointment,
   fetchRequestMessages,
 } from '../actions/appointments';
-import { getAppointmentType } from '../utils/appointment';
+import { getAppointmentType, getRealFacilityId } from '../utils/appointment';
 import { FETCH_STATUS, APPOINTMENT_TYPES } from '../utils/constants';
 import CancelAppointmentModal from '../components/CancelAppointmentModal';
 import { getCancelInfo, vaosCancel, vaosRequests } from '../utils/selectors';
 import { scrollAndFocus } from '../utils/scrollAndFocus';
-
-function getRealFacilityId(facilityId) {
-  if (!environment.isProduction() && facilityId) {
-    return facilityId.replace('983', '442').replace('984', '552');
-  }
-
-  return facilityId;
-}
 
 export class AppointmentsPage extends Component {
   componentDidMount() {

--- a/src/applications/vaos/tests/components/CancelAppointmentModal.unit.spec.jsx
+++ b/src/applications/vaos/tests/components/CancelAppointmentModal.unit.spec.jsx
@@ -88,6 +88,7 @@ describe('VAOS <CancelAppointmentModal>', () => {
         showCancelModal
         cancelAppointmentStatus={FETCH_STATUS.failed}
         appointmentToCancel={{
+          startDate: '11/20/2018',
           clinicFriendlyName: 'Testing',
           facilityId: '983',
         }}
@@ -99,7 +100,7 @@ describe('VAOS <CancelAppointmentModal>', () => {
       tree
         .find('Modal')
         .children()
-        .at(5)
+        .at(2)
         .text(),
     ).to.contain('Testing');
 

--- a/src/applications/vaos/tests/utils/selectors.unit.spec.js
+++ b/src/applications/vaos/tests/utils/selectors.unit.spec.js
@@ -15,6 +15,7 @@ import {
   getTypeOfCare,
   selectConfirmedAppointment,
   selectPendingAppointment,
+  getCancelInfo,
 } from '../../utils/selectors';
 
 describe('VAOS selectors', () => {
@@ -347,6 +348,28 @@ describe('VAOS selectors', () => {
         group: 'primary',
         name: 'Primary care',
       });
+    });
+  });
+  describe('getCancelInfo', () => {
+    it('should fetch facility in info', () => {
+      const state = {
+        appointments: {
+          appointmentToCancel: {
+            facility: {
+              facilityCode: '123',
+            },
+          },
+          facilityData: {
+            123: {},
+          },
+        },
+      };
+
+      const cancelInfo = getCancelInfo(state);
+
+      expect(cancelInfo.facility).to.equal(
+        state.appointments.facilityData['123'],
+      );
     });
   });
 });

--- a/src/applications/vaos/utils/appointment.jsx
+++ b/src/applications/vaos/utils/appointment.jsx
@@ -344,3 +344,11 @@ export function sortFutureRequests(a, b) {
 export function sortMessages(a, b) {
   return moment(a.attributes.date).isBefore(b.attributes.date) ? -1 : 1;
 }
+
+export function getRealFacilityId(facilityId) {
+  if (!environment.isProduction() && facilityId) {
+    return facilityId.replace('983', '442').replace('984', '552');
+  }
+
+  return facilityId;
+}

--- a/src/applications/vaos/utils/selectors.js
+++ b/src/applications/vaos/utils/selectors.js
@@ -1,6 +1,6 @@
 import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
 
-import { getAppointmentId } from './appointment';
+import { getAppointmentId, getRealFacilityId } from './appointment';
 import { isEligible } from './eligibility';
 import { getTimezoneAbbrBySystemId } from './timezone';
 import {
@@ -210,9 +210,19 @@ export function getCancelInfo(state) {
     appointmentToCancel,
     showCancelModal,
     cancelAppointmentStatus,
+    facilityData,
   } = state.appointments;
 
+  let facility = null;
+  if (appointmentToCancel) {
+    facility =
+      facilityData[
+        getRealFacilityId(appointmentToCancel.facility?.facilityCode)
+      ];
+  }
+
   return {
+    facility,
     appointmentToCancel,
     showCancelModal,
     cancelAppointmentStatus,


### PR DESCRIPTION
## Description
This updates the content for cancel modal failed state. It's slightly different than the content from Peggy, because we have two variants and aren't able to pull facility information for one of those variants yet.

## Testing done
Local testing

## Screenshots
![Screen Shot 2019-11-27 at 10 16 42 AM](https://user-images.githubusercontent.com/634932/69735835-5e1ec080-10ff-11ea-9fe6-a1fee21dc752.png)
![Screen Shot 2019-11-27 at 10 13 16 AM](https://user-images.githubusercontent.com/634932/69735836-5e1ec080-10ff-11ea-9ff7-54041ff76436.png)

## Acceptance criteria
- [ ] Cancel modal content updated.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
