### PR TITLE
VAGOV-6390: Updating social block to be consistent on facility pages.

### DIFF
--- a/src/site/facilities/facility_social_links.drupal.liquid
+++ b/src/site/facilities/facility_social_links.drupal.liquid
@@ -4,7 +4,7 @@
 
         {% if fieldGovdeliveryIdEmerg != empty or if fieldGovdeliveryIdNews != empty %}
             <div class="usa-width-one-half social-links">
-                {% if fieldLinkFacilityNewsList != empty %}
+                {% if fieldGovdeliveryIdNews != empty %}
                         <div class="social-links-email vads-u-margin-bottom--2">
                             <a class="vads-u-display--flex vads-u-align-items--baseline vads-u-text-decoration--none"
                                 target="_blank" href="https://public.govdelivery.com/accounts/USVHA/subscriber/new?topic_id={{ fieldGovdeliveryIdNews }}">

--- a/src/site/layouts/health_care_local_facility.drupal.liquid
+++ b/src/site/layouts/health_care_local_facility.drupal.liquid
@@ -408,9 +408,16 @@ more.\r\n",
 
 
           <!-- Social Links -->
-          {% if fieldFacebook != empty || fieldFlickr != empty || fieldInstagram != empty || fieldTwitter != empty || fieldEmailSubscription != empty || (fieldLinks != empty and fieldLinks.length)%}
-          {% include "src/site/facilities/facility_social_links.drupal.liquid" with regionNickname = fieldRegionPage.entity.fieldNicknameForThisFacility %}
-          {% endif %}
+          {% include "src/site/facilities/facility_social_links.drupal.liquid"
+          with regionNickname = fieldRegionPage.entity.fieldNicknameForThisFacility
+          fieldGovdeliveryIdEmerg = fieldRegionPage.entity.fieldGovdeliveryIdEmerg
+          fieldGovdeliveryIdNews = fieldRegionPage.entity.fieldGovdeliveryIdNews
+          fieldOperatingStatus = fieldRegionPage.entity.fieldOperatingStatus
+          fieldFacebook = fieldRegionPage.entity.fieldFacebook
+          fieldTwitter = fieldRegionPage.entity.fieldTwitter
+          fieldFlickr = fieldRegionPage.entity.fieldFlickr
+          fieldInstagram = fieldRegionPage.entity.fieldInstagram
+          %}
 
         </article>
         <div class="last-updated usa-content">

--- a/src/site/stages/build/drupal/graphql/healthCareLocalFacilityPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/healthCareLocalFacilityPage.graphql.js
@@ -21,6 +21,43 @@ module.exports = `
         }
       }
     }
+    fieldRegionPage {
+      entity {
+        ... on NodeHealthCareRegionPage {
+          fieldFacebook {
+            title
+            url {
+              path
+            }
+          }
+          fieldTwitter {
+            title
+            url {
+              path
+            }
+          }
+          fieldFlickr {
+            title
+            url {
+              path
+            }
+          }
+          fieldInstagram {
+            title
+            url {
+              path
+            }
+          }
+          fieldGovdeliveryIdEmerg
+          fieldGovdeliveryIdNews
+          fieldOperatingStatus {
+            url {
+              path
+            }
+          }
+        }
+      }
+    }
     fieldAddress {
       addressLine1
       locality


### PR DESCRIPTION
## Description
Makes social block on facility pages consistent with system pages

## Testing done
Visual

## Screenshots
![image](https://user-images.githubusercontent.com/2404547/72181512-87e22d00-33b7-11ea-96a6-945b344fef41.png)

## Acceptance criteria
- [ ] Social block should look the same here: `/pittsburgh-health-care/`, as it does here: `/pittsburgh-health-care/locations/pittsburgh-va-medical-center-university-drive/`