### PR TITLE
Scroll keyword search input box to center of screen when using small screen resolution

### DIFF
--- a/src/applications/gi/components/Checkbox.jsx
+++ b/src/applications/gi/components/Checkbox.jsx
@@ -4,6 +4,7 @@ import _ from 'lodash';
 import classNames from 'classnames';
 
 import ToolTip from './ToolTip';
+import { SMALL_SCREEN_WIDTH } from '../constants';
 
 /**
  * A form checkbox with a label that can display error messages.
@@ -29,6 +30,12 @@ class Checkbox extends React.Component {
   handleChange(domEvent) {
     this.props.onChange(domEvent);
   }
+
+  handleFocus = e => {
+    if (window.innerWidth <= SMALL_SCREEN_WIDTH) {
+      e.target.scrollIntoView();
+    }
+  };
 
   render() {
     // TODO: extract error logic into a utility function
@@ -75,6 +82,7 @@ class Checkbox extends React.Component {
           name={this.props.name}
           type="checkbox"
           onChange={this.handleChange}
+          onFocus={this.handleFocus}
         />
         <label
           className={classNames('gi-checkbox-label', {

--- a/src/applications/gi/components/Dropdown.jsx
+++ b/src/applications/gi/components/Dropdown.jsx
@@ -1,15 +1,27 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import { SMALL_SCREEN_WIDTH } from '../constants';
 
 class Dropdown extends React.Component {
+  constructor(props) {
+    super(props);
+    this.dropdownId = `${this.props.name}-dropdown`;
+  }
+
+  handleFocus = () => {
+    const field = document.getElementById(this.dropdownId);
+    if (field && window.innerWidth <= SMALL_SCREEN_WIDTH) {
+      field.scrollIntoView();
+    }
+  };
+
   render() {
     if (!this.props.visible) {
       return null;
     }
     const hideArrowsClass = this.props.hideArrows ? 'hide-arrows' : '';
-
     return (
-      <div className={this.props.className}>
+      <div className={this.props.className} id={this.dropdownId}>
         <label htmlFor={this.props.name}>{this.props.label}</label>
         <select
           className={hideArrowsClass}
@@ -18,6 +30,7 @@ class Dropdown extends React.Component {
           alt={this.props.alt}
           value={this.props.value}
           onChange={this.props.onChange}
+          onFocus={this.handleFocus}
         >
           {this.props.options.map(({ value, label }) => (
             <option key={value} value={value}>

--- a/src/applications/gi/components/RadioButtons.jsx
+++ b/src/applications/gi/components/RadioButtons.jsx
@@ -4,6 +4,7 @@ import _ from 'lodash';
 
 import ToolTip from './ToolTip';
 import ExpandingGroup from '@department-of-veterans-affairs/formation-react/ExpandingGroup';
+import { SMALL_SCREEN_WIDTH } from '../constants';
 
 /**
  * A radio button group with a label.
@@ -25,6 +26,13 @@ class RadioButtons extends React.Component {
 
   handleChange = domEvent => {
     this.props.onChange(domEvent);
+  };
+
+  handleFocus = () => {
+    const field = document.getElementById(`${this.inputId}-legend`);
+    if (field && window.innerWidth <= SMALL_SCREEN_WIDTH) {
+      field.scrollIntoView();
+    }
   };
 
   renderOptions = () => {
@@ -64,6 +72,7 @@ class RadioButtons extends React.Component {
             type="radio"
             value={optionValue}
             onChange={this.handleChange}
+            onFocus={this.handleFocus}
             aria-labelledby={`${this.inputId}-legend ${labelId}`}
           />
           <label

--- a/src/applications/gi/components/profile/CalculatorForm.jsx
+++ b/src/applications/gi/components/profile/CalculatorForm.jsx
@@ -13,7 +13,7 @@ import ErrorableTextInput from '@department-of-veterans-affairs/formation-react/
 import OnlineClassesFilter from '../search/OnlineClassesFilter';
 import Checkbox from '../Checkbox';
 import recordEvent from 'platform/monitoring/record-event';
-import { ariaLabels } from '../../constants';
+import { ariaLabels, SMALL_SCREEN_WIDTH } from '../../constants';
 
 class CalculatorForm extends React.Component {
   constructor(props) {
@@ -141,6 +141,13 @@ class CalculatorForm extends React.Component {
     }
   };
 
+  handleInputFocus = fieldId => {
+    const field = document.getElementById(fieldId);
+    if (field && window.innerWidth <= SMALL_SCREEN_WIDTH) {
+      field.scrollIntoView();
+    }
+  };
+
   resetBuyUp = event => {
     event.preventDefault();
     if (this.props.inputs.buyUpAmount > 600) {
@@ -208,8 +215,9 @@ class CalculatorForm extends React.Component {
     if (!this.props.displayedInputs.tuition) return null;
 
     const inStateTuitionFeesId = 'inStateTuitionFees';
+    const inStateFieldId = `${inStateTuitionFeesId}-fields`;
     const inStateTuitionInput = this.props.inputs.inState === 'no' && (
-      <div>
+      <div id={inStateFieldId}>
         <label htmlFor={inStateTuitionFeesId}>
           {this.renderLearnMoreLabel({
             text: 'In-state tuition and fees per year',
@@ -223,13 +231,15 @@ class CalculatorForm extends React.Component {
           id={inStateTuitionFeesId}
           value={formatCurrency(this.props.inputs.inStateTuitionFees)}
           onChange={this.handleInputChange}
+          onFocus={this.handleInputFocus.bind(this, inStateFieldId)}
         />
       </div>
     );
 
     const tuitionFeesId = 'tuitionFees';
+    const tuitionFeesFieldId = `${tuitionFeesId}-field`;
     return (
-      <div>
+      <div id={tuitionFeesFieldId}>
         <label htmlFor={tuitionFeesId} className="vads-u-display--inline-block">
           Tuition and fees per year
         </label>
@@ -247,6 +257,7 @@ class CalculatorForm extends React.Component {
           id={tuitionFeesId}
           value={formatCurrency(this.props.inputs.tuitionFees)}
           onChange={this.handleInputChange}
+          onFocus={this.handleInputFocus.bind(this, tuitionFeesFieldId)}
         />
         {inStateTuitionInput}
       </div>
@@ -256,8 +267,9 @@ class CalculatorForm extends React.Component {
   renderBooks = () => {
     if (!this.props.displayedInputs.books) return null;
     const booksId = 'books';
+    const booksFieldId = 'books-field';
     return (
-      <div>
+      <div id={booksFieldId}>
         <label htmlFor={booksId}>Books and supplies per year</label>
         <input
           type="text"
@@ -265,6 +277,7 @@ class CalculatorForm extends React.Component {
           id={booksId}
           value={formatCurrency(this.props.inputs.books)}
           onChange={this.handleInputChange}
+          onFocus={this.handleInputFocus.bind(this, booksFieldId)}
         />
       </div>
     );
@@ -291,7 +304,7 @@ class CalculatorForm extends React.Component {
     }));
     const showYellowRibbonOptions = yellowRibbonDegreeLevelOptions.length > 1;
     const showYellowRibbonDetails = yellowRibbonDivisionOptions.length > 0;
-
+    const yellowRibbonFieldId = 'yellowRibbonField';
     return (
       <div>
         <RadioButtons
@@ -330,7 +343,7 @@ class CalculatorForm extends React.Component {
               value={this.props.inputs.yellowRibbonDivision}
               onChange={this.handleInputChange}
             />
-            <div>
+            <div id={yellowRibbonFieldId}>
               <label htmlFor="yellowRibbonContributionAmount">
                 Yellow Ribbon amount from school per year
               </label>
@@ -340,6 +353,7 @@ class CalculatorForm extends React.Component {
                 name="yellowRibbonAmount"
                 value={formatCurrency(this.props.inputs.yellowRibbonAmount)}
                 onChange={this.handleInputChange}
+                onFocus={this.handleInputFocus.bind(this, yellowRibbonFieldId)}
               />
             </div>
             <AlertBox
@@ -369,8 +383,9 @@ class CalculatorForm extends React.Component {
   renderScholarships = () => {
     if (!this.props.displayedInputs.scholarships) return null;
     const scholarshipsId = 'scholarships';
+    const scholarshipsFieldId = `${scholarshipsId}-field`;
     return (
-      <div>
+      <div id={scholarshipsFieldId}>
         <label htmlFor={scholarshipsId}>
           {this.renderLearnMoreLabel({
             text: 'Scholarships (excluding Pell)',
@@ -384,6 +399,7 @@ class CalculatorForm extends React.Component {
           id={scholarshipsId}
           value={formatCurrency(this.props.inputs.scholarships)}
           onChange={this.handleInputChange}
+          onFocus={this.handleInputFocus.bind(this, scholarshipsFieldId)}
         />
       </div>
     );
@@ -392,8 +408,9 @@ class CalculatorForm extends React.Component {
   renderTuitionAssist = () => {
     if (!this.props.displayedInputs.tuitionAssist) return null;
     const tuitionAssistId = 'tuitionAssist';
+    const tuitionAssistFieldId = `${tuitionAssistId}-field`;
     return (
-      <div>
+      <div id={tuitionAssistFieldId}>
         <label htmlFor={tuitionAssistId}>
           {this.renderLearnMoreLabel({
             text: 'How much are you receiving in military tuition assistance',
@@ -406,6 +423,7 @@ class CalculatorForm extends React.Component {
           id={tuitionAssistId}
           value={formatCurrency(this.props.inputs.tuitionAssist)}
           onChange={this.handleInputChange}
+          onFocus={this.handleInputFocus.bind(this, tuitionAssistFieldId)}
         />
       </div>
     );
@@ -544,8 +562,9 @@ class CalculatorForm extends React.Component {
 
     if (this.props.inputs.kickerEligible === 'yes') {
       const kickerAmountId = 'kickerAmount';
+      const kickerFieldId = `${kickerAmountId}-field`;
       amountInput = (
-        <div>
+        <div id={kickerFieldId}>
           <label htmlFor={kickerAmountId}>How much is your kicker?</label>
           <input
             type="text"
@@ -553,6 +572,7 @@ class CalculatorForm extends React.Component {
             id={kickerAmountId}
             value={formatCurrency(this.props.inputs.kickerAmount)}
             onChange={this.handleInputChange}
+            onFocus={this.handleInputFocus.bind(this, kickerFieldId)}
           />
         </div>
       );
@@ -726,8 +746,9 @@ class CalculatorForm extends React.Component {
 
     if (this.props.inputs.buyUp === 'yes') {
       const buyUpAmountId = 'buyUpAmount';
+      const buyUpFieldId = `${buyUpAmountId}-field`;
       amountInput = (
-        <div>
+        <div id={buyUpFieldId}>
           <label htmlFor={buyUpAmountId}>
             How much did you pay toward buy-up (up to $600)?
           </label>
@@ -738,6 +759,7 @@ class CalculatorForm extends React.Component {
             value={formatCurrency(this.props.inputs.buyUpAmount)}
             onChange={this.handleInputChange}
             onBlur={this.resetBuyUp}
+            onFocus={this.handleInputFocus.bind(this, buyUpFieldId)}
           />
         </div>
       );

--- a/src/applications/gi/components/search/KeywordSearch.jsx
+++ b/src/applications/gi/components/search/KeywordSearch.jsx
@@ -55,6 +55,13 @@ export class KeywordSearch extends React.Component {
     this.props.onFilterChange(searchQuery);
   };
 
+  handleFocus = () => {
+    const smallScreenWidth = 481;
+    if (window.innerWidth <= smallScreenWidth) {
+      document.getElementsByClassName('keyword-search')[0].scrollIntoView();
+    }
+  };
+
   render() {
     const { suggestions, searchTerm } = this.props.autocomplete;
     let errorSpan = '';
@@ -105,6 +112,7 @@ export class KeywordSearch extends React.Component {
                   type: 'text',
                   onChange: this.handleChange,
                   onKeyUp: this.handleKeyUp,
+                  onFocus: this.handleFocus,
                   'aria-labelledby': 'institution-search-label',
                 })}
               />

--- a/src/applications/gi/components/search/KeywordSearch.jsx
+++ b/src/applications/gi/components/search/KeywordSearch.jsx
@@ -4,7 +4,7 @@ import { debounce } from 'lodash';
 import recordEvent from 'platform/monitoring/record-event';
 import Downshift from 'downshift';
 import classNames from 'classnames';
-import { WAIT_INTERVAL } from '../../constants';
+import { WAIT_INTERVAL, SMALL_SCREEN_WIDTH, KEY_CODES } from '../../constants';
 
 export class KeywordSearch extends React.Component {
   constructor(props) {
@@ -18,7 +18,7 @@ export class KeywordSearch extends React.Component {
 
   handleKeyUp = e => {
     const { onFilterChange, autocomplete } = this.props;
-    if ((e.which || e.keyCode) === 13) {
+    if ((e.which || e.keyCode) === KEY_CODES.enterKey) {
       e.target.blur();
       onFilterChange(autocomplete.searchTerm);
     }
@@ -56,8 +56,7 @@ export class KeywordSearch extends React.Component {
   };
 
   handleFocus = () => {
-    const smallScreenWidth = 481;
-    if (window.innerWidth <= smallScreenWidth) {
+    if (window.innerWidth <= SMALL_SCREEN_WIDTH) {
       document.getElementsByClassName('keyword-search')[0].scrollIntoView();
     }
   };

--- a/src/applications/gi/components/search/KeywordSearch.jsx
+++ b/src/applications/gi/components/search/KeywordSearch.jsx
@@ -56,8 +56,9 @@ export class KeywordSearch extends React.Component {
   };
 
   handleFocus = () => {
-    if (window.innerWidth <= SMALL_SCREEN_WIDTH) {
-      document.getElementsByClassName('keyword-search')[0].scrollIntoView();
+    const field = document.getElementsByClassName('keyword-search')[0];
+    if (field && window.innerWidth <= SMALL_SCREEN_WIDTH) {
+      field.scrollIntoView();
     }
   };
 

--- a/src/applications/gi/constants.js
+++ b/src/applications/gi/constants.js
@@ -1,6 +1,13 @@
 // WAIT_INTERVAL is in milliseconds.
 export const WAIT_INTERVAL = 333;
 
+// SMALL_SCREEN_WIDTH is in pixels
+export const SMALL_SCREEN_WIDTH = 481;
+
+export const KEY_CODES = Object.freeze({
+  enterKey: 13,
+});
+
 export const ariaLabels = Object.freeze({
   learnMore: {
     giBillBenefits: 'Learn more about VA education and training programs',


### PR DESCRIPTION
## Description
https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/1278

This addresses the problem where fields are not properly being scrolled to when a user navigates to it with the keyboard and have their monitor set to 400% zoom. In order to be more accessible, we added `onFocus()` action listeners to these fields that will force the screen to scroll to the element when the monitor's resolution is less than or equal to vets-website's `small-screen` width value. 

## Testing done
Dev tested. 

## Screenshots


## Acceptance criteria
- [x] When user tabs to the keyword search field, the input box is visible.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
