### PR TITLE
fixed accordian from reading anything below and fixed enrolled dropdown from reading everything above on option change

### DIFF
--- a/src/applications/gi/components/AccordionItem.jsx
+++ b/src/applications/gi/components/AccordionItem.jsx
@@ -26,27 +26,29 @@ class AccordionItem extends React.Component {
   render() {
     const expanded = this.state.expanded;
     return (
-      <li>
-        <h2 aria-live="off" className="accordion-button-wrapper">
-          <button
-            onClick={this.toggle}
-            className="usa-accordion-button"
-            aria-expanded={expanded}
-            aria-controls={this.id}
+      <div>
+        <li>
+          <h2 aria-live="off" className="accordion-button-wrapper">
+            <button
+              onClick={this.toggle}
+              className="usa-accordion-button"
+              aria-expanded={expanded}
+              aria-controls={this.id}
+            >
+              <span className="vads-u-font-family--serif accordion-button-text">
+                {this.props.button}
+              </span>
+            </button>
+          </h2>
+          <div
+            id={this.id}
+            className="usa-accordion-content"
+            aria-hidden={!expanded}
           >
-            <span className="vads-u-font-family--serif accordion-button-text">
-              {this.props.button}
-            </span>
-          </button>
-        </h2>
-        <div
-          id={this.id}
-          className="usa-accordion-content"
-          aria-hidden={!expanded}
-        >
-          {this.props.children}
-        </div>
-      </li>
+            {this.props.children}
+          </div>
+        </li>
+      </div>
     );
   }
 }

--- a/src/applications/gi/components/AccordionItem.jsx
+++ b/src/applications/gi/components/AccordionItem.jsx
@@ -27,7 +27,7 @@ class AccordionItem extends React.Component {
     const expanded = this.state.expanded;
     return (
       <li>
-        <h2 className="accordion-button-wrapper">
+        <h2 aria-live="off" className="accordion-button-wrapper">
           <button
             onClick={this.toggle}
             className="usa-accordion-button"

--- a/src/applications/gi/components/profile/Calculator.jsx
+++ b/src/applications/gi/components/profile/Calculator.jsx
@@ -83,29 +83,27 @@ export class Calculator extends React.Component {
 
     return (
       <div aria-live="off" className="calculator-inputs">
-        <button
-          aria-expanded={expanded}
-          onClick={this.toggleCalculatorForm}
-          className="usa-button-secondary"
-        >
-          {expanded ? 'Hide' : 'Edit'} calculator fields
-        </button>
+        <div aria-live="off">
+          <button
+            aria-expanded={expanded}
+            onClick={this.toggleCalculatorForm}
+            className="usa-button-secondary"
+          >
+            {expanded ? 'Hide' : 'Edit'} calculator fields
+          </button>
+        </div>
         <div>
           {expanded ? (
-            <form>
-              <CalculatorForm
-                profile={profile}
-                eligibility={this.props.eligibility}
-                eligibilityChange={this.props.eligibilityChange}
-                inputs={inputs}
-                displayedInputs={displayed}
-                onShowModal={this.props.showModal}
-                onInputChange={this.props.calculatorInputChange}
-                onBeneficiaryZIPCodeChanged={
-                  this.props.beneficiaryZIPCodeChanged
-                }
-              />
-            </form>
+            <CalculatorForm
+              profile={profile}
+              eligibility={this.props.eligibility}
+              eligibilityChange={this.props.eligibilityChange}
+              inputs={inputs}
+              displayedInputs={displayed}
+              onShowModal={this.props.showModal}
+              onInputChange={this.props.calculatorInputChange}
+              onBeneficiaryZIPCodeChanged={this.props.beneficiaryZIPCodeChanged}
+            />
           ) : null}
         </div>
       </div>


### PR DESCRIPTION
## Description
When using the JAWS screenreader combined with Firefox, JAWS continues to read the text after the Estimate Your Benefits header. This applies to both vettec and non-vettec institutions.

https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/4940

After you select a school, when tabbing past Scholarships to the next field “Enrolled” the screen reader (JAWS) starts reading from the top of the frame “hide eligibility details, what is your military status?...” this continues as you tab down the screen JAWs starts reading from the top with every tab.

https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/1062

## Testing done
VM with JAWS 
## Screenshots


## Acceptance criteria
- [x] Estimate your benefits does not read past the button
- [x] Enrolled dropdown only reads options and not from the top

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
