### PR TITLE
Update dates in mock data used for e2e tests

### DIFF
--- a/src/applications/vaos/tests/e2e/00.appointment-list.e2e.spec.js
+++ b/src/applications/vaos/tests/e2e/00.appointment-list.e2e.spec.js
@@ -19,6 +19,7 @@ module.exports = E2eHelpers.createE2eTest(client => {
     .axeCheck('.main');
 
   client
+    .pause(60000)
     .click('.vaos-appts__cancel-btn')
     .waitForElementVisible('#cancelAppt', Timeouts.normal)
     .axeCheck('.main')

--- a/src/applications/vaos/tests/e2e/00.appointment-list.e2e.spec.js
+++ b/src/applications/vaos/tests/e2e/00.appointment-list.e2e.spec.js
@@ -19,7 +19,6 @@ module.exports = E2eHelpers.createE2eTest(client => {
     .axeCheck('.main');
 
   client
-    .pause(60000)
     .click('.vaos-appts__cancel-btn')
     .waitForElementVisible('#cancelAppt', Timeouts.normal)
     .axeCheck('.main')

--- a/src/applications/vaos/tests/e2e/vaos-helpers.js
+++ b/src/applications/vaos/tests/e2e/vaos-helpers.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-param-reassign */
+const moment = require('moment');
 const mock = require('../../../../platform/testing/e2e/mock-helpers');
 
 const confirmedVA = require('../../api/confirmed_va.json');
@@ -5,6 +7,44 @@ const confirmedCC = require('../../api/confirmed_cc.json');
 const requests = require('../../api/requests.json');
 const cancelReasons = require('../../api/cancel_reasons.json');
 const systems = require('../../api/systems.json');
+
+function updateConfirmedVADates(data) {
+  data.data.forEach(item => {
+    const futureDateStr = moment()
+      .add(3, 'days')
+      .toISOString();
+
+    item.attributes.startDate = futureDateStr;
+    if (item.attributes.vdsAppointments[0]) {
+      item.attributes.vdsAppointments[0].appointmentTime = futureDateStr;
+    } else {
+      item.attributes.vvsAppointments[0].dateTime = futureDateStr;
+    }
+  });
+  return data;
+}
+
+function updateConfirmedCCDates(data) {
+  data.data.forEach(item => {
+    const futureDateStr = moment()
+      .add(4, 'days')
+      .format('MM/DD/YYYY HH:mm:ss');
+
+    item.attributes.appointmentTime = futureDateStr;
+  });
+  return data;
+}
+
+function updateRequestDates(data) {
+  data.data.forEach(item => {
+    const futureDateStr = moment()
+      .add(5, 'days')
+      .format('MM/DD/YYYY');
+
+    item.attributes.optionDate1 = futureDateStr;
+  });
+  return data;
+}
 
 function initAppointmentListMock(token) {
   mock(token, {
@@ -34,18 +74,18 @@ function initAppointmentListMock(token) {
     path: '/v0/vaos/appointments',
     verb: 'get',
     query: 'type=va',
-    value: confirmedVA,
+    value: updateConfirmedVADates(confirmedVA),
   });
   mock(token, {
     path: '/v0/vaos/appointments',
     verb: 'get',
     query: 'type=cc',
-    value: confirmedCC,
+    value: updateConfirmedCCDates(confirmedCC),
   });
   mock(token, {
     path: '/v0/vaos/appointment_requests',
     verb: 'get',
-    value: requests,
+    value: updateRequestDates(requests),
   });
   mock(token, {
     path: '/v0/vaos/appointments/cancel',


### PR DESCRIPTION
## Description
The VAOS appointment list filters out past appointments, so we need to make sure dates are after the current date when we send back mock data. This adds some data updating code in the VAOS e2e helper.

## Testing done
Local testing

## Acceptance criteria
- [ ] Tests use dates in the future

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
