### PR TITLE
Fix selectors for VA Facility page

### DIFF
--- a/src/applications/vaos/tests/utils/selectors.unit.spec.js
+++ b/src/applications/vaos/tests/utils/selectors.unit.spec.js
@@ -6,6 +6,7 @@ import {
   getClinicPageInfo,
   getClinicsForChosenFacility,
   getDateTimeSelect,
+  getFacilityPageInfo,
   getFlowType,
   getFormData,
   getFormPageInfo,
@@ -74,6 +75,29 @@ describe('VAOS selectors', () => {
       );
       expect(pageInfo.data).to.equal(state.newAppointment.data);
       expect(pageInfo.schema).to.equal(state.newAppointment.pages.testPage);
+    });
+  });
+
+  describe('getFacilityPageInfo', () => {
+    it('should return typeOfCare string and begin loading systems', () => {
+      const state = {
+        newAppointment: {
+          pages: {},
+          data: {
+            typeOfCareId: '160',
+            facilityType: 'vamc',
+            vaSystem: '983',
+          },
+          facilities: {},
+          eligibility: {},
+          systems: [{}],
+          facilityDetails: {},
+        },
+      };
+
+      const newState = getFacilityPageInfo(state);
+      expect(newState.typeOfCare).to.equal('Pharmacy');
+      expect(newState.loadingSystems).to.be.true;
     });
   });
 

--- a/src/applications/vaos/utils/selectors.js
+++ b/src/applications/vaos/utils/selectors.js
@@ -127,8 +127,8 @@ export function hasSingleValidVALocation(state) {
   );
 }
 
-export function getFacilityPageInfo(state, pageKey) {
-  const formInfo = getFormPageInfo(state, pageKey);
+export function getFacilityPageInfo(state) {
+  const formInfo = getFormPageInfo(state, 'vaFacility');
   const data = getFormData(state);
   const newAppointment = getNewAppointment(state);
   const eligibilityStatus = getEligibilityStatus(state);

--- a/src/applications/vaos/utils/selectors.js
+++ b/src/applications/vaos/utils/selectors.js
@@ -129,6 +129,7 @@ export function hasSingleValidVALocation(state) {
 
 export function getFacilityPageInfo(state, pageKey) {
   const formInfo = getFormPageInfo(state, pageKey);
+  const data = getFormData(state);
   const newAppointment = getNewAppointment(state);
   const eligibilityStatus = getEligibilityStatus(state);
 
@@ -145,9 +146,7 @@ export function getFacilityPageInfo(state, pageKey) {
       eligibilityStatus.direct || eligibilityStatus.request,
     singleValidVALocation: hasSingleValidVALocation(state),
     noValidVASystems:
-      !formInfo.data.vaSystem &&
-      formInfo.schema &&
-      !formInfo.schema.properties.vaSystem,
+      !data.vaSystem && formInfo.schema && !formInfo.schema.properties.vaSystem,
     noValidVAFacilities:
       !!formInfo.schema && !!formInfo.schema.properties.vaFacilityMessage,
     facilityDetailsStatus: newAppointment.facilityDetailsStatus,
@@ -155,6 +154,8 @@ export function getFacilityPageInfo(state, pageKey) {
       newAppointment.systemsStatus === FETCH_STATUS.failed ||
       newAppointment.childFacilitiesStatus === FETCH_STATUS.failed ||
       newAppointment.elibilityStatus === FETCH_STATUS.failed,
+    typeOfCare: getTypeOfCare(data)?.name,
+    systemDetails: newAppointment?.facilityDetails[data.vaSystem],
   };
 }
 


### PR DESCRIPTION
## Description
`<NoValidVAFacilities/>` was missing the data it needed to display the type of care and facility info.  This work fixes the selector so that we can pass the appropriate data.

The selectors were present before but may have gotten overwritten in a merge.

## Testing done
Local

## Screenshots
![image](https://user-images.githubusercontent.com/786704/71226015-297dcf00-228f-11ea-9560-d95bcd17ccb2.png)


## Acceptance criteria
- [ ] Facility details show and type of care is not `undefined`

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
