### PR TITLE
Send correct data to VAOS preferences endpoint

### DIFF
--- a/src/applications/vaos/actions/newAppointment.js
+++ b/src/applications/vaos/actions/newAppointment.js
@@ -493,7 +493,10 @@ export function updateCCEligibility(isEligible) {
 
 async function buildPreferencesDataAndUpdate(newAppointment) {
   const preferenceData = await getPreferences();
-  const preferenceBody = createPreferenceBody(newAppointment, preferenceData);
+  const preferenceBody = createPreferenceBody(
+    newAppointment.data,
+    preferenceData,
+  );
   return updatePreferences(preferenceBody);
 }
 

--- a/src/applications/vaos/actions/newAppointment.js
+++ b/src/applications/vaos/actions/newAppointment.js
@@ -494,8 +494,8 @@ export function updateCCEligibility(isEligible) {
 async function buildPreferencesDataAndUpdate(newAppointment) {
   const preferenceData = await getPreferences();
   const preferenceBody = createPreferenceBody(
-    newAppointment.data,
     preferenceData,
+    newAppointment.data,
   );
   return updatePreferences(preferenceBody);
 }

--- a/src/applications/vaos/api/index.js
+++ b/src/applications/vaos/api/index.js
@@ -487,7 +487,7 @@ export function sendRequestMessage(id, messageText) {
 export function getPreferences() {
   let promise;
   if (USE_MOCK_DATA) {
-    promise = Promise.resolve({ data: { attributes: {} } });
+    promise = Promise.resolve({ data: { attributes: { emailAllowed: true } } });
   } else {
     promise = apiRequest(`/vaos/preferences`);
   }

--- a/src/applications/vaos/utils/data.js
+++ b/src/applications/vaos/utils/data.js
@@ -256,7 +256,7 @@ export function transformFormToAppointment(state) {
   };
 }
 
-export function createPreferenceBody(data, preferences) {
+export function createPreferenceBody(preferences, data) {
   return {
     ...preferences,
     emailAddress: data.email,

--- a/src/applications/vaos/utils/data.js
+++ b/src/applications/vaos/utils/data.js
@@ -256,7 +256,7 @@ export function transformFormToAppointment(state) {
   };
 }
 
-export function createPreferenceBody(preferences, data) {
+export function createPreferenceBody(data, preferences) {
   return {
     ...preferences,
     emailAddress: data.email,


### PR DESCRIPTION
## Description
This fixes a parameter swap issue so that we send the expected data to the preferences endpoint.

## Testing done
Local testing

## Acceptance criteria
- [ ] Preferences data is correct

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
