### PR TITLE
Prevent users from entering invalid zip codes

### DIFF
--- a/src/applications/letters/components/ErrorableTextInput.jsx
+++ b/src/applications/letters/components/ErrorableTextInput.jsx
@@ -49,7 +49,7 @@ class ErrorableTextInput extends React.Component {
 
     // Calculate max characters and display '(Max. XX characters)' when max is hit.
     if (this.props.value) {
-      if (this.props.charMax === this.props.value.length) {
+      if (this.props.charMax < this.props.value.length) {
         maxCharacters = <small>(Max. {this.props.charMax} characters)</small>;
       }
     }

--- a/src/platform/user/profile/vet360/components/AddressField/AddressEditModal.jsx
+++ b/src/platform/user/profile/vet360/components/AddressField/AddressEditModal.jsx
@@ -17,7 +17,7 @@ export default class AddressEditModal extends React.Component {
       ...this.props.field.value,
       [field]: value,
     };
-    this.props.onChange(newFieldValue, field);
+    this.props.onChange(newFieldValue, field, true);
   };
 
   getInitialFormValues = () =>

--- a/src/platform/user/profile/vet360/components/AddressField/AddressField.jsx
+++ b/src/platform/user/profile/vet360/components/AddressField/AddressField.jsx
@@ -63,6 +63,16 @@ export const convertNextValueToCleanData = value => {
   };
 };
 
+const validateZipCode = zipCode => {
+  let result = '';
+  if (!zipCode) {
+    result = 'Zip code is required';
+  } else if (!zipCode.match(/\d{5}/)) {
+    result = 'Zip code must be 5 digits';
+  }
+  return result;
+};
+
 export const validateCleanData = (
   {
     addressLine1,
@@ -92,9 +102,9 @@ export const validateCleanData = (
         ? 'State is required'
         : '',
     zipCode:
-      (property === 'zipCode' || validateAll) && !isInternational && !zipCode
-        ? 'Zip code is required'
-        : '',
+      (property === 'zipCode' || validateAll) &&
+      !isInternational &&
+      validateZipCode(zipCode),
     internationalPostalCode:
       (property === 'internationalPostalCode' || validateAll) &&
       isInternational &&

--- a/src/platform/user/profile/vet360/components/AddressField/AddressForm.jsx
+++ b/src/platform/user/profile/vet360/components/AddressField/AddressForm.jsx
@@ -141,7 +141,7 @@ class AddressForm extends React.Component {
           />
         )}
 
-        {/* Hide the zip code for addresseses that aren't in the US */}
+        {/* Hide the zip code for addresses that aren't in the US */}
         {isUSA && (
           <ErrorableTextInput
             errorMessage={errorMessages.zipCode}


### PR DESCRIPTION
## Description
This prevents the user from entering and submitting bad zip code; they are now forced to enter 5 digits while previously they could enter non-digits and less than 5 characters.

## Testing done
Local

## Screenshots
The new error message:
![image](https://user-images.githubusercontent.com/20728956/70076020-cc0d3100-15b2-11ea-95a8-f4543bfc1c68.png)

And the old one also still shows up when needed:
![image](https://user-images.githubusercontent.com/20728956/70076059-de876a80-15b2-11ea-8d28-ef19e0df8884.png)

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs