### PR TITLE
bradl3yC - 4837 - Clear address validation errors on initialize

### DIFF
--- a/src/platform/user/profile/vet360/reducers/index.js
+++ b/src/platform/user/profile/vet360/reducers/index.js
@@ -214,6 +214,9 @@ export default function vet360(state = initialState, action) {
     case ADDRESS_VALIDATION_INITIALIZE:
       return {
         ...state,
+        addressValidation: {
+          ...initialAddressValidationState,
+        },
         fieldTransactionMap: {
           ...state.fieldTransactionMap,
           [action.fieldName]: { isPending: true },
@@ -236,6 +239,7 @@ export default function vet360(state = initialState, action) {
           selectedAddress: action.selectedAddress,
           selectedAddressId: action.selectedAddressId,
           confirmedSuggestions: action.confirmedSuggestions,
+          addressValidationError: false,
         },
         modal: 'addressValidation',
       };

--- a/src/platform/user/profile/vet360/tests/reducers/index.unit.spec.js
+++ b/src/platform/user/profile/vet360/tests/reducers/index.unit.spec.js
@@ -438,6 +438,23 @@ describe('vet360 reducer', () => {
         fieldName: 'mailingAddress',
       };
       const expectedState = {
+        addressValidation: {
+          addressFromUser: {
+            addressLine1: '',
+            addressLine2: '',
+            addressLine3: '',
+            city: '',
+            stateCode: '',
+            zipCode: '',
+          },
+          addressValidationError: false,
+          addressValidationType: '',
+          confirmedSuggestions: [],
+          selectedAddress: {},
+          selectedAddressId: null,
+          suggestedAddresses: [],
+          validationKey: null,
+        },
         fieldTransactionMap: {
           mailingAddress: { isPending: true },
         },


### PR DESCRIPTION
## Description
- [x] - Reset modal state when modal first loads before network request is sent

## Testing done
- [x] - Modified current unit tests

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
