### PR TITLE
VAGOV-6329: Add 8 other VISN 4 VAMC system menus.

### DIFF
--- a/src/site/stages/build/drupal/graphql/navigation-fragments/facilitySidebar.nav.graphql.js
+++ b/src/site/stages/build/drupal/graphql/navigation-fragments/facilitySidebar.nav.graphql.js
@@ -11,7 +11,6 @@ const FACILITY_MENU_NAMES = [
   'va-altoona-health-care',
   'va-butler-health-care',
   'va-coatesville-health-care',
-  'va-altoona-health-care',
   'va-erie-health-care',
   'va-lebanon',
   'va-philadelphia-health-care',

--- a/src/site/stages/build/drupal/graphql/navigation-fragments/facilitySidebar.nav.graphql.js
+++ b/src/site/stages/build/drupal/graphql/navigation-fragments/facilitySidebar.nav.graphql.js
@@ -9,6 +9,14 @@ const { camelize } = require('./../../../../../utilities/stringHelpers');
 const FACILITY_MENU_NAMES = [
   'pittsburgh-health-care',
   'va-altoona-health-care',
+  'va-butler-health-care',
+  'va-coatesville-health-care',
+  'va-altoona-health-care',
+  'va-erie-health-care',
+  'va-lebanon',
+  'va-philadelphia-health-care',
+  'va-wilkes-barre-health-care',
+  'va-wilmington-health-care',
 ];
 
 const FACILITY_SIDEBAR_QUERY = `


### PR DESCRIPTION
## Description
We're adding 8 more VAMC systems, each with their own menu. Eventually this will need to be refactored to scale for ~144 systems. 

https://va-gov.atlassian.net/browse/VAGOV-6329 

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
