### PR TITLE
remove 'not available programs' column from profile page

### DIFF
--- a/src/applications/gi/components/profile/Programs.jsx
+++ b/src/applications/gi/components/profile/Programs.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import environment from 'platform/utilities/environment';
 
 export class Programs extends React.Component {
   constructor(props) {
@@ -117,25 +118,45 @@ export class Programs extends React.Component {
     const it = this.props.institution;
     const programs = Object.keys(this.programs);
     const available = programs.filter(key => !!it[key] === true);
-    const notAvailable = programs.filter(key => !!it[key] === false);
+    // prod flag for BAH 4227
+    if (environment.isProduction()) {
+      const notAvailable = programs.filter(key => !!it[key] === false);
+      return (
+        <div className="programs row">
+          {available.length > 0 && (
+            <div className="usa-width-one-half medium-6 large-6 column">
+              <h3>Available at this campus</h3>
+              {available.map(program =>
+                this.renderProgramLabel.bind(this, program, true)(),
+              )}
+              <br />
+            </div>
+          )}
+          {notAvailable.length > 0 && (
+            <div className="usa-width-one-half medium-6 large-6 column">
+              <h3>Not available at this campus</h3>
+              {notAvailable.map(program =>
+                this.renderProgramLabel.bind(this, program, false)(),
+              )}
+            </div>
+          )}
+        </div>
+      );
+    }
     return (
       <div className="programs row">
-        {available.length > 0 && (
+        {available.length > 0 ? (
           <div className="usa-width-one-half medium-6 large-6 column">
-            <h3>Available at this campus</h3>
             {available.map(program =>
               this.renderProgramLabel.bind(this, program, true)(),
             )}
             <br />
           </div>
-        )}
-        {notAvailable.length > 0 && (
-          <div className="usa-width-one-half medium-6 large-6 column">
-            <h3>Not available at this campus</h3>
-            {notAvailable.map(program =>
-              this.renderProgramLabel.bind(this, program, false)(),
-            )}
-          </div>
+        ) : (
+          <p>
+            Please contact the school or their military office directly for
+            information on the Veteran programs they offer.
+          </p>
         )}
       </div>
     );

--- a/src/applications/gi/components/profile/Programs.jsx
+++ b/src/applications/gi/components/profile/Programs.jsx
@@ -118,7 +118,7 @@ export class Programs extends React.Component {
     const it = this.props.institution;
     const programs = Object.keys(this.programs);
     const available = programs.filter(key => !!it[key] === true);
-    // prod flag for BAH 4227
+    // prod flag for BAH 4227. There is also flag in VetTecPrograms.jsx
     if (environment.isProduction()) {
       const notAvailable = programs.filter(key => !!it[key] === false);
       return (

--- a/src/applications/gi/components/profile/Programs.jsx
+++ b/src/applications/gi/components/profile/Programs.jsx
@@ -118,7 +118,7 @@ export class Programs extends React.Component {
     const it = this.props.institution;
     const programs = Object.keys(this.programs);
     const available = programs.filter(key => !!it[key] === true);
-    // prod flag for BAH 4227. There is also flag in VetTecPrograms.jsx
+    // prod flag for BAH 4227. There are also flag in VetTecPrograms.jsx and VetTecInstitutionProfile.jsx
     if (environment.isProduction()) {
       const notAvailable = programs.filter(key => !!it[key] === false);
       return (

--- a/src/applications/gi/components/vet-tec/VetTecInstitutionProfile.jsx
+++ b/src/applications/gi/components/vet-tec/VetTecInstitutionProfile.jsx
@@ -11,6 +11,7 @@ import { renderVetTecLogo } from '../../utils/render';
 import classNames from 'classnames';
 import VetTecVeteranPrograms from './VetTecVeteranPrograms';
 import _ from 'lodash';
+import environment from 'platform/utilities/environment';
 
 const VetTecInstitutionProfile = ({
   institution,
@@ -39,7 +40,15 @@ const VetTecInstitutionProfile = ({
           <AccordionItem button="Estimate your benefits">
             <VetTecCalculator showModal={showModal} />
           </AccordionItem>
-          {displayVeteranPrograms() && (
+          {/* prod flag for BAH 4227. There are also flags in Programs.jsx and VetTecPrograms.jsx */}
+          {environment.isProduction() && displayVeteranPrograms() ? (
+            <AccordionItem button="Veteran programs">
+              <VetTecVeteranPrograms
+                institution={institution}
+                onShowModal={showModal}
+              />
+            </AccordionItem>
+          ) : (
             <AccordionItem button="Veteran programs">
               <VetTecVeteranPrograms
                 institution={institution}

--- a/src/applications/gi/components/vet-tec/VetTecVeteranPrograms.jsx
+++ b/src/applications/gi/components/vet-tec/VetTecVeteranPrograms.jsx
@@ -105,7 +105,6 @@ export class VetTecVeteranPrograms extends React.Component {
       <div className="programs row">
         {availablePrograms.length > 0 ? (
           <div className="usa-width-one-half medium-6 large-6 column vads-u-margin-top--2">
-            <h3>Available at this campus</h3>
             {availablePrograms.map((program, index) =>
               this.renderProgramLabel(program, index),
             )}

--- a/src/applications/gi/components/vet-tec/VetTecVeteranPrograms.jsx
+++ b/src/applications/gi/components/vet-tec/VetTecVeteranPrograms.jsx
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import _ from 'lodash';
+import environment from 'platform/utilities/environment';
 
 export class VetTecVeteranPrograms extends React.Component {
   programs = () => {
@@ -73,10 +74,36 @@ export class VetTecVeteranPrograms extends React.Component {
   render() {
     const programs = this.programs();
     const availablePrograms = programs.filter(program => program.available);
-    const notAvailablePrograms = programs.filter(program => !program.available);
+    // prod flag for BAH 4227. There is also flag in Programs.jsx
+    if (environment.isProduction()) {
+      const notAvailablePrograms = programs.filter(
+        program => !program.available,
+      );
+      return (
+        <div className="programs row">
+          {availablePrograms.length > 0 && (
+            <div className="usa-width-one-half medium-6 large-6 column vads-u-margin-top--2">
+              <h3>Available at this campus</h3>
+              {availablePrograms.map((program, index) =>
+                this.renderProgramLabel(program, index),
+              )}
+              <br />
+            </div>
+          )}
+          {notAvailablePrograms.length > 0 && (
+            <div className="usa-width-one-half medium-6 large-6 column">
+              <h3>Not available at this campus</h3>
+              {notAvailablePrograms.map((program, index) =>
+                this.renderProgramLabel(program, index),
+              )}
+            </div>
+          )}
+        </div>
+      );
+    }
     return (
       <div className="programs row">
-        {availablePrograms.length > 0 && (
+        {availablePrograms.length > 0 ? (
           <div className="usa-width-one-half medium-6 large-6 column vads-u-margin-top--2">
             <h3>Available at this campus</h3>
             {availablePrograms.map((program, index) =>
@@ -84,14 +111,11 @@ export class VetTecVeteranPrograms extends React.Component {
             )}
             <br />
           </div>
-        )}
-        {notAvailablePrograms.length > 0 && (
-          <div className="usa-width-one-half medium-6 large-6 column">
-            <h3>Not available at this campus</h3>
-            {notAvailablePrograms.map((program, index) =>
-              this.renderProgramLabel(program, index),
-            )}
-          </div>
+        ) : (
+          <p>
+            Please contact the school or their military office directly for
+            information on the Veteran programs they offer.
+          </p>
         )}
       </div>
     );

--- a/src/applications/gi/components/vet-tec/VetTecVeteranPrograms.jsx
+++ b/src/applications/gi/components/vet-tec/VetTecVeteranPrograms.jsx
@@ -74,7 +74,7 @@ export class VetTecVeteranPrograms extends React.Component {
   render() {
     const programs = this.programs();
     const availablePrograms = programs.filter(program => program.available);
-    // prod flag for BAH 4227. There is also flag in Programs.jsx
+    // prod flag for BAH 4227. There are also flags in Programs.jsx and VetTecInstitutionProfile.jsx
     if (environment.isProduction()) {
       const notAvailablePrograms = programs.filter(
         program => !program.available,


### PR DESCRIPTION
## Description
https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/4227

Removes the `Not Available At this Campus` column in the `Programs` section of the profile page. 

## Testing done


## Screenshots

![image](https://user-images.githubusercontent.com/48804654/71103882-e5080b80-2188-11ea-87b5-cdd9a714e81b.png)
##
![image](https://user-images.githubusercontent.com/48804654/71103893-e9ccbf80-2188-11ea-977b-35731d175125.png)


## Acceptance criteria
- [ ] The "Not available at this campus" column and related data is no longer displayed.
- [ ] The "Available at this campus" header is no longer displayed.
- [ ] If the are no programs available at a campus the following informational message is displayed: "Please contact the school or their military office directly for information on the Veteran programs they offer.".

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
