### PR TITLE
Add feedback link to need help component

### DIFF
--- a/src/applications/vaos/components/NeedHelp.jsx
+++ b/src/applications/vaos/components/NeedHelp.jsx
@@ -43,13 +43,14 @@ export default function NeedHelp() {
           <li>Monday &ndash; Friday, 8:00 a.m. &ndash; 8:00 p.m. ET</li>
         </ul>
       </div>
-      {/* TODO: Re-add once we have the proper URL
-    
-    <a href="" className="vads-u-display--block vads-u-margin-top--2">
-      Leave feedback for this application
-    </a> 
-    
-    */}
+      <a
+        href="https://veteran.apps.va.gov/feedback-web/v1/?appId=85870ADC-CC55-405E-9AC3-976A92BBBBEE"
+        className="vads-u-display--block vads-u-margin-top--2"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        Leave feedback for this application
+      </a>
     </div>
   );
 }

--- a/src/applications/vaos/tests/components/NeedHelp.unit.spec.jsx
+++ b/src/applications/vaos/tests/components/NeedHelp.unit.spec.jsx
@@ -11,7 +11,7 @@ describe('VAOS <NeedHelp>', () => {
     expect(tree.find('h2').text()).to.contain('Need help?');
 
     const links = tree.find('a');
-    expect(links.length).to.equal(4);
+    expect(links.length).to.equal(5);
     expect(links.at(0).props().href).to.equal('tel:8772228387');
     expect(links.at(0).text()).to.equal('877-222-8387');
     expect(links.at(1).props().href).to.equal('tel:8008778339');
@@ -20,6 +20,10 @@ describe('VAOS <NeedHelp>', () => {
     expect(links.at(2).text()).to.equal('877-222-8387');
     expect(links.at(3).props().href).to.equal('tel:8008778339');
     expect(links.at(3).text()).to.equal('800-877-8339');
+    expect(links.at(4).props().href).to.equal(
+      'https://veteran.apps.va.gov/feedback-web/v1/?appId=85870ADC-CC55-405E-9AC3-976A92BBBBEE',
+    );
+    expect(links.at(4).text()).to.equal('Leave feedback for this application');
     tree.unmount();
   });
 });


### PR DESCRIPTION
## Description
Add feedback link to `<NeedHelp/>` component

## Testing done
Local and unit

## Screenshots
<img width="701" alt="Screen Shot 2020-01-13 at 10 00 43 PM" src="https://user-images.githubusercontent.com/786704/72318124-43bd8980-3650-11ea-8551-6c49c280afae.png">


## Acceptance criteria
- [ ] Link is displayed and redirects to feedback tool

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
