### PR TITLE
Filter transform support service

### DIFF
--- a/src/site/stages/build/process-cms-exports/schemas/raw/node-support_service.js
+++ b/src/site/stages/build/process-cms-exports/schemas/raw/node-support_service.js
@@ -4,7 +4,19 @@ module.exports = {
   type: 'object',
   properties: {
     title: { $ref: 'GenericNestedString' },
-    field_link: { $ref: 'GenericNestedString' },
+    field_link: {
+      type: 'array',
+      maxItems: 1,
+      items: {
+        type: 'object',
+        properties: {
+          uri: { type: 'string' },
+          title: { type: 'string' },
+          options: { type: 'array' },
+        },
+        required: ['uri', 'title', 'options'],
+      },
+    },
     field_phone_number: { $ref: 'GenericNestedString' },
   },
   required: ['title', 'field_link', 'field_phone_number'],

--- a/src/site/stages/build/process-cms-exports/schemas/raw/node-support_service.js
+++ b/src/site/stages/build/process-cms-exports/schemas/raw/node-support_service.js
@@ -1,0 +1,11 @@
+/* eslint-disable camelcase */
+
+module.exports = {
+  type: 'object',
+  properties: {
+    title: { $ref: 'GenericNestedString' },
+    field_link: { $ref: 'GenericNestedString' },
+    field_phone_number: { $ref: 'GenericNestedString' },
+  },
+  required: ['title', 'field_link', 'field_phone_number'],
+};

--- a/src/site/stages/build/process-cms-exports/schemas/transformed/node-support_service.js
+++ b/src/site/stages/build/process-cms-exports/schemas/transformed/node-support_service.js
@@ -9,7 +9,7 @@ module.exports = {
         entityBundle: { enum: ['support_service'] },
         title: { type: 'string' },
         fieldLink: {
-          type: 'object',
+          type: ['object', 'null'],
           properties: {
             url: {
               type: 'object',
@@ -23,7 +23,7 @@ module.exports = {
           },
           required: ['url', 'title', 'options'],
         },
-        fieldPhoneNumber: { type: 'string' },
+        fieldPhoneNumber: { type: ['string', 'null'] },
       },
       required: ['title', 'fieldLink', 'fieldPhoneNumber'],
     },

--- a/src/site/stages/build/process-cms-exports/schemas/transformed/node-support_service.js
+++ b/src/site/stages/build/process-cms-exports/schemas/transformed/node-support_service.js
@@ -1,0 +1,18 @@
+module.exports = {
+  type: 'object',
+  properties: {
+    contentModelType: { enum: ['node-support_service'] },
+    entity: {
+      type: 'object',
+      properties: {
+        entityType: { enum: ['node'] },
+        entityBundle: { enum: ['support_service'] },
+        title: { type: 'string' },
+        fieldLink: { type: 'string' },
+        fieldPhoneNumber: { type: 'string' },
+      },
+      required: ['title', 'fieldLink', 'fieldPhoneNumber'],
+    },
+  },
+  required: ['entity'],
+};

--- a/src/site/stages/build/process-cms-exports/schemas/transformed/node-support_service.js
+++ b/src/site/stages/build/process-cms-exports/schemas/transformed/node-support_service.js
@@ -8,7 +8,21 @@ module.exports = {
         entityType: { enum: ['node'] },
         entityBundle: { enum: ['support_service'] },
         title: { type: 'string' },
-        fieldLink: { type: 'string' },
+        fieldLink: {
+          type: 'object',
+          properties: {
+            url: {
+              type: 'object',
+              properties: {
+                path: { type: 'string' },
+              },
+              required: ['path'],
+            },
+            title: { type: 'string' },
+            options: { type: 'array' },
+          },
+          required: ['url', 'title', 'options'],
+        },
         fieldPhoneNumber: { type: 'string' },
       },
       required: ['title', 'fieldLink', 'fieldPhoneNumber'],

--- a/src/site/stages/build/process-cms-exports/tests/transformed-entities/node-support_service.json
+++ b/src/site/stages/build/process-cms-exports/tests/transformed-entities/node-support_service.json
@@ -1,6 +1,7 @@
 {
+  "contentModelType": "node-support_service",
   "entity": {
-    "entityId": "76",
+    "entityType": "node",
     "entityBundle": "support_service",
     "title": "All other VA life insurance programs:",
     "fieldLink": {

--- a/src/site/stages/build/process-cms-exports/tests/transformed-entities/node-support_service.json
+++ b/src/site/stages/build/process-cms-exports/tests/transformed-entities/node-support_service.json
@@ -1,0 +1,15 @@
+{
+  "entity": {
+    "entityId": "76",
+    "entityBundle": "support_service",
+    "title": "All other VA life insurance programs:",
+    "fieldLink": {
+      "url": {
+        "path": "tel:+1-800-669-8477"
+      },
+      "title": "",
+      "options": []
+    },
+    "fieldPhoneNumber": "800-669-8477"
+  }
+}

--- a/src/site/stages/build/process-cms-exports/tests/transformer-helpers.unit.spec.js
+++ b/src/site/stages/build/process-cms-exports/tests/transformer-helpers.unit.spec.js
@@ -1,6 +1,7 @@
 const { expect } = require('chai');
 const {
   combineItemsInIndexedObject,
+  createLink,
   getWysiwygString,
   unescapeUnicode,
 } = require('../transformers/helpers');
@@ -53,6 +54,60 @@ describe('CMS export transformer helpers', () => {
         expect(unescapeUnicode(`a ${codePoint} ${codePoint} a`)).to.equal(
           `a ${character} ${character} a`,
         );
+      });
+    });
+  });
+
+  describe('createLink', () => {
+    it('should return null for an empty array', () => {
+      expect(createLink([])).to.equal(null);
+    });
+
+    it('returns a properly formatted link object', () => {
+      const fieldLink = [
+        {
+          uri: 'foo',
+          title: 'Hello, World!',
+          options: ['big'],
+        },
+      ];
+
+      expect(createLink(fieldLink)).to.deep.equal({
+        url: {
+          path: 'foo',
+        },
+        title: 'Hello, World!',
+        options: ['big'],
+      });
+    });
+
+    it('can select only part of the returned object properties', () => {
+      const fieldLink = [
+        {
+          uri: 'foo',
+          title: 'Hello, World!',
+          options: ['big'],
+        },
+      ];
+
+      const urlOnly = ['url'];
+      const titleOnly = ['title'];
+
+      expect(createLink(fieldLink, urlOnly)).to.deep.equal({
+        url: {
+          path: 'foo',
+        },
+      });
+
+      expect(createLink(fieldLink, titleOnly)).to.deep.equal({
+        title: 'Hello, World!',
+      });
+
+      expect(createLink(fieldLink, [...urlOnly, ...titleOnly])).to.deep.equal({
+        url: {
+          path: 'foo',
+        },
+        title: 'Hello, World!',
       });
     });
   });

--- a/src/site/stages/build/process-cms-exports/transformers/helpers.js
+++ b/src/site/stages/build/process-cms-exports/transformers/helpers.js
@@ -1,5 +1,5 @@
 const assert = require('assert');
-const { sortBy, unescape } = require('lodash');
+const { sortBy, unescape, pick } = require('lodash');
 
 /**
  * Takes a string with escaped unicode code points and replaces them
@@ -42,6 +42,16 @@ function createMetaTag(type, key, value) {
   };
 }
 
+/**
+ * This is currently a dummy function, but we may
+ * need it in the future to convert weird uris like
+ * `entity:node/27` to something resembling a
+ * relative url
+ */
+function uriToUrl(uri) {
+  return uri;
+}
+
 module.exports = {
   getDrupalValue,
   createMetaTag,
@@ -78,12 +88,28 @@ module.exports = {
   },
 
   /**
-   * This is currently a dummy function, but we may
-   * need it in the future to convert weird uris like
-   * `entity:node/27` to something resembling a
-   * relative url
+   * Takes an array meant to contain only one object.
+   * If this object exists, an object will be returned matching what is expected for "fieldLink" objects,
+   * otherwise null is returned.
+   *
+   * If the optional parameter is used, the returned object will only contain those attributes.
+   *
+   * @param {array} fieldLink
+   * @param {array} attrs
+   * @return {object}
    */
-  uriToUrl(uri) {
-    return uri;
+  createLink(fieldLink, attrs = ['url', 'title', 'options']) {
+    const { uri, title, options } = fieldLink[0] || {};
+
+    return fieldLink[0]
+      ? pick(
+          {
+            url: { path: uriToUrl(uri) },
+            title,
+            options,
+          },
+          attrs,
+        )
+      : null;
   },
 };

--- a/src/site/stages/build/process-cms-exports/transformers/node-support_service.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-support_service.js
@@ -5,7 +5,13 @@ const transform = entity => ({
     entityType: 'node',
     entityBundle: 'support_service',
     title: getDrupalValue(entity.title),
-    fieldLink: getDrupalValue(entity.fieldLink),
+    fieldLink: {
+      url: {
+        path: entity.fieldLink[0].uri,
+      },
+      title: entity.fieldLink[0].title,
+      options: entity.fieldLink[0].options,
+    },
     fieldPhoneNumber: getDrupalValue(entity.fieldPhoneNumber),
   },
 });

--- a/src/site/stages/build/process-cms-exports/transformers/node-support_service.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-support_service.js
@@ -1,26 +1,15 @@
-const { getDrupalValue, uriToUrl } = require('./helpers');
+const { getDrupalValue, createLink } = require('./helpers');
 
-const transform = entity => {
-  const { fieldLink } = entity;
-  const { uri, title, options } = fieldLink[0] || {};
+const transform = entity => ({
+  entity: {
+    entityType: 'node',
+    entityBundle: 'support_service',
+    title: getDrupalValue(entity.title),
+    fieldLink: createLink(entity.fieldLink),
 
-  return {
-    entity: {
-      entityType: 'node',
-      entityBundle: 'support_service',
-      title: getDrupalValue(entity.title),
-      fieldLink: fieldLink[0]
-        ? {
-            url: { path: uriToUrl(uri) },
-            title,
-            options,
-          }
-        : null,
-
-      fieldPhoneNumber: getDrupalValue(entity.fieldPhoneNumber),
-    },
-  };
-};
+    fieldPhoneNumber: getDrupalValue(entity.fieldPhoneNumber),
+  },
+});
 module.exports = {
   filter: ['title', 'field_link', 'field_phone_number'],
   transform,

--- a/src/site/stages/build/process-cms-exports/transformers/node-support_service.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-support_service.js
@@ -1,0 +1,15 @@
+const { getDrupalValue } = require('./helpers');
+
+const transform = entity => ({
+  entity: {
+    entityType: 'node',
+    entityBundle: 'support_service',
+    title: getDrupalValue(entity.title),
+    fieldLink: getDrupalValue(entity.fieldLink),
+    fieldPhoneNumber: getDrupalValue(entity.fieldPhoneNumber),
+  },
+});
+module.exports = {
+  filter: ['title', 'field_link', 'field_phone_number'],
+  transform,
+};

--- a/src/site/stages/build/process-cms-exports/transformers/node-support_service.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-support_service.js
@@ -1,20 +1,26 @@
-const { getDrupalValue } = require('./helpers');
+const { getDrupalValue, uriToUrl } = require('./helpers');
 
-const transform = entity => ({
-  entity: {
-    entityType: 'node',
-    entityBundle: 'support_service',
-    title: getDrupalValue(entity.title),
-    fieldLink: {
-      url: {
-        path: entity.fieldLink[0].uri,
-      },
-      title: entity.fieldLink[0].title,
-      options: entity.fieldLink[0].options,
+const transform = entity => {
+  const { fieldLink } = entity;
+  const { uri, title, options } = fieldLink[0] || {};
+
+  return {
+    entity: {
+      entityType: 'node',
+      entityBundle: 'support_service',
+      title: getDrupalValue(entity.title),
+      fieldLink: fieldLink[0]
+        ? {
+            url: { path: uriToUrl(uri) },
+            title,
+            options,
+          }
+        : null,
+
+      fieldPhoneNumber: getDrupalValue(entity.fieldPhoneNumber),
     },
-    fieldPhoneNumber: getDrupalValue(entity.fieldPhoneNumber),
-  },
-});
+  };
+};
 module.exports = {
   filter: ['title', 'field_link', 'field_phone_number'],
   transform,

--- a/src/site/stages/build/process-cms-exports/transformers/paragraph-link_teaser.js
+++ b/src/site/stages/build/process-cms-exports/transformers/paragraph-link_teaser.js
@@ -1,24 +1,11 @@
-const { getDrupalValue, uriToUrl } = require('./helpers');
+const { getDrupalValue, createLink } = require('./helpers');
 
-function transform(entity) {
-  const { fieldLink, fieldLinkSummary } = entity;
-  const { uri, title, options } = fieldLink[0] || {};
-
-  const transformed = {
-    entity: {
-      fieldLink: fieldLink[0]
-        ? {
-            url: { path: uriToUrl(uri) },
-            title,
-            options,
-          }
-        : null,
-      fieldLinkSummary: getDrupalValue(fieldLinkSummary),
-    },
-  };
-
-  return transformed;
-}
+const transform = entity => ({
+  entity: {
+    fieldLink: createLink(entity.fieldLink),
+    fieldLinkSummary: getDrupalValue(entity.fieldLinkSummary),
+  },
+});
 
 module.exports = {
   filter: ['field_link', 'field_link_summary'],

--- a/src/site/stages/build/process-cms-exports/transformers/paragraph-react_widget.js
+++ b/src/site/stages/build/process-cms-exports/transformers/paragraph-react_widget.js
@@ -1,7 +1,7 @@
 // omit.js uses export default function
 const omit = require('lodash/fp/omit');
 
-const { getDrupalValue } = require('./helpers');
+const { getDrupalValue, createLink } = require('./helpers');
 
 const transform = entity => ({
   entity: {
@@ -9,12 +9,7 @@ const transform = entity => ({
     entityBundle: 'react_widget',
     fieldButtonFormat: getDrupalValue(entity.fieldButtonFormat),
     fieldCtaWidget: getDrupalValue(entity.fieldCtaWidget),
-    fieldDefaultLink: entity.fieldDefaultLink[0]
-      ? {
-          url: { path: entity.fieldDefaultLink[0].uri },
-          title: entity.fieldDefaultLink[0].title,
-        }
-      : null,
+    fieldDefaultLink: createLink(entity.fieldDefaultLink, ['url', 'title']),
     fieldErrorMessage: entity.fieldErrorMessage[0]
       ? omit(['format'], entity.fieldErrorMessage[0])
       : null,

--- a/src/site/stages/build/process-cms-exports/transformers/taxonomy_term-administration.js
+++ b/src/site/stages/build/process-cms-exports/transformers/taxonomy_term-administration.js
@@ -1,4 +1,4 @@
-const { getDrupalValue, uriToUrl } = require('./helpers');
+const { getDrupalValue, createLink } = require('./helpers');
 
 const transform = entity => {
   const fsml = entity.fieldSocialMediaLinks[0];
@@ -15,13 +15,7 @@ const transform = entity => {
       ),
       fieldEmailUpdatesUrl: getDrupalValue(entity.fieldEmailUpdatesUrl),
       fieldIntroText: getDrupalValue(entity.fieldIntroText),
-      fieldLink: entity.fieldLink.length
-        ? {
-            url: {
-              path: uriToUrl(entity.fieldLink[0].uri),
-            },
-          }
-        : null,
+      fieldLink: createLink(entity.fieldLink, ['url']),
       fieldSocialMediaLinks: {
         platform: fsml.platform,
         value: fsml.value,


### PR DESCRIPTION
## Description

### Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/3325

This filters & transforms content for `node-support_service` entities.

There is also some refactoring which pulls out some of the common transformations around link-type objects into a helper.  This touches the following entity types in addition to `node-support_service`:
- `paragraph-link_teaser`
- `paragraph-react_widget`
- `taxonomy_term-administration`

## Testing done

The usual

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
