### PR TITLE
CT 116: Remove Feature Flag for VETTEC programs filter #4709

### DIFF
--- a/src/applications/gi/components/vet-tec/VetTecFilterBy.jsx
+++ b/src/applications/gi/components/vet-tec/VetTecFilterBy.jsx
@@ -111,8 +111,7 @@ class VetTecFilterBy extends React.Component {
           onChange={this.handleFilterChange}
           options={options}
         />
-        {this.props.giVetTecProgramProviderFilters &&
-          this.renderProviderFilters()}
+        {this.renderProviderFilters()}
       </div>
     );
   }

--- a/src/applications/gi/components/vet-tec/VetTecSearchForm.jsx
+++ b/src/applications/gi/components/vet-tec/VetTecSearchForm.jsx
@@ -122,7 +122,6 @@ class VetTecSearchForm extends React.Component {
       providers={this.props.search.facets.provider}
       handleFilterChange={this.props.handleFilterChange}
       handleProviderFilterChange={this.props.handleProviderFilterChange}
-      giVetTecProgramProviderFilters={this.props.giVetTecProgramProviderFilters}
     />
   );
 

--- a/src/applications/gi/containers/VetTecSearchPage.jsx
+++ b/src/applications/gi/containers/VetTecSearchPage.jsx
@@ -20,7 +20,6 @@ import {
 import LoadingIndicator from '@department-of-veterans-affairs/formation-react/LoadingIndicator';
 import Pagination from '@department-of-veterans-affairs/formation-react/Pagination';
 import { getScrollOptions, focusElement } from 'platform/utilities/ui';
-import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
 import VetTecProgramSearchResult from '../components/vet-tec/VetTecProgramSearchResult';
 import VetTecSearchForm from '../components/vet-tec/VetTecSearchForm';
 import { renderVetTecLogo } from '../utils/render';
@@ -274,9 +273,6 @@ export class VetTecSearchPage extends React.Component {
             eligibility={this.props.eligibility}
             showModal={this.props.showModal}
             eligibilityChange={this.props.eligibilityChange}
-            giVetTecProgramProviderFilters={
-              this.props.giVetTecProgramProviderFilters
-            }
           />
         </div>
       </ScrollElement>
@@ -292,8 +288,6 @@ const mapStateToProps = state => ({
   filters: state.filters,
   search: state.search,
   eligibility: state.eligibility,
-  giVetTecProgramProviderFilters: toggleValues(state)
-    .giVetTecProgramProviderFilters,
 });
 
 const mapDispatchToProps = {

--- a/src/applications/gi/tests/components/VetTecFilterBy.unit.spec.jsx
+++ b/src/applications/gi/tests/components/VetTecFilterBy.unit.spec.jsx
@@ -18,7 +18,6 @@ describe('<VetTecFilterBy>', () => {
       showModal: () => {},
       handleProviderFilterChange: () => {},
       handleFilterChange: () => {},
-      giVetTecProgramProviderFilters: true,
     };
 
     const wrapper = mount(<VetTecFilterBy {...props} />);
@@ -45,7 +44,6 @@ describe('<VetTecFilterBy>', () => {
       showModal: () => {},
       handleProviderFilterChange: () => {},
       handleFilterChange: () => {},
-      giVetTecProgramProviderFilters: true,
     };
 
     const wrapper = mount(<VetTecFilterBy {...props} />);
@@ -74,7 +72,6 @@ describe('<VetTecFilterBy>', () => {
       showModal: () => {},
       handleProviderFilterChange: () => {},
       handleFilterChange: () => {},
-      giVetTecProgramProviderFilters: true,
     };
 
     const wrapper = mount(<VetTecFilterBy {...props} />);
@@ -105,7 +102,6 @@ describe('<VetTecFilterBy>', () => {
         selectedVal = provider;
       },
       handleFilterChange: () => {},
-      giVetTecProgramProviderFilters: true,
     };
 
     const wrapper = mount(<VetTecFilterBy {...props} />);

--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -6,7 +6,6 @@ const FEATURE_FLAG_NAMES = Object.freeze({
   vaOnlineSchedulingRequests: 'vaOnlineSchedulingRequests',
   vaOnlineSchedulingCommunityCare: 'vaOnlineSchedulingCommunityCare',
   vaOnlineSchedulingDirect: 'vaOnlineSchedulingDirect',
-  giVetTecProgramProviderFilters: 'giVetTecProgramProviderFilters',
   vaGlobalDowntimeNotification: 'vaGlobalDowntimeNotification',
 });
 


### PR DESCRIPTION
## Description
As a developer, I need to remove the feature flag for VET TEC programs filter after the feature goes live because it will no longer be used after than point.

https://github.com/department-of-veterans-affairs/va.gov-team/issues/4709

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
