### PR TITLE
20061: SCO: Update 'See past announcements' link

### DIFF
--- a/src/applications/static-pages/school-resources/ScoAnnouncementsWidget.jsx
+++ b/src/applications/static-pages/school-resources/ScoAnnouncementsWidget.jsx
@@ -84,10 +84,10 @@ export default class ScoAnnouncementsWidget extends React.Component {
         {this.renderAnnouncements()}
         <p className="vads-u-margin-bottom--0">
           <a
-            href="https://benefits.va.gov/gibill/index.asp"
+            href="https://www.benefits.va.gov/GIBILL/index.asp#Announcements "
             className="vads-u-text-decoration--none"
           >
-            See past announcements...
+            See all announcements...
           </a>
         </p>
       </div>


### PR DESCRIPTION
## Description
As a developer, I need to update the "See past announcements" link so that it matches the update content and design.

https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/vets.gov-team/20061

## Testing done
Testing passes locally

## Screenshots
![image](https://user-images.githubusercontent.com/48804834/70172898-ae69c580-169f-11ea-8693-4466b950717b.png)


## Acceptance criteria
- [x] The "See past announcements" link text is replaced with "See all announcements...".
- [x] The link links to the following page: https://www.benefits.va.gov/GIBILL/index.asp#Announcements 

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
