### PR TITLE
Fix error in VAOS when one system doesn't support type of care

### DIFF
--- a/src/applications/vaos/actions/newAppointment.js
+++ b/src/applications/vaos/actions/newAppointment.js
@@ -244,7 +244,7 @@ export function openFacilityPage(page, uiSchema, schema) {
       }
 
       const facilityId =
-        newAppointment.data.vaFacility || facilities?.[0].facilityId;
+        newAppointment.data.vaFacility || facilities?.[0]?.facilityId;
       if (
         facilityId &&
         !newAppointment.eligibility[`${facilityId}_${typeOfCareId}`]

--- a/src/applications/vaos/tests/actions/newAppointment.unit.spec.js
+++ b/src/applications/vaos/tests/actions/newAppointment.unit.spec.js
@@ -262,6 +262,32 @@ describe('VAOS newAppointment actions', () => {
       expect(firstAction.eligibilityData).to.not.be.null;
     });
 
+    it('should skip eligibility request and succeed if facility list is empty', async () => {
+      setFetchJSONResponse(global.fetch, { data: [] });
+      const dispatch = sinon.spy();
+      const state = set('newAppointment.data.vaSystem', '983', defaultState);
+      const getState = () => state;
+
+      const thunk = openFacilityPage('vaFacility', {}, defaultSchema);
+      await thunk(dispatch, getState);
+
+      expect(dispatch.firstCall.args[0].type).to.equal(
+        FORM_PAGE_FACILITY_OPEN_SUCCEEDED,
+      );
+
+      const succeededAction = dispatch.firstCall.args[0];
+      expect(succeededAction).to.deep.equal({
+        type: FORM_PAGE_FACILITY_OPEN_SUCCEEDED,
+        schema: defaultSchema,
+        page: 'vaFacility',
+        uiSchema: {},
+        systems,
+        facilities: [],
+        eligibilityData: null,
+        typeOfCareId: defaultState.newAppointment.data.typeOfCareId,
+      });
+    });
+
     it('should not fetch anything if system did not change', async () => {
       const dispatch = sinon.spy();
       const getState = () => ({


### PR DESCRIPTION
## Description
When a user is registered in one system that doesn't have any facilities supporting the type of care they chose, we're getting an empty facility list and failing. We should not fail, we should keep going and show the expected message.

## Testing done
Local and unit testing

## Acceptance criteria
- [ ] Empty facility list doesn't cause error

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
