### PR TITLE
[Development] HLR remove "pension" from content

### DIFF
--- a/src/applications/disability-benefits/996/components/HLRWizard.jsx
+++ b/src/applications/disability-benefits/996/components/HLRWizard.jsx
@@ -21,7 +21,7 @@ const HLRWizard = ({ initChoice = null, initExpanded = false }) => {
 
   const name = 'higher-level-review';
   const options = [
-    { value: 'disabilityOrPension', label: wizardLabels.disabilityOrPension },
+    { value: 'compensation', label: wizardLabels.compensation },
     { value: 'other', label: wizardLabels.other },
   ];
 

--- a/src/applications/disability-benefits/996/content/contestedIssues.js
+++ b/src/applications/disability-benefits/996/content/contestedIssues.js
@@ -62,7 +62,7 @@ export const disabilitiesExplanation = (
         The decision might be for another benefit type, like health care,
         insurance, or education. Decisions for these benefit types won’t appear
         on this list. If you want to request Higher-Level Review for benefit
-        types other than compensation or pension, you’ll need to fill out a{' '}
+        types other than compensation, you’ll need to fill out a{' '}
         <a href={FORM_URL}>
           Decision Review Request: Higher-Level Review (VA Form 20-0996)
         </a>

--- a/src/applications/disability-benefits/996/content/wizardLabels.jsx
+++ b/src/applications/disability-benefits/996/content/wizardLabels.jsx
@@ -8,8 +8,8 @@ export const wizardDescription = `What type of claim are you requesting for a
   Higher-Level Review?`;
 
 export const wizardLabels = {
-  disabilityOrPension: 'A disability compensation claim or a pension claim',
-  other: 'A benefit claim other than compensation or pension',
+  compensation: 'A disability compensation claim',
+  other: 'A benefit claim other than compensation',
 };
 
 export const startPageText = 'Request a Higher-Level Review';
@@ -21,7 +21,7 @@ export const AlertContent = (
   <>
     <p>
       We’re sorry. You can only request a Higher-Level Review online for
-      compensation and pension claims right now.
+      compensation claims right now.
     </p>
     <p>
       To request a Higher-Level Review for another benefit type, please fill out

--- a/src/applications/disability-benefits/996/tests/containers/HLR-wizard.unit.spec.jsx
+++ b/src/applications/disability-benefits/996/tests/containers/HLR-wizard.unit.spec.jsx
@@ -30,13 +30,13 @@ describe('<HLRWizard>', () => {
   });
 
   // 2 choices
-  it('should show link when "disability or pension" is chosen', () => {
+  it('should show link when "compensation" is chosen', () => {
     const tree = SkinDeep.shallowRender(
-      <HLRWizard initExpanded initChoice={'disabilityOrPension'} />,
+      <HLRWizard initExpanded initChoice={'compensation'} />,
     );
     expect(tree.subTree('button')).not.to.be.false;
     expect(tree.subTree('#wizardOptions')).not.to.be.false;
-    expect(getSelected(tree)).to.equal('disabilityOrPension');
+    expect(getSelected(tree)).to.equal('compensation');
     expect(tree.subTree('.usa-button').props.href).to.equal(BASE_URL);
     expect(tree.subTree('AlertBox')).to.be.false;
   });


### PR DESCRIPTION
## Description

The Higher-Level Review form, currently a MVP, will only support handling of compensation claims. As such, pension claims would require the veteran to fill out the paper form. Some content includes "pension" as supported. We need to remove that, for now.

## Testing done

Local unit tests

## Screenshots

![](https://user-images.githubusercontent.com/136959/72446101-811d3680-3778-11ea-9ed5-5f21ecd9e7b6.png)

## Acceptance criteria
- [ ] All mention of "pension" has been removed from the HLR form, and landing page wizard

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
