### PR TITLE
Fix <FacilityAddress /> on Clinic Choice page

### DIFF
--- a/src/applications/vaos/actions/newAppointment.js
+++ b/src/applications/vaos/actions/newAppointment.js
@@ -415,8 +415,8 @@ export function openSelectAppointmentPage(page, uiSchema, schema) {
           .startOf('month')
           .format('YYYY-MM-DD'),
         moment(data.preferredDate)
-          .startOf('month')
-          .add(90, 'days')
+          .add(1, 'months')
+          .endOf('month')
           .format('YYYY-MM-DD'),
       );
 

--- a/src/applications/vaos/actions/newAppointment.js
+++ b/src/applications/vaos/actions/newAppointment.js
@@ -415,8 +415,8 @@ export function openSelectAppointmentPage(page, uiSchema, schema) {
           .startOf('month')
           .format('YYYY-MM-DD'),
         moment(data.preferredDate)
-          .add(1, 'months')
-          .endOf('month')
+          .startOf('month')
+          .add(90, 'days')
           .format('YYYY-MM-DD'),
       );
 

--- a/src/applications/vaos/components/FacilityAddress.jsx
+++ b/src/applications/vaos/components/FacilityAddress.jsx
@@ -1,7 +1,11 @@
 import React from 'react';
 import FacilityDirectionsLink from '../components/FacilityDirectionsLink';
 
-export default function FacilityAddress({ name, facility }) {
+export default function FacilityAddress({
+  name,
+  facility,
+  showDirectionsLink,
+}) {
   const address = facility?.address?.physical;
   const phone = facility?.phone?.main;
 
@@ -21,9 +25,13 @@ export default function FacilityAddress({ name, facility }) {
       {!!address.address3 && <br />}
       {address.city}, {address.state} {address.zip}
       <br />
-      <FacilityDirectionsLink location={facility} />
-      <br />
-      <br />
+      {showDirectionsLink && (
+        <>
+          <FacilityDirectionsLink location={facility} />
+          <br />
+          <br />
+        </>
+      )}
       {!!phone && (
         <dl className="vads-u-margin-y--0">
           <dt className="vads-u-display--inline">

--- a/src/applications/vaos/containers/ClinicChoicePage.jsx
+++ b/src/applications/vaos/containers/ClinicChoicePage.jsx
@@ -107,12 +107,12 @@ export class ClinicChoicePage extends React.Component {
             In the last 24 months you have had {typeOfCareLabel} appointments in
             the following clinics, located at:
             {facilityDetails && (
-              <p>
+              <div className="vads-u-margin-y--2p5">
                 <FacilityAddress
                   name={facilityDetails.name}
                   facility={facilityDetails}
                 />
-              </p>
+              </div>
             )}
           </>
         )}

--- a/src/applications/vaos/containers/ClinicChoicePage.jsx
+++ b/src/applications/vaos/containers/ClinicChoicePage.jsx
@@ -93,7 +93,7 @@ export class ClinicChoicePage extends React.Component {
               <p>
                 <FacilityAddress
                   name={facilityDetails.name}
-                  address={facilityDetails.address.physical}
+                  facility={facilityDetails}
                 />
               </p>
             )}
@@ -110,7 +110,7 @@ export class ClinicChoicePage extends React.Component {
               <p>
                 <FacilityAddress
                   name={facilityDetails.name}
-                  address={facilityDetails.address.physical}
+                  facility={facilityDetails}
                 />
               </p>
             )}

--- a/src/applications/vaos/tests/components/FacilityAddress.unit.spec.jsx
+++ b/src/applications/vaos/tests/components/FacilityAddress.unit.spec.jsx
@@ -49,6 +49,14 @@ describe('VAOS <FacilityAddress>', () => {
     expect(tree.text()).to.contain(address.state);
     expect(tree.text()).to.contain(address.zip);
     expect(tree.text()).to.contain(facility.phone.main);
+    expect(tree.exists('FacilityDirectionsLink')).to.be.false;
+    tree.unmount();
+  });
+
+  it('should show directions link if showDirectionsLink === true', () => {
+    const tree = shallow(
+      <FacilityAddress facility={facility} showDirectionsLink />,
+    );
     expect(tree.exists('FacilityDirectionsLink')).to.be.true;
     tree.unmount();
   });

--- a/src/applications/vaos/utils/appointment.jsx
+++ b/src/applications/vaos/utils/appointment.jsx
@@ -168,6 +168,7 @@ export function getAppointmentLocation(appt, facility) {
       <FacilityAddress
         name={type === APPOINTMENT_TYPES.request ? '' : facility.name}
         facility={facility}
+        showDirectionsLink
       />
     );
   }


### PR DESCRIPTION
## Description
Update Clinic Choice page to use changes to `<FacilityAddress/>`.  Makes "Directions" link optional for `<FacilityAddress/>` component

## Testing done
Local and unit

## Acceptance criteria
- [ ] Clinic choice page does not crash and displays facility address
- [ ] Directions link is optional

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
