### PR TITLE
add VSA reviewed directories

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,3 +9,4 @@
 src/applications/proxy-rewrite/redirects/crossDomainRedirects.json @department-of-veterans-affairs/vsa-frontend
 src/applications/find-va-forms @department-of-veterans-affairs/vsa-frontend
 src/platform/site-wide @department-of-veterans-affairs/vsa-frontend
+src/applications/yellow-ribbon @department-of-veterans-affairs/vsa-frontend

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,3 +4,8 @@
 # review when someone opens a pull request.
 
 *       @department-of-veterans-affairs/frontend-review-group
+
+# VSA
+src/applications/proxy-rewrite/redirects/crossDomainRedirects.json @department-of-veterans-affairs/vsa-frontend
+src/applications/find-va-forms @department-of-veterans-affairs/vsa-frontend
+src/platform/site-wide @department-of-veterans-affairs/vsa-frontend


### PR DESCRIPTION
## Description
- test codeowner behavior with small group of approvers 
- once this is merged we should validate 
  - does a codeowner github team need to have write access to the repo in order to be notified / approve the change 
  - only designated reviewers are notified 
  - do required reviewers appropriately understand their responsibility and how to manage the github team
- document process for creating and managing teams 

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
