### PR TITLE
UI changes to the claim status tool to clarify sorting

### DIFF
--- a/src/applications/claims-status/components/appeals-v2/AppealListItemV2.jsx
+++ b/src/applications/claims-status/components/appeals-v2/AppealListItemV2.jsx
@@ -66,7 +66,7 @@ export default function AppealListItem({ appeal, name, external = false }) {
   // "Disability Compensation Appeal Receieved March 6, 2019"
   //
   // programArea or requestEvent might be missing:
-  // "Appeal Received March 6, 2019"
+  // "Appeal updated on March 6, 2019"
   // "Disability Compensation Appeal"
 
   let appealTitle = '';
@@ -83,11 +83,9 @@ export default function AppealListItem({ appeal, name, external = false }) {
     }
   }
 
-  if (requestEvent) {
-    appealTitle += ` received ${moment(requestEvent.date).format(
-      'MMMM D, YYYY',
-    )}`;
-  }
+  appealTitle += ` updated on ${moment(appeal.attributes.updated).format(
+    'MMMM D, YYYY',
+  )}`;
   appealTitle = capitalizeWord(appealTitle);
 
   return (
@@ -113,6 +111,14 @@ export default function AppealListItem({ appeal, name, external = false }) {
           </strong>{' '}
           {appeal.attributes.description}
         </p>
+      )}
+      {requestEvent && (
+        <div className="card-status">
+          <p>
+            <strong>Submitted on:</strong>{' '}
+            {moment(requestEvent.date).format('MMMM D, YYYY')}
+          </p>
+        </div>
       )}
       {!external && (
         <Link

--- a/src/applications/claims-status/components/appeals-v2/AppealListItemV2.jsx
+++ b/src/applications/claims-status/components/appeals-v2/AppealListItemV2.jsx
@@ -57,6 +57,8 @@ export default function AppealListItem({ appeal, name, external = false }) {
   const requestEvent = appeal.attributes.events.find(
     event => event.type === requestEventType,
   );
+  const updatedEventDateString =
+    appeal.attributes.events[appeal.attributes.events.length - 1].date;
   const programArea = programAreaMap[appeal.attributes.programArea];
 
   // appealTitle is in the format:
@@ -83,7 +85,7 @@ export default function AppealListItem({ appeal, name, external = false }) {
     }
   }
 
-  appealTitle += ` updated on ${moment(appeal.attributes.updated).format(
+  appealTitle += ` updated on ${moment(updatedEventDateString).format(
     'MMMM D, YYYY',
   )}`;
   appealTitle = capitalizeWord(appealTitle);

--- a/src/applications/claims-status/components/appeals-v2/ClaimsListItemV2.jsx
+++ b/src/applications/claims-status/components/appeals-v2/ClaimsListItemV2.jsx
@@ -15,7 +15,7 @@ function listPhase(phase) {
 
 export default function ClaimsListItem({ claim }) {
   const inProgress = !isClaimComplete(claim);
-  const formattedReceiptDate = moment(claim.attributes.dateFiled).format(
+  const formattedUpdatedOnDate = moment(claim.attributes.updatedAt).format(
     'MMMM D, YYYY',
   );
   return (
@@ -23,7 +23,7 @@ export default function ClaimsListItem({ claim }) {
       <h3 className="claim-list-item-header-v2">
         Claim for {getClaimType(claim)}
         <br />
-        received {formattedReceiptDate}
+        updated on {formattedUpdatedOnDate}
       </h3>
       <div className="card-status">
         <div
@@ -55,8 +55,14 @@ export default function ClaimsListItem({ claim }) {
           </li>
         ) : null}
       </ul>
+      <div className="card-status">
+        <p>
+          <strong>Submitted on:</strong>{' '}
+          {moment(claim.attributes.dateFiled).format('MMMM D, YYYY')}
+        </p>
+      </div>
       <Link
-        aria-label={`View status of claim received ${formattedReceiptDate}`}
+        aria-label={`View status of claim received ${formattedUpdatedOnDate}`}
         className="usa-button usa-button-primary"
         to={`your-claims/${claim.id}/status`}
       >

--- a/src/applications/claims-status/components/appeals-v2/ClaimsListItemV2.jsx
+++ b/src/applications/claims-status/components/appeals-v2/ClaimsListItemV2.jsx
@@ -15,7 +15,7 @@ function listPhase(phase) {
 
 export default function ClaimsListItem({ claim }) {
   const inProgress = !isClaimComplete(claim);
-  const formattedUpdatedOnDate = moment(claim.attributes.updatedAt).format(
+  const formattedReceiptDate = moment(claim.attributes.dateFiled).format(
     'MMMM D, YYYY',
   );
   return (
@@ -23,7 +23,8 @@ export default function ClaimsListItem({ claim }) {
       <h3 className="claim-list-item-header-v2">
         Claim for {getClaimType(claim)}
         <br />
-        updated on {formattedUpdatedOnDate}
+        updated on{' '}
+        {moment(claim.attributes.phaseChangeDate).format('MMMM D, YYYY')}
       </h3>
       <div className="card-status">
         <div
@@ -57,12 +58,11 @@ export default function ClaimsListItem({ claim }) {
       </ul>
       <div className="card-status">
         <p>
-          <strong>Submitted on:</strong>{' '}
-          {moment(claim.attributes.dateFiled).format('MMMM D, YYYY')}
+          <strong>Submitted on:</strong> {formattedReceiptDate}
         </p>
       </div>
       <Link
-        aria-label={`View status of claim received ${formattedUpdatedOnDate}`}
+        aria-label={`View status of claim received ${formattedReceiptDate}`}
         className="usa-button usa-button-primary"
         to={`your-claims/${claim.id}/status`}
       >

--- a/src/applications/claims-status/tests/components/appeals-v2/AppealListItemV2.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/appeals-v2/AppealListItemV2.unit.spec.jsx
@@ -93,7 +93,7 @@ describe('<AppealListItemV2/>', () => {
         .find('h3.claim-list-item-header-v2')
         .render()
         .text(),
-    ).to.equal('Supplemental claim for health care received May 1, 2016');
+    ).to.equal('Supplemental claim for health care updated on May 1, 2016');
     wrapper.unmount();
   });
 

--- a/src/applications/claims-status/tests/components/appeals-v2/AppealListItemV2.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/appeals-v2/AppealListItemV2.unit.spec.jsx
@@ -86,6 +86,17 @@ describe('<AppealListItemV2/>', () => {
     wrapper.unmount();
   });
 
+  it('should show the right date with submitted on', () => {
+    const wrapper = shallow(<AppealListItemV2 {...defaultProps} />);
+    expect(
+      wrapper
+        .find('p')
+        .last()
+        .text(),
+    ).to.equal('Submitted on: May 1, 2016');
+    wrapper.unmount();
+  });
+
   it('should correctly title a VHA Supplemental Claim', () => {
     const wrapper = shallow(<AppealListItemV2 {...vhaScProps} />);
     expect(

--- a/src/applications/claims-status/tests/components/appeals-v2/ClaimListItemV2.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/appeals-v2/ClaimListItemV2.unit.spec.jsx
@@ -167,4 +167,25 @@ describe('<ClaimsListItemV2>', () => {
     ).to.equal(`your-claims/${claim.id}/status`);
     tree.unmount();
   });
+
+  it('should render updated on and submitted on with proper date', () => {
+    const claim = {
+      id: 1,
+      attributes: {
+        phase: 8,
+        open: false,
+        phaseChangeDate: '2019-08-20',
+        dateFiled: '2019-02-10',
+      },
+    };
+    const tree = shallow(<ClaimsListItemV2 claim={claim} />);
+    expect(tree.find('h3').text()).to.contain('updated on August 20, 2019');
+    expect(
+      tree
+        .find('p')
+        .last()
+        .text(),
+    ).to.equal('Submitted on: February 10, 2019');
+    tree.unmount();
+  });
 });

--- a/src/applications/claims-status/tests/e2e/00.claims-list.e2e.spec.js
+++ b/src/applications/claims-status/tests/e2e/00.claims-list.e2e.spec.js
@@ -31,9 +31,9 @@ module.exports = E2eHelpers.createE2eTest(client => {
 
   client.expect
     .element('.claim-list-item-header-v2')
-    // .text.to.equal('Disability Compensation Claim – Received September 23, 2008');
+    // .text.to.equal('Disability Compensation Claim – updated on September 23, 2008');
     .text.to.equal(
-      'Claim for disability compensation\nreceived September 23, 2008',
+      'Claim for disability compensation\nupdated on September 23, 2008',
     );
 
   // Click to detail view

--- a/src/applications/claims-status/tests/e2e/00.claims-list.e2e.spec.js
+++ b/src/applications/claims-status/tests/e2e/00.claims-list.e2e.spec.js
@@ -33,7 +33,7 @@ module.exports = E2eHelpers.createE2eTest(client => {
     .element('.claim-list-item-header-v2')
     // .text.to.equal('Disability Compensation Claim – updated on September 23, 2008');
     .text.to.equal(
-      'Claim for disability compensation\nupdated on September 23, 2008',
+      'Claim for disability compensation\nupdated on October 31, 2016',
     );
 
   // Click to detail view


### PR DESCRIPTION
## Description
The claim status tool orders the claims/appeals by the date they were updated, but this is not indicated to the user in any way. In fact, the only prevalent date on the page is the date the claim/appeal was received, which is confusing to a user as it appears that all the claims/appeals are out of order. To clarify the sorting, some UI changes have been made.

## Screenshots
![image](https://user-images.githubusercontent.com/53942725/70164353-00561f80-168f-11ea-9cf5-b180d4002deb.png)

## Acceptance criteria
- [ ] UI changes have been made to the claim status tool to clarify how the claims/appeals are sorted
