### PR TITLE
Claim status tool additional evidence checkbox: remove default error state

### DIFF
--- a/src/applications/claims-status/components/AddFilesForm.jsx
+++ b/src/applications/claims-status/components/AddFilesForm.jsx
@@ -51,7 +51,11 @@ class AddFilesForm extends React.Component {
     this.add = this.add.bind(this);
     this.getErrorMessage = this.getErrorMessage.bind(this);
     this.submit = this.submit.bind(this);
-    this.state = { errorMessage: null, checked: false };
+    this.state = {
+      errorMessage: null,
+      checked: false,
+      errorMessageCheckbox: null,
+    };
   }
   getErrorMessage() {
     if (this.state.errorMessage) {
@@ -87,6 +91,12 @@ class AddFilesForm extends React.Component {
     }
   }
   submit() {
+    this.setState(
+      this.state.checked
+        ? { errorMessageCheckbox: null }
+        : { errorMessageCheckbox: 'Please accept the above' },
+    );
+
     if (
       this.props.files.length > 0 &&
       this.props.files.every(isValidDocument) &&
@@ -185,11 +195,7 @@ class AddFilesForm extends React.Component {
             this.setState({ checked });
           }}
           checked={this.state.checked}
-          errorMessage={
-            !this.state.checked
-              ? 'Please accept the above to submit files for review.'
-              : null
-          }
+          errorMessage={this.state.errorMessageCheckbox}
           label={
             <div>
               <strong>


### PR DESCRIPTION
## Description
When the checkbox for adding additional evidence was added, the default state was to show an error message. This has been changed to not show the error message until the user clicks the submit button.

## Screenshot
![image](https://user-images.githubusercontent.com/53942725/71820485-33f4e280-305d-11ea-9fd3-811b43b5f72d.png)

## Acceptance criteria
- [ ] Checkbox no longer defaults to error state