### PR TITLE
Make sure correct REST method is used to update/save address

### DIFF
--- a/src/platform/user/profile/vet360/actions/transactions.js
+++ b/src/platform/user/profile/vet360/actions/transactions.js
@@ -209,7 +209,7 @@ export const validateAddress = (
           secondAddress.addressMetaData?.confidenceScore -
           firstAddress.addressMetaData?.confidenceScore,
       )
-      // add the address type and POU to each suggestion
+      // add the address type, POU, and original id to each suggestion
       .map(address => ({
         addressMetaData: { ...address.addressMetaData },
         ...inferAddressType(address.address),
@@ -217,6 +217,7 @@ export const validateAddress = (
           fieldName === FIELD_NAMES.MAILING_ADDRESS
             ? ADDRESS_POU.CORRESPONDENCE
             : ADDRESS_POU.RESIDENCE,
+        id: payload.id || null,
       }));
     const confirmedSuggestions = suggestedAddresses.filter(
       suggestion =>
@@ -225,10 +226,6 @@ export const validateAddress = (
     const payloadWithSuggestedAddress = {
       ...confirmedSuggestions[0],
     };
-    // only add the id to the payload if it existed on the user-entered address
-    if (payload.id) {
-      payloadWithSuggestedAddress.id = payload.id;
-    }
 
     // we use the unfiltered list of suggested addresses to determine if we need
     // to show the modal because the only time we will skip the modal is if one

--- a/src/platform/user/profile/vet360/tests/actions/transactions.unit.spec.js
+++ b/src/platform/user/profile/vet360/tests/actions/transactions.unit.spec.js
@@ -54,6 +54,7 @@ describe('validateAddress', () => {
           zipCodeSuffix: '5252',
           type: 'DOMESTIC',
           addressPou: 'RESIDENCE/CHOICE',
+          id: 123,
         },
         {
           addressMetaData: {
@@ -74,6 +75,7 @@ describe('validateAddress', () => {
           zipCodeSuffix: '5026',
           type: 'DOMESTIC',
           addressPou: 'RESIDENCE/CHOICE',
+          id: 123,
         },
         {
           addressMetaData: {
@@ -95,6 +97,7 @@ describe('validateAddress', () => {
           zipCodeSuffix: '6463',
           type: 'DOMESTIC',
           addressPou: 'RESIDENCE/CHOICE',
+          id: 123,
         },
       ]);
     });

--- a/src/platform/user/profile/vet360/util/local-vet360.js
+++ b/src/platform/user/profile/vet360/util/local-vet360.js
@@ -227,6 +227,35 @@ export default {
       1000,
     );
   },
+  addressValidationSuccessSingleLowConfidenceSuggestion() {
+    return asyncReturn(
+      {
+        addresses: [
+          {
+            address: {
+              addressLine1: '400 N 65th St',
+              addressType: 'DOMESTIC',
+              city: 'Seattle',
+              countryName: 'United States',
+              countryCodeIso3: 'USA',
+              countyCode: '53033',
+              countyName: 'King',
+              stateCode: 'WA',
+              zipCode: '98103',
+              zipCodeSuffix: '5252',
+            },
+            addressMetaData: {
+              confidenceScore: 77.0,
+              addressType: 'Domestic',
+              deliveryPointValidation: 'CONFIRMED',
+            },
+          },
+        ],
+        validationKey: -245128725,
+      },
+      1000,
+    );
+  },
   addressValidationSuccessSingleMissingUnitNumber() {
     return asyncReturn(
       {


### PR DESCRIPTION
## Description
The existence of an `id` property on an address object indicates if the user already has an address on file and thus is used to determine if we should use the `PUT` or the `POST` endpoint. This `id` property was not getting properly passed to the validation modal, thus when the user picked a suggested address in the modal, there was no `id` on that address and the modal assumed that there wasn't an address on file yet. Thus is would call the `POST` endpoint, resulting in an error.

## Testing done
Local using the browser debugger

## Screenshots
N/A

## Acceptance criteria
- [ ] 

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs