### PR TITLE
Disable VAOS CC e2e test

### DIFF
--- a/src/applications/vaos/tests/e2e/community-care.e2e.spec.js
+++ b/src/applications/vaos/tests/e2e/community-care.e2e.spec.js
@@ -3,6 +3,7 @@ const VAOSHelpers = require('./vaos-helpers');
 const Auth = require('../../../../platform/testing/e2e/auth');
 
 module.exports = {
+  '@disabled': true,
   after: (client, done) => {
     client.deleteCookies();
     client.end();


### PR DESCRIPTION
## Description
The CC e2e test is failing in a strange way, by opening a `data;` page instead of going to the next page sometimes, this disables it until we can figure out why.

## Acceptance criteria
- [ ] Build passes and skips test

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
