### PR TITLE
Add MVP of content language linting plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends gconf-service l
 RUN curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > /cc-test-reporter
 RUN chmod +x /cc-test-reporter
 
+# Install vale for plain language linting
+RUN curl -sfL https://install.goreleaser.com/github.com/ValeLint/vale.sh | sh -s latest \
+  && export PATH="./bin:$PATH" \
+  && vale -v
+
 RUN mkdir -p /application
 
 WORKDIR /application

--- a/script/preview.js
+++ b/script/preview.js
@@ -6,7 +6,7 @@ const commandLineArgs = require('command-line-args');
 const path = require('path');
 const express = require('express');
 const proxy = require('express-http-proxy');
-const createPipieline = require('../src/site/stages/preview');
+const createPipeline = require('../src/site/stages/preview');
 
 const getDrupalClient = require('../src/site/stages/build/drupal/api');
 const {
@@ -35,6 +35,7 @@ const COMMAND_LINE_OPTIONS_DEFINITIONS = [
   { name: 'destination', type: String, defaultValue: null },
   { name: 'content-directory', type: String, defaultValue: defaultContentDir },
   { name: 'accessibility', type: Boolean, defaultValue: true },
+  { name: 'lint-plain-language', type: Boolean, defaultValue: false },
   {
     name: 'drupal-address',
     type: String,
@@ -112,7 +113,7 @@ app.get('/health', (req, res) => {
 
 app.get('/preview', async (req, res, next) => {
   try {
-    const smith = await createPipieline({
+    const smith = await createPipeline({
       ...options,
       isPreviewServer: true,
       port: process.env.PORT || 3001,

--- a/script/vale/.vale.ini
+++ b/script/vale/.vale.ini
@@ -3,4 +3,4 @@ MinAlertLevel = suggestion
 
 # Global settings
 [*]
-BasedOnStyles = PlainLanguage, VAGov
+BasedOnStyles = PlainLanguage, VAgov

--- a/script/vale/.vale.ini
+++ b/script/vale/.vale.ini
@@ -1,0 +1,6 @@
+StylesPath = styles/
+MinAlertLevel = suggestion
+
+# Global settings
+[*]
+BasedOnStyles = PlainLanguage, VAGov

--- a/script/vale/TEST.md
+++ b/script/vale/TEST.md
@@ -1,0 +1,50 @@
+# Test File for Linting
+
+## Background
+
+This is a test `.MD` file for VA.gov Vale Plain Language Linting rules.
+
+
+#### Contractions
+
+##### The following words should raise warnings:
+
+Please use it's it is it has
+
+Would've
+Could've
+Should've
+
+#### Conversational Tone
+When referring to VA, use the first-person pronoun (we, us, our).
+When referring to Veterans, service members, family member, use the second person pronoun (you, your)
+
+<!-- NOTE These are more like grammatical rules, hard to fix in vale -->
+
+#### Sentence-case capitalization
+We use sentence-case capitalization for most content, including page titles, headings, subheadings, buttons, and text links unless a word is a proper noun.
+
+(Examples of proper nouns: “VA.gov,” the word “Veteran" or "Veterans," official VA program names, state names, names of federal agencies, days of the week, months, book titles)
+
+<!-- Each of these are subcategories:
+
+- VA specific proper nouns (Brand.yml)
+- VA Program names (Brand.yml or Jargon.yml)
+- State names
+- Federal agencies
+- Days of the week, months
+- Book titles  -->
+
+#### Time
+--Write out times, using a.m. and p.m. with periods: for example, 9:00 a.m. NOT: 9 am or 9 a.m.
+--Spell out noon and midnight. Don’t use 12:00 p.m. or 12:00 a.m.
+
+#### Specific style and formatting of commonly used words on VA.gov
+
+--service member: this should be lowercase and two words. Don't write as Servicemember
+--active duty: Hyphenate when it modifies a noun and don’t capitalize. (for example, active-duty service member
+--federal: don't capitalize for generic usage (for example, federal agency)
+--GI: this shouldn't have any periods. Don't write as G.I.
+--PO Box: this shouldn't have any periods. Don't write as P.O. Box
+--service connected: Don't hyphenate unless it appears before a noun (for example, service-connected disability)
+--sign in, sign out: We use sign in/sign out on VA.gov. Don’t use log in, log out, login ID, or sign on.

--- a/script/vale/dictionary.txt
+++ b/script/vale/dictionary.txt
@@ -1,0 +1,6 @@
+www
+html
+src
+env
+https
+telehealth

--- a/script/vale/styles/PlainLanguage/Contractions.yml
+++ b/script/vale/styles/PlainLanguage/Contractions.yml
@@ -1,8 +1,9 @@
-extends: substitution
+extends: substituti1n
 message: Use ’%s’ instead of ’%s.’
 level: suggestion
 ignorecase: true
 swap:
+  are not: aren't
   it is: it’s
   it will: it’ll
   we are: we’re
@@ -25,7 +26,6 @@ swap:
   how is: how’s
   how will: how’ll
   is not: isn’t
-  are not: aren’t
   was not: wasn’t
   were not: weren’t
   have not: haven’t

--- a/script/vale/styles/PlainLanguage/Contractions.yml
+++ b/script/vale/styles/PlainLanguage/Contractions.yml
@@ -1,0 +1,40 @@
+extends: substitution
+message: Use ’%s’ instead of ’%s.’
+level: suggestion
+ignorecase: true
+swap:
+  it is: it’s
+  it will: it’ll
+  we are: we’re
+  we will: we’ll
+  we have: we’ve
+  they are: they’re
+  they will: they’ll
+  that is: that’s
+  that will: that’ll
+  who is: who’s
+  who will: who’ll
+  what is: what’s
+  what will: what’ll
+  where is: where’s
+  where will: where’ll
+  when is: when’s
+  when will: when’ll
+  why is: why’s
+  why will: why’ll
+  how is: how’s
+  how will: how’ll
+  is not: isn’t
+  are not: aren’t
+  was not: wasn’t
+  were not: weren’t
+  have not: haven’t
+  has not: hasn’t
+  will not: won’t
+  do not: don’t
+  does not: doesn’t
+  did not: didn’t
+  cannot: can’t
+  could not: couldn’t
+  should not: shouldn’t
+  could not: couldn’t

--- a/script/vale/styles/PlainLanguage/Words.yml
+++ b/script/vale/styles/PlainLanguage/Words.yml
@@ -1,0 +1,7 @@
+extends: substitution
+message: Use ’%s’ instead of ’%s.’
+level: suggestion
+ignorecase: true
+swap:
+  G\.I\.: GI
+  P\.O\.: PO

--- a/script/vale/styles/VAgov/Brand.yml
+++ b/script/vale/styles/VAgov/Brand.yml
@@ -1,0 +1,9 @@
+extends: substitution
+message: Use ’%s’ instead of ’%s’.
+level: suggestion
+ignorecase: true
+swap:
+  "(?va\.gov)": VA.gov
+  "(?:Va\.gov)": VA.gov
+  "(?:vets\.gov)": VA.gov
+  dsva: DEPO

--- a/script/vale/styles/VAgov/JargonMilitary.yml
+++ b/script/vale/styles/VAgov/JargonMilitary.yml
@@ -1,0 +1,6 @@
+extends: substitution
+message: Use ’%s’ instead of ’%s’.
+level: error
+ignorecase: true
+swap:
+  servicemember: service member

--- a/script/vale/styles/VAgov/JargonTech.yml
+++ b/script/vale/styles/VAgov/JargonTech.yml
@@ -1,0 +1,43 @@
+extends: substitution
+message: Use ’%s’ instead of ’%s’.
+level: suggestion
+ignorecase: true
+swap:
+  (?:log in|login): sign in
+  (?:log out|logout): sign out
+  "(?:LetsEncrypt|Let’s Encrypt)": Let’s Encrypt
+  "(?:ReHat|RedHat)": RedHat
+  "Mac ?OS ?X": Mac OS X
+  "mongoDB": MongoDB
+  "node[.]?js": Node.js
+  "Post?gr?e(?:SQL)": PostgreSQL
+  "java[ -]?scripts?": JavaScript
+  automattic: Automattic
+  centOS: CentOS
+  cloudflare: Cloudflare
+  debian: Debian
+  fedora: Fedora
+  gentoo: Gentoo
+  homebrew: Homebrew
+  linode cli: Linode CLI
+  linode manager: Linode Manager
+  linode: Linode
+  longview: Longview
+  macOS: macOS
+  metabase: Metabase
+  miniconda: Miniconda
+  nodebalancer: NodeBalancer
+  nodebalancers: NodeBalancers
+  openSUSE: OpenSUSE
+  slackware: Slackware
+  ubuntu: Ubuntu
+  wordpress: WordPress
+  yaml: YAML
+  urls: URLs
+  uris: URIs
+  Cuda: CUDA
+  gpu: GPU
+  stackscript: StackScript
+  typescript: TypeScript
+  pulumi: Pulumi
+  markdown: Markdown

--- a/script/vale/styles/VAgov/JargonVSP.yml
+++ b/script/vale/styles/VAgov/JargonVSP.yml
@@ -1,0 +1,5 @@
+extends: substitution
+message: Use ’%s’ instead of ’%s’.
+level: suggestion
+ignorecase: true
+swap:

--- a/script/vale/styles/VAgov/Spelling.yml
+++ b/script/vale/styles/VAgov/Spelling.yml
@@ -1,0 +1,4 @@
+extends: spelling
+message: "Did you really mean ’%s’?"
+level: suggestion
+ignore: script/vale/dictionary.txt

--- a/src/site/stages/build/options.js
+++ b/src/site/stages/build/options.js
@@ -51,6 +51,7 @@ const COMMAND_LINE_OPTIONS_DEFINITIONS = [
   { name: 'local-proxy-rewrite', type: Boolean, defaultValue: false },
   { name: 'local-css-sourcemaps', type: Boolean, defaultValue: false },
   { name: 'accessibility', type: Boolean, defaultValue: false },
+  { name: 'lint-plain-language', type: Boolean, defaultValue: false },
   { name: 'unexpected', type: String, multile: true, defaultOption: true },
 ];
 

--- a/src/site/stages/build/plugins/inject-vale-linter.js
+++ b/src/site/stages/build/plugins/inject-vale-linter.js
@@ -51,7 +51,7 @@ function runValeCheck(contentFilename) {
  *
  */
 function createTempFile(dataBuffer) {
-  const temp = tmp.fileSync({ prefix: 'vale-' });
+  const temp = tmp.fileSync({ prefix: 'vale-', postfix: '.html' });
   fs.writeSync(temp.fd, dataBuffer);
   return temp.name;
 }
@@ -64,10 +64,6 @@ function createTempFile(dataBuffer) {
  *
  */
 function buildDetailsMarkup(issues) {
-  if (typeof issues.length === 'undefined') {
-    return true;
-  }
-
   let details =
     '<details class="vads-u-background-color--primary-alt-lightest vads-u-border-color--secondary-lighter vads-u-border-bottom--2px vads-u-padding--1">';
   details += `<summary><h4 class="vads-u-display--inline-block vads-u-margin-y--2">There are (${
@@ -132,9 +128,8 @@ function injectValeLinter(buildOptions) {
         const valeOutput = await runValeCheck(tempfile);
         if (typeof valeOutput.results.length === 'undefined') continue;
 
-        const parsedOutput = JSON.parse(valeOutput.results);
+        const parsedOutput = JSON.parse(valeOutput.results)[tempfile];
         const elements = buildDetailsMarkup(parsedOutput);
-
         dom('body').prepend(elements);
         file.modified = true;
       } catch (e) {

--- a/src/site/stages/build/plugins/inject-vale-linter.js
+++ b/src/site/stages/build/plugins/inject-vale-linter.js
@@ -1,0 +1,133 @@
+/* eslint-disable no-continue */
+/* eslint-disable no-await-in-loop */
+
+/**
+ * Run vale lint on the page content and inject suggestions into the rendered HTML
+ */
+const { spawn } = require('child_process');
+const fs = require('fs');
+const tmp = require('tmp');
+
+/**
+ *  Method to execute vale check on content via child process
+ *
+ * @param {String} contentFilename a tempfile name including the page content, to be passed to vale
+ * @return {Promise} resolves with vale results in object
+ *
+ */
+function runValeCheck(contentFilename) {
+  const promise = new Promise((resolve, reject) => {
+    const output = {};
+    const vale = spawn('vale', [
+      '--config=script/vale/.vale.ini',
+      '--output=JSON',
+      `${contentFilename}`,
+    ]);
+
+    vale.stdout.on('data', data => {
+      output.results = data;
+    });
+
+    vale.stderr.on('data', data => {
+      output.errors = data.toString();
+    });
+
+    vale.on('exit', code => {
+      if (code !== 0) {
+        reject('Vale exited with non-zero exit code:', code);
+      }
+      output.code = code.toString();
+      resolve(output);
+    });
+  });
+  return promise;
+}
+
+/**
+ * Method to create a tempfile for the page content
+ *
+ * @param {Buffer} dataBuffer the content to write to file
+ * @return {String} filename of the generated tempfile
+ *
+ */
+function createTempFile(dataBuffer) {
+  const temp = tmp.fileSync({ prefix: 'vale-' });
+  fs.writeSync(temp.fd, dataBuffer);
+  return temp.name;
+}
+
+/**
+ * Build the page header banner element
+ *
+ * @param {Object} issues an object containing a collection of linting issues
+ * @return {String} an HTML string containing elements to be injected into the DOM
+ *
+ */
+function buildDetailsMarkup(issues) {
+  let details =
+    '<details class="vads-u-background-color--primary-alt-lightest vads-u-border-color--secondary-lighter vads-u-border-bottom--2px vads-u-padding--1">';
+  details += `<summary><h4 class="vads-u-display--inline-block vads-u-margin-y--2">There are (${
+    issues.length
+  }) content suggestions found on this page.</h4></summary>`;
+
+  let issuesList =
+    '<ul class="usa-unstyled-list vads-u-border-color--primary-darker vads-u-border-top--1px vads-u-padding-x--6 vads-u-padding-y--2">';
+
+  issues.forEach(issue => {
+    let issueEl = '<li class=vads-u-margin-y--1">';
+    issueEl += '<details>';
+    issueEl += `<summary><strong>${issue.Message}</strong></summary>`;
+    issueEl += `<ul class="usa-unstyled-list vads-u-padding-y--1 vads-u-padding-x--2">`;
+
+    issueEl += '</ul>';
+    issueEl += '</details>';
+    issueEl += '</li>';
+
+    issuesList += issueEl;
+  });
+
+  issuesList += '</ul>';
+
+  details += issuesList;
+  details += '</details>';
+  return details;
+}
+
+/**
+ * Run the vale plain language linter on previewed content files
+ *
+ * @param {Object} files
+ * @param {Metalsmith} metalsmith
+ * @param {Function} done
+ *
+ */
+function injectValeLinter(buildOptions) {
+  return async (files, metalsmith, done) => {
+    if (!buildOptions['lint-plain-language']) {
+      done();
+      return 'Plain language linting skipped';
+    }
+
+    for (const fileName of Object.keys(files)) {
+      if (!fileName.endsWith('.html')) continue;
+
+      /*
+       * Because the file is only linted for plain language on the preview server, which is dynamically served via preview.js, we need to read the contents directly and put them in a tmpfile. Passing contents in directly leads to very large argument lists which causes vale to error out.
+       */
+      const file = files[fileName];
+      const tempfile = createTempFile(file.contents);
+      const { dom } = file;
+
+      const valeOutput = await runValeCheck(tempfile);
+
+      const parsedOutput = JSON.parse(valeOutput.results)[tempfile];
+      const elements = buildDetailsMarkup(parsedOutput);
+
+      dom('body').prepend(elements);
+      file.modified = true;
+    }
+    return done();
+  };
+}
+
+module.exports = injectValeLinter;

--- a/src/site/stages/preview/index.js
+++ b/src/site/stages/preview/index.js
@@ -22,6 +22,7 @@ const addSubheadingsIds = require('../build/plugins/add-id-to-subheadings');
 const parseHtml = require('../build/plugins/parse-html');
 const replaceContentsWithDom = require('../build/plugins/replace-contents-with-dom');
 const injectAxeCore = require('../build/plugins/inject-axe-core');
+const injectValeLinter = require('../build/plugins/inject-vale-linter');
 
 async function createPipeline(options) {
   const BUILD_OPTIONS = await getOptions(options);
@@ -76,7 +77,7 @@ async function createPipeline(options) {
 
   // Responsible for create permalink structure. Most commonly used change foo.md to foo/index.html.
   //
-  // This must come before navigation module, otherwise breadcrunmbs will see the wrong URLs.
+  // This must come before navigation module, otherwise breadcrumbs will see the wrong URLs.
   //
   // It also must come AFTER the markdown() module because it only recognizes .html files. See
   // comment above the inPlace() module for explanation of effects on the metadata().
@@ -142,6 +143,7 @@ async function createPipeline(options) {
   smith.use(updateExternalLinks(BUILD_OPTIONS));
   smith.use(addSubheadingsIds(BUILD_OPTIONS));
   smith.use(injectAxeCore(BUILD_OPTIONS));
+  smith.use(injectValeLinter(BUILD_OPTIONS));
   smith.use(replaceContentsWithDom);
 
   return smith;


### PR DESCRIPTION

## Description
This PR adds basic support for plain language content linting, via [vale](https://github.com/errata-ai/vale), by adding a metalsmith plugin which will optionally run on `/preview` requests.

## Testing done
- [x] Tested locally to ensure logic is correct
- [x] Tested `Dockerfile` builds w/ new dependency
- [x] Tested in a live preview instance

## Screenshots

![screenshot-localhost_3001-2019 12 10-12_08_25](https://user-images.githubusercontent.com/11085141/70556916-6fc48700-1b47-11ea-840b-ab69942f7958.png)

## Acceptance criteria
- [x] MVP of linting plugin returns suggestions for content changing on preview pages

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
