### PR TITLE
Get bank info from view:originalBankAccount, if available

### DIFF
--- a/src/applications/disability-benefits/all-claims/components/PaymentView.jsx
+++ b/src/applications/disability-benefits/all-claims/components/PaymentView.jsx
@@ -38,13 +38,15 @@ const accountsDifferContent = (
 );
 
 export const PaymentView = ({ formData = {}, originalData = {} }) => {
-  const bankAccountType =
-    formData.bankAccountType || originalData['view:bankAccountType'];
-  const bankAccountNumber =
-    formData.bankAccountNumber || originalData['view:bankAccountNumber'];
-  const bankRoutingNumber =
-    formData.bankRoutingNumber || originalData['view:bankRoutingNumber'];
-  const bankName = formData.bankName || originalData['view:bankName'];
+  const getBankData = name =>
+    formData[name] ||
+    formData['view:originalBankAccount']?.[`view:${name}`] ||
+    originalData[`view:${name}`];
+
+  const bankAccountType = getBankData('bankAccountType');
+  const bankAccountNumber = getBankData('bankAccountNumber');
+  const bankRoutingNumber = getBankData('bankRoutingNumber');
+  const bankName = getBankData('bankName');
 
   const dataChanged = !isEqual(
     viewifyFields({


### PR DESCRIPTION
## Description

The previously saved banking info is not showing up in the review form of form 526 (staging & dev)

![](https://user-images.githubusercontent.com/136959/70186037-9ea6ad00-16b0-11ea-864c-be07ade4a989.png)

But if I edit the banking info, or enter new banking account info, it does display on the review page

![Screen Shot 2019-12-04 at 2 39 26 PM](https://user-images.githubusercontent.com/136959/70186134-d9a8e080-16b0-11ea-918d-efce323c1bb3.png)

From using the Redux browser extension, I see saved bank account information in the `formData['view:originalBankAccount']` key.

This PR modifies the `PaymentView` widget to first get data directly from the `formData` (as it was before), then from the `view:originalbankAccount` key, then finally from the `originalData` key (which appears to only be used for testing).

There's no guarantee that this change will fix the problem. We won't know until it's available on staging - this is because banking info isn't prefilling while using local host (not sure why).

## Testing done

Local unit tests

## Screenshots

See description

## Acceptance criteria
- [ ] Prefilled banking info is displayed in the review form

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
