### PR TITLE
Fix letters JS error

### DIFF
--- a/src/applications/letters/tests/utils/helpers.unit.spec.jsx
+++ b/src/applications/letters/tests/utils/helpers.unit.spec.jsx
@@ -11,6 +11,8 @@ import {
   stripEmpties,
   toGenericAddress,
   isAddressEmpty,
+  formatStreetAddress,
+  formatCityStatePostal,
 } from '../../utils/helpers';
 
 const address = {
@@ -291,11 +293,24 @@ describe('Letters helpers: ', () => {
       expect(nonMilitaryTest).to.not.equal(domesticAddress);
     });
   });
+  // Check empty address parameters
   describe('isAddressEmpty', () => {
     expect(isAddressEmpty()).to.be.true;
     expect(isAddressEmpty({})).to.be.true;
     // type & countryName are ignored
     expect(isAddressEmpty({ type: 'foo', countryName: 'bar' })).to.be.true;
     expect(isAddressEmpty({ foo: 'bar' })).to.be.false;
+  });
+  describe('formatStreetAddress', () => {
+    expect(formatStreetAddress()).to.equal('');
+    expect(formatStreetAddress({})).to.equal('');
+  });
+  describe('formatCityStatePostal', () => {
+    expect(formatCityStatePostal()).to.equal('');
+    expect(formatCityStatePostal({})).to.equal('');
+    // uses isEmptyAddress
+    expect(formatCityStatePostal({ type: 'foo', countryName: 'bar' })).to.equal(
+      '',
+    );
   });
 });

--- a/src/applications/letters/tests/utils/helpers.unit.spec.jsx
+++ b/src/applications/letters/tests/utils/helpers.unit.spec.jsx
@@ -10,6 +10,7 @@ import {
   resetDisallowedAddressFields,
   stripEmpties,
   toGenericAddress,
+  isAddressEmpty,
 } from '../../utils/helpers';
 
 const address = {
@@ -289,5 +290,12 @@ describe('Letters helpers: ', () => {
       expect(militaryTest).to.not.equal(militaryAddress);
       expect(nonMilitaryTest).to.not.equal(domesticAddress);
     });
+  });
+  describe('isAddressEmpty', () => {
+    expect(isAddressEmpty()).to.be.true;
+    expect(isAddressEmpty({})).to.be.true;
+    // type & countryName are ignored
+    expect(isAddressEmpty({ type: 'foo', countryName: 'bar' })).to.be.true;
+    expect(isAddressEmpty({ foo: 'bar' })).to.be.false;
   });
 });

--- a/src/applications/letters/utils/helpers.jsx
+++ b/src/applications/letters/utils/helpers.jsx
@@ -578,7 +578,7 @@ export function isAddressEmpty(address = {}) {
   );
 }
 
-export function formatStreetAddress(address) {
+export function formatStreetAddress(address = {}) {
   let formattedAddress = '';
 
   if (address.addressOne) {
@@ -593,7 +593,7 @@ export function formatStreetAddress(address) {
   return formattedAddress;
 }
 
-export function formatCityStatePostal(address) {
+export function formatCityStatePostal(address = {}) {
   // Formats to "city, state, postal code" for the second line of an address
   let cityStatePostal = '';
 

--- a/src/applications/letters/utils/helpers.jsx
+++ b/src/applications/letters/utils/helpers.jsx
@@ -566,7 +566,7 @@ export const getStatus = response =>
     : 'unknown';
 
 // NOTE: It "shouldn't" ever happen...but it did. In production.
-export function isAddressEmpty(address) {
+export function isAddressEmpty(address = {}) {
   // An address will always have:
   //  type because it errors out on the api if it doesn't exist (pretty sure)
   //  countryName because of toGenericAddress() adds it


### PR DESCRIPTION
## Description

While attempting to get a VA Benefits Letter, a JS error prevents rendering of the review address form page (see https://github.com/department-of-veterans-affairs/va.gov-team/issues/5107 for details).

## Testing done

Local unit testing

## Screenshots

![](https://user-images.githubusercontent.com/136959/73024226-caadf700-3df2-11ea-901a-e26a317593c5.png)
![](https://user-images.githubusercontent.com/136959/73024252-d7324f80-3df2-11ea-9e25-b084cda97046.png)

## Acceptance criteria
- [ ] VA letters and documents form page to verify an address is rendered.
- [ ] No JS errors

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
