### PR TITLE
Update review page to latest mocks and add how to be seen info

### DIFF
--- a/src/applications/vaos/api/index.js
+++ b/src/applications/vaos/api/index.js
@@ -362,7 +362,7 @@ export function getAvailableSlots(
 ) {
   let promise;
 
-  if (false && USE_MOCK_DATA) {
+  if (USE_MOCK_DATA) {
     promise = import('./slots.json').then(
       module => (module.default ? module.default : module),
     );

--- a/src/applications/vaos/components/ConfirmationDirectScheduleInfo.jsx
+++ b/src/applications/vaos/components/ConfirmationDirectScheduleInfo.jsx
@@ -24,7 +24,7 @@ export default function ConfirmationDirectScheduleInfo({
             'MMMM D, YYYY [at] hh:mm a',
           )}{' '}
         </h2>
-        <hr />
+        <hr className="vads-u-margin-y--2" />
         <h3 className="vads-u-font-size--base vads-u-font-family--sans vads-u-margin-top--0 vads-u-margin-bottom--2">
           {getTypeOfCare(data)?.name} appointment
         </h3>

--- a/src/applications/vaos/components/NewAppointmentLayout.jsx
+++ b/src/applications/vaos/components/NewAppointmentLayout.jsx
@@ -25,6 +25,7 @@ export default class NewAppointmentLayout extends React.Component {
 
   render() {
     const { children } = this.props;
+    const isReviewPage = this.props.location.pathname.includes('review');
 
     return (
       <div className="vads-l-grid-container vads-u-padding-x--2p5 large-screen:vads-u-padding-x--0 vads-u-padding-bottom--2">
@@ -33,9 +34,11 @@ export default class NewAppointmentLayout extends React.Component {
         </Breadcrumbs>
         <div className="vads-l-row">
           <div className="vads-l-col--12 medium-screen:vads-l-col--8">
-            <span className="vaos-form__title vaos-u-margin-bottom--1 vads-u-font-size--sm vads-u-font-weight--normal vads-u-font-family--sans">
-              New appointment
-            </span>
+            {!isReviewPage && (
+              <span className="vaos-form__title vaos-u-margin-bottom--1 vads-u-font-size--sm vads-u-font-weight--normal vads-u-font-family--sans">
+                New appointment
+              </span>
+            )}
             {children}
             <NeedHelp />
           </div>

--- a/src/applications/vaos/components/review/AppointmentDate.jsx
+++ b/src/applications/vaos/components/review/AppointmentDate.jsx
@@ -4,12 +4,11 @@ import { getTimezoneAbbrBySystemId } from '../../utils/timezone';
 
 export default function AppointmentDate(props) {
   const dates = props.dates?.map((selected, i) => (
-    <h2 key={i} className="vads-u-font-size--md">
+    <h3 key={i} className="vaos-appts__block-label">
       {moment(selected.datetime, 'YYYY-MM-DDThh:mm:ssZ').format(
-        'MMMM DD, YYYY [at] h:mm a ',
+        'dddd, MMMM DD, YYYY [at] h:mm a ',
       ) + getTimezoneAbbrBySystemId(props.systemId)}
-      <br />
-    </h2>
+    </h3>
   ));
 
   return dates;

--- a/src/applications/vaos/components/review/CommunityCareSection.jsx
+++ b/src/applications/vaos/components/review/CommunityCareSection.jsx
@@ -7,14 +7,14 @@ import PreferredProviderSection from './PreferredProviderSection';
 export default function CommunityCareSection(props) {
   return (
     <>
+      <PreferredDatesSection data={props.data} />
+      <hr className="vads-u-margin-y--2" />
       <PreferredProviderSection
         data={props.data}
         vaCityState={props.vaCityState}
       />
       <hr className="vads-u-margin-y--2" />
       <ReasonForAppointmentSection data={props.data} />
-      <hr className="vads-u-margin-y--2" />
-      <PreferredDatesSection data={props.data} />
       <hr className="vads-u-margin-y--2" />
       <ContactDetailSection data={props.data} />
     </>

--- a/src/applications/vaos/components/review/CommunityCareSection.jsx
+++ b/src/applications/vaos/components/review/CommunityCareSection.jsx
@@ -11,11 +11,11 @@ export default function CommunityCareSection(props) {
         data={props.data}
         vaCityState={props.vaCityState}
       />
-      <hr />
+      <hr className="vads-u-margin-y--2" />
       <ReasonForAppointmentSection data={props.data} />
-      <hr />
+      <hr className="vads-u-margin-y--2" />
       <PreferredDatesSection data={props.data} />
-      <hr />
+      <hr className="vads-u-margin-y--2" />
       <ContactDetailSection data={props.data} />
     </>
   );

--- a/src/applications/vaos/components/review/Description.jsx
+++ b/src/applications/vaos/components/review/Description.jsx
@@ -3,13 +3,13 @@ import { getTypeOfCare } from '../../utils/selectors';
 import { FLOW_TYPES, FACILITY_TYPES } from '../../utils/constants';
 import { lowerCase } from '../../utils/appointment';
 
-export default function Description({ data }) {
+export default function Description({ data, flowType }) {
   const typeOfCare = lowerCase(getTypeOfCare(data).name);
   const description =
     data.facilityType === FACILITY_TYPES.COMMUNITY_CARE
       ? 'Community Care'
       : typeOfCare;
-  const isDirectSchedule = data.flowType === FLOW_TYPES.DIRECT;
+  const isDirectSchedule = flowType === FLOW_TYPES.DIRECT;
 
   return (
     <>

--- a/src/applications/vaos/components/review/Description.jsx
+++ b/src/applications/vaos/components/review/Description.jsx
@@ -22,14 +22,14 @@ export default function Description({ data, flowType }) {
           Please review the information before confirming your appointment. If
           you need to update any details, click Edit to go back to the screen
           where you entered the information. After you update your information,
-          you'll need to go through the tool again to schedule your appointment.
+          you’ll need to go through the tool again to schedule your appointment.
         </p>
       )}
       {!isDirectSchedule && (
         <p className="vads-u-margin-top--1 vads-u-margin-bottom--4">
           Please review the information before submitting your request. If you
           need to update any details, click Edit to go back to the screen where
-          you entered the information. After you update your information, you'll
+          you entered the information. After you update your information, you’ll
           need to go through the tool again to request your appointment.
         </p>
       )}

--- a/src/applications/vaos/components/review/Description.jsx
+++ b/src/applications/vaos/components/review/Description.jsx
@@ -1,16 +1,20 @@
 import React from 'react';
 import { getTypeOfCare } from '../../utils/selectors';
-import { FLOW_TYPES } from '../../utils/constants';
+import { FLOW_TYPES, FACILITY_TYPES } from '../../utils/constants';
 import { lowerCase } from '../../utils/appointment';
 
 export default function Description({ data }) {
   const typeOfCare = lowerCase(getTypeOfCare(data).name);
+  const description =
+    data.facilityType === FACILITY_TYPES.COMMUNITY_CARE
+      ? 'Community Care'
+      : typeOfCare;
   const isDirectSchedule = data.flowType === FLOW_TYPES.DIRECT;
 
   return (
     <>
       <h2 className="vads-u-margin-bottom--0 vads-u-margin-top--3 vads-u-font-size--h3">
-        You're {isDirectSchedule ? 'scheduling' : 'requesting'} a {typeOfCare}{' '}
+        You're {isDirectSchedule ? 'scheduling' : 'requesting'} a {description}{' '}
         appointment
       </h2>
       {isDirectSchedule && (

--- a/src/applications/vaos/components/review/Description.jsx
+++ b/src/applications/vaos/components/review/Description.jsx
@@ -14,7 +14,7 @@ export default function Description({ data, flowType }) {
   return (
     <>
       <h2 className="vads-u-margin-bottom--0 vads-u-margin-top--3 vads-u-font-size--h3">
-        You're {isDirectSchedule ? 'scheduling' : 'requesting'} a {description}{' '}
+        You’re {isDirectSchedule ? 'scheduling' : 'requesting'} a {description}{' '}
         appointment
       </h2>
       {isDirectSchedule && (

--- a/src/applications/vaos/components/review/Description.jsx
+++ b/src/applications/vaos/components/review/Description.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { getTypeOfCare } from '../../utils/selectors';
+import { FLOW_TYPES } from '../../utils/constants';
+import { lowerCase } from '../../utils/appointment';
+
+export default function Description({ data }) {
+  const typeOfCare = lowerCase(getTypeOfCare(data).name);
+  const isDirectSchedule = data.flowType === FLOW_TYPES.DIRECT;
+
+  return (
+    <>
+      <h2 className="vads-u-margin-bottom--0 vads-u-margin-top--3 vads-u-font-size--h3">
+        You're {isDirectSchedule ? 'scheduling' : 'requesting'} a {typeOfCare}{' '}
+        appointment
+      </h2>
+      {isDirectSchedule && (
+        <p className="vads-u-margin-top--1 vads-u-margin-bottom--4">
+          Please review the information before confirming your appointment. If
+          you need to update any details, click Edit to go back to the screen
+          where you entered the information. After you update your information,
+          you'll need to go through the tool again to schedule your appointment.
+        </p>
+      )}
+      {!isDirectSchedule && (
+        <p className="vads-u-margin-top--1 vads-u-margin-bottom--4">
+          Please review the information before submitting your request. If you
+          need to update any details, click Edit to go back to the screen where
+          you entered the information. After you update your information, you'll
+          need to go through the tool again to request your appointment.
+        </p>
+      )}
+    </>
+  );
+}

--- a/src/applications/vaos/components/review/PreferredDates.jsx
+++ b/src/applications/vaos/components/review/PreferredDates.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { formatDateLong } from '../../../../platform/utilities/date';
+import { formatDateLong } from 'platform/utilities/date';
 
 function PreferredDates(props) {
   const dates = props.dates?.map((selected, i) => (

--- a/src/applications/vaos/components/review/PreferredProviderSection.jsx
+++ b/src/applications/vaos/components/review/PreferredProviderSection.jsx
@@ -60,15 +60,14 @@ export default function PreferredProviderSection(props) {
             Provider not specified
             <br />
             <br />
-            Prefers provider to speak &nbsp;
+            Prefers provider to speak{' '}
             {
               LANGUAGES.find(
                 language => language.id === props.data.preferredLanguage,
               )?.value
             }
             <br />
-            Practice in &nbsp;
-            {props.vaCityState}
+            Practice in {props.vaCityState}
           </span>
         </>
       )}

--- a/src/applications/vaos/components/review/ReviewDirectScheduleInfo.jsx
+++ b/src/applications/vaos/components/review/ReviewDirectScheduleInfo.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { FLOW_TYPES } from '../../utils/constants';
 import ReasonForAppointmentSection from './ReasonForAppointmentSection';
 import ContactDetailSection from './ContactDetailSection';
 import AppointmentDate from './AppointmentDate';
@@ -9,7 +10,7 @@ export default function ReviewDirectScheduleInfo({ data, facility, clinic }) {
   return (
     <div>
       <h1 className="vads-u-font-size--h2">Review your appointment details</h1>
-      <Description data={data} />
+      <Description data={data} flowType={FLOW_TYPES.DIRECT} />
       <TypeOfAppointmentSection data={data} />
       <hr className="vads-u-margin-y--2" />
       <AppointmentDate

--- a/src/applications/vaos/components/review/ReviewDirectScheduleInfo.jsx
+++ b/src/applications/vaos/components/review/ReviewDirectScheduleInfo.jsx
@@ -1,31 +1,31 @@
 import React from 'react';
-import { getTypeOfCare } from '../../utils/selectors';
 import ReasonForAppointmentSection from './ReasonForAppointmentSection';
 import ContactDetailSection from './ContactDetailSection';
 import AppointmentDate from './AppointmentDate';
+import Description from './Description';
+import TypeOfAppointmentSection from './TypeOfAppointmentSection';
 
 export default function ReviewDirectScheduleInfo({ data, facility, clinic }) {
   return (
     <div>
       <h1 className="vads-u-font-size--h2">Review your appointment details</h1>
+      <Description data={data} />
+      <TypeOfAppointmentSection data={data} />
+      <hr className="vads-u-margin-y--2" />
       <AppointmentDate
         dates={data.calendarData.selectedDates}
         systemId={data.vaSystem}
       />
-      <hr />
-      <h2 className="vaos-appts__block-label vads-u-margin-top--2">
-        {getTypeOfCare(data)?.name}
-      </h2>
-      <hr />
+      <hr className="vads-u-margin-y--2" />
       <h3 className="vaos-appts__block-label">
         {clinic.clinicFriendlyLocationName || clinic.clinicName}
       </h3>
       {facility.authoritativeName}
       <br />
       {facility.city}, {facility.stateAbbrev}
-      <hr />
+      <hr className="vads-u-margin-y--2" />
       <ReasonForAppointmentSection data={data} />
-      <hr />
+      <hr className="vads-u-margin-y--2" />
       <ContactDetailSection data={data} />
     </div>
   );

--- a/src/applications/vaos/components/review/ReviewDirectScheduleInfo.jsx
+++ b/src/applications/vaos/components/review/ReviewDirectScheduleInfo.jsx
@@ -9,7 +9,7 @@ import TypeOfAppointmentSection from './TypeOfAppointmentSection';
 export default function ReviewDirectScheduleInfo({ data, facility, clinic }) {
   return (
     <div>
-      <h1 className="vads-u-font-size--h2">Review your appointment details</h1>
+      <h1 className="vads-u-font-size--h2">Review your appointment</h1>
       <Description data={data} flowType={FLOW_TYPES.DIRECT} />
       <TypeOfAppointmentSection data={data} />
       <hr className="vads-u-margin-y--2" />

--- a/src/applications/vaos/components/review/ReviewRequestInfo.jsx
+++ b/src/applications/vaos/components/review/ReviewRequestInfo.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { FACILITY_TYPES } from '../../utils/constants';
+import { FACILITY_TYPES, FLOW_TYPES } from '../../utils/constants';
 import TypeOfAppointmentSection from './TypeOfAppointmentSection';
 import VAAppointmentSection from './VAAppointmentSection';
 import CommunityCareSection from './CommunityCareSection';
@@ -12,7 +12,7 @@ export default function ReviewRequestInfo({ data, facility, vaCityState }) {
   return (
     <div>
       <h1 className="vads-u-font-size--h2">Review your appointment</h1>
-      <Description data={data} />
+      <Description data={data} flowType={FLOW_TYPES.REQUEST} />
       <TypeOfAppointmentSection data={data} />
       <hr className="vads-u-margin-y--2" />
       {isCommunityCare && (

--- a/src/applications/vaos/components/review/ReviewRequestInfo.jsx
+++ b/src/applications/vaos/components/review/ReviewRequestInfo.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import { getTypeOfCare } from '../../utils/selectors';
 import { FACILITY_TYPES } from '../../utils/constants';
 import TypeOfAppointmentSection from './TypeOfAppointmentSection';
 import VAAppointmentSection from './VAAppointmentSection';
 import CommunityCareSection from './CommunityCareSection';
+import Description from './Description';
 
 export default function ReviewRequestInfo({ data, facility, vaCityState }) {
   const isCommunityCare = data.facilityType === FACILITY_TYPES.COMMUNITY_CARE;
@@ -11,11 +11,10 @@ export default function ReviewRequestInfo({ data, facility, vaCityState }) {
 
   return (
     <div>
-      <h1 className="vads-u-font-size--h2">Review your appointment details</h1>
+      <h1 className="vads-u-font-size--h2">Review your appointment</h1>
+      <Description data={data} />
       <TypeOfAppointmentSection data={data} />
-      <hr />
-      <h3 className="vaos-appts__block-label">{getTypeOfCare(data)?.name}</h3>
-      <hr />
+      <hr className="vads-u-margin-y--2" />
       {isCommunityCare && (
         <CommunityCareSection
           data={data}
@@ -23,7 +22,9 @@ export default function ReviewRequestInfo({ data, facility, vaCityState }) {
           vaCityState={vaCityState}
         />
       )}
-      {isVAAppointment && <VAAppointmentSection data={data} />}
+      {isVAAppointment && (
+        <VAAppointmentSection facility={facility} data={data} />
+      )}
     </div>
   );
 }

--- a/src/applications/vaos/components/review/TypeOfAppointmentSection.jsx
+++ b/src/applications/vaos/components/review/TypeOfAppointmentSection.jsx
@@ -1,20 +1,22 @@
 import React from 'react';
 import { FACILITY_TYPES } from '../../utils/constants';
+import { getTypeOfCare } from '../../utils/selectors';
 
-export default function TypeOfAppointmentSection(props) {
-  if (props.data.facilityType === FACILITY_TYPES.COMMUNITY_CARE) {
-    return (
-      <h2 className="usa-alert-heading vads-u-padding-top--1">
-        Community care appointment
+export default function TypeOfAppointmentSection({ data }) {
+  const typeOfCare = getTypeOfCare(data)?.name;
+  const typeOfAppt =
+    data.facilityType === FACILITY_TYPES.COMMUNITY_CARE
+      ? 'Community Care Appointment'
+      : 'VA Appointment';
+
+  return (
+    <>
+      <span className="vaos-form__title vads-u-font-size--sm vads-u-font-weight--normal vads-u-font-family--sans">
+        {typeOfAppt}
+      </span>
+      <h2 className="vads-u-font-size--h3 vads-u-margin-top--0">
+        {typeOfCare}
       </h2>
-    );
-  } else if (props.data.facilityType !== FACILITY_TYPES.COMMUNITY_CARE) {
-    return (
-      <h2 className="usa-alert-heading vads-u-padding-top--1">
-        VA appointment
-      </h2>
-    );
-  }
-  // TODO: Add direct schedule???
-  return null;
+    </>
+  );
 }

--- a/src/applications/vaos/components/review/TypeOfAppointmentSection.jsx
+++ b/src/applications/vaos/components/review/TypeOfAppointmentSection.jsx
@@ -6,7 +6,7 @@ export default function TypeOfAppointmentSection({ data }) {
   const typeOfCare = getTypeOfCare(data)?.name;
   const typeOfAppt =
     data.facilityType === FACILITY_TYPES.COMMUNITY_CARE
-      ? 'Community Care Appointment'
+      ? 'Community Care'
       : 'VA Appointment';
 
   return (

--- a/src/applications/vaos/components/review/VAAppointmentSection.jsx
+++ b/src/applications/vaos/components/review/VAAppointmentSection.jsx
@@ -1,18 +1,55 @@
 import React from 'react';
-// import { Link } from 'react-router';
-// import newAppointmentFlow from '../../newAppointmentFlow';
+import { Link } from 'react-router';
+import newAppointmentFlow from '../../newAppointmentFlow';
 import PreferredDatesSection from './PreferredDatesSection';
 import ContactDetailSection from './ContactDetailSection';
 import ReasonForAppointmentSection from './ReasonForAppointmentSection';
+import { TYPE_OF_VISIT } from '../../utils/constants';
 
-export default function VAAppointmentSection(props) {
+export default function VAAppointmentSection({ data, facility }) {
   return (
     <>
-      <ReasonForAppointmentSection data={props.data} />
-      <hr />
-      <PreferredDatesSection data={props.data} />
-      <hr />
-      <ContactDetailSection data={props.data} />
+      <div className="vads-l-grid-container vads-u-padding--0">
+        <div className="vads-l-row">
+          <div className="vads-l-col--6">
+            <h3 className="vaos-appts__block-label">
+              {facility.authoritativeName}
+            </h3>
+          </div>
+          <div className="vads-l-col--6 vads-u-text-align--right">
+            <Link
+              to={newAppointmentFlow.vaFacility.url}
+              aria-label="Edit location of appointment"
+            >
+              Edit
+            </Link>
+          </div>
+        </div>
+      </div>
+      {facility.city}, {facility.stateAbbrev}
+      <hr className="vads-u-margin-y--2" />
+      <PreferredDatesSection data={data} />
+      <hr className="vads-u-margin-y--2" />
+      <ReasonForAppointmentSection data={data} />
+      <hr className="vads-u-margin-y--2" />
+      <div className="vads-l-grid-container vads-u-padding--0">
+        <div className="vads-l-row">
+          <div className="vads-l-col--6">
+            <h3 className="vaos-appts__block-label">How to be seen</h3>
+          </div>
+          <div className="vads-l-col--6 vads-u-text-align--right">
+            <Link
+              to={newAppointmentFlow.visitType.url}
+              aria-label="Edit how to be seen"
+            >
+              Edit
+            </Link>
+          </div>
+        </div>
+      </div>
+      {TYPE_OF_VISIT.find(visit => visit.id === data.visitType)?.name}
+      <hr className="vads-u-margin-y--2" />
+      <ContactDetailSection data={data} />
     </>
   );
 }

--- a/src/applications/vaos/components/review/VAAppointmentSection.jsx
+++ b/src/applications/vaos/components/review/VAAppointmentSection.jsx
@@ -9,26 +9,10 @@ import { TYPE_OF_VISIT } from '../../utils/constants';
 export default function VAAppointmentSection({ data, facility }) {
   return (
     <>
-      <div className="vads-l-grid-container vads-u-padding--0">
-        <div className="vads-l-row">
-          <div className="vads-l-col--6">
-            <h3 className="vaos-appts__block-label">
-              {facility.authoritativeName}
-            </h3>
-          </div>
-          <div className="vads-l-col--6 vads-u-text-align--right">
-            <Link
-              to={newAppointmentFlow.vaFacility.url}
-              aria-label="Edit location of appointment"
-            >
-              Edit
-            </Link>
-          </div>
-        </div>
-      </div>
-      {facility.city}, {facility.stateAbbrev}
-      <hr className="vads-u-margin-y--2" />
       <PreferredDatesSection data={data} />
+      <hr className="vads-u-margin-y--2" />
+      <h3 className="vaos-appts__block-label">{facility.authoritativeName}</h3>
+      {facility.city}, {facility.stateAbbrev}
       <hr className="vads-u-margin-y--2" />
       <ReasonForAppointmentSection data={data} />
       <hr className="vads-u-margin-y--2" />

--- a/src/applications/vaos/tests/components/ReviewDirectScheduleInfo.unit.spec.jsx
+++ b/src/applications/vaos/tests/components/ReviewDirectScheduleInfo.unit.spec.jsx
@@ -58,9 +58,9 @@ describe('VAOS <ReviewDirectScheduleInfo>', () => {
       expect(
         tree
           .find(AppointmentDate)
-          .find('h2')
+          .find('h3')
           .text(),
-      ).to.equal('December 20, 2019 at 10:00 a.m. CT');
+      ).to.equal('Friday, December 20, 2019 at 10:00 a.m. CT');
     });
 
     it('should render type of care section', () => {

--- a/src/applications/vaos/tests/components/ReviewRequestInfo.unit.spec.jsx
+++ b/src/applications/vaos/tests/components/ReviewRequestInfo.unit.spec.jsx
@@ -55,7 +55,7 @@ describe('VAOS <ReviewRequestInfo>', () => {
 
     // console.log(tree.debug());
     it('should render VA request section', () => {
-      expect(text).to.contain('VA appointment');
+      expect(text).to.contain('VA Appointment');
     });
 
     it('should render type of care section', () => {
@@ -111,7 +111,7 @@ describe('VAOS <ReviewRequestInfo>', () => {
     });
 
     it('should render CC request section', () => {
-      expect(text).to.contain('Community care appointment');
+      expect(text).to.contain('Community Care');
     });
 
     it('should render type of care section', () => {
@@ -165,7 +165,7 @@ describe('VAOS <ReviewRequestInfo>', () => {
     });
 
     it('should render CC request section', () => {
-      expect(text).to.contain('Community care appointment');
+      expect(text).to.contain('Community Care');
     });
 
     it('should render type of care section', () => {

--- a/src/applications/vaos/tests/components/TypeOfAppointmentSection.unit.spec.jsx
+++ b/src/applications/vaos/tests/components/TypeOfAppointmentSection.unit.spec.jsx
@@ -10,7 +10,7 @@ describe('VAOS <TypeOfAppointmentSection>', () => {
     const data = { facilityType: FACILITY_TYPES.COMMUNITY_CARE };
     const tree = shallow(<TypeOfAppointmentSection data={data} />);
 
-    expect(tree.find('h2').text()).to.equal('Community care appointment');
+    expect(tree.text()).to.contain('Community Care');
 
     tree.unmount();
   });
@@ -19,7 +19,7 @@ describe('VAOS <TypeOfAppointmentSection>', () => {
     const data = { facilityType: 'garbage' };
     const tree = shallow(<TypeOfAppointmentSection data={data} />);
 
-    expect(tree.find('h2').text()).to.equal('VA appointment');
+    expect(tree.text()).to.contain('VA Appointment');
 
     tree.unmount();
   });

--- a/src/applications/vaos/tests/e2e/vaos-helpers.js
+++ b/src/applications/vaos/tests/e2e/vaos-helpers.js
@@ -99,8 +99,7 @@ function contactInformationTest(client) {
 function reviewAppointmentTest(client) {
   client
     .click('button.usa-button.usa-button-primary')
-    .waitForElementPresent('.usa-alert-success', Timeouts.normal)
-    .assert.containsText('h1', 'Your appointment request has been submitted');
+    .waitForElementPresent('.usa-alert-success', Timeouts.normal);
 
   return client;
 }

--- a/src/applications/vaos/tests/e2e/vaos-helpers.js
+++ b/src/applications/vaos/tests/e2e/vaos-helpers.js
@@ -91,7 +91,7 @@ function contactInformationTest(client) {
     .click('input#root_bestTimeToCall_morning')
     .fill('input#root_email', 'mail@gmail.com')
     .click('.rjsf [type="submit"]')
-    .assert.containsText('h1', 'Review your appointment details');
+    .assert.containsText('h1', 'Review your appointment');
 
   return client;
 }

--- a/src/applications/vaos/utils/appointment.jsx
+++ b/src/applications/vaos/utils/appointment.jsx
@@ -79,6 +79,19 @@ export function sentenceCase(str) {
     .join(' ');
 }
 
+export function lowerCase(str) {
+  return str
+    .split(' ')
+    .map(word => {
+      if (/^[^a-z]*$/.test(word)) {
+        return word;
+      }
+
+      return word.toLowerCase();
+    })
+    .join(' ');
+}
+
 export function getLocationHeader(appt) {
   const type = getAppointmentType(appt);
 


### PR DESCRIPTION
## Description
This updates the review page to match more recent mocks and add back some missing information (how to be seen and the VA appt location for requests)

## Testing done
Local and unit testing

## Screenshots
<img width="762" alt="Screen Shot 2019-12-17 at 9 50 00 AM" src="https://user-images.githubusercontent.com/634932/71007300-c46e8180-20b4-11ea-973a-55c22ead8bbe.png">
<img width="773" alt="Screen Shot 2019-12-17 at 9 42 15 AM" src="https://user-images.githubusercontent.com/634932/71007301-c46e8180-20b4-11ea-8d52-cbc315adc6da.png">
<img width="758" alt="Screen Shot 2019-12-17 at 10 13 37 AM" src="https://user-images.githubusercontent.com/634932/71008014-eae0ec80-20b5-11ea-8c37-2995cc69f85b.png">

## Acceptance criteria
- [ ] Missing info is added back, new description text is at the top of page

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
