### PR TITLE
Remove SideNav on select subpages that contain /safety-security/

### DIFF
--- a/src/site/layouts/health_care_region_detail_page.drupal.liquid
+++ b/src/site/layouts/health_care_region_detail_page.drupal.liquid
@@ -6,7 +6,6 @@
   <main class="va-l-detail-page va-facility-page">
     <div class="usa-grid usa-grid-full">
       {% if entityUrl.path contains "/safety-security/" and buildtype != 'vagovprod' %}
-        {% include "src/site/components/navigation-sidebar-trigger.html" with menuId = "va-detailpage-sidebar" %}
           <article aria-labelledby="article-heading" role="region" class="usa-content">
             <h1 id="article-heading">{{ title }}</h1>
             <div class="va-introtext">

--- a/src/site/layouts/health_care_region_detail_page.drupal.liquid
+++ b/src/site/layouts/health_care_region_detail_page.drupal.liquid
@@ -5,79 +5,149 @@
 <div class="interior" id="content">
   <main class="va-l-detail-page va-facility-page">
     <div class="usa-grid usa-grid-full">
-      {% if entityUrl.path == "/outreach-and-events" %}
-        {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with sidebarData = outreachSidebar %}
-      {% else %}
-        {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with sidebarData = facilitySidebar %}
-      {% endif %}
-      <div class="usa-width-three-fourths">
-       {% include "src/site/components/navigation-sidebar-trigger.html" with menuId = "va-detailpage-sidebar" %}
-        <article aria-labelledby="article-heading" role="region" class="usa-content">
-          <h1 id="article-heading">{{ title }}</h1>
-          <div class="va-introtext">
-            <p>{{ fieldIntroText }}</p>
-          </div>
+      {% if entityUrl.path contains "/safety-security/" %}
+        {% include "src/site/components/navigation-sidebar-trigger.html" with menuId = "va-detailpage-sidebar" %}
+          <article aria-labelledby="article-heading" role="region" class="usa-content">
+            <h1 id="article-heading">{{ title }}</h1>
+            <div class="va-introtext">
+              <p>{{ fieldIntroText }}</p>
+            </div>
 
-          {% assign isContactPage = entityUrl.path | isPage: "contact-us" %}
-          {% assign isProgramsChildPage = entityUrl | isChildPageOf: "Programs" %}
-          {% if isContactPage || isProgramsChildPage %}
-            <div class="usa-grid usa-grid-full vads-u-margin-y--1p5">{% assign basePath = entityUrl.path | regionBasePath %}
-              {% include "src/site/facilities/main_buttons.drupal.liquid" with path = basePath %}</div>
-          {% endif %}
+            {% assign isContactPage = entityUrl.path | isPage: "contact-us" %}
+            {% assign isProgramsChildPage = entityUrl | isChildPageOf: "Programs" %}
+            {% if isContactPage || isProgramsChildPage %}
+              <div class="usa-grid usa-grid-full vads-u-margin-y--1p5">{% assign basePath = entityUrl.path | regionBasePath %}
+                {% include "src/site/facilities/main_buttons.drupal.liquid" with path = basePath %}</div>
+            {% endif %}
 
-          {% if fieldAlert != empty and fieldAlert.length %}
-            {% for alert in fieldAlert %}
-              {% include "src/site/blocks/alert.drupal.liquid" with alert = alert.entity %}
-            {% endfor %}
-          {% endif %}
-
-
-          {% if fieldTableOfContentsBoolean != empty and fieldTableOfContentsBoolean %}
-            <section id="table-of-contents">
-              <h2 class="vads-u-margin-bottom--2 vads-u-font-size--lg">On this page</h2>
-              <ul class="usa-unstyled-list"></ul>
-            </section>
-          {% endif %}
-
-          {% if fieldFeaturedContent != empty and fieldFeaturedContent.length > 0 %}
-            <div class="feature">
-              {% for block in fieldFeaturedContent %}
-                {% assign bundleComponent = "src/site/paragraphs/" | append: block.entity.entityBundle %}
-                {% assign bundleComponentWithExtension = bundleComponent | append: ".drupal.liquid" %}
-                {% include {{ bundleComponentWithExtension }} with entity = block.entity %}
+            {% if fieldAlert != empty and fieldAlert.length %}
+              {% for alert in fieldAlert %}
+                {% include "src/site/blocks/alert.drupal.liquid" with alert = alert.entity %}
               {% endfor %}
-            </div>
-          {% endif %}
-          {% for block in fieldContentBlock %}
-          {% if block.entity.entityBundle != "staff_profile" %}
-            {% assign bundleComponent = "src/site/paragraphs/" | append: block.entity.entityBundle %}
-            {% assign bundleComponentWithExtension = bundleComponent | append: ".drupal.liquid" %}
-            {% include {{ bundleComponentWithExtension }} with entity = block.entity %}
             {% endif %}
-            {% if block.entity.entityBundle == "staff_profile" %}
-              {% include "src/site/includes/bioParagraph.drupal.liquid" with bio = block.entity.queryFieldStaffProfile.entities.0 %}
+
+
+            {% if fieldTableOfContentsBoolean != empty and fieldTableOfContentsBoolean %}
+              <section id="table-of-contents">
+                <h2 class="vads-u-margin-bottom--2 vads-u-font-size--lg">On this page</h2>
+                <ul class="usa-unstyled-list"></ul>
+              </section>
             {% endif %}
-          {% endfor %}
 
-          {% if fieldRelatedLinks and fieldRelatedLinks.entity.fieldVaParagraphs and fieldRelatedLinks.entity.fieldVaParagraphs.0.entity.fieldLink %}
-            <div class="va-nav-linkslist va-nav-linkslist--related">
-              {% include 'src/site/paragraphs/list_of_link_teasers.drupal.liquid' entity = fieldRelatedLinks.entity %}
-            </div>
-          {%  endif %}
-
-          <!-- Social Links -->
-          {% if isContactPage %}
-            {% if fieldFacebook != empty || fieldFlickr != empty || fieldInstagram != empty || fieldTwitter != empty || fieldEmailSubscription != empty || (fieldLinks != empty and fieldLinks.length)%}
-              {% include "src/site/facilities/facility_social_links.drupal.liquid" with regionNickname = fieldOffice.entity.fieldNicknameForThisFacility %}
+            {% if fieldFeaturedContent != empty and fieldFeaturedContent.length > 0 %}
+              <div class="feature">
+                {% for block in fieldFeaturedContent %}
+                  {% assign bundleComponent = "src/site/paragraphs/" | append: block.entity.entityBundle %}
+                  {% assign bundleComponentWithExtension = bundleComponent | append: ".drupal.liquid" %}
+                  {% include {{ bundleComponentWithExtension }} with entity = block.entity %}
+                {% endfor %}
+              </div>
             {% endif %}
-          {% endif %}
-        </article>
+            {% for block in fieldContentBlock %}
+            {% if block.entity.entityBundle != "staff_profile" %}
+              {% assign bundleComponent = "src/site/paragraphs/" | append: block.entity.entityBundle %}
+              {% assign bundleComponentWithExtension = bundleComponent | append: ".drupal.liquid" %}
+              {% include {{ bundleComponentWithExtension }} with entity = block.entity %}
+              {% endif %}
+              {% if block.entity.entityBundle == "staff_profile" %}
+                {% include "src/site/includes/bioParagraph.drupal.liquid" with bio = block.entity.queryFieldStaffProfile.entities.0 %}
+              {% endif %}
+            {% endfor %}
 
-        <div class="last-updated usa-content">
-          Last updated:
-          <time datetime="{{ changed | dateFromUnix: 'YYYY-MM-DD'}}">{{ changed | humanizeTimestamp }}</time>
+            {% if fieldRelatedLinks and fieldRelatedLinks.entity.fieldVaParagraphs and fieldRelatedLinks.entity.fieldVaParagraphs.0.entity.fieldLink %}
+              <div class="va-nav-linkslist va-nav-linkslist--related">
+                {% include 'src/site/paragraphs/list_of_link_teasers.drupal.liquid' entity = fieldRelatedLinks.entity %}
+              </div>
+            {%  endif %}
+
+            <!-- Social Links -->
+            {% if isContactPage %}
+              {% if fieldFacebook != empty || fieldFlickr != empty || fieldInstagram != empty || fieldTwitter != empty || fieldEmailSubscription != empty || (fieldLinks != empty and fieldLinks.length)%}
+                {% include "src/site/facilities/facility_social_links.drupal.liquid" with regionNickname = fieldOffice.entity.fieldNicknameForThisFacility %}
+              {% endif %}
+            {% endif %}
+          </article>
+
+          <div class="last-updated usa-content">
+            Last updated:
+            <time datetime="{{ changed | dateFromUnix: 'YYYY-MM-DD'}}">{{ changed | humanizeTimestamp }}</time>
+          </div>
         </div>
-      </div>
+      {% else %}
+        {% if entityUrl.path == "/outreach-and-events" %}
+          {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with sidebarData = outreachSidebar %}
+        {% else %}
+          {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with sidebarData = facilitySidebar %}
+        {% endif %}
+        <div class="usa-width-three-fourths">
+        {% include "src/site/components/navigation-sidebar-trigger.html" with menuId = "va-detailpage-sidebar" %}
+          <article aria-labelledby="article-heading" role="region" class="usa-content">
+            <h1 id="article-heading">{{ title }}</h1>
+            <div class="va-introtext">
+              <p>{{ fieldIntroText }}</p>
+            </div>
+
+            {% assign isContactPage = entityUrl.path | isPage: "contact-us" %}
+            {% assign isProgramsChildPage = entityUrl | isChildPageOf: "Programs" %}
+            {% if isContactPage || isProgramsChildPage %}
+              <div class="usa-grid usa-grid-full vads-u-margin-y--1p5">{% assign basePath = entityUrl.path | regionBasePath %}
+                {% include "src/site/facilities/main_buttons.drupal.liquid" with path = basePath %}</div>
+            {% endif %}
+
+            {% if fieldAlert != empty and fieldAlert.length %}
+              {% for alert in fieldAlert %}
+                {% include "src/site/blocks/alert.drupal.liquid" with alert = alert.entity %}
+              {% endfor %}
+            {% endif %}
+
+
+            {% if fieldTableOfContentsBoolean != empty and fieldTableOfContentsBoolean %}
+              <section id="table-of-contents">
+                <h2 class="vads-u-margin-bottom--2 vads-u-font-size--lg">On this page</h2>
+                <ul class="usa-unstyled-list"></ul>
+              </section>
+            {% endif %}
+
+            {% if fieldFeaturedContent != empty and fieldFeaturedContent.length > 0 %}
+              <div class="feature">
+                {% for block in fieldFeaturedContent %}
+                  {% assign bundleComponent = "src/site/paragraphs/" | append: block.entity.entityBundle %}
+                  {% assign bundleComponentWithExtension = bundleComponent | append: ".drupal.liquid" %}
+                  {% include {{ bundleComponentWithExtension }} with entity = block.entity %}
+                {% endfor %}
+              </div>
+            {% endif %}
+            {% for block in fieldContentBlock %}
+            {% if block.entity.entityBundle != "staff_profile" %}
+              {% assign bundleComponent = "src/site/paragraphs/" | append: block.entity.entityBundle %}
+              {% assign bundleComponentWithExtension = bundleComponent | append: ".drupal.liquid" %}
+              {% include {{ bundleComponentWithExtension }} with entity = block.entity %}
+              {% endif %}
+              {% if block.entity.entityBundle == "staff_profile" %}
+                {% include "src/site/includes/bioParagraph.drupal.liquid" with bio = block.entity.queryFieldStaffProfile.entities.0 %}
+              {% endif %}
+            {% endfor %}
+
+            {% if fieldRelatedLinks and fieldRelatedLinks.entity.fieldVaParagraphs and fieldRelatedLinks.entity.fieldVaParagraphs.0.entity.fieldLink %}
+              <div class="va-nav-linkslist va-nav-linkslist--related">
+                {% include 'src/site/paragraphs/list_of_link_teasers.drupal.liquid' entity = fieldRelatedLinks.entity %}
+              </div>
+            {%  endif %}
+
+            <!-- Social Links -->
+            {% if isContactPage %}
+              {% if fieldFacebook != empty || fieldFlickr != empty || fieldInstagram != empty || fieldTwitter != empty || fieldEmailSubscription != empty || (fieldLinks != empty and fieldLinks.length)%}
+                {% include "src/site/facilities/facility_social_links.drupal.liquid" with regionNickname = fieldOffice.entity.fieldNicknameForThisFacility %}
+              {% endif %}
+            {% endif %}
+          </article>
+
+          <div class="last-updated usa-content">
+            Last updated:
+            <time datetime="{{ changed | dateFromUnix: 'YYYY-MM-DD'}}">{{ changed | humanizeTimestamp }}</time>
+          </div>
+        </div>
+      {% endif %}
     </div>
   </main>
 </div>

--- a/src/site/layouts/health_care_region_detail_page.drupal.liquid
+++ b/src/site/layouts/health_care_region_detail_page.drupal.liquid
@@ -5,7 +5,7 @@
 <div class="interior" id="content">
   <main class="va-l-detail-page va-facility-page">
     <div class="usa-grid usa-grid-full">
-      {% if entityUrl.path contains "/safety-security/" %}
+      {% if entityUrl.path contains "/safety-security/" and buildtype != 'vagovprod' %}
         {% include "src/site/components/navigation-sidebar-trigger.html" with menuId = "va-detailpage-sidebar" %}
           <article aria-labelledby="article-heading" role="region" class="usa-content">
             <h1 id="article-heading">{{ title }}</h1>


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/3995

The ticket calls for us to not render the SideNav on select Research subpages, which are currently using the template `src/site/layouts/health_care_region_detail_page.drupal.liquid`. However, this template is also currently used by the About Us pages that **do need the SideNav rendered**.

Therefore, I went with adding a conditional in the template, but ideally we'd have more meta info from Drupal to say whether we should render the SideNav for a specific page.

## Testing done
Locally.

## Screenshots
`http://localhost:3001/pittsburgh-health-care/research/safety-security/`:
![image](https://user-images.githubusercontent.com/12773166/70657057-6820e300-1c18-11ea-8b48-3dc9fa7c6833.png)


`http://localhost:3001/pittsburgh-health-care/research/safety-security/animal-research/`:
![image](https://user-images.githubusercontent.com/12773166/70657133-84bd1b00-1c18-11ea-89d8-51e9c4895276.png)


`http://localhost:3001/pittsburgh-health-care/research/safety-security/human-research/`:
![image](https://user-images.githubusercontent.com/12773166/70657167-8f77b000-1c18-11ea-91a8-48ad4755aa72.png)


`http://localhost:3001/pittsburgh-health-care/research/safety-security/radiation/`:
![image](https://user-images.githubusercontent.com/12773166/70657186-969ebe00-1c18-11ea-9797-7a1f4ea9bae0.png)


## Acceptance criteria
Remove SideNav on `Research` subpages, like 
- [x] `/pittsburgh-health-care/research/safety-security/animal-research`
- [x] `/pittsburgh-health-care/research/safety-security/human-research`
- [x] `/pittsburgh-health-care/research/safety-security/radiation`

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
