### PR TITLE
Metatags helper

### DIFF
--- a/src/site/stages/build/process-cms-exports/tests/transformed-entities/node-page.json
+++ b/src/site/stages/build/process-cms-exports/tests/transformed-entities/node-page.json
@@ -49,34 +49,49 @@
   "entityPublished": true,
   "entityMetaTags": [
     {
-      "type": "MetaValue",
       "key": "title",
+      "type": "MetaValue",
       "value": "Principles Of Excellence Program | Veterans Affairs"
     },
     {
-      "type": "MetaValue",
       "key": "twitter:card",
+      "type": "MetaValue",
       "value": "summary_large_image"
     },
     {
-      "type": "MetaProperty",
       "key": "og:site_name",
+      "type": "MetaProperty",
       "value": "Veterans Affairs"
     },
     {
+      "key": "twitter:description",
       "type": "MetaValue",
+      "value": "Learn about guidelines for programs that receive federal funding through programs like the GI Bill. Some foreign schools, high schools, internships, residencies, and apprenticeships don't have to follow these guidelines."
+    },
+    {
+      "key": "description",
+      "type": "MetaValue",
+      "value": "Learn about guidelines for programs that receive federal funding through programs like the GI Bill. Some foreign schools, high schools, internships, residencies, and apprenticeships don't have to follow these guidelines."
+    },
+    {
       "key": "twitter:title",
+      "type": "MetaValue",
       "value": "Principles of Excellence program | Veterans Affairs"
     },
     {
-      "type": "MetaValue",
       "key": "twitter:site",
+      "type": "MetaValue",
       "value": "@DeptVetAffairs"
     },
     {
-      "type": "MetaProperty",
       "key": "og:title",
+      "type": "MetaProperty",
       "value": "Principles of Excellence program | Veterans Affairs"
+    },
+    {
+      "key": "og:description",
+      "type": "MetaProperty",
+      "value": "Learn about guidelines for programs that receive federal funding through programs like the GI Bill. Some foreign schools, high schools, internships, residencies, and apprenticeships don't have to follow these guidelines."
     }
   ]
 }

--- a/src/site/stages/build/process-cms-exports/tests/transformer-helpers.unit.spec.js
+++ b/src/site/stages/build/process-cms-exports/tests/transformer-helpers.unit.spec.js
@@ -4,6 +4,7 @@ const {
   createLink,
   getWysiwygString,
   unescapeUnicode,
+  createMetaTagArray,
 } = require('../transformers/helpers');
 
 describe('CMS export transformer helpers', () => {
@@ -109,6 +110,114 @@ describe('CMS export transformer helpers', () => {
         },
         title: 'Hello, World!',
       });
+    });
+  });
+
+  describe('createMetaTagArray', () => {
+    it('should create all the tags', () => {
+      /* eslint-disable camelcase */
+      const raw = {
+        title:
+          'VA Pittsburgh health care | Veterans Town Hall on the Move | Veterans Affairs',
+        twitter_cards_type: 'summary_large_image',
+        og_site_name: 'Veterans Affairs',
+        twitter_cards_description:
+          'VA Pittsburgh Healthcare System Interim Director Barbara Forsha invites you to attend the Town Hall event. Veterans, their families and the public are welcome to attend.',
+        description:
+          'VA Pittsburgh Healthcare System Interim Director Barbara Forsha invites you to attend the Town Hall event. Veterans, their families and the public are welcome to attend.',
+        twitter_cards_title:
+          'Veterans Town Hall on the Move | VA Pittsburgh health care | Veterans Affairs',
+        twitter_cards_site: '@DeptVetAffairs',
+        og_title:
+          'Veterans Town Hall on the Move | VA Pittsburgh health care | Veterans Affairs',
+        og_description:
+          'VA Pittsburgh Healthcare System Interim Director Barbara Forsha invites you to attend the Town Hall event. Veterans, their families and the public are welcome to attend.',
+        og_image_height: '314',
+      };
+      /* eslint-enable camelcase */
+
+      const transformed = [
+        {
+          __typename: 'MetaValue',
+          key: 'title',
+          value:
+            'VA Pittsburgh health care | Veterans Town Hall on the Move | Veterans Affairs',
+        },
+        {
+          __typename: 'MetaValue',
+          key: 'twitter:card',
+          value: 'summary_large_image',
+        },
+        {
+          __typename: 'MetaProperty',
+          key: 'og:site_name',
+          value: 'Veterans Affairs',
+        },
+        {
+          __typename: 'MetaValue',
+          key: 'twitter:description',
+          value:
+            'VA Pittsburgh Healthcare System Interim Director Barbara Forsha invites you to attend the Town Hall event. Veterans, their families and the public are welcome to attend.',
+        },
+        {
+          __typename: 'MetaValue',
+          key: 'description',
+          value:
+            'VA Pittsburgh Healthcare System Interim Director Barbara Forsha invites you to attend the Town Hall event. Veterans, their families and the public are welcome to attend.',
+        },
+        {
+          __typename: 'MetaValue',
+          key: 'twitter:title',
+          value:
+            'Veterans Town Hall on the Move | VA Pittsburgh health care | Veterans Affairs',
+        },
+        {
+          __typename: 'MetaValue',
+          key: 'twitter:site',
+          value: '@DeptVetAffairs',
+        },
+        {
+          __typename: 'MetaProperty',
+          key: 'og:title',
+          value:
+            'Veterans Town Hall on the Move | VA Pittsburgh health care | Veterans Affairs',
+        },
+        {
+          __typename: 'MetaProperty',
+          key: 'og:description',
+          value:
+            'VA Pittsburgh Healthcare System Interim Director Barbara Forsha invites you to attend the Town Hall event. Veterans, their families and the public are welcome to attend.',
+        },
+        {
+          __typename: 'MetaProperty',
+          key: 'og:image:height',
+          value: '314',
+        },
+      ];
+
+      expect(createMetaTagArray(raw)).to.deep.equal(transformed);
+    });
+
+    it('should omit tags with no value', () => {
+      const raw = {
+        title: 'foo',
+      };
+
+      const transformed = [
+        {
+          __typename: 'MetaValue',
+          key: 'title',
+          value: 'foo',
+        },
+      ];
+
+      expect(createMetaTagArray(raw)).to.deep.equal(transformed);
+    });
+
+    it('should ignore unrecognized tags', () => {
+      const raw = { unknown: 'Dunno' };
+      const transformed = [];
+      expect(createMetaTagArray(raw)).to.deep.equal(transformed);
     });
   });
 });

--- a/src/site/stages/build/process-cms-exports/transformers/helpers.js
+++ b/src/site/stages/build/process-cms-exports/transformers/helpers.js
@@ -35,14 +35,6 @@ function getDrupalValue(arr) {
   return null;
 }
 
-function createMetaTag(type, key, value) {
-  return {
-    type,
-    key,
-    value,
-  };
-}
-
 /**
  * This is currently a dummy function, but we may
  * need it in the future to convert weird uris like
@@ -55,7 +47,6 @@ function uriToUrl(uri) {
 
 module.exports = {
   getDrupalValue,
-  createMetaTag,
   unescapeUnicode,
   uriToUrl,
 
@@ -121,5 +112,36 @@ module.exports = {
    */
   utcToEpochTime(timeString) {
     return moment.tz(timeString, 'UTC').unix();
+  },
+
+  createMetaTagArray(metaTags, typeName = '__typename') {
+    function createMetaTag(type, key, value) {
+      return {
+        [typeName]: type,
+        key,
+        value,
+      };
+    }
+
+    return [
+      createMetaTag('MetaValue', 'title', metaTags.title),
+      createMetaTag('MetaValue', 'twitter:card', metaTags.twitter_cards_type),
+      createMetaTag('MetaProperty', 'og:site_name', metaTags.og_site_name),
+      createMetaTag(
+        'MetaValue',
+        'twitter:description',
+        metaTags.twitter_cards_description,
+      ),
+      createMetaTag('MetaValue', 'description', metaTags.description),
+      createMetaTag('MetaValue', 'twitter:title', metaTags.twitter_cards_title),
+      createMetaTag('MetaValue', 'twitter:site', metaTags.twitter_cards_site),
+      createMetaTag('MetaProperty', 'og:title', metaTags.og_title),
+      createMetaTag('MetaProperty', 'og:description', metaTags.og_description),
+      createMetaTag(
+        'MetaProperty',
+        'og:image:height',
+        metaTags.og_image_height,
+      ),
+    ].filter(t => t.value);
   },
 };

--- a/src/site/stages/build/process-cms-exports/transformers/node-event.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-event.js
@@ -3,6 +3,7 @@ const {
   utcToEpochTime,
   getWysiwygString,
   createLink,
+  createMetaTagArray,
 } = require('./helpers');
 const { mapKeys, camelCase } = require('lodash');
 const assert = require('assert');
@@ -17,84 +18,49 @@ function fakeUtc(timeString) {
   return `${timeString.replace('T', ' ')} UTC`;
 }
 
-// Same as the createMetaTag in the transformer helpers, but uses
-// __typename instead of type. Because consistency.
-function createMetaTag(type, key, value) {
-  return {
-    __typename: type,
-    key,
-    value,
-  };
-}
-
-const transform = entity => {
-  const metaTags = entity.metatag.value;
-
-  return {
-    entityType: 'node',
-    entityBundle: 'event',
-    title: getDrupalValue(entity.title),
-    uid: entity.uid[0],
-    changed: utcToEpochTime(getDrupalValue(entity.changed)),
-    entityUrl: {
-      // TODO: Get the breadcrumb from the CMS export when it's available
-      breadcrumb: [],
-      path: entity.path[0].alias,
-    },
-    entityMetatags: [
-      createMetaTag('MetaValue', 'title', metaTags.title),
-      createMetaTag('MetaValue', 'twitter:card', metaTags.twitter_cards_type),
-      createMetaTag('MetaProperty', 'og:site_name', metaTags.og_site_name),
-      createMetaTag(
-        'MetaValue',
-        'twitter:description',
-        metaTags.twitter_cards_description,
-      ),
-      createMetaTag('MetaValue', 'description', metaTags.description),
-      createMetaTag('MetaValue', 'twitter:title', metaTags.twitter_cards_title),
-      createMetaTag('MetaValue', 'twitter:site', metaTags.twitter_cards_site),
-      createMetaTag('MetaProperty', 'og:title', metaTags.og_title),
-      createMetaTag('MetaProperty', 'og:description', metaTags.og_description),
-      createMetaTag(
-        'MetaProperty',
-        'og:image:height',
-        metaTags.og_image_height,
-      ),
-    ],
-    // TODO: Verify this is how to derive the entityPublished state
-    entityPublished: entity.moderationState[0].value === 'published',
-    fieldAdditionalInformationAbo: entity.fieldAdditionalInformationAbo.value
-      ? {
-          processed: getWysiwygString(
-            getDrupalValue(entity.fieldAdditionalInformationAbo),
-          ),
-        }
-      : null,
-    // The keys of fieldAddress[0] are snake_case, but we want camelCase
-    fieldAddress: mapKeys(entity.fieldAddress[0], (v, k) => camelCase(k)),
-    fieldBody: {
-      processed: getWysiwygString(getDrupalValue(entity.fieldBody)),
-    },
-    fieldDate: {
-      startDate: fakeUtc(entity.fieldDate[0].value),
-      value: entity.fieldDate[0].value,
-      endDate: fakeUtc(entity.fieldDate[0].end_value),
-      endValue: entity.fieldDate[0].end_value,
-    },
-    fieldDescription: getDrupalValue(entity.fieldDescription),
-    fieldEventCost: getDrupalValue(entity.fieldEventCost),
-    fieldEventCta: getDrupalValue(entity.fieldEventCta),
-    fieldEventRegistrationrequired: getDrupalValue(
-      entity.fieldEventRegistrationrequired,
-    ),
-    fieldFacilityLocation: entity.fieldFacilityLocation[0] || null,
-    fieldLink: createLink(entity.fieldLink, ['url']),
-    fieldLocationHumanreadable: getDrupalValue(
-      entity.fieldLocationHumanreadable,
-    ),
-    fieldMedia: entity.fieldMedia[0] || null,
-  };
-};
+const transform = entity => ({
+  entityType: 'node',
+  entityBundle: 'event',
+  title: getDrupalValue(entity.title),
+  uid: entity.uid[0],
+  changed: utcToEpochTime(getDrupalValue(entity.changed)),
+  entityUrl: {
+    // TODO: Get the breadcrumb from the CMS export when it's available
+    breadcrumb: [],
+    path: entity.path[0].alias,
+  },
+  entityMetatags: createMetaTagArray(entity.metatag.value),
+  // TODO: Verify this is how to derive the entityPublished state
+  entityPublished: entity.moderationState[0].value === 'published',
+  fieldAdditionalInformationAbo: entity.fieldAdditionalInformationAbo.value
+    ? {
+        processed: getWysiwygString(
+          getDrupalValue(entity.fieldAdditionalInformationAbo),
+        ),
+      }
+    : null,
+  // The keys of fieldAddress[0] are snake_case, but we want camelCase
+  fieldAddress: mapKeys(entity.fieldAddress[0], (v, k) => camelCase(k)),
+  fieldBody: {
+    processed: getWysiwygString(getDrupalValue(entity.fieldBody)),
+  },
+  fieldDate: {
+    startDate: fakeUtc(entity.fieldDate[0].value),
+    value: entity.fieldDate[0].value,
+    endDate: fakeUtc(entity.fieldDate[0].end_value),
+    endValue: entity.fieldDate[0].end_value,
+  },
+  fieldDescription: getDrupalValue(entity.fieldDescription),
+  fieldEventCost: getDrupalValue(entity.fieldEventCost),
+  fieldEventCta: getDrupalValue(entity.fieldEventCta),
+  fieldEventRegistrationrequired: getDrupalValue(
+    entity.fieldEventRegistrationrequired,
+  ),
+  fieldFacilityLocation: entity.fieldFacilityLocation[0] || null,
+  fieldLink: createLink(entity.fieldLink, ['url']),
+  fieldLocationHumanreadable: getDrupalValue(entity.fieldLocationHumanreadable),
+  fieldMedia: entity.fieldMedia[0] || null,
+});
 
 module.exports = {
   filter: [

--- a/src/site/stages/build/process-cms-exports/transformers/node-page.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-page.js
@@ -1,6 +1,6 @@
 const moment = require('moment-timezone');
 const { flatten, isEmpty } = require('lodash');
-const { getDrupalValue, createMetaTag } = require('./helpers');
+const { getDrupalValue, createMetaTagArray } = require('./helpers');
 
 function pageTransform(entity) {
   const {
@@ -36,14 +36,7 @@ function pageTransform(entity) {
     // ).toUTCString(),
 
     entityPublished: published === 'published',
-    entityMetaTags: [
-      createMetaTag('MetaValue', 'title', metaTags.title),
-      createMetaTag('MetaValue', 'twitter:card', metaTags.twitter_cards_type),
-      createMetaTag('MetaProperty', 'og:site_name', metaTags.og_site_name),
-      createMetaTag('MetaValue', 'twitter:title', metaTags.twitter_cards_title),
-      createMetaTag('MetaValue', 'twitter:site', metaTags.twitter_cards_site),
-      createMetaTag('MetaProperty', 'og:title', metaTags.og_title),
-    ],
+    entityMetaTags: createMetaTagArray(metaTags, 'type'),
   });
 
   transformed.fieldAlert = !isEmpty(flatten(fieldAlert)) ? fieldAlert[0] : null;


### PR DESCRIPTION
## Description
Added a helper function to create the array of metatags so we didn't need to re-do it every time.

**Note:** This may mean that the metatags are in a different order than expected in some cases, but I have a hard time imagining that's going to be a problem.

## Testing done
Made sure the existing unit tests still passed. I did have to add a few metatags to `node-page` since we're apparently supplied with more than we were getting in `pages.json`. (Which...I'm not sure if that should be concerning or not...)

## Screenshots
N/A

## Acceptance criteria
- [x] The unit tests still pass
- [x] The helper function builds an array of metatag objects with either the `__typename` (default) or `type`