### PR TITLE
Update search results to include new Caution Flag design

### DIFF
--- a/src/applications/gi/components/search/SearchResult.jsx
+++ b/src/applications/gi/components/search/SearchResult.jsx
@@ -111,7 +111,16 @@ export class SearchResult extends React.Component {
               <div className="row">
                 <div className="small-12 usa-width-seven-twelfths medium-7 columns">
                   <h2>
-                    <Link to={linkTo}>{name}</Link>
+                    <a
+                      href={linkTo.pathname}
+                      aria-label={`${name} ${locationInfo(
+                        city,
+                        state,
+                        country,
+                      )}`}
+                    >
+                      {name}
+                    </a>
                   </h2>
                 </div>
               </div>
@@ -126,7 +135,7 @@ export class SearchResult extends React.Component {
               <div className="row">
                 <div className="small-12 usa-width-seven-twelfths medium-7 columns">
                   <div style={{ position: 'relative', bottom: 0 }}>
-                    <p className="locality">
+                    <p className="locality" id={`location-${facilityCode}`}>
                       {locationInfo(city, state, country)}
                     </p>
                     <p className="count">

--- a/src/applications/gi/components/search/SearchResult.jsx
+++ b/src/applications/gi/components/search/SearchResult.jsx
@@ -4,7 +4,13 @@ import { Link } from 'react-router';
 
 import { estimatedBenefits } from '../../selectors/estimator';
 import { formatCurrency, locationInfo } from '../../utils/helpers';
-import { renderCautionFlag, renderSchoolClosingFlag } from '../../utils/render';
+import {
+  renderCautionFlag,
+  renderSchoolClosingFlag,
+  renderCautionAlert,
+  renderSchoolClosingAlert,
+} from '../../utils/render';
+import environment from 'platform/utilities/environment';
 
 export class SearchResult extends React.Component {
   estimate = ({ qualifier, value }) => {
@@ -41,62 +47,132 @@ export class SearchResult extends React.Component {
 
     return (
       <div className="search-result">
-        <div className="outer">
-          {renderSchoolClosingFlag({ schoolClosing })}
-          {renderCautionFlag({ cautionFlag })}
-          <div className="inner">
-            <div className="row">
-              <div className="small-12 usa-width-seven-twelfths medium-7 columns">
-                <h2>
-                  <Link to={linkTo}>{name}</Link>
-                </h2>
-                <div style={{ position: 'relative', bottom: 0 }}>
-                  <p className="locality">
-                    {locationInfo(city, state, country)}
-                  </p>
-                  <p className="count">
-                    {(+studentCount).toLocaleString()} GI Bill Students
-                  </p>
+        {/* prod flag for bah 4926 */}
+        {environment.isProduction() ? (
+          <div className="outer">
+            {renderSchoolClosingFlag({ schoolClosing })}
+            {renderCautionFlag({ cautionFlag })}
+            <div className="inner">
+              <div className="row">
+                <div className="small-12 usa-width-seven-twelfths medium-7 columns">
+                  <h2>
+                    <Link to={linkTo}>{name}</Link>
+                  </h2>
+                  <div style={{ position: 'relative', bottom: 0 }}>
+                    <p className="locality">
+                      {locationInfo(city, state, country)}
+                    </p>
+                    <p className="count">
+                      {(+studentCount).toLocaleString()} GI Bill Students
+                    </p>
+                  </div>
+                </div>
+                <div className="small-12 usa-width-five-twelfths medium-5 columns estimated-benefits">
+                  <h3>You may be eligible for up to:</h3>
+                  <div className="row">
+                    <div className="columns">
+                      <h4>
+                        <i className="fa fa-graduation-cap fa-search-result" />
+                        Tuition <span>(annually):</span>
+                        <div>{tuition}</div>
+                      </h4>
+                    </div>
+                  </div>
+                  <div className="row">
+                    <div className="columns">
+                      <h4>
+                        <i className="fa fa-home fa-search-result" />
+                        Housing <span>(monthly):</span>
+                        <div>{housing}</div>
+                      </h4>
+                    </div>
+                  </div>
+                  <div className="row">
+                    <div className="columns">
+                      <h4>
+                        <i className="fa fa-book fa-search-result" />
+                        Books <span>(annually):</span>
+                        <div>{books}</div>
+                      </h4>
+                    </div>
+                  </div>
                 </div>
               </div>
-              <div className="small-12 usa-width-five-twelfths medium-5 columns estimated-benefits">
-                <h3>You may be eligible for up to:</h3>
-                <div className="row">
-                  <div className="columns">
-                    <h4>
-                      <i className="fa fa-graduation-cap fa-search-result" />
-                      Tuition <span>(annually):</span>
-                      <div>{tuition}</div>
-                    </h4>
-                  </div>
+              <div className="row">
+                <div className="view-details columns">
+                  <Link to={linkTo}>View details ›</Link>
                 </div>
-                <div className="row">
-                  <div className="columns">
-                    <h4>
-                      <i className="fa fa-home fa-search-result" />
-                      Housing <span>(monthly):</span>
-                      <div>{housing}</div>
-                    </h4>
-                  </div>
-                </div>
-                <div className="row">
-                  <div className="columns">
-                    <h4>
-                      <i className="fa fa-book fa-search-result" />
-                      Books <span>(annually):</span>
-                      <div>{books}</div>
-                    </h4>
-                  </div>
-                </div>
-              </div>
-            </div>
-            <div className="row">
-              <div className="view-details columns">
-                <Link to={linkTo}>View details ›</Link>
               </div>
             </div>
           </div>
-        </div>
+        ) : (
+          <div className="outer">
+            <div className="inner">
+              <div className="row">
+                <div className="small-12 usa-width-seven-twelfths medium-7 columns">
+                  <h2>
+                    <Link to={linkTo}>{name}</Link>
+                  </h2>
+                </div>
+              </div>
+              {(schoolClosing || cautionFlag) && (
+                <div className="row alert-row">
+                  <div className="small-12 columns">
+                    {renderSchoolClosingAlert({ schoolClosing })}
+                    {renderCautionAlert({ cautionFlag })}
+                  </div>
+                </div>
+              )}
+              <div className="row">
+                <div className="small-12 usa-width-seven-twelfths medium-7 columns">
+                  <div style={{ position: 'relative', bottom: 0 }}>
+                    <p className="locality">
+                      {locationInfo(city, state, country)}
+                    </p>
+                    <p className="count">
+                      {(+studentCount).toLocaleString()} GI Bill Students
+                    </p>
+                  </div>
+                </div>
+                <div className="small-12 usa-width-five-twelfths medium-5 columns estimated-benefits">
+                  <h3>You may be eligible for up to:</h3>
+                  <div className="row">
+                    <div className="columns">
+                      <h4>
+                        <i className="fa fa-graduation-cap fa-search-result" />
+                        Tuition <span>(annually):</span>
+                        <div>{tuition}</div>
+                      </h4>
+                    </div>
+                  </div>
+                  <div className="row">
+                    <div className="columns">
+                      <h4>
+                        <i className="fa fa-home fa-search-result" />
+                        Housing <span>(monthly):</span>
+                        <div>{housing}</div>
+                      </h4>
+                    </div>
+                  </div>
+                  <div className="row">
+                    <div className="columns">
+                      <h4>
+                        <i className="fa fa-book fa-search-result" />
+                        Books <span>(annually):</span>
+                        <div>{books}</div>
+                      </h4>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div className="row">
+                <div className="view-details columns">
+                  <Link to={linkTo}>View details ›</Link>
+                </div>
+              </div>
+            </div>
+          </div>
+        )}
       </div>
     );
   }

--- a/src/applications/gi/components/vet-tec/VetTecProgramSearchResult.jsx
+++ b/src/applications/gi/components/vet-tec/VetTecProgramSearchResult.jsx
@@ -2,7 +2,12 @@ import React from 'react';
 import { Link } from 'react-router';
 
 import { formatCurrency, isPresent, locationInfo } from '../../utils/helpers';
-import { renderPreferredProviderFlag } from '../../utils/render';
+import {
+  renderPreferredProviderFlag,
+  renderCautionAlert,
+  renderSchoolClosingAlert,
+} from '../../utils/render';
+import environment from 'platform/utilities/environment';
 
 class VetTecProgramSearchResult extends React.Component {
   render() {
@@ -17,7 +22,10 @@ class VetTecProgramSearchResult extends React.Component {
       tuitionAmount,
       lengthInHours,
       dodBah,
+      schoolClosing,
+      cautionFlag,
     } = result;
+
     const tuition = isPresent(tuitionAmount)
       ? formatCurrency(tuitionAmount)
       : 'TBD';
@@ -44,6 +52,15 @@ class VetTecProgramSearchResult extends React.Component {
                 {renderPreferredProviderFlag(this.props.result)}
               </div>
             </div>
+            {!environment.isProduction() &&
+              (schoolClosing || cautionFlag) && (
+                <div className="row alert-row">
+                  <div className="small-12 columns">
+                    {renderSchoolClosingAlert({ schoolClosing })}
+                    {renderCautionAlert({ cautionFlag })}
+                  </div>
+                </div>
+              )}
             <div className="row vads-u-padding-top--1p5">
               <div className="small-12 medium-7 columns">
                 <div style={{ position: 'relative', bottom: 0 }}>

--- a/src/applications/gi/components/vet-tec/VetTecProgramSearchResult.jsx
+++ b/src/applications/gi/components/vet-tec/VetTecProgramSearchResult.jsx
@@ -54,7 +54,7 @@ class VetTecProgramSearchResult extends React.Component {
                     )}`}
                   >
                     {description}
-                  </a>{' '}
+                  </a>
                 </h2>
               </div>
               <div className="small-12 medium-3 columns">

--- a/src/applications/gi/components/vet-tec/VetTecProgramSearchResult.jsx
+++ b/src/applications/gi/components/vet-tec/VetTecProgramSearchResult.jsx
@@ -45,7 +45,16 @@ class VetTecProgramSearchResult extends React.Component {
             <div className="row vads-u-padding-top--1p5">
               <div className="small-12 medium-7 columns">
                 <h2>
-                  <Link to={linkTo}>{description}</Link>
+                  <a
+                    href={linkTo}
+                    aria-label={`${description} ${locationInfo(
+                      city,
+                      state,
+                      country,
+                    )}`}
+                  >
+                    {description}
+                  </a>{' '}
                 </h2>
               </div>
               <div className="small-12 medium-3 columns">

--- a/src/applications/gi/components/vet-tec/VetTecProgramSearchResult.jsx
+++ b/src/applications/gi/components/vet-tec/VetTecProgramSearchResult.jsx
@@ -46,7 +46,7 @@ class VetTecProgramSearchResult extends React.Component {
               <div className="small-12 medium-7 columns">
                 <h2>
                   <a
-                    href={linkTo}
+                    href={linkTo.pathname}
                     aria-label={`${description} ${locationInfo(
                       city,
                       state,

--- a/src/applications/gi/sass/partials/_gi-search-page.scss
+++ b/src/applications/gi/sass/partials/_gi-search-page.scss
@@ -180,4 +180,21 @@
   .gi-checkbox-label:before {
     box-shadow: 0 0 0 2px white, 0 0 0 3px $color-gray-medium;
   }
+
+  .usa-alert {
+    background-color: white;
+    padding-top: .5em;
+    padding-bottom: .5em;
+    margin-top: .5em;
+  }
+
+  .usa-alert-text {
+    margin-top: .25em;
+  }
+
+  .alert-row {
+    margin-bottom: 1em;
+  }
+
+
 }

--- a/src/applications/gi/tests/components/VetTecProgramSearchResult.unit.spec.jsx
+++ b/src/applications/gi/tests/components/VetTecProgramSearchResult.unit.spec.jsx
@@ -18,6 +18,8 @@ const defaultProps = {
     programType: 'NCD',
     state: 'IL',
     tuitionAmount: 10000,
+    schoolClosing: false,
+    cautionFlag: false,
   },
   constants: {
     AVGDODBAH: 1000,
@@ -80,4 +82,18 @@ describe('<VetTecProgramSearchResult>', () => {
     expect(wrapper.find('.info-flag').text()).to.eq('TBD');
     wrapper.unmount();
   });
+});
+
+it('should display school closing and caution alerts', () => {
+  const props = {
+    ...defaultProps,
+    result: {
+      ...defaultProps.result,
+      schoolClosing: true,
+      cautionFlag: true,
+    },
+  };
+  const wrapper = mount(<VetTecProgramSearchResult {...props} />);
+  expect(wrapper.find('.usa-alert')).to.have.lengthOf(2);
+  wrapper.unmount();
 });

--- a/src/applications/gi/utils/render.jsx
+++ b/src/applications/gi/utils/render.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 
 export const renderSchoolClosingFlag = result => {
   const { schoolClosing } = result;
@@ -22,6 +23,31 @@ export const renderCautionFlag = result => {
   );
 };
 
+export const renderSchoolClosingAlert = result => {
+  const { schoolClosing } = result;
+  if (!schoolClosing) return null;
+  return (
+    <AlertBox
+      content={<p>Upcoming campus closure</p>}
+      headline="School closure"
+      isVisible={!!schoolClosing}
+      status="warning"
+    />
+  );
+};
+
+export const renderCautionAlert = result => {
+  const { cautionFlag } = result;
+  if (!cautionFlag) return null;
+  return (
+    <AlertBox
+      content={<p>This school has cautionary warnings</p>}
+      headline="Caution"
+      isVisible={!!cautionFlag}
+      status="warning"
+    />
+  );
+};
 export const renderPreferredProviderFlag = result => {
   const { preferredProvider } = result;
   if (!preferredProvider) return <br />;


### PR DESCRIPTION
## Description
https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/4926


## Testing done
Updated unit tests.
Tested locally.

## Screenshots
![image](https://user-images.githubusercontent.com/48804654/72905653-dfa95e00-3cfe-11ea-95af-50454a1ef4cb.png)

![image](https://user-images.githubusercontent.com/48804654/72905668-e637d580-3cfe-11ea-905b-d4e3138bc3ae.png)

![image](https://user-images.githubusercontent.com/48804654/72994448-1f3a7d80-3dc5-11ea-91b1-50f823d13e86.png)

![image](https://user-images.githubusercontent.com/48804654/72994541-442ef080-3dc5-11ea-9b83-0f1831af12ae.png)

## Acceptance criteria
- [x] The "School Closure" caution flag is displayed under the institution name.
- [x] The "School Closure" caution flag matches DSVA style guidelines.
- [x] The "Caution" caution flag is displayed under the institution name.
- [x] The "Caution" caution flag matches DSVA style guidelines.
- [x] AC 1 - 4 are applicable to:
     - The regular search results
     - The VET TEC search results
- [x] If an institution has both warnings, the "School Closure" is displayed first.
- [x] The updated user interface is 508 compliant (see #4919)

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
