### PR TITLE
bradl3yC - 5180 - Add helper method to shape payload

### DIFF
--- a/src/platform/user/profile/vet360/actions/transactions.js
+++ b/src/platform/user/profile/vet360/actions/transactions.js
@@ -289,8 +289,7 @@ export const updateValidationKeyAndSave = (
   analyticsSectionName,
 ) => async dispatch => {
   try {
-    const addressPayload = { address: { ...payload } };
-
+    const addressPayload = { address: addCountryCodeIso3ToAddress(payload) };
     const options = {
       body: JSON.stringify(addressPayload),
       method: 'POST',


### PR DESCRIPTION
## Description
In the situation where a suggested address is used, we update the validationKey via the Address Validation API.  During that process, key pieces of data were missing from the payload.  This PR will use the appropriate helper method to add those back to the payload as required by the Address Validation API.


## Testing done
Removed those key pieces of data from test payloads and verify they're added back in by the helper method upon request submission.

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
