### PR TITLE
Extend appt list dates to 1 year

### DIFF
--- a/src/applications/vaos/actions/appointments.js
+++ b/src/applications/vaos/actions/appointments.js
@@ -73,14 +73,14 @@ export function fetchFutureAppointments() {
               .toISOString(),
             moment()
               .startOf('day')
-              .add(120, 'days')
+              .add(1, 'years')
               .toISOString(),
           ),
           getConfirmedAppointments(
             'cc',
             moment().format('YYYY-MM-DD'),
             moment()
-              .add(120, 'days')
+              .add(1, 'years')
               .format('YYYY-MM-DD'),
           ),
           getPendingAppointments(


### PR DESCRIPTION
## Description
We should fetch a year's worth of future appointments, to better match the appointment list in other systems.

## Testing done
Tested service on staging

## Acceptance criteria
- [ ] Date params are set to 1 year out

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
