### PR TITLE
Show cancel modal for CC Appointments and Video Visits

### DIFF
--- a/src/applications/vaos/components/CancelAppointmentModal.jsx
+++ b/src/applications/vaos/components/CancelAppointmentModal.jsx
@@ -32,7 +32,7 @@ export default class CancelAppointmentModal extends React.Component {
 
     if (isVideo || isCC) {
       const facilityName = isVideo
-        ? facility.name
+        ? facility?.name
         : appointmentToCancel.providerPractice;
 
       const phone = isVideo

--- a/src/applications/vaos/components/CancelAppointmentModal.jsx
+++ b/src/applications/vaos/components/CancelAppointmentModal.jsx
@@ -150,7 +150,11 @@ export default class CancelAppointmentModal extends React.Component {
                 {appointmentToCancel.facility.name}
                 <br />
                 {!!facility?.phone?.main && (
-                  <a href={`tel:${facility.phone.main.replace(/\D/g, '')}`}>
+                  <a
+                    href={`tel:${formatPhoneNumberForHref(
+                      facility.phone.main,
+                    )}`}
+                  >
                     {facility.phone.main}
                   </a>
                 )}

--- a/src/applications/vaos/components/CancelAppointmentModal.jsx
+++ b/src/applications/vaos/components/CancelAppointmentModal.jsx
@@ -4,7 +4,11 @@ import LoadingButton from 'platform/site-wide/loading-button/LoadingButton';
 import Modal from '@department-of-veterans-affairs/formation-react/Modal';
 
 import { FETCH_STATUS, APPOINTMENT_TYPES } from '../utils/constants';
-import { getAppointmentType } from '../utils/appointment';
+import { getAppointmentType, isVideoVisit } from '../utils/appointment';
+import {
+  formatPhoneNumber,
+  formatPhoneNumberForHref,
+} from '../utils/formatters';
 
 export default class CancelAppointmentModal extends React.Component {
   render() {
@@ -19,6 +23,52 @@ export default class CancelAppointmentModal extends React.Component {
 
     if (!showCancelModal) {
       return null;
+    }
+
+    const isVideo = isVideoVisit(appointmentToCancel);
+    const isCC =
+      getAppointmentType(appointmentToCancel) ===
+      APPOINTMENT_TYPES.ccAppointment;
+
+    if (isVideo || isCC) {
+      const facilityName = isVideo
+        ? facility.name
+        : appointmentToCancel.providerPractice;
+
+      const phone = isVideo
+        ? facility?.phone?.main
+        : appointmentToCancel.providerPhone;
+
+      return (
+        <Modal
+          id="cancelAppt"
+          status="warning"
+          visible
+          onClose={onClose}
+          title="You have to call your provider to cancel this appointment"
+        >
+          <p>
+            {isVideo ? 'VA Video Connect' : 'Community Care'} appointments can’t
+            be canceled online. Please call the below VA facility to cancel your
+            appointment.
+          </p>
+          {phone && (
+            <p>
+              {facilityName}
+              <br />
+              <a href={`tel:${formatPhoneNumberForHref(phone)}`}>
+                {formatPhoneNumber(phone)}
+              </a>
+            </p>
+          )}
+
+          <div className="vads-u-margin-top--2">
+            <button className="usa-button" onClick={onClose}>
+              OK
+            </button>
+          </div>
+        </Modal>
+      );
     }
 
     if (
@@ -100,7 +150,7 @@ export default class CancelAppointmentModal extends React.Component {
                 {appointmentToCancel.facility.name}
                 <br />
                 {!!facility?.phone?.main && (
-                  <a href={`tel:${facility.phone.main.replace(/-/g, '')}`}>
+                  <a href={`tel:${facility.phone.main.replace(/\D/g, '')}`}>
                     {facility.phone.main}
                   </a>
                 )}

--- a/src/applications/vaos/components/ConfirmedAppointmentListItem.jsx
+++ b/src/applications/vaos/components/ConfirmedAppointmentListItem.jsx
@@ -32,11 +32,7 @@ export default function ConfirmedAppointmentListItem({
     );
   }
 
-  const allowCancel =
-    showCancelButton &&
-    !canceled &&
-    type !== APPOINTMENT_TYPES.ccAppointment &&
-    !isVideoVisit(appointment);
+  const allowCancel = showCancelButton && !canceled;
 
   const itemClasses = classNames(
     'vads-u-background-color--gray-lightest vads-u-padding--2p5 vads-u-margin-bottom--3',

--- a/src/applications/vaos/tests/components/CancelAppointmentModal.unit.spec.jsx
+++ b/src/applications/vaos/tests/components/CancelAppointmentModal.unit.spec.jsx
@@ -5,6 +5,31 @@ import { shallow } from 'enzyme';
 import CancelAppointmentModal from '../../components/CancelAppointmentModal';
 import { FETCH_STATUS } from '../../utils/constants';
 
+const vaAppointment = {
+  clinicId: '123',
+  startDate: '11/20/2018',
+  clinicFriendlyName: 'Testing',
+  facilityId: '983',
+};
+
+const ccAppointment = {
+  appointmentTime: '01/25/2019 13:30:00',
+  providerPractice: 'Atlantic Medical Care',
+  providerPhone: '(407) 555-1212',
+};
+
+const videoAppointment = {
+  ...vaAppointment,
+  vvsAppointments: [{}],
+};
+
+const facility = {
+  name: 'Cheyenne VA Medical Center',
+  phone: {
+    main: '307-778-7550',
+  },
+};
+
 describe('VAOS <CancelAppointmentModal>', () => {
   it('should not render modal if showCancelModal is false', () => {
     const tree = shallow(<CancelAppointmentModal showCancelModal={false} />);
@@ -19,6 +44,7 @@ describe('VAOS <CancelAppointmentModal>', () => {
       <CancelAppointmentModal
         showCancelModal
         cancelAppointmentStatus={FETCH_STATUS.notStarted}
+        appointmentToCancel={vaAppointment}
       />,
     );
 
@@ -39,11 +65,83 @@ describe('VAOS <CancelAppointmentModal>', () => {
     tree.unmount();
   });
 
+  it('should render a modal for cc appointments', () => {
+    const tree = shallow(
+      <CancelAppointmentModal
+        showCancelModal
+        cancelAppointmentStatus={FETCH_STATUS.notStarted}
+        appointmentToCancel={ccAppointment}
+      />,
+    );
+
+    const modal = tree.find('Modal');
+
+    expect(modal.exists()).to.be.true;
+    expect(modal.props().title).to.equal(
+      'You have to call your provider to cancel this appointment',
+    );
+    expect(modal.find('.usa-button').prop('children')).to.equal('OK');
+    expect(
+      modal
+        .children()
+        .at(1)
+        .text(),
+    ).to.contain(ccAppointment.providerPractice);
+
+    expect(
+      modal
+        .children()
+        .at(1)
+        .text(),
+    ).to.contain('407-555-1212');
+
+    expect(modal.find('a').props().href).to.equal('tel:4075551212');
+
+    tree.unmount();
+  });
+
+  it('should render a modal for video appointments', () => {
+    const tree = shallow(
+      <CancelAppointmentModal
+        showCancelModal
+        cancelAppointmentStatus={FETCH_STATUS.notStarted}
+        appointmentToCancel={videoAppointment}
+        facility={facility}
+      />,
+    );
+
+    const modal = tree.find('Modal');
+
+    expect(modal.exists()).to.be.true;
+    expect(modal.props().title).to.equal(
+      'You have to call your provider to cancel this appointment',
+    );
+    expect(modal.find('.usa-button').prop('children')).to.equal('OK');
+    expect(
+      modal
+        .children()
+        .at(1)
+        .text(),
+    ).to.contain(facility.name);
+
+    expect(
+      modal
+        .children()
+        .at(1)
+        .text(),
+    ).to.contain(facility.phone.main);
+
+    expect(modal.find('a').props().href).to.equal('tel:3077787550');
+
+    tree.unmount();
+  });
+
   it('should render loading state when cancelling', () => {
     const tree = shallow(
       <CancelAppointmentModal
         showCancelModal
         cancelAppointmentStatus={FETCH_STATUS.loading}
+        appointmentToCancel={vaAppointment}
       />,
     );
 
@@ -68,6 +166,7 @@ describe('VAOS <CancelAppointmentModal>', () => {
       <CancelAppointmentModal
         showCancelModal
         cancelAppointmentStatus={FETCH_STATUS.succeeded}
+        appointmentToCancel={vaAppointment}
       />,
     );
 
@@ -87,12 +186,7 @@ describe('VAOS <CancelAppointmentModal>', () => {
       <CancelAppointmentModal
         showCancelModal
         cancelAppointmentStatus={FETCH_STATUS.failed}
-        appointmentToCancel={{
-          clinicId: '123',
-          startDate: '11/20/2018',
-          clinicFriendlyName: 'Testing',
-          facilityId: '983',
-        }}
+        appointmentToCancel={vaAppointment}
       />,
     );
 

--- a/src/applications/vaos/tests/utils/selectors.unit.spec.js
+++ b/src/applications/vaos/tests/utils/selectors.unit.spec.js
@@ -297,15 +297,41 @@ describe('VAOS selectors', () => {
       });
     });
   });
+
   describe('getCancelInfo', () => {
-    it('should fetch facility in info', () => {
+    const request = {
+      typeOfCareId: 'CCAUDHEAR',
+      facility: {
+        facilityCode: '123',
+      },
+    };
+
+    const video = {
+      facilityId: '123',
+      vvsAppointments: [{}],
+    };
+
+    it('should fetch facility in info for request cancellation', () => {
       const state = {
         appointments: {
-          appointmentToCancel: {
-            facility: {
-              facilityCode: '123',
-            },
+          appointmentToCancel: request,
+          facilityData: {
+            123: {},
           },
+        },
+      };
+
+      const cancelInfo = getCancelInfo(state);
+
+      expect(cancelInfo.facility).to.equal(
+        state.appointments.facilityData['123'],
+      );
+    });
+
+    it('should fetch facility in info for video visit cancellation', () => {
+      const state = {
+        appointments: {
+          appointmentToCancel: video,
           facilityData: {
             123: {},
           },

--- a/src/applications/vaos/utils/formatters.js
+++ b/src/applications/vaos/utils/formatters.js
@@ -42,6 +42,16 @@ export function formatTypeOfCare(careLabel) {
   return careLabel.slice(0, 1).toLowerCase() + careLabel.slice(1);
 }
 
+export function formatPhoneNumberForHref(phone) {
+  return phone.replace(/\D/g, '');
+}
+
+export function formatPhoneNumber(phone) {
+  return phone
+    .replace(/[^\d]+/g, '')
+    .replace(/(\d{3})(\d{3})(\d{4})/, '$1-$2-$3');
+}
+
 export const formatOperatingHours = operatingHours => {
   if (!operatingHours) return operatingHours;
   // Remove all whitespace.

--- a/src/applications/vaos/utils/selectors.js
+++ b/src/applications/vaos/utils/selectors.js
@@ -1,14 +1,15 @@
 import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
 
-import { getRealFacilityId } from './appointment';
+import { getRealFacilityId, getAppointmentType } from './appointment';
 import { isEligible } from './eligibility';
 import { getTimezoneAbbrBySystemId } from './timezone';
 import {
-  FACILITY_TYPES,
-  TYPES_OF_CARE,
+  APPOINTMENT_TYPES,
   AUDIOLOGY_TYPES_OF_CARE,
-  TYPES_OF_SLEEP_CARE,
+  FACILITY_TYPES,
   FETCH_STATUS,
+  TYPES_OF_CARE,
+  TYPES_OF_SLEEP_CARE,
 } from './constants';
 
 export function getNewAppointment(state) {
@@ -210,10 +211,13 @@ export function getCancelInfo(state) {
 
   let facility = null;
   if (appointmentToCancel) {
-    facility =
-      facilityData[
-        getRealFacilityId(appointmentToCancel.facility?.facilityCode)
-      ];
+    const appointmentType = getAppointmentType(appointmentToCancel);
+    const facilityId =
+      appointmentType === APPOINTMENT_TYPES.request ||
+      appointmentType === APPOINTMENT_TYPES.ccRequest
+        ? getRealFacilityId(appointmentToCancel.facility?.facilityCode)
+        : getRealFacilityId(appointmentToCancel.facilityId);
+    facility = facilityData[facilityId];
   }
 
   return {


### PR DESCRIPTION
## Description
The cancel link is currently hidden for CC appointments and Video visits.  This PR enables the links for them and displays a message saying that they need to call the facility to cancel. It also provides the facility name and phone number to call.

## Testing done
Local and unit

## Screenshots
![image](https://user-images.githubusercontent.com/786704/71022998-a99d0c80-20b6-11ea-8e13-ba5c5ae3094c.png)
![image](https://user-images.githubusercontent.com/786704/71023004-abff6680-20b6-11ea-98f3-0f5bceeb80b9.png)


## Acceptance criteria
- [ ] Cancel links exist for cc and video appointments
- [ ] Modal displays appropriate title and message
- [ ] Facility name and phone is displayed

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
