### PR TITLE
Suggestion: change Nightwatch retries to suite retries

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "lint:sass": "sass-lint -c config/sass-lint.yml --verbose",
     "new:app": "yo @department-of-veterans-affairs/vets-website",
     "new:cms-content-model": "yo ./src/site/stages/build/process-cms-exports/generator-cms-content-model/generators/app/index.js",
-    "nightwatch:docker": "nightwatch -c config/nightwatch.docker-compose.js --retries 3",
+    "nightwatch:docker": "nightwatch -c config/nightwatch.docker-compose.js --suiteRetries 3",
     "nightwatch": "nightwatch -c config/nightwatch.js",
     "nightwatch-sauce": "nightwatch -c config/nightwatch-sauce.js",
     "nightwatch-visual": "node src/platform/testing/visual-regression/index.js",

--- a/src/applications/vaos/tests/e2e/community-care.e2e.spec.js
+++ b/src/applications/vaos/tests/e2e/community-care.e2e.spec.js
@@ -3,7 +3,6 @@ const VAOSHelpers = require('./vaos-helpers');
 const Auth = require('../../../../platform/testing/e2e/auth');
 
 module.exports = {
-  '@disabled': true,
   after: (client, done) => {
     client.deleteCookies();
     client.end();


### PR DESCRIPTION
## Description
Currently, we have Nightwatch set to retry tests 3 times. This assumes that all our e2e tests are written inside a single Nightwatch "test," however, the VAOS e2e tests were broken out into individual tests to improve readability (see https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/applications/vaos/tests/e2e/va-appointment.e2e.spec.js, for example).

The result of this is that when there's a failure, Nightwatch tries to re-run the individual test, not the whole file. I thought this would be useful, but in fact it seems to prevent recovery of intermittent errors because you don't necessarily know what page you're on when it fails, and sometimes tests just fail and need to be started completely over to work.

This change would make the whole module run again, instead of an individual test. This should have no impact to tests other than VAOS, since other tests are one test per module.

## Testing done
Jenkins build

## Acceptance criteria
- [ ] Retries still work

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
