### PR TITLE
VAGOV-852: Adding check to prevent orphaned status header.

### DIFF
--- a/src/site/layouts/vamc_operating_status_and_alerts.drupal.liquid
+++ b/src/site/layouts/vamc_operating_status_and_alerts.drupal.liquid
@@ -37,7 +37,7 @@
                             id="on-this-page">On this
                             page</h2>
                         <ul class="usa-unstyled-list">
-                            {% if fieldBannerAlert.0.entity %}
+                            {% if fieldBannerAlert.0.entity.status != false and fieldBannerAlert.0.entity.fieldSituationUpdates.0.entity %}
                             <li class="vads-u-margin-bottom--2">
                                 <a href="#situation-updates"
                                     onclick="recordEvent({ event: 'nav-jumplink-click' });"
@@ -71,7 +71,7 @@
                         </ul>
                     </section>
 
-                    {% if fieldBannerAlert.0.entity %}
+                    {% if fieldBannerAlert.0.entity.status != false and fieldBannerAlert.0.entity.fieldSituationUpdates.0.entity %}
                     {% include "src/site/components/situation_updates.drupal.liquid" with fieldBannerAlert %}
                     {% endif %}
 


### PR DESCRIPTION
## Description
On `pittsburgh-health-care/operating-status/` prevent empty `Situation updates and information` header and jump links from appearing when banner is unpublished

## Testing done
Visual

## Screenshots
Bad:
![image](https://user-images.githubusercontent.com/2404547/72924291-aaad0380-3d1e-11ea-9af1-27c9cde7b2e1.png)

Good:
![image](https://user-images.githubusercontent.com/2404547/72924300-ae408a80-3d1e-11ea-8a77-931f3fade4b9.png)