### PR TITLE
Refine GA reporting of fraud errors

### DIFF
--- a/src/applications/personalization/profile360/tests/util/index.unit.spec.js
+++ b/src/applications/personalization/profile360/tests/util/index.unit.spec.js
@@ -26,8 +26,11 @@ describe('profile utils', () => {
     const badWorkPhoneDataObject = createEventDataObjectWithError(
       'work-phone-error-update',
     );
-    const flaggedForFraudDataObject = createEventDataObjectWithError(
-      'flagged-for-fraud-error-update',
+    const accountFlaggedForFraudDataObject = createEventDataObjectWithError(
+      'account-flagged-for-fraud-error-update',
+    );
+    const routingNumberFlaggedForFraudDataObject = createEventDataObjectWithError(
+      'routing-number-flagged-for-fraud-error-update',
     );
     const invalidRoutingNumberDataObject = createEventDataObjectWithError(
       'invalid-routing-number-error-update',
@@ -109,47 +112,49 @@ describe('profile utils', () => {
       ]);
       expect(eventDataObject).to.deep.equal(badHomePhoneDataObject);
     });
-    it('returns the correct data when a flagged for fraud error is passed', () => {
+    it('returns the correct data when a routing number flagged for fraud error is passed', () => {
       const eventDataObject = createDirectDepositAnalyticsDataObject([
         {
-          title: 'Unprocessable Entity',
-          detail: 'One or more unprocessable user payment properties',
-          code: '126',
-          source: 'EVSS::PPIU::Service',
-          status: '422',
+          code: '135',
+          detail: 'Routing number related to potential fraud',
           meta: {
             messages: [
               {
                 key: 'cnp.payment.routing.number.fraud.message',
                 severity: 'ERROR',
-                text: '',
+                text: 'Routing number related to potential fraud',
               },
             ],
           },
-        },
-      ]);
-      expect(eventDataObject).to.deep.equal(flaggedForFraudDataObject);
-    });
-    it('returns the correct data when a flagged for fraud error is passed', () => {
-      const eventDataObject = createDirectDepositAnalyticsDataObject([
-        {
-          title: 'Unprocessable Entity',
-          detail: 'One or more unprocessable user payment properties',
-          code: '126',
           source: 'EVSS::PPIU::Service',
           status: '422',
+          title: 'Potential Fraud',
+        },
+      ]);
+      expect(eventDataObject).to.deep.equal(
+        routingNumberFlaggedForFraudDataObject,
+      );
+    });
+    it('returns the correct data when an account flagged for fraud error is passed', () => {
+      const eventDataObject = createDirectDepositAnalyticsDataObject([
+        {
+          code: '136',
+          detail: 'The account has been flagged',
           meta: {
             messages: [
               {
                 key: 'cnp.payment.flashes.on.record.message',
                 severity: 'ERROR',
-                text: '',
+                text: 'Flashes on record',
               },
             ],
           },
+          source: 'EVSS::PPIU::Service',
+          status: '422',
+          title: 'Account Flagged',
         },
       ]);
-      expect(eventDataObject).to.deep.equal(flaggedForFraudDataObject);
+      expect(eventDataObject).to.deep.equal(accountFlaggedForFraudDataObject);
     });
     it('returns the correct data when an invalid routing number error is passed', () => {
       const eventDataObject = createDirectDepositAnalyticsDataObject([

--- a/src/applications/personalization/profile360/util/index.js
+++ b/src/applications/personalization/profile360/util/index.js
@@ -13,7 +13,10 @@ const ROUTING_NUMBER_FLAGGED_FOR_FRAUD_KEY =
 const GA_ERROR_KEY_BAD_ADDRESS = 'mailing-address-error';
 const GA_ERROR_KEY_BAD_HOME_PHONE = 'home-phone-error';
 const GA_ERROR_KEY_BAD_WORK_PHONE = 'work-phone-error';
-const GA_ERROR_KEY_FLAGGED_FOR_FRAUD = 'flagged-for-fraud-error';
+const GA_ERROR_KEY_ACCOUNT_FLAGGED_FOR_FRAUD =
+  'account-flagged-for-fraud-error';
+const GA_ERROR_KEY_ROUTING_NUMBER_FLAGGED_FOR_FRAUD =
+  'routing-number-flagged-for-fraud-error';
 const GA_ERROR_KEY_INVALID_ROUTING_NUMBER = 'invalid-routing-number-error';
 const GA_ERROR_KEY_PAYMENT_RESTRICTIONS =
   'payment-restriction-indicators-error';
@@ -42,6 +45,12 @@ const hasErrorMessage = (errors, errorKey, errorText) => {
     err.meta.messages.some(message => message.key === errorKey),
   );
 };
+
+export const hasAccountFlaggedError = errors =>
+  hasErrorMessage(errors, ACCOUNT_FLAGGED_FOR_FRAUD_KEY);
+
+export const hasRoutingNumberFlaggedError = errors =>
+  hasErrorMessage(errors, ROUTING_NUMBER_FLAGGED_FOR_FRAUD_KEY);
 
 export const hasFlaggedForFraudError = errors =>
   hasErrorMessage(errors, ACCOUNT_FLAGGED_FOR_FRAUD_KEY) ||
@@ -75,8 +84,10 @@ export const createDirectDepositAnalyticsDataObject = (
 ) => {
   const key = 'error-key';
   let errorCode = GA_ERROR_KEY_DEFAULT;
-  if (hasFlaggedForFraudError(errors)) {
-    errorCode = GA_ERROR_KEY_FLAGGED_FOR_FRAUD;
+  if (hasAccountFlaggedError(errors)) {
+    errorCode = GA_ERROR_KEY_ACCOUNT_FLAGGED_FOR_FRAUD;
+  } else if (hasRoutingNumberFlaggedError(errors)) {
+    errorCode = GA_ERROR_KEY_ROUTING_NUMBER_FLAGGED_FOR_FRAUD;
   } else if (hasInvalidRoutingNumberError(errors)) {
     errorCode = GA_ERROR_KEY_INVALID_ROUTING_NUMBER;
   } else if (hasInvalidAddressError(errors)) {


### PR DESCRIPTION
## Description
With this change we'll no longer send the generic `flagged-for-fraud-error` error keys to GA. Instead we'll send more specific `account-flagged-for-fraud-error` and `routing-number-flagged-for-fraud-error` error keys, depending on which error we get from EVSS PPIU.

## Testing done
Expanded existing unit tests.

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs