### PR TITLE
Added helper method to sort states

### DIFF
--- a/src/applications/gi/components/search/InstitutionFilterForm.jsx
+++ b/src/applications/gi/components/search/InstitutionFilterForm.jsx
@@ -4,7 +4,11 @@ import React from 'react';
 import Checkbox from '../Checkbox';
 import Dropdown from '../Dropdown';
 import SearchResultTypeOfInstitutionFilter from './SearchResultTypeOfInstitutionFilter';
-import { addAllOption, getStateNameForCode } from '../../utils/helpers';
+import {
+  addAllOption,
+  getStateNameForCode,
+  sortOptionsByStateName,
+} from '../../utils/helpers';
 
 class InstitutionFilterForm extends React.Component {
   handleDropdownChange = e => {
@@ -49,13 +53,13 @@ class InstitutionFilterForm extends React.Component {
       value: state,
       label: getStateNameForCode(state),
     }));
-
+    const sortedOptions = options.sort(sortOptionsByStateName);
     return (
       <Dropdown
         label="State"
         name="state"
         alt="Filter results by state"
-        options={addAllOption(options)}
+        options={addAllOption(sortedOptions)}
         value={this.props.filters.state}
         onChange={this.handleDropdownChange}
         visible

--- a/src/applications/gi/tests/utils/helpers.unit.spec.js
+++ b/src/applications/gi/tests/utils/helpers.unit.spec.js
@@ -87,16 +87,18 @@ describe('GIBCT helpers:', () => {
   describe('sortOptionsByStateName', () => {
     it('should sort an array of objects by label', () => {
       const data = [
-        { value: 'AP', label: 'Apple' },
-        { value: 'OG', label: 'Orange' },
-        { value: 'GP', label: 'Grape' },
-        { value: 'BN', label: 'Banana' },
+        { value: 'AK', label: 'Alaska' },
+        { value: 'AL', label: 'Alabama' },
+        { value: 'AR', label: 'Arkansas' },
+        { value: 'AZ', label: 'Arizona' },
+        { value: 'CA', label: 'California' },
       ];
       const sortedData = [
-        { value: 'AP', label: 'Apple' },
-        { value: 'BN', label: 'Banana' },
-        { value: 'GP', label: 'Grape' },
-        { value: 'OG', label: 'Orange' },
+        { value: 'AL', label: 'Alabama' },
+        { value: 'AK', label: 'Alaska' },
+        { value: 'AZ', label: 'Arizona' },
+        { value: 'AR', label: 'Arkansas' },
+        { value: 'CA', label: 'California' },
       ];
       expect(data.sort(sortOptionsByStateName)).to.deep.equal(sortedData);
     });

--- a/src/applications/gi/tests/utils/helpers.unit.spec.js
+++ b/src/applications/gi/tests/utils/helpers.unit.spec.js
@@ -8,6 +8,7 @@ import {
   isCountryUSA,
   isCountryInternational,
   rubyifyKeys,
+  sortOptionsByStateName,
 } from '../../utils/helpers';
 
 describe('GIBCT helpers:', () => {
@@ -80,6 +81,24 @@ describe('GIBCT helpers:', () => {
         testKey: ['a', 'b'],
       };
       expect(rubyifyKeys(data)).to.have.key('test_key[]');
+    });
+  });
+
+  describe('sortOptionsByStateName', () => {
+    it('should sort an array of objects by label', () => {
+      const data = [
+        { value: 'AP', label: 'Apple' },
+        { value: 'OG', label: 'Orange' },
+        { value: 'GP', label: 'Grape' },
+        { value: 'BN', label: 'Banana' },
+      ];
+      const sortedData = [
+        { value: 'AP', label: 'Apple' },
+        { value: 'BN', label: 'Banana' },
+        { value: 'GP', label: 'Grape' },
+        { value: 'OG', label: 'Orange' },
+      ];
+      expect(data.sort(sortOptionsByStateName)).to.deep.equal(sortedData);
     });
   });
 });

--- a/src/applications/gi/utils/helpers.js
+++ b/src/applications/gi/utils/helpers.js
@@ -72,3 +72,13 @@ export const getStateNameForCode = stateCode => {
   );
   return stateLabel !== undefined ? stateLabel.label : stateCode.toUpperCase();
 };
+
+export const sortOptionsByStateName = (stateA, stateB) => {
+  if (stateA.label < stateB.label) {
+    return -1;
+  }
+  if (stateA.label > stateB.label) {
+    return 1;
+  }
+  return 0;
+};


### PR DESCRIPTION
## Description
State names in the GIBCT states dropdown need to be sorted in alphabetical order.

Story:
https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/4737

## Testing done
Local testing completed

## Screenshots

<img width="249" alt="Screen Shot 2020-01-09 at 6 11 29 PM" src="https://user-images.githubusercontent.com/50601724/72120726-e8755980-3326-11ea-8a42-df3c16fba07f.png">



## Acceptance criteria
- [x] Sort the state names in alphabetical order

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
