### PR TITLE
HLR: Fix review page a11y issues

### DIFF
--- a/src/applications/disability-benefits/996/containers/ForwardingAddressReviewField.jsx
+++ b/src/applications/disability-benefits/996/containers/ForwardingAddressReviewField.jsx
@@ -17,7 +17,7 @@ export default function ForwardingAddressReviewField(props) {
         {forwardingAddressCheckboxDescription}
       </dt>
       <dd>
-        <strong className="vads-u-flex-1">{children}</strong>
+        <strong>{children}</strong>
       </dd>
     </div>
   ) : (

--- a/src/applications/disability-benefits/996/containers/ForwardingAddressReviewField.jsx
+++ b/src/applications/disability-benefits/996/containers/ForwardingAddressReviewField.jsx
@@ -8,18 +8,17 @@ import {
 export default function ForwardingAddressReviewField(props) {
   const { children } = props;
 
-  // Not using <dt> & <dd> as the <dt> matches the width of the other
-  // elements inside the wrapping <dl>. The design calls for the content
-  // to be much wider
   return children?.props.formData ? (
-    <div className="review-row vads-u-display--flex">
-      <div className="vads-u-flex-fill">
+    <div className="review-row">
+      <dt className="vads-u-measure--none">
         {forwardingAddressCheckboxLabel}
         <br />
         <br />
         {forwardingAddressCheckboxDescription}
-      </div>
-      <strong className="vads-u-flex-1">{children}</strong>
+      </dt>
+      <dd>
+        <strong className="vads-u-flex-1">{children}</strong>
+      </dd>
     </div>
   ) : (
     <div className="review-row">

--- a/src/applications/disability-benefits/996/containers/ScheduleTimesReviewField.jsx
+++ b/src/applications/disability-benefits/996/containers/ScheduleTimesReviewField.jsx
@@ -18,13 +18,13 @@ export default function ScheduleTimesReviewField(props) {
   const timeSlot = informalConferenceTimeAllLabels?.[children?.props.name];
 
   return (
-    <dl className="review-row">
+    <div className="review-row">
       <dt>
         <span className="time-contact" role="presentation">
           {label}
         </span>
       </dt>
       <dd>{timeSlot}</dd>
-    </dl>
+    </div>
   );
 }

--- a/src/applications/disability-benefits/996/containers/ScheduleTimesReviewField.jsx
+++ b/src/applications/disability-benefits/996/containers/ScheduleTimesReviewField.jsx
@@ -19,11 +19,7 @@ export default function ScheduleTimesReviewField(props) {
 
   return (
     <div className="review-row">
-      <dt>
-        <span className="time-contact" role="presentation">
-          {label}
-        </span>
-      </dt>
+      <dt>{label}</dt>
       <dd>{timeSlot}</dd>
     </div>
   );

--- a/src/applications/disability-benefits/all-claims/components/SelectArrayItemsWidget.jsx
+++ b/src/applications/disability-benefits/all-claims/components/SelectArrayItemsWidget.jsx
@@ -26,7 +26,7 @@ export default class SelectArrayItemsWidget extends React.Component {
 
     // Note: Much of this was stolen from CheckboxWidget
     return (
-      <div>
+      <>
         {customTitle &&
           items && <h5 className="all-disabilities-title">{customTitle}</h5>}
         {items &&
@@ -49,27 +49,32 @@ export default class SelectArrayItemsWidget extends React.Component {
             );
 
             return (
-              <div key={index} className={widgetClasses}>
-                <input
-                  type="checkbox"
-                  id={elementId}
-                  name={elementId}
-                  checked={
-                    typeof itemIsSelected === 'undefined'
-                      ? false
-                      : itemIsSelected
-                  }
-                  required={required}
-                  disabled={itemIsDisabled}
-                  onChange={event => this.onChange(index, event.target.checked)}
-                />
-                <label className="schemaform-label" htmlFor={elementId}>
-                  {labelWithData}
-                </label>
+              <div key={index}>
+                <dt className={widgetClasses}>
+                  <input
+                    type="checkbox"
+                    id={elementId}
+                    name={elementId}
+                    checked={
+                      typeof itemIsSelected === 'undefined'
+                        ? false
+                        : itemIsSelected
+                    }
+                    required={required}
+                    disabled={itemIsDisabled}
+                    onChange={event =>
+                      this.onChange(index, event.target.checked)
+                    }
+                  />
+                  <label className="schemaform-label" htmlFor={elementId}>
+                    {labelWithData}
+                  </label>
+                </dt>
+                <dd />
               </div>
             );
           })}
-      </div>
+      </>
     );
   }
 }

--- a/src/platform/forms-system/src/js/review/ArrayField.jsx
+++ b/src/platform/forms-system/src/js/review/ArrayField.jsx
@@ -207,7 +207,9 @@ class ArrayField extends React.Component {
       <div className={itemsNeeded ? 'schemaform-review-array-warning' : null}>
         {title && (
           <div className="form-review-panel-page-header-row">
-            <h5 className="form-review-panel-page-header">{title}</h5>
+            {title ? (
+              <h5 className="form-review-panel-page-header">{title}</h5>
+            ) : null}
             {itemsNeeded && (
               <span className="schemaform-review-array-warning-icon" />
             )}

--- a/src/platform/forms-system/src/js/review/ObjectField.jsx
+++ b/src/platform/forms-system/src/js/review/ObjectField.jsx
@@ -139,9 +139,9 @@ class ObjectField extends React.Component {
         <>
           {!formContext.hideHeaderRow && (
             <div className="form-review-panel-page-header-row">
-              <h5 className="form-review-panel-page-header">
-                {!formContext.hideTitle ? title : null}
-              </h5>
+              {formContext.hideTitle || title.trim() === '' ? null : (
+                <h5 className="form-review-panel-page-header">{title}</h5>
+              )}
               <button
                 type="button"
                 className="edit-btn primary-outline"

--- a/src/platform/forms-system/test/js/review/ObjectField.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/review/ObjectField.unit.spec.jsx
@@ -133,7 +133,8 @@ describe('Schemaform review: ObjectField', () => {
 
     expect(tree.everySubTree('.form-review-panel-page-header-row')).not.to.be
       .empty;
-    expect(tree.subTree('.form-review-panel-page-header').text()).to.be.empty;
+    // Empty headers are no longer rendered
+    expect(tree.subTree('.form-review-panel-page-header')).to.be.false;
   });
   it('should hide expand under items when collapsed', () => {
     const onChange = sinon.spy();

--- a/src/platform/forms-system/test/js/review/ReviewCollapsibleChapter.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/review/ReviewCollapsibleChapter.unit.spec.jsx
@@ -522,7 +522,6 @@ describe('<ReviewCollapsibleChapter>', () => {
     const titleDiv = wrapper.find('.form-review-panel-page-header');
     // Title is no longer rendered if it contains an empty string
     expect(titleDiv.length).to.equal(0);
-    // expect(titleDiv.text()).to.equal('');
 
     wrapper.unmount();
   });

--- a/src/platform/forms-system/test/js/review/ReviewCollapsibleChapter.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/review/ReviewCollapsibleChapter.unit.spec.jsx
@@ -520,8 +520,9 @@ describe('<ReviewCollapsibleChapter>', () => {
     );
 
     const titleDiv = wrapper.find('.form-review-panel-page-header');
-    expect(titleDiv.length).to.equal(1);
-    expect(titleDiv.text()).to.equal('');
+    // Title is no longer rendered if it contains an empty string
+    expect(titleDiv.length).to.equal(0);
+    // expect(titleDiv.text()).to.equal('');
 
     wrapper.unmount();
   });


### PR DESCRIPTION
## Description

The axe browser extension reported a few a11y issues that are fixed in this PR:

* Remove nested `<div>`s within `<dl>` elements.
* Must include `<dt>` and `<dd>` elements within a `<dl>`.
* Do not render empty headers

## Testing done

Updated unit tests that checked for a rendered header

## Screenshots

N/A - changes are within the markup

## Acceptance criteria
- [ ] axe extension no longer reports issues with nested divs or empty headers on the review page

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
