### PR TITLE
bradl3yC 4485 Show spinner as address val api is called

### DIFF
--- a/src/platform/user/profile/vet360/actions/transactions.js
+++ b/src/platform/user/profile/vet360/actions/transactions.js
@@ -33,6 +33,7 @@ export const VET360_CLEAR_TRANSACTION_STATUS =
 export const ADDRESS_VALIDATION_CONFIRM = 'ADDRESS_VALIDATION_CONFIRM';
 export const ADDRESS_VALIDATION_ERROR = 'ADDRESS_VALIDATION_ERROR';
 export const ADDRESS_VALIDATION_RESET = 'ADDRESS_VALIDATION_RESET';
+export const ADDRESS_VALIDATION_INITIALIZE = 'ADDRESS_VALIDATION_INITIALIZE';
 
 export function clearTransactionStatus() {
   return {
@@ -190,7 +191,10 @@ export const validateAddress = (
   analyticsSectionName,
 ) => async dispatch => {
   const userEnteredAddress = { address: addCountryCodeIso3ToAddress(payload) };
-
+  dispatch({
+    type: ADDRESS_VALIDATION_INITIALIZE,
+    fieldName,
+  });
   const options = {
     body: JSON.stringify(userEnteredAddress),
     method: 'POST',
@@ -198,6 +202,7 @@ export const validateAddress = (
       'Content-Type': 'application/json',
     },
   };
+
   try {
     const response = isVet360Configured()
       ? await apiRequest('/profile/address_validation', options)

--- a/src/platform/user/profile/vet360/reducers/index.js
+++ b/src/platform/user/profile/vet360/reducers/index.js
@@ -15,6 +15,7 @@ import {
   ADDRESS_VALIDATION_ERROR,
   ADDRESS_VALIDATION_RESET,
   UPDATE_SELECTED_ADDRESS,
+  ADDRESS_VALIDATION_INITIALIZE,
 } from '../actions';
 
 import { isFailedTransaction } from '../util/transactions';
@@ -209,9 +210,22 @@ export default function vet360(state = initialState, action) {
     case OPEN_MODAL:
       return { ...state, modal: action.modal, modalData: action.modalData };
 
+    case ADDRESS_VALIDATION_INITIALIZE:
+      return {
+        ...state,
+        fieldTransactionMap: {
+          ...state.fieldTransactionMap,
+          [action.fieldName]: { isPending: true },
+        },
+      };
+
     case ADDRESS_VALIDATION_CONFIRM:
       return {
         ...state,
+        fieldTransactionMap: {
+          ...state.fieldTransactionMap,
+          [action.addressValidationType]: { isPending: false },
+        },
         addressValidation: {
           ...state.addressValidation,
           addressFromUser: action.addressFromUser,
@@ -227,6 +241,10 @@ export default function vet360(state = initialState, action) {
     case ADDRESS_VALIDATION_ERROR:
       return {
         ...state,
+        fieldTransactionMap: {
+          ...state.fieldTransactionMap,
+          [action.addressValidationType]: { isPending: false },
+        },
         addressValidation: {
           ...state.addressValidation,
           addressValidationError: action.addressValidationError,

--- a/src/platform/user/profile/vet360/tests/actions/transactions.unit.spec.js
+++ b/src/platform/user/profile/vet360/tests/actions/transactions.unit.spec.js
@@ -2,6 +2,7 @@ import {
   resetAddressValidation,
   validateAddress,
   ADDRESS_VALIDATION_CONFIRM,
+  ADDRESS_VALIDATION_INITIALIZE,
   ADDRESS_VALIDATION_RESET,
 } from '../../actions/transactions';
 import sinon from 'sinon';
@@ -42,9 +43,12 @@ describe('validateAddress', () => {
       analyticsSectionName,
     )(dispatch).then(() => {
       expect(dispatch.firstCall.args[0].type).to.equal(
+        ADDRESS_VALIDATION_INITIALIZE,
+      );
+      expect(dispatch.secondCall.args[0].type).to.equal(
         ADDRESS_VALIDATION_CONFIRM,
       );
-      expect(dispatch.firstCall.args[0].suggestedAddresses).to.deep.equal([
+      expect(dispatch.secondCall.args[0].suggestedAddresses).to.deep.equal([
         {
           addressMetaData: {
             confidenceScore: 100,

--- a/src/platform/user/profile/vet360/tests/reducers/index.unit.spec.js
+++ b/src/platform/user/profile/vet360/tests/reducers/index.unit.spec.js
@@ -5,6 +5,7 @@ import * as VET360 from '../../constants';
 import {
   ADDRESS_VALIDATION_RESET,
   UPDATE_SELECTED_ADDRESS,
+  ADDRESS_VALIDATION_INITIALIZE,
 } from '../../actions';
 
 describe('vet360 reducer', () => {
@@ -392,6 +393,26 @@ describe('vet360 reducer', () => {
         addressValidation: {
           selectedAddress: { street: '123 main' },
           selectedAddressId: '0',
+        },
+      };
+      expect(vet360(state, action)).to.eql(expectedState);
+    });
+  });
+
+  describe('ADDRESS_VALIDATION_INITIALIZE action', () => {
+    it('sets inProgress to true', () => {
+      const state = {
+        fieldTransactionMap: {
+          mailingAddress: { isPending: false },
+        },
+      };
+      const action = {
+        type: ADDRESS_VALIDATION_INITIALIZE,
+        fieldName: 'mailingAddress',
+      };
+      const expectedState = {
+        fieldTransactionMap: {
+          mailingAddress: { isPending: true },
         },
       };
       expect(vet360(state, action)).to.eql(expectedState);


### PR DESCRIPTION
## Description
Show the spinner as address validation API is called - indicating to the user that work is in progress


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
