### PR TITLE
[KEYBOARD]: VAOS Scheduler - The video appointment links can be tabbed to and opened by pressing ENTER

### DIFF
--- a/src/applications/vaos/components/VideoVisitSection.jsx
+++ b/src/applications/vaos/components/VideoVisitSection.jsx
@@ -34,7 +34,11 @@ export default function VideoVisitSection({ appointment }) {
       linkContent = (
         <div className="vaos-appts__video-visit">
           <a
-            aria-describedby={`description-join-link-${appointment.id}`}
+            aria-describedby={
+              disableVideoLink
+                ? `description-join-link-${appointment.id}`
+                : undefined
+            }
             href={videoLink}
             target="_blank"
             rel="noopener noreferrer"

--- a/src/applications/vaos/components/VideoVisitSection.jsx
+++ b/src/applications/vaos/components/VideoVisitSection.jsx
@@ -34,15 +34,20 @@ export default function VideoVisitSection({ appointment }) {
       linkContent = (
         <div className="vaos-appts__video-visit">
           <a
+            aria-describedby={`description-join-link-${appointment.id}`}
             href={videoLink}
             target="_blank"
             rel="noopener noreferrer"
             className={linkClasses}
+            onClick={disableVideoLink ? e => e.preventDefault() : undefined}
           >
             Join session
           </a>
           {disableVideoLink && (
-            <span className="vads-u-display--block vads-u-font-style--italic">
+            <span
+              id={`description-join-link-${appointment.id}`}
+              className="vads-u-display--block vads-u-font-style--italic"
+            >
               You can join VA Video Connect 30 minutes prior to the start time
             </span>
           )}

--- a/src/applications/vaos/tests/components/VideoVisitSection.unit.spec.jsx
+++ b/src/applications/vaos/tests/components/VideoVisitSection.unit.spec.jsx
@@ -15,6 +15,7 @@ describe('Video visit', () => {
   const appointment = {
     facilityId: '984',
     clinicId: '456',
+    id: '123',
     vvsAppointments: [
       {
         patients: [
@@ -90,6 +91,11 @@ describe('Video visit', () => {
     const tree = shallow(<VideoVisitSection appointment={futureAppointment} />);
     expect(tree.exists('.usa-button')).to.equal(true);
     expect(tree.exists('.usa-button-disabled')).to.equal(true);
+
+    const describedById = 'description-join-link-123';
+    const link = tree.find('.usa-button');
+    expect(link.props()['aria-describedby']).to.equal(describedById);
+    expect(tree.exists(`span#${describedById}`)).to.be.true;
     tree.unmount();
   });
 

--- a/src/applications/vaos/tests/components/VideoVisitSection.unit.spec.jsx
+++ b/src/applications/vaos/tests/components/VideoVisitSection.unit.spec.jsx
@@ -64,7 +64,10 @@ describe('Video visit', () => {
     };
 
     const tree = shallow(<VideoVisitSection appointment={pastAppointment} />);
-    expect(tree.exists('.usa-button')).to.equal(true);
+    const link = tree.find('.usa-button');
+    expect(link.length).to.equal(1);
+    expect(link.props()['aria-describedby']).to.equal(undefined);
+    expect(tree.exists('span')).to.equal(false);
     expect(tree.exists('.usa-button-disabled')).to.equal(false);
     tree.unmount();
   });


### PR DESCRIPTION
## Description
The "Join" link was already abled to be tabbed to, but added `aria-describedby` attribute for screen reader.  Also fixed a bug where even though the "Join" button had a disabled CSS class, if the user tabbed to it and pressed enter, they could still launch the link.

## Testing done
Local testing

## Acceptance criteria
- [ ] Unique `aria-describedby` attribute added to link, and span has same value set to its `id`
- [ ] If the join link is disabled and tabbed to, pressing enter should not launch the link

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
