### PR TITLE
Pass loadingStatus to CalendarWidget

### DIFF
--- a/src/applications/vaos/api/index.js
+++ b/src/applications/vaos/api/index.js
@@ -382,9 +382,13 @@ export function getAvailableSlots(
   let promise;
 
   if (USE_MOCK_DATA) {
-    promise = import('./slots.json').then(
-      module => (module.default ? module.default : module),
-    );
+    promise = new Promise(resolve => {
+      setTimeout(() => {
+        import('./slots.json').then(module =>
+          resolve(module.default ? module.default : module),
+        );
+      }, 500);
+    });
   } else {
     promise = apiRequest(
       `/vaos/facilities/${facilityId}/available_appointments?type_of_care_id=${typeOfCareId}&clinic_ids[]=${clinicId}&start_date=${startDate}&end_date=${endDate}`,

--- a/src/applications/vaos/components/DateTimeSelectField.jsx
+++ b/src/applications/vaos/components/DateTimeSelectField.jsx
@@ -46,6 +46,7 @@ class DateTimeSelectField extends Component {
           maxSelections: 1,
           getOptionsByDate: this.getOptionsByDate,
         }}
+        loadingStatus={formContext?.loadingStatus}
         onChange={this.props.onChange}
         onClickNext={formContext?.getAppointmentSlots}
         onClickPrev={formContext?.getAppointmentSlots}


### PR DESCRIPTION
## Description
Month by month fetching was working, but loading indicator wasn't showing.  This passes loadingStatus to the CalendarWidget and adds timeout back to mock fetch to simulate on localhost.  

There are already unit tests for loadingStatus on these components, but just forgot to pass it down through formContext.

## Testing done
Local

## Acceptance criteria
- [ ] loadingStatus is passed on to CalendarWidget

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
