### PR TITLE
Provide Source-App-Name header in save-in-progress requests

### DIFF
--- a/src/platform/forms/save-in-progress/actions.js
+++ b/src/platform/forms/save-in-progress/actions.js
@@ -236,6 +236,7 @@ export function fetchInProgressForm(
       headers: {
         'Content-Type': 'application/json',
         'X-Key-Inflection': 'camel',
+        'Source-App-Name': window.appName,
       },
     })
       .then(res => {

--- a/src/platform/forms/save-in-progress/api.js
+++ b/src/platform/forms/save-in-progress/api.js
@@ -11,6 +11,7 @@ export function removeFormApi(formId) {
     headers: {
       'Content-Type': 'application/json',
       'X-Key-Inflection': 'camel',
+      'Source-App-Name': window.appName,
     },
   })
     .then(res => {
@@ -56,6 +57,7 @@ export function saveFormApi(
     headers: {
       'Content-Type': 'application/json',
       'X-Key-Inflection': 'camel',
+      'Source-App-Name': window.appName,
     },
     body,
   })


### PR DESCRIPTION
## Description
Found a few more places withiin the save-in-progress code that weren't providing the `Source-App-Name` header for product mapping.

## Testing done
Signed in and started HCA form. Verified that it's sending the header.

## Acceptance criteria
- [ ] SIP forms should be providing their app names in the headers of requests they send.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
