### PR TITLE
[Development] HLR same office checkbox made global in a separate step

### DIFF
--- a/src/applications/disability-benefits/996/20-0996-schema.json
+++ b/src/applications/disability-benefits/996/20-0996-schema.json
@@ -445,14 +445,14 @@
           "diagnosticCode": {
             "type": "number"
           },
-          "useSameOffice": {
-            "type": "boolean"
-          },
           "additionalNote": {
             "type": "string"
           }
         }
       }
+    },
+    "sameOffice": {
+      "type": "boolean"
     },
     "informalConferenceChoice": {
       "type": "string",
@@ -880,6 +880,9 @@
     },
     "contestedIssues": {
       "$ref": "#/definitions/contestedIssues"
+    },
+    "sameOffice": {
+      "$ref": "#/definitions/sameOffice"
     },
     "informalConferenceChoice": {
       "$ref": "#/defintions/informalConferenceChoice"

--- a/src/applications/disability-benefits/996/TODO.md
+++ b/src/applications/disability-benefits/996/TODO.md
@@ -49,13 +49,13 @@
 - [x] Add unit tests
 - [ ] Add e2e tests
 
-### Office of review
+### Office of review (Step 3)
 
 - [x] Choose same regional office yes/no
 - [x] Add unit tests
 - [ ] Add e2e tests
 
-### Request an informal conference (Step 3)
+### Request an informal conference (Step 4)
 
 - [x] Build form `requestAnInformalConference` in `config/form.js`
 - [x] Awaiting design on "Weekday" dropdown content - remove
@@ -63,7 +63,7 @@
 - [x] Add unit tests
 - [ ] Add e2e tests
 
-### Submit your application (Step 4)
+### Submit your application (Step 5)
 
 - [x] Is there a design? This page was automaticaly added by the form builder.
 - [x] Change wording to be "Review and submit your

--- a/src/applications/disability-benefits/996/TODO.md
+++ b/src/applications/disability-benefits/996/TODO.md
@@ -45,8 +45,13 @@
 ### Same jurisdiction & add notes (Step 2c)
 
 - [x] Build form `addNotes` in `config/form.js`
-- [x] Choose same regional office yes/no
 - [x] Add note for relevant evidence
+- [x] Add unit tests
+- [ ] Add e2e tests
+
+### Office of review
+
+- [x] Choose same regional office yes/no
 - [x] Add unit tests
 - [ ] Add e2e tests
 

--- a/src/applications/disability-benefits/996/TODO.md
+++ b/src/applications/disability-benefits/996/TODO.md
@@ -4,7 +4,7 @@
 
 - Update `IntroductionPage.jsx`
   - [x] Replace placeholder `isInLegacySystem` with value from API
-  - [ ] Add code to update `isInLegacySystem` (or whatever it's named).
+  - [x] Add code to update `isInLegacySystem` (or whatever it's named).
 -  Update `OptOutFromLegacySystem.jsx`
   - [x] Consider converting the `OptOutFromLegacySystem` component into a
         standalone form with it's own form schema - suggested by Erik Hansen.
@@ -70,19 +70,19 @@
 ### Confirmation page
 
 - [x] Update pre-built page from design
-- [ ] Update link "after you apply" when available
+- [x] Update link "after you apply" when available
 - [x] Add unit tests
 - [ ] Add e2e tests
 
 ### Move opt out page
 
-- [ ] Opt out page should only be visible if user has a legacy appeal
-- [ ] Consider updating JSON form schema library to accept an option to add an
+- [x] ~Opt out page should only be visible if user has a legacy appeal~ - N/A, always visible now
+- [x] Consider updating JSON form schema library to accept an option to add an
       opt out/in page after the introduction page
 
 ### Before Production
 - [ ] Check for, and remove, all console logs.
-- [ ] Move `20-0996-schema.json` to `vets-json-schema` repo.
+- [x] Move `20-0996-schema.json` to `vets-json-schema` repo.
 - [ ] Ensure matching tracking prefixes (if changed)
   - `src/applications/disability-benefits/996/config/form.js` in `formConfig.trackingPrefix`.
   - `src/applications/personalization/dashboard/helpers.jsx` ~line 146

--- a/src/applications/disability-benefits/996/config/form.js
+++ b/src/applications/disability-benefits/996/config/form.js
@@ -24,6 +24,7 @@ import veteranDetailsDescription from '../pages/confirmVeteranDetails';
 import contactInfo from '../pages/contactInformation';
 import contestedIssuesPage from '../pages/contestedIssues';
 import contestedIssueFollowup from '../pages/contestedIssueFollowup';
+import officeForReview from '../pages/officeForReview';
 import { contestedIssuesNotesStart } from '../content/contestedIssues';
 import informalConference from '../pages/informalConference';
 import optOutOfOldAppeals from '../pages/optOutOfOldAppeals';
@@ -160,6 +161,17 @@ const formConfig = {
           uiSchema: contestedIssueFollowup.uiSchema,
           schema: contestedIssueFollowup.schema,
           initialData,
+        },
+      },
+    },
+    officeForReview: {
+      title: 'Office for review',
+      pages: {
+        sameOffice: {
+          title: ' ',
+          path: 'office-for-review',
+          uiSchema: officeForReview.uiSchema,
+          schema: officeForReview.schema,
         },
       },
     },

--- a/src/applications/disability-benefits/996/content/OfficeForReview.jsx
+++ b/src/applications/disability-benefits/996/content/OfficeForReview.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
+
+export const OfficeForReviewTitle = (
+  <>
+    Would you like the same office that issued your prior decision to conduct
+    the Higher-Level Review?
+  </>
+);
+
+export const OfficeForReviewChoiceAlert = () => (
+  <AlertBox
+    status="info"
+    className="contested-issues-information"
+    headline="We will try to fulfill your request"
+    content={
+      <>
+        Some issues can only be reviewed at the office that issued your prior
+        decision. And some decisions are only processed at one VA office or
+        facility.
+        <br />
+        <p>
+          If we can’t fulfill your request, we will notify you at the time the
+          Higher-Level Review decision is made.
+        </p>
+      </>
+    }
+  />
+);

--- a/src/applications/disability-benefits/996/content/contestedIssueFollowup.js
+++ b/src/applications/disability-benefits/996/content/contestedIssueFollowup.js
@@ -1,36 +1,8 @@
 import React from 'react';
 
 import AdditionalInfo from '@department-of-veterans-affairs/formation-react/AdditionalInfo';
-import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 import { capitalizeEachWord } from '../../all-claims/utils.jsx';
 import { NULL_CONDITION_STRING } from '../constants';
-
-export const contestedIssueOfficeTitle = (
-  <>
-    Would you like the same office that issued your prior decision to conduct
-    the Higher-Level Review?
-  </>
-);
-
-export const contestedIssueOfficeChoiceAlert = () => (
-  <AlertBox
-    status="info"
-    className="contested-issues-information"
-    headline="We will try to fulfill your request"
-    content={
-      <>
-        Some issues can only be reviewed at the office that issued your prior
-        decision. And some decisions are only processed at one VA office or
-        facility.
-        <br />
-        <p>
-          If we can’t fulfill your request, we will notify you at the time the
-          Higher-Level Review decision is made.
-        </p>
-      </>
-    }
-  />
-);
 
 export const contestedIssueFollowupDescription = (
   <>

--- a/src/applications/disability-benefits/996/pages/contestedIssueFollowup.js
+++ b/src/applications/disability-benefits/996/pages/contestedIssueFollowup.js
@@ -5,14 +5,11 @@ import { validateLength } from 'platform/forms/validations';
 import { errorMessages, NULL_CONDITION_STRING } from '../constants';
 import {
   contestedIssueNameTitle,
-  contestedIssueOfficeTitle,
-  contestedIssueOfficeChoiceAlert,
   contestedIssueFollowupDescription,
   contestedIssueFollowupEvidenceInfo,
 } from '../content/contestedIssueFollowup';
 
 const {
-  useSameOffice,
   additionalNote,
 } = fullSchema.definitions.contestedIssues.items.properties;
 
@@ -27,17 +24,6 @@ const contestedIssueFollowup = {
       },
       items: {
         'ui:title': contestedIssueNameTitle,
-        useSameOffice: {
-          'ui:title': contestedIssueOfficeTitle,
-          'ui:widget': 'yesNo',
-        },
-        'view:contestedIssueSameOffice': {
-          'ui:description': contestedIssueOfficeChoiceAlert,
-          'ui:options': {
-            hideIf: (formData, index) =>
-              formData?.contestedIssues?.[index]?.useSameOffice !== false,
-          },
-        },
         additionalNote: {
           'ui:title': contestedIssueFollowupDescription,
           'ui:widget': 'textarea',
@@ -60,11 +46,6 @@ const contestedIssueFollowup = {
         items: {
           type: 'object',
           properties: {
-            useSameOffice,
-            'view:contestedIssueSameOffice': {
-              type: 'object',
-              properties: {},
-            },
             additionalNote,
             'view:evidenceInfo': {
               type: 'object',

--- a/src/applications/disability-benefits/996/pages/officeForReview.js
+++ b/src/applications/disability-benefits/996/pages/officeForReview.js
@@ -1,0 +1,35 @@
+import {
+  OfficeForReviewTitle,
+  OfficeForReviewChoiceAlert,
+} from '../content/OfficeForReview';
+
+const OfficeForReview = {
+  uiSchema: {
+    'ui:title': ' ',
+    sameOffice: {
+      'ui:title': OfficeForReviewTitle,
+      'ui:widget': 'yesNo',
+    },
+    'view:sameOffice': {
+      'ui:description': OfficeForReviewChoiceAlert,
+      'ui:options': {
+        hideIf: formData => formData?.sameOffice !== false,
+      },
+    },
+  },
+
+  schema: {
+    type: 'object',
+    properties: {
+      sameOffice: {
+        type: 'boolean',
+      },
+      'view:sameOffice': {
+        type: 'object',
+        properties: {},
+      },
+    },
+  },
+};
+
+export default OfficeForReview;

--- a/src/applications/disability-benefits/996/tests/components/contestedIssueFollowup.unit.spec.jsx
+++ b/src/applications/disability-benefits/996/tests/components/contestedIssueFollowup.unit.spec.jsx
@@ -35,7 +35,6 @@ describe('Higher-Level Review 0996 choose contested issues', () => {
       />,
     );
     const formDOM = getFormDOM(form);
-    expect($$('input[type="radio"]', formDOM).length).to.equal(2);
     expect($$('textarea', formDOM).length).to.equal(1);
     // No info alert
     expect($$('.usa-alert-info', formDOM).length).to.equal(0);
@@ -65,33 +64,6 @@ describe('Higher-Level Review 0996 choose contested issues', () => {
     expect(onSubmit.called).to.be.true;
   });
 
-  it('should render the info alert only when "No" is selected for same office', () => {
-    const onSubmit = sinon.spy();
-    const form = ReactTestUtils.renderIntoDocument(
-      <DefinitionTester
-        definitions={formConfig.defaultDefinitions}
-        onSubmit={onSubmit}
-        schema={schema}
-        data={{
-          contestedIssues: [
-            {
-              name: 'test',
-              'view:selected': true,
-              useSameOffice: false,
-            },
-          ],
-        }}
-        uiSchema={uiSchema}
-      />,
-    );
-    const formDOM = getFormDOM(form);
-    expect($$('.usa-alert-info', formDOM).length).to.equal(1);
-    formDOM.setYesNo('#root_contestedIssues_0_useSameOfficeYes', 'Y');
-    submitForm(form);
-    expect($$('.usa-alert-info', formDOM).length).to.equal(0);
-    expect(onSubmit.called).to.be.true;
-  });
-
   it('should allow submit the textarea content with no error', () => {
     const onSubmit = sinon.spy();
     const form = ReactTestUtils.renderIntoDocument(
@@ -104,7 +76,6 @@ describe('Higher-Level Review 0996 choose contested issues', () => {
             {
               name: 'test',
               'view:selected': true,
-              useSameOffice: true,
               additionalNote: 'Lorem ipsum dolor sit amet.',
             },
           ],

--- a/src/applications/disability-benefits/996/tests/components/officeForReview.unit.spec.js
+++ b/src/applications/disability-benefits/996/tests/components/officeForReview.unit.spec.js
@@ -1,0 +1,72 @@
+import React from 'react';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import ReactTestUtils from 'react-dom/test-utils';
+
+import {
+  DefinitionTester,
+  submitForm,
+  getFormDOM,
+} from 'platform/testing/unit/schemaform-utils';
+
+import { $$ } from '../../helpers';
+
+import formConfig from '../../config/form.js';
+import officeForReview from '../../pages/officeForReview';
+
+const { schema, uiSchema } = officeForReview;
+
+describe('Higher-Level Review 0996 office for review', () => {
+  it('should render the yes/no widget radios', () => {
+    const form = ReactTestUtils.renderIntoDocument(
+      <DefinitionTester
+        definitions={formConfig.defaultDefinitions}
+        schema={schema}
+        data={{}}
+        uiSchema={uiSchema}
+      />,
+    );
+    const formDOM = getFormDOM(form);
+    expect($$('input[type="radio"]', formDOM).length).to.equal(2);
+    // No info alert
+    expect($$('.usa-alert-info', formDOM).length).to.equal(0);
+  });
+
+  it('should allow submit with no change', () => {
+    const onSubmit = sinon.spy();
+    const form = ReactTestUtils.renderIntoDocument(
+      <DefinitionTester
+        definitions={formConfig.defaultDefinitions}
+        onSubmit={onSubmit}
+        schema={schema}
+        data={{}}
+        uiSchema={uiSchema}
+      />,
+    );
+    const formDOM = getFormDOM(form);
+    submitForm(form);
+    expect($$('.usa-input-error', formDOM).length).to.equal(0);
+    expect(onSubmit.called).to.be.true;
+  });
+
+  it('should render the info alert only when "No" is selected for same office', () => {
+    const onSubmit = sinon.spy();
+    const form = ReactTestUtils.renderIntoDocument(
+      <DefinitionTester
+        definitions={formConfig.defaultDefinitions}
+        onSubmit={onSubmit}
+        schema={schema}
+        data={{
+          sameOffice: false,
+        }}
+        uiSchema={uiSchema}
+      />,
+    );
+    const formDOM = getFormDOM(form);
+    expect($$('.usa-alert-info', formDOM).length).to.equal(1);
+    formDOM.setYesNo('#root_sameOfficeYes', 'Y');
+    submitForm(form);
+    expect($$('.usa-alert-info', formDOM).length).to.equal(0);
+    expect(onSubmit.called).to.be.true;
+  });
+});

--- a/src/applications/disability-benefits/996/tests/schema/initialData.js
+++ b/src/applications/disability-benefits/996/tests/schema/initialData.js
@@ -56,7 +56,6 @@ export default {
       ratingDecisionId: '63655',
       diagnosticCode: 5238,
       ratingPercentage: 10,
-      useSameOffice: true,
       additionalNote: `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam finibus pulvinar erat, ac luctus felis porttitor eget. Aenean luctus urna libero, tincidunt mollis ante cursus sed. Fusce a vehicula est, eget dignissim purus. Vestibulum quis placerat sapien. Vestibulum gravida libero quis lectus auctor, ut vehicula turpis maximus. Donec ultrices eu orci tincidunt elementum. Phasellus eros eros ornare.`,
       'view:selected': false,
     },
@@ -71,6 +70,7 @@ export default {
     },
   ],
 
+  sameOffice: true,
   informalConferenceChoice: null,
   contactRepresentativeChoice: null,
   representative: {


### PR DESCRIPTION
## Description

The request the same office review for the Higher-Level Review form was being presented to the veteran as a checkbox that could be set per contested issue. On the original form is globally applied to all included issues. This PR moves the checkbox into a separate step, now step 3/5. 

## Testing done

Updated unit tests; ran locally

## Screenshots

<details>
<summary>Step 2(c)/5 Updated contested issue followup page</summary>

<!-- leave a blank line above -->
![Screen Shot 2020-01-20 at 9 51 16 AM](https://user-images.githubusercontent.com/136959/72740084-97593700-3b6a-11ea-877b-378d7f3c28bb.png)
</details><details>
<summary>Step 3/5 Same office checkbox</summary>

<!-- leave a blank line above -->
![Screen Shot 2020-01-20 at 9 50 21 AM](https://user-images.githubusercontent.com/136959/72739953-53663200-3b6a-11ea-8307-3e64057e9c35.png)
</details><details>
<summary>Step 5/5 Updated review page</summary>

<!-- leave a blank line above -->
![Screen Shot 2020-01-20 at 10 00 12 AM](https://user-images.githubusercontent.com/136959/72740707-ce7c1800-3b6b-11ea-8ec1-a5798538088f.png)
</details>

## Acceptance criteria
- [ ] Same office checkbox included as a separate step with path set to `/office-for-review`
- [ ] Review page section title set as "Office for review" and content is appropriate

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
