### PR TITLE
Ensure the correct SideNav is rendered

### DIFF
--- a/src/platform/site-wide/side-nav/components/SideNav.js
+++ b/src/platform/site-wide/side-nav/components/SideNav.js
@@ -1,7 +1,7 @@
 // Dependencies
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { find, filter, get, map, orderBy } from 'lodash';
+import { find, filter, get, includes, map, orderBy } from 'lodash';
 // Relative
 import NavItem from './NavItem';
 
@@ -76,7 +76,10 @@ class SideNav extends Component {
     const { navItemsLookup } = this.props;
 
     // Derive the parent-most nav item. This is O(n), which isn't great but I'm assuming there won't be 1000s of side nav items.
-    const parentMostNavItem = find(navItemsLookup, item => !item.parentID);
+    const parentMostNavItem = find(
+      navItemsLookup,
+      item => !item.parentID && includes(window.location.pathname, item.href),
+    );
     const parentMostID = get(parentMostNavItem, 'id');
 
     // Escape early if we have no nav items to render.

--- a/src/platform/site-wide/side-nav/components/SideNav.js
+++ b/src/platform/site-wide/side-nav/components/SideNav.js
@@ -1,7 +1,7 @@
 // Dependencies
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { find, filter, get, includes, map, orderBy } from 'lodash';
+import { find, filter, get, map, orderBy } from 'lodash';
 // Relative
 import NavItem from './NavItem';
 
@@ -76,10 +76,7 @@ class SideNav extends Component {
     const { navItemsLookup } = this.props;
 
     // Derive the parent-most nav item. This is O(n), which isn't great but I'm assuming there won't be 1000s of side nav items.
-    const parentMostNavItem = find(
-      navItemsLookup,
-      item => !item.parentID && includes(window.location.pathname, item.href),
-    );
+    const parentMostNavItem = find(navItemsLookup, item => !item.parentID);
     const parentMostID = get(parentMostNavItem, 'id');
 
     // Escape early if we have no nav items to render.

--- a/src/platform/site-wide/side-nav/helpers.js
+++ b/src/platform/site-wide/side-nav/helpers.js
@@ -1,5 +1,14 @@
 // Dependencies
-import { each, get, uniqueId, isEmpty, set, trimEnd } from 'lodash';
+import {
+  each,
+  filter,
+  get,
+  includes,
+  isEmpty,
+  set,
+  trimEnd,
+  uniqueId,
+} from 'lodash';
 
 /* Recursive function that expands all `parentID`s.
   @param {Object}, options:
@@ -135,9 +144,14 @@ export const normalizeSideNavData = data => {
   // Derive properties we need from data.
   const items = get(data, 'links');
 
+  // Derive only nav items that are relevant for the current page.
+  const relevantNavItems = filter(items, item =>
+    includes(window.location.pathname, get(item, 'url.path')),
+  );
+
   // Derive a nav items array and a lookup table.
   const navItemsLookup = deriveNavItemsLookup({
-    items,
+    items: relevantNavItems,
     navItemsLookup: {},
   });
 

--- a/src/platform/site-wide/side-nav/tests/components/SideNav.unit.spec.js
+++ b/src/platform/site-wide/side-nav/tests/components/SideNav.unit.spec.js
@@ -35,20 +35,6 @@ describe('<SideNav>', () => {
     },
   };
 
-  const oldWindow = global.window;
-
-  beforeEach(() => {
-    global.window = {
-      location: {
-        pathname: '/',
-      },
-    };
-  });
-
-  afterEach(() => {
-    global.window = oldWindow;
-  });
-
   it('should not render when there are no nav items to show', () => {
     const wrapper = shallow(<SideNav />);
     expect(wrapper.type()).to.equal(null);


### PR DESCRIPTION
## Description
The SideNav data has changed since last week as there is now a new `VA Eerie health care` parent-most nav item within the `VA Pittsburgh health care` SideNav data.

This new data made it so that we only render the `VA Eerie health care` nav items since it was the first parent-most nav item we find (where the nav item does not have a `parentID`).

This PR fixes this by ensuring we only show the nav items that pertain to the correct health care facility.

## Testing done
Locally.

## Screenshots
![image](https://user-images.githubusercontent.com/12773166/70451424-9230a480-1a62-11ea-877f-42253edb5390.png)

## Acceptance criteria
- [x] Ensure the SideNav renders the nav items it needs to based on the current URL.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
