### PR TITLE
Adjust handling of appointment post response

### DIFF
--- a/src/applications/vaos/api/index.js
+++ b/src/applications/vaos/api/index.js
@@ -473,15 +473,14 @@ export function submitAppointment(appointment) {
         attributes: {},
       },
     });
-  } else {
-    promise = apiRequest('/vaos/appointments', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(appointment),
-    });
+    return promise.then(resp => resp.data.attributes);
   }
 
-  return promise.then(resp => resp.data.attributes);
+  return apiRequest('/vaos/appointments', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(appointment),
+  });
 }
 
 export function sendRequestMessage(id, messageText) {

--- a/src/applications/vaos/api/index.js
+++ b/src/applications/vaos/api/index.js
@@ -466,14 +466,8 @@ export function submitRequest(type, request) {
 }
 
 export function submitAppointment(appointment) {
-  let promise;
   if (USE_MOCK_DATA) {
-    promise = Promise.resolve({
-      data: {
-        attributes: {},
-      },
-    });
-    return promise.then(resp => resp.data.attributes);
+    return Promise.resolve();
   }
 
   return apiRequest('/vaos/appointments', {


### PR DESCRIPTION
## Description
POSTing to `/vaos/appointments` returns a `204` without content.  This code adjusts the api call to handle that response, instead of a `200` with JSON response we were previously expecting.

## Testing done
Local


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
