### PR TITLE
Lowercase the "A" in banner title

### DIFF
--- a/src/site/includes/decision-reviews-banner.html
+++ b/src/site/includes/decision-reviews-banner.html
@@ -1,17 +1,17 @@
   <div class="usa-alert-full-width usa-alert-full-width-warning" role="region" aria-labelledby="appeal-heading">
     <div class="usa-alert usa-alert-warning" aria-live="assertive" role="alert">
       <div class="usa-alert-body">
-        <h3 class="usa-alert-heading" id="appeal-heading">The Appeals process has changed</h3>
+        <h3 class="usa-alert-heading" id="appeal-heading">The appeals process has changed</h3>
         <div class="usa-alert-text">
           <p>
-          <b>For VA decisions you received on or after February 19, 2019</b> 
+          <b>For VA decisions you received on or after February 19, 2019</b>
           <br>
-          Please keep reading below to learn about your decision review options. 
+          Please keep reading below to learn about your decision review options.
           <br>
           <br>
-          <b>For VA decisions you received before February 19, 2019</b> 
+          <b>For VA decisions you received before February 19, 2019</b>
           <br>
-          You'll need to follow a different process to appeal your disability compensation decision. 
+          You'll need to follow a different process to appeal your disability compensation decision.
           <br>
           <a href="/disability/file-an-appeal/">Learn how to file an appeal</a>.
           </p>


### PR DESCRIPTION
## Description
This PR lowercases an "A" because our site should be using sentence-casing.

See thread - https://dsva.slack.com/archives/C52CL1PKQ/p1576521796025800

## Testing done
Not necessary

## Screenshots
The banner in question -

![image](https://user-images.githubusercontent.com/1915775/70934804-c1b85180-200c-11ea-91b3-cacc2078dbb1.png)


## Acceptance criteria
- [ ] A is lowercase

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
