### PR TITLE
Scope selector in E2E test to <main> element

### DIFF
--- a/src/applications/edu-benefits/tests/edu-apply-wizard.e2e.spec.js
+++ b/src/applications/edu-benefits/tests/edu-apply-wizard.e2e.spec.js
@@ -36,13 +36,13 @@ module.exports = E2eHelpers.createE2eTest(client => {
       '/education/apply-for-education-benefits/application/1990N',
     );
 
-  client.expect.element('.usa-alert-warning').to.be.present;
+  client.expect.element('main .usa-alert-warning').to.be.present;
 
   // Select non-veteran
   client.click('#serviceBenefitBasedOn-1').expect.element('#apply-now-link').not
     .to.be.present;
 
-  client.expect.element('.usa-alert-warning').not.to.be.present;
+  client.expect.element('main .usa-alert-warning').not.to.be.present;
 
   client.waitForElementVisible(
     'label[for="sponsorDeceasedDisabledMIA-0"]',
@@ -86,7 +86,7 @@ module.exports = E2eHelpers.createE2eTest(client => {
     .click('#sponsorTransferredBenefits-1')
     .waitForElementVisible('#apply-now-link', Timeouts.normal);
 
-  client.expect.element('.usa-alert-warning').to.be.present;
+  client.expect.element('main .usa-alert-warning').to.be.present;
 
   client.expect
     .element('#apply-now-link')
@@ -109,7 +109,7 @@ module.exports = E2eHelpers.createE2eTest(client => {
     .click('#transferredEduBenefits-2')
     .waitForElementVisible('#apply-now-link', Timeouts.normal);
 
-  client.expect.element('.usa-alert-warning').not.to.be.present;
+  client.expect.element('main .usa-alert-warning').not.to.be.present;
 
   client.expect
     .element('#apply-now-link')


### PR DESCRIPTION
## Description
This PR added logic to create site-wide, full-width banners from Drupal - https://github.com/department-of-veterans-affairs/vets-website/pull/11475. This PR makes an E2E test narrow its selector for AlertBoxes to look only in the `main` element.

## Testing done
Ran the test locally. 

## Screenshots
N/A

## Acceptance criteria
- [ ] CI passes

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
