### PR TITLE
4222 handle mvi errors rd

### DIFF
--- a/src/applications/personalization/rated-disabilities/components/RatedDisabilityView.jsx
+++ b/src/applications/personalization/rated-disabilities/components/RatedDisabilityView.jsx
@@ -1,9 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 import Breadcrumbs from '@department-of-veterans-affairs/formation-react/Breadcrumbs';
 import RatedDisabilityList from './RatedDisabilityList';
 import TotalRatedDisabilities from '../components/TotalRatedDisabilities';
 import RatedDisabilitiesSidebar from '../components/RatedDisabilitiesSidebar';
+import facilityLocator from 'applications/facility-locator/manifest.json';
 
 class RatedDisabilityView extends React.Component {
   static propTypes = {
@@ -15,6 +17,37 @@ class RatedDisabilityView extends React.Component {
 
   componentDidMount() {
     this.props.fetchTotalDisabilityRating();
+  }
+
+  renderMVIError() {
+    return (
+      <AlertBox
+        headline="We’re having trouble matching your information to our veteran records"
+        content={
+          <div>
+            <p>
+              We’re having trouble matching your information to our veteran
+              records, so we can’t give you access to tools for managing your
+              health and benefits.
+            </p>
+            <p>
+              If you’d like to use these tools on VA.gov, please contact your
+              nearest VA medical center. Let them know you need to verify the
+              information in your records, and update it as needed. The
+              operator, or a patient advocate, can connect you with the right
+              person who can help.
+            </p>
+            <p>
+              <a href={facilityLocator.rootUrl}>
+                Find your nearest VA medical center
+              </a>
+            </p>
+          </div>
+        }
+        status="warning"
+        className="vads-u-margin-y--2"
+      />
+    );
   }
 
   render() {
@@ -55,6 +88,8 @@ class RatedDisabilityView extends React.Component {
             </div>
           </>
         );
+      } else {
+        content = this.renderMVIError();
       }
     }
 

--- a/src/applications/personalization/rated-disabilities/tests/components/RatedDisabilityView.unit.spec.jsx
+++ b/src/applications/personalization/rated-disabilities/tests/components/RatedDisabilityView.unit.spec.jsx
@@ -33,4 +33,24 @@ describe('<RatedDisabilityView/>', () => {
     ).to.be.true;
     wrapper.unmount();
   });
+
+  it('should render a MVI warning if profile status is not OK', () => {
+    const userError = {
+      profile: {
+        verified: true,
+        status: 'NOT_FOUND',
+      },
+    };
+    const wrapper = shallow(
+      <RatedDisabilityView
+        user={userError}
+        fetchRatedDisabilities={fetchRatedDisabilities}
+        fetchTotalDisabilityRating={fetchTotalDisabilityRating}
+        ratedDisabilities={ratedDisabilities}
+      />,
+    );
+
+    expect(wrapper.find('.usa-alert-warning')).to.exist;
+    wrapper.unmount();
+  });
 });


### PR DESCRIPTION
## Description
Original ticket - https://github.com/department-of-veterans-affairs/va.gov-team/issues/4222

There was a need to handle potential MVI errors, or scenarios where a veteran's profile status came back as anything other than 'OK'. Currently on staging, logging in with test user #10 demonstrates this issue, where a user would be met with nothing but the header, footer, and a white strip where content should have been (screenshot below). 

Adding a check for status enables us to present the user with actionable information in the event of an error that prevents their profile from properly loading.

Error handling is consistent with other applications on VA.gov found [here](https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/applications/personalization/account/components/AccountMain.jsx#L22) and [here](https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/applications/personalization/profile360/components/ProfileView.jsx#L150)

## Testing done
- local

## Screenshots
- Staging:
![Screen Shot 2019-12-12 at 2 51 26 PM](https://user-images.githubusercontent.com/15097156/71130639-4ccd4f00-21a7-11ea-847a-fd0b9de99d52.png)

- Proposed fix shown locally:
<img width="1076" alt="Screen Shot 2019-12-18 at 2 46 52 PM" src="https://user-images.githubusercontent.com/15097156/71130668-5eaef200-21a7-11ea-8b1e-c89f6ca0b8db.png">


## Acceptance criteria
- [x] add profile check
- [x] add unit test

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
