### PR TITLE
VAGOV-6271: Adding date sort to outreach events.

### DIFF
--- a/src/site/components/events_list.drupal.liquid
+++ b/src/site/components/events_list.drupal.liquid
@@ -4,7 +4,8 @@
   {% if outreachSidebar.name == 'Outreach and events' %}
     {% assign eventsArray = reverseFieldOfficeNode.entities %}
   {% endif %}
-  {% for event in eventsArray %}
+  {% assign sortedEventsArray = eventsArray | eventSorter %}
+  {% for event in sortedEventsArray %}
   {% if event.title.length %}
   {% assign count = count | plus:1 %}
   <div class="vads-u-margin-bottom--2">

--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -241,6 +241,20 @@ module.exports = function registerFilters() {
     return sorted;
   };
 
+  liquid.filters.eventSorter = item => {
+    const sorted = item.sort((a, b) => {
+      const aTime = Math.floor(
+        new Date(a.fieldDate.startDate).getTime() / 1000,
+      );
+      const bTime = Math.floor(
+        new Date(b.fieldDate.startDate).getTime() / 1000,
+      );
+      const sorter = bTime - aTime;
+      return sorter;
+    });
+    return sorted;
+  };
+
   // Find the current path in an array of nested link arrays and then return it's depth + it's parent and children
   liquid.filters.findCurrentPathDepth = (linksArray, currentPath) => {
     const getDeepLinks = (path, linkArr) => {


### PR DESCRIPTION
## Description
Sort outreach events (`outreach-and-events/events/`) by newest first

## Testing done
Visual

## Screenshots
Good:
![image](https://user-images.githubusercontent.com/2404547/73022198-1367af00-3df7-11ea-9c24-50bc4b0ece30.png)

