### PR TITLE
Show correct address in address edit modal

### DIFF
--- a/src/platform/user/profile/vet360/actions/transactions.js
+++ b/src/platform/user/profile/vet360/actions/transactions.js
@@ -32,6 +32,7 @@ export const VET360_CLEAR_TRANSACTION_STATUS =
   'VET360_CLEAR_TRANSACTION_STATUS';
 export const ADDRESS_VALIDATION_CONFIRM = 'ADDRESS_VALIDATION_CONFIRM';
 export const ADDRESS_VALIDATION_ERROR = 'ADDRESS_VALIDATION_ERROR';
+export const ADDRESS_VALIDATION_RESET = 'ADDRESS_VALIDATION_RESET';
 
 export function clearTransactionStatus() {
   return {
@@ -304,3 +305,7 @@ export const updateValidationKeyAndSave = (
     });
   }
 };
+
+export const resetAddressValidation = () => ({
+  type: ADDRESS_VALIDATION_RESET,
+});

--- a/src/platform/user/profile/vet360/actions/ui.js
+++ b/src/platform/user/profile/vet360/actions/ui.js
@@ -2,7 +2,11 @@ export const UPDATE_PROFILE_FORM_FIELD = 'UPDATE_PROFILE_FORM_FIELD';
 export const OPEN_MODAL = 'OPEN_MODAL';
 export const UPDATE_SELECTED_ADDRESS = 'UPDATE_SELECTED_ADDRESS';
 
-export const openModal = modal => ({ type: OPEN_MODAL, modal });
+export const openModal = (modal, modalData = null) => ({
+  type: OPEN_MODAL,
+  modal,
+  modalData,
+});
 
 export const closeModal = () => ({ type: OPEN_MODAL });
 

--- a/src/platform/user/profile/vet360/components/AddressField/AddressEditModal.jsx
+++ b/src/platform/user/profile/vet360/components/AddressField/AddressEditModal.jsx
@@ -63,7 +63,7 @@ class AddressEditModal extends React.Component {
 }
 
 const mapStateToProps = state => ({
-  modalData: state?.vet360?.modalData,
+  modalData: state.vet360?.modalData,
 });
 
 export default connect(mapStateToProps)(AddressEditModal);

--- a/src/platform/user/profile/vet360/components/AddressField/AddressEditModal.jsx
+++ b/src/platform/user/profile/vet360/components/AddressField/AddressEditModal.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { connect } from 'react-redux';
 
 import { FIELD_NAMES, ADDRESS_FORM_VALUES, USA } from 'vet360/constants';
 
@@ -7,7 +8,7 @@ import Vet360EditModal from '../base/Vet360EditModal';
 import CopyMailingAddress from 'vet360/containers/CopyMailingAddress';
 import AddressForm from './AddressForm';
 
-export default class AddressEditModal extends React.Component {
+class AddressEditModal extends React.Component {
   onBlur = field => {
     this.props.onChange(this.props.field.value, field);
   };
@@ -21,6 +22,7 @@ export default class AddressEditModal extends React.Component {
   };
 
   getInitialFormValues = () =>
+    this.props.modalData ||
     this.props.data || { countryName: USA.COUNTRY_NAME };
 
   copyMailingAddress = mailingAddress => {
@@ -59,3 +61,9 @@ export default class AddressEditModal extends React.Component {
     );
   }
 }
+
+const mapStateToProps = state => ({
+  modalData: state?.vet360?.modalData,
+});
+
+export default connect(mapStateToProps)(AddressEditModal);

--- a/src/platform/user/profile/vet360/containers/AddressValidationModal.jsx
+++ b/src/platform/user/profile/vet360/containers/AddressValidationModal.jsx
@@ -227,6 +227,7 @@ class AddressValidationModal extends React.Component {
             )}
           {this.renderPrimaryButton()}
           <button
+            type="button"
             className="usa-button-secondary"
             onClick={resetDataAndCloseModal}
           >

--- a/src/platform/user/profile/vet360/containers/AddressValidationModal.jsx
+++ b/src/platform/user/profile/vet360/containers/AddressValidationModal.jsx
@@ -12,6 +12,7 @@ import {
   updateSelectedAddress,
   updateValidationKeyAndSave,
   closeModal as closeAddressValidationModal,
+  resetAddressValidation as resetAddressValidationAction,
 } from '../actions';
 import { getValidationMessageKey } from '../../utilities';
 import {
@@ -161,7 +162,13 @@ class AddressValidationModal extends React.Component {
       validationKey,
       addressValidationError,
       closeModal,
+      resetAddressValidation,
     } = this.props;
+
+    const resetDataAndCloseModal = () => {
+      resetAddressValidation();
+      closeModal();
+    };
 
     const confirmedSuggestions = suggestedAddresses.filter(
       suggestion =>
@@ -187,7 +194,7 @@ class AddressValidationModal extends React.Component {
             : 'Edit home address'
         }
         id="address-validation-warning"
-        onClose={closeModal}
+        onClose={resetDataAndCloseModal}
         visible={isAddressValidationModalVisible}
       >
         <AlertBox
@@ -210,7 +217,10 @@ class AddressValidationModal extends React.Component {
               this.renderAddressOption(address, String(index)),
             )}
           {this.renderPrimaryButton()}
-          <button className="usa-button-secondary" onClick={closeModal}>
+          <button
+            className="usa-button-secondary"
+            onClick={resetDataAndCloseModal}
+          >
             Cancel
           </button>
         </form>
@@ -248,6 +258,7 @@ const mapDispatchToProps = dispatch => ({
       updateSelectedAddress,
       updateValidationKeyAndSave,
       createTransaction,
+      resetAddressValidation: resetAddressValidationAction,
     },
     dispatch,
   ),

--- a/src/platform/user/profile/vet360/containers/AddressValidationModal.jsx
+++ b/src/platform/user/profile/vet360/containers/AddressValidationModal.jsx
@@ -68,13 +68,16 @@ class AddressValidationModal extends React.Component {
       addressValidationType,
       validationKey,
       isLoading,
+      addressFromUser,
     } = this.props;
 
     if (addressValidationError && !validationKey) {
       return (
         <button
           className="usa-button-primary"
-          onClick={() => this.props.openModal(addressValidationType)}
+          onClick={() =>
+            this.props.openModal(addressValidationType, addressFromUser)
+          }
         >
           Edit Address
         </button>
@@ -94,6 +97,7 @@ class AddressValidationModal extends React.Component {
       addressValidationError,
       addressValidationType,
       selectedId,
+      addressFromUser,
     } = this.props;
     const {
       addressLine1,
@@ -143,7 +147,11 @@ class AddressValidationModal extends React.Component {
               zipCode && <span>{` ${city}, ${stateCode} ${zipCode}`}</span>}
             {isAddressFromUser &&
               showEditLink && (
-                <a onClick={() => this.props.openModal(addressValidationType)}>
+                <a
+                  onClick={() =>
+                    this.props.openModal(addressValidationType, addressFromUser)
+                  }
+                >
                   Edit Address
                 </a>
               )}

--- a/src/platform/user/profile/vet360/reducers/index.js
+++ b/src/platform/user/profile/vet360/reducers/index.js
@@ -13,10 +13,28 @@ import {
   VET360_CLEAR_TRANSACTION_STATUS,
   ADDRESS_VALIDATION_CONFIRM,
   ADDRESS_VALIDATION_ERROR,
+  ADDRESS_VALIDATION_RESET,
   UPDATE_SELECTED_ADDRESS,
 } from '../actions';
 
 import { isFailedTransaction } from '../util/transactions';
+
+const initialAddressValidationState = {
+  addressValidationType: '',
+  suggestedAddresses: [],
+  addressFromUser: {
+    addressLine1: '',
+    addressLine2: '',
+    addressLine3: '',
+    city: '',
+    stateCode: '',
+    zipCode: '',
+  },
+  addressValidationError: false,
+  validationKey: null,
+  selectedAddress: {},
+  selectedAddressId: '0',
+};
 
 const initialState = {
   modal: null,
@@ -28,20 +46,7 @@ const initialState = {
     mostRecentErroredTransactionId: '',
   },
   addressValidation: {
-    addressValidationType: '',
-    suggestedAddresses: [],
-    addressFromUser: {
-      addressLine1: '',
-      addressLine2: '',
-      addressLine3: '',
-      city: '',
-      stateCode: '',
-      zipCode: '',
-    },
-    addressValidationError: false,
-    validationKey: null,
-    selectedAddress: {},
-    selectedAddressId: '0',
+    ...initialAddressValidationState,
   },
   transactionStatus: '',
 };
@@ -229,6 +234,12 @@ export default function vet360(state = initialState, action) {
           addressFromUser: action.addressFromUser,
         },
         modal: 'addressValidation',
+      };
+
+    case ADDRESS_VALIDATION_RESET:
+      return {
+        ...state,
+        addressValidation: { ...initialAddressValidationState },
       };
 
     case UPDATE_SELECTED_ADDRESS:

--- a/src/platform/user/profile/vet360/reducers/index.js
+++ b/src/platform/user/profile/vet360/reducers/index.js
@@ -38,6 +38,7 @@ const initialAddressValidationState = {
 
 const initialState = {
   modal: null,
+  modalData: null,
   formFields: {},
   transactions: [],
   fieldTransactionMap: {},
@@ -206,7 +207,7 @@ export default function vet360(state = initialState, action) {
     }
 
     case OPEN_MODAL:
-      return { ...state, modal: action.modal };
+      return { ...state, modal: action.modal, modalData: action.modalData };
 
     case ADDRESS_VALIDATION_CONFIRM:
       return {

--- a/src/platform/user/profile/vet360/tests/actions/transactions.unit.spec.js
+++ b/src/platform/user/profile/vet360/tests/actions/transactions.unit.spec.js
@@ -1,6 +1,8 @@
 import {
+  resetAddressValidation,
   validateAddress,
   ADDRESS_VALIDATION_CONFIRM,
+  ADDRESS_VALIDATION_RESET,
 } from '../../actions/transactions';
 import sinon from 'sinon';
 import { expect } from 'chai';
@@ -21,6 +23,13 @@ const payload = {
   addressPou: 'CORRESPONDENCE',
 };
 const analyticsSectionName = 'bar';
+
+describe('resetAddressValidation', () => {
+  it('creates the correct action', () => {
+    const action = resetAddressValidation();
+    expect(action).to.deep.equal({ type: ADDRESS_VALIDATION_RESET });
+  });
+});
 
 describe('validateAddress', () => {
   it('verify return data', () => {

--- a/src/platform/user/profile/vet360/tests/containers/AddressValidationModal.unit.spec.jsx
+++ b/src/platform/user/profile/vet360/tests/containers/AddressValidationModal.unit.spec.jsx
@@ -13,6 +13,7 @@ describe('<AddressValidationModal/>', () => {
           },
         },
         modal: 'addressValidation',
+        modalData: null,
         addressValidation: {
           addressFromUser: {
             addressLine1: '12345 1st Ave',

--- a/src/platform/user/profile/vet360/tests/reducers/index.unit.spec.js
+++ b/src/platform/user/profile/vet360/tests/reducers/index.unit.spec.js
@@ -2,6 +2,7 @@ import { expect } from 'chai';
 
 import vet360 from '../../reducers';
 import * as VET360 from '../../constants';
+import { ADDRESS_VALIDATION_RESET } from '../../actions';
 
 describe('vet360 reducer', () => {
   it('should return array of transaction data', () => {
@@ -316,5 +317,53 @@ describe('vet360 reducer', () => {
     expect(state.addressValidation.addressValidationType).to.eql(
       'mailingAddress',
     );
+  });
+
+  describe('ADDRESS_VALIDATION_RESET action', () => {
+    it('resets the addressValidation state', () => {
+      const state = {
+        modal: 'modalName',
+        modalData: { foo: 'bar' },
+        addressValidation: {
+          addressValidationType: 'address',
+          suggestedAddresses: [{ street: '123 Main St' }],
+          addressFromUser: {
+            addressLine1: '123 main',
+            addressLine2: '',
+            addressLine3: '',
+            city: 'sf',
+            stateCode: 'CA',
+            zipCode: '12345',
+          },
+          addressValidationError: false,
+          validationKey: 1234,
+          selectedAddress: {},
+          selectedAddressId: '0',
+        },
+      };
+      const action = {
+        type: ADDRESS_VALIDATION_RESET,
+      };
+      const expectedState = {
+        ...state,
+        addressValidation: {
+          addressValidationType: '',
+          suggestedAddresses: [],
+          addressFromUser: {
+            addressLine1: '',
+            addressLine2: '',
+            addressLine3: '',
+            city: '',
+            stateCode: '',
+            zipCode: '',
+          },
+          addressValidationError: false,
+          validationKey: null,
+          selectedAddress: {},
+          selectedAddressId: '0',
+        },
+      };
+      expect(vet360(state, action)).to.eql(expectedState);
+    });
   });
 });


### PR DESCRIPTION
## Description
Addresses department-of-veterans-affairs/va.gov-team#4271 by expanding on the open modal action creator, allowing you to optionally pass data that the modal might need.

## Testing done
Local

## Screenshots
This GIF shows the address form showing the user-entered address when they go back to it from the validation modal.
![back-to-edit](https://user-images.githubusercontent.com/20728956/71481431-ac80b700-27b2-11ea-957c-f118b06b6013.gif)

## Acceptance criteria
- [x] when going back to the edit screen from the validation modal the user sees the address they had entered instead of the address that's already saved on file
- [x] they still see the address that's on file when they open the modal from the profile screen

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs