### PR TITLE
[Build] Disable link-checker during watch

### DIFF
--- a/src/site/stages/build/plugins/check-broken-links/index.js
+++ b/src/site/stages/build/plugins/check-broken-links/index.js
@@ -15,6 +15,11 @@ function getMiddleware(
   applyIgnoredRoutes = _applyIgnoredRoutes,
   getErrorOutput = _getErrorOutput,
 ) {
+  if (buildOptions.watch) {
+    const noop = () => {};
+    return noop;
+  }
+
   return (files, metalsmith, done) => {
     // 1. Loop through all of the HTML files in the Metalsmith pipeline
     // 2. Extract all of the broken HREF/SRC values using the helper getBrokenLinks


### PR DESCRIPTION
## Description
We get a bunch of output about bad links during the `watch` task. Most if not all of that output is because Webpack keeps assets only in memory during `watch`, so they don't actually exist in the file system, causing broken links. This PR just disables the link-checker altogether during `watch`.

## Testing done
Ran `npm run watch`

## Screenshots
N/A

## Acceptance criteria
- [x] No giant output of broken links during website startup

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
