### PR TITLE
bradl3yC - 2435 - Add space between phone inputs

### DIFF
--- a/src/platform/user/profile/vet360/components/PhoneField/PhoneEditModal.jsx
+++ b/src/platform/user/profile/vet360/components/PhoneField/PhoneEditModal.jsx
@@ -94,23 +94,28 @@ class PhoneEditModal extends React.Component {
           international number, please check back later.
         </p>
       </AlertBox>
-
-      <PhoneTextInput
-        additionalClass="usa-only-phone"
-        label="Number"
-        charMax={14}
-        required
-        field={{ value: this.props.field.value.inputPhoneNumber, dirty: false }}
-        onValueChange={this.onChange('inputPhoneNumber')}
-        errorMessage={this.props.field.validations.inputPhoneNumber}
-      />
-
-      <ErrorableTextInput
-        label="Extension"
-        charMax={10}
-        field={{ value: this.props.field.value.extension, dirty: false }}
-        onValueChange={this.onChange('extension')}
-      />
+      <div className="vads-u-padding-y--1p5">
+        <PhoneTextInput
+          additionalClass="usa-only-phone"
+          label="Number"
+          charMax={14}
+          required
+          field={{
+            value: this.props.field.value.inputPhoneNumber,
+            dirty: false,
+          }}
+          onValueChange={this.onChange('inputPhoneNumber')}
+          errorMessage={this.props.field.validations.inputPhoneNumber}
+        />
+      </div>
+      <div className="vads-u-padding-y--1p5">
+        <ErrorableTextInput
+          label="Extension"
+          charMax={10}
+          field={{ value: this.props.field.value.extension, dirty: false }}
+          onValueChange={this.onChange('extension')}
+        />
+      </div>
 
       <ReceiveTextMessagesCheckbox
         showReceiveTextNotifications={this.props.showReceiveTextNotifications}


### PR DESCRIPTION
## Description
- [x] - Add space between inputs on phone edit modal

## Testing done


## Screenshots

### Before:
![Screen Shot 2020-01-17 at 11 28 39 AM](https://user-images.githubusercontent.com/6165421/72628562-8b783580-391c-11ea-8394-7355301b34f4.png)

### After:
![Screen Shot 2020-01-17 at 11 27 48 AM](https://user-images.githubusercontent.com/6165421/72628569-9206ad00-391c-11ea-9a71-a3e9d8ffdb5c.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
