### PR TITLE
Disable mock data for self-schedule POST on staging/prod

### DIFF
--- a/src/applications/vaos/api/index.js
+++ b/src/applications/vaos/api/index.js
@@ -463,7 +463,7 @@ export function submitRequest(type, request) {
 
 export function submitAppointment(appointment) {
   let promise;
-  if (USE_MOCK_DATA || true) {
+  if (USE_MOCK_DATA) {
     promise = Promise.resolve({
       data: {
         attributes: {},


### PR DESCRIPTION
## Description
This flag needed to be removed in order to disable the use of mock data on staging/prod appointment POSTs

## Testing done
Local

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
