### PR TITLE
VAGOV-6403: Adding breadcrumb cleanup logic.

### DIFF
--- a/src/platform/site-wide/breadcrumb-title-match.js
+++ b/src/platform/site-wide/breadcrumb-title-match.js
@@ -1,10 +1,13 @@
 // Nodes with identical titles result in url strings with digits appended.
 // This creates ugly breadcrumbs - logic below prevents this.
-const lastCrumb = document.querySelector('#va-breadcrumbs-list li:last-child a')
-  .textContent;
-const pageTitle = document.getElementsByTagName('h1')[0].innerHTML;
-if (pageTitle !== undefined && lastCrumb !== pageTitle) {
-  document.querySelector(
+document.addEventListener('DOMContentLoaded', () => {
+  const lastCrumb = document.querySelector(
     '#va-breadcrumbs-list li:last-child a',
-  ).textContent = pageTitle;
-}
+  ).textContent;
+  const pageTitle = document.getElementsByTagName('h1')[0].innerHTML;
+  if (pageTitle !== undefined && lastCrumb !== pageTitle) {
+    document.querySelector(
+      '#va-breadcrumbs-list li:last-child a',
+    ).textContent = pageTitle;
+  }
+});

--- a/src/platform/site-wide/breadcrumb-title-match.js
+++ b/src/platform/site-wide/breadcrumb-title-match.js
@@ -4,7 +4,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const lastCrumb = document.querySelector(
     '#va-breadcrumbs-list li:last-child a',
   ).textContent;
-  const pageTitle = document.getElementsByTagName('h1')[0].innerHTML;
+  const pageTitle = document.getElementsByTagName('h1')[0].textContent;
   if (pageTitle !== undefined && lastCrumb !== pageTitle) {
     document.querySelector(
       '#va-breadcrumbs-list li:last-child a',

--- a/src/platform/site-wide/breadcrumb-title-match.js
+++ b/src/platform/site-wide/breadcrumb-title-match.js
@@ -1,0 +1,10 @@
+// Nodes with identical titles result in url strings with digits appended.
+// This creates ugly breadcrumbs - logic below prevents this.
+const lastCrumb = document.querySelector('#va-breadcrumbs-list li:last-child a')
+  .textContent;
+const pageTitle = document.getElementsByTagName('h1')[0].innerHTML;
+if (pageTitle !== undefined && lastCrumb !== pageTitle) {
+  document.querySelector(
+    '#va-breadcrumbs-list li:last-child a',
+  ).textContent = pageTitle;
+}

--- a/src/platform/site-wide/index.js
+++ b/src/platform/site-wide/index.js
@@ -7,6 +7,7 @@ import './legacy/menu'; // Used in the footer.
 import './moment-setup';
 import './popups';
 import './wysiwyg-analytics-setup';
+import './breadcrumb-title-match';
 import addMenuListeners from './accessible-menus';
 import startUserNavWidget from './user-nav';
 import startMegaMenuWidget from './mega-menu';


### PR DESCRIPTION
## Description
Breadcrumbs are generated from path url string being chopped up into array. In cases of content with duplicate title, we end up with number strings being appended to the url, resulting in ugly breadcrumbs, e.g.: `/pittsburgh-health-care/events/mindful-mondays-0/` has active crumb read as `Mindful mondays-0`
This pr addresses this behavior by checking to see if the page title and last crumb are out of sync, and changes the last crumb to match the page title if they are

## Testing done
Visual

## Screenshots
![image](https://user-images.githubusercontent.com/2404547/72293384-697f6a00-3621-11ea-8148-77a96b138902.png)
![image](https://user-images.githubusercontent.com/2404547/72293373-64221f80-3621-11ea-9480-a169b51f9f5d.png)
