### PR TITLE
Integrate request limits call in VAOS

### DIFF
--- a/src/applications/vaos/api/index.js
+++ b/src/applications/vaos/api/index.js
@@ -213,17 +213,24 @@ export function checkPastVisits(facilityId, typeOfCareId, directOrRequest) {
   });
 }
 
-// GET /vaos/facilities/{facilityId}/limits
-// eslint-disable-next-line no-unused-vars
 export function getRequestLimits(facilityId, typeOfCareId) {
-  return new Promise(resolve => {
-    setTimeout(() => {
-      resolve({
-        requestLimit: 1,
-        numberOfRequests: facilityId.includes('984') ? 1 : 0,
-      });
-    }, 500);
-  });
+  let promise;
+  if (USE_MOCK_DATA) {
+    promise = Promise.resolve({
+      data: {
+        attributes: {
+          requestLimit: 1,
+          numberOfRequests: facilityId.includes('984') ? 1 : 0,
+        },
+      },
+    });
+  } else {
+    promise = apiRequest(
+      `/vaos/facilities/${facilityId}/limits?type_of_care_id=${typeOfCareId}`,
+    );
+  }
+
+  return promise.then(resp => resp.data.attributes);
 }
 
 export function getClinics(facilityId, typeOfCareId) {

--- a/src/applications/vaos/tests/actions/newAppointment.unit.spec.js
+++ b/src/applications/vaos/tests/actions/newAppointment.unit.spec.js
@@ -282,7 +282,15 @@ describe('VAOS newAppointment actions', () => {
     });
 
     it('should fetch eligibility info if facility is selected', async () => {
-      setFetchJSONResponse(global.fetch, clinics);
+      setFetchJSONResponse(global.fetch, {
+        data: {
+          attributes: {
+            numberOfRequests: 0,
+            requestLimit: 0,
+          },
+        },
+      });
+      setFetchJSONResponse(global.fetch.onCall(1), clinics);
       const dispatch = sinon.spy();
       const previousState = {
         ...defaultState,


### PR DESCRIPTION
## Description
This adds a real api call for the request limits endpoint

## Testing done
Local and unit testing

## Acceptance criteria
- [ ] API is called to get request limits

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
