### PR TITLE
Measure build memory usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,6 +112,7 @@
     "@sentry/browser": "^5.4.0",
     "ajv": "^6.10.2",
     "append-query": "2.0.1",
+    "ascii-table": "^0.0.9",
     "autoprefixer": "^9.5.1",
     "axe-core": "^2.6.0",
     "babel-core": "^7.0.0-bridge.0",

--- a/src/site/stages/build/index.js
+++ b/src/site/stages/build/index.js
@@ -1,6 +1,4 @@
 // Builds the site using Metalsmith as the top-level build runner.
-const chalk = require('chalk');
-const Metalsmith = require('metalsmith');
 const assets = require('metalsmith-assets');
 const collections = require('metalsmith-collections');
 const dateInFilename = require('metalsmith-date-in-filename');
@@ -11,6 +9,7 @@ const markdown = require('metalsmith-markdownit');
 const navigation = require('metalsmith-navigation');
 const permalinks = require('metalsmith-permalinks');
 
+const silverSmith = require('./silversmith');
 const getOptions = require('./options');
 const registerLiquidFilters = require('../../filters/liquid');
 const { getDrupalContent } = require('./drupal/metalsmith-drupal');
@@ -42,40 +41,7 @@ const updateExternalLinks = require('./plugins/update-external-links');
 const updateRobots = require('./plugins/update-robots');
 
 function defaultBuild(BUILD_OPTIONS) {
-  const smith = Metalsmith(__dirname); // eslint-disable-line new-cap
-
-  // Override the normal use function to provide timing and logging information
-  smith._use = smith.use;
-  let stepCount = 0;
-  smith.use = function use(plugin, description) {
-    const step = ++stepCount;
-    if (!description) return smith._use(plugin);
-
-    let timerStart;
-
-    /* eslint-disable no-console */
-    return smith
-      ._use(() => {
-        console.log(chalk.cyan(`\nStep ${step} start: ${description}`));
-        timerStart = process.hrtime.bigint();
-      })
-      ._use(plugin)
-      ._use(() => {
-        const time = (process.hrtime.bigint() - timerStart) / 1000000n;
-
-        // Color the time
-        let color;
-        if (time < 1000) color = chalk.green;
-        else if (time < 10000) color = chalk.yellow;
-        else color = chalk.red;
-        const coloredTime = color(`[${time}ms]`);
-
-        console.log(
-          chalk.cyan(`Step ${step} end ${coloredTime}: ${description}`),
-        );
-      });
-    /* eslint-enable no-console */
-  };
+  const smith = silverSmith();
 
   registerLiquidFilters();
 

--- a/src/site/stages/build/index.js
+++ b/src/site/stages/build/index.js
@@ -212,6 +212,7 @@ function defaultBuild(BUILD_OPTIONS) {
     if (BUILD_OPTIONS.watch) {
       console.log('Metalsmith build finished!  Starting webpack-dev-server...');
     } else {
+      smith.printSummary();
       console.log('Build finished!');
     }
   });

--- a/src/site/stages/build/silversmith.js
+++ b/src/site/stages/build/silversmith.js
@@ -6,7 +6,7 @@ const chalk = require('chalk');
 const formatMemory = m => Math.round((m / 1024 / 1024) * 100) / 100;
 
 const logStepStart = (step, description) =>
-  console.log(chalk.cyan(`\nStep ${step} start: ${description}`));
+  console.log(chalk.cyan(`\nStep ${step + 1} start: ${description}`));
 
 const logStepEnd = (step, description, timerStart) => {
   const time = (process.hrtime.bigint() - timerStart) / 1000000n;
@@ -18,7 +18,9 @@ const logStepEnd = (step, description, timerStart) => {
   else color = chalk.red;
   const coloredTime = color(`[${time}ms]`);
 
-  console.log(chalk.cyan(`Step ${step} end ${coloredTime}: ${description}`));
+  console.log(
+    chalk.cyan(`Step ${step + 1} end ${coloredTime}: ${description}`),
+  );
 };
 
 const logMemoryUsage = heapUsedStart => {
@@ -44,7 +46,7 @@ module.exports = () => {
   smith._use = smith.use;
   let stepCount = 0;
   smith.use = function use(plugin, description) {
-    const step = ++stepCount;
+    const step = stepCount++;
     if (!description) return smith._use(plugin);
 
     let timerStart;

--- a/src/site/stages/build/silversmith.js
+++ b/src/site/stages/build/silversmith.js
@@ -1,0 +1,42 @@
+const Metalsmith = require('metalsmith');
+const chalk = require('chalk');
+
+/**
+ * It's Metalsmith with some added shine.
+ */
+module.exports = () => {
+  const smith = Metalsmith(__dirname);
+
+  // Override the normal use function to provide timing and logging information
+  smith._use = smith.use;
+  let stepCount = 0;
+  smith.use = function use(plugin, description) {
+    const step = ++stepCount;
+    if (!description) return smith._use(plugin);
+
+    let timerStart;
+
+    /* eslint-disable no-console */
+    return smith
+      ._use(() => {
+        console.log(chalk.cyan(`\nStep ${step} start: ${description}`));
+        timerStart = process.hrtime.bigint();
+      })
+      ._use(plugin)
+      ._use(() => {
+        const time = (process.hrtime.bigint() - timerStart) / 1000000n;
+
+        // Color the time
+        let color;
+        if (time < 1000) color = chalk.green;
+        else if (time < 10000) color = chalk.yellow;
+        else color = chalk.red;
+        const coloredTime = color(`[${time}ms]`);
+
+        console.log(
+          chalk.cyan(`Step ${step} end ${coloredTime}: ${description}`),
+        );
+      });
+    /* eslint-enable no-console */
+  };
+};

--- a/src/site/stages/build/silversmith.js
+++ b/src/site/stages/build/silversmith.js
@@ -40,7 +40,7 @@ const logMemoryUsage = heapUsedStart => {
 module.exports = () => {
   const smith = Metalsmith(__dirname);
 
-  // Override the normal use function to provide timing and logging information
+  // Override the normal use function to log additional information
   smith._use = smith.use;
   let stepCount = 0;
   smith.use = function use(plugin, description) {

--- a/src/site/stages/build/silversmith.js
+++ b/src/site/stages/build/silversmith.js
@@ -1,6 +1,8 @@
 const Metalsmith = require('metalsmith');
 const chalk = require('chalk');
 
+const formatMemory = m => Math.round((m / 1024 / 1024) * 100) / 100;
+
 /**
  * It's Metalsmith with some added shine.
  */
@@ -15,10 +17,12 @@ module.exports = () => {
     if (!description) return smith._use(plugin);
 
     let timerStart;
+    let heapUsedStart;
 
     /* eslint-disable no-console */
     return smith
       ._use(() => {
+        heapUsedStart = process.memoryUsage().heapUsed;
         console.log(chalk.cyan(`\nStep ${step} start: ${description}`));
         timerStart = process.hrtime.bigint();
       })
@@ -36,7 +40,23 @@ module.exports = () => {
         console.log(
           chalk.cyan(`Step ${step} end ${coloredTime}: ${description}`),
         );
+
+        const heapUsedEnd = process.memoryUsage().heapUsed;
+        console.log(
+          chalk.bold('Starting memory:'),
+          `${formatMemory(heapUsedStart)}mB`,
+        );
+        console.log(
+          chalk.bold('Ending memory:'),
+          `${formatMemory(heapUsedEnd)}mB`,
+        );
+        console.log(
+          chalk.bold('Delta:'),
+          `${formatMemory(heapUsedEnd - heapUsedStart)}mB`,
+        );
       });
     /* eslint-enable no-console */
   };
+
+  return smith;
 };

--- a/src/site/stages/build/silversmith.js
+++ b/src/site/stages/build/silversmith.js
@@ -45,13 +45,9 @@ module.exports = () => {
   // Override the normal use function to log additional information
   smith._use = smith.use;
   let stepCount = 0;
-  smith.use = function use(plugin, description) {
+  smith.use = function use(plugin, description = 'Unknown Plugin') {
     const step = stepCount++;
     smith.stepStats[step] = { description };
-    if (!description) {
-      smith.stepStats[step].untracked = true;
-      return smith._use(plugin);
-    }
 
     let timerStart;
     let heapUsedStart;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1493,6 +1493,11 @@ asap@~2.0.3:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
 
+ascii-table@^0.0.9:
+  version "0.0.9"
+  resolved "https://registry.yarnpkg.com/ascii-table/-/ascii-table-0.0.9.tgz#06a6604d6a55d4bf41a9a47d9872d7a78da31e73"
+  integrity sha1-BqZgTWpV1L9BqaR9mHLXp42jHnM=
+
 asn1.js@^4.0.0:
   version "4.9.1"
   resolved "https://registry.yarnpkg.com/asn1.js/-/asn1.js-4.9.1.tgz#48ba240b45a9280e94748990ba597d216617fd40"


### PR DESCRIPTION
## Description
This is the first step in tracking down what's going on in https://github.com/department-of-veterans-affairs/va.gov-team/issues/5116.

I've done a few things in this PR:
1. Pulled the logging chunk I wrote up in `build/index.js` into a separate file
2. Refactored it to be a little cleaner
3. Added logging the memory usage per step while it's run
    - This is a rough usage based on the used heap size before and after the plugin runs
       - See https://www.valentinog.com/blog/memory-usage-node-js/ for more details
       - Thanks to @bkjohnson for sending me that resource!
    - This doesn't take into account the memory usage _while_ the plugin is running
4. Added a table at the end of a `yarn build`
    - This won't affect `yarn watch`

## Testing done
Ran it locally. See the screenshots.

## Screenshots
### Output during the build
![image](https://user-images.githubusercontent.com/12970166/73102308-72383180-3ea6-11ea-8c64-0519e512b0b2.png)
These will show up even in `yarn watch`

### Output after the build
![image](https://user-images.githubusercontent.com/12970166/73102275-5cc30780-3ea6-11ea-8417-2599935380a0.png)
This will only show up after a (successful) `yarn build`.

## Acceptance criteria
- [x] The memory usage is logged