### PR TITLE
Fixed autocomplete selection search

### DIFF
--- a/src/applications/gi/containers/SearchPage.jsx
+++ b/src/applications/gi/containers/SearchPage.jsx
@@ -126,7 +126,7 @@ export class SearchPage extends React.Component {
     const query = {
       ...this.props.location.query,
       [field]: value,
-      name: field,
+      name: field === 'category' ? this.props.autocomplete.searchTerm : field,
     };
     // Don’t update the route if the query hasn’t changed.
     if (

--- a/src/applications/gi/containers/SearchPage.jsx
+++ b/src/applications/gi/containers/SearchPage.jsx
@@ -126,7 +126,7 @@ export class SearchPage extends React.Component {
     const query = {
       ...this.props.location.query,
       [field]: value,
-      name: field === 'category' ? this.props.autocomplete.searchTerm : field,
+      name: value === undefined ? field : this.props.autocomplete.searchTerm,
     };
     // Don’t update the route if the query hasn’t changed.
     if (

--- a/src/applications/gi/containers/SearchPage.jsx
+++ b/src/applications/gi/containers/SearchPage.jsx
@@ -125,6 +125,7 @@ export class SearchPage extends React.Component {
     // Translate form selections to query params.
     const query = {
       ...this.props.location.query,
+      [field]: value,
       name: field,
     };
     // Don’t update the route if the query hasn’t changed.

--- a/src/applications/gi/containers/SearchPage.jsx
+++ b/src/applications/gi/containers/SearchPage.jsx
@@ -125,10 +125,8 @@ export class SearchPage extends React.Component {
     // Translate form selections to query params.
     const query = {
       ...this.props.location.query,
-      [field]: value,
-      name: this.props.autocomplete.searchTerm,
+      name: field,
     };
-
     // Don’t update the route if the query hasn’t changed.
     if (
       _.isEqual(query, this.props.location.query) ||

--- a/src/applications/gi/containers/VetTecSearchPage.jsx
+++ b/src/applications/gi/containers/VetTecSearchPage.jsx
@@ -126,7 +126,7 @@ export class VetTecSearchPage extends React.Component {
     const query = {
       ...this.props.location.query,
       [field]: value,
-      name: this.props.autocomplete.searchTerm,
+      name: value === undefined ? field : this.props.autocomplete.searchTerm,
     };
 
     // Don’t update the route if the query hasn’t changed.


### PR DESCRIPTION
## Description
After searching for schools in the Comparison tool, a user has the option to refine their results using a keyword. When a user partially enters the name of a school or program, a drop-down appears with several valid options. A user should be able to click one of these options rather than typing it out completely. Currently, clicking one of the results will run a search using the partial name typed into the search bar. This applies to both regular and VET TEC search results.

https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/4190

## Testing done
Local testing

## Screenshots
![ezgif-6-a4884cb7dfe6](https://user-images.githubusercontent.com/50601724/70916449-b1db4600-1fe9-11ea-971a-890a2ac5577e.gif)

## Acceptance criteria
- [x] Autocomplete selection search works properly

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
