### PR TITLE
bradl3yC 4632 Update Address Validation Button text and form logic

### DIFF
--- a/src/platform/user/profile/vet360/actions/transactions.js
+++ b/src/platform/user/profile/vet360/actions/transactions.js
@@ -235,6 +235,14 @@ export const validateAddress = (
 
     const selectedAddressId = confirmedSuggestions.length > 0 ? '0' : null;
 
+    // always select first address as default if there are any
+    let selectedAddress = confirmedSuggestions[0];
+
+    if (!confirmedSuggestions.length && validationKey) {
+      // if there are no confirmed suggestions and user can override, fall back to submitted address
+      selectedAddress = payload;
+    }
+
     // we use the unfiltered list of suggested addresses to determine if we need
     // to show the modal because the only time we will skip the modal is if one
     // and only one confirmed address came back from the API
@@ -246,10 +254,11 @@ export const validateAddress = (
         type: ADDRESS_VALIDATION_CONFIRM,
         addressFromUser: userEnteredAddress.address, // need to use the address with iso3 code added to it
         addressValidationType: fieldName,
-        selectedAddress: confirmedSuggestions[0], // always select the first address as the default
+        selectedAddress,
         suggestedAddresses,
         selectedAddressId,
         validationKey,
+        confirmedSuggestions,
       });
     }
     // otherwise just send the first suggestion to the API

--- a/src/platform/user/profile/vet360/containers/AddressValidationModal.jsx
+++ b/src/platform/user/profile/vet360/containers/AddressValidationModal.jsx
@@ -15,10 +15,7 @@ import {
   resetAddressValidation as resetAddressValidationAction,
 } from '../actions';
 import { getValidationMessageKey } from '../../utilities';
-import {
-  ADDRESS_VALIDATION_MESSAGES,
-  CONFIRMED,
-} from '../../constants/addressValidationMessages';
+import { ADDRESS_VALIDATION_MESSAGES } from '../../constants/addressValidationMessages';
 
 import * as VET360 from '../constants';
 
@@ -69,10 +66,18 @@ class AddressValidationModal extends React.Component {
       validationKey,
       isLoading,
       addressFromUser,
-      selectedAddressId,
+      confirmedSuggestions,
     } = this.props;
 
-    const disableButton = selectedAddressId === null;
+    let buttonText = 'Update';
+
+    if (confirmedSuggestions.length === 0 && validationKey) {
+      buttonText = 'Use this address';
+    }
+
+    if (confirmedSuggestions.length === 1) {
+      buttonText = 'Use suggested address';
+    }
 
     if (addressValidationError && !validationKey) {
       return (
@@ -88,12 +93,8 @@ class AddressValidationModal extends React.Component {
     }
 
     return (
-      <LoadingButton
-        disabled={disableButton}
-        isLoading={isLoading}
-        className="usa-button-primary"
-      >
-        Update
+      <LoadingButton isLoading={isLoading} className="usa-button-primary">
+        {buttonText}
       </LoadingButton>
     );
   };
@@ -105,6 +106,7 @@ class AddressValidationModal extends React.Component {
       addressValidationType,
       addressFromUser,
       selectedAddressId,
+      confirmedSuggestions,
     } = this.props;
     const {
       addressLine1,
@@ -116,6 +118,7 @@ class AddressValidationModal extends React.Component {
     } = address;
 
     const isAddressFromUser = id === 'userEntered';
+    const isNotSingleSuggestion = confirmedSuggestions.length > 1;
     const showEditLinkErrorState = addressValidationError && validationKey;
     const showEditLinkNonErrorState = !addressValidationError;
     const showEditLink = showEditLinkErrorState || showEditLinkNonErrorState;
@@ -125,23 +128,20 @@ class AddressValidationModal extends React.Component {
     return (
       <div
         key={id}
-        className={
-          isFirstOptionOrEnabled
-            ? 'vads-u-display--flex vads-u-flex-direction--column vads-u-justify-content--center'
-            : 'vads-u-display--flex vads-u-flex-direction--column vads-u-justify-content--center vads-u-margin-left--2 vads-u-margin-bottom--1p5'
-        }
+        className="vads-u-display--flex vads-u-flex-direction--column vads-u-margin-bottom--1p5"
       >
-        {isFirstOptionOrEnabled && (
-          <input
-            type="radio"
-            name={id}
-            disabled={isAddressFromUser && !validationKey}
-            onChange={
-              isFirstOptionOrEnabled && this.onChangeHandler(address, id)
-            }
-            checked={selectedAddressId === id}
-          />
-        )}
+        {isFirstOptionOrEnabled &&
+          isNotSingleSuggestion && (
+            <input
+              type="radio"
+              name={id}
+              disabled={isAddressFromUser && !validationKey}
+              onChange={
+                isFirstOptionOrEnabled && this.onChangeHandler(address, id)
+              }
+              checked={selectedAddressId === id}
+            />
+          )}
         <label
           htmlFor={id}
           className="vads-u-margin-top--2 vads-u-display--flex vads-u-align-items--center"
@@ -179,17 +179,13 @@ class AddressValidationModal extends React.Component {
       addressValidationError,
       closeModal,
       resetAddressValidation,
+      confirmedSuggestions,
     } = this.props;
 
     const resetDataAndCloseModal = () => {
       resetAddressValidation();
       closeModal();
     };
-
-    const confirmedSuggestions = suggestedAddresses.filter(
-      suggestion =>
-        suggestion.addressMetaData?.deliveryPointValidation === CONFIRMED,
-    );
 
     const validationMessageKey = getValidationMessageKey(
       suggestedAddresses,
@@ -259,6 +255,7 @@ const mapStateToProps = state => {
     addressValidationError:
       state.vet360.addressValidation.addressValidationError,
     suggestedAddresses: state.vet360.addressValidation.suggestedAddresses,
+    confirmedSuggestions: state.vet360.addressValidation.confirmedSuggestions,
     addressValidationType,
     validationKey: state.vet360.addressValidation.validationKey,
     addressFromUser: state.vet360.addressValidation.addressFromUser,
@@ -286,6 +283,7 @@ AddressValidationModal.propTypes = {
   isAddressValidationModalVisible: PropTypes.bool.isRequired,
   addressValidationError: PropTypes.bool.isRequired,
   suggestedAddresses: PropTypes.array.isRequired,
+  confirmedSuggestions: PropTypes.array.isRequired,
   addressValidationType: PropTypes.string.isRequired,
   validationKey: PropTypes.number,
   addressFromUser: PropTypes.object.isRequired,

--- a/src/platform/user/profile/vet360/containers/AddressValidationModal.jsx
+++ b/src/platform/user/profile/vet360/containers/AddressValidationModal.jsx
@@ -118,7 +118,7 @@ class AddressValidationModal extends React.Component {
     } = address;
 
     const isAddressFromUser = id === 'userEntered';
-    const isNotSingleSuggestion = confirmedSuggestions.length > 1;
+    const greaterThanOneSuggestion = confirmedSuggestions.length > 1;
     const showEditLinkErrorState = addressValidationError && validationKey;
     const showEditLinkNonErrorState = !addressValidationError;
     const showEditLink = showEditLinkErrorState || showEditLinkNonErrorState;
@@ -131,7 +131,7 @@ class AddressValidationModal extends React.Component {
         className="vads-u-display--flex vads-u-flex-direction--column vads-u-margin-bottom--1p5"
       >
         {isFirstOptionOrEnabled &&
-          isNotSingleSuggestion && (
+          greaterThanOneSuggestion && (
             <input
               type="radio"
               name={id}
@@ -283,7 +283,21 @@ AddressValidationModal.propTypes = {
   isAddressValidationModalVisible: PropTypes.bool.isRequired,
   addressValidationError: PropTypes.bool.isRequired,
   suggestedAddresses: PropTypes.array.isRequired,
-  confirmedSuggestions: PropTypes.array.isRequired,
+  confirmedSuggestions: PropTypes.arrayOf(
+    PropTypes.shape({
+      addressLine1: PropTypes.string.isRequired,
+      addressType: PropTypes.string.isRequired,
+      city: PropTypes.string.isRequired,
+      countryName: PropTypes.string.isRequired,
+      countryCodeIso3: PropTypes.string.isRequired,
+      countyCode: PropTypes.string.isRequired,
+      countyName: PropTypes.string.isRequired,
+      stateCode: PropTypes.string.isRequired,
+      zipCode: PropTypes.string.isRequired,
+      type: PropTypes.string.isRequired,
+      addressPou: PropTypes.string.isRequired,
+    }),
+  ),
   addressValidationType: PropTypes.string.isRequired,
   validationKey: PropTypes.number,
   addressFromUser: PropTypes.object.isRequired,

--- a/src/platform/user/profile/vet360/containers/AddressValidationModal.jsx
+++ b/src/platform/user/profile/vet360/containers/AddressValidationModal.jsx
@@ -79,7 +79,10 @@ class AddressValidationModal extends React.Component {
       buttonText = 'Use suggested address';
     }
 
-    if (addressValidationError && !validationKey) {
+    if (
+      addressValidationError ||
+      (!confirmedSuggestions.length && !validationKey)
+    ) {
       return (
         <button
           className="usa-button-primary"
@@ -128,7 +131,7 @@ class AddressValidationModal extends React.Component {
     return (
       <div
         key={id}
-        className="vads-u-display--flex vads-u-flex-direction--column vads-u-margin-bottom--1p5"
+        className="vads-u-display--flex vads-u-flex-direction--column vads-u-justify-content--center vads-u-margin-bottom--1p5"
       >
         {isFirstOptionOrEnabled &&
           greaterThanOneSuggestion && (
@@ -301,7 +304,7 @@ AddressValidationModal.propTypes = {
   addressValidationType: PropTypes.string.isRequired,
   validationKey: PropTypes.number,
   addressFromUser: PropTypes.object.isRequired,
-  selectedAddress: PropTypes.object.isRequired,
+  selectedAddress: PropTypes.object,
   selectedAddressId: PropTypes.string,
   closeModal: PropTypes.func.isRequired,
   openModal: PropTypes.func.isRequired,

--- a/src/platform/user/profile/vet360/reducers/index.js
+++ b/src/platform/user/profile/vet360/reducers/index.js
@@ -23,6 +23,7 @@ import { isFailedTransaction } from '../util/transactions';
 const initialAddressValidationState = {
   addressValidationType: '',
   suggestedAddresses: [],
+  confirmedSuggestions: [],
   addressFromUser: {
     addressLine1: '',
     addressLine2: '',
@@ -234,6 +235,7 @@ export default function vet360(state = initialState, action) {
           validationKey: action.validationKey,
           selectedAddress: action.selectedAddress,
           selectedAddressId: action.selectedAddressId,
+          confirmedSuggestions: action.confirmedSuggestions,
         },
         modal: 'addressValidation',
       };

--- a/src/platform/user/profile/vet360/tests/containers/AddressValidationModal.unit.spec.jsx
+++ b/src/platform/user/profile/vet360/tests/containers/AddressValidationModal.unit.spec.jsx
@@ -29,6 +29,7 @@ describe('<AddressValidationModal/>', () => {
           addressValidationType: 'mailingAddress',
           userEnteredAddress: {},
           validationKey: 1234,
+          confirmedSuggestions: [],
           suggestedAddresses: [
             {
               addressLine1: '12345 1st Ave',
@@ -89,7 +90,7 @@ describe('<AddressValidationModal/>', () => {
       <AddressValidationModal store={fakeStore} />,
     );
 
-    expect(component.find('LoadingButton').text()).to.equal('Update');
+    expect(component.find('LoadingButton').text()).to.equal('Use this address');
     expect(component.find('.usa-button-secondary').text()).to.equal('Cancel');
     component.unmount();
   });
@@ -116,6 +117,7 @@ describe('<AddressValidationModal/>', () => {
             isAddressValidationModalVisible: true,
             addressValidationError: true,
             suggestedAddresses: [],
+            confirmedSuggestions: [],
             addressValidationType: 'mailingAddress',
             userEnteredAddress: {},
             validationKey: null,
@@ -137,9 +139,257 @@ describe('<AddressValidationModal/>', () => {
     component.unmount();
   });
 
-  it('validates inputs', () => {
+  it('renders multiple suggestion button text', () => {
+    const newFakeStore = {
+      getState: () => ({
+        vet360: {
+          fieldTransactionMap: {
+            mailingAddress: {
+              isPending: false,
+            },
+          },
+          modal: 'addressValidation',
+          addressValidation: {
+            addressFromUser: {
+              addressLine1: '12345 1st Ave',
+              addressLine2: 'bldg 2',
+              addressLine3: 'apt 23',
+              city: 'Tampa',
+              stateCode: 'FL',
+              zipCode: '12346',
+            },
+            isAddressValidationModalVisible: true,
+            addressValidationError: false,
+            suggestedAddresses: [
+              {
+                addressLine1: '12345 1st Ave',
+                addressLine2: 'bldg 2',
+                addressLine3: 'apt 23',
+                city: 'Tampa',
+                stateCode: 'FL',
+                zipCode: '12346',
+                addressMetaData: {
+                  confidenceScore: 100.0,
+                  addressType: 'Domestic',
+                  deliveryPointValidation: 'CONFIRMED',
+                  residentialDeliveryIndicator: 'MIXED',
+                },
+              },
+              {
+                addressLine1: '22222 1st Ave',
+                addressLine2: 'bldg 2',
+                addressLine3: 'apt 23',
+                city: 'Saint Petersburg',
+                stateCode: 'FL',
+                zipCode: '55555',
+                addressMetaData: {
+                  confidenceScore: 100.0,
+                  addressType: 'Domestic',
+                  deliveryPointValidation: 'CONFIRMED',
+                  residentialDeliveryIndicator: 'MIXED',
+                },
+              },
+            ],
+            confirmedSuggestions: [
+              {
+                addressLine1: '12345 1st Ave',
+                addressLine2: 'bldg 2',
+                addressLine3: 'apt 23',
+                city: 'Tampa',
+                stateCode: 'FL',
+                zipCode: '12346',
+                addressMetaData: {
+                  confidenceScore: 100.0,
+                  addressType: 'Domestic',
+                  deliveryPointValidation: 'CONFIRMED',
+                  residentialDeliveryIndicator: 'MIXED',
+                },
+              },
+              {
+                addressLine1: '22222 1st Ave',
+                addressLine2: 'bldg 2',
+                addressLine3: 'apt 23',
+                city: 'Saint Petersburg',
+                stateCode: 'FL',
+                zipCode: '55555',
+                addressMetaData: {
+                  confidenceScore: 100.0,
+                  addressType: 'Domestic',
+                  deliveryPointValidation: 'CONFIRMED',
+                  residentialDeliveryIndicator: 'MIXED',
+                },
+              },
+            ],
+            addressValidationType: 'mailingAddress',
+            userEnteredAddress: {},
+            validationKey: 12345,
+          },
+        },
+      }),
+      subscribe: () => {},
+      dispatch: () => {},
+    };
+
     const component = enzyme.mount(
-      <AddressValidationModal store={fakeStore} />,
+      <AddressValidationModal store={newFakeStore} />,
+    );
+
+    expect(component.find('LoadingButton').text()).to.equal('Update');
+    expect(component.find('.usa-button-secondary').text()).to.equal('Cancel');
+    component.unmount();
+  });
+
+  it('renders use suggested button text', () => {
+    const newFakeStore = {
+      getState: () => ({
+        vet360: {
+          fieldTransactionMap: {
+            mailingAddress: {
+              isPending: false,
+            },
+          },
+          modal: 'addressValidation',
+          addressValidation: {
+            addressFromUser: {
+              addressLine1: '12345 1st Ave',
+              addressLine2: 'bldg 2',
+              addressLine3: 'apt 23',
+              city: 'Tampa',
+              stateCode: 'FL',
+              zipCode: '12346',
+            },
+            isAddressValidationModalVisible: true,
+            addressValidationError: false,
+            suggestedAddresses: [
+              {
+                addressLine1: '12345 1st Ave',
+                addressLine2: 'bldg 2',
+                addressLine3: 'apt 23',
+                city: 'Tampa',
+                stateCode: 'FL',
+                zipCode: '12346',
+                addressMetaData: {
+                  confidenceScore: 100.0,
+                  addressType: 'Domestic',
+                  deliveryPointValidation: 'CONFIRMED',
+                  residentialDeliveryIndicator: 'MIXED',
+                },
+              },
+              {
+                addressLine1: '22222 1st Ave',
+                addressLine2: 'bldg 2',
+                addressLine3: 'apt 23',
+                city: 'Saint Petersburg',
+                stateCode: 'FL',
+                zipCode: '55555',
+                addressMetaData: {
+                  confidenceScore: 100.0,
+                  addressType: 'Domestic',
+                  deliveryPointValidation: 'CONFIRMED',
+                  residentialDeliveryIndicator: 'MIXED',
+                },
+              },
+            ],
+            confirmedSuggestions: [
+              {
+                addressLine1: '12345 1st Ave',
+                addressLine2: 'bldg 2',
+                addressLine3: 'apt 23',
+                city: 'Tampa',
+                stateCode: 'FL',
+                zipCode: '12346',
+                addressMetaData: {
+                  confidenceScore: 100.0,
+                  addressType: 'Domestic',
+                  deliveryPointValidation: 'CONFIRMED',
+                  residentialDeliveryIndicator: 'MIXED',
+                },
+              },
+            ],
+            addressValidationType: 'mailingAddress',
+            userEnteredAddress: {},
+            validationKey: null,
+          },
+        },
+      }),
+      subscribe: () => {},
+      dispatch: () => {},
+    };
+
+    const component = enzyme.mount(
+      <AddressValidationModal store={newFakeStore} />,
+    );
+
+    expect(component.find('LoadingButton').text()).to.equal(
+      'Use suggested address',
+    );
+    expect(component.find('.usa-button-secondary').text()).to.equal('Cancel');
+    component.unmount();
+  });
+
+  it('validates inputs', () => {
+    const newFakeStore = {
+      getState: () => ({
+        vet360: {
+          fieldTransactionMap: {
+            mailingAddress: {
+              isPending: false,
+            },
+          },
+          modal: 'addressValidation',
+          addressValidation: {
+            addressFromUser: {
+              addressLine1: '12345 1st Ave',
+              addressLine2: 'bldg 2',
+              addressLine3: 'apt 23',
+              city: 'Tampa',
+              stateCode: 'FL',
+              zipCode: '12346',
+            },
+            isAddressValidationModalVisible: true,
+            addressValidationError: true,
+            suggestedAddresses: [],
+            confirmedSuggestions: [
+              {
+                addressLine1: '12345 1st Ave',
+                addressLine2: 'bldg 2',
+                addressLine3: 'apt 23',
+                city: 'Tampa',
+                stateCode: 'FL',
+                zipCode: '12346',
+                addressMetaData: {
+                  confidenceScore: 100.0,
+                  addressType: 'Domestic',
+                  deliveryPointValidation: 'CONFIRMED',
+                  residentialDeliveryIndicator: 'MIXED',
+                },
+              },
+              {
+                addressLine1: '22222 1st Ave',
+                addressLine2: 'bldg 2',
+                addressLine3: 'apt 23',
+                city: 'Saint Petersburg',
+                stateCode: 'FL',
+                zipCode: '55555',
+                addressMetaData: {
+                  confidenceScore: 100.0,
+                  addressType: 'Domestic',
+                  deliveryPointValidation: 'CONFIRMED',
+                  residentialDeliveryIndicator: 'MIXED',
+                },
+              },
+            ],
+            addressValidationType: 'mailingAddress',
+            userEnteredAddress: {},
+            validationKey: null,
+          },
+        },
+      }),
+      subscribe: () => {},
+      dispatch: () => {},
+    };
+    const component = enzyme.mount(
+      <AddressValidationModal store={newFakeStore} />,
     );
 
     expect(

--- a/src/platform/user/profile/vet360/tests/reducers/index.unit.spec.js
+++ b/src/platform/user/profile/vet360/tests/reducers/index.unit.spec.js
@@ -336,6 +336,7 @@ describe('vet360 reducer', () => {
           selectedAddress: {},
           selectedAddressId: null,
           suggestedAddresses: [],
+          confirmedSuggestions: [],
           validationKey: null,
         },
         fieldTransactionMap: {
@@ -354,6 +355,7 @@ describe('vet360 reducer', () => {
         modalData: { foo: 'bar' },
         addressValidation: {
           addressValidationType: 'address',
+          confirmedSuggestions: [],
           suggestedAddresses: [{ street: '123 Main St' }],
           addressFromUser: {
             addressLine1: '123 main',
@@ -377,6 +379,7 @@ describe('vet360 reducer', () => {
         addressValidation: {
           addressValidationType: '',
           suggestedAddresses: [],
+          confirmedSuggestions: [],
           addressFromUser: {
             addressLine1: '',
             addressLine2: '',


### PR DESCRIPTION
## Description
- [x] - If only one option or selection - do not show the radio button but still keep it as the default selection if user elects to continue - button text should read 'Use suggested address' 
- [x] -  If no suggested addresses are presented and the user can 'override' - change button text to 'Use this address' - pressing to continue should send the payload with the user entered address.
- [x] - If multiple confirmed addresses are presented, the first option should be default selected, pressing continue will submit that address as the payload


## Testing done
Updated and added new unit test coverage

## Screenshots

### 1. 
![Screen Shot 2020-01-08 at 1 03 07 PM](https://user-images.githubusercontent.com/6165421/72005252-2f762880-321b-11ea-8a8d-0265ca9be318.png)
![singleSuggestionPayload](https://user-images.githubusercontent.com/6165421/72005821-757fbc00-321c-11ea-9e45-fe7cd0b99b39.png)


### 2.
![noSuggestionsCanOverride](https://user-images.githubusercontent.com/6165421/72005749-51bc7600-321c-11ea-9736-3450640cddee.png)
![payloadUserEntered](https://user-images.githubusercontent.com/6165421/72005758-54b76680-321c-11ea-8f62-f64a3fea9474.png)


### 3.
![Screen Shot 2020-01-08 at 1 04 52 PM](https://user-images.githubusercontent.com/6165421/72005384-7f54ef80-321b-11ea-8628-3dbc46537de0.png)
![payloadFirstSuggestion](https://user-images.githubusercontent.com/6165421/72005925-a5c75a80-321c-11ea-978a-29e7e8669d3d.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
