### PR TITLE
fix unit test to eliminate warning message

### DIFF
--- a/src/applications/vaos/tests/containers/TypeOfCarePage.unit.spec.jsx
+++ b/src/applications/vaos/tests/containers/TypeOfCarePage.unit.spec.jsx
@@ -3,11 +3,7 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import { mount } from 'enzyme';
 
-import {
-  resetFetch,
-  mockFetch,
-  setFetchJSONResponse,
-} from 'platform/testing/unit/helpers';
+import { mockFetch, setFetchJSONResponse } from 'platform/testing/unit/helpers';
 
 import { selectRadio } from 'platform/testing/unit/schemaform-utils.jsx';
 import { TypeOfCarePage } from '../../containers/TypeOfCarePage';
@@ -73,7 +69,6 @@ describe('VAOS <TypeOfCarePage>', () => {
 
     expect(updateFormData.firstCall.args[2].typeOfCareId).to.equal('323');
     form.unmount();
-    resetFetch();
   });
 
   it('should submit with valid data', () => {

--- a/src/applications/vaos/tests/containers/TypeOfCarePage.unit.spec.jsx
+++ b/src/applications/vaos/tests/containers/TypeOfCarePage.unit.spec.jsx
@@ -69,6 +69,7 @@ describe('VAOS <TypeOfCarePage>', () => {
 
     expect(updateFormData.firstCall.args[2].typeOfCareId).to.equal('323');
     form.unmount();
+    global.fetch.resetHistory();
   });
 
   it('should submit with valid data', () => {


### PR DESCRIPTION
## Description
eliminate warning message when running unit test specific to VAOS
`yarn test:unit src/applications/vaos/tests`

## Testing done
unit test

## Screenshots


## Acceptance criteria
- [ ] no warning message when running `yarn test:unit src/applications/vaos/tests`


## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
