### PR TITLE
Only lint staged JS files

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "lint:changed": "npm run lint:js:changed && npm run lint:sass",
     "lint:js": "eslint --quiet --ext .js --ext .jsx .",
     "lint:js:fix": "eslint --fix --quiet --ext .js --ext .jsx .",
-    "lint:js:changed": "LIST=`git diff-index --name-only HEAD | grep \"\\.js[x]\\{0,1\\}$\"`; if [ \"$LIST\" ]; then eslint --quiet $LIST; fi",
+    "lint:js:changed": "LIST=`git diff-index --name-only --cached HEAD | grep \"\\.js[x]\\{0,1\\}$\"`; if [ \"$LIST\" ]; then eslint --quiet $LIST; fi",
     "lint:js:changed:fix": "LIST=`git diff-index --name-only HEAD | grep \"\\.js[x]\\{0,1\\}$\"`; if [ \"$LIST\" ]; then eslint --fix --quiet $LIST; fi",
     "lint:sass": "sass-lint -c config/sass-lint.yml --verbose",
     "new:app": "yo @department-of-veterans-affairs/vets-website",


### PR DESCRIPTION
## Description
I got tired of linting errors that I wasn't trying to commit prevent me from committing. We shouldn't have to `--force` commit because of that (might miss legitimate errors that way).

Adding the `--cached` flag looks at only the staged files. See `man git diff` for more details.

**Note:** If you have unstaged linting errors in a file with staged changes, this will still prevent the commit.

**Note:** `npm run lint:js:changed:fix` will still apply the fixes to all the changed files, not just the staged ones.

## Testing done
Made sure it ignored unstaged files linting errors, but caught linting errors in staged files.

## Screenshots
N/A

## Acceptance criteria
- [x] Unstaged files with linting errors are ignored in the `pre-commit` hook's `npm run lint:changed` command
- [x] Staged files with linting errors are not ignored in the above