### PR TITLE
Remove domain from "dest" value

### DIFF
--- a/src/applications/proxy-rewrite/redirects/crossDomainRedirects.json
+++ b/src/applications/proxy-rewrite/redirects/crossDomainRedirects.json
@@ -2,7 +2,7 @@
   {
     "domain": "www.cem.va.gov",
     "src": "/cem/burial_benefits/eligible.asp",
-    "dest": "www.va.gov/burials-memorials/eligibility/"
+    "dest": "/burials-memorials/eligibility/"
   },
   {
     "domain": "www.cem.va.gov",


### PR DESCRIPTION
## Description
The redirect being corrected in this PR currently goes to `https://www.va.govwww.va.gov/burials-memorials/eligibility/`. This removes the extra domain.

Ticket - https://github.com/department-of-veterans-affairs/va.gov-team/issues/4645#issuecomment-575819524

## Testing done
None, can't be done easily locally (thought we're gonna try to change that)

## Screenshots
N/A

## Acceptance criteria
- [ ] Redirect isn't broken anymore

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
