### PR TITLE
Disable failing e2e test

### DIFF
--- a/src/applications/vaos/tests/e2e/direct-schedule.e2e.spec.js
+++ b/src/applications/vaos/tests/e2e/direct-schedule.e2e.spec.js
@@ -4,6 +4,7 @@ const VAOSHelpers = require('./vaos-helpers');
 const Auth = require('../../../../platform/testing/e2e/auth');
 
 module.exports = {
+  '@disabled': true,
   after: (client, done) => {
     client.deleteCookies();
     client.end();


### PR DESCRIPTION
## Description
This test is failing a lot and breaking builds, disabling until I can figure out the issue.

## Acceptance criteria
- [ ] Test doesn't run

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
