### PR TITLE
bradl3yC - 2440 - Add aria-label to profile edit links

### DIFF
--- a/src/platform/user/profile/vet360/components/base/Vet360ProfileFieldHeading.jsx
+++ b/src/platform/user/profile/vet360/components/base/Vet360ProfileFieldHeading.jsx
@@ -6,6 +6,7 @@ function Vet360ProfileFieldHeading({ children, onEditClick }) {
       <h3 style={{ display: 'inline-block' }}>{children}</h3>{' '}
       {onEditClick && (
         <button
+          aria-label={`Edit ${children}`}
           type="button"
           data-action="edit"
           onClick={onEditClick}

--- a/src/platform/user/profile/vet360/components/base/Vet360ProfileFieldHeading.jsx
+++ b/src/platform/user/profile/vet360/components/base/Vet360ProfileFieldHeading.jsx
@@ -22,6 +22,7 @@ function Vet360ProfileFieldHeading({ children, onEditClick }) {
 
 Vet360ProfileFieldHeading.propTypes = {
   children: PropTypes.string.isRequired,
+  onEditClick: PropTypes.func,
 };
 
 export default Vet360ProfileFieldHeading;

--- a/src/platform/user/profile/vet360/components/base/Vet360ProfileFieldHeading.jsx
+++ b/src/platform/user/profile/vet360/components/base/Vet360ProfileFieldHeading.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 function Vet360ProfileFieldHeading({ children, onEditClick }) {
   return (
@@ -18,5 +19,9 @@ function Vet360ProfileFieldHeading({ children, onEditClick }) {
     </div>
   );
 }
+
+Vet360ProfileFieldHeading.propTypes = {
+  children: PropTypes.string.isRequired,
+};
 
 export default Vet360ProfileFieldHeading;


### PR DESCRIPTION
## Description
- [x] - Add aria-labels with text "Edit {section title}"

## Testing done


## Screenshots
![Screen Shot 2020-01-17 at 10 07 53 AM](https://user-images.githubusercontent.com/6165421/72622457-40a4f080-3911-11ea-890b-cb6d3946044d.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
