### PR TITLE
Make best times to call required

### DIFF
--- a/src/applications/vaos/containers/ContactInfoPage.jsx
+++ b/src/applications/vaos/containers/ContactInfoPage.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import SchemaForm from 'platform/forms-system/src/js/components/SchemaForm';
 import phoneUI from 'platform/forms-system/src/js/definitions/phone';
+import { validateBooleanGroup } from 'platform/forms-system/src/js/validation';
 import FormButtons from '../components/FormButtons';
 
 import {
@@ -14,7 +15,7 @@ import { getFormPageInfo } from '../utils/selectors';
 
 const initialSchema = {
   type: 'object',
-  required: ['phoneNumber', 'email'],
+  required: ['phoneNumber', 'email', 'bestTimeToCall'],
   properties: {
     phoneNumber: {
       type: 'string',
@@ -63,6 +64,11 @@ const uiSchema = {
   phoneNumber: phoneUI('Phone number'),
   bestTimeToCall: {
     'ui:title': 'Best times for us to call you',
+    'ui:validations': [validateBooleanGroup],
+    'ui:options': {
+      showFieldLabel: true,
+      classNames: 'vaos-form__checkboxgroup',
+    },
     morning: {
       'ui:title': 'Morning (8 a.m. – noon)',
       'ui:options': {

--- a/src/applications/vaos/sass/vaos.scss
+++ b/src/applications/vaos/sass/vaos.scss
@@ -232,3 +232,12 @@
 h1:focus {
   outline: none !important;
 }
+
+.vaos-form__checkboxgroup {
+  .schemaform-block {
+    margin-top: 0;
+  }
+  > .usa-input-error {
+    margin-top: 0;
+  }
+}

--- a/src/applications/vaos/tests/containers/ContactInfoPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/containers/ContactInfoPage.unit.spec.jsx
@@ -35,7 +35,7 @@ describe('VAOS <ContactInfoPage>', () => {
 
     form.find('form').simulate('submit');
 
-    expect(form.find('.usa-input-error').length).to.equal(2);
+    expect(form.find('.usa-input-error').length).to.equal(3);
     expect(router.push.called).to.be.false;
     form.unmount();
   });
@@ -70,7 +70,13 @@ describe('VAOS <ContactInfoPage>', () => {
       <ContactInfoPage
         openFormPage={openFormPage}
         routeToNextAppointmentPage={routeToNextAppointmentPage}
-        data={{ phoneNumber: '5555555555', email: 'fake@va.gov' }}
+        data={{
+          phoneNumber: '5555555555',
+          email: 'fake@va.gov',
+          bestTimeToCall: {
+            morning: true,
+          },
+        }}
       />,
     );
 


### PR DESCRIPTION
## Description
We need users to select at least one time to call, so this makes the field required and fixes some visual issues

## Testing done
Local and unit testing

## Screenshots
![Screen Shot 2019-12-05 at 10 32 29 AM](https://user-images.githubusercontent.com/634932/70249905-15908400-174b-11ea-95b9-449d34580018.png)
![Screen Shot 2019-12-05 at 10 32 25 AM](https://user-images.githubusercontent.com/634932/70249906-15908400-174b-11ea-92ed-a3ee70995f0d.png)


## Acceptance criteria
- [ ] Best time to call field is required

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
