### PR TITLE
Enable "go back" links in validation modal messages

### DIFF
--- a/src/platform/user/profile/constants/addressValidationMessages.js
+++ b/src/platform/user/profile/constants/addressValidationMessages.js
@@ -1,7 +1,17 @@
 import React from 'react';
 
+export const ADDRESS_VALIDATION_TYPES = Object.freeze({
+  BAD_UNIT: 'badUnitNumber',
+  BAD_UNIT_OVERRIDE: 'badUnitNumberOverride',
+  MISSING_UNIT: 'missingUnitNumber',
+  MISSING_UNIT_OVERRIDE: 'missingUnitNumberOverride',
+  SHOW_SUGGESTIONS: 'showSuggestions',
+  SHOW_SUGGESTIONS_OVERRIDE: 'showSuggestionsOverride',
+  VALIDATION_ERROR: 'validationError',
+});
+
 export const ADDRESS_VALIDATION_MESSAGES = Object.freeze({
-  badUnitNumber: {
+  [ADDRESS_VALIDATION_TYPES.BAD_UNIT]: {
     headline: 'Please update your unit number',
     ModalText: ({ editFunction }) => (
       <p>
@@ -12,7 +22,7 @@ export const ADDRESS_VALIDATION_MESSAGES = Object.freeze({
       </p>
     ),
   },
-  badUnitNumberOverride: {
+  [ADDRESS_VALIDATION_TYPES.BAD_UNIT_OVERRIDE]: {
     headline: 'Please update or confirm your unit number',
     ModalText: ({ editFunction }) => (
       <p>
@@ -24,7 +34,7 @@ export const ADDRESS_VALIDATION_MESSAGES = Object.freeze({
       </p>
     ),
   },
-  missingUnitNumber: {
+  [ADDRESS_VALIDATION_TYPES.MISSING_UNIT]: {
     headline: 'Please add a unit number',
     ModalText: ({ editFunction }) => (
       <p>
@@ -35,7 +45,7 @@ export const ADDRESS_VALIDATION_MESSAGES = Object.freeze({
       </p>
     ),
   },
-  missingUnitNumberOverride: {
+  [ADDRESS_VALIDATION_TYPES.MISSING_UNIT_OVERRIDE]: {
     headline: 'Please add a unit number',
     ModalText: ({ editFunction }) => (
       <p>
@@ -46,7 +56,7 @@ export const ADDRESS_VALIDATION_MESSAGES = Object.freeze({
       </p>
     ),
   },
-  showSuggestions: {
+  [ADDRESS_VALIDATION_TYPES.SHOW_SUGGESTIONS]: {
     headline: `We couldn’t verify your address`,
     ModalText: ({ editFunction }) => (
       <p>
@@ -57,7 +67,7 @@ export const ADDRESS_VALIDATION_MESSAGES = Object.freeze({
       </p>
     ),
   },
-  showSuggestionsOverride: {
+  [ADDRESS_VALIDATION_TYPES.SHOW_SUGGESTIONS_OVERRIDE]: {
     headline: 'Please confirm your address',
     ModalText: ({ editFunction }) => (
       <p>
@@ -68,7 +78,7 @@ export const ADDRESS_VALIDATION_MESSAGES = Object.freeze({
       </p>
     ),
   },
-  validationError: {
+  [ADDRESS_VALIDATION_TYPES.VALIDATION_ERROR]: {
     headline: `We couldn’t verify your address`,
     ModalText: ({ editFunction }) => (
       <p>

--- a/src/platform/user/profile/constants/addressValidationMessages.js
+++ b/src/platform/user/profile/constants/addressValidationMessages.js
@@ -3,79 +3,79 @@ import React from 'react';
 export const ADDRESS_VALIDATION_MESSAGES = Object.freeze({
   badUnitNumber: {
     headline: 'Please update your unit number',
-    modalText: editFunction => (
-      <>
+    ModalText: ({ editFunction }) => (
+      <p>
         We couldn’t verify your address with the U.S. Postal Service because
         there may be a problem with the unit number. Please{' '}
         <a onClick={editFunction}>edit your address</a> below to update the unit
         number.
-      </>
+      </p>
     ),
   },
   badUnitNumberOverride: {
     headline: 'Please update or confirm your unit number',
-    modalText: editFunction => (
-      <>
+    ModalText: ({ editFunction }) => (
+      <p>
         We couldn’t verify your address with the U.S. Postal Service because
         there may be a problem with the unit number. Please{' '}
         <a onClick={editFunction}>edit your address</a> to update the unit
         number. If your unit number is already correct, please continue with the
         address you entered below.
-      </>
+      </p>
     ),
   },
   missingUnitNumber: {
     headline: 'Please add a unit number',
-    modalText: editFunction => (
-      <>
+    ModalText: ({ editFunction }) => (
+      <p>
         We couldn’t verify your address with the U.S. Postal Service because
         it’s missing a unit number. Please{' '}
         <a onClick={editFunction}>edit your address</a> below to add a unit
         number.
-      </>
+      </p>
     ),
   },
   missingUnitNumberOverride: {
     headline: 'Please add a unit number',
-    modalText: editFunction => (
-      <>
+    ModalText: ({ editFunction }) => (
+      <p>
         It looks like your address is missing a unit number. Please{' '}
         <a onClick={editFunction}>edit your address</a> to add a unit number. If
         you don’t have a unit number and the address you entered below is
         correct, please select Continue.
-      </>
+      </p>
     ),
   },
   showSuggestions: {
     headline: `We couldn’t verify your address`,
-    modalText: editFunction => (
-      <>
+    ModalText: ({ editFunction }) => (
+      <p>
         We’re sorry. We couldn’t verify your address with the U.S. Postal
         Service, so we won't be able to deliver your VA mail to that address.
         Please <a onClick={editFunction}>edit the address</a> you entered or
         choose a suggested address below.
-      </>
+      </p>
     ),
   },
   showSuggestionsOverride: {
     headline: 'Please confirm your address',
-    modalText: editFunction => (
-      <>
+    ModalText: ({ editFunction }) => (
+      <p>
         We couldn’t confirm your address with the U.S. Postal Service. Please
         verify your address so we can save it to your VA profile. If the address
         you entered isn’t correct, please <a onClick={editFunction}>edit it</a>{' '}
         or choose a suggested address below.
-      </>
+      </p>
     ),
   },
   validationError: {
     headline: `We couldn’t verify your address`,
-    modalText: editFunction => (
-      <>
+    ModalText: ({ editFunction }) => (
+      <p>
         We’re sorry. We couldn’t verify your address with the U.S. Postal
         Service, so we will not be able to deliver your VA mail to that address.
         Please <a onClick={editFunction}>edit the address</a> you entered.
-      </>
+      </p>
     ),
   },
 });

--- a/src/platform/user/profile/constants/addressValidationMessages.js
+++ b/src/platform/user/profile/constants/addressValidationMessages.js
@@ -1,31 +1,82 @@
+import React from 'react';
+
 export const ADDRESS_VALIDATION_MESSAGES = Object.freeze({
   badUnitNumber: {
     headline: 'Please update your unit number',
-    modalText: `We couldn’t verify your address with the U.S. Postal Service because there may be a problem with the unit number. Please edit your address below to update the unit number.`,
+    modalText: editFunction => (
+      <>
+        We couldn’t verify your address with the U.S. Postal Service because
+        there may be a problem with the unit number. Please{' '}
+        <a onClick={editFunction}>edit your address</a> below to update the unit
+        number.
+      </>
+    ),
   },
   badUnitNumberOverride: {
     headline: 'Please update or confirm your unit number',
-    modalText: `We couldn’t verify your address with the U.S. Postal Service because there may be a problem with the unit number. Please edit your address to update the unit number. If your unit number is already correct, please continue with the address you entered below.`,
+    modalText: editFunction => (
+      <>
+        We couldn’t verify your address with the U.S. Postal Service because
+        there may be a problem with the unit number. Please{' '}
+        <a onClick={editFunction}>edit your address</a> to update the unit
+        number. If your unit number is already correct, please continue with the
+        address you entered below.
+      </>
+    ),
   },
   missingUnitNumber: {
     headline: 'Please add a unit number',
-    modalText: `We couldn’t verify your address with the U.S. Postal Service because it’s missing a unit number. Please edit your address below to add a unit number.`,
+    modalText: editFunction => (
+      <>
+        We couldn’t verify your address with the U.S. Postal Service because
+        it’s missing a unit number. Please{' '}
+        <a onClick={editFunction}>edit your address</a> below to add a unit
+        number.
+      </>
+    ),
   },
   missingUnitNumberOverride: {
     headline: 'Please add a unit number',
-    modalText: `It looks like your address is missing a unit number. Please edit your address to add a unit number. If you don’t have a unit number and the address you entered below is correct, please select Continue.`,
+    modalText: editFunction => (
+      <>
+        It looks like your address is missing a unit number. Please{' '}
+        <a onClick={editFunction}>edit your address</a> to add a unit number. If
+        you don’t have a unit number and the address you entered below is
+        correct, please select Continue.
+      </>
+    ),
   },
   showSuggestions: {
     headline: `We couldn’t verify your address`,
-    modalText: `We’re sorry.  We couldn’t verify your address with the U.S. Postal Service, so we won't be able to deliver your VA mail to that address.  Please edit the address you entered or choose a suggested address below.`,
+    modalText: editFunction => (
+      <>
+        We’re sorry. We couldn’t verify your address with the U.S. Postal
+        Service, so we won't be able to deliver your VA mail to that address.
+        Please <a onClick={editFunction}>edit the address</a> you entered or
+        choose a suggested address below.
+      </>
+    ),
   },
   showSuggestionsOverride: {
     headline: 'Please confirm your address',
-    modalText: `We couldn’t confirm your address with the U.S. Postal Service.  Please verify your address so we can save it to your VA profile.  If the address you entered isn’t correct, please edit it or choose a suggested address below.`,
+    modalText: editFunction => (
+      <>
+        We couldn’t confirm your address with the U.S. Postal Service. Please
+        verify your address so we can save it to your VA profile. If the address
+        you entered isn’t correct, please <a onClick={editFunction}>edit it</a>{' '}
+        or choose a suggested address below.
+      </>
+    ),
   },
   validationError: {
     headline: `We couldn’t verify your address`,
-    modalText: `We’re sorry.  We couldn’t verify your address with the U.S. Postal Service, so we will not be able to deliver your VA mail to that address.  Please edit the address you entered.`,
+    modalText: editFunction => (
+      <>
+        We’re sorry. We couldn’t verify your address with the U.S. Postal
+        Service, so we will not be able to deliver your VA mail to that address.
+        Please <a onClick={editFunction}>edit the address</a> you entered.
+      </>
+    ),
   },
 });
 

--- a/src/platform/user/profile/utilities/index.js
+++ b/src/platform/user/profile/utilities/index.js
@@ -4,9 +4,10 @@ import {
   setSentryLoginType,
   clearSentryLoginType,
 } from '../../authentication/utilities';
-import localStorage from '../../../utilities/storage/localStorage';
+import localStorage from 'platform/utilities/storage/localStorage';
 
 import {
+  ADDRESS_VALIDATION_TYPES,
   BAD_UNIT_NUMBER,
   MISSING_UNIT_NUMBER,
   CONFIRMED,
@@ -169,15 +170,19 @@ export const getValidationMessageKey = (
     ).length > 0;
 
   if (addressValidationError) {
-    return 'validationError';
+    return ADDRESS_VALIDATION_TYPES.VALIDATION_ERROR;
   }
 
   if (singleSuggestion && containsBadUnitNumber) {
-    return validationKey ? 'badUnitNumberOverride' : 'badUnitNumber';
+    return validationKey
+      ? ADDRESS_VALIDATION_TYPES.BAD_UNIT_OVERRIDE
+      : ADDRESS_VALIDATION_TYPES.BAD_UNIT;
   }
 
   if (singleSuggestion && containsMissingUnitNumber) {
-    return validationKey ? 'missingUnitNumberOverride' : 'missingUnitNumber';
+    return validationKey
+      ? ADDRESS_VALIDATION_TYPES.MISSING_UNIT_OVERRIDE
+      : ADDRESS_VALIDATION_TYPES.MISSING_UNIT;
   }
 
   if (
@@ -185,14 +190,18 @@ export const getValidationMessageKey = (
     !containsMissingUnitNumber &&
     !containsBadUnitNumber
   ) {
-    return validationKey ? 'showSuggestionsOverride' : 'showSuggestions';
+    return validationKey
+      ? ADDRESS_VALIDATION_TYPES.SHOW_SUGGESTIONS_OVERRIDE
+      : ADDRESS_VALIDATION_TYPES.SHOW_SUGGESTIONS;
   }
 
   if (multipleSuggestions) {
-    return validationKey ? 'showSuggestionsOverride' : 'showSuggestions';
+    return validationKey
+      ? ADDRESS_VALIDATION_TYPES.SHOW_SUGGESTIONS_OVERRIDE
+      : ADDRESS_VALIDATION_TYPES.SHOW_SUGGESTIONS;
   }
 
-  return 'showSuggestions'; // defaulting here so the modal will show but not allow override
+  return ADDRESS_VALIDATION_TYPES.SHOW_SUGGESTIONS; // defaulting here so the modal will show but not allow override
 };
 
 // Determines if we need to prompt the user to pick from a list of suggested

--- a/src/platform/user/profile/vet360/containers/AddressValidationModal.jsx
+++ b/src/platform/user/profile/vet360/containers/AddressValidationModal.jsx
@@ -218,11 +218,11 @@ class AddressValidationModal extends React.Component {
           status="warning"
           headline={addressValidationMessage.headline}
         >
-          <p>
-            {addressValidationMessage.modalText(() => {
+          <addressValidationMessage.ModalText
+            editFunction={() => {
               this.props.openModal(addressValidationType, addressFromUser);
-            })}
-          </p>
+            }}
+          />
         </AlertBox>
         <form onSubmit={this.onSubmit}>
           <span className="vads-u-font-weight--bold">You entered:</span>

--- a/src/platform/user/profile/vet360/containers/AddressValidationModal.jsx
+++ b/src/platform/user/profile/vet360/containers/AddressValidationModal.jsx
@@ -218,7 +218,11 @@ class AddressValidationModal extends React.Component {
           status="warning"
           headline={addressValidationMessage.headline}
         >
-          <p>{addressValidationMessage.modalText}</p>
+          <p>
+            {addressValidationMessage.modalText(() => {
+              this.props.openModal(addressValidationType, addressFromUser);
+            })}
+          </p>
         </AlertBox>
         <form onSubmit={this.onSubmit}>
           <span className="vads-u-font-weight--bold">You entered:</span>

--- a/src/platform/user/tests/profile/addressValidationMessages.spec.js
+++ b/src/platform/user/tests/profile/addressValidationMessages.spec.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+import sinon from 'sinon';
+import {
+  ADDRESS_VALIDATION_MESSAGES,
+  ADDRESS_VALIDATION_TYPES,
+} from '../../profile/constants/addressValidationMessages';
+
+describe('ADDRESS_VALIDATION_MESSAGES object', () => {
+  it('has a valid data object for each validation type', () => {
+    const validationTypes = Object.values(ADDRESS_VALIDATION_TYPES);
+    validationTypes.forEach(type => {
+      const messageData = ADDRESS_VALIDATION_MESSAGES[type];
+      const editSpy = sinon.spy();
+      expect(typeof messageData).to.equal('object');
+      expect(typeof messageData.headline).to.equal('string');
+      expect(typeof messageData.ModalText).to.equal('function');
+      const modalTextComponent = shallow(
+        <messageData.ModalText editFunction={editSpy} />,
+      );
+      modalTextComponent.find('a').simulate('click');
+      expect(editSpy.called).to.be.true;
+      modalTextComponent.unmount();
+    });
+  });
+});


### PR DESCRIPTION
## Description
Adds a clickable link in the address validation message text, giving the user another way to go back and edit their address.

## Testing done
Local

## Screenshots
![ScreenFlow](https://user-images.githubusercontent.com/20728956/71733056-83d56e80-2dfd-11ea-95a4-0ca662e7642e.gif)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs