### PR TITLE
Update error handling and form reset logic on VAOS

### DIFF
--- a/src/applications/vaos/actions/newAppointment.js
+++ b/src/applications/vaos/actions/newAppointment.js
@@ -36,6 +36,7 @@ import { getEligibilityData } from '../utils/eligibility';
 
 export const FORM_DATA_UPDATED = 'newAppointment/FORM_DATA_UPDATED';
 export const FORM_PAGE_OPENED = 'newAppointment/FORM_PAGE_OPENED';
+export const FORM_RESET = 'newAppointment/FORM_RESET';
 export const FORM_TYPE_OF_CARE_PAGE_OPENED =
   'newAppointment/TYPE_OF_CARE_PAGE_OPENED';
 export const FORM_PAGE_CHANGE_STARTED =
@@ -47,16 +48,22 @@ export const FORM_UPDATE_FACILITY_TYPE =
 export const FORM_PAGE_FACILITY_OPEN = 'newAppointment/FACILITY_PAGE_OPEN';
 export const FORM_PAGE_FACILITY_OPEN_SUCCEEDED =
   'newAppointment/FACILITY_PAGE_OPEN_SUCCEEDED';
+export const FORM_PAGE_FACILITY_OPEN_FAILED =
+  'newAppointment/FACILITY_PAGE_OPEN_FAILED';
 export const FORM_FETCH_CHILD_FACILITIES =
   'newAppointment/FORM_FETCH_CHILD_FACILITIES';
 export const FORM_FETCH_CHILD_FACILITIES_SUCCEEDED =
   'newAppointment/FORM_FETCH_CHILD_FACILITIES_SUCCEEDED';
+export const FORM_FETCH_CHILD_FACILITIES_FAILED =
+  'newAppointment/FORM_FETCH_CHILD_FACILITIES_FAILED';
 export const FORM_VA_SYSTEM_CHANGED = 'newAppointment/FORM_VA_SYSTEM_CHANGED';
 export const FORM_VA_SYSTEM_UPDATE_CC_ENABLED_SYSTEMS =
   'newAppointment/FORM_VA_SYSTEM_UPDATE_CC_ENABLED_SYSTEMS';
 export const FORM_ELIGIBILITY_CHECKS = 'newAppointment/FORM_ELIGIBILITY_CHECKS';
 export const FORM_ELIGIBILITY_CHECKS_SUCCEEDED =
   'newAppointment/FORM_ELIGIBILITY_CHECKS_SUCCEEDED';
+export const FORM_ELIGIBILITY_CHECKS_FAILED =
+  'newAppointment/FORM_ELIGIBILITY_CHECKS_FAILED';
 export const FORM_CLINIC_PAGE_OPENED = 'newAppointment/FORM_CLINIC_PAGE_OPENED';
 export const FORM_CLINIC_PAGE_OPENED_SUCCEEDED =
   'newAppointment/FORM_CLINIC_PAGE_OPENED_SUCCEEDED';
@@ -78,6 +85,8 @@ export const FORM_PAGE_COMMUNITY_CARE_PREFS_OPEN =
   'newAppointment/FORM_PAGE_COMMUNITY_CARE_PREFS_OPEN';
 export const FORM_PAGE_COMMUNITY_CARE_PREFS_OPEN_SUCCEEDED =
   'newAppointment/FORM_PAGE_COMMUNITY_CARE_PREFS_OPEN_SUCCEEDED';
+export const FORM_PAGE_COMMUNITY_CARE_PREFS_OPEN_FAILED =
+  'newAppointment/FORM_PAGE_COMMUNITY_CARE_PREFS_OPEN_FAILED';
 export const FORM_SUBMIT = 'newAppointment/FORM_SUBMIT';
 export const FORM_SUBMIT_SUCCEEDED = 'newAppointment/FORM_SUBMIT_SUCCEEDED';
 export const FORM_SUBMIT_FAILED = 'newAppointment/FORM_SUBMIT_FAILED';
@@ -90,6 +99,12 @@ export function openFormPage(page, uiSchema, schema) {
     page,
     uiSchema,
     schema,
+  };
+}
+
+export function resetForm() {
+  return {
+    type: FORM_RESET,
   };
 }
 
@@ -167,48 +182,55 @@ export function openFacilityPage(page, uiSchema, schema) {
     let facilities = null;
     let eligibilityData = null;
 
-    // If we have the VA systems in our state, we don't need to
-    // fetch them again
-    if (!systems) {
-      const userSystemIds = await getSystemIdentifiers();
-      systems = await getSystemDetails(userSystemIds);
-    }
-    const canShowFacilities =
-      newAppointment.data.vaSystem || systems?.length === 1;
-    const typeOfCareId = getTypeOfCare(newAppointment.data)?.id;
+    try {
+      // If we have the VA systems in our state, we don't need to
+      // fetch them again
+      if (!systems) {
+        const userSystemIds = await getSystemIdentifiers();
+        systems = await getSystemDetails(userSystemIds);
+      }
+      const canShowFacilities =
+        newAppointment.data.vaSystem || systems?.length === 1;
+      const typeOfCareId = getTypeOfCare(newAppointment.data)?.id;
 
-    const hasExistingFacilities = !!newAppointment.facilities[
-      `${typeOfCareId}_${newAppointment.data.vaSystem}`
-    ];
+      const hasExistingFacilities = !!newAppointment.facilities[
+        `${typeOfCareId}_${newAppointment.data.vaSystem}`
+      ];
 
-    if (canShowFacilities && !hasExistingFacilities) {
-      const systemId =
-        newAppointment.data.vaSystem || systems[0].institutionCode;
-      facilities = await getFacilitiesBySystemAndTypeOfCare(
-        systemId,
+      if (canShowFacilities && !hasExistingFacilities) {
+        const systemId =
+          newAppointment.data.vaSystem || systems[0].institutionCode;
+        facilities = await getFacilitiesBySystemAndTypeOfCare(
+          systemId,
+          typeOfCareId,
+        );
+      }
+
+      const facilityId =
+        newAppointment.data.vaFacility || facilities?.[0].facilityId;
+      if (
+        facilityId &&
+        !newAppointment.eligibility[`${facilityId}_${typeOfCareId}`]
+      ) {
+        eligibilityData = await getEligibilityData(facilityId, typeOfCareId);
+      }
+
+      dispatch({
+        type: FORM_PAGE_FACILITY_OPEN_SUCCEEDED,
+        page,
+        uiSchema,
+        schema,
+        systems,
+        facilities,
         typeOfCareId,
-      );
+        eligibilityData,
+      });
+    } catch (e) {
+      Sentry.captureException(e);
+      dispatch({
+        type: FORM_PAGE_FACILITY_OPEN_FAILED,
+      });
     }
-
-    const facilityId =
-      newAppointment.data.vaFacility || facilities?.[0].facilityId;
-    if (
-      facilityId &&
-      !newAppointment.eligibility[`${facilityId}_${typeOfCareId}`]
-    ) {
-      eligibilityData = await getEligibilityData(facilityId, typeOfCareId);
-    }
-
-    dispatch({
-      type: FORM_PAGE_FACILITY_OPEN_SUCCEEDED,
-      page,
-      uiSchema,
-      schema,
-      systems,
-      facilities,
-      typeOfCareId,
-      eligibilityData,
-    });
   };
 }
 
@@ -227,17 +249,24 @@ export function updateFacilityPageData(page, uiSchema, data) {
         type: FORM_FETCH_CHILD_FACILITIES,
       });
 
-      facilities = await getFacilitiesBySystemAndTypeOfCare(
-        data.vaSystem,
-        typeOfCareId,
-      );
+      try {
+        facilities = await getFacilitiesBySystemAndTypeOfCare(
+          data.vaSystem,
+          typeOfCareId,
+        );
 
-      dispatch({
-        type: FORM_FETCH_CHILD_FACILITIES_SUCCEEDED,
-        uiSchema,
-        facilities,
-        typeOfCareId,
-      });
+        dispatch({
+          type: FORM_FETCH_CHILD_FACILITIES_SUCCEEDED,
+          uiSchema,
+          facilities,
+          typeOfCareId,
+        });
+      } catch (e) {
+        Sentry.captureException(e);
+        dispatch({
+          type: FORM_FETCH_CHILD_FACILITIES_FAILED,
+        });
+      }
     } else if (
       data.vaSystem &&
       previousNewAppointmentState.data.vaSystem !== data.vaSystem
@@ -257,16 +286,23 @@ export function updateFacilityPageData(page, uiSchema, data) {
         type: FORM_ELIGIBILITY_CHECKS,
       });
 
-      const eligibilityData = await getEligibilityData(
-        data.vaFacility,
-        typeOfCareId,
-      );
+      try {
+        const eligibilityData = await getEligibilityData(
+          data.vaFacility,
+          typeOfCareId,
+        );
 
-      dispatch({
-        type: FORM_ELIGIBILITY_CHECKS_SUCCEEDED,
-        typeOfCareId,
-        eligibilityData,
-      });
+        dispatch({
+          type: FORM_ELIGIBILITY_CHECKS_SUCCEEDED,
+          typeOfCareId,
+          eligibilityData,
+        });
+      } catch (e) {
+        Sentry.captureException(e);
+        dispatch({
+          type: FORM_ELIGIBILITY_CHECKS_FAILED,
+        });
+      }
     }
   };
 }
@@ -384,17 +420,24 @@ export function openCommunityCarePreferencesPage(page, uiSchema, schema) {
       type: FORM_PAGE_COMMUNITY_CARE_PREFS_OPEN,
     });
 
-    if (!newAppointment.systems) {
-      systems = await getSystemDetails(systemIds);
-    }
+    try {
+      if (!newAppointment.systems) {
+        systems = await getSystemDetails(systemIds);
+      }
 
-    dispatch({
-      type: FORM_PAGE_COMMUNITY_CARE_PREFS_OPEN_SUCCEEDED,
-      page,
-      uiSchema,
-      schema,
-      systems,
-    });
+      dispatch({
+        type: FORM_PAGE_COMMUNITY_CARE_PREFS_OPEN_SUCCEEDED,
+        page,
+        uiSchema,
+        schema,
+        systems,
+      });
+    } catch (e) {
+      Sentry.captureException(e);
+      dispatch({
+        type: FORM_PAGE_COMMUNITY_CARE_PREFS_OPEN_FAILED,
+      });
+    }
   };
 }
 

--- a/src/applications/vaos/actions/newAppointment.js
+++ b/src/applications/vaos/actions/newAppointment.js
@@ -350,6 +350,7 @@ export function openClinicPage(page, uiSchema, schema) {
         getState().newAppointment.data.vaFacility,
       );
     } catch (e) {
+      Sentry.captureException(e);
       facilityDetails = null;
     }
 

--- a/src/applications/vaos/components/ErrorMessage.jsx
+++ b/src/applications/vaos/components/ErrorMessage.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
+
+export default function ErrorMessage() {
+  return (
+    <AlertBox status="error" headline="Sorry, something went wrong">
+      We're sorry, we ran into an error. Please try again later.
+    </AlertBox>
+  );
+}

--- a/src/applications/vaos/components/ErrorMessage.jsx
+++ b/src/applications/vaos/components/ErrorMessage.jsx
@@ -6,7 +6,7 @@ export default function ErrorMessage() {
   return (
     <div aria-atomic="true" aria-live="assertive">
       <AlertBox status="error" headline="Sorry, something went wrong">
-        We're sorry, we ran into an error. Please try again later.
+        We’re sorry, we ran into an error. Please try again later.
       </AlertBox>
     </div>
   );

--- a/src/applications/vaos/components/ErrorMessage.jsx
+++ b/src/applications/vaos/components/ErrorMessage.jsx
@@ -4,8 +4,10 @@ import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 
 export default function ErrorMessage() {
   return (
-    <AlertBox status="error" headline="Sorry, something went wrong">
-      We're sorry, we ran into an error. Please try again later.
-    </AlertBox>
+    <div aria-atomic="true" aria-live="assertive">
+      <AlertBox status="error" headline="Sorry, something went wrong">
+        We're sorry, we ran into an error. Please try again later.
+      </AlertBox>
+    </div>
   );
 }

--- a/src/applications/vaos/components/NewAppointmentLayout.jsx
+++ b/src/applications/vaos/components/NewAppointmentLayout.jsx
@@ -1,24 +1,44 @@
 import React from 'react';
 import { Link } from 'react-router';
 import Breadcrumbs from './Breadcrumbs';
-import { useScrollAndFocus } from '../utils/scrollAndFocus';
+import { scrollAndFocus } from '../utils/scrollAndFocus';
 
-export default function NewAppointmentLayout({ children }) {
-  useScrollAndFocus();
+export default class NewAppointmentLayout extends React.Component {
+  componentDidMount() {
+    if (window.History) {
+      window.History.scrollRestoration = 'manual';
+    }
 
-  return (
-    <div className="vads-l-grid-container vads-u-padding-x--2p5 large-screen:vads-u-padding-x--0 vads-u-padding-bottom--2">
-      <Breadcrumbs>
-        <Link to="new-appointment">New appointment</Link>
-      </Breadcrumbs>
-      <div className="vads-l-row">
-        <div className="vads-l-col--12 medium-screen:vads-l-col--8">
-          <span className="vaos-form__title vaos-u-margin-bottom--1 vads-u-font-size--sm vads-u-font-weight--normal vads-u-font-family--sans">
-            New appointment
-          </span>
-          {children}
+    scrollAndFocus();
+
+    // We don't want people to start in the middle of the form, so redirect them when they jump
+    // in the middle
+    if (!this.props.location.pathname.endsWith('new-appointment')) {
+      this.props.router.replace('/new-appointment');
+    }
+  }
+
+  componentDidUpdate() {
+    scrollAndFocus();
+  }
+
+  render() {
+    const { children } = this.props;
+
+    return (
+      <div className="vads-l-grid-container vads-u-padding-x--2p5 large-screen:vads-u-padding-x--0 vads-u-padding-bottom--2">
+        <Breadcrumbs>
+          <Link to="new-appointment">New appointment</Link>
+        </Breadcrumbs>
+        <div className="vads-l-row">
+          <div className="vads-l-col--12 medium-screen:vads-l-col--8">
+            <span className="vaos-form__title vaos-u-margin-bottom--1 vads-u-font-size--sm vads-u-font-weight--normal vads-u-font-family--sans">
+              New appointment
+            </span>
+            {children}
+          </div>
         </div>
       </div>
-    </div>
-  );
+    );
+  }
 }

--- a/src/applications/vaos/containers/CommunityCarePreferencesPage.jsx
+++ b/src/applications/vaos/containers/CommunityCarePreferencesPage.jsx
@@ -6,6 +6,7 @@ import phoneUI from 'platform/forms-system/src/js/definitions/phone';
 import FormButtons from '../components/FormButtons';
 import * as address from '../utils/address';
 import { LANGUAGES } from './../utils/constants';
+import ErrorMessage from '../components/ErrorMessage';
 
 import {
   openCommunityCarePreferencesPage,
@@ -135,17 +136,26 @@ export class CommunityCarePreferencesPage extends React.Component {
   };
 
   render() {
-    const { schema, data, pageChangeInProgress, loading } = this.props;
+    const {
+      schema,
+      data,
+      pageChangeInProgress,
+      loading,
+      hasDataFetchingError,
+    } = this.props;
 
     return (
       <div>
         <h1 className="vads-u-font-size--h2">
           Share your community care provider preferences
         </h1>
-        {(!schema || loading) && (
-          <LoadingIndicator message="Loading Community Care facilities" />
-        )}
+        {hasDataFetchingError && <ErrorMessage />}
+        {(!schema || loading) &&
+          !hasDataFetchingError && (
+            <LoadingIndicator message="Loading Community Care facilities" />
+          )}
         {!!schema &&
+          !hasDataFetchingError &&
           !loading && (
             <SchemaForm
               name="ccPreferences"

--- a/src/applications/vaos/containers/ConfirmationPage.jsx
+++ b/src/applications/vaos/containers/ConfirmationPage.jsx
@@ -8,11 +8,15 @@ import {
   getFlowType,
   getChosenClinicInfo,
 } from '../utils/selectors';
+import { resetForm } from '../actions/newAppointment';
 import { FLOW_TYPES } from '../utils/constants';
 import ConfirmationDirectScheduleInfo from '../components/ConfirmationDirectScheduleInfo';
 import ConfirmationRequestInfo from '../components/ConfirmationRequestInfo';
 
 export class ConfirmationPage extends React.Component {
+  componentWillUnmount() {
+    this.props.resetForm();
+  }
   render() {
     const { data, facility, clinic, flowType } = this.props;
     const isDirectSchedule = flowType === FLOW_TYPES.DIRECT;
@@ -57,4 +61,11 @@ function mapStateToProps(state) {
   };
 }
 
-export default connect(mapStateToProps)(ConfirmationPage);
+const mapDispatchToProps = {
+  resetForm,
+};
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(ConfirmationPage);

--- a/src/applications/vaos/containers/VAFacilityPage.jsx
+++ b/src/applications/vaos/containers/VAFacilityPage.jsx
@@ -6,6 +6,7 @@ import SchemaForm from 'platform/forms-system/src/js/components/SchemaForm';
 import FormButtons from '../components/FormButtons';
 import EligibilityCheckMessage from '../components/EligibilityCheckMessage';
 import SingleFacilityEligibilityCheckMessage from '../components/SingleFacilityEligibilityCheckMessage';
+import ErrorMessage from '../components/ErrorMessage';
 import { scrollAndFocus } from '../utils/scrollAndFocus';
 
 import {
@@ -110,6 +111,7 @@ export class VAFacilityPage extends React.Component {
       noValidVAFacilities,
       eligibility,
       canScheduleAtChosenFacility,
+      hasDataFetchingError,
     } = this.props;
 
     const notEligibleAtChosenFacility =
@@ -118,6 +120,15 @@ export class VAFacilityPage extends React.Component {
       !loadingEligibility &&
       eligibility &&
       !canScheduleAtChosenFacility;
+
+    if (hasDataFetchingError) {
+      return (
+        <div>
+          {title}
+          <ErrorMessage />
+        </div>
+      );
+    }
 
     if (loadingSystems) {
       return (

--- a/src/applications/vaos/containers/VAOSApp.jsx
+++ b/src/applications/vaos/containers/VAOSApp.jsx
@@ -1,3 +1,4 @@
+import * as Sentry from '@sentry/browser';
 import React from 'react';
 import { connect } from 'react-redux';
 
@@ -11,28 +12,56 @@ import DowntimeNotification, {
 import { vaosApplication } from '../utils/selectors';
 import RegistrationCheck from './RegistrationCheck';
 import AppUnavailable from '../components/AppUnavailable';
+import ErrorMessage from '../components/ErrorMessage';
 
-export function VAOSApp({ user, children, showApplication }) {
-  return (
-    <RequiredLoginView
-      authRequired={1}
-      serviceRequired={[
-        backendServices.USER_PROFILE,
-        backendServices.FACILITIES,
-      ]}
-      user={user}
-    >
-      {showApplication && (
-        <DowntimeNotification
-          appTitle="VA online scheduling"
-          dependencies={[externalServices.mvi, externalServices.vaos]}
-        >
-          <RegistrationCheck>{children}</RegistrationCheck>
-        </DowntimeNotification>
-      )}
-      {!showApplication && <AppUnavailable />}
-    </RequiredLoginView>
-  );
+export class VAOSApp extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      hasError: false,
+    };
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error) {
+    Sentry.captureException(error);
+  }
+
+  render() {
+    const { user, children, showApplication } = this.props;
+
+    if (this.state.hasError) {
+      return (
+        <div className="vads-u-margin-y--2">
+          <ErrorMessage />
+        </div>
+      );
+    }
+
+    return (
+      <RequiredLoginView
+        authRequired={1}
+        serviceRequired={[
+          backendServices.USER_PROFILE,
+          backendServices.FACILITIES,
+        ]}
+        user={user}
+      >
+        {showApplication && (
+          <DowntimeNotification
+            appTitle="VA online scheduling"
+            dependencies={[externalServices.mvi, externalServices.vaos]}
+          >
+            <RegistrationCheck>{children}</RegistrationCheck>
+          </DowntimeNotification>
+        )}
+        {!showApplication && <AppUnavailable />}
+      </RequiredLoginView>
+    );
+  }
 }
 
 function mapStateToProps(state) {

--- a/src/applications/vaos/newAppointmentFlow.js
+++ b/src/applications/vaos/newAppointmentFlow.js
@@ -111,6 +111,10 @@ export default {
           dispatch(updateFacilityType(FACILITY_TYPES.VAMC));
           return 'vaFacility';
         } catch (e) {
+          Sentry.captureException(e);
+          Sentry.captureMessage(
+            'Community Care eligibility check failed with errors',
+          );
           return 'vaFacility';
         }
       }

--- a/src/applications/vaos/reducers/newAppointment.js
+++ b/src/applications/vaos/reducers/newAppointment.js
@@ -16,16 +16,20 @@ import {
 import {
   FORM_DATA_UPDATED,
   FORM_PAGE_OPENED,
+  FORM_RESET,
   FORM_PAGE_CHANGE_STARTED,
   FORM_PAGE_CHANGE_COMPLETED,
   FORM_UPDATE_FACILITY_TYPE,
   FORM_PAGE_FACILITY_OPEN_SUCCEEDED,
+  FORM_PAGE_FACILITY_OPEN_FAILED,
   FORM_FETCH_CHILD_FACILITIES,
   FORM_FETCH_CHILD_FACILITIES_SUCCEEDED,
+  FORM_FETCH_CHILD_FACILITIES_FAILED,
   FORM_VA_SYSTEM_CHANGED,
   FORM_VA_SYSTEM_UPDATE_CC_ENABLED_SYSTEMS,
   FORM_ELIGIBILITY_CHECKS,
   FORM_ELIGIBILITY_CHECKS_SUCCEEDED,
+  FORM_ELIGIBILITY_CHECKS_FAILED,
   START_DIRECT_SCHEDULE_FLOW,
   START_REQUEST_APPOINTMENT_FLOW,
   FORM_CLINIC_PAGE_OPENED,
@@ -37,6 +41,7 @@ import {
   FORM_REASON_FOR_APPOINTMENT_CHANGED,
   FORM_PAGE_COMMUNITY_CARE_PREFS_OPEN,
   FORM_PAGE_COMMUNITY_CARE_PREFS_OPEN_SUCCEEDED,
+  FORM_PAGE_COMMUNITY_CARE_PREFS_OPEN_FAILED,
   FORM_SUBMIT,
   FORM_SUBMIT_FAILED,
   FORM_SUBMIT_SUCCEEDED,
@@ -70,6 +75,7 @@ const initialState = {
   availableSlots: null,
   submitStatus: FETCH_STATUS.notStarted,
   isCCEligible: false,
+  hasDataFetchingError: false,
 };
 
 function getFacilities(state, typeOfCareId, vaSystem) {
@@ -168,10 +174,22 @@ export default function formReducer(state = initialState, action) {
         },
       };
     }
+    case FORM_RESET: {
+      return {
+        ...initialState,
+        systems: state.systems,
+        facilities: state.facilities,
+        clinics: state.clinics,
+        eligibility: state.eligibility,
+        pastAppointments: state.pastAppointments,
+        submitStatus: FETCH_STATUS.notStarted,
+      };
+    }
     case FORM_PAGE_CHANGE_STARTED: {
       return {
         ...state,
         pageChangeInProgress: true,
+        hasDataFetchingError: false,
       };
     }
     case FORM_PAGE_CHANGE_COMPLETED: {
@@ -297,6 +315,12 @@ export default function formReducer(state = initialState, action) {
         eligibility,
       };
     }
+    case FORM_PAGE_FACILITY_OPEN_FAILED: {
+      return {
+        ...state,
+        hasDataFetchingError: true,
+      };
+    }
     case FORM_FETCH_CHILD_FACILITIES: {
       let newState = unset('pages.vaFacility.properties.vaFacility', state);
       newState = unset(
@@ -308,6 +332,7 @@ export default function formReducer(state = initialState, action) {
         { type: 'string' },
         newState,
       );
+
       return newState;
     }
     case FORM_FETCH_CHILD_FACILITIES_SUCCEEDED: {
@@ -341,6 +366,18 @@ export default function formReducer(state = initialState, action) {
           ...state.pages,
           vaFacility: schema,
         },
+      };
+    }
+    case FORM_FETCH_CHILD_FACILITIES_FAILED: {
+      const pages = unset(
+        'vaFacility.properties.vaFacilityLoading',
+        state.pages,
+      );
+
+      return {
+        ...state,
+        pages,
+        hasDataFetchingError: true,
       };
     }
     case FORM_VA_SYSTEM_CHANGED: {
@@ -397,6 +434,12 @@ export default function formReducer(state = initialState, action) {
           [`${state.data.vaFacility}_${action.typeOfCareId}`]: eligibility,
         },
         loadingEligibility: false,
+      };
+    }
+    case FORM_ELIGIBILITY_CHECKS_FAILED: {
+      return {
+        ...state,
+        hasDataFetchingError: true,
       };
     }
     case START_DIRECT_SCHEDULE_FLOW:
@@ -598,6 +641,12 @@ export default function formReducer(state = initialState, action) {
           ...state.pages,
           [action.page]: schema,
         },
+      };
+    }
+    case FORM_PAGE_COMMUNITY_CARE_PREFS_OPEN_FAILED: {
+      return {
+        ...state,
+        hasDataFetchingError: true,
       };
     }
     case FORM_SUBMIT:

--- a/src/applications/vaos/reducers/newAppointment.js
+++ b/src/applications/vaos/reducers/newAppointment.js
@@ -189,7 +189,6 @@ export default function formReducer(state = initialState, action) {
       return {
         ...state,
         pageChangeInProgress: true,
-        hasDataFetchingError: false,
       };
     }
     case FORM_PAGE_CHANGE_COMPLETED: {

--- a/src/applications/vaos/tests/components/ErrorMessage.unit.spec.jsx
+++ b/src/applications/vaos/tests/components/ErrorMessage.unit.spec.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { expect } from 'chai';
+
+import ErrorMessage from '../../components/ErrorMessage';
+
+describe('VAOS <ErrorMessage>', () => {
+  it('should render', () => {
+    const tree = shallow(<ErrorMessage />);
+
+    expect(tree.find('AlertBox').props().status).to.equal('error');
+
+    tree.unmount();
+  });
+});

--- a/src/applications/vaos/tests/containers/ConfirmationPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/containers/ConfirmationPage.unit.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import { expect } from 'chai';
+import sinon from 'sinon';
 import { FLOW_TYPES } from '../../utils/constants';
 
 import { ConfirmationPage } from '../../containers/ConfirmationPage';
@@ -8,23 +9,39 @@ import { ConfirmationPage } from '../../containers/ConfirmationPage';
 describe('VAOS <ConfirmationPage>', () => {
   it('should render direct schedule view', () => {
     const flowType = FLOW_TYPES.DIRECT;
+    const resetForm = sinon.spy();
     const data = {};
 
-    const tree = shallow(<ConfirmationPage flowType={flowType} data={data} />);
+    const tree = shallow(
+      <ConfirmationPage
+        resetForm={resetForm}
+        flowType={flowType}
+        data={data}
+      />,
+    );
 
     expect(tree.find('ConfirmationDirectScheduleInfo').exists()).to.be.true;
 
     tree.unmount();
+    expect(resetForm.called).to.be.true;
   });
 
   it('should render request view', () => {
     const flowType = FLOW_TYPES.REQUEST;
+    const resetForm = sinon.spy();
     const data = {};
 
-    const tree = shallow(<ConfirmationPage flowType={flowType} data={data} />);
+    const tree = shallow(
+      <ConfirmationPage
+        resetForm={resetForm}
+        flowType={flowType}
+        data={data}
+      />,
+    );
 
     expect(tree.find('ConfirmationRequestInfo').exists()).to.be.true;
 
     tree.unmount();
+    expect(resetForm.called).to.be.true;
   });
 });

--- a/src/applications/vaos/tests/containers/VAOSApp.unit.spec.jsx
+++ b/src/applications/vaos/tests/containers/VAOSApp.unit.spec.jsx
@@ -29,7 +29,8 @@ describe('VAOS <VAOSApp>', () => {
 
     tree.unmount();
   });
-  it('should render app unavailble messages', () => {
+
+  it('should render app unavailable messages', () => {
     const user = {
       profile: {
         services: [backendServices.USER_PROFILE, backendServices.FACILITIES],
@@ -56,6 +57,24 @@ describe('VAOS <VAOSApp>', () => {
         .find('AppUnavailable')
         .exists(),
     ).to.be.true;
+
+    tree.unmount();
+  });
+
+  it('should render error boundary UI', () => {
+    const user = {
+      profile: {
+        services: [backendServices.USER_PROFILE, backendServices.FACILITIES],
+      },
+      login: {
+        currentlyLoggedIn: true,
+      },
+    };
+
+    const tree = shallow(<VAOSApp user={user} showApplication />);
+    tree.setState({ hasError: true });
+    tree.update();
+    expect(tree.find('ErrorMessage').exists()).to.be.true;
 
     tree.unmount();
   });

--- a/src/applications/vaos/tests/reducers/newAppointment.unit.spec.js
+++ b/src/applications/vaos/tests/reducers/newAppointment.unit.spec.js
@@ -6,22 +6,27 @@ import {
   FORM_PAGE_CHANGE_STARTED,
   FORM_PAGE_CHANGE_COMPLETED,
   FORM_PAGE_FACILITY_OPEN_SUCCEEDED,
+  FORM_PAGE_FACILITY_OPEN_FAILED,
   FORM_FETCH_CHILD_FACILITIES,
   FORM_FETCH_CHILD_FACILITIES_SUCCEEDED,
+  FORM_FETCH_CHILD_FACILITIES_FAILED,
   FORM_VA_SYSTEM_CHANGED,
   FORM_ELIGIBILITY_CHECKS,
   FORM_ELIGIBILITY_CHECKS_SUCCEEDED,
+  FORM_ELIGIBILITY_CHECKS_FAILED,
   START_DIRECT_SCHEDULE_FLOW,
   FORM_CLINIC_PAGE_OPENED,
   FORM_CLINIC_PAGE_OPENED_SUCCEEDED,
   FORM_PAGE_COMMUNITY_CARE_PREFS_OPEN,
   FORM_PAGE_COMMUNITY_CARE_PREFS_OPEN_SUCCEEDED,
+  FORM_PAGE_COMMUNITY_CARE_PREFS_OPEN_FAILED,
   FORM_SUBMIT,
   FORM_SUBMIT_SUCCEEDED,
   FORM_SUBMIT_FAILED,
   FORM_TYPE_OF_CARE_PAGE_OPENED,
   FORM_SHOW_TYPE_OF_CARE_UNAVAILABLE_MODAL,
   FORM_HIDE_TYPE_OF_CARE_UNAVAILABLE_MODAL,
+  FORM_RESET,
 } from '../../actions/newAppointment';
 
 import systems from '../../api/facilities.json';
@@ -210,6 +215,19 @@ describe('VAOS reducer: newAppointment', () => {
         properties: {},
       });
     });
+
+    it('should set error when failed', () => {
+      const currentState = {
+        ...defaultState,
+      };
+      const action = {
+        type: FORM_PAGE_FACILITY_OPEN_FAILED,
+      };
+
+      const newState = newAppointmentReducer(currentState, action);
+
+      expect(newState.hasDataFetchingError).to.be.true;
+    });
   });
 
   describe('update facility data reducer', () => {
@@ -331,6 +349,18 @@ describe('VAOS reducer: newAppointment', () => {
       expect(newState.pages.vaFacility.properties.vaFacility).to.be.undefined;
       expect(newState.data.vaFacility).to.equal('983');
     });
+    it('should set error when failed', () => {
+      const currentState = {
+        ...defaultState,
+      };
+      const action = {
+        type: FORM_FETCH_CHILD_FACILITIES_FAILED,
+      };
+
+      const newState = newAppointmentReducer(currentState, action);
+
+      expect(newState.hasDataFetchingError).to.be.true;
+    });
   });
   describe('fetch eligibility checks reducers', () => {
     it('should set loading state for eligibility', () => {
@@ -367,6 +397,15 @@ describe('VAOS reducer: newAppointment', () => {
         action.eligibilityData.clinics,
       );
       expect(newState.eligibility['983_323']).to.not.be.undefined;
+    });
+
+    it('should set error state', () => {
+      const action = {
+        type: FORM_ELIGIBILITY_CHECKS_FAILED,
+      };
+
+      const newState = newAppointmentReducer(defaultState, action);
+      expect(newState.hasDataFetchingError).to.be.true;
     });
   });
   describe('open clinic page reducers', () => {
@@ -577,6 +616,16 @@ describe('VAOS reducer: newAppointment', () => {
         enumNames: ['Cheyenne, WY', 'Dayton, OH'],
       });
     });
+
+    it('should set error', () => {
+      const action = {
+        type: FORM_PAGE_COMMUNITY_CARE_PREFS_OPEN_FAILED,
+      };
+
+      const newState = newAppointmentReducer(defaultState, action);
+
+      expect(newState.hasDataFetchingError).to.be.true;
+    });
   });
   describe('submit request', () => {
     it('should set loading', () => {
@@ -654,5 +703,20 @@ describe('VAOS reducer: newAppointment', () => {
     const newState = newAppointmentReducer(currentState, action);
 
     expect(newState.showTypeOfCareUnavailableModal).to.be.false;
+  });
+
+  it('should reset form state', () => {
+    const currentState = {
+      data: { test: 'blah' },
+      hasDataFetchingError: true,
+    };
+    const action = {
+      type: FORM_RESET,
+    };
+
+    const newState = newAppointmentReducer(currentState, action);
+
+    expect(newState.data).to.deep.equal({});
+    expect(newState.hasDataFetchingError).to.be.false;
   });
 });

--- a/src/applications/vaos/utils/selectors.js
+++ b/src/applications/vaos/utils/selectors.js
@@ -41,6 +41,7 @@ export function getFormPageInfo(state, pageKey) {
     schema: getNewAppointment(state).pages[pageKey],
     data: getFormData(state),
     pageChangeInProgress: getNewAppointment(state).pageChangeInProgress,
+    hasDataFetchingError: getNewAppointment(state).hasDataFetchingError,
   };
 }
 


### PR DESCRIPTION
## Description
We have some gaps in our error handling and need to show error messages when different API calls fail. There's not much we can do when these fail, so a generic message should be enough.

I've also added some logic to reset the form after the confirmation page and also to redirect to the start of the form if you try to start in the middle, since these impact how we reset the form errors.

## Testing done
Local testing

## Screenshots
![Screen Shot 2019-12-02 at 3 43 38 PM](https://user-images.githubusercontent.com/634932/69996452-18f3f780-1520-11ea-8060-babd80e549a3.png)
![Screen Shot 2019-12-02 at 3 28 21 PM](https://user-images.githubusercontent.com/634932/69996453-18f3f780-1520-11ea-9d3a-ce2cb8fbe364.png)


## Acceptance criteria
- [ ] API calls in actions have appropriately handled failure cases.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
