### PR TITLE
bradl3yC - 2430 - Set focus when phone number is deleted

### DIFF
--- a/src/platform/user/profile/vet360/components/base/Vet360EditModalActionButtons.jsx
+++ b/src/platform/user/profile/vet360/components/base/Vet360EditModalActionButtons.jsx
@@ -15,6 +15,24 @@ class Vet360EditModalActionButtons extends React.Component {
     };
   }
 
+  componentDidUpdate(prevProps, prevState) {
+    // Once the AlertBox is mounted, we want to set the focus to the heading
+    // for screen reader use
+    if (this.state.deleteInitiated && !prevState.deleteInitiated) {
+      const heading = document.getElementById('deleteConfirmationHeading');
+      if (heading) {
+        heading.focus();
+      }
+    }
+    // If delete is cancelled, put focus back on modal close button
+    if (!this.state.deleteInitiated && prevState.deleteInitiated) {
+      const closeButton = document.getElementsByClassName('va-modal-close')[0];
+      if (closeButton) {
+        closeButton.focus();
+      }
+    }
+  }
+
   cancelDeleteAction = () => {
     this.setState({ deleteInitiated: false });
     recordEvent({
@@ -63,7 +81,9 @@ class Vet360EditModalActionButtons extends React.Component {
   render() {
     const alertContent = (
       <div>
-        <h3>Are you sure?</h3>
+        <h3 tabIndex="-1" id="deleteConfirmationHeading">
+          Are you sure?
+        </h3>
         <p>
           This will delete your {toLower(this.props.title)} across many VA
           records. You can always come back to your profile later if you'd like

--- a/src/platform/user/profile/vet360/containers/Vet360ProfileField.jsx
+++ b/src/platform/user/profile/vet360/containers/Vet360ProfileField.jsx
@@ -71,7 +71,6 @@ class Vet360ProfileField extends React.Component {
         this.props.fieldName,
       );
     }
-
     this.props.createTransaction(
       this.props.apiRoute,
       'DELETE',


### PR DESCRIPTION
## Description
- [x] - From a profile modal, if a user clicks delete, focus must be added to the heading element for screen readers

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
