### PR TITLE
[Due on 1/29] [Pittsburgh] Remove section from robots.txt

### DIFF
--- a/src/site/assets/robots.txt
+++ b/src/site/assets/robots.txt
@@ -95,7 +95,6 @@ Disallow: /analytics-opt-out.html
 Disallow: /cgi-bin/
 Disallow: /scorecard
 Disallow: /drupal
-Disallow: /pittsburgh-health-care
 
 # sitemap index
 Sitemap: https://www.va.gov/sitemap.xml


### PR DESCRIPTION
## Description
The Pittsburgh health care section of the website is going live, so we can remove this line from the robots.txt so it will be indexed by Google.

https://github.com/department-of-veterans-affairs/va.gov-team/issues/5113

## Testing done
N/A

## Screenshots
N/A

## Acceptance criteria
- [ ] PHC removed from robots.txt

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
