### PR TITLE
Prevent ITF alert showing expired future dates

### DIFF
--- a/src/applications/disability-benefits/526EZ/tests/reducers.unit.spec.js
+++ b/src/applications/disability-benefits/526EZ/tests/reducers.unit.spec.js
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
+import moment from 'moment';
 
-import { requestStates } from '../../../../platform/utilities/constants';
+import { requestStates } from 'platform/utilities/constants';
 import { itfStatuses } from '../constants';
 
 import {
@@ -44,13 +45,17 @@ describe('ITF reducer', () => {
               {
                 type: 'compensation',
                 status: itfStatuses.active,
-                expirationDate: '2014-07-28T19:53:45.810+0000',
+                expirationDate: moment()
+                  .add(1, 'days')
+                  .format(),
               },
               {
                 // duplicate ITF with later expiration date; should use the active one
                 type: 'compensation',
                 status: itfStatuses.duplicate,
-                expirationDate: '2015-07-28T19:53:45.810+0000',
+                expirationDate: moment()
+                  .add(1, 'year')
+                  .format(),
               },
             ],
           },
@@ -73,12 +78,16 @@ describe('ITF reducer', () => {
               {
                 type: 'compensation',
                 status: itfStatuses.expired,
-                expirationDate: '2014-07-28T19:53:45.810+0000',
+                expirationDate: moment()
+                  .subtract(1, 'd')
+                  .format(),
               },
               {
                 type: 'compensation',
                 status: itfStatuses.duplicate,
-                expirationDate: '2015-07-28T19:53:45.810+0000',
+                expirationDate: moment()
+                  .add(1, 'd')
+                  .format(),
               },
             ],
           },

--- a/src/applications/disability-benefits/all-claims/components/ITFBanner.jsx
+++ b/src/applications/disability-benefits/all-claims/components/ITFBanner.jsx
@@ -20,7 +20,7 @@ export default class ITFBanner extends React.Component {
 
   render() {
     if (this.state.messageDismissed) {
-      return <div>{this.props.children}</div>;
+      return <>{this.props.children}</>;
     }
 
     let message;
@@ -55,7 +55,7 @@ export default class ITFBanner extends React.Component {
     }
 
     return (
-      <div className="usa-grid" style={{ marginBottom: '2em' }}>
+      <div className="usa-grid vads-u-margin-bottom--2">
         {message}
         {this.props.status !== 'error' && (
           <button className="usa-button-primary" onClick={this.dismissMessage}>

--- a/src/applications/disability-benefits/all-claims/containers/ITFWrapper.jsx
+++ b/src/applications/disability-benefits/all-claims/containers/ITFWrapper.jsx
@@ -6,7 +6,7 @@ import LoadingIndicator from '@department-of-veterans-affairs/formation-react/Lo
 
 import ITFBanner from '../components/ITFBanner';
 import { isActiveITF } from '../utils';
-import { requestStates } from '../../../../platform/utilities/constants';
+import { requestStates } from 'platform/utilities/constants';
 import { itfStatuses } from '../constants';
 import {
   createITF as createITFAction,
@@ -44,7 +44,8 @@ export class ITFWrapper extends React.Component {
       nextProps.fetchITF();
     }
 
-    // If we've already fetched the ITFs, have none active, and haven't already called createITF, submit a new ITF
+    // If we've already fetched the ITFs, have none active, and haven't already
+    // called createITF, submit a new ITF
     const hasActiveITF = isActiveITF(itf.currentITF);
 
     const createITFCalled = itf.creationCallState !== requestStates.notCalled;
@@ -59,7 +60,8 @@ export class ITFWrapper extends React.Component {
   }
 
   /**
-   * Checks to see if the given pathname should be blocked from making any ITF calls.
+   * Checks to see if the given pathname should be blocked from making any ITF
+   * calls.
    */
   shouldBlockITF(pathname) {
     return this.props.noITFPages.some(
@@ -74,8 +76,8 @@ export class ITFWrapper extends React.Component {
     if (this.shouldBlockITF(this.props.location.pathname)) {
       return this.props.children;
     } else if (fetchWaitingStates.includes(itf.fetchCallState)) {
-      // If we get here, componentDidMount or componentWillRecieveProps called fetchITF
-      // While we're waiting, show the loading indicator...
+      // If we get here, componentDidMount or componentWillRecieveProps called
+      // fetchITF; While we're waiting, show the loading indicator...
       return (
         <div className="vads-u-margin-bottom--4">
           <LoadingIndicator message="Please wait while we check to see if you have an existing Intent to File." />
@@ -84,14 +86,18 @@ export class ITFWrapper extends React.Component {
     } else if (itf.fetchCallState === requestStates.failed) {
       // We'll get here after the fetchITF promise is fulfilled
       return <ITFBanner status="error" />;
-    } else if (itf.currentITF && itf.currentITF.status === itfStatuses.active) {
+    } else if (itf?.currentITF?.status === itfStatuses.active) {
+      const status =
+        itf.creationCallState === 'succeeded' ? 'itf-created' : 'itf-found';
       const { expirationDate: currentExpDate } = itf.currentITF;
+
       if (itf.previousITF) {
         const { expirationDate: prevExpDate } = itf.previousITF;
-        // If there was a previous ITF, we created one; show the creation success message
+        // If there was a previous ITF, we created one; show the creation
+        // success message
         return (
           <ITFBanner
-            status="itf-created"
+            status={status}
             previousITF={itf.previousITF}
             currentExpDate={currentExpDate}
             previousExpDate={prevExpDate}
@@ -103,13 +109,13 @@ export class ITFWrapper extends React.Component {
 
       // Else we fetched an active ITF
       return (
-        <ITFBanner status="itf-found" currentExpDate={currentExpDate}>
+        <ITFBanner status={status} currentExpDate={currentExpDate}>
           {this.props.children}
         </ITFBanner>
       );
     } else if (fetchWaitingStates.includes(itf.creationCallState)) {
-      // componentWillRecieveProps called createITF if there was no active ITF found
-      // While we're waiting (again), show the loading indicator...again
+      // componentWillRecieveProps called createITF if there was no active ITF
+      // found; While we're waiting (again), show the loading indicator...again
       return (
         <div className="vads-u-margin-bottom--4">
           <LoadingIndicator message="Submitting a new Intent to File..." />
@@ -117,8 +123,8 @@ export class ITFWrapper extends React.Component {
       );
     }
 
-    // We'll get here after the createITF promise is fulfilled and we have no active ITF
-    //  because of a failed creation call
+    // We'll get here after the createITF promise is fulfilled and we have no
+    // active ITF because of a failed creation call
     return <ITFBanner status="error" />;
   }
 }

--- a/src/applications/disability-benefits/all-claims/content/itfWrapper.jsx
+++ b/src/applications/disability-benefits/all-claims/content/itfWrapper.jsx
@@ -14,15 +14,8 @@ const displayDate = dateString =>
 export const itfMessage = (headline, content, status) => (
   // Inline style to match .full-page-alert bottom margin because usa-grid > :last-child has a
   //  bottom margin of 0 and overrides it
-  <div className="full-page-alert">
-    <div>
-      <AlertBox
-        isVisible
-        headline={headline}
-        content={content}
-        status={status}
-      />
-    </div>
+  <div className="full-page-alert itf-wrapper">
+    <AlertBox isVisible headline={headline} content={content} status={status} />
   </div>
 );
 

--- a/src/applications/disability-benefits/all-claims/reducers/itf.js
+++ b/src/applications/disability-benefits/all-claims/reducers/itf.js
@@ -1,7 +1,7 @@
-import get from '../../../../platform/utilities/data/get';
-import set from '../../../../platform/utilities/data/set';
-import { requestStates } from '../../../../platform/utilities/constants';
+import set from 'platform/utilities/data/set';
+import { requestStates } from 'platform/utilities/constants';
 import { itfStatuses } from '../constants';
+import { isNotExpired } from '../utils';
 import {
   ITF_FETCH_INITIATED,
   ITF_FETCH_SUCCEEDED,
@@ -35,23 +35,32 @@ export default (state = initialState, action) => {
       return set('fetchCallState', requestStates.pending, state);
     case ITF_FETCH_SUCCEEDED: {
       const newState = set('fetchCallState', requestStates.succeeded, state);
+      newState.currentITF = null;
 
-      // The full list is potentially more than just compensation ITFs, but we don't need those
-      const itfList = get('attributes.intentToFile', action.data).filter(
+      // The full list is potentially more than just compensation ITFs, but we
+      // don't need those
+      const itfList = (action.data?.attributes?.intentToFile || []).filter(
         i => i.type === 'compensation',
       );
       const activeITF = itfList.find(i => i.status === itfStatuses.active);
+      const latestITF = findLastITF(itfList);
 
-      // Set the curentITFStatus
-      if (activeITF) {
-        // Pulled the active ITF out like this in case it's not technically the latest (not sure that's possible, though)
-        newState.currentITF = activeITF;
-        return newState;
+      if (activeITF?.expirationDate) {
+        // Pulled the active ITF out like this in case it's not technically the
+        // latest (not sure that's possible, though)
+        if (isNotExpired(activeITF.expirationDate)) {
+          newState.currentITF = activeITF;
+        } else {
+          newState.previousITF = activeITF;
+        }
       }
-
-      // No active ITF found; use the one with the last expiration date
-      newState.currentITF = findLastITF(itfList);
-
+      if (!newState.currentITF && latestITF?.expirationDate) {
+        if (isNotExpired(latestITF.expirationDate)) {
+          newState.currentITF = latestITF;
+        } else {
+          newState.previousITF = latestITF;
+        }
+      }
       return newState;
     }
     case ITF_FETCH_FAILED:
@@ -60,7 +69,7 @@ export default (state = initialState, action) => {
       return set('creationCallState', requestStates.pending, state);
     case ITF_CREATION_SUCCEEDED: {
       const newState = set('creationCallState', requestStates.succeeded, state);
-      newState.previousITF = state.currentITF;
+      newState.previousITF = state.currentITF || state.previousITF;
       newState.currentITF = action.data.attributes.intentToFile;
       return newState;
     }

--- a/src/applications/disability-benefits/all-claims/tests/automated-tests.puppeteer.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/automated-tests.puppeteer.spec.js
@@ -1,9 +1,9 @@
 const join = require('path').join;
 const _ = require('lodash/fp');
 
-const testForm = require('../../../../platform/testing/e2e/form-tester');
-const formFiller = require('../../../../platform/testing/e2e/form-tester/form-filler');
-const getTestDataSets = require('../../../../platform/testing/e2e/form-tester/util')
+const testForm = require('platform/testing/e2e/form-tester');
+const formFiller = require('platform/testing/e2e/form-tester/form-filler');
+const getTestDataSets = require('platform/testing/e2e/form-tester/util')
   .getTestDataSets;
 const PageHelpers = require('./disability-benefits-helpers');
 

--- a/src/applications/disability-benefits/all-claims/tests/containers/ITFWrapper.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/containers/ITFWrapper.unit.spec.jsx
@@ -3,6 +3,7 @@ import { expect } from 'chai';
 import { shallow, mount } from 'enzyme';
 import sinon from 'sinon';
 import { merge } from 'lodash/fp';
+import moment from 'moment';
 
 import { ITFWrapper } from '../../containers/ITFWrapper';
 import { itfStatuses } from '../../constants';
@@ -156,7 +157,9 @@ describe('526 ITFWrapper', () => {
   });
 
   it('should submit a new ITF if the current ITF is expired', () => {
-    const expirationDate = '2015-08-28T19:47:52.786+00:00';
+    const expirationDate = moment()
+      .subtract(1, 'd')
+      .format();
     const tree = shallow(
       <ITFWrapper {...defaultProps}>
         <p>Shouldn't see me yet...</p>
@@ -199,7 +202,9 @@ describe('526 ITFWrapper', () => {
   });
 
   it('should render a success message for fetched ITF', () => {
-    const expirationDate = '2015-08-28T19:47:52.786+00:00';
+    const expirationDate = moment()
+      .add(1, 'd')
+      .format();
     const props = merge(defaultProps, {
       itf: {
         fetchCallState: requestStates.succeeded,
@@ -223,8 +228,12 @@ describe('526 ITFWrapper', () => {
   });
 
   it('should render a success message for newly created ITF', () => {
-    const expirationDate = '2015-08-28T19:47:52.786+00:00';
-    const previousExpirationDate = '2014-08-28T19:47:52.786+00:00';
+    const expirationDate = moment()
+      .add(1, 'd')
+      .format();
+    const previousExpirationDate = moment()
+      .subtract(1, 'd')
+      .format();
     const props = merge(defaultProps, {
       itf: {
         fetchCallState: requestStates.succeeded,

--- a/src/applications/disability-benefits/all-claims/tests/disability-benefits-helpers.js
+++ b/src/applications/disability-benefits/all-claims/tests/disability-benefits-helpers.js
@@ -1,4 +1,6 @@
-const mock = require('../../../../platform/testing/e2e/mock-helpers');
+import moment from 'moment';
+
+const mock = require('platform/testing/e2e/mock-helpers');
 
 function initDocumentUploadMock() {
   mock(null, {
@@ -41,7 +43,9 @@ function initItfMock(token) {
             {
               id: '1',
               creationDate: '2014-07-28T19:53:45.810+00:00',
-              expirationDate: '2015-08-28T19:47:52.786+00:00',
+              expirationDate: moment()
+                .add(1, 'd')
+                .format(),
               participantId: 1,
               source: 'EBN',
               status: 'active',

--- a/src/applications/disability-benefits/all-claims/utils.jsx
+++ b/src/applications/disability-benefits/all-claims/utils.jsx
@@ -68,11 +68,14 @@ export const srSubstitute = (srIgnored, substitutionText) => (
   </span>
 );
 
+// moment().isSameOrBefore() => true; so expirationDate can't be undefined
+export const isNotExpired = (expirationDate = '') =>
+  moment().isSameOrBefore(expirationDate);
+
 export const isActiveITF = currentITF => {
   if (currentITF) {
     const isActive = currentITF.status === itfStatuses.active;
-    const isNotExpired = moment().isBefore(currentITF.expirationDate);
-    return isActive && isNotExpired;
+    return isActive && isNotExpired(currentITF.expirationDate);
   }
   return false;
 };


### PR DESCRIPTION
## Description

Intent to file (ITF) messages was creating a new ITF & displaying an "expired" ITF with a future date. See https://github.com/department-of-veterans-affairs/va.gov-team/issues/3814.

This update checks that the active compensation ITF (if it exists) is not expired. If expired, it checks if the latest compensation ITF is expired. It will use the ITF that isn't expired. If both are expired or non-existent, only then will a new ITF be created.

## Testing done

Local unit tests; new one added.

## Screenshots

![](https://user-images.githubusercontent.com/136959/71628807-9febcc80-2bbf-11ea-8db5-2614e2efc8ba.png)

## Acceptance criteria
- [ ] ITF message does not show an expired ITF with a date in the future
- [ ] ITF creation should occur if a previously active ITF has expired

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
