### PR TITLE
Update School Locations section to have "Show more" buttons on profile page

### DIFF
--- a/src/applications/gi/components/profile/InstitutionProfile.jsx
+++ b/src/applications/gi/components/profile/InstitutionProfile.jsx
@@ -9,6 +9,8 @@ import SchoolLocations from './SchoolLocations';
 import Calculator from './Calculator';
 import CautionaryInformation from './CautionaryInformation';
 import AdditionalInformation from './AdditionalInformation';
+import environment from 'platform/utilities/environment';
+import SchoolLocationsOld from './SchoolLocationsOld';
 
 export class InstitutionProfile extends React.Component {
   static propTypes = {
@@ -48,14 +50,26 @@ export class InstitutionProfile extends React.Component {
             )}
             {this.shouldShowSchoolLocations(profile.attributes.facilityMap) && (
               <AccordionItem button="School locations">
-                <SchoolLocations
-                  institution={profile.attributes}
-                  facilityMap={profile.attributes.facilityMap}
-                  calculator={this.props.calculator}
-                  eligibility={this.props.eligibility}
-                  constants={constants}
-                  version={this.props.version}
-                />
+                {/* prod flag for bah 4383. SchoolLocationsOld.jsx should be deleted when story is approved */
+                environment.isProduction() ? (
+                  <SchoolLocationsOld
+                    institution={profile.attributes}
+                    facilityMap={profile.attributes.facilityMap}
+                    calculator={this.props.calculator}
+                    eligibility={this.props.eligibility}
+                    constants={constants}
+                    version={this.props.version}
+                  />
+                ) : (
+                  <SchoolLocations
+                    institution={profile.attributes}
+                    facilityMap={profile.attributes.facilityMap}
+                    calculator={this.props.calculator}
+                    eligibility={this.props.eligibility}
+                    constants={constants}
+                    version={this.props.version}
+                  />
+                )}
               </AccordionItem>
             )}
             <AccordionItem

--- a/src/applications/gi/components/profile/SchoolLocations.jsx
+++ b/src/applications/gi/components/profile/SchoolLocations.jsx
@@ -303,15 +303,16 @@ export class SchoolLocations extends React.Component {
         const remainingRowCount = totalRowCount - viewableRowCount;
         const showNextCount = remainingRowCount < 10 ? remainingRowCount : 10;
         return (
-          <div>
+          <div className="vads-u-padding-top--1">
             <button
               type="button"
               className="va-button-link learn-more-button"
               onClick={this.showMoreClicked}
             >
               Show next {showNextCount}
+              <i className="fas fa-chevron-down fa-xs vads-u-padding-left--1" />
             </button>
-            &nbsp;&nbsp;&nbsp; | &nbsp;&nbsp;&nbsp;
+            <span className="vads-u-padding--2">|</span>
             <button
               type="button"
               className="va-button-link learn-more-button"
@@ -323,7 +324,7 @@ export class SchoolLocations extends React.Component {
         );
       }
       return (
-        <div>
+        <div className="vads-u-padding-top--1">
           <button
             type="button"
             className="va-button-link learn-more-button"
@@ -341,7 +342,7 @@ export class SchoolLocations extends React.Component {
     const totalRows = this.state.totalRowCount;
     const viewableRows = this.state.viewableRowCount;
     return (
-      <div>
+      <div className="vads-u-padding-top--2">
         <i>
           Showing {viewableRows} out of {totalRows}
         </i>

--- a/src/applications/gi/components/profile/SchoolLocations.jsx
+++ b/src/applications/gi/components/profile/SchoolLocations.jsx
@@ -16,14 +16,14 @@ export class SchoolLocations extends React.Component {
 
   constructor(props) {
     super(props);
-    this.state = { viewMore: false };
+    this.state = { viewAll: false };
   }
 
   institutionIsBeingViewed = facilityCode =>
     facilityCode === this.props.institution.facilityCode;
 
-  shouldHideViewMore = (facilityMap, maxRows) =>
-    this.totalRows(facilityMap) > maxRows && !this.state.viewMore;
+  shouldHideViewAll = (facilityMap, maxRows) =>
+    this.totalRows(facilityMap) > maxRows && !this.state.viewAll;
 
   totalRows = ({ branches, extensions }) => {
     let totalRows = 1 + branches.length + extensions.length; // always has a main row
@@ -52,8 +52,12 @@ export class SchoolLocations extends React.Component {
     return <a href={`${facilityCode}${query}`}>{name}</a>;
   };
 
-  handleViewMoreClicked = () => {
-    this.setState({ viewMore: true });
+  handleViewAllClicked = () => {
+    this.setState({ viewAll: true });
+  };
+
+  handleViewLessClicked = () => {
+    this.setState({ viewAll: false });
   };
 
   schoolLocationTableInfo = (city, state, country, zip) => {
@@ -119,7 +123,7 @@ export class SchoolLocations extends React.Component {
   renderExtensionRows = (rows, extensions, maxRows) => {
     for (const extension of extensions) {
       // check if should add more rows
-      if (!this.state.viewMore && rows.length >= maxRows - 1) {
+      if (!this.state.viewAll && rows.length >= maxRows - 1) {
         break;
       }
       const nameLabel = (
@@ -135,7 +139,7 @@ export class SchoolLocations extends React.Component {
   renderBranchRows = (rows, branches, maxRows) => {
     for (const branch of branches) {
       // check if should add more rows
-      if (!this.state.viewMore && rows.length >= maxRows - 1) {
+      if (!this.state.viewAll && rows.length >= maxRows - 1) {
         break;
       }
 
@@ -210,7 +214,7 @@ export class SchoolLocations extends React.Component {
   renderBranchItems = (rows, branches, maxRows) => {
     for (const branch of branches) {
       // check if should add more rows
-      if (!this.state.viewMore && rows.length >= maxRows - 1) {
+      if (!this.state.viewAll && rows.length >= maxRows - 1) {
         break;
       }
 
@@ -232,7 +236,7 @@ export class SchoolLocations extends React.Component {
   renderExtensionItems = (rows, extensions, maxRows) => {
     for (const extension of extensions) {
       // check if should add more rows
-      if (!this.state.viewMore && rows.length >= maxRows - 1) {
+      if (!this.state.viewAll && rows.length >= maxRows - 1) {
         break;
       }
       const nameLabel = <span>{extension.institution}</span>;
@@ -270,21 +274,29 @@ export class SchoolLocations extends React.Component {
     );
   };
 
-  renderViewMore = main => {
+  renderViewButtons = main => {
     const maxRows = this.numberOfRowsToDisplay(main);
 
-    if (this.shouldHideViewMore(main, maxRows)) {
+    if (this.shouldHideViewAll(main, maxRows)) {
       return (
         <button
           type="button"
           className="va-button-link learn-more-button"
-          onClick={this.handleViewMoreClicked}
+          onClick={this.handleViewAllClicked}
         >
-          View more...
+          View all
         </button>
       );
     }
-    return null;
+    return (
+      <button
+        type="button"
+        className="va-button-link learn-more-button"
+        onClick={this.handleViewLessClicked}
+      >
+        View less...
+      </button>
+    );
   };
 
   render() {
@@ -304,7 +316,7 @@ export class SchoolLocations extends React.Component {
         </span>
         {this.renderFacilityMapTable(main)}
         {this.renderFacilityMapList(main)}
-        {this.renderViewMore(main)}
+        {this.renderViewButtons(main)}
       </div>
     );
   }

--- a/src/applications/gi/components/profile/SchoolLocations.jsx
+++ b/src/applications/gi/components/profile/SchoolLocations.jsx
@@ -5,6 +5,8 @@ import { locationInfo } from '../../utils/helpers';
 
 const DEFAULT_ROWS_VIEWABLE = window.innerWidth > 781 ? 10 : 5;
 
+const NEXT_ROWS_VIEWABLE = 10;
+
 export class SchoolLocations extends React.Component {
   static propTypes = {
     institution: PropTypes.object,
@@ -72,8 +74,10 @@ export class SchoolLocations extends React.Component {
   showMoreClicked = () => {
     const remainingRowCount =
       this.state.totalRowCount - this.state.viewableRowCount;
-    if (remainingRowCount >= 10) {
-      this.setState({ viewableRowCount: this.state.viewableRowCount + 10 });
+    if (remainingRowCount >= NEXT_ROWS_VIEWABLE) {
+      this.setState({
+        viewableRowCount: this.state.viewableRowCount + NEXT_ROWS_VIEWABLE,
+      });
     } else {
       this.setState({
         viewableRowCount: this.state.viewableRowCount + remainingRowCount,
@@ -301,7 +305,10 @@ export class SchoolLocations extends React.Component {
     if (totalRowCount > DEFAULT_ROWS_VIEWABLE) {
       if (viewableRowCount !== totalRowCount) {
         const remainingRowCount = totalRowCount - viewableRowCount;
-        const showNextCount = remainingRowCount < 10 ? remainingRowCount : 10;
+        const showNextCount =
+          remainingRowCount < NEXT_ROWS_VIEWABLE
+            ? remainingRowCount
+            : NEXT_ROWS_VIEWABLE;
         return (
           <div className="vads-u-padding-top--1">
             <button


### PR DESCRIPTION
## Description
https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/4383

The school locations section will have a "Show 10 more", "view all" and "view less" buttons if there are more than 10 locations. 

## Testing done


## Screenshots
![image](https://user-images.githubusercontent.com/48804654/71624950-2ea61c80-2bb3-11ea-8f37-ef6a53b5d944.png)
##
![image](https://user-images.githubusercontent.com/48804654/71625144-416d2100-2bb4-11ea-94f5-e47b075f77ba.png)
##
![image](https://user-images.githubusercontent.com/48804654/71625181-72e5ec80-2bb4-11ea-8141-ae9756500009.png)


## Acceptance criteria
- [x] On mobile, the initial display is the first 5 locations.
- [x] On non-mobile, the initial display is the first 10 locations.
- [x] There is an informational message stating "Showing X of Y locations" if there are more locations than specified for the display type in AC 1 & 2.
     a. X is equal to the number of locations currently displayed
     b. Y is the total number of locations that are possible to be displayed
- [x]  The user can view 10 additional locations at a time.
     a. The additional locations are appended to the list.
     b. If there are less than 10 additional locations, the button only prompts to show the remaining locations (ex. "Show 3 additional locations)
- [x] The user has the ability to view all locations at once
- [x]  Once all locations are being displayed, the user has the ability to revert the locations display the initial locations display

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
