### PR TITLE
Fix disability summary message (form 526)

### DIFF
--- a/src/applications/disability-benefits/all-claims/config/form.js
+++ b/src/applications/disability-benefits/all-claims/config/form.js
@@ -154,7 +154,7 @@ const formConfig = {
   defaultDefinitions: {
     ...fullSchema.definitions,
   },
-  title: 'Apply for disability compensation',
+  title: 'File for disability compensation',
   subTitle: 'Form 21-526EZ',
   preSubmitInfo,
   chapters: {

--- a/src/applications/disability-benefits/all-claims/content/summaryOfDisabilities.jsx
+++ b/src/applications/disability-benefits/all-claims/content/summaryOfDisabilities.jsx
@@ -60,11 +60,7 @@ export const SummaryOfDisabilitiesDescription = ({ formData }) => {
       <p>
         Below is the list of disabilities you’re claiming in this application.
         If a disability is missing from the list, please go back and{' '}
-        <Link
-          aria-label="Add missing disabilities"
-          title="Add missing disabilities"
-          to={orientationPath}
-        >
+        <Link aria-label="Add missing disabilities" to={orientationPath}>
           add it
         </Link>
         .

--- a/src/applications/disability-benefits/all-claims/content/summaryOfDisabilities.jsx
+++ b/src/applications/disability-benefits/all-claims/content/summaryOfDisabilities.jsx
@@ -1,6 +1,9 @@
 import React from 'react';
+import { Link } from 'react-router';
+
 import { capitalizeEachWord, isDisabilityPtsd } from '../utils';
 import { ptsdTypeEnum } from './ptsdTypeInfo';
+import formConfig from '../config/form';
 import { NULL_CONDITION_STRING } from '../constants';
 
 const mapDisabilityName = (disabilityName, formData, index) => {
@@ -49,14 +52,24 @@ export const SummaryOfDisabilitiesDescription = ({ formData }) => {
   const selectedDisabilitiesList = ratedDisabilityNames
     .concat(newDisabilityNames)
     .map((name, i) => mapDisabilityName(name, formData, i));
+  const orientationPath =
+    formConfig?.chapters.disabilities.pages.disabilitiesOrientation.path || '/';
+
   return (
-    <div>
+    <>
       <p>
         Below is the list of disabilities you’re claiming in this application.
-        If a disability is missing from the list, please go back one screen and
-        add it.
+        If a disability is missing from the list, please go back and{' '}
+        <Link
+          aria-label="Add missing disabilities"
+          title="Add missing disabilities"
+          to={orientationPath}
+        >
+          add it
+        </Link>
+        .
       </p>
       <ul>{selectedDisabilitiesList}</ul>
-    </div>
+    </>
   );
 };

--- a/src/applications/disability-benefits/all-claims/content/summaryOfDisabilities.jsx
+++ b/src/applications/disability-benefits/all-claims/content/summaryOfDisabilities.jsx
@@ -59,9 +59,9 @@ export const SummaryOfDisabilitiesDescription = ({ formData }) => {
     <>
       <p>
         Below is the list of disabilities you’re claiming in this application.
-        If a disability is missing from the list, please go back and{' '}
+        If a disability is missing from the list, please{' '}
         <Link aria-label="Add missing disabilities" to={orientationPath}>
-          add it
+          go back and add it
         </Link>
         .
       </p>


### PR DESCRIPTION
## Description

In form 526, the summary of disabilities screen included wording to "go back one screen" to add a missing disability. The screen is actually 8 or more steps back.

![](https://camo.githubusercontent.com/a5b3c6bb490ad9b8867fc346865a50be3cce7f48/68747470733a2f2f696d616765732e7a656e68756275736572636f6e74656e742e636f6d2f3564353263333234343737336364333465626466343836372f32336431646136622d333363612d346336332d393561632d373662633135336264376432)

The issue (#3801) stated that the wording should be changed, but this PR instead adds a link back to the beginning of step 2. This is the point where the user can choose from existing and new disabilities, or add a missing disability.

## Testing done

Local unit testing

## Screenshots

![](https://user-images.githubusercontent.com/136959/71491916-1fad1c00-27f9-11ea-865e-5f5bba922c31.png)

## Acceptance criteria
- [ ] A link (vs rewording) is appropriate in this context
- [ ] Link destination is appropriate
- [ ] Content review done

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
