### PR TITLE
Letters app address updater: initialize Vet360

### DIFF
--- a/src/applications/letters/containers/AddressSection.jsx
+++ b/src/applications/letters/containers/AddressSection.jsx
@@ -6,6 +6,10 @@ import { focusElement } from '../../../platform/utilities/ui';
 import { isAddressEmpty } from '../utils/helpers';
 import noAddressBanner from '../components/NoAddressBanner';
 
+import { TRANSACTION_CATEGORY_TYPES } from 'vet360/constants';
+
+import Vet360InitializeID from 'vet360/containers/InitializeVet360ID';
+import Vet360PendingTransactionCategory from 'vet360/containers/Vet360PendingTransactionCategory';
 import MailingAddress from 'vet360/components/MailingAddress';
 
 export class AddressSection extends React.Component {
@@ -26,7 +30,13 @@ export class AddressSection extends React.Component {
       <div className="step-content">
         <p>Downloaded documents will list your address as:</p>
         <div className="va-profile-wrapper">
-          <MailingAddress />
+          <Vet360InitializeID>
+            <Vet360PendingTransactionCategory
+              categoryType={TRANSACTION_CATEGORY_TYPES.ADDRESS}
+            >
+              <MailingAddress />
+            </Vet360PendingTransactionCategory>
+          </Vet360InitializeID>
         </div>
         <p>
           When you download a letter, it will show this address. If this address


### PR DESCRIPTION
## Description
This PR wraps the `MailingAddress` component (from Vet360 profile) used in the letters app with the `Vet360InitializeId` and `Vet360PendingTransactionCategory` components. This should deal with the bug outlined in the linked ticket where users who have not been initialized in Vet360 (VA Profile) cannot access the letters app. Adding these components also more closely mirrors how the `MailingAddress` component is implemented in the profile section.

## Acceptance criteria
- [ ] The `MailingAddress` component is wrapped in the `Vet360InitializeId` and `Vet360PendingTransactionCategory` components
