### PR TITLE
Clear address validation state on validation error

### DIFF
--- a/src/platform/user/profile/vet360/reducers/index.js
+++ b/src/platform/user/profile/vet360/reducers/index.js
@@ -228,10 +228,10 @@ export default function vet360(state = initialState, action) {
       return {
         ...state,
         addressValidation: {
-          ...state.addressValidation,
+          ...initialAddressValidationState,
           addressValidationError: action.addressValidationError,
           addressValidationType: action.addressValidationType,
-          validationKey: action.validationKey,
+          validationKey: action.validationKey || null,
           addressFromUser: action.addressFromUser,
         },
         modal: 'addressValidation',

--- a/src/platform/user/profile/vet360/tests/reducers/index.unit.spec.js
+++ b/src/platform/user/profile/vet360/tests/reducers/index.unit.spec.js
@@ -305,21 +305,39 @@ describe('vet360 reducer', () => {
     expect(state.addressValidation.validationKey).to.eql(123456);
   });
 
-  it('should update addressValidation on error', () => {
-    const state = vet360(
-      {},
-      {
+  describe('ADDRESS_VALIDATION_ERROR', () => {
+    it('sets the correct data on the redux state', () => {
+      const state = {
+        metadata: {},
+        otherData: true,
+        modal: null,
+        addressValidation: {
+          suggestedAddresses: [{ street: '123 oak st' }],
+          selectedAddress: { street: '456 elm' },
+          selectedAddressId: 'userEntered',
+        },
+      };
+      const action = {
         type: 'ADDRESS_VALIDATION_ERROR',
         addressValidationError: true,
         addressValidationType: 'mailingAddress',
+        addressFromUser: { street: '987 main' },
+      };
+      const expectedState = {
+        ...state,
+        addressValidation: {
+          addressValidationError: true,
+          addressValidationType: 'mailingAddress',
+          addressFromUser: { street: '987 main' },
+          selectedAddress: {},
+          selectedAddressId: '0',
+          suggestedAddresses: [],
+          validationKey: null,
+        },
         modal: 'addressValidation',
-      },
-    );
-    expect(state.modal).to.eql('addressValidation');
-    expect(state.addressValidation.addressValidationError).to.eql(true);
-    expect(state.addressValidation.addressValidationType).to.eql(
-      'mailingAddress',
-    );
+      };
+      expect(vet360(state, action)).to.eql(expectedState);
+    });
   });
 
   describe('ADDRESS_VALIDATION_RESET action', () => {

--- a/src/platform/user/profile/vet360/util/local-vet360.js
+++ b/src/platform/user/profile/vet360/util/local-vet360.js
@@ -418,6 +418,30 @@ export default {
       1000,
     );
   },
+  addressValidationError() {
+    return asyncReturn(
+      {
+        errors: [
+          {
+            title: 'Address Validation Error',
+            detail: {
+              messages: [
+                {
+                  code: 'ADDRVAL108',
+                  key: 'CandidateAddressNotFound',
+                  severity: 'INFO',
+                  text: 'No Candidate Address Found',
+                },
+              ],
+            },
+            code: 'VET360_AV_ERROR',
+            status: '400',
+          },
+        ],
+      },
+      1000,
+    );
+  },
   addressValidationSuccess() {
     return asyncReturn(
       {


### PR DESCRIPTION
## Description
Reset the address validation state when a validation error occurs to fix an edge case where as user might be shown suggested addresses from a previous validation attempt.

## Testing done
Local. I temporarily made more elaborate local mocks so that in the first call we got back multiple suggested addresses from the API and the second call resulted in an error to mimic the scenario that uncovered this bug in staging. Also expanded the test coverage of the relevant reducer.

## Screenshots
N/A

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs