### PR TITLE
Fix 4328

### DIFF
--- a/src/platform/user/profile/vet360/actions/transactions.js
+++ b/src/platform/user/profile/vet360/actions/transactions.js
@@ -141,6 +141,8 @@ export function createTransaction(
   analyticsSectionName,
 ) {
   return async dispatch => {
+    // eslint-disable-next-line no-debugger
+    debugger;
     const options = {
       body: JSON.stringify(payload),
       method,

--- a/src/platform/user/profile/vet360/actions/ui.js
+++ b/src/platform/user/profile/vet360/actions/ui.js
@@ -1,6 +1,6 @@
 export const UPDATE_PROFILE_FORM_FIELD = 'UPDATE_PROFILE_FORM_FIELD';
 export const OPEN_MODAL = 'OPEN_MODAL';
-export const UPDATE_ADDRESS = 'UPDATE_ADDRESS';
+export const UPDATE_SELECTED_ADDRESS = 'UPDATE_SELECTED_ADDRESS';
 
 export const openModal = modal => ({ type: OPEN_MODAL, modal });
 
@@ -29,7 +29,7 @@ export const updateFormField = (
 };
 
 export const updateSelectedAddress = (address, selectedId) => ({
-  type: UPDATE_ADDRESS,
+  type: UPDATE_SELECTED_ADDRESS,
   selectedAddress: address,
   selectedId,
 });

--- a/src/platform/user/profile/vet360/containers/AddressValidationModal.jsx
+++ b/src/platform/user/profile/vet360/containers/AddressValidationModal.jsx
@@ -228,7 +228,7 @@ const mapStateToProps = state => {
     validationKey: state.vet360.addressValidation.validationKey,
     addressFromUser: state.vet360.addressValidation.addressFromUser,
     selectedAddress: state.vet360.addressValidation.selectedAddress,
-    selectedId: state.vet360.addressValidation.selectedId,
+    selectedId: state.vet360.addressValidation.selectedAddressId,
   };
 };
 

--- a/src/platform/user/profile/vet360/reducers/index.js
+++ b/src/platform/user/profile/vet360/reducers/index.js
@@ -13,7 +13,7 @@ import {
   VET360_CLEAR_TRANSACTION_STATUS,
   ADDRESS_VALIDATION_CONFIRM,
   ADDRESS_VALIDATION_ERROR,
-  UPDATE_ADDRESS,
+  UPDATE_SELECTED_ADDRESS,
 } from '../actions';
 
 import { isFailedTransaction } from '../util/transactions';
@@ -41,7 +41,7 @@ const initialState = {
     addressValidationError: false,
     validationKey: null,
     selectedAddress: {},
-    selectedId: '0',
+    selectedAddressId: '0',
   },
   transactionStatus: '',
 };
@@ -213,6 +213,7 @@ export default function vet360(state = initialState, action) {
           suggestedAddresses: action.suggestedAddresses,
           validationKey: action.validationKey,
           selectedAddress: action.selectedAddress,
+          selectedAddressId: '0',
         },
         modal: 'addressValidation',
       };
@@ -230,13 +231,13 @@ export default function vet360(state = initialState, action) {
         modal: 'addressValidation',
       };
 
-    case UPDATE_ADDRESS:
+    case UPDATE_SELECTED_ADDRESS:
       return {
         ...state,
         addressValidation: {
           ...state.addressValidation,
           selectedAddress: action.selectedAddress,
-          selectedId: action.selectedId,
+          selectedAddressId: action.selectedAddressId,
         },
       };
 

--- a/src/platform/user/profile/vet360/tests/actions/transactions.unit.spec.js
+++ b/src/platform/user/profile/vet360/tests/actions/transactions.unit.spec.js
@@ -77,26 +77,6 @@ describe('validateAddress', () => {
         },
         {
           addressMetaData: {
-            confidenceScore: 100,
-            addressType: 'Domestic',
-            deliveryPointValidation: 'CONFIRMED',
-            residentialDeliveryIndicator: 'RESIDENTIAL',
-          },
-          addressLine1: '400 NW 65th Street',
-          addressType: 'DOMESTIC',
-          city: 'Seattle',
-          countryName: 'United States',
-          countryCodeIso3: 'USA',
-          countyCode: '53033',
-          countyName: 'King',
-          stateCode: 'WA',
-          zipCode: '98117',
-          zipCodeSuffix: '5026',
-          type: 'DOMESTIC',
-          addressPou: 'RESIDENCE/CHOICE',
-        },
-        {
-          addressMetaData: {
             confidenceScore: 98,
             addressType: 'Domestic',
             deliveryPointValidation:

--- a/src/platform/user/profile/vet360/util/local-vet360.js
+++ b/src/platform/user/profile/vet360/util/local-vet360.js
@@ -384,26 +384,6 @@ export default {
           },
           {
             address: {
-              addressLine1: '400 NW 65th Street',
-              addressType: 'DOMESTIC',
-              city: 'Seattle',
-              countryName: 'United States',
-              countryCodeIso3: 'USA',
-              countyCode: '53033',
-              countyName: 'King',
-              stateCode: 'WA',
-              zipCode: '98117',
-              zipCodeSuffix: '5026',
-            },
-            addressMetaData: {
-              confidenceScore: 100.0,
-              addressType: 'Domestic',
-              deliveryPointValidation: 'CONFIRMED',
-              residentialDeliveryIndicator: 'RESIDENTIAL',
-            },
-          },
-          {
-            address: {
               addressLine1: '400 NE 65th St',
               addressType: 'DOMESTIC',
               city: 'Seattle',
@@ -424,7 +404,7 @@ export default {
             },
           },
         ],
-        validationKey: 12345,
+        validationKey: -2009470897,
       },
       1000,
     );


### PR DESCRIPTION
## Description
This PR addresses two issues:
- resolves https://github.com/department-of-veterans-affairs/va.gov-team/issues/4328: prevent the FE from sending a "bad" suggested address to the update endpoint
- resolves https://github.com/department-of-veterans-affairs/va.gov-team/issues/4264: reset the radio button state each time the validation modal opens.
- should also resolve https://github.com/department-of-veterans-affairs/va.gov-team/issues/4327: the second time you try to force through a "bad" user-entered address the update fails

## Testing done
Local

## Screenshots
N/A

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs