### PR TITLE
[Development] Replace "apply for" to "file for" content in form 526

### DIFF
--- a/src/applications/disability-benefits/526EZ/config/form.js
+++ b/src/applications/disability-benefits/526EZ/config/form.js
@@ -127,7 +127,7 @@ const formConfig = {
   prefillEnabled: true,
   verifyRequiredPrefill: true,
   savedFormMessages: {
-    notFound: 'Please start over to apply for disability claims increase.',
+    notFound: 'Please start over to file for disability claims increase.',
     noAuth:
       'Please sign in again to resume your application for disability claims increase.',
   },

--- a/src/applications/disability-benefits/all-claims/config/form.js
+++ b/src/applications/disability-benefits/all-claims/config/form.js
@@ -140,7 +140,7 @@ const formConfig = {
   prefillEnabled: true,
   verifyRequiredPrefill: true,
   savedFormMessages: {
-    notFound: 'Please start over to apply for disability claims increase.',
+    notFound: 'Please start over to file for disability claims increase.',
     noAuth:
       'Please sign in again to resume your application for disability claims increase.',
   },

--- a/src/applications/disability-benefits/all-claims/manifest.json
+++ b/src/applications/disability-benefits/all-claims/manifest.json
@@ -4,7 +4,7 @@
   "entryName": "526EZ-all-claims",
   "rootUrl": "/disability/file-disability-claim-form-21-526ez",
   "template": {
-    "title": "Apply for disability benefits",
+    "title": "File for disability benefits",
     "layout": "page-react.html",
     "description": "Learn how to apply online for disability compensation.",
     "hideFromSidebar": true,

--- a/src/applications/personalization/dashboard/containers/DashboardApp.jsx
+++ b/src/applications/personalization/dashboard/containers/DashboardApp.jsx
@@ -51,7 +51,7 @@ const EmptyStateLinks = () => (
         >
           <h4 className="va-nav-linkslist-title">Disability benefits</h4>
           <p className="va-nav-linkslist-description">
-            Apply for disability compensation and other benefits for conditions
+            File for disability compensation and other benefits for conditions
             related to your military service.
           </p>
         </a>

--- a/src/platform/site-wide/cta-widget/helpers.js
+++ b/src/platform/site-wide/cta-widget/helpers.js
@@ -242,7 +242,7 @@ export const serviceDescription = appId => {
       return 'check your GI Bill Benefits';
 
     case widgetTypes.DISABILITY_BENEFITS:
-      return 'apply for disability benefits';
+      return 'file for disability benefits';
 
     case widgetTypes.CLAIMS_AND_APPEALS:
       return 'see your claim or appeal status';

--- a/src/site/includes/common-and-popular.html
+++ b/src/site/includes/common-and-popular.html
@@ -6,7 +6,7 @@
         <a href="/health-care/how-to-apply/">How do I apply for health care?</a>
      </li>
      <li>
-        <a href="/disability/how-to-file-claim/">How do I apply for disability benefits?</a>
+        <a href="/disability/how-to-file-claim/">How do I file for disability benefits?</a>
       </li>
       <li>
         <a href="/education/how-to-apply/">How do I apply for education benefits?</a>


### PR DESCRIPTION
## Description

The original ticket (#1712) required a content change of the form 526, to "file" not "apply" for disability compensation, as research indicates. Currently, the that content which needed changing has since been migrated and updated from the vagov-content repo into Drupal.

This PR is fixing the few remaining instances of the wording "Apply for disability compensation" to "File for disability compensation". It includes updates to form 526, the dashboard, CTA widget and the common-and-popular site page.

## Testing done

Local unit tests

## Screenshots

N/A

## Acceptance criteria
- [ ] Change all instances of "Apply for disability..." to "File for disability..."

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
