### PR TITLE
Prevent users from going into the request flow on clinic page when unsupported

### DIFF
--- a/src/applications/vaos/actions/newAppointment.js
+++ b/src/applications/vaos/actions/newAppointment.js
@@ -254,7 +254,7 @@ export function openFacilityPage(page, uiSchema, schema) {
         const systemId =
           newAppointment.data.vaSystem || systems[0].institutionCode;
         eligibilityData = await getEligibilityData(
-          facilityId,
+          facilities.find(facility => facility.institutionCode === facilityId),
           typeOfCareId,
           systemId,
           directSchedulingEnabled,
@@ -343,7 +343,9 @@ export function updateFacilityPageData(page, uiSchema, data) {
 
       try {
         const eligibilityData = await getEligibilityData(
-          data.vaFacility,
+          facilities.find(
+            facility => facility.institutionCode === data.vaFacility,
+          ),
           typeOfCareId,
           data.vaSystem,
           directSchedulingEnabled,

--- a/src/applications/vaos/actions/newAppointment.js
+++ b/src/applications/vaos/actions/newAppointment.js
@@ -217,8 +217,12 @@ export function openFacilityPage(page, uiSchema, schema) {
   return async (dispatch, getState) => {
     const directSchedulingEnabled = vaosDirectScheduling(getState());
     const newAppointment = getState().newAppointment;
+    const typeOfCareId = getTypeOfCare(newAppointment.data)?.id;
     let systems = newAppointment.systems;
-    let facilities = null;
+    let facilities =
+      newAppointment.facilities[
+        `${typeOfCareId}_${newAppointment.data.vaSystem}`
+      ] || null;
     let eligibilityData = null;
 
     try {
@@ -230,13 +234,8 @@ export function openFacilityPage(page, uiSchema, schema) {
       }
       const canShowFacilities =
         newAppointment.data.vaSystem || systems?.length === 1;
-      const typeOfCareId = getTypeOfCare(newAppointment.data)?.id;
 
-      const hasExistingFacilities = !!newAppointment.facilities[
-        `${typeOfCareId}_${newAppointment.data.vaSystem}`
-      ];
-
-      if (canShowFacilities && !hasExistingFacilities) {
+      if (canShowFacilities && !facilities) {
         const systemId =
           newAppointment.data.vaSystem || systems[0].institutionCode;
         facilities = await getFacilitiesBySystemAndTypeOfCare(

--- a/src/applications/vaos/components/EligibilityCheckMessage.jsx
+++ b/src/applications/vaos/components/EligibilityCheckMessage.jsx
@@ -2,6 +2,20 @@ import React from 'react';
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 
 export default function EligibilityCheckMessage({ eligibility }) {
+  if (!eligibility.requestSupported) {
+    return (
+      <div aria-atomic="true" aria-live="assertive">
+        <AlertBox
+          status="warning"
+          headline="This facility does not allow online requests for this type of care"
+        >
+          This facility does not allow scheduling requests for this type of care
+          to be made online. Not all facilities support online scheduling for
+          all types of care.
+        </AlertBox>
+      </div>
+    );
+  }
   if (!eligibility.requestPastVisit) {
     return (
       <div aria-atomic="true" aria-live="assertive">

--- a/src/applications/vaos/components/SingleFacilityEligibilityCheckMessage.jsx
+++ b/src/applications/vaos/components/SingleFacilityEligibilityCheckMessage.jsx
@@ -15,7 +15,7 @@ export default function VAFacilityInfoMessage({ facility, eligibility }) {
   } else if (!eligibility.requestSupported) {
     message = (
       <>
-        However, this facility does not allow online scheduling for this type of
+        However, this facility does not allow online requests for this type of
         care.
       </>
     );

--- a/src/applications/vaos/components/SingleFacilityEligibilityCheckMessage.jsx
+++ b/src/applications/vaos/components/SingleFacilityEligibilityCheckMessage.jsx
@@ -12,6 +12,13 @@ export default function VAFacilityInfoMessage({ facility, eligibility }) {
         {eligibility.requestPastVisitValue} months.
       </>
     );
+  } else if (!eligibility.requestSupported) {
+    message = (
+      <>
+        However, this facility does not allow online scheduling for this type of
+        care.
+      </>
+    );
   } else if (!eligibility.requestLimit) {
     message = (
       <>

--- a/src/applications/vaos/containers/ClinicChoicePage.jsx
+++ b/src/applications/vaos/containers/ClinicChoicePage.jsx
@@ -97,7 +97,8 @@ export class ClinicChoicePage extends React.Component {
     }
 
     const typeOfCareLabel = formatTypeOfCare(typeOfCare.name);
-    const continueDisabled = data.clinicId === 'NONE' && !canMakeRequests;
+    const usingUnsupportedRequestFlow =
+      data.clinicId === 'NONE' && !canMakeRequests;
 
     return (
       <div>
@@ -146,15 +147,14 @@ export class ClinicChoicePage extends React.Component {
           }
           data={data}
         >
-          {data.clinicId === 'NONE' &&
-            !canMakeRequests && (
-              <div className="vads-u-margin-top--2">
-                <EligibilityCheckMessage eligibility={eligibility} />
-              </div>
-            )}
+          {usingUnsupportedRequestFlow && (
+            <div className="vads-u-margin-top--2">
+              <EligibilityCheckMessage eligibility={eligibility} />
+            </div>
+          )}
           <FormButtons
             onBack={this.goBack}
-            disabled={continueDisabled}
+            disabled={usingUnsupportedRequestFlow}
             pageChangeInProgress={pageChangeInProgress}
           />
         </SchemaForm>

--- a/src/applications/vaos/containers/ClinicChoicePage.jsx
+++ b/src/applications/vaos/containers/ClinicChoicePage.jsx
@@ -3,6 +3,7 @@ import { connect } from 'react-redux';
 import LoadingIndicator from '@department-of-veterans-affairs/formation-react/LoadingIndicator';
 import SchemaForm from 'platform/forms-system/src/js/components/SchemaForm';
 import FormButtons from '../components/FormButtons';
+import EligibilityCheckMessage from '../components/EligibilityCheckMessage';
 import FacilityAddress from '../components/FacilityAddress';
 import { scrollAndFocus } from '../utils/scrollAndFocus';
 import { FETCH_STATUS } from '../utils/constants';
@@ -85,6 +86,8 @@ export class ClinicChoicePage extends React.Component {
       typeOfCare,
       clinics,
       facilityDetailsStatus,
+      eligibility,
+      canMakeRequests,
     } = this.props;
 
     if (!schema || facilityDetailsStatus === FETCH_STATUS.loading) {
@@ -94,6 +97,7 @@ export class ClinicChoicePage extends React.Component {
     }
 
     const typeOfCareLabel = formatTypeOfCare(typeOfCare.name);
+    const continueDisabled = data.clinicId === 'NONE' && !canMakeRequests;
 
     return (
       <div>
@@ -142,8 +146,15 @@ export class ClinicChoicePage extends React.Component {
           }
           data={data}
         >
+          {data.clinicId === 'NONE' &&
+            !canMakeRequests && (
+              <div className="vads-u-margin-top--2">
+                <EligibilityCheckMessage eligibility={eligibility} />
+              </div>
+            )}
           <FormButtons
             onBack={this.goBack}
+            disabled={continueDisabled}
             pageChangeInProgress={pageChangeInProgress}
           />
         </SchemaForm>

--- a/src/applications/vaos/tests/components/EligibilityCheckMessage.unit.spec.jsx
+++ b/src/applications/vaos/tests/components/EligibilityCheckMessage.unit.spec.jsx
@@ -7,6 +7,7 @@ import EligibilityCheckMessage from '../../components/EligibilityCheckMessage';
 describe('VAOS <EligibilityCheckMessage>', () => {
   it('should render past visit message', () => {
     const eligibility = {
+      requestSupported: true,
       requestPastVisit: false,
       requestPastVisitValue: 24,
     };
@@ -20,6 +21,7 @@ describe('VAOS <EligibilityCheckMessage>', () => {
 
   it('should render limit message', () => {
     const eligibility = {
+      requestSupported: true,
       requestPastVisit: true,
       requestLimit: false,
     };
@@ -33,6 +35,7 @@ describe('VAOS <EligibilityCheckMessage>', () => {
 
   it('should render generic message', () => {
     const eligibility = {
+      requestSupported: true,
       requestPastVisit: true,
       requestLimit: true,
     };
@@ -40,6 +43,20 @@ describe('VAOS <EligibilityCheckMessage>', () => {
     const tree = mount(<EligibilityCheckMessage eligibility={eligibility} />);
 
     expect(tree.text()).to.contain('trouble verifying');
+    expect(tree.find('[aria-atomic="true"]').exists()).to.be.true;
+    tree.unmount();
+  });
+
+  it('should render not supported message', () => {
+    const eligibility = {
+      requestSupported: false,
+      requestPastVisit: true,
+      requestLimit: true,
+    };
+
+    const tree = mount(<EligibilityCheckMessage eligibility={eligibility} />);
+
+    expect(tree.text()).to.contain('does not allow online');
     expect(tree.find('[aria-atomic="true"]').exists()).to.be.true;
     tree.unmount();
   });

--- a/src/applications/vaos/tests/components/SingleFacilityEligibilityCheckMessage.unit.spec.jsx
+++ b/src/applications/vaos/tests/components/SingleFacilityEligibilityCheckMessage.unit.spec.jsx
@@ -4,9 +4,10 @@ import { mount } from 'enzyme';
 
 import SingleFacilityEligibilityCheckMessage from '../../components/SingleFacilityEligibilityCheckMessage';
 
-describe('VAOS <EligibilityCheckMessage>', () => {
+describe('VAOS <SingleFacilityEligibilityCheckMessage>', () => {
   it('should render past visit message', () => {
     const eligibility = {
+      requestSupported: true,
       requestPastVisit: false,
       requestPastVisitValue: 24,
     };
@@ -26,6 +27,7 @@ describe('VAOS <EligibilityCheckMessage>', () => {
 
   it('should render limit message', () => {
     const eligibility = {
+      requestSupported: true,
       requestPastVisit: true,
       requestLimit: false,
     };
@@ -45,6 +47,7 @@ describe('VAOS <EligibilityCheckMessage>', () => {
 
   it('should render generic message', () => {
     const eligibility = {
+      requestSupported: true,
       requestPastVisit: true,
       requestLimit: true,
     };
@@ -58,6 +61,26 @@ describe('VAOS <EligibilityCheckMessage>', () => {
     );
 
     expect(tree.text()).to.contain('trouble verifying');
+    expect(tree.find('[aria-atomic="true"]').exists()).to.be.true;
+    tree.unmount();
+  });
+
+  it('should render not supported message', () => {
+    const eligibility = {
+      requestSupported: false,
+      requestPastVisit: true,
+      requestLimit: true,
+    };
+    const facility = {};
+
+    const tree = mount(
+      <SingleFacilityEligibilityCheckMessage
+        facility={facility}
+        eligibility={eligibility}
+      />,
+    );
+
+    expect(tree.text()).to.contain('does not allow online');
     expect(tree.find('[aria-atomic="true"]').exists()).to.be.true;
     tree.unmount();
   });

--- a/src/applications/vaos/tests/newAppointmentFlow.unit.spec.js
+++ b/src/applications/vaos/tests/newAppointmentFlow.unit.spec.js
@@ -115,6 +115,7 @@ describe('VAOS newAppointmentFlow', () => {
           ...defaultState.newAppointment,
           eligibility: {
             '983_323': {
+              directSupported: true,
               directPastVisit: true,
               directPACT: true,
               directClinics: true,
@@ -142,9 +143,11 @@ describe('VAOS newAppointmentFlow', () => {
           ...defaultState.newAppointment,
           eligibility: {
             '983_323': {
+              directSupported: true,
               directPastVisit: false,
               directPACT: true,
               directClinics: true,
+              requestSupported: true,
               requestPastVisit: true,
               requestLimit: true,
             },

--- a/src/applications/vaos/tests/utils/eligibility.unit.spec.js
+++ b/src/applications/vaos/tests/utils/eligibility.unit.spec.js
@@ -25,7 +25,11 @@ describe('VAOS scheduling eligibility logic', () => {
     });
     it('should fetch all data', async () => {
       const eligibilityData = await getEligibilityData(
-        '983',
+        {
+          institutionCode: '983',
+          directSchedulingSupported: true,
+          requestSupported: true,
+        },
         '323',
         '983',
         true,
@@ -34,6 +38,8 @@ describe('VAOS scheduling eligibility logic', () => {
       expect(Object.keys(eligibilityData)).to.deep.equal([
         'requestPastVisit',
         'requestLimits',
+        'directSupported',
+        'requestSupported',
         'directPastVisit',
         'clinics',
         'pacTeam',
@@ -41,7 +47,11 @@ describe('VAOS scheduling eligibility logic', () => {
     });
     it('should skip pact if not primary care', async () => {
       const eligibilityData = await getEligibilityData(
-        '983',
+        {
+          institutionCode: '983',
+          directSchedulingSupported: true,
+          requestSupported: true,
+        },
         '502',
         '983',
         true,
@@ -50,6 +60,8 @@ describe('VAOS scheduling eligibility logic', () => {
       expect(Object.keys(eligibilityData)).to.deep.equal([
         'requestPastVisit',
         'requestLimits',
+        'directSupported',
+        'requestSupported',
         'directPastVisit',
         'clinics',
       ]);
@@ -60,6 +72,8 @@ describe('VAOS scheduling eligibility logic', () => {
       const eligibilityChecks = getEligibilityChecks('983', '323', {
         pacTeam: [],
         clinics: [],
+        directSupported: true,
+        requestSupported: true,
         directPastVisit: {
           durationInMonths: 12,
           hasVisitedInPastMonths: false,
@@ -83,6 +97,8 @@ describe('VAOS scheduling eligibility logic', () => {
         requestPastVisitValue: 24,
         requestLimit: false,
         requestLimitValue: 1,
+        directSupported: true,
+        requestSupported: true,
       });
     });
 
@@ -90,6 +106,8 @@ describe('VAOS scheduling eligibility logic', () => {
       const eligibilityChecks = getEligibilityChecks('983', '323', {
         pacTeam: [{ facilityId: '983' }],
         clinics: [{}],
+        directSupported: true,
+        requestSupported: true,
         directPastVisit: {
           durationInMonths: 12,
           hasVisitedInPastMonths: true,
@@ -109,6 +127,8 @@ describe('VAOS scheduling eligibility logic', () => {
         directPastVisitValue: 12,
         directPACT: true,
         directClinics: true,
+        directSupported: true,
+        requestSupported: true,
         requestPastVisit: true,
         requestPastVisitValue: 24,
         requestLimit: true,
@@ -122,6 +142,8 @@ describe('VAOS scheduling eligibility logic', () => {
         directPastVisit: false,
         directClinics: true,
         directPACT: true,
+        directSupported: true,
+        requestSupported: true,
         requestPastVisit: true,
         requestLimit: true,
       });

--- a/src/applications/vaos/tests/utils/selectors.unit.spec.js
+++ b/src/applications/vaos/tests/utils/selectors.unit.spec.js
@@ -293,15 +293,19 @@ describe('VAOS selectors', () => {
   });
 
   describe('getClinicPageInfo', () => {
-    it('should return info needed for then clinic page', () => {
+    it('should return info needed for the clinic page', () => {
       const state = {
         newAppointment: {
           pages: {},
           data: {
             typeOfCareId: '323',
+            vaFacility: '983',
           },
           pageChangeInProgress: false,
           clinics: {},
+          eligibility: {
+            '983_323': {},
+          },
         },
       };
       const pageInfo = getClinicPageInfo(state, 'clinicChoice');

--- a/src/applications/vaos/utils/selectors.js
+++ b/src/applications/vaos/utils/selectors.js
@@ -188,6 +188,7 @@ export function getClinicPageInfo(state, pageKey) {
   const formPageInfo = getFormPageInfo(state, pageKey);
   const newAppointment = getNewAppointment(state);
   const facilityDetails = newAppointment.facilityDetails;
+  const eligibility = getEligibilityChecks(state);
 
   return {
     ...formPageInfo,
@@ -195,6 +196,8 @@ export function getClinicPageInfo(state, pageKey) {
     typeOfCare: getTypeOfCare(formPageInfo.data),
     clinics: getClinicsForChosenFacility(state),
     facilityDetailsStatus: newAppointment.facilityDetailsStatus,
+    eligibility,
+    canMakeRequests: isEligible(eligibility).request,
   };
 }
 


### PR DESCRIPTION
## Description
There's a case where a user could get put on the clinic page and not be able to make a request. So, if they choose the option that will put them in that flow, we need to show a message.

I also discovered that we weren't fully respecting the two supported flags from VATS.

## Testing done
Local and unit testing.

## Screenshots
![Screen Shot 2020-01-15 at 4 21 25 PM](https://user-images.githubusercontent.com/634932/72472719-1ccb9880-37b3-11ea-9605-8a70cf40a6b5.png)
![Screen Shot 2020-01-15 at 4 25 02 PM](https://user-images.githubusercontent.com/634932/72473010-cca10600-37b3-11ea-993f-ec80b31c87f1.png)


## Acceptance criteria
- [ ] Users aren't incorrectly put back in request flow

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
