### PR TITLE
restore address selection radio button

### DIFF
--- a/src/platform/user/profile/vet360/reducers/index.js
+++ b/src/platform/user/profile/vet360/reducers/index.js
@@ -237,7 +237,7 @@ export default function vet360(state = initialState, action) {
         addressValidation: {
           ...state.addressValidation,
           selectedAddress: action.selectedAddress,
-          selectedAddressId: action.selectedAddressId,
+          selectedAddressId: action.selectedId,
         },
       };
 

--- a/src/platform/user/profile/vet360/util/local-vet360.js
+++ b/src/platform/user/profile/vet360/util/local-vet360.js
@@ -227,6 +227,56 @@ export default {
       1000,
     );
   },
+  addressValidationSuccessTwoConfirmedSuggestions() {
+    return asyncReturn(
+      {
+        addresses: [
+          {
+            address: {
+              addressLine1: '575 20th St',
+              addressType: 'DOMESTIC',
+              city: 'San Francisco',
+              countryName: 'United States',
+              countryCodeIso3: 'USA',
+              countyCode: '06075',
+              countyName: 'San Francisco',
+              stateCode: 'CA',
+              zipCode: '94107',
+              zipCodeSuffix: '4345',
+            },
+            addressMetaData: {
+              confidenceScore: 100.0,
+              addressType: 'Domestic',
+              deliveryPointValidation: 'CONFIRMED',
+              residentialDeliveryIndicator: 'BUSINESS',
+            },
+          },
+          {
+            address: {
+              addressLine1: '575 20th Ave',
+              addressType: 'DOMESTIC',
+              city: 'San Francisco',
+              countryName: 'United States',
+              countryCodeIso3: 'USA',
+              countyCode: '06075',
+              countyName: 'San Francisco',
+              stateCode: 'CA',
+              zipCode: '94121',
+              zipCodeSuffix: '3122',
+            },
+            addressMetaData: {
+              confidenceScore: 100.0,
+              addressType: 'Domestic',
+              deliveryPointValidation: 'CONFIRMED',
+              residentialDeliveryIndicator: 'RESIDENTIAL',
+            },
+          },
+        ],
+        validationKey: -773295895,
+      },
+      1000,
+    );
+  },
   addressValidationSuccessSingleLowConfidenceSuggestion() {
     return asyncReturn(
       {


### PR DESCRIPTION
## Description
Fixes vanishing address selection radio button
Also adds yet another mock response from the validation endpoint

## Testing done
Verified in browser that the radio buttons work

## Screenshots


## Acceptance criteria
- [x] Radio button doesn't vanish on change.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs