### PR TITLE
Cleanup some schemas

### DIFF
--- a/src/site/stages/build/process-cms-exports/schemas/common/entity-url.js
+++ b/src/site/stages/build/process-cms-exports/schemas/common/entity-url.js
@@ -2,7 +2,7 @@ module.exports = {
   $id: 'EntityUrl',
   type: 'object',
   properties: {
-    path: { type: 'string' },
+    path: { type: ['string', 'null'] },
     breadcrumb: {
       type: 'array',
       items: {

--- a/src/site/stages/build/process-cms-exports/schemas/common/processed-string.js
+++ b/src/site/stages/build/process-cms-exports/schemas/common/processed-string.js
@@ -4,6 +4,5 @@ module.exports = {
   properties: {
     processed: { type: 'string' },
   },
-  // breadcrumbs are left out for now until we get them from the CMS
   required: ['processed'],
 };

--- a/src/site/stages/build/process-cms-exports/schemas/common/processed-string.js
+++ b/src/site/stages/build/process-cms-exports/schemas/common/processed-string.js
@@ -1,0 +1,9 @@
+module.exports = {
+  $id: 'ProcessedString',
+  type: 'object',
+  properties: {
+    processed: { type: 'string' },
+  },
+  // breadcrumbs are left out for now until we get them from the CMS
+  required: ['processed'],
+};

--- a/src/site/stages/build/process-cms-exports/schemas/transformed/node-event.js
+++ b/src/site/stages/build/process-cms-exports/schemas/transformed/node-event.js
@@ -5,32 +5,7 @@ module.exports = {
     entityType: { enum: ['node'] },
     entityBundle: { enum: ['event'] },
     title: { type: 'string' },
-    entityUrl: {
-      // Probably should pull this out into a common schema
-      type: 'object',
-      properties: {
-        breadcrumb: {
-          type: 'array',
-          items: {
-            type: 'object',
-            properties: {
-              url: {
-                type: 'object',
-                properties: {
-                  path: { type: 'string' },
-                  routed: { type: 'boolean' },
-                },
-                required: ['path', 'routed'],
-              },
-              text: { type: 'string' },
-            },
-            required: ['url', 'text'],
-          },
-        },
-        path: { type: 'string' },
-      },
-      required: ['breadcrumb', 'path'],
-    },
+    entityUrl: { $ref: 'EntityUrl' },
     entityMetaTags: {
       // Probably should be a common schema...except it's got
       // __typename instead of type, so it's different.

--- a/src/site/stages/build/process-cms-exports/schemas/transformed/node-event.js
+++ b/src/site/stages/build/process-cms-exports/schemas/transformed/node-event.js
@@ -60,10 +60,7 @@ module.exports = {
       },
     },
     fieldAdditionalInformationAbo: {
-      type: ['object', 'null'],
-      properties: {
-        processed: { type: 'string' },
-      },
+      oneOf: [{ $ref: 'ProcessedString' }, { type: 'null' }],
     },
     fieldAddress: {
       type: ['object', 'null'],
@@ -74,12 +71,7 @@ module.exports = {
         administrativeArea: { type: 'string' },
       },
     },
-    fieldBody: {
-      type: 'object',
-      properties: {
-        processed: { type: 'string' },
-      },
-    },
+    fieldBody: { $ref: 'ProcessedString' },
     fieldDate: {
       type: 'object',
       properties: {

--- a/src/site/stages/build/process-cms-exports/schemas/transformed/node-health_care_local_health_service.js
+++ b/src/site/stages/build/process-cms-exports/schemas/transformed/node-health_care_local_health_service.js
@@ -7,12 +7,7 @@ module.exports = {
       properties: {
         entityType: { enum: ['node'] },
         entityBundle: { enum: ['health_care_local_health_service'] },
-        fieldBody: {
-          type: 'object',
-          properties: {
-            processed: { type: 'string' },
-          },
-        },
+        fieldBody: { $ref: 'ProcessedString' },
         fieldRegionalHealthService: {
           $ref: 'transformed/node-regional_health_care_service_des',
         },

--- a/src/site/stages/build/process-cms-exports/schemas/transformed/node-health_care_region_detail_page.js
+++ b/src/site/stages/build/process-cms-exports/schemas/transformed/node-health_care_region_detail_page.js
@@ -6,14 +6,7 @@ module.exports = {
     entityBundle: { enum: ['health_care_region_detail_page'] },
     title: { type: 'string' },
     changed: { type: 'number' },
-    entityUrl: {
-      type: 'object',
-      // TODO: Add breadcrumb here
-      properties: {
-        path: { type: 'string' },
-      },
-      required: ['path'],
-    },
+    entityUrl: { $ref: 'EntityUrl' },
     fieldAlert: { type: ['string', 'null'] },
     fieldContentBlock: {
       type: 'array',

--- a/src/site/stages/build/process-cms-exports/schemas/transformed/node-health_care_region_page.js
+++ b/src/site/stages/build/process-cms-exports/schemas/transformed/node-health_care_region_page.js
@@ -8,14 +8,7 @@ module.exports = {
         entityType: { enum: ['node'] },
         entityBundle: { enum: ['health_care_region_page'] },
         title: { type: 'string' },
-        entityUrl: {
-          type: 'object',
-          properties: {
-            // TODO: add breadcrumb
-            path: { type: 'string' },
-          },
-          required: ['path'],
-        },
+        entityUrl: { $ref: 'EntityUrl' },
         fieldNicknameForThisFacility: { type: 'string' },
         // TODO: Figure out the type vs. __typename stuff
         entityMetaTags: {

--- a/src/site/stages/build/process-cms-exports/schemas/transformed/node-news_story.js
+++ b/src/site/stages/build/process-cms-exports/schemas/transformed/node-news_story.js
@@ -13,12 +13,7 @@ module.exports = {
     fieldAuthor: {
       oneOf: [{ $ref: 'transformed/node-person_profile' }, { type: 'null' }],
     },
-    fieldFullStory: {
-      type: 'object',
-      properties: {
-        processed: { type: 'string' },
-      },
-    },
+    fieldFullStory: { $ref: 'ProcessedString' },
     fieldImageCaption: { type: ['string', 'null'] },
     fieldIntroText: { type: 'string' },
     fieldMedia: { oneOf: [{ $ref: 'Media' }, { type: 'null' }] },

--- a/src/site/stages/build/process-cms-exports/schemas/transformed/node-person_profile.js
+++ b/src/site/stages/build/process-cms-exports/schemas/transformed/node-person_profile.js
@@ -4,14 +4,7 @@ module.exports = {
     contentModelType: { enum: ['node-person_profile'] },
     entityType: { enum: ['node'] },
     entityBundle: { enum: ['person_profile'] },
-    entityUrl: {
-      // This one doesn't have a breadcrumb, interestingly enough
-      type: 'object',
-      properties: {
-        path: { type: ['string', 'null'] },
-      },
-      required: ['path'],
-    },
+    entityUrl: { $ref: 'EntityUrl' },
     fieldBody: { type: ['string', 'null'] },
     fieldDescription: { type: ['string', 'null'] },
     fieldEmailAddress: { type: ['string', 'null'] },

--- a/src/site/stages/build/process-cms-exports/schemas/transformed/node-regional_health_care_service_des.js
+++ b/src/site/stages/build/process-cms-exports/schemas/transformed/node-regional_health_care_service_des.js
@@ -7,13 +7,7 @@ module.exports = {
       properties: {
         entityType: { enum: ['node'] },
         entityBundle: { enum: ['regional_health_care_service_des'] },
-        fieldBody: {
-          type: 'object',
-          properties: {
-            processed: { type: 'string' },
-          },
-          required: ['processed'],
-        },
+        fieldBody: { $ref: 'ProcessedString' },
         fieldServiceNameAndDescripti: {
           $ref: 'transformed/taxonomy_term-health_care_service_taxonomy',
         },

--- a/src/site/stages/build/process-cms-exports/schemas/transformed/paragraph-collapsible_panel_item.js
+++ b/src/site/stages/build/process-cms-exports/schemas/transformed/paragraph-collapsible_panel_item.js
@@ -12,10 +12,7 @@ module.exports = {
           type: 'array',
           items: { $ref: 'Paragraph' },
         },
-        fieldWysiwyg: {
-          type: 'object',
-          properties: { processed: { type: 'string' } },
-        },
+        fieldWysiwyg: { $ref: 'ProcessedString' },
       },
       required: ['fieldTitle', 'fieldVaParagraphs', 'fieldWysiwyg'],
     },

--- a/src/site/stages/build/process-cms-exports/schemas/transformed/paragraph-expandable_text.js
+++ b/src/site/stages/build/process-cms-exports/schemas/transformed/paragraph-expandable_text.js
@@ -8,10 +8,7 @@ module.exports = {
       type: 'object',
       required: ['fieldWysiwyg', 'fieldTextExpander'],
       properties: {
-        fieldWysiwyg: {
-          type: 'object',
-          properties: { processed: { type: 'string' } },
-        },
+        fieldWysiwyg: { $ref: 'ProcessedString' },
         fieldTextExpander: { type: 'string' },
       },
     },

--- a/src/site/stages/build/process-cms-exports/schemas/transformed/paragraph-health_care_local_facility_servi.js
+++ b/src/site/stages/build/process-cms-exports/schemas/transformed/paragraph-health_care_local_facility_servi.js
@@ -8,10 +8,7 @@ module.exports = {
       type: 'object',
       required: ['fieldWysiwyg', 'fieldTitle'],
       properties: {
-        fieldWysiwyg: {
-          type: 'object',
-          properties: { processed: { type: 'string' } },
-        },
+        fieldWysiwyg: { $ref: 'ProcessedString' },
         fieldTitle: { type: 'string' },
       },
     },

--- a/src/site/stages/build/process-cms-exports/schemas/transformed/paragraph-number_callout.js
+++ b/src/site/stages/build/process-cms-exports/schemas/transformed/paragraph-number_callout.js
@@ -8,10 +8,7 @@ module.exports = {
         entityType: { enum: ['paragraph'] },
         entityBundle: { enum: ['number_callout'] },
         fieldShortPhraseWithANumber: { type: 'string' },
-        fieldWysiwyg: {
-          type: 'object',
-          properties: { processed: { type: 'string' } },
-        },
+        fieldWysiwyg: { $ref: 'ProcessedString' },
       },
       required: ['fieldShortPhraseWithANumber', 'fieldWysiwyg'],
     },

--- a/src/site/stages/build/process-cms-exports/schemas/transformed/paragraph-process.js
+++ b/src/site/stages/build/process-cms-exports/schemas/transformed/paragraph-process.js
@@ -7,14 +7,7 @@ module.exports = {
       properties: {
         fieldSteps: {
           type: 'array',
-          items: {
-            type: 'object',
-            properties: {
-              processed: {
-                type: 'string',
-              },
-            },
-          },
+          items: { $ref: 'ProcessedString' },
         },
       },
     },

--- a/src/site/stages/build/process-cms-exports/schemas/transformed/paragraph-spanish_translation_summary.js
+++ b/src/site/stages/build/process-cms-exports/schemas/transformed/paragraph-spanish_translation_summary.js
@@ -8,10 +8,7 @@ module.exports = {
         entityType: { enum: ['paragraph'] },
         entityBundle: { enum: ['spanish_translation_summary'] },
         fieldTextExpander: { type: 'string' },
-        fieldWysiwyg: {
-          type: 'object',
-          properties: { processed: { type: 'string' } },
-        },
+        fieldWysiwyg: { $ref: 'ProcessedString' },
       },
       required: ['fieldTextExpander', 'fieldWysiwyg'],
     },

--- a/src/site/stages/build/process-cms-exports/schemas/transformed/paragraph-wysiwyg.js
+++ b/src/site/stages/build/process-cms-exports/schemas/transformed/paragraph-wysiwyg.js
@@ -5,14 +5,7 @@ module.exports = {
       type: 'object',
       required: ['fieldWysiwyg'],
       properties: {
-        fieldWysiwyg: {
-          type: 'object',
-          properties: {
-            processed: {
-              type: 'string',
-            },
-          },
-        },
+        fieldWysiwyg: { $ref: 'ProcessedString' },
       },
     },
   },

--- a/src/site/stages/build/process-cms-exports/schemas/transformed/taxonomy_term-health_care_service_taxonomy.js
+++ b/src/site/stages/build/process-cms-exports/schemas/transformed/taxonomy_term-health_care_service_taxonomy.js
@@ -8,15 +8,7 @@ module.exports = {
         entityType: { enum: ['taxonomy_term'] },
         entityBundle: { enum: ['health_care_service_taxonomy'] },
         name: { type: 'string' },
-        description: {
-          type: 'object',
-          properties: {
-            processed: {
-              type: ['string', 'null'],
-            },
-          },
-          required: ['processed'],
-        },
+        description: { $ref: 'ProcessedString' },
         parent: {
           type: 'array',
           items: {


### PR DESCRIPTION
## Description

There are lots of pieces of duplicate sub-schemas across our schemas for the CMS transformer work.  The goal of this PR is to reduce some of that duplication, add some consistency, and not make things too fragmented in the process.

A new `ProcessedString` common schema is added, and the existing `EntityUrl` is now used in more places.

## Testing done
Yup - The tests and the build pass

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
