### PR TITLE
Remove DS types check from new appointment flow

### DIFF
--- a/src/applications/vaos/tests/newAppointmentFlow.unit.spec.js
+++ b/src/applications/vaos/tests/newAppointmentFlow.unit.spec.js
@@ -108,7 +108,6 @@ describe('VAOS newAppointmentFlow', () => {
           ...defaultState.newAppointment,
           eligibility: {
             '983_323': {
-              directTypes: true,
               directPastVisit: true,
               directPACT: true,
               directClinics: true,
@@ -136,7 +135,6 @@ describe('VAOS newAppointmentFlow', () => {
           ...defaultState.newAppointment,
           eligibility: {
             '983_323': {
-              directTypes: true,
               directPastVisit: false,
               directPACT: true,
               directClinics: true,

--- a/src/applications/vaos/tests/utils/eligibility.unit.spec.js
+++ b/src/applications/vaos/tests/utils/eligibility.unit.spec.js
@@ -96,13 +96,13 @@ describe('VAOS scheduling eligibility logic', () => {
 
       expect(eligibilityChecks).to.deep.equal({
         directPastVisit: true,
-        directPastVisitValue: null,
+        directPastVisitValue: 12,
         directPACT: true,
         directClinics: true,
         requestPastVisit: true,
-        requestPastVisitValue: null,
+        requestPastVisitValue: 24,
         requestLimit: true,
-        requestLimitValue: null,
+        requestLimitValue: 1,
       });
     });
   });

--- a/src/applications/vaos/tests/utils/eligibility.unit.spec.js
+++ b/src/applications/vaos/tests/utils/eligibility.unit.spec.js
@@ -34,14 +34,6 @@ describe('VAOS scheduling eligibility logic', () => {
         'pacTeam',
       ]);
     });
-    it('should skip direct fetches if not a matching type', async () => {
-      const eligibilityData = await getEligibilityData('983', 'blah');
-
-      expect(Object.keys(eligibilityData)).to.deep.equal([
-        'requestPastVisit',
-        'requestLimits',
-      ]);
-    });
     it('should skip pact if not primary care', async () => {
       const eligibilityData = await getEligibilityData('983', '502');
 
@@ -73,7 +65,6 @@ describe('VAOS scheduling eligibility logic', () => {
       });
 
       expect(eligibilityChecks).to.deep.equal({
-        directTypes: true,
         directPastVisit: false,
         directPastVisitValue: 12,
         directPACT: false,
@@ -104,7 +95,6 @@ describe('VAOS scheduling eligibility logic', () => {
       });
 
       expect(eligibilityChecks).to.deep.equal({
-        directTypes: true,
         directPastVisit: true,
         directPastVisitValue: null,
         directPACT: true,
@@ -121,7 +111,6 @@ describe('VAOS scheduling eligibility logic', () => {
       const { direct, request } = isEligible({
         directPastVisit: false,
         directClinics: true,
-        directTypes: true,
         directPACT: true,
         requestPastVisit: true,
         requestLimit: true,

--- a/src/applications/vaos/utils/constants.js
+++ b/src/applications/vaos/utils/constants.js
@@ -267,4 +267,3 @@ export const REASON_MAX_CHARS = {
 export const DISABLED_LIMIT_VALUE = 0;
 export const PRIMARY_CARE = '323';
 export const MENTAL_HEALTH = '502';
-export const DIRECT_SCHEDULE_TYPES = new Set([PRIMARY_CARE, '502']);


### PR DESCRIPTION
## Description
We don't want to restrict the types of care you can direct schedule with to primary and mental health anymore, so this removes that logic from our eligibility code.

## Testing done
Unit testing

## Acceptance criteria
- [ ] All types can be direct scheduled

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
