### PR TITLE
VAGOV-6425 listings conversion to Drupal

### DIFF
--- a/src/site/components/events_list.drupal.liquid
+++ b/src/site/components/events_list.drupal.liquid
@@ -3,57 +3,57 @@
   {% assign count = 0 %}
   {% assign eventsArray = fieldOffice.entity.reverseFieldOfficeNode.entities %}
   {% if outreachSidebar.name == 'Outreach and events' %}
-  {% assign eventsArray = reverseFieldOfficeNode.entities %}
+    {% assign eventsArray = reverseFieldOfficeNode.entities %}
   {% endif %}
   {% assign sortedEventsArray = eventsArray | eventSorter %}
   {% for event in sortedEventsArray %}
-  {% if event.title.length %}
-  {% assign count = count | plus:1 %}
-  <div class="vads-u-margin-bottom--2">
-    <h4>
-      <a href="{{event.entityUrl.path}}">{{event.title}}</a>
-    </h4>
-    <p>{{event.fieldDescription}}</p>
-    {% if event.fieldDate.startDate and event.fieldDate.value %}
-    <div class="usa-grid usa-grid-full">
-      <div class="usa-width-one-sixth">
-        <strong>When:</strong>
-      </div>
-      <div class="usa-width-five-sixths">
-        <span>{{ event.fieldDate.value | humanizeDate }}</span><br>
-        <span>{{ event.fieldDate.startDate | timeZone: timezone, "h:mm A"}}
-          {% if event.fieldDate.endDate %}
-          –
-          {{ event.fieldDate.endDate | timeZone: timezone, "h:mm A" }} ET</span>
+    {% if event.title.length %}
+      {% assign count = count | plus:1 %}
+      <div class="vads-u-margin-bottom--2">
+        <h4>
+          <a href="{{event.entityUrl.path}}">{{event.title}}</a>
+        </h4>
+        <p>{{event.fieldDescription}}</p>
+        {% if event.fieldDate.startDate and event.fieldDate.value %}
+          <div class="usa-grid usa-grid-full">
+            <div class="usa-width-one-sixth">
+              <strong>When:</strong>
+            </div>
+            <div class="usa-width-five-sixths">
+              <span>{{ event.fieldDate.value | humanizeDate }}</span><br>
+              <span>{{ event.fieldDate.startDate | timeZone: timezone, "h:mm A"}}
+                {% if event.fieldDate.endDate %}
+                  –
+                  {{ event.fieldDate.endDate | timeZone: timezone, "h:mm A" }}
+                  ET</span>
+              {% endif %}
+            </div>
+          </div>
         {% endif %}
+        <div class="usa-grid usa-grid-full">
+          {% if event.fieldFacilityLocation.entity.entityUrl.path %}
+            <div class="usa-width-one-sixth">
+              <strong>Where:</strong>
+            </div>
+            <div class="usa-width-five-sixths">
+              <p>
+                <a href="{{event.fieldFacilityLocation.entity.entityUrl.path}}">{{event.fieldFacilityLocation.entity.title}}</a>
+              </p>
+            </div>
+          {% endif %}
+        </div>
       </div>
-    </div>
     {% endif %}
-    <div class="usa-grid usa-grid-full">
-      {% if event.fieldFacilityLocation.entity.entityUrl.path %}
-      <div class="usa-width-one-sixth">
-        <strong>Where:</strong>
-      </div>
-      <div class="usa-width-five-sixths">
-        <p>
-          <a
-            href="{{event.fieldFacilityLocation.entity.entityUrl.path}}">{{event.fieldFacilityLocation.entity.title}}</a>
-        </p>
-      </div>
-      {% endif %}
-    </div>
-  </div>
-  {% endif %}
   {% endfor %}
   {% if count == 0 %}
-  <div class="vads-u-margin-bottom--2">
-    <div>
-      <p>
-        <i>We're sorry, there are no events to display at this time. Check back
-          regularly
-          for new event listings.</i>
-      </p>
+    <div class="vads-u-margin-bottom--2">
+      <div>
+        <p>
+          <i>We're sorry, there are no events to display at this time. Check back
+                      regularly
+                      for new event listings.</i>
+        </p>
+      </div>
     </div>
-  </div>
   {% endif %}
 </div>

--- a/src/site/components/events_list.drupal.liquid
+++ b/src/site/components/events_list.drupal.liquid
@@ -2,77 +2,58 @@
 <div class="events-listing events-show">
   {% assign count = 0 %}
   {% assign eventsArray = fieldOffice.entity.reverseFieldOfficeNode.entities %}
-  {{ eventsArray | json }}
   {% if outreachSidebar.name == 'Outreach and events' %}
-    {% assign eventsArray = reverseFieldOfficeNode.entities %}
+  {% assign eventsArray = reverseFieldOfficeNode.entities %}
   {% endif %}
   {% assign sortedEventsArray = eventsArray | eventSorter %}
   {% for event in sortedEventsArray %}
-    {% if event.title.length %}
-      {% assign count = count | plus:1 %}
-      <div class="vads-u-margin-bottom--2">
-        <h4>
-          <a href="{{event.entityUrl.path}}">{{event.title}}</a>
-        </h4>
-        <p>{{event.fieldDescription}}</p>
-<<<<<<< HEAD
-        {% if event.fieldDate.startDate and event.fieldDate.value %}
-          <div class="usa-grid usa-grid-full">
-=======
-        <div class="usa-grid usa-grid-full">
-          {% if event.fieldDate.value %}
->>>>>>> VAGOV-6425: Adding drupal events listing data.
-            <div class="usa-width-one-sixth">
-              <strong>When:</strong>
-            </div>
-            <div class="usa-width-five-sixths">
-              <span>{{ event.fieldDate.value | humanizeDate }}</span><br>
-<<<<<<< HEAD
-              <span>{{ event.fieldDate.startDate | timeZone: timezone, "h:mm A"}}
-                {% if event.fieldDate.endDate %}
-                  –
-                  {{ event.fieldDate.endDate | timeZone: timezone, "h:mm A" }} ET</span>
-              {% endif %}
-            </div>
-          </div>
-        {% endif %}
-=======
-              <span>{{ event.fieldDate.value | humanizeTime }}
-                –
-                {{ event.fieldDate.endValue | humanizeTime }}</span>
-            </div>
-          {% endif %}
-        </div>
->>>>>>> VAGOV-6425: Adding drupal events listing data.
-        <div class="usa-grid usa-grid-full">
-          {% if event.fieldFacilityLocation.entity.entityUrl.path %}
-            <div class="usa-width-one-sixth">
-              <strong>Where:</strong>
-            </div>
-            <div class="usa-width-five-sixths">
-              <p>
-                <a href="{{event.fieldFacilityLocation.entity.entityUrl.path}}">{{event.fieldFacilityLocation.entity.title}}</a>
-              </p>
-            </div>
-          {% endif %}
-        </div>
+  {% if event.title.length %}
+  {% assign count = count | plus:1 %}
+  <div class="vads-u-margin-bottom--2">
+    <h4>
+      <a href="{{event.entityUrl.path}}">{{event.title}}</a>
+    </h4>
+    <p>{{event.fieldDescription}}</p>
+    {% if event.fieldDate.startDate and event.fieldDate.value %}
+    <div class="usa-grid usa-grid-full">
+      <div class="usa-width-one-sixth">
+        <strong>When:</strong>
       </div>
-    {% endif %}
-  {% endfor %}
-  {% if count == 0 %}
-    <div class="vads-u-margin-bottom--2">
-      <div>
-        <p>
-<<<<<<< HEAD
-          <i>We're sorry, there are no events to display at this time. Check back
-                      regularly
-                      for new event listings.</i>
-=======
-          <i>We're sorry, there are no events to display at this time. Check back regularly
-                                for new event listings.</i>
->>>>>>> VAGOV-6425: Adding drupal events listing data.
-        </p>
+      <div class="usa-width-five-sixths">
+        <span>{{ event.fieldDate.value | humanizeDate }}</span><br>
+        <span>{{ event.fieldDate.startDate | timeZone: timezone, "h:mm A"}}
+          {% if event.fieldDate.endDate %}
+          –
+          {{ event.fieldDate.endDate | timeZone: timezone, "h:mm A" }} ET</span>
+        {% endif %}
       </div>
     </div>
+    {% endif %}
+    <div class="usa-grid usa-grid-full">
+      {% if event.fieldFacilityLocation.entity.entityUrl.path %}
+      <div class="usa-width-one-sixth">
+        <strong>Where:</strong>
+      </div>
+      <div class="usa-width-five-sixths">
+        <p>
+          <a
+            href="{{event.fieldFacilityLocation.entity.entityUrl.path}}">{{event.fieldFacilityLocation.entity.title}}</a>
+        </p>
+      </div>
+      {% endif %}
+    </div>
+  </div>
+  {% endif %}
+  {% endfor %}
+  {% if count == 0 %}
+  <div class="vads-u-margin-bottom--2">
+    <div>
+      <p>
+        <i>We're sorry, there are no events to display at this time. Check back
+          regularly
+          for new event listings.</i>
+      </p>
+    </div>
+  </div>
   {% endif %}
 </div>

--- a/src/site/components/events_list.drupal.liquid
+++ b/src/site/components/events_list.drupal.liquid
@@ -2,6 +2,7 @@
 <div class="events-listing events-show">
   {% assign count = 0 %}
   {% assign eventsArray = fieldOffice.entity.reverseFieldOfficeNode.entities %}
+  {{ eventsArray | json }}
   {% if outreachSidebar.name == 'Outreach and events' %}
     {% assign eventsArray = reverseFieldOfficeNode.entities %}
   {% endif %}
@@ -14,13 +15,19 @@
           <a href="{{event.entityUrl.path}}">{{event.title}}</a>
         </h4>
         <p>{{event.fieldDescription}}</p>
+<<<<<<< HEAD
         {% if event.fieldDate.startDate and event.fieldDate.value %}
           <div class="usa-grid usa-grid-full">
+=======
+        <div class="usa-grid usa-grid-full">
+          {% if event.fieldDate.value %}
+>>>>>>> VAGOV-6425: Adding drupal events listing data.
             <div class="usa-width-one-sixth">
               <strong>When:</strong>
             </div>
             <div class="usa-width-five-sixths">
               <span>{{ event.fieldDate.value | humanizeDate }}</span><br>
+<<<<<<< HEAD
               <span>{{ event.fieldDate.startDate | timeZone: timezone, "h:mm A"}}
                 {% if event.fieldDate.endDate %}
                   –
@@ -29,6 +36,14 @@
             </div>
           </div>
         {% endif %}
+=======
+              <span>{{ event.fieldDate.value | humanizeTime }}
+                –
+                {{ event.fieldDate.endValue | humanizeTime }}</span>
+            </div>
+          {% endif %}
+        </div>
+>>>>>>> VAGOV-6425: Adding drupal events listing data.
         <div class="usa-grid usa-grid-full">
           {% if event.fieldFacilityLocation.entity.entityUrl.path %}
             <div class="usa-width-one-sixth">
@@ -48,9 +63,14 @@
     <div class="vads-u-margin-bottom--2">
       <div>
         <p>
+<<<<<<< HEAD
           <i>We're sorry, there are no events to display at this time. Check back
                       regularly
                       for new event listings.</i>
+=======
+          <i>We're sorry, there are no events to display at this time. Check back regularly
+                                for new event listings.</i>
+>>>>>>> VAGOV-6425: Adding drupal events listing data.
         </p>
       </div>
     </div>

--- a/src/site/facilities/facilities_events_toggle.drupal.liquid
+++ b/src/site/facilities/facilities_events_toggle.drupal.liquid
@@ -36,7 +36,7 @@
                         no-left-button-right-radius-treatment
                         vads-u-padding--1p5"
                         >Upcoming events</a>
-                        <a role="button" href="{{ url }}/past-events" class="
+                        <a role="button" href="{{ url | regionBasePath | append: '/events/past-events' | prepend: '/' }}" class="
                         vads-u-margin-top--0
                         half-em-bottom-margin
                         vads-u-flex--1

--- a/src/site/facilities/facilities_events_toggle.drupal.liquid
+++ b/src/site/facilities/facilities_events_toggle.drupal.liquid
@@ -9,7 +9,7 @@
         vads-u-flex-direction--row
         medium-screen:vads-u-align-items--flex-start">
                 {% if url contains 'past-events' %}
-                        <a role="button" href="{{ url | regionBasePath | append: '/events' | prepend: '/' }}" class="
+                        <a role="button" href="/{{ url | regionBasePath | append: '/events' }}" class="
                         vads-u-flex--1
                         vads-u-margin-right--0
                         usa-button
@@ -36,7 +36,7 @@
                         no-left-button-right-radius-treatment
                         vads-u-padding--1p5"
                         >Upcoming events</a>
-                        <a role="button" href="{{ url | regionBasePath | append: '/events/past-events' | prepend: '/' }}" class="
+                        <a role="button" href="/{{ url | regionBasePath | append: '/events/past-events' }}" class="
                         vads-u-margin-top--0
                         half-em-bottom-margin
                         vads-u-flex--1

--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -233,16 +233,8 @@ module.exports = function registerFilters() {
     return JSON.stringify(id);
   };
 
-  liquid.filters.sortMainFacility = item => {
-    let sorted;
-    if (item) {
-      sorted = item.sort((a, b) => {
-        const sorter = a.entityId - b.entityId;
-        return sorter;
-      });
-    }
-    return sorted;
-  };
+  liquid.filters.sortMainFacility = item =>
+    item ? item.sort((a, b) => a.entityId - b.entityId) : undefined;
 
   liquid.filters.eventSorter = item => {
     const sorted = item.sort((a, b) => {
@@ -252,6 +244,7 @@ module.exports = function registerFilters() {
       const bTime = Math.floor(
         new Date(b.fieldDate.startDate).getTime() / 1000,
       );
+      // Sort order needs to be oldest first.
       const sorter = aTime - bTime;
       return sorter;
     });

--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -398,6 +398,8 @@ module.exports = function registerFilters() {
       : null;
   };
 
+  liquid.filters.getPagerPage = page => parseInt(page.split('page-')[1], 10);
+
   liquid.filters.featureSingleValueFieldLink = fieldLink => {
     if (fieldLink && cmsFeatureFlags.FEATURE_SINGLE_VALUE_FIELD_LINK) {
       return fieldLink[0];

--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -234,10 +234,13 @@ module.exports = function registerFilters() {
   };
 
   liquid.filters.sortMainFacility = item => {
-    const sorted = item.sort((a, b) => {
-      const sorter = a.entityId - b.entityId;
-      return sorter;
-    });
+    let sorted;
+    if (item) {
+      sorted = item.sort((a, b) => {
+        const sorter = a.entityId - b.entityId;
+        return sorter;
+      });
+    }
     return sorted;
   };
 

--- a/src/site/includes/pagination.drupal.liquid
+++ b/src/site/includes/pagination.drupal.liquid
@@ -1,42 +1,55 @@
 {% comment %}
-  paginator {
-    prev: url or null
-    page {
-      href: url or null
-      class:
-      href:
-      label
-    }
-    prev: url or null
-  }
+paginator {
+prev: url or null
+page {
+href: url or null
+class:
+href:
+label
+}
+prev: url or null
+}
 {% endcomment %}
 
-{% if paginator != empty %}
-  <div class="va-pagination">
-    {% if paginator.prev != empty %}
-      <span class="va-pagination-prev">
-      <a href="{{ paginator.prev }}" aria-label="Load previous page{{ paginator.ariaLabel }}">
-        <abbr title="Previous">Prev</abbr>
-      </a>
-    </span>
+
+{% assign paginatorCount = paginator.inner | size %}
+{% assign totalItems = paginatorCount %}
+
+{% if numItems %}
+{% assign totalItems = numItems | times: .1 %}
+{% endif%}
+
+{% if paginator != empty and totalItems <= paginatorCount %}
+
+<div class="va-pagination">
+  {% if paginator.prev != empty %}
+  <span class="va-pagination-prev">
+    <a href="{{ paginator.prev }}"
+      aria-label="Load previous page{{ paginator.ariaLabel }}">
+      <abbr title="Previous">Prev</abbr>
+    </a>
+  </span>
+  {% endif %}
+  <div class="va-pagination-inner">
+    {% for page in paginator.inner %}
+    {% if page.class != "va-pagination-active" and totalItems <= paginatorCount %}
+    <a href="{{ page.href }}" class="{{ page.class }}"
+      aria-label="Load page {{ page.label }}{{ paginator.ariaLabel }}">
+      {{ page.label }}
+    </a>
+    {% else %}
+    {{ page.label }}
     {% endif %}
-    <div class="va-pagination-inner">
-      {% for page in paginator.inner %}
-      {% if page.class != "va-pagination-active" %}
-        <a href="{{ page.href }}" class="{{ page.class }}" aria-label="Load page {{ page.label }}{{ paginator.ariaLabel }}">
-          {{ page.label }}
-        </a>
-        {% else %}
-        {{ page.label }}
-        {% endif %}
-      {% endfor %}
-    </div>
-    {% if paginator.next != empty %}
-      <span class="va-pagination-next">
-        <a href="{{ paginator.next }}" aria-label="Load next page{{ paginator.ariaLabel }}">
-          Next
-        </a>
-      </span>
-    {% endif %}
+    {% assign totalItems = totalItems | minus: 1 %}
+    {% endfor %}
   </div>
+  {% if paginator.next != empty %}
+  <span class="va-pagination-next">
+    <a href="{{ paginator.next }}"
+      aria-label="Load next page{{ paginator.ariaLabel }}">
+      Next
+    </a>
+  </span>
+  {% endif %}
+</div>
 {% endif %}

--- a/src/site/includes/pagination.drupal.liquid
+++ b/src/site/includes/pagination.drupal.liquid
@@ -1,14 +1,14 @@
 {% comment %}
-paginator {
-prev: url or null
-page {
-href: url or null
-class:
-href:
-label
-}
-prev: url or null
-}
+  paginator {
+    prev: url or null
+    page {
+      href: url or null
+      class:
+      href:
+      label
+    }
+    prev: url or null
+  }
 {% endcomment %}
 
 
@@ -21,35 +21,32 @@ prev: url or null
 
 {% if paginator != empty and totalItems <= paginatorCount %}
 
-<div class="va-pagination">
-  {% if paginator.prev != empty %}
-  <span class="va-pagination-prev">
-    <a href="{{ paginator.prev }}"
-      aria-label="Load previous page{{ paginator.ariaLabel }}">
-      <abbr title="Previous">Prev</abbr>
-    </a>
-  </span>
-  {% endif %}
-  <div class="va-pagination-inner">
-    {% for page in paginator.inner %}
-    {% if page.class != "va-pagination-active" and totalItems <= paginatorCount %}
-    <a href="{{ page.href }}" class="{{ page.class }}"
-      aria-label="Load page {{ page.label }}{{ paginator.ariaLabel }}">
-      {{ page.label }}
-    </a>
-    {% else %}
-    {{ page.label }}
+  <div class="va-pagination">
+    {% if paginator.prev != empty %}
+      <span class="va-pagination-prev">
+        <a href="{{ paginator.prev }}" aria-label="Load previous page{{ paginator.ariaLabel }}">
+          <abbr title="Previous">Prev</abbr>
+        </a>
+      </span>
     {% endif %}
-    {% assign totalItems = totalItems | minus: 1 %}
-    {% endfor %}
+    <div class="va-pagination-inner">
+      {% for page in paginator.inner %}
+        {% if page.class != "va-pagination-active" and totalItems <= paginatorCount %}
+          <a href="{{ page.href }}" class="{{ page.class }}" aria-label="Load page {{ page.label }}{{ paginator.ariaLabel }}">
+            {{ page.label }}
+          </a>
+        {% else %}
+          {{ page.label }}
+        {% endif %}
+        {% assign totalItems = totalItems | minus: 1 %}
+      {% endfor %}
+    </div>
+    {% if paginator.next != empty %}
+      <span class="va-pagination-next">
+        <a href="{{ paginator.next }}" aria-label="Load next page{{ paginator.ariaLabel }}">
+          Next
+        </a>
+      </span>
+    {% endif %}
   </div>
-  {% if paginator.next != empty %}
-  <span class="va-pagination-next">
-    <a href="{{ paginator.next }}"
-      aria-label="Load next page{{ paginator.ariaLabel }}">
-      Next
-    </a>
-  </span>
-  {% endif %}
-</div>
 {% endif %}

--- a/src/site/layouts/bios_page.drupal.liquid
+++ b/src/site/layouts/bios_page.drupal.liquid
@@ -1,37 +1,37 @@
 {% comment %}
     Example data:
     "entityPublished": true,
-    "fieldNameFirst": "Sheila",
-    "fieldLastName": "Tunney",
-    "fieldSuffix": null,
-    "fieldDescription": "Public Affairs Specialist",
-    "fieldOffice": {
-    "entity": {
-    "entityLabel": "Pittsburgh Health Care System",
-    "entityType": "node"
-    }
+      "fieldNameFirst": "Sheila",
+        "fieldLastName": "Tunney",
+          "fieldSuffix": null,
+            "fieldDescription": "Public Affairs Specialist",
+              "fieldOffice": {
+      "entity": {
+        "entityLabel": "Pittsburgh Health Care System",
+          "entityType": "node"
+      }
     },
     "fieldIntroText": null,
-    "fieldPhotoAllowHiresDownload": false,
-    "fieldMedia": {
-    "entity": {
-    "image": {
-    "alt": "Robert L Wilkie",
-    "title": "",
-    "derivative": {
-    "url": "http://dev.va.agile6.com/sites/default/files/styles/1_1_square_medium_thumbnail/public/2019-03/Robert_L_Wilkie_8x10.jpg?h=59bf76d8&itok=Q-x_2QaJ",
-    "width": 240,
-    "height": 240
-    }
-    }
-    }
+      "fieldPhotoAllowHiresDownload": false,
+        "fieldMedia": {
+      "entity": {
+        "image": {
+          "alt": "Robert L Wilkie",
+            "title": "",
+              "derivative": {
+            "url": "http://dev.va.agile6.com/sites/default/files/styles/1_1_square_medium_thumbnail/public/2019-03/Robert_L_Wilkie_8x10.jpg?h=59bf76d8&itok=Q-x_2QaJ",
+              "width": 240,
+                "height": 240
+          }
+        }
+      }
     },
     "fieldBody": null,
-    "changed": 1552424311,
-    "entityUrl": {
-    "path": "/pittsburgh-health-care/sheila-tunney"
+      "changed": 1552424311,
+        "entityUrl": {
+      "path": "/pittsburgh-health-care/sheila-tunney"
     }
-    }
+  }
 {% endcomment %}
 {% include "src/site/includes/header.html" with drupalTags = true %}
 {% include "src/site/includes/alerts.drupal.liquid" %}

--- a/src/site/layouts/event.drupal.liquid
+++ b/src/site/layouts/event.drupal.liquid
@@ -97,13 +97,13 @@ Ultimately, we will allow check to use user timezone.
 {% assign current_timestamp = fieldDate.value | currentUnixFromDate %}
 
 {% if fieldDate.value != empty and fieldDate.endValue == empty %}
-{% assign date_type = "start_date_only" %}
+  {% assign date_type = "start_date_only" %}
 {% else %}
-{% if start_date_no_time == end_date_no_time %}
-{% assign date_type = "same_day" %}
-{% else %}
-{% assign date_type = "all_dates" %}
-{% endif %}
+  {% if start_date_no_time == end_date_no_time %}
+    {% assign date_type = "same_day" %}
+  {% else %}
+    {% assign date_type = "all_dates" %}
+  {% endif %}
 {% endif %}
 <div class="interior" id="content">
   <main class="va-l-detail-page va-facility-page">
@@ -122,78 +122,84 @@ Ultimately, we will allow check to use user timezone.
         <div class="usa-width-three-fourths">
           {% include "src/site/components/navigation-sidebar-trigger.html" with menuId = "va-detailpage-sidebar" %}
           {% if !entityPublished %}
-          <div class="usa-alert usa-alert-info">
-            <div class="usa-alert-body">
-              <p class="usa-alert-text">You are viewing a draft.</p>
+            <div class="usa-alert usa-alert-info">
+              <div class="usa-alert-body">
+                <p class="usa-alert-text">You are viewing a draft.</p>
+              </div>
             </div>
-          </div>
           {% endif %}
 
-          <article aria-labelledby="article-heading" role="region"class="usa-content">
+          <article aria-labelledby="article-heading" class="usa-content" role="region">
             <div class="usa-grid usa-grid-full">
-              <h1 id="article-heading" class="{% if fieldMedia %}vads-u-margin-bottom--4{% else %}vads-u-margin-bottom--2{% endif %}">{{ title }}</h1>
+              <h1 id="article-heading" class="{% if fieldMedia %}vads-u-margin-bottom--4{% else %}vads-u-margin-bottom--2{% endif %}">
+                {{ title }}</h1>
               {% if fieldMedia %}
-                  <img class="event-detail-img vads-u-margin-bottom--3 medium-screen:vads-u-margin-bottom--4" alt="{{fieldMedia.entity.image.alt}}"
-                    src="{{fieldMedia.entity.image.derivative.url}}" />
+                <img class="event-detail-img vads-u-margin-bottom--3 medium-screen:vads-u-margin-bottom--4" alt="{{fieldMedia.entity.image.alt}}" src="{{fieldMedia.entity.image.derivative.url}}"/>
               {% endif %}
               <div class="va-introtext">
-                <p class="vads-u-margin-top--0 vads-u-margin-bottom--1 medium-screen:vads-u-margin-bottom--4">{{ fieldDescription }}</p>
+                <p class="vads-u-margin-top--0 vads-u-margin-bottom--1 medium-screen:vads-u-margin-bottom--4">
+                  {{ fieldDescription }}</p>
               </div>
 
               <div class="usa-width-one-half vads-u-margin-bottom--2p5 medium-screen:vads-u-margin-bottom--0">
                 {% assign facility = fieldFacilityLocation.entity %}
                 <dl class="va-c-event-info">
-                  <dt class="vads-u-font-weight--bold when-where-width vads-u-margin-right--2">When</dt>
+                  <dt class="vads-u-font-weight--bold when-where-width vads-u-margin-right--2">
+                    When</dt>
                   <dd>
                     {% if date_type == "start_date_only" %}
-                    <span>{{ start_date_no_time }}</span><br>
-                    <span>{{ start_time }}</span>
+                      <span>{{ start_date_no_time }}</span><br>
+                      <span>{{ start_time }}</span>
                     {% else %}
-                    {% if date_type == "same_day" %}
-                    <span>{{ start_date_no_time }}</span><br>
-                    <span>{{ start_time }}
-                      –
-                      {{ end_time }}</span>
-                    {% else %}
-                    <span>{{ start_date_full }}
-                      –</span><br>
-                    <span>{{ end_date_full }}</span>
+                      {% if date_type == "same_day" %}
+                        <span>{{ start_date_no_time }}</span><br>
+                        <span>{{ start_time }}
+                          –
+                          {{ end_time }}</span>
+                      {% else %}
+                        <span>{{ start_date_full }}
+                          –</span><br>
+                        <span>{{ end_date_full }}</span>
+                      {% endif %}
                     {% endif %}
-                    {% endif %}
-                    <span> ET</span>
+                    <span>
+                      ET</span>
                   </dd>
                 </dl>
 
                 {% if fieldFacilityLocation or fieldAddress.addressLine1 %}
-                <dl class="va-c-event-info">
-                  <dt class="vads-u-font-weight--bold when-where-width vads-u-margin-right--2">Where</dt>
-                  <dd>
-                    {% if facility %}
-                    <p class="vads-u-margin--0">
-                      <a
-                        href="{{ facility.entityUrl.path }}">{{ facility.title }}</a>
-                    </p>
-                    <p class="vads-u-margin--0">{{ fieldLocationHumanreadable }}
-                    </p>
-                    {% else %}
+                  <dl class="va-c-event-info">
+                    <dt class="vads-u-font-weight--bold when-where-width vads-u-margin-right--2">
+                      Where</dt>
+                    <dd>
+                      {% if facility %}
+                        <p class="vads-u-margin--0">
+                          <a href="{{ facility.entityUrl.path }}">{{ facility.title }}</a>
+                        </p>
+                        <p class="vads-u-margin--0">{{ fieldLocationHumanreadable }}
+                        </p>
+                      {% else %}
                         {% if fieldAddress.addressLine1 %}
-                          <p class="vads-u-margin--0">{{ fieldAddress.addressLine1 }}</p>
+                          <p class="vads-u-margin--0">{{ fieldAddress.addressLine1 }}
+                          </p>
                         {% endif %}
                         {% if fieldAddress.addressLine2 %}
-                          <p class="vads-u-margin--0">{{ fieldAddress.addressLine2 }}</p>
+                          <p class="vads-u-margin--0">{{ fieldAddress.addressLine2 }}
+                          </p>
                         {% endif %}
                         <p class="vads-u-margin--0">
                           {% if fieldAddress.locality %}
-                              {{ fieldAddress.locality }}
+                            {{ fieldAddress.locality }}
                           {% endif %}
                           {% if fieldAddress.administrativeArea %}
-                          , {{ fieldAddress.administrativeArea }}
+                            ,
+                            {{ fieldAddress.administrativeArea }}
                           {% endif %}
                         </p>
-                    {% endif %}
-                  </dd>
+                      {% endif %}
+                    </dd>
 
-                </dl>
+                  </dl>
                 {% endif %}
 
                   {% if fieldEventCost %}
@@ -229,87 +235,91 @@ Ultimately, we will allow check to use user timezone.
                   {% endif %}
               </div>
 
-                  <div class="usa-width-one-half va-c-event-share vads-u-margin-bottom--1">
-                      {% include "src/site/includes/social-share.drupal.liquid" %}
-                  </div>
+              <div class="usa-width-one-half va-c-event-share vads-u-margin-bottom--1">
+                {% include "src/site/includes/social-share.drupal.liquid" %}
               </div>
+            </div>
 
             <div class="usa-grid usa-grid-full vads-u-margin-top--2">
               <div class="event-description">
                 {{ fieldBody.processed }}
               </div>
             </div>
-              {% assign index = entityUrl.breadcrumb.length | minus: 2 %}
-            <a onClick="recordEvent({ event: 'nav-secondary-button-click' });" href="{{ entityUrl.breadcrumb | getValueFromArrayObjPath: index, 'url.path' }}">See all events</a>
+            {% assign index = entityUrl.breadcrumb.length | minus: 2 %}
+            <a onclick="recordEvent({ event: 'nav-secondary-button-click' });" href="{{ entityUrl.breadcrumb | getValueFromArrayObjPath: index, 'url.path' }}">See
+                          all events</a>
           </article>
 
           <div class="last-updated usa-content">
             Last updated:
-            <time
-              datetime="{{ changed | dateFromUnix: 'YYYY-MM-DD'}}">{{ changed | humanizeTimestamp }}</time>
+            <time datetime="{{ changed | dateFromUnix: 'YYYY-MM-DD'}}">{{ changed | humanizeTimestamp }}</time>
           </div>
         </div>
       </div>
 
-    {% comment %} On non-prod environments, do not show the SideNav. {% endcomment %}
+      {% comment %} On non-prod environments, do not show the SideNav.
+    {% endcomment %}
     {% else %}
       <div class="usa-grid usa-grid-full">
         {% include "src/site/components/navigation-sidebar-trigger.html" with menuId = "va-detailpage-sidebar" %}
         {% if !entityPublished %}
-        <div class="usa-alert usa-alert-info">
-          <div class="usa-alert-body">
-            <p class="usa-alert-text">You are viewing a draft.</p>
+          <div class="usa-alert usa-alert-info">
+            <div class="usa-alert-body">
+              <p class="usa-alert-text">You are viewing a draft.</p>
+            </div>
           </div>
-        </div>
         {% endif %}
 
-        <article aria-labelledby="article-heading" role="region"class="usa-content">
+        <article aria-labelledby="article-heading" class="usa-content" role="region">
           <div class="usa-grid usa-grid-full">
-            <h1 id="article-heading" class="{% if fieldMedia %}vads-u-margin-bottom--4{% else %}vads-u-margin-bottom--2{% endif %}">{{ title }}</h1>
+            <h1 id="article-heading" class="{% if fieldMedia %}vads-u-margin-bottom--4{% else %}vads-u-margin-bottom--2{% endif %}">
+              {{ title }}</h1>
             {% if fieldMedia %}
-                <img class="event-detail-img vads-u-margin-bottom--3 medium-screen:vads-u-margin-bottom--4" alt="{{fieldMedia.entity.image.alt}}"
-                  src="{{fieldMedia.entity.image.derivative.url}}" />
+              <img class="event-detail-img vads-u-margin-bottom--3 medium-screen:vads-u-margin-bottom--4" alt="{{fieldMedia.entity.image.alt}}" src="{{fieldMedia.entity.image.derivative.url}}"/>
             {% endif %}
             <div class="va-introtext">
-              <p class="vads-u-margin-top--0 vads-u-margin-bottom--1 medium-screen:vads-u-margin-bottom--4">{{ fieldDescription }}</p>
+              <p class="vads-u-margin-top--0 vads-u-margin-bottom--1 medium-screen:vads-u-margin-bottom--4">
+                {{ fieldDescription }}</p>
             </div>
 
             <div class="usa-width-one-half vads-u-margin-bottom--2p5 medium-screen:vads-u-margin-bottom--0">
               {% assign facility = fieldFacilityLocation.entity %}
               <dl class="va-c-event-info">
-                <dt class="vads-u-font-weight--bold when-where-width vads-u-margin-right--2">When</dt>
+                <dt class="vads-u-font-weight--bold when-where-width vads-u-margin-right--2">
+                  When</dt>
                 <dd>
                   {% if date_type == "start_date_only" %}
-                  <span>{{ start_date_no_time }}</span><br>
-                  <span>{{ start_time }}</span>
+                    <span>{{ start_date_no_time }}</span><br>
+                    <span>{{ start_time }}</span>
                   {% else %}
-                  {% if date_type == "same_day" %}
-                  <span>{{ start_date_no_time }}</span><br>
-                  <span>{{ start_time }}
-                    –
-                    {{ end_time }}</span>
-                  {% else %}
-                  <span>{{ start_date_full }}
-                    –</span><br>
-                  <span>{{ end_date_full }}</span>
+                    {% if date_type == "same_day" %}
+                      <span>{{ start_date_no_time }}</span><br>
+                      <span>{{ start_time }}
+                        –
+                        {{ end_time }}</span>
+                    {% else %}
+                      <span>{{ start_date_full }}
+                        –</span><br>
+                      <span>{{ end_date_full }}</span>
+                    {% endif %}
                   {% endif %}
-                  {% endif %}
-                  <span> ET</span>
+                  <span>
+                    ET</span>
                 </dd>
               </dl>
 
               {% if fieldFacilityLocation or fieldAddress.addressLine1 %}
-              <dl class="va-c-event-info">
-                <dt class="vads-u-font-weight--bold when-where-width vads-u-margin-right--2">Where</dt>
-                <dd>
-                  {% if facility %}
-                  <p class="vads-u-margin--0">
-                    <a
-                      href="{{ facility.entityUrl.path }}">{{ facility.title }}</a>
-                  </p>
-                  <p class="vads-u-margin--0">{{ fieldLocationHumanreadable }}
-                  </p>
-                  {% else %}
+                <dl class="va-c-event-info">
+                  <dt class="vads-u-font-weight--bold when-where-width vads-u-margin-right--2">
+                    Where</dt>
+                  <dd>
+                    {% if facility %}
+                      <p class="vads-u-margin--0">
+                        <a href="{{ facility.entityUrl.path }}">{{ facility.title }}</a>
+                      </p>
+                      <p class="vads-u-margin--0">{{ fieldLocationHumanreadable }}
+                      </p>
+                    {% else %}
                       {% if fieldAddress.addressLine1 %}
                         <p class="vads-u-margin--0">{{ fieldAddress.addressLine1 }}</p>
                       {% endif %}
@@ -318,16 +328,17 @@ Ultimately, we will allow check to use user timezone.
                       {% endif %}
                       <p class="vads-u-margin--0">
                         {% if fieldAddress.locality %}
-                            {{ fieldAddress.locality }}
+                          {{ fieldAddress.locality }}
                         {% endif %}
                         {% if fieldAddress.administrativeArea %}
-                        , {{ fieldAddress.administrativeArea }}
+                          ,
+                          {{ fieldAddress.administrativeArea }}
                         {% endif %}
                       </p>
-                  {% endif %}
-                </dd>
+                    {% endif %}
+                  </dd>
 
-              </dl>
+                </dl>
               {% endif %}
 
                 {% if fieldEventCost %}
@@ -363,9 +374,9 @@ Ultimately, we will allow check to use user timezone.
                 {% endif %}
             </div>
 
-                <div class="usa-width-one-half va-c-event-share vads-u-margin-bottom--1">
-                    {% include "src/site/includes/social-share.drupal.liquid" %}
-                </div>
+            <div class="usa-width-one-half va-c-event-share vads-u-margin-bottom--1">
+              {% include "src/site/includes/social-share.drupal.liquid" %}
+            </div>
           </div>
 
           <div class="usa-grid usa-grid-full vads-u-margin-top--2">
@@ -373,14 +384,14 @@ Ultimately, we will allow check to use user timezone.
               {{ fieldBody.processed }}
             </div>
           </div>
-            {% assign index = entityUrl.breadcrumb.length | minus: 2 %}
-          <a onClick="recordEvent({ event: 'nav-secondary-button-click' });" href="{{ entityUrl.breadcrumb | getValueFromArrayObjPath: index, 'url.path' }}">See all events</a>
+          {% assign index = entityUrl.breadcrumb.length | minus: 2 %}
+          <a onclick="recordEvent({ event: 'nav-secondary-button-click' });" href="{{ entityUrl.breadcrumb | getValueFromArrayObjPath: index, 'url.path' }}">See
+                      all events</a>
         </article>
 
         <div class="last-updated usa-content">
           Last updated:
-          <time
-            datetime="{{ changed | dateFromUnix: 'YYYY-MM-DD'}}">{{ changed | humanizeTimestamp }}</time>
+          <time datetime="{{ changed | dateFromUnix: 'YYYY-MM-DD'}}">{{ changed | humanizeTimestamp }}</time>
         </div>
       </div>
     {% endif %}

--- a/src/site/layouts/event_listing.drupal.liquid
+++ b/src/site/layouts/event_listing.drupal.liquid
@@ -13,13 +13,6 @@
       {% endif %}
       <div class="usa-width-three-fourths">
         {% include "src/site/components/navigation-sidebar-trigger.html" with menuId = "va-detailpage-sidebar" %}
-        {% if !entityPublished %}
-          <div class="usa-alert usa-alert-info">
-            <div class="usa-alert-body">
-              <p class="usa-alert-text">You are viewing a draft.</p>
-            </div>
-          </div>
-        {% endif %}
 
         <article aria-labelledby="article-heading" class="vads-l-grid-container--full" role="region">
           <div class="vads-l-grid-container--full">
@@ -34,40 +27,46 @@
               </div>
               {% if entityUrl.breadcrumb.1.text != "Outreach and events" %}
                 {% include "src/site/facilities/facilities_events_toggle.drupal.liquid" with url = entityUrl.path %}
-                {% assign featuredUrl = null %}
-                {% assign featuredItemSet = false %}
-                {% for featuredEvent in allEventTeasers.entities %}
-                  {% if featuredEvent.fieldFeatured == true %}
-                    {% unless entityUrl.path contains 'past-events' %}
-                      {% if featuredItemSet == false %}
-                        {% assign featuredUrl = featuredEvent.entityUrl.path %}
-                        <div class="usa-width-two-thirds">
-                          <div class="usa-grid usa-grid-full vads-u-margin-bottom--3 medium-screen:vads-u-margin-bottom--4 vads-u-display--flex vads-u-flex-direction--column medium-screen:vads-u-flex-direction--row vads-u-border-left--7px vads-u-border-color--primary-alt-lightest" id="featured-content">
-                            <div class="usa-width-full vads-u-padding-left--2">
-                              <div class="vads-u-margin-bottom--2">
-                                <strong>In the spotlight at
-                                  {{ fieldOffice.entity.title }}</strong>
-                              </div>
-                              {% include "src/site/teasers/event_featured.drupal.liquid" with node = featuredEvent %}
+              {% endif %}
+              {% assign featuredUrl = null %}
+              {% assign featuredItemSet = false %}
+
+              {% for featuredEvent in allEventTeasers.entities %}
+                {% if featuredEvent.fieldFeatured == true %}
+                  {% unless entityUrl.path contains 'past-events' %}
+                    {% if featuredItemSet == false %}
+                      {% assign featuredUrl = featuredEvent.entityUrl.path %}
+                      <div class="usa-width-two-thirds">
+                        <div class="usa-grid usa-grid-full vads-u-margin-bottom--3 medium-screen:vads-u-margin-bottom--4 vads-u-display--flex vads-u-flex-direction--column medium-screen:vads-u-flex-direction--row vads-u-border-left--7px vads-u-border-color--primary-alt-lightest" id="featured-content">
+                          <div class="usa-width-full vads-u-padding-left--2">
+                            <div class="vads-u-margin-bottom--2">
+                              <strong>In the spotlight at
+                                {{ fieldOffice.entity.title }}</strong>
                             </div>
+                            {% include "src/site/teasers/event_featured.drupal.liquid" with node = featuredEvent %}
                           </div>
                         </div>
-                      {% endif %}
-                    {% endunless %}
-                    {% assign featuredItemSet = true %}
-                  {% endif %}
-                {% endfor %}
-                {% for event in pagedItems %}
-                  {% if featuredUrl != event.entityUrl.path %}
-                    <div class="usa-width-two-thirds">
-                      {% include "src/site/teasers/event.drupal.liquid" with node = event %}
-                    </div>
-                  {% endif %}
-                {% endfor %}
-                {% include "src/site/includes/pagination.drupal.liquid" %}
-              {% else %}
-                {% include 'src/site/components/events_list.drupal.liquid' %}
+                      </div>
+                    {% endif %}
+                  {% endunless %}
+                  {% assign featuredItemSet = true %}
+                {% endif %}
+              {% endfor %}
+
+              {% assign sortedEventsArray = pagedItems | eventSorter | pastPresent: path %}
+              {% assign numItems = sortedEventsArray | size %}
+              {% if numItems < 1 %}
+                <div>No events at this time.</div>
               {% endif %}
+              {% for event in sortedEventsArray %}
+                {% if featuredUrl != event.entityUrl.path %}
+                  <div class="usa-width-two-thirds">
+                    {% include "src/site/teasers/event.drupal.liquid" with node = event %}
+                  </div>
+                {% endif %}
+              {% endfor %}
+              {% include "src/site/includes/pagination.drupal.liquid" with numItems %}
+
             </div>
           </div>
         </article>

--- a/src/site/layouts/event_listing.drupal.liquid
+++ b/src/site/layouts/event_listing.drupal.liquid
@@ -6,30 +6,68 @@
 <div class="interior" id="content">
   <main class="va-l-detail-page va-facility-page">
     <div class="usa-grid usa-grid-full">
-      {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with sidebarData = outreachSidebar %}
+      {% if entityUrl.breadcrumb.1.text == "Outreach and events" %}
+        {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with sidebarData = outreachSidebar %}
+      {% else %}
+        {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with sidebarData = facilitySidebar%}
+      {% endif %}
       <div class="usa-width-three-fourths">
         {% include "src/site/components/navigation-sidebar-trigger.html" with menuId = "va-detailpage-sidebar" %}
         {% if !entityPublished %}
-        <div class="usa-alert usa-alert-info">
-          <div class="usa-alert-body">
-            <p class="usa-alert-text">You are viewing a draft.</p>
+          <div class="usa-alert usa-alert-info">
+            <div class="usa-alert-body">
+              <p class="usa-alert-text">You are viewing a draft.</p>
+            </div>
           </div>
-        </div>
         {% endif %}
 
-        <article aria-labelledby="article-heading"
-          class="vads-l-grid-container--full" role="region">
+        <article aria-labelledby="article-heading" class="vads-l-grid-container--full" role="region">
           <div class="vads-l-grid-container--full">
             <h1 id="article-heading">{{ title }}</h1>
             <div class="vads-l-grid-container--full">
               <div class="va-introtext">
                 {% if fieldIntroText %}
-                <p class="events-show" id="office-events-description">
-                  {{ fieldIntroText }}
-                </p>
+                  <p class="events-show" id="office-events-description">
+                    {{ fieldIntroText }}
+                  </p>
                 {% endif %}
               </div>
-              {% include 'src/site/components/events_list.drupal.liquid' %}
+              {% if entityUrl.breadcrumb.1.text != "Outreach and events" %}
+                {% include "src/site/facilities/facilities_events_toggle.drupal.liquid" with url = entityUrl.path %}
+                {% assign featuredUrl = null %}
+                {% assign featuredItemSet = false %}
+                {% for featuredEvent in allEventTeasers.entities %}
+                  {% if featuredEvent.fieldFeatured == true %}
+                    {% unless entityUrl.path contains 'past-events' %}
+                      {% if featuredItemSet == false %}
+                        {% assign featuredUrl = featuredEvent.entityUrl.path %}
+                        <div class="usa-width-two-thirds">
+                          <div class="usa-grid usa-grid-full vads-u-margin-bottom--3 medium-screen:vads-u-margin-bottom--4 vads-u-display--flex vads-u-flex-direction--column medium-screen:vads-u-flex-direction--row vads-u-border-left--7px vads-u-border-color--primary-alt-lightest" id="featured-content">
+                            <div class="usa-width-full vads-u-padding-left--2">
+                              <div class="vads-u-margin-bottom--2">
+                                <strong>In the spotlight at
+                                  {{ fieldOffice.entity.title }}</strong>
+                              </div>
+                              {% include "src/site/teasers/event_featured.drupal.liquid" with node = featuredEvent %}
+                            </div>
+                          </div>
+                        </div>
+                      {% endif %}
+                    {% endunless %}
+                    {% assign featuredItemSet = true %}
+                  {% endif %}
+                {% endfor %}
+                {% for event in pagedItems %}
+                  {% if featuredUrl != event.entityUrl.path %}
+                    <div class="usa-width-two-thirds">
+                      {% include "src/site/teasers/event.drupal.liquid" with node = event %}
+                    </div>
+                  {% endif %}
+                {% endfor %}
+                {% include "src/site/includes/pagination.drupal.liquid" %}
+              {% else %}
+                {% include 'src/site/components/events_list.drupal.liquid' %}
+              {% endif %}
             </div>
           </div>
         </article>

--- a/src/site/layouts/events_page.drupal.liquid
+++ b/src/site/layouts/events_page.drupal.liquid
@@ -1,54 +1,53 @@
 {% comment %}
 Example data:
-"entityUrl": {
-"breadcrumb": [
-{
-"url": {
-"path": "/",
-"routed": true
-},
-"text": "Home"
-}
-],
-"path": "/pittsburgh-health-care"
-},
-"entityId": "83",
-"entityBundle": "health_care_region_page",
-"entityPublished": true,
-"title": "Pittsburgh Health Care System",
-"allEventTeasers": {
-"entities": [
-{
-"title": "Test Event",
-"fieldEventDate": {
-"value": "2019-03-15T08:00:00"
-},
-"fieldEventDateEnd": {
-"value": "2019-03-15T11:00:00"
-},
-"fieldDescription": "This is an event to test. ",
-"fieldLocationHumanreadable": "Kittery Public Library, 3rd Floor Meeting Room",
-"fieldFacilityLocation": {
-"entity": {
-"title": "H. John Heinz III Department of Veterans Affairs Medical Center",
-"entityUrl": {
-"path": "/pittsburgh-health-care/locations/heinz-medical-center"
-}
-}
-},
-"entityUrl": {
-"path": "/pittsburgh-health-care/events/test-event"
-}
-}
-]
-},
-}
+  "entityUrl": {
+    "breadcrumb": [
+      {
+        "url": {
+          "path": "/",
+          "routed": true
+        },
+        "text": "Home"
+      }
+    ],
+      "path": "/pittsburgh-health-care"
+  },
+  "entityId": "83",
+    "entityBundle": "health_care_region_page",
+      "entityPublished": true,
+        "title": "Pittsburgh Health Care System",
+          "allEventTeasers": {
+    "entities": [
+      {
+        "title": "Test Event",
+        "fieldEventDate": {
+          "value": "2019-03-15T08:00:00"
+        },
+        "fieldEventDateEnd": {
+          "value": "2019-03-15T11:00:00"
+        },
+        "fieldDescription": "This is an event to test. ",
+        "fieldLocationHumanreadable": "Kittery Public Library, 3rd Floor Meeting Room",
+        "fieldFacilityLocation": {
+          "entity": {
+            "title": "H. John Heinz III Department of Veterans Affairs Medical Center",
+            "entityUrl": {
+              "path": "/pittsburgh-health-care/locations/heinz-medical-center"
+            }
+          }
+        },
+        "entityUrl": {
+          "path": "/pittsburgh-health-care/events/test-event"
+        }
+      }
+    ]
+  },
 {% endcomment %}
 {% include "src/site/includes/header.html" with drupalTags = true %}
 {% include "src/site/includes/alerts.drupal.liquid" %}
 {% include "src/site/includes/preview-edit.drupal.liquid" %}
 {% include "src/site/includes/breadcrumbs.drupal.liquid" with hideHomeBreadcrumb = true %}
-<div class="interior" id="content">
+<div id="content" class="interior">
   <main class="va-l-detail-page va-facility-page">
     <div class="usa-grid usa-grid-full">
       {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with sidebarData = facilitySidebar %}
@@ -70,13 +69,13 @@ Example data:
                   {% assign featuredUrl = featuredEvent.entityUrl.path %}
                   <div class="usa-width-two-thirds">
                     <div class="usa-grid usa-grid-full
-                                      vads-u-margin-bottom--3
-                                      medium-screen:vads-u-margin-bottom--4
-                                      vads-u-display--flex
-                                      vads-u-flex-direction--column
-                                      medium-screen:vads-u-flex-direction--row
-                                      vads-u-border-left--7px
-                                      vads-u-border-color--primary-alt-lightest" id="featured-content">
+                                vads-u-margin-bottom--3
+                                medium-screen:vads-u-margin-bottom--4
+                                vads-u-display--flex
+                                vads-u-flex-direction--column
+                                medium-screen:vads-u-flex-direction--row
+                                vads-u-border-left--7px
+                                vads-u-border-color--primary-alt-lightest" id="featured-content">
                       <div class="usa-width-full vads-u-padding-left--2">
                         <div class="vads-u-margin-bottom--2">
                           <strong>In the spotlight at

--- a/src/site/layouts/events_page.drupal.liquid
+++ b/src/site/layouts/events_page.drupal.liquid
@@ -48,7 +48,7 @@ Example data:
 {% include "src/site/includes/alerts.drupal.liquid" %}
 {% include "src/site/includes/preview-edit.drupal.liquid" %}
 {% include "src/site/includes/breadcrumbs.drupal.liquid" with hideHomeBreadcrumb = true %}
-<div id="content" class="interior">
+<div class="interior" id="content">
   <main class="va-l-detail-page va-facility-page">
     <div class="usa-grid usa-grid-full">
       {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with sidebarData = facilitySidebar %}
@@ -64,30 +64,31 @@ Example data:
 
           {% assign featuredUrl = null %}
           {% if paginator.prev == null %}
-          {% for featuredEvent in eventTeasers.entities %}
-          {% if forloop.first == true %}
-          {% unless entityUrl.path contains 'past-events' %}
-          {% assign featuredUrl = featuredEvent.entityUrl.path %}
-            <div class="usa-width-two-thirds">
-              <div id="featured-content" class="usa-grid usa-grid-full
-                vads-u-margin-bottom--3
-                medium-screen:vads-u-margin-bottom--4
-                vads-u-display--flex
-                vads-u-flex-direction--column
-                medium-screen:vads-u-flex-direction--row
-                vads-u-border-left--7px
-                vads-u-border-color--primary-alt-lightest">
-                <div class="usa-width-full vads-u-padding-left--2">
-                  <div class="vads-u-margin-bottom--2">
-                    <strong>In the spotlight at {{ regionOrOffice }}</strong>
+            {% for featuredEvent in eventTeasers.entities %}
+              {% if forloop.first == true %}
+                {% unless entityUrl.path contains 'past-events' %}
+                  {% assign featuredUrl = featuredEvent.entityUrl.path %}
+                  <div class="usa-width-two-thirds">
+                    <div class="usa-grid usa-grid-full
+                                      vads-u-margin-bottom--3
+                                      medium-screen:vads-u-margin-bottom--4
+                                      vads-u-display--flex
+                                      vads-u-flex-direction--column
+                                      medium-screen:vads-u-flex-direction--row
+                                      vads-u-border-left--7px
+                                      vads-u-border-color--primary-alt-lightest" id="featured-content">
+                      <div class="usa-width-full vads-u-padding-left--2">
+                        <div class="vads-u-margin-bottom--2">
+                          <strong>In the spotlight at
+                            {{ regionOrOffice }}</strong>
+                        </div>
+                        {% include "src/site/teasers/event_featured.drupal.liquid" with node = featuredEvent %}
+                      </div>
+                    </div>
                   </div>
-                    {% include "src/site/teasers/event_featured.drupal.liquid" with node = featuredEvent %}
-                </div>
-              </div>
-            </div>
-          {% endunless %}
-          {% endif %}
-          {% endfor %}
+                {% endunless %}
+              {% endif %}
+            {% endfor %}
           {% endif %}
           {% for event in pagedItems %}
             {% if featuredUrl != event.entityUrl.path %}

--- a/src/site/layouts/health_care_region_locations_page.drupal.liquid
+++ b/src/site/layouts/health_care_region_locations_page.drupal.liquid
@@ -1,0 +1,50 @@
+{% include "src/site/includes/header.html" with drupalTags = true %}
+{% include "src/site/includes/alerts.drupal.liquid" %}
+{% include "src/site/includes/preview-edit.drupal.liquid" %}
+{% include "src/site/includes/breadcrumbs.drupal.liquid" with hideHomeBreadcrumb = true %}
+<div id="content" class="interior">
+  <main class="va-l-detail-page va-facility-page">
+    <div class="usa-grid usa-grid-full">
+      {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with sidebarData = facilitySidebar %}
+      <div class="usa-width-three-fourths">
+        {% include "src/site/components/navigation-sidebar-trigger.html" with menuId = "va-detailpage-sidebar" %}
+
+        <article class="usa-content">
+          <h1 class="vads-u-margin-bottom--2">Locations</h1>
+          <div class="va-introtext vads-u-margin-bottom--0">
+            {{ fieldLocationsIntroBlurb.processed }}
+          </div>
+          <div class="usa-grid usa-grid-full vads-u-margin-y--1p5">
+            {% assign basePath = entityUrl.path | regionBasePath %}
+            {% include "src/site/facilities/main_buttons.drupal.liquid" with path = basePath %}
+          </div>
+          <section class="locations clearfix">
+            <h2 id="main-locations"
+              class="vads-u-font-size--xl vads-u-margin-top--3 medium-screen:vads-u-margin-top--5 vads-u-margin-bottom--2p5 medium-screen:vads-u-margin-bottom--3">
+              Main locations</h2>
+            {% assign mainFacility = mainFacilities.entities | sortMainFacility %}
+
+            {% for main in mainFacility %}
+            {% include 'src/site/includes/facilityListing.drupal.liquid' with entity = main %}
+            {% endfor %}
+            <h2 id="community-clinic-locations"
+              class="medium-screen:vads-u-margin-bottom--4">Health
+              clinic locations</h2>
+            {% for other in otherFacilities.entities %}
+            {% include 'src/site/includes/facilityListing.drupal.liquid' with entity = other %}
+            {% endfor %}
+            {% if fieldOtherVaLocations != empty and fieldOtherVaLocations.length %}
+            <h2 id="other-nearby-va-locations"
+              class="medium-screen:vads-u-margin-bottom--4">Other
+              nearby VA locations</h2>
+            <div data-widget-type="other-facility-locations-list"
+              data-facilities="{{ fieldOtherVaLocations }}"></div>
+            {% endif %}
+          </section>
+        </article>
+      </div>
+    </div>
+  </main>
+</div>
+{% include "src/site/includes/footer.html" %}
+{% include "src/site/includes/debug.drupal.liquid" %}

--- a/src/site/layouts/health_care_region_locations_page.drupal.liquid
+++ b/src/site/layouts/health_care_region_locations_page.drupal.liquid
@@ -2,7 +2,7 @@
 {% include "src/site/includes/alerts.drupal.liquid" %}
 {% include "src/site/includes/preview-edit.drupal.liquid" %}
 {% include "src/site/includes/breadcrumbs.drupal.liquid" with hideHomeBreadcrumb = true %}
-<div id="content" class="interior">
+<div class="interior" id="content">
   <main class="va-l-detail-page va-facility-page">
     <div class="usa-grid usa-grid-full">
       {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with sidebarData = facilitySidebar %}
@@ -19,26 +19,22 @@
             {% include "src/site/facilities/main_buttons.drupal.liquid" with path = basePath %}
           </div>
           <section class="locations clearfix">
-            <h2 id="main-locations"
-              class="vads-u-font-size--xl vads-u-margin-top--3 medium-screen:vads-u-margin-top--5 vads-u-margin-bottom--2p5 medium-screen:vads-u-margin-bottom--3">
+            <h2 class="vads-u-font-size--xl vads-u-margin-top--3 medium-screen:vads-u-margin-top--5 vads-u-margin-bottom--2p5 medium-screen:vads-u-margin-bottom--3" id="main-locations">
               Main locations</h2>
             {% assign mainFacility = mainFacilities.entities | sortMainFacility %}
 
             {% for main in mainFacility %}
-            {% include 'src/site/includes/facilityListing.drupal.liquid' with entity = main %}
+              {% include 'src/site/includes/facilityListing.drupal.liquid' with entity = main %}
             {% endfor %}
-            <h2 id="community-clinic-locations"
-              class="medium-screen:vads-u-margin-bottom--4">Health
-              clinic locations</h2>
+            <h2 class="medium-screen:vads-u-margin-bottom--4" id="community-clinic-locations">Health
+                            clinic locations</h2>
             {% for other in otherFacilities.entities %}
-            {% include 'src/site/includes/facilityListing.drupal.liquid' with entity = other %}
+              {% include 'src/site/includes/facilityListing.drupal.liquid' with entity = other %}
             {% endfor %}
             {% if fieldOtherVaLocations != empty and fieldOtherVaLocations.length %}
-            <h2 id="other-nearby-va-locations"
-              class="medium-screen:vads-u-margin-bottom--4">Other
-              nearby VA locations</h2>
-            <div data-widget-type="other-facility-locations-list"
-              data-facilities="{{ fieldOtherVaLocations }}"></div>
+              <h2 class="medium-screen:vads-u-margin-bottom--4" id="other-nearby-va-locations">Other
+                              nearby VA locations</h2>
+              <div data-widget-type="other-facility-locations-list" data-facilities="{{ fieldOtherVaLocations }}"></div>
             {% endif %}
           </section>
         </article>

--- a/src/site/layouts/health_services_listing.drupal.liquid
+++ b/src/site/layouts/health_services_listing.drupal.liquid
@@ -1,0 +1,66 @@
+{% include "src/site/includes/header.html" with drupalTags = true %}
+{% include "src/site/includes/alerts.drupal.liquid" %}
+{% include "src/site/includes/preview-edit.drupal.liquid" %}
+{% include "src/site/includes/breadcrumbs.drupal.liquid" with hideHomeBreadcrumb = true %}
+<div class="interior" id="content">
+  <main class="va-l-detail-page va-facility-page">
+    <div class="usa-grid usa-grid-full">
+      {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with sidebarData = facilitySidebar %}
+      <div class="usa-width-three-fourths">
+        {% include "src/site/components/navigation-sidebar-trigger.html" with menuId = "va-detailpage-sidebar" %}
+        <article class="usa-content">
+          <h1 class="vads-u-margin-bottom--1 medium-screen:vads-u-margin-bottom--2">
+            {{title}}</h1>
+          <div class="va-introtext">
+            {% if fieldIntroText %}
+              <p class="events-show" id="office-events-description">
+                {{ fieldIntroText }}
+              </p>
+            {% endif %}
+          </div>
+
+          <div class="usa-grid usa-grid-full vads-u-margin-top--0p5 vads-u-margin-bottom--4">
+            <div class="usa-grid usa-grid-full vads-u-margin-y--0 vads-u-margin-bottom--0">
+              {% assign basePath = entityUrl.path | regionBasePath %}
+              {% include "src/site/facilities/facilities_health_services_buttons.drupal.liquid" with path = basePath %}
+            </div>
+          </div>
+
+          <section id="table-of-contents">
+            <h2 class="vads-u-margin-bottom--2 vads-u-font-size--lg">On this page</h2>
+            <ul class="usa-unstyled-list"></ul>
+          </section>
+
+          {% if fieldFeaturedContentHealthser.length %}
+            <section class="featured-services" id="featured-services">
+              <h3>In the spotlight at
+                {{ fieldOffice.entity.title }}</h3>
+              <ul class="usa-grid usa-grid-full vads-u-margin-top--3 vads-u-margin-bottom--4 vads-u-display--flex vads-u-flex-direction--column medium-screen:vads-u-flex-direction--row">
+                {% for featuredService in fieldFeaturedContentHealthser %}
+                  {% include "src/site/paragraphs/link_teaser_featured_content.drupal.liquid" with linkTeaser = featuredService.entity %}
+                {% endfor %}
+              </ul>
+            </section>
+          {% endif %}
+
+          {% for healthServiceGroup in clinicalHealthServices %}
+            {% assign groupName = healthServiceGroup.0.fieldServiceNameAndDescripti.entity.parent.0.entity.name %}
+            <section>
+              <h2>{{groupName}}</h2>
+              {% for service in healthServiceGroup %}
+                {% include "src/site/facilities/health_service.drupal.liquid" with healthService = service %}
+              {% endfor %}
+            </section>
+          {% endfor %}
+
+          {% if clinicalHealthServices == false %}
+            <div>No health services at this time.</div>
+          {% endif %}
+
+        </article>
+      </div>
+    </div>
+  </main>
+</div>
+{% include "src/site/includes/footer.html" %}
+{% include "src/site/includes/debug.drupal.liquid" %}

--- a/src/site/layouts/leadership_listing.drupal.liquid
+++ b/src/site/layouts/leadership_listing.drupal.liquid
@@ -1,0 +1,69 @@
+{% comment %}
+Example data:
+"entityPublished": true,
+"fieldNameFirst": "Sheila",
+"fieldLastName": "Tunney",
+"fieldSuffix": null,
+"fieldDescription": "Public Affairs Specialist",
+"fieldOffice": {
+"entity": {
+"entityLabel": "Pittsburgh Health Care System",
+"entityType": "node"
+}
+},
+"fieldIntroText": null,
+"fieldPhotoAllowHiresDownload": false,
+"fieldMedia": {
+"entity": {
+"image": {
+"alt": "Robert L Wilkie",
+"title": "",
+"derivative": {
+"url":
+"http://dev.va.agile6.com/sites/default/files/styles/1_1_square_medium_thumbnail/public/2019-03/Robert_L_Wilkie_8x10.jpg?h=59bf76d8&itok=Q-x_2QaJ",
+"width": 240,
+"height": 240
+}
+}
+}
+},
+"fieldBody": null,
+"changed": 1552424311,
+"entityUrl": {
+"path": "/pittsburgh-health-care/sheila-tunney"
+}
+}
+{% endcomment %}
+{% include "src/site/includes/header.html" with drupalTags = true %}
+{% include "src/site/includes/alerts.drupal.liquid" %}
+{% include "src/site/includes/preview-edit.drupal.liquid" %}
+{% include "src/site/includes/breadcrumbs.drupal.liquid" %}
+<div class="interior" id="content">
+    <main class="va-l-detail-page va-facility-page">
+        <div class="usa-grid usa-grid-full">
+
+            {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with sidebarData = facilitySidebar %}
+
+            <div class="usa-width-three-fourths">
+                {% include "src/site/components/navigation-sidebar-trigger.html" with menuId = "va-detailpage-sidebar" %}
+                <article class="usa-content">
+                    <h1 class="vads-u-margin-bottom--3">{{ title }}</h1>
+                        {% if fieldIntroText %}
+                        <div class="va-introtext vads-u-margin-bottom--0">
+                            {{ fieldIntroText }}
+                        </div>
+                        {% endif %}
+                        {% assign iterator = fieldLeadership %}
+                        {% if pagedItems %}
+                        {% assign iterator = pagedItemd%}
+                        {% endif %}
+                        {% for bio in iterator %}
+                        {% include "src/site/teasers/bio.drupal.liquid" with node = bio.entity %}
+                        {% endfor %}
+                </article>
+            </div>
+        </div>
+    </main>
+</div>
+{% include "src/site/includes/footer.html" %}
+{% include "src/site/includes/debug.drupal.liquid" %}

--- a/src/site/layouts/locations_listing.drupal.liquid
+++ b/src/site/layouts/locations_listing.drupal.liquid
@@ -12,7 +12,7 @@
                 <article class="usa-content">
                     <h1 class="vads-u-margin-bottom--2">Locations</h1>
                     <div class="va-introtext vads-u-margin-bottom--0">
-                        {{ fieldLocationsIntroBlurb.processed }}
+                        {{ fieldLocationsIntroText }}
                     </div>
                     <div class="usa-grid usa-grid-full vads-u-margin-y--1p5">
                         {% assign basePath = entityUrl.path | regionBasePath %}
@@ -22,7 +22,7 @@
                         <h2 id="main-locations"
                             class="vads-u-font-size--xl vads-u-margin-top--3 medium-screen:vads-u-margin-top--5 vads-u-margin-bottom--2p5 medium-screen:vads-u-margin-bottom--3">
                             Main locations</h2>
-                        {% assign mainFacility = mainFacilities.entities | sortMainFacility %}
+                        {% assign mainFacility = fieldOffice.entity.mainFacilities.entities | sortMainFacility %}
 
                         {% for main in mainFacility %}
                         {% include 'src/site/includes/facilityListing.drupal.liquid' with entity = main %}
@@ -30,15 +30,15 @@
                         <h2 id="community-clinic-locations"
                             class="medium-screen:vads-u-margin-bottom--4">Health
                             clinic locations</h2>
-                        {% for other in otherFacilities.entities %}
+                        {% for other in fieldOffice.entity.otherFacilities.entities %}
                         {% include 'src/site/includes/facilityListing.drupal.liquid' with entity = other %}
                         {% endfor %}
-                        {% if fieldOtherVaLocations != empty and fieldOtherVaLocations.length %}
+                        {% if fieldOffice.entity.fieldOtherVaLocations != empty and fieldOffice.entity.fieldOtherVaLocations.length %}
                         <h2 id="other-nearby-va-locations"
                             class="medium-screen:vads-u-margin-bottom--4">Other
                             nearby VA locations</h2>
                         <div data-widget-type="other-facility-locations-list"
-                            data-facilities="{{ fieldOtherVaLocations }}"></div>
+                            data-facilities="{{ fieldOffice.entity.fieldOtherVaLocations }}"></div>
                         {% endif %}
                     </section>
                 </article>

--- a/src/site/layouts/locations_listing.drupal.liquid
+++ b/src/site/layouts/locations_listing.drupal.liquid
@@ -10,9 +10,9 @@
                 {% include "src/site/components/navigation-sidebar-trigger.html" with menuId = "va-detailpage-sidebar" %}
 
                 <article class="usa-content">
-                    <h1 class="vads-u-margin-bottom--2">Locations</h1>
+                    <h1 class="vads-u-margin-bottom--2">{{title}}</h1>
                     <div class="va-introtext vads-u-margin-bottom--0">
-                        {{ fieldLocationsIntroText }}
+                        {{ fieldIntroText }}
                     </div>
                     <div class="usa-grid usa-grid-full vads-u-margin-y--1p5">
                         {% assign basePath = entityUrl.path | regionBasePath %}
@@ -33,6 +33,11 @@
                         {% for other in fieldOffice.entity.otherFacilities.entities %}
                         {% include 'src/site/includes/facilityListing.drupal.liquid' with entity = other %}
                         {% endfor %}
+
+                        {% if mainFacility == false and fieldOffice.entity.otherFacilities.entities == false %}
+                        <div>No locations at this time.</div>
+                        {% endif %}
+
                         {% if fieldOffice.entity.fieldOtherVaLocations != empty and fieldOffice.entity.fieldOtherVaLocations.length %}
                         <h2 id="other-nearby-va-locations"
                             class="medium-screen:vads-u-margin-bottom--4">Other

--- a/src/site/layouts/news_stories_page.drupal.liquid
+++ b/src/site/layouts/news_stories_page.drupal.liquid
@@ -59,13 +59,13 @@ Example data:
         <article class="usa-content">
             <h1 id="article-heading">{{ title }}</h1>
             <div class="vads-l-grid-container--full">
+            {% if fieldIntroText %}
               <div class="va-introtext">
-                {% if fieldIntroText %}
                 <p class="events-show" id="office-events-description">
                   {{ fieldIntroText }}
                 </p>
-                {% endif %}
               </div>
+            {% endif %}
           {% if paginator.prev == null %}
           {% for storyFeature in newsStoryTeasers.entities %}
             {% if forloop.first == true %}

--- a/src/site/layouts/press_releases_listing.drupal.liquid
+++ b/src/site/layouts/press_releases_listing.drupal.liquid
@@ -1,0 +1,88 @@
+{% comment %}
+Example data:
+"entityUrl": {
+"breadcrumb": [
+{
+"url": {
+"path": "/",
+"routed": true
+},
+"text": "Home"
+}
+],
+"path": "/pittsburgh-health-care"
+},
+"entityId": "83",
+"entityBundle": "health_care_region_page",
+"entityPublished": true,
+"title": "Pittsburgh Health Care System",
+"allPressReleaseTeasers": {
+"entities": [
+{
+"title": "Fayette County Veterans getting larger, more modern VA outpatient
+clinic",
+"entityUrl": {
+"path":
+"/pittsburgh-health-care/press-releases/fayette-county-veterans-getting-larger-more-modern-va-outpatient-clinic"
+}
+"fieldReleaseDate": {
+"value": "2018-11-26T05:43:34"
+},
+"fieldIntroText": "The Fayette County VA Outpatient Clinic will move to its new,
+larger space in the Fayette Plaza at 627 Pittsburgh Road, Suite 2, Uniontown,
+PA, on Dec. 3."
+},
+{
+"title": "Cogo Duis Magna",
+"entityUrl": {
+"path": "/pittsburgh-health-care/press-releases/cogo-duis-magna"
+}
+"fieldReleaseDate": {
+"value": "2018-11-19T03:20:44"
+},
+"fieldIntroText": "Eligo iustum mauris nimis ratis roto tego velit. Abluo
+consectetuer duis. Camur decet exerci pala paulatim vicis volutpat..."
+},
+}
+{% endcomment %}
+{% include "src/site/includes/header.html" with drupalTags = true %}
+{% include "src/site/includes/alerts.drupal.liquid" %}
+{% include "src/site/includes/preview-edit.drupal.liquid" %}
+{% include "src/site/includes/breadcrumbs.drupal.liquid" with hideHomeBreadcrumb = true %}
+
+<div id="content" class="interior">
+  <main class="va-l-detail-page va-facility-page">
+    <div class="usa-grid usa-grid-full">
+
+      {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with sidebarData = facilitySidebar %}
+
+      <div class="usa-width-three-fourths">
+        {% include "src/site/components/navigation-sidebar-trigger.html" with menuId = "va-detailpage-sidebar" %}
+        <article class="usa-content">
+          <h1 id="article-heading">{{ title }}</h1>
+          <div class="vads-l-grid-container--full">
+            <div class="va-introtext">
+              {% if fieldIntroText %}
+              <p class="events-show" id="office-events-description">
+                {{ fieldIntroText }}
+              </p>
+              {% endif %}
+            </div>
+            {% for pr in pagedItems %}
+            <section class="vads-u-margin-bottom--4">
+              <h3
+                class="vads-u-margin-bottom--1p5 vads-u-font-size--md medium-screen:vads-u-font-size--lg">
+                <a href="{{ pr.entityUrl.path }}">{{ pr.title }}</a></h3>
+              <strong>{{ pr.fieldReleaseDate.value | formatDate: "MMMM DD, YYYY" }}</strong>
+              <p class="vads-u-margin-top--0">
+                {{ pr.fieldIntroText | truncatewords: 60, "..." }}</p>
+            </section>
+            {% endfor %}
+            {% include "src/site/includes/pagination.drupal.liquid" %}
+        </article>
+      </div>
+    </div>
+  </main>
+</div>
+{% include "src/site/includes/footer.html" %}
+{% include "src/site/includes/debug.drupal.liquid" %}

--- a/src/site/layouts/press_releases_listing.drupal.liquid
+++ b/src/site/layouts/press_releases_listing.drupal.liquid
@@ -78,6 +78,11 @@ consectetuer duis. Camur decet exerci pala paulatim vicis volutpat..."
                 {{ pr.fieldIntroText | truncatewords: 60, "..." }}</p>
             </section>
             {% endfor %}
+
+            {% if pagedItems == false %}
+            <div>No news releases at this time.</div>
+            {% endif %}
+
             {% include "src/site/includes/pagination.drupal.liquid" %}
         </article>
       </div>

--- a/src/site/layouts/press_releases_listing.drupal.liquid
+++ b/src/site/layouts/press_releases_listing.drupal.liquid
@@ -1,48 +1,49 @@
 {% comment %}
 Example data:
-"entityUrl": {
-"breadcrumb": [
-{
-"url": {
-"path": "/",
-"routed": true
-},
-"text": "Home"
-}
-],
-"path": "/pittsburgh-health-care"
-},
-"entityId": "83",
-"entityBundle": "health_care_region_page",
-"entityPublished": true,
-"title": "Pittsburgh Health Care System",
-"allPressReleaseTeasers": {
-"entities": [
-{
-"title": "Fayette County Veterans getting larger, more modern VA outpatient
+
+  "entityUrl": {
+    "breadcrumb": [
+      {
+        "url": {
+          "path": "/",
+          "routed": true
+        },
+        "text": "Home"
+      }
+    ],
+      "path": "/pittsburgh-health-care"
+  },
+  "entityId": "83",
+    "entityBundle": "health_care_region_page",
+      "entityPublished": true,
+        "title": "Pittsburgh Health Care System",
+          "allPressReleaseTeasers": {
+    "entities": [
+      {
+        "title": "Fayette County Veterans getting larger, more modern VA outpatient
 clinic",
 "entityUrl": {
-"path":
-"/pittsburgh-health-care/press-releases/fayette-county-veterans-getting-larger-more-modern-va-outpatient-clinic"
-}
+        "path":
+          "/pittsburgh-health-care/press-releases/fayette-county-veterans-getting-larger-more-modern-va-outpatient-clinic"
+      }
 "fieldReleaseDate": {
-"value": "2018-11-26T05:43:34"
-},
-"fieldIntroText": "The Fayette County VA Outpatient Clinic will move to its new,
+        "value": "2018-11-26T05:43:34"
+      },
+      "fieldIntroText": "The Fayette County VA Outpatient Clinic will move to its new,
 larger space in the Fayette Plaza at 627 Pittsburgh Road, Suite 2, Uniontown,
-PA, on Dec. 3."
+      PA, on Dec. 3."
 },
-{
-"title": "Cogo Duis Magna",
-"entityUrl": {
-"path": "/pittsburgh-health-care/press-releases/cogo-duis-magna"
-}
-"fieldReleaseDate": {
-"value": "2018-11-19T03:20:44"
-},
-"fieldIntroText": "Eligo iustum mauris nimis ratis roto tego velit. Abluo
-consectetuer duis. Camur decet exerci pala paulatim vicis volutpat..."
-},
+  {
+    "title": "Cogo Duis Magna",
+      "entityUrl": {
+      "path": "/pittsburgh-health-care/press-releases/cogo-duis-magna"
+    }
+    "fieldReleaseDate": {
+      "value": "2018-11-19T03:20:44"
+    },
+    "fieldIntroText": "Eligo iustum mauris nimis ratis roto tego velit. Abluo
+    consectetuer duis.Camur decet exerci pala paulatim vicis volutpat..."
+  },
 }
 {% endcomment %}
 {% include "src/site/includes/header.html" with drupalTags = true %}

--- a/src/site/layouts/story_listing.drupal.liquid
+++ b/src/site/layouts/story_listing.drupal.liquid
@@ -67,7 +67,7 @@ Example data:
                 {% endif %}
               </div>
           {% if paginator.prev == null %}
-          {% for storyFeature in newsStoryTeasers.entities %}
+          {% for storyFeature in allNewsStoryTeasers.entities %}
             {% if forloop.first == true %}
               {% include "src/site/teasers/news_story_page_feature.drupal.liquid" with node = storyFeature %}
             {% endif %}

--- a/src/site/layouts/story_listing.drupal.liquid
+++ b/src/site/layouts/story_listing.drupal.liquid
@@ -78,6 +78,11 @@ Example data:
               {% include "src/site/teasers/news_story_page.drupal.liquid" with node = story %}
             {% endif %}
           {% endfor %}
+
+          {% if pagedItems == false %}
+          <div>No stories at this time.</div>
+          {% endif %}
+
           {% include "src/site/includes/pagination.drupal.liquid" %}
         </article>
       </div>

--- a/src/site/stages/build/drupal/graphql/GetAllPages.graphql.js
+++ b/src/site/stages/build/drupal/graphql/GetAllPages.graphql.js
@@ -20,6 +20,7 @@ const bioPage = require('./bioPage.graphql');
 const benefitListingPage = require('./benefitListingPage.graphql');
 const eventListingPage = require('./eventListingPage.graphql');
 const storyListingPage = require('./storyListingPage.graphql');
+const pressReleasesListingPage = require('./pressReleasesListingPage.graphql');
 const locationListingPage = require('./locationsListingPage.graphql');
 const homePageQuery = require('./homePage.graphql');
 const allSideNavMachineNamesQuery = require('./navigation-fragments/allSideNavMachineNames.nav.graphql');
@@ -62,6 +63,7 @@ const buildQuery = ({ useTomeSync }) => {
   ${benefitListingPage}
   ${eventListingPage}
   ${storyListingPage}
+  ${pressReleasesListingPage}
   ${locationListingPage}
 `;
 
@@ -90,6 +92,7 @@ const buildQuery = ({ useTomeSync }) => {
         ... benefitListingPage
         ... eventListingPage
         ... storyListingPage
+        ... pressReleasesListingPage
         ... locationListingPage
       }
     }`;

--- a/src/site/stages/build/drupal/graphql/GetAllPages.graphql.js
+++ b/src/site/stages/build/drupal/graphql/GetAllPages.graphql.js
@@ -19,6 +19,7 @@ const outreachAssetsQuery = require('./file-fragments/outreachAssets.graphql');
 const bioPage = require('./bioPage.graphql');
 const benefitListingPage = require('./benefitListingPage.graphql');
 const eventListingPage = require('./eventListingPage.graphql');
+const locationListingPage = require('./locationsListingPage.graphql');
 const homePageQuery = require('./homePage.graphql');
 const allSideNavMachineNamesQuery = require('./navigation-fragments/allSideNavMachineNames.nav.graphql');
 const menuLinksQuery = require('./navigation-fragments/menuLinks.nav.graphql');
@@ -59,6 +60,7 @@ const buildQuery = ({ useTomeSync }) => {
   ${bioPage}
   ${benefitListingPage}
   ${eventListingPage}
+  ${locationListingPage}
 `;
 
   const todayQueryVar = useTomeSync ? '' : '$today: String!,';
@@ -85,6 +87,7 @@ const buildQuery = ({ useTomeSync }) => {
         ... bioPage
         ... benefitListingPage
         ... eventListingPage
+        ... locationListingPage
       }
     }`;
 

--- a/src/site/stages/build/drupal/graphql/GetAllPages.graphql.js
+++ b/src/site/stages/build/drupal/graphql/GetAllPages.graphql.js
@@ -20,6 +20,7 @@ const bioPage = require('./bioPage.graphql');
 const benefitListingPage = require('./benefitListingPage.graphql');
 const eventListingPage = require('./eventListingPage.graphql');
 const storyListingPage = require('./storyListingPage.graphql');
+const leadershipListingPage = require('./leadershipListingPage.graphql');
 const pressReleasesListingPage = require('./pressReleasesListingPage.graphql');
 const healthServicesListingPage = require('./healthServicesListingPage.graphql');
 const locationListingPage = require('./locationsListingPage.graphql');
@@ -64,6 +65,7 @@ const buildQuery = ({ useTomeSync }) => {
   ${benefitListingPage}
   ${eventListingPage}
   ${storyListingPage}
+  ${leadershipListingPage}
   ${healthServicesListingPage}
   ${pressReleasesListingPage}
   ${locationListingPage}
@@ -94,6 +96,7 @@ const buildQuery = ({ useTomeSync }) => {
         ... benefitListingPage
         ... eventListingPage
         ... storyListingPage
+        ... leadershipListingPage
         ... pressReleasesListingPage
         ... healthServicesListingPage
         ... locationListingPage

--- a/src/site/stages/build/drupal/graphql/GetAllPages.graphql.js
+++ b/src/site/stages/build/drupal/graphql/GetAllPages.graphql.js
@@ -21,6 +21,7 @@ const benefitListingPage = require('./benefitListingPage.graphql');
 const eventListingPage = require('./eventListingPage.graphql');
 const storyListingPage = require('./storyListingPage.graphql');
 const pressReleasesListingPage = require('./pressReleasesListingPage.graphql');
+const healthServicesListingPage = require('./healthServicesListingPage.graphql');
 const locationListingPage = require('./locationsListingPage.graphql');
 const homePageQuery = require('./homePage.graphql');
 const allSideNavMachineNamesQuery = require('./navigation-fragments/allSideNavMachineNames.nav.graphql');
@@ -63,6 +64,7 @@ const buildQuery = ({ useTomeSync }) => {
   ${benefitListingPage}
   ${eventListingPage}
   ${storyListingPage}
+  ${healthServicesListingPage}
   ${pressReleasesListingPage}
   ${locationListingPage}
 `;
@@ -93,6 +95,7 @@ const buildQuery = ({ useTomeSync }) => {
         ... eventListingPage
         ... storyListingPage
         ... pressReleasesListingPage
+        ... healthServicesListingPage
         ... locationListingPage
       }
     }`;

--- a/src/site/stages/build/drupal/graphql/GetAllPages.graphql.js
+++ b/src/site/stages/build/drupal/graphql/GetAllPages.graphql.js
@@ -19,6 +19,7 @@ const outreachAssetsQuery = require('./file-fragments/outreachAssets.graphql');
 const bioPage = require('./bioPage.graphql');
 const benefitListingPage = require('./benefitListingPage.graphql');
 const eventListingPage = require('./eventListingPage.graphql');
+const storyListingPage = require('./storyListingPage.graphql');
 const locationListingPage = require('./locationsListingPage.graphql');
 const homePageQuery = require('./homePage.graphql');
 const allSideNavMachineNamesQuery = require('./navigation-fragments/allSideNavMachineNames.nav.graphql');
@@ -60,6 +61,7 @@ const buildQuery = ({ useTomeSync }) => {
   ${bioPage}
   ${benefitListingPage}
   ${eventListingPage}
+  ${storyListingPage}
   ${locationListingPage}
 `;
 
@@ -87,6 +89,7 @@ const buildQuery = ({ useTomeSync }) => {
         ... bioPage
         ... benefitListingPage
         ... eventListingPage
+        ... storyListingPage
         ... locationListingPage
       }
     }`;

--- a/src/site/stages/build/drupal/graphql/eventListingPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/eventListingPage.graphql.js
@@ -49,10 +49,16 @@ module.exports = `
     fieldOffice {
       targetId
       entity {
-        reverseFieldOfficeNode(limit: 500, filter: {conditions: [{field: "status", value: "1", operator: EQUAL}]}, sort: {field: "changed", direction: DESC}) {
+        ...on NodeHealthCareRegionPage {
+          entityLabel
+          title
+          fieldNicknameForThisFacility
+        }
+        reverseFieldOfficeNode(limit: 500, filter: {conditions: [{field: "type", value: "event"}, {field: "status", value: "1", operator: EQUAL}]}, sort: {field: "changed", direction: DESC}) {
             entities {
               ... on NodeEvent {
                 title
+                fieldFeatured
                 entityUrl {
                   path
                 }

--- a/src/site/stages/build/drupal/graphql/healthServicesListingPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/healthServicesListingPage.graphql.js
@@ -1,0 +1,112 @@
+/**
+ * An event detail page
+ * Example: /pittsburgh-health-care/events/example-event
+ */
+const entityElementsFromPages = require('./entityElementsForPages.graphql');
+
+module.exports = `
+ fragment healthServicesListingPage on NodeHealthServicesListing {
+    ${entityElementsFromPages}
+    title
+    fieldIntroText
+    fieldFeaturedContentHealthser {
+      entity {
+        ... on ParagraphLinkTeaser {
+          fieldLinkSummary
+          fieldLink {
+            title
+            url {
+              path
+            }
+          }
+        }
+      }
+    }
+    entityUrl {
+      path
+    }
+    fieldOffice {
+      entity {
+        entityUrl {
+          path
+        }
+        title
+        reverseFieldRegionPageNode(limit: 500, filter: {conditions: [{field: "type", value: "regional_health_care_service_des"}, {field: "status", value: "1", operator: EQUAL}]}) {
+          entities {
+            ... on NodeRegionalHealthCareServiceDes {
+              entityId
+              entityType
+              entityUrl {
+                path
+              }
+              fieldBody {
+                processed
+              }
+              fieldLocalHealthCareService {
+                entity {
+                  ... on NodeHealthCareLocalHealthService {
+                    entityUrl {
+                      path
+                    }
+                    fieldFacilityLocation {
+                      entity {
+                        ... on NodeHealthCareLocalFacility {
+                          entityUrl {
+                            ... on EntityCanonicalUrl {
+                              breadcrumb {
+                                url {
+                                  path
+                                  routed
+                                }
+                                text
+                              }
+                              path
+                            }
+                          }
+                          fieldNicknameForThisFacility
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+              fieldServiceNameAndDescripti {
+                entity {
+                  ... on TaxonomyTermHealthCareServiceTaxonomy {
+                    weight
+                    entityId
+                    entityBundle
+                    fieldAlsoKnownAs
+                    fieldCommonlyTreatedCondition
+                    name
+                    description {
+                      processed
+                    }
+                    parent {
+                      entity {
+                        ... on TaxonomyTermHealthCareServiceTaxonomy {
+                          weight
+                          name
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    fieldOffice {
+      targetId
+      entity {
+        ... on NodeHealthCareRegionPage {
+          entityLabel
+          title
+          fieldNicknameForThisFacility
+        }
+      }
+    }
+ }
+`;

--- a/src/site/stages/build/drupal/graphql/leadershipListingPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/leadershipListingPage.graphql.js
@@ -1,0 +1,118 @@
+/**
+ * An event detail page
+ * Example: /pittsburgh-health-care/events/example-event
+ */
+const entityElementsFromPages = require('./entityElementsForPages.graphql');
+
+module.exports = `
+ fragment leadershipListingPage on NodeLeadershipListing {
+    ${entityElementsFromPages}
+    title
+    fieldIntroText
+    entityUrl {
+      path
+    }
+    fieldLeadership {
+      entity {
+        ... on NodePersonProfile {
+          title
+          fieldPhoneNumber
+          entityPublished
+          fieldNameFirst
+          fieldLastName
+          fieldSuffix
+          fieldDescription
+          fieldOffice {
+            entity {
+              entityLabel
+              entityType
+            }
+          }
+          fieldIntroText
+          fieldPhotoAllowHiresDownload
+          fieldBody {
+            processed
+          }
+          changed
+          entityUrl {
+            path
+          }
+          fieldMedia {
+            entity {
+              ... on MediaImage {
+                image {
+                  alt
+                  title
+                  derivative(style: _23MEDIUMTHUMBNAIL) {
+                    url
+                    width
+                    height
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    fieldOffice {
+      entity {
+        entityUrl {
+          path
+        }
+        title
+        reverseFieldOfficeNode(limit: 500, filter: {conditions: [{field: "type", value: "person_profile"}, {field: "status", value: "1", operator: EQUAL}]}) {
+          entities {
+            ... on NodePersonProfile {
+              title
+              fieldNameFirst
+              fieldLastName
+              fieldSuffix
+              fieldDescription
+              fieldOffice {
+                entity {
+                  entityLabel
+                  entityType
+                }
+              }
+              fieldIntroText
+              fieldPhotoAllowHiresDownload
+              fieldBody {
+                processed
+              }
+              changed
+              entityUrl {
+                path
+              }
+              fieldMedia {
+                entity {
+                  ... on MediaImage {
+                    image {
+                      alt
+                      title
+                      derivative(style: _21MEDIUMTHUMBNAIL) {
+                        url
+                        width
+                        height
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    fieldOffice {
+      targetId
+      entity {
+        ... on NodeHealthCareRegionPage {
+          entityLabel
+          title
+          fieldNicknameForThisFacility
+        }
+      }
+    }
+ }
+`;

--- a/src/site/stages/build/drupal/graphql/locationsListingPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/locationsListingPage.graphql.js
@@ -1,0 +1,29 @@
+/**
+ * An event detail page
+ * Example: /pittsburgh-health-care/events/example-event
+ */
+const entityElementsFromPages = require('./entityElementsForPages.graphql');
+const healthCareLocalFacilities = require('./facilities-fragments/healthCareLocalFacility.node.graphql');
+
+module.exports = `
+ fragment locationListingPage on NodeLocationsListing {
+    ${entityElementsFromPages}
+    title
+    entityId
+    fieldIntroText
+    fieldMetaTags
+    fieldMetaTitle
+    fieldOffice {
+      targetId
+      entity {
+        ...on NodeHealthCareRegionPage {
+          ${healthCareLocalFacilities}
+          fieldOtherVaLocations
+          entityLabel
+          title
+          fieldNicknameForThisFacility
+        }
+      }
+    }
+ }
+`;

--- a/src/site/stages/build/drupal/graphql/pressReleasesListingPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/pressReleasesListingPage.graphql.js
@@ -1,0 +1,68 @@
+/**
+ * An event detail page
+ * Example: /pittsburgh-health-care/events/example-event
+ */
+const entityElementsFromPages = require('./entityElementsForPages.graphql');
+
+module.exports = `
+ fragment pressReleasesListingPage on NodePressReleasesListing {
+    ${entityElementsFromPages}
+    fieldOffice {
+      entity {
+        title
+        reverseFieldOfficeNode(limit: 500, filter: {conditions: [{field: "type", value: "press_release"}, {field: "status", value: "1", operator: EQUAL}]}) {
+          entities {
+            ... on NodePressRelease {
+              entityId
+              title
+              entityUrl {
+                path
+              }
+              uid {
+                targetId
+                ... on FieldNodeUid {
+                  entity {
+                    name
+                    timezone
+                  }
+                }
+              }
+              promote
+              created
+              fieldOffice {
+                entity {
+                  ... on NodeHealthCareRegionPage {
+                    entityLabel
+                    entityUrl {
+                      ... on EntityCanonicalUrl {
+                        breadcrumb {
+                          url {
+                            path
+                            routed
+                          }
+                          text
+                        }
+                        path
+                      }
+                    }
+                  }
+                }
+              }
+              fieldIntroText
+            }
+          }
+        }
+      }
+    }
+    fieldOffice {
+      targetId
+      entity {
+        ... on NodeHealthCareRegionPage {
+          entityLabel
+          title
+          fieldNicknameForThisFacility
+        }
+      }
+    }
+ }
+`;

--- a/src/site/stages/build/drupal/graphql/pressReleasesListingPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/pressReleasesListingPage.graphql.js
@@ -7,6 +7,7 @@ const entityElementsFromPages = require('./entityElementsForPages.graphql');
 module.exports = `
  fragment pressReleasesListingPage on NodePressReleasesListing {
     ${entityElementsFromPages}
+    fieldIntroText
     fieldOffice {
       entity {
         title

--- a/src/site/stages/build/drupal/graphql/storyListingPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/storyListingPage.graphql.js
@@ -1,0 +1,96 @@
+/**
+ * An event detail page
+ * Example: /pittsburgh-health-care/events/example-event
+ */
+const entityElementsFromPages = require('./entityElementsForPages.graphql');
+
+module.exports = `
+ fragment storyListingPage on NodeStoryListing {
+    ${entityElementsFromPages}
+    fieldOffice {
+      entity {
+        title
+        reverseFieldOfficeNode(limit: 500, filter: {conditions: [{field: "type", value: "news_story"}, {field: "status", value: "1", operator: EQUAL}]}) {
+          entities {
+            ... on NodeNewsStory {
+              entityId
+              title
+              fieldFeatured
+              entityUrl {
+                path
+              }
+              uid {
+                targetId
+                ... on FieldNodeUid {
+                  entity {
+                    name
+                    timezone
+                  }
+                }
+              }
+              promote
+              created
+              fieldOffice {
+                entity {
+                  ... on NodeHealthCareRegionPage {
+                    entityLabel
+                    entityUrl {
+                      ... on EntityCanonicalUrl {
+                        breadcrumb {
+                          url {
+                            path
+                            routed
+                          }
+                          text
+                        }
+                        path
+                      }
+                    }
+                  }
+                }
+              }
+              fieldAuthor {
+                entity {
+                  ...on NodePersonProfile {
+                    title
+                    fieldDescription
+                  }
+                }
+              }
+              fieldImageCaption
+              fieldIntroText
+              fieldMedia {
+                entity {
+                  ... on MediaImage {
+                    image {
+                      alt
+                      title
+                      derivative(style: _21MEDIUMTHUMBNAIL) {
+                        url
+                        width
+                        height
+                      }
+                    }
+                  }
+                }
+              }
+              fieldFullStory {
+                processed
+              }
+            }
+          }
+        }
+      }
+    }
+    fieldOffice {
+      targetId
+      entity {
+        ... on NodeHealthCareRegionPage {
+          entityLabel
+          title
+          fieldNicknameForThisFacility
+        }
+      }
+    }
+ }
+`;

--- a/src/site/stages/build/drupal/graphql/storyListingPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/storyListingPage.graphql.js
@@ -7,6 +7,7 @@ const entityElementsFromPages = require('./entityElementsForPages.graphql');
 module.exports = `
  fragment storyListingPage on NodeStoryListing {
     ${entityElementsFromPages}
+    fieldIntroText
     fieldOffice {
       entity {
         title

--- a/src/site/stages/build/drupal/health-care-region.js
+++ b/src/site/stages/build/drupal/health-care-region.js
@@ -38,28 +38,6 @@ function createHealthCareRegionListPages(page, drupalPagePath, files) {
     'health_care_facility_status.drupal.liquid',
   );
 
-  // Create the top-level locations page for Health Care Regions
-  const locEntityUrl = createEntityUrlObj(drupalPagePath);
-  const locObj = {
-    mainFacilities: page.mainFacilities,
-    otherFacilities: page.otherFacilities,
-    fieldOtherVaLocations: page.fieldOtherVaLocations,
-    fieldLocationsIntroBlurb: page.fieldLocationsIntroBlurb,
-    facilitySidebar: sidebar,
-    entityUrl: locEntityUrl,
-    alert: page.alert,
-    title: page.title,
-  };
-  const locPage = updateEntityUrlObj(locObj, drupalPagePath, 'Locations');
-  const locPath = locPage.entityUrl.path;
-  locPage.regionOrOffice = page.title;
-  locPage.entityUrl = generateBreadCrumbs(locPath);
-
-  files[`${drupalPagePath}/locations/index.html`] = createFileObj(
-    locPage,
-    'health_care_region_locations_page.drupal.liquid',
-  );
-
   // Create "A-Z Services" || "Our health services" Page
   // sort and group health services by their weight in drupal
   if (page.fieldClinicalHealthServices && page.fieldClinicalHealthServices) {
@@ -269,11 +247,10 @@ function createHealthCareRegionListPages(page, drupalPagePath, files) {
  * @return nothing
  */
 function addGetUpdatesFields(page, pages) {
-  const regionPage = pages.find(
-    p =>
-      p.entityUrl
-        ? p.entityUrl.path === page.entityUrl.breadcrumb[1].url.path
-        : false,
+  const regionPage = pages.find(p =>
+    p.entityUrl
+      ? p.entityUrl.path === page.entityUrl.breadcrumb[1].url.path
+      : false,
   );
 
   if (regionPage) {

--- a/src/site/stages/build/drupal/health-care-region.js
+++ b/src/site/stages/build/drupal/health-care-region.js
@@ -298,49 +298,27 @@ function addGetUpdatesFields(page, pages) {
 }
 
 /**
- * Modify the list pages.
+ * Add pagers to cms content listing pages.
  *
  * @param {page} page The page object.
- * @param {pages} pages an array of page of objects containing a page
+ * @param {files} files The generated file.
+ * @param {field} field The target field.
+ * @param {template} template The template for output formatting.
+ * @param {files} files The acessibility aria.
  * @return nothing
  */
-function modListPages(page, files, field, template, aria) {
-  switch (page.entityBundle) {
-    case 'event_listing':
-      page.allEventTeasers = page.fieldOffice.entity.reverseFieldOfficeNode
-        .entities.length
-        ? page.fieldOffice.entity.reverseFieldOfficeNode
-        : page.reverseFieldOfficeNode;
-      break;
-    case 'story_listing':
-      page.allNewsStoryTeasers = page.fieldOffice.entity.reverseFieldOfficeNode;
-      break;
-    case 'press_releases_listing':
-      page.allPressReleaseTeasers =
-        page.fieldOffice.entity.reverseFieldOfficeNode;
-      break;
-    case 'health_services_listing':
-      page.clinicalHealthServices = sortServices(
-        page.fieldOffice.entity.reverseFieldRegionPageNode.entities,
-      );
-      break;
-    case 'leadership_listing':
-      page.allStaffProfiles = page.fieldLeadership;
-      break;
-    default:
-  }
+function addPager(page, files, field, template, aria) {
   // Add our pager to the Drupal page.
-  if (page.entityBundle !== 'health_services_listing') {
-    const pagingObject = paginatePages(page, files, field, template, aria);
-    if (pagingObject[0]) {
-      page.pagedItems = pagingObject[0].pagedItems;
-      page.paginator = pagingObject[0].paginator;
-    }
+  const pagingObject = paginatePages(page, files, field, template, aria);
+  if (pagingObject[0]) {
+    page.pagedItems = pagingObject[0].pagedItems;
+    page.paginator = pagingObject[0].paginator;
   }
 }
 
 module.exports = {
   createHealthCareRegionListPages,
   addGetUpdatesFields,
-  modListPages,
+  addPager,
+  sortServices,
 };

--- a/src/site/stages/build/drupal/health-care-region.js
+++ b/src/site/stages/build/drupal/health-care-region.js
@@ -281,10 +281,11 @@ function createHealthCareRegionListPages(page, drupalPagePath, files) {
  * @return nothing
  */
 function addGetUpdatesFields(page, pages) {
-  const regionPage = pages.find(p =>
-    p.entityUrl
-      ? p.entityUrl.path === page.entityUrl.breadcrumb[1].url.path
-      : false,
+  const regionPage = pages.find(
+    p =>
+      p.entityUrl
+        ? p.entityUrl.path === page.entityUrl.breadcrumb[1].url.path
+        : false,
   );
 
   if (regionPage) {
@@ -303,7 +304,7 @@ function addGetUpdatesFields(page, pages) {
  * @param {pages} pages an array of page of objects containing a page
  * @return nothing
  */
-function modListPages(page, pages, files, field, template, aria) {
+function modListPages(page, files, field, template, aria) {
   switch (page.entityBundle) {
     case 'event_listing':
       page.allEventTeasers = page.fieldOffice.entity.reverseFieldOfficeNode

--- a/src/site/stages/build/drupal/health-care-region.js
+++ b/src/site/stages/build/drupal/health-care-region.js
@@ -268,7 +268,7 @@ function createHealthCareRegionListPages(page, drupalPagePath, files) {
     bioListingPage,
     files,
     'allStaffProfiles',
-    'bios_page.drupal.liquid',
+    'leadership_listing.drupal.liquid',
     'bio',
   );
 }
@@ -281,11 +281,10 @@ function createHealthCareRegionListPages(page, drupalPagePath, files) {
  * @return nothing
  */
 function addGetUpdatesFields(page, pages) {
-  const regionPage = pages.find(
-    p =>
-      p.entityUrl
-        ? p.entityUrl.path === page.entityUrl.breadcrumb[1].url.path
-        : false,
+  const regionPage = pages.find(p =>
+    p.entityUrl
+      ? p.entityUrl.path === page.entityUrl.breadcrumb[1].url.path
+      : false,
   );
 
   if (regionPage) {
@@ -323,6 +322,9 @@ function modListPages(page, pages, files, field, template, aria) {
       page.clinicalHealthServices = sortServices(
         page.fieldOffice.entity.reverseFieldRegionPageNode.entities,
       );
+      break;
+    case 'leadership_listing':
+      page.allStaffProfiles = page.fieldLeadership;
       break;
     default:
   }

--- a/src/site/stages/build/drupal/health-care-region.js
+++ b/src/site/stages/build/drupal/health-care-region.js
@@ -267,8 +267,12 @@ function modListPages(page, pages, files, field, template, aria) {
     case 'event_listing':
       page.allEventTeasers = page.fieldOffice.entity.reverseFieldOfficeNode;
       break;
+    case 'story_listing':
+      page.allNewsStoryTeasers = page.fieldOffice.entity.reverseFieldOfficeNode;
+      break;
     default:
   }
+  // Add our pager to the Drupal page.
   const pagingObject = paginatePages(page, files, field, template, aria);
   if (pagingObject[0]) {
     page.pagedItems = pagingObject[0].pagedItems;

--- a/src/site/stages/build/drupal/health-care-region.js
+++ b/src/site/stages/build/drupal/health-care-region.js
@@ -270,6 +270,10 @@ function modListPages(page, pages, files, field, template, aria) {
     case 'story_listing':
       page.allNewsStoryTeasers = page.fieldOffice.entity.reverseFieldOfficeNode;
       break;
+    case 'press_releases_listing':
+      page.allPressReleaseTeasers =
+        page.fieldOffice.entity.reverseFieldOfficeNode;
+      break;
     default:
   }
   // Add our pager to the Drupal page.

--- a/src/site/stages/build/drupal/health-care-region.js
+++ b/src/site/stages/build/drupal/health-care-region.js
@@ -172,14 +172,6 @@ function createHealthCareRegionListPages(page, drupalPagePath, files) {
   eventPage.regionOrOffice = page.title;
   eventPage.entityUrl = generateBreadCrumbs(eventPagePath);
 
-  paginatePages(
-    eventPage,
-    files,
-    'allEventTeasers',
-    'events_page.drupal.liquid',
-    'events',
-  );
-
   // Past Events listing page
   const pastEventsEntityUrl = createEntityUrlObj(`${drupalPagePath}/events`);
 
@@ -237,6 +229,7 @@ function createHealthCareRegionListPages(page, drupalPagePath, files) {
     'bios_page.drupal.liquid',
     'bio',
   );
+  return eventObj;
 }
 
 /**
@@ -262,4 +255,29 @@ function addGetUpdatesFields(page, pages) {
   }
 }
 
-module.exports = { createHealthCareRegionListPages, addGetUpdatesFields };
+/**
+ * Modify the list pages.
+ *
+ * @param {page} page The page object.
+ * @param {pages} pages an array of page of objects containing a page
+ * @return nothing
+ */
+function modListPages(page, pages, files, field, template, aria) {
+  switch (page.entityBundle) {
+    case 'event_listing':
+      page.allEventTeasers = page.fieldOffice.entity.reverseFieldOfficeNode;
+      break;
+    default:
+  }
+  const pagingObject = paginatePages(page, files, field, template, aria);
+  if (pagingObject[0]) {
+    page.pagedItems = pagingObject[0].pagedItems;
+    page.paginator = pagingObject[0].paginator;
+  }
+}
+
+module.exports = {
+  createHealthCareRegionListPages,
+  addGetUpdatesFields,
+  modListPages,
+};

--- a/src/site/stages/build/drupal/metalsmith-drupal.js
+++ b/src/site/stages/build/drupal/metalsmith-drupal.js
@@ -96,6 +96,16 @@ function pipeDrupalPagesIntoMetalsmith(contentData, files) {
           'event',
         );
         break;
+      case 'story_listing':
+        modListPages(
+          pageCompiled,
+          pages,
+          files,
+          page.allNewsStoryTeasers,
+          'story_listing.drupal.liquid',
+          'story',
+        );
+        break;
       case 'page':
         addHubIconField(pageCompiled, pages);
         break;

--- a/src/site/stages/build/drupal/metalsmith-drupal.js
+++ b/src/site/stages/build/drupal/metalsmith-drupal.js
@@ -13,6 +13,7 @@ const { compilePage, createFileObj } = require('./page');
 const {
   createHealthCareRegionListPages,
   addGetUpdatesFields,
+  modListPages,
 } = require('./health-care-region');
 const { addHubIconField } = require('./benefit-hub');
 const { addHomeContent } = require('./home');
@@ -84,6 +85,16 @@ function pipeDrupalPagesIntoMetalsmith(contentData, files) {
         break;
       case 'health_care_region_detail_page':
         addGetUpdatesFields(pageCompiled, pages);
+        break;
+      case 'event_listing':
+        modListPages(
+          pageCompiled,
+          pages,
+          files,
+          page.allEventTeasers,
+          'event_listing.drupal.liquid',
+          'event',
+        );
         break;
       case 'page':
         addHubIconField(pageCompiled, pages);

--- a/src/site/stages/build/drupal/metalsmith-drupal.js
+++ b/src/site/stages/build/drupal/metalsmith-drupal.js
@@ -13,8 +13,10 @@ const { compilePage, createFileObj } = require('./page');
 const {
   createHealthCareRegionListPages,
   addGetUpdatesFields,
-  modListPages,
+  addPager,
+  sortServices,
 } = require('./health-care-region');
+
 const { addHubIconField } = require('./benefit-hub');
 const { addHomeContent } = require('./home');
 
@@ -87,46 +89,51 @@ function pipeDrupalPagesIntoMetalsmith(contentData, files) {
         addGetUpdatesFields(pageCompiled, pages);
         break;
       case 'event_listing':
-        modListPages(
+        pageCompiled.allEventTeasers = pageCompiled.fieldOffice.entity
+          .reverseFieldOfficeNode.entities.length
+          ? pageCompiled.fieldOffice.entity.reverseFieldOfficeNode
+          : pageCompiled.reverseFieldOfficeNode;
+        addPager(
           pageCompiled,
           files,
-          page.allEventTeasers,
+          pageCompiled.allEventTeasers,
           'event_listing.drupal.liquid',
           'event',
         );
         break;
       case 'story_listing':
-        modListPages(
+        pageCompiled.allNewsStoryTeasers =
+          page.fieldOffice.entity.reverseFieldOfficeNode;
+        addPager(
           pageCompiled,
           files,
-          page.allNewsStoryTeasers,
+          pageCompiled.allNewsStoryTeasers,
           'story_listing.drupal.liquid',
           'story',
         );
         break;
       case 'press_releases_listing':
-        modListPages(
+        pageCompiled.allPressReleaseTeasers =
+          page.fieldOffice.entity.reverseFieldOfficeNode;
+        addPager(
           pageCompiled,
           files,
-          page.allPressReleaseTeasers,
+          pageCompiled.allPressReleaseTeasers,
           'press_releases_listing.drupal.liquid',
           'press_release',
         );
         break;
       case 'health_services_listing':
-        modListPages(
-          pageCompiled,
-          files,
-          page.clinicalHealthServices,
-          'health_services_listing.drupal.liquid',
-          'health_services',
+        pageCompiled.clinicalHealthServices = sortServices(
+          pageCompiled.fieldOffice.entity.reverseFieldRegionPageNode.entities,
         );
         break;
       case 'leaderships_listing':
-        modListPages(
+        pageCompiled.allStaffProfiles = page.fieldLeadership;
+        addPager(
           pageCompiled,
           files,
-          page.allStaffProfiles,
+          pageCompiled.allStaffProfiles,
           'leadership_listing.drupal.liquid',
           'bio',
         );

--- a/src/site/stages/build/drupal/metalsmith-drupal.js
+++ b/src/site/stages/build/drupal/metalsmith-drupal.js
@@ -116,6 +116,16 @@ function pipeDrupalPagesIntoMetalsmith(contentData, files) {
           'press_release',
         );
         break;
+      case 'health_services_listing':
+        modListPages(
+          pageCompiled,
+          pages,
+          files,
+          page.clinicalHealthServices,
+          'health_services_listing.drupal.liquid',
+          'health_services',
+        );
+        break;
       case 'page':
         addHubIconField(pageCompiled, pages);
         break;

--- a/src/site/stages/build/drupal/metalsmith-drupal.js
+++ b/src/site/stages/build/drupal/metalsmith-drupal.js
@@ -106,6 +106,16 @@ function pipeDrupalPagesIntoMetalsmith(contentData, files) {
           'story',
         );
         break;
+      case 'press_releases_listing':
+        modListPages(
+          pageCompiled,
+          pages,
+          files,
+          page.allPressReleaseTeasers,
+          'press_releases_listing.drupal.liquid',
+          'press_release',
+        );
+        break;
       case 'page':
         addHubIconField(pageCompiled, pages);
         break;

--- a/src/site/stages/build/drupal/metalsmith-drupal.js
+++ b/src/site/stages/build/drupal/metalsmith-drupal.js
@@ -89,7 +89,6 @@ function pipeDrupalPagesIntoMetalsmith(contentData, files) {
       case 'event_listing':
         modListPages(
           pageCompiled,
-          pages,
           files,
           page.allEventTeasers,
           'event_listing.drupal.liquid',
@@ -99,7 +98,6 @@ function pipeDrupalPagesIntoMetalsmith(contentData, files) {
       case 'story_listing':
         modListPages(
           pageCompiled,
-          pages,
           files,
           page.allNewsStoryTeasers,
           'story_listing.drupal.liquid',
@@ -109,7 +107,6 @@ function pipeDrupalPagesIntoMetalsmith(contentData, files) {
       case 'press_releases_listing':
         modListPages(
           pageCompiled,
-          pages,
           files,
           page.allPressReleaseTeasers,
           'press_releases_listing.drupal.liquid',
@@ -119,7 +116,6 @@ function pipeDrupalPagesIntoMetalsmith(contentData, files) {
       case 'health_services_listing':
         modListPages(
           pageCompiled,
-          pages,
           files,
           page.clinicalHealthServices,
           'health_services_listing.drupal.liquid',
@@ -129,7 +125,6 @@ function pipeDrupalPagesIntoMetalsmith(contentData, files) {
       case 'leaderships_listing':
         modListPages(
           pageCompiled,
-          pages,
           files,
           page.allStaffProfiles,
           'leadership_listing.drupal.liquid',

--- a/src/site/stages/build/drupal/metalsmith-drupal.js
+++ b/src/site/stages/build/drupal/metalsmith-drupal.js
@@ -126,6 +126,16 @@ function pipeDrupalPagesIntoMetalsmith(contentData, files) {
           'health_services',
         );
         break;
+      case 'leaderships_listing':
+        modListPages(
+          pageCompiled,
+          pages,
+          files,
+          page.allStaffProfiles,
+          'leadership_listing.drupal.liquid',
+          'bio',
+        );
+        break;
       case 'page':
         addHubIconField(pageCompiled, pages);
         break;

--- a/src/site/stages/build/drupal/page.js
+++ b/src/site/stages/build/drupal/page.js
@@ -49,7 +49,17 @@ function paginatePages(page, files, field, layout, ariaLabel, perPage) {
     ariaLabel = ` of ${ariaLabel}`;
   }
 
-  const pagedEntities = _.chunk(page[field].entities, perPage);
+  let chunker;
+  switch (page.entityBundle) {
+    case 'event_listing':
+      chunker = page.allEventTeasers.entities;
+      break;
+
+    default:
+      chunker = page[field].entities;
+  }
+  const pagedEntities = _.chunk(chunker, perPage);
+  const pageReturn = [];
   for (let pageNum = 0; pageNum < pagedEntities.length; pageNum++) {
     let pagedPage = Object.assign({}, page);
 
@@ -104,12 +114,14 @@ function paginatePages(page, files, field, layout, ariaLabel, perPage) {
             ? `${page.entityUrl.path}${paginationPath(pageNum + 1)}`
             : null,
       };
+      pageReturn.push(pagedPage);
     }
 
     const fileName = path.join('.', pagedPage.entityUrl.path, 'index.html');
 
     files[fileName] = createFileObj(pagedPage, layout);
   }
+  return pageReturn;
 }
 
 // Return page object with path, breadcrumb and title set.
@@ -288,9 +300,20 @@ function compilePage(page, contentData) {
   let pageCompiled;
 
   switch (entityBundle) {
+    case 'event_listing':
+      pageCompiled = Object.assign(
+        {},
+        page,
+        facilitySidebarNavItems,
+        outreachSidebarNavItems,
+        alertItems,
+        bannerAlertsItems,
+        pageId,
+      );
+      break;
+
     case 'office':
     case 'publication_listing':
-    case 'event_listing':
     case 'locations_listing':
       pageCompiled = Object.assign(
         {},

--- a/src/site/stages/build/drupal/page.js
+++ b/src/site/stages/build/drupal/page.js
@@ -57,6 +57,9 @@ function paginatePages(page, files, field, layout, ariaLabel, perPage) {
     case 'story_listing':
       chunker = page.allNewsStoryTeasers.entities;
       break;
+    case 'press_releases_listing':
+      chunker = page.allPressReleaseTeasers.entities;
+      break;
 
     default:
       chunker = page[field].entities;
@@ -303,22 +306,12 @@ function compilePage(page, contentData) {
   let pageCompiled;
 
   switch (entityBundle) {
-    case 'event_listing':
-    case 'story_listing':
-      pageCompiled = Object.assign(
-        {},
-        page,
-        facilitySidebarNavItems,
-        outreachSidebarNavItems,
-        alertItems,
-        bannerAlertsItems,
-        pageId,
-      );
-      break;
-
     case 'office':
     case 'publication_listing':
     case 'locations_listing':
+    case 'event_listing':
+    case 'story_listing':
+    case 'press_releases_listing':
       pageCompiled = Object.assign(
         {},
         page,

--- a/src/site/stages/build/drupal/page.js
+++ b/src/site/stages/build/drupal/page.js
@@ -54,6 +54,9 @@ function paginatePages(page, files, field, layout, ariaLabel, perPage) {
     case 'event_listing':
       chunker = page.allEventTeasers.entities;
       break;
+    case 'story_listing':
+      chunker = page.allNewsStoryTeasers.entities;
+      break;
 
     default:
       chunker = page[field].entities;
@@ -301,6 +304,7 @@ function compilePage(page, contentData) {
 
   switch (entityBundle) {
     case 'event_listing':
+    case 'story_listing':
       pageCompiled = Object.assign(
         {},
         page,

--- a/src/site/stages/build/drupal/page.js
+++ b/src/site/stages/build/drupal/page.js
@@ -60,7 +60,6 @@ function paginatePages(page, files, field, layout, ariaLabel, perPage) {
     case 'press_releases_listing':
       chunker = page.allPressReleaseTeasers.entities;
       break;
-
     default:
       chunker = page[field].entities;
   }
@@ -231,12 +230,11 @@ function getFacilitySidebar(page, contentData) {
       : pageTitle;
 
     // choose the correct menu name to retrieve the object from contentData
-    const facilitySidebarNavName = Object.keys(
-      contentData.data,
-    ).find(attribute =>
-      contentData.data[attribute]
-        ? contentData.data[attribute].name === facilityNavName
-        : false,
+    const facilitySidebarNavName = Object.keys(contentData.data).find(
+      attribute =>
+        contentData.data[attribute]
+          ? contentData.data[attribute].name === facilityNavName
+          : false,
     );
 
     if (facilitySidebarNavName) {
@@ -312,6 +310,7 @@ function compilePage(page, contentData) {
     case 'event_listing':
     case 'story_listing':
     case 'press_releases_listing':
+    case 'health_services_listing':
       pageCompiled = Object.assign(
         {},
         page,

--- a/src/site/stages/build/drupal/page.js
+++ b/src/site/stages/build/drupal/page.js
@@ -57,6 +57,9 @@ function paginatePages(page, files, field, layout, ariaLabel, perPage) {
     case 'story_listing':
       chunker = page.allNewsStoryTeasers.entities;
       break;
+    case 'leadership_listing':
+      chunker = page.fieldLeadership;
+      break;
     case 'press_releases_listing':
       chunker = page.allPressReleaseTeasers.entities;
       break;
@@ -308,6 +311,7 @@ function compilePage(page, contentData) {
     case 'publication_listing':
     case 'locations_listing':
     case 'event_listing':
+    case 'leadership_listing':
     case 'story_listing':
     case 'press_releases_listing':
     case 'health_services_listing':

--- a/src/site/stages/build/drupal/page.js
+++ b/src/site/stages/build/drupal/page.js
@@ -213,11 +213,12 @@ function getFacilitySidebar(page, contentData) {
       : pageTitle;
 
     // choose the correct menu name to retrieve the object from contentData
-    const facilitySidebarNavName = Object.keys(contentData.data).find(
-      attribute =>
-        contentData.data[attribute]
-          ? contentData.data[attribute].name === facilityNavName
-          : false,
+    const facilitySidebarNavName = Object.keys(
+      contentData.data,
+    ).find(attribute =>
+      contentData.data[attribute]
+        ? contentData.data[attribute].name === facilityNavName
+        : false,
     );
 
     if (facilitySidebarNavName) {
@@ -290,6 +291,7 @@ function compilePage(page, contentData) {
     case 'office':
     case 'publication_listing':
     case 'event_listing':
+    case 'locations_listing':
       pageCompiled = Object.assign(
         {},
         page,

--- a/src/site/stages/build/drupal/page.js
+++ b/src/site/stages/build/drupal/page.js
@@ -49,24 +49,19 @@ function paginatePages(page, files, field, layout, ariaLabel, perPage) {
     ariaLabel = ` of ${ariaLabel}`;
   }
 
-  let chunker;
-  switch (page.entityBundle) {
-    case 'event_listing':
-      chunker = page.allEventTeasers.entities;
-      break;
-    case 'story_listing':
-      chunker = page.allNewsStoryTeasers.entities;
-      break;
-    case 'leadership_listing':
-      chunker = page.fieldLeadership;
-      break;
-    case 'press_releases_listing':
-      chunker = page.allPressReleaseTeasers.entities;
-      break;
-    default:
-      chunker = page[field].entities;
-  }
-  const pagedEntities = _.chunk(chunker, perPage);
+  /* eslint-disable camelcase */
+  // Map the page.entityBundle value to a property value we want for page
+  const bundleToField = {
+    event_listing: 'allEventTeasers',
+    story_listing: 'allNewsStoryTeasers',
+    leadership_listing: 'fieldLeadership',
+    press_releases_listing: 'allPressReleaseTeasers',
+  };
+
+  /* eslint-enable camelcase */
+  const pageField = _.get(bundleToField, page.entityBundle, field);
+  const pagedEntities = _.chunk(page[pageField].entities, perPage);
+
   const pageReturn = [];
   for (let pageNum = 0; pageNum < pagedEntities.length; pageNum++) {
     let pagedPage = Object.assign({}, page);

--- a/src/site/teasers/bio.drupal.liquid
+++ b/src/site/teasers/bio.drupal.liquid
@@ -2,37 +2,36 @@
 Required variable: node - bio entity
 Optional variable: header - the header level ('h2','h3', etc.) defaults to h4
 Example data:
-{
 "entityPublished": true,
 "fieldNameFirst": "Sheila",
-"fieldLastName": "Tunney",
-"fieldSuffix": null,
-"fieldDescription": "Public Affairs Specialist",
-"fieldOffice": {
+    "fieldLastName": "Tunney",
+    "fieldSuffix": null,
+        "fieldDescription": "Public Affairs Specialist",
+        "fieldOffice": {
 "entity": {
-"entityLabel": "Pittsburgh Health Care System",
-"entityType": "node"
+    "entityLabel": "Pittsburgh Health Care System",
+    "entityType": "node"
 }
 },
 "fieldIntroText": null,
 "fieldPhotoAllowHiresDownload": false,
-"fieldMedia": {
+    "fieldMedia": {
 "entity": {
-"image": {
-"alt": "Robert L Wilkie",
-"title": "",
-"derivative": {
-"url":
-"http://dev.va.agile6.com/sites/default/files/styles/1_1_square_medium_thumbnail/public/2019-03/Robert_L_Wilkie_8x10.jpg?h=59bf76d8&itok=Q-x_2QaJ",
-"width": 240,
-"height": 240
-}
-}
+    "image": {
+    "alt": "Robert L Wilkie",
+        "title": "",
+        "derivative": {
+        "url":
+        "http://dev.va.agile6.com/sites/default/files/styles/1_1_square_medium_thumbnail/public/2019-03/Robert_L_Wilkie_8x10.jpg?h=59bf76d8&itok=Q-x_2QaJ",
+        "width": 240,
+            "height": 240
+    }
+    }
 }
 },
 "fieldBody": null,
 "changed": 1552424311,
-"entityUrl": {
+    "entityUrl": {
 "path": "/pittsburgh-health-care/sheila-tunney"
 }
 },

--- a/src/site/teasers/event.drupal.liquid
+++ b/src/site/teasers/event.drupal.liquid
@@ -35,14 +35,14 @@ Example data:
     {% endif %}
     {% endcomment %}
 
-    {% assign start_date_no_time = node.fieldDate.startDate | timeZone: timezone, "dddd, MMM D" %}
-    {% assign end_date_no_time = node.fieldDate.endDate | timeZone: timezone , "dddd, MMM D" %}
+    {% assign start_date_no_time = node.fieldDate.startDate | timeZone: timezone, "dddd, MMM D YYYY" %}
+    {% assign end_date_no_time = node.fieldDate.endDate | timeZone: timezone , "dddd, MMM D YYYY" %}
 
     {% assign start_time = node.fieldDate.startDate | timeZone: timezone, "h:mm A" %}
     {% assign end_time = node.fieldDate.endDate | timeZone: timezone, "h:mm A" %}
 
-    {% assign start_date_full = node.fieldDate.startDate | timeZone: timezone, "dddd, MMM D, h:mm A" %}
-    {% assign end_date_full = node.fieldDate.endDate | timeZone: timezone, "dddd, MMM D, h:mm A" %}
+    {% assign start_date_full = node.fieldDate.startDate | timeZone: timezone, "dddd, MMM D YYYY, h:mm A" %}
+    {% assign end_date_full = node.fieldDate.endDate | timeZone: timezone, "dddd, MMM D YYYY, h:mm A" %}
 
     {% if node.fieldDate.value != empty and node.fieldDate.endValue == empty %}
         {% assign date_type = "start_date_only" %}

--- a/src/site/teasers/event_featured.drupal.liquid
+++ b/src/site/teasers/event_featured.drupal.liquid
@@ -2,29 +2,29 @@
 Required variable: node - the news story entity
 Optional variable: header - the header level ('h2','h3', etc.) defaults to h4
 Example data:
-{
-"title": "Another Test Event",
-"fieldDate": {
-"startDate": "2019-03-16 10:00:01 UTC",
-"value": "2019-03-16T10:00:01",
-"endDate": "2019-03-16 11:00:00 UTC",
-"endValue": "2019-03-16T11:00:00"
-},
-"fieldDescription": "This gives the user an overview of the event in teaser
-views",
-"fieldLocationHumanreadable": "Here",
-"fieldFacilityLocation": {
-"entity": {
-"title": "Westmoreland County VA Clinic",
-"entityUrl": {
-"path": "/pittsburgh-health-care/locations/westmoreland-county"
-}
-}
-},
-"entityUrl": {
-"path": "/node/98"
-}
-}
+  {
+    "title": "Another Test Event",
+      "fieldDate": {
+      "startDate": "2019-03-16 10:00:01 UTC",
+        "value": "2019-03-16T10:00:01",
+          "endDate": "2019-03-16 11:00:00 UTC",
+            "endValue": "2019-03-16T11:00:00"
+    },
+    "fieldDescription": "This gives the user an overview of the event in teaser
+    views",
+    "fieldLocationHumanreadable": "Here",
+      "fieldFacilityLocation": {
+      "entity": {
+        "title": "Westmoreland County VA Clinic",
+          "entityUrl": {
+          "path": "/pittsburgh-health-care/locations/westmoreland-county"
+        }
+      }
+    },
+    "entityUrl": {
+      "path": "/node/98"
+    }
+  }
 {% endcomment %}
 {% if node != empty %}
 
@@ -32,7 +32,7 @@ views",
   {% comment %}
   Ultimately, we will allow check to use user timezone.
   {% if uid.entity.timezone != empty %}
-  {% assign timezone = uid.entity.timezone %}
+    {% assign timezone = uid.entity.timezone %}
   {% endif %}
   {% endcomment %}
 

--- a/src/site/teasers/event_featured.drupal.liquid
+++ b/src/site/teasers/event_featured.drupal.liquid
@@ -36,74 +36,74 @@ views",
   {% endif %}
   {% endcomment %}
 
-{% assign start_date_no_time = node.fieldDate.startDate | timeZone: timezone, "dddd, MMM D" %}
-{% assign end_date_no_time = node.fieldDate.endDate | timeZone: timezone , "dddd, MMM D" %}
+  {% assign start_date_no_time = node.fieldDate.startDate | timeZone: timezone, "dddd, MMM D YYYY" %}
+  {% assign end_date_no_time = node.fieldDate.endDate | timeZone: timezone , "dddd, MMM D YYYY" %}
 
-{% assign start_time = node.fieldDate.startDate | timeZone: timezone, "h:mm A" %}
-{% assign end_time = node.fieldDate.endDate | timeZone: timezone, "h:mm A" %}
+  {% assign start_time = node.fieldDate.startDate | timeZone: timezone, "h:mm A" %}
+  {% assign end_time = node.fieldDate.endDate | timeZone: timezone, "h:mm A" %}
 
-{% assign start_date_full = node.fieldDate.startDate | timeZone: timezone, "dddd, MMM D, h:mm A" %}
-{% assign end_date_full = node.fieldDate.startDate | timeZone: timezone, "dddd, MMM D, h:mm A" %}
+  {% assign start_date_full = node.fieldDate.startDate | timeZone: timezone, "dddd, MMM D YYYY, h:mm A" %}
+  {% assign end_date_full = node.fieldDate.startDate | timeZone: timezone, "dddd, MMM D YYYY, h:mm A" %}
 
-{% if node.fieldDate.value != empty and node.fieldDate.endValue == empty %}
-{% assign date_type = "start_date_only" %}
-{% else %}
-{% if start_date_no_time == end_date_no_time %}
-{% assign date_type = "same_day" %}
-{% else %}
-{% assign date_type = "all_dates" %}
-{% endif %}
-{% endif %}
-
-{% if header == empty %}
-{% assign header = "h4" %}
-{% endif %}
-{% assign isEventsPage = entityUrl.path | isPage: "events" %}
-
-<{{ header }}
-  class="vads-u-margin-top--0 vad-u-margin-bottom-1 {% if isEventsPage %}vads-u-font-size--md medium-screen:vads-u-font-size--lg{% endif %}">
-  <a href="{{ node.entityUrl.path }}">{{ node.title }}</a></{{ header }}>
-<p class="vads-u-margin-bottom--1p5 vads-u-margin-top--0">
-  {{ node.fieldDescription | truncatewords: 60, "..." }}</p>
-<div
-  class="usa-grid usa-grid-full vads-u-display--flex vads-u-flex-direction--row vads-u-margin-bottom--1">
-  <div class="vads-u-margin-right--2 when-where-width">
-    <strong>When</strong>
-  </div>
-  <div class="usa-width-five-sixths">
-    {% if date_type == "start_date_only" %}
-    <span>{{ start_date_no_time }}</span><br>
-    <span>{{ start_time }}</span>
+  {% if node.fieldDate.value != empty and node.fieldDate.endValue == empty %}
+    {% assign date_type = "start_date_only" %}
+  {% else %}
+    {% if start_date_no_time == end_date_no_time %}
+      {% assign date_type = "same_day" %}
     {% else %}
-    {% if date_type == "same_day" %}
-    <span>{{ start_date_no_time }}</span><br>
-    <span>{{ start_time }} – {{ end_time }}</span>
-    {% else %}
-    <span>{{ start_date_full }} –</span><br>
-    <span>{{ end_date_full }}</span>
+      {% assign date_type = "all_dates" %}
     {% endif %}
-    {% endif %}
-    <span> ET</span>
+  {% endif %}
+
+  {% if header == empty %}
+    {% assign header = "h4" %}
+  {% endif %}
+  {% assign isEventsPage = entityUrl.path | isPage: "events" %}
+
+  <{{header}} class="vads-u-margin-top--0 vad-u-margin-bottom-1 {% if isEventsPage %}vads-u-font-size--md medium-screen:vads-u-font-size--lg{% endif %}">
+    <a href="{{ node.entityUrl.path }}">{{ node.title }}</a>
+  </{{header}}>
+  <p class="vads-u-margin-bottom--1p5 vads-u-margin-top--0">
+    {{ node.fieldDescription | truncatewords: 60, "..." }}</p>
+  <div class="usa-grid usa-grid-full vads-u-display--flex vads-u-flex-direction--row vads-u-margin-bottom--1">
+    <div class="vads-u-margin-right--2 when-where-width">
+      <strong>When</strong>
+    </div>
+    <div class="usa-width-five-sixths">
+      {% if date_type == "start_date_only" %}
+        <span>{{ start_date_no_time }}</span><br>
+        <span>{{ start_time }}</span>
+      {% else %}
+        {% if date_type == "same_day" %}
+          <span>{{ start_date_no_time }}</span><br>
+          <span>{{ start_time }}
+            –
+            {{ end_time }}</span>
+        {% else %}
+          <span>{{ start_date_full }}
+            –</span><br>
+          <span>{{ end_date_full }}</span>
+        {% endif %}
+      {% endif %}
+      <span>
+        ET</span>
+    </div>
   </div>
-</div>
-{% if node.fieldFacilityLocation != empty %}
-<div
-  class="usa-grid usa-grid-full vads-u-display--flex vads-u-flex-direction--row">
-  <div class="vads-u-margin-right--2 when-where-width">
-    <strong>Where</strong>
-  </div>
-  <div class="usa-width-five-sixths">
-    <p class="vads-u-margin-top--0 vads-u-margin-bottom--1">
-      <a
-        onClick="recordEvent({ event: 'nav-featured-content-link-click' });"
-        href="{{ node.fieldFacilityLocation.entity.entityUrl.path }}">{{ node.fieldFacilityLocation.entity.title }}</a>
-    </p>
-    {% if node.fieldLocationHumanreadable != empty %}
-    <span>{{ node.fieldLocationHumanreadable }}</span>
-    {% endif %}
-  </div>
-</div>
-{% endif %}
+  {% if node.fieldFacilityLocation != empty %}
+    <div class="usa-grid usa-grid-full vads-u-display--flex vads-u-flex-direction--row">
+      <div class="vads-u-margin-right--2 when-where-width">
+        <strong>Where</strong>
+      </div>
+      <div class="usa-width-five-sixths">
+        <p class="vads-u-margin-top--0 vads-u-margin-bottom--1">
+          <a onclick="recordEvent({ event: 'nav-featured-content-link-click' });" href="{{ node.fieldFacilityLocation.entity.entityUrl.path }}">{{ node.fieldFacilityLocation.entity.title }}</a>
+        </p>
+        {% if node.fieldLocationHumanreadable != empty %}
+          <span>{{ node.fieldLocationHumanreadable }}</span>
+        {% endif %}
+      </div>
+    </div>
+  {% endif %}
 
 
 {% endif %}

--- a/src/site/teasers/news_story_page_feature.drupal.liquid
+++ b/src/site/teasers/news_story_page_feature.drupal.liquid
@@ -5,7 +5,7 @@
 
 <div id="featured-content" class="usa-grid usa-grid-full vads-u-margin-bottom--3 medium-screen:vads-u-margin-bottom--4 vads-u-display--flex vads-u-flex-direction--column medium-screen:vads-u-flex-direction--row vads-u-border-left--7px vads-u-border-color--primary-alt-lightest">
     <div class="usa-width-one-half medium-screen:vads-u-padding-left--2">
-        <span class="vads-u-font-weight--bold vads-u-display--block">In the spotlight at {{ regionOrOffice | remove: "health care" }}</span>
+        <span class="vads-u-font-weight--bold vads-u-display--block">In the spotlight at {{ fieldOffice.entity.title | remove: "health care" }}</span>
         <h2 class="vads-u-margin-y--1"><a onClick="recordEvent({ event: 'nav-featured-content-link-click' });" href="{{ node.entityUrl.path }}">{{ node.title }}</a></h2>
         <p class="vads-u-margin-y--0">{{ node.fieldIntroText | truncatewords: 60, "..." }}</p>
     </div>


### PR DESCRIPTION
## Description
Refactors 5 health service listing pages to pull from drupal content, as opposed to being generated entirely by Metalsmith at build time.

## Testing done
Visual

## Screenshots
![image](https://user-images.githubusercontent.com/2404547/73508525-36233600-43aa-11ea-9d7e-37b748999d35.png)
![image](https://user-images.githubusercontent.com/2404547/73508532-3a4f5380-43aa-11ea-8727-ccd5e6f6af80.png)
![image](https://user-images.githubusercontent.com/2404547/73508541-3f140780-43aa-11ea-8cf0-77a628712637.png)
![image](https://user-images.githubusercontent.com/2404547/73508543-43d8bb80-43aa-11ea-8d85-f84d4b037f1a.png)
![image](https://user-images.githubusercontent.com/2404547/73508548-4804d900-43aa-11ea-8235-f2b004e51778.png)

## Acceptance criteria
- [ ] News releases, health services, locations, events, and story listing pages pull data from drupal.