### PR TITLE
remove form tag causing re-rendering issue with JAWS and IE11

### DIFF
--- a/src/applications/gi/components/profile/Calculator.jsx
+++ b/src/applications/gi/components/profile/Calculator.jsx
@@ -92,20 +92,16 @@ export class Calculator extends React.Component {
         </button>
         <div>
           {expanded ? (
-            <form>
-              <CalculatorForm
-                profile={profile}
-                eligibility={this.props.eligibility}
-                eligibilityChange={this.props.eligibilityChange}
-                inputs={inputs}
-                displayedInputs={displayed}
-                onShowModal={this.props.showModal}
-                onInputChange={this.props.calculatorInputChange}
-                onBeneficiaryZIPCodeChanged={
-                  this.props.beneficiaryZIPCodeChanged
-                }
-              />
-            </form>
+            <CalculatorForm
+              profile={profile}
+              eligibility={this.props.eligibility}
+              eligibilityChange={this.props.eligibilityChange}
+              inputs={inputs}
+              displayedInputs={displayed}
+              onShowModal={this.props.showModal}
+              onInputChange={this.props.calculatorInputChange}
+              onBeneficiaryZIPCodeChanged={this.props.beneficiaryZIPCodeChanged}
+            />
           ) : null}
         </div>
       </div>


### PR DESCRIPTION
## Description
https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/1062

To fix the JAWS/IE11 bug, we had to remove the form tag.

## Testing done


## Screenshots


## Acceptance criteria
- [x] JAWS reads as expected.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
