### PR TITLE
VAGOV-6278: Removing featured events and stories from paged output.

### DIFF
--- a/src/site/layouts/events_page.drupal.liquid
+++ b/src/site/layouts/events_page.drupal.liquid
@@ -62,10 +62,12 @@ Example data:
 
           {% include "src/site/facilities/facilities_events_toggle.drupal.liquid" with url = entityUrl.path %}
 
+          {% assign featuredUrl = null %}
           {% if paginator.prev == null %}
           {% for featuredEvent in eventTeasers.entities %}
           {% if forloop.first == true %}
           {% unless entityUrl.path contains 'past-events' %}
+          {% assign featuredUrl = featuredEvent.entityUrl.path %}
             <div class="usa-width-two-thirds">
               <div id="featured-content" class="usa-grid usa-grid-full
                 vads-u-margin-bottom--3
@@ -88,9 +90,11 @@ Example data:
           {% endfor %}
           {% endif %}
           {% for event in pagedItems %}
-          <div class="usa-width-two-thirds">
-            {% include "src/site/teasers/event.drupal.liquid" with node = event %}
-          </div>
+            {% if featuredUrl != event.entityUrl.path %}
+              <div class="usa-width-two-thirds">
+                {% include "src/site/teasers/event.drupal.liquid" with node = event %}
+              </div>
+            {% endif %}
           {% endfor %}
           {% include "src/site/includes/pagination.drupal.liquid" %}
         </article>

--- a/src/site/layouts/news_stories_page.drupal.liquid
+++ b/src/site/layouts/news_stories_page.drupal.liquid
@@ -68,7 +68,9 @@ Example data:
           {% endfor %}
           {% endif %}
           {% for story in pagedItems %}
+            {% if story.fieldFeatured == false %}
               {% include "src/site/teasers/news_story_page.drupal.liquid" with node = story %}
+            {% endif %}
           {% endfor %}
           {% include "src/site/includes/pagination.drupal.liquid" %}
         </article>


### PR DESCRIPTION
## Description
pittsburgh-health-care/stories/ & pittsburgh-health-care/events/ have one featured item appearing above the standard listing output. Presently, the featured item is also appearing in the standard listing output. This pr removes the featured item from the standard listing output.

## Testing done
Visual

## Screenshots
![image](https://user-images.githubusercontent.com/2404547/70446877-c5c3fc80-1a6b-11ea-8a89-f75442ffb6e2.png)
![image](https://user-images.githubusercontent.com/2404547/70446885-c9f01a00-1a6b-11ea-9a2f-69b750056f36.png)


## Acceptance criteria
- [ ] Go to pittsburgh-health-care/stories/ & pittsburgh-health-care/events, and visually verify that featured item does not appear in standard listing output
