### PR TITLE
removed online only and distance learning instances

### DIFF
--- a/src/applications/gi/components/profile/Programs.jsx
+++ b/src/applications/gi/components/profile/Programs.jsx
@@ -57,18 +57,6 @@ export class Programs extends React.Component {
         text: 'Priority Enrollment',
         link: false,
       },
-
-      onlineOnly: {
-        modal: 'onlineOnlyDistanceLearning',
-        text: 'Online Only',
-        link: false,
-      },
-
-      distanceLearning: {
-        modal: 'onlineOnlyDistanceLearning',
-        text: 'Distance Learning',
-        link: false,
-      },
     };
   }
 

--- a/src/applications/gi/components/profile/Programs.jsx
+++ b/src/applications/gi/components/profile/Programs.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import environment from 'platform/utilities/environment';
 
 export class Programs extends React.Component {
   constructor(props) {
@@ -7,57 +8,121 @@ export class Programs extends React.Component {
     this.renderProgramLabel = this.renderProgramLabel.bind(this);
 
     const { institution } = props;
-    this.programs = {
-      yr: {
-        modal: 'yribbon',
-        text: 'Yellow Ribbon',
-        link: false,
-      },
+    this.programs = environment.isProduction()
+      ? {
+          yr: {
+            modal: 'yribbon',
+            text: 'Yellow Ribbon',
+            link: false,
+          },
 
-      studentVeteran: {
-        modal: 'vetgroups',
-        text: 'Student Veteran Group',
-        link: {
-          href: institution.studentVeteranLink,
-          text: 'Site',
-        },
-      },
+          studentVeteran: {
+            modal: 'vetgroups',
+            text: 'Student Veteran Group',
+            link: {
+              href: institution.studentVeteranLink,
+              text: 'Site',
+            },
+          },
 
-      poe: {
-        modal: 'poe',
-        text: 'Principles of Excellence',
-        link: false,
-      },
+          poe: {
+            modal: 'poe',
+            text: 'Principles of Excellence',
+            link: false,
+          },
 
-      eightKeys: {
-        modal: 'eightKeys',
-        text: '8 Keys to Veteran Success',
-        link: false,
-      },
+          eightKeys: {
+            modal: 'eightKeys',
+            text: '8 Keys to Veteran Success',
+            link: false,
+          },
 
-      vetSuccessName: {
-        modal: 'vsoc',
-        text: 'VetSuccess on Campus',
-        link: {
-          href:
-            institution.vetSuccessEmail &&
-            `mailto:${institution.vetSuccessEmail}`,
-          text: `Email ${institution.vetSuccessName}`,
-        },
-      },
+          vetSuccessName: {
+            modal: 'vsoc',
+            text: 'VetSuccess on Campus',
+            link: {
+              href:
+                institution.vetSuccessEmail &&
+                `mailto:${institution.vetSuccessEmail}`,
+              text: `Email ${institution.vetSuccessName}`,
+            },
+          },
 
-      dodmou: {
-        modal: 'ta',
-        text: 'Military Tuition Assistance (TA)',
-        link: false,
-      },
+          dodmou: {
+            modal: 'ta',
+            text: 'Military Tuition Assistance (TA)',
+            link: false,
+          },
 
-      priorityEnrollment: {
-        modal: 'priEnroll',
-        text: 'Priority Enrollment',
-        link: false,
-      },
-    };
+          priorityEnrollment: {
+            modal: 'priEnroll',
+            text: 'Priority Enrollment',
+            link: false,
+          },
+
+          onlineOnly: {
+            modal: 'onlineOnlyDistanceLearning',
+            text: 'Online Only',
+            link: false,
+          },
+
+          distanceLearning: {
+            modal: 'onlineOnlyDistanceLearning',
+            text: 'Distance Learning',
+            link: false,
+          },
+        }
+      : {
+          yr: {
+            modal: 'yribbon',
+            text: 'Yellow Ribbon',
+            link: false,
+          },
+
+          studentVeteran: {
+            modal: 'vetgroups',
+            text: 'Student Veteran Group',
+            link: {
+              href: institution.studentVeteranLink,
+              text: 'Site',
+            },
+          },
+
+          poe: {
+            modal: 'poe',
+            text: 'Principles of Excellence',
+            link: false,
+          },
+
+          eightKeys: {
+            modal: 'eightKeys',
+            text: '8 Keys to Veteran Success',
+            link: false,
+          },
+
+          vetSuccessName: {
+            modal: 'vsoc',
+            text: 'VetSuccess on Campus',
+            link: {
+              href:
+                institution.vetSuccessEmail &&
+                `mailto:${institution.vetSuccessEmail}`,
+              text: `Email ${institution.vetSuccessName}`,
+            },
+          },
+
+          dodmou: {
+            modal: 'ta',
+            text: 'Military Tuition Assistance (TA)',
+            link: false,
+          },
+
+          priorityEnrollment: {
+            modal: 'priEnroll',
+            text: 'Priority Enrollment',
+            link: false,
+          },
+        };
   }
 
   renderProgramLabel(programKey, available) {

--- a/src/applications/gi/components/search/InstitutionFilterForm.jsx
+++ b/src/applications/gi/components/search/InstitutionFilterForm.jsx
@@ -5,6 +5,7 @@ import Checkbox from '../Checkbox';
 import Dropdown from '../Dropdown';
 import SearchResultTypeOfInstitutionFilter from './SearchResultTypeOfInstitutionFilter';
 import { addAllOption } from '../../utils/helpers';
+import environment from 'platform/utilities/environment';
 
 class InstitutionFilterForm extends React.Component {
   handleDropdownChange = e => {
@@ -111,6 +112,26 @@ class InstitutionFilterForm extends React.Component {
           label="Independent Study"
           onChange={this.handleCheckboxChange}
         />
+        <div>
+          {environment.isProduction() ? (
+            <div>
+              <Checkbox
+                checked={filters.onlineOnly}
+                name="onlineOnly"
+                label="Online Only"
+                onChange={this.handleCheckboxChange}
+              />
+              <Checkbox
+                checked={filters.distanceLearning}
+                name="distanceLearning"
+                label="Distance Learning"
+                onChange={this.handleCheckboxChange}
+              />
+            </div>
+          ) : (
+            <div />
+          )}
+        </div>
       </div>
     );
   };

--- a/src/applications/gi/components/search/InstitutionFilterForm.jsx
+++ b/src/applications/gi/components/search/InstitutionFilterForm.jsx
@@ -111,18 +111,6 @@ class InstitutionFilterForm extends React.Component {
           label="Independent Study"
           onChange={this.handleCheckboxChange}
         />
-        <Checkbox
-          checked={filters.onlineOnly}
-          name="onlineOnly"
-          label="Online Only"
-          onChange={this.handleCheckboxChange}
-        />
-        <Checkbox
-          checked={filters.distanceLearning}
-          name="distanceLearning"
-          label="Distance Learning"
-          onChange={this.handleCheckboxChange}
-        />
       </div>
     );
   };


### PR DESCRIPTION
## Description
As a veteran, I no longer need indicators/filters for "online only" and "distance learning" in the Comparison Tool so that I am no longer confused by the differences and language in the tool.

https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/4275

## Testing done
Local Testing

## Screenshots
![Screen Shot 2019-12-17 at 11 57 46 AM](https://user-images.githubusercontent.com/50601724/71017376-7e211e80-20c4-11ea-95ae-44b8050fa1d6.png)
![Screen Shot 2019-12-17 at 11 57 06 AM](https://user-images.githubusercontent.com/50601724/71017414-86795980-20c4-11ea-9f9b-945428c4f76f.png)


## Acceptance criteria
- [x] The following filters are no longer available in the non vettec search results:
- Online Only
- Distance Learning

- [x] The following programs are no longer available in the Veteran programs section of the profile:
- Online Only
- Distance Learning


## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
