### PR TITLE
Fix supported sites endpoint url

### DIFF
--- a/src/applications/vaos/api/index.js
+++ b/src/applications/vaos/api/index.js
@@ -361,7 +361,7 @@ export function getSitesSupportingVAR(systemIds) {
     );
   } else {
     promise = apiRequest(
-      `/vaos/community_care/supported_sites?site_codes=${systemIds
+      `/vaos/community_care/supported_sites?${systemIds
         .map(id => `site_codes[]=${id}`)
         .join('&')}`,
     );

--- a/src/applications/vaos/tests/e2e/community-care.e2e.spec.js
+++ b/src/applications/vaos/tests/e2e/community-care.e2e.spec.js
@@ -41,7 +41,7 @@ module.exports = {
   'What date and time would you like to make an appointment?': client => {
     VAOSHelpers.appointmentDateTimeTest(
       client,
-      'Share your community care provider preferences',
+      'Tell us your Community Care preferences',
     );
   },
   'Share your community care provider preferences': client => {


### PR DESCRIPTION
## Description
Fix endpoint url which was adding an extra `site_codes=` at the beginning of the query

## Testing done
Local and unit

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
