### PR TITLE
Filter transform media document

### DIFF
--- a/src/site/stages/build/process-cms-exports/schemas/raw/media-document.js
+++ b/src/site/stages/build/process-cms-exports/schemas/raw/media-document.js
@@ -4,7 +4,17 @@ module.exports = {
   type: 'object',
   properties: {
     name: { $ref: 'GenericNestedString' },
-    path: { $ref: 'GenericNestedString' },
+    path: {
+      type: 'array',
+      maxItems: 1,
+      items: {
+        type: 'object',
+        properties: {
+          alias: { type: 'string' },
+        },
+        required: ['alias'],
+      },
+    },
   },
   required: ['name', 'path'],
 };

--- a/src/site/stages/build/process-cms-exports/schemas/raw/media-document.js
+++ b/src/site/stages/build/process-cms-exports/schemas/raw/media-document.js
@@ -10,7 +10,7 @@ module.exports = {
       items: {
         type: 'object',
         properties: {
-          alias: { type: 'string' },
+          alias: { type: ['string', 'null'] },
         },
         required: ['alias'],
       },

--- a/src/site/stages/build/process-cms-exports/schemas/raw/media-document.js
+++ b/src/site/stages/build/process-cms-exports/schemas/raw/media-document.js
@@ -1,0 +1,10 @@
+/* eslint-disable camelcase */
+
+module.exports = {
+  type: 'object',
+  properties: {
+    name: { $ref: 'GenericNestedString' },
+    path: { $ref: 'GenericNestedString' },
+  },
+  required: ['name', 'path'],
+};

--- a/src/site/stages/build/process-cms-exports/schemas/transformed/media-document.js
+++ b/src/site/stages/build/process-cms-exports/schemas/transformed/media-document.js
@@ -14,7 +14,7 @@ module.exports = {
               type: 'object',
               properties: {
                 filename: { type: 'string' },
-                url: { type: 'string' },
+                url: { type: ['string', 'null'] },
               },
               required: ['filename', 'url'],
             },

--- a/src/site/stages/build/process-cms-exports/schemas/transformed/media-document.js
+++ b/src/site/stages/build/process-cms-exports/schemas/transformed/media-document.js
@@ -1,0 +1,17 @@
+module.exports = {
+  type: 'object',
+  properties: {
+    contentModelType: { enum: ['media-document'] },
+    entity: {
+      type: 'object',
+      properties: {
+        entityType: { enum: ['media'] },
+        entityBundle: { enum: ['document'] },
+        name: { type: 'string' },
+        path: { type: 'string' },
+      },
+      required: ['name', 'path'],
+    },
+  },
+  required: ['entity'],
+};

--- a/src/site/stages/build/process-cms-exports/schemas/transformed/media-document.js
+++ b/src/site/stages/build/process-cms-exports/schemas/transformed/media-document.js
@@ -7,10 +7,22 @@ module.exports = {
       properties: {
         entityType: { enum: ['media'] },
         entityBundle: { enum: ['document'] },
-        name: { type: 'string' },
-        path: { type: 'string' },
+        fieldDocument: {
+          type: 'object',
+          properties: {
+            entity: {
+              type: 'object',
+              properties: {
+                filename: { type: 'string' },
+                url: { type: 'string' },
+              },
+              required: ['filename', 'url'],
+            },
+          },
+          required: ['entity'],
+        },
       },
-      required: ['name', 'path'],
+      required: ['fieldDocument'],
     },
   },
   required: ['entity'],

--- a/src/site/stages/build/process-cms-exports/tests/entities/index.js
+++ b/src/site/stages/build/process-cms-exports/tests/entities/index.js
@@ -9,7 +9,7 @@ module.exports = {
   'crop-2_1': 'crop.1d1c14bc-edb7-4dfc-baf5-cf0ad1810da7.json',
   entity_subqueue: 'entity_subqueue.0af013c4-9e81-4a3e-b74f-437536621cc3.json',
   file: 'file.0a3713c8-3533-4676-a894-c79ace11ea53.json',
-  'media-document': 'media.0005d6c0-7b1e-4454-afe2-9176705a52a1.json',
+  'media-document': 'media.10e78352-6dc0-411a-8c41-807f78d9a921.json',
   'media-image': 'media.003339cb-d979-442e-853e-7e56c8f86002.json',
   'media-video': 'media.012ecad1-2030-4ca6-a48f-996921a5816a.json',
   'menu_link_content-burials-and-memorials-benef':

--- a/src/site/stages/build/process-cms-exports/tests/entities/media.10e78352-6dc0-411a-8c41-807f78d9a921.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/media.10e78352-6dc0-411a-8c41-807f78d9a921.json
@@ -1,7 +1,7 @@
 {
     "uuid": [
         {
-            "value": "0005d6c0-7b1e-4454-afe2-9176705a52a1"
+            "value": "10e78352-6dc0-411a-8c41-807f78d9a921"
         }
     ],
     "langcode": [
@@ -31,7 +31,7 @@
     ],
     "name": [
         {
-            "value": "s-004_ibc-policy-for-partnership-with-pitt2019c.doc"
+            "value": "authorizationtopurchaseorusex-rayequipment_va_rsc313x.doc"
         }
     ],
     "thumbnail": [
@@ -58,7 +58,7 @@
     ],
     "changed": [
         {
-            "value": "2019-08-21T00:57:50+00:00",
+            "value": "2019-08-21T00:49:25+00:00",
             "format": "Y-m-d\\TH:i:sP"
         }
     ],
@@ -85,7 +85,7 @@
     },
     "path": [
         {
-            "alias": "\/media\/document\/454",
+            "alias": "\/media\/document\/330",
             "langcode": "en",
             "pathauto": 1
         }
@@ -95,7 +95,7 @@
             "display": null,
             "description": null,
             "target_type": "file",
-            "target_uuid": "1a709dfa-5ca5-4d21-98bd-28b0c181f29d"
+            "target_uuid": "aed04564-efd5-482f-be12-760f305af696"
         }
     ],
     "field_media_in_library": [

--- a/src/site/stages/build/process-cms-exports/tests/transformed-entities/media-document.json
+++ b/src/site/stages/build/process-cms-exports/tests/transformed-entities/media-document.json
@@ -1,10 +1,12 @@
 {
+  "contentModelType": "media-document",
   "entity": {
     "entityBundle": "document",
+    "entityType": "media",
     "fieldDocument": {
       "entity": {
         "filename": "authorizationtopurchaseorusex-rayequipment_va_rsc313x.doc",
-        "url": "https://dev.cms.va.gov/sites/default/files/2019-08/authorizationtopurchaseorusex-rayequipment_va_rsc313x.doc"
+        "url": "/media/document/330"
       }
     }
   }

--- a/src/site/stages/build/process-cms-exports/tests/transformed-entities/media-document.json
+++ b/src/site/stages/build/process-cms-exports/tests/transformed-entities/media-document.json
@@ -1,0 +1,11 @@
+{
+  "entity": {
+    "entityBundle": "document",
+    "fieldDocument": {
+      "entity": {
+        "filename": "authorizationtopurchaseorusex-rayequipment_va_rsc313x.doc",
+        "url": "https://dev.cms.va.gov/sites/default/files/2019-08/authorizationtopurchaseorusex-rayequipment_va_rsc313x.doc"
+      }
+    }
+  }
+}

--- a/src/site/stages/build/process-cms-exports/transformers/media-document.js
+++ b/src/site/stages/build/process-cms-exports/transformers/media-document.js
@@ -4,8 +4,12 @@ const transform = entity => ({
   entity: {
     entityType: 'media',
     entityBundle: 'document',
-    name: getDrupalValue(entity.name),
-    path: entity.path[0].alias,
+    fieldDocument: {
+      entity: {
+        filename: getDrupalValue(entity.name),
+        url: entity.path[0].alias,
+      },
+    },
   },
 });
 module.exports = {

--- a/src/site/stages/build/process-cms-exports/transformers/media-document.js
+++ b/src/site/stages/build/process-cms-exports/transformers/media-document.js
@@ -1,0 +1,14 @@
+const { getDrupalValue } = require('./helpers');
+
+const transform = entity => ({
+  entity: {
+    entityType: 'media',
+    entityBundle: 'document',
+    name: getDrupalValue(entity.name),
+    path: getDrupalValue(entity.path),
+  },
+});
+module.exports = {
+  filter: ['name', 'path'],
+  transform,
+};

--- a/src/site/stages/build/process-cms-exports/transformers/media-document.js
+++ b/src/site/stages/build/process-cms-exports/transformers/media-document.js
@@ -5,7 +5,7 @@ const transform = entity => ({
     entityType: 'media',
     entityBundle: 'document',
     name: getDrupalValue(entity.name),
-    path: getDrupalValue(entity.path),
+    path: entity.path[0].alias,
   },
 });
 module.exports = {


### PR DESCRIPTION
## Description

### Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/3317

**Note:** A test currently fails because the `alias` is required to be a string according to the raw schema yet we find an entity where it is null (`media.6c3238d2-99a3-4829-bb54-5c86dd69a285.json `)

Similar to how #11353 is getting the `derivitive`, we may want to have the CMS give us a proper `url` rather than relying on `path[0].alias`

Until we have this, I'm not sure if we should allow `alias` to be null in the schema.  All thoughts welcome.  Here is the troublesome entity (by allowing `alias` to be null, we end up with a filename but no real way to get the file):

```
{
    "uuid": [
        {
            "value": "6c3238d2-99a3-4829-bb54-5c86dd69a285"
        }
    ],
    "langcode": [
        {
            "value": "en"
        }
    ],
    "bundle": [
        {
            "target_id": "document",
            "target_type": "media_type",
            "target_uuid": "584b28c1-b73f-43c8-b1e9-02c86ac63d49"
        }
    ],
    "revision_created": [
        {
            "value": "2019-08-26T21:40:06+00:00",
            "format": "Y-m-d\\TH:i:sP"
        }
    ],
    "revision_user": [
        {
            "target_type": "user",
            "target_uuid": "fd71292f-3dc7-409d-b0e8-500204cb005a"
        }
    ],
    "revision_log_message": [],
    "status": [
        {
            "value": true
        }
    ],
    "name": [
        {
            "value": "VA Form 10-10EZ"
        }
    ],
    "thumbnail": [
        {
            "alt": "",
            "title": null,
            "width": null,
            "height": null,
            "target_type": "file",
            "target_uuid": "bd3b1fc6-cb65-4def-9c2e-21cca6aa48d1"
        }
    ],
    "uid": [
        {
            "target_type": "user",
            "target_uuid": "fd71292f-3dc7-409d-b0e8-500204cb005a"
        }
    ],
    "created": [
        {
            "value": "2019-08-26T21:39:39+00:00",
            "format": "Y-m-d\\TH:i:sP"
        }
    ],
    "changed": [
        {
            "value": "2019-08-26T21:40:06+00:00",
            "format": "Y-m-d\\TH:i:sP"
        }
    ],
    "default_langcode": [
        {
            "value": true
        }
    ],
    "revision_translation_affected": [
        {
            "value": true
        }
    ],
    "moderation_state": [],
    "metatag": {
        "value": {
            "title": "| Veterans Affairs",
            "twitter_cards_type": "summary_large_image",
            "og_site_name": "Veterans Affairs",
            "twitter_cards_title": "| Veterans Affairs",
            "twitter_cards_site": "@DeptVetAffairs",
            "og_title": "| Veterans Affairs"
        }
    },
    "path": [
        {
            "alias": null,
            "pid": null,
            "langcode": "en",
            "pathauto": 1
        }
    ],
    "field_document": [
        {
            "display": true,
            "description": "",
            "target_type": "file",
            "target_uuid": "ffc1d671-71c0-4f90-ab45-d99e7a1f1f3d"
        }
    ],
    "field_media_in_library": [
        {
            "value": true
        }
    ],
    "field_media_submission_guideline": [],
    "field_owner": [
        {
            "target_type": "taxonomy_term",
            "target_uuid": "e5820ec7-83b0-4d03-8ebf-ed50fa8cc211"
        }
    ]
}
```

## Testing done

Yup

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
