### PR TITLE
VAGOV-6401: Remove orphaned label and add some margin space.

### DIFF
--- a/src/site/layouts/event.drupal.liquid
+++ b/src/site/layouts/event.drupal.liquid
@@ -201,23 +201,23 @@ Example data:
                         </dd>
                       </dl>
                   {% endif %}
-
-                  <div class="registration vads-u-margin-top--4 vads-u-margin-bottom--3 medium-screen:vads-u-margin-bottom--1">
-                      <p class="vads-u-font-weight--bold vads-u-margin-top--0 vads-u-margin-bottom--1">Registration</p>
-                      {% if start_timestamp < current_timestamp %}
-                          <p class="vads-u-margin--0 vads-u-color--secondary vads-u-font-weight--bold">This event already happened.</p>
-                      {% else %}
-                          {% if fieldLink %}
-                              <p class="vads-u-margin--0"><a
-                                          href="{{ fieldLink.url.path }}"><button class="vads-u-margin--0">{{fieldEventCta | listValue | capitalize}}</button></a>
-                              </p>
-                          {% endif %}
-                          {% if fieldAdditionalInformationAbo %}
-                              <p class="vads-u-margin--0">{{ fieldAdditionalInformationAbo.processed | outputLinks }}</p>
-                          {% endif %}
-
-                      {% endif %}
-                  </div>
+                  {% if fieldLink or fieldEventCta or fieldAdditionalInformationAbo %}
+                    <div class="registration vads-u-margin-top--4 vads-u-margin-bottom--3 medium-screen:vads-u-margin-bottom--1">
+                        <p class="vads-u-font-weight--bold vads-u-margin-top--0 vads-u-margin-bottom--1">Registration</p>
+                        {% if start_timestamp < current_timestamp %}
+                            <p class="vads-u-margin--0 vads-u-color--secondary vads-u-font-weight--bold">This event already happened.</p>
+                        {% else %}
+                            {% if fieldLink %}
+                                <p class="vads-u-margin--0"><a
+                                            href="{{ fieldLink.url.path }}"><button class="vads-u-margin--0">{{fieldEventCta | listValue | capitalize}}</button></a>
+                                </p>
+                            {% endif %}
+                            {% if fieldAdditionalInformationAbo %}
+                                <p class="vads-u-margin--0">{{ fieldAdditionalInformationAbo.processed | outputLinks }}</p>
+                            {% endif %}
+                        {% endif %}
+                    </div>
+                  {% endif %}
               </div>
 
                   <div class="usa-width-one-half va-c-event-share vads-u-margin-bottom--1">
@@ -225,7 +225,7 @@ Example data:
                   </div>
               </div>
 
-            <div class="usa-grid usa-grid-full">
+            <div class="usa-grid usa-grid-full vads-u-margin-top--2">
               <div class="event-description">
                 {{ fieldBody.processed }}
               </div>
@@ -329,31 +329,31 @@ Example data:
                       </dd>
                     </dl>
                 {% endif %}
-
-                <div class="registration vads-u-margin-top--4 vads-u-margin-bottom--3 medium-screen:vads-u-margin-bottom--1">
-                    <p class="vads-u-font-weight--bold vads-u-margin-top--0 vads-u-margin-bottom--1">Registration</p>
-                    {% if start_timestamp < current_timestamp %}
-                        <p class="vads-u-margin--0 vads-u-color--secondary vads-u-font-weight--bold">This event already happened.</p>
-                    {% else %}
-                        {% if fieldLink %}
-                            <p class="vads-u-margin--0"><a
-                                        href="{{ fieldLink.url.path }}"><button class="vads-u-margin--0">{{fieldEventCta | listValue | capitalize}}</button></a>
-                            </p>
-                        {% endif %}
-                        {% if fieldAdditionalInformationAbo %}
-                            <p class="vads-u-margin--0">{{ fieldAdditionalInformationAbo.processed | outputLinks }}</p>
-                        {% endif %}
-
-                    {% endif %}
-                </div>
+                {% if fieldLink or fieldEventCta or fieldAdditionalInformationAbo %}
+                  <div class="registration vads-u-margin-top--4 vads-u-margin-bottom--3 medium-screen:vads-u-margin-bottom--1">
+                      <p class="vads-u-font-weight--bold vads-u-margin-top--0 vads-u-margin-bottom--1">Registration</p>
+                      {% if start_timestamp < current_timestamp %}
+                          <p class="vads-u-margin--0 vads-u-color--secondary vads-u-font-weight--bold">This event already happened.</p>
+                      {% else %}
+                          {% if fieldLink %}
+                              <p class="vads-u-margin--0"><a
+                                          href="{{ fieldLink.url.path }}"><button class="vads-u-margin--0">{{fieldEventCta | listValue | capitalize}}</button></a>
+                              </p>
+                          {% endif %}
+                          {% if fieldAdditionalInformationAbo %}
+                              <p class="vads-u-margin--0">{{ fieldAdditionalInformationAbo.processed | outputLinks }}</p>
+                          {% endif %}
+                      {% endif %}
+                  </div>
+                {% endif %}
             </div>
 
                 <div class="usa-width-one-half va-c-event-share vads-u-margin-bottom--1">
                     {% include "src/site/includes/social-share.drupal.liquid" %}
                 </div>
-            </div>
+          </div>
 
-          <div class="usa-grid usa-grid-full">
+          <div class="usa-grid usa-grid-full vads-u-margin-top--2">
             <div class="event-description">
               {{ fieldBody.processed }}
             </div>


### PR DESCRIPTION
## Description
On events pages, when no registration data is available, we are still outputting the label - this pr removes said label when this occurs. Also adds a bit of margin to the body text div so that socials aren't right on top

## Testing done
Visual

## Screenshots
This is what we want / what this pr achieves:
![image](https://user-images.githubusercontent.com/2404547/72473846-8e0c4b00-37b5-11ea-9562-dfeb48664cb2.png)

