### PR TITLE
Add new error message for flagged routing numbers

### DIFF
--- a/src/applications/personalization/profile360/components/PaymentInformationEditModalError.jsx
+++ b/src/applications/personalization/profile360/components/PaymentInformationEditModalError.jsx
@@ -32,25 +32,26 @@ function FlaggedAccount() {
   );
 }
 
-// TODO: Update this copy with messaging specific to the routing number being
-// flagged and blocked when the copy has been written:
-// https://github.com/department-of-veterans-affairs/va.gov-team/issues/4109
 function FlaggedRoutingNumber() {
   return (
     <>
       <p>
-        We’re sorry. You can’t change your direct deposit information right now
-        because we’ve locked the ability to edit this information. We do this to
-        protect your bank account information and prevent fraud when we think
-        there may be a security issue.
-      </p>
-      <p>
-        To request that we unlock this function, please call us at{' '}
+        We’re sorry. The bank routing number you entered requires additional
+        verification before we can save your information. To use this bank
+        routing number, you’ll need to call us at{' '}
         <span className="no-wrap">
           <a href="tel:1-800-827-1000">800-827-1000</a>
         </span>{' '}
         (TTY: <span className="no-wrap">800-829-4833</span>
         ). We’re here Monday through Friday, 8:00 a.m. to 9:00 p.m. ET.
+      </p>
+      <p>
+        You can also update this information by mail or in person at a VA
+        regional office.{' '}
+        <a href="/change-direct-deposit">
+          Learn how to update your direct deposit bank information
+        </a>
+        .
       </p>
     </>
   );
@@ -119,6 +120,7 @@ export default function PaymentInformationEditModalError({
   closeModal,
 }) {
   let content = <GenericError />;
+  let headline = 'We couldn’t update your bank information';
 
   if (responseError.error) {
     const { errors = [] } = responseError.error;
@@ -130,6 +132,7 @@ export default function PaymentInformationEditModalError({
       content = <FlaggedAccount />;
     } else if (hasRoutingNumberFlaggedError(errors)) {
       content = <FlaggedRoutingNumber />;
+      headline = 'We can’t save your bank routing number';
     } else if (hasInvalidRoutingNumberError(errors)) {
       content = <InvalidRoutingNumber />;
     } else if (hasInvalidAddressError(errors)) {
@@ -152,11 +155,7 @@ export default function PaymentInformationEditModalError({
   }
 
   return (
-    <AlertBox
-      status="error"
-      headline="We couldn’t update your bank information"
-      isVisible
-    >
+    <AlertBox status="error" headline={headline} isVisible>
       {content}
     </AlertBox>
   );

--- a/src/applications/personalization/profile360/components/PaymentInformationEditModalError.jsx
+++ b/src/applications/personalization/profile360/components/PaymentInformationEditModalError.jsx
@@ -2,7 +2,8 @@ import React from 'react';
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 
 import {
-  hasFlaggedForFraudError,
+  hasAccountFlaggedError,
+  hasRoutingNumberFlaggedError,
   hasInvalidAddressError,
   hasInvalidHomePhoneNumberError,
   hasInvalidRoutingNumberError,
@@ -11,6 +12,30 @@ import {
 } from '../util';
 
 function FlaggedAccount() {
+  return (
+    <>
+      <p>
+        We’re sorry. You can’t change your direct deposit information right now
+        because we’ve locked the ability to edit this information. We do this to
+        protect your bank account information and prevent fraud when we think
+        there may be a security issue.
+      </p>
+      <p>
+        To request that we unlock this function, please call us at{' '}
+        <span className="no-wrap">
+          <a href="tel:1-800-827-1000">800-827-1000</a>
+        </span>{' '}
+        (TTY: <span className="no-wrap">800-829-4833</span>
+        ). We’re here Monday through Friday, 8:00 a.m. to 9:00 p.m. ET.
+      </p>
+    </>
+  );
+}
+
+// TODO: Update this copy with messaging specific to the routing number being
+// flagged and blocked when the copy has been written:
+// https://github.com/department-of-veterans-affairs/va.gov-team/issues/4109
+function FlaggedRoutingNumber() {
   return (
     <>
       <p>
@@ -99,10 +124,12 @@ export default function PaymentInformationEditModalError({
     const { errors = [] } = responseError.error;
 
     if (
-      hasFlaggedForFraudError(errors) ||
+      hasAccountFlaggedError(errors) ||
       hasPaymentRestrictionIndicatorsError(errors)
     ) {
       content = <FlaggedAccount />;
+    } else if (hasRoutingNumberFlaggedError(errors)) {
+      content = <FlaggedRoutingNumber />;
     } else if (hasInvalidRoutingNumberError(errors)) {
       content = <InvalidRoutingNumber />;
     } else if (hasInvalidAddressError(errors)) {

--- a/src/applications/personalization/profile360/tests/components/PaymentInformationEditModalError.unit.spec.jsx
+++ b/src/applications/personalization/profile360/tests/components/PaymentInformationEditModalError.unit.spec.jsx
@@ -261,21 +261,23 @@ describe('<PaymentInformationEditModalError />', () => {
 
     wrapper = shallow(
       <PaymentInformationEditModalError
-        responseError={{ error: routingNumberFlaggedError }}
+        responseError={{ error: restrictionIndicatorsPresentError }}
       />,
     );
     expect(wrapper.html()).to.contain(
       'We’re sorry. You can’t change your direct deposit information right now because we’ve locked the ability to edit this information. We do this to protect your bank account information and prevent fraud when we think there may be a security issue.',
     );
     wrapper.unmount();
+  });
 
-    wrapper = shallow(
+  it('renders the flagged routing number error', () => {
+    const wrapper = shallow(
       <PaymentInformationEditModalError
-        responseError={{ error: restrictionIndicatorsPresentError }}
+        responseError={{ error: routingNumberFlaggedError }}
       />,
     );
     expect(wrapper.html()).to.contain(
-      'We’re sorry. You can’t change your direct deposit information right now because we’ve locked the ability to edit this information. We do this to protect your bank account information and prevent fraud when we think there may be a security issue.',
+      'We’re sorry. The bank routing number you entered requires additional verification before we can save your information. To use this bank routing number, you’ll need to call us at <span class="no-wrap"><a href="tel:1-800-827-1000">800-827-1000</a></span> (TTY: <span class="no-wrap">800-829-4833</span>). We’re here Monday through Friday, 8:00 a.m. to 9:00 p.m. ET.',
     );
     wrapper.unmount();
   });

--- a/src/applications/personalization/profile360/tests/util/index.unit.spec.js
+++ b/src/applications/personalization/profile360/tests/util/index.unit.spec.js
@@ -2,7 +2,8 @@ import { expect } from 'chai';
 
 import {
   createDirectDepositAnalyticsDataObject,
-  hasFlaggedForFraudError,
+  hasAccountFlaggedError,
+  hasRoutingNumberFlaggedError,
   hasInvalidHomePhoneNumberError,
 } from '../../util';
 
@@ -224,7 +225,29 @@ describe('profile utils', () => {
   });
 
   describe('PaymentInformation error parsing methods', () => {
-    it('hasFlaggedForFraudError returns true on error', () => {
+    it('hasRoutingNumberFlaggedError returns true on error', () => {
+      const errors = [
+        {
+          code: '135',
+          detail: 'Routing number related to potential fraud',
+          meta: {
+            messages: [
+              {
+                key: 'cnp.payment.routing.number.fraud.message',
+                severity: 'ERROR',
+                text: 'Routing number related to potential fraud',
+              },
+            ],
+          },
+          source: 'EVSS::PPIU::Service',
+          status: '422',
+          title: 'Potential Fraud',
+        },
+      ];
+      expect(hasRoutingNumberFlaggedError(errors)).to.equal(true);
+    });
+
+    it('hasAccountFlaggedError returns true on error', () => {
       const errors = [
         {
           title: 'Account Flagged',
@@ -243,7 +266,7 @@ describe('profile utils', () => {
           },
         },
       ];
-      expect(hasFlaggedForFraudError(errors)).to.equal(true);
+      expect(hasAccountFlaggedError(errors)).to.equal(true);
     });
 
     it('hasInvalidHomePhoneNumberError returns false if text does not contain night phone', () => {

--- a/src/applications/personalization/profile360/util/index.js
+++ b/src/applications/personalization/profile360/util/index.js
@@ -52,10 +52,6 @@ export const hasAccountFlaggedError = errors =>
 export const hasRoutingNumberFlaggedError = errors =>
   hasErrorMessage(errors, ROUTING_NUMBER_FLAGGED_FOR_FRAUD_KEY);
 
-export const hasFlaggedForFraudError = errors =>
-  hasErrorMessage(errors, ACCOUNT_FLAGGED_FOR_FRAUD_KEY) ||
-  hasErrorMessage(errors, ROUTING_NUMBER_FLAGGED_FOR_FRAUD_KEY);
-
 export const hasInvalidRoutingNumberError = errors =>
   hasErrorMessage(errors, INVALID_ROUTING_NUMBER_KEY) ||
   hasErrorMessage(errors, GENERIC_ERROR_KEY, 'Invalid Routing Number');


### PR DESCRIPTION
## Description
We are adding a new error message to handle the situation where a routing number has been flagged as fraudulent.

## Testing done
Local. Confirmed the link to the `change-direct-deposit` page works. + unit tests

## Screenshots
![image](https://user-images.githubusercontent.com/20728956/71035447-589a1200-20d0-11ea-97f1-ecb419de8c2b.png)

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs