### PR TITLE
Fix additional info title copy if reasonForAdditionalInfo is set

### DIFF
--- a/src/applications/vaos/actions/newAppointment.js
+++ b/src/applications/vaos/actions/newAppointment.js
@@ -25,8 +25,8 @@ import {
 import {
   FACILITY_TYPES,
   FLOW_TYPES,
-  REASON_MAX_CHARS,
   GA_PREFIX,
+  REASON_MAX_CHARS,
 } from '../utils/constants';
 import {
   transformFormToVARequest,
@@ -90,6 +90,8 @@ export const FORM_SHOW_TYPE_OF_CARE_UNAVAILABLE_MODAL =
   'newAppointment/FORM_SHOW_TYPE_OF_CARE_UNAVAILABLE_MODAL';
 export const FORM_HIDE_TYPE_OF_CARE_UNAVAILABLE_MODAL =
   'newAppointment/FORM_HIDE_TYPE_OF_CARE_UNAVAILABLE_MODAL';
+export const FORM_REASON_FOR_APPOINTMENT_PAGE_OPENED =
+  'newAppointment/FORM_REASON_FOR_APPOINTMENT_PAGE_OPENED';
 export const FORM_REASON_FOR_APPOINTMENT_CHANGED =
   'newAppointment/FORM_REASON_FOR_APPOINTMENT_CHANGED';
 export const FORM_PAGE_COMMUNITY_CARE_PREFS_OPEN =
@@ -359,6 +361,15 @@ export function updateFacilityPageData(page, uiSchema, data) {
         });
       }
     }
+  };
+}
+
+export function openReasonForAppointment(page, uiSchema, schema) {
+  return {
+    type: FORM_REASON_FOR_APPOINTMENT_PAGE_OPENED,
+    page,
+    uiSchema,
+    schema,
   };
 }
 

--- a/src/applications/vaos/containers/ReasonForAppointmentPage.jsx
+++ b/src/applications/vaos/containers/ReasonForAppointmentPage.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import {
-  openFormPage,
+  openReasonForAppointment,
   updateReasonForAppointmentData,
   routeToNextAppointmentPage,
   routeToPreviousAppointmentPage,
@@ -46,7 +46,7 @@ const pageKey = 'reasonForAppointment';
 
 export class ReasonForAppointmentPage extends React.Component {
   componentDidMount() {
-    this.props.openFormPage(pageKey, uiSchema, initialSchema);
+    this.props.openReasonForAppointment(pageKey, uiSchema, initialSchema);
   }
 
   goBack = () => {
@@ -133,7 +133,7 @@ function mapStateToProps(state) {
 }
 
 const mapDispatchToProps = {
-  openFormPage,
+  openReasonForAppointment,
   updateReasonForAppointmentData,
   routeToNextAppointmentPage,
   routeToPreviousAppointmentPage,

--- a/src/applications/vaos/reducers/newAppointment.js
+++ b/src/applications/vaos/reducers/newAppointment.js
@@ -38,6 +38,7 @@ import {
   FORM_SCHEDULE_APPOINTMENT_PAGE_OPENED_SUCCEEDED,
   FORM_SHOW_TYPE_OF_CARE_UNAVAILABLE_MODAL,
   FORM_HIDE_TYPE_OF_CARE_UNAVAILABLE_MODAL,
+  FORM_REASON_FOR_APPOINTMENT_PAGE_OPENED,
   FORM_REASON_FOR_APPOINTMENT_CHANGED,
   FORM_PAGE_COMMUNITY_CARE_PREFS_OPEN,
   FORM_PAGE_COMMUNITY_CARE_PREFS_OPEN_SUCCEEDED,
@@ -129,6 +130,12 @@ function updateFacilitiesSchemaAndData(systems, facilities, schema, data) {
   }
 
   return { schema: newSchema, data: newData };
+}
+
+function getReasonAdditionalInfoTitle(reason) {
+  return reason === 'other'
+    ? REASON_ADDITIONAL_INFO_TITLES.other
+    : REASON_ADDITIONAL_INFO_TITLES.default;
 }
 
 export default function formReducer(state = initialState, action) {
@@ -495,18 +502,39 @@ export default function formReducer(state = initialState, action) {
         },
       };
     }
+    case FORM_REASON_FOR_APPOINTMENT_PAGE_OPENED: {
+      const { data, schema } = setupFormData(
+        state.data,
+        action.schema,
+        action.uiSchema,
+      );
+
+      let reasonSchema = { ...schema };
+
+      if (state.data?.reasonForAppointment) {
+        reasonSchema = set(
+          'properties.reasonAdditionalInfo.title',
+          getReasonAdditionalInfoTitle(state.data.reasonForAppointment),
+          reasonSchema,
+        );
+      }
+
+      return {
+        ...state,
+        data,
+        pages: {
+          ...state.pages,
+          [action.page]: reasonSchema,
+        },
+      };
+    }
     case FORM_REASON_FOR_APPOINTMENT_CHANGED: {
       let newSchema = state.pages.reasonForAppointment;
 
       // Update additional info title based on radio selection
-      const additionalInfoTitle =
-        action.data.reasonForAppointment === 'other'
-          ? REASON_ADDITIONAL_INFO_TITLES.other
-          : REASON_ADDITIONAL_INFO_TITLES.default;
-
       newSchema = set(
         'properties.reasonAdditionalInfo.title',
-        additionalInfoTitle,
+        getReasonAdditionalInfoTitle(action.data.reasonForAppointment),
         newSchema,
       );
 

--- a/src/applications/vaos/tests/containers/ReasonForAppointmentPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/containers/ReasonForAppointmentPage.unit.spec.jsx
@@ -8,12 +8,12 @@ import { ReasonForAppointmentPage } from '../../containers/ReasonForAppointmentP
 
 describe('VAOS <ReasonForAppointmentPage>', () => {
   it('should render', () => {
-    const openFormPage = sinon.spy();
+    const openReasonForAppointment = sinon.spy();
     const updateReasonForAppointmentData = sinon.spy();
 
     const form = mount(
       <ReasonForAppointmentPage
-        openFormPage={openFormPage}
+        openReasonForAppointment={openReasonForAppointment}
         updateReasonForAppointmentData={updateReasonForAppointmentData}
         data={{}}
       />,
@@ -25,14 +25,14 @@ describe('VAOS <ReasonForAppointmentPage>', () => {
   });
 
   it('should not submit empty form', () => {
-    const openFormPage = sinon.spy();
+    const openReasonForAppointment = sinon.spy();
     const router = {
       push: sinon.spy(),
     };
 
     const form = mount(
       <ReasonForAppointmentPage
-        openFormPage={openFormPage}
+        openReasonForAppointment={openReasonForAppointment}
         router={router}
         data={{}}
       />,
@@ -48,7 +48,7 @@ describe('VAOS <ReasonForAppointmentPage>', () => {
   });
 
   it('should call updateReasonForAppointmentData after change', () => {
-    const openFormPage = sinon.spy();
+    const openReasonForAppointment = sinon.spy();
     const updateReasonForAppointmentData = sinon.spy();
     const router = {
       push: sinon.spy(),
@@ -56,7 +56,7 @@ describe('VAOS <ReasonForAppointmentPage>', () => {
 
     const form = mount(
       <ReasonForAppointmentPage
-        openFormPage={openFormPage}
+        openReasonForAppointment={openReasonForAppointment}
         updateReasonForAppointmentData={updateReasonForAppointmentData}
         router={router}
         data={{}}
@@ -72,12 +72,12 @@ describe('VAOS <ReasonForAppointmentPage>', () => {
   });
 
   it('should submit with valid data', () => {
-    const openFormPage = sinon.spy();
+    const openReasonForAppointment = sinon.spy();
     const routeToNextAppointmentPage = sinon.spy();
 
     const form = mount(
       <ReasonForAppointmentPage
-        openFormPage={openFormPage}
+        openReasonForAppointment={openReasonForAppointment}
         routeToNextAppointmentPage={routeToNextAppointmentPage}
         data={{
           reasonForAppointment: 'routine-follow-up',
@@ -92,12 +92,12 @@ describe('VAOS <ReasonForAppointmentPage>', () => {
   });
 
   it('should render alert message with aria label', () => {
-    const openFormPage = sinon.spy();
+    const openReasonForAppointment = sinon.spy();
     const updateReasonForAppointmentData = sinon.spy();
 
     const form = mount(
       <ReasonForAppointmentPage
-        openFormPage={openFormPage}
+        openReasonForAppointment={openReasonForAppointment}
         updateReasonForAppointmentData={updateReasonForAppointmentData}
         data={{}}
       />,

--- a/src/applications/vaos/tests/reducers/newAppointment.unit.spec.js
+++ b/src/applications/vaos/tests/reducers/newAppointment.unit.spec.js
@@ -651,11 +651,18 @@ describe('VAOS reducer: newAppointment', () => {
         uiSchema: {},
       };
 
-      const newState = newAppointmentReducer(state, action);
+      let newState = newAppointmentReducer(state, action);
       expect(
         newState.pages.reasonForAppointment.properties.reasonAdditionalInfo
           .title,
       ).to.equal(REASON_ADDITIONAL_INFO_TITLES.other);
+
+      state.data.reasonForAppointment = 'follow-up';
+      newState = newAppointmentReducer(state, action);
+      expect(
+        newState.pages.reasonForAppointment.properties.reasonAdditionalInfo
+          .title,
+      ).to.equal(REASON_ADDITIONAL_INFO_TITLES.default);
     });
 
     it('should not set additional info title if reason for appointment is unset', () => {

--- a/src/applications/vaos/tests/reducers/newAppointment.unit.spec.js
+++ b/src/applications/vaos/tests/reducers/newAppointment.unit.spec.js
@@ -28,11 +28,15 @@ import {
   FORM_SHOW_TYPE_OF_CARE_UNAVAILABLE_MODAL,
   FORM_HIDE_TYPE_OF_CARE_UNAVAILABLE_MODAL,
   FORM_CLOSED_CONFIRMATION_PAGE,
+  FORM_REASON_FOR_APPOINTMENT_PAGE_OPENED,
 } from '../../actions/newAppointment';
 
 import systems from '../../api/facilities.json';
 import facilities983 from '../../api/facilities_983.json';
-import { FETCH_STATUS } from '../../utils/constants';
+import {
+  FETCH_STATUS,
+  REASON_ADDITIONAL_INFO_TITLES,
+} from '../../utils/constants';
 
 const systemsParsed = systems.data.map(item => ({
   ...item.attributes,
@@ -629,6 +633,49 @@ describe('VAOS reducer: newAppointment', () => {
       ]);
     });
   });
+
+  describe('Reason for appointment page', () => {
+    it('should set additional info title if reason for appointment is already in data', () => {
+      const state = {
+        ...defaultState,
+        data: { ...defaultState.data, reasonForAppointment: 'other' },
+      };
+
+      const action = {
+        type: FORM_REASON_FOR_APPOINTMENT_PAGE_OPENED,
+        page: 'reasonForAppointment',
+        schema: {
+          type: 'object',
+          properties: {},
+        },
+        uiSchema: {},
+      };
+
+      const newState = newAppointmentReducer(state, action);
+      expect(
+        newState.pages.reasonForAppointment.properties.reasonAdditionalInfo
+          .title,
+      ).to.equal(REASON_ADDITIONAL_INFO_TITLES.other);
+    });
+
+    it('should not set additional info title if reason for appointment is unset', () => {
+      const action = {
+        type: FORM_REASON_FOR_APPOINTMENT_PAGE_OPENED,
+        page: 'reasonForAppointment',
+        schema: {
+          type: 'object',
+          properties: {},
+        },
+        uiSchema: {},
+      };
+
+      const newState = newAppointmentReducer(defaultState, action);
+      expect(
+        newState.pages.reasonForAppointment.properties.reasonAdditionalInfo,
+      ).to.equal(undefined);
+    });
+  });
+
   describe('CC preferences page', () => {
     it('should set loading state', () => {
       const action = {


### PR DESCRIPTION
## Description
On the Reason for Appointment page, the title/label for "Additional Info" is typically set onChange of the reason radio buttons above.  When the user passes the Reason for Appointment page and then goes back, there is a bug and title is unset and displays as `reasonAdditionInfo`. 

This ticket displays the correct copy on page load if `data.reasonForAppointment` has a value.

## Testing done
Local and unit

## Screenshots
### Before
![Screen Shot 2019-12-16 at 12.26.39 PM.png](https://images.zenhubusercontent.com/59c29173b0222d5de478791d/d7d2b49e-1dd3-4ba1-9214-b777a6acd030)

### After
![image](https://user-images.githubusercontent.com/786704/71062039-65455700-211e-11ea-9cc1-718cad117f6f.png)


## Acceptance criteria
- [ ] When going back to the reason for appointment page, appropriate title for additional info field is displayed

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
