### PR TITLE
Disable HLR forwarding address

### DIFF
--- a/src/applications/disability-benefits/996/pages/contactInformation.js
+++ b/src/applications/disability-benefits/996/pages/contactInformation.js
@@ -3,7 +3,7 @@ import merge from 'lodash/merge';
 // import fullSchema from 'vets-json-schema/dist/20-0996-schema.json';
 import fullSchema from '../20-0996-schema.json';
 
-import dateRangeUI from 'platform/forms-system/src/js/definitions/dateRange';
+// import dateRangeUI from 'platform/forms-system/src/js/definitions/dateRange';
 import PhoneNumberWidget from 'platform/forms-system/src/js/widgets/PhoneNumberWidget';
 import PhoneNumberReviewWidget from 'platform/forms-system/src/js/review/PhoneNumberWidget';
 
@@ -15,6 +15,9 @@ import {
   phoneEmailViewField,
 } from '../../all-claims/content/contactInformation';
 
+import { errorMessages, patternMessages } from '../constants';
+
+/*
 import { hasForwardingAddress, forwardingCountryIsUSA } from '../helpers';
 import {
   ForwardingAddressViewField,
@@ -23,12 +26,12 @@ import {
   ForwardingAddressReviewWidget,
 } from '../content/ForwardingAddress';
 import { checkDateRange } from '../validations';
-import { errorMessages, patternMessages } from '../constants';
 import ForwardingAddressReviewField from '../containers/ForwardingAddressReviewField';
+*/
 
 const {
   mailingAddress,
-  forwardingAddress,
+  // forwardingAddress,
   emailAddress,
   phone,
 } = fullSchema.properties;
@@ -99,6 +102,7 @@ const contactInfo = {
         },
       },
     ),
+    /*
     'view:hasForwardingAddress': {
       'ui:title': forwardingAddressCheckboxLabel,
       'ui:field': 'StringField',
@@ -179,6 +183,7 @@ const contactInfo = {
         },
       },
     ),
+    */
     'view:contactInfoDescription': {
       'ui:description': contactInfoUpdateHelp,
     },
@@ -196,6 +201,7 @@ const contactInfo = {
         },
       },
       mailingAddress,
+      /*
       'view:hasForwardingAddress': {
         type: 'boolean',
       },
@@ -204,6 +210,7 @@ const contactInfo = {
         type: 'object',
         properties: {},
       },
+      */
     },
   },
 };

--- a/src/applications/disability-benefits/996/tests/components/contactInfo.unit.spec.jsx
+++ b/src/applications/disability-benefits/996/tests/components/contactInfo.unit.spec.jsx
@@ -36,7 +36,7 @@ describe('Higher-Level Review 0996 contact information', () => {
     // country
     expect(form.find('select').length).to.equal(1);
     // street 1, 2, 3, city, phone, email, fwding address checkbox
-    expect(form.find('input').length).to.equal(7);
+    expect(form.find('input').length).to.equal(6);
     form.unmount();
   });
 
@@ -58,7 +58,7 @@ describe('Higher-Level Review 0996 contact information', () => {
     // country, state
     expect(form.find('select').length).to.equal(2);
     // street 1, 2, 3, city, zip, phone, email, fwding address checkbox
-    expect(form.find('input').length).to.equal(8);
+    expect(form.find('input').length).to.equal(7);
     form.unmount();
   });
 
@@ -81,7 +81,7 @@ describe('Higher-Level Review 0996 contact information', () => {
     // country
     expect(form.find('select').length).to.equal(1);
     // street 1, 2, 3, city, phone, email, fwding address checkbox
-    expect(form.find('input').length).to.equal(7);
+    expect(form.find('input').length).to.equal(6);
     form.unmount();
   });
 
@@ -199,6 +199,7 @@ describe('Higher-Level Review 0996 contact information', () => {
     form.unmount();
   });
 
+  /*
   it('expands forwarding address fields when forwarding address checked', () => {
     const form = mount(
       <DefinitionTester
@@ -396,6 +397,7 @@ describe('Higher-Level Review 0996 contact information', () => {
     expect(onSubmit.called).to.be.false;
     form.unmount();
   });
+  */
 
   it('does not submit without required info', () => {
     const onSubmit = sinon.spy();
@@ -430,7 +432,7 @@ describe('Higher-Level Review 0996 contact information', () => {
     );
 
     form.find('form').simulate('submit');
-    expect(form.find('.usa-input-error-message').length).to.equal(9);
+    expect(form.find('.usa-input-error-message').length).to.equal(5);
     expect(onSubmit.called).to.be.false;
     form.unmount();
   });

--- a/src/applications/disability-benefits/996/tests/validations/validations.unit.spec.js
+++ b/src/applications/disability-benefits/996/tests/validations/validations.unit.spec.js
@@ -1,11 +1,12 @@
 import { expect } from 'chai';
 
-import { checkDateRange, checkConferenceTimes } from '../../validations';
-import { addXMonths } from '../../helpers';
+import { /* checkDateRange, */ checkConferenceTimes } from '../../validations';
+// import { addXMonths } from '../../helpers';
 import { errorMessages } from '../../constants';
 
 const mockFormData = { informalConferenceChoice: 'me' };
 
+/*
 describe('From Date validations', () => {
   it('should allow start dates after today', () => {
     let errorMessage = '';
@@ -89,6 +90,7 @@ describe('From Date validations', () => {
     expect(errorMessage).to.equal(errorMessages.endDateBeforeStart);
   });
 });
+*/
 
 describe('Informal conference time validation', () => {
   it('should show an error if no times are selected', () => {


### PR DESCRIPTION
## Description

Disable HLR forwarding address block to make the form consistent with other forms

## Testing done

Local unit tests

## Screenshots

![Screen Shot 2020-01-06 at 7 55 43 AM](https://user-images.githubusercontent.com/136959/71822232-fd699880-3059-11ea-99b0-0d1001d608b6.png)

## Acceptance criteria
- [ ] Forwarding address block disabled

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
