### PR TITLE
Update content model generator template

### DIFF
--- a/src/site/stages/build/process-cms-exports/generator-cms-content-model/generators/app/index.js
+++ b/src/site/stages/build/process-cms-exports/generator-cms-content-model/generators/app/index.js
@@ -222,11 +222,13 @@ module.exports = class extends Generator {
     this.fs.copyTpl(path.join(templatesPath, 'raw-schema'), rawSchemaPath, {
       propertyNames: this.rawPropertyNames,
     });
+    const [baseType, subType] = this.contentModelType.split('-');
     this.fs.copyTpl(
       path.join(templatesPath, 'transformed-schema'),
       transformedSchemaPath,
       {
-        baseType: this.contentModelType.split('-')[0],
+        baseType,
+        subType,
         contentModelType: this.contentModelType,
         propertyNames: this.transformedPropertyNames,
       },

--- a/src/site/stages/build/process-cms-exports/generator-cms-content-model/generators/app/index.js
+++ b/src/site/stages/build/process-cms-exports/generator-cms-content-model/generators/app/index.js
@@ -226,6 +226,8 @@ module.exports = class extends Generator {
       path.join(templatesPath, 'transformed-schema'),
       transformedSchemaPath,
       {
+        baseType: this.contentModelType.split('-')[0],
+        contentModelType: this.contentModelType,
         propertyNames: this.transformedPropertyNames,
       },
     );

--- a/src/site/stages/build/process-cms-exports/generator-cms-content-model/templates/raw-schema
+++ b/src/site/stages/build/process-cms-exports/generator-cms-content-model/templates/raw-schema
@@ -7,5 +7,5 @@ module.exports = {
     <%= key _%>: { $ref: 'GenericNestedString' },
     <%_ }); _%>
   },
-  required: [<%- propertyNames.map(n => `'${n}'`).join(', ') %>]
+  required: [<%- propertyNames.map(n => `'${n}'`).join(', ') %>],
 };

--- a/src/site/stages/build/process-cms-exports/generator-cms-content-model/templates/transformed-schema
+++ b/src/site/stages/build/process-cms-exports/generator-cms-content-model/templates/transformed-schema
@@ -8,8 +8,8 @@ module.exports = {
         <%= key _%>: { type: 'string' },
         <%_ }); _%>
       },
-      required: [<%- propertyNames.map(n => `'${n}'`).join(', ') %>]
-    }
+      required: [<%- propertyNames.map(n => `'${n}'`).join(', ') %>],
+    },
   },
   required: ['entity'],
 };

--- a/src/site/stages/build/process-cms-exports/generator-cms-content-model/templates/transformed-schema
+++ b/src/site/stages/build/process-cms-exports/generator-cms-content-model/templates/transformed-schema
@@ -1,11 +1,12 @@
 module.exports = {
   type: 'object',
   properties: {
-    baseType: { enum: ['<%= baseType %>'] },
     contentModelType: { enum: ['<%= contentModelType %>'] },
     entity: {
       type: 'object',
       properties: {
+        entityType: { enum: ['<%= baseType %>'] },
+        entityBundle: { enum: ['<%= subType %>'] },
         <%_ propertyNames.forEach(key => { _%>
         <%= key _%>: { type: 'string' },
         <%_ }); _%>

--- a/src/site/stages/build/process-cms-exports/generator-cms-content-model/templates/transformed-schema
+++ b/src/site/stages/build/process-cms-exports/generator-cms-content-model/templates/transformed-schema
@@ -1,6 +1,8 @@
 module.exports = {
   type: 'object',
   properties: {
+    baseType: { enum: ['<%= baseType %>'] },
+    contentModelType: { enum: ['<%= contentModelType %>'] },
     entity: {
       type: 'object',
       properties: {


### PR DESCRIPTION
## Description
Updates include:
- `Prettier` commas
- Adding `contentModelType`, `entityType`, and `entityBundle` to the transformed schema
  - `entityType` and `entityBundle` are already in the transformer template
  - `contentModelType` gets added after the transformer

## Testing done
Ensured that the changes worked and were formatted properly.

## Screenshots
N/A
(I mean, I _could_ take one, but :man_shrugging:)

## Acceptance criteria
- [ ] The templates don't contain simple Prettier / eslint violations
  - Not including any that may happen from long lines
- [ ] The transformed template includes all the basic post-transformation data