### PR TITLE
Fix back button errors on VAOS

### DIFF
--- a/src/applications/post-911-gib-status/tests/post-911-gib-status-helpers.js
+++ b/src/applications/post-911-gib-status/tests/post-911-gib-status-helpers.js
@@ -99,6 +99,7 @@ function initApplicationMock(token) {
     verb: 'get',
     value: backendStatus,
   });
+
   mock(token, {
     path: '/v0/feature_toggles',
     verb: 'get',

--- a/src/applications/post-911-gib-status/tests/post-911-gib-status-helpers.js
+++ b/src/applications/post-911-gib-status/tests/post-911-gib-status-helpers.js
@@ -99,16 +99,6 @@ function initApplicationMock(token) {
     verb: 'get',
     value: backendStatus,
   });
-
-  mock(token, {
-    path: '/v0/feature_toggles',
-    verb: 'get',
-    value: {
-      data: {
-        features: [],
-      },
-    },
-  });
 }
 
 module.exports = {

--- a/src/applications/post-911-gib-status/tests/post-911-gib-status-helpers.js
+++ b/src/applications/post-911-gib-status/tests/post-911-gib-status-helpers.js
@@ -99,6 +99,15 @@ function initApplicationMock(token) {
     verb: 'get',
     value: backendStatus,
   });
+  mock(token, {
+    path: '/v0/feature_toggles',
+    verb: 'get',
+    value: {
+      data: {
+        features: [],
+      },
+    },
+  });
 }
 
 module.exports = {

--- a/src/applications/vaos/newAppointmentFlow.js
+++ b/src/applications/vaos/newAppointmentFlow.js
@@ -4,7 +4,7 @@ import {
   getNewAppointment,
   getEligibilityStatus,
   vaosCommunityCare,
-  getTypeOfCare,
+  getCCEType,
   getClinicsForChosenFacility,
 } from './utils/selectors';
 import { FACILITY_TYPES, FLOW_TYPES, TYPES_OF_CARE } from './utils/constants';
@@ -89,9 +89,7 @@ export default {
 
             // Reroute to VA facility page if none of the user's registered systems support community care.
             if (ccEnabledSystems.length) {
-              const response = await getCommunityCare(
-                getTypeOfCare(getNewAppointment(state).data).cceType,
-              );
+              const response = await getCommunityCare(getCCEType(state));
 
               dispatch(updateCCEligibility(response.eligible));
 
@@ -157,13 +155,7 @@ export default {
   ccPreferences: {
     url: '/new-appointment/community-care-preferences',
     next: 'reasonForAppointment',
-    previous(state) {
-      if (isCCAudiology(state)) {
-        return 'audiologyCareType';
-      }
-
-      return 'typeOfFacility';
-    },
+    previous: 'requestDateTime',
   },
   vaFacility: {
     url: '/new-appointment/va-facility',

--- a/src/applications/vaos/tests/newAppointmentFlow.unit.spec.js
+++ b/src/applications/vaos/tests/newAppointmentFlow.unit.spec.js
@@ -565,31 +565,6 @@ describe('VAOS newAppointmentFlow', () => {
       resetFetch();
     });
   });
-  describe('ccPreferences page', () => {
-    it('should return to type of facility page', () => {
-      const state = {
-        newAppointment: {
-          data: {},
-        },
-      };
-      expect(newAppointmentFlow.ccPreferences.previous(state)).to.equal(
-        'typeOfFacility',
-      );
-    });
-    it('should return to choose audiology care type page', () => {
-      const state = {
-        newAppointment: {
-          data: {
-            facilityType: FACILITY_TYPES.COMMUNITY_CARE,
-            typeOfCareId: '203',
-          },
-        },
-      };
-      expect(newAppointmentFlow.ccPreferences.previous(state)).to.equal(
-        'audiologyCareType',
-      );
-    });
-  });
   describe('contact info page', () => {
     it('should return to choose visit type page', () => {
       const state = {

--- a/src/applications/vaos/tests/utils/selectors.unit.spec.js
+++ b/src/applications/vaos/tests/utils/selectors.unit.spec.js
@@ -15,6 +15,7 @@ import {
   getPreferredDate,
   getTypeOfCare,
   getCancelInfo,
+  getCCEType,
 } from '../../utils/selectors';
 
 describe('VAOS selectors', () => {
@@ -357,6 +358,20 @@ describe('VAOS selectors', () => {
       expect(cancelInfo.facility).to.equal(
         state.appointments.facilityData['123'],
       );
+    });
+  });
+  describe('getCCEType', () => {
+    it('should return cce type', () => {
+      const state = {
+        appointment: {},
+        newAppointment: {
+          data: {
+            typeOfCareId: '203',
+          },
+        },
+      };
+      const cceType = getCCEType(state);
+      expect(cceType).to.equal('Audiology');
     });
   });
 });

--- a/src/applications/vaos/utils/selectors.js
+++ b/src/applications/vaos/utils/selectors.js
@@ -51,7 +51,7 @@ export function getTypeOfCare(data) {
 }
 
 export function getCCEType(state) {
-  const data = getNewAppointment(state).data;
+  const data = getFormData(state);
 
   const typeOfCare = TYPES_OF_CARE.find(care => care.id === data.typeOfCareId);
 

--- a/src/applications/vaos/utils/selectors.js
+++ b/src/applications/vaos/utils/selectors.js
@@ -50,6 +50,14 @@ export function getTypeOfCare(data) {
   return TYPES_OF_CARE.find(care => care.id === data.typeOfCareId);
 }
 
+export function getCCEType(state) {
+  const data = getNewAppointment(state).data;
+
+  const typeOfCare = TYPES_OF_CARE.find(care => care.id === data.typeOfCareId);
+
+  return typeOfCare?.cceType;
+}
+
 export function getSystems(state) {
   return getNewAppointment(state).systems;
 }


### PR DESCRIPTION
## Description
We have two back button errors currently. One is just that the ccPreferences page was misconfigured. The other was that in our CC logic, the way we get the cceType was breaking if you had already been through the check once and went back and chose Audiology.

## Testing done
Local and unit testing

## Acceptance criteria
- [ ] Back button works like you'd expect

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
