### PR TITLE
Take preferred date into account when setting max month

### DIFF
--- a/src/applications/vaos/components/DateTimeSelectField.jsx
+++ b/src/applications/vaos/components/DateTimeSelectField.jsx
@@ -29,6 +29,10 @@ class DateTimeSelectField extends Component {
     const { formContext, formData } = this.props;
     const { currentlySelectedDate, selectedDates } = formData;
 
+    const startMonth = formContext?.preferredDate
+      ? moment(formContext.preferredDate).format('YYYY-MM')
+      : null;
+
     return (
       <CalendarWidget
         monthsToShowAtOnce={2}
@@ -49,7 +53,7 @@ class DateTimeSelectField extends Component {
         maxDate={moment()
           .add(395, 'days')
           .format('YYYY-MM-DD')}
-        startMonth={formContext?.preferredDate}
+        startMonth={startMonth}
       />
     );
   }

--- a/src/applications/vaos/components/calendar/CalendarWidget.jsx
+++ b/src/applications/vaos/components/calendar/CalendarWidget.jsx
@@ -12,6 +12,8 @@ import {
   removeDateOptionPairFromSelectedArray,
 } from '../../utils/calendar';
 
+const DEFAULT_MAX_DAYS_AHEAD = 90;
+
 export default class CalendarWidget extends Component {
   static props = {
     // TODO: add "showWeekends" prop
@@ -71,7 +73,7 @@ export default class CalendarWidget extends Component {
   };
 
   getMaxMonth = () => {
-    const { availableDates, minDate, maxDate } = this.props;
+    const { availableDates, minDate, maxDate, startMonth } = this.props;
     if (Array.isArray(availableDates) && availableDates.length) {
       // sort available dates
       let sortedDates = this.sortDates(availableDates);
@@ -94,15 +96,22 @@ export default class CalendarWidget extends Component {
 
       const lastAvailableDateMonth = moment(
         sortedDates[sortedDates.length - 1],
-      ).format('YYYYMM');
+      ).format('YYYY-MM');
 
       return lastAvailableDateMonth;
     }
 
-    // If no available dates array provided, set max to 90 days from now
-    return moment()
-      .add(90, 'days')
-      .format('YYYYMM');
+    const defaultMaxMonth = moment()
+      .add(DEFAULT_MAX_DAYS_AHEAD, 'days')
+      .format('YYYY-MM');
+
+    // If user preferred date is beyond our default of 90 days, display that month
+    if (startMonth && moment(startMonth).format('YYYY-MM') > defaultMaxMonth) {
+      return moment(startMonth).format('YYYY-MM');
+    }
+
+    // If no available dates array provided, set max to default from now
+    return defaultMaxMonth;
   };
 
   availableDatesChanged = prevDates => {
@@ -334,10 +343,10 @@ export default class CalendarWidget extends Component {
     const nextMonthToDisplay = months[months.length - 1]
       ?.clone()
       .add(1, 'months')
-      .format('YYYYMM');
+      .format('YYYY-MM');
 
     const prevDisabled =
-      months[0].format('YYYYMM') <= currentDate.format('YYYYMM');
+      months[0].format('YYYY-MM') <= currentDate.format('YYYY-MM');
     const nextDisabled = nextMonthToDisplay > maxMonth;
 
     return (
@@ -372,7 +381,7 @@ export default class CalendarWidget extends Component {
         <div className="vaos-calendar__calendars vads-u-flex--1">
           {months.map(
             (month, index) =>
-              month.format('YYYYMM') <= maxMonth ? (
+              month.format('YYYY-MM') <= maxMonth ? (
                 <div
                   key={`month-${index}`}
                   className="vaos-calendar__container vads-u-margin-bottom--3"

--- a/src/applications/vaos/components/calendar/CalendarWidget.jsx
+++ b/src/applications/vaos/components/calendar/CalendarWidget.jsx
@@ -18,12 +18,12 @@ export default class CalendarWidget extends Component {
   static props = {
     // TODO: add "showWeekends" prop
     additionalOptions: PropTypes.object,
-    availableDates: PropTypes.array,
-    minDate: PropTypes.string,
-    maxDate: PropTypes.string,
+    availableDates: PropTypes.array, // ['YYYY-MM-DD']
+    minDate: PropTypes.string, // YYYY-MM-DD
+    maxDate: PropTypes.string, // YYYY-MM-DD
     maxSelections: PropTypes.number,
     monthsToShowAtOnce: PropTypes.number,
-    startMonth: PropTypes.string,
+    startMonth: PropTypes.string, // YYYY-MM
     onChange: PropTypes.func,
   };
 
@@ -53,6 +53,7 @@ export default class CalendarWidget extends Component {
     if (monthsToShowAtOnce > this.state.months.length) {
       const months = [];
       const startDate = startMonth ? moment(startMonth) : moment();
+
       for (let index = 0; index < monthsToShowAtOnce; index++) {
         months.push(startDate.clone().add(index, 'months'));
       }
@@ -105,9 +106,9 @@ export default class CalendarWidget extends Component {
       .add(DEFAULT_MAX_DAYS_AHEAD, 'days')
       .format('YYYY-MM');
 
-    // If user preferred date is beyond our default of 90 days, display that month
-    if (startMonth && moment(startMonth).format('YYYY-MM') > defaultMaxMonth) {
-      return moment(startMonth).format('YYYY-MM');
+    // If provided start month is beyond our default, set that month as max month
+    if (startMonth && startMonth > defaultMaxMonth) {
+      return startMonth;
     }
 
     // If no available dates array provided, set max to default from now

--- a/src/applications/vaos/tests/components/calendar/CalendarWidget.unit.spec.jsx
+++ b/src/applications/vaos/tests/components/calendar/CalendarWidget.unit.spec.jsx
@@ -16,6 +16,19 @@ describe('VAOS <CalendarWidget>', () => {
     tree.unmount();
   });
 
+  it('should still rendar a calendar if startMonth is beyond 90 day default', () => {
+    const tree = shallow(
+      <CalendarWidget monthsToShowAtOnce={2} startMonth="2020-11-20" />,
+    );
+    const cell = tree.find('.vaos-calendar__container');
+    expect(cell.length).to.equal(1);
+    const navigation = tree.find('CalendarNavigation');
+    expect(navigation.length).to.equal(1);
+    const weekdayHeaders = tree.find('CalendarWeekdayHeader');
+    expect(weekdayHeaders.length).to.equal(1);
+    tree.unmount();
+  });
+
   it('should display the same month as startMonth', () => {
     const tree = shallow(
       <CalendarWidget monthsToShowAtOnce={2} startMonth="2019-11-20" />,

--- a/src/applications/vaos/tests/components/calendar/CalendarWidget.unit.spec.jsx
+++ b/src/applications/vaos/tests/components/calendar/CalendarWidget.unit.spec.jsx
@@ -16,7 +16,7 @@ describe('VAOS <CalendarWidget>', () => {
     tree.unmount();
   });
 
-  it('should still rendar a calendar if startMonth is beyond 90 day default', () => {
+  it('should still render a calendar if startMonth is beyond 90 day default', () => {
     const tree = shallow(
       <CalendarWidget monthsToShowAtOnce={2} startMonth="2020-11-20" />,
     );


### PR DESCRIPTION
## Description
The calendar widget was originally set for the max month to be 90 days from today. This was not adjusted when we added the preferred date, so it was displaying 0 calendars since the preferred date was beyond 90 days. 

## Testing done
Unit and local testing

## Screenshots
![image](https://user-images.githubusercontent.com/786704/70672087-028e2000-1c33-11ea-83a3-00c1ccbebd7a.png)


## Acceptance criteria
- [ ] Calendar widget displays even if preferred date is beyond 90 days from today

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
