### PR TITLE
Adding removed block banner logic.

### DIFF
--- a/src/site/stages/build/drupal/graphql/GetAllPages.graphql.js
+++ b/src/site/stages/build/drupal/graphql/GetAllPages.graphql.js
@@ -9,7 +9,8 @@ const vamcOperatingStatusAndAlerts = require('./vamcOperatingStatusAndAlerts.gra
 const fragments = require('./fragments.graphql');
 const newsStoryPage = require('./newStoryPage.graphql');
 const sidebarQuery = require('./navigation-fragments/sidebar.nav.graphql');
-const alertsQuery = require('./bannerAlerts.graphql');
+const alertsQuery = require('./alerts.graphql');
+const bannerAlertsQuery = require('./bannerAlerts.graphql');
 const eventPage = require('./eventPage.graphql');
 const facilitySidebarQuery = require('./navigation-fragments/facilitySidebar.nav.graphql');
 const outreachSidebarQuery = require('./navigation-fragments/outreachSidebar.nav.graphql');
@@ -80,6 +81,7 @@ module.exports = `
     ${facilitySidebarQuery}
     ${outreachSidebarQuery}
     ${alertsQuery}
+    ${bannerAlertsQuery}
     ${outreachAssetsQuery}
     ${homePageQuery}
     ${

--- a/src/site/stages/build/drupal/graphql/GetLatestPageById.graphql.js
+++ b/src/site/stages/build/drupal/graphql/GetLatestPageById.graphql.js
@@ -12,7 +12,8 @@ const sidebarQuery = require('./navigation-fragments/sidebar.nav.graphql');
 const facilitySidebarQuery = require('./navigation-fragments/facilitySidebar.nav.graphql');
 const bioPage = require('./bioPage.graphql');
 const eventPage = require('./eventPage.graphql');
-const alertsQuery = require('./bannerAlerts.graphql');
+const alertsQuery = require('./alerts.graphql');
+const bannerAlertsQuery = require('./bannerAlerts.graphql');
 const icsFileQuery = require('./file-fragments/ics.file.graphql');
 const allSideNavMachineNamesQuery = require('./navigation-fragments/allSideNavMachineNames.nav.graphql');
 const menuLinksQuery = require('./navigation-fragments/menuLinks.nav.graphql');
@@ -67,6 +68,7 @@ module.exports = `
     ${sidebarQuery}
     ${facilitySidebarQuery}
     ${alertsQuery}
+    ${bannerAlertsQuery}
     ${
       cmsFeatureFlags.FEATURE_ALL_HUB_SIDE_NAVS
         ? `${allSideNavMachineNamesQuery}`

--- a/src/site/stages/build/drupal/graphql/alerts.graphql.js
+++ b/src/site/stages/build/drupal/graphql/alerts.graphql.js
@@ -1,0 +1,28 @@
+/**
+ * The alerts that appear above content.
+ */
+
+module.exports = `
+    alerts:   blockContentQuery(filter: {conditions: [{field: "type", value: "alert"}, {field: "status", value: "1"}]},
+    sort: {field: "field_node_reference", direction: DESC}
+    limit: 100) {
+    entities {
+      ... on BlockContentAlert {
+        id
+        fieldAlertDismissable
+        fieldAlertFrequency
+        fieldNodeReference {
+          targetId
+        }
+        fieldIsThisAHeaderAlert
+        fieldAlertType
+        fieldAlertTitle
+        fieldAlertContent {
+          entity {
+            entityRendered
+          }
+        }
+      }
+    }
+  }
+`;

--- a/src/site/stages/build/drupal/graphql/bannerAlerts.graphql.js
+++ b/src/site/stages/build/drupal/graphql/bannerAlerts.graphql.js
@@ -3,7 +3,7 @@
  */
 
 module.exports = `
-  alerts: nodeQuery(limit: 500, filter: {conditions: [{field: "status", value: "1", operator: EQUAL}, {field: "type", value: "full_width_banner_alert"}]}) {
+  bannerAlerts: nodeQuery(limit: 500, filter: {conditions: [{field: "status", value: "1", operator: EQUAL}, {field: "type", value: "full_width_banner_alert"}]}) {
     entities {
       ... on NodeFullWidthBannerAlert {
         title


### PR DESCRIPTION
## Description
Fixes missing sitewide banner block placement bug. First method for placing banners allowed for associations to be made directly in drupal block ui via reference field. This pr restores this logic.

## Testing done
Visual

## Screenshots
![image](https://user-images.githubusercontent.com/2404547/70942137-026b9700-201c-11ea-9125-fd0d85c90534.png)
![image](https://user-images.githubusercontent.com/2404547/70942152-0992a500-201c-11ea-84eb-51eaca9fdef7.png)


## Acceptance criteria
- [ ] `The appeals process has changed` banner appears, here: `/disability/file-an-appeal/`
