### PR TITLE
Fix paragraph alert

### DIFF
--- a/src/site/stages/build/process-cms-exports/schemas/transformed/paragraph-alert.js
+++ b/src/site/stages/build/process-cms-exports/schemas/transformed/paragraph-alert.js
@@ -8,13 +8,13 @@ module.exports = {
         entityType: { type: 'string' },
         entityBundle: { type: 'string' },
         fieldAlertType: { type: 'string' },
-        fieldAlertHeading: { type: 'string' },
+        fieldAlertHeading: { type: ['string', 'null'] },
         fieldVaParagraphs: {
-          type: 'array',
+          type: ['array', 'null'],
           items: { $ref: 'Paragraph' },
         },
         fieldAlertBlockReference: {
-          type: ['null', 'array'],
+          type: ['array', 'null'],
           items: {
             $ref: 'BlockContent',
           },

--- a/src/site/stages/build/process-cms-exports/transformers/helpers.js
+++ b/src/site/stages/build/process-cms-exports/transformers/helpers.js
@@ -9,7 +9,10 @@ const { unescape } = require('lodash');
  * @return {String}
  */
 function unescapeUnicode(string) {
-  assert(typeof string === 'string');
+  assert(
+    typeof string === 'string',
+    `Expected type String in unescapeUnicode, but found ${typeof string}: ${string}`,
+  );
   return string.replace(/\\u(\d{2,4})/g, (wholeMatch, codePoint) =>
     String.fromCharCode(`0x${codePoint}`),
   );
@@ -22,7 +25,10 @@ function unescapeUnicode(string) {
  */
 function getDrupalValue(arr) {
   if (arr.length === 0) return null;
-  if (arr.length === 1) return unescapeUnicode(arr[0].value);
+  if (arr.length === 1)
+    return typeof arr[0].value === 'string'
+      ? unescapeUnicode(arr[0].value)
+      : arr[0].value;
   // eslint-disable-next-line no-console
   console.warn(`Unexpected argument: ${arr.toString()}`);
   return null;


### PR DESCRIPTION
## Description
Fixes the tests that are broken in master.

In short, this was caused by two PRs that were fine on their own, but when they were both merged, caused a problem. One PR introduced `unescapeUnicode` which `assert`s that the argument passed to it is a string. The second PR used `getDrupalValue` to grab a boolean. This was passed through `unescapeUnicode`, which failed the `assert`.

To fix the problem, I made `getDrupalValue` only use `unescapeUnicode` if the value is a string.

Additionally, I added better logging to that `assert` and modified the `paragraph-alert` schema to allow for some `null` properties so it passes the `yarn build:content:test` smoke test.

## Testing done
Um...yup. Did that. See above. :sweat_smile: 

## Screenshots
N/A

## Acceptance criteria
- [x] The tests pass