### PR TITLE
Update all instances of benefit office to regional office

### DIFF
--- a/src/applications/facility-locator/containers/VAMap.jsx
+++ b/src/applications/facility-locator/containers/VAMap.jsx
@@ -664,7 +664,7 @@ class VAMap extends Component {
           <p>
             Find VA locations near you with our facility locator tool. You can
             search for your nearest VA medical center as well as other health
-            facilities, benefit offices, cemeteries, community care providers
+            facilities, regional offices, cemeteries, community care providers
             and Vet Centers. You can also filter your results by service type to
             find locations that offer the specific service you’re looking for.
           </p>

--- a/src/applications/facility-locator/manifest.json
+++ b/src/applications/facility-locator/manifest.json
@@ -6,7 +6,7 @@
   "template": {
     "title": "Find VA Locations",
     "layout": "page-react.html",
-    "description": "Find a VA medical center, clinic, hospital, national cemetery, or VA benefit office near you. You can search by city, state, zip code, or service. You'll get wait times and directions.",
+    "description": "Find a VA medical center, clinic, hospital, national cemetery, or VA regional office near you. You can search by city, state, zip code, or service. You'll get wait times and directions.",
     "keywords": "VA location by zip code, VA clinic, VA near me"
   }
 }

--- a/src/applications/personalization/profile360/components/ContactInformationExplanation.jsx
+++ b/src/applications/personalization/profile360/components/ContactInformationExplanation.jsx
@@ -47,7 +47,7 @@ export default function ContactInformationExplanation() {
           <li>
             <strong>For home loan benefits:</strong> Call 877-827-3702, Monday
             through Friday, 8:00 a.m. to 6:00 p.m. ET to reach the nearest VA
-            regional benefit office with loan guaranty staff.
+            regional regional office with loan guaranty staff.
           </li>
           <li>
             <strong>For Veterans' Mortgage Life Insurance:</strong> Call the VA

--- a/src/applications/personalization/profile360/components/ContactInformationExplanation.jsx
+++ b/src/applications/personalization/profile360/components/ContactInformationExplanation.jsx
@@ -47,7 +47,7 @@ export default function ContactInformationExplanation() {
           <li>
             <strong>For home loan benefits:</strong> Call 877-827-3702, Monday
             through Friday, 8:00 a.m. to 6:00 p.m. ET to reach the nearest VA
-            regional regional office with loan guaranty staff.
+            regional office with loan guaranty staff.
           </li>
           <li>
             <strong>For Veterans' Mortgage Life Insurance:</strong> Call the VA

--- a/src/applications/personalization/profile360/components/MilitaryInformation.jsx
+++ b/src/applications/personalization/profile360/components/MilitaryInformation.jsx
@@ -36,11 +36,11 @@ class MilitaryInformationContent extends React.Component {
                   We’re sorry. We can’t find your Department of Defense (DoD)
                   ID. We need this to access your military service records.
                   Please call us at 800-827-1000, or visit your nearest VA
-                  regional benefit office and request to be added to the Defense
+                  regional office and request to be added to the Defense
                   Enrollment Eligibility Reporting System (DEERS).
                 </p>
                 <a href={facilityLocator.rootUrl}>
-                  Find your nearest VA regional benefit office
+                  Find your nearest VA regional office
                 </a>
                 .
                 <p>

--- a/src/applications/personalization/profile360/components/PersonalInformation.jsx
+++ b/src/applications/personalization/profile360/components/PersonalInformation.jsx
@@ -76,11 +76,11 @@ class PersonalInformationContent extends React.Component {
               If you receive VA benefits, but aren't enrolled in VA health care
             </strong>
             <br />
-            Please contact your nearest VA regional benefit office to update
-            your personal information.
+            Please contact your nearest VA regional office to update your
+            personal information.
             <br />
             <a href={`${facilityLocator.rootUrl}/?facilityType=benefits`}>
-              Find your nearest VA regional benefit office
+              Find your nearest VA regional office
             </a>
           </p>
         </AdditionalInfo>

--- a/src/site/layouts/home.drupal.liquid
+++ b/src/site/layouts/home.drupal.liquid
@@ -59,7 +59,7 @@
             </div>
             <!-- div required for alignment -->
             <div class="button-inner">
-              <span>Find a VA health facility, benefit office, or cemetery</span>
+              <span>Find a VA health facility, regional office, or cemetery</span>
             </div>
           </a>
         </div>
@@ -98,7 +98,7 @@
 
   <section id="homepage-news">
     <div class="usa-grid usa-grid-full">
-    {% comment %} Promos is an array of Drupal promo block entities. See /src/site/stages/build/drupal/home.js. {% endcomment %}  
+    {% comment %} Promos is an array of Drupal promo block entities. See /src/site/stages/build/drupal/home.js. {% endcomment %}
     {% for promo in promos %}
       <div class="usa-width-one-third homepage-news-story" data-e2e="news">
         <div class="homepage-image-wrapper">

--- a/src/site/layouts/home.html
+++ b/src/site/layouts/home.html
@@ -60,7 +60,7 @@
             </div>
             <!-- div required for alignment -->
             <div class="button-inner">
-              <span>Find a VA health facility, benefit office, or cemetery</span>
+              <span>Find a VA health facility, regional office, or cemetery</span>
             </div>
           </a>
         </div>


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/4658

**Current Behavior:** We have instances of `regional benefit office` and `benefit office` throughout `vets-website`.

**Expected Behavior:** We only have instances of `regional office` in `vets-website`.

This PR implements the above behavior/content.

## Testing done
Local.

## Screenshots
N/A

## Acceptance criteria
- [x] Update content to only use `regional office`.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
