### PR TITLE
Adding regex to remove violation.help brackets for better rendering.

### DIFF
--- a/src/site/assets/js/execute-axe-check.js
+++ b/src/site/assets/js/execute-axe-check.js
@@ -16,10 +16,11 @@ function processAxeCheckResults(error, results) {
 
   results.violations.forEach(function(violation) {
     var violationEl = '<li class="vads-u-margin-y--1">';
-    var violationHelp = violation.help.replace(/\</g,'').replace(/>/g,'');
+    var violationHelp = document.createElement('strong');
+    violationHelp.innerText = violation.help;
 
     violationEl += '<details>';
-    violationEl += '<summary><strong>' + violationHelp + '</strong></summary>';
+    violationEl += '<summary>' + violationHelp.outerHTML + '</summary>';
     violationEl += '<ul class="usa-unstyled-list vads-u-padding-y--1 vads-u-padding-x--2">';
 
     violationEl += '<li><strong>Description</strong>: ' + violation.description + '</li>';

--- a/src/site/assets/js/execute-axe-check.js
+++ b/src/site/assets/js/execute-axe-check.js
@@ -16,9 +16,10 @@ function processAxeCheckResults(error, results) {
 
   results.violations.forEach(function(violation) {
     var violationEl = '<li class="vads-u-margin-y--1">';
+    var violationHelp = violation.help.replace(/\</g,'').replace(/>/g,'');
 
     violationEl += '<details>';
-    violationEl += '<summary><strong>' + violation.help + '</strong></summary>';
+    violationEl += '<summary><strong>' + violationHelp + '</strong></summary>';
     violationEl += '<ul class="usa-unstyled-list vads-u-padding-y--1 vads-u-padding-x--2">';
 
     violationEl += '<li><strong>Description</strong>: ' + violation.description + '</li>';

--- a/src/site/assets/js/execute-axe-check.js
+++ b/src/site/assets/js/execute-axe-check.js
@@ -1,3 +1,10 @@
+function sanitizeString(dirtyString, elem) {
+  var sanitizedString = document.createElement(elem);
+  sanitizedString.innerText = dirtyString;
+
+  return sanitizedString.outerHTML;
+}
+
 function processAxeCheckResults(error, results) {
   if (error) {
     console.log('Error executing the Axe check!');
@@ -16,28 +23,22 @@ function processAxeCheckResults(error, results) {
 
   results.violations.forEach(function(violation) {
     var violationEl = '<li class="vads-u-margin-y--1">';
-    var violationHelp = document.createElement('strong');
-    violationHelp.innerText = violation.help;
 
     violationEl += '<details>';
-    violationEl += '<summary>' + violationHelp.outerHTML + '</summary>';
+    violationEl += '<summary>' + sanitizeString(violation.help, 'strong') + '</summary>';
     violationEl += '<ul class="usa-unstyled-list vads-u-padding-y--1 vads-u-padding-x--2">';
 
-    violationEl += '<li><strong>Description</strong>: ' + violation.description + '</li>';
-    violationEl += '<li><strong>Impact</strong>: ' + violation.impact + '</li>';
-    violationEl += '<li><strong>Tags</strong>: ' + violation.tags.join(', ') + '</li>';
-    violationEl += '<li><strong>Help</strong>: <a href="' + violation.helpUrl + '" target="blank" rel="noopener noreferrer">' + violation.helpUrl + '</a></li>';
+    violationEl += '<li><strong>Description</strong>: ' + sanitizeString(violation.description, 'span') + '</li>';
+    violationEl += '<li><strong>Impact</strong>: ' + sanitizeString(violation.impact, 'span') + '</li>';
+    violationEl += '<li><strong>Tags</strong>: ' + sanitizeString(violation.tags.join(', '), 'span') + '</li>';
+    violationEl += '<li><strong>Help</strong>: <a href="' + violation.helpUrl + '" target="blank" rel="noopener noreferrer">' + sanitizeString(violation.helpUrl, 'span') + '</a></li>';
 
     var nodeList = '<li><strong>HTML</strong>:';
     nodeList += '<ol>';
 
     violation.nodes.forEach(function(node) {
       var nodeEl = '<li>';
-      var code = document.createElement('code');
-
-      code.innerText = node.html;
-      nodeEl += code.outerHTML + '</li>';
-
+      nodeEl += sanitizeString(node.html, 'code');
       nodeList += nodeEl;
     });
 


### PR DESCRIPTION
## UPDATE 12/12
~~I improved the `violationHelp` string to properly sanitize input that might contain HTML tags per @ncksllvn suggestion on the original PR. Will merge directly after one more look.~~

I wrote a basic `sanitizeString` function that accepts two arguments:

1. The potentially dirty string we want to sanitize
2. The element we'd like to wrap our cleaned string in

This gave me an easy one-line call for each segment of the result object we wanted to add to the page, without having to refactor a ton of work. Screenshot attached below.

## Description
I noticed during a CMS demo today that some of our CMS accessibility violations were not outputting text correctly. I discovered that the browser was trying to render HTML instead of a string of HTML, and causing the break. Screenshots of before and after attached below.

## Testing done
* Tried out the fix locally
* Confirmed the fix worked on local preview node

## Original issue
* https://github.com/department-of-veterans-affairs/vets-website/pull/10836

## Definition of done
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs

## Screenshots
![Screen Shot 2019-12-10 at 3 30 04 PM](https://user-images.githubusercontent.com/934879/70575292-d2c81500-1b6b-11ea-9ca2-bf03acff562c.png)

---
**SCREENSHOT 12/12**

![Screen Shot 2019-12-12 at 4 35 14 PM](https://user-images.githubusercontent.com/934879/70754943-1eaac380-1cfe-11ea-9ad4-ad18e4609537.png)


