### PR TITLE
[Promo Banner] Add some analytics

### DIFF
--- a/src/applications/find-va-forms/components/Card.jsx
+++ b/src/applications/find-va-forms/components/Card.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import classnames from 'classnames';
+import recordEvent from 'platform/monitoring/record-event';
 
 export default function Card({ heading, href, rel, target, description }) {
   const containerClassName = classnames(
@@ -14,6 +15,12 @@ export default function Card({ heading, href, rel, target, description }) {
     <a
       href={href}
       target={target}
+      onClick={() =>
+        recordEvent({
+          event: 'nav-featured-content-link-click',
+          'featured-content-header': heading,
+        })
+      }
       rel={rel}
       className={containerClassName}
       aria-label={heading}

--- a/src/applications/find-va-forms/components/Card.jsx
+++ b/src/applications/find-va-forms/components/Card.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import classnames from 'classnames';
-import recordEvent from 'platform/monitoring/record-event';
 
 export default function Card({ heading, href, rel, target, description }) {
   const containerClassName = classnames(
@@ -15,12 +14,6 @@ export default function Card({ heading, href, rel, target, description }) {
     <a
       href={href}
       target={target}
-      onClick={() =>
-        recordEvent({
-          event: 'nav-featured-content-link-click',
-          'featured-content-header': heading,
-        })
-      }
       rel={rel}
       className={containerClassName}
       aria-label={heading}

--- a/src/platform/site-wide/announcements/components/PromoBanner.jsx
+++ b/src/platform/site-wide/announcements/components/PromoBanner.jsx
@@ -1,9 +1,13 @@
 import React from 'react';
 
 import PromoBanner from '@department-of-veterans-affairs/formation-react/PromoBanner';
-import recordEvent from 'platform/monitoring/record-event';
+import _recordEvent from 'platform/monitoring/record-event';
 
-export default function PromoBannerWithAnalytics({ onClose, ...props }) {
+export default function PromoBannerWithAnalytics({
+  recordEvent = _recordEvent,
+  onClose,
+  ...props
+}) {
   return (
     <PromoBanner
       {...props}

--- a/src/platform/site-wide/announcements/components/PromoBanner.jsx
+++ b/src/platform/site-wide/announcements/components/PromoBanner.jsx
@@ -7,12 +7,12 @@ export default function PromoBannerWithAnalytics({ onClose, ...props }) {
   return (
     <PromoBanner
       {...props}
-      onClose={event => {
+      onClose={() => {
         recordEvent({
-          'event': 'nav-promo-banner-link'
+          event: 'nav-promo-banner-link',
         });
         onClose();
       }}
     />
-  )
+  );
 }

--- a/src/platform/site-wide/announcements/components/PromoBanner.jsx
+++ b/src/platform/site-wide/announcements/components/PromoBanner.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+import PromoBanner from '@department-of-veterans-affairs/formation-react/PromoBanner';
+import recordEvent from 'platform/monitoring/record-event';
+
+export default function PromoBannerWithAnalytics({ onClose, ...props }) {
+  return (
+    <PromoBanner
+      {...props}
+      onClose={event => {
+        recordEvent({
+          'event': 'nav-promo-banner-link'
+        });
+        onClose();
+      }}
+    />
+  )
+}

--- a/src/platform/site-wide/announcements/components/TestPromoBanner.jsx
+++ b/src/platform/site-wide/announcements/components/TestPromoBanner.jsx
@@ -1,8 +1,6 @@
 import React from 'react';
 
-import {
-  PROMO_BANNER_TYPES,
-} from '@department-of-veterans-affairs/formation-react/PromoBanner';
+import { PROMO_BANNER_TYPES } from '@department-of-veterans-affairs/formation-react/PromoBanner';
 
 import PromoBanner from './PromoBanner';
 

--- a/src/platform/site-wide/announcements/components/TestPromoBanner.jsx
+++ b/src/platform/site-wide/announcements/components/TestPromoBanner.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+import {
+  PROMO_BANNER_TYPES,
+} from '@department-of-veterans-affairs/formation-react/PromoBanner';
+
+import PromoBanner from './PromoBanner';
+
+export default function TestPromoBanner({ dismiss }) {
+  return (
+    <PromoBanner
+      type={PROMO_BANNER_TYPES.announcement}
+      onClose={dismiss}
+      href="https://www.va.gov/health-care"
+      text="This is a sample Promo Banner"
+    />
+  );
+}

--- a/src/platform/site-wide/announcements/config/index.js
+++ b/src/platform/site-wide/announcements/config/index.js
@@ -1,3 +1,5 @@
+import environment from 'platform/utilities/environment';
+
 // Relative imports.
 import ExploreVAModal from '../components/ExploreVAModal';
 import FindVABenefitsIntro from '../components/FindVABenefitsIntro';
@@ -5,6 +7,8 @@ import PersonalizationBanner from '../components/PersonalizationBanner';
 import Profile360Intro from '../components/Profile360Intro';
 import VAPlusVetsModal from '../components/VAPlusVetsModal';
 import WelcomeToNewVAModal from '../components/WelcomeToNewVAModal';
+
+import TestPromoBanner from '../components/TestPromoBanner';
 
 const config = {
   announcements: [
@@ -27,6 +31,12 @@ const config = {
       name: 'welcome-to-new-va',
       paths: /^\/$/,
       component: WelcomeToNewVAModal,
+    },
+    {
+      name: 'test-promo-banner',
+      paths: /^\/$/,
+      component: TestPromoBanner,
+      disabled: environment.isProduction(),
     },
     {
       name: 'find-benefits-intro',

--- a/src/platform/site-wide/announcements/tests/components/PromoBanner.unit.spec.jsx
+++ b/src/platform/site-wide/announcements/tests/components/PromoBanner.unit.spec.jsx
@@ -1,0 +1,38 @@
+// Dependencies.
+import React from 'react';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+import sinon from 'sinon';
+// Relative imports.
+import PromoBannerWithAnalytics from '../../components/PromoBanner';
+
+describe('Find VA Forms <PromoBannerWithAnalytics>', () => {
+  it('should render', () => {
+    const recordEvent = sinon.stub();
+    const onClose = sinon.stub();
+
+    const props = {
+      type: 'announcement',
+      href: 'https://www.va.gov',
+      text: 'Some announcement',
+    };
+
+    const tree = shallow(
+      <PromoBannerWithAnalytics
+        {...props}
+        onClose={onClose}
+        recordEvent={recordEvent}
+      />,
+    );
+
+    tree
+      .find('PromoBanner')
+      .props()
+      .onClose();
+
+    expect(recordEvent.called).to.be.true;
+    expect(onClose.called).to.be.true;
+
+    tree.unmount();
+  });
+});


### PR DESCRIPTION
## Description
This PR adds a GA event into the PromoBanner by creating a wrapped version of the design system's PromoBanner. It also adds a test-only PromoBanner so that the analytics teams can confirm the events are setup okay.

I considered implementing a new custom event in the design system like [here](https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/blob/master/packages/formation/js/additional-info.js#L3) and then subscribing to that event in [vets-website](https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/applications/static-pages/subscribeAdditionalInfoEvents.js). However, that pattern is right now only for non-React component, so it seemed like unnecessary complexity to do that also from a React component, since we already have to implement click handlers.

Ticket - https://github.com/department-of-veterans-affairs/va.gov-team/issues/3238

## Testing done
Ran it locally and confirmed the event triggers

## Screenshots
![image](https://user-images.githubusercontent.com/1915775/72741969-c1185b00-3b76-11ea-8b2b-4fd0e9c06b79.png)


## Acceptance criteria
- [ ] Events are added into the PromoBanner

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
