### PR TITLE
Fix overlap of calendar headings at high zoom and small screen sizes

### DIFF
--- a/src/applications/vaos/components/calendar/CalendarWeekdayHeader.jsx
+++ b/src/applications/vaos/components/calendar/CalendarWeekdayHeader.jsx
@@ -1,5 +1,4 @@
-import React, { useState, useEffect } from 'react';
-import debounce from 'platform/utilities/data/debounce';
+import React from 'react';
 
 const days = [
   {
@@ -24,27 +23,7 @@ const days = [
   },
 ];
 
-const mediaQuery = window.matchMedia('(min-width: 481px)');
-
 export default function CalendarWeekdayHeader() {
-  const [isSmallScreenOrLarger, setIsSmallScreenOrLarger] = useState(
-    mediaQuery.matches,
-  );
-
-  useEffect(() => {
-    const onResize = debounce(50, () => {
-      if (mediaQuery.matches !== isSmallScreenOrLarger) {
-        setIsSmallScreenOrLarger(mediaQuery.matches);
-      }
-    });
-
-    window.addEventListener('resize', onResize);
-
-    return () => {
-      window.removeEventListener('resize', onResize);
-    };
-  });
-
   return (
     <div role="rowgroup">
       <div
@@ -57,13 +36,13 @@ export default function CalendarWeekdayHeader() {
             role="columnheader"
             className="vaos-calendar__weekday vads-u-font-weight--bold vads-u-text-align--center vads-u-margin-bottom--0p5"
           >
-            {isSmallScreenOrLarger && day.name}
-            {!isSmallScreenOrLarger && (
-              <>
-                <span aria-hidden="true">{day.abbr}</span>
-                <span className="sr-only">{day.name}</span>
-              </>
-            )}
+            <span className="vads-u-display--none small-screen:vads-u-display--inline">
+              {day.name}
+            </span>
+            <span className="small-screen:vads-u-display--none">
+              <span aria-hidden="true">{day.abbr}</span>
+              <span className="sr-only">{day.name}</span>
+            </span>
           </div>
         ))}
       </div>

--- a/src/applications/vaos/components/calendar/CalendarWeekdayHeader.jsx
+++ b/src/applications/vaos/components/calendar/CalendarWeekdayHeader.jsx
@@ -23,29 +23,29 @@ const days = [
   },
 ];
 
-export default function CalendarWeekdayHeader() {
-  return (
-    <div role="rowgroup">
-      <div
-        className="vaos-calendar__weekday-container vads-u-display--flex vads-u-justify-content--space-between"
-        role="row"
-      >
-        {days.map((day, index) => (
-          <div
-            key={`weekday-${index}`}
-            role="columnheader"
-            className="vaos-calendar__weekday vads-u-font-weight--bold vads-u-text-align--center vads-u-margin-bottom--0p5"
-          >
-            <span className="vads-u-display--none small-screen:vads-u-display--inline">
-              {day.name}
-            </span>
-            <span className="small-screen:vads-u-display--none">
-              <span aria-hidden="true">{day.abbr}</span>
-              <span className="sr-only">{day.name}</span>
-            </span>
-          </div>
-        ))}
-      </div>
+const CalendarWeekdayHeader = () => (
+  <div role="rowgroup">
+    <div
+      className="vaos-calendar__weekday-container vads-u-display--flex vads-u-justify-content--space-between"
+      role="row"
+    >
+      {days.map((day, index) => (
+        <div
+          key={`weekday-${index}`}
+          role="columnheader"
+          className="vaos-calendar__weekday vads-u-font-weight--bold vads-u-text-align--center vads-u-margin-bottom--0p5"
+        >
+          <span className="vads-u-display--none small-screen:vads-u-display--inline">
+            {day.name}
+          </span>
+          <span className="small-screen:vads-u-display--none">
+            <span aria-hidden="true">{day.abbr}</span>
+            <span className="sr-only">{day.name}</span>
+          </span>
+        </div>
+      ))}
     </div>
-  );
-}
+  </div>
+);
+
+export default CalendarWeekdayHeader;

--- a/src/applications/vaos/components/calendar/CalendarWeekdayHeader.jsx
+++ b/src/applications/vaos/components/calendar/CalendarWeekdayHeader.jsx
@@ -1,27 +1,72 @@
-import React from 'react';
-import isMobile from 'ismobilejs';
+import React, { useState, useEffect } from 'react';
+import debounce from 'platform/utilities/data/debounce';
 
-const days = isMobile.phone
-  ? ['Mon', 'Tue', 'Wed', 'Thu', 'Fri']
-  : ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday'];
+const days = [
+  {
+    name: 'Monday',
+    abbr: 'Mon',
+  },
+  {
+    name: 'Tuesday',
+    abbr: 'Tue',
+  },
+  {
+    name: 'Wednesday',
+    abbr: 'Wed',
+  },
+  {
+    name: 'Thursday',
+    abbr: 'Thu',
+  },
+  {
+    name: 'Friday',
+    abbr: 'Fri',
+  },
+];
 
-const CalendarWeekdayHeader = () => (
-  <div role="rowgroup">
-    <div
-      className="vaos-calendar__weekday-container vads-u-display--flex vads-u-justify-content--space-between"
-      role="row"
-    >
-      {days.map((day, index) => (
-        <div
-          key={`weekday-${index}`}
-          role="columnheader"
-          className="vaos-calendar__weekday vads-u-font-weight--bold vads-u-text-align--center vads-u-margin-bottom--0p5"
-        >
-          {day}
-        </div>
-      ))}
+const mediaQuery = window.matchMedia('(min-width: 481px)');
+
+export default function CalendarWeekdayHeader() {
+  const [isSmallScreenOrLarger, setIsSmallScreenOrLarger] = useState(
+    mediaQuery.matches,
+  );
+
+  useEffect(() => {
+    const onResize = debounce(50, () => {
+      if (mediaQuery.matches !== isSmallScreenOrLarger) {
+        setIsSmallScreenOrLarger(mediaQuery.matches);
+      }
+    });
+
+    window.addEventListener('resize', onResize);
+
+    return () => {
+      window.removeEventListener('resize', onResize);
+    };
+  });
+
+  return (
+    <div role="rowgroup">
+      <div
+        className="vaos-calendar__weekday-container vads-u-display--flex vads-u-justify-content--space-between"
+        role="row"
+      >
+        {days.map((day, index) => (
+          <div
+            key={`weekday-${index}`}
+            role="columnheader"
+            className="vaos-calendar__weekday vads-u-font-weight--bold vads-u-text-align--center vads-u-margin-bottom--0p5"
+          >
+            {isSmallScreenOrLarger && day.name}
+            {!isSmallScreenOrLarger && (
+              <>
+                <span aria-hidden="true">{day.abbr}</span>
+                <span className="sr-only">{day.name}</span>
+              </>
+            )}
+          </div>
+        ))}
+      </div>
     </div>
-  </div>
-);
-
-export default CalendarWeekdayHeader;
+  );
+}

--- a/src/applications/vaos/tests/components/calendar/CalendarWeekdayHeader.unit.spec.jsx
+++ b/src/applications/vaos/tests/components/calendar/CalendarWeekdayHeader.unit.spec.jsx
@@ -10,11 +10,41 @@ describe('VAOS <CalendarWeekdayHeader>', () => {
 
     const items = tree.find('.vaos-calendar__weekday');
     expect(items.length).to.equal(5);
-    expect(items.at(0).text()).to.equal('Monday');
-    expect(items.at(1).text()).to.equal('Tuesday');
-    expect(items.at(2).text()).to.equal('Wednesday');
-    expect(items.at(3).text()).to.equal('Thursday');
-    expect(items.at(4).text()).to.equal('Friday');
+    expect(
+      items
+        .at(0)
+        .find('span')
+        .first()
+        .text(),
+    ).to.equal('Monday');
+    expect(
+      items
+        .at(1)
+        .find('span')
+        .first()
+        .text(),
+    ).to.equal('Tuesday');
+    expect(
+      items
+        .at(2)
+        .find('span')
+        .first()
+        .text(),
+    ).to.equal('Wednesday');
+    expect(
+      items
+        .at(3)
+        .find('span')
+        .first()
+        .text(),
+    ).to.equal('Thursday');
+    expect(
+      items
+        .at(4)
+        .find('span')
+        .first()
+        .text(),
+    ).to.equal('Friday');
     tree.unmount();
   });
 });


### PR DESCRIPTION
## Description
The day of the week header text was overlapping at high zoom levels and small screen sizes. It looks like we were trying to work around this by abbreviating the day text on mobile, but that won't cover zoomed desktops. This change updates it to use CSS to hide and show the right text, which works on both small screens and when zooming.

## Testing done
Local testing

## Screenshots
![Screen Shot 2020-01-23 at 11 59 00 AM](https://user-images.githubusercontent.com/634932/73017742-4f4a4680-3dee-11ea-847a-cc0d9fefb87b.png)

## Acceptance criteria
- [ ] Zoomed text looks good

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
