### PR TITLE
bradl3yC 4483 Disable update button if no suggestions

### DIFF
--- a/src/platform/user/profile/vet360/actions/transactions.js
+++ b/src/platform/user/profile/vet360/actions/transactions.js
@@ -240,7 +240,7 @@ export const validateAddress = (
         addressFromUser: userEnteredAddress.address, // need to use the address with iso3 code added to it
         addressValidationType: fieldName,
         selectedAddress: confirmedSuggestions[0], // always select the first address as the default
-        suggestedAddresses,
+        confirmedSuggestions,
         validationKey,
       });
     }

--- a/src/platform/user/profile/vet360/actions/transactions.js
+++ b/src/platform/user/profile/vet360/actions/transactions.js
@@ -228,6 +228,8 @@ export const validateAddress = (
       ...confirmedSuggestions[0],
     };
 
+    const selectedAddressId = confirmedSuggestions.length > 0 ? '0' : null;
+
     // we use the unfiltered list of suggested addresses to determine if we need
     // to show the modal because the only time we will skip the modal is if one
     // and only one confirmed address came back from the API
@@ -240,7 +242,8 @@ export const validateAddress = (
         addressFromUser: userEnteredAddress.address, // need to use the address with iso3 code added to it
         addressValidationType: fieldName,
         selectedAddress: confirmedSuggestions[0], // always select the first address as the default
-        confirmedSuggestions,
+        suggestedAddresses,
+        selectedAddressId,
         validationKey,
       });
     }

--- a/src/platform/user/profile/vet360/containers/AddressValidationModal.jsx
+++ b/src/platform/user/profile/vet360/containers/AddressValidationModal.jsx
@@ -15,10 +15,7 @@ import {
   resetAddressValidation as resetAddressValidationAction,
 } from '../actions';
 import { getValidationMessageKey } from '../../utilities';
-import {
-  ADDRESS_VALIDATION_MESSAGES,
-  CONFIRMED,
-} from '../../constants/addressValidationMessages';
+import { ADDRESS_VALIDATION_MESSAGES } from '../../constants/addressValidationMessages';
 
 import * as VET360 from '../constants';
 
@@ -69,7 +66,12 @@ class AddressValidationModal extends React.Component {
       validationKey,
       isLoading,
       addressFromUser,
+      confirmedSuggestions,
+      selectedAddressId,
     } = this.props;
+
+    const disableButton =
+      selectedAddressId !== 'userEntered' && confirmedSuggestions.length === 0;
 
     if (addressValidationError && !validationKey) {
       return (
@@ -85,7 +87,11 @@ class AddressValidationModal extends React.Component {
     }
 
     return (
-      <LoadingButton isLoading={isLoading} className="usa-button-primary">
+      <LoadingButton
+        disabled={disableButton}
+        isLoading={isLoading}
+        className="usa-button-primary"
+      >
         Update
       </LoadingButton>
     );
@@ -166,7 +172,7 @@ class AddressValidationModal extends React.Component {
     const {
       isAddressValidationModalVisible,
       addressValidationType,
-      suggestedAddresses,
+      confirmedSuggestions,
       addressFromUser,
       validationKey,
       addressValidationError,
@@ -179,13 +185,8 @@ class AddressValidationModal extends React.Component {
       closeModal();
     };
 
-    const confirmedSuggestions = suggestedAddresses.filter(
-      suggestion =>
-        suggestion.addressMetaData?.deliveryPointValidation === CONFIRMED,
-    );
-
     const validationMessageKey = getValidationMessageKey(
-      suggestedAddresses,
+      confirmedSuggestions,
       validationKey,
       addressValidationError,
     );
@@ -251,7 +252,7 @@ const mapStateToProps = state => {
       selectCurrentlyOpenEditModal(state) === 'addressValidation',
     addressValidationError:
       state.vet360.addressValidation.addressValidationError,
-    suggestedAddresses: state.vet360.addressValidation.suggestedAddresses,
+    confirmedSuggestions: state.vet360.addressValidation.confirmedSuggestions,
     addressValidationType,
     validationKey: state.vet360.addressValidation.validationKey,
     addressFromUser: state.vet360.addressValidation.addressFromUser,
@@ -278,7 +279,7 @@ AddressValidationModal.propTypes = {
   analyticsSectionName: PropTypes.string,
   isAddressValidationModalVisible: PropTypes.bool.isRequired,
   addressValidationError: PropTypes.bool.isRequired,
-  suggestedAddresses: PropTypes.array.isRequired,
+  confirmedSuggestions: PropTypes.array.isRequired,
   addressValidationType: PropTypes.string.isRequired,
   validationKey: PropTypes.number,
   addressFromUser: PropTypes.object.isRequired,

--- a/src/platform/user/profile/vet360/containers/AddressValidationModal.jsx
+++ b/src/platform/user/profile/vet360/containers/AddressValidationModal.jsx
@@ -15,7 +15,10 @@ import {
   resetAddressValidation as resetAddressValidationAction,
 } from '../actions';
 import { getValidationMessageKey } from '../../utilities';
-import { ADDRESS_VALIDATION_MESSAGES } from '../../constants/addressValidationMessages';
+import {
+  ADDRESS_VALIDATION_MESSAGES,
+  CONFIRMED,
+} from '../../constants/addressValidationMessages';
 
 import * as VET360 from '../constants';
 
@@ -66,12 +69,10 @@ class AddressValidationModal extends React.Component {
       validationKey,
       isLoading,
       addressFromUser,
-      confirmedSuggestions,
       selectedAddressId,
     } = this.props;
 
-    const disableButton =
-      selectedAddressId !== 'userEntered' && confirmedSuggestions.length === 0;
+    const disableButton = selectedAddressId === null;
 
     if (addressValidationError && !validationKey) {
       return (
@@ -172,12 +173,12 @@ class AddressValidationModal extends React.Component {
     const {
       isAddressValidationModalVisible,
       addressValidationType,
-      confirmedSuggestions,
       addressFromUser,
       validationKey,
       addressValidationError,
       closeModal,
       resetAddressValidation,
+      suggestedAddresses,
     } = this.props;
 
     const resetDataAndCloseModal = () => {
@@ -186,13 +187,18 @@ class AddressValidationModal extends React.Component {
     };
 
     const validationMessageKey = getValidationMessageKey(
-      confirmedSuggestions,
+      suggestedAddresses,
       validationKey,
       addressValidationError,
     );
 
     const addressValidationMessage =
       ADDRESS_VALIDATION_MESSAGES[validationMessageKey];
+
+    const confirmedSuggestions = suggestedAddresses.filter(
+      suggestion =>
+        suggestion.addressMetaData?.deliveryPointValidation === CONFIRMED,
+    );
 
     const shouldShowSuggestions = confirmedSuggestions.length > 0;
 
@@ -252,7 +258,7 @@ const mapStateToProps = state => {
       selectCurrentlyOpenEditModal(state) === 'addressValidation',
     addressValidationError:
       state.vet360.addressValidation.addressValidationError,
-    confirmedSuggestions: state.vet360.addressValidation.confirmedSuggestions,
+    suggestedAddresses: state.vet360.addressValidation.suggestedAddresses,
     addressValidationType,
     validationKey: state.vet360.addressValidation.validationKey,
     addressFromUser: state.vet360.addressValidation.addressFromUser,

--- a/src/platform/user/profile/vet360/containers/AddressValidationModal.jsx
+++ b/src/platform/user/profile/vet360/containers/AddressValidationModal.jsx
@@ -173,18 +173,23 @@ class AddressValidationModal extends React.Component {
     const {
       isAddressValidationModalVisible,
       addressValidationType,
+      suggestedAddresses,
       addressFromUser,
       validationKey,
       addressValidationError,
       closeModal,
       resetAddressValidation,
-      suggestedAddresses,
     } = this.props;
 
     const resetDataAndCloseModal = () => {
       resetAddressValidation();
       closeModal();
     };
+
+    const confirmedSuggestions = suggestedAddresses.filter(
+      suggestion =>
+        suggestion.addressMetaData?.deliveryPointValidation === CONFIRMED,
+    );
 
     const validationMessageKey = getValidationMessageKey(
       suggestedAddresses,
@@ -194,11 +199,6 @@ class AddressValidationModal extends React.Component {
 
     const addressValidationMessage =
       ADDRESS_VALIDATION_MESSAGES[validationMessageKey];
-
-    const confirmedSuggestions = suggestedAddresses.filter(
-      suggestion =>
-        suggestion.addressMetaData?.deliveryPointValidation === CONFIRMED,
-    );
 
     const shouldShowSuggestions = confirmedSuggestions.length > 0;
 
@@ -285,7 +285,7 @@ AddressValidationModal.propTypes = {
   analyticsSectionName: PropTypes.string,
   isAddressValidationModalVisible: PropTypes.bool.isRequired,
   addressValidationError: PropTypes.bool.isRequired,
-  confirmedSuggestions: PropTypes.array.isRequired,
+  suggestedAddresses: PropTypes.array.isRequired,
   addressValidationType: PropTypes.string.isRequired,
   validationKey: PropTypes.number,
   addressFromUser: PropTypes.object.isRequired,

--- a/src/platform/user/profile/vet360/reducers/index.js
+++ b/src/platform/user/profile/vet360/reducers/index.js
@@ -21,7 +21,7 @@ import { isFailedTransaction } from '../util/transactions';
 
 const initialAddressValidationState = {
   addressValidationType: '',
-  suggestedAddresses: [],
+  confirmedSuggestions: [],
   addressFromUser: {
     addressLine1: '',
     addressLine2: '',
@@ -216,7 +216,7 @@ export default function vet360(state = initialState, action) {
           ...state.addressValidation,
           addressFromUser: action.addressFromUser,
           addressValidationType: action.addressValidationType,
-          suggestedAddresses: action.suggestedAddresses,
+          confirmedSuggestions: action.confirmedSuggestions,
           validationKey: action.validationKey,
           selectedAddress: action.selectedAddress,
           selectedAddressId: '0',

--- a/src/platform/user/profile/vet360/reducers/index.js
+++ b/src/platform/user/profile/vet360/reducers/index.js
@@ -21,7 +21,7 @@ import { isFailedTransaction } from '../util/transactions';
 
 const initialAddressValidationState = {
   addressValidationType: '',
-  confirmedSuggestions: [],
+  suggestedAddresses: [],
   addressFromUser: {
     addressLine1: '',
     addressLine2: '',
@@ -33,7 +33,7 @@ const initialAddressValidationState = {
   addressValidationError: false,
   validationKey: null,
   selectedAddress: {},
-  selectedAddressId: '0',
+  selectedAddressId: null,
 };
 
 const initialState = {
@@ -216,10 +216,10 @@ export default function vet360(state = initialState, action) {
           ...state.addressValidation,
           addressFromUser: action.addressFromUser,
           addressValidationType: action.addressValidationType,
-          confirmedSuggestions: action.confirmedSuggestions,
+          suggestedAddresses: action.suggestedAddresses,
           validationKey: action.validationKey,
           selectedAddress: action.selectedAddress,
-          selectedAddressId: '0',
+          selectedAddressId: action.selectedAddressId,
         },
         modal: 'addressValidation',
       };

--- a/src/platform/user/profile/vet360/tests/reducers/index.unit.spec.js
+++ b/src/platform/user/profile/vet360/tests/reducers/index.unit.spec.js
@@ -341,7 +341,7 @@ describe('vet360 reducer', () => {
           addressValidationError: false,
           validationKey: 1234,
           selectedAddress: {},
-          selectedAddressId: '0',
+          selectedAddressId: null,
         },
       };
       const action = {
@@ -363,7 +363,7 @@ describe('vet360 reducer', () => {
           addressValidationError: false,
           validationKey: null,
           selectedAddress: {},
-          selectedAddressId: '0',
+          selectedAddressId: null,
         },
       };
       expect(vet360(state, action)).to.eql(expectedState);


### PR DESCRIPTION
## Description
Disable the button in the instance that there is no selection made by the user or a default selection made for them

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
