### PR TITLE
VAGOV-6364: Remove unpublished situation updates from output.

### DIFF
--- a/src/site/layouts/vamc_operating_status_and_alerts.drupal.liquid
+++ b/src/site/layouts/vamc_operating_status_and_alerts.drupal.liquid
@@ -71,11 +71,9 @@
                         </ul>
                     </section>
 
-                    {% if fieldBannerAlert.0.entity %}
+                    {% if fieldBannerAlert.0.entity and fieldBannerAlert.0.entity.status == true %}
                     {% include "src/site/components/situation_updates.drupal.liquid" with fieldBannerAlert %}
                     {% endif %}
-
-
 
                     {% if fieldFacilityOperatingStatus.0.entity %}
                     <section id="operating-statuses"

--- a/src/site/stages/build/drupal/graphql/vamcOperatingStatusAndAlerts.graphql.js
+++ b/src/site/stages/build/drupal/graphql/vamcOperatingStatusAndAlerts.graphql.js
@@ -35,6 +35,7 @@ module.exports = `
     fieldBannerAlert {
       entity {
         ... on NodeFullWidthBannerAlert {
+          status
           title
           fieldBannerAlertSituationinfo {
             processed


### PR DESCRIPTION
## Description
Removes situation updates from output when parent node is unpublished

## Testing done
Visual

## Screenshots
![image](https://user-images.githubusercontent.com/2404547/71910846-af7b9000-3140-11ea-954c-a000c07c85d3.png)
![image](https://user-images.githubusercontent.com/2404547/71910856-b4d8da80-3140-11ea-9bd7-acfa244b552d.png)

## Acceptance criteria
- [ ] After unpublishing a VAMC system banner alert with situation updates node, situation updates should no longer appear. Specific case: unpublish drupal /node/2348/edit, and confirm vets website /pittsburgh-health-care/operating-status/ no longer has situation updates
