### PR TITLE
Require Character of Service field in 10-10ez

### DIFF
--- a/src/applications/hca/config/form.js
+++ b/src/applications/hca/config/form.js
@@ -44,8 +44,6 @@ import {
   fileHelp,
   financialDisclosureText,
   incomeDescription,
-  isAfterCentralTimeDate,
-  isBeforeCentralTimeDate,
   isEssentialAcaCoverageDescription,
   lastServiceBranchLabels,
   medicaidDescription,
@@ -54,7 +52,6 @@ import {
   medicarePartADescription,
   prefillTransformer,
   transform,
-  validateDate,
 } from '../helpers';
 
 import migrations from './migrations';
@@ -481,12 +478,8 @@ const formConfig = {
             lastDischargeDate: dateUI('Service end date'),
             dischargeType: {
               'ui:title': 'Character of service',
-              'ui:required': ({ lastDischargeDate: LDD }) =>
-                validateDate(LDD) && isBeforeCentralTimeDate(LDD),
               'ui:options': {
                 labels: dischargeTypeLabels,
-                hideIf: ({ lastDischargeDate: LDD }) =>
-                  !validateDate(LDD) || isAfterCentralTimeDate(LDD),
               },
             },
             'ui:validations': [validateServiceDates],
@@ -503,6 +496,7 @@ const formConfig = {
               'lastServiceBranch',
               'lastEntryDate',
               'lastDischargeDate',
+              'dischargeType',
             ],
           },
         },

--- a/src/applications/hca/tests/config/serviceInformation.unit.spec.js
+++ b/src/applications/hca/tests/config/serviceInformation.unit.spec.js
@@ -29,7 +29,7 @@ describe('Hca serviceInformation', () => {
     );
 
     expect(form.find('input').length).to.equal(2);
-    expect(form.find('select').length).to.equal(5);
+    expect(form.find('select').length).to.equal(6);
     form.unmount();
   });
 
@@ -47,7 +47,7 @@ describe('Hca serviceInformation', () => {
     );
 
     form.find('form').simulate('submit');
-    expect(form.find('.usa-input-error').length).to.equal(3);
+    expect(form.find('.usa-input-error').length).to.equal(4);
 
     expect(onSubmit.called).to.be.false;
     form.unmount();
@@ -74,6 +74,7 @@ describe('Hca serviceInformation', () => {
         .add(130, 'days')
         .format('YYYY-MM-DD'),
     );
+    fillData(form, 'select#root_dischargeType', 'general');
 
     form.find('form').simulate('submit');
     expect(form.find('.usa-input-error').length).to.equal(0);


### PR DESCRIPTION
## Description
Currently, the Character of Service field inside the 10-10ez form only appears and is only required when then veteran has been discharged and marks the Service End Date field as a date prior to today's date. However, being discharged is required to receive the health benefits. This is somewhat redundant logic, so the functionality has been changed to where the Character of Service field is always visible and is always required.

## Screenshots
![image](https://user-images.githubusercontent.com/53942725/72451971-c34f7380-378a-11ea-9e45-93de06a7781a.png)

## Acceptance criteria
- [ ] The Character of Service field inside the 10-10ez form is always required and visible