### PR TITLE
Fix data transformations for sleep and cc audiology requests

### DIFF
--- a/src/applications/vaos/tests/utils/data.unit.spec.js
+++ b/src/applications/vaos/tests/utils/data.unit.spec.js
@@ -94,6 +94,94 @@ describe('VAOS data transformation', () => {
       providerOption: '',
     });
   });
+  it('should transform form for Sleep Care into VA request', () => {
+    const state = {
+      newAppointment: {
+        data: {
+          phoneNumber: '5035551234',
+          bestTimeToCall: {
+            morning: true,
+          },
+          email: 'test@va.gov',
+          visitType: 'office',
+          reasonForAppointment: 'routine-follow-up',
+          reasonAdditionalInfo: 'Testing',
+          calendarData: {
+            currentlySelectedDate: '2019-11-20',
+            selectedDates: [
+              {
+                date: '2019-11-20',
+                optionTime: 'PM',
+              },
+            ],
+            currentRowIndex: 3,
+          },
+          vaSystem: '983',
+          vaFacility: '983GB',
+          facilityType: 'vamc',
+          typeOfCareId: 'SLEEP',
+          typeOfSleepCareId: '349',
+        },
+        facilities: {
+          '349_983': [
+            {
+              institutionCode: '983GB',
+              name: 'CHYSHR-Cheyenne VA Medical Center',
+              city: 'Cheyenne',
+              stateAbbrev: 'WY',
+              authoritativeName: 'CHYSHR-Cheyenne VA Medical Center',
+              rootStationCode: '983',
+              parentStationCode: '983',
+              institutionTimezone: 'America/Denver',
+            },
+          ],
+        },
+      },
+    };
+    const data = transformFormToVARequest(state);
+    expect(data).to.deep.equal({
+      typeOfCare: 'SLEEP',
+      typeOfCareId: '349',
+      appointmentType: 'Continuous Positive Airway Pressure (CPAP)',
+      cityState: {
+        institutionCode: '983',
+        rootStationCode: '983',
+        parentStationCode: '983',
+        adminParent: true,
+      },
+      status: 'Submitted',
+      facility: {
+        name: 'CHYSHR-Cheyenne VA Medical Center',
+        facilityCode: '983GB',
+        parentSiteCode: '983',
+      },
+      purposeOfVisit: 'Routine Follow-up',
+      otherPurposeOfVisit: null,
+      visitType: 'Office Visit',
+      phoneNumber: '5035551234',
+      verifyPhoneNumber: '5035551234',
+      optionDate1: '11/20/2019',
+      optionDate2: 'No Date Selected',
+      optionDate3: 'No Date Selected',
+      optionTime1: 'PM',
+      optionTime2: 'No Time Selected',
+      optionTime3: 'No Time Selected',
+      bestTimetoCall: ['Morning'],
+      emailPreferences: {
+        emailAddress: 'test@va.gov',
+        notificationFrequency: 'Each new message',
+        emailAllowed: true,
+        textMsgAllowed: false,
+        textMsgPhNumber: '',
+      },
+      email: 'test@va.gov',
+      schedulingMethod: 'clerk',
+      requestedPhoneCall: false,
+      providerId: '0',
+      providerOption: '',
+    });
+  });
+
   it('should transform form into CC request', () => {
     const state = {
       user: {
@@ -177,6 +265,147 @@ describe('VAOS data transformation', () => {
       typeOfCare: 'CCPRMYRTNE',
       typeOfCareId: 'CCPRMYRTNE',
       appointmentType: 'Primary care',
+      cityState: {
+        institutionCode: '983',
+        parentStationCode: '983',
+        rootStationCode: '983',
+        adminParent: true,
+      },
+      facility: {
+        name: 'CHYSHR-Cheyenne VA Medical Center',
+        facilityCode: '983',
+        parentSiteCode: '983',
+      },
+      purposeOfVisit: 'routine-follow-up',
+      phoneNumber: '5035551234',
+      verifyPhoneNumber: '5035551234',
+      bestTimetoCall: ['Afternoon'],
+      preferredProviders: [
+        {
+          address: {
+            street: '456 elm st, sfasdf',
+            city: 'northampton',
+            state: 'MA',
+            zipCode: '01050',
+          },
+          practiceName: 'Practice',
+          firstName: 'asdf',
+          lastName: 'asdf',
+          providerStreet: '456 elm st, sfasdf',
+          providerCity: 'northampton',
+          providerState: 'MA',
+          providerZipCode1: '01050',
+        },
+      ],
+      newMessage: 'asdf',
+      preferredLanguage: 'English',
+      optionDate1: '11/20/2019',
+      optionDate2: 'No Date Selected',
+      optionDate3: 'No Date Selected',
+      optionTime1: 'PM',
+      optionTime2: 'No Time Selected',
+      optionTime3: 'No Time Selected',
+      preferredCity: 'Cheyenne',
+      preferredState: 'WY',
+      requestedPhoneCall: false,
+      email: 'test@va.gov',
+      officeHours: [],
+      reasonForVisit: '',
+      visitType: 'Office Visit',
+      distanceWillingToTravel: 40,
+      secondRequest: false,
+      secondRequestSubmitted: false,
+      inpatient: false,
+      status: 'Submitted',
+      providerId: '0',
+      providerOption: '',
+    });
+  });
+
+  it('should transform audiology form into audiology CC request', () => {
+    const state = {
+      user: {
+        profile: {
+          vet360: {},
+        },
+      },
+      newAppointment: {
+        data: {
+          phoneNumber: '5035551234',
+          bestTimeToCall: {
+            afternoon: true,
+          },
+          email: 'test@va.gov',
+          reasonForAppointment: 'routine-follow-up',
+          reasonAdditionalInfo: 'asdf',
+          communityCareSystemId: '983',
+          preferredLanguage: 'english',
+          hasCommunityCareProvider: true,
+          communityCareProvider: {
+            firstName: 'asdf',
+            lastName: 'asdf',
+            practiceName: 'Practice',
+            address: {
+              street: '456 elm st',
+              street2: 'sfasdf',
+              state: 'MA',
+              city: 'northampton',
+              postalCode: '01050',
+            },
+            phone: '2342444444',
+          },
+          calendarData: {
+            currentlySelectedDate: '2019-11-20',
+            selectedDates: [
+              {
+                date: '2019-11-20',
+                optionTime: 'PM',
+              },
+            ],
+            currentRowIndex: 3,
+          },
+          facilityType: 'communityCare',
+          typeOfCareId: '203',
+          audiologyType: 'CCAUDHEAR',
+        },
+        facilities: {},
+        facilityDetails: {},
+        clinics: {},
+        eligibility: {},
+        systems: [
+          {
+            institutionCode: '983',
+            city: 'Cheyenne',
+            stateAbbrev: 'WY',
+            authoritativeName: 'CHYSHR-Cheyenne VA Medical Center',
+            rootStationCode: '983',
+            adminParent: true,
+            parentStationCode: '983',
+          },
+          {
+            institutionCode: '984',
+            city: 'Dayton',
+            stateAbbrev: 'OH',
+            authoritativeName: 'DAYTSHR -Dayton VA Medical Center',
+            rootStationCode: '984',
+            adminParent: true,
+            parentStationCode: '984',
+          },
+        ],
+        ccEnabledSystems: ['984', '983'],
+        pageChangeInProgress: false,
+        systemsStatus: FETCH_STATUS.succeeded,
+        eligibilityStatus: FETCH_STATUS.succeeded,
+        facilityDetailsStatus: FETCH_STATUS.succeeded,
+        pastAppointments: null,
+        submitStatus: 'succeeded',
+      },
+    };
+    const data = transformFormToCCRequest(state);
+    expect(data).to.deep.equal({
+      typeOfCare: 'CCAUDHEAR',
+      typeOfCareId: 'CCAUDHEAR',
+      appointmentType: 'Hearing aid support',
       cityState: {
         institutionCode: '983',
         parentStationCode: '983',

--- a/src/applications/vaos/tests/utils/data.unit.spec.js
+++ b/src/applications/vaos/tests/utils/data.unit.spec.js
@@ -140,7 +140,7 @@ describe('VAOS data transformation', () => {
     };
     const data = transformFormToVARequest(state);
     expect(data).to.deep.equal({
-      typeOfCare: 'SLEEP',
+      typeOfCare: '349',
       typeOfCareId: '349',
       appointmentType: 'Continuous Positive Airway Pressure (CPAP)',
       cityState: {

--- a/src/applications/vaos/tests/utils/selectors.unit.spec.js
+++ b/src/applications/vaos/tests/utils/selectors.unit.spec.js
@@ -175,6 +175,19 @@ describe('VAOS selectors', () => {
   });
 
   describe('getTypeOfCare', () => {
+    it('get sleep type of care', () => {
+      const data = {
+        typeOfCareId: 'SLEEP',
+        typeOfSleepCareId: '349',
+      };
+
+      const typeOfCare = getTypeOfCare(data);
+      expect(typeOfCare.id).to.equal('349');
+      expect(typeOfCare.name).to.equal(
+        'Continuous Positive Airway Pressure (CPAP)',
+      );
+    });
+
     it('get audiology type of care', () => {
       const data = {
         typeOfCareId: '203',
@@ -183,7 +196,7 @@ describe('VAOS selectors', () => {
       };
 
       const typeOfCare = getTypeOfCare(data);
-      expect(typeOfCare.id).to.equal('CCAUDHEAR');
+      expect(typeOfCare.ccId).to.equal('CCAUDHEAR');
     });
 
     it('get podiatry type of care', () => {

--- a/src/applications/vaos/utils/constants.js
+++ b/src/applications/vaos/utils/constants.js
@@ -138,6 +138,17 @@ export const TYPES_OF_SLEEP_CARE = [
   },
 ];
 
+export const AUDIOLOGY_TYPES_OF_CARE = [
+  {
+    ccId: 'CCAUDRTNE',
+    name: 'Routine hearing exam',
+  },
+  {
+    ccId: 'CCAUDHEAR',
+    name: 'Hearing aid support',
+  },
+];
+
 export const FACILITY_TYPES = {
   VAMC: 'vamc',
   COMMUNITY_CARE: 'communityCare',
@@ -203,17 +214,6 @@ export const LANGUAGES = [
     id: 'other',
     text: 'Other',
     value: 'Other',
-  },
-];
-
-export const AUDIOLOGY_TYPES_OF_CARE = [
-  {
-    id: 'CCAUDRTNE',
-    name: 'Routine hearing exam',
-  },
-  {
-    id: 'CCAUDHEAR',
-    name: 'Hearing aid support',
   },
 ];
 

--- a/src/applications/vaos/utils/constants.js
+++ b/src/applications/vaos/utils/constants.js
@@ -138,17 +138,6 @@ export const TYPES_OF_SLEEP_CARE = [
   },
 ];
 
-export const AUDIOLOGY_TYPES_OF_CARE = [
-  {
-    ccId: 'CCAUDRTNE',
-    name: 'Routine hearing exam',
-  },
-  {
-    ccId: 'CCAUDHEAR',
-    name: 'Hearing aid support',
-  },
-];
-
 export const FACILITY_TYPES = {
   VAMC: 'vamc',
   COMMUNITY_CARE: 'communityCare',
@@ -214,6 +203,17 @@ export const LANGUAGES = [
     id: 'other',
     text: 'Other',
     value: 'Other',
+  },
+];
+
+export const AUDIOLOGY_TYPES_OF_CARE = [
+  {
+    ccId: 'CCAUDRTNE',
+    name: 'Routine hearing exam',
+  },
+  {
+    ccId: 'CCAUDHEAR',
+    name: 'Hearing aid support',
   },
 ];
 

--- a/src/applications/vaos/utils/data.js
+++ b/src/applications/vaos/utils/data.js
@@ -42,7 +42,7 @@ export function transformFormToVARequest(state) {
   const typeOfCare = getTypeOfCare(data);
 
   return {
-    typeOfCare: data.typeOfCareId,
+    typeOfCare: typeOfCare.id,
     typeOfCareId: typeOfCare.id,
     appointmentType: getTypeOfCare(data).name,
     cityState: {

--- a/src/applications/vaos/utils/data.js
+++ b/src/applications/vaos/utils/data.js
@@ -39,10 +39,11 @@ function getUserMessage(data) {
 export function transformFormToVARequest(state) {
   const facility = getChosenFacilityInfo(state);
   const data = getFormData(state);
+  const typeOfCare = getTypeOfCare(data);
 
   return {
     typeOfCare: data.typeOfCareId,
-    typeOfCareId: data.typeOfCareId,
+    typeOfCareId: typeOfCare.id,
     appointmentType: getTypeOfCare(data).name,
     cityState: {
       institutionCode: data.vaSystem,
@@ -136,10 +137,12 @@ export function transformFormToCCRequest(state) {
     };
   }
 
+  const typeOfCare = getTypeOfCare(data);
+
   return {
-    typeOfCare: getTypeOfCare(data).ccId,
-    typeOfCareId: getTypeOfCare(data).ccId,
-    appointmentType: getTypeOfCare(data).name,
+    typeOfCare: typeOfCare.ccId,
+    typeOfCareId: typeOfCare.ccId,
+    appointmentType: typeOfCare.name,
     cityState: {
       institutionCode: data.communityCareSystemId,
       rootStationCode: data.communityCareSystemId,

--- a/src/applications/vaos/utils/selectors.js
+++ b/src/applications/vaos/utils/selectors.js
@@ -42,7 +42,9 @@ export function getTypeOfCare(data) {
     data.typeOfCareId === AUDIOLOGY &&
     data.facilityType === FACILITY_TYPES.COMMUNITY_CARE
   ) {
-    return AUDIOLOGY_TYPES_OF_CARE.find(care => care.id === data.audiologyType);
+    return AUDIOLOGY_TYPES_OF_CARE.find(
+      care => care.ccId === data.audiologyType,
+    );
   }
 
   return TYPES_OF_CARE.find(care => care.id === data.typeOfCareId);


### PR DESCRIPTION
## Description
Fixes `typeOfCareId` in appointment and CC request data transformations for `POST` body.

## Testing done
Local and unit


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
