### PR TITLE
bradl3yC - 4489 - Add formation classnames to left justify text

### DIFF
--- a/src/platform/user/profile/vet360/components/AddressField/AddressForm.jsx
+++ b/src/platform/user/profile/vet360/components/AddressField/AddressForm.jsx
@@ -116,7 +116,7 @@ class AddressForm extends React.Component {
     return (
       <div>
         {isMailingAddress && (
-          <div>
+          <div className="form-checkbox">
             <input
               type="checkbox"
               name="is-military-base-mailing-address"

--- a/src/platform/user/profile/vet360/containers/CopyMailingAddress.jsx
+++ b/src/platform/user/profile/vet360/containers/CopyMailingAddress.jsx
@@ -34,7 +34,7 @@ class CopyMailingAddress extends React.Component {
     if (this.props.hasEmptyMailingAddress) return <div />;
     return (
       <div className="copy-mailing-address-to-residential-address">
-        <div className="form-checkbox-buttons">
+        <div className="form-checkbox-buttons form-checkbox">
           <input
             type="checkbox"
             name="copy-mailing-address-to-residential-address"


### PR DESCRIPTION
## Description
Add classnames to left justify label text so that it does not wrap under the check box

## Testing done


## Screenshots
![Screen Shot 2020-01-23 at 3 02 10 PM](https://user-images.githubusercontent.com/6165421/73028392-70696200-3e03-11ea-825e-0bc0cb066d86.png)
![Screen Shot 2020-01-23 at 5 08 26 PM](https://user-images.githubusercontent.com/6165421/73028408-765f4300-3e03-11ea-9b5b-b4ceba49c8f5.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
