### PR TITLE
Remove max-width queries in VAOS SASS, clean up lint errors

### DIFF
--- a/src/applications/vaos/components/AppointmentRequestListItem.jsx
+++ b/src/applications/vaos/components/AppointmentRequestListItem.jsx
@@ -99,8 +99,8 @@ export default class AppointmentRequestListItem extends React.Component {
             </div>
           </span>
         </div>
-        <div className="vaos-appts__split-section vads-u-margin-top--2">
-          <div className="vads-u-flex--1 vads-u-margin-right--1">
+        <div className="vads-u-display--flex vads-u-flex-direction--column small-screen:vads-u-flex-direction--row">
+          <div className="vads-u-flex--1 vads-u-margin-right--1 vads-u-margin-top--2">
             <dl className="vads-u-margin--0">
               <dt className="vads-u-font-weight--bold">
                 {getLocationHeader(appointment)}
@@ -108,7 +108,7 @@ export default class AppointmentRequestListItem extends React.Component {
               <dd>{getAppointmentLocation(appointment, facility)}</dd>
             </dl>
           </div>
-          <div className="vads-u-flex--1 vaos-appts__preferred-dates">
+          <div className="vads-u-flex--1 vads-u-margin-top--2">
             <dl className="vads-u-margin--0">
               <dt className="vads-u-font-weight--bold">
                 Preferred date and time
@@ -126,7 +126,7 @@ export default class AppointmentRequestListItem extends React.Component {
             triggerText={showMore ? 'Show less' : 'Show more'}
             onClick={this.toggleShowMore}
           >
-            <div className="vaos-appts__split-section">
+            <div className="vads-u-display--flex vads-u-flex-direction--column small-screen:vads-u-flex-direction--row">
               <div className="vaos_appts__message vads-u-flex--1">
                 <dl className="vads-u-margin--0">
                   <dt className="vads-u-font-weight--bold">
@@ -135,7 +135,7 @@ export default class AppointmentRequestListItem extends React.Component {
                   <dd>{firstMessage}</dd>
                 </dl>
               </div>
-              <div className="vads-u-flex--1">
+              <div className="vads-u-flex--1 vads-u-margin-top--2 small-screen:vads-u-margin-top--0">
                 <dl className="vads-u-margin--0">
                   <dt className="vads-u-font-weight--bold vads-u-display--block">
                     Your contact details

--- a/src/applications/vaos/components/ConfirmationDirectScheduleInfo.jsx
+++ b/src/applications/vaos/components/ConfirmationDirectScheduleInfo.jsx
@@ -28,18 +28,16 @@ export default function ConfirmationDirectScheduleInfo({
             'MMMM D, YYYY [at] hh:mm a',
           )}{' '}
         </h2>
-        <div className="vads-u-display--flex vads-u-justify-content--space-between vads-u-margin-top--2">
-          <div className="vaos-appts__status vads-u-flex--1">
-            <i className="fas fa-check-circle" />
-            <span className="vads-u-font-weight--bold vads-u-margin-left--1 vads-u-display--inline-block">
-              Confirmed
-              <span className="sr-only"> appointment</span>
-            </span>
-          </div>
+        <div className="vads-u-margin-top--2">
+          <i className="fas fa-check-circle" />
+          <span className="vads-u-font-weight--bold vads-u-margin-left--1 vads-u-display--inline-block">
+            Confirmed
+            <span className="sr-only"> appointment</span>
+          </span>
         </div>
 
-        <div className="vaos-appts__split-section vads-u-margin-top--2">
-          <div className="vads-u-flex--1">
+        <div className="vads-u-display--flex vads-u-flex-direction--column small-screen:vads-u-flex-direction--row">
+          <div className="vads-u-flex--1 vads-u-margin-top--2">
             <dl className="vads-u-margin--0">
               <dt className="vads-u-font-weight--bold">
                 {clinic?.clinicFriendlyLocationName || clinic?.clinicName}
@@ -55,7 +53,7 @@ export default function ConfirmationDirectScheduleInfo({
               </dd>
             </dl>
           </div>
-          <div className="vads-u-flex--1">
+          <div className="vads-u-flex--1 vads-u-margin-top--2">
             <dl className="vads-u-margin--0">
               <dt className="vads-u-font-weight--bold">
                 {

--- a/src/applications/vaos/components/ConfirmationRequestInfo.jsx
+++ b/src/applications/vaos/components/ConfirmationRequestInfo.jsx
@@ -70,8 +70,8 @@ export default function ConfirmationRequestInfo({
             </div>
           </span>
         </div>
-        <div className="vaos-appts__split-section vads-u-margin-top--2">
-          <div className="vads-u-flex--1 vads-u-margin-right--1">
+        <div className="vads-u-display--flex vads-u-flex-direction--column small-screen:vads-u-flex-direction--row">
+          <div className="vads-u-flex--1 vads-u-margin-right--1 vads-u-margin-top--2">
             <dl className="vads-u-margin--0">
               {isCommunityCare &&
                 !data.hasCommunityCareProvider && (
@@ -129,7 +129,7 @@ export default function ConfirmationRequestInfo({
                 )}
             </dl>
           </div>
-          <div className="vads-u-flex--1 vaos-appts__preferred-dates">
+          <div className="vads-u-flex--1 vads-u-margin-top--2">
             <dl className="vads-u-margin--0">
               <dt className="vads-u-font-weight--bold">
                 Preferred date and time
@@ -156,7 +156,7 @@ export default function ConfirmationRequestInfo({
             triggerText={isAdditionalInfoOpen ? 'Show less' : 'Show more'}
             onClick={() => toggleAdditionalInfo(!isAdditionalInfoOpen)}
           >
-            <div className="vaos-appts__split-section">
+            <div className="vads-u-display--flex vads-u-flex-direction--column small-screen:vads-u-flex-direction--row">
               <div className="vaos_appts__message vads-u-flex--1">
                 <dl className="vads-u-margin--0">
                   <dt className="vads-u-font-weight--bold">
@@ -169,7 +169,7 @@ export default function ConfirmationRequestInfo({
                   <dd>{data.reasonAdditionalInfo}</dd>
                 </dl>
               </div>
-              <div className="vads-u-flex--1">
+              <div className="vads-u-flex--1 vads-u-margin-top--2 small-screen:vads-u-margin-top--0">
                 <dl className="vads-u-margin--0">
                   <dt className="vads-u-font-weight--bold vads-u-display--block">
                     Your contact details

--- a/src/applications/vaos/components/ConfirmedAppointmentListItem.jsx
+++ b/src/applications/vaos/components/ConfirmedAppointmentListItem.jsx
@@ -55,25 +55,23 @@ export default function ConfirmedAppointmentListItem({
       <h2 className="vaos-appts__date-time vads-u-font-size--lg vads-u-margin-x--0">
         {getAppointmentDateTime(appointment)}
       </h2>
-      <div className="vads-u-display--flex vads-u-justify-content--space-between vads-u-margin-top--2">
-        <div className="vaos-appts__status vads-u-flex--1">
-          {canceled ? (
-            <i className="fas fa-exclamation-circle" />
-          ) : (
-            <i className="fas fa-check-circle" />
-          )}
-          <span
-            id={`card-${index}`}
-            className="vads-u-font-weight--bold vads-u-margin-left--1 vads-u-display--inline-block"
-          >
-            {canceled ? 'Canceled' : 'Confirmed'}
-            <span className="sr-only"> appointment</span>
-          </span>
-        </div>
+      <div className="vads-u-margin-top--2">
+        {canceled ? (
+          <i className="fas fa-exclamation-circle" />
+        ) : (
+          <i className="fas fa-check-circle" />
+        )}
+        <span
+          id={`card-${index}`}
+          className="vads-u-font-weight--bold vads-u-margin-left--1 vads-u-display--inline-block"
+        >
+          {canceled ? 'Canceled' : 'Confirmed'}
+          <span className="sr-only"> appointment</span>
+        </span>
       </div>
 
-      <div className="vaos-appts__split-section vads-u-margin-top--2">
-        <div className="vads-u-flex--1">
+      <div className="vads-u-display--flex vads-u-flex-direction--column small-screen:vads-u-flex-direction--row">
+        <div className="vads-u-flex--1 vads-u-margin-top--2">
           {isVideoVisit(appointment) ? (
             <VideoVisitSection appointment={appointment} />
           ) : (
@@ -86,7 +84,7 @@ export default function ConfirmedAppointmentListItem({
           )}
         </div>
         {hasInstructions(appointment) && (
-          <div className="vads-u-flex--1">
+          <div className="vads-u-flex--1 vads-u-margin-top--2">
             <dl className="vads-u-margin--0">
               <dt className="vads-u-font-weight--bold">
                 {getAppointmentInstructionsHeader(appointment)}

--- a/src/applications/vaos/sass/vaos.scss
+++ b/src/applications/vaos/sass/vaos.scss
@@ -1,5 +1,5 @@
-@import '~@department-of-veterans-affairs/formation/sass/shared-variables';
-@import '../../../platform/forms/sass/m-schemaform';
+@import "~@department-of-veterans-affairs/formation/sass/shared-variables";
+@import "../../../platform/forms/sass/m-schemaform";
 
 .vaos-option-list__icon {
   display: inline-block;
@@ -46,7 +46,7 @@
 }
 
 .vaos-form__detailed-radio {
-  input[type='radio'] + label::before {
+  input[type="radio"] + label::before {
     margin-top: 0.6em;
   }
 
@@ -86,7 +86,7 @@
   flex-grow: 1;
   flex-basis: 0;
   margin: 4px;
-  
+
   @include media($small-screen) {
     margin: 8px;
   }

--- a/src/applications/vaos/sass/vaos.scss
+++ b/src/applications/vaos/sass/vaos.scss
@@ -12,36 +12,8 @@
   padding: 14px 0 0 17px;
 }
 
-.vaos-appts__status {
-  @media (max-width: $small-screen) {
-    display: flex;
-  }
-}
-
-.vaos-appts__cancel-btn {
-  @media (max-width: $small-screen) {
-    max-width: 90px;
-  }
-}
-
 .vaos-appts__date-time {
   margin: 0 0 16px;
-
-  @media (max-width: $small-screen) {
-    margin: 16px 0;
-  }
-}
-
-.vaos-appts__split-section {
-  display: flex;
-
-  @media (max-width: $small-screen) {
-    flex-direction: column;
-
-    .vaos-appts__preferred-dates {
-      margin-bottom: 16px;
-    }
-  }
 }
 
 .vaos-appts__block-label {
@@ -113,7 +85,11 @@
 .vaos-calendar__calendar-day {
   flex-grow: 1;
   flex-basis: 0;
-  margin: 8px;
+  margin: 4px;
+  
+  @include media($small-screen) {
+    margin: 8px;
+  }
 
   button {
     width: 100%;
@@ -238,25 +214,19 @@
   border-radius: 5px;
   padding: 8px 4px;
 
-  input[type='radio'],
-  input[type='checkbox'] {
+  input[type="radio"],
+  input[type="checkbox"] {
     width: unset;
   }
 
-  input[type='radio'] + label::before {
+  input[type="radio"] + label::before {
     margin-top: 0;
     box-shadow: 0 0 0 2px $color-white, 0 0 0 3px $color-primary;
   }
 
-  input[type='checkbox'] + label::before {
+  input[type="checkbox"] + label::before {
     margin-top: 0;
     box-shadow: 0 0 0 1px $color-primary;
-  }
-}
-
-@media (max-width: $small-screen) {
-  .vaos-calendar__calendar-day {
-    margin: 4px;
   }
 }
 

--- a/src/applications/vaos/tests/components/AppointmentRequestListItem.unit.spec.jsx
+++ b/src/applications/vaos/tests/components/AppointmentRequestListItem.unit.spec.jsx
@@ -62,7 +62,7 @@ describe('VAOS <AppointmentRequestListItem>', () => {
     const toggleExpand = tree.find('AdditionalInfo');
     toggleExpand.props().onClick();
 
-    const preferredDates = tree.find('.vaos-appts__preferred-dates li');
+    const preferredDates = tree.find('ul li');
 
     expect(preferredDates.at(0).text()).to.equal(
       'Wed, May 22, 2019 in the afternoon',
@@ -176,8 +176,10 @@ describe('VAOS <AppointmentRequestListItem>', () => {
 
     const toggleExpand = tree.find('AdditionalInfo');
     toggleExpand.props().onClick();
-
-    const preferredDates = tree.find('.vaos-appts__preferred-dates li');
+    const preferredDates = tree
+      .find('ul')
+      .at(1)
+      .find('li');
 
     expect(preferredDates.at(0).text()).to.equal(
       'Wed, May 22, 2019 in the afternoon',

--- a/src/applications/vaos/tests/components/ConfirmedAppointmentListItem.unit.spec.jsx
+++ b/src/applications/vaos/tests/components/ConfirmedAppointmentListItem.unit.spec.jsx
@@ -63,8 +63,8 @@ describe('VAOS <ConfirmedAppointmentListItem> Regular Appointment', () => {
   it('should have a status of "confirmed"', () => {
     expect(
       tree
-        .find('.vaos-appts__status span')
-        .at(0)
+        .find('span')
+        .at(2)
         .text(),
     ).to.contain('Confirmed');
   });
@@ -81,7 +81,7 @@ describe('VAOS <ConfirmedAppointmentListItem> Regular Appointment', () => {
   it('should display clinic name', () => {
     expect(
       tree
-        .find('.vaos-appts__split-section dt')
+        .find('dt')
         .first()
         .text(),
     ).to.contain('C&P BEV AUDIO FTC1');
@@ -116,8 +116,8 @@ describe('VAOS <ConfirmedAppointmentListItem> Community Care Appointment', () =>
   it('should have a status of "confirmed"', () => {
     expect(
       tree
-        .find('.vaos-appts__status span')
-        .at(0)
+        .find('span')
+        .at(2)
         .text(),
     ).to.contain('Confirmed');
   });
@@ -132,13 +132,11 @@ describe('VAOS <ConfirmedAppointmentListItem> Community Care Appointment', () =>
   });
 
   it('should display clinic name', () => {
-    expect(tree.find('.vaos-appts__split-section dt').text()).to.contain(
-      'My Clinic',
-    );
+    expect(tree.find('dt').text()).to.contain('My Clinic');
   });
 
   it('should display clinic address', () => {
-    expect(tree.find('.vaos-appts__split-section dd').text()).to.contain(
+    expect(tree.find('dd').text()).to.contain(
       '123 second stNorthampton, MA 22222',
     );
   });


### PR DESCRIPTION
## Description
This removes max-width media query code from the VAOS scss file, since we should write styles mobile first. This led me to replacing some classes with utilities, since some of them were simplified with this process or were already dead code.

I've also cleaned up the linter warnings we were generating.

## Testing done
Local and unit testing

## Screenshots
Matches existing screens

## Acceptance criteria
- [ ] Screens look the same and there are no max-width media queries

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
