### PR TITLE
Fix errors when refreshing review and confirmation pages

### DIFF
--- a/src/applications/vaos/components/ConfirmationRequestInfo.jsx
+++ b/src/applications/vaos/components/ConfirmationRequestInfo.jsx
@@ -136,7 +136,7 @@ export default function ConfirmationRequestInfo({
               </dt>
               <dd>
                 <ul className="usa-unstyled-list">
-                  {data.calendarData.selectedDates.map(
+                  {data.calendarData?.selectedDates.map(
                     ({ date, optionTime }) => (
                       <li key={`${date}-${optionTime}`}>
                         {moment(date).format('MMMM D, YYYY')}{' '}

--- a/src/applications/vaos/components/review/Description.jsx
+++ b/src/applications/vaos/components/review/Description.jsx
@@ -4,7 +4,7 @@ import { FLOW_TYPES, FACILITY_TYPES } from '../../utils/constants';
 import { lowerCase } from '../../utils/appointment';
 
 export default function Description({ data, flowType }) {
-  const typeOfCare = lowerCase(getTypeOfCare(data).name);
+  const typeOfCare = lowerCase(getTypeOfCare(data)?.name);
   const description =
     data.facilityType === FACILITY_TYPES.COMMUNITY_CARE
       ? 'Community Care'

--- a/src/applications/vaos/utils/appointment.jsx
+++ b/src/applications/vaos/utils/appointment.jsx
@@ -80,7 +80,7 @@ export function sentenceCase(str) {
     .join(' ');
 }
 
-export function lowerCase(str) {
+export function lowerCase(str = '') {
   return str
     .split(' ')
     .map(word => {


### PR DESCRIPTION
## Description
When you refresh the review or confirmation page, you get an error, when you should actually get sent back to the start of the form.

## Testing done
Local testing

## Acceptance criteria
- [ ] Refreshing takes you to the start of the form on all pages

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
