### PR TITLE
Send the App-Name header with each API request

### DIFF
--- a/src/platform/startup/index.js
+++ b/src/platform/startup/index.js
@@ -40,6 +40,9 @@ export default function startApp({
   // Set further errors to have the appropriate source tag
   Sentry.setTag('source', entryName);
 
+  // Set the app name for use in the apiRequest helper
+  window.appName = entryName;
+
   const store = createCommonStore(reducer, analyticsEvents);
   connectFeatureToggle(store.dispatch);
 

--- a/src/platform/utilities/api/index.js
+++ b/src/platform/utilities/api/index.js
@@ -66,6 +66,7 @@ export function apiRequest(resource, optionalSettings = {}, success, error) {
     credentials: 'include',
     headers: {
       'X-Key-Inflection': 'camel',
+      'App-Name': window.appName,
     },
   };
 

--- a/src/platform/utilities/api/index.js
+++ b/src/platform/utilities/api/index.js
@@ -66,7 +66,7 @@ export function apiRequest(resource, optionalSettings = {}, success, error) {
     credentials: 'include',
     headers: {
       'X-Key-Inflection': 'camel',
-      'App-Name': window.appName,
+      'Source-App-Name': window.appName,
     },
   };
 


### PR DESCRIPTION
## Description
Like it says on the tin.

Not sure what we want to actually call the header, though. @omgitsbillryan Do you have ideas or opinions?

## Testing done
Manually checked that it was there. See screenshots below.

## Screenshots
### From in an app
![image](https://user-images.githubusercontent.com/12970166/70002028-be549e80-1513-11ea-9409-fb55e4ad4e5e.png)

### From a static page
![image](https://user-images.githubusercontent.com/12970166/70001988-a9780b00-1513-11ea-8436-b28537eeadab.png)
I'm not sure if we want to omit the header when it's undefined, or use a sane default. This will happen for one of three reasons:
- The API request is made from a static page
  - Probably just trying to log in, but maybe something else
- The app was bootstrapped using something other than `startApp`
  - Maybe like in a React widget on a static page
- The `entryName` is undefined somehow in `startApp`
  - Shouldn't ever happen, but y'never know

It's also worth noting that if an app makes an API call without using the `apiRequest` helper, the request won't get this header (unless specified manually, of course). I don't _think_ we're doing that anywhere, but like I said, it's worth mentioning.

## Acceptance criteria
- [ ] The header is sent

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
