### PR TITLE
Add events around submitting VAOS form

### DIFF
--- a/src/applications/vaos/actions/newAppointment.js
+++ b/src/applications/vaos/actions/newAppointment.js
@@ -508,19 +508,19 @@ export function submitAppointmentOrRequest(router) {
         });
       }
     } else {
+      const isCommunityCare =
+        newAppointment.data.facilityType === FACILITY_TYPES.COMMUNITY_CARE;
+      const eventType = isCommunityCare ? 'community-care' : 'request';
+
       recordEvent({
-        event: `${GA_PREFIX}-request-submission`,
+        event: `${GA_PREFIX}-${eventType}-submission`,
       });
+
       try {
         let requestBody;
         let requestData;
 
-        if (
-          newAppointment.data.facilityType === FACILITY_TYPES.COMMUNITY_CARE
-        ) {
-          recordEvent({
-            event: `${GA_PREFIX}-community-care-submission`,
-          });
+        if (isCommunityCare) {
           requestBody = transformFormToCCRequest(getState());
           requestData = await submitRequest('cc', requestBody);
         } else {
@@ -543,7 +543,7 @@ export function submitAppointmentOrRequest(router) {
         });
 
         recordEvent({
-          event: `${GA_PREFIX}-request-submission-successful`,
+          event: `${GA_PREFIX}-${eventType}-submission-successful`,
         });
         router.push('/new-appointment/confirmation');
       } catch (error) {
@@ -552,7 +552,7 @@ export function submitAppointmentOrRequest(router) {
           type: FORM_SUBMIT_FAILED,
         });
         recordEvent({
-          event: `${GA_PREFIX}-request-submission-failed`,
+          event: `${GA_PREFIX}-${eventType}-submission-failed`,
         });
       }
     }

--- a/src/applications/vaos/containers/AppointmentsPage.jsx
+++ b/src/applications/vaos/containers/AppointmentsPage.jsx
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import { Link } from 'react-router';
 import LoadingIndicator from '@department-of-veterans-affairs/formation-react/LoadingIndicator';
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
+import recordEvent from 'platform/monitoring/record-event';
 import Breadcrumbs from '../components/Breadcrumbs';
 import ConfirmedAppointmentListItem from '../components/ConfirmedAppointmentListItem';
 import AppointmentRequestListItem from '../components/AppointmentRequestListItem';
@@ -15,7 +16,7 @@ import {
   fetchRequestMessages,
 } from '../actions/appointments';
 import { getAppointmentType, getRealFacilityId } from '../utils/appointment';
-import { FETCH_STATUS, APPOINTMENT_TYPES } from '../utils/constants';
+import { FETCH_STATUS, APPOINTMENT_TYPES, GA_PREFIX } from '../utils/constants';
 import CancelAppointmentModal from '../components/CancelAppointmentModal';
 import { getCancelInfo, vaosCancel, vaosRequests } from '../utils/selectors';
 import { scrollAndFocus } from '../utils/scrollAndFocus';
@@ -24,6 +25,12 @@ export class AppointmentsPage extends Component {
   componentDidMount() {
     scrollAndFocus();
     this.props.fetchFutureAppointments();
+  }
+
+  recordStartEvent() {
+    recordEvent({
+      event: `${GA_PREFIX}-schedule-new-appointment-started`,
+    });
   }
 
   render() {
@@ -171,7 +178,7 @@ export class AppointmentsPage extends Component {
                   Schedule an appointment at a VA medical center, clinic, or
                   Community Care facility.
                 </p>
-                <Link to="/new-appointment">
+                <Link to="/new-appointment" onClick={this.recordStartEvent}>
                   <button className="usa-button vads-u-margin--0 vads-u-font-weight--bold vads-u-font-size--md">
                     Schedule an appointment
                   </button>

--- a/src/applications/vaos/utils/constants.js
+++ b/src/applications/vaos/utils/constants.js
@@ -267,4 +267,4 @@ export const REASON_MAX_CHARS = {
 export const DISABLED_LIMIT_VALUE = 0;
 export const PRIMARY_CARE = '323';
 export const MENTAL_HEALTH = '502';
-export const GA_PREFIX = 'vaos-';
+export const GA_PREFIX = 'vaos';

--- a/src/applications/vaos/utils/constants.js
+++ b/src/applications/vaos/utils/constants.js
@@ -267,3 +267,4 @@ export const REASON_MAX_CHARS = {
 export const DISABLED_LIMIT_VALUE = 0;
 export const PRIMARY_CARE = '323';
 export const MENTAL_HEALTH = '502';
+export const GA_PREFIX = 'vaos-';


### PR DESCRIPTION
## Description
This adds our typical form submission events to the VAOS form, following the naming convention from other forms.

Events will be:
- vaos-request-submission
- vaos-request-submission-successful
- vaos-request-submission-failed
- vaos-direct-submission
- vaos-direct-submission-successful
- vaos-direct-submission-failed
- vaos-community-care-submission
- vaos-community-care-submission-successful
- vaos-community-care-submission-failed

## Testing done
Local testing

## Acceptance criteria
- [ ] Events are sent

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
