### PR TITLE
Bug fix for accordion headers causing disappearing UI on review page of 526

### DIFF
--- a/src/platform/forms-system/src/js/review/ObjectField.jsx
+++ b/src/platform/forms-system/src/js/review/ObjectField.jsx
@@ -139,7 +139,7 @@ class ObjectField extends React.Component {
         <>
           {!formContext.hideHeaderRow && (
             <div className="form-review-panel-page-header-row">
-              {formContext.hideTitle || title.trim() === '' ? null : (
+              {!title?.trim() || formContext.hideTitle ? null : (
                 <h5 className="form-review-panel-page-header">{title}</h5>
               )}
               <button


### PR DESCRIPTION
## Description
A bug was discovered on the review page of 526 that would cause the entire form UI to disappear. This would happen when a user would open on of the accordions. This was happening because `.trim()` was being called on an undefined variable. A code change adding the `.trim()` line was done about a week ago, so this is simply rewriting that line to handle `undefined`.

While this change does fix the issue, I think a more thorough investigation into why the `title` is `undefined` is necessary. Upon first look, it seems like these titles are blank on purpose, but I'll need to verify that theory. 

## Acceptance criteria
- [ ] Line is rewritten to no longer call `.trim()` on `undefined`
- [ ] Opening accordions no longer causes UI to disappear
