### PR TITLE
[Find Forms] Add "PDF" to links

### DIFF
--- a/src/applications/find-va-forms/helpers/index.js
+++ b/src/applications/find-va-forms/helpers/index.js
@@ -16,7 +16,7 @@ export const normalizeFormsForTable = forms =>
     // Derive the ID field.
     const idLabel = (
       <a href={downloadURL} rel="noopener noreferrer" target="_blank">
-        {id}
+        {id} (PDF)
       </a>
     );
 

--- a/src/applications/find-va-forms/helpers/index.js
+++ b/src/applications/find-va-forms/helpers/index.js
@@ -16,7 +16,7 @@ export const normalizeFormsForTable = forms =>
     // Derive the ID field.
     const idLabel = (
       <a href={downloadURL} rel="noopener noreferrer" target="_blank">
-        {id} (PDF)
+        {id} {downloadURL.toLowerCase().includes('.pdf') && '(PDF)'}
       </a>
     );
 


### PR DESCRIPTION
## Description
This PR adds `(PDF)` into the PDF links in the table so that users know it's a download.

https://github.com/department-of-veterans-affairs/va.gov-team/issues/5171

## Testing done
- Go to http://localhost:3001/find-va-forms-beta/?q=health
- Observe `(PDF)` in the table

## Screenshots
![image](https://user-images.githubusercontent.com/1915775/73202121-651a7d00-4108-11ea-9d80-c57ada73d190.png)


## Acceptance criteria
- [ ] Users know the link is to a PDF

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
