### PR TITLE
Add block_content-promo

### DIFF
--- a/src/site/stages/build/process-cms-exports/schemas/common/media.js
+++ b/src/site/stages/build/process-cms-exports/schemas/common/media.js
@@ -1,0 +1,10 @@
+/* eslint-disable import/no-dynamic-require */
+const { getAllSchemasOfType } = require('./helpers');
+
+module.exports = {
+  $id: 'Media',
+  // Adding the catch-all object schema is a temporary fix
+  // until we have schemas & transformers for all
+  // media entities
+  anyOf: getAllSchemasOfType('media').concat([{ type: 'object' }]),
+};

--- a/src/site/stages/build/process-cms-exports/schemas/raw/block_content-promo.js
+++ b/src/site/stages/build/process-cms-exports/schemas/raw/block_content-promo.js
@@ -1,0 +1,10 @@
+/* eslint-disable camelcase */
+
+module.exports = {
+  type: 'object',
+  properties: {
+    field_image: { $ref: 'EntityReferenceArray' },
+    field_promo_link: { $ref: 'EntityReferenceArray' },
+  },
+  required: ['field_image', 'field_promo_link'],
+};

--- a/src/site/stages/build/process-cms-exports/schemas/transformed/block_content-promo.js
+++ b/src/site/stages/build/process-cms-exports/schemas/transformed/block_content-promo.js
@@ -1,0 +1,23 @@
+module.exports = {
+  type: 'object',
+  properties: {
+    contentModelType: { enum: ['block_content-promo'] },
+    entity: {
+      type: 'object',
+      properties: {
+        entityType: { enum: ['block_content'] },
+        entityBundle: { enum: ['promo'] },
+        fieldImage: {
+          type: 'array',
+          items: { $ref: 'Media' },
+        },
+        fieldPromoLink: {
+          type: 'array',
+          items: { $ref: 'Paragraph' },
+        },
+      },
+      required: ['fieldImage', 'fieldPromoLink'],
+    },
+  },
+  required: ['entity'],
+};

--- a/src/site/stages/build/process-cms-exports/tests/entities/file.63ab88b7-ab8d-4a52-b59e-b93b63056cd2.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/file.63ab88b7-ab8d-4a52-b59e-b93b63056cd2.json
@@ -1,0 +1,50 @@
+{
+    "uuid": [
+        {
+            "value": "63ab88b7-ab8d-4a52-b59e-b93b63056cd2"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "uid": [],
+    "filename": [
+        {
+            "value": "records.png"
+        }
+    ],
+    "uri": [
+        {
+            "value": "public:\/\/hub_promos\/records.png"
+        }
+    ],
+    "filemime": [
+        {
+            "value": "image\/png"
+        }
+    ],
+    "filesize": [
+        {
+            "value": 58286
+        }
+    ],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-01-28T20:45:49+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-01-28T20:46:40+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/media.84efa2f5-9d94-4d54-8fc7-9c9d43021e76.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/media.84efa2f5-9d94-4d54-8fc7-9c9d43021e76.json
@@ -1,0 +1,110 @@
+{
+    "uuid": [
+        {
+            "value": "84efa2f5-9d94-4d54-8fc7-9c9d43021e76"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "bundle": [
+        {
+            "target_id": "image",
+            "target_type": "media_type",
+            "target_uuid": "92f64a34-81e5-4094-82a9-4fe61d7f2227"
+        }
+    ],
+    "revision_created": [
+        {
+            "value": "2019-01-28T20:46:40+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_user": [],
+    "revision_log_message": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "name": [
+        {
+            "value": "records.png"
+        }
+    ],
+    "thumbnail": [
+        {
+            "alt": null,
+            "title": null,
+            "width": 456,
+            "height": 304,
+            "target_type": "file",
+            "target_uuid": "63ab88b7-ab8d-4a52-b59e-b93b63056cd2"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "b02c2ff5-dfe1-4542-beec-3fd410a3f267"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-01-28T20:46:40+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-03-22T19:01:43+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [],
+    "metatag": {
+        "value": {
+            "title": "| Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "| Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "| Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": "\/media\/image\/9",
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "field_media_in_library": [
+        {
+            "value": true
+        }
+    ],
+    "field_media_submission_guideline": [],
+    "field_owner": [],
+    "image": [
+        {
+            "alt": null,
+            "title": null,
+            "width": 456,
+            "height": 304,
+            "target_type": "file",
+            "target_uuid": "63ab88b7-ab8d-4a52-b59e-b93b63056cd2"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/paragraph.69620159-bb03-45bc-915e-35147050d1d8.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/paragraph.69620159-bb03-45bc-915e-35147050d1d8.json
@@ -1,0 +1,57 @@
+{
+    "uuid": [
+        {
+            "value": "69620159-bb03-45bc-915e-35147050d1d8"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "link_teaser",
+            "target_type": "paragraphs_type",
+            "target_uuid": "072db7a4-476e-41a6-ab49-c44184281451"
+        }
+    ],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-03-22T19:02:00+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "behavior_settings": [
+        {
+            "value": []
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "field_link": [
+        {
+            "uri": "internal:\/records\/download-va-letters\/",
+            "title": "Confirm your VA benefit status",
+            "options": []
+        }
+    ],
+    "field_link_summary": [
+        {
+            "value": "Download letters like your eligibility or award letter for certain benefits."
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/transformed-entities/block_content-promo.json
+++ b/src/site/stages/build/process-cms-exports/tests/transformed-entities/block_content-promo.json
@@ -1,0 +1,212 @@
+{
+  "contentModelType": "block_content-promo",
+  "entity": {
+    "entityType": "block_content",
+    "entityBundle": "promo",
+    "fieldImage": [
+      {
+        "uuid": "84efa2f5-9d94-4d54-8fc7-9c9d43021e76",
+        "langcode": [
+          {
+            "value": "en"
+          }
+        ],
+        "bundle": [
+          {
+            "target_id": "image",
+            "target_type": "media_type",
+            "target_uuid": "92f64a34-81e5-4094-82a9-4fe61d7f2227"
+          }
+        ],
+        "revisionCreated": [
+          {
+            "value": "2019-01-28T20:46:40+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+          }
+        ],
+        "revisionUser": [],
+        "revisionLogMessage": [],
+        "status": [
+          {
+            "value": true
+          }
+        ],
+        "name": [
+          {
+            "value": "records.png"
+          }
+        ],
+        "thumbnail": [
+          {
+            "uuid": "63ab88b7-ab8d-4a52-b59e-b93b63056cd2",
+            "langcode": [
+              {
+                "value": "en"
+              }
+            ],
+            "uid": [],
+            "filename": [
+              {
+                "value": "records.png"
+              }
+            ],
+            "uri": [
+              {
+                "value": "public://hub_promos/records.png"
+              }
+            ],
+            "filemime": [
+              {
+                "value": "image/png"
+              }
+            ],
+            "filesize": [
+              {
+                "value": 58286
+              }
+            ],
+            "status": [
+              {
+                "value": true
+              }
+            ],
+            "created": [
+              {
+                "value": "2019-01-28T20:45:49+00:00",
+                "format": "Y-m-d\\TH:i:sP"
+              }
+            ],
+            "changed": [
+              {
+                "value": "2019-01-28T20:46:40+00:00",
+                "format": "Y-m-d\\TH:i:sP"
+              }
+            ],
+            "baseType": "file",
+            "contentModelType": "file"
+          }
+        ],
+        "uid": [
+          {
+            "target_type": "user",
+            "target_uuid": "b02c2ff5-dfe1-4542-beec-3fd410a3f267"
+          }
+        ],
+        "created": [
+          {
+            "value": "2019-01-28T20:46:40+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+          }
+        ],
+        "changed": [
+          {
+            "value": "2019-03-22T19:01:43+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+          }
+        ],
+        "defaultLangcode": [
+          {
+            "value": true
+          }
+        ],
+        "revisionTranslationAffected": [
+          {
+            "value": true
+          }
+        ],
+        "moderationState": [],
+        "metatag": {
+          "value": {
+            "title": "| Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "| Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "| Veterans Affairs"
+          }
+        },
+        "path": [
+          {
+            "alias": "/media/image/9",
+            "langcode": "en",
+            "pathauto": 1
+          }
+        ],
+        "fieldMediaInLibrary": [
+          {
+            "value": true
+          }
+        ],
+        "fieldMediaSubmissionGuideline": [],
+        "fieldOwner": [],
+        "image": [
+          {
+            "uuid": "63ab88b7-ab8d-4a52-b59e-b93b63056cd2",
+            "langcode": [
+              {
+                "value": "en"
+              }
+            ],
+            "uid": [],
+            "filename": [
+              {
+                "value": "records.png"
+              }
+            ],
+            "uri": [
+              {
+                "value": "public://hub_promos/records.png"
+              }
+            ],
+            "filemime": [
+              {
+                "value": "image/png"
+              }
+            ],
+            "filesize": [
+              {
+                "value": 58286
+              }
+            ],
+            "status": [
+              {
+                "value": true
+              }
+            ],
+            "created": [
+              {
+                "value": "2019-01-28T20:45:49+00:00",
+                "format": "Y-m-d\\TH:i:sP"
+              }
+            ],
+            "changed": [
+              {
+                "value": "2019-01-28T20:46:40+00:00",
+                "format": "Y-m-d\\TH:i:sP"
+              }
+            ],
+            "baseType": "file",
+            "contentModelType": "file"
+          }
+        ],
+        "baseType": "media",
+        "contentModelType": "media-image"
+      }
+    ],
+    "fieldPromoLink": [
+      {
+        "contentModelType": "paragraph-link_teaser",
+        "entity": {
+          "fieldLink": {
+            "url": {
+              "path": "internal:/records/download-va-letters/"
+            },
+            "title": "Confirm your VA benefit status",
+            "options": []
+          },
+          "fieldLinkSummary": "Download letters like your eligibility or award letter for certain benefits."
+        }
+      }
+    ]
+  }
+}

--- a/src/site/stages/build/process-cms-exports/transformers/block_content-promo.js
+++ b/src/site/stages/build/process-cms-exports/transformers/block_content-promo.js
@@ -1,0 +1,12 @@
+const transform = entity => ({
+  entity: {
+    entityType: 'block_content',
+    entityBundle: 'promo',
+    fieldImage: entity.fieldImage,
+    fieldPromoLink: entity.fieldPromoLink,
+  },
+});
+module.exports = {
+  filter: ['field_image', 'field_promo_link'],
+  transform,
+};


### PR DESCRIPTION
## Description
The block_content-promo transformer. I added a generic `Media` schema helper to pull in all the media schemas. Just like we're doing with paragraph and block_content.

## Testing done
Yerp

## Screenshots
Nope

## Acceptance criteria
- [x] The transformer works as expected
- [x] The tests pass
- [x] `npm run build:content:test` completes with no errors