### PR TITLE
Fix HLR wizard button issues

### DIFF
--- a/src/applications/disability-benefits/996/components/HLRWizard.jsx
+++ b/src/applications/disability-benefits/996/components/HLRWizard.jsx
@@ -29,9 +29,10 @@ const HLRWizard = ({ initChoice = null, initExpanded = false }) => {
     <>
       <button
         type="button"
-        aria-expanded="false"
+        aria-expanded={expanded}
         aria-controls="wizardOptions"
-        classnames="usa-button-primary wizard-button va-button-primary"
+        className={`usa-button-primary wizard-button ${!expanded &&
+          'va-button-primary'}`}
         onClick={() => setExpanded(!expanded)}
       >
         {wizardButtonText}

--- a/src/applications/disability-benefits/996/components/HLRWizard.jsx
+++ b/src/applications/disability-benefits/996/components/HLRWizard.jsx
@@ -31,8 +31,9 @@ const HLRWizard = ({ initChoice = null, initExpanded = false }) => {
         type="button"
         aria-expanded={expanded}
         aria-controls="wizardOptions"
-        className={`usa-button-primary wizard-button ${!expanded &&
-          'va-button-primary'}`}
+        className={`usa-button-primary wizard-button${
+          expanded ? '' : ' va-button-primary'
+        }`}
         onClick={() => setExpanded(!expanded)}
       >
         {wizardButtonText}

--- a/src/applications/disability-benefits/996/tests/containers/HLR-wizard.unit.spec.jsx
+++ b/src/applications/disability-benefits/996/tests/containers/HLR-wizard.unit.spec.jsx
@@ -9,14 +9,20 @@ const getSelected = tree =>
   tree.subTree('ErrorableRadioButtons').props.value.value;
 
 describe('<HLRWizard>', () => {
-  it('should show button and no questions', () => {
+  it('should show button and no questions (collapsed)', () => {
     const tree = SkinDeep.shallowRender(<HLRWizard />);
-    expect(tree.subTree('button')).not.to.be.false;
+    const button = tree.subTree('button');
+    expect(button).not.to.be.false;
+    expect(button.props['aria-expanded']).to.be.false;
+    expect(button.props.className).to.include('va-button-primary');
     expect(tree.subTree('#wizardOptions')).to.be.false;
   });
-  it('should show button empty choices', () => {
+  it('should show button empty choices (expanded)', () => {
     const tree = SkinDeep.shallowRender(<HLRWizard initExpanded />);
-    expect(tree.subTree('button')).not.to.be.false;
+    const button = tree.subTree('button');
+    expect(button).not.to.be.false;
+    expect(button.props['aria-expanded']).not.to.be.false;
+    expect(button.props.className).not.to.include('va-button-primary');
     expect(tree.subTree('#wizardOptions')).not.to.be.false;
     expect(getSelected(tree)).to.be.null;
     expect(tree.subTree('.usa-button')).to.be.false;


### PR DESCRIPTION
## Description

The HLR gating wizard button is the wrong color, and the `aria-expanded` attribute is not properly being updated after clicking the wizard button.

## Testing done

Updated unit tests to include aria-expanded & class name checked

## Screenshots

Note: The arrow inside the button is not included in these screenshots because of the testing environment. They will be visible when injected into the static page

<details>
<summary>HLR wizard collapsed</summary>

<!-- leave a blank line above -->
![Screen Shot 2019-12-03 at 5 04 41 PM](https://user-images.githubusercontent.com/136959/70097941-37c1bf00-15f0-11ea-8349-7a075c1124e2.png)
</details>
<details>
<summary>HLR Wizard expanded</summary>

<!-- leave a blank line above -->
![Screen Shot 2019-12-03 at 5 05 51 PM](https://user-images.githubusercontent.com/136959/70097955-414b2700-15f0-11ea-831d-ed9e295d45c7.png)
</details>

## Acceptance criteria
- [ ] HLR wizard button is the correct color when collapsed & expanded.
- [ ] The `aria-expanded` attribute is appropriately updated.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
