### PR TITLE
Update FE data structure for Direct Schedule POST

### DIFF
--- a/src/applications/vaos/tests/utils/data.unit.spec.js
+++ b/src/applications/vaos/tests/utils/data.unit.spec.js
@@ -306,35 +306,12 @@ describe('VAOS data transformation', () => {
         institutionName: 'CHYSHR-Cheyenne VA Medical Center',
         institutionCode: '983',
       },
-      direct: {
-        purpose: 'Follow-up/Routine: asdfasdf',
-        desiredDate: '11/22/2019 00:00:00',
-        dateTime: '11/22/2019 09:30:00',
-        apptLength: 30,
-      },
       desiredDate: '2019-11-22T00:00:00+00:00',
       dateTime: '2019-11-22T09:30:00+00:00',
       duration: 30,
       bookingNotes: 'Follow-up/Routine: asdfasdf',
-      patients: {
-        patient: [
-          {
-            contactInformation: {
-              preferredEmail: 'test@va.gov',
-              timeZone: 'America/Denver',
-            },
-            location: {
-              type: 'VA',
-              facility: {
-                name: 'CHYSHR-Cheyenne VA Medical Center',
-                siteCode: '983',
-                timeZone: 'America/Denver',
-              },
-              clinic: { ien: '308', name: 'CHY PC KILPATRICK' },
-            },
-          },
-        ],
-      },
+      preferredEmail: 'test@va.gov',
+      timeZone: 'America/Denver',
       apptType: 'P',
       purpose: '9',
       lvl: '1',
@@ -345,7 +322,6 @@ describe('VAOS data transformation', () => {
       type: 'REGULAR',
       appointmentKind: 'TRADITIONAL',
       schedulingMethod: 'direct',
-      providers: { provider: [{ location: { type: 'VA' } }] },
     });
   });
 });

--- a/src/applications/vaos/utils/data.js
+++ b/src/applications/vaos/utils/data.js
@@ -197,42 +197,14 @@ export function transformFormToAppointment(state) {
 
   return {
     clinic,
-    direct: {
-      purpose,
-      desiredDate: moment(slot.date, 'YYYY-MM-DD').format(
-        'MM/DD/YYYY [00:00:00]',
-      ),
-      dateTime: moment(slot.datetime).format('MM/DD/YYYY HH:mm:ss'),
-      apptLength: appointmentLength,
-    },
     // These times are a lie, they're actually in local time, but the upstream
     // service expects the 0 offset.
     desiredDate: `${slot.date}T00:00:00+00:00`,
     dateTime: moment(slot.datetime).format('YYYY-MM-DD[T]HH:mm:ss[+00:00]'),
     duration: appointmentLength,
     bookingNotes: purpose,
-    patients: {
-      patient: [
-        {
-          contactInformation: {
-            preferredEmail: data.email,
-            timeZone: facility.institutionTimezone,
-          },
-          location: {
-            type: 'VA',
-            facility: {
-              name: facility.name,
-              siteCode: facility.rootStationCode,
-              timeZone: facility.institutionTimezone,
-            },
-            clinic: {
-              ien: clinic.clinicId,
-              name: clinic.clinicName,
-            },
-          },
-        },
-      ],
-    },
+    preferredEmail: data.email,
+    timeZone: facility.institutionTimezone,
     // defaulted values
     apptType: 'P',
     purpose: '9',
@@ -244,15 +216,6 @@ export function transformFormToAppointment(state) {
     type: 'REGULAR',
     appointmentKind: 'TRADITIONAL',
     schedulingMethod: 'direct',
-    providers: {
-      provider: [
-        {
-          location: {
-            type: 'VA',
-          },
-        },
-      ],
-    },
   };
 }
 


### PR DESCRIPTION
## Description
Updated `transformFormToAppointment` to match [the controller](https://github.com/department-of-veterans-affairs/vets-api/blob/master/modules/vaos/app/controllers/vaos/appointments_controller.rb) that @saneshark created.  The controller  takes care of some of the defaulted and redundant data so I've removed it the appointment body we send

## Testing done
Local and unit

## Acceptance criteria
- [ ] Appointment body matches with params in https://github.com/department-of-veterans-affairs/vets-api/blob/master/modules/vaos/app/controllers/vaos/appointments_controller.rb

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
