### PR TITLE
Update VAOS to use Community Care and direct scheduling feature flags

### DIFF
--- a/src/applications/vaos/newAppointmentFlow.js
+++ b/src/applications/vaos/newAppointmentFlow.js
@@ -4,6 +4,8 @@ import {
   getNewAppointment,
   getEligibilityStatus,
   getClinicsForChosenFacility,
+  vaosCommunityCare,
+  vaosDirectScheduling,
 } from './utils/selectors';
 import { FACILITY_TYPES, FLOW_TYPES, TYPES_OF_CARE } from './utils/constants';
 import {
@@ -71,34 +73,37 @@ export default {
     url: '/new-appointment',
     async next(state, dispatch) {
       let nextState = 'vaFacility';
+      const communityCareEnabled = vaosCommunityCare(state);
 
       if (isSleepCare(state)) {
         nextState = 'typeOfSleepCare';
       } else if (isCommunityCare(state)) {
         try {
-          // Check if user registered systems support community care...
-          const userSystemIds = await getSystemIdentifiers();
-          const ccSites = await getSitesSupportingVAR();
-          const ccEnabledSystems = userSystemIds
-            .map(system => system.assigningAuthority.substr(4))
-            .filter(id => ccSites.some(site => site._id === id));
-          dispatch(updateCCEnabledSystems(ccEnabledSystems));
+          if (communityCareEnabled) {
+            // Check if user registered systems support community care...
+            const userSystemIds = await getSystemIdentifiers();
+            const ccSites = await getSitesSupportingVAR();
+            const ccEnabledSystems = userSystemIds
+              .map(system => system.assigningAuthority.substr(4))
+              .filter(id => ccSites.some(site => site._id === id));
+            dispatch(updateCCEnabledSystems(ccEnabledSystems));
 
-          // Reroute to VA facility page if none of the user's registered systems support community care.
-          if (ccEnabledSystems.length) {
-            const data = await getCommunityCare(
-              '/vaos/community-care/eligibility',
-            );
+            // Reroute to VA facility page if none of the user's registered systems support community care.
+            if (ccEnabledSystems.length) {
+              const data = await getCommunityCare(
+                '/vaos/community-care/eligibility',
+              );
 
-            dispatch(updateCCEligibility(data.isEligible));
+              dispatch(updateCCEligibility(data.isEligible));
 
-            if (data.isEligible) {
-              // If CC enabled systems and toc is podiatry, skip typeOfFacility
-              if (isPodiatry(state)) {
-                dispatch(updateFacilityType(FACILITY_TYPES.COMMUNITY_CARE));
-                return 'requestDateTime';
+              if (data.isEligible) {
+                // If CC enabled systems and toc is podiatry, skip typeOfFacility
+                if (isPodiatry(state)) {
+                  dispatch(updateFacilityType(FACILITY_TYPES.COMMUNITY_CARE));
+                  return 'requestDateTime';
+                }
+                return 'typeOfFacility';
               }
-              return 'typeOfFacility';
             }
           }
 
@@ -115,10 +120,12 @@ export default {
           Sentry.captureMessage(
             'Community Care eligibility check failed with errors',
           );
+          dispatch(updateFacilityType(FACILITY_TYPES.VAMC));
           return 'vaFacility';
         }
       }
 
+      dispatch(updateFacilityType(FACILITY_TYPES.VAMC));
       return nextState;
     },
     previous: 'home',
@@ -140,7 +147,7 @@ export default {
   },
   typeOfSleepCare: {
     url: '/new-appointment/choose-sleep-care',
-    next: 'typeOfFacility',
+    next: 'vaFacility',
     previous: 'typeOfCare',
   },
   audiologyCareType: {
@@ -165,8 +172,9 @@ export default {
       const eligibilityStatus = getEligibilityStatus(state);
       const clinics = getClinicsForChosenFacility(state);
       const facilityId = getFormData(state).vaFacility;
+      const directSchedulingEnabled = vaosDirectScheduling(state);
 
-      if (eligibilityStatus.direct) {
+      if (directSchedulingEnabled && eligibilityStatus.direct) {
         try {
           const appointments = await getLongTermAppointmentHistory();
 
@@ -188,8 +196,9 @@ export default {
     },
     previous(state) {
       let nextState = 'typeOfCare';
+      const communityCareEnabled = vaosCommunityCare(state);
 
-      if (isCCEligible(state)) {
+      if (communityCareEnabled && isCCEligible(state)) {
         nextState = 'typeOfFacility';
       }
 

--- a/src/applications/vaos/tests/newAppointmentFlow.unit.spec.js
+++ b/src/applications/vaos/tests/newAppointmentFlow.unit.spec.js
@@ -80,6 +80,11 @@ describe('VAOS newAppointmentFlow', () => {
   });
   describe('va facility page', () => {
     const defaultState = {
+      featureToggles: {
+        loading: false,
+        vaOnlineSchedulingDirect: true,
+        vaOnlineSchedulingCommunityCare: true,
+      },
       newAppointment: {
         data: {
           typeOfCareId: '323',
@@ -388,6 +393,11 @@ describe('VAOS newAppointmentFlow', () => {
       });
 
       const state = {
+        featureToggles: {
+          loading: false,
+          vaOnlineSchedulingDirect: true,
+          vaOnlineSchedulingCommunityCare: true,
+        },
         newAppointment: {
           data: {
             typeOfCareId: '372',
@@ -410,6 +420,11 @@ describe('VAOS newAppointmentFlow', () => {
         data: [{ attributes: { assigningAuthority: 'dfn-000' } }],
       });
       const state = {
+        featureToggles: {
+          loading: false,
+          vaOnlineSchedulingDirect: true,
+          vaOnlineSchedulingCommunityCare: true,
+        },
         newAppointment: {
           data: {
             typeOfCareId: 'tbd-podiatry',
@@ -430,6 +445,11 @@ describe('VAOS newAppointmentFlow', () => {
       mockFetch();
       setFetchJSONResponse(global.fetch, systems);
       const state = {
+        featureToggles: {
+          loading: false,
+          vaOnlineSchedulingDirect: true,
+          vaOnlineSchedulingCommunityCare: true,
+        },
         newAppointment: {
           data: {
             typeOfCareId: 'tbd-podiatry',
@@ -447,7 +467,13 @@ describe('VAOS newAppointmentFlow', () => {
     });
 
     it('should choose Sleep care page', async () => {
+      const dispatch = sinon.spy();
       const state = {
+        featureToggles: {
+          loading: false,
+          vaOnlineSchedulingDirect: true,
+          vaOnlineSchedulingCommunityCare: true,
+        },
         newAppointment: {
           data: {
             typeOfCareId: 'SLEEP',
@@ -455,7 +481,10 @@ describe('VAOS newAppointmentFlow', () => {
         },
       };
 
-      const nextState = await newAppointmentFlow.typeOfCare.next(state);
+      const nextState = await newAppointmentFlow.typeOfCare.next(
+        state,
+        dispatch,
+      );
       expect(nextState).to.equal('typeOfSleepCare');
     });
 
@@ -463,6 +492,11 @@ describe('VAOS newAppointmentFlow', () => {
       mockFetch();
       setFetchJSONResponse(global.fetch, systems);
       const state = {
+        featureToggles: {
+          loading: false,
+          vaOnlineSchedulingDirect: true,
+          vaOnlineSchedulingCommunityCare: true,
+        },
         newAppointment: {
           data: {
             typeOfCareId: '323',

--- a/src/applications/vaos/utils/selectors.js
+++ b/src/applications/vaos/utils/selectors.js
@@ -249,3 +249,7 @@ export const vaosApplication = state => toggleValues(state).vaOnlineScheduling;
 export const vaosCancel = state => toggleValues(state).vaOnlineSchedulingCancel;
 export const vaosRequests = state =>
   toggleValues(state).vaOnlineSchedulingRequests;
+export const vaosCommunityCare = state =>
+  toggleValues(state).vaOnlineSchedulingCommunityCare;
+export const vaosDirectScheduling = state =>
+  toggleValues(state).vaOnlineSchedulingDirect;

--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -5,6 +5,8 @@ const FEATURE_FLAG_NAMES = Object.freeze({
   vaOnlineScheduling: 'vaOnlineScheduling',
   vaOnlineSchedulingCancel: 'vaOnlineSchedulingCancel',
   vaOnlineSchedulingRequests: 'vaOnlineSchedulingRequests',
+  vaOnlineSchedulingCommunityCare: 'vaOnlineSchedulingCommunityCare',
+  vaOnlineSchedulingDirect: 'vaOnlineSchedulingDirect',
   giVetTecProgramProviderFilters: 'giVetTecProgramProviderFilters',
 });
 


### PR DESCRIPTION
## Description
We're getting closer to launching the request flow and need to be able to turn off CC and DS, since those won't be ready initially.

## Testing done
Local testing

## Acceptance criteria
- [x] New appointment flow sends you into the regular request flow when flags are off

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
