### PR TITLE
Copy all descendants, not just direct children

### DIFF
--- a/src/site/stages/build/process-cms-exports/generator-cms-content-model/generators/app/index.js
+++ b/src/site/stages/build/process-cms-exports/generator-cms-content-model/generators/app/index.js
@@ -193,48 +193,96 @@ module.exports = class extends Generator {
     ])).names;
   }
 
-  /**
-   * Copies the example entity's children.
-   * Note: This doesn't copy grandchildren or deeper.
-   */
-  copyExampleChildren() {
-    // Iterate through the example file's kept properties
-    Object.keys(this.exampleEntity)
-      .filter(propName => this.rawPropertyNames.includes(propName))
-      .forEach(propName => {
-        const prop = this.exampleEntity[propName];
-        if (Array.isArray(prop)) {
-          prop.forEach(p => {
-            if (p.target_uuid && p.target_type) {
-              // We have an entity reference!
-              const childFileName = `${p.target_type}.${p.target_uuid}.json`;
-              const testChildPath = path.join(
-                processEntitiesRoot,
-                'tests/entities/',
-                childFileName,
-              );
+  // Largely copied from scripts/copy-entities.js
+  copyDescendants() {
+    const propBlacklist = [
+      'type',
+      'bundle',
+      'vid',
+      'uid',
+      'revision_uid',
+      'roles',
+    ];
+    const copiedUuids = new Set();
 
-              // Copy the child
-              if (!fs.existsSync(testChildPath)) {
-                fs.copyFileSync(
-                  path.join(tomeSyncContent, childFileName),
-                  testChildPath,
+    const copyChildren = entity => {
+      const uuid = entity.uuid[0].value;
+      // Avoid infinite loops
+      if (copiedUuids.has(uuid)) return;
+      copiedUuids.add(uuid);
+
+      // Iterate through the non-blacklisted properties
+      // When an entity reference is found, copy it over and recurse on it
+      Object.keys(entity)
+        .filter(k => !propBlacklist.includes(k))
+        .forEach(propName => {
+          // Properties should always be arrays, but just in case, check
+          if (Array.isArray(entity[propName])) {
+            entity[propName].forEach((p, index) => {
+              if (p.target_type && p.target_uuid) {
+                // Found an entity reference!
+                const fileName = `${p.target_type}.${p.target_uuid}.json`;
+                const sourceFile = path.join(tomeSyncContent, fileName);
+                const destFile = path.join(
+                  processEntitiesRoot,
+                  'tests/entities/',
+                  fileName,
                 );
-                this.log(
-                  chalk.green(
-                    `Added required child (${propName}): ${childFileName}`,
+                if (!fs.existsSync(destFile)) {
+                  try {
+                    fs.copyFileSync(sourceFile, destFile);
+                    this.log(
+                      chalk.grey(`${uuid}: `),
+                      chalk.green(
+                        `Added child entity (${propName}[${index}]): ${fileName}`,
+                      ),
+                    );
+                  } catch (e) {
+                    this.log(
+                      chalk.grey(`${uuid}: `),
+                      chalk.red(`Error copying ${fileName}.`),
+                    );
+                    this.log(
+                      chalk.grey(`${uuid}: `),
+                      chalk.yellow('  This UUID: '),
+                      entity.uuid[0].value,
+                    );
+                    this.log(
+                      chalk.grey(`${uuid}: `),
+                      chalk.yellow('  Child found at: '),
+                      `${propName}[${index}]`,
+                    );
+                    this.log(chalk.yellow('  Child: '), p);
+                    throw e;
+                  }
+                } else
+                  this.log(
+                    chalk.grey(`${uuid}: `),
+                    chalk.blue(
+                      `Found child entity (${propName}[${index}]): ${fileName}`,
+                    ),
+                  );
+
+                // Recurse!
+                copyChildren(
+                  JSON.parse(
+                    fs
+                      .readFileSync(
+                        path.join(
+                          tomeSyncContent,
+                          `${p.target_type}.${p.target_uuid}.json`,
+                        ),
+                      )
+                      .toString('utf8'),
                   ),
                 );
-              } else
-                this.log(
-                  chalk.green(
-                    `Found required child (${propName}): ${childFileName}`,
-                  ),
-                );
-            }
-          });
-        } else this.log(`${propName} is not an array. That's unexpected.`);
-      });
+              }
+            });
+          }
+        });
+    };
+    // Start copying!
+    copyChildren(this.exampleEntity);
   }
 
   writeSchemas() {


### PR DESCRIPTION
## Description
The CMS export transformer generator robot overlord was only copying direct children of entities. This update makes it copy _all_ descendants, not just direct children.

This has the potential side-effect of copying in more test data than we actually _need_, but it's hard to say.

Mostly, I didn't want to copy all the children of all the `node`s of the `node-health_care_local_facility` I'm working on. Using this, I was able to copy all 318(!) in a snap.

## Testing done
I mean, I used it, and it worked.

I even fiddled around with it to make better error logging when it didn't find an entity I thought it should. (Turns out, I was using it on old test data, which referenced entities which no longer existed.)

## Screenshots
![image](https://user-images.githubusercontent.com/12970166/72573796-ac3c7e80-387b-11ea-9c2e-c1788b8ad3ab.png)

## Acceptance criteria
- [x] The direct children of the example entity we're generating scaffolding for are copied
- [x] All descendants are also copied