### PR TITLE
Kelsonic 3997 remove "Home" breadcrumb

### DIFF
--- a/src/platform/site-wide/side-nav/components/SideNav.js
+++ b/src/platform/site-wide/side-nav/components/SideNav.js
@@ -1,7 +1,7 @@
 // Dependencies
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { find, filter, get, map, orderBy } from 'lodash';
+import { find, filter, get, includes, map, orderBy } from 'lodash';
 // Relative
 import NavItem from './NavItem';
 
@@ -76,7 +76,10 @@ class SideNav extends Component {
     const { navItemsLookup } = this.props;
 
     // Derive the parent-most nav item. This is O(n), which isn't great but I'm assuming there won't be 1000s of side nav items.
-    const parentMostNavItem = find(navItemsLookup, item => !item.parentID);
+    const parentMostNavItem = find(
+      navItemsLookup,
+      item => !item.parentID && includes(window.location.pathname, item.href),
+    );
     const parentMostID = get(parentMostNavItem, 'id');
 
     // Escape early if we have no nav items to render.

--- a/src/platform/site-wide/side-nav/components/SideNav.js
+++ b/src/platform/site-wide/side-nav/components/SideNav.js
@@ -1,7 +1,7 @@
 // Dependencies
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { find, filter, get, includes, map, orderBy } from 'lodash';
+import { find, filter, get, map, orderBy } from 'lodash';
 // Relative
 import NavItem from './NavItem';
 
@@ -76,10 +76,7 @@ class SideNav extends Component {
     const { navItemsLookup } = this.props;
 
     // Derive the parent-most nav item. This is O(n), which isn't great but I'm assuming there won't be 1000s of side nav items.
-    const parentMostNavItem = find(
-      navItemsLookup,
-      item => !item.parentID && includes(window.location.pathname, item.href),
-    );
+    const parentMostNavItem = find(navItemsLookup, item => !item.parentID);
     const parentMostID = get(parentMostNavItem, 'id');
 
     // Escape early if we have no nav items to render.

--- a/src/platform/site-wide/side-nav/helpers.js
+++ b/src/platform/site-wide/side-nav/helpers.js
@@ -1,14 +1,5 @@
 // Dependencies
-import {
-  each,
-  filter,
-  get,
-  includes,
-  isEmpty,
-  set,
-  trimEnd,
-  uniqueId,
-} from 'lodash';
+import { each, get, isEmpty, set, trimEnd, uniqueId } from 'lodash';
 
 /* Recursive function that expands all `parentID`s.
   @param {Object}, options:
@@ -142,11 +133,11 @@ const deriveNavItemsLookup = options => {
 */
 export const normalizeSideNavData = data => {
   // Derive properties we need from data.
-  const items = get(data, 'links');
+  const items = data?.links;
 
   // Derive only nav items that are relevant for the current page.
-  const relevantNavItems = filter(items, item =>
-    includes(window.location.pathname, get(item, 'url.path')),
+  const relevantNavItems = items.filter(item =>
+    window.location.pathname.includes(item?.url?.path),
   );
 
   // Derive a nav items array and a lookup table.

--- a/src/platform/site-wide/side-nav/helpers.js
+++ b/src/platform/site-wide/side-nav/helpers.js
@@ -1,5 +1,14 @@
 // Dependencies
-import { each, get, uniqueId, isEmpty, set, trimEnd } from 'lodash';
+import {
+  each,
+  filter,
+  get,
+  includes,
+  isEmpty,
+  set,
+  trimEnd,
+  uniqueId,
+} from 'lodash';
 
 /* Recursive function that expands all `parentID`s.
   @param {Object}, options:
@@ -135,9 +144,14 @@ export const normalizeSideNavData = data => {
   // Derive properties we need from data.
   const items = get(data, 'links');
 
+  // Derive only nav items that are relevant for the current page.
+  const relevantNavItems = filter(items, item =>
+    includes(window.location.pathname, get(item, 'url.path')),
+  );
+
   // Derive a nav items array and a lookup table.
   const navItemsLookup = deriveNavItemsLookup({
-    items,
+    items: relevantNavItems,
     navItemsLookup: {},
   });
 

--- a/src/platform/site-wide/side-nav/tests/components/SideNav.unit.spec.js
+++ b/src/platform/site-wide/side-nav/tests/components/SideNav.unit.spec.js
@@ -35,20 +35,6 @@ describe('<SideNav>', () => {
     },
   };
 
-  const oldWindow = global.window;
-
-  beforeEach(() => {
-    global.window = {
-      location: {
-        pathname: '/',
-      },
-    };
-  });
-
-  afterEach(() => {
-    global.window = oldWindow;
-  });
-
   it('should not render when there are no nav items to show', () => {
     const wrapper = shallow(<SideNav />);
     expect(wrapper.type()).to.equal(null);

--- a/src/site/includes/breadcrumbs.drupal.liquid
+++ b/src/site/includes/breadcrumbs.drupal.liquid
@@ -5,7 +5,7 @@
         <li><a aria-current="page" href="/{{ path }}">{{ crumb.text }}</a></li>
       {% elsif crumb.url.path %}
         {% if crumb.url.path == '/' %}
-          {% if hideHomeBreadcrumb != true %}
+          {% if hideHomeBreadcrumb != true or buildtype == 'vagovprod' %}
             <li>
               <a href="{{ crumb.url.path }}" onClick="recordEvent({ event: 'nav-breadcrumb', 'nav-breadcrumb-section': 'home' });">{{ crumb.text }}</a>
             </li>

--- a/src/site/includes/breadcrumbs.drupal.liquid
+++ b/src/site/includes/breadcrumbs.drupal.liquid
@@ -1,17 +1,19 @@
 <nav aria-label="Breadcrumb" aria-live="polite" class="va-nav-breadcrumbs" id="va-breadcrumbs">
   <ul class="row va-nav-breadcrumbs-list columns" id="va-breadcrumbs-list">
     {% for crumb in entityUrl.breadcrumb %}
-        {% if forloop.last == true %}
-            <li><a aria-current="page" href="/{{ path }}">{{ crumb.text }}</a></li>
-        {% elsif crumb.url.path %}
-            {% if crumb.url.path == '/' %}
-                <li>
-                    <a href="{{ crumb.url.path }}" onClick="recordEvent({ event: 'nav-breadcrumb', 'nav-breadcrumb-section': 'home' });">{{ crumb.text }}</a>
-                </li>
-            {% else %}
-                <li><a href="{{ crumb.url.path }}">{{ crumb.text }}</a></li>
-            {% endif %}
+      {% if forloop.last == true %}
+        <li><a aria-current="page" href="/{{ path }}">{{ crumb.text }}</a></li>
+      {% elsif crumb.url.path %}
+        {% if crumb.url.path == '/' %}
+          {% if hideHomeBreadcrumb != true %}
+            <li>
+              <a href="{{ crumb.url.path }}" onClick="recordEvent({ event: 'nav-breadcrumb', 'nav-breadcrumb-section': 'home' });">{{ crumb.text }}</a>
+            </li>
+          {% endif %}
+        {% else %}
+          <li><a href="{{ crumb.url.path }}">{{ crumb.text }}</a></li>
         {% endif %}
+      {% endif %}
     {% endfor %}
   </ul>
 </nav>

--- a/src/site/layouts/event.drupal.liquid
+++ b/src/site/layouts/event.drupal.liquid
@@ -74,7 +74,7 @@ Example data:
 {% include "src/site/includes/header.html" with drupalTags = true %}
 {% include "src/site/includes/alerts.drupal.liquid" %}
 {% include "src/site/includes/preview-edit.drupal.liquid" %}
-{% include "src/site/includes/breadcrumbs.drupal.liquid" %}
+{% include "src/site/includes/breadcrumbs.drupal.liquid" with hideHomeBreadcrumb = true %}
 
 {% assign timezone = "America/New_York" %}
 {% if uid.entity.timezone != empty %}

--- a/src/site/layouts/events_page.drupal.liquid
+++ b/src/site/layouts/events_page.drupal.liquid
@@ -47,7 +47,7 @@ Example data:
 {% include "src/site/includes/header.html" with drupalTags = true %}
 {% include "src/site/includes/alerts.drupal.liquid" %}
 {% include "src/site/includes/preview-edit.drupal.liquid" %}
-{% include "src/site/includes/breadcrumbs.drupal.liquid" %}
+{% include "src/site/includes/breadcrumbs.drupal.liquid" with hideHomeBreadcrumb = true %}
 <div id="content" class="interior">
   <main class="va-l-detail-page va-facility-page">
     <div class="usa-grid usa-grid-full">

--- a/src/site/layouts/health_care_region_health_services_page.drupal.liquid
+++ b/src/site/layouts/health_care_region_health_services_page.drupal.liquid
@@ -1,7 +1,7 @@
 {% include "src/site/includes/header.html" with drupalTags = true %}
 {% include "src/site/includes/alerts.drupal.liquid" %}
 {% include "src/site/includes/preview-edit.drupal.liquid" %}
-{% include "src/site/includes/breadcrumbs.drupal.liquid" %}
+{% include "src/site/includes/breadcrumbs.drupal.liquid" with hideHomeBreadcrumb = true %}
 <div id="content" class="interior">
     <main class="va-l-detail-page va-facility-page">
     <div class="usa-grid usa-grid-full">

--- a/src/site/layouts/health_care_region_locations_page.drupal.liquid
+++ b/src/site/layouts/health_care_region_locations_page.drupal.liquid
@@ -1,7 +1,7 @@
 {% include "src/site/includes/header.html" with drupalTags = true %}
 {% include "src/site/includes/alerts.drupal.liquid" %}
 {% include "src/site/includes/preview-edit.drupal.liquid" %}
-{% include "src/site/includes/breadcrumbs.drupal.liquid" %}
+{% include "src/site/includes/breadcrumbs.drupal.liquid" with hideHomeBreadcrumb = true %}
 <div id="content" class="interior">
     <main class="va-l-detail-page va-facility-page">
         <div class="usa-grid usa-grid-full">

--- a/src/site/layouts/news_stories_page.drupal.liquid
+++ b/src/site/layouts/news_stories_page.drupal.liquid
@@ -48,7 +48,8 @@ Example data:
 {% include "src/site/includes/header.html" with drupalTags = true %}
 {% include "src/site/includes/alerts.drupal.liquid" %}
 {% include "src/site/includes/preview-edit.drupal.liquid" %}
-{% include "src/site/includes/breadcrumbs.drupal.liquid" %}
+{% include "src/site/includes/breadcrumbs.drupal.liquid" with hideHomeBreadcrumb = true %}
+
 <div id="content" class="interior">
   <main class="va-l-detail-page va-facility-page">
     <div class="usa-grid usa-grid-full">
@@ -76,5 +77,6 @@ Example data:
     </div>
   </main>
 </div>
+
 {% include "src/site/includes/footer.html" %}
 {% include "src/site/includes/debug.drupal.liquid" %}

--- a/src/site/layouts/news_story.drupal.liquid
+++ b/src/site/layouts/news_story.drupal.liquid
@@ -58,7 +58,8 @@ Example data:
 {% include "src/site/includes/header.html" with drupalTags = true %}
 {% include "src/site/includes/alerts.drupal.liquid" %}
 {% include "src/site/includes/preview-edit.drupal.liquid" %}
-{% include "src/site/includes/breadcrumbs.drupal.liquid" %}
+{% include "src/site/includes/breadcrumbs.drupal.liquid" with hideHomeBreadcrumb = true %}
+
 <div id="content" class="interior">
     <main class="va-l-detail-page va-facility-page">
         {% comment %} On prod environments, show the SideNav. {% endcomment %}

--- a/src/site/layouts/press_release.drupal.liquid
+++ b/src/site/layouts/press_release.drupal.liquid
@@ -94,7 +94,8 @@
 {% include "src/site/includes/header.html" with drupalTags = true %}
 {% include "src/site/includes/alerts.drupal.liquid" %}
 {% include "src/site/includes/preview-edit.drupal.liquid" %}
-{% include "src/site/includes/breadcrumbs.drupal.liquid" %}
+{% include "src/site/includes/breadcrumbs.drupal.liquid" with hideHomeBreadcrumb = true %}
+
 <div id="content" class="interior">
     <main class="va-l-detail-page va-facility-page">
         {% comment %} On prod, show the SideNav. {% endcomment %}

--- a/src/site/layouts/press_releases_page.drupal.liquid
+++ b/src/site/layouts/press_releases_page.drupal.liquid
@@ -43,7 +43,8 @@ Example data:
 {% include "src/site/includes/header.html" with drupalTags = true %}
 {% include "src/site/includes/alerts.drupal.liquid" %}
 {% include "src/site/includes/preview-edit.drupal.liquid" %}
-{% include "src/site/includes/breadcrumbs.drupal.liquid" %}
+{% include "src/site/includes/breadcrumbs.drupal.liquid" with hideHomeBreadcrumb = true %}
+
 <div id="content" class="interior">
   <main class="va-l-detail-page va-facility-page">
     <div class="usa-grid usa-grid-full">


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/3997

The `"Home"` breadcrumb still appears on the following pages:

* [VA Pittsburgh Health Care | Patient And Health Services | Veterans Affairs](https://staging.va.gov/pittsburgh-health-care/health-services/)
* [VA Pittsburgh Health Care | Locations | Veterans Affairs](https://staging.va.gov/pittsburgh-health-care/locations/)
* [VA Pittsburgh Health Care | Events | Veterans Affairs](https://staging.va.gov/pittsburgh-health-care/events/)
* [VA Pittsburgh health care | Veterans Town Hall | Veterans Affairs](https://staging.va.gov/pittsburgh-health-care/events/veterans-town-hall-1/)
* [VA Pittsburgh Health Care | Community Stories | Veterans Affairs](https://staging.va.gov/pittsburgh-health-care/stories/)
* [VA Pittsburgh Health Care | News Releases | Veterans Affairs](https://staging.va.gov/pittsburgh-health-care/news-releases/)

The desired behavior is that the "Home" breadcrumb does not appear on the above pages. While we originally thought this would be controlled by Drupal, it seems as though the breadcrumbs on these pages is actually custom within `vets-website`.

This PR implements the desired behavior.

## Testing done
Locally.

## Screenshots
`http://localhost:3001/pittsburgh-health-care/health-services/`:
![image](https://user-images.githubusercontent.com/12773166/70478093-7e536580-1a97-11ea-9347-16902b96a809.png)

`http://localhost:3001/pittsburgh-health-care/locations/`:
![image](https://user-images.githubusercontent.com/12773166/70478077-73003a00-1a97-11ea-98b2-e63060323935.png)

`http://localhost:3001/pittsburgh-health-care/events/`:
![image](https://user-images.githubusercontent.com/12773166/70478025-595ef280-1a97-11ea-9f58-1158b6da6f07.png)

`http://localhost:3001/pittsburgh-health-care/events/veterans-town-hall-1/`:
![image](https://user-images.githubusercontent.com/12773166/70478054-67147800-1a97-11ea-91a1-e0811666d2dc.png)

`http://localhost:3001/pittsburgh-health-care/stories/`:
![image](https://user-images.githubusercontent.com/12773166/70477971-3fbdab00-1a97-11ea-8be0-84890accc35d.png)

`http://localhost:3001/pittsburgh-health-care/stories/battlefield-acupuncture-comes-to-va-pittsburgh/`:
![image](https://user-images.githubusercontent.com/12773166/70477990-4a784000-1a97-11ea-8fbd-95bf2d1269ce.png)

`http://localhost:3001/pittsburgh-health-care/news-releases/`:
![image](https://user-images.githubusercontent.com/12773166/70477919-287ebd80-1a97-11ea-8bdd-8c1f307eaf6c.png)

`http://localhost:3001/pittsburgh-health-care/news-releases/va-pittsburgh-healthcare-system-to-open-second-fisher-house/`:
![image](https://user-images.githubusercontent.com/12773166/70477883-1735b100-1a97-11ea-9e4b-1c3484c14c2a.png)


## Acceptance criteria
- [x] Remove "Home" breadcrumb on [VA Pittsburgh Health Care | Patient And Health Services | Veterans Affairs](https://staging.va.gov/pittsburgh-health-care/health-services/)
- [x] Remove "Home" breadcrumb on [VA Pittsburgh Health Care | Locations | Veterans Affairs](https://staging.va.gov/pittsburgh-health-care/locations/)
- [x] Remove "Home" breadcrumb on [VA Pittsburgh Health Care | Events | Veterans Affairs](https://staging.va.gov/pittsburgh-health-care/events/)
- [x] Remove "Home" breadcrumb on [VA Pittsburgh health care | Veterans Town Hall | Veterans Affairs](https://staging.va.gov/pittsburgh-health-care/events/veterans-town-hall-1/)
- [x] Remove "Home" breadcrumb on [VA Pittsburgh Health Care | Community Stories | Veterans Affairs](https://staging.va.gov/pittsburgh-health-care/stories/)
- [x] Remove "Home" breadcrumb on [VA Pittsburgh Health Care | News Releases | Veterans Affairs](https://staging.va.gov/pittsburgh-health-care/news-releases/)

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
