### PR TITLE
Fix async mock of unit test

### DIFF
--- a/src/applications/find-va-forms/actions/index.js
+++ b/src/applications/find-va-forms/actions/index.js
@@ -37,22 +37,22 @@ export const updateResultsAction = results => ({
 // ============
 // Redux Thunks
 // ============
-export const fetchFormsThunk = query => async dispatch => {
+export const fetchFormsThunk = (
+  query,
+  location = window.location,
+  history = window.history,
+) => async dispatch => {
   // Change the `fetching` state in our store.
   dispatch(fetchFormsAction(query));
 
   // Derive the current query params.
-  const queryParams = new URLSearchParams(window.location.search);
+  const queryParams = new URLSearchParams(location.search);
 
   // Update the query params with the new `query`.
   queryParams.set('q', query);
 
   // Update the URL with the new query param.
-  window.history.replaceState(
-    {},
-    '',
-    `${window.location.pathname}?${queryParams}`,
-  );
+  history.replaceState({}, '', `${location.pathname}?${queryParams}`);
 
   try {
     // Attempt to make the API request to retreive forms.

--- a/src/applications/find-va-forms/tests/actions/index.unit.spec.js
+++ b/src/applications/find-va-forms/tests/actions/index.unit.spec.js
@@ -51,34 +51,28 @@ describe('Find VA Forms actions', () => {
   });
 
   describe('fetchFormsThunk', () => {
-    let oldWindow;
+    let mockedLocation;
+    let mockedHistory;
 
     beforeEach(() => {
-      oldWindow = global.window;
-      global.window = {
-        ...global.window,
-        location: {
-          search: '',
-          pathname: '',
-        },
-        history: {
-          replaceState: sinon.stub(),
-        },
+      mockedLocation = {
+        search: '',
+        pathname: '',
       };
-    });
 
-    afterEach(() => {
-      global.window = oldWindow;
+      mockedHistory = {
+        replaceState: sinon.stub(),
+      };
     });
 
     it('updates search params', async () => {
       const dispatch = () => {};
       const query = 'health';
-      const thunk = fetchFormsThunk(query);
+      const thunk = fetchFormsThunk(query, mockedLocation, mockedHistory);
 
       await thunk(dispatch);
 
-      const replaceStateStub = global.window.history.replaceState;
+      const replaceStateStub = mockedHistory.replaceState;
 
       expect(replaceStateStub.calledOnce).to.be.true;
       expect(replaceStateStub.firstCall.args[2]).to.be.equal('?q=health');
@@ -87,7 +81,7 @@ describe('Find VA Forms actions', () => {
     it('calls dispatch', async () => {
       const dispatch = sinon.stub();
       const query = 'health';
-      const thunk = fetchFormsThunk(query);
+      const thunk = fetchFormsThunk(query, mockedLocation, mockedHistory);
 
       await thunk(dispatch);
 

--- a/src/applications/find-va-forms/tests/actions/index.unit.spec.js
+++ b/src/applications/find-va-forms/tests/actions/index.unit.spec.js
@@ -56,6 +56,7 @@ describe('Find VA Forms actions', () => {
     beforeEach(() => {
       oldWindow = global.window;
       global.window = {
+        ...global.window,
         location: {
           search: '',
           pathname: '',

--- a/src/applications/find-va-forms/tests/containers/SearchForm.unit.spec.jsx
+++ b/src/applications/find-va-forms/tests/containers/SearchForm.unit.spec.jsx
@@ -20,6 +20,7 @@ describe('Find VA Forms <SearchForm>', () => {
     const oldWindow = global.window;
 
     global.window = {
+      ...global.window,
       location: {
         search: '?q=testing',
       },

--- a/src/applications/find-va-forms/tests/containers/SearchForm.unit.spec.jsx
+++ b/src/applications/find-va-forms/tests/containers/SearchForm.unit.spec.jsx
@@ -20,7 +20,6 @@ describe('Find VA Forms <SearchForm>', () => {
     const oldWindow = global.window;
 
     global.window = {
-      ...global.window,
       location: {
         search: '?q=testing',
       },


### PR DESCRIPTION
## Description
We're still seeing unit tests fail randomly with strange stacktraces. This PR hopefully fixes that by mocking `global.window` more fully.

## Testing done
The test will be the unit tests on this PR

## Screenshots
N/A

## Acceptance criteria
- [ ] Unit tests don't fail randomly

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
