### PR TITLE
Replaced abbrevated state names with fullnames

### DIFF
--- a/src/applications/gi/components/search/InstitutionFilterForm.jsx
+++ b/src/applications/gi/components/search/InstitutionFilterForm.jsx
@@ -4,7 +4,7 @@ import React from 'react';
 import Checkbox from '../Checkbox';
 import Dropdown from '../Dropdown';
 import SearchResultTypeOfInstitutionFilter from './SearchResultTypeOfInstitutionFilter';
-import { addAllOption } from '../../utils/helpers';
+import { addAllOption, getStateNameForCode } from '../../utils/helpers';
 import environment from 'platform/utilities/environment';
 
 class InstitutionFilterForm extends React.Component {
@@ -48,7 +48,7 @@ class InstitutionFilterForm extends React.Component {
   renderStateFilter = () => {
     const options = Object.keys(this.props.search.facets.state).map(state => ({
       value: state,
-      label: state,
+      label: getStateNameForCode(state),
     }));
 
     return (

--- a/src/applications/gi/components/vet-tec/VetTecSearchForm.jsx
+++ b/src/applications/gi/components/vet-tec/VetTecSearchForm.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import KeywordSearch from '../search/KeywordSearch';
 import CheckboxGroup from '../CheckboxGroup';
-import { addAllOption } from '../../utils/helpers';
+import { addAllOption, getStateNameForCode } from '../../utils/helpers';
 import PropTypes from 'prop-types';
 import Dropdown from '../Dropdown';
 import VetTecFilterBy from './VetTecFilterBy';
@@ -99,7 +99,7 @@ class VetTecSearchForm extends React.Component {
       .sort()
       .map(state => ({
         value: state,
-        label: state,
+        label: getStateNameForCode(state),
       }));
 
     return (

--- a/src/applications/gi/tests/components/InstitutionFilterForm.unit.spec.jsx
+++ b/src/applications/gi/tests/components/InstitutionFilterForm.unit.spec.jsx
@@ -20,8 +20,8 @@ const defaultProps = {
 describe('<InstitutionFilterForm>', () => {
   it('Should display full state or US territory name based on state abbreviation', () => {
     const wrapper = mount(<InstitutionFilterForm {...defaultProps} />);
-    const stateCode = wrapper.find('option[value="PR"]').text();
-    expect(getStateNameForCode(stateCode)).to.eq('Puerto Rico');
+    const stateLabel = wrapper.find('option[value="PR"]').text();
+    expect(stateLabel).to.eq('Puerto Rico');
     wrapper.unmount();
   });
 

--- a/src/applications/gi/tests/components/InstitutionFilterForm.unit.spec.jsx
+++ b/src/applications/gi/tests/components/InstitutionFilterForm.unit.spec.jsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import { expect } from 'chai';
+import { mount } from 'enzyme';
+import InstitutionFilterForm from '../../components/search/InstitutionFilterForm';
+import { getStateNameForCode } from '../../utils/helpers';
+
+const defaultProps = {
+  search: {
+    facets: {
+      category: { school: 17, employer: 0 },
+      type: { 'for profit': 1, private: 16 },
+      state: { PR: 1 },
+      country: [{ name: 'USA', count: 17 }],
+    },
+  },
+  filters: {},
+  handleFilterChange: () => {},
+};
+
+describe('<InstitutionFilterForm>', () => {
+  it('Should display full state or US territory name based on state abbreviation', () => {
+    const wrapper = mount(<InstitutionFilterForm {...defaultProps} />);
+    const stateCode = wrapper.find('option[value="PR"]').text();
+    expect(getStateNameForCode(stateCode)).to.eq('Puerto Rico');
+    wrapper.unmount();
+  });
+
+  it('Should display abbreviation if full state or US territory is undefined', () => {
+    const props = {
+      search: {
+        facets: {
+          category: { school: 17, employer: 0 },
+          type: { 'for profit': 1, private: 16 },
+          state: { ZZ: 1 },
+          country: [{ name: 'USA', count: 17 }],
+        },
+      },
+      filters: {},
+      handleFilterChange: () => {},
+    };
+    const wrapper = mount(<InstitutionFilterForm {...props} />);
+    const stateCode = wrapper.find('option[value="ZZ"]').text();
+    expect(getStateNameForCode(stateCode)).to.eq('ZZ');
+    wrapper.unmount();
+  });
+});

--- a/src/applications/gi/utils/helpers.js
+++ b/src/applications/gi/utils/helpers.js
@@ -69,6 +69,6 @@ export const isPresent = value => value && value !== '';
 export const getStateNameForCode = stateCode => {
   const stateLabel = constants.states.USA.find(
     state => state.value === stateCode,
-  ).label;
-  return stateLabel !== undefined ? stateLabel : stateCode;
+  );
+  return stateLabel !== undefined ? stateLabel.label : stateCode;
 };

--- a/src/applications/gi/utils/helpers.js
+++ b/src/applications/gi/utils/helpers.js
@@ -67,8 +67,8 @@ export const rubyifyKeys = query =>
 export const isPresent = value => value && value !== '';
 
 export const getStateNameForCode = stateCode => {
-  const filteredStates = constants.states.USA.filter(
+  const stateLabel = constants.states.USA.find(
     state => state.value === stateCode,
-  );
-  return filteredStates.length > 0 ? filteredStates[0].label : stateCode;
+  ).label;
+  return stateLabel !== undefined ? stateLabel : stateCode;
 };

--- a/src/applications/gi/utils/helpers.js
+++ b/src/applications/gi/utils/helpers.js
@@ -68,7 +68,7 @@ export const isPresent = value => value && value !== '';
 
 export const getStateNameForCode = stateCode => {
   const stateLabel = constants.states.USA.find(
-    state => state.value === stateCode,
+    state => state.value.toUpperCase() === stateCode.toUpperCase(),
   );
   return stateLabel !== undefined ? stateLabel.label : stateCode;
 };

--- a/src/applications/gi/utils/helpers.js
+++ b/src/applications/gi/utils/helpers.js
@@ -1,4 +1,5 @@
 import { snakeCase } from 'lodash';
+import constants from 'vets-json-schema/dist/constants.json';
 
 export const formatNumber = value => {
   const str = (+value).toString();
@@ -64,3 +65,10 @@ export const rubyifyKeys = query =>
   }, {});
 
 export const isPresent = value => value && value !== '';
+
+export const getStateNameForCode = stateCode => {
+  const filteredStates = constants.states.USA.filter(
+    state => state.value === stateCode,
+  );
+  return filteredStates.length > 0 ? filteredStates[0].label : stateCode;
+};

--- a/src/applications/gi/utils/helpers.js
+++ b/src/applications/gi/utils/helpers.js
@@ -70,5 +70,5 @@ export const getStateNameForCode = stateCode => {
   const stateLabel = constants.states.USA.find(
     state => state.value.toUpperCase() === stateCode.toUpperCase(),
   );
-  return stateLabel !== undefined ? stateLabel.label : stateCode;
+  return stateLabel !== undefined ? stateLabel.label : stateCode.toUpperCase();
 };


### PR DESCRIPTION
## Description
Our states menu has just two-letter abbreviations. Screen readers do not read these out as proper abbreviations because they are just text strings. It would be a good enhancement to add the full state name, such as "CA - California" to that menu.

https://github.com/department-of-veterans-affairs/va.gov-team/issues/1259

## Testing done
Local Testing Completed

## Screenshots
<img width="386" alt="Screen Shot 2020-01-03 at 4 21 13 PM" src="https://user-images.githubusercontent.com/50601724/71750016-22d18900-2e45-11ea-82fa-0858f74dedb0.png">


## Acceptance criteria
- [x] As a screen reader user, I would like to hear the full state name read out when I have the States filter expanded.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
