### PR TITLE
VAGOV-6309: Updating op status badge styles.

### DIFF
--- a/src/site/includes/facilityListing.drupal.liquid
+++ b/src/site/includes/facilityListing.drupal.liquid
@@ -5,7 +5,7 @@
       class="vads-u-margin-bottom--1 vads-u-margin-top--0 vads-u-font-size--md medium-screen:vads-u-font-size--lg">
       <a href="{{entity.entityUrl.path}}">{{entity.title}}</a> </h3>
     {% if entity.fieldOperatingStatusFacility and entity.fieldOperatingStatusFacility != 'normal' %}
-    <div class="vads-u-display--inline-block vads-u-margin-bottom--2p5">
+    <div class="vads-u-display--inline-block vads-u-margin-bottom--1">
       {% include "src/site/includes/operatingStatusFlags.drupal.liquid" with entity %}
     </div>
     {% endif %}

--- a/src/site/includes/operatingStatusFlags.drupal.liquid
+++ b/src/site/includes/operatingStatusFlags.drupal.liquid
@@ -40,7 +40,7 @@
   class="operating-status-link"
   href="{{facilitySidebar.links.0.url.path}}/operating-status">
   <span
-    class="operating-status-flag operating-status-flag-notice operating-status usa-alert usa-alert-info background-color-only vads-u-margin-top--1 vads-u-padding--1p5">
+    class="operating-status-flag operating-status-flag-notice operating-status usa-alert usa-alert-info background-color-only vads-u-margin-top--1 vads-u-padding-y--1 vads-u-padding-x--1p5">
     <i class="fa fa-info-circle" aria-hidden="true"></i> Facility notice <i
       class="fa fa-chevron-right vads-u-padding-left--0p5"" aria-hidden="
       true"></i>
@@ -49,7 +49,7 @@
 {% elsif fieldOperatingStatusFacility == 'limited' %}
 <a class="operating-status-link"
   href="{{facilitySidebar.links.0.url.path}}/operating-status"><span
-    class="operating-status-flag operating-status-flag-warning operating-status usa-alert usa-alert-warning background-color-only vads-u-margin-top--1 vads-u-padding--1p5">
+    class="operating-status-flag operating-status-flag-warning operating-status usa-alert usa-alert-warning background-color-only vads-u-margin-top--1 vads-u-padding-y--1 vads-u-padding-x--1p5">
     <i class="fa fa-exclamation-triangle" aria-hidden="true"></i> Limited
     services and hours <i class="fa fa-chevron-right vads-u-padding-left--0p5"
       aria-hidden="true"></i>
@@ -58,7 +58,7 @@
 {% elsif fieldOperatingStatusFacility == 'closed' %}
 <a class="operating-status-link"
   href="{{facilitySidebar.links.0.url.path}}/operating-status"><span
-    class="operating-status-flag operating-status-flag-error operating-status usa-alert usa-alert-error background-color-only vads-u-margin-top--1 vads-u-padding--1p5">
+    class="operating-status-flag operating-status-flag-error operating-status usa-alert usa-alert-error background-color-only vads-u-margin-top--1 vads-u-padding-y--1 vads-u-padding-x--1p5">
     <i class="fa fa-exclamation-circle" aria-hidden="true"></i> Facility
     Closed <i
       class="fa fa-chevron-right vads-u-padding-left--0p5"" aria-hidden="

--- a/src/site/layouts/vamc_operating_status_and_alerts.drupal.liquid
+++ b/src/site/layouts/vamc_operating_status_and_alerts.drupal.liquid
@@ -1,3 +1,8 @@
+<style>
+    .facility-title-width {
+        max-width: 90%;
+    }
+</style>
 {% include "src/site/includes/header.html" with drupalTags = true %}
 {% include "src/site/includes/alerts.drupal.liquid" %}
 {% include "src/site/includes/preview-edit.drupal.liquid" %}
@@ -82,8 +87,8 @@
                             <div
                                 class="vads-l-row vads-u-border-top--1px vads-u-border-color--gray-light">
                                 <div
-                                    class="vads-l-col--6 vads-u-display--flex operating-status-title">
-                                    <a class="vads-u-font-weight--bold"
+                                    class="vads-l-col--6 vads-u-margin-y--3 vads-u-display--flex operating-status-title">
+                                    <a class="facility-title-width vads-u-font-weight--bold"
                                         href="{{status.entity.entityUrl.path}}">{{ status.entity.title }}</a>
                                 </div>
                                 <div class="vads-l-col--6">
@@ -97,7 +102,7 @@
                                         </span>
                                         {% elsif status.entity.fieldOperatingStatusFacility == 'normal' %}
                                         <span
-                                            class="operating-status normal-hours vads-u-margin-top--2 vads-u-display--block">
+                                            class="operating-status normal-hours vads-u-margin-top--1p5 vads-u-display--block">
                                             Normal services and hours
                                         </span>
                                         {% elsif status.entity.fieldOperatingStatusFacility == 'limited' %}


### PR DESCRIPTION
## Description
Minor operating status badge styling (padding, spacing) on these pages: `pittsburgh-health-care/operating-status/`, `pittsburgh-health-care/locations/pittsburgh-va-medical-center-university-drive/`, `pittsburgh-health-care/operating-status/`

## Testing done
Visual

## Screenshots
![image](https://user-images.githubusercontent.com/2404547/70480225-2e7f9900-1aad-11ea-9934-3d2d9ad43c89.png)
![image](https://user-images.githubusercontent.com/2404547/70480235-34757a00-1aad-11ea-9e98-7c2edb78e6b3.png)
![image](https://user-images.githubusercontent.com/2404547/70480241-39d2c480-1aad-11ea-927f-abf996ed4973.png)

## Acceptance criteria
- [ ] Padding, margins, spacing are updated per https://va-gov.atlassian.net/browse/VAGOV-6309
