### PR TITLE
[Development] Add reject timer to 526 form submission promise

### DIFF
--- a/src/applications/disability-benefits/all-claims/config/submitForm.js
+++ b/src/applications/disability-benefits/all-claims/config/submitForm.js
@@ -3,12 +3,14 @@ import recordEvent from 'platform/monitoring/record-event';
 import * as Sentry from '@sentry/browser';
 
 const submitFormFor = eventName =>
-  function submitForm(form, formConfig) {
+  function submitForm(form, formConfig, { mode } = {}) {
     const body = formConfig.transformForSubmit
       ? formConfig.transformForSubmit(formConfig, form)
       : transformForSubmit(formConfig, form);
 
     let timer;
+    // Reject promise timer set to 30 seconds; except while testing
+    const rejectTime = mode === 'testing' ? 1 : 3e4;
 
     // Copied and pasted from USFS with a couple changes:
     // 1. Sets `withCredentials` to true
@@ -70,21 +72,20 @@ const submitFormFor = eventName =>
       req.setRequestHeader('X-Key-Inflection', 'camel');
       req.setRequestHeader('Content-Type', 'application/json');
 
-      // Throw an error after 30 seconds
+      // Log an error after the timeout fires
       timer = setTimeout(() => {
         const error = new Error('client_error: Request taking too long');
         recordEvent({ event: `${eventName}--submission-taking-too-long` });
         Sentry.withScope(scope => {
           scope.setExtra('XMLHttpRequest', req);
-          // Too much PII for sentry?
-          // scope.setExtra('form data', form);
-          // scope.setExtra('request body', body);
           Sentry.captureMessage('Form 526: submission request taking too long');
         });
-        // eslint-disable-next-line no-console
-        console.log(req, form, JSON.parse(body));
+        if (mode !== 'testing') {
+          // eslint-disable-next-line no-console
+          console.log(req, form, JSON.parse(body));
+        }
         reject(error);
-      }, 3e4);
+      }, rejectTime);
 
       req.send(body);
     });

--- a/src/applications/disability-benefits/all-claims/config/submitForm.js
+++ b/src/applications/disability-benefits/all-claims/config/submitForm.js
@@ -86,7 +86,7 @@ const submitFormFor = eventName =>
         reject(error);
       }, 3e4);
 
-      // req.send(body);
+      req.send(body);
     });
   };
 

--- a/src/applications/disability-benefits/all-claims/submit-transformer.js
+++ b/src/applications/disability-benefits/all-claims/submit-transformer.js
@@ -232,7 +232,7 @@ export function transform(formConfig, form) {
         getClaimedConditionNames(formData),
       ).map(name => name.toLowerCase());
       clonedData.newDisabilities = clonedData.newDisabilities.map(d => {
-        if (powDisabilities.includes(d.condition.toLowerCase())) {
+        if (powDisabilities.includes(d.condition?.toLowerCase())) {
           const newSpecialIssues = (d.specialIssues || []).slice();
           newSpecialIssues.push(specialIssueTypes.POW);
           return _.set('specialIssues', newSpecialIssues, d);
@@ -251,7 +251,7 @@ export function transform(formConfig, form) {
           'newDisabilities',
           formData.newDisabilities.map(
             disability =>
-              disability.condition.toLowerCase().includes('ptsd')
+              disability.condition?.toLowerCase().includes('ptsd')
                 ? _.set('cause', causeTypes.NEW, disability)
                 : disability,
           ),
@@ -269,7 +269,7 @@ export function transform(formConfig, form) {
 
     const flippedDisabilityLabels = {};
     Object.entries(disabilityLabels).forEach(([code, description]) => {
-      flippedDisabilityLabels[description.toLowerCase()] = code;
+      flippedDisabilityLabels[description?.toLowerCase()] = code;
     });
 
     const newDisabilitiesWithClassificationCodes = newDisabilities.map(
@@ -278,7 +278,7 @@ export function transform(formConfig, form) {
         if (!condition) {
           return disability;
         }
-        const loweredDisabilityName = condition.toLowerCase();
+        const loweredDisabilityName = condition?.toLowerCase();
         return flippedDisabilityLabels[loweredDisabilityName]
           ? _.set(
               'classificationCode',

--- a/src/applications/disability-benefits/all-claims/tests/config/submitForm.unit.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/config/submitForm.unit.spec.js
@@ -1,0 +1,44 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import formConfig from '../../config/form';
+
+describe('Form 526 submit reject timer', () => {
+  let xhr;
+  let requests = [];
+
+  beforeEach(() => {
+    xhr = sinon.useFakeXMLHttpRequest();
+    xhr.onCreate = req => {
+      requests.push(req);
+    };
+  });
+
+  afterEach(() => {
+    global.XMLHttpRequest = window.XMLHttpRequest;
+    xhr.restore();
+    requests = [];
+  });
+
+  it('should trigger reject timer', async () => {
+    const blankFormConfig = {
+      chapters: {},
+    };
+    const form = {
+      pages: {
+        testing: {},
+      },
+      data: {
+        testing: 1,
+      },
+    };
+
+    const promise = await formConfig
+      .submit(form, blankFormConfig, { mode: 'testing' })
+      .catch(error => {
+        expect(error.message).to.eql('client_error: Request taking too long');
+      });
+
+    return promise;
+  });
+});


### PR DESCRIPTION
## Description

Form 526 submission has been noted to become "stuck" during a shared-screen session with a veteran. The submit button turns gray, but never completes, even after waiting several minutes. No network call was made, and there was no way to check the state of the form.

The only way to reproduce this issue was to block the form submit Promise from sending/resolving. So, in the unlikely case that the Promise never resolves or rejects, this PR adds a reject timer set for 30 seconds. And then logs the `XMLHttpRequest`, `form` state and a parsed request body to allow for troubleshooting. The PII in the logs will permanently disappear once the veteran reloads or closes the tab, or closes the browser.

Note: Discussed this solution with Rian Fowler [in Slack](https://dsva.slack.com/archives/C5HP4GN3F/p1579185350026300)

## Testing done

The only way to test this modification is to comment out the line `req.send(body)` in the `src/applications/disability-benefits/all-claims/config/submitForm.js` file. This would not be possible in automated testing

## Screenshots

![Screen Shot 2020-01-16 at 4 59 00 PM](https://user-images.githubusercontent.com/136959/72570111-992cad00-3881-11ea-89bc-32bc59f26809.png)

## Acceptance criteria
- [ ] Submission that take more than 30 seconds will abort and display relevant data in the browsers developers console log. 

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs - screenshot shows mock user data
