### PR TITLE
changed language in cautionary info

### DIFF
--- a/src/applications/gi/components/profile/CautionaryInformation.jsx
+++ b/src/applications/gi/components/profile/CautionaryInformation.jsx
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
+import environment from 'platform/utilities/environment';
 
 const TableRow = ({ description, thisCampus, allCampuses }) => {
   if (!thisCampus && !allCampuses) return null;
@@ -143,6 +144,7 @@ export class CautionaryInformation extends React.Component {
               >
                 student complaints
               </a>
+              {environment.isProduction() ? '' : ' in the last 24 months'}
             </h3>
             <span>
               &nbsp;(


### PR DESCRIPTION
## Description
As a veteran, I need the "Cautionary information" section of the profile pages in the Comparison Tool to display language about how recent complaints are so that I can make an accurate decision about where I will choose to use my education benefits.

https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-
veterans-affairs/va.gov-team/4277

## Testing done
Local testing using Ashford university 

http://localhost:3001/gi-bill-comparison-tool/profile/21007103

## Screenshots
<img width="528" alt="Screen Shot 2019-12-20 at 2 28 40 PM" src="https://user-images.githubusercontent.com/50601724/71286217-17ef0280-2335-11ea-9fcd-ecef82ef024c.png">


## Acceptance criteria
- [x] Cautionary language should read "37 student complaints in the last 24 months"

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
