### PR TITLE
Use PACT endpoint in VAOS

### DIFF
--- a/src/applications/vaos/api/index.js
+++ b/src/applications/vaos/api/index.js
@@ -289,20 +289,23 @@ export function getClinics(facilityId, typeOfCareId, systemId) {
   );
 }
 
-// GET /vaos/systems/{systemId}/pact
-// eslint-disable-next-line no-unused-vars
 export function getPacTeam(systemId) {
-  return new Promise(resolve => {
-    setTimeout(() => {
-      if (systemId === '983') {
-        import('./pact.json').then(module =>
-          resolve(module.default ? module.default : module),
-        );
-      } else {
-        resolve([]);
-      }
-    }, 750);
-  });
+  let promise;
+  if (USE_MOCK_DATA) {
+    if (systemId.includes('983')) {
+      promise = import('./pact.json').then(
+        module => (module.default ? module.default : module),
+      );
+    } else {
+      promise = Promise.resolve({ data: [] });
+    }
+  } else {
+    promise = apiRequest(`/vaos/systems${systemId}/pact`);
+  }
+
+  return promise.then(resp =>
+    resp.data.map(item => ({ ...item.attributes, id: item.id })),
+  );
 }
 
 export function getFacilityInfo(facilityId) {

--- a/src/applications/vaos/api/index.js
+++ b/src/applications/vaos/api/index.js
@@ -300,7 +300,7 @@ export function getPacTeam(systemId) {
       promise = Promise.resolve({ data: [] });
     }
   } else {
-    promise = apiRequest(`/vaos/systems${systemId}/pact`);
+    promise = apiRequest(`/vaos/systems/${systemId}/pact`);
   }
 
   return promise.then(resp =>

--- a/src/applications/vaos/api/pact.json
+++ b/src/applications/vaos/api/pact.json
@@ -1,13 +1,169 @@
-[
-  {
-    "facilityId": "983",
-    "teamSid": "1400018881",
-    "teamName": "GREEN-FOUR",
-    "teamPurpose": "PRIMARY CARE",
-    "providerSid": "3080868",
-    "staffName": "PROVIDER,NATALIE M",
-    "providerPosition": "GREEN-FOUR PHYSICIAN",
-    "possiblePrimary": "Y",
-    "title": "PHYSICIAN-ATTENDING"
-  }
-]
+{
+  "data": [
+    {
+      "id": "983416899",
+      "type": "system_pact",
+      "attributes": {
+        "facilityId": "983",
+        "possiblePrimary": "Y",
+        "providerPosition": "GREEN TEAM PROV 1",
+        "providerSid": "983416899",
+        "staffName": "KILPATRICK,DAVID M",
+        "teamName": "GREEN TEAM",
+        "teamPurpose": "PRIMARY CARE",
+        "teamSid": "983000076",
+        "title": "PHYSICIAN-PRIMARY CARE"
+      }
+    },
+    {
+      "id": "983410226",
+      "type": "system_pact",
+      "attributes": {
+        "facilityId": "983",
+        "possiblePrimary": "Y",
+        "providerPosition": "GREEN TEAM PROV 3",
+        "providerSid": "983410226",
+        "staffName": "MCINTYRE,WILLIAM W",
+        "teamName": "GREEN TEAM",
+        "teamPurpose": "PRIMARY CARE",
+        "teamSid": "983000076",
+        "title": "PHYSICIAN-PRIMARY CARE"
+      }
+    },
+    {
+      "id": "983453217",
+      "type": "system_pact",
+      "attributes": {
+        "facilityId": "983",
+        "possiblePrimary": "Y",
+        "providerPosition": "CHY PC VAR2 PROV 1",
+        "providerSid": "983453217",
+        "staffName": "EVANS,KAYLEEN A",
+        "teamName": "CHY PC VAR2",
+        "teamPurpose": "PRIMARY CARE",
+        "teamSid": "983000075",
+        "title": "PHYSICIAN-PRIMARY CARE"
+      }
+    },
+    {
+      "id": "983410226",
+      "type": "system_pact",
+      "attributes": {
+        "facilityId": "983",
+        "possiblePrimary": "Y",
+        "providerPosition": "CHY PC VAR2 PROV 2",
+        "providerSid": "983410226",
+        "staffName": "MCINTYRE,WILLIAM W",
+        "teamName": "CHY PC VAR2",
+        "teamPurpose": "PRIMARY CARE",
+        "teamSid": "983000075",
+        "title": "PHYSICIAN-PRIMARY CARE"
+      }
+    },
+    {
+      "id": "983416723",
+      "type": "system_pact",
+      "attributes": {
+        "facilityId": "983",
+        "possiblePrimary": "Y",
+        "providerPosition": "GREEN TEAM PROV 2",
+        "providerSid": "983416723",
+        "staffName": "CASSIDY,THOMAS G",
+        "teamName": "GREEN TEAM",
+        "teamPurpose": "PRIMARY CARE",
+        "teamSid": "983000076",
+        "title": "PHYSICIAN-PRIMARY CARE"
+      }
+    },
+    {
+      "id": "983416004",
+      "type": "system_pact",
+      "attributes": {
+        "facilityId": "983",
+        "possiblePrimary": "N",
+        "providerPosition": "CHY PC VAR2 NURSE 1",
+        "providerSid": "983416004",
+        "staffName": "MCINTYRE,CAROL F",
+        "teamName": "CHY PC VAR2",
+        "teamPurpose": "PRIMARY CARE",
+        "teamSid": "983000075",
+        "title": "NURSE (RN)"
+      }
+    },
+    {
+      "id": "983413123",
+      "type": "system_pact",
+      "attributes": {
+        "facilityId": "983",
+        "possiblePrimary": "N",
+        "providerPosition": "GREEN TEAM NURSE 1",
+        "providerSid": "983413123",
+        "staffName": "HATCH,JANET C",
+        "teamName": "GREEN TEAM",
+        "teamPurpose": "PRIMARY CARE",
+        "teamSid": "983000076",
+        "title": "NURSE (RN)"
+      }
+    },
+    {
+      "id": "983412449",
+      "type": "system_pact",
+      "attributes": {
+        "facilityId": "983",
+        "possiblePrimary": "N",
+        "providerPosition": "CHY PC VAR2 SW",
+        "providerSid": "983412449",
+        "staffName": "ANDERSON,WILLIAM D",
+        "teamName": "CHY PC VAR2",
+        "teamPurpose": "PRIMARY CARE",
+        "teamSid": "983000075",
+        "title": "SOCIAL WORKER"
+      }
+    },
+    {
+      "id": "983416057",
+      "type": "system_pact",
+      "attributes": {
+        "facilityId": "983",
+        "possiblePrimary": "N",
+        "providerPosition": "CHY PC VAR2 MSA 1",
+        "providerSid": "983416057",
+        "staffName": "GULLIVER,BETTY J",
+        "teamName": "CHY PC VAR2",
+        "teamPurpose": "PRIMARY CARE",
+        "teamSid": "983000075",
+        "title": "PATIENT SERVICES ASSISTANT"
+      }
+    },
+    {
+      "id": "983445174",
+      "type": "system_pact",
+      "attributes": {
+        "facilityId": "983",
+        "possiblePrimary": "N",
+        "providerPosition": "CHY PC VAR2 PHARM",
+        "providerSid": "983445174",
+        "staffName": "HOOD,TANYA R",
+        "teamName": "CHY PC VAR2",
+        "teamPurpose": "PRIMARY CARE",
+        "teamSid": "983000075",
+        "title": "CLINICAL PHARMACIST"
+      }
+    },
+    {
+      "id": "983442842",
+      "type": "system_pact",
+      "attributes": {
+        "facilityId": "983",
+        "possiblePrimary": "N",
+        "providerPosition": "GREEN TEAM NURSE 2",
+        "providerSid": "983442842",
+        "staffName": "FUCHS,TAMMI L",
+        "teamName": "GREEN TEAM",
+        "teamPurpose": "PRIMARY CARE",
+        "teamSid": "983000076",
+        "title": "NURSE (LPN)"
+      }
+    }
+  ]
+}

--- a/src/applications/vaos/reducers/newAppointment.js
+++ b/src/applications/vaos/reducers/newAppointment.js
@@ -286,7 +286,7 @@ export default function formReducer(state = initialState, action) {
       let eligibility = state.eligibility;
       if (action.eligibilityData) {
         const facilityEligibility = getEligibilityChecks(
-          newData.vaFacility,
+          newData.vaSystem,
           action.typeOfCareId,
           action.eligibilityData,
         );
@@ -416,7 +416,7 @@ export default function formReducer(state = initialState, action) {
     }
     case FORM_ELIGIBILITY_CHECKS_SUCCEEDED: {
       const eligibility = getEligibilityChecks(
-        state.data.vaFacility,
+        state.data.vaSystem,
         action.typeOfCareId,
         action.eligibilityData,
       );

--- a/src/applications/vaos/tests/actions/newAppointment.unit.spec.js
+++ b/src/applications/vaos/tests/actions/newAppointment.unit.spec.js
@@ -45,6 +45,7 @@ import systems from '../../api/facilities.json';
 import systemIdentifiers from '../../api/systems.json';
 import facilities983 from '../../api/facilities_983.json';
 import clinics from '../../api/clinicList983.json';
+import pacTeam from '../../api/pact.json';
 import {
   FACILITY_TYPES,
   FETCH_STATUS,
@@ -373,6 +374,7 @@ describe('VAOS newAppointment actions', () => {
         },
       });
       setFetchJSONResponse(global.fetch.onCall(3), clinics);
+      setFetchJSONResponse(global.fetch.onCall(4), pacTeam);
       const dispatch = sinon.spy();
       const previousState = {
         ...defaultState,

--- a/src/applications/vaos/utils/eligibility.js
+++ b/src/applications/vaos/utils/eligibility.js
@@ -71,12 +71,10 @@ function hasVisitedInPastMonthsRequest(eligibilityData) {
   );
 }
 
-function hasPACTeamIfPrimaryCare(eligibilityData, typeOfCareId, vaFacility) {
+function hasPACTeamIfPrimaryCare(eligibilityData, typeOfCareId, vaSystem) {
   return (
     typeOfCareId !== PRIMARY_CARE ||
-    eligibilityData.pacTeam.some(
-      provider => provider.facilityId === vaFacility.substring(0, 3),
-    )
+    eligibilityData.pacTeam.some(provider => provider.facilityId === vaSystem)
   );
 }
 
@@ -88,11 +86,7 @@ function isUnderRequestLimit(eligibilityData) {
   );
 }
 
-export function getEligibilityChecks(
-  vaFacility,
-  typeOfCareId,
-  eligibilityData,
-) {
+export function getEligibilityChecks(vaSystem, typeOfCareId, eligibilityData) {
   // If we're missing this property, it means no DS checks were made
   // because it's disabled
   const directSchedulingEnabled =
@@ -106,7 +100,7 @@ export function getEligibilityChecks(
       eligibilityData.directPastVisit.durationInMonths,
     directPACT:
       directSchedulingEnabled &&
-      hasPACTeamIfPrimaryCare(eligibilityData, typeOfCareId, vaFacility),
+      hasPACTeamIfPrimaryCare(eligibilityData, typeOfCareId, vaSystem),
     directClinics: directSchedulingEnabled && !!eligibilityData.clinics.length,
     requestPastVisit: hasVisitedInPastMonthsRequest(eligibilityData),
     requestPastVisitValue: eligibilityData.requestPastVisit.durationInMonths,


### PR DESCRIPTION
## Description
This updates the VAOS FE to call the actual PACT endpoint.

## Testing done
Local and unit testing

## Acceptance criteria
- [ ] PACT endpoint is called

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
