### PR TITLE
removed REAP option from 1995 frontend

### DIFF
--- a/src/applications/edu-benefits/1995/pages/benefitSelection.js
+++ b/src/applications/edu-benefits/1995/pages/benefitSelection.js
@@ -2,6 +2,8 @@ import fullSchema from 'vets-json-schema/dist/22-1995-schema.json';
 
 import { benefitsLabels } from '../../utils/labels';
 
+import environment from 'platform/utilities/environment';
+
 const { benefit } = fullSchema.properties;
 
 // 1995-STEM related
@@ -10,6 +12,8 @@ const displayBenefit = {
   enum: [...benefit.enum],
 };
 displayBenefit.enum.splice(1, 0, 'fryScholarship');
+// PROD FLAG FOR 4765
+if (!environment.isProduction()) displayBenefit.enum.splice(6, 1);
 
 export const uiSchema = {
   benefit: {

--- a/src/applications/edu-benefits/tests/1995/pages/benefitSelection.unit.spec.jsx
+++ b/src/applications/edu-benefits/tests/1995/pages/benefitSelection.unit.spec.jsx
@@ -24,7 +24,7 @@ describe('Edu 1995 benefitSelection', () => {
         uiSchema={uiSchema}
       />,
     );
-    expect(form.find('input').length).to.equal(7);
+    expect(form.find('input').length).to.equal(6);
     form.unmount();
   });
 


### PR DESCRIPTION
## Description
As a benefits applicant, I should not be able to select the REAP benefit because it was retired in November of 2019.

https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/4765

## Testing done
Local testing completed

## Screenshots
![Screen Shot 2020-01-24 at 9 54 12 AM](https://user-images.githubusercontent.com/50601724/73078591-7bb69f00-3e90-11ea-97fe-fced60c6484e.png)


## Acceptance criteria
- [x] The "Reserve Educational Assistance Program (REAP, Chapter 1607)" is not an available benefit option when completing the 1995 form. 

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
