### PR TITLE
Change View status button to say "View details" in claim status tool

### DIFF
--- a/src/applications/claims-status/components/appeals-v2/AppealListItemV2.jsx
+++ b/src/applications/claims-status/components/appeals-v2/AppealListItemV2.jsx
@@ -127,17 +127,17 @@ export default function AppealListItem({ appeal, name, external = false }) {
           className="usa-button usa-button-primary"
           to={`appeals/${appeal.id}/status`}
         >
-          View status
+          View details
           <i className="fa fa-chevron-right" />
         </Link>
       )}
       {external && (
         <Link
-          aria-label={`View status of ${appealTitle} `}
+          aria-label={`View details of ${appealTitle} `}
           className="usa-button usa-button-primary"
           href={`/track-claims/appeals/${appeal.id}/status`}
         >
-          View status
+          View details
           <i className="fa fa-chevron-right" />
         </Link>
       )}

--- a/src/applications/claims-status/components/appeals-v2/ClaimsListItemV2.jsx
+++ b/src/applications/claims-status/components/appeals-v2/ClaimsListItemV2.jsx
@@ -62,11 +62,11 @@ export default function ClaimsListItem({ claim }) {
         </p>
       </div>
       <Link
-        aria-label={`View status of claim received ${formattedReceiptDate}`}
+        aria-label={`View details of claim received ${formattedReceiptDate}`}
         className="usa-button usa-button-primary"
         to={`your-claims/${claim.id}/status`}
       >
-        View status
+        View details
         <i className="fa fa-chevron-right" />
       </Link>
     </div>


### PR DESCRIPTION
## Description
Users have been referring to the "View status" button as "View details", so the text is being changed to accommodate this and to more accurately describe what the button does.

## Screenshots
![image](https://user-images.githubusercontent.com/53942725/70908468-36719880-1fd9-11ea-82ad-673ff8c36bf6.png)

## Acceptance criteria
- [ ] All View status buttons say View details on claim status tool listing page