### PR TITLE
Guess fields to keep

### DIFF
--- a/src/site/stages/build/process-cms-exports/generator-cms-content-model/generators/app/index.js
+++ b/src/site/stages/build/process-cms-exports/generator-cms-content-model/generators/app/index.js
@@ -21,6 +21,24 @@ const templatesPath = path.join(
   'generator-cms-content-model/templates/',
 );
 
+/**
+ * Takes an object and returns all the property names of itself and
+ * its nested objects recursively.
+ *
+ * @param {Object} obj - The object to get the property names from
+ * @return {Set<string>} - All the unique property names in snake_case
+ */
+const allSnakeCasedPropertyNames = obj =>
+  new Set(
+    _.flatten(
+      Object.keys(obj).map(key => {
+        if (typeof obj[key] === 'object' && !Array.isArray(obj[key]))
+          return Array.from(allSnakeCasedPropertyNames(obj[key])).concat([key]);
+        return key;
+      }),
+    ),
+  );
+
 module.exports = class extends Generator {
   async getContentModelType() {
     this.contentModelType = (await this.prompt([

--- a/src/site/stages/build/process-cms-exports/generator-cms-content-model/generators/app/index.js
+++ b/src/site/stages/build/process-cms-exports/generator-cms-content-model/generators/app/index.js
@@ -33,8 +33,10 @@ const allSnakeCasedPropertyNames = obj =>
     _.flatten(
       Object.keys(obj).map(key => {
         if (typeof obj[key] === 'object' && !Array.isArray(obj[key]))
-          return Array.from(allSnakeCasedPropertyNames(obj[key])).concat([key]);
-        return key;
+          return Array.from(allSnakeCasedPropertyNames(obj[key])).concat([
+            _.snakeCase(key),
+          ]);
+        return _.snakeCase(key);
       }),
     ),
   );

--- a/src/site/stages/build/process-cms-exports/generator-cms-content-model/generators/app/index.js
+++ b/src/site/stages/build/process-cms-exports/generator-cms-content-model/generators/app/index.js
@@ -133,6 +133,9 @@ module.exports = class extends Generator {
         chalk.green(`Found transformed entity test file:`),
         transformedEntityTestFile,
       );
+      this.transformedTestData = JSON.parse(
+        fs.readFileSync(transformedEntityTestFile),
+      );
       return;
     }
     // TODO: Generate search suggestions

--- a/src/site/stages/build/process-cms-exports/generator-cms-content-model/generators/app/index.js
+++ b/src/site/stages/build/process-cms-exports/generator-cms-content-model/generators/app/index.js
@@ -171,12 +171,16 @@ module.exports = class extends Generator {
   }
 
   async getFilters() {
+    const guesses = allSnakeCasedPropertyNames(this.transformedTestData);
     this.rawPropertyNames = (await this.prompt([
       {
         type: 'checkbox',
         name: 'names',
         message: 'Which keys do you want to keep?',
-        choices: Object.keys(this.exampleEntity),
+        choices: Object.keys(this.exampleEntity).map(key => ({
+          value: key,
+          checked: guesses.has(key),
+        })),
       },
     ])).names;
   }


### PR DESCRIPTION
## Description
I found I was looking up the corresponding entity in `pages.json` before selecting the fields to keep, so I switched up the order of questions to ask for the example entity first. Doing this, I could make guesses on which fields we wanted to keep.

Just another quality of life improvement. :smile: 

**Note:** Because we're recursively getting all the field names and using them as guesses, this may select fields we don't actually want because they were included in child entities. Just be aware and actually verify that they're all correct.

We might could make it only recurse to a depth of 2, since that's _typically_ all we want, but I wasn't sure if that would miss things in some cases. :man_shrugging: 

## Testing done
All the manual tests!
Could write unit tests for this whole generator, but...uh... :man_shrugging: 

## Screenshots
N/A

## Acceptance criteria
- [ ] The generator successfully runs all the way through
- [ ] The filter step automatically selects all the fields that we _probably_ want, but allows the user to override the selections