### PR TITLE
SCO: [serious] <ul> and <ol> must only directly contain <li>, <script> or <template> elements

### DIFF
--- a/src/applications/static-pages/school-resources/ScoAnnouncementsWidget.jsx
+++ b/src/applications/static-pages/school-resources/ScoAnnouncementsWidget.jsx
@@ -69,7 +69,9 @@ export default class ScoAnnouncementsWidget extends React.Component {
             );
           })
       ) : (
-        <p>No new announcements are available at this time.</p>
+        <li>
+          <p>No new announcements are available at this time.</p>
+        </li>
       );
 
     return <ul className="va-nav-linkslist-list">{announcements}</ul>;

--- a/src/applications/static-pages/school-resources/ScoEventsWidget.jsx
+++ b/src/applications/static-pages/school-resources/ScoEventsWidget.jsx
@@ -93,7 +93,9 @@ export default class ScoEventsWidget extends React.Component {
             </li>
           ))
       ) : (
-        <p>No new events are available at this time.</p>
+        <li>
+          <p>No new events are available at this time.</p>
+        </li>
       );
     return (
       <ul id="get" className="hub-page-link-list">


### PR DESCRIPTION
## Description
Builds failures reported in http://jenkins.vfs.va.gov/job/testing/job/vets-website/job/master/5768/display/redirect due to announcements expiring

```
 - sitemap 4/4 (42.531s)

[2019-12-23T14:31:30.315Z]    Failed [fail]: (http://vets-website:3001/school-administrators/: [serious] <ul> and <ol> must only directly contain <li>, <script> or <template> elements

[2019-12-23T14:31:30.315Z]    See https://dequeuniversity.com/rules/axe/2.6/list?application=axeAPI
```

Wrapping elements that are displayed when lists are empty in `<li>` tags

## Testing done
- local testing

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
