### PR TITLE
add build time to build.txt

### DIFF
--- a/jenkins/common.groovy
+++ b/jenkins/common.groovy
@@ -65,7 +65,7 @@ def runDeploy(String jobName, String ref, boolean waitForDeploy) {
   ], wait: waitForDeploy
 }
 
-def buildDetails(String buildtype, String ref) {
+def buildDetails(String buildtype, String ref, Long buildtime) {
   return """\
 BUILDTYPE=${buildtype}
 NODE_ENV=production
@@ -74,6 +74,7 @@ CHANGE_TARGET=${env.CHANGE_TARGET}
 BUILD_ID=${env.BUILD_ID}
 BUILD_NUMBER=${env.BUILD_NUMBER}
 REF=${ref}
+BUILDTIME=${buildtime}
 """
 }
 
@@ -183,7 +184,8 @@ def checkForBrokenLinks(String buildLogPath, String envName, Boolean contentOnly
 }
 
 def build(String ref, dockerContainer, String assetSource, String envName, Boolean useCache, Boolean contentOnlyBuild) {
-  def buildDetails = buildDetails(envName, ref)
+  def long buildtime = unixTime = System.currentTimeMillis() / 1000L;
+  def buildDetails = buildDetails(envName, ref, buildtime)
   def drupalAddress = DRUPAL_ADDRESSES.get(envName)
   def drupalCred = DRUPAL_CREDENTIALS.get(envName)
   def drupalMode = useCache ? '' : '--pull-drupal'

--- a/jenkins/common.groovy
+++ b/jenkins/common.groovy
@@ -184,7 +184,7 @@ def checkForBrokenLinks(String buildLogPath, String envName, Boolean contentOnly
 }
 
 def build(String ref, dockerContainer, String assetSource, String envName, Boolean useCache, Boolean contentOnlyBuild) {
-  def long buildtime = unixTime = System.currentTimeMillis() / 1000L;
+  def long buildtime = System.currentTimeMillis() / 1000L;
   def buildDetails = buildDetails(envName, ref, buildtime)
   def drupalAddress = DRUPAL_ADDRESSES.get(envName)
   def drupalCred = DRUPAL_CREDENTIALS.get(envName)


### PR DESCRIPTION
## Description
This adds the unix timestamp of the build before to build.txt.  This information is needed by CMS in a post-deploy action in order to process queued events waiting on the deploy.

## Testing done
Jenkins on this PR.

## Screenshots
n/a

## Acceptance criteria
- Build.txt has a unixtime entry in it

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
  - department-of-veterans-affairs/va.gov-team#3036
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs