### PR TITLE
bradl3yC 4213 Add spinner to continue button

### DIFF
--- a/src/platform/user/profile/vet360/containers/AddressValidationModal.jsx
+++ b/src/platform/user/profile/vet360/containers/AddressValidationModal.jsx
@@ -82,7 +82,7 @@ class AddressValidationModal extends React.Component {
 
     return (
       <LoadingButton isLoading={isLoading} className="usa-button-primary">
-        Continue
+        Update
       </LoadingButton>
     );
   };

--- a/src/platform/user/profile/vet360/containers/AddressValidationModal.jsx
+++ b/src/platform/user/profile/vet360/containers/AddressValidationModal.jsx
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import Modal from '@department-of-veterans-affairs/formation-react/Modal';
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
+import LoadingButton from 'platform/site-wide/loading-button/LoadingButton';
 import { selectCurrentlyOpenEditModal } from '../selectors';
 import {
   openModal,
@@ -65,6 +66,7 @@ class AddressValidationModal extends React.Component {
       addressValidationError,
       addressValidationType,
       validationKey,
+      isLoading,
     } = this.props;
 
     if (addressValidationError && !validationKey) {
@@ -78,7 +80,11 @@ class AddressValidationModal extends React.Component {
       );
     }
 
-    return <button className="usa-button-primary">Continue</button>;
+    return (
+      <LoadingButton isLoading={isLoading} className="usa-button-primary">
+        Continue
+      </LoadingButton>
+    );
   };
 
   renderAddressOption = (address, id = 'userEntered') => {
@@ -219,6 +225,8 @@ const mapStateToProps = state => {
 
   return {
     analyticsSectionName: VET360.ANALYTICS_FIELD_MAP[addressValidationType],
+    isLoading:
+      state.vet360.fieldTransactionMap[addressValidationType]?.isPending,
     isAddressValidationModalVisible:
       selectCurrentlyOpenEditModal(state) === 'addressValidation',
     addressValidationError:

--- a/src/platform/user/profile/vet360/tests/containers/AddressValidationModal.unit.spec.jsx
+++ b/src/platform/user/profile/vet360/tests/containers/AddressValidationModal.unit.spec.jsx
@@ -7,6 +7,11 @@ describe('<AddressValidationModal/>', () => {
   const fakeStore = {
     getState: () => ({
       vet360: {
+        fieldTransactionMap: {
+          mailingAddress: {
+            isPending: false,
+          },
+        },
         modal: 'addressValidation',
         addressValidation: {
           addressFromUser: {
@@ -83,7 +88,7 @@ describe('<AddressValidationModal/>', () => {
       <AddressValidationModal store={fakeStore} />,
     );
 
-    expect(component.find('.usa-button-primary').text()).to.equal('Continue');
+    expect(component.find('LoadingButton').text()).to.equal('Update');
     expect(component.find('.usa-button-secondary').text()).to.equal('Cancel');
     component.unmount();
   });
@@ -92,6 +97,11 @@ describe('<AddressValidationModal/>', () => {
     const newFakeStore = {
       getState: () => ({
         vet360: {
+          fieldTransactionMap: {
+            mailingAddress: {
+              isPending: false,
+            },
+          },
           modal: 'addressValidation',
           addressValidation: {
             addressFromUser: {


### PR DESCRIPTION
## Description
After a user hits Continue - while the transaction is pending - display a spinner in place of the continue button to give some indication that its in progress.

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
