### PR TITLE
Fix letters app vet360 address updater on smaller screens

### DIFF
--- a/src/applications/letters/containers/AddressSection.jsx
+++ b/src/applications/letters/containers/AddressSection.jsx
@@ -25,7 +25,9 @@ export class AddressSection extends React.Component {
     const addressContent = (
       <div className="step-content">
         <p>Downloaded documents will list your address as:</p>
-        <MailingAddress />
+        <div className="va-profile-wrapper">
+          <MailingAddress />
+        </div>
         <p>
           When you download a letter, it will show this address. If this address
           is incorrect you may want to update it, but your letter will still be

--- a/src/applications/letters/sass/letters.scss
+++ b/src/applications/letters/sass/letters.scss
@@ -211,3 +211,7 @@ label + div {
 
 // --- End copy from _m-schemaform.css --- //
 
+.va-profile-wrapper .va-modal-inner {
+  max-height: 100%;
+  overflow-y: auto;
+}


### PR DESCRIPTION
## Description
The vet360 address updater in the letters app was not rendering properly on smaller screens. This PR fixes that scenario by adding the appropriate CSS.

## Screenshots
![vet360lettersapp](https://user-images.githubusercontent.com/53942725/70948336-3dc09280-2029-11ea-841f-f2aae81526db.PNG)

## Acceptance criteria
- [ ] The address updater in the letters app renders properly on smaller screens