### PR TITLE
Move global.window stub into Mocha hook

### DIFF
--- a/src/applications/find-va-forms/tests/actions/index.unit.spec.js
+++ b/src/applications/find-va-forms/tests/actions/index.unit.spec.js
@@ -51,9 +51,10 @@ describe('Find VA Forms actions', () => {
   });
 
   describe('fetchFormsThunk', () => {
-    const oldWindow = global.window;
+    let oldWindow;
 
     beforeEach(() => {
+      oldWindow = global.window;
       global.window = {
         location: {
           search: '',


### PR DESCRIPTION
## Description
This PR fixes a unit test error that pops up randomly about the `scroll` method on `global.window`. This PR should fix the test case.

## Testing done
Locally ran all unit tests several times

## Screenshots
N/A

## Acceptance criteria
- [ ] Unit test doesn't impact other unit tests during global execution

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
