### PR TITLE
VAGOV-6410: Change sort on stoies to use creation time.

### DIFF
--- a/src/site/stages/build/drupal/graphql/facilities-fragments/healthCareRegionNewsStories.node.graphql.js
+++ b/src/site/stages/build/drupal/graphql/facilities-fragments/healthCareRegionNewsStories.node.graphql.js
@@ -37,7 +37,7 @@ function queryFilter(isAll) {
         { field: "type", value: "news_story"}
         { field: "status", value: "1"}
         ${isAll ? '' : '{ field: "field_featured" value: "1"}'}
-      ]} sort: {field: "changed", direction: DESC }, limit:${
+      ]} sort: {field: "created", direction: DESC }, limit:${
         isAll ? '500' : '2'
       })
   `;


### PR DESCRIPTION
## Description
Sort stories listing (e.g.: pittsburgh-health-care/stories/) by creation date instead of last edit time.

## Testing done
Visual

## QA
In drupal, create a new Pittsburgh story
Rebuild vets-website, confirm new story appears at top of list, here: pittsburgh-health-care/stories/