### PR TITLE
Add specific table styling for find-va-forms

### DIFF
--- a/src/applications/find-va-forms/containers/SearchResults.jsx
+++ b/src/applications/find-va-forms/containers/SearchResults.jsx
@@ -14,19 +14,19 @@ const ASCENDING = 'ASC';
 const DESCENDING = 'DESC';
 const FIELD_LABELS = [
   {
-    label: 'Form ID',
+    label: 'Form number',
     value: 'idLabel',
   },
   {
-    label: 'Form Name',
+    label: 'Form name',
     value: 'titleLabel',
   },
   {
-    label: 'Issue Date',
+    label: 'Issue date',
     value: 'firstIssuedOnLabel',
   },
   {
-    label: 'Revision Date',
+    label: 'Revision date',
     value: 'lastRevisionOnLabel',
   },
 ];

--- a/src/applications/find-va-forms/containers/SearchResults.jsx
+++ b/src/applications/find-va-forms/containers/SearchResults.jsx
@@ -182,7 +182,7 @@ export class SearchResults extends Component {
 
         {/* Table of Forms */}
         <SortableTable
-          className="vads-u-margin--0"
+          className="find-va-forms-table vads-u-margin--0"
           currentSort={{ order: selectedFieldOrder, value: selectedFieldLabel }}
           data={slice(results, startIndex, lastIndex)}
           fields={FIELD_LABELS}

--- a/src/applications/find-va-forms/containers/SearchResults.jsx
+++ b/src/applications/find-va-forms/containers/SearchResults.jsx
@@ -14,7 +14,7 @@ const ASCENDING = 'ASC';
 const DESCENDING = 'DESC';
 const FIELD_LABELS = [
   {
-    label: 'Form #',
+    label: 'Form ID',
     value: 'idLabel',
   },
   {

--- a/src/applications/find-va-forms/containers/SearchResults.jsx
+++ b/src/applications/find-va-forms/containers/SearchResults.jsx
@@ -14,11 +14,11 @@ const ASCENDING = 'ASC';
 const DESCENDING = 'DESC';
 const FIELD_LABELS = [
   {
-    label: 'VA form number',
+    label: 'Form #',
     value: 'idLabel',
   },
   {
-    label: 'Form name',
+    label: 'Form Name',
     value: 'titleLabel',
   },
   {

--- a/src/applications/find-va-forms/sass/find-va-forms.scss
+++ b/src/applications/find-va-forms/sass/find-va-forms.scss
@@ -1,15 +1,5 @@
 .find-va-forms-table {
   th {
-    &:nth-of-type(1) {
-      width: 120px;
-    }
-
-    &:nth-of-type(3) {
-      width: 125px;
-    }
-
-    &:nth-of-type(4) {
-      width: 145px;
-    }
+    min-width: 120px;
   }
 }

--- a/src/applications/find-va-forms/sass/find-va-forms.scss
+++ b/src/applications/find-va-forms/sass/find-va-forms.scss
@@ -1,0 +1,15 @@
+.find-va-forms-table {
+  th {
+    &:nth-of-type(1) {
+      width: 120px;
+    }
+
+    &:nth-of-type(3) {
+      width: 125px;
+    }
+
+    &:nth-of-type(4) {
+      width: 145px;
+    }
+  }
+}


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/4516

**Current Behavior:** The column widths at `/find-va-forms-beta` do not have a fixed width to display headers on 1-line.

**Desired Behavior:** The column widths at `/find-va-forms-beta` do have a fixed width to display headers on 1-line.

This PR implements the desired behavior mentioned above.

## Testing done
Locally.

## Screenshots
![image](https://user-images.githubusercontent.com/12773166/71904964-661d4780-3124-11ea-9a78-0a6d90ac176b.png)

## Acceptance criteria
- [x] Column widths do not change after performing a sort.
- [x] Column headers do not wrap more than 2 lines even when toggled.
- [x] Update column names to [these names](https://github.com/department-of-veterans-affairs/va.gov-team/issues/4516#issuecomment-571338998).

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
