### PR TITLE
[Redirect] Link to specific part of page

### DIFF
--- a/src/applications/proxy-rewrite/redirects/disabilityRedirects.json
+++ b/src/applications/proxy-rewrite/redirects/disabilityRedirects.json
@@ -217,6 +217,6 @@
   {
     "domain": "www.benefits.va.gov",
     "src": "/gibill/yellow_ribbon/yrp_list_2019.asp",
-    "dest": "/education/about-gi-bill-benefits/post-9-11/yellow-ribbon-program/"
+    "dest": "/education/about-gi-bill-benefits/post-9-11/yellow-ribbon-program/#does-my-school-participate-in-"
   }
 ]


### PR DESCRIPTION
## Description
This PR changes a Yellow Ribbon redirect to point to a specific part of the destination page.

## Testing done
Can't be well-tested locally, but I did make sure `window.location.href =` can accepts a hash at the end of the URL.

## Screenshots
This part of the page is the destination -

![image](https://user-images.githubusercontent.com/1915775/70741663-cf5a9800-1ce9-11ea-87b9-16d74139f07c.png)


## Acceptance criteria
- [ ] Redirect goes to a specific part of the destination

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
