### PR TITLE
Fail build on ERROR commit status & add logging to Jenkins output to mirror Slack notifications.

### DIFF
--- a/Jenkinsfile.content
+++ b/Jenkinsfile.content
@@ -9,7 +9,9 @@ node('vetsgov-general-purpose') {
 
   refStatusState = getGithubCommitState("vets-website", ref)
   if ("${refStatusState}" != "SUCCESS") {
-    slackSend(message:"Web content refresh on ${params.env} aborted due to '${refStatusState}' status on vets-website commit ${ref}.",
+    message = "Web content refresh on ${params.env} aborted due to '${refStatusState}' status on vets-website commit ${ref}."
+    echo message
+    slackSend(message: message,
               color: "warning",
               channel: "cms-notifications")
 
@@ -40,8 +42,9 @@ node('vetsgov-general-purpose') {
   stage("Deploy Dev or Staging") {
     if (params.env != "vagovprod" && params.deploy) {
       commonStages.runDeploy("deploys/vets-website-${params.env}", ref, true)
-
-      slackSend(message:"Web content refresh in ${params.env} completed.",
+      message = "Web content refresh in ${params.env} completed."
+      echo message
+      slackSend(message: message,
                 color: "good",
                 channel: "cms-notifications")
     }

--- a/Jenkinsfile.content
+++ b/Jenkinsfile.content
@@ -15,6 +15,7 @@ node('vetsgov-general-purpose') {
               color: "warning",
               channel: "cms-notifications")
 
+    currentBuild.result = 'FAILURE'
     return
   }
 

--- a/Jenkinsfile.content
+++ b/Jenkinsfile.content
@@ -10,8 +10,8 @@ node('vetsgov-general-purpose') {
   refStatusState = getGithubCommitState("vets-website", ref)
   if ("${refStatusState}" != "SUCCESS") {
     message = "Web content refresh on ${params.env} aborted due to '${refStatusState}' status on vets-website commit ${ref}."
-    echo message
-    slackSend(message: message,
+    echo "${message}"
+    slackSend(message: "${message}",
               color: "warning",
               channel: "cms-notifications")
 
@@ -44,8 +44,8 @@ node('vetsgov-general-purpose') {
     if (params.env != "vagovprod" && params.deploy) {
       commonStages.runDeploy("deploys/vets-website-${params.env}", ref, true)
       message = "Web content refresh in ${params.env} completed."
-      echo message
-      slackSend(message: message,
+      echo "${message}"
+      slackSend(message: "${message}",
                 color: "good",
                 channel: "cms-notifications")
     }


### PR DESCRIPTION
## Description

Was hard to debug why a job was acting as a "no-op". Logging was only
getting sent to Slack channel. In our case the commit status was "error"
and the job had logic to not go any further, but we didn't know that
until we looked at the Slack channel for the log message.

https://va-gov.atlassian.net/browse/VAGOV-6361

## Testing done
Tested a replay here 
http://jenkins.vfs.va.gov/job/builds/job/vets-website-content-vagovstaging/129/console

## Screenshots
![image](https://user-images.githubusercontent.com/1504756/71038617-145e4000-20d7-11ea-9f75-4f803ae4c58a.png)

![image](https://user-images.githubusercontent.com/1504756/71040463-7a4cc680-20db-11ea-8e6e-38127e00014e.png)

## Acceptance criteria
- [ ]

## Definition of done
- [x] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs