### PR TITLE
SSO login page

### DIFF
--- a/src/applications/login/app-entry.jsx
+++ b/src/applications/login/app-entry.jsx
@@ -1,0 +1,14 @@
+import '../../platform/polyfills';
+import './sass/login-page.scss';
+
+import startApp from '../../platform/startup';
+
+import routes from './routes';
+import reducer from './reducers';
+import manifest from './manifest.json';
+
+startApp({
+  url: manifest.rootUrl,
+  reducer,
+  routes,
+});

--- a/src/applications/login/containers/App.jsx
+++ b/src/applications/login/containers/App.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import SignInApp from './SignInApp';
+
+export default function App({ children }) {
+  return (
+    <>
+      <header className="login-header">
+        <div className="usa-grid-full">
+          <div className="header-wrapper">
+            <img src="/img/header-logo.png" alt="VA Logo" />
+          </div>
+        </div>
+      </header>
+      <div>
+        <SignInApp />
+        {children}
+      </div>
+    </>
+  );
+}

--- a/src/applications/login/containers/SignInApp.jsx
+++ b/src/applications/login/containers/SignInApp.jsx
@@ -29,13 +29,11 @@ class SignInModal extends React.Component {
     this.state = {
       globalDowntime: false,
     };
-
-    this.setGlobalDowntimeState = this.setGlobalDowntimeState.bind(this);
   }
 
-  setGlobalDowntimeState() {
+  setGlobalDowntimeState = () => {
     this.setState({ globalDowntime: true });
-  }
+  };
 
   downtimeBanner = (
     { dependencies, headline, status, message, globalDowntime },

--- a/src/applications/login/containers/SignInApp.jsx
+++ b/src/applications/login/containers/SignInApp.jsx
@@ -2,20 +2,19 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
-import Modal from '@department-of-veterans-affairs/formation-react/Modal';
 
 import ExternalServicesError from 'platform/monitoring/external-services/ExternalServicesError';
-import { EXTERNAL_SERVICES } from 'platform/monitoring/external-services/config';
-import recordEvent from 'platform/monitoring/record-event';
+// import recordEvent from 'platform/monitoring/record-event';
 import SubmitSignInForm from 'platform/static-data/SubmitSignInForm';
 import { login, signup } from 'platform/user/authentication/utilities';
 import environment from 'platform/utilities/environment';
 
-import scheduledDowntimeWindow from 'platform/monitoring/DowntimeNotification/config/scheduledDowntimeWindow';
+import downtimeBanners from '../utilities/downtimeBanners';
 
 const loginHandler = loginType => () => {
-  recordEvent({ event: `login-attempted-${loginType}` });
-  login(loginType);
+  // TODO add separate login tracking for this page
+  //   recordEvent({ event: `login-attempted-${loginType}` });
+  login(loginType, 'v1');
 };
 
 const handleDsLogon = loginHandler('dslogon');
@@ -23,7 +22,6 @@ const handleMhv = loginHandler('mhv');
 const handleIdMe = loginHandler('idme');
 
 const vaGovFullDomain = environment.BASE_URL;
-const logoSrc = `${vaGovFullDomain}/img/design/logo/va-logo.png`;
 
 class SignInModal extends React.Component {
   constructor(props) {
@@ -35,20 +33,19 @@ class SignInModal extends React.Component {
     this.setGlobalDowntimeState = this.setGlobalDowntimeState.bind(this);
   }
 
-  componentDidUpdate(prevProps) {
-    if (!prevProps.visible && this.props.visible) {
-      recordEvent({ event: 'login-modal-opened' });
-    } else if (prevProps.visible && !this.props.visible) {
-      recordEvent({ event: 'login-modal-closed' });
-    }
-  }
-
   setGlobalDowntimeState() {
     this.setState({ globalDowntime: true });
   }
 
-  downtimeBanner = (dependencies, headline, status, message, onRender) => (
-    <ExternalServicesError dependencies={dependencies} onRender={onRender}>
+  downtimeBanner = (
+    { dependencies, headline, status, message, globalDowntime },
+    index,
+  ) => (
+    <ExternalServicesError
+      dependencies={dependencies}
+      onRender={globalDowntime ? this.setGlobalDowntimeState : null}
+      key={index}
+    >
       <div className="downtime-notification row">
         <div className="columns small-12">
           <div className="form-warning-banner">
@@ -62,229 +59,168 @@ class SignInModal extends React.Component {
     </ExternalServicesError>
   );
 
-  renderModalContent = ({ globalDowntime }) => (
-    <main className="login">
-      <div className="row">
-        <div className="columns">
-          <div className="logo">
-            <a href="/">
-              <img alt="VA.gov" className="va-header-logo" src={logoSrc} />
-            </a>
-          </div>
-        </div>
-      </div>
-      <div className="container">
-        <div className="row">
-          <div className="columns small-12">
-            <h1>Sign in to VA.gov</h1>
-          </div>
-        </div>
-        <div className="row medium-screen:vads-u-display--none mobile-explanation">
-          <div className="columns small-12">
-            <h2>
-              One site. A lifetime of benefits and services at your fingertips.
-            </h2>
-          </div>
-        </div>
-        {this.downtimeBanner(
-          [EXTERNAL_SERVICES.idme],
-          'Our sign in process isn’t working right now',
-          'error',
-          'We’re sorry. We’re working to fix some problems with our sign in process. If you’d like to sign in to VA.gov, please check back later.',
-        )}
-        {this.downtimeBanner(
-          [EXTERNAL_SERVICES.dslogon],
-          'You may have trouble signing in with DS Logon',
-          'warning',
-          'We’re sorry. We’re working to fix some problems with our DS Logon sign in process. If you’d like to sign in to VA.gov with your DS Logon account, please check back later.',
-        )}
-        {this.downtimeBanner(
-          [EXTERNAL_SERVICES.mhv],
-          'You may have trouble signing in with My HealtheVet',
-          'warning',
-          'We’re sorry. We’re working to fix some problems with our My HealtheVet sign in process. If you’d like to sign in to VA.gov with your My HealtheVet username and password, please check back later.',
-        )}
-        {this.downtimeBanner(
-          [EXTERNAL_SERVICES.mvi],
-          'You may have trouble signing in or using some tools or services',
-          'warning',
-          'We’re sorry. We’re working to fix a problem that affects some parts of our site. If you have trouble signing in or using any tools or services, please check back soon.',
-        )}
-        {this.downtimeBanner(
-          [EXTERNAL_SERVICES.global],
-          'You may have trouble signing in or using some tools or services',
-          'warning',
-          `We’re doing some work on VA.gov right now. We hope to finish our work by ${
-            scheduledDowntimeWindow.downtimeEnd
-          }. If you have trouble signing in or using any tools or services, please check back after then.`,
-          this.setGlobalDowntimeState,
-        )}
+  render() {
+    const { globalDowntime } = this.state;
 
-        <div>
-          <div className="usa-width-one-half">
-            <div className="signin-actions-container">
-              <div className="top-banner">
-                <div>
-                  <img
-                    alt="ID.me"
-                    src={`${vaGovFullDomain}/img/signin/lock-icon.svg`}
-                  />{' '}
-                  Secured & powered by{' '}
-                  <img
-                    alt="ID.me"
-                    src={`${vaGovFullDomain}/img/signin/idme-icon-dark.svg`}
-                  />
-                </div>
-              </div>
-              <div className="signin-actions">
-                <h5>Sign in with an existing account</h5>
-                <div>
-                  <button
-                    disabled={globalDowntime}
-                    className="dslogon"
-                    onClick={handleDsLogon}
-                  >
-                    <img
-                      alt="DS Logon"
-                      src={`${vaGovFullDomain}/img/signin/dslogon-icon.svg`}
-                    />
-                    <strong> Sign in with DS Logon</strong>
-                  </button>
-                  <button
-                    disabled={globalDowntime}
-                    className="mhv"
-                    onClick={handleMhv}
-                  >
-                    <img
-                      alt="My HealtheVet"
-                      src={`${vaGovFullDomain}/img/signin/mhv-icon.svg`}
-                    />
-                    <strong> Sign in with My HealtheVet</strong>
-                  </button>
-                  <button
-                    disabled={globalDowntime}
-                    className="usa-button-primary va-button-primary"
-                    onClick={handleIdMe}
-                  >
+    return (
+      <main className="login">
+        <div className="container">
+          <div className="row">
+            <div className="columns small-12">
+              {/* TODO this title will need to be dynamic in the future */}
+              <h1>Sign in to My Healthy Life</h1>
+            </div>
+          </div>
+          <div className="row medium-screen:vads-u-display--none mobile-explanation">
+            <div className="columns small-12">
+              {/* TODO this content will need to be dynamic in the future */}
+              <h2>One account to access My Healthy Life and VA.gov.</h2>
+            </div>
+          </div>
+          {downtimeBanners.map((props, index) =>
+            this.downtimeBanner(props, index),
+          )}
+          <div className="row">
+            <div className="usa-width-one-half">
+              <div className="signin-actions-container">
+                <div className="top-banner">
+                  <div>
                     <img
                       alt="ID.me"
-                      src={`${vaGovFullDomain}/img/signin/idme-icon-white.svg`}
+                      src={`${vaGovFullDomain}/img/signin/lock-icon.svg`}
+                    />{' '}
+                    Secured & powered by{' '}
+                    <img
+                      alt="ID.me"
+                      src={`${vaGovFullDomain}/img/signin/idme-icon-dark.svg`}
                     />
-                    <strong> Sign in with ID.me</strong>
-                  </button>
-                  <span className="sidelines">OR</span>
-                  <div className="alternate-signin">
-                    <h5>Don't have those accounts?</h5>
+                  </div>
+                </div>
+                <div className="signin-actions">
+                  <h5>Sign in with an existing account</h5>
+                  <div>
                     <button
                       disabled={globalDowntime}
-                      className="idme-create usa-button usa-button-secondary"
-                      onClick={signup}
+                      className="dslogon"
+                      onClick={handleDsLogon}
+                    >
+                      <img
+                        alt="DS Logon"
+                        src={`${vaGovFullDomain}/img/signin/dslogon-icon.svg`}
+                      />
+                      <strong> Sign in with DS Logon</strong>
+                    </button>
+                    <button
+                      disabled={globalDowntime}
+                      className="mhv"
+                      onClick={handleMhv}
+                    >
+                      <img
+                        alt="My HealtheVet"
+                        src={`${vaGovFullDomain}/img/signin/mhv-icon.svg`}
+                      />
+                      <strong> Sign in with My HealtheVet</strong>
+                    </button>
+                    <button
+                      disabled={globalDowntime}
+                      className="usa-button-primary va-button-primary"
+                      onClick={handleIdMe}
                     >
                       <img
                         alt="ID.me"
-                        src={`${vaGovFullDomain}/img/signin/idme-icon-dark.svg`}
+                        src={`${vaGovFullDomain}/img/signin/idme-icon-white.svg`}
                       />
-                      <strong> Create an ID.me account</strong>
+                      <strong> Sign in with ID.me</strong>
                     </button>
-                    <p>Use your email, Google, or Facebook</p>
+                    <span className="sidelines">OR</span>
+                    <div className="alternate-signin">
+                      <h5>Don't have those accounts?</h5>
+                      <button
+                        disabled={globalDowntime}
+                        className="idme-create usa-button usa-button-secondary"
+                        onClick={signup}
+                      >
+                        <img
+                          alt="ID.me"
+                          src={`${vaGovFullDomain}/img/signin/idme-icon-dark.svg`}
+                        />
+                        <strong> Create an ID.me account</strong>
+                      </button>
+                      <p>Use your email, Google, or Facebook</p>
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
-          </div>
-          <div className="usa-width-one-half">
-            <div className="explanation-content">
-              <div className="vads-u-display--none medium-screen:vads-u-display--block usa-font-lead">
-                One site. A lifetime of benefits and services at your
-                fingertips.
+            <div className="usa-width-one-half">
+              <div className="explanation-content">
+                {/* TODO this content will need to be dynamic in the future */}
+                <div className="vads-u-display--none medium-screen:vads-u-display--block usa-font-lead">
+                  One account to access My Healthy Life and VA.gov.
+                </div>
+                <p className="vads-u-margin-y--5">
+                  Use your existing DS Logon, MyHealtheVet, or ID.me account to
+                  log in to My Healthy Life. Access and manage your VA benefits
+                  and health care without creating another account.
+                </p>
+                <p>
+                  <strong>A secure account powered by ID.me</strong>
+                  <br />
+                  ID.me is our trusted technology partner in helping to keep
+                  your personal information safe. They specialize in digital
+                  identity protection and help us make sure you're you—and not
+                  someone pretending to be you—before we give you access to your
+                  information.
+                </p>
+                <p>
+                  <a href="/sign-in-faq/#what-is-idme" target="_blank">
+                    Learn more about ID.me
+                  </a>
+                </p>
               </div>
-              <p>
-                You spoke. We listened. VA.gov is the direct result of what you
-                said you wanted most—one easy-to-use place to:
-              </p>
-              <ul>
-                <li>Check your disability claim and appeal status</li>
-                <li>
-                  Find out how much money you have left to pay for school or
-                  training
-                </li>
-                <li>
-                  Refill your prescriptions and communicate with your health
-                  care team
-                </li>
-                <li>...and more</li>
-              </ul>
-              <p>
-                <strong>A secure account powered by ID.me</strong>
-                <br />
-                ID.me is our trusted technology partner in helping to keep your
-                personal information safe. They specialize in digital identity
-                protection and help us make sure you're you—and not someone
-                pretending to be you—before we give you access to your
-                information.
-              </p>
-              <p>
-                <a href="/sign-in-faq/#what-is-idme" target="_blank">
-                  Learn more about ID.me
-                </a>
-              </p>
+            </div>
+          </div>
+          <div className="row">
+            <div className="columns small-12">
+              <div className="help-info">
+                <h4>Having trouble signing in?</h4>
+                <p>
+                  <a href="/sign-in-faq/" target="_blank">
+                    Get answers to Frequently Asked Questions
+                  </a>
+                </p>
+                <p>
+                  <SubmitSignInForm startSentence />
+                </p>
+              </div>
+              <hr />
+              <div className="fed-warning">
+                <p>
+                  When you sign in to VA.gov, you’re using a United States
+                  federal government information system.
+                </p>
+                <p>
+                  By signing in, you agree to only use information you have
+                  legal authority to view and use. You also agree to let us
+                  monitor and record your activity on the system and share this
+                  information with auditors or law enforcement officials.
+                </p>
+                <p>
+                  By signing in, you confirm that you understand the following:
+                </p>
+                <p>
+                  Unauthorized use of this system is prohibited and may result
+                  in criminal, civil, or administrative penalties. Unauthorized
+                  use includes gaining unauthorized data access, changing data,
+                  harming the system or its data, or misusing the system. We can
+                  suspend or block your access to this system if we suspect any
+                  unauthorized use.
+                </p>
+              </div>
             </div>
           </div>
         </div>
-        <div className="row">
-          <div className="columns small-12">
-            <div className="help-info">
-              <h4>Having trouble signing in?</h4>
-              <p>
-                <a href="/sign-in-faq/" target="_blank">
-                  Get answers to Frequently Asked Questions
-                </a>
-              </p>
-              <p>
-                <SubmitSignInForm startSentence />
-              </p>
-            </div>
-            <hr />
-            <div className="fed-warning">
-              <p>
-                When you sign in to VA.gov, you’re using a United States federal
-                government information system.
-              </p>
-              <p>
-                By signing in, you agree to only use information you have legal
-                authority to view and use. You also agree to let us monitor and
-                record your activity on the system and share this information
-                with auditors or law enforcement officials.
-              </p>
-              <p>
-                By signing in, you confirm that you understand the following:
-              </p>
-              <p>
-                Unauthorized use of this system is prohibited and may result in
-                criminal, civil, or administrative penalties. Unauthorized use
-                includes gaining unauthorized data access, changing data,
-                harming the system or its data, or misusing the system. We can
-                suspend or block your access to this system if we suspect any
-                unauthorized use.
-              </p>
-            </div>
-          </div>
-        </div>
-      </div>
-    </main>
-  );
-
-  render() {
-    return (
-      <Modal
-        cssClass="va-modal-large"
-        visible={this.props.visible}
-        focusSelector="button"
-        onClose={this.props.onClose}
-        id="signin-signup-modal"
-      >
-        {this.renderModalContent(this.state)}
-      </Modal>
+      </main>
     );
   }
 }

--- a/src/applications/login/containers/SignInApp.jsx
+++ b/src/applications/login/containers/SignInApp.jsx
@@ -1,0 +1,297 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
+import Modal from '@department-of-veterans-affairs/formation-react/Modal';
+
+import ExternalServicesError from 'platform/monitoring/external-services/ExternalServicesError';
+import { EXTERNAL_SERVICES } from 'platform/monitoring/external-services/config';
+import recordEvent from 'platform/monitoring/record-event';
+import SubmitSignInForm from 'platform/static-data/SubmitSignInForm';
+import { login, signup } from 'platform/user/authentication/utilities';
+import environment from 'platform/utilities/environment';
+
+import scheduledDowntimeWindow from 'platform/monitoring/DowntimeNotification/config/scheduledDowntimeWindow';
+
+const loginHandler = loginType => () => {
+  recordEvent({ event: `login-attempted-${loginType}` });
+  login(loginType);
+};
+
+const handleDsLogon = loginHandler('dslogon');
+const handleMhv = loginHandler('mhv');
+const handleIdMe = loginHandler('idme');
+
+const vaGovFullDomain = environment.BASE_URL;
+const logoSrc = `${vaGovFullDomain}/img/design/logo/va-logo.png`;
+
+class SignInModal extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      globalDowntime: false,
+    };
+
+    this.setGlobalDowntimeState = this.setGlobalDowntimeState.bind(this);
+  }
+
+  componentDidUpdate(prevProps) {
+    if (!prevProps.visible && this.props.visible) {
+      recordEvent({ event: 'login-modal-opened' });
+    } else if (prevProps.visible && !this.props.visible) {
+      recordEvent({ event: 'login-modal-closed' });
+    }
+  }
+
+  setGlobalDowntimeState() {
+    this.setState({ globalDowntime: true });
+  }
+
+  downtimeBanner = (dependencies, headline, status, message, onRender) => (
+    <ExternalServicesError dependencies={dependencies} onRender={onRender}>
+      <div className="downtime-notification row">
+        <div className="columns small-12">
+          <div className="form-warning-banner">
+            <AlertBox headline={headline} isVisible status={status}>
+              {message}
+            </AlertBox>
+            <br />
+          </div>
+        </div>
+      </div>
+    </ExternalServicesError>
+  );
+
+  renderModalContent = ({ globalDowntime }) => (
+    <main className="login">
+      <div className="row">
+        <div className="columns">
+          <div className="logo">
+            <a href="/">
+              <img alt="VA.gov" className="va-header-logo" src={logoSrc} />
+            </a>
+          </div>
+        </div>
+      </div>
+      <div className="container">
+        <div className="row">
+          <div className="columns small-12">
+            <h1>Sign in to VA.gov</h1>
+          </div>
+        </div>
+        <div className="row medium-screen:vads-u-display--none mobile-explanation">
+          <div className="columns small-12">
+            <h2>
+              One site. A lifetime of benefits and services at your fingertips.
+            </h2>
+          </div>
+        </div>
+        {this.downtimeBanner(
+          [EXTERNAL_SERVICES.idme],
+          'Our sign in process isn’t working right now',
+          'error',
+          'We’re sorry. We’re working to fix some problems with our sign in process. If you’d like to sign in to VA.gov, please check back later.',
+        )}
+        {this.downtimeBanner(
+          [EXTERNAL_SERVICES.dslogon],
+          'You may have trouble signing in with DS Logon',
+          'warning',
+          'We’re sorry. We’re working to fix some problems with our DS Logon sign in process. If you’d like to sign in to VA.gov with your DS Logon account, please check back later.',
+        )}
+        {this.downtimeBanner(
+          [EXTERNAL_SERVICES.mhv],
+          'You may have trouble signing in with My HealtheVet',
+          'warning',
+          'We’re sorry. We’re working to fix some problems with our My HealtheVet sign in process. If you’d like to sign in to VA.gov with your My HealtheVet username and password, please check back later.',
+        )}
+        {this.downtimeBanner(
+          [EXTERNAL_SERVICES.mvi],
+          'You may have trouble signing in or using some tools or services',
+          'warning',
+          'We’re sorry. We’re working to fix a problem that affects some parts of our site. If you have trouble signing in or using any tools or services, please check back soon.',
+        )}
+        {this.downtimeBanner(
+          [EXTERNAL_SERVICES.global],
+          'You may have trouble signing in or using some tools or services',
+          'warning',
+          `We’re doing some work on VA.gov right now. We hope to finish our work by ${
+            scheduledDowntimeWindow.downtimeEnd
+          }. If you have trouble signing in or using any tools or services, please check back after then.`,
+          this.setGlobalDowntimeState,
+        )}
+
+        <div>
+          <div className="usa-width-one-half">
+            <div className="signin-actions-container">
+              <div className="top-banner">
+                <div>
+                  <img
+                    alt="ID.me"
+                    src={`${vaGovFullDomain}/img/signin/lock-icon.svg`}
+                  />{' '}
+                  Secured & powered by{' '}
+                  <img
+                    alt="ID.me"
+                    src={`${vaGovFullDomain}/img/signin/idme-icon-dark.svg`}
+                  />
+                </div>
+              </div>
+              <div className="signin-actions">
+                <h5>Sign in with an existing account</h5>
+                <div>
+                  <button
+                    disabled={globalDowntime}
+                    className="dslogon"
+                    onClick={handleDsLogon}
+                  >
+                    <img
+                      alt="DS Logon"
+                      src={`${vaGovFullDomain}/img/signin/dslogon-icon.svg`}
+                    />
+                    <strong> Sign in with DS Logon</strong>
+                  </button>
+                  <button
+                    disabled={globalDowntime}
+                    className="mhv"
+                    onClick={handleMhv}
+                  >
+                    <img
+                      alt="My HealtheVet"
+                      src={`${vaGovFullDomain}/img/signin/mhv-icon.svg`}
+                    />
+                    <strong> Sign in with My HealtheVet</strong>
+                  </button>
+                  <button
+                    disabled={globalDowntime}
+                    className="usa-button-primary va-button-primary"
+                    onClick={handleIdMe}
+                  >
+                    <img
+                      alt="ID.me"
+                      src={`${vaGovFullDomain}/img/signin/idme-icon-white.svg`}
+                    />
+                    <strong> Sign in with ID.me</strong>
+                  </button>
+                  <span className="sidelines">OR</span>
+                  <div className="alternate-signin">
+                    <h5>Don't have those accounts?</h5>
+                    <button
+                      disabled={globalDowntime}
+                      className="idme-create usa-button usa-button-secondary"
+                      onClick={signup}
+                    >
+                      <img
+                        alt="ID.me"
+                        src={`${vaGovFullDomain}/img/signin/idme-icon-dark.svg`}
+                      />
+                      <strong> Create an ID.me account</strong>
+                    </button>
+                    <p>Use your email, Google, or Facebook</p>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div className="usa-width-one-half">
+            <div className="explanation-content">
+              <div className="vads-u-display--none medium-screen:vads-u-display--block usa-font-lead">
+                One site. A lifetime of benefits and services at your
+                fingertips.
+              </div>
+              <p>
+                You spoke. We listened. VA.gov is the direct result of what you
+                said you wanted most—one easy-to-use place to:
+              </p>
+              <ul>
+                <li>Check your disability claim and appeal status</li>
+                <li>
+                  Find out how much money you have left to pay for school or
+                  training
+                </li>
+                <li>
+                  Refill your prescriptions and communicate with your health
+                  care team
+                </li>
+                <li>...and more</li>
+              </ul>
+              <p>
+                <strong>A secure account powered by ID.me</strong>
+                <br />
+                ID.me is our trusted technology partner in helping to keep your
+                personal information safe. They specialize in digital identity
+                protection and help us make sure you're you—and not someone
+                pretending to be you—before we give you access to your
+                information.
+              </p>
+              <p>
+                <a href="/sign-in-faq/#what-is-idme" target="_blank">
+                  Learn more about ID.me
+                </a>
+              </p>
+            </div>
+          </div>
+        </div>
+        <div className="row">
+          <div className="columns small-12">
+            <div className="help-info">
+              <h4>Having trouble signing in?</h4>
+              <p>
+                <a href="/sign-in-faq/" target="_blank">
+                  Get answers to Frequently Asked Questions
+                </a>
+              </p>
+              <p>
+                <SubmitSignInForm startSentence />
+              </p>
+            </div>
+            <hr />
+            <div className="fed-warning">
+              <p>
+                When you sign in to VA.gov, you’re using a United States federal
+                government information system.
+              </p>
+              <p>
+                By signing in, you agree to only use information you have legal
+                authority to view and use. You also agree to let us monitor and
+                record your activity on the system and share this information
+                with auditors or law enforcement officials.
+              </p>
+              <p>
+                By signing in, you confirm that you understand the following:
+              </p>
+              <p>
+                Unauthorized use of this system is prohibited and may result in
+                criminal, civil, or administrative penalties. Unauthorized use
+                includes gaining unauthorized data access, changing data,
+                harming the system or its data, or misusing the system. We can
+                suspend or block your access to this system if we suspect any
+                unauthorized use.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </main>
+  );
+
+  render() {
+    return (
+      <Modal
+        cssClass="va-modal-large"
+        visible={this.props.visible}
+        focusSelector="button"
+        onClose={this.props.onClose}
+        id="signin-signup-modal"
+      >
+        {this.renderModalContent(this.state)}
+      </Modal>
+    );
+  }
+}
+
+SignInModal.propTypes = {
+  onClose: PropTypes.func,
+  visible: PropTypes.bool,
+};
+
+export default SignInModal;

--- a/src/applications/login/manifest.json
+++ b/src/applications/login/manifest.json
@@ -1,0 +1,13 @@
+{
+  "appName": "Login Page",
+  "entryFile": "./app-entry.jsx",
+  "entryName": "login-page",
+  "rootUrl": "/login",
+  "production": false,
+  "template": {
+    "vagovprod": false,
+    "layout": "page-react.html",
+    "includeBreadcrumbs": false,
+    "noHeader": true
+  }
+}

--- a/src/applications/login/reducers/index.js
+++ b/src/applications/login/reducers/index.js
@@ -1,0 +1,1 @@
+export default {};

--- a/src/applications/login/routes.jsx
+++ b/src/applications/login/routes.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+import { Route } from 'react-router';
+import App from './containers/App.jsx';
+
+const routes = <Route path="/" component={App} />;
+
+export default routes;

--- a/src/applications/login/sass/login-page.scss
+++ b/src/applications/login/sass/login-page.scss
@@ -1,0 +1,15 @@
+@import '~@department-of-veterans-affairs/formation/sass/shared-variables';
+
+$teamsite-dark-blue: #112e51;
+
+.login-header {
+  background: $teamsite-dark-blue;
+  padding: 1em;
+}
+
+.header-wrapper {
+  margin: 0 auto;
+  width: 100%;
+  max-width: 300px;
+  height: auto;
+}

--- a/src/applications/login/sass/login-page.scss
+++ b/src/applications/login/sass/login-page.scss
@@ -1,4 +1,4 @@
-@import '~@department-of-veterans-affairs/formation/sass/shared-variables';
+@import "~@department-of-veterans-affairs/formation/sass/shared-variables";
 
 $teamsite-dark-blue: #112e51;
 

--- a/src/applications/login/tests/00.login-page.e2e.spec.js
+++ b/src/applications/login/tests/00.login-page.e2e.spec.js
@@ -1,0 +1,15 @@
+const Timeouts = require('../../../platform/testing/e2e/timeouts');
+const E2eHelpers = require('../../../platform/testing/e2e/helpers');
+const manifest = require('../manifest.json');
+
+module.exports = E2eHelpers.createE2eTest(client => {
+  client
+    .url(`${E2eHelpers.baseUrl}/login`)
+    .waitForElementVisible('body', Timeouts.normal)
+    .axeCheck('.main');
+
+  client.end();
+});
+
+module.exports['@disabled'] =
+  !manifest.production || __BUILDTYPE__ !== 'production';

--- a/src/applications/login/utilities/downtimeBanners.js
+++ b/src/applications/login/utilities/downtimeBanners.js
@@ -1,0 +1,44 @@
+import { EXTERNAL_SERVICES } from 'platform/monitoring/external-services/config';
+import scheduledDowntimeWindow from 'platform/monitoring/DowntimeNotification/config/scheduledDowntimeWindow';
+
+const downtimeBanners = [
+  {
+    dependencies: [EXTERNAL_SERVICES.idme],
+    headline: 'Our sign in process isn’t working right now',
+    status: 'error',
+    message:
+      'We’re sorry. We’re working to fix some problems with our sign in process. If you’d like to sign in to VA.gov, please check back later.',
+  },
+  {
+    dependencies: [EXTERNAL_SERVICES.dslogon],
+    headline: 'You may have trouble signing in with DS Logon',
+    status: 'warning',
+    message:
+      'We’re sorry. We’re working to fix some problems with our DS Logon sign in process. If you’d like to sign in to VA.gov with your DS Logon account, please check back later.',
+  },
+  {
+    dependencies: [EXTERNAL_SERVICES.mhv],
+    headline: 'You may have trouble signing in with My HealtheVet',
+    status: 'warning',
+    message:
+      'We’re sorry. We’re working to fix some problems with our My HealtheVet sign in process. If you’d like to sign in to VA.gov with your My HealtheVet username and password, please check back later.',
+  },
+  {
+    dependencies: [EXTERNAL_SERVICES.mvi],
+    headline: 'You may have trouble signing in or using some tools or services',
+    status: 'warning',
+    message:
+      'We’re sorry. We’re working to fix a problem that affects some parts of our site. If you have trouble signing in or using any tools or services, please check back soon.',
+  },
+  {
+    dependencies: [EXTERNAL_SERVICES.global],
+    headline: 'You may have trouble signing in or using some tools or services',
+    status: 'warning',
+    message: `We’re doing some work on VA.gov right now. We hope to finish our work by ${
+      scheduledDowntimeWindow.downtimeEnd
+    }. If you have trouble signing in or using any tools or services, please check back after then.`,
+    globalDowntime: true,
+  },
+];
+
+export default downtimeBanners;

--- a/src/applications/login/utilities/downtimeBanners.js
+++ b/src/applications/login/utilities/downtimeBanners.js
@@ -1,5 +1,4 @@
 import { EXTERNAL_SERVICES } from 'platform/monitoring/external-services/config';
-import scheduledDowntimeWindow from 'platform/monitoring/DowntimeNotification/config/scheduledDowntimeWindow';
 
 const downtimeBanners = [
   {
@@ -29,15 +28,6 @@ const downtimeBanners = [
     status: 'warning',
     message:
       'We’re sorry. We’re working to fix a problem that affects some parts of our site. If you have trouble signing in or using any tools or services, please check back soon.',
-  },
-  {
-    dependencies: [EXTERNAL_SERVICES.global],
-    headline: 'You may have trouble signing in or using some tools or services',
-    status: 'warning',
-    message: `We’re doing some work on VA.gov right now. We hope to finish our work by ${
-      scheduledDowntimeWindow.downtimeEnd
-    }. If you have trouble signing in or using any tools or services, please check back after then.`,
-    globalDowntime: true,
   },
 ];
 

--- a/src/platform/user/authentication/utilities.js
+++ b/src/platform/user/authentication/utilities.js
@@ -8,25 +8,28 @@ export const authnSettings = {
   RETURN_URL: 'authReturnUrl',
 };
 
-const SESSIONS_URI = `${environment.API_URL}/sessions`;
-const sessionTypeUrl = type => `${SESSIONS_URI}/${type}/new`;
+function sessionTypeUrl(type, version = 'v0') {
+  const SESSIONS_URI =
+    version === 'v1'
+      ? `${environment.API_URL}/v1/sessions`
+      : `${environment.API_URL}/sessions`;
+
+  return `${SESSIONS_URI}/${type}/new`;
+}
 
 const SIGNUP_URL = sessionTypeUrl('signup');
-const MHV_URL = sessionTypeUrl('mhv');
-const DSLOGON_URL = sessionTypeUrl('dslogon');
-const IDME_URL = sessionTypeUrl('idme');
 const MFA_URL = sessionTypeUrl('mfa');
 const VERIFY_URL = sessionTypeUrl('verify');
 const LOGOUT_URL = sessionTypeUrl('slo');
 
-const loginUrl = policy => {
+const loginUrl = (policy, version) => {
   switch (policy) {
     case 'mhv':
-      return MHV_URL;
+      return sessionTypeUrl('mhv', version);
     case 'dslogon':
-      return DSLOGON_URL;
+      return sessionTypeUrl('dslogon', version);
     default:
-      return IDME_URL;
+      return sessionTypeUrl('idme', version);
   }
 };
 
@@ -74,8 +77,8 @@ function redirect(redirectUrl, clickedEvent) {
   }
 }
 
-export function login(policy) {
-  return redirect(loginUrl(policy), 'login-link-clicked-modal');
+export function login(policy, version = 'v0') {
+  return redirect(loginUrl(policy, version), 'login-link-clicked-modal');
 }
 
 export function mfa() {


### PR DESCRIPTION
## Description
The startup team is working on SSO for users of VA.gov. Part of this includes a login page for external users coming from the forthcoming Cerner “My Healthy Life” EHR system to be authenticated and establishing an SSO session w/ VA.gov and SSOe before being redirected back to Cerner.

While this is not replacing the sign-in modal, much of the code is borrowed/duplicated from there, in the hopes that some of the flexibility/abstractions baked into that could be utilized in case a migration towards broader usage of this page is desired down the line. 

There are a few key differences between the existing modal and this page:
1. It uses a “v1” sessions endpoint in `vets-api`, which is the complementary back-end work being done by the SSO team to establish/maintain the parallel session between `vets-api` and SSOe. As the scope of who is using this page is determined, this could definitely have a need to expand to be conditional on user between hitting a v0 or v1 sessions endpoint (the FAQ sheet talks more about rollout options).
2. Tentatively, this is initially only intended to be used as a intermediary page for external users to get sent to for authentication, rather than an alternative to the existing modal.
3. It's flagged behind staging right now, as this is far from ready to be rolled out.

## Testing

From my understanding, the existing sign-in modal doesn't have any specific tests. This page would be a good opportunity to hearing f there's any pain points in the current modal and what would benefit the most from being tested.

## Screenshots
This [presentation](https://docs.google.com/presentation/d/1BiKaGHn1bquXAHcuDFtlOpGHNzUHwXYIX5DMQyc5vN8/edit#slide=id.p) shows the design mock, along with user journeys and other design notes. Other than some differences in wording, it’s more or less identical to the existing sign in modal.

## Acceptance criteria
- [ ] Enables a user to establish both a VA.gov and SSOe session
- [ ] Feature flagged behind staging
