### PR TITLE
bradl3yC 3960 Updates to Address Validation Modal

### DIFF
--- a/src/platform/user/profile/vet360/actions/transactions.js
+++ b/src/platform/user/profile/vet360/actions/transactions.js
@@ -206,6 +206,7 @@ export const validateAddress = (
           firstAddress?.addressMetaData?.confidenceScore,
       )
       .map(address => ({
+        addressMetaData: { ...address.addressMetaData },
         ...inferAddressType(address.address),
         addressPou:
           fieldName === FIELD_NAMES.MAILING_ADDRESS
@@ -217,13 +218,16 @@ export const validateAddress = (
       id: payload?.id,
     };
 
-    // If multiple suggestions, present them to the modal
-    if (suggestedAddresses.length > 1) {
+    // If the highest confidence score is below 80 regardless of number of addresses, show the modal
+    if (
+      suggestedAddresses.length > 1 ||
+      suggestedAddresses[0]?.addressMetaData?.confidenceScore < 80
+    ) {
       return dispatch({
         type: ADDRESS_VALIDATION_CONFIRM,
         addressFromUser: payload,
         addressValidationType: fieldName,
-        selectedAddress: suggestedAddresses[0], // always select the first address as the default
+        selectedAddress: suggestedAddresses[0].address, // always select the first address as the default
         suggestedAddresses,
         validationKey: response.validationKey,
       });

--- a/src/platform/user/profile/vet360/actions/transactions.js
+++ b/src/platform/user/profile/vet360/actions/transactions.js
@@ -227,7 +227,7 @@ export const validateAddress = (
         type: ADDRESS_VALIDATION_CONFIRM,
         addressFromUser: payload,
         addressValidationType: fieldName,
-        selectedAddress: suggestedAddresses[0].address, // always select the first address as the default
+        selectedAddress: suggestedAddresses[0], // always select the first address as the default
         suggestedAddresses,
         validationKey: response.validationKey,
       });

--- a/src/platform/user/profile/vet360/actions/transactions.js
+++ b/src/platform/user/profile/vet360/actions/transactions.js
@@ -1,7 +1,7 @@
 import { apiRequest } from 'platform/utilities/api';
 import { refreshProfile } from 'platform/user/profile/actions';
 import recordEvent from 'platform/monitoring/record-event';
-import { inferAddressType } from '../../../../../applications/letters/utils/helpers';
+import { inferAddressType } from 'applications/letters/utils/helpers';
 
 import localVet360, { isVet360Configured } from '../util/local-vet360';
 import {

--- a/src/platform/user/profile/vet360/actions/transactions.js
+++ b/src/platform/user/profile/vet360/actions/transactions.js
@@ -185,7 +185,7 @@ export const validateAddress = (
   payload,
   analyticsSectionName,
 ) => async dispatch => {
-  const addressPayload = { address: payload };
+  const addressPayload = { address: { ...payload } };
   const options = {
     body: JSON.stringify(addressPayload),
     method: 'POST',

--- a/src/platform/user/profile/vet360/actions/ui.js
+++ b/src/platform/user/profile/vet360/actions/ui.js
@@ -4,6 +4,8 @@ export const UPDATE_ADDRESS = 'UPDATE_ADDRESS';
 
 export const openModal = modal => ({ type: OPEN_MODAL, modal });
 
+export const closeModal = () => ({ type: OPEN_MODAL });
+
 export const updateFormField = (
   fieldName,
   convertNextValueToCleanData,

--- a/src/platform/user/profile/vet360/containers/AddressValidationModal.jsx
+++ b/src/platform/user/profile/vet360/containers/AddressValidationModal.jsx
@@ -264,7 +264,6 @@ const mapStateToProps = state => {
 };
 
 const mapDispatchToProps = dispatch => ({
-  dispatch,
   ...bindActionCreators(
     {
       closeModal,

--- a/src/platform/user/profile/vet360/containers/AddressValidationModal.jsx
+++ b/src/platform/user/profile/vet360/containers/AddressValidationModal.jsx
@@ -20,7 +20,8 @@ class AddressValidationModal extends React.Component {
     this.props.updateSelectedAddress(address, selectedId);
   };
 
-  onSubmit = () => {
+  onSubmit = event => {
+    event.preventDefault();
     const {
       validationKey,
       addressValidationType,

--- a/src/platform/user/profile/vet360/containers/AddressValidationModal.jsx
+++ b/src/platform/user/profile/vet360/containers/AddressValidationModal.jsx
@@ -291,6 +291,7 @@ AddressValidationModal.propTypes = {
   openModal: PropTypes.func.isRequired,
   createTransaction: PropTypes.func.isRequired,
   updateSelectedAddress: PropTypes.func.isRequired,
+  updateValidationKeyAndSave: PropTypes.func.isRequired,
 };
 
 export default connect(

--- a/src/platform/user/profile/vet360/containers/AddressValidationModal.jsx
+++ b/src/platform/user/profile/vet360/containers/AddressValidationModal.jsx
@@ -61,11 +61,11 @@ class AddressValidationModal extends React.Component {
 
     let warningText;
 
-    if (suggestedAddresses.length > 1 && validationKey) {
+    if (suggestedAddresses.length && validationKey) {
       warningText = `We couldn’t confirm your address with the U.S. Postal Service.  Please verify your address so we can save it to your VA profile.  If the address you entered isn’t correct, please edit it or choose a suggested address below`;
     }
 
-    if (suggestedAddresses.length > 1 && !validationKey) {
+    if (suggestedAddresses.length && !validationKey) {
       warningText = `We’re sorry.  We couldn’t verify your address with the U.S. Postal Service, so we won't be able to deliver your VA mail to that address.  Please edit the address you entered or choose a suggested address below.`;
     }
 

--- a/src/platform/user/profile/vet360/containers/AddressValidationModal.jsx
+++ b/src/platform/user/profile/vet360/containers/AddressValidationModal.jsx
@@ -10,7 +10,7 @@ import {
   createTransaction,
   updateSelectedAddress,
   updateValidationKeyAndSave,
-  closeModal,
+  closeModal as closeValidationModal,
 } from '../actions';
 
 import * as VET360 from '../constants';
@@ -213,7 +213,7 @@ class AddressValidationModal extends React.Component {
             : 'Edit home address'
         }
         id="address-validation-warning"
-        onClose={this.props.closeModal}
+        onClose={closeValidationModal}
         visible={isAddressValidationModalVisible}
       >
         <AlertBox
@@ -236,7 +236,10 @@ class AddressValidationModal extends React.Component {
               this.renderAddressOption(address, String(index)),
             )}
           {this.renderPrimaryButton()}
-          <button className="usa-button-secondary" onClick={closeModal}>
+          <button
+            className="usa-button-secondary"
+            onClick={closeValidationModal}
+          >
             Cancel
           </button>
         </form>
@@ -267,7 +270,7 @@ const mapStateToProps = state => {
 const mapDispatchToProps = dispatch => ({
   ...bindActionCreators(
     {
-      closeModal,
+      closeValidationModal,
       openModal,
       updateSelectedAddress,
       updateValidationKeyAndSave,

--- a/src/platform/user/profile/vet360/containers/AddressValidationModal.jsx
+++ b/src/platform/user/profile/vet360/containers/AddressValidationModal.jsx
@@ -147,16 +147,28 @@ class AddressValidationModal extends React.Component {
     const showEditLinkErrorState = addressValidationError && validationKey;
     const showEditLinkNonErrorState = !addressValidationError;
     const showEditLink = showEditLinkErrorState || showEditLinkNonErrorState;
+    const showFirstRadioButton =
+      (isAddressFromUser && validationKey) || !isAddressFromUser;
 
     return (
-      <div onClick={this.onChangeHandler(address, id)} key={id}>
-        <input
-          style={{ zIndex: '1' }}
-          type="radio"
-          name={id}
-          disabled={isAddressFromUser && !validationKey}
-          checked={selectedId === id}
-        />
+      <div
+        onClick={this.onChangeHandler(address, id)}
+        key={id}
+        className={
+          showFirstRadioButton
+            ? ''
+            : 'vads-u-margin-left--2 vads-u-margin-bottom--1p5'
+        }
+      >
+        {showFirstRadioButton && (
+          <input
+            style={{ zIndex: '1' }}
+            type="radio"
+            name={id}
+            disabled={isAddressFromUser && !validationKey}
+            checked={selectedId === id}
+          />
+        )}
         <label
           htmlFor={id}
           className="vads-u-margin-top--2 vads-u-display--flex vads-u-align-items--center"

--- a/src/platform/user/profile/vet360/containers/AddressValidationModal.jsx
+++ b/src/platform/user/profile/vet360/containers/AddressValidationModal.jsx
@@ -8,6 +8,7 @@ import {
   openModal,
   createTransaction,
   updateSelectedAddress,
+  updateValidationKeyAndSave,
 } from '../actions';
 
 import * as VET360 from '../constants';
@@ -22,17 +23,25 @@ class AddressValidationModal extends React.Component {
       validationKey,
       addressValidationType,
       selectedAddress,
+      selectedId,
     } = this.props;
+
     const payload = {
       ...selectedAddress,
       validationKey,
-      addressPou:
-        addressValidationType === VET360.FIELD_NAMES.MAILING_ADDRESS
-          ? VET360.ADDRESS_POU.CORRESPONDENCE
-          : VET360.ADDRESS_POU.RESIDENCE,
     };
 
     const method = payload.id ? 'PUT' : 'POST';
+
+    if (selectedId !== 'userEntered') {
+      this.props.updateValidationKeyAndSave(
+        VET360.API_ROUTES.ADDRESSES,
+        method,
+        addressValidationType,
+        payload,
+        this.props.analyticsSectionName,
+      );
+    }
 
     this.props.createTransaction(
       VET360.API_ROUTES.ADDRESSES,
@@ -140,14 +149,13 @@ class AddressValidationModal extends React.Component {
     const showEditLink = showEditLinkErrorState || showEditLinkNonErrorState;
 
     return (
-      <div key={id}>
+      <div onClick={this.onChangeHandler(address, id)} key={id}>
         <input
           style={{ zIndex: '1' }}
           type="radio"
           name={id}
           disabled={isAddressFromUser && !validationKey}
           checked={selectedId === id}
-          onClick={this.onChangeHandler(address, id)}
         />
         <label
           htmlFor={id}
@@ -246,6 +254,7 @@ const mapDispatchToProps = dispatch => ({
   closeModal: () => dispatch(openModal(null)),
   openModal: modalName => dispatch(openModal(modalName)),
   createTransaction,
+  updateValidationKeyAndSave,
   updateSelectedAddress: (address, selectedId) =>
     dispatch(updateSelectedAddress(address, selectedId)),
 });

--- a/src/platform/user/profile/vet360/containers/AddressValidationModal.jsx
+++ b/src/platform/user/profile/vet360/containers/AddressValidationModal.jsx
@@ -43,15 +43,15 @@ class AddressValidationModal extends React.Component {
         payload,
         this.props.analyticsSectionName,
       );
+    } else {
+      this.props.createTransaction(
+        VET360.API_ROUTES.ADDRESSES,
+        method,
+        addressValidationType,
+        payload,
+        this.props.analyticsSectionName,
+      );
     }
-
-    this.props.createTransaction(
-      VET360.API_ROUTES.ADDRESSES,
-      method,
-      addressValidationType,
-      payload,
-      this.props.analyticsSectionName,
-    );
   };
 
   renderWarningText = () => {
@@ -149,20 +149,20 @@ class AddressValidationModal extends React.Component {
     const showEditLinkErrorState = addressValidationError && validationKey;
     const showEditLinkNonErrorState = !addressValidationError;
     const showEditLink = showEditLinkErrorState || showEditLinkNonErrorState;
-    const showFirstRadioButton =
+    const isFirstOptionOrEnabled =
       (isAddressFromUser && validationKey) || !isAddressFromUser;
 
     return (
       <div
-        onClick={this.onChangeHandler(address, id)}
+        onClick={isFirstOptionOrEnabled && this.onChangeHandler(address, id)}
         key={id}
         className={
-          showFirstRadioButton
+          isFirstOptionOrEnabled
             ? ''
             : 'vads-u-margin-left--2 vads-u-margin-bottom--1p5'
         }
       >
-        {showFirstRadioButton && (
+        {isFirstOptionOrEnabled && (
           <input
             style={{ zIndex: '1' }}
             type="radio"

--- a/src/platform/user/profile/vet360/containers/AddressValidationModal.jsx
+++ b/src/platform/user/profile/vet360/containers/AddressValidationModal.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
 import Modal from '@department-of-veterans-affairs/formation-react/Modal';
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 import { selectCurrentlyOpenEditModal } from '../selectors';
@@ -9,6 +10,7 @@ import {
   createTransaction,
   updateSelectedAddress,
   updateValidationKeyAndSave,
+  closeModal,
 } from '../actions';
 
 import * as VET360 from '../constants';
@@ -194,7 +196,6 @@ class AddressValidationModal extends React.Component {
 
   render() {
     const {
-      closeModal,
       isAddressValidationModalVisible,
       addressValidationType,
       suggestedAddresses,
@@ -211,7 +212,7 @@ class AddressValidationModal extends React.Component {
             : 'Edit home address'
         }
         id="address-validation-warning"
-        onClose={closeModal}
+        onClose={this.props.closeModal}
         visible={isAddressValidationModalVisible}
       >
         <AlertBox
@@ -263,12 +264,17 @@ const mapStateToProps = state => {
 };
 
 const mapDispatchToProps = dispatch => ({
-  closeModal: () => dispatch(openModal(null)),
-  openModal: modalName => dispatch(openModal(modalName)),
-  createTransaction,
-  updateValidationKeyAndSave,
-  updateSelectedAddress: (address, selectedId) =>
-    dispatch(updateSelectedAddress(address, selectedId)),
+  dispatch,
+  ...bindActionCreators(
+    {
+      closeModal,
+      openModal,
+      updateSelectedAddress,
+      updateValidationKeyAndSave,
+      createTransaction,
+    },
+    dispatch,
+  ),
 });
 
 AddressValidationModal.propTypes = {

--- a/src/platform/user/profile/vet360/tests/actions/transactions.unit.spec.js
+++ b/src/platform/user/profile/vet360/tests/actions/transactions.unit.spec.js
@@ -125,6 +125,11 @@ describe('validateAddress', () => {
       );
       expect(dispatch.firstCall.args[0].suggestedAddresses).to.deep.equal([
         {
+          addressMetaData: {
+            confidenceScore: 100,
+            addressType: 'Domestic',
+            deliveryPointValidation: 'UNDELIVERABLE',
+          },
           addressLine1: '400 N 65th St',
           addressType: 'DOMESTIC',
           city: 'Seattle',
@@ -135,8 +140,16 @@ describe('validateAddress', () => {
           stateCode: 'WA',
           zipCode: '98103',
           zipCodeSuffix: '5252',
+          type: 'DOMESTIC',
+          addressPou: 'RESIDENCE/CHOICE',
         },
         {
+          addressMetaData: {
+            confidenceScore: 100,
+            addressType: 'Domestic',
+            deliveryPointValidation: 'CONFIRMED',
+            residentialDeliveryIndicator: 'RESIDENTIAL',
+          },
           addressLine1: '400 NW 65th St',
           addressType: 'DOMESTIC',
           city: 'Seattle',
@@ -147,8 +160,16 @@ describe('validateAddress', () => {
           stateCode: 'WA',
           zipCode: '98117',
           zipCodeSuffix: '5026',
+          type: 'DOMESTIC',
+          addressPou: 'RESIDENCE/CHOICE',
         },
         {
+          addressMetaData: {
+            confidenceScore: 100,
+            addressType: 'Domestic',
+            deliveryPointValidation: 'CONFIRMED',
+            residentialDeliveryIndicator: 'RESIDENTIAL',
+          },
           addressLine1: '400 NW 65th Street',
           addressType: 'DOMESTIC',
           city: 'Seattle',
@@ -159,8 +180,17 @@ describe('validateAddress', () => {
           stateCode: 'WA',
           zipCode: '98117',
           zipCodeSuffix: '5026',
+          type: 'DOMESTIC',
+          addressPou: 'RESIDENCE/CHOICE',
         },
         {
+          addressMetaData: {
+            confidenceScore: 98,
+            addressType: 'Domestic',
+            deliveryPointValidation:
+              'STREET_NUMBER_VALIDATED_BUT_MISSING_UNIT_NUMBER',
+            residentialDeliveryIndicator: 'RESIDENTIAL',
+          },
           addressLine1: '400 NE 65th St',
           addressType: 'DOMESTIC',
           city: 'Seattle',
@@ -171,6 +201,8 @@ describe('validateAddress', () => {
           stateCode: 'WA',
           zipCode: '98115',
           zipCodeSuffix: '6463',
+          type: 'DOMESTIC',
+          addressPou: 'RESIDENCE/CHOICE',
         },
       ]);
     });


### PR DESCRIPTION
## Description
- [x] Create thunk to fetch validation key and submit that key to save API with the suggested address selection.

- [x] Remove the 'disabled' input if the user cannot override

- [x] Change the modal to display single address suggestions that fall below the 80% confidence score threshold

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
