### PR TITLE
Fix back behavior for VA Facility Page and Request Date Time Page

### DIFF
--- a/src/applications/vaos/newAppointmentFlow.js
+++ b/src/applications/vaos/newAppointmentFlow.js
@@ -213,7 +213,11 @@ export default {
       let nextState = 'typeOfCare';
       const communityCareEnabled = vaosCommunityCare(state);
 
-      if (communityCareEnabled && isCCEligible(state)) {
+      if (
+        communityCareEnabled &&
+        isCCEligible(state) &&
+        isCommunityCare(state)
+      ) {
         nextState = 'typeOfFacility';
       }
 
@@ -258,6 +262,9 @@ export default {
       }
 
       if (isCCFacility(state)) {
+        if (isCCAudiology(state)) {
+          return 'audiologyCareType';
+        }
         return 'typeOfFacility';
       }
 

--- a/src/applications/vaos/tests/newAppointmentFlow.unit.spec.js
+++ b/src/applications/vaos/tests/newAppointmentFlow.unit.spec.js
@@ -217,6 +217,26 @@ describe('VAOS newAppointmentFlow', () => {
       const nextState = newAppointmentFlow.vaFacility.previous(state);
       expect(nextState).to.equal('typeOfCare');
     });
+
+    it('should return to typeOfCare if selected type of care is not CC eligible', () => {
+      const state = {
+        ...defaultState,
+        newAppointment: {
+          ...defaultState.newAppointment,
+          data: {
+            typeOfCareId: '502',
+            vaSystem: '983',
+            vaFacility: '983',
+            facilityType: FACILITY_TYPES.VAMC,
+          },
+          ccEnabledSystems: ['983'],
+          isCCEligible: true,
+        },
+      };
+
+      const nextState = newAppointmentFlow.vaFacility.previous(state);
+      expect(nextState).to.equal('typeOfCare');
+    });
   });
   describe('request date/time page', () => {
     it('should go to CC preferences page if CC', () => {
@@ -257,6 +277,20 @@ describe('VAOS newAppointmentFlow', () => {
       const nextState = newAppointmentFlow.requestDateTime.previous(state);
 
       expect(nextState).to.equal('typeOfFacility');
+    });
+    it('should go back to audiology preferences page if type of care is audiology', () => {
+      const state = {
+        newAppointment: {
+          data: {
+            facilityType: FACILITY_TYPES.COMMUNITY_CARE,
+            typeOfCareId: '203',
+          },
+        },
+      };
+
+      const nextState = newAppointmentFlow.requestDateTime.previous(state);
+
+      expect(nextState).to.equal('audiologyCareType');
     });
     it('should go back to va facility page if not cc', () => {
       const state = {


### PR DESCRIPTION
## Description
Fixes back behavior when a user initially chooses a type of care that is va/cc eligible (e.g. audiology), then goes back and chooses another type of care that is not va/cc eligible (e.g. mental health).  Previously it would show the "Choose Facility Type" page even if the 2nd type of care they chose was not cc eligible

Also fixes back behavior on request calendar if user chooses Audiology.  Previously it would return them back to the "Choose Facility Type" page, but it should return them to the audiology preferences page

### Previous behavior for CC
- Select audiology as type of care
- Hit continue
- Go back
- Switch to 'mental health' or 'amputation care' or another type of VA-only care
- Hit continue to go to the facility selection page
- Go back: you end up on the 'Choose VA or CC' page

### Fixed behavior
You end up on the Type of Care page, since that's the last page you were on and you're not eligible for CC given the type of care selection.

## Testing done
Local and unit


## Acceptance criteria
- [ ] Back behavior is fixed on VA Facility page and Request date time page

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
