### PR TITLE
Replace unset with auto

### DIFF
--- a/src/applications/vaos/sass/vaos.scss
+++ b/src/applications/vaos/sass/vaos.scss
@@ -216,7 +216,7 @@
 
   input[type="radio"],
   input[type="checkbox"] {
-    width: unset;
+    width: auto;
   }
 
   input[type="radio"] + label::before {


### PR DESCRIPTION
## Description
Unset is a property that we can't use in IE11, so we shouldn't use it in our scss file. Replacing it with `auto` in this case achieves the same result.

## Testing done
Local testing

## Acceptance criteria
- [ ] .scss file doesn't use `unset`

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
