### PR TITLE
Remove Slack handle from build notification

### DIFF
--- a/jenkins/common.groovy
+++ b/jenkins/common.groovy
@@ -95,7 +95,7 @@ def puppeteerNotification() {
 }
 
 def slackIntegrationNotify() {
-  message = "(Testing) @jbalboni: integration tests failed. |${env.RUN_DISPLAY_URL}".stripMargin()
+  message = "(Testing): integration tests failed. |${env.RUN_DISPLAY_URL}".stripMargin()
   slackSend message: message,
     color: 'danger',
     failOnError: true


### PR DESCRIPTION
## Description
I don't need to be notified of these failures, someone on VSP should take a look at them.


## Acceptance criteria
- [ ] I don't get @ mentioned by these test failures

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
