### PR TITLE
Fix continue button on VA single location view

### DIFF
--- a/src/applications/vaos/actions/newAppointment.js
+++ b/src/applications/vaos/actions/newAppointment.js
@@ -246,7 +246,7 @@ export function openFacilityPage(page, uiSchema, schema) {
       }
 
       const facilityId =
-        newAppointment.data.vaFacility || facilities?.[0]?.facilityId;
+        newAppointment.data.vaFacility || facilities?.[0]?.institutionCode;
       if (
         facilityId &&
         !newAppointment.eligibility[`${facilityId}_${typeOfCareId}`]

--- a/src/applications/vaos/actions/newAppointment.js
+++ b/src/applications/vaos/actions/newAppointment.js
@@ -213,6 +213,17 @@ export function fetchFacilityDetails(facilityId) {
   };
 }
 
+/*
+ * The facility page can be opened with data in a variety of states and conditions.
+ * We always need the list of systems (VAMCs) they can access. After that:
+ *
+ * 1. A user has multiple systems to choose from, so we just need to display them
+ * 2. A user has only one system, so we also need to fetch facilities
+ * 3. A user might only have one system and facility available, so we need to also
+ *    do eligibility checks
+ * 4. A user might already have been on this page, in which case we may have some 
+ *    of the above data already and don't want to make another api call
+*/
 export function openFacilityPage(page, uiSchema, schema) {
   return async (dispatch, getState) => {
     const directSchedulingEnabled = vaosDirectScheduling(getState());
@@ -231,6 +242,7 @@ export function openFacilityPage(page, uiSchema, schema) {
         const userSystemIds = await getSystemIdentifiers();
         systems = await getSystemDetails(userSystemIds);
       }
+
       const canShowFacilities = !!systemId || systems?.length === 1;
 
       if (canShowFacilities && !systemId) {

--- a/src/applications/vaos/actions/newAppointment.js
+++ b/src/applications/vaos/actions/newAppointment.js
@@ -265,10 +265,10 @@ export function openFacilityPage(page, uiSchema, schema) {
         facilityId = facilities[0].institutionCode;
       }
 
-      eligibilityData =
+      const eligibilityChecks =
         newAppointment.eligibility[`${facilityId}_${typeOfCareId}`] || null;
 
-      if (eligibilityDataNeeded && !eligibilityData) {
+      if (eligibilityDataNeeded && !eligibilityChecks) {
         eligibilityData = await getEligibilityData(
           facilities.find(facility => facility.institutionCode === facilityId),
           typeOfCareId,

--- a/src/applications/vaos/actions/newAppointment.js
+++ b/src/applications/vaos/actions/newAppointment.js
@@ -220,6 +220,8 @@ export function openFacilityPage(page, uiSchema, schema) {
     let systems = newAppointment.systems;
     let facilities = null;
     let eligibilityData = null;
+    let systemId = newAppointment.data.vaSystem;
+    let facilityId = newAppointment.data.vaFacility;
 
     try {
       // If we have the VA systems in our state, we don't need to
@@ -232,27 +234,24 @@ export function openFacilityPage(page, uiSchema, schema) {
         newAppointment.data.vaSystem || systems?.length === 1;
       const typeOfCareId = getTypeOfCare(newAppointment.data)?.id;
 
+      systemId = systemId || systems?.[0]?.institutionCode;
       const hasExistingFacilities = !!newAppointment.facilities[
-        `${typeOfCareId}_${newAppointment.data.vaSystem}`
+        `${typeOfCareId}_${systemId}`
       ];
 
       if (canShowFacilities && !hasExistingFacilities) {
-        const systemId =
-          newAppointment.data.vaSystem || systems[0].institutionCode;
         facilities = await getFacilitiesBySystemAndTypeOfCare(
           systemId,
           typeOfCareId,
         );
       }
 
-      const facilityId =
-        newAppointment.data.vaFacility || facilities?.[0]?.institutionCode;
-      if (
-        facilityId &&
-        !newAppointment.eligibility[`${facilityId}_${typeOfCareId}`]
-      ) {
-        const systemId =
-          newAppointment.data.vaSystem || systems[0].institutionCode;
+      const shouldFetchEligibility = !!facilityId || facilities?.length === 1;
+      facilityId = facilityId || facilities?.[0]?.institutionCode;
+      const hasExistingEligibility = !!newAppointment.eligibility[
+        `${facilityId}_${typeOfCareId}`
+      ];
+      if (shouldFetchEligibility && !hasExistingEligibility) {
         eligibilityData = await getEligibilityData(
           facilityId,
           typeOfCareId,

--- a/src/applications/vaos/actions/newAppointment.js
+++ b/src/applications/vaos/actions/newAppointment.js
@@ -230,11 +230,14 @@ export function openFacilityPage(page, uiSchema, schema) {
         const userSystemIds = await getSystemIdentifiers();
         systems = await getSystemDetails(userSystemIds);
       }
-      const canShowFacilities =
-        newAppointment.data.vaSystem || systems?.length === 1;
+      const canShowFacilities = !!systemId || systems?.length === 1;
+
+      if (canShowFacilities && !systemId) {
+        systemId = systems[0].institutionCode;
+      }
+
       const typeOfCareId = getTypeOfCare(newAppointment.data)?.id;
 
-      systemId = systemId || systems?.[0]?.institutionCode;
       const hasExistingFacilities = !!newAppointment.facilities[
         `${typeOfCareId}_${systemId}`
       ];
@@ -246,12 +249,16 @@ export function openFacilityPage(page, uiSchema, schema) {
         );
       }
 
-      const shouldFetchEligibility = !!facilityId || facilities?.length === 1;
-      facilityId = facilityId || facilities?.[0]?.institutionCode;
+      const eligibilityDataNeeded = !!facilityId || facilities?.length === 1;
+
+      if (eligibilityDataNeeded && !facilityId) {
+        facilityId = facilities[0].institutionCode;
+      }
+
       const hasExistingEligibility = !!newAppointment.eligibility[
         `${facilityId}_${typeOfCareId}`
       ];
-      if (shouldFetchEligibility && !hasExistingEligibility) {
+      if (eligibilityDataNeeded && !hasExistingEligibility) {
         eligibilityData = await getEligibilityData(
           facilityId,
           typeOfCareId,

--- a/src/applications/vaos/components/FormButtons.jsx
+++ b/src/applications/vaos/components/FormButtons.jsx
@@ -5,6 +5,7 @@ import LoadingButton from 'platform/site-wide/loading-button/LoadingButton';
 
 export default function FormButtons({
   onBack,
+  onSubmit,
   pageChangeInProgress,
   disabled,
 }) {
@@ -22,6 +23,7 @@ export default function FormButtons({
         <LoadingButton
           isLoading={pageChangeInProgress}
           type="submit"
+          onClick={onSubmit}
           disabled={disabled}
           className="usa-button usa-button-primary vads-u-width--full"
         >

--- a/src/applications/vaos/containers/VAFacilityPage.jsx
+++ b/src/applications/vaos/containers/VAFacilityPage.jsx
@@ -166,6 +166,7 @@ export class VAFacilityPage extends React.Component {
           <div className="vads-u-margin-top--2">
             <FormButtons
               onBack={this.goBack}
+              onSubmit={this.goForward}
               pageChangeInProgress={pageChangeInProgress}
             />
           </div>

--- a/src/applications/vaos/reducers/newAppointment.js
+++ b/src/applications/vaos/reducers/newAppointment.js
@@ -289,6 +289,7 @@ export default function formReducer(state = initialState, action) {
       );
 
       let eligibility = state.eligibility;
+      let clinics = state.clinics;
       if (action.eligibilityData) {
         const facilityEligibility = getEligibilityChecks(
           newData.vaSystem,
@@ -298,7 +299,12 @@ export default function formReducer(state = initialState, action) {
 
         eligibility = {
           ...state.eligibility,
-          [`${newData.vaFacility}_${action.typeOfCareId}`]: facilityEligibility,
+          [`${data.vaFacility}_${action.typeOfCareId}`]: facilityEligibility,
+        };
+        clinics = {
+          ...state.clinics,
+          [`${data.vaFacility}_${action.typeOfCareId}`]: action.eligibilityData
+            .clinics,
         };
       }
 
@@ -316,6 +322,7 @@ export default function formReducer(state = initialState, action) {
           [action.page]: schema,
         },
         eligibility,
+        clinics,
       };
     }
     case FORM_PAGE_FACILITY_OPEN_FAILED: {

--- a/src/applications/vaos/tests/containers/VAFacilityPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/containers/VAFacilityPage.unit.spec.jsx
@@ -67,6 +67,27 @@ describe('VAOS <VAFacilityPage>', () => {
     form.unmount();
   });
 
+  it('should go forward from single facility view', () => {
+    const openFormPage = sinon.spy();
+    const routeToNextAppointmentPage = sinon.spy();
+    const form = shallow(
+      <VAFacilityPage
+        routeToNextAppointmentPage={routeToNextAppointmentPage}
+        singleValidVALocation
+        data={{}}
+        openFacilityPage={openFormPage}
+      />,
+    );
+
+    expect(form.find('VAFacilityInfoMessage').exists()).to.be.true;
+    form
+      .find('FormButtons')
+      .props()
+      .onSubmit();
+    expect(routeToNextAppointmentPage.called).to.be.true;
+    form.unmount();
+  });
+
   it('should render form with facility loading message', () => {
     const openFormPage = sinon.spy();
     const schema = {

--- a/src/applications/vaos/tests/reducers/newAppointment.unit.spec.js
+++ b/src/applications/vaos/tests/reducers/newAppointment.unit.spec.js
@@ -219,6 +219,13 @@ describe('VAOS reducer: newAppointment', () => {
         ...defaultOpenPageAction,
         systems: systemsParsed.slice(0, 1),
         facilities: facilities983Parsed.slice(0, 1),
+        eligibilityData: {
+          clinics: [],
+          requestPastVisit: {},
+          directPastVisit: {},
+          requestLimits: {},
+          pacTeam: [],
+        },
       };
 
       const newState = newAppointmentReducer(defaultState, action);
@@ -233,6 +240,9 @@ describe('VAOS reducer: newAppointment', () => {
         type: 'object',
         properties: {},
       });
+      expect(newState.clinics['983_323']).to.equal(
+        action.eligibilityData.clinics,
+      );
     });
 
     it('should set error when failed', () => {


### PR DESCRIPTION
## Description
When you see the single location view on the VA facility page, we're not rendering the SchemaForm and therefore the submit buttons triggering a "submit" event doesn't do anything. This updates the code to trigger the `goForward` method directly. It also fixes some other errors I found after fixing that, since we apparently didn't test this path through the application.

## Testing done
Local and unit testing

## Screenshots


## Acceptance criteria
- [ ] Single VA location page allows you to continue

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
