### PR TITLE
restore address selection radio button

### DIFF
--- a/src/platform/user/profile/vet360/reducers/index.js
+++ b/src/platform/user/profile/vet360/reducers/index.js
@@ -249,7 +249,7 @@ export default function vet360(state = initialState, action) {
         addressValidation: {
           ...state.addressValidation,
           selectedAddress: action.selectedAddress,
-          selectedAddressId: action.selectedId,
+          selectedAddressId: action.selectedAddressId,
         },
       };
 

--- a/src/platform/user/profile/vet360/tests/reducers/index.unit.spec.js
+++ b/src/platform/user/profile/vet360/tests/reducers/index.unit.spec.js
@@ -2,7 +2,10 @@ import { expect } from 'chai';
 
 import vet360 from '../../reducers';
 import * as VET360 from '../../constants';
-import { ADDRESS_VALIDATION_RESET } from '../../actions';
+import {
+  ADDRESS_VALIDATION_RESET,
+  UPDATE_SELECTED_ADDRESS,
+} from '../../actions';
 
 describe('vet360 reducer', () => {
   it('should return array of transaction data', () => {
@@ -360,6 +363,34 @@ describe('vet360 reducer', () => {
           addressValidationError: false,
           validationKey: null,
           selectedAddress: {},
+          selectedAddressId: '0',
+        },
+      };
+      expect(vet360(state, action)).to.eql(expectedState);
+    });
+  });
+
+  describe('UPDATE_SELECTED_ADDRESS action', () => {
+    it('sets the selectedAddress and selectedAddressId from the action', () => {
+      const state = {
+        metadata: {},
+        otherData: true,
+        addressValidation: {
+          selectedAddress: { street: '456 elm' },
+          selectedAddressId: 'userEntered',
+        },
+      };
+      const action = {
+        type: UPDATE_SELECTED_ADDRESS,
+        selectedAddress: {
+          street: '123 main',
+        },
+        selectedAddressId: '0',
+      };
+      const expectedState = {
+        ...state,
+        addressValidation: {
+          selectedAddress: { street: '123 main' },
           selectedAddressId: '0',
         },
       };


### PR DESCRIPTION
## Description
- Fix bug in reducer
- Add tests for the existing reducer

## Testing done
local

## Screenshots
![fixed](https://user-images.githubusercontent.com/20728956/71525243-a6a7d600-2885-11ea-8d53-9c4ebb59c71c.gif)

## Acceptance criteria
- [x] radio button stops vanishing when you change the selection

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs