### PR TITLE
fix styling issues for alert messages

### DIFF
--- a/src/applications/gi/sass/partials/_gi-search-page.scss
+++ b/src/applications/gi/sass/partials/_gi-search-page.scss
@@ -183,9 +183,7 @@
 
   .usa-alert {
     background-color: white;
-    padding-top: .5em;
-    padding-bottom: .5em;
-    margin-top: .5em;
+    padding: .5em 1em;
   }
 
   .usa-alert-text {
@@ -196,5 +194,12 @@
     margin-bottom: 1em;
   }
 
+  .usa-alert-warning:before {
+    font-size: 1em;
+  }
+
+  .usa-alert-heading {
+    font-size: 1em;
+  }
 
 }


### PR DESCRIPTION
## Description

The alert messages needed resizing to better utilize their use of space in the Search Results Cards. These revisions are In [story 4926](https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/4926) in [this comment](https://github.com/department-of-veterans-affairs/va.gov-team/issues/4926#issuecomment-578233927).
## Testing done


## Screenshots
![image](https://user-images.githubusercontent.com/48804654/73100858-71aa9580-3ebc-11ea-8ab8-e3e22789cb7d.png)

![image](https://user-images.githubusercontent.com/48804654/73100890-87b85600-3ebc-11ea-9e96-ad4bf1dfd98f.png)


## Acceptance criteria
- [x] resize the header text to 17px (1em).
- [x] reduce the padding left and right of the alert box body.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
