### PR TITLE
Update validation modal proptypes

### DIFF
--- a/src/platform/user/profile/vet360/containers/AddressValidationModal.jsx
+++ b/src/platform/user/profile/vet360/containers/AddressValidationModal.jsx
@@ -290,7 +290,7 @@ AddressValidationModal.propTypes = {
   validationKey: PropTypes.number,
   addressFromUser: PropTypes.object.isRequired,
   selectedAddress: PropTypes.object.isRequired,
-  selectedAddressId: PropTypes.string.isRequired,
+  selectedAddressId: PropTypes.string,
   closeModal: PropTypes.func.isRequired,
   openModal: PropTypes.func.isRequired,
   createTransaction: PropTypes.func.isRequired,


### PR DESCRIPTION
## Description
We changed how we use the `selectedAddressId` prop and didn't update the propType declaration so we were getting this error:

```
Warning: Failed prop type: The prop `selectedAddressId` is marked as required in `AddressValidationModal`, but its value is `null`.`
```

## Testing done
Local

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs