### PR TITLE
Create CTA widget for View Disability Ratings

### DIFF
--- a/src/platform/site-wide/cta-widget/helpers.js
+++ b/src/platform/site-wide/cta-widget/helpers.js
@@ -9,6 +9,7 @@ export const widgetTypes = {
   CLAIMS_AND_APPEALS: 'claims-and-appeals',
   DIRECT_DEPOSIT: 'direct-deposit',
   DISABILITY_BENEFITS: 'disability-benefits',
+  DISABILITY_RATINGS: 'disability-ratings',
   GI_BILL_BENEFITS: 'gi-bill-benefits',
   HEALTH_RECORDS: 'health-records',
   LAB_AND_TEST_RESULTS: 'lab-and-test-results',
@@ -166,6 +167,12 @@ export const toolUrl = appId => {
         redirect: false,
       };
 
+    case widgetTypes.DISABILITY_RATINGS:
+      return {
+        url: '/disability/view-disability-rating/rating',
+        redirect: false,
+      };
+
     default:
       return {};
   }
@@ -251,6 +258,9 @@ export const serviceDescription = appId => {
 
     case widgetTypes.DIRECT_DEPOSIT:
       return 'change your direct deposit information online';
+
+    case widgetTypes.DISABILITY_RATINGS:
+      return 'view your VA disability rating';
 
     default:
       return 'use this service';


### PR DESCRIPTION
## Description
This PR creates a CTA widget (a prompt for the user to login to access an application) for the upcoming Disability Ratings application. It is planned to be visible on `/disability/view-disability-rating/`, but this page doesn't exist yet.

Ticket - https://github.com/department-of-veterans-affairs/va.gov-team/issues/3767

## Testing done
CTA widgets are built in React but the page has to be edited in Drupal to add the widget. To simulate this, I did this -

1. Opened `.cache/localhost/drupal/pages.json`
1. Searched for `"path": "/disability/about-disability-ratings"` to find the page data for `/disability/about-disability-ratings`
1. Scrolled to the `"fieldContentBlock"` property.
1. Replaced the first element there (the React calculator widget) with -

```js
{
  "entity": {
    "entityType": "paragraph",
    "entityBundle": "react_widget",
    "fieldTimeout": 20,
    "fieldCtaWidget": true,
    "fieldWidgetType": "disability-ratings",
    "fieldDefaultLink": null,
    "fieldButtonFormat": false,
    "fieldErrorMessage": null,
    "fieldLoadingMessage": null
  }
},
```

Then, I -

1. Started the site
1. Navigated to `http://localhost:3001/disability/about-disability-ratings/`
1. Confirmed UX for unauthenticated user
1. Followed prompt to login
1. Confirmed UX for authenticated user

## Screenshots

### Unauthenticated
![image](https://user-images.githubusercontent.com/1915775/71589895-93e70880-2af4-11ea-8501-780b71738881.png)

### Authenticated
![image](https://user-images.githubusercontent.com/1915775/71589942-bbd66c00-2af4-11ea-8903-e32fdfcf2f73.png)


## Acceptance criteria
- [x] CTA widget is ready for upcoming `/disability/view-disability-rating/` rollout

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
