### PR TITLE
RFC- do not require FE review group manual approval for changes to /src/applications 

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,4 +3,12 @@
 #  @department-of-veterans-affairs/frontend-review-group will be requested for
 # review when someone opens a pull request.
 
-*       @department-of-veterans-affairs/frontend-review-group
+/* @department-of-veterans-affairs/frontend-review-group
+/certs/ @department-of-veterans-affairs/frontend-review-group
+/config/ @department-of-veterans-affairs/frontend-review-group
+/docs/ @department-of-veterans-affairs/frontend-review-group
+/jenkins/ @department-of-veterans-affairs/frontend-review-group
+/script/ @department-of-veterans-affairs/frontend-review-group
+/src/* @department-of-veterans-affairs/frontend-review-group
+/src/platform/ @department-of-veterans-affairs/frontend-review-group
+/src/site/ @department-of-veterans-affairs/frontend-review-group

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,12 +3,7 @@
 #  @department-of-veterans-affairs/frontend-review-group will be requested for
 # review when someone opens a pull request.
 
-/* @department-of-veterans-affairs/frontend-review-group
-/certs/ @department-of-veterans-affairs/frontend-review-group
-/config/ @department-of-veterans-affairs/frontend-review-group
-/docs/ @department-of-veterans-affairs/frontend-review-group
-/jenkins/ @department-of-veterans-affairs/frontend-review-group
-/script/ @department-of-veterans-affairs/frontend-review-group
-/src/* @department-of-veterans-affairs/frontend-review-group
-/src/platform/ @department-of-veterans-affairs/frontend-review-group
-/src/site/ @department-of-veterans-affairs/frontend-review-group
+* @department-of-veterans-affairs/frontend-review-group
+/src/applications/vaos/ @department-of-veterans-affairs/teams/va-gov-vaos
+*.scss @department-of-veterans-affairs/frontend-review-group
+*.css @department-of-veterans-affairs/frontend-review-group


### PR DESCRIPTION
## Overview 

- due to time constraints and lack of familiarity, FE review group is not creating useful feedback for application specific code 
- FE review group's time could be better spent focusing on the common components in vets-website like the shared css, build process, or site wide components 

## Review instructions 

- Add a comment providing pros, cons, and concerns with this approach. 
- Review the configuration carefully- [example](https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax)
- Add an approving review if approved. Add needs changes if you disapprove (everyone has a veto) 
- PR will remain open until 12/17/2019


I will add a documented decision [here](https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/tree/master/packages/documentation/src/pages/platform/front-end-standards/documented-decisions). 