### PR TITLE
Rename template filters export to be filter

### DIFF
--- a/src/site/stages/build/process-cms-exports/generator-cms-content-model/templates/transformer
+++ b/src/site/stages/build/process-cms-exports/generator-cms-content-model/templates/transformer
@@ -10,6 +10,6 @@ const transform = entity => ({
   },
 });
 module.exports = {
-  filters: [<%- rawPropertyNames.map(key => `'${key}'`).join(', ') %>],
+  filter: [<%- rawPropertyNames.map(key => `'${key}'`).join(', ') %>],
   transform,
 };


### PR DESCRIPTION
## Description

The transformers are exporting a `filter` array and that is what the [`getAllImportsFrom` is looking for](https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/site/stages/build/process-cms-exports/filters.js#L7).

## Testing done
Manual (:eyes: )

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
