### PR TITLE
fixed double logo issue on small devices

### DIFF
--- a/src/applications/gi/components/vet-tec/VetTecHeadingSummary.jsx
+++ b/src/applications/gi/components/vet-tec/VetTecHeadingSummary.jsx
@@ -71,7 +71,7 @@ export const VetTecHeadingSummary = ({ institution, showModal }) => {
           </div>
         </div>
         <div className="usa-width-one-third medium-8 small-12 vads-padding-left-0p5 vads-u-margin-top--neg6">
-          <div className="vettecLogoDesktop vettec-logo-container vads-u-padding-top--0 vads-u-padding-bottom--0p5">
+          <div className="vettec-logo-desktop vettec-logo-container vads-u-padding-top--0 vads-u-padding-bottom--0p5">
             {renderVetTecLogo(classNames('vettec-logo'))}
           </div>
         </div>

--- a/src/applications/gi/components/vet-tec/VetTecHeadingSummary.jsx
+++ b/src/applications/gi/components/vet-tec/VetTecHeadingSummary.jsx
@@ -71,7 +71,10 @@ export const VetTecHeadingSummary = ({ institution, showModal }) => {
           </div>
         </div>
         <div className="usa-width-one-third medium-8 small-12 vads-padding-left-0p5 vads-u-margin-top--neg6">
-          <div className="vettec-logo-container vads-u-padding-top--0 vads-u-padding-bottom--0p5">
+          <div
+            id="vettecLogoDesktop"
+            className="vettec-logo-container vads-u-padding-top--0 vads-u-padding-bottom--0p5"
+          >
             {renderVetTecLogo(classNames('vettec-logo'))}
           </div>
         </div>

--- a/src/applications/gi/components/vet-tec/VetTecHeadingSummary.jsx
+++ b/src/applications/gi/components/vet-tec/VetTecHeadingSummary.jsx
@@ -71,7 +71,7 @@ export const VetTecHeadingSummary = ({ institution, showModal }) => {
           </div>
         </div>
         <div className="usa-width-one-third medium-8 small-12 vads-padding-left-0p5 vads-u-margin-top--neg6">
-          <div className="vettec-logo-desktop vettec-logo-container vads-u-padding-top--0 vads-u-padding-bottom--0p5">
+          <div className="vads-u-display--none medium-screen:vads-u-display--block vettec-logo-container vads-u-padding-top--0 vads-u-padding-bottom--0p5">
             {renderVetTecLogo(classNames('vettec-logo'))}
           </div>
         </div>

--- a/src/applications/gi/components/vet-tec/VetTecHeadingSummary.jsx
+++ b/src/applications/gi/components/vet-tec/VetTecHeadingSummary.jsx
@@ -71,10 +71,7 @@ export const VetTecHeadingSummary = ({ institution, showModal }) => {
           </div>
         </div>
         <div className="usa-width-one-third medium-8 small-12 vads-padding-left-0p5 vads-u-margin-top--neg6">
-          <div
-            id="vettecLogoDesktop"
-            className="vettec-logo-container vads-u-padding-top--0 vads-u-padding-bottom--0p5"
-          >
+          <div className="vettecLogoDesktop vettec-logo-container vads-u-padding-top--0 vads-u-padding-bottom--0p5">
             {renderVetTecLogo(classNames('vettec-logo'))}
           </div>
         </div>

--- a/src/applications/gi/sass/partials/_gi-vet-tec.scss
+++ b/src/applications/gi/sass/partials/_gi-vet-tec.scss
@@ -23,7 +23,7 @@
   $single-column-width: 641px;
 
   @media only screen and (max-width: 767px) {
-    .vettecLogoDesktop {
+    .vettec-logo-desktop {
       display: none;
     }
   }

--- a/src/applications/gi/sass/partials/_gi-vet-tec.scss
+++ b/src/applications/gi/sass/partials/_gi-vet-tec.scss
@@ -22,12 +22,6 @@
 
   $single-column-width: 641px;
 
-  @media only screen and (max-width: 767px) {
-    .vettec-logo-desktop {
-      display: none;
-    }
-  }
-
   @media (min-width: $single-column-width) {
     .single-column-display-block {
       display: block !important;

--- a/src/applications/gi/sass/partials/_gi-vet-tec.scss
+++ b/src/applications/gi/sass/partials/_gi-vet-tec.scss
@@ -23,7 +23,7 @@
   $single-column-width: 641px;
 
   @media only screen and (max-width: 767px) {
-    #vettecLogoDesktop {
+    .vettecLogoDesktop {
       display: none;
     }
   }

--- a/src/applications/gi/sass/partials/_gi-vet-tec.scss
+++ b/src/applications/gi/sass/partials/_gi-vet-tec.scss
@@ -22,6 +22,12 @@
 
   $single-column-width: 641px;
 
+  @media only screen and (max-width: 767px) {
+    #vettecLogoDesktop {
+      display: none;
+    }
+  }
+
   @media (min-width: $single-column-width) {
     .single-column-display-block {
       display: block !important;
@@ -34,5 +40,4 @@
   .vettec-sco-list {
     list-style: none;
   }
-
 }


### PR DESCRIPTION
## Description
When viewing any Vet Tec provider profile page on mobile the Vet Tec logo shows up twice - once above and once below the institution name. The logo should only appear once above the institution's name. See attached screenshots.

https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/4974

Original requirement for logo position located here:
https://github.com/department-of-veterans-affairs/vets.gov-team/issues/19184

## Testing done
Local testing completed

## Screenshots
<img width="373" alt="Screen Shot 2020-01-20 at 11 36 33 PM" src="https://user-images.githubusercontent.com/50601724/72775797-c230a300-3bdd-11ea-85af-a003ebef792c.png">


## Acceptance criteria
- [x] Only one logo is displayed and in proper position

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
