### PR TITLE
Fixes for high volumes of 'undefined' and 'not_provided' reported in app to API mapping

### DIFF
--- a/src/applications/claims-status/claims-status-entry.jsx
+++ b/src/applications/claims-status/claims-status-entry.jsx
@@ -18,6 +18,8 @@ import manifest from './manifest.json';
 
 import { setLastPage } from './actions/index.jsx';
 
+window.appName = manifest.entryName;
+
 const store = createCommonStore(reducer);
 
 const history = useRouterHistory(createHistory)({

--- a/src/applications/claims-status/utils/helpers.js
+++ b/src/applications/claims-status/utils/helpers.js
@@ -260,6 +260,7 @@ export function makeAuthRequest(
       mode: 'cors',
       headers: {
         'X-Key-Inflection': 'camel',
+        'Source-App-Name': window.appName,
       },
       responseType: 'json',
     },

--- a/src/applications/facility-locator/config.js
+++ b/src/applications/facility-locator/config.js
@@ -1,5 +1,6 @@
 import environment from '../../platform/utilities/environment';
 import { LocationType, FacilityType } from './constants';
+import manifest from './manifest.json';
 
 // TODO: Remove me when done bug fixing
 // const environment = {
@@ -14,7 +15,7 @@ export const api = {
     credentials: 'include',
     headers: {
       'X-Key-Inflection': 'camel',
-      'Source-App-Name': window.appName,
+      'Source-App-Name': manifest.entryName,
     },
   },
 };

--- a/src/applications/facility-locator/config.js
+++ b/src/applications/facility-locator/config.js
@@ -15,6 +15,10 @@ export const api = {
     credentials: 'include',
     headers: {
       'X-Key-Inflection': 'camel',
+
+      // Pull app name directly from manifest since this config is defined
+      // before startApp, and using window.appName here would result in
+      // undefined for all requests that use this config.
       'Source-App-Name': manifest.entryName,
     },
   },

--- a/src/applications/facility-locator/config.js
+++ b/src/applications/facility-locator/config.js
@@ -14,6 +14,7 @@ export const api = {
     credentials: 'include',
     headers: {
       'X-Key-Inflection': 'camel',
+      'Source-App-Name': window.appName,
     },
   },
 };

--- a/src/applications/gi/config.js
+++ b/src/applications/gi/config.js
@@ -6,6 +6,7 @@ export const api = {
     credentials: 'include',
     headers: {
       'X-Key-Inflection': 'camel',
+      'Source-App-Name': window.appName,
     },
   },
 };

--- a/src/applications/gi/config.js
+++ b/src/applications/gi/config.js
@@ -7,6 +7,10 @@ export const api = {
     credentials: 'include',
     headers: {
       'X-Key-Inflection': 'camel',
+
+      // Pull app name directly from manifest since this config is defined
+      // before startApp, and using window.appName here would result in
+      // undefined for all requests that use this config.
       'Source-App-Name': manifest.entryName,
     },
   },

--- a/src/applications/gi/config.js
+++ b/src/applications/gi/config.js
@@ -1,4 +1,5 @@
 import environment from '../../platform/utilities/environment';
+import manifest from './manifest.json';
 
 export const api = {
   url: `${environment.API_URL}/v0/gi`,
@@ -6,7 +7,7 @@ export const api = {
     credentials: 'include',
     headers: {
       'X-Key-Inflection': 'camel',
-      'Source-App-Name': window.appName,
+      'Source-App-Name': manifest.entryName,
     },
   },
 };

--- a/src/applications/pensions/helpers.jsx
+++ b/src/applications/pensions/helpers.jsx
@@ -35,6 +35,7 @@ function checkStatus(guid) {
   const headers = {
     'Content-Type': 'application/json',
     'X-Key-Inflection': 'camel',
+    'Source-App-Name': window.appName,
   };
 
   return fetch(`${environment.API_URL}/v0/pension_claims/${guid}`, {
@@ -112,6 +113,7 @@ export function submit(form, formConfig) {
   const headers = {
     'Content-Type': 'application/json',
     'X-Key-Inflection': 'camel',
+    'Source-App-Name': window.appName,
   };
 
   const body = transform(formConfig, form);

--- a/src/applications/pre-need/utils/helpers.js
+++ b/src/applications/pre-need/utils/helpers.js
@@ -405,6 +405,7 @@ export function getCemeteries() {
     credentials: 'include',
     headers: {
       'X-Key-Inflection': 'camel',
+      'Source-App-Name': window.appName,
     },
   })
     .then(res => {

--- a/src/applications/static-pages/static-pages-entry.js
+++ b/src/applications/static-pages/static-pages-entry.js
@@ -43,6 +43,9 @@ import {
   createScoAnnouncementsWidget,
 } from './school-resources/SchoolResources';
 
+// Set the app name header when using the apiRequest helper
+window.appName = 'static-pages';
+
 // Set further errors to have the appropriate source tag
 Sentry.configureScope(scope => scope.setTag('source', 'static-pages'));
 

--- a/src/applications/vic-v2/helpers.jsx
+++ b/src/applications/vic-v2/helpers.jsx
@@ -126,6 +126,7 @@ function pollStatus(guid, onDone, onError) {
 export function fetchPreview(id) {
   const headers = {
     'X-Key-Inflection': 'camel',
+    'Source-App-Name': window.appName,
   };
 
   return fetch(


### PR DESCRIPTION
## Description
### `undefined` App Names
The `window.appName` attribute gets set in the `startApp` function, but `static-pages-entry` does not use that function, so static pages were probably sending `'Source-App-Name': 'undefined'` in the header. This change will include that attribute on static pages.

### `'not_provided'` App Names
There are several apps that do not use `apiRequest`, and they don't include the `Source-App-Name` header in their fetches, resulting in the API tagging those apps as `'not_provided'`. I've supplemented the fetches in each app with that header.

## Testing done
- Local testing verified that `'static-pages'` was getting sent to the API.
- Local testing with GIBCT indicated `gi` was being sent in the header.
- Will verify after deploy whether there is a significant reduction in app names being tagged as `undefined` or `'not_provided'`.

## Acceptance criteria
- [ ] Static pages should be identified in the product mapping when the API receives those requests.
- [ ] Apps should report their `entryName`s in the `Source-App-Name` header.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
