### PR TITLE
VAGOV-6299: Removing fieldMedia from detail pages.

### DIFF
--- a/src/site/layouts/health_care_region_detail_page.drupal.liquid
+++ b/src/site/layouts/health_care_region_detail_page.drupal.liquid
@@ -59,27 +59,6 @@
             {% endif %}
           {% endfor %}
 
-          {% if fieldMedia != empty %}
-            <section class="vads-u-margin-bottom--5">
-              <div class="vads-u-font-weight--bold vads-u-margin-bottom--1p5">Download media assets</div>
-              {% for asset in fieldMedia %}
-                {% assign a = asset.entity %}
-                <ul class="vads-u-margin-bottom--1 usa-unstyled-list">
-                  <li>
-                    {% case a.entityBundle %}
-                  {% when 'document' %}
-                    <a href="{{ a.fieldDocument.entity.url }}" download>{{ a.name }}</a>
-                  {% when a.entityBundle === 'image' %}
-                    <a href="{{ a.image.url }}" download>{{ a.name }}</a>
-                  {% when a.entityBundle === 'video' %}
-                    <a href="{{ a.fieldMediaVideoEmbedField }}">{{ a.name }}</a>
-                    {%  endcase %}
-                  </li>
-                </ul>
-              {% endfor %}
-            </section>
-          {%  endif %}
-
           {% if fieldRelatedLinks and fieldRelatedLinks.entity.fieldVaParagraphs and fieldRelatedLinks.entity.fieldVaParagraphs.0.entity.fieldLink %}
             <div class="va-nav-linkslist va-nav-linkslist--related">
               {% include 'src/site/paragraphs/list_of_link_teasers.drupal.liquid' entity = fieldRelatedLinks.entity %}

--- a/src/site/stages/build/drupal/graphql/healthCareRegionDetailPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/healthCareRegionDetailPage.graphql.js
@@ -60,32 +60,6 @@ module.exports = `
     }
     ${FIELD_RELATED_LINKS}
     ${FIELD_ALERT}
-    fieldMedia {
-      entity {
-        entityId
-        entityBundle
-        name
-        ...on MediaDocument {
-          fieldDocument {
-            entity {
-              ...on File {
-                filename
-                url
-              }
-            }
-          }
-        }
-        ...on MediaImage {
-          image {
-            alt
-            url
-          }
-        }
-        ...on MediaVideo {
-          fieldMediaVideoEmbedField
-        }
-      }
-    }
     fieldOffice {
       entity {
         ...on NodeHealthCareRegionPage {


### PR DESCRIPTION
## Description
Removes deprecated `fieldMedia` from `health_care_region_detail_page`

## Testing done
Visual

## Screenshots
N/A

## Acceptance criteria
- [ ] fieldMedia has been removed from `src/site/stages/build/drupal/graphql/healthCareRegionDetailPage.graphql.js` and `src/site/layouts/health_care_region_detail_page.drupal.liquid`
