### PR TITLE
Add beforeunload event listener to new appointment flow

### DIFF
--- a/src/applications/vaos/components/NewAppointmentLayout.jsx
+++ b/src/applications/vaos/components/NewAppointmentLayout.jsx
@@ -11,6 +11,7 @@ export default class NewAppointmentLayout extends React.Component {
     }
 
     scrollAndFocus();
+    window.addEventListener('beforeunload', this.onBeforeUnload);
 
     // We don't want people to start in the middle of the form, so redirect them when they jump
     // in the middle
@@ -20,8 +21,26 @@ export default class NewAppointmentLayout extends React.Component {
   }
 
   componentDidUpdate() {
+    if (this.props.location.pathname.endsWith('confirmation')) {
+      this.removeBeforeUnloadHook();
+    }
+
     scrollAndFocus();
   }
+
+  componentWillUnmount() {
+    this.removeBeforeUnloadHook();
+  }
+
+  onBeforeUnload = e => {
+    e.preventDefault();
+    e.returnValue =
+      'Are you sure you wish to leave this application? All progress will be lost.';
+  };
+
+  removeBeforeUnloadHook = () => {
+    window.removeEventListener('beforeunload', this.onBeforeUnload);
+  };
 
   render() {
     const { children } = this.props;


### PR DESCRIPTION
## Description
Adds `onbeforeunload` window event to all pages in new appointment flow besides confirmation page.

## Testing done
Local.  Could use feedback on how to properly write a unit test for window event listener if it seems necessary.

## Screenshots
![image](https://user-images.githubusercontent.com/786704/71645792-6d5ed400-2c92-11ea-88b1-36edd54bd9ef.png)


## Acceptance criteria
- [ ] User is warned before leaving any page on new appointment flow besides confirmation page.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
