### PR TITLE
Ignore offset for appointment time slot and add appointmentType to appointment body

### DIFF
--- a/src/applications/vaos/actions/newAppointment.js
+++ b/src/applications/vaos/actions/newAppointment.js
@@ -451,7 +451,7 @@ export function getAppointmentSlots(startDate, endDate) {
         const now = moment();
 
         mappedSlots = fetchedSlots.reduce((acc, slot) => {
-          const dateObj = moment(slot.startDateTime);
+          const dateObj = moment(slot.startDateTime.split('+')[0]);
           if (dateObj.isAfter(now)) {
             acc.push({
               date: dateObj.format('YYYY-MM-DD'),

--- a/src/applications/vaos/actions/newAppointment.js
+++ b/src/applications/vaos/actions/newAppointment.js
@@ -451,6 +451,12 @@ export function getAppointmentSlots(startDate, endDate) {
         const now = moment();
 
         mappedSlots = fetchedSlots.reduce((acc, slot) => {
+          /**
+           * The datetime we get back for startDateTime and endDateTime includes
+           * an offset of +00:00 that isn't actually accurate. The times returned are
+           * already in the time zone of the facility. In order to prevent
+           * moment from using this offset, we'll remove it in the next line
+           */
           const dateObj = moment(slot.startDateTime?.split('+')?.[0]);
           if (dateObj.isValid() && dateObj.isAfter(now)) {
             acc.push({

--- a/src/applications/vaos/actions/newAppointment.js
+++ b/src/applications/vaos/actions/newAppointment.js
@@ -451,8 +451,8 @@ export function getAppointmentSlots(startDate, endDate) {
         const now = moment();
 
         mappedSlots = fetchedSlots.reduce((acc, slot) => {
-          const dateObj = moment(slot.startDateTime.split('+')[0]);
-          if (dateObj.isAfter(now)) {
+          const dateObj = moment(slot.startDateTime?.split('+')?.[0]);
+          if (dateObj.isValid() && dateObj.isAfter(now)) {
             acc.push({
               date: dateObj.format('YYYY-MM-DD'),
               datetime: dateObj.format('YYYY-MM-DD[T]HH:mm:ss'),

--- a/src/applications/vaos/tests/actions/newAppointment.unit.spec.js
+++ b/src/applications/vaos/tests/actions/newAppointment.unit.spec.js
@@ -723,7 +723,7 @@ describe('VAOS newAppointment actions', () => {
     expect(dispatch.firstCall.args[0].email).to.equal('test@va.gov');
   });
 
-  it('should fetch appointment slots', async () => {
+  it('should fetch appointment slots and not adjust time', async () => {
     mockFetch();
     const tomorrowString = moment()
       .add(1, 'days')

--- a/src/applications/vaos/tests/actions/newAppointment.unit.spec.js
+++ b/src/applications/vaos/tests/actions/newAppointment.unit.spec.js
@@ -725,19 +725,18 @@ describe('VAOS newAppointment actions', () => {
 
   it('should fetch appointment slots', async () => {
     mockFetch();
+    const tomorrowString = moment()
+      .add(1, 'days')
+      .format('YYYY-MM-DD');
     setFetchJSONResponse(global.fetch, {
       data: [
         {
           attributes: {
-            appointmentLength: 30,
+            appointmentLength: 20,
             appointmentTimeSlot: [
               {
-                startDateTime: moment()
-                  .add(30, 'minutes')
-                  .toISOString(),
-                endDateTime: moment()
-                  .add(60, 'minutes')
-                  .toISOString(),
+                startDateTime: `${tomorrowString}T14:20:00.000+00:00`,
+                endDateTime: `${tomorrowString}T14:40:00.000+00:00`,
               },
             ],
           },
@@ -776,7 +775,11 @@ describe('VAOS newAppointment actions', () => {
     );
 
     expect(dispatch.secondCall.args[0].availableSlots.length).to.equal(1);
-    expect(dispatch.secondCall.args[0].appointmentLength).to.equal(30);
+    expect(dispatch.secondCall.args[0].availableSlots[0]).to.deep.equal({
+      date: tomorrowString,
+      datetime: `${tomorrowString}T14:20:00`,
+    });
+    expect(dispatch.secondCall.args[0].appointmentLength).to.equal(20);
 
     resetFetch();
   });

--- a/src/applications/vaos/tests/utils/data.unit.spec.js
+++ b/src/applications/vaos/tests/utils/data.unit.spec.js
@@ -306,7 +306,7 @@ describe('VAOS data transformation', () => {
         institutionName: 'CHYSHR-Cheyenne VA Medical Center',
         institutionCode: '983',
       },
-      desiredDate: '2019-11-22T00:00:00+00:00',
+      desiredDate: '2019-12-02T00:00:00+00:00',
       dateTime: '2019-11-22T09:30:00+00:00',
       duration: 30,
       bookingNotes: 'Follow-up/Routine: asdfasdf',

--- a/src/applications/vaos/tests/utils/data.unit.spec.js
+++ b/src/applications/vaos/tests/utils/data.unit.spec.js
@@ -321,6 +321,7 @@ describe('VAOS data transformation', () => {
       schedulingRequestType: 'NEXT_AVAILABLE_APPT',
       type: 'REGULAR',
       appointmentKind: 'TRADITIONAL',
+      appointmentType: 'Primary care',
       schedulingMethod: 'direct',
     });
   });

--- a/src/applications/vaos/utils/data.js
+++ b/src/applications/vaos/utils/data.js
@@ -200,7 +200,7 @@ export function transformFormToAppointment(state) {
     clinic,
     // These times are a lie, they're actually in local time, but the upstream
     // service expects the 0 offset.
-    desiredDate: `${slot.date}T00:00:00+00:00`,
+    desiredDate: `${data.preferredDate}T00:00:00+00:00`,
     dateTime: moment(slot.datetime).format('YYYY-MM-DD[T]HH:mm:ss[+00:00]'),
     duration: appointmentLength,
     bookingNotes: purpose,

--- a/src/applications/vaos/utils/data.js
+++ b/src/applications/vaos/utils/data.js
@@ -196,6 +196,7 @@ export function transformFormToAppointment(state) {
   );
 
   return {
+    appointmentType: getTypeOfCare(data).name,
     clinic,
     // These times are a lie, they're actually in local time, but the upstream
     // service expects the 0 offset.


### PR DESCRIPTION
## Description
The appointment slots returned from the API include an offset with the datetime that is not actually accurate and is always `+00:00`.  Moment was using this offset to convert the timezone, resulting in an incorrect time displayed in the calendar and passed to the API

This PR updates the calendar to disregard the offset and also include `appointmentType` to the appointment body when submitting.

## Testing done
Local and unit

## Screenshots
### Before
<img width="662" alt="Screen Shot 2020-01-21 at 5 43 05 PM" src="https://user-images.githubusercontent.com/786704/72858434-b2649d80-3c75-11ea-87ed-12f6326da68d.png">

### After
<img width="662" alt="Screen Shot 2020-01-21 at 5 42 28 PM" src="https://user-images.githubusercontent.com/786704/72858427-aa0c6280-3c75-11ea-9806-579bc068ce11.png">


## Acceptance criteria
- [ ] Time slots are not converted using provided offset
- [ ] `appointmentType` is passed along to API

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
