### PR TITLE
Add api error handling

### DIFF
--- a/src/applications/find-va-forms/actions/index.js
+++ b/src/applications/find-va-forms/actions/index.js
@@ -79,7 +79,7 @@ export const fetchFormsThunk = (query, options = {}) => async dispatch => {
     // If we are here, the API request failed.
     dispatch(
       fetchFormsFailure(
-        'Something went wrong. Our servers may be offline. Please try again later.',
+        'We’re sorry. Something went wrong on our end. Please try again later.',
       ),
     );
   }

--- a/src/applications/find-va-forms/actions/index.js
+++ b/src/applications/find-va-forms/actions/index.js
@@ -18,7 +18,8 @@ export const fetchFormsAction = query => ({
   type: FETCH_FORMS,
 });
 
-export const fetchFormsFailure = () => ({
+export const fetchFormsFailure = error => ({
+  error,
   type: FETCH_FORMS_FAILURE,
 });
 
@@ -76,6 +77,10 @@ export const fetchFormsThunk = (query, options = {}) => async dispatch => {
     dispatch(fetchFormsSuccess(results));
   } catch (error) {
     // If we are here, the API request failed.
-    dispatch(fetchFormsFailure());
+    dispatch(
+      fetchFormsFailure(
+        'Something went wrong. Our servers may be offline. Please try again later.',
+      ),
+    );
   }
 };

--- a/src/applications/find-va-forms/containers/SearchResults.jsx
+++ b/src/applications/find-va-forms/containers/SearchResults.jsx
@@ -1,6 +1,7 @@
 // Dependencies.
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 import LoadingIndicator from '@department-of-veterans-affairs/formation-react/LoadingIndicator';
 import Pagination from '@department-of-veterans-affairs/formation-react/Pagination';
 import SortableTable from '@department-of-veterans-affairs/formation-react/SortableTable';
@@ -34,6 +35,10 @@ export const MAX_PAGE_LIST_LENGTH = 10;
 export class SearchResults extends Component {
   static propTypes = {
     // From mapStateToProps.
+    error: PropTypes.string.isRequired,
+    fetching: PropTypes.bool.isRequired,
+    page: PropTypes.number.isRequired,
+    query: PropTypes.string.isRequired,
     results: PropTypes.arrayOf(
       PropTypes.shape({
         // Original form data key-value pairs.
@@ -53,9 +58,6 @@ export class SearchResults extends Component {
         lastRevisionOnLabel: PropTypes.node.isRequired,
       }).isRequired,
     ),
-    fetching: PropTypes.bool.isRequired,
-    query: PropTypes.string.isRequired,
-    page: PropTypes.number.isRequired,
     startIndex: PropTypes.number.isRequired,
     // From mapDispatchToProps.
     updatePagination: PropTypes.func.isRequired,
@@ -127,12 +129,23 @@ export class SearchResults extends Component {
 
   render() {
     const { onHeaderClick, onPageSelect } = this;
-    const { fetching, page, query, results, startIndex } = this.props;
+    const { error, fetching, page, query, results, startIndex } = this.props;
     const { selectedFieldLabel, selectedFieldOrder } = this.state;
 
     // Show loading indicator if we are fetching.
     if (fetching) {
       return <LoadingIndicator message="Loading search results..." />;
+    }
+
+    // Show the error alert box if there was an error.
+    if (error) {
+      return (
+        <AlertBox
+          headline="Something went wrong"
+          content={error}
+          status="error"
+        />
+      );
     }
 
     // Do not render if we have not fetched, yet.
@@ -192,6 +205,7 @@ export class SearchResults extends Component {
 }
 
 const mapStateToProps = state => ({
+  error: state.findVAFormsReducer.error,
   fetching: state.findVAFormsReducer.fetching,
   page: state.findVAFormsReducer.page,
   query: state.findVAFormsReducer.query,

--- a/src/applications/find-va-forms/reducers/findVAFormsReducer.js
+++ b/src/applications/find-va-forms/reducers/findVAFormsReducer.js
@@ -8,6 +8,7 @@ import {
 } from '../constants';
 
 const initialState = {
+  error: '',
   fetching: false,
   page: 1,
   query: '',
@@ -18,10 +19,10 @@ const initialState = {
 export default (state = initialState, action) => {
   switch (action.type) {
     case FETCH_FORMS: {
-      return { ...state, fetching: true, query: action.query };
+      return { ...state, error: '', fetching: true, query: action.query };
     }
     case FETCH_FORMS_FAILURE: {
-      return { ...state, fetching: false };
+      return { ...state, error: action.error, fetching: false };
     }
     case FETCH_FORMS_SUCCESS: {
       return { ...state, fetching: false, results: action.results };

--- a/src/applications/find-va-forms/tests/actions/index.unit.spec.js
+++ b/src/applications/find-va-forms/tests/actions/index.unit.spec.js
@@ -33,9 +33,10 @@ describe('Find VA Forms actions', () => {
 
   describe('fetchFormsFailure', () => {
     it('should return an action in the shape we expect', () => {
-      const action = fetchFormsFailure();
+      const action = fetchFormsFailure('test');
 
       expect(action).to.be.deep.equal({
+        error: 'test',
         type: FETCH_FORMS_FAILURE,
       });
     });

--- a/src/applications/find-va-forms/tests/containers/SearchResults.unit.spec.jsx
+++ b/src/applications/find-va-forms/tests/containers/SearchResults.unit.spec.jsx
@@ -23,6 +23,7 @@ describe('Find VA Forms <SearchResults>', () => {
     const tree = shallow(<SearchResults error="test" />);
 
     expect(tree.html()).to.include('test');
+    expect(tree.html()).to.include('Something went wrong');
 
     tree.unmount();
   });

--- a/src/applications/find-va-forms/tests/containers/SearchResults.unit.spec.jsx
+++ b/src/applications/find-va-forms/tests/containers/SearchResults.unit.spec.jsx
@@ -19,6 +19,14 @@ describe('Find VA Forms <SearchResults>', () => {
     tree.unmount();
   });
 
+  it('renders an error alert box', () => {
+    const tree = shallow(<SearchResults error="test" />);
+
+    expect(tree.html()).to.include('test');
+
+    tree.unmount();
+  });
+
   it('renders nothing', () => {
     const tree = shallow(<SearchResults />);
 

--- a/src/applications/find-va-forms/tests/reducers/findVAFormsReducer.unit.spec.js
+++ b/src/applications/find-va-forms/tests/reducers/findVAFormsReducer.unit.spec.js
@@ -10,6 +10,7 @@ describe('Find VA Forms reducer: findVAFormsReducer', () => {
     const result = findVAFormsReducer(undefined, emptyAction);
 
     expect(result).to.be.deep.equal({
+      error: '',
       fetching: false,
       page: 1,
       query: '',
@@ -23,6 +24,7 @@ describe('Find VA Forms reducer: findVAFormsReducer', () => {
     const state = findVAFormsReducer(undefined, action);
 
     expect(state).to.be.deep.equal({
+      error: '',
       fetching: true,
       page: 1,
       query: 'testing',


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/4150

**Current Behavior:** There is no error alerts when the server is offline.

**Desired Behavior:** There is an error alert when the server is offline.

This PR implements the above desired behavior.

## Testing done
Updated unit tests. Tested locally, view screenshot below:

## Screenshots
![image](https://user-images.githubusercontent.com/12773166/71625812-1b8d4f80-2ba7-11ea-8bae-8c28fd6a361c.png)

## Acceptance criteria
- [x] Add error handling when there is an API error.

## Definition of done
- [ ] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
