### PR TITLE
Show Open Past Requests that are within 30 days

### DIFF
--- a/src/applications/vaos/reducers/appointments.js
+++ b/src/applications/vaos/reducers/appointments.js
@@ -17,7 +17,7 @@ import { FORM_CLOSED_CONFIRMATION_PAGE } from '../actions/newAppointment';
 
 import {
   filterFutureConfirmedAppointments,
-  filterFutureRequests,
+  filterRequests,
   sortFutureConfirmedAppointments,
   sortFutureRequests,
   sortMessages,
@@ -51,7 +51,7 @@ export default function appointmentsReducer(state = initialState, action) {
         .sort(sortFutureConfirmedAppointments);
 
       const requestsFilteredAndSorted = [
-        ...requests.filter(req => filterFutureRequests(req, action.today)),
+        ...requests.filter(req => filterRequests(req, action.today)),
       ].sort(sortFutureRequests);
 
       return {

--- a/src/applications/vaos/tests/utils/appointment.unit.spec.jsx
+++ b/src/applications/vaos/tests/utils/appointment.unit.spec.jsx
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 
 import {
   getAppointmentTitle,
-  filterFutureRequests,
+  filterRequests,
   filterFutureConfirmedAppointments,
   sentenceCase,
   sortFutureRequests,
@@ -130,10 +130,10 @@ describe('VAOS appointment helpers', () => {
     expect(sorted[0].startDate).to.equal('2099-04-27T05:35:00');
   });
 
-  it('should filter future requests', () => {
+  it('should filter requests', () => {
     const requests = [
       {
-        status: 'Booked',
+        status: 'Booked', // booked - should not show
         appointmentType: 'Primary Care',
         optionDate1: now
           .clone()
@@ -141,17 +141,15 @@ describe('VAOS appointment helpers', () => {
           .format('MM/DD/YYYY'),
       },
       {
-        attributes: {
-          status: 'Submitted',
-          appointmentType: 'Primary Care',
-          optionDate1: now
-            .clone()
-            .add(-2, 'days')
-            .format('MM/DD/YYYY'),
-        },
+        status: 'Submitted', // open past date - should show
+        appointmentType: 'Primary Care',
+        optionDate1: now
+          .clone()
+          .subtract(2, 'days')
+          .format('MM/DD/YYYY'),
       },
       {
-        status: 'Submitted',
+        status: 'Submitted', // future date - should show
         appointmentType: 'Primary Care',
         optionDate1: now
           .clone()
@@ -159,17 +157,25 @@ describe('VAOS appointment helpers', () => {
           .format('MM/DD/YYYY'),
       },
       {
-        status: 'Cancelled',
+        status: 'Cancelled', // cancelled future date - should show
         appointmentType: 'Primary Care',
         optionDate1: now
           .clone()
           .add(3, 'days')
           .format('MM/DD/YYYY'),
       },
+      {
+        status: 'Cancelled', // cancelled past date - should not show
+        appointmentType: 'Primary Care',
+        optionDate1: now
+          .clone()
+          .add(-3, 'days')
+          .format('MM/DD/YYYY'),
+      },
     ];
 
-    const filteredRequests = requests.filter(r => filterFutureRequests(r, now));
-    expect(filteredRequests.length).to.equal(2);
+    const filteredRequests = requests.filter(r => filterRequests(r, now));
+    expect(filteredRequests.length).to.equal(3);
   });
 
   it('should sort future requests', () => {

--- a/src/applications/vaos/utils/appointment.jsx
+++ b/src/applications/vaos/utils/appointment.jsx
@@ -326,18 +326,19 @@ export function sortFutureConfirmedAppointments(a, b) {
   return getMomentConfirmedDate(a).isBefore(getMomentConfirmedDate(b)) ? -1 : 1;
 }
 
-export function filterFutureRequests(request, today) {
+export function filterRequests(request, today) {
+  const status = request?.status;
   const optionDate1 = moment(request.optionDate1, 'MM/DD/YYYY');
   const optionDate2 = moment(request.optionDate2, 'MM/DD/YYYY');
   const optionDate3 = moment(request.optionDate3, 'MM/DD/YYYY');
 
-  const VALID_STATUSES = ['Submitted', 'Cancelled'];
+  const hasValidDateAfterToday =
+    (optionDate1.isValid() && optionDate1.isAfter(today)) ||
+    (optionDate2.isValid() && optionDate2.isAfter(today)) ||
+    (optionDate3.isValid() && optionDate3.isAfter(today));
 
   return (
-    VALID_STATUSES.includes(request.status) &&
-    ((optionDate1.isValid() && optionDate1.isAfter(today)) ||
-      (optionDate2.isValid() && optionDate2.isAfter(today)) ||
-      (optionDate3.isValid() && optionDate3.isAfter(today)))
+    status === 'Submitted' || (status === 'Cancelled' && hasValidDateAfterToday)
   );
 }
 


### PR DESCRIPTION
## Description
If you have an open outstanding request which has preferred dates in the past, that request will count against the request limit for new requests, but you won't be able to cancel it from the appointment list, because it isn't shown.

This PR updates the filter to show open requests on the appt list even if their preferred dates are in the past.

## Testing done
Local and unit

## Screenshots
![image](https://user-images.githubusercontent.com/786704/72495468-a8591f80-37db-11ea-9a61-1d37fcd9d7d5.png)


## Acceptance criteria
- [ ] Pending requests that are for a past date should show if they are >= 30 days ago

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
