### PR TITLE
[Yellow Ribbon] Initial app scaffolding and URL

### DIFF
--- a/src/applications/yellow-ribbon/containers/YellowRibbonApp.jsx
+++ b/src/applications/yellow-ribbon/containers/YellowRibbonApp.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+export default class YellowRibbonApp extends React.Component {
+  render() {
+    return (
+      <div className="vads-l-grid-container vads-u-padding-x--2p5 large-screen:vads-u-padding-x--0 vads-u-padding-bottom--2p5">
+        <div className="vads-l-row">
+          <div className="vads-l-col--12 medium-screen:vads-l-col--8 vads-u-margin-bottom--4">
+            <h1 className="vads-u-margin-top--2">Yellow Ribbon Schools</h1>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}

--- a/src/applications/yellow-ribbon/manifest.json
+++ b/src/applications/yellow-ribbon/manifest.json
@@ -1,0 +1,13 @@
+{
+  "appName": "Yellow Ribbon Schools",
+  "entryFile": "./yellow-ribbon-entry",
+  "entryName": "yellow-ribbon",
+  "rootUrl": "/yellow-ribbon/schools",
+  "production": false,
+  "template": {
+    "vagovprod": false,
+    "vagovstaging": false,
+    "vagovdev": false,
+    "layout": "page-react.html"
+  }
+}

--- a/src/applications/yellow-ribbon/reducers/index.js
+++ b/src/applications/yellow-ribbon/reducers/index.js
@@ -1,0 +1,9 @@
+const initialState = {};
+
+function yellowRibbon(state = initialState, _action) {
+  return state;
+}
+
+export default {
+  yellowRibbon,
+};

--- a/src/applications/yellow-ribbon/routes/index.js
+++ b/src/applications/yellow-ribbon/routes/index.js
@@ -1,0 +1,8 @@
+import YellowRibbonApp from '../containers/YellowRibbonApp';
+
+const routes = {
+  path: '/',
+  component: YellowRibbonApp,
+};
+
+export default routes;

--- a/src/applications/yellow-ribbon/sass/yellow-ribbon.scss
+++ b/src/applications/yellow-ribbon/sass/yellow-ribbon.scss
@@ -1,0 +1,1 @@
+// Hopefully, this will be pretty slim or empty :-)

--- a/src/applications/yellow-ribbon/yellow-ribbon-entry.jsx
+++ b/src/applications/yellow-ribbon/yellow-ribbon-entry.jsx
@@ -1,0 +1,14 @@
+import 'platform/polyfills';
+import './sass/yellow-ribbon.scss';
+
+import startApp from 'platform/startup';
+import routes from './routes';
+import manifest from './manifest.json';
+import reducer from './reducers';
+
+startApp({
+  url: manifest.rootUrl,
+  routes,
+  reducer,
+  entryName: manifest.entryName,
+});


### PR DESCRIPTION
## Description
This PR creates a new application at `http://localhost:3001/yellow-ribbon/schools/`, feature flagged to not render on any environments except localhost.

Ticket - https://github.com/department-of-veterans-affairs/va.gov-team/issues/4800

## Testing done
`npm run watch -- --entry=yellow-ribbon`

- Looked at the page locally

## Screenshots
![image](https://user-images.githubusercontent.com/1915775/72470854-8cd81f80-37af-11ea-977f-87bb73b993b7.png)


## Acceptance criteria
- [x] Yellow Ribbon temporary URL has been created

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
