### PR TITLE
Add support for uiSchema replaceSchema callback

### DIFF
--- a/src/platform/forms-system/src/js/state/helpers.js
+++ b/src/platform/forms-system/src/js/state/helpers.js
@@ -241,10 +241,10 @@ export function removeHiddenData(schema, data) {
 }
 
 /*
- * This is similar to the hidden fields schema function above, except more general.
- * It will step through a schema and replace parts of it based on an updateSchema
- * function in uiSchema. This means the schema can be re-calculated based on data
- * a user has entered.
+ * This is similar to the hidden fields schema function above, except more
+ * general. It will step through a schema and replace parts of it based on an
+ * updateSchema or replaceSchema function in uiSchema. This means the schema can
+ * be re-calculated based on data a user has entered.
  */
 export function updateSchemaFromUiSchema(
   schema,
@@ -324,6 +324,22 @@ export function updateSchemaFromUiSchema(
 
       return current;
     }, currentSchema);
+
+    if (newSchema !== currentSchema) {
+      return newSchema;
+    }
+  }
+
+  const replaceSchema = get(['ui:options', 'replaceSchema'], uiSchema);
+
+  if (replaceSchema) {
+    const newSchema = replaceSchema(
+      formData,
+      currentSchema,
+      uiSchema,
+      index,
+      path,
+    );
 
     if (newSchema !== currentSchema) {
       return newSchema;

--- a/src/platform/forms-system/test/js/state/helpers.unit.spec.js
+++ b/src/platform/forms-system/test/js/state/helpers.unit.spec.js
@@ -434,6 +434,23 @@ describe('Schemaform formState:', () => {
       expect(newSchema).to.eql({ type: 'number' });
       expect(newSchema).not.to.equal(schema);
     });
+    it('should completely replace schema', () => {
+      const schema = {
+        type: 'string',
+        enum: ['a', 'b'],
+      };
+      const uiSchema = {
+        'ui:options': {
+          replaceSchema: () => ({ type: 'string' }),
+        },
+      };
+
+      const newSchema = updateSchemaFromUiSchema(schema, uiSchema);
+
+      expect(newSchema).to.eql({ type: 'string' });
+      expect(Object.keys(newSchema)).to.eql(['type']);
+      expect(newSchema).not.to.equal(schema);
+    });
     it('should update schema in object', () => {
       const schema = {
         type: 'object',


### PR DESCRIPTION
## Description
Operates like the existing updateSchema callback, but totally replaces the current schema rather than merging the new schema with the old one. The updateSchema callback does not allow you to totally remove/delete schema properties, only override them. I specifically need to remove the `enum` from a schema based on the form data.

## Testing done
Local + unit tests

## Screenshots
Changing "City" from text field to select drop down and back again.
![ScreenFlow](https://user-images.githubusercontent.com/20728956/73208031-95f3b580-40fa-11ea-8ac8-b5e0f7de6c4a.gif)


## Acceptance criteria
- [x] You can change a string field from a text field widget to a select and back again by adding and removing an `enum` to the schema.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs