### PR TITLE
Add copy-entities.js script

### DIFF
--- a/script/copy-entities.js
+++ b/script/copy-entities.js
@@ -1,0 +1,73 @@
+/* eslint-disable no-console */
+
+const fs = require('fs');
+const path = require('path');
+const chalk = require('chalk');
+
+// Take a root-level entity
+// Look for all entity references
+// When one is found, copy the file and recurse on it
+const originalTomeSyncDir = path.join(
+  __dirname,
+  '../../tome-sync-output/content',
+);
+const testTomeSyncDir = path.join(
+  __dirname,
+  '../../test-tome-sync-output/content',
+);
+
+const propBlacklist = ['type', 'bundle', 'vid', 'uid', 'revision_uid'];
+
+const readEntity = (baseType, uuid, dir = originalTomeSyncDir) =>
+  JSON.parse(
+    fs
+      .readFileSync(path.join(dir, `${baseType}.${uuid}.json`))
+      .toString('utf8'),
+  );
+
+const copyEntity = (baseType, uuid) => {
+  const fileName = `${baseType}.${uuid}.json`;
+  fs.copyFileSync(
+    path.join(originalTomeSyncDir, fileName),
+    path.join(testTomeSyncDir, fileName),
+  );
+};
+
+const copyChildren = (entity, depth = 0) => {
+  // Set up a little pretty formatting
+  const spaces = ' '.repeat(depth * 2);
+  console.log(spaces, chalk.green(entity.uuid[0].value));
+
+  // Iterate through the non-blacklisted properties
+  // When an entity reference is found, copy it over and recurse on it
+  Object.keys(entity)
+    .filter(k => !propBlacklist.includes(k))
+    .forEach(propName => {
+      // Properties should always be arrays, but just in case, check
+      if (Array.isArray(entity[propName])) {
+        entity[propName].forEach((p, index) => {
+          if (p.target_type && p.target_uuid) {
+            // Found an entity reference!
+            console.log(
+              spaces,
+              'Copying entity found at',
+              chalk.blue(`${propName}[${index}]`),
+            );
+            copyEntity(p.target_type, p.target_uuid);
+            copyChildren(readEntity(p.target_type, p.target_uuid), depth + 1);
+          }
+        });
+      } else {
+        console.log(spaces, chalk.yellow(`Prop ${propName} is not an array.`));
+      }
+    });
+};
+
+// Do this when called from the CLI
+// Get the entity filename from the args
+const fileName = process.argv[2];
+
+const [baseType, uuid] = fileName.split('.').slice(0, 2);
+
+copyEntity(baseType, uuid);
+copyChildren(readEntity(baseType, uuid));


### PR DESCRIPTION
## Description
### What this does
Run this script to copy an entity and all its descendants from `tome-sync-output` to `test-tome-sync-output`. Both of these directories are assumed to be sibling to `vets-website`.

### Why it does it
In order to test out how the CMS content model transformations will work _before_ we get through _all_ of them, we can run through the build process using a small subset of all the pages we'll eventually be building.

To do this, we need to copy over only the entities we care about—those we want to test—into a new directory, and then point the build script to this new directory.

This script is a tool to help us pull out those entities.

### Usage
```
node script/copy-entities.js node.<uuid>.json
```

### Life span of this script
Once we have feature parity between the two ways to get content from the CMS (tome-sync vs GraphQL), and are using only the tome-sync approach, this script will no longer be useful and can be deleted.

## Testing done
Manually ensured that it worked as expected.

I _did_ `mkdir` the required destination directories, though; this will probably fail if they don't already exist.

## Screenshots
![image](https://user-images.githubusercontent.com/12970166/70285079-16d9a500-177b-11ea-8e97-21c17668eb53.png)
**Note:** The nested lines are there to kind of indicate that the operations performed are on children. So when we see
```
410f20c7-e49b-4289-8759-ee34d8b6432a
 Prop metatag is not an array.
 Copying entity found at field_administration[0]
   fb7324c9-382a-4a85-8bed-8864273c9b54
```
it means that for the entity `410f20c7-e49b-4289-8759-ee34d8b6432a`, the prop `metatag` isn't an array, and the property `field_administration` at index 0 contains an entity reference which we're copying, `fb7324c9-382a-4a85-8bed-8864273c9b54`.

I could have spent more time cleaning up the output, but eh. Didn't seem like the best use of my time.

## Acceptance criteria
- [ ] The entity specified is copied
- [ ] All its descendants are copied