### PR TITLE
Only show parent facilities that are root facilities on VAOS

### DIFF
--- a/src/applications/vaos/api/index.js
+++ b/src/applications/vaos/api/index.js
@@ -170,7 +170,11 @@ export function getSystemDetails(systemIds) {
   }
 
   return promise.then(resp =>
-    resp.data.map(item => ({ ...item.attributes, id: item.id })),
+    resp.data
+      .map(item => ({ ...item.attributes, id: item.id }))
+      // Sometimes facilities that aren't in our codes list come back, because they're
+      // marked as parents. We don't want this, so we're filtering them out
+      .filter(item => item.rootStationNumber === item.institutionCode),
   );
 }
 
@@ -188,7 +192,7 @@ export function getFacilitiesBySystemAndTypeOfCare(systemId, typeOfCareId) {
     }
   } else {
     promise = apiRequest(
-      `/vaos/systems/${systemId}/direct_scheduling_facilities?type_of_care_id=${typeOfCareId}&parent_code=${systemId}`,
+      `/vaos/systems/${systemId}/direct_scheduling_facilities?type_of_care_id=${typeOfCareId}`,
     );
   }
 

--- a/src/applications/vaos/api/index.js
+++ b/src/applications/vaos/api/index.js
@@ -174,7 +174,7 @@ export function getSystemDetails(systemIds) {
       .map(item => ({ ...item.attributes, id: item.id }))
       // Sometimes facilities that aren't in our codes list come back, because they're
       // marked as parents. We don't want this, so we're filtering them out
-      .filter(item => item.rootStationNumber === item.institutionCode),
+      .filter(item => item.rootStationCode === item.institutionCode),
   );
 }
 


### PR DESCRIPTION
## Description
We're getting back facilities that aren't root facilities, but are parent facilities, in the facilities service call, which is breaking things. This PR filters those out and then removes the `parent_code` param from a later service call so that we get all children of a root facility, rather than ones with a specific parent. This is confusing to explain!

## Testing done
Local testing

## Acceptance criteria
- [ ] Facility page works for weird systems with multiple parents

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
