### PR TITLE
Fix CC timezone handling on appt list page

### DIFF
--- a/src/applications/vaos/api/confirmed_cc.json
+++ b/src/applications/vaos/api/confirmed_cc.json
@@ -16,8 +16,8 @@
           "zipCode": "32826"
         },
         "instructionsToVeteran": "Please arrive 15 minutes ahead of appointment.",
-        "appointmentTime": "01/25/2020 13:30:00",
-        "timeZone": "-04:00 EDT"
+        "appointmentTime": "02/25/2020 03:45:00",
+        "timeZone": "+08:00 WITA"
       }
     },
     {
@@ -36,8 +36,8 @@
           "zipCode": "20151"
         },
         "instructionsToVeteran": "Bring your glasses",
-        "appointmentTime": "12/20/2019 14:15:00",
-        "timeZone": "-04:00 EDT"
+        "appointmentTime": "02/20/2020 14:15:00",
+        "timeZone": "UTC"
       }
     },
     {

--- a/src/applications/vaos/api/confirmed_cc.json
+++ b/src/applications/vaos/api/confirmed_cc.json
@@ -56,8 +56,8 @@
           "zipCode": "45405"
         },
         "instructionsToVeteran": "Please arrive 20 minutes before the start of your appointment",
-        "appointmentTime": "12/22/2019 18:20:00",
-        "timeZone": "-04:00 EDT"
+        "appointmentTime": "02/05/2020 19:30:00",
+        "timeZone": "-09:00 AKST"
       }
     },
     {

--- a/src/applications/vaos/tests/components/ConfirmedAppointmentListItem.unit.spec.jsx
+++ b/src/applications/vaos/tests/components/ConfirmedAppointmentListItem.unit.spec.jsx
@@ -101,6 +101,7 @@ describe('VAOS <ConfirmedAppointmentListItem> Community Care Appointment', () =>
     appointmentRequestId: 'guid',
     appointmentTime: '05/22/2019 10:00:00',
     providerPractice: 'My Clinic',
+    timeZone: 'UTC',
     address: {
       street: '123 second st',
       city: 'Northampton',

--- a/src/applications/vaos/tests/reducers/appointments.unit.spec.js
+++ b/src/applications/vaos/tests/reducers/appointments.unit.spec.js
@@ -69,18 +69,20 @@ describe('VAOS reducer: appointments', () => {
               },
             ],
           },
-        ],
-        [
-          { appointmentTime: '05/29/2099 05:30:00', appointmentRequestId: '1' },
           // Cancelled should not show
           {
-            appointmentTime: '05/29/2099 05:32:00',
-            appointmentRequestId: '2',
             vdsAppointments: [
               {
                 currentStatus: 'CANCELLED BY CLINIC',
               },
             ],
+          },
+        ],
+        [
+          {
+            appointmentTime: '05/29/2099 05:30:00',
+            timeZone: 'UTC',
+            appointmentRequestId: '1',
           },
         ],
         [{ optionDate1: '05/29/2099' }],

--- a/src/applications/vaos/tests/utils/appointment.unit.spec.jsx
+++ b/src/applications/vaos/tests/utils/appointment.unit.spec.jsx
@@ -289,6 +289,7 @@ describe('VAOS appointment helpers', () => {
       const appt = {
         typeOfCareId: 'CC',
         appointmentTime: now,
+        timeZone: 'UTC',
       };
 
       const facility = {

--- a/src/applications/vaos/tests/utils/timezone.unit.spec.js
+++ b/src/applications/vaos/tests/utils/timezone.unit.spec.js
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { getTimezoneAbbrBySystemId } from '../../utils/timezone';
+import { getTimezoneAbbrBySystemId, stripDST } from '../../utils/timezone';
 
 describe('timezone util', () => {
   it('should return the correct abbreviation', () => {
@@ -10,5 +10,17 @@ describe('timezone util', () => {
   it('should not strip middle char if not an american zone', () => {
     const abbr = getTimezoneAbbrBySystemId(358); // manila
     expect(abbr).to.equal('PHT');
+  });
+
+  describe('stripDST', () => {
+    it('should convert lower-48 tz to two chars', () => {
+      const tz = stripDST('MST');
+      expect(tz).to.equal('MT');
+    });
+
+    it('should skip 4 digit timezones', () => {
+      const tz = stripDST('AKST');
+      expect(tz).to.equal('AKST');
+    });
   });
 });

--- a/src/applications/vaos/utils/appointment.jsx
+++ b/src/applications/vaos/utils/appointment.jsx
@@ -196,7 +196,11 @@ export function getAppointmentLocation(appt, facility) {
 
 export function getMomentConfirmedDate(appt) {
   if (isCommunityCare(appt)) {
-    return moment(appt.appointmentTime, 'MM/DD/YYYY HH:mm:ss');
+    const zoneSplit = appt.timeZone.split(' ');
+    const offset = zoneSplit.length > 1 ? zoneSplit[0] : '+0:00';
+    return moment
+      .utc(appt.appointmentTime, 'MM/DD/YYYY HH:mm:ss')
+      .utcOffset(offset);
   }
 
   const timezone = getTimezoneBySystemId(appt.facilityId)?.timezone;
@@ -219,8 +223,10 @@ export function getAppointmentTimezoneAbbreviation(appt) {
   const type = getAppointmentType(appt);
 
   switch (type) {
-    case APPOINTMENT_TYPES.ccAppointment:
-      return stripDST(appt?.timeZone?.split(' ')?.[1]);
+    case APPOINTMENT_TYPES.ccAppointment: {
+      const tzAbbr = appt?.timeZone?.split(' ')?.[1] || appt?.timeZone;
+      return stripDST(tzAbbr);
+    }
     case APPOINTMENT_TYPES.ccRequest:
     case APPOINTMENT_TYPES.request:
       return getTimezoneAbbrBySystemId(appt?.facility?.facilityCode);

--- a/src/applications/vaos/utils/timezone.js
+++ b/src/applications/vaos/utils/timezone.js
@@ -10,7 +10,11 @@ const TIMEZONE_LABELS = {
 };
 
 export function stripDST(abbr) {
-  return abbr?.replace('ST', 'T').replace('DT', 'T');
+  if (/^[PMCE][DS]T$/.test(abbr)) {
+    return abbr?.replace('ST', 'T').replace('DT', 'T');
+  }
+
+  return abbr;
 }
 
 export function getTimezoneBySystemId(id) {


### PR DESCRIPTION
## Description
Community care appt times are in UTC and have an offset included in a separate field. We were not using this offset and were just displaying the zone abbreviation. We are also incorrectly removing letters from some timezones outside the common 4 US zones.

## Testing done
Local and unit testing

## Screenshots
![Screen Shot 2020-01-23 at 4 22 19 PM](https://user-images.githubusercontent.com/634932/73025021-d6062000-3dfc-11ea-936c-aa70f1fb09ba.png)


## Acceptance criteria
- [ ] CC appointment times are displayed correctly

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
