### PR TITLE
Add ALL THE JSON!!!

### DIFF
--- a/src/site/stages/build/process-cms-exports/tests/entities/file.18584ab9-5bf7-4aa4-a474-e84106c3619e.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/file.18584ab9-5bf7-4aa4-a474-e84106c3619e.json
@@ -1,0 +1,55 @@
+{
+    "uuid": [
+        {
+            "value": "18584ab9-5bf7-4aa4-a474-e84106c3619e"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "filename": [
+        {
+            "value": "Fayette County VA Outpatient Clinic_20190423_0002.jpg"
+        }
+    ],
+    "uri": [
+        {
+            "value": "public:\/\/2019-06\/Fayette County VA Outpatient Clinic_20190423_0002.jpg"
+        }
+    ],
+    "filemime": [
+        {
+            "value": "image\/jpeg"
+        }
+    ],
+    "filesize": [
+        {
+            "value": 3253062
+        }
+    ],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-06-07T18:22:28+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-06-07T18:22:51+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/file.31a4ecd6-8648-4237-8d1f-45a18f2c4b60.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/file.31a4ecd6-8648-4237-8d1f-45a18f2c4b60.json
@@ -1,0 +1,55 @@
+{
+    "uuid": [
+        {
+            "value": "31a4ecd6-8648-4237-8d1f-45a18f2c4b60"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "b02c2ff5-dfe1-4542-beec-3fd410a3f267"
+        }
+    ],
+    "filename": [
+        {
+            "value": "HJ-heinz-ambulatory-care3.jpg"
+        }
+    ],
+    "uri": [
+        {
+            "value": "public:\/\/2019-02\/HJ-heinz-ambulatory-care3_0.jpg"
+        }
+    ],
+    "filemime": [
+        {
+            "value": "image\/jpeg"
+        }
+    ],
+    "filesize": [
+        {
+            "value": 44348
+        }
+    ],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-02-20T13:41:17+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-02-20T13:44:05+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/file.52e73c6a-338a-4f5d-9b6b-397f4062c940.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/file.52e73c6a-338a-4f5d-9b6b-397f4062c940.json
@@ -1,0 +1,55 @@
+{
+    "uuid": [
+        {
+            "value": "52e73c6a-338a-4f5d-9b6b-397f4062c940"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "8bea8773-6a06-4afd-99b5-1dfa7a2192ea"
+        }
+    ],
+    "filename": [
+        {
+            "value": "cboc-washington.jpg"
+        }
+    ],
+    "uri": [
+        {
+            "value": "public:\/\/2019-10\/cboc-washington.jpg"
+        }
+    ],
+    "filemime": [
+        {
+            "value": "image\/jpeg"
+        }
+    ],
+    "filesize": [
+        {
+            "value": 43554
+        }
+    ],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-10-18T18:03:41+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-10-18T18:04:18+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/file.9af781fa-7a4d-45c3-8455-e6644d7c4add.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/file.9af781fa-7a4d-45c3-8455-e6644d7c4add.json
@@ -1,0 +1,55 @@
+{
+    "uuid": [
+        {
+            "value": "9af781fa-7a4d-45c3-8455-e6644d7c4add"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "filename": [
+        {
+            "value": "Beaver County Outpatient Clinic_20170713_4790.jpg"
+        }
+    ],
+    "uri": [
+        {
+            "value": "public:\/\/2019-06\/Beaver County Outpatient Clinic_20170713_4790.jpg"
+        }
+    ],
+    "filemime": [
+        {
+            "value": "image\/jpeg"
+        }
+    ],
+    "filesize": [
+        {
+            "value": 2608561
+        }
+    ],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-06-07T18:06:15+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-06-07T18:06:45+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/file.bbe4c66d-f245-4185-bdd8-182323cc45c8.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/file.bbe4c66d-f245-4185-bdd8-182323cc45c8.json
@@ -1,0 +1,55 @@
+{
+    "uuid": [
+        {
+            "value": "bbe4c66d-f245-4185-bdd8-182323cc45c8"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "b02c2ff5-dfe1-4542-beec-3fd410a3f267"
+        }
+    ],
+    "filename": [
+        {
+            "value": "university-drive-consolidation-building2.jpg"
+        }
+    ],
+    "uri": [
+        {
+            "value": "public:\/\/2019-02\/university-drive-consolidation-building2.jpg"
+        }
+    ],
+    "filemime": [
+        {
+            "value": "image\/jpeg"
+        }
+    ],
+    "filesize": [
+        {
+            "value": 105848
+        }
+    ],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-02-20T13:44:15+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-02-20T13:45:05+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/file.cc39b742-c260-4d81-8893-63f131249cd5.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/file.cc39b742-c260-4d81-8893-63f131249cd5.json
@@ -1,0 +1,55 @@
+{
+    "uuid": [
+        {
+            "value": "cc39b742-c260-4d81-8893-63f131249cd5"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "filename": [
+        {
+            "value": "Belmont_County_CBOC.jpg"
+        }
+    ],
+    "uri": [
+        {
+            "value": "public:\/\/2019-08\/Belmont_County_CBOC.jpg"
+        }
+    ],
+    "filemime": [
+        {
+            "value": "image\/jpeg"
+        }
+    ],
+    "filesize": [
+        {
+            "value": 1190396
+        }
+    ],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-08-06T13:11:01+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-08-06T13:11:21+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/media.1e069ce4-0b80-4618-93c4-e398d47b6363.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/media.1e069ce4-0b80-4618-93c4-e398d47b6363.json
@@ -1,0 +1,110 @@
+{
+    "uuid": [
+        {
+            "value": "1e069ce4-0b80-4618-93c4-e398d47b6363"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "bundle": [
+        {
+            "target_id": "image",
+            "target_type": "media_type",
+            "target_uuid": "92f64a34-81e5-4094-82a9-4fe61d7f2227"
+        }
+    ],
+    "revision_created": [
+        {
+            "value": "2019-06-07T18:06:45+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_user": [],
+    "revision_log_message": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "name": [
+        {
+            "value": "Beaver County Outpatient Clinic_20170713_4790.jpg"
+        }
+    ],
+    "thumbnail": [
+        {
+            "alt": "Exterior view of Beaver County Outpatient Clinic",
+            "title": null,
+            "width": 2784,
+            "height": 1856,
+            "target_type": "file",
+            "target_uuid": "9af781fa-7a4d-45c3-8455-e6644d7c4add"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-06-07T18:06:15+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-06-07T18:06:15+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [],
+    "metatag": {
+        "value": {
+            "title": "| Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "| Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "| Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": "\/media\/image\/123",
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "field_media_in_library": [
+        {
+            "value": true
+        }
+    ],
+    "field_media_submission_guideline": [],
+    "field_owner": [],
+    "image": [
+        {
+            "alt": "Exterior view of Beaver County Outpatient Clinic",
+            "title": "",
+            "width": 2784,
+            "height": 1856,
+            "target_type": "file",
+            "target_uuid": "9af781fa-7a4d-45c3-8455-e6644d7c4add"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/media.5f21a6e2-bf59-4dc3-9c4e-620eca8348b4.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/media.5f21a6e2-bf59-4dc3-9c4e-620eca8348b4.json
@@ -1,0 +1,116 @@
+{
+    "uuid": [
+        {
+            "value": "5f21a6e2-bf59-4dc3-9c4e-620eca8348b4"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "bundle": [
+        {
+            "target_id": "image",
+            "target_type": "media_type",
+            "target_uuid": "92f64a34-81e5-4094-82a9-4fe61d7f2227"
+        }
+    ],
+    "revision_created": [
+        {
+            "value": "2019-10-18T18:04:18+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_user": [],
+    "revision_log_message": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "name": [
+        {
+            "value": "cboc-washington.jpg"
+        }
+    ],
+    "thumbnail": [
+        {
+            "alt": "Washington County VA Clinic",
+            "title": null,
+            "width": 480,
+            "height": 330,
+            "target_type": "file",
+            "target_uuid": "52e73c6a-338a-4f5d-9b6b-397f4062c940"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "8bea8773-6a06-4afd-99b5-1dfa7a2192ea"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-10-18T18:03:41+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-10-18T18:03:41+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [],
+    "metatag": {
+        "value": {
+            "title": "| Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "| Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "| Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "field_media_in_library": [
+        {
+            "value": true
+        }
+    ],
+    "field_media_submission_guideline": [],
+    "field_owner": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "image": [
+        {
+            "alt": "Washington County VA Clinic",
+            "title": "",
+            "width": 480,
+            "height": 330,
+            "target_type": "file",
+            "target_uuid": "52e73c6a-338a-4f5d-9b6b-397f4062c940"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/media.73c36aab-ba2b-4f04-8302-24b27b0b6837.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/media.73c36aab-ba2b-4f04-8302-24b27b0b6837.json
@@ -1,0 +1,120 @@
+{
+    "uuid": [
+        {
+            "value": "73c36aab-ba2b-4f04-8302-24b27b0b6837"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "bundle": [
+        {
+            "target_id": "image",
+            "target_type": "media_type",
+            "target_uuid": "92f64a34-81e5-4094-82a9-4fe61d7f2227"
+        }
+    ],
+    "revision_created": [
+        {
+            "value": "2019-08-27T19:42:36+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_user": [
+        {
+            "target_type": "user",
+            "target_uuid": "fd71292f-3dc7-409d-b0e8-500204cb005a"
+        }
+    ],
+    "revision_log_message": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "name": [
+        {
+            "value": "university-drive-consolidation-building2.jpg"
+        }
+    ],
+    "thumbnail": [
+        {
+            "alt": "The entrance to the Pittsburgh VA Medical Center--University Drive",
+            "title": null,
+            "width": 480,
+            "height": 330,
+            "target_type": "file",
+            "target_uuid": "bbe4c66d-f245-4185-bdd8-182323cc45c8"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "b02c2ff5-dfe1-4542-beec-3fd410a3f267"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-02-20T13:44:15+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-08-27T19:42:36+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [],
+    "metatag": {
+        "value": {
+            "title": "| Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "| Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "| Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": "\/media\/image\/14",
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "field_media_in_library": [
+        {
+            "value": true
+        }
+    ],
+    "field_media_submission_guideline": [],
+    "field_owner": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "image": [
+        {
+            "alt": "The entrance to the Pittsburgh VA Medical Center--University Drive",
+            "title": "",
+            "width": 480,
+            "height": 330,
+            "target_type": "file",
+            "target_uuid": "bbe4c66d-f245-4185-bdd8-182323cc45c8"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/media.8140b30e-34d1-4bf7-9570-4bdcff5b4f19.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/media.8140b30e-34d1-4bf7-9570-4bdcff5b4f19.json
@@ -1,0 +1,110 @@
+{
+    "uuid": [
+        {
+            "value": "8140b30e-34d1-4bf7-9570-4bdcff5b4f19"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "bundle": [
+        {
+            "target_id": "image",
+            "target_type": "media_type",
+            "target_uuid": "92f64a34-81e5-4094-82a9-4fe61d7f2227"
+        }
+    ],
+    "revision_created": [
+        {
+            "value": "2019-02-20T13:44:05+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_user": [],
+    "revision_log_message": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "name": [
+        {
+            "value": "HJ-heinz-ambulatory-care3.jpg"
+        }
+    ],
+    "thumbnail": [
+        {
+            "alt": "Heinz campus of the VA hospital system in Pittsburgh",
+            "title": null,
+            "width": 480,
+            "height": 330,
+            "target_type": "file",
+            "target_uuid": "31a4ecd6-8648-4237-8d1f-45a18f2c4b60"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "b02c2ff5-dfe1-4542-beec-3fd410a3f267"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-02-20T13:41:17+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-02-20T20:27:49+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [],
+    "metatag": {
+        "value": {
+            "title": "| Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "| Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "| Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": "\/media\/image\/13",
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "field_media_in_library": [
+        {
+            "value": true
+        }
+    ],
+    "field_media_submission_guideline": [],
+    "field_owner": [],
+    "image": [
+        {
+            "alt": "Heinz campus of the VA hospital system in Pittsburgh",
+            "title": "",
+            "width": 480,
+            "height": 330,
+            "target_type": "file",
+            "target_uuid": "31a4ecd6-8648-4237-8d1f-45a18f2c4b60"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/media.d239d448-ff23-4fd5-a348-c83ecf12684d.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/media.d239d448-ff23-4fd5-a348-c83ecf12684d.json
@@ -1,0 +1,111 @@
+{
+    "uuid": [
+        {
+            "value": "d239d448-ff23-4fd5-a348-c83ecf12684d"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "bundle": [
+        {
+            "target_id": "image",
+            "target_type": "media_type",
+            "target_uuid": "92f64a34-81e5-4094-82a9-4fe61d7f2227"
+        }
+    ],
+    "revision_created": [
+        {
+            "value": "2019-08-06T13:11:21+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_user": [],
+    "revision_log_message": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "name": [
+        {
+            "value": "Belmont County CBOC"
+        }
+    ],
+    "thumbnail": [
+        {
+            "alt": "Exterior of Belmont County CBOC",
+            "title": null,
+            "width": 1565,
+            "height": 1043,
+            "target_type": "file",
+            "target_uuid": "cc39b742-c260-4d81-8893-63f131249cd5"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-08-06T13:11:01+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-08-06T13:11:21+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [],
+    "metatag": {
+        "value": {
+            "title": "| Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "| Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "| Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "field_media_in_library": [
+        {
+            "value": true
+        }
+    ],
+    "field_media_submission_guideline": [],
+    "field_owner": [],
+    "image": [
+        {
+            "alt": "Exterior of Belmont County CBOC",
+            "title": "",
+            "width": 1565,
+            "height": 1043,
+            "target_type": "file",
+            "target_uuid": "cc39b742-c260-4d81-8893-63f131249cd5"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/media.f89fef08-d2bf-424e-bc7d-22eb2fbed349.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/media.f89fef08-d2bf-424e-bc7d-22eb2fbed349.json
@@ -1,0 +1,110 @@
+{
+    "uuid": [
+        {
+            "value": "f89fef08-d2bf-424e-bc7d-22eb2fbed349"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "bundle": [
+        {
+            "target_id": "image",
+            "target_type": "media_type",
+            "target_uuid": "92f64a34-81e5-4094-82a9-4fe61d7f2227"
+        }
+    ],
+    "revision_created": [
+        {
+            "value": "2019-06-07T18:22:51+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_user": [],
+    "revision_log_message": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "name": [
+        {
+            "value": "Fayette County VA Outpatient Clinic_20190423_0002.jpg"
+        }
+    ],
+    "thumbnail": [
+        {
+            "alt": "Exterior of Fayette County VA Outpatient Clinic",
+            "title": null,
+            "width": 2784,
+            "height": 1856,
+            "target_type": "file",
+            "target_uuid": "18584ab9-5bf7-4aa4-a474-e84106c3619e"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-06-07T18:22:28+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-06-07T18:22:28+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [],
+    "metatag": {
+        "value": {
+            "title": "| Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "| Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "| Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": "\/media\/image\/124",
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "field_media_in_library": [
+        {
+            "value": true
+        }
+    ],
+    "field_media_submission_guideline": [],
+    "field_owner": [],
+    "image": [
+        {
+            "alt": "Exterior of Fayette County VA Outpatient Clinic",
+            "title": "",
+            "width": 2784,
+            "height": 1856,
+            "target_type": "file",
+            "target_uuid": "18584ab9-5bf7-4aa4-a474-e84106c3619e"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.0226b192-3b20-404c-a8d4-f3ae1a7c279c.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.0226b192-3b20-404c-a8d4-f3ae1a7c279c.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "0226b192-3b20-404c-a8d4-f3ae1a7c279c"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-05T15:44:49+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Optometry at Pittsburgh VA Medical Center-University Drive"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "fd71292f-3dc7-409d-b0e8-500204cb005a"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-05-10T22:12:46+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-05T15:44:49+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Optometry at Pittsburgh VA Medical Center-University Drive | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Optometry at Pittsburgh VA Medical Center-University Drive | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Optometry at Pittsburgh VA Medical Center-University Drive | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Where to find us<\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>Main hospital<\/strong><br \/>\r\nBuilding 1<br \/>\r\n1-East<br \/>\r\n<a data-entity-substitution=\"canonical\" data-entity-type=\"node\" data-entity-uuid=\"71ffee52-a47f-4909-ad7e-21ece5728be3\" href=\"\/node\/783\">Map of University Drive campus<\/a><br \/>\r\n<strong>Phone:&nbsp;<\/strong><a href=\"tel: +1412-360-6700\">412-360-6700<\/a><br \/>\r\n<strong>Hours:&nbsp;<\/strong>Monday \u2013&nbsp;Friday, 8:00 a.m. to 4:30 p.m. ET<\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you\u2019ll need to contact your primary care provider first.<\/p>\r\n\r\n<p><strong>Referral needed?<\/strong>&nbsp;No<br \/>\r\n<strong>Phone:&nbsp;<\/strong><a href=\"tel: +1412-360-6700\">412-360-6700<\/a><\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "0b968788-cfb0-41aa-8206-2577105072fa"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "45fa1aaa-22f3-44a9-944d-0aef13efbc9a"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.0397ed34-18a5-4907-bb12-8526d4504be8.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.0397ed34-18a5-4907-bb12-8526d4504be8.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "0397ed34-18a5-4907-bb12-8526d4504be8"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-05T17:03:03+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Psychology at Pittsburgh VA Medical Center-University Drive"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "a6af4eb9-ef34-420e-8a20-e2fba1a5afa2"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-06-17T19:59:59+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-05T17:03:03+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Psychology at Pittsburgh VA Medical Center-University Drive | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Psychology at Pittsburgh VA Medical Center-University Drive | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Psychology at Pittsburgh VA Medical Center-University Drive | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Location and contact information<\/h3>\r\n\r\n<p><strong>Consolidation building<\/strong><br \/>\r\nFirst floor<br \/>\r\n<a data-entity-substitution=\"canonical\" data-entity-type=\"node\" data-entity-uuid=\"71ffee52-a47f-4909-ad7e-21ece5728be3\" href=\"\/node\/783\">Map of University Drive campus<\/a><br \/>\r\n<strong>Phone:&nbsp;<\/strong><br \/>\r\n<a href=\"tel: +1412-360-6600\">412-360-6600<\/a><br \/>\r\n<strong>Hours: <\/strong>Monday \u2013 Friday, 8:00 a.m. to 4:30 p.m.<\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you\u2019ll need to contact your primary care provider first.<\/p>\r\n\r\n<p><strong>Referral needed?<\/strong>&nbsp;Yes<br \/>\r\n<strong>Walk-ins accepted?<\/strong>&nbsp;Yes<br \/>\r\n<strong>Phone:&nbsp;<\/strong><a href=\"tel: +1412-360-6600\">412-360-6600<\/a><\/p>\r\n\r\n<p>&nbsp;<\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "0b968788-cfb0-41aa-8206-2577105072fa"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "19810ce7-1e0d-4548-92da-5d261bccb75c"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.0699952f-9e65-4654-a90a-8501fe076ae2.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.0699952f-9e65-4654-a90a-8501fe076ae2.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "0699952f-9e65-4654-a90a-8501fe076ae2"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-04T19:46:28+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Intimate partner violence at Pittsburgh VA Medical Center-University Drive"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-10-30T20:01:12+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-04T19:46:28+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Intimate partner violence at Pittsburgh VA Medical Center-University Drive | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Intimate partner violence at Pittsburgh VA Medical Center-University Drive | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Intimate partner violence at Pittsburgh VA Medical Center-University Drive | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Location and contact information<\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>Intimate Partner Violence Champion<br \/>\r\nPhone:&nbsp;<\/strong><a href=\"tel: +14128521963\">412-8<\/a><a href=\"tel: +14128222359\">22-2359<\/a><br \/>\r\n<strong>Hours:&nbsp;<\/strong>Monday \u2013 Friday, 8:00 a.m. to 4:30 p.m. ET<\/p>\r\n\r\n<p class=\"va-address-block\"><strong>National Domestic Violence 24-hour Hotline<\/strong><br \/>\r\n<strong>Phone:<\/strong> <a href=\"tel: +18007997233\">1-800-799-SAFE (7233)<\/a> or <a href=\"tel: +18007873224\">1-800-787-3224 (TTY)<\/a><br \/>\r\n<strong>Hours:<\/strong>&nbsp;24\/7<\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you\u2019ll need to contact your primary care provider first.<\/p>\r\n\r\n<p><strong>Referral needed? <\/strong>No<br \/>\r\n<strong>Phone:&nbsp;<\/strong><a href=\"tel: +14128521963\">412-8<\/a><a href=\"tel: +14128222359\">22-2359<\/a><\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "0b968788-cfb0-41aa-8206-2577105072fa"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "e453f2c1-fe99-427f-a256-92fd1f103c25"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.06ed0062-a1d1-4ca4-bb14-7ce841061693.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.06ed0062-a1d1-4ca4-bb14-7ce841061693.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "06ed0062-a1d1-4ca4-bb14-7ce841061693"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-04T19:01:02+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "MOVE! weight management at Washington County VA Clinic"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "a6af4eb9-ef34-420e-8a20-e2fba1a5afa2"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-06-05T02:04:19+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-04T19:01:02+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "MOVE! weight management at Washington County VA Clinic | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "MOVE! weight management at Washington County VA Clinic | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "MOVE! weight management at Washington County VA Clinic | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Location and contact information<\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>MOVE! group meetings<\/strong><br \/>\r\nRoom 450<br \/>\r\n<strong>Phone:&nbsp;<\/strong><a href=\"tel: +14128223114\">412-822-3114<\/a><br \/>\r\n<strong>Email:&nbsp;<\/strong><a href=\"mailto:melanie.erskine@va.gov\">melanie.erskine@va.gov<\/a><br \/>\r\n<strong>Hours:<\/strong> Tuesday, 9:00 a.m. to 10:00 a.m. ET<br \/>\r\n&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;Thursday, 2:00 p.m. to 3:00 p.m. ET&nbsp;<br \/>\r\n&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;Friday,<strong>&nbsp;<\/strong>10:30 a.m. to 11:30 a.m. ET<\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you\u2019ll need to contact your primary care provider first.<br \/>\r\n<br \/>\r\n<strong>Phone:&nbsp;<\/strong><a href=\"tel: +14128223114\">412-822-3114<\/a><br \/>\r\n<strong>Email:&nbsp;<\/strong><a href=\"mailto:melanie.erskine@va.gov\">melanie.erskine@va.gov<\/a><br \/>\r\n<br \/>\r\n<a class=\"usa-button\" data-entity-substitution=\"canonical\" data-entity-type=\"node\" data-entity-uuid=\"4578cb13-d680-426f-8f2d-ff000e990cb3\" href=\"\/node\/37\">Schedule an appointment online<\/a><\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "a6826998-b7f7-434f-8999-959b1dab0c52"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "a27c5805-47de-4dc1-917c-4e3855fbd3cb"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.077bad0f-e9f1-4f6b-94cc-fb021b287f0e.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.077bad0f-e9f1-4f6b-94cc-fb021b287f0e.json
@@ -1,0 +1,133 @@
+{
+    "uuid": [
+        {
+            "value": "077bad0f-e9f1-4f6b-94cc-fb021b287f0e"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "regional_health_care_service_des",
+            "target_type": "node_type",
+            "target_uuid": "d2e27d2b-acb1-471b-a628-4c41c3778729"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-09-23T17:25:17+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "fd71292f-3dc7-409d-b0e8-500204cb005a"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Cardiology"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "fd71292f-3dc7-409d-b0e8-500204cb005a"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-05-10T21:38:24+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-09-23T17:25:17+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Cardiology | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Cardiology | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Cardiology | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": "\/cardiology",
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Care we provide at VA Pittsburgh<\/h3>\r\n\r\n<p>We perform non-invasive tests and&nbsp;minimally invasive cardiac catheterizations in state of the art lab facilities, and we treat you with the most effective medications. Our doctors can provide:<\/p>\r\n\r\n<ul>\r\n\t<li>Evaluation&nbsp;for&nbsp;coronary heart disease, heart valve disease, and heart defects<\/li>\r\n\t<li>Determining how well blood flows through heart vessels or the cause of&nbsp;heart failure<\/li>\r\n\t<li>Non-surgical or minimally invasive operations to open and support heart vessels, such as&nbsp;balloon angioplasty&nbsp;or stents<\/li>\r\n\t<li>Non-invasive monitoring to look for changes in heart rhythm<\/li>\r\n<\/ul>\r\n\r\n<p><a data-entity-substitution=\"canonical\" data-entity-type=\"node\" data-entity-uuid=\"016896fb-cf41-4732-83b0-5d14a4607913\" href=\"\/node\/772\">Learn more about cardiology at VA Pittsburgh<\/a><\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_local_health_care_service_": [
+        {
+            "target_type": "node",
+            "target_uuid": "a888b5f5-9c73-4d7b-ba2c-7717ca79ec4b"
+        }
+    ],
+    "field_region_page": [
+        {
+            "target_type": "node",
+            "target_uuid": "2bddb1a7-6fb1-4503-838d-9c2fcb51c46a"
+        }
+    ],
+    "field_service_name_and_descripti": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "fc8527c3-7ded-47b3-a24c-d54821b23765"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.0a618bda-2a2f-4450-88f2-30d21109d39d.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.0a618bda-2a2f-4450-88f2-30d21109d39d.json
@@ -1,0 +1,137 @@
+{
+    "uuid": [
+        {
+            "value": "0a618bda-2a2f-4450-88f2-30d21109d39d"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "regional_health_care_service_des",
+            "target_type": "node_type",
+            "target_uuid": "d2e27d2b-acb1-471b-a628-4c41c3778729"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-05T16:56:30+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "fd71292f-3dc7-409d-b0e8-500204cb005a"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Recreation and creative arts therapy"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "061ad5e6-930a-4a63-b897-b98d90289003"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-07-25T18:56:05+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-05T16:56:30+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Recreation and creative arts therapy | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Recreation and creative arts therapy | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Recreation and creative arts therapy | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": "\/recreation-and-creative-arts-therapy",
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3><strong>Care we provide at VA Pittsburgh<\/strong><\/h3>\r\n\r\n<p>Recreation and Creative Arts Therapists (Art, Dance Movement, Drama, Music) conduct consult-driven assessments and provide inpatient, outpatient, and telehealth therapeutic interventions with Veterans. Therapist and Veterans collaborate on therapeutic goals to maintain\/improve quality of life by identifying core problems, managing symptoms, and rehabilitating to the greatest extent possible. Our services include:&nbsp;<\/p>\r\n\r\n<ul>\r\n\t<li>Dance Movement Therapy for eating disorders, trauma including military sexual trauma, moral injury, pain &amp; mood management<\/li>\r\n\t<li>Drama Therapy for memory care, gender transition, behavioral challenges, pain &amp; mood management<\/li>\r\n\t<li>Music Therapy for hospice\/palliative care, memory care, substance abuse, aphasia, sleep disorders, pain &amp; mood management, adaptive music instruction<\/li>\r\n\t<li>Recreation Therapy including adaptive sports, leisure education counseling, life skills management, social skills counseling, community integration\/reintegration<\/li>\r\n\t<li>Meaning recreation activities including cognitive skills maintenance, creative arts expression, physical exercise, and social activities<\/li>\r\n<\/ul>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_local_health_care_service_": [
+        {
+            "target_type": "node",
+            "target_uuid": "bd0e24f1-eae2-43a2-8fc3-dea764d6c87b"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "4dfc146c-7010-4e16-8782-e747a504eeb5"
+        }
+    ],
+    "field_region_page": [
+        {
+            "target_type": "node",
+            "target_uuid": "2bddb1a7-6fb1-4503-838d-9c2fcb51c46a"
+        }
+    ],
+    "field_service_name_and_descripti": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "73d2fb6b-d074-42c0-a513-4d26d03ff8a0"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.0b968788-cfb0-41aa-8206-2577105072fa.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.0b968788-cfb0-41aa-8206-2577105072fa.json
@@ -1,0 +1,450 @@
+{
+    "uuid": [
+        {
+            "value": "0b968788-cfb0-41aa-8206-2577105072fa"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_facility",
+            "target_type": "node_type",
+            "target_uuid": "5ecbcf0c-b701-49d5-a47e-08803d42dd80"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-10-22T20:36:35+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "d5b8f9a1-0178-484a-be39-40cb6d91a7a7"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Pittsburgh VA Medical Center-University Drive"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "b02c2ff5-dfe1-4542-beec-3fd410a3f267"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-02-15T20:26:59+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-05T12:52:48+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "VA Pittsburgh Health Care | University Drive Campus | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_description": "Learn about about Pittsburgh VA Medical Center-University Drive, part of the VA Pittsburgh Health Care system, to help prepare you for your visit.",
+            "description": "University Drive VA medical hospital provides primary care as well as acute medical care and other specialty care including surgery, neurology, audiology, dermatology, optometry, and more.",
+            "twitter_cards_title": "Pittsburgh VA Medical Center-University Drive | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "keywords": "VA University Drive medical hospital",
+            "image_src": "http:\/\/default\/sites\/default\/files\/2019-02\/university-drive-consolidation-building2.jpg",
+            "og_title": "Pittsburgh VA Medical Center-University Drive | Veterans Affairs",
+            "og_description": "Learn about about Pittsburgh VA Medical Center-University Drive, part of the VA Pittsburgh Health Care system, to help prepare you for your visit.",
+            "twitter_cards_image": "http:\/\/default\/sites\/default\/files\/2019-02\/university-drive-consolidation-building2.jpg",
+            "og_image_0": "http:\/\/default\/sites\/default\/files\/2019-02\/university-drive-consolidation-building2.jpg"
+        }
+    },
+    "path": [
+        {
+            "alias": "\/pittsburgh-health-care\/locations\/pittsburgh-va-medical-center-university-drive",
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_address": [
+        {
+            "langcode": null,
+            "country_code": "US",
+            "administrative_area": "PA",
+            "locality": "Pittsburgh",
+            "dependent_locality": null,
+            "postal_code": "15240-1003",
+            "sorting_code": null,
+            "address_line1": "University Drive C",
+            "address_line2": null,
+            "organization": null,
+            "given_name": null,
+            "additional_name": null,
+            "family_name": null
+        }
+    ],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_description": [
+        {
+            "value": "Learn about about Pittsburgh VA Medical Center-University Drive, part of the VA Pittsburgh Health Care system, to help prepare you for your visit. "
+        }
+    ],
+    "field_email_subscription": [],
+    "field_facebook": [],
+    "field_facility_classification": [
+        {
+            "value": "1"
+        }
+    ],
+    "field_facility_hours": [
+        {
+            "value": [
+                [
+                    "Mon",
+                    "24\/7"
+                ],
+                [
+                    "Tue",
+                    "24\/7"
+                ],
+                [
+                    "Wed",
+                    "24\/7"
+                ],
+                [
+                    "Thu",
+                    "24\/7"
+                ],
+                [
+                    "Fri",
+                    "24\/7"
+                ],
+                [
+                    "Sat",
+                    "24\/7"
+                ],
+                [
+                    "Sun",
+                    "24\/7"
+                ]
+            ],
+            "format": null,
+            "caption": null
+        }
+    ],
+    "field_facility_locator_api_id": [
+        {
+            "value": "vha_646"
+        }
+    ],
+    "field_flickr": [],
+    "field_instagram": [],
+    "field_intro_text": [
+        {
+            "value": "Our Pittsburgh University Drive campus provides primary care and specialty health services, including hearing care, sleep studies, cardiac surgery and oncology referral centers, and more."
+        }
+    ],
+    "field_local_health_care_service_": [
+        {
+            "target_type": "node",
+            "target_uuid": "e62113c9-7c94-48a6-911a-41e63e43b808"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "ef6567c1-7111-431b-8e53-2f3209de506c"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "af8dcdad-b2e8-41cd-83ee-4945fbd8c9a0"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "975984ef-4be6-4b83-a828-36b879bc3463"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "a888b5f5-9c73-4d7b-ba2c-7717ca79ec4b"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "1ec0e232-4abb-460d-b5f7-112ae612eea8"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "6d30b38b-9705-473b-bddb-76b0cb835829"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "0226b192-3b20-404c-a8d4-f3ae1a7c279c"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "f4d32e3c-eee5-4c37-b3f9-4289b632967c"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "70151b1a-6176-41b2-9774-a71825d6b1f2"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "fba97a2a-de8f-4846-a384-04a8ec50555b"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "97bc639c-1ae1-41d4-ba0b-9513a20ec8ce"
+        },
+        [],
+        [],
+        {
+            "target_type": "node",
+            "target_uuid": "ddabd0e0-0b96-4ffc-816b-25a99338e0f0"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "d2461b77-505d-4f8a-9a07-1024cc9bbe3d"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "7e73815f-ef67-4483-8ac2-62aa605b968b"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "220e5f74-5c79-4462-9dd4-67f9305d6298"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "4fe38129-50e1-47d4-acae-f51d85ac9e18"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "be082d1b-5392-47d6-a65b-4927efd83c4e"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "2c329dde-6736-4705-bd8d-afb1eee964c2"
+        },
+        [],
+        {
+            "target_type": "node",
+            "target_uuid": "196659d0-dcff-45b7-afe3-8de947a1a934"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "b3949e02-0e6a-4a35-b036-4f3749f3321c"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "1effd0d7-c579-4a58-a3ca-4fd17ce0d060"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "234f7c8f-c84e-47c6-ad3c-ec97ed1e18eb"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "80d4cd36-8b7a-47cb-94b1-9ac6e50d1548"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "7cab2517-d064-4901-8ee2-d8db73fc654b"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "e615f046-866b-44e0-a96b-c84c931a69cc"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "0397ed34-18a5-4907-bb12-8526d4504be8"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "590a1d20-ba72-4fe9-8061-59067fb65de0"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "23dd7ec7-2537-49dc-9e03-5fb44df89892"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "f12abb98-89c9-4605-b45d-c8e8920cf62d"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "61c521fa-834b-44c2-adb5-7f4124b11188"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "c41d704b-0fe8-462d-bf7f-b8a92d842089"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "47fa8893-288b-4fa4-8d93-0354854d367b"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "83e125c4-642c-4c70-849c-48882ebb853d"
+        },
+        [],
+        {
+            "target_type": "node",
+            "target_uuid": "0b0e1af6-6ec0-4073-94b1-a99e0383f5c8"
+        },
+        [],
+        {
+            "target_type": "node",
+            "target_uuid": "f33134e5-6ced-4e92-8a77-ec6a67913264"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "15c1bcda-9fa7-4b0f-b238-b0c1d162db0c"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "0699952f-9e65-4654-a90a-8501fe076ae2"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "4dfc146c-7010-4e16-8782-e747a504eeb5"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "61516de8-202a-4ee5-859b-8dd5f7ee92ea"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "644d5e70-1538-4979-8449-f52b4c2a5ca5"
+        }
+    ],
+    "field_location_services": [
+        {
+            "target_type": "paragraph",
+            "target_uuid": "dd090d59-0fe5-4c5e-ba46-443443b9e56e"
+        },
+        {
+            "target_type": "paragraph",
+            "target_uuid": "f7f422cd-cf36-4463-a7c8-997d2218f0ba"
+        },
+        {
+            "target_type": "paragraph",
+            "target_uuid": "7241348a-14a8-4b7a-8c2a-69b99a6c476b"
+        },
+        {
+            "target_type": "paragraph",
+            "target_uuid": "bea4655c-f1e8-4cd1-a5f3-208d808d7911"
+        },
+        {
+            "target_type": "paragraph",
+            "target_uuid": "2ce8568f-bdf2-4736-be10-fb3a37144a20"
+        },
+        {
+            "target_type": "paragraph",
+            "target_uuid": "979bce27-fb3e-4d0f-aa83-abe4338e774e"
+        },
+        {
+            "target_type": "paragraph",
+            "target_uuid": "ea40834e-b567-4da5-981e-848b43d8b69a"
+        },
+        {
+            "target_type": "paragraph",
+            "target_uuid": "70f4e892-3f51-44c9-a2c0-b6f57852f6c6"
+        }
+    ],
+    "field_main_location": [
+        {
+            "value": true
+        }
+    ],
+    "field_media": [
+        {
+            "target_type": "media",
+            "target_uuid": "73c36aab-ba2b-4f04-8302-24b27b0b6837"
+        }
+    ],
+    "field_mental_health_phone": [
+        {
+            "value": "412-360-6600"
+        }
+    ],
+    "field_meta_tags": [
+        {
+            "value": {
+                "description": "University Drive VA medical hospital provides primary care as well as acute medical care and other specialty care including surgery, neurology, audiology, dermatology, optometry, and more.",
+                "keywords": "VA University Drive medical hospital"
+            }
+        }
+    ],
+    "field_meta_title": [
+        {
+            "value": "VA Pittsburgh Health Care | University Drive Campus | Veterans Affairs"
+        }
+    ],
+    "field_nickname_for_this_facility": [
+        {
+            "value": "University Drive campus"
+        }
+    ],
+    "field_operating_status_facility": [
+        {
+            "value": "normal"
+        }
+    ],
+    "field_operating_status_more_info": [],
+    "field_phone_number": [
+        {
+            "value": "866-482-7488"
+        }
+    ],
+    "field_region_page": [
+        {
+            "target_type": "node",
+            "target_uuid": "2bddb1a7-6fb1-4503-838d-9c2fcb51c46a"
+        }
+    ],
+    "field_twitter": []
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.0d73b85c-b637-4527-9e8b-6f78f05a2ab4.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.0d73b85c-b637-4527-9e8b-6f78f05a2ab4.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "0d73b85c-b637-4527-9e8b-6f78f05a2ab4"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-05T14:03:26+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Dental\/oral surgery at H. John Heinz III Department of Veterans Affairs Medical Center"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "fd71292f-3dc7-409d-b0e8-500204cb005a"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-05-10T22:16:07+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-05T14:03:26+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Dental\/oral surgery at H. John Heinz III Department of Veterans Affairs Medical Center | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Dental\/oral surgery at H. John Heinz III Department of Veterans Affairs Medical Center | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Dental\/oral surgery at H. John Heinz III Department of Veterans Affairs Medical Center | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Location and contact information<\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>Ambulatory Care Center<\/strong><br \/>\r\nBuilding 71<br \/>\r\n1st Floor<br \/>\r\n<a data-entity-substitution=\"canonical\" data-entity-type=\"node\" data-entity-uuid=\"a2d3391d-7196-4a3e-bdf5-a71a7b214195\" href=\"\/node\/781\">Map of the Heinz campus<\/a><br \/>\r\n<strong>Phone:&nbsp;<\/strong><a href=\"tel: +14128222130\">412-822-2130<\/a><br \/>\r\n<strong>Phone:&nbsp;<\/strong><a href=\"tel: +14128222131\">412-822-2131<\/a><br \/>\r\n<strong>Phone:&nbsp;<\/strong><a href=\"tel: +14128222132\">412-822-2132<\/a><br \/>\r\n<strong>Hours:&nbsp;<\/strong>Monday \u2013&nbsp;Friday,&nbsp;8:00 a.m. to&nbsp; 4:30 p.m. ET<\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you\u2019ll need to contact your primary care provider first.<\/p>\r\n\r\n<p><strong>Phone:<\/strong>&nbsp;<a href=\"tel: +14128222130\">412-822-2130<\/a><br \/>\r\n<strong>Phone:&nbsp;<\/strong><a href=\"tel: +14128222131\">412-822-2131<\/a><br \/>\r\n<strong>Phone:&nbsp;<\/strong><a href=\"tel: +14128222132\">412-822-2132<\/a><\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "e15ebe41-f7cf-4f2c-a407-3728c341220b"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "fc92e5b2-a387-4421-8943-246140fd497f"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.1022cfac-6ae5-4519-aa95-8820a8dab66a.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.1022cfac-6ae5-4519-aa95-8820a8dab66a.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "1022cfac-6ae5-4519-aa95-8820a8dab66a"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-05T14:38:43+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Laboratory and pathology at Washington County VA Clinic"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "a6af4eb9-ef34-420e-8a20-e2fba1a5afa2"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-05-30T23:22:29+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-05T14:38:43+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Laboratory and pathology at Washington County VA Clinic | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Laboratory and pathology at Washington County VA Clinic | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Laboratory and pathology at Washington County VA Clinic | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3><strong>Location and contact information<\/strong><\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>Phone:&nbsp;<\/strong><a href=\"tel: +1412-360-1572\">412-360-1572<\/a><br \/>\r\n<strong>Hours:&nbsp;<\/strong>Monday \u2013&nbsp;Friday, 8:00 a.m. to 4:30 p.m. ET<\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you\u2019ll need to contact your primary care provider first.<\/p>\r\n\r\n<p><strong>Phone:&nbsp;<\/strong><a href=\"tel: +1412-360-1572\">412-360-1572<\/a><\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "a6826998-b7f7-434f-8999-959b1dab0c52"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "04b5f49e-4a46-481c-a494-bd43a8598094"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.13798a02-e68d-4517-8db8-d670a8adfb15.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.13798a02-e68d-4517-8db8-d670a8adfb15.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "13798a02-e68d-4517-8db8-d670a8adfb15"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-04T19:48:54+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Intimate partner violence at Washington County VA Clinic"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-10-30T20:07:37+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-04T19:48:54+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Intimate partner violence at Washington County VA Clinic | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Intimate partner violence at Washington County VA Clinic | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Intimate partner violence at Washington County VA Clinic | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Location and contact information<\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>Intimate Partner Violence Champion<br \/>\r\nPhone:&nbsp;<\/strong><a href=\"tel: +17247096005\">724-<\/a><a href=\"tel: +17242507790\">250-7790<\/a><br \/>\r\n<strong>Hours:&nbsp;<\/strong>Monday \u2013 Friday, 8:00 a.m. to 4:30 p.m. ET<\/p>\r\n\r\n<p class=\"va-address-block\"><strong>National Domestic Violence 24-hour Hotline<\/strong><br \/>\r\n<strong>Phone:<\/strong>&nbsp;<a href=\"tel: +18007997233\">1-800-799-SAFE (7233)<\/a>&nbsp;or&nbsp;<a href=\"tel: +18007873224\">1-800-787-3224 (TTY)<\/a><br \/>\r\n<strong>Hours:<\/strong>&nbsp;24\/7<\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you\u2019ll need to contact your primary care provider first.<\/p>\r\n\r\n<p><strong>Referral needed?&nbsp;<\/strong>No\u200b\u200b\u200b\u200b\u200b\u200b\u200b<br \/>\r\n<strong>Phone:&nbsp;<\/strong><a href=\"tel: +17247096005\">724-<\/a><a href=\"tel: +17242507790\">250-7790<\/a><\/p>\r\n\r\n<p>&nbsp;<\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "a6826998-b7f7-434f-8999-959b1dab0c52"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "e453f2c1-fe99-427f-a256-92fd1f103c25"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.14e57845-110f-4166-a8cd-8bae2d886913.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.14e57845-110f-4166-a8cd-8bae2d886913.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "14e57845-110f-4166-a8cd-8bae2d886913"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-05T14:17:53+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Caregiver support at H. John Heinz III Department of Veterans Affairs Medical Center"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "a6af4eb9-ef34-420e-8a20-e2fba1a5afa2"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-05-30T21:09:51+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-05T14:17:53+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Caregiver support at H. John Heinz III Department of Veterans Affairs Medical Center | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Caregiver support at H. John Heinz III Department of Veterans Affairs Medical Center | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Caregiver support at H. John Heinz III Department of Veterans Affairs Medical Center | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Location and contact information<\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>Caregiver support coordinator<\/strong><br \/>\r\n\u2028<strong>Phone:<\/strong>&nbsp;\u2028<a href=\"tel: +14128222364\">412-822-2364<\/a><br \/>\r\n<strong>\u2028Hours:<\/strong>&nbsp;Monday \u2013&nbsp;Friday, 8:00 a.m. to 4:30 p.m. ET<br \/>\r\n<strong>Email:&nbsp;<\/strong>sarah.merlina@va.gov<\/p>\r\n\r\n<p class=\"va-address-block\"><strong>VA Caregiver Support Line<\/strong><br \/>\r\n<strong>Phone:<\/strong> <a href=\"tel: +18552603274\">1-855-260-3274<\/a><\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you\u2019ll need to contact your primary care provider first.<\/p>\r\n\r\n<p><strong>Phone:<\/strong>&nbsp;\u2028<a href=\"tel: +14128222364\">412-822-2364<\/a><\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "e15ebe41-f7cf-4f2c-a407-3728c341220b"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "e1b68b35-f5f7-44ec-9808-9a642d669ce5"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.15955ffa-e870-4d3a-bc7b-c6fdb17f80ed.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.15955ffa-e870-4d3a-bc7b-c6fdb17f80ed.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "15955ffa-e870-4d3a-bc7b-c6fdb17f80ed"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-05T13:14:23+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Radiology\/imaging at Washington County VA Clinic"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "a6af4eb9-ef34-420e-8a20-e2fba1a5afa2"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-06-17T21:52:15+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-05T16:55:48+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Radiology\/imaging at Washington County VA Clinic | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Radiology\/imaging at Washington County VA Clinic | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Radiology\/imaging at Washington County VA Clinic | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Location and contact information<\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>Phone:&nbsp;<\/strong><a href=\"tel: +14128223000\">412-822-3000<\/a><br \/>\r\n<strong>Hours:<\/strong>&nbsp;Monday \u2013 Friday, 8:00 a.m. to 4:30 p.m. ET<\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you\u2019ll need to contact your primary care provider first.<\/p>\r\n\r\n<p><strong>Phone:&nbsp;<\/strong><a href=\"tel: +14128223000\">412-822-3000<\/a><\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "a6826998-b7f7-434f-8999-959b1dab0c52"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "72ff4ca7-0310-4786-b7ff-502486b88efc"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.15c1bcda-9fa7-4b0f-b238-b0c1d162db0c.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.15c1bcda-9fa7-4b0f-b238-b0c1d162db0c.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "15c1bcda-9fa7-4b0f-b238-b0c1d162db0c"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-05T14:42:01+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Minority Veteran care at Pittsburgh VA Medical Center-University Drive"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-10-30T18:42:45+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-05T14:42:01+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Minority Veteran care at Pittsburgh VA Medical Center-University Drive | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Minority Veteran care at Pittsburgh VA Medical Center-University Drive | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Minority Veteran care at Pittsburgh VA Medical Center-University Drive | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Location and contact information<\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>Minority Veterans Program<\/strong><br \/>\r\n<strong>Phone:<\/strong>&nbsp;<a href=\"tel: +14128223537\">412-822-3537<\/a><br \/>\r\n<strong>Email:<\/strong>&nbsp;<a href=\"mailto:heather.steele@va.gov\">heather.steele@va.gov<\/a><br \/>\r\n<strong>Hours:&nbsp;<\/strong>Monday \u2013&nbsp;Friday, 7:00 a.m.&nbsp;to 3:30 p.m. ET<\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you\u2019ll need to contact your primary care provider first.<\/p>\r\n\r\n<p><strong>Phone:<\/strong>&nbsp;<a href=\"tel: +14128223537\">412-822-3537<\/a><\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "0b968788-cfb0-41aa-8206-2577105072fa"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "a3dbd92d-9e31-4766-962c-5cb52b8353fe"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.196659d0-dcff-45b7-afe3-8de947a1a934.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.196659d0-dcff-45b7-afe3-8de947a1a934.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "196659d0-dcff-45b7-afe3-8de947a1a934"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-09-10T14:15:47+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "8d4a7bed-f4ba-499f-afd4-8e1cbeadfc4a"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Nephrology, renal, kidney at Pittsburgh VA Medical Center-University Drive"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "a6af4eb9-ef34-420e-8a20-e2fba1a5afa2"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-06-13T23:33:25+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-04T20:26:51+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Nephrology, renal, kidney at Pittsburgh VA Medical Center-University Drive | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Nephrology, renal, kidney at Pittsburgh VA Medical Center-University Drive | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Nephrology, renal, kidney at Pittsburgh VA Medical Center-University Drive | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Location and contact information<\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>Main hospital<\/strong><br \/>\r\nBuilding 1<br \/>\r\n7 East, Room 129<br \/>\r\n<a data-entity-substitution=\"canonical\" data-entity-type=\"node\" data-entity-uuid=\"71ffee52-a47f-4909-ad7e-21ece5728be3\" href=\"\/node\/783\">Map of University Drive campus<\/a><br \/>\r\n<strong>Phone:&nbsp;<\/strong><a href=\"tel: +1412-360-3818\">412-360-3818<\/a><br \/>\r\n<strong>Hours:&nbsp;<\/strong>Monday \u2013&nbsp;Saturday, 5:00 a.m. to 4:00 p.m. ET<\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you\u2019ll need to contact your primary care provider first.<\/p>\r\n\r\n<p><strong>Referral needed?<\/strong> Yes<\/p>\r\n\r\n<p><strong>Walk-ins accepted?<\/strong> No<\/p>\r\n\r\n<p><strong>Phone:&nbsp;<\/strong><a href=\"tel: +1412-360-3818\">412-360-3818<\/a><\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "0b968788-cfb0-41aa-8206-2577105072fa"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "27a7587b-c51b-4eea-956b-587819b1b630"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.19810ce7-1e0d-4548-92da-5d261bccb75c.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.19810ce7-1e0d-4548-92da-5d261bccb75c.json
@@ -1,0 +1,137 @@
+{
+    "uuid": [
+        {
+            "value": "19810ce7-1e0d-4548-92da-5d261bccb75c"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "regional_health_care_service_des",
+            "target_type": "node_type",
+            "target_uuid": "d2e27d2b-acb1-471b-a628-4c41c3778729"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-08-27T17:50:02+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "fd71292f-3dc7-409d-b0e8-500204cb005a"
+        }
+    ],
+    "revision_log": [
+        {
+            "value": "Bulk operation publish revision"
+        }
+    ],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Psychology"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "a6af4eb9-ef34-420e-8a20-e2fba1a5afa2"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-06-17T19:47:39+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-08-27T17:50:02+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Psychology | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Psychology | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Psychology | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": "\/psychology",
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Care we provide at VA Pittsburgh<\/h3>\r\n\r\n<p>Our psychology teams offer consultation, evaluation and treatment for Veterans dealing&nbsp;with:<\/p>\r\n\r\n<ul>\r\n\t<li>Depression (including sadness and grief)&nbsp;and\/or anxiety (including worry and nervousness)<\/li>\r\n\t<li>Addictive behaviors<\/li>\r\n\t<li>Post-traumatic stress disorder and combat related stress disorder<\/li>\r\n\t<li>Emotional problems, such as managing anger, and relationship problems<\/li>\r\n\t<li>Confused thinking, memory problems, and troublesome thoughts or ideas<\/li>\r\n\t<li>Aggressive or self-harming behaviors<\/li>\r\n<\/ul>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_local_health_care_service_": [
+        {
+            "target_type": "node",
+            "target_uuid": "0397ed34-18a5-4907-bb12-8526d4504be8"
+        }
+    ],
+    "field_region_page": [
+        {
+            "target_type": "node",
+            "target_uuid": "2bddb1a7-6fb1-4503-838d-9c2fcb51c46a"
+        }
+    ],
+    "field_service_name_and_descripti": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "2acc2da7-84dc-4cfe-af86-68a87d0f9861"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.1ec0e232-4abb-460d-b5f7-112ae612eea8.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.1ec0e232-4abb-460d-b5f7-112ae612eea8.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "1ec0e232-4abb-460d-b5f7-112ae612eea8"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-05T14:29:57+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Dermatology at Pittsburgh VA Medical Center-University Drive"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "fd71292f-3dc7-409d-b0e8-500204cb005a"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-05-10T22:09:29+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-05T14:29:57+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Dermatology at Pittsburgh VA Medical Center-University Drive | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Dermatology at Pittsburgh VA Medical Center-University Drive | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Dermatology at Pittsburgh VA Medical Center-University Drive | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Location and contact information<\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>Main&nbsp;Hospital<\/strong><br \/>\r\nBuilding 1<br \/>\r\nSuite C<br \/>\r\n<a data-entity-substitution=\"canonical\" data-entity-type=\"node\" data-entity-uuid=\"71ffee52-a47f-4909-ad7e-21ece5728be3\" href=\"\/node\/783\">Map of University Drive campus<\/a><br \/>\r\n<strong>Phone:&nbsp;<\/strong><a href=\"tel: +14123606242\">412-360-6242<\/a><br \/>\r\n<strong>Hours:&nbsp;<\/strong>Monday \u2013&nbsp;Friday, 8:00 a.m. to 4:00 p.m. ET<\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you\u2019ll need to contact your primary care provider first.<\/p>\r\n\r\n<p><strong>Phone:&nbsp;<\/strong><a href=\"tel: +14123606242\">412-360-6242<\/a><\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "0b968788-cfb0-41aa-8206-2577105072fa"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "8bd98812-e275-4740-8d96-a4d293e856b7"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.1ec72de4-d502-42e6-8e11-75d3cc4bd815.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.1ec72de4-d502-42e6-8e11-75d3cc4bd815.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "1ec72de4-d502-42e6-8e11-75d3cc4bd815"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-05T15:26:07+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Women Veteran care at Belmont County VA Clinic"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "fd71292f-3dc7-409d-b0e8-500204cb005a"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-10-30T19:56:34+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-05T15:26:07+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Women Veteran care at Belmont County VA Clinic | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Women Veteran care at Belmont County VA Clinic | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Women Veteran care at Belmont County VA Clinic | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Location and contact information<\/h3>\r\n\r\n<p class=\"va-address-block\">Suite 215<br \/>\r\n<strong>Phone:&nbsp;<\/strong><a href=\"tel: +17406959321\">740-695-9321<\/a><\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you\u2019ll need to contact your primary care provider first.<\/p>\r\n\r\n<p><strong>Phone:&nbsp;<\/strong><a href=\"tel: +17406959321\">740-695-9321<\/a><\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "eac71fd5-260c-4f44-8507-8b803ad2324f"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "1fdda7ec-a660-4fa7-86be-ef2421cb4e6f"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.1effd0d7-c579-4a58-a3ca-4fd17ce0d060.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.1effd0d7-c579-4a58-a3ca-4fd17ce0d060.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "1effd0d7-c579-4a58-a3ca-4fd17ce0d060"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-09-10T14:38:25+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "8d4a7bed-f4ba-499f-afd4-8e1cbeadfc4a"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Patient advocates at Pittsburgh VA Medical Center-University Drive"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "a6af4eb9-ef34-420e-8a20-e2fba1a5afa2"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-06-14T21:06:26+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-09-10T14:38:25+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Patient advocates at Pittsburgh VA Medical Center-University Drive | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Patient advocates at Pittsburgh VA Medical Center-University Drive | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Patient advocates at Pittsburgh VA Medical Center-University Drive | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3 id=\"location-and-contact-informati-633\">Location and contact information<\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>Hours:&nbsp;<\/strong>Monday \u2013 Friday, 8:00 a.m. to 4:30 p.m. ET<\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "0b968788-cfb0-41aa-8206-2577105072fa"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "85ecc815-a3fc-4978-9e7a-2cfd55dc9b72"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.2121b5e0-743d-44bc-a9ea-8947f961500e.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.2121b5e0-743d-44bc-a9ea-8947f961500e.json
@@ -1,0 +1,132 @@
+{
+    "uuid": [
+        {
+            "value": "2121b5e0-743d-44bc-a9ea-8947f961500e"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-05T14:58:50+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "revision_log": [
+        {
+            "value": "Bulk operation publish revision"
+        }
+    ],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "My HealtheVet coordinator at Beaver County VA Clinic"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-11-05T14:57:00+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-05T14:58:50+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "My HealtheVet coordinator at Beaver County VA Clinic | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "My HealtheVet coordinator at Beaver County VA Clinic | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "My HealtheVet coordinator at Beaver County VA Clinic | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Location and contact information<\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>Hours:<\/strong>&nbsp;Thursdays 10:00 a.m. - 11:00 a.m. ET<\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "a1eabfea-4a7e-4d22-ad09-1d85b884145f"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "54d15687-aac6-4457-8560-5d93fe233967"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.220e5f74-5c79-4462-9dd4-67f9305d6298.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.220e5f74-5c79-4462-9dd4-67f9305d6298.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "220e5f74-5c79-4462-9dd4-67f9305d6298"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-05T14:37:37+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Laboratory and pathology at Pittsburgh VA Medical Center-University Drive"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "a6af4eb9-ef34-420e-8a20-e2fba1a5afa2"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-05-30T23:19:28+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-05T14:37:37+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Laboratory and pathology at Pittsburgh VA Medical Center-University Drive | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Laboratory and pathology at Pittsburgh VA Medical Center-University Drive | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Laboratory and pathology at Pittsburgh VA Medical Center-University Drive | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3><strong>Location and contact information<\/strong><\/h3>\r\n\r\n<p class=\"va-address-block\">First and second floors<br \/>\r\n<strong>Phone:&nbsp;<\/strong><a href=\"tel: +1412-360-1572\">412-360-1572<\/a><br \/>\r\n<strong>Hours:&nbsp;<\/strong>Monday \u2013&nbsp;Friday, 8:00 a.m. to 4:30 p.m. ET<\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you\u2019ll need to contact your primary care provider first.<\/p>\r\n\r\n<p><strong>Phone:&nbsp;<\/strong><a href=\"tel: +1412-360-1572\">412-360-1572<\/a><\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "0b968788-cfb0-41aa-8206-2577105072fa"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "04b5f49e-4a46-481c-a494-bd43a8598094"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.234f7c8f-c84e-47c6-ad3c-ec97ed1e18eb.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.234f7c8f-c84e-47c6-ad3c-ec97ed1e18eb.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "234f7c8f-c84e-47c6-ad3c-ec97ed1e18eb"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-05T13:02:27+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Pharmacy at Pittsburgh VA Medical Center-University Drive"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "a6af4eb9-ef34-420e-8a20-e2fba1a5afa2"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-06-14T21:26:15+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-05T13:02:27+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Pharmacy at Pittsburgh VA Medical Center-University Drive | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Pharmacy at Pittsburgh VA Medical Center-University Drive | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Pharmacy at Pittsburgh VA Medical Center-University Drive | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Location and contact information<\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>Pharmacy<\/strong><br \/>\r\nMain Hospital<br \/>\r\nBuilding 1<br \/>\r\n<a data-entity-substitution=\"canonical\" data-entity-type=\"node\" data-entity-uuid=\"71ffee52-a47f-4909-ad7e-21ece5728be3\" href=\"\/node\/783\">Map of University Drive campus<\/a><br \/>\r\n<strong>Phone:&nbsp;<\/strong><a href=\"tel: +1866-400-1242\">866-400-1242<\/a><br \/>\r\n<strong>Hours:<\/strong><br \/>\r\nMonday \u2013&nbsp;Friday, 7:30 a.m. to 9:00 p.m. ET<br \/>\r\nSaturday, Sunday, and holidays, 7:30 a.m. to 4:00 p.m. ET<\/p>\r\n\r\n<p class=\"va-address-block\"><strong>Prescription refills<\/strong><br \/>\r\nMain Hospital<br \/>\r\nBuilding 1<br \/>\r\n<a data-entity-substitution=\"canonical\" data-entity-type=\"node\" data-entity-uuid=\"71ffee52-a47f-4909-ad7e-21ece5728be3\" href=\"\/node\/783\">Map of University Drive campus<\/a><br \/>\r\n<strong>Phone:&nbsp;<\/strong><a href=\"tel: +14128223140\">412-822-3140<\/a><br \/>\r\n<strong>Hours:<\/strong>&nbsp;Monday \u2013 Friday, 8:00 a.m. to 4:30 p.m. ET<\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you\u2019ll need to contact your primary care provider first.<br \/>\r\n<br \/>\r\n<strong>Walk-ins accepted?<\/strong>&nbsp;No<br \/>\r\n<strong>Phone:&nbsp;<\/strong><a href=\"tel: +18664001242\">866-400-1242<br \/>\r\n\u200b\u200b\u200b\u200b\u200b\u200b\u200b<\/a><strong>Phone:&nbsp;<\/strong><a href=\"tel: +14128223140\">412-822-3140<\/a><\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "0b968788-cfb0-41aa-8206-2577105072fa"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "929402f4-2a85-4659-a1bf-900264984903"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.23dd7ec7-2537-49dc-9e03-5fb44df89892.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.23dd7ec7-2537-49dc-9e03-5fb44df89892.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "23dd7ec7-2537-49dc-9e03-5fb44df89892"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-05T17:02:15+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "PTSD treatment at Pittsburgh VA Medical Center-University Drive"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "a6af4eb9-ef34-420e-8a20-e2fba1a5afa2"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-06-17T21:33:08+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-05T17:02:15+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "PTSD treatment at Pittsburgh VA Medical Center-University Drive | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "PTSD treatment at Pittsburgh VA Medical Center-University Drive | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "PTSD treatment at Pittsburgh VA Medical Center-University Drive | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Location and contact information<\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>Consolidation building<\/strong><br \/>\r\nFirst floor<br \/>\r\n<a data-entity-substitution=\"canonical\" data-entity-type=\"node\" data-entity-uuid=\"71ffee52-a47f-4909-ad7e-21ece5728be3\" href=\"\/node\/783\">Map of University Drive campus<\/a><br \/>\r\n<strong>Phone:&nbsp;<\/strong><a href=\"tel: +1412-360-6600\">412-360-6600<\/a><br \/>\r\n<strong>Hours: <\/strong>Monday \u2013 Friday, 8:00 a.m. to 4:30 p.m.<\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you\u2019ll need to contact your primary care provider first.<\/p>\r\n\r\n<p><strong>Referral needed?<\/strong>&nbsp;Yes<br \/>\r\n<strong>Walk-ins accepted?<\/strong>&nbsp;Yes<br \/>\r\n<strong>Phone:&nbsp;<\/strong><a href=\"tel: +1412-360-6600\">412-360-6600<\/a><\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "0b968788-cfb0-41aa-8206-2577105072fa"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "84515c3f-69da-41ed-81d1-083c995c0642"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.24295ad0-0b7a-4a09-b8fa-bf335930c4af.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.24295ad0-0b7a-4a09-b8fa-bf335930c4af.json
@@ -1,0 +1,132 @@
+{
+    "uuid": [
+        {
+            "value": "24295ad0-0b7a-4a09-b8fa-bf335930c4af"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-04T21:19:44+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "revision_log": [
+        {
+            "value": "Bulk operation publish revision"
+        }
+    ],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "HIV\/hepatitis at Washington County VA Clinic"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-11-04T20:18:56+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-04T21:19:44+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "HIV\/hepatitis at Washington County VA Clinic | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "HIV\/hepatitis at Washington County VA Clinic | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "HIV\/hepatitis at Washington County VA Clinic | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3><strong>Location and contact information<\/strong><\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>Crossroads Center<\/strong><br \/>\r\n<strong>Phone:<a href=\"tel: +17242507790\">&nbsp;<\/a><\/strong><a href=\"tel: +17247096005\">7<\/a><a href=\"tel: +17244394990\">24-<\/a><a href=\"tel: +17242507790\">250-7790<\/a><br \/>\r\n<strong>Hours:&nbsp;<\/strong>Monday \u2013&nbsp;Friday, 8:00 a.m. to 4:00 p.m. ET<\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you\u2019ll need to contact your primary care provider first.<\/p>\r\n\r\n<p><strong>Referral needed?<\/strong>&nbsp;Yes<br \/>\r\n<strong>Walk-ins accepted?<\/strong>&nbsp;No<br \/>\r\n<strong>Phone:<a href=\"tel: +17242507790\">&nbsp;<\/a><\/strong><a href=\"tel: +17247096005\">7<\/a><a href=\"tel: +17244394990\">24-<\/a><a href=\"tel: +17242507790\">250-7790<\/a><\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "a6826998-b7f7-434f-8999-959b1dab0c52"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "02e024f0-e9c8-4d11-8d71-6a4f3e91366d"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.24d1ecae-b3e4-4beb-a905-5411d0a5f3b7.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.24d1ecae-b3e4-4beb-a905-5411d0a5f3b7.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "24d1ecae-b3e4-4beb-a905-5411d0a5f3b7"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-04T20:19:39+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "HIV\/hepatitis at Fayette County VA Clinic"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-10-30T19:37:17+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-04T20:19:39+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "HIV\/hepatitis at Fayette County VA Clinic | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "HIV\/hepatitis at Fayette County VA Clinic | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "HIV\/hepatitis at Fayette County VA Clinic | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3><strong>Location and contact information<\/strong><\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>Suite 2<\/strong><br \/>\r\n<strong>Phone: <\/strong><a href=\"tel: +17247096005\">7<\/a><a href=\"tel: +17244394990\">24-439-4990<\/a><br \/>\r\n<strong>Hours:&nbsp;<\/strong>Monday \u2013&nbsp;Friday, 8:00 a.m. to 4:00 p.m. ET<\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you\u2019ll need to contact your primary care provider first.<\/p>\r\n\r\n<p><strong>Referral needed?<\/strong>&nbsp;Yes<br \/>\r\n<strong>Walk-ins accepted?<\/strong>&nbsp;No<br \/>\r\n<strong>Phone: <\/strong><a href=\"tel: +17247096005\">7<\/a><a href=\"tel: +17244394990\">24-439-4990<\/a><\/p>\r\n\r\n<p>&nbsp;<\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "4a987e19-688b-4840-964a-cfefc730fc6c"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "02e024f0-e9c8-4d11-8d71-6a4f3e91366d"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.257fad79-2fcc-4b39-9702-1ecd32847c5a.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.257fad79-2fcc-4b39-9702-1ecd32847c5a.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "257fad79-2fcc-4b39-9702-1ecd32847c5a"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-09-11T17:35:58+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "8d4a7bed-f4ba-499f-afd4-8e1cbeadfc4a"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Primary care at Washington County VA Clinic"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "a6af4eb9-ef34-420e-8a20-e2fba1a5afa2"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-06-17T19:41:36+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-05T01:11:20+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Primary care at Washington County VA Clinic | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Primary care at Washington County VA Clinic | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Primary care at Washington County VA Clinic | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Location and contact information<\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>Primary Care Services<br \/>\r\nPhone:&nbsp;<\/strong><a href=\"tel: +17244394990\">724-250-7790<\/a><br \/>\r\n<strong>Hours: <\/strong>Monday \u2013&nbsp;Friday, 8:00 a.m. to 4:30 p.m. ET<\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment.&nbsp;<\/p>\r\n\r\n<p><strong>Referral needed?<\/strong> No<\/p>\r\n\r\n<p><strong>Phone:&nbsp;<\/strong><a href=\"tel: +17244394990\">724-250-7790<\/a><\/p>\r\n\r\n<p><a class=\"usa-button\" data-entity-substitution=\"canonical\" data-entity-type=\"node\" data-entity-uuid=\"4578cb13-d680-426f-8f2d-ff000e990cb3\" href=\"\/node\/37\">Schedule an appointment online<\/a><\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "a6826998-b7f7-434f-8999-959b1dab0c52"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "c4f23a23-0885-4e1a-b282-48c421fb9203"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.26bd1dc9-e9f5-44eb-a029-73eb54842237.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.26bd1dc9-e9f5-44eb-a029-73eb54842237.json
@@ -1,0 +1,133 @@
+{
+    "uuid": [
+        {
+            "value": "26bd1dc9-e9f5-44eb-a029-73eb54842237"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "regional_health_care_service_des",
+            "target_type": "node_type",
+            "target_uuid": "d2e27d2b-acb1-471b-a628-4c41c3778729"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-12T20:32:35+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "76a324e9-c71f-4524-9a21-ab167cbd4542"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Wheelchair and mobility"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "a8dc1b57-781b-4ae4-8395-feb87b55de1f"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-03-26T21:07:35+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-12T20:32:35+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Wheelchair and mobility | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Wheelchair and mobility | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Wheelchair and mobility | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": "\/wheelchair-and-mobility",
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<p>You can visit our wheelchair and mobility clinic to be evaluated for mobility devices that meet your needs. If you\u2019re already a patient at VA Pittsburgh, you don\u2019t need a primary care referral.<\/p>\r\n\r\n<h3>Learn how to&nbsp;<a href=\"https:\/\/www.va.gov\/pittsburgh-health-care\/become-a-patient\">become a patient with VA Pittsburgh<\/a><\/h3>\r\n\r\n<p>Comprehensive adaptive mobility devices products inservices including:<\/p>\r\n\r\n<ul>\r\n\t<li>Wheelchair training for functional and efficient mobility<\/li>\r\n\t<li>Environmental control<\/li>\r\n\t<li>Specialty Control Devices<\/li>\r\n\t<li>Pressure mapping to identify areas of the body at highest risk of skin breakdown<\/li>\r\n\t<li>Custom molded systems for fixed postural deformities<\/li>\r\n<\/ul>\r\n\r\n<p>To make an appointment, call the clinic at 412-822-2180, or contact us via secure messaging on&nbsp;<a href=\"https:\/\/www.myhealth.va.gov\/mhv-portal-web\/home\">My HealtheVet<\/a>.<\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_local_health_care_service_": [
+        {
+            "target_type": "node",
+            "target_uuid": "676acdff-d8f1-46c8-8ae5-49457f101c7b"
+        }
+    ],
+    "field_region_page": [
+        {
+            "target_type": "node",
+            "target_uuid": "2bddb1a7-6fb1-4503-838d-9c2fcb51c46a"
+        }
+    ],
+    "field_service_name_and_descripti": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "f4eb738f-cafb-428b-9f32-160bfa083367"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.27a7587b-c51b-4eea-956b-587819b1b630.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.27a7587b-c51b-4eea-956b-587819b1b630.json
@@ -1,0 +1,133 @@
+{
+    "uuid": [
+        {
+            "value": "27a7587b-c51b-4eea-956b-587819b1b630"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "regional_health_care_service_des",
+            "target_type": "node_type",
+            "target_uuid": "d2e27d2b-acb1-471b-a628-4c41c3778729"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-04T20:26:51+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "fd71292f-3dc7-409d-b0e8-500204cb005a"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Nephrology, renal and kidney"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "fd71292f-3dc7-409d-b0e8-500204cb005a"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-05-10T21:47:18+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-04T20:26:51+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Nephrology, renal and kidney | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Nephrology, renal and kidney | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Nephrology, renal and kidney | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": "\/nephrology-renal-and-kidney",
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Care we provide at VA Pittsburgh&nbsp;<\/h3>\r\n\r\n<ul>\r\n\t<li>Pre End Stage Renal Disease (ESRD) education<\/li>\r\n\t<li>Onsite dialysis (inpatient and outpatient) and home dialysis and training (Peritoneal and Hemodialysis)<\/li>\r\n\t<li>Continuous Renal Replacement Therapy (CRRT)<\/li>\r\n\t<li>Home patient monitoring<\/li>\r\n\t<li>Kidney transplant evaluation and post-transplant care<\/li>\r\n<\/ul>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_local_health_care_service_": [
+        {
+            "target_type": "node",
+            "target_uuid": "196659d0-dcff-45b7-afe3-8de947a1a934"
+        }
+    ],
+    "field_region_page": [
+        {
+            "target_type": "node",
+            "target_uuid": "2bddb1a7-6fb1-4503-838d-9c2fcb51c46a"
+        }
+    ],
+    "field_service_name_and_descripti": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "ba71e44c-f5b4-46c2-ada4-dc908281dbea"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.28d358e6-3838-40e5-92e1-fd30d33e174d.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.28d358e6-3838-40e5-92e1-fd30d33e174d.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "28d358e6-3838-40e5-92e1-fd30d33e174d"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-05T13:17:59+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Spinal cord injury and disorders at H. John Heinz III Department of Veterans Affairs Medical Center"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "a6af4eb9-ef34-420e-8a20-e2fba1a5afa2"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-06-17T22:38:27+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-05T17:01:36+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Spinal cord injury and disorders at H. John Heinz III Department of Veterans Affairs Medical Center | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Spinal cord injury and disorders at H. John Heinz III Department of Veterans Affairs Medical Center | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Spinal cord injury and disorders at H. John Heinz III Department of Veterans Affairs Medical Center | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Location and contact information<\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>Ambulatory Care Center<\/strong><br \/>\r\n2nd Floor<br \/>\r\n<a data-entity-substitution=\"canonical\" data-entity-type=\"node\" data-entity-uuid=\"a2d3391d-7196-4a3e-bdf5-a71a7b214195\" href=\"\/node\/781\">Map of the Heinz campus<\/a><br \/>\r\n<strong>Phone:&nbsp;<\/strong><a href=\"tel: +14128223000\">412-822-3000<\/a><br \/>\r\n<strong>Hours:&nbsp;<\/strong>Monday &nbsp;8:00 a.m. to 4:30 p.m. ET<br \/>\r\n&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; Wed.&nbsp;\u2014&nbsp;Fri.&nbsp;8:00 a.m. to 4:30 p.m. ET<\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you\u2019ll need to contact your primary care provider first.<\/p>\r\n\r\n<p><strong>Phone:&nbsp;<\/strong><a href=\"tel: +14128223000\">412-822-3000<\/a><\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "e15ebe41-f7cf-4f2c-a407-3728c341220b"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "f88a91dc-918b-40da-a76d-baa3bd19c4ac"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.2ad0413f-9f1f-4ffe-a35c-5c06030e2873.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.2ad0413f-9f1f-4ffe-a35c-5c06030e2873.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "2ad0413f-9f1f-4ffe-a35c-5c06030e2873"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-05T14:48:27+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "My HealtheVet coordinator at H. John Heinz III Department of Veterans Affairs Medical Center"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-10-30T16:47:05+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-05T14:48:27+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "My HealtheVet coordinator at H. John Heinz III Department of Veterans Affairs Medical Center | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "My HealtheVet coordinator at H. John Heinz III Department of Veterans Affairs Medical Center | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "My HealtheVet coordinator at H. John Heinz III Department of Veterans Affairs Medical Center | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Location and contact information<\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>Registration desk<\/strong><br \/>\r\nBuilding 51<br \/>\r\nFirst Floor<br \/>\r\n1A109<br \/>\r\n<a data-entity-substitution=\"canonical\" data-entity-type=\"node\" data-entity-uuid=\"71ffee52-a47f-4909-ad7e-21ece5728be3\" href=\"\/node\/783\">Map of&nbsp;<\/a><a href=\"pittsburgh-health-care\/hj-heinz-iii-campus-map\">H. John Heinz III Campus<\/a><br \/>\r\nPhone:&nbsp;<a href=\"tel: +1412-360-6838\">412-360-6838<\/a><br \/>\r\n<strong>Fax:<\/strong>&nbsp;<a href=\"tel: +1412-360-6447\">412-360-6447<\/a><br \/>\r\n<strong>Hours:<\/strong>&nbsp; Wednesday&nbsp;12:00 p.m. \u2013 12:45 p.m. ET<br \/>\r\n&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; Friday&nbsp;&nbsp;9:00 a.m. \u2013 10:00 a.m. ET<br \/>\r\n&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp;MOVE by secure messaging or phone 1-800-767-1750 code 65074#<\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you\u2019ll need to contact your primary care provider first.<\/p>\r\n\r\n<p><strong>Phone:<\/strong>&nbsp;<a href=\"tel: +1412-360-6838\">412-360-6838<\/a><\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "e15ebe41-f7cf-4f2c-a407-3728c341220b"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "54d15687-aac6-4457-8560-5d93fe233967"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.2c329dde-6736-4705-bd8d-afb1eee964c2.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.2c329dde-6736-4705-bd8d-afb1eee964c2.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "2c329dde-6736-4705-bd8d-afb1eee964c2"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-05T14:48:48+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "My HealtheVet coordinator at Pittsburgh VA Medical Center-University Drive"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "a6af4eb9-ef34-420e-8a20-e2fba1a5afa2"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-06-05T02:47:30+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-05T14:48:48+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "My HealtheVet coordinator at Pittsburgh VA Medical Center-University Drive | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "My HealtheVet coordinator at Pittsburgh VA Medical Center-University Drive | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "My HealtheVet coordinator at Pittsburgh VA Medical Center-University Drive | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Location and contact information<\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>Registration desk<\/strong><br \/>\r\nConsolidation building<br \/>\r\nBuilding 29<br \/>\r\n<a data-entity-substitution=\"canonical\" data-entity-type=\"node\" data-entity-uuid=\"71ffee52-a47f-4909-ad7e-21ece5728be3\" href=\"\/node\/783\">Map of University Drive campus<\/a><br \/>\r\nPhone:&nbsp;<a href=\"tel: +1412-360-6838\">412-360-6838<\/a><br \/>\r\n<strong>Fax:<\/strong>&nbsp;<a href=\"tel: +1412-360-6447\">412-360-6447<\/a><br \/>\r\n<strong>Hours:<\/strong>&nbsp;Monday \u2013&nbsp;Friday, 7:00 a.m. to 3:30 p.m. ET<\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you\u2019ll need to contact your primary care provider first.<\/p>\r\n\r\n<p><strong>Phone:<\/strong>&nbsp;<a href=\"tel: +1412-360-6838\">412-360-6838<\/a><\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "0b968788-cfb0-41aa-8206-2577105072fa"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "54d15687-aac6-4457-8560-5d93fe233967"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.2f44780a-d49c-43e6-87c8-ef66eb9f18ff.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.2f44780a-d49c-43e6-87c8-ef66eb9f18ff.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "2f44780a-d49c-43e6-87c8-ef66eb9f18ff"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-04T19:22:03+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "LGBT Veteran care at H. John Heinz III Department of Veterans Affairs Medical Center"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "a6af4eb9-ef34-420e-8a20-e2fba1a5afa2"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-05-30T23:38:18+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-04T19:22:03+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "LGBT Veteran care at H. John Heinz III Department of Veterans Affairs Medical Center | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "LGBT Veteran care at H. John Heinz III Department of Veterans Affairs Medical Center | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "LGBT Veteran care at H. John Heinz III Department of Veterans Affairs Medical Center | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Location and contact information<\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>Phone:<\/strong> <a href=\"tel: +14128221069\">412-822-1069<\/a><br \/>\r\n<strong>Phone:<\/strong> <a href=\"tel: +14128221069\">412-<\/a><a href=\"tel: +14123601210\">360-1210<\/a><\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you\u2019ll need to contact your primary care provider first.<\/p>\r\n\r\n<p><strong>Phone:<\/strong> <a href=\"tel: +14128221069\">412-822-1069<\/a><br \/>\r\n<strong>Phone:<\/strong> <a href=\"tel: +14128221069\">412-<\/a><a href=\"tel: +14123601210\">360-1210<\/a><\/p>\r\n\r\n<p>&nbsp;<\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "e15ebe41-f7cf-4f2c-a407-3728c341220b"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "5483b3ee-eeb5-4286-9ff1-2d463784031b"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.36f7cebd-08bd-4b77-a5f8-f4904cf210b6.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.36f7cebd-08bd-4b77-a5f8-f4904cf210b6.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "36f7cebd-08bd-4b77-a5f8-f4904cf210b6"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-04T20:22:05+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "HIV\/hepatitis at H. John Heinz III Department of Veterans Affairs Medical Center"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "a6af4eb9-ef34-420e-8a20-e2fba1a5afa2"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-05-30T23:04:27+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-04T20:22:05+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "HIV\/hepatitis at H. John Heinz III Department of Veterans Affairs Medical Center | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "HIV\/hepatitis at H. John Heinz III Department of Veterans Affairs Medical Center | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "HIV\/hepatitis at H. John Heinz III Department of Veterans Affairs Medical Center | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3><strong>Location and contact information<\/strong><\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>Building 71 <\/strong>(<a href=\"https:\/\/www.pittsburgh.va.gov\/about\/heinz-facility-map.asp\">map<\/a>)<br \/>\r\nFirst floor pharmacy<br \/>\r\n<strong>Phone:&nbsp;<\/strong><a href=\"tel: +14123601232\">412-8<\/a><a href=\"tel: +14128223000\">22-3000<\/a><br \/>\r\n<strong>Hours:&nbsp;<\/strong>Monday \u2013&nbsp;Friday, 8:00 a.m. to 4:00 p.m. ET<\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you\u2019ll need to contact your primary care provider first.<\/p>\r\n\r\n<p><strong>Referral needed?<\/strong>&nbsp;Yes<br \/>\r\n<strong>Walk-ins accepted?<\/strong>&nbsp;No<br \/>\r\n<strong>Phone:&nbsp;<\/strong><a href=\"tel: +14123601232\">412-8<\/a><a href=\"tel: +14128223000\">22-3000<\/a><\/p>\r\n\r\n<p>&nbsp;<\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "e15ebe41-f7cf-4f2c-a407-3728c341220b"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "02e024f0-e9c8-4d11-8d71-6a4f3e91366d"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.3d792ced-59f4-4b71-8633-dae36bef86eb.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.3d792ced-59f4-4b71-8633-dae36bef86eb.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "3d792ced-59f4-4b71-8633-dae36bef86eb"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-05T13:28:27+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Travel reimbursement at H. John Heinz III Department of Veterans Affairs Medical Center"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "a6af4eb9-ef34-420e-8a20-e2fba1a5afa2"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-06-14T02:20:48+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-05T17:02:04+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Travel reimbursement at H. John Heinz III Department of Veterans Affairs Medical Center | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Travel reimbursement at H. John Heinz III Department of Veterans Affairs Medical Center | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Travel reimbursement at H. John Heinz III Department of Veterans Affairs Medical Center | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Location and contact information<\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>Building 71<\/strong><br \/>\r\nPatient Registration<br \/>\r\n<a data-entity-substitution=\"canonical\" data-entity-type=\"node\" data-entity-uuid=\"a2d3391d-7196-4a3e-bdf5-a71a7b214195\" href=\"\/node\/781\">Map of the Heinz campus<\/a><br \/>\r\n<strong>Phone:&nbsp;<\/strong><a href=\"tel: +14128222040\">412-822-2040<\/a><br \/>\r\n<strong>Hours:&nbsp;<\/strong>Monday \u2013&nbsp;Friday, 8:00 a.m. to 4:30 p.m. ET<\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you\u2019ll need to contact your primary care provider first.<\/p>\r\n\r\n<p><strong>Referral needed?<\/strong>&nbsp;No<br \/>\r\n<strong>Walk-ins accepted?<\/strong>&nbsp;Yes<br \/>\r\n<strong>Phone:&nbsp;<\/strong><a href=\"tel: +14128222040\">412-822-2040<\/a><\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "e15ebe41-f7cf-4f2c-a407-3728c341220b"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "993ca7e5-e745-4add-890d-66da2f52a52d"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.3e0b8838-033d-475f-919c-8ff55154a23a.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.3e0b8838-033d-475f-919c-8ff55154a23a.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "3e0b8838-033d-475f-919c-8ff55154a23a"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-05T13:13:18+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Radiology\/imaging at Beaver County VA Clinic"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "a6af4eb9-ef34-420e-8a20-e2fba1a5afa2"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-06-17T21:50:34+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-05T16:55:48+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Radiology\/imaging at Beaver County VA Clinic | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Radiology\/imaging at Beaver County VA Clinic | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Radiology\/imaging at Beaver County VA Clinic | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Location and contact information<\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>Phone:&nbsp;<\/strong><a href=\"tel: +14128223000\">412-822-3000<\/a><br \/>\r\n<strong>Hours:<\/strong>&nbsp;Monday \u2013 Friday, 8:00 a.m. to 4:30 p.m. ET<\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you\u2019ll need to contact your primary care provider first.<\/p>\r\n\r\n<p><strong>Phone:&nbsp;<\/strong><a href=\"tel: +14128223000\">412-822-3000<\/a><\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "a1eabfea-4a7e-4d22-ad09-1d85b884145f"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "72ff4ca7-0310-4786-b7ff-502486b88efc"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.3ec5cffb-1025-4d98-9ba5-a22cdbc66698.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.3ec5cffb-1025-4d98-9ba5-a22cdbc66698.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "3ec5cffb-1025-4d98-9ba5-a22cdbc66698"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-04T19:30:27+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Registry exams at H. John Heinz III Department of Veterans Affairs Medical Center"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "a6af4eb9-ef34-420e-8a20-e2fba1a5afa2"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-06-17T22:09:37+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-05T17:00:49+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Registry exams at H. John Heinz III Department of Veterans Affairs Medical Center | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Registry exams at H. John Heinz III Department of Veterans Affairs Medical Center | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Registry exams at H. John Heinz III Department of Veterans Affairs Medical Center | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Location and contact information<\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>Environmental Health Coordinator<\/strong><br \/>\r\nBuilding 50, North<br \/>\r\nGround Floor<br \/>\r\nGA159<br \/>\r\nPhone:&nbsp;<a href=\"tel: +14128221707\">412-822-1707<\/a><br \/>\r\n<strong>Email:&nbsp;<\/strong><a href=\"mailto:douglas.turner5@va.gov\">douglas.turner5@va.gov<\/a><br \/>\r\n<strong>Hours:&nbsp;<\/strong>Wednesday&nbsp;&nbsp;8:00 a.m. to&nbsp;&nbsp;2:00 p.m. ET<br \/>\r\n&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp;Thursday&nbsp;8:00 a.m. to&nbsp;&nbsp;2:00 p.m. ET<\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you\u2019ll need to contact your primary care provider first.<\/p>\r\n\r\n<p><strong>Referral needed?<\/strong>&nbsp;No<br \/>\r\n<strong>Walk-ins accepted?<\/strong>&nbsp;Yes<br \/>\r\n<strong>Phone:<\/strong>&nbsp;<a href=\"tel: +14128221707\">412-822-1707<\/a><\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "e15ebe41-f7cf-4f2c-a407-3728c341220b"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "3e92eaa8-bbf8-4173-84f8-d187b281d548"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.3f49a39f-3457-4e19-9433-e2d16015d471.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.3f49a39f-3457-4e19-9433-e2d16015d471.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "3f49a39f-3457-4e19-9433-e2d16015d471"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-09-10T11:05:55+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "8d4a7bed-f4ba-499f-afd4-8e1cbeadfc4a"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Rehabilitation and prosthetics at H. John Heinz III Department of Veterans Affairs Medical Center"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "a6af4eb9-ef34-420e-8a20-e2fba1a5afa2"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-06-17T22:17:33+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-05T01:21:52+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Rehabilitation and prosthetics at H. John Heinz III Department of Veterans Affairs Medical Center | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Rehabilitation and prosthetics at H. John Heinz III Department of Veterans Affairs Medical Center | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Rehabilitation and prosthetics at H. John Heinz III Department of Veterans Affairs Medical Center | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Location and contact information<\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>Prosthetics and prosthetics warehouse<\/strong><br \/>\r\nBuilding 49<br \/>\r\nFirst floor, room 1D111A<br \/>\r\n<a data-entity-substitution=\"canonical\" data-entity-type=\"node\" data-entity-uuid=\"a2d3391d-7196-4a3e-bdf5-a71a7b214195\" href=\"\/node\/781\">Map of the Heinz campus<\/a><br \/>\r\n<strong>Phone:&nbsp;<\/strong><a href=\"tel: +14128223728\">412-822-3728<\/a><br \/>\r\n<strong>Hours:&nbsp;<\/strong>Monday \u2013&nbsp;Friday, 7:30 a.m. to 4:00 p.m. ET<\/p>\r\n\r\n<p class=\"va-address-block\"><strong>Orthotics clinic in ambulatory care center<\/strong><br \/>\r\nBuilding 71<br \/>\r\nFirst floor, room 1B119<br \/>\r\n<strong>Phone:<\/strong> <a href=\"tel:4128222110\">412-822-2110<\/a><\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you\u2019ll need to contact your primary care provider first.<\/p>\r\n\r\n<p><strong>Referral needed?<\/strong> Yes<\/p>\r\n\r\n<p><strong>Walk-ins accepted?<\/strong> Yes, at the prosthetics and prosthetics warehouse in building 49 only.<\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "e15ebe41-f7cf-4f2c-a407-3728c341220b"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "ddd4532d-9c31-4f87-af7f-ecbc83116592"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.42c48aee-830b-4355-93eb-a407ba9ded72.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.42c48aee-830b-4355-93eb-a407ba9ded72.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "42c48aee-830b-4355-93eb-a407ba9ded72"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-09-11T17:36:01+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "8d4a7bed-f4ba-499f-afd4-8e1cbeadfc4a"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Primary care at Beaver County VA Clinic"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "a6af4eb9-ef34-420e-8a20-e2fba1a5afa2"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-06-17T19:35:25+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-05T01:11:20+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Primary care at Beaver County VA Clinic | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Primary care at Beaver County VA Clinic | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Primary care at Beaver County VA Clinic | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Location and contact information<\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>Primary Care Services<br \/>\r\nPhone:&nbsp;<\/strong><a href=\"tel:724-709-6005\">724-709-6005<\/a><strong><a href=\"tel:724-709-6005\">&nbsp;<\/a><br \/>\r\nHours: <\/strong>Monday \u2013&nbsp;Friday, 8:00 a.m. to 4:30 p.m. ET<\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment.&nbsp;<\/p>\r\n\r\n<p><strong>Referral needed?<\/strong> No<\/p>\r\n\r\n<p><strong>Phone:&nbsp;<\/strong><a href=\"tel:724-709-6005\">724-709-6005<\/a><strong><a href=\"tel:724-709-6005\">&nbsp;<\/a><\/strong><br \/>\r\n<br \/>\r\n<a class=\"usa-button\" data-entity-substitution=\"canonical\" data-entity-type=\"node\" data-entity-uuid=\"4578cb13-d680-426f-8f2d-ff000e990cb3\" href=\"\/node\/37\">Schedule an appointment online<\/a><\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "a1eabfea-4a7e-4d22-ad09-1d85b884145f"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "c4f23a23-0885-4e1a-b282-48c421fb9203"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.444fedd1-b1a2-4d5c-bec5-b5bc9f6317c1.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.444fedd1-b1a2-4d5c-bec5-b5bc9f6317c1.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "444fedd1-b1a2-4d5c-bec5-b5bc9f6317c1"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-05T14:42:36+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Minority Veteran care at Belmont County VA Clinic"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-10-30T18:44:11+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-05T14:42:36+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Minority Veteran care at Belmont County VA Clinic | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Minority Veteran care at Belmont County VA Clinic | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Minority Veteran care at Belmont County VA Clinic | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Location and contact information<\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>Minority Veterans Program<\/strong><br \/>\r\n<strong>Phone:<\/strong>&nbsp;<a href=\"tel: +14128223537\">412-822-3537<\/a><br \/>\r\n<strong>Email:<\/strong>&nbsp;<a href=\"mailto:heather.steele@va.gov\">heather.steele@va.gov<\/a><br \/>\r\n<strong>Hours:&nbsp;<\/strong>Monday \u2013&nbsp;Friday, 7:00 a.m.&nbsp;to 3:30 p.m. ET<\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you\u2019ll need to contact your primary care provider first.<\/p>\r\n\r\n<p><strong>Phone:<\/strong>&nbsp;<a href=\"tel: +14128223537\">412-822-3537<\/a><\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "eac71fd5-260c-4f44-8507-8b803ad2324f"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "a3dbd92d-9e31-4766-962c-5cb52b8353fe"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.45fa1aaa-22f3-44a9-944d-0aef13efbc9a.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.45fa1aaa-22f3-44a9-944d-0aef13efbc9a.json
@@ -1,0 +1,133 @@
+{
+    "uuid": [
+        {
+            "value": "45fa1aaa-22f3-44a9-944d-0aef13efbc9a"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "regional_health_care_service_des",
+            "target_type": "node_type",
+            "target_uuid": "d2e27d2b-acb1-471b-a628-4c41c3778729"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-10-30T21:54:43+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "fd71292f-3dc7-409d-b0e8-500204cb005a"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Optometry"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "fd71292f-3dc7-409d-b0e8-500204cb005a"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-05-10T21:48:25+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-10-30T21:54:43+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Optometry | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Optometry | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Optometry | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": "\/optometry",
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Care we provide at VA Pittsburgh<\/h3>\r\n\r\n<ul>\r\n\t<li>Comprehensive evaluation of ocular diseases<\/li>\r\n\t<li>Subspecialty services such as retina, cornea, and glaucoma evaluation and treatment<\/li>\r\n\t<li>Low vision services<\/li>\r\n\t<li>Diabetic eye exams<\/li>\r\n<\/ul>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_local_health_care_service_": [
+        {
+            "target_type": "node",
+            "target_uuid": "0226b192-3b20-404c-a8d4-f3ae1a7c279c"
+        }
+    ],
+    "field_region_page": [
+        {
+            "target_type": "node",
+            "target_uuid": "2bddb1a7-6fb1-4503-838d-9c2fcb51c46a"
+        }
+    ],
+    "field_service_name_and_descripti": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "eb25f62a-778b-429d-a67f-075e98a46b52"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.47fa8893-288b-4fa4-8d93-0354854d367b.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.47fa8893-288b-4fa4-8d93-0354854d367b.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "47fa8893-288b-4fa4-8d93-0354854d367b"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-09-10T15:51:19+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "8bea8773-6a06-4afd-99b5-1dfa7a2192ea"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Telehealth at Pittsburgh VA Medical Center-University Drive"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "a6af4eb9-ef34-420e-8a20-e2fba1a5afa2"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-06-17T23:37:56+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-05T01:26:21+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Telehealth at Pittsburgh VA Medical Center-University Drive | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Telehealth at Pittsburgh VA Medical Center-University Drive | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Telehealth at Pittsburgh VA Medical Center-University Drive | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Location and contact information<\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>Phone:&nbsp;<\/strong><a href=\"tel:+14128222222\">412-822-2222<\/a><br \/>\r\n<strong>Hours:&nbsp;<\/strong>Monday \u2013&nbsp;Friday, 8:00 a.m. to 4:30 p.m. ET<\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you\u2019ll need to contact your primary care provider first.<\/p>\r\n\r\n<p><strong>Phone:<\/strong> <a href=\"tel:+18664827488\">866-482-7488<\/a><\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "0b968788-cfb0-41aa-8206-2577105072fa"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "7bc4ce20-f573-4ea6-b361-b3060be2e2ea"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.4a987e19-688b-4840-964a-cfefc730fc6c.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.4a987e19-688b-4840-964a-cfefc730fc6c.json
@@ -1,0 +1,315 @@
+{
+    "uuid": [
+        {
+            "value": "4a987e19-688b-4840-964a-cfefc730fc6c"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_facility",
+            "target_type": "node_type",
+            "target_uuid": "5ecbcf0c-b701-49d5-a47e-08803d42dd80"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-10-29T21:19:52+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "efa9900b-7446-41bf-b6a9-a99287ae2235"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Fayette County VA Clinic"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "b02c2ff5-dfe1-4542-beec-3fd410a3f267"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-02-15T20:33:52+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-10-31T19:55:51+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "VA Pittsburgh Health Care | Fayette County Clinic | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_description": "Learn details about about the Fayette County outpatient clinic, part of the VA Pittsburgh Health Care system, to help you prepare for your visit.",
+            "description": "Fayette County Outpatient VA Clinic - where you can receive general medical care, physical exams, laboratory, radiology, dietary and podiatry services.",
+            "twitter_cards_title": "Fayette County VA Clinic | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "keywords": "VA Outpatient Clinic Fayette County",
+            "image_src": "http:\/\/default\/sites\/default\/files\/2019-06\/Fayette%20County%20VA%20Outpatient%20Clinic_20190423_0002.jpg",
+            "og_title": "Fayette County VA Clinic | Veterans Affairs",
+            "og_description": "Learn details about about the Fayette County outpatient clinic, part of the VA Pittsburgh Health Care system, to help you prepare for your visit.",
+            "twitter_cards_image": "http:\/\/default\/sites\/default\/files\/2019-06\/Fayette%20County%20VA%20Outpatient%20Clinic_20190423_0002.jpg",
+            "og_image_0": "http:\/\/default\/sites\/default\/files\/2019-06\/Fayette%20County%20VA%20Outpatient%20Clinic_20190423_0002.jpg"
+        }
+    },
+    "path": [
+        {
+            "alias": "\/pittsburgh-health-care\/locations\/fayette-county-va-clinic",
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_address": [
+        {
+            "langcode": null,
+            "country_code": "US",
+            "administrative_area": "PA",
+            "locality": "Uniontown",
+            "dependent_locality": null,
+            "postal_code": "15401-2200",
+            "sorting_code": null,
+            "address_line1": "627 Pittsburgh Road, Suite 2",
+            "address_line2": null,
+            "organization": null,
+            "given_name": null,
+            "additional_name": null,
+            "family_name": null
+        }
+    ],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_description": [
+        {
+            "value": "Learn details about about the Fayette County outpatient clinic, part of the VA Pittsburgh Health Care system, to help you prepare for your visit. "
+        }
+    ],
+    "field_email_subscription": [],
+    "field_facebook": [],
+    "field_facility_classification": [
+        {
+            "value": "4"
+        }
+    ],
+    "field_facility_hours": [
+        {
+            "value": [
+                [
+                    "Mon",
+                    "800AM-430PM"
+                ],
+                [
+                    "Tue",
+                    "800AM-430PM"
+                ],
+                [
+                    "Wed",
+                    "800AM-430PM"
+                ],
+                [
+                    "Thu",
+                    "800AM-430PM"
+                ],
+                [
+                    "Fri",
+                    "800AM-430PM"
+                ],
+                [
+                    "Sat",
+                    "Closed"
+                ],
+                [
+                    "Sun",
+                    "Closed"
+                ]
+            ],
+            "format": null,
+            "caption": null
+        }
+    ],
+    "field_facility_locator_api_id": [
+        {
+            "value": "vha_646GE"
+        }
+    ],
+    "field_flickr": [],
+    "field_instagram": [],
+    "field_intro_text": [
+        {
+            "value": "The Fayette County outpatient clinic offers Veterans general medical care, including physical exams, lab work, x-rays, nutrition counseling, and foot care."
+        }
+    ],
+    "field_local_health_care_service_": [
+        {
+            "target_type": "node",
+            "target_uuid": "7e94a44e-e243-4f38-8a9f-8f17d705db88"
+        },
+        [],
+        {
+            "target_type": "node",
+            "target_uuid": "7ae2bb0d-7fd8-4f0f-bfd6-4a3c77752872"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "b14b30e7-2b21-4ae9-9e57-c93f4901e3b0"
+        },
+        [],
+        {
+            "target_type": "node",
+            "target_uuid": "f2151138-ae2f-45c3-9c70-4b4e40a78182"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "a7f56ad4-acb0-4def-b7f0-34dc9638c107"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "b381eb3a-62ce-402f-8799-ce22f61f3e34"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "9217736f-deec-4154-b8e3-9dcb1f285b61"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "b49759f3-5655-41b0-b6ec-70be3690bc6d"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "24d1ecae-b3e4-4beb-a905-5411d0a5f3b7"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "59a6a7e2-de40-41a8-8c84-76529ae089cf"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "8bd1d7de-13f7-4430-bde1-e1fad573c439"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "9326c56e-0435-470e-b372-602a019ebe3a"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "6e4f6862-2a5e-49d2-8a4c-adcb954c0ad0"
+        }
+    ],
+    "field_location_services": [
+        {
+            "target_type": "paragraph",
+            "target_uuid": "32b1d373-a32e-46f3-8329-4f42d95d8fb7"
+        },
+        {
+            "target_type": "paragraph",
+            "target_uuid": "a0a57c48-86e4-4d9d-8a33-df479aacb882"
+        },
+        {
+            "target_type": "paragraph",
+            "target_uuid": "d0a9d603-e89a-43ca-bd45-c255861d836b"
+        }
+    ],
+    "field_main_location": [
+        {
+            "value": false
+        }
+    ],
+    "field_media": [
+        {
+            "target_type": "media",
+            "target_uuid": "f89fef08-d2bf-424e-bc7d-22eb2fbed349"
+        }
+    ],
+    "field_mental_health_phone": [
+        {
+            "value": "412-360-6600"
+        }
+    ],
+    "field_meta_tags": [
+        {
+            "value": {
+                "description": "Fayette County Outpatient VA Clinic - where you can receive general medical care, physical exams, laboratory, radiology, dietary and podiatry services.",
+                "keywords": "VA Outpatient Clinic Fayette County"
+            }
+        }
+    ],
+    "field_meta_title": [
+        {
+            "value": "VA Pittsburgh Health Care | Fayette County Clinic | Veterans Affairs"
+        }
+    ],
+    "field_nickname_for_this_facility": [
+        {
+            "value": "Fayette County clinic"
+        }
+    ],
+    "field_operating_status_facility": [
+        {
+            "value": "normal"
+        }
+    ],
+    "field_operating_status_more_info": [],
+    "field_phone_number": [
+        {
+            "value": "724-439-4990"
+        }
+    ],
+    "field_region_page": [
+        {
+            "target_type": "node",
+            "target_uuid": "2bddb1a7-6fb1-4503-838d-9c2fcb51c46a"
+        }
+    ],
+    "field_twitter": []
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.4aa8d80c-c3b0-4e10-9b0b-e22d71b3d6d4.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.4aa8d80c-c3b0-4e10-9b0b-e22d71b3d6d4.json
@@ -1,0 +1,137 @@
+{
+    "uuid": [
+        {
+            "value": "4aa8d80c-c3b0-4e10-9b0b-e22d71b3d6d4"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "regional_health_care_service_des",
+            "target_type": "node_type",
+            "target_uuid": "d2e27d2b-acb1-471b-a628-4c41c3778729"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-08-27T17:50:02+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "fd71292f-3dc7-409d-b0e8-500204cb005a"
+        }
+    ],
+    "revision_log": [
+        {
+            "value": "Bulk operation publish revision"
+        }
+    ],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Psychiatry"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "b02c2ff5-dfe1-4542-beec-3fd410a3f267"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-03-01T01:51:14+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-08-27T17:50:02+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Psychiatry | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Psychiatry | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Psychiatry | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": "\/psychiatry",
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Care we provide at VA Pittsburgh<\/h3>\r\n\r\n<p>Our psychiatry teams offer consultation, evaluation and treatment for Veterans dealing&nbsp;with:<\/p>\r\n\r\n<ul>\r\n\t<li>Depression (including sadness and grief)&nbsp;and\/or anxiety (including worry and nervousness)<\/li>\r\n\t<li>Addictive behaviors<\/li>\r\n\t<li>Post-traumatic stress disorder and combat related stress disorder<\/li>\r\n\t<li>Emotional problems, such as managing anger, and relationship problems<\/li>\r\n\t<li>Confused thinking, memory problems, and troublesome thoughts or ideas<\/li>\r\n\t<li>Aggressive or self-harming behaviors<\/li>\r\n<\/ul>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_local_health_care_service_": [
+        {
+            "target_type": "node",
+            "target_uuid": "590a1d20-ba72-4fe9-8061-59067fb65de0"
+        }
+    ],
+    "field_region_page": [
+        {
+            "target_type": "node",
+            "target_uuid": "2bddb1a7-6fb1-4503-838d-9c2fcb51c46a"
+        }
+    ],
+    "field_service_name_and_descripti": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "e93e002b-25d8-4f00-ad39-945ae41a182c"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.4cad2f34-1e07-49b9-a021-dd0d10016149.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.4cad2f34-1e07-49b9-a021-dd0d10016149.json
@@ -1,0 +1,137 @@
+{
+    "uuid": [
+        {
+            "value": "4cad2f34-1e07-49b9-a021-dd0d10016149"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "regional_health_care_service_des",
+            "target_type": "node_type",
+            "target_uuid": "d2e27d2b-acb1-471b-a628-4c41c3778729"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-05T00:58:33+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "fd71292f-3dc7-409d-b0e8-500204cb005a"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Physical medicine and rehabilitation"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "fd71292f-3dc7-409d-b0e8-500204cb005a"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-05-10T21:49:19+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-05T00:58:33+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Physical medicine and rehabilitation | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Physical medicine and rehabilitation | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Physical medicine and rehabilitation | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": "\/physical-medicine-and-rehabilitation",
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Care we provide at VA Pittsburgh<\/h3>\r\n\r\n<ul>\r\n\t<li>Outpatient physical and occupational therapy<\/li>\r\n\t<li>Physical medicine and rehabilitation<\/li>\r\n\t<li>Blind and low vision services<\/li>\r\n\t<li>Traumatic brain injury\/polytrauma services<\/li>\r\n\t<li>Geriatric evaluation &amp; management<\/li>\r\n\t<li>Wheelchair and power mobility services<\/li>\r\n<\/ul>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_local_health_care_service_": [
+        {
+            "target_type": "node",
+            "target_uuid": "b874472c-c66c-4f88-a789-ba31d33d2e11"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "80d4cd36-8b7a-47cb-94b1-9ac6e50d1548"
+        }
+    ],
+    "field_region_page": [
+        {
+            "target_type": "node",
+            "target_uuid": "2bddb1a7-6fb1-4503-838d-9c2fcb51c46a"
+        }
+    ],
+    "field_service_name_and_descripti": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "157c46b3-6307-444c-96cc-20323c67077c"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.4dfc146c-7010-4e16-8782-e747a504eeb5.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.4dfc146c-7010-4e16-8782-e747a504eeb5.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "4dfc146c-7010-4e16-8782-e747a504eeb5"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-04T19:26:16+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Recreation and creative arts therapy at Pittsburgh VA Medical Center-University Drive"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "fd71292f-3dc7-409d-b0e8-500204cb005a"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-10-30T20:19:31+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-05T16:56:30+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Recreation and creative arts therapy at Pittsburgh VA Medical Center-University Drive | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Recreation and creative arts therapy at Pittsburgh VA Medical Center-University Drive | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Recreation and creative arts therapy at Pittsburgh VA Medical Center-University Drive | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Location and contact information<\/h3>\r\n\r\n<p><strong>Behavioral Health<br \/>\r\nMedical Office<\/strong><br \/>\r\nWomen's Health Clinic<br \/>\r\n<a data-entity-substitution=\"canonical\" data-entity-type=\"node\" data-entity-uuid=\"a2d3391d-7196-4a3e-bdf5-a71a7b214195\" href=\"\/node\/781\">Map of Heinz campus<\/a><br \/>\r\n<strong>Phone:<\/strong>&nbsp;<a href=\"tel: +14128223080\">412-822-3080<\/a><br \/>\r\n<strong>Hours:&nbsp;<\/strong>Inpatient and outpatient referrals<\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you\u2019ll need to contact your primary care provider first.<\/p>\r\n\r\n<p><strong>Phone:<\/strong>&nbsp;<a href=\"tel: +14128223080\">412-822-3080<\/a><\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "0b968788-cfb0-41aa-8206-2577105072fa"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "0a618bda-2a2f-4450-88f2-30d21109d39d"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.4fb285c4-c72c-4220-9487-99b70bc0f8aa.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.4fb285c4-c72c-4220-9487-99b70bc0f8aa.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "4fb285c4-c72c-4220-9487-99b70bc0f8aa"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-05T15:23:14+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Women Veteran care at Beaver County VA Clinic"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "fd71292f-3dc7-409d-b0e8-500204cb005a"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-10-30T19:55:36+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-05T15:23:14+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Women Veteran care at Beaver County VA Clinic | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Women Veteran care at Beaver County VA Clinic | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Women Veteran care at Beaver County VA Clinic | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Location and contact information<\/h3>\r\n\r\n<p class=\"va-address-block\">Suite 110<br \/>\r\n<strong>Phone:<\/strong>&nbsp;<a href=\"tel: +724-709-6005\">724-709-6005<\/a><\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you\u2019ll need to contact your primary care provider first.<\/p>\r\n\r\n<p><strong>Phone:<\/strong>&nbsp;<a href=\"tel:+724-709-6005\">724-709-6005<\/a><\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "a1eabfea-4a7e-4d22-ad09-1d85b884145f"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "1fdda7ec-a660-4fa7-86be-ef2421cb4e6f"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.4fe38129-50e1-47d4-acae-f51d85ac9e18.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.4fe38129-50e1-47d4-acae-f51d85ac9e18.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "4fe38129-50e1-47d4-acae-f51d85ac9e18"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-04T19:22:21+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "LGBT Veteran care at Pittsburgh VA Medical Center-University Drive"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "a6af4eb9-ef34-420e-8a20-e2fba1a5afa2"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-05-30T23:36:20+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-04T19:22:21+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "LGBT Veteran care at Pittsburgh VA Medical Center-University Drive | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "LGBT Veteran care at Pittsburgh VA Medical Center-University Drive | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "LGBT Veteran care at Pittsburgh VA Medical Center-University Drive | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Location and contact information<\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>Phone:<\/strong> <a href=\"tel: +14128221069\">412-822-1069<\/a><br \/>\r\n<strong>Phone:<\/strong> <a href=\"tel: +14128221069\">412-<\/a><a href=\"tel: +14123601210\">360-1210<\/a><\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you\u2019ll need to contact your primary care provider first.<\/p>\r\n\r\n<p><strong>Phone:<\/strong> <a href=\"tel: +14128221069\">412-822-1069<\/a><br \/>\r\n<strong>Phone:<\/strong> <a href=\"tel: +14128221069\">412-<\/a><a href=\"tel: +14123601210\">360-1210<\/a><\/p>\r\n\r\n<p>&nbsp;<\/p>\r\n\r\n<p>&nbsp;<\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "0b968788-cfb0-41aa-8206-2577105072fa"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "5483b3ee-eeb5-4286-9ff1-2d463784031b"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.522a27a3-cb38-4f07-8c03-9263015c6b50.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.522a27a3-cb38-4f07-8c03-9263015c6b50.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "522a27a3-cb38-4f07-8c03-9263015c6b50"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-04T19:00:29+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "MOVE! weight management at Belmont County VA Clinic"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "a6af4eb9-ef34-420e-8a20-e2fba1a5afa2"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-06-05T02:02:47+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-04T19:00:29+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "MOVE! weight management at Belmont County VA Clinic | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "MOVE! weight management at Belmont County VA Clinic | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "MOVE! weight management at Belmont County VA Clinic | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Location and contact information<\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>MOVE! group meetings<\/strong><br \/>\r\n<strong>Phone:&nbsp;<\/strong><a href=\"tel: +14128223114\">412-822-3114<\/a><br \/>\r\n<strong>Email:&nbsp;<\/strong><a href=\"mailto:melanie.erskine@va.gov\">melanie.erskine@va.gov<\/a><br \/>\r\n<strong>Hours:&nbsp;<\/strong>Fridays,<strong>&nbsp;<\/strong>9:00 a.m. to 10:30 a.m. ET<\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you\u2019ll need to contact your primary care provider first.<br \/>\r\n<br \/>\r\n<strong>Phone:&nbsp;<\/strong><a href=\"tel: +14128223114\">412-822-3114<\/a><br \/>\r\n<strong>Email:&nbsp;<\/strong><a href=\"mailto:melanie.erskine@va.gov\">melanie.erskine@va.gov<\/a><br \/>\r\n<br \/>\r\n<a class=\"usa-button\" data-entity-substitution=\"canonical\" data-entity-type=\"node\" data-entity-uuid=\"4578cb13-d680-426f-8f2d-ff000e990cb3\" href=\"\/node\/37\">Schedule an appointment online<\/a><\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "eac71fd5-260c-4f44-8507-8b803ad2324f"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "a27c5805-47de-4dc1-917c-4e3855fbd3cb"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.54d15687-aac6-4457-8560-5d93fe233967.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.54d15687-aac6-4457-8560-5d93fe233967.json
@@ -1,0 +1,153 @@
+{
+    "uuid": [
+        {
+            "value": "54d15687-aac6-4457-8560-5d93fe233967"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "regional_health_care_service_des",
+            "target_type": "node_type",
+            "target_uuid": "d2e27d2b-acb1-471b-a628-4c41c3778729"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-09-10T20:35:30+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "8d4a7bed-f4ba-499f-afd4-8e1cbeadfc4a"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "My HealtheVet coordinator"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "a8dc1b57-781b-4ae4-8395-feb87b55de1f"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-03-26T16:12:36+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-05T14:57:00+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "My HealtheVet coordinator | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "My HealtheVet coordinator | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "My HealtheVet coordinator | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": "\/my-healthevet-coordinator",
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3 dir=\"LTR\">Care we provide at VA Pittsburgh<\/h3>\r\n\r\n<p dir=\"LTR\">My HealtheVet coordinators provide assistance with&nbsp;My HealtheVet by phone or in person. They can give you:<\/p>\r\n\r\n<ul dir=\"ltr\">\r\n\t<li>Answers to your questions about My HealtheVet<\/li>\r\n\t<li>Help with in-person authentication (IPA), which is required for some features of My HealtheVet&nbsp;(also available in person)<\/li>\r\n\t<li>Help resolving&nbsp;issues with your account<\/li>\r\n<\/ul>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_local_health_care_service_": [
+        {
+            "target_type": "node",
+            "target_uuid": "2c329dde-6736-4705-bd8d-afb1eee964c2"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "2ad0413f-9f1f-4ffe-a35c-5c06030e2873"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "808fb0ce-2019-444a-b19f-809e98f72106"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "61f79e11-a30b-485c-baeb-3f91aa142a8e"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "c0c47dc3-a90c-44b8-a227-e1fc6f583915"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "2121b5e0-743d-44bc-a9ea-8947f961500e"
+        }
+    ],
+    "field_region_page": [
+        {
+            "target_type": "node",
+            "target_uuid": "2bddb1a7-6fb1-4503-838d-9c2fcb51c46a"
+        }
+    ],
+    "field_service_name_and_descripti": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "603b9ef3-2516-4acc-ae25-ad1fc2ec6291"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.5571a858-a6a4-4e9d-a110-110b1c5d7ebf.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.5571a858-a6a4-4e9d-a110-110b1c5d7ebf.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "5571a858-a6a4-4e9d-a110-110b1c5d7ebf"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-05T14:39:54+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Mental health care at H. John Heinz III Department of Veterans Affairs Medical Center"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "fd71292f-3dc7-409d-b0e8-500204cb005a"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-05-10T22:16:26+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-05T14:39:54+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Mental health care at H. John Heinz III Department of Veterans Affairs Medical Center | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Mental health care at H. John Heinz III Department of Veterans Affairs Medical Center | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Mental health care at H. John Heinz III Department of Veterans Affairs Medical Center | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3><strong>Location and contact information<\/strong><\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>Transition and care management for returning Veterans (OIF\/OEF\/OND)<\/strong><br \/>\r\nAmbulatory Care Center<br \/>\r\nSecond floor<br \/>\r\n<a data-entity-substitution=\"canonical\" data-entity-type=\"node\" data-entity-uuid=\"a2d3391d-7196-4a3e-bdf5-a71a7b214195\" href=\"\/node\/781\">Map of the Heinz campus<\/a><br \/>\r\n<strong>Phone:&nbsp;<\/strong><a href=\"tel: +14128222362\">412-822-2362<\/a><br \/>\r\n<strong>Hours:&nbsp;<\/strong><br \/>\r\nMonday, Tuesday, Thursday, and Friday, 8:00 a.m. to 4:30 p.m. ET<br \/>\r\nClosed Wednesdays and weekends<\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you\u2019ll need to contact your primary care provider first.<\/p>\r\n\r\n<p><strong>Phone:&nbsp;<\/strong><a href=\"tel: +14128222362\">412-822-2362<\/a><\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "e15ebe41-f7cf-4f2c-a407-3728c341220b"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "b516b8f9-af49-4402-8a42-5e4428bfdda0"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.573b012c-719d-417b-9575-e147a037986d.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.573b012c-719d-417b-9575-e147a037986d.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "573b012c-719d-417b-9575-e147a037986d"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-05T14:43:10+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Minority Veteran care at Washington County VA Clinic"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-10-30T18:46:04+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-05T14:43:10+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Minority Veteran care at Washington County VA Clinic | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Minority Veteran care at Washington County VA Clinic | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Minority Veteran care at Washington County VA Clinic | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Location and contact information<\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>Minority Veterans Program<\/strong><br \/>\r\n<strong>Phone:<\/strong>&nbsp;<a href=\"tel: +14128223537\">412-822-3537<\/a><br \/>\r\n<strong>Email:<\/strong>&nbsp;<a href=\"mailto:heather.steele@va.gov\">heather.steele@va.gov<\/a><br \/>\r\n<strong>Hours:&nbsp;<\/strong>Monday \u2013&nbsp;Friday, 7:00 a.m.&nbsp;to 3:30 p.m. ET<\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you\u2019ll need to contact your primary care provider first.<\/p>\r\n\r\n<p><strong>Phone:<\/strong>&nbsp;<a href=\"tel: +14128223537\">412-822-3537<\/a><\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "a6826998-b7f7-434f-8999-959b1dab0c52"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "a3dbd92d-9e31-4766-962c-5cb52b8353fe"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.590a1d20-ba72-4fe9-8061-59067fb65de0.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.590a1d20-ba72-4fe9-8061-59067fb65de0.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "590a1d20-ba72-4fe9-8061-59067fb65de0"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-05T17:01:22+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Psychiatry at Pittsburgh VA Medical Center-University Drive"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "a6af4eb9-ef34-420e-8a20-e2fba1a5afa2"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-06-17T21:17:47+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-05T17:01:22+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Psychiatry at Pittsburgh VA Medical Center-University Drive | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Psychiatry at Pittsburgh VA Medical Center-University Drive | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Psychiatry at Pittsburgh VA Medical Center-University Drive | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Location and contact information<\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>Consolidation building<\/strong><br \/>\r\nFirst floor<br \/>\r\n<a data-entity-substitution=\"canonical\" data-entity-type=\"node\" data-entity-uuid=\"71ffee52-a47f-4909-ad7e-21ece5728be3\" href=\"\/node\/783\">Map of University Drive campus<\/a><br \/>\r\n<strong>Phone:&nbsp;<\/strong><br \/>\r\n<a href=\"tel: +1412-360-6600\">412-360-6600<\/a><br \/>\r\n<strong>Hours: <\/strong>Monday \u2013 Friday, 8:00 a.m. to 4:30 p.m.<\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you\u2019ll need to contact your primary care provider first.<\/p>\r\n\r\n<p><strong>Referral needed?<\/strong>&nbsp;Yes<br \/>\r\n<strong>Walk-ins accepted?<\/strong>&nbsp;Yes<br \/>\r\n<strong>Phone:&nbsp;<\/strong><a href=\"tel: +1412-360-6600\">412-360-6600<\/a><\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "0b968788-cfb0-41aa-8206-2577105072fa"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "4aa8d80c-c3b0-4e10-9b0b-e22d71b3d6d4"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.59a6a7e2-de40-41a8-8c84-76529ae089cf.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.59a6a7e2-de40-41a8-8c84-76529ae089cf.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "59a6a7e2-de40-41a8-8c84-76529ae089cf"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-05T15:26:55+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Women Veteran care at Fayette County VA Clinic"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "fd71292f-3dc7-409d-b0e8-500204cb005a"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-10-30T19:57:47+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-05T15:26:55+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Women Veteran care at Fayette County VA Clinic | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Women Veteran care at Fayette County VA Clinic | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Women Veteran care at Fayette County VA Clinic | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Location and contact information<\/h3>\r\n\r\n<p class=\"va-address-block\">Suite 2<br \/>\r\n<strong>Phone:&nbsp;<\/strong><a href=\"tel: +17244394990\">724-439-4990<\/a><\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you\u2019ll need to contact your primary care provider first.<\/p>\r\n\r\n<p><strong>Phone:&nbsp;<\/strong><a href=\"tel: +17244394990\">724-439-4990<\/a><\/p>\r\n\r\n<p>&nbsp;<\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "4a987e19-688b-4840-964a-cfefc730fc6c"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "1fdda7ec-a660-4fa7-86be-ef2421cb4e6f"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.59c40ffd-c8f0-4a9a-80c6-11406b933542.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.59c40ffd-c8f0-4a9a-80c6-11406b933542.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "59c40ffd-c8f0-4a9a-80c6-11406b933542"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-04T19:22:33+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "LGBT Veteran care at Beaver County VA Clinic"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-10-30T20:45:28+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-04T19:22:33+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "LGBT Veteran care at Beaver County VA Clinic | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "LGBT Veteran care at Beaver County VA Clinic | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "LGBT Veteran care at Beaver County VA Clinic | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Location and contact information<\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>Phone:<\/strong> <a href=\"tel: +14128221069\">412-822-1069<\/a><br \/>\r\n<strong>Phone:<\/strong> <a href=\"tel: +14128221069\">412-<\/a><a href=\"tel: +14123601210\">360-1210<\/a><\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you\u2019ll need to contact your primary care provider first.<\/p>\r\n\r\n<p><strong>Phone:<\/strong> <a href=\"tel: +14128221069\">412-822-1069<\/a><br \/>\r\n<strong>Phone:<\/strong> <a href=\"tel: +14128221069\">412-<\/a><a href=\"tel: +14123601210\">360-1210<\/a><\/p>\r\n\r\n<p>&nbsp;<\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "a1eabfea-4a7e-4d22-ad09-1d85b884145f"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "5483b3ee-eeb5-4286-9ff1-2d463784031b"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.5c2a855e-39b0-4413-8232-1aa143ff5747.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.5c2a855e-39b0-4413-8232-1aa143ff5747.json
@@ -1,0 +1,133 @@
+{
+    "uuid": [
+        {
+            "value": "5c2a855e-39b0-4413-8232-1aa143ff5747"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "regional_health_care_service_des",
+            "target_type": "node_type",
+            "target_uuid": "d2e27d2b-acb1-471b-a628-4c41c3778729"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-09-09T21:44:57+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "8d4a7bed-f4ba-499f-afd4-8e1cbeadfc4a"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Surgery"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "fd71292f-3dc7-409d-b0e8-500204cb005a"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-05-10T22:01:57+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-09-09T21:44:57+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Surgery | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Surgery | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Surgery | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": "\/surgery",
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Care we provide at VA Pittsburgh<\/h3>\r\n\r\n<ul>\r\n\t<li>General surgery services<\/li>\r\n\t<li>Anesthesia<\/li>\r\n\t<li>Cardiac surgery<\/li>\r\n\t<li>Neurosurgery<\/li>\r\n\t<li>Orthopedic surgery<\/li>\r\n\t<li>Transplantation<\/li>\r\n<\/ul>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_local_health_care_service_": [
+        {
+            "target_type": "node",
+            "target_uuid": "c41d704b-0fe8-462d-bf7f-b8a92d842089"
+        }
+    ],
+    "field_region_page": [
+        {
+            "target_type": "node",
+            "target_uuid": "2bddb1a7-6fb1-4503-838d-9c2fcb51c46a"
+        }
+    ],
+    "field_service_name_and_descripti": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "5fe3592a-7766-4ff1-a2df-2cdf6a992683"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.5d109f49-1af7-47ac-8f6d-cc1697ca39d8.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.5d109f49-1af7-47ac-8f6d-cc1697ca39d8.json
@@ -1,0 +1,132 @@
+{
+    "uuid": [
+        {
+            "value": "5d109f49-1af7-47ac-8f6d-cc1697ca39d8"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-04T21:19:44+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "revision_log": [
+        {
+            "value": "Bulk operation publish revision"
+        }
+    ],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Registry exams at Beaver County VA Clinic"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-10-30T18:31:33+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-05T17:00:49+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Registry exams at Beaver County VA Clinic | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Registry exams at Beaver County VA Clinic | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Registry exams at Beaver County VA Clinic | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Location and contact information<\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>Environmental Health Coordinator<\/strong><br \/>\r\nPhone:&nbsp;<a href=\"tel: +14128221707\">412-822-1707<\/a><br \/>\r\n<strong>Email:&nbsp;<\/strong><a href=\"mailto:douglas.turner5@va.gov\">douglas.turner5@va.gov<\/a><\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you\u2019ll need to contact your primary care provider first.<\/p>\r\n\r\n<p><strong>Referral needed?<\/strong>&nbsp;No<br \/>\r\n<strong>Walk-ins accepted?<\/strong>&nbsp;No<br \/>\r\n<strong>Phone:<\/strong>&nbsp;<a href=\"tel: +14128221707\">412-822-1707<\/a><\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "a1eabfea-4a7e-4d22-ad09-1d85b884145f"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "3e92eaa8-bbf8-4173-84f8-d187b281d548"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.61516de8-202a-4ee5-859b-8dd5f7ee92ea.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.61516de8-202a-4ee5-859b-8dd5f7ee92ea.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "61516de8-202a-4ee5-859b-8dd5f7ee92ea"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-09-10T11:05:55+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "8d4a7bed-f4ba-499f-afd4-8e1cbeadfc4a"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Rehabilitation and prosthetics at Pittsburgh VA Medical Center-University Drive"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "a6af4eb9-ef34-420e-8a20-e2fba1a5afa2"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-06-17T22:17:33+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-09-10T11:05:55+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Rehabilitation and prosthetics at Pittsburgh VA Medical Center-University Drive | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Rehabilitation and prosthetics at Pittsburgh VA Medical Center-University Drive | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Rehabilitation and prosthetics at Pittsburgh VA Medical Center-University Drive | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 0
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Location and contact information<\/h3>\r\n\r\n<p class=\"va-address-block\">10 West, room 113<br \/>\r\n<a data-entity-substitution=\"canonical\" data-entity-type=\"node\" data-entity-uuid=\"71ffee52-a47f-4909-ad7e-21ece5728be3\" href=\"\/node\/783\">Map of the&nbsp;University Drive Campus<\/a><br \/>\r\n<strong>Phone:&nbsp;<\/strong><a href=\"tel: +14128223728\">412-822-3728<\/a><br \/>\r\n<strong>Hours:&nbsp;<\/strong>Monday \u2013&nbsp;Friday, 7:30 a.m. to 3:30 p.m. ET<\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you\u2019ll need to contact your primary care provider first.<\/p>\r\n\r\n<p><strong>Referral needed?<\/strong> Yes<\/p>\r\n\r\n<p><strong>Walk-ins accepted?<\/strong> Yes<\/p>\r\n\r\n<p><strong>Phone:<\/strong>&nbsp;<a href=\"tel: +14128223728\">412-822-3728<\/a><\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "0b968788-cfb0-41aa-8206-2577105072fa"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "ddd4532d-9c31-4f87-af7f-ecbc83116592"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.61b011db-8239-4637-a042-08a6fbf6aa8a.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.61b011db-8239-4637-a042-08a6fbf6aa8a.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "61b011db-8239-4637-a042-08a6fbf6aa8a"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-05T15:06:41+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Podiatry at Washington County VA Clinic"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "a6af4eb9-ef34-420e-8a20-e2fba1a5afa2"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-06-14T22:08:28+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-05T15:06:41+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Podiatry at Washington County VA Clinic | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Podiatry at Washington County VA Clinic | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Podiatry at Washington County VA Clinic | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Location and contact information<\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>Phone:&nbsp;<\/strong><a href=\"tel: +14128223000\">412-822-3000<\/a><br \/>\r\n<strong>Hours:&nbsp;<\/strong>Monday \u2013&nbsp;Friday, 8:00 a.m. to 4:30 p.m. ET<\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you\u2019ll need to contact your primary care provider first.<\/p>\r\n\r\n<p><strong>Referral needed?<\/strong>&nbsp;No<br \/>\r\n<strong>Phone:&nbsp;<\/strong><a href=\"tel: +14128223000\">412-822-3000<\/a><\/p>\r\n\r\n<p>&nbsp;<\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "a6826998-b7f7-434f-8999-959b1dab0c52"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "8c838193-be61-48ea-8f1c-a1839b57f1fc"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.61c521fa-834b-44c2-adb5-7f4124b11188.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.61c521fa-834b-44c2-adb5-7f4124b11188.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "61c521fa-834b-44c2-adb5-7f4124b11188"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-05T15:13:27+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Suicide prevention at Pittsburgh VA Medical Center-University Drive"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "a6af4eb9-ef34-420e-8a20-e2fba1a5afa2"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-06-17T22:48:09+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-05T15:13:27+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Suicide prevention at Pittsburgh VA Medical Center-University Drive | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Suicide prevention at Pittsburgh VA Medical Center-University Drive | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Suicide prevention at Pittsburgh VA Medical Center-University Drive | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Location and contact information<\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>Consolidation Building<\/strong><br \/>\r\nBuilding 29<br \/>\r\n1M-109<br \/>\r\n<a data-entity-substitution=\"canonical\" data-entity-type=\"node\" data-entity-uuid=\"71ffee52-a47f-4909-ad7e-21ece5728be3\" href=\"\/node\/783\">Map of University Drive campus<\/a><br \/>\r\n<strong>Phone:&nbsp;<\/strong><a href=\"tel: +14123606515\">412-360-6515<\/a><br \/>\r\n<strong>Hours:&nbsp;<\/strong>Monday \u2013&nbsp;Friday, 8:00 a.m. to 4:30 p.m. ET<\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you\u2019ll need to contact your primary care provider first.<\/p>\r\n\r\n<p><strong>Phone:&nbsp;&nbsp;<\/strong><a href=\"tel: +14123606515\">412-360-6515<\/a><\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "0b968788-cfb0-41aa-8206-2577105072fa"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "d6a14b35-382e-4df7-bd42-b3572f0727e9"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.61f79e11-a30b-485c-baeb-3f91aa142a8e.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.61f79e11-a30b-485c-baeb-3f91aa142a8e.json
@@ -1,0 +1,132 @@
+{
+    "uuid": [
+        {
+            "value": "61f79e11-a30b-485c-baeb-3f91aa142a8e"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-05T14:58:50+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "revision_log": [
+        {
+            "value": "Bulk operation publish revision"
+        }
+    ],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "My HealtheVet coordinator at Belmont County VA Clinic"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-11-05T14:51:06+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-05T14:58:50+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "My HealtheVet coordinator at Belmont County VA Clinic | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "My HealtheVet coordinator at Belmont County VA Clinic | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "My HealtheVet coordinator at Belmont County VA Clinic | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Location and contact information<\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>Hours:<\/strong>&nbsp;Fridays 9:00 a.m. - 10:30 a.m. ET<\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "eac71fd5-260c-4f44-8507-8b803ad2324f"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "54d15687-aac6-4457-8560-5d93fe233967"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.644d5e70-1538-4979-8449-f52b4c2a5ca5.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.644d5e70-1538-4979-8449-f52b4c2a5ca5.json
@@ -1,0 +1,132 @@
+{
+    "uuid": [
+        {
+            "value": "644d5e70-1538-4979-8449-f52b4c2a5ca5"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-05T14:06:29+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "revision_log": [
+        {
+            "value": "Bulk operation publish revision"
+        }
+    ],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Nutrition, food, and dietary at Pittsburgh VA Medical Center-University Drive"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-11-05T12:52:48+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-05T14:06:29+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Nutrition, food, and dietary at Pittsburgh VA Medical Center-University Drive | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Nutrition, food, and dietary at Pittsburgh VA Medical Center-University Drive | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Nutrition, food, and dietary at Pittsburgh VA Medical Center-University Drive | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Location and contact information<\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>Hours:&nbsp;<\/strong>Monday \u2013&nbsp;Friday, 8:00 a.m. to 4:30 p.m. ET<\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you\u2019ll need to contact your primary care provider first.<\/p>\r\n\r\n<p><strong>Phone:&nbsp;<\/strong><a href=\"tel: +14128223000\">412-822-3000<\/a><\/p>\r\n\r\n<p><a class=\"usa-button\" data-entity-substitution=\"canonical\" data-entity-type=\"node\" data-entity-uuid=\"4578cb13-d680-426f-8f2d-ff000e990cb3\" href=\"\/node\/37\">Schedule an appointment online<\/a><\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "0b968788-cfb0-41aa-8206-2577105072fa"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "c88adf39-6ca4-4859-8877-ad6b5706257e"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.676acdff-d8f1-46c8-8ae5-49457f101c7b.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.676acdff-d8f1-46c8-8ae5-49457f101c7b.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "676acdff-d8f1-46c8-8ae5-49457f101c7b"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-12T20:22:04+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "76a324e9-c71f-4524-9a21-ab167cbd4542"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Wheelchair and mobility clinics at H. John Heinz III Department of Veterans Affairs Medical Center"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "a6af4eb9-ef34-420e-8a20-e2fba1a5afa2"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-06-18T00:48:35+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-12T20:22:04+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Wheelchair and mobility clinics at H. John Heinz III Department of Veterans Affairs Medical Center | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Wheelchair and mobility clinics at H. John Heinz III Department of Veterans Affairs Medical Center | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Wheelchair and mobility clinics at H. John Heinz III Department of Veterans Affairs Medical Center | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Location and contact information<\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>Wheelchair, Seating and Power Mobility Clinic<\/strong><br \/>\r\nAmbulatory Care Center<br \/>\r\nBuilding 71<br \/>\r\nRoom 1B100<br \/>\r\n<a data-entity-substitution=\"canonical\" data-entity-type=\"node\" data-entity-uuid=\"a2d3391d-7196-4a3e-bdf5-a71a7b214195\" href=\"\/node\/781\">Map of the Heinz campus<\/a><br \/>\r\n<strong>Phone: <\/strong><a href=\"tel: +14128222180\">412-822-2180<\/a><br \/>\r\n<strong>Hours:&nbsp;<\/strong>Monday \u2013&nbsp;Friday, 8:00 a.m. to 4:30 p.m. ET<\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you\u2019ll need to contact your primary care provider first.<\/p>\r\n\r\n<p><strong>Referral needed?<\/strong>&nbsp;No<br \/>\r\n<strong>Phone:&nbsp;<\/strong><a href=\"tel: +14128222180\">412-822-2180<\/a><\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "e15ebe41-f7cf-4f2c-a407-3728c341220b"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "26bd1dc9-e9f5-44eb-a029-73eb54842237"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.67ecbd95-f39c-43c2-a866-5b0c9df56ad9.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.67ecbd95-f39c-43c2-a866-5b0c9df56ad9.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "67ecbd95-f39c-43c2-a866-5b0c9df56ad9"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-04T19:38:33+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Military sexual trauma at Belmont County VA Clinic"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-10-30T21:04:05+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-04T19:38:33+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Military sexual trauma at Belmont County VA Clinic | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Military sexual trauma at Belmont County VA Clinic | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Military sexual trauma at Belmont County VA Clinic | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Location and contact information&nbsp;<\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>Psychology \/ Social Work<\/strong><br \/>\r\n<strong>Phone:<\/strong><a href=\"tel: +17247096005\"> 7<\/a><a href=\"tel: +17406959321\">40-695-9321<\/a><br \/>\r\n<strong>Hours:&nbsp;<\/strong>Monday \u2013&nbsp;Friday, 8:00 a.m. \u2013&nbsp;4:30 p.m. ET<\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you\u2019ll need to contact your primary care provider first.<\/p>\r\n\r\n<p><strong>Phone:<\/strong><a href=\"tel: +17247096005\"> 7<\/a><a href=\"tel: +17406959321\">40-695-9321<\/a><\/p>\r\n\r\n<p>&nbsp;<\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "eac71fd5-260c-4f44-8507-8b803ad2324f"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "6d59f042-c372-436c-a8ff-7a8f017ad89f"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.697f3d8b-7f89-4b28-bef3-bed0db89c2d2.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.697f3d8b-7f89-4b28-bef3-bed0db89c2d2.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "697f3d8b-7f89-4b28-bef3-bed0db89c2d2"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-04T18:59:51+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "MOVE! weight management at Beaver County VA Clinic"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-10-31T18:45:33+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-04T18:59:51+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "MOVE! weight management at Beaver County VA Clinic | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "MOVE! weight management at Beaver County VA Clinic | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "MOVE! weight management at Beaver County VA Clinic | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Location and contact information<\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>MOVE! group meetings<\/strong><br \/>\r\n<strong>Phone:&nbsp;<\/strong><a href=\"tel: +14128223114\">412-822-3114<\/a><br \/>\r\n<strong>Email:&nbsp;<\/strong><a href=\"mailto:melanie.erskine@va.gov\">melanie.erskine@va.gov<\/a><br \/>\r\n<strong>Hours:<\/strong> Thursday, 10:00 a.m. to 11:00 a.m. ET<br \/>\r\n&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;<\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you\u2019ll need to contact your primary care provider first.<br \/>\r\n<br \/>\r\n<strong>Phone:&nbsp;<\/strong><a href=\"tel: +14128223114\">412-822-3114<\/a><br \/>\r\n<strong>Email:&nbsp;<\/strong><a href=\"mailto:melanie.erskine@va.gov\">melanie.erskine@va.gov<\/a><\/p>\r\n\r\n<p><a class=\"usa-button\" data-entity-substitution=\"canonical\" data-entity-type=\"node\" data-entity-uuid=\"4578cb13-d680-426f-8f2d-ff000e990cb3\" href=\"\/node\/37\">Schedule an appointment online<\/a><\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "a1eabfea-4a7e-4d22-ad09-1d85b884145f"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "a27c5805-47de-4dc1-917c-4e3855fbd3cb"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.6d30b38b-9705-473b-bddb-76b0cb835829.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.6d30b38b-9705-473b-bddb-76b0cb835829.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "6d30b38b-9705-473b-bddb-76b0cb835829"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-05T14:32:31+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Gastroenterology at Pittsburgh VA Medical Center-University Drive"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "fd71292f-3dc7-409d-b0e8-500204cb005a"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-05-10T22:09:43+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-05T14:32:31+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Gastroenterology at Pittsburgh VA Medical Center-University Drive | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Gastroenterology at Pittsburgh VA Medical Center-University Drive | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Gastroenterology at Pittsburgh VA Medical Center-University Drive | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Location and contact information<\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>Outpatient gastrointestinal (GI) clinics<\/strong><br \/>\r\nMain Hospital<br \/>\r\nBuilding 1<br \/>\r\nFloor&nbsp;8-West<br \/>\r\n<a data-entity-substitution=\"canonical\" data-entity-type=\"node\" data-entity-uuid=\"71ffee52-a47f-4909-ad7e-21ece5728be3\" href=\"\/node\/783\">Map of University Drive campus<\/a><br \/>\r\n<strong>Phone:<\/strong>&nbsp;<a href=\"tel: +14123606242\">412-360-6242<\/a><br \/>\r\n<strong>Hours:&nbsp;<\/strong>Monday \u2013&nbsp;Friday, 8:00 a.m. to 5:00 p.m. ET<\/p>\r\n\r\n<p class=\"va-address-block\"><strong>GI outpatient procedure lab<\/strong><br \/>\r\nMain Hospital<br \/>\r\nBuilding 1<br \/>\r\nFloor 3-West<br \/>\r\nASU Check in area<br \/>\r\n<a data-entity-substitution=\"canonical\" data-entity-type=\"node\" data-entity-uuid=\"71ffee52-a47f-4909-ad7e-21ece5728be3\" href=\"\/node\/783\">Map of University Drive campus<\/a><br \/>\r\n<strong>Phone:<\/strong><br \/>\r\n<a href=\"tel: +14123601130\">412-360-1130<\/a> -&nbsp;Procedure\/preparation questions<br \/>\r\n<a href=\"tel: +14123606177\">412-360-6177<\/a> - Scheduling or canceling<br \/>\r\n<strong>Hours:&nbsp;<\/strong>Monday \u2013&nbsp;Friday, 8:00 a.m. to 4:00 p.m. ET<\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you\u2019ll need to contact your primary care provider first.<\/p>\r\n\r\n<p><strong>Phone:<\/strong>&nbsp;<a href=\"tel: +14123606177\">412-360-6177<\/a><\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "0b968788-cfb0-41aa-8206-2577105072fa"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "94177aa5-4a5e-4a66-97d5-e721b8f02f92"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.6d71dc89-32bd-4c61-932f-68ebad4b04dc.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.6d71dc89-32bd-4c61-932f-68ebad4b04dc.json
@@ -1,0 +1,123 @@
+{
+    "uuid": [
+        {
+            "value": "6d71dc89-32bd-4c61-932f-68ebad4b04dc"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-10-30T21:40:13+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "fd71292f-3dc7-409d-b0e8-500204cb005a"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Intimate partner violence at H. John Heinz III Department of Veterans Affairs Medical Center"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "8d4a7bed-f4ba-499f-afd4-8e1cbeadfc4a"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-09-19T20:06:04+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-10-30T21:40:13+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Intimate partner violence at H. John Heinz III Department of Veterans Affairs Medical Center | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Intimate partner violence at H. John Heinz III Department of Veterans Affairs Medical Center | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Intimate partner violence at H. John Heinz III Department of Veterans Affairs Medical Center | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [],
+    "field_body": [
+        {
+            "value": "<h3>Location and contact information<\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>Domestic Violence\/Intimate Partner Violence Coordinator<br \/>\r\nPhone:&nbsp;<\/strong><a href=\"tel: +14128521963\">412-8<\/a><a href=\"tel: +14128222359\">22-2359<\/a><br \/>\r\n<strong>Hours:&nbsp;<\/strong>Monday \u2013 Friday, 8:00 a.m. to 4:30 p.m. ET<\/p>\r\n\r\n<p class=\"va-address-block\"><strong>National Domestic Violence 24-hour Hotline<\/strong><br \/>\r\n<strong>Phone:<\/strong> <a href=\"tel: +18007997233\">1-800-799-SAFE (7233)<\/a> or <a href=\"tel: +18007873224\">1-800-787-3224 (TTY)<\/a><br \/>\r\n<strong>Hours:<\/strong>&nbsp;24\/7<\/p>\r\n\r\n<h3>Make an appointment<\/h3>\r\n\r\n<p>If you are interested in more information, experiencing domestic or intimate partner violence, or concerned about someone else who is, reach out now.<\/p>\r\n\r\n<p><strong>Phone:&nbsp;<\/strong><a href=\"tel: +14128521963\">412-852-1963<\/a><\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "e15ebe41-f7cf-4f2c-a407-3728c341220b"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "e453f2c1-fe99-427f-a256-92fd1f103c25"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.6e4f6862-2a5e-49d2-8a4c-adcb954c0ad0.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.6e4f6862-2a5e-49d2-8a4c-adcb954c0ad0.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "6e4f6862-2a5e-49d2-8a4c-adcb954c0ad0"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-04T19:39:05+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Military sexual trauma at Fayette County VA Clinic"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-10-30T21:05:49+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-04T19:39:05+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Military sexual trauma at Fayette County VA Clinic | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Military sexual trauma at Fayette County VA Clinic | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Military sexual trauma at Fayette County VA Clinic | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Location and contact information&nbsp;<\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>Psychology \/ Social Work<\/strong><br \/>\r\n<strong>Phone:<\/strong><a href=\"tel: +17247096005\">&nbsp;7<\/a><a href=\"tel: +17244394990\">24-439-4990<\/a><br \/>\r\n<strong>Hours:&nbsp;<\/strong>Monday \u2013&nbsp;Friday, 8:00 a.m. \u2013&nbsp;4:30 p.m. ET<\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you\u2019ll need to contact your primary care provider first.<\/p>\r\n\r\n<p><strong>Phone:&nbsp;<\/strong><a href=\"tel: +17247096005\">7<\/a><a href=\"tel: +17244394990\">24-439-4990<\/a><\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "4a987e19-688b-4840-964a-cfefc730fc6c"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "6d59f042-c372-436c-a8ff-7a8f017ad89f"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.6ef7d829-5a74-4846-be1c-cf45d1e0c46d.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.6ef7d829-5a74-4846-be1c-cf45d1e0c46d.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "6ef7d829-5a74-4846-be1c-cf45d1e0c46d"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-05T13:09:38+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Radiology\/imaging at H. John Heinz III Department of Veterans Affairs Medical Center"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "a6af4eb9-ef34-420e-8a20-e2fba1a5afa2"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-06-17T21:49:17+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-05T16:55:48+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Radiology\/imaging at H. John Heinz III Department of Veterans Affairs Medical Center | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Radiology\/imaging at H. John Heinz III Department of Veterans Affairs Medical Center | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Radiology\/imaging at H. John Heinz III Department of Veterans Affairs Medical Center | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Location and contact information<\/h3>\r\n\r\n<p class=\"va-address-block\">Community Living Center<br \/>\r\nBuilding 51<br \/>\r\n<a data-entity-substitution=\"canonical\" data-entity-type=\"node\" data-entity-uuid=\"a2d3391d-7196-4a3e-bdf5-a71a7b214195\" href=\"\/node\/781\">Map of the Heinz campus<\/a><br \/>\r\n<strong>Phone:&nbsp;<\/strong><a href=\"tel: +14128223000\">412-<\/a><a href=\"tel: +14123606105\">360-6105<\/a><br \/>\r\n<strong>Hours: <\/strong>Monday \u2013 Friday, 8:00 a.m. to 4:30 p.m. ET<\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you\u2019ll need to contact your primary care provider first.<\/p>\r\n\r\n<p><strong>Phone:&nbsp;<\/strong><a href=\"tel: +14128223000\">412-<\/a><a href=\"tel: +14123606105\">360-6105<\/a><\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "e15ebe41-f7cf-4f2c-a407-3728c341220b"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "72ff4ca7-0310-4786-b7ff-502486b88efc"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.70151b1a-6176-41b2-9774-a71825d6b1f2.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.70151b1a-6176-41b2-9774-a71825d6b1f2.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "70151b1a-6176-41b2-9774-a71825d6b1f2"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-05T13:26:34+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Gynecology at Pittsburgh VA Medical Center-University Drive"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "fd71292f-3dc7-409d-b0e8-500204cb005a"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-05-13T16:23:59+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-05T13:26:34+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Gynecology at Pittsburgh VA Medical Center-University Drive | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Gynecology at Pittsburgh VA Medical Center-University Drive | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Gynecology at Pittsburgh VA Medical Center-University Drive | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3><strong>Location and contact information<\/strong><\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>Main hospital<\/strong><br \/>\r\nBuilding 1<br \/>\r\nFirst floor, Women's Health Clinic<br \/>\r\nRoom 1A175<br \/>\r\n<a data-entity-substitution=\"canonical\" data-entity-type=\"node\" data-entity-uuid=\"71ffee52-a47f-4909-ad7e-21ece5728be3\" href=\"\/node\/783\">Map of University Drive campus<\/a><br \/>\r\n<strong>Phone:<\/strong>&nbsp;<a href=\"tel: +14123603671\">412-360-3671<\/a><br \/>\r\n<strong>Phone:&nbsp;<\/strong><a href=\"tel: +14123603753\">412-360-3753<\/a><br \/>\r\n<strong>Hours:<\/strong>&nbsp;<br \/>\r\nTuesday 8:30 a.m. to 11:00 a.m. ET<br \/>\r\nFriday 8:30 a.m. to 3:00 p.m. ET<\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you\u2019ll need to contact your primary care provider first.<\/p>\r\n\r\n<p><strong>Referral needed?<\/strong>&nbsp;Yes<br \/>\r\n<strong>Walk-ins accepted?<\/strong>&nbsp;No<br \/>\r\n<strong>Phone:<\/strong>&nbsp;<a href=\"tel: +14123603671\">412-360-3671<\/a><br \/>\r\n<strong>Phone:&nbsp;<\/strong><a href=\"tel: +14123603753\">412-360-3753<\/a><\/p>\r\n\r\n<p>&nbsp;<\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "0b968788-cfb0-41aa-8206-2577105072fa"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "c8ea6d96-9263-4d1d-ac90-c90b55ba13c9"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.7a214dbf-b83f-4a6a-b747-d841b7dbcfb6.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.7a214dbf-b83f-4a6a-b747-d841b7dbcfb6.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "7a214dbf-b83f-4a6a-b747-d841b7dbcfb6"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-04T19:38:08+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Military sexual trauma at Beaver County VA Clinic"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-10-30T21:02:08+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-04T19:38:08+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Military sexual trauma at Beaver County VA Clinic | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Military sexual trauma at Beaver County VA Clinic | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Military sexual trauma at Beaver County VA Clinic | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Location and contact information&nbsp;<\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>Psychology \/ Social Work<\/strong><br \/>\r\n<strong>Phone:<\/strong><a href=\"tel: +17247096005\"> 724-709-6005<\/a><br \/>\r\n<strong>Hours:&nbsp;<\/strong>Monday \u2013&nbsp;Friday, 8:00 a.m. \u2013&nbsp;4:30 p.m. ET<\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you\u2019ll need to contact your primary care provider first.<\/p>\r\n\r\n<p><strong>Phone:&nbsp;<\/strong><a href=\"tel: +17247096005\">724-709-6005<\/a><\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "a1eabfea-4a7e-4d22-ad09-1d85b884145f"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "6d59f042-c372-436c-a8ff-7a8f017ad89f"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.7ab831f3-b998-413d-beb9-c17ccf514514.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.7ab831f3-b998-413d-beb9-c17ccf514514.json
@@ -1,0 +1,133 @@
+{
+    "uuid": [
+        {
+            "value": "7ab831f3-b998-413d-beb9-c17ccf514514"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "regional_health_care_service_des",
+            "target_type": "node_type",
+            "target_uuid": "d2e27d2b-acb1-471b-a628-4c41c3778729"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-04T20:18:42+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "fd71292f-3dc7-409d-b0e8-500204cb005a"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Amputation care"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "fd71292f-3dc7-409d-b0e8-500204cb005a"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-05-10T21:37:28+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-04T20:18:42+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Amputation care | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Amputation care | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Amputation care | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": "\/amputation-care",
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Care we provide at VA Pittsburgh<\/h3>\r\n\r\n<p>Whether your amputation was due to trauma or medical necessity, our specially trained&nbsp;physiatrists and nurse practitioners can help you&nbsp;maximize your independence, achieve your goals, and return to doing the things you enjoy. Our services include:<\/p>\r\n\r\n<ul>\r\n\t<li>Initial prosthesis selection and fitting<\/li>\r\n\t<li>Prosthesis adjustments<\/li>\r\n\t<li>Therapy aid training<\/li>\r\n\t<li>Prosthesis changes to achieve&nbsp;independence and activity goals<\/li>\r\n<\/ul>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_local_health_care_service_": [
+        {
+            "target_type": "node",
+            "target_uuid": "ea7f52c8-203f-4cdb-8437-fd3648b3807f"
+        }
+    ],
+    "field_region_page": [
+        {
+            "target_type": "node",
+            "target_uuid": "2bddb1a7-6fb1-4503-838d-9c2fcb51c46a"
+        }
+    ],
+    "field_service_name_and_descripti": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "d657ae30-f9de-48f0-8a2f-c776a5252443"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.7ae2bb0d-7fd8-4f0f-bfd6-4a3c77752872.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.7ae2bb0d-7fd8-4f0f-bfd6-4a3c77752872.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "7ae2bb0d-7fd8-4f0f-bfd6-4a3c77752872"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-09-10T19:39:01+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "8d4a7bed-f4ba-499f-afd4-8e1cbeadfc4a"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Patient advocates at Fayette County VA Clinic"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "a6af4eb9-ef34-420e-8a20-e2fba1a5afa2"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-06-14T21:05:35+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-09-10T19:39:01+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Patient advocates at Fayette County VA Clinic | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Patient advocates at Fayette County VA Clinic | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Patient advocates at Fayette County VA Clinic | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3 id=\"location-and-contact-informati-633\">Location and contact information<\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>Hours:&nbsp;<\/strong>Monday \u2013 Friday, 8:00 a.m. to 4:30 p.m. ET<\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "4a987e19-688b-4840-964a-cfefc730fc6c"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "85ecc815-a3fc-4978-9e7a-2cfd55dc9b72"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.7bc4ce20-f573-4ea6-b361-b3060be2e2ea.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.7bc4ce20-f573-4ea6-b361-b3060be2e2ea.json
@@ -1,0 +1,137 @@
+{
+    "uuid": [
+        {
+            "value": "7bc4ce20-f573-4ea6-b361-b3060be2e2ea"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "regional_health_care_service_des",
+            "target_type": "node_type",
+            "target_uuid": "d2e27d2b-acb1-471b-a628-4c41c3778729"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-05T01:26:21+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "fd71292f-3dc7-409d-b0e8-500204cb005a"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Telehealth"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "a6af4eb9-ef34-420e-8a20-e2fba1a5afa2"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-06-17T23:20:27+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-05T01:26:21+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Telehealth | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Telehealth | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Telehealth | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": "\/telehealth",
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Care we provide at VA Pittsburgh<\/h3>\r\n\r\n<p>We use the latest in secure digital technology to provide remote visits with health care providers. Our telehealth technologies include video conferencing, home telehealth (which lets you send us vital health information, like blood pressure readings, over the phone or internet), and store-and-forward telehealth (which helps you send your health information to experts at VA facilities using secure technology). We offer telehealth visits with providers in these fields:<\/p>\r\n\r\n<ul>\r\n\t<li>Mental health&nbsp;<\/li>\r\n\t<li>Retinal care&nbsp;<\/li>\r\n\t<li>Dermatology&nbsp;<\/li>\r\n\t<li>Rehabilitation&nbsp;<\/li>\r\n\t<li>Primary care<\/li>\r\n<\/ul>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_local_health_care_service_": [
+        {
+            "target_type": "node",
+            "target_uuid": "d72934eb-42d0-4413-bcf9-67f4b2bebee5"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "47fa8893-288b-4fa4-8d93-0354854d367b"
+        }
+    ],
+    "field_region_page": [
+        {
+            "target_type": "node",
+            "target_uuid": "2bddb1a7-6fb1-4503-838d-9c2fcb51c46a"
+        }
+    ],
+    "field_service_name_and_descripti": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "c6670e19-6527-4cd5-9fb5-6f6cc62abd71"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.7cab2517-d064-4901-8ee2-d8db73fc654b.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.7cab2517-d064-4901-8ee2-d8db73fc654b.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "7cab2517-d064-4901-8ee2-d8db73fc654b"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-05T15:05:38+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Podiatry at Pittsburgh VA Medical Center-University Drive"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "a6af4eb9-ef34-420e-8a20-e2fba1a5afa2"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-06-14T22:04:37+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-05T15:05:38+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Podiatry at Pittsburgh VA Medical Center-University Drive | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Podiatry at Pittsburgh VA Medical Center-University Drive | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Podiatry at Pittsburgh VA Medical Center-University Drive | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Location and contact information<\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>Main hospital<\/strong><br \/>\r\nBuilding 1<br \/>\r\n<a data-entity-substitution=\"canonical\" data-entity-type=\"node\" data-entity-uuid=\"71ffee52-a47f-4909-ad7e-21ece5728be3\" href=\"\/node\/783\">Map of University Drive campus<\/a><strong>&nbsp;<br \/>\r\nPhone:&nbsp;<\/strong><a href=\"tel: +14128223000\">412-822-3000<\/a><br \/>\r\n<strong>Hours:&nbsp;<\/strong>Monday \u2013&nbsp;Friday, 8:00 a.m. to 4:30 p.m. ET<\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you\u2019ll need to contact your primary care provider first.<\/p>\r\n\r\n<p><strong>Referral needed?<\/strong>&nbsp;No<br \/>\r\n<strong>Phone:&nbsp;<\/strong><a href=\"tel: +14128223000\">412-822-3000<\/a><\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "0b968788-cfb0-41aa-8206-2577105072fa"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "8c838193-be61-48ea-8f1c-a1839b57f1fc"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.7e73815f-ef67-4483-8ac2-62aa605b968b.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.7e73815f-ef67-4483-8ac2-62aa605b968b.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "7e73815f-ef67-4483-8ac2-62aa605b968b"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-04T20:22:01+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "HIV\/hepatitis at Pittsburgh VA Medical Center-University Drive"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "a6af4eb9-ef34-420e-8a20-e2fba1a5afa2"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-05-30T23:02:53+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-04T20:22:01+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "HIV\/hepatitis at Pittsburgh VA Medical Center-University Drive | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "HIV\/hepatitis at Pittsburgh VA Medical Center-University Drive | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "HIV\/hepatitis at Pittsburgh VA Medical Center-University Drive | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3><strong>Location and contact information<\/strong><\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>Building 1<\/strong><br \/>\r\nFirst floor pharmacy<br \/>\r\n<a data-entity-substitution=\"canonical\" data-entity-type=\"node\" data-entity-uuid=\"71ffee52-a47f-4909-ad7e-21ece5728be3\" href=\"\/node\/783\">Map of University Drive campus<\/a><br \/>\r\n<strong>Phone:&nbsp;<\/strong><a href=\"tel:412-822-3000\">412-822-3000<\/a><br \/>\r\n<strong>Hours:&nbsp;<\/strong>Monday \u2013&nbsp;Friday, 8:00 a.m. to 4:00 p.m. ET<\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you\u2019ll need to contact your primary care provider first.<\/p>\r\n\r\n<p><strong>Referral needed?<\/strong>&nbsp;Yes<br \/>\r\n<strong>Walk-ins accepted?<\/strong>&nbsp;No<br \/>\r\n<strong>Phone:&nbsp;<\/strong><a href=\"tel:412-822-3000\">412-822-3000<\/a><\/p>\r\n\r\n<p>&nbsp;<\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "0b968788-cfb0-41aa-8206-2577105072fa"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "02e024f0-e9c8-4d11-8d71-6a4f3e91366d"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.7e94a44e-e243-4f38-8a9f-8f17d705db88.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.7e94a44e-e243-4f38-8a9f-8f17d705db88.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "7e94a44e-e243-4f38-8a9f-8f17d705db88"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-04T19:00:43+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "MOVE! weight management at Fayette County VA Clinic"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "a6af4eb9-ef34-420e-8a20-e2fba1a5afa2"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-06-05T02:03:23+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-04T19:00:43+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "MOVE! weight management at Fayette County VA Clinic | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "MOVE! weight management at Fayette County VA Clinic | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "MOVE! weight management at Fayette County VA Clinic | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Location and contact information<\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>MOVE! group meetings<\/strong><br \/>\r\n<strong>Phone:&nbsp;<\/strong><a href=\"tel: +14128223114\">412-822-3114<\/a><br \/>\r\n<strong>Email:&nbsp;<\/strong><a href=\"mailto:melanie.erskine@va.gov\">melanie.erskine@va.gov<\/a><br \/>\r\n<strong>Hours:&nbsp;<\/strong>Friday,<strong>&nbsp;<\/strong>10:30 a.m. to 11:30 a.m. ET<\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you\u2019ll need to contact your primary care provider first.<br \/>\r\n<br \/>\r\n<strong>Phone:&nbsp;<\/strong><a href=\"tel: +14128223114\">412-822-3114<\/a><br \/>\r\n<strong>Email:&nbsp;<\/strong><a href=\"mailto:melanie.erskine@va.gov\">melanie.erskine@va.gov<\/a><br \/>\r\n<br \/>\r\n<a class=\"usa-button\" data-entity-substitution=\"canonical\" data-entity-type=\"node\" data-entity-uuid=\"4578cb13-d680-426f-8f2d-ff000e990cb3\" href=\"\/node\/37\">Schedule an appointment online<\/a><\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "4a987e19-688b-4840-964a-cfefc730fc6c"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "a27c5805-47de-4dc1-917c-4e3855fbd3cb"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.808fb0ce-2019-444a-b19f-809e98f72106.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.808fb0ce-2019-444a-b19f-809e98f72106.json
@@ -1,0 +1,132 @@
+{
+    "uuid": [
+        {
+            "value": "808fb0ce-2019-444a-b19f-809e98f72106"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-04T21:19:44+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "revision_log": [
+        {
+            "value": "Bulk operation publish revision"
+        }
+    ],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "My HealtheVet coordinator at Beaver County VA Clinic"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-10-30T16:53:18+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-04T21:19:44+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "My HealtheVet coordinator at Beaver County VA Clinic | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "My HealtheVet coordinator at Beaver County VA Clinic | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "My HealtheVet coordinator at Beaver County VA Clinic | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Location and contact information<\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>Hours:<\/strong>&nbsp;Thursdays 10:00 a.m. - 11:00 a.m.<\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "a1eabfea-4a7e-4d22-ad09-1d85b884145f"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "54d15687-aac6-4457-8560-5d93fe233967"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.80d4cd36-8b7a-47cb-94b1-9ac6e50d1548.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.80d4cd36-8b7a-47cb-94b1-9ac6e50d1548.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "80d4cd36-8b7a-47cb-94b1-9ac6e50d1548"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-09-10T21:17:31+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "8d4a7bed-f4ba-499f-afd4-8e1cbeadfc4a"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Physical medicine and rehabilitation at Pittsburgh VA Medical Center-University Drive"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "a6af4eb9-ef34-420e-8a20-e2fba1a5afa2"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-06-14T21:52:55+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-04T20:48:30+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Physical medicine and rehabilitation at Pittsburgh VA Medical Center-University Drive | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Physical medicine and rehabilitation at Pittsburgh VA Medical Center-University Drive | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Physical medicine and rehabilitation at Pittsburgh VA Medical Center-University Drive | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Location and contact information<\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>Main Hospital<\/strong><br \/>\r\nBuilding 1<br \/>\r\n10th floor, Room 10W141A<br \/>\r\n<a data-entity-substitution=\"canonical\" data-entity-type=\"node\" data-entity-uuid=\"71ffee52-a47f-4909-ad7e-21ece5728be3\" href=\"\/node\/783\">Map of University Drive campus<\/a><br \/>\r\n<strong>Phone:&nbsp;<\/strong><a href=\"tel:412-360-1358\">412-360-1358<\/a><br \/>\r\n<strong>Hours:&nbsp;<\/strong>Monday \u2013&nbsp;Friday, 8:00 a.m. to 4:30 p.m. ET<\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you\u2019ll need to contact your primary care provider first.<\/p>\r\n\r\n<p><strong>Phone:&nbsp;<\/strong><a href=\"tel:412-360-1358\">412-360-1358<\/a><\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "0b968788-cfb0-41aa-8206-2577105072fa"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "4cad2f34-1e07-49b9-a021-dd0d10016149"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.81664424-6415-4064-b987-64a95a22f2e0.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.81664424-6415-4064-b987-64a95a22f2e0.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "81664424-6415-4064-b987-64a95a22f2e0"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-05T13:13:34+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Radiology\/imaging at Belmont County VA Clinic"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "a6af4eb9-ef34-420e-8a20-e2fba1a5afa2"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-06-17T21:50:54+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-05T16:55:48+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Radiology\/imaging at Belmont County VA Clinic | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Radiology\/imaging at Belmont County VA Clinic | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Radiology\/imaging at Belmont County VA Clinic | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Location and contact information<\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>Phone:&nbsp;<\/strong><a href=\"tel: +14128223000\">412-822-3000<\/a><br \/>\r\n<strong>Hours:<\/strong>&nbsp;Monday \u2013 Friday, 8:00 a.m. to 4:30 p.m. ET<\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you\u2019ll need to contact your primary care provider first.<\/p>\r\n\r\n<p><strong>Phone:&nbsp;<\/strong><a href=\"tel: +14128223000\">412-822-3000<\/a><\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "eac71fd5-260c-4f44-8507-8b803ad2324f"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "72ff4ca7-0310-4786-b7ff-502486b88efc"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.82fc56d3-e6a6-43e3-98c1-c87e0f8366dd.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.82fc56d3-e6a6-43e3-98c1-c87e0f8366dd.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "82fc56d3-e6a6-43e3-98c1-c87e0f8366dd"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-05T15:05:01+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Podiatry at H. John Heinz III Department of Veterans Affairs Medical Center"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "a6af4eb9-ef34-420e-8a20-e2fba1a5afa2"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-06-14T22:08:03+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-05T15:05:01+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Podiatry at H. John Heinz III Department of Veterans Affairs Medical Center | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Podiatry at H. John Heinz III Department of Veterans Affairs Medical Center | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Podiatry at H. John Heinz III Department of Veterans Affairs Medical Center | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Location and contact information<\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>Ambulatory Care Center<\/strong><br \/>\r\nBuilding 71<br \/>\r\n2nd floor&nbsp;<br \/>\r\n<a data-entity-substitution=\"canonical\" data-entity-type=\"node\" data-entity-uuid=\"a2d3391d-7196-4a3e-bdf5-a71a7b214195\" href=\"\/node\/781\">Map of the Heinz campus<\/a><br \/>\r\n<strong>Phone:&nbsp;<\/strong><a href=\"tel: +14128223000\">412-822-3000<\/a><br \/>\r\n<strong>Hours: <\/strong>Monday \u2013 Friday, 8:00 a.m. to 4:30 p.m.<\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you\u2019ll need to contact your primary care provider first.<\/p>\r\n\r\n<p><strong>Referral needed?<\/strong>&nbsp;No<br \/>\r\n<strong>Phone:&nbsp;<\/strong><a href=\"tel: +14128223000\">412-822-3000<\/a><\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "e15ebe41-f7cf-4f2c-a407-3728c341220b"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "8c838193-be61-48ea-8f1c-a1839b57f1fc"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.83e125c4-642c-4c70-849c-48882ebb853d.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.83e125c4-642c-4c70-849c-48882ebb853d.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "83e125c4-642c-4c70-849c-48882ebb853d"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-05T13:40:03+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Transplant surgery at Pittsburgh VA Medical Center-University Drive"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "a6af4eb9-ef34-420e-8a20-e2fba1a5afa2"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-06-17T23:46:02+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-05T13:40:03+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Transplant surgery at Pittsburgh VA Medical Center-University Drive | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Transplant surgery at Pittsburgh VA Medical Center-University Drive | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Transplant surgery at Pittsburgh VA Medical Center-University Drive | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Location and contact information<\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>Transplantation surgery<\/strong><br \/>\r\nMain hospital<br \/>\r\nBuilding 1<br \/>\r\n6 East Clinic\/11 West<br \/>\r\n<a data-entity-substitution=\"canonical\" data-entity-type=\"node\" data-entity-uuid=\"71ffee52-a47f-4909-ad7e-21ece5728be3\" href=\"\/node\/783\">Map of University Drive campus<\/a><br \/>\r\n<strong>Phone:<\/strong>&nbsp;<a href=\"tel: +1 412-360-6155\">&nbsp;412-360-6155<\/a><\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you\u2019ll need to contact your primary care provider first.<\/p>\r\n\r\n<p><strong>Referral needed?<\/strong>&nbsp;Yes<br \/>\r\n<strong>Phone:<\/strong>&nbsp;<a href=\"tel: +1 412-360-6155\">&nbsp;412-360-6155<\/a><\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "0b968788-cfb0-41aa-8206-2577105072fa"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "f25b7f27-0320-404a-b116-dc2b21178818"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.84515c3f-69da-41ed-81d1-083c995c0642.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.84515c3f-69da-41ed-81d1-083c995c0642.json
@@ -1,0 +1,133 @@
+{
+    "uuid": [
+        {
+            "value": "84515c3f-69da-41ed-81d1-083c995c0642"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "regional_health_care_service_des",
+            "target_type": "node_type",
+            "target_uuid": "d2e27d2b-acb1-471b-a628-4c41c3778729"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-09-10T20:30:20+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "8d4a7bed-f4ba-499f-afd4-8e1cbeadfc4a"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "PTSD treatment"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "fd71292f-3dc7-409d-b0e8-500204cb005a"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-05-10T22:00:11+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-09-10T20:30:20+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "PTSD treatment | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "PTSD treatment | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "PTSD treatment | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": "\/ptsd-treatment",
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Care we provide at VA Pittsburgh<\/h3>\r\n\r\n<p>You can access these&nbsp;treatment options&nbsp;in at least one of our two medical centers:<\/p>\r\n\r\n<ul>\r\n\t<li>Psychiatry (outpatient &amp; inpatient) and psychology<\/li>\r\n\t<li>Homeless Veterans services<\/li>\r\n\t<li>Treatment for Addictive Disorders, including residential rehabilitation treatment program<\/li>\r\n\t<li>Psychiatric residential rehabilitation treatment program<\/li>\r\n\t<li>OIF\/OEF\/OND services<\/li>\r\n<\/ul>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_local_health_care_service_": [
+        {
+            "target_type": "node",
+            "target_uuid": "23dd7ec7-2537-49dc-9e03-5fb44df89892"
+        }
+    ],
+    "field_region_page": [
+        {
+            "target_type": "node",
+            "target_uuid": "2bddb1a7-6fb1-4503-838d-9c2fcb51c46a"
+        }
+    ],
+    "field_service_name_and_descripti": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "f750bca5-c4d7-424b-af63-70de3479c24c"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.88a5e744-5cfb-491a-bf53-ac6c0fc07f4b.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.88a5e744-5cfb-491a-bf53-ac6c0fc07f4b.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "88a5e744-5cfb-491a-bf53-ac6c0fc07f4b"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-09-11T17:36:10+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "8d4a7bed-f4ba-499f-afd4-8e1cbeadfc4a"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Primary care at H. John Heinz III Department of Veterans Affairs Medical Center"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "fd71292f-3dc7-409d-b0e8-500204cb005a"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-05-10T22:16:39+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-05T01:11:20+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Primary care at H. John Heinz III Department of Veterans Affairs Medical Center | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Primary care at H. John Heinz III Department of Veterans Affairs Medical Center | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Primary care at H. John Heinz III Department of Veterans Affairs Medical Center | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Location and contact information<\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>Primary Care Services<\/strong><br \/>\r\nAmbulatory Care Center<br \/>\r\nBuilding 71<br \/>\r\n2nd floor<br \/>\r\n<a data-entity-substitution=\"canonical\" data-entity-type=\"node\" data-entity-uuid=\"a2d3391d-7196-4a3e-bdf5-a71a7b214195\" href=\"\/node\/781\">Map of Heinz campus<\/a><br \/>\r\n<strong>Phone:&nbsp;<\/strong><a href=\"tel: +14128223000\">412-822-3000<\/a><br \/>\r\n<strong>Hours:&nbsp;<\/strong>Monday \u2013&nbsp;Friday, 8:00 a.m. \u2013&nbsp;4:30 p.m. ET<\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment.&nbsp;<\/p>\r\n\r\n<p><strong>Referral needed?<\/strong> No<\/p>\r\n\r\n<p><strong>Phone:&nbsp;<\/strong><a href=\"tel: +14128223000\">412-822-3000<\/a><br \/>\r\n<br \/>\r\n<a class=\"usa-button\" data-entity-substitution=\"canonical\" data-entity-type=\"node\" data-entity-uuid=\"4578cb13-d680-426f-8f2d-ff000e990cb3\" href=\"\/node\/37\">Schedule an appointment online<\/a><\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "e15ebe41-f7cf-4f2c-a407-3728c341220b"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "c4f23a23-0885-4e1a-b282-48c421fb9203"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.88ad402e-5f72-40af-9c99-5c97f76bbfbb.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.88ad402e-5f72-40af-9c99-5c97f76bbfbb.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "88ad402e-5f72-40af-9c99-5c97f76bbfbb"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-05T15:12:55+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Vocational rehabilitation and employment programs at H. John Heinz III Department of Veterans Affairs Medical Center"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "a6af4eb9-ef34-420e-8a20-e2fba1a5afa2"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-06-18T00:34:15+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-05T15:12:55+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Vocational rehabilitation and employment programs at H. John Heinz III Department of Veterans Affairs Medical Center | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Vocational rehabilitation and employment programs at H. John Heinz III Department of Veterans Affairs Medical Center | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Vocational rehabilitation and employment programs at H. John Heinz III Department of Veterans Affairs Medical Center | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Location and contact information<\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>Veterans Recovery Center<\/strong><br \/>\r\nBuilding 69<br \/>\r\n1st Floor<br \/>\r\n<a data-entity-substitution=\"canonical\" data-entity-type=\"node\" data-entity-uuid=\"a2d3391d-7196-4a3e-bdf5-a71a7b214195\" href=\"\/node\/781\">Map of the Heinz campus<\/a><br \/>\r\n<strong>Phone:&nbsp;<\/strong><a href=\"tel: +14128223815\">412-822-3815<\/a><br \/>\r\n<strong>Phone:&nbsp;<\/strong><a href=\"tel: +14128223815\">412-822-1<\/a><a href=\"tel: +14128221287\">287<\/a><\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you\u2019ll need to contact your primary care provider first.<\/p>\r\n\r\n<p><strong>Referral needed?<\/strong>&nbsp;No<br \/>\r\n<strong>Walk-ins accepted?<\/strong> Yes<br \/>\r\n<strong>Phone:&nbsp;<\/strong><a href=\"tel: +14128223815\">412-822-3815<\/a><br \/>\r\n<strong>Phone:&nbsp;<\/strong><a href=\"tel: +14128223815\">412-822-1<\/a><a href=\"tel: +14128221287\">287<\/a><\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "e15ebe41-f7cf-4f2c-a407-3728c341220b"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "fa9fd27d-aa1c-4cc0-b31b-569e779c034d"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.89733fed-7f21-4c29-8e50-003424df1afb.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.89733fed-7f21-4c29-8e50-003424df1afb.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "89733fed-7f21-4c29-8e50-003424df1afb"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-04T18:52:17+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "MOVE! weight management at H. John Heinz III Department of Veterans Affairs Medical Center"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "a6af4eb9-ef34-420e-8a20-e2fba1a5afa2"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-06-05T02:01:02+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-04T18:52:17+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "MOVE! weight management at H. John Heinz III Department of Veterans Affairs Medical Center | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "MOVE! weight management at H. John Heinz III Department of Veterans Affairs Medical Center | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "MOVE! weight management at H. John Heinz III Department of Veterans Affairs Medical Center | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Location and contact information<\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>MOVE!<\/strong><br \/>\r\nCommunity Living Center<br \/>\r\nBuilding 50<br \/>\r\nGround floor<br \/>\r\nRoom 1A-109<br \/>\r\n<a data-entity-substitution=\"canonical\" data-entity-type=\"node\" data-entity-uuid=\"a2d3391d-7196-4a3e-bdf5-a71a7b214195\" href=\"\/node\/781\">Map of the Heinz campus<\/a><br \/>\r\n<strong>Phone:&nbsp;<\/strong><a href=\"tel: +14128223114\">412-822-3114<\/a><br \/>\r\n<strong>Email:&nbsp;<\/strong><a href=\"mailto:melanie.erskine@va.gov\">melanie.erskine@va.gov<\/a><br \/>\r\n<strong>Hours:&nbsp;<\/strong>Mon.&nbsp;\u2013 Fri., 8:00 a.m. to 4:30 p.m. ET<\/p>\r\n\r\n<p class=\"va-address-block\"><strong>MOVE! Teleconference&nbsp;<br \/>\r\nHours:&nbsp;<\/strong>Wednesday 12:00 p.m. to 12:45 p.m. ET by dialing 1-800-767-1750 code 65074# or<br \/>\r\nMOVE by secure messaging<\/p>\r\n\r\n<p class=\"va-address-block\"><strong>MOVE! group meetings<\/strong><br \/>\r\nCommunity Living Center<br \/>\r\nBuilding 50&nbsp;(<a href=\"https:\/\/www.pittsburgh.va.gov\/about\/heinz-facility-map.asp\">map<\/a>)<br \/>\r\nRoom 1A-109<br \/>\r\n<a data-entity-substitution=\"canonical\" data-entity-type=\"node\" data-entity-uuid=\"a2d3391d-7196-4a3e-bdf5-a71a7b214195\" href=\"\/node\/781\">Map of the Heinz campus<\/a><br \/>\r\n<strong>Phone:&nbsp;<\/strong><a href=\"tel: +14128223114\">412-822-3114<\/a><br \/>\r\n<strong>Email:&nbsp;<\/strong><a href=\"mailto:melanie.erskine@va.gov\">melanie.erskine@va.gov<\/a><br \/>\r\n<strong>Hours: <\/strong>Friday,<strong>&nbsp;<\/strong>9:00 a.m. to 10:00 a.m. ET<\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you\u2019ll need to contact your primary care provider first.<br \/>\r\n<br \/>\r\n<strong>Phone:&nbsp;<\/strong><a href=\"tel: +14128223114\">412-822-3114<\/a><br \/>\r\n<strong>Email:<\/strong>&nbsp;<a href=\"mailto:scheduling@va-pittsburgh.gov\">scheduling@va-pittsburgh.gov<\/a><\/p>\r\n\r\n<p><a class=\"usa-button\" data-entity-substitution=\"canonical\" data-entity-type=\"node\" data-entity-uuid=\"4578cb13-d680-426f-8f2d-ff000e990cb3\" href=\"\/node\/37\">Schedule an appointment online<\/a><\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "e15ebe41-f7cf-4f2c-a407-3728c341220b"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "a27c5805-47de-4dc1-917c-4e3855fbd3cb"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.89a107e4-b645-4a01-a19c-10e52d93fd78.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.89a107e4-b645-4a01-a19c-10e52d93fd78.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "89a107e4-b645-4a01-a19c-10e52d93fd78"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-04T19:37:27+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Military sexual trauma at H. John Heinz III Department of Veterans Affairs Medical Center"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-10-30T20:58:19+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-04T19:37:27+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Military sexual trauma at H. John Heinz III Department of Veterans Affairs Medical Center | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Military sexual trauma at H. John Heinz III Department of Veterans Affairs Medical Center | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Military sexual trauma at H. John Heinz III Department of Veterans Affairs Medical Center | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Location and contact information&nbsp;<\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>Behavioral&nbsp;Health&nbsp;<\/strong><br \/>\r\n<a data-entity-substitution=\"canonical\" data-entity-type=\"node\" data-entity-uuid=\"71ffee52-a47f-4909-ad7e-21ece5728be3\" href=\"\/node\/783\">Map of&nbsp;<\/a><a href=\"pittsburgh-health-care\/hj-heinz-iii-campus-map\">H.J.&nbsp;Heinz III Campus<\/a><br \/>\r\n<strong>Phone:&nbsp;<\/strong><a href=\"tel: +1412-360-6600\">412-360-<\/a><a href=\"tel: +1412-360-1040\">1040<\/a><br \/>\r\n<strong>Hours:&nbsp;<\/strong>Monday \u2013&nbsp;Friday, 8:00 a.m. \u2013&nbsp;4:30 p.m. ET<\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you\u2019ll need to contact your primary care provider first.<\/p>\r\n\r\n<p><strong>Phone:&nbsp;<\/strong><a href=\"tel: +1412-360-6600\">412-360-<\/a><a href=\"tel: +1412-360-1040\">1040<\/a><\/p>\r\n\r\n<p>&nbsp;<\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "e15ebe41-f7cf-4f2c-a407-3728c341220b"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "6d59f042-c372-436c-a8ff-7a8f017ad89f"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.8bd1d7de-13f7-4430-bde1-e1fad573c439.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.8bd1d7de-13f7-4430-bde1-e1fad573c439.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "8bd1d7de-13f7-4430-bde1-e1fad573c439"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-04T19:48:17+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Intimate partner violence at Fayette County VA Clinic"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-10-30T20:05:56+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-04T19:48:17+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Intimate partner violence at Fayette County VA Clinic | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Intimate partner violence at Fayette County VA Clinic | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Intimate partner violence at Fayette County VA Clinic | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Location and contact information<\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>Intimate Partner Violence Champion<br \/>\r\nPhone:&nbsp;<\/strong><a href=\"tel: +17247096005\">724-<\/a><a href=\"tel: +17244394990\">439-4990<\/a><br \/>\r\n<strong>Hours:&nbsp;<\/strong>Monday \u2013 Friday, 8:00 a.m. to 4:30 p.m. ET<\/p>\r\n\r\n<p class=\"va-address-block\"><strong>National Domestic Violence 24-hour Hotline<\/strong><br \/>\r\n<strong>Phone:<\/strong>&nbsp;<a href=\"tel: +18007997233\">1-800-799-SAFE (7233)<\/a>&nbsp;or&nbsp;<a href=\"tel: +18007873224\">1-800-787-3224 (TTY)<\/a><br \/>\r\n<strong>Hours:<\/strong>&nbsp;24\/7<\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you\u2019ll need to contact your primary care provider first.<\/p>\r\n\r\n<p><strong>Referral needed?&nbsp;<\/strong>No\u200b\u200b\u200b\u200b\u200b\u200b\u200b<br \/>\r\n\u200b\u200b\u200b\u200b\u200b\u200b\u200b<strong>Phone:&nbsp;<\/strong><a href=\"tel: +17247096005\">724-<\/a><a href=\"tel: +17244394990\">439-4990<\/a><\/p>\r\n\r\n<p>&nbsp;<\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "4a987e19-688b-4840-964a-cfefc730fc6c"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "e453f2c1-fe99-427f-a256-92fd1f103c25"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.8bd98812-e275-4740-8d96-a4d293e856b7.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.8bd98812-e275-4740-8d96-a4d293e856b7.json
@@ -1,0 +1,133 @@
+{
+    "uuid": [
+        {
+            "value": "8bd98812-e275-4740-8d96-a4d293e856b7"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "regional_health_care_service_des",
+            "target_type": "node_type",
+            "target_uuid": "d2e27d2b-acb1-471b-a628-4c41c3778729"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-09-09T21:06:23+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "8d4a7bed-f4ba-499f-afd4-8e1cbeadfc4a"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Dermatology"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "fd71292f-3dc7-409d-b0e8-500204cb005a"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-05-10T21:41:46+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-09-09T21:06:23+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Dermatology | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Dermatology | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Dermatology | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": "\/dermatology",
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Care we provide at VA Pittsburgh<\/h3>\r\n\r\n<p>We offer regular clinic visits and dermatologic surgery for Veterans. Our three full-time and six part-time board-certified dermatologists provide:<\/p>\r\n\r\n<ul>\r\n\t<li>Treatment of medically necessary skin conditions, including skin cancer and rashes<\/li>\r\n\t<li>Referrals for complex conditions<\/li>\r\n\t<li>Teledermatology, which provides patients with quick access to expert opinions<\/li>\r\n<\/ul>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_local_health_care_service_": [
+        {
+            "target_type": "node",
+            "target_uuid": "1ec0e232-4abb-460d-b5f7-112ae612eea8"
+        }
+    ],
+    "field_region_page": [
+        {
+            "target_type": "node",
+            "target_uuid": "2bddb1a7-6fb1-4503-838d-9c2fcb51c46a"
+        }
+    ],
+    "field_service_name_and_descripti": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "b2264cc5-bdcc-48fb-b9c8-9f036656690c"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.9130891f-4884-4d10-a0a0-671730f2cec5.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.9130891f-4884-4d10-a0a0-671730f2cec5.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "9130891f-4884-4d10-a0a0-671730f2cec5"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-05T14:37:24+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Laboratory and pathology at H. John Heinz III Department of Veterans Affairs Medical Center"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "a6af4eb9-ef34-420e-8a20-e2fba1a5afa2"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-05-30T23:20:58+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-05T14:37:24+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Laboratory and pathology at H. John Heinz III Department of Veterans Affairs Medical Center | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Laboratory and pathology at H. John Heinz III Department of Veterans Affairs Medical Center | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Laboratory and pathology at H. John Heinz III Department of Veterans Affairs Medical Center | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3><strong>Location and contact information&nbsp;<\/strong><\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>Laboratory and pathology<\/strong><br \/>\r\nAmbulatory Care Center<br \/>\r\n2nd Floor<br \/>\r\n<a data-entity-substitution=\"canonical\" data-entity-type=\"node\" data-entity-uuid=\"a2d3391d-7196-4a3e-bdf5-a71a7b214195\" href=\"\/node\/781\">Map of the Heinz campus<\/a><br \/>\r\n<strong>Phone:&nbsp;<\/strong><a href=\"tel:\u00a0+14123601572\">412-360-1572<\/a><br \/>\r\n<strong>Hours:&nbsp;<\/strong>Monday \u2013&nbsp;Friday, 8:00 a.m. to 4:30 p.m. ET<\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you\u2019ll need to contact your primary care provider first.<\/p>\r\n\r\n<p><strong>Phone:&nbsp;<\/strong><a href=\"tel:\u00a0+14123601572\">412-360-1572<\/a><\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "e15ebe41-f7cf-4f2c-a407-3728c341220b"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "04b5f49e-4a46-481c-a494-bd43a8598094"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.9198779f-53e0-4e22-8160-3e612c39e97a.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.9198779f-53e0-4e22-8160-3e612c39e97a.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "9198779f-53e0-4e22-8160-3e612c39e97a"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-05T15:20:32+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Women Veteran care at H. John Heinz III Department of Veterans Affairs Medical Center"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "fd71292f-3dc7-409d-b0e8-500204cb005a"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-10-30T19:53:30+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-05T15:20:32+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Women Veteran care at H. John Heinz III Department of Veterans Affairs Medical Center | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Women Veteran care at H. John Heinz III Department of Veterans Affairs Medical Center | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Women Veteran care at H. John Heinz III Department of Veterans Affairs Medical Center | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Location and contact information<\/h3>\r\n\r\n<p class=\"va-address-block\">Building 71<br \/>\r\n<a data-entity-substitution=\"canonical\" data-entity-type=\"node\" data-entity-uuid=\"a2d3391d-7196-4a3e-bdf5-a71a7b214195\" href=\"\/node\/781\">Map of H.J. Heinz&nbsp;III campus<\/a><br \/>\r\n<strong>Phone:<\/strong>&nbsp;<a href=\"tel:+14123606289\">412-<\/a><a href=\"tel:412-822-3000\">822-3000<\/a><\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you\u2019ll need to contact your primary care provider first.<\/p>\r\n\r\n<p><strong>Phone:<\/strong>&nbsp;<a href=\"tel:+14123606289\">412-<\/a><a href=\"tel:412-822-3000\">822-3000<\/a><\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "e15ebe41-f7cf-4f2c-a407-3728c341220b"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "1fdda7ec-a660-4fa7-86be-ef2421cb4e6f"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.9217736f-deec-4154-b8e3-9dcb1f285b61.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.9217736f-deec-4154-b8e3-9dcb1f285b61.json
@@ -1,0 +1,132 @@
+{
+    "uuid": [
+        {
+            "value": "9217736f-deec-4154-b8e3-9dcb1f285b61"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-04T21:19:44+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "revision_log": [
+        {
+            "value": "Bulk operation publish revision"
+        }
+    ],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Registry exams at Fayette County VA Clinic"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-10-30T18:33:26+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-05T17:00:49+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Registry exams at Fayette County VA Clinic | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Registry exams at Fayette County VA Clinic | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Registry exams at Fayette County VA Clinic | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Location and contact information<\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>Environmental Health Coordinator<\/strong><br \/>\r\nPhone:&nbsp;<a href=\"tel: +14128221707\">412-822-1707<\/a><br \/>\r\n<strong>Email:&nbsp;<\/strong><a href=\"mailto:douglas.turner5@va.gov\">douglas.turner5@va.gov<\/a><\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you\u2019ll need to contact your primary care provider first.<\/p>\r\n\r\n<p><strong>Referral needed?<\/strong>&nbsp;No<br \/>\r\n<strong>Walk-ins accepted?<\/strong>&nbsp;No<br \/>\r\n<strong>Phone:<\/strong>&nbsp;<a href=\"tel: +14128221707\">412-822-1707<\/a><\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "4a987e19-688b-4840-964a-cfefc730fc6c"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "3e92eaa8-bbf8-4173-84f8-d187b281d548"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.929402f4-2a85-4659-a1bf-900264984903.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.929402f4-2a85-4659-a1bf-900264984903.json
@@ -1,0 +1,137 @@
+{
+    "uuid": [
+        {
+            "value": "929402f4-2a85-4659-a1bf-900264984903"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "regional_health_care_service_des",
+            "target_type": "node_type",
+            "target_uuid": "d2e27d2b-acb1-471b-a628-4c41c3778729"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-09-23T18:36:25+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "fd71292f-3dc7-409d-b0e8-500204cb005a"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Pharmacy"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "8bea8773-6a06-4afd-99b5-1dfa7a2192ea"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-04-03T13:24:02+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-09-23T18:36:25+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Pharmacy | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Pharmacy | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Pharmacy | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": "\/pharmacy",
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Care we provide at VA Pittsburgh&nbsp;<\/h3>\r\n\r\n<ul>\r\n\t<li>New prescriptions available for in-person pick up<\/li>\r\n\t<li>Refills online and by phone or mail<\/li>\r\n\t<li>Safe disposal of medicines<\/li>\r\n<\/ul>\r\n\r\n<p><a data-entity-substitution=\"canonical\" data-entity-type=\"node\" data-entity-uuid=\"d323fc5c-81a7-4388-a3e6-e5a8ff2a3f05\" href=\"\/node\/268\">Learn more about pharmacy services<\/a><\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_local_health_care_service_": [
+        {
+            "target_type": "node",
+            "target_uuid": "f1e75524-194c-4c05-a086-8c8b1248abb8"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "234f7c8f-c84e-47c6-ad3c-ec97ed1e18eb"
+        }
+    ],
+    "field_region_page": [
+        {
+            "target_type": "node",
+            "target_uuid": "2bddb1a7-6fb1-4503-838d-9c2fcb51c46a"
+        }
+    ],
+    "field_service_name_and_descripti": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "ca88c56c-eaec-4570-9370-e783510b602a"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.92d10b5d-71d3-4432-b793-e30167fdb857.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.92d10b5d-71d3-4432-b793-e30167fdb857.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "92d10b5d-71d3-4432-b793-e30167fdb857"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-05T15:06:01+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Podiatry at Beaver County VA Clinic"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "a6af4eb9-ef34-420e-8a20-e2fba1a5afa2"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-06-14T22:06:48+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-05T15:06:01+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Podiatry at Beaver County VA Clinic | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Podiatry at Beaver County VA Clinic | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Podiatry at Beaver County VA Clinic | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Location and contact information<\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>Phone:&nbsp;<\/strong><a href=\"tel: +14128223000\">412-822-3000<\/a><br \/>\r\n<strong>Hours:&nbsp;<\/strong>Monday \u2013&nbsp;Friday, 8:00 a.m. to 4:30 p.m. ET<\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you\u2019ll need to contact your primary care provider first.<\/p>\r\n\r\n<p><strong>Referral needed?<\/strong>&nbsp;No<br \/>\r\n<strong>Phone:&nbsp;<\/strong><a href=\"tel: +14128223000\">412-822-3000<\/a><\/p>\r\n\r\n<p>&nbsp;<\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "a1eabfea-4a7e-4d22-ad09-1d85b884145f"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "8c838193-be61-48ea-8f1c-a1839b57f1fc"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.9326c56e-0435-470e-b372-602a019ebe3a.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.9326c56e-0435-470e-b372-602a019ebe3a.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "9326c56e-0435-470e-b372-602a019ebe3a"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-04T19:23:00+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "LGBT Veteran care at Fayette County VA Clinic"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-10-30T20:46:28+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-04T19:23:00+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "LGBT Veteran care at Fayette County VA Clinic | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "LGBT Veteran care at Fayette County VA Clinic | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "LGBT Veteran care at Fayette County VA Clinic | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Location and contact information<\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>Phone:<\/strong> <a href=\"tel: +14128221069\">412-822-1069<\/a><br \/>\r\n<strong>Phone:<\/strong> <a href=\"tel: +14128221069\">412-<\/a><a href=\"tel: +14123601210\">360-1210<\/a><\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you\u2019ll need to contact your primary care provider first.<\/p>\r\n\r\n<p><strong>Phone:<\/strong> <a href=\"tel: +14128221069\">412-822-1069<\/a><br \/>\r\n<strong>Phone:<\/strong> <a href=\"tel: +14128221069\">412-<\/a><a href=\"tel: +14123601210\">360-1210<\/a><\/p>\r\n\r\n<p>&nbsp;<\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "4a987e19-688b-4840-964a-cfefc730fc6c"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "5483b3ee-eeb5-4286-9ff1-2d463784031b"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.933048f9-a7c0-4629-ba8b-782845a28ec1.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.933048f9-a7c0-4629-ba8b-782845a28ec1.json
@@ -1,0 +1,132 @@
+{
+    "uuid": [
+        {
+            "value": "933048f9-a7c0-4629-ba8b-782845a28ec1"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-04T21:19:44+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "revision_log": [
+        {
+            "value": "Bulk operation publish revision"
+        }
+    ],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Registry exams at Washington County VA Clinic"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-10-30T18:34:26+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-05T17:00:49+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Registry exams at Washington County VA Clinic | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Registry exams at Washington County VA Clinic | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Registry exams at Washington County VA Clinic | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Location and contact information<\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>Environmental Health Coordinator<\/strong><br \/>\r\nPhone:&nbsp;<a href=\"tel: +14128221707\">412-822-1707<\/a><br \/>\r\n<strong>Email:&nbsp;<\/strong><a href=\"mailto:douglas.turner5@va.gov\">douglas.turner5@va.gov<\/a><\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you\u2019ll need to contact your primary care provider first.<\/p>\r\n\r\n<p><strong>Referral needed?<\/strong>&nbsp;No<br \/>\r\n<strong>Walk-ins accepted?<\/strong>&nbsp;No<br \/>\r\n<strong>Phone:<\/strong>&nbsp;<a href=\"tel: +14128221707\">412-822-1707<\/a><\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "a6826998-b7f7-434f-8999-959b1dab0c52"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "3e92eaa8-bbf8-4173-84f8-d187b281d548"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.94177aa5-4a5e-4a66-97d5-e721b8f02f92.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.94177aa5-4a5e-4a66-97d5-e721b8f02f92.json
@@ -1,0 +1,133 @@
+{
+    "uuid": [
+        {
+            "value": "94177aa5-4a5e-4a66-97d5-e721b8f02f92"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "regional_health_care_service_des",
+            "target_type": "node_type",
+            "target_uuid": "d2e27d2b-acb1-471b-a628-4c41c3778729"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-09-09T21:09:52+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "8d4a7bed-f4ba-499f-afd4-8e1cbeadfc4a"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Gastroenterology"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "fd71292f-3dc7-409d-b0e8-500204cb005a"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-05-10T21:43:06+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-09-09T21:09:52+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Gastroenterology | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Gastroenterology | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Gastroenterology | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": "\/gastroenterology",
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Care we provide at VA Pittsburgh<\/h3>\r\n\r\n<p>Staff in our gastroenterology department can provide the following treatments:<\/p>\r\n\r\n<ul>\r\n\t<li>Colonoscopy<\/li>\r\n\t<li>Esophagogastroduodenoscopy (EGD)<\/li>\r\n\t<li>Manometry studies<\/li>\r\n\t<li>Endoscopic ultrasound and&nbsp;Endoscopic Retrograde Cholangiopancreatography&nbsp;(ERCP)<\/li>\r\n\t<li>Small bowel capsule endoscopy<\/li>\r\n\t<li>24-hour pH studies<\/li>\r\n<\/ul>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_local_health_care_service_": [
+        {
+            "target_type": "node",
+            "target_uuid": "6d30b38b-9705-473b-bddb-76b0cb835829"
+        }
+    ],
+    "field_region_page": [
+        {
+            "target_type": "node",
+            "target_uuid": "2bddb1a7-6fb1-4503-838d-9c2fcb51c46a"
+        }
+    ],
+    "field_service_name_and_descripti": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "023f7f13-50bb-4eef-9570-78bdad529a3c"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.95bf151d-92d5-4a29-b73f-48cea20465f7.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.95bf151d-92d5-4a29-b73f-48cea20465f7.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "95bf151d-92d5-4a29-b73f-48cea20465f7"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-04T19:23:12+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "LGBT Veteran care at Washington County VA Clinic"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-10-30T20:46:57+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-04T19:23:12+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "LGBT Veteran care at Washington County VA Clinic | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "LGBT Veteran care at Washington County VA Clinic | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "LGBT Veteran care at Washington County VA Clinic | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Location and contact information<\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>Phone:<\/strong> <a href=\"tel: +14128221069\">412-822-1069<\/a><br \/>\r\n<strong>Phone:<\/strong> <a href=\"tel: +14128221069\">412-<\/a><a href=\"tel: +14123601210\">360-1210<\/a><\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you\u2019ll need to contact your primary care provider first.<\/p>\r\n\r\n<p><strong>Phone:<\/strong> <a href=\"tel: +14128221069\">412-822-1069<\/a><br \/>\r\n<strong>Phone:<\/strong> <a href=\"tel: +14128221069\">412-<\/a><a href=\"tel: +14123601210\">360-1210<\/a><\/p>\r\n\r\n<p>&nbsp;<\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "a6826998-b7f7-434f-8999-959b1dab0c52"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "5483b3ee-eeb5-4286-9ff1-2d463784031b"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.96dc069a-e27e-4b24-bdc6-64f95ed71507.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.96dc069a-e27e-4b24-bdc6-64f95ed71507.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "96dc069a-e27e-4b24-bdc6-64f95ed71507"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-09-10T21:18:20+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "8d4a7bed-f4ba-499f-afd4-8e1cbeadfc4a"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Urology at H. John Heinz III Department of Veterans Affairs Medical Center"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "fd71292f-3dc7-409d-b0e8-500204cb005a"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-05-13T16:23:41+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-05T01:35:28+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Urology at H. John Heinz III Department of Veterans Affairs Medical Center | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Urology at H. John Heinz III Department of Veterans Affairs Medical Center | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Urology at H. John Heinz III Department of Veterans Affairs Medical Center | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 0
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Location and contact information<\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>Primary care area<\/strong><br \/>\r\n2nd floor<br \/>\r\n<a data-entity-substitution=\"canonical\" data-entity-type=\"node\" data-entity-uuid=\"a2d3391d-7196-4a3e-bdf5-a71a7b214195\" href=\"\/node\/781\">Map of&nbsp;H.J. Heinz III Campus<\/a><br \/>\r\n<strong>Phone:&nbsp;<\/strong><a href=\"tel:+14128222222\">412-822-2222<\/a><br \/>\r\n<strong>Hours:&nbsp;<\/strong>Select Tuesdays monthly, 8:00 a.m. to 4:00 p.m. ET<\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you\u2019ll need to contact your primary care provider first.<\/p>\r\n\r\n<p><strong>Referral needed? <\/strong>Yes<\/p>\r\n\r\n<p><strong>Walk-ins accepted?<\/strong> No<\/p>\r\n\r\n<p><strong>Phone:&nbsp;<\/strong><a href=\"tel:+14123606700\">412-360-6700<\/a><\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "e15ebe41-f7cf-4f2c-a407-3728c341220b"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "fa8d2d15-0e41-4ef0-a606-c0da352fe76d"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.975984ef-4be6-4b83-a828-36b879bc3463.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.975984ef-4be6-4b83-a828-36b879bc3463.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "975984ef-4be6-4b83-a828-36b879bc3463"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-05T13:36:16+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Audiology and speech at Pittsburgh VA Medical Center-University Drive"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "fd71292f-3dc7-409d-b0e8-500204cb005a"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-05-10T22:08:59+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-05T13:36:16+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Audiology and speech at Pittsburgh VA Medical Center-University Drive | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Audiology and speech at Pittsburgh VA Medical Center-University Drive | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Audiology and speech at Pittsburgh VA Medical Center-University Drive | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Location and contact information<\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>Consolidation Building<\/strong><br \/>\r\nSecond floor<br \/>\r\n<a data-entity-substitution=\"canonical\" data-entity-type=\"node\" data-entity-uuid=\"71ffee52-a47f-4909-ad7e-21ece5728be3\" href=\"\/node\/783\">Map of University Drive campus<\/a><br \/>\r\n<strong>Phone:&nbsp;<\/strong><br \/>\r\n<a href=\"tel: +14123606400\">412-360-6400<\/a><br \/>\r\n<a href=\"tel: +14123606428\">412-360-6428<\/a>&nbsp;<br \/>\r\n<strong>Hours:&nbsp;<\/strong>Monday \u2013&nbsp;Friday, 8:00 a.m. to 4:30 p.m. ET<\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you\u2019ll need to contact your primary care provider first.<\/p>\r\n\r\n<p><strong>Referral needed?<\/strong>&nbsp;No<br \/>\r\n<strong>Phone:&nbsp;<\/strong><a href=\"tel: +14123606400\">412-360-6400<\/a><br \/>\r\n<strong>Phone:&nbsp;<\/strong><a href=\"tel: +14123606428\">412-360-6428<\/a>&nbsp;<\/p>\r\n\r\n<p>&nbsp;<\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "0b968788-cfb0-41aa-8206-2577105072fa"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "a192dca3-0ebd-44a5-8cdb-d70c2d8cc4bc"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.97bc639c-1ae1-41d4-ba0b-9513a20ec8ce.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.97bc639c-1ae1-41d4-ba0b-9513a20ec8ce.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "97bc639c-1ae1-41d4-ba0b-9513a20ec8ce"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-05T15:36:36+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Ophthalmology at Pittsburgh VA Medical Center-University Drive"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "fd71292f-3dc7-409d-b0e8-500204cb005a"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-05-10T22:17:24+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-05T15:36:36+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Ophthalmology at Pittsburgh VA Medical Center-University Drive | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Ophthalmology at Pittsburgh VA Medical Center-University Drive | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Ophthalmology at Pittsburgh VA Medical Center-University Drive | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Location and contact information<\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>Main hospital<\/strong><br \/>\r\nBuilding 1<br \/>\r\n1-East<br \/>\r\n<a data-entity-substitution=\"canonical\" data-entity-type=\"node\" data-entity-uuid=\"71ffee52-a47f-4909-ad7e-21ece5728be3\" href=\"\/node\/783\">Map of University Drive campus<\/a><br \/>\r\n<strong>Phone:&nbsp;<\/strong><a href=\"tel: +1412-360-6700\">412-360-6700<\/a><br \/>\r\n<strong>Hours:&nbsp;<\/strong>Monday \u2013&nbsp;Friday, 8:00 a.m. to 4:30 p.m. ET<\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you\u2019ll need to contact your primary care provider first.<\/p>\r\n\r\n<p><strong>Phone:&nbsp;<\/strong><a href=\"tel: +1412-360-6700\">412-360-6700<\/a><\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "0b968788-cfb0-41aa-8206-2577105072fa"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "cbd42261-56b9-4bd3-8e95-317797682663"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.993ca7e5-e745-4add-890d-66da2f52a52d.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.993ca7e5-e745-4add-890d-66da2f52a52d.json
@@ -1,0 +1,137 @@
+{
+    "uuid": [
+        {
+            "value": "993ca7e5-e745-4add-890d-66da2f52a52d"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "regional_health_care_service_des",
+            "target_type": "node_type",
+            "target_uuid": "d2e27d2b-acb1-471b-a628-4c41c3778729"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-05T17:02:04+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "fd71292f-3dc7-409d-b0e8-500204cb005a"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Travel reimbursement"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "fd71292f-3dc7-409d-b0e8-500204cb005a"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-05-10T21:48:55+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-05T17:02:04+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Travel reimbursement | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Travel reimbursement | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Travel reimbursement | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": "\/travel-reimbursement",
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Care we provide at VA Pittsburgh<\/h3>\r\n\r\n<p>You can sign up for a travel reimbursement service&nbsp;by&nbsp;visiting the agent cashier at the University Drive or Heinz campus, or at the check-in desk at our outpatient clinics.&nbsp;Our travel reimbursement services include:<\/p>\r\n\r\n<ul>\r\n\t<li>Round-trip transportation services from your home to our facility (beneficiary travel)<\/li>\r\n\t<li>Mileage reimbursement debit card<\/li>\r\n<\/ul>\r\n\r\n<p><a href=\"https:\/\/www.va.gov\/HealthBenefits\/vtp\/Beneficiary_Travel.asp\">Learn more about whether you qualify for the VA Beneficiary Travel program<\/a><\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_local_health_care_service_": [
+        {
+            "target_type": "node",
+            "target_uuid": "3d792ced-59f4-4b71-8633-dae36bef86eb"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "b3949e02-0e6a-4a35-b036-4f3749f3321c"
+        }
+    ],
+    "field_region_page": [
+        {
+            "target_type": "node",
+            "target_uuid": "2bddb1a7-6fb1-4503-838d-9c2fcb51c46a"
+        }
+    ],
+    "field_service_name_and_descripti": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "e5d2d0df-ab4c-424f-b108-5f735fc320d5"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.9cd25d9b-2590-4c8d-ab91-6ebe860876f4.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.9cd25d9b-2590-4c8d-ab91-6ebe860876f4.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "9cd25d9b-2590-4c8d-ab91-6ebe860876f4"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-05T14:38:12+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Laboratory and pathology at Belmont County VA Clinic"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "a6af4eb9-ef34-420e-8a20-e2fba1a5afa2"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-05-30T23:22:03+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-05T14:38:12+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Laboratory and pathology at Belmont County VA Clinic | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Laboratory and pathology at Belmont County VA Clinic | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Laboratory and pathology at Belmont County VA Clinic | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3><strong>Location and contact information<\/strong><\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>Phone:&nbsp;<\/strong><a href=\"tel: +1412-360-1572\">412-360-1572<\/a><br \/>\r\n<strong>Hours:&nbsp;<\/strong>Monday \u2013&nbsp;Friday, 8:00 a.m. to 4:30 p.m. ET<\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you\u2019ll need to contact your primary care provider first.<\/p>\r\n\r\n<p><strong>Phone:&nbsp;<\/strong><a href=\"tel: +1412-360-1572\">412-360-1572<\/a><\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "eac71fd5-260c-4f44-8507-8b803ad2324f"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "04b5f49e-4a46-481c-a494-bd43a8598094"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.a044cafe-b5d0-4aa9-9633-8852790df828.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.a044cafe-b5d0-4aa9-9633-8852790df828.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "a044cafe-b5d0-4aa9-9633-8852790df828"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-09-10T10:32:29+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "8d4a7bed-f4ba-499f-afd4-8e1cbeadfc4a"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Patient advocates at H. John Heinz III Department of Veterans Affairs Medical Center"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "a6af4eb9-ef34-420e-8a20-e2fba1a5afa2"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-06-14T21:05:58+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-09-10T10:32:29+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Patient advocates at H. John Heinz III Department of Veterans Affairs Medical Center | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Patient advocates at H. John Heinz III Department of Veterans Affairs Medical Center | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Patient advocates at H. John Heinz III Department of Veterans Affairs Medical Center | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Location and contact information<\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>Hours: <\/strong>Monday \u2013 Friday, 8:00 a.m. to 4:30 p.m. ET<\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "e15ebe41-f7cf-4f2c-a407-3728c341220b"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "85ecc815-a3fc-4978-9e7a-2cfd55dc9b72"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.a192dca3-0ebd-44a5-8cdb-d70c2d8cc4bc.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.a192dca3-0ebd-44a5-8cdb-d70c2d8cc4bc.json
@@ -1,0 +1,137 @@
+{
+    "uuid": [
+        {
+            "value": "a192dca3-0ebd-44a5-8cdb-d70c2d8cc4bc"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "regional_health_care_service_des",
+            "target_type": "node_type",
+            "target_uuid": "d2e27d2b-acb1-471b-a628-4c41c3778729"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-09-09T20:56:36+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "8d4a7bed-f4ba-499f-afd4-8e1cbeadfc4a"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Audiology and speech"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "b02c2ff5-dfe1-4542-beec-3fd410a3f267"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-02-28T17:39:31+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-09-09T20:56:36+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Audiology and speech | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Audiology and speech | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Audiology and speech | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": "\/audiology-and-speech",
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Care we provide at VA Pittsburgh<\/h3>\r\n\r\n<ul>\r\n\t<li>Hearing and balance evaluations<\/li>\r\n\t<li>Hearing aid selection, management, and repair, and assistive listening device assessments<\/li>\r\n\t<li>Evaluation, programming, and management for cochlear implants and&nbsp;bone-anchored implants<\/li>\r\n\t<li>Auditory processing evaluations and treatment<\/li>\r\n\t<li>Speech pathology services that help with speech, language, fluency, voice, cognitive communication, swallowing, stuttering, and laryngectomy<\/li>\r\n<\/ul>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_local_health_care_service_": [
+        {
+            "target_type": "node",
+            "target_uuid": "c8c43cec-81d2-495b-be81-5129490622c1"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "975984ef-4be6-4b83-a828-36b879bc3463"
+        }
+    ],
+    "field_region_page": [
+        {
+            "target_type": "node",
+            "target_uuid": "2bddb1a7-6fb1-4503-838d-9c2fcb51c46a"
+        }
+    ],
+    "field_service_name_and_descripti": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "6fe1da43-4b95-41f4-a343-c773b3c90297"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.a1eabfea-4a7e-4d22-ad09-1d85b884145f.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.a1eabfea-4a7e-4d22-ad09-1d85b884145f.json
@@ -1,0 +1,321 @@
+{
+    "uuid": [
+        {
+            "value": "a1eabfea-4a7e-4d22-ad09-1d85b884145f"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_facility",
+            "target_type": "node_type",
+            "target_uuid": "5ecbcf0c-b701-49d5-a47e-08803d42dd80"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-10-29T21:18:38+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "efa9900b-7446-41bf-b6a9-a99287ae2235"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Beaver County VA Clinic"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "b02c2ff5-dfe1-4542-beec-3fd410a3f267"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-02-15T20:34:30+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-05T14:57:00+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "VA Pittsburgh Health Care | Beaver County Clinic | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_description": "Learn details about about the Beaver County outpatient clinic, part of the VA Pittsburgh Health Care system, to help prepare for your visit.",
+            "description": "Beaver County Outpatient VA Clinic - where you can receive general medical care, physical exams, and laboratory, radiology, dietary and podiatry services.",
+            "twitter_cards_title": "Beaver County VA Clinic | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "keywords": "VA Outpatient Clinic Beaver County",
+            "image_src": "http:\/\/default\/sites\/default\/files\/2019-06\/Beaver%20County%20Outpatient%20Clinic_20170713_4790.jpg",
+            "og_title": "Beaver County VA Clinic | Veterans Affairs",
+            "og_description": "Learn details about about the Beaver County outpatient clinic, part of the VA Pittsburgh Health Care system, to help prepare for your visit.",
+            "twitter_cards_image": "http:\/\/default\/sites\/default\/files\/2019-06\/Beaver%20County%20Outpatient%20Clinic_20170713_4790.jpg",
+            "og_image_0": "http:\/\/default\/sites\/default\/files\/2019-06\/Beaver%20County%20Outpatient%20Clinic_20170713_4790.jpg"
+        }
+    },
+    "path": [
+        {
+            "alias": "\/pittsburgh-health-care\/locations\/beaver-county-va-clinic",
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_address": [
+        {
+            "langcode": null,
+            "country_code": "US",
+            "administrative_area": "PA",
+            "locality": "Rochester",
+            "dependent_locality": null,
+            "postal_code": "15074-2135",
+            "sorting_code": null,
+            "address_line1": "300 Brighton Avenue, Suite 110",
+            "address_line2": null,
+            "organization": null,
+            "given_name": null,
+            "additional_name": null,
+            "family_name": null
+        }
+    ],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_description": [
+        {
+            "value": "Learn details about about the Beaver County outpatient clinic, part of the VA Pittsburgh Health Care system, to help prepare for your visit. "
+        }
+    ],
+    "field_email_subscription": [],
+    "field_facebook": [],
+    "field_facility_classification": [
+        {
+            "value": "3"
+        }
+    ],
+    "field_facility_hours": [
+        {
+            "value": [
+                [
+                    "Mon",
+                    "800AM-430PM"
+                ],
+                [
+                    "Tue",
+                    "800AM-430PM"
+                ],
+                [
+                    "Wed",
+                    "800AM-430PM"
+                ],
+                [
+                    "Thu",
+                    "800AM-430PM"
+                ],
+                [
+                    "Fri",
+                    "800AM-430PM"
+                ],
+                [
+                    "Sat",
+                    "Closed"
+                ],
+                [
+                    "Sun",
+                    "Closed"
+                ]
+            ],
+            "format": null,
+            "caption": null
+        }
+    ],
+    "field_facility_locator_api_id": [
+        {
+            "value": "vha_646GC"
+        }
+    ],
+    "field_flickr": [],
+    "field_instagram": [],
+    "field_intro_text": [
+        {
+            "value": "The Beaver County outpatient clinic offers general medical care, including physical exams, laboratory services, radiology, dietary services, and podiatry (foot care).\r\n"
+        }
+    ],
+    "field_local_health_care_service_": [
+        {
+            "target_type": "node",
+            "target_uuid": "a66a9b8f-3ec3-4bce-b74e-a1c6e53bd547"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "92d10b5d-71d3-4432-b793-e30167fdb857"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "42c48aee-830b-4355-93eb-a407ba9ded72"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "3e0b8838-033d-475f-919c-8ff55154a23a"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "d9936c6b-6c41-4fb5-a975-ae17b0fa4193"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "808fb0ce-2019-444a-b19f-809e98f72106"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "5d109f49-1af7-47ac-8f6d-cc1697ca39d8"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "d616e6d4-2002-4aa9-a678-2797b21849bd"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "ed7ba178-a831-49bd-8a11-9f28ae46da8c"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "4fb285c4-c72c-4220-9487-99b70bc0f8aa"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "d01200a7-f5fb-4b5d-bc98-5cd1a656bb2f"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "59c40ffd-c8f0-4a9a-80c6-11406b933542"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "7a214dbf-b83f-4a6a-b747-d841b7dbcfb6"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "697f3d8b-7f89-4b28-bef3-bed0db89c2d2"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "2121b5e0-743d-44bc-a9ea-8947f961500e"
+        }
+    ],
+    "field_location_services": [
+        {
+            "target_type": "paragraph",
+            "target_uuid": "7e6fe218-4890-4ed5-ab9e-5df64229f7d1"
+        },
+        {
+            "target_type": "paragraph",
+            "target_uuid": "49172c9a-f504-4f7d-8da6-87627b35a8d8"
+        },
+        {
+            "target_type": "paragraph",
+            "target_uuid": "1455ec3f-b678-4eec-9fae-9a5a03251bc3"
+        }
+    ],
+    "field_main_location": [
+        {
+            "value": false
+        }
+    ],
+    "field_media": [
+        {
+            "target_type": "media",
+            "target_uuid": "1e069ce4-0b80-4618-93c4-e398d47b6363"
+        }
+    ],
+    "field_mental_health_phone": [
+        {
+            "value": "412-360-6600"
+        }
+    ],
+    "field_meta_tags": [
+        {
+            "value": {
+                "description": "Beaver County Outpatient VA Clinic - where you can receive general medical care, physical exams, and laboratory, radiology, dietary and podiatry services.",
+                "keywords": "VA Outpatient Clinic Beaver County"
+            }
+        }
+    ],
+    "field_meta_title": [
+        {
+            "value": "VA Pittsburgh Health Care | Beaver County Clinic | Veterans Affairs"
+        }
+    ],
+    "field_nickname_for_this_facility": [
+        {
+            "value": "Beaver County clinic"
+        }
+    ],
+    "field_operating_status_facility": [
+        {
+            "value": "normal"
+        }
+    ],
+    "field_operating_status_more_info": [],
+    "field_phone_number": [
+        {
+            "value": "724-709-6005"
+        }
+    ],
+    "field_region_page": [
+        {
+            "target_type": "node",
+            "target_uuid": "2bddb1a7-6fb1-4503-838d-9c2fcb51c46a"
+        }
+    ],
+    "field_twitter": []
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.a3e20785-6bc2-44b4-a3d2-a3837a70b5f0.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.a3e20785-6bc2-44b4-a3d2-a3837a70b5f0.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "a3e20785-6bc2-44b4-a3d2-a3837a70b5f0"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-05T12:50:04+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Nutrition, food, and dietary at H. John Heinz III Department of Veterans Affairs Medical Center"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "a6af4eb9-ef34-420e-8a20-e2fba1a5afa2"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-06-13T23:41:33+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-05T12:50:04+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Nutrition, food, and dietary at H. John Heinz III Department of Veterans Affairs Medical Center | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Nutrition, food, and dietary at H. John Heinz III Department of Veterans Affairs Medical Center | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Nutrition, food, and dietary at H. John Heinz III Department of Veterans Affairs Medical Center | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Location and contact information<\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>Hours:&nbsp;<\/strong>Monday \u2013&nbsp;Friday, 8:00 a.m. to 4:30 p.m. ET<\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you\u2019ll need to contact your primary care provider first.<\/p>\r\n\r\n<p><strong>Referral needed?<\/strong>&nbsp;No<br \/>\r\n<strong>Phone:&nbsp;<\/strong><a href=\"tel: +14128223000\">412-822-3000<\/a><\/p>\r\n\r\n<p><a class=\"usa-button\" data-entity-substitution=\"canonical\" data-entity-type=\"node\" data-entity-uuid=\"4578cb13-d680-426f-8f2d-ff000e990cb3\" href=\"\/node\/37\">Schedule an appointment online<\/a><\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "e15ebe41-f7cf-4f2c-a407-3728c341220b"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "c88adf39-6ca4-4859-8877-ad6b5706257e"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.a502e932-d460-436e-a67b-83eefdef3a7b.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.a502e932-d460-436e-a67b-83eefdef3a7b.json
@@ -1,0 +1,138 @@
+{
+    "uuid": [
+        {
+            "value": "a502e932-d460-436e-a67b-83eefdef3a7b"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "regional_health_care_service_des",
+            "target_type": "node_type",
+            "target_uuid": "d2e27d2b-acb1-471b-a628-4c41c3778729"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-08-27T17:50:02+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "fd71292f-3dc7-409d-b0e8-500204cb005a"
+        }
+    ],
+    "revision_log": [
+        {
+            "value": "Bulk operation publish revision"
+        }
+    ],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Addiction and substance abuse treatment"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "fd71292f-3dc7-409d-b0e8-500204cb005a"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-05-10T20:47:57+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-08-27T17:50:02+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Addiction and substance abuse treatment | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Addiction and substance abuse treatment | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Addiction and substance abuse treatment | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": "\/addiction-and-substance-abuse-treatment",
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Care we provide at VA Pittsburgh<\/h3>\r\n\r\n<p>Our Center for Treatment of Addictive Disorders (CTAD) offers both residential and outpatient treatment for substance use problems. Some of our services include:<\/p>\r\n\r\n<ul>\r\n\t<li>Alcohol screening<\/li>\r\n\t<li>Abuse counseling<\/li>\r\n\t<li>Outpatient detox<\/li>\r\n\t<li>Opiate abuse counseling, suboxone therapy, and&nbsp;polysubstance abuse counseling<\/li>\r\n\t<li>Pre-operative evaluations<\/li>\r\n\t<li>Management of care for patients&nbsp;who require opiate therapy for pain control and who need close follow-up and monitoring<\/li>\r\n<\/ul>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_local_health_care_service_": [
+        [],
+        {
+            "target_type": "node",
+            "target_uuid": "e615f046-866b-44e0-a96b-c84c931a69cc"
+        }
+    ],
+    "field_region_page": [
+        {
+            "target_type": "node",
+            "target_uuid": "2bddb1a7-6fb1-4503-838d-9c2fcb51c46a"
+        }
+    ],
+    "field_service_name_and_descripti": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "df6f3c6c-cd45-4f0c-9c89-affe932043a6"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.a66a9b8f-3ec3-4bce-b74e-a1c6e53bd547.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.a66a9b8f-3ec3-4bce-b74e-a1c6e53bd547.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "a66a9b8f-3ec3-4bce-b74e-a1c6e53bd547"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-09-10T19:39:24+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "8d4a7bed-f4ba-499f-afd4-8e1cbeadfc4a"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Patient advocates at Beaver County VA Clinic"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "a6af4eb9-ef34-420e-8a20-e2fba1a5afa2"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-06-14T21:04:13+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-09-10T19:39:24+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Patient advocates at Beaver County VA Clinic | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Patient advocates at Beaver County VA Clinic | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Patient advocates at Beaver County VA Clinic | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3 id=\"location-and-contact-informati-633\">Location and contact information<\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>Hours:&nbsp;<\/strong>Monday \u2013 Friday, 8:00 a.m. to 4:30 p.m. ET<\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "a1eabfea-4a7e-4d22-ad09-1d85b884145f"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "85ecc815-a3fc-4978-9e7a-2cfd55dc9b72"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.a6826998-b7f7-434f-8999-959b1dab0c52.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.a6826998-b7f7-434f-8999-959b1dab0c52.json
@@ -1,0 +1,317 @@
+{
+    "uuid": [
+        {
+            "value": "a6826998-b7f7-434f-8999-959b1dab0c52"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_facility",
+            "target_type": "node_type",
+            "target_uuid": "5ecbcf0c-b701-49d5-a47e-08803d42dd80"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-10-29T21:19:35+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "efa9900b-7446-41bf-b6a9-a99287ae2235"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Washington County VA Clinic"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "b02c2ff5-dfe1-4542-beec-3fd410a3f267"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-02-15T20:33:51+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-05T14:55:12+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "VA Pittsburgh Health Care | Washington County Clinic",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_description": "Learn details about about the Washington County outpatient clinic, part of the VA Pittsburgh Health Care system, to help you prepare for your visit.",
+            "description": "Washington County Outpatient VA Clinic - where you can receive general medical care, physical exams, laboratory, radiology, dietary and podiatry services.",
+            "twitter_cards_title": "Washington County VA Clinic | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "keywords": "VA Outpatient Clinic Washington County",
+            "image_src": "http:\/\/default\/sites\/default\/files\/2019-10\/cboc-washington.jpg",
+            "og_title": "Washington County VA Clinic | Veterans Affairs",
+            "og_description": "Learn details about about the Washington County outpatient clinic, part of the VA Pittsburgh Health Care system, to help you prepare for your visit.",
+            "twitter_cards_image": "http:\/\/default\/sites\/default\/files\/2019-10\/cboc-washington.jpg",
+            "og_image_0": "http:\/\/default\/sites\/default\/files\/2019-10\/cboc-washington.jpg"
+        }
+    },
+    "path": [
+        {
+            "alias": "\/pittsburgh-health-care\/locations\/washington-county-va-clinic",
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_address": [
+        {
+            "langcode": null,
+            "country_code": "US",
+            "administrative_area": "PA",
+            "locality": "Washington",
+            "dependent_locality": null,
+            "postal_code": "15301-6800",
+            "sorting_code": null,
+            "address_line1": "95 West Beau Street, Crossroads Center, Suite 200",
+            "address_line2": null,
+            "organization": null,
+            "given_name": null,
+            "additional_name": null,
+            "family_name": null
+        }
+    ],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_description": [
+        {
+            "value": "Learn details about about the Washington County outpatient clinic, part of the VA Pittsburgh Health Care system, to help you prepare for your visit. "
+        }
+    ],
+    "field_email_subscription": [],
+    "field_facebook": [],
+    "field_facility_classification": [
+        {
+            "value": "3"
+        }
+    ],
+    "field_facility_hours": [
+        {
+            "value": [
+                [
+                    "Mon",
+                    "800AM-430PM"
+                ],
+                [
+                    "Tue",
+                    "800AM-430PM"
+                ],
+                [
+                    "Wed",
+                    "800AM-430PM"
+                ],
+                [
+                    "Thu",
+                    "800AM-430PM"
+                ],
+                [
+                    "Fri",
+                    "800AM-430PM"
+                ],
+                [
+                    "Sat",
+                    "Closed"
+                ],
+                [
+                    "Sun",
+                    "Closed"
+                ]
+            ],
+            "format": null,
+            "caption": null
+        }
+    ],
+    "field_facility_locator_api_id": [
+        {
+            "value": "vha_646GD"
+        }
+    ],
+    "field_flickr": [],
+    "field_instagram": [],
+    "field_intro_text": [
+        {
+            "value": "The Washington County outpatient clinic offers Veterans general medical care, including physical exams, lab work, x-rays, nutrition counseling, and foot care."
+        }
+    ],
+    "field_local_health_care_service_": [
+        {
+            "target_type": "node",
+            "target_uuid": "1022cfac-6ae5-4519-aa95-8820a8dab66a"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "06ed0062-a1d1-4ca4-bb14-7ce841061693"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "b98ca96d-ce11-42a8-9c09-446922ff7bed"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "61b011db-8239-4637-a042-08a6fbf6aa8a"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "257fad79-2fcc-4b39-9702-1ecd32847c5a"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "15955ffa-e870-4d3a-bc7b-c6fdb17f80ed"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "933048f9-a7c0-4629-ba8b-782845a28ec1"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "573b012c-719d-417b-9575-e147a037986d"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "ef6d9811-71ac-42ff-ad23-e5086e6c9b21"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "13798a02-e68d-4517-8db8-d670a8adfb15"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "95bf151d-92d5-4a29-b73f-48cea20465f7"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "f9b03ff3-98d9-4ded-93c9-569dd0d85d8b"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "24295ad0-0b7a-4a09-b8fa-bf335930c4af"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "c0c47dc3-a90c-44b8-a227-e1fc6f583915"
+        }
+    ],
+    "field_location_services": [
+        {
+            "target_type": "paragraph",
+            "target_uuid": "c92943d7-33a0-40c9-951c-2d070f46a7d1"
+        },
+        {
+            "target_type": "paragraph",
+            "target_uuid": "a73e09d2-6b2e-446c-92c1-09752128d37c"
+        },
+        {
+            "target_type": "paragraph",
+            "target_uuid": "007b6402-f065-4f30-99e0-cac1a2d59b50"
+        }
+    ],
+    "field_main_location": [
+        {
+            "value": false
+        }
+    ],
+    "field_media": [
+        {
+            "target_type": "media",
+            "target_uuid": "5f21a6e2-bf59-4dc3-9c4e-620eca8348b4"
+        }
+    ],
+    "field_mental_health_phone": [
+        {
+            "value": "412-360-6600"
+        }
+    ],
+    "field_meta_tags": [
+        {
+            "value": {
+                "description": "Washington County Outpatient VA Clinic - where you can receive general medical care, physical exams, laboratory, radiology, dietary and podiatry services.",
+                "keywords": "VA Outpatient Clinic Washington County"
+            }
+        }
+    ],
+    "field_meta_title": [
+        {
+            "value": "VA Pittsburgh Health Care | Washington County Clinic"
+        }
+    ],
+    "field_nickname_for_this_facility": [
+        {
+            "value": "Washington County clinic"
+        }
+    ],
+    "field_operating_status_facility": [
+        {
+            "value": "normal"
+        }
+    ],
+    "field_operating_status_more_info": [],
+    "field_phone_number": [
+        {
+            "value": "724-250-7790"
+        }
+    ],
+    "field_region_page": [
+        {
+            "target_type": "node",
+            "target_uuid": "2bddb1a7-6fb1-4503-838d-9c2fcb51c46a"
+        }
+    ],
+    "field_twitter": []
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.a7f56ad4-acb0-4def-b7f0-34dc9638c107.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.a7f56ad4-acb0-4def-b7f0-34dc9638c107.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "a7f56ad4-acb0-4def-b7f0-34dc9638c107"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-05T13:13:53+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Radiology\/imaging at Fayette County VA Clinic"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "a6af4eb9-ef34-420e-8a20-e2fba1a5afa2"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-06-17T21:51:12+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-05T16:55:48+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Radiology\/imaging at Fayette County VA Clinic | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Radiology\/imaging at Fayette County VA Clinic | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Radiology\/imaging at Fayette County VA Clinic | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Location and contact information<\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>Phone:&nbsp;<\/strong><a href=\"tel: +14128223000\">412-822-3000<\/a><br \/>\r\n<strong>Hours:<\/strong>&nbsp;Monday \u2013 Friday, 8:00 a.m. to 4:30 p.m. ET<\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you\u2019ll need to contact your primary care provider first.<\/p>\r\n\r\n<p><strong>Phone:&nbsp;<\/strong><a href=\"tel: +14128223000\">412-822-3000<\/a><\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "4a987e19-688b-4840-964a-cfefc730fc6c"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "72ff4ca7-0310-4786-b7ff-502486b88efc"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.a888b5f5-9c73-4d7b-ba2c-7717ca79ec4b.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.a888b5f5-9c73-4d7b-ba2c-7717ca79ec4b.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "a888b5f5-9c73-4d7b-ba2c-7717ca79ec4b"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-05T14:27:08+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Cardiology at Pittsburgh VA Medical Center-University Drive"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "fd71292f-3dc7-409d-b0e8-500204cb005a"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-05-10T22:09:18+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-05T14:27:08+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Cardiology at Pittsburgh VA Medical Center-University Drive | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Cardiology at Pittsburgh VA Medical Center-University Drive | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Cardiology at Pittsburgh VA Medical Center-University Drive | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Location and contact information<\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>Main Hospital<\/strong><br \/>\r\nBuilding 1<br \/>\r\n<a href=\"tel: +18664827488\">Map of University Drive campus<\/a><br \/>\r\n<strong>Phone:&nbsp;<\/strong><a href=\"tel: +18664827488\">866-482-7488<\/a><br \/>\r\n<strong>Hours:&nbsp;<\/strong><br \/>\r\nMonday \u2013&nbsp;Friday, 6:00 a.m. to 5:30 p.m. ET<br \/>\r\nOn call 24\/7<\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you\u2019ll need to contact your primary care provider first.<\/p>\r\n\r\n<p><strong>Phone:&nbsp;<\/strong><a href=\"tel: +18664827488\">866-482-7488<\/a><\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "0b968788-cfb0-41aa-8206-2577105072fa"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "077bad0f-e9f1-4f6b-94cc-fb021b287f0e"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.a92ad77b-0180-4564-a77d-5574cb9678b0.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.a92ad77b-0180-4564-a77d-5574cb9678b0.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "a92ad77b-0180-4564-a77d-5574cb9678b0"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-04T19:22:47+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "LGBT Veteran care at Belmont County VA Clinic"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-10-30T20:46:00+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-04T19:22:47+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "LGBT Veteran care at Belmont County VA Clinic | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "LGBT Veteran care at Belmont County VA Clinic | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "LGBT Veteran care at Belmont County VA Clinic | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Location and contact information<\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>Phone:<\/strong> <a href=\"tel: +14128221069\">412-822-1069<\/a><br \/>\r\n<strong>Phone:<\/strong> <a href=\"tel: +14128221069\">412-<\/a><a href=\"tel: +14123601210\">360-1210<\/a><\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you\u2019ll need to contact your primary care provider first.<\/p>\r\n\r\n<p><strong>Phone:<\/strong> <a href=\"tel: +14128221069\">412-822-1069<\/a><br \/>\r\n<strong>Phone:<\/strong> <a href=\"tel: +14128221069\">412-<\/a><a href=\"tel: +14123601210\">360-1210<\/a><\/p>\r\n\r\n<p>&nbsp;<\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "eac71fd5-260c-4f44-8507-8b803ad2324f"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "5483b3ee-eeb5-4286-9ff1-2d463784031b"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.aac60ec2-0468-49c6-be40-65c8a21b0513.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.aac60ec2-0468-49c6-be40-65c8a21b0513.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "aac60ec2-0468-49c6-be40-65c8a21b0513"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-05T14:41:40+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Minority Veteran care at H. John Heinz III Department of Veterans Affairs Medical Center"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "061ad5e6-930a-4a63-b897-b98d90289003"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-07-25T20:08:37+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-05T14:41:40+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Minority Veteran care at H. John Heinz III Department of Veterans Affairs Medical Center | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Minority Veteran care at H. John Heinz III Department of Veterans Affairs Medical Center | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Minority Veteran care at H. John Heinz III Department of Veterans Affairs Medical Center | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Location and contact information<\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>Minority Veterans Program<\/strong><br \/>\r\n<strong>Phone:<\/strong>&nbsp;<a href=\"tel: +14128223537\">412-822-3537<\/a><br \/>\r\n<strong>Email:<\/strong>&nbsp;<a href=\"mailto:heather.steele@va.gov\">heather.steele@va.gov<\/a><br \/>\r\n<strong>Hours:&nbsp;<\/strong>Monday \u2013&nbsp;Friday, 7:00 a.m.&nbsp;to 3:30 p.m. ET<\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you\u2019ll need to contact your primary care provider first.<\/p>\r\n\r\n<p><strong>Phone:<\/strong>&nbsp;<a href=\"tel: +14128223537\">412-822-3537<\/a><\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "e15ebe41-f7cf-4f2c-a407-3728c341220b"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "a3dbd92d-9e31-4766-962c-5cb52b8353fe"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.af8dcdad-b2e8-41cd-83ee-4945fbd8c9a0.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.af8dcdad-b2e8-41cd-83ee-4945fbd8c9a0.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "af8dcdad-b2e8-41cd-83ee-4945fbd8c9a0"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-05T14:31:34+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Emergency medicine at Pittsburgh VA Medical Center-University Drive"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "fd71292f-3dc7-409d-b0e8-500204cb005a"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-05-10T22:08:45+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-05T14:31:34+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Emergency medicine at Pittsburgh VA Medical Center-University Drive | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Emergency medicine at Pittsburgh VA Medical Center-University Drive | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Emergency medicine at Pittsburgh VA Medical Center-University Drive | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Location and contact information<\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>Consolidation Building<\/strong><br \/>\r\nBuilding 29<br \/>\r\nFirst Floor<br \/>\r\n<a data-entity-substitution=\"canonical\" data-entity-type=\"node\" data-entity-uuid=\"71ffee52-a47f-4909-ad7e-21ece5728be3\" href=\"\/node\/783\">Map of University Drive campus<\/a><br \/>\r\n<strong>Phone:&nbsp;<\/strong><a href=\"tel: +14123606322\">412-360-6322<\/a><br \/>\r\n<strong>Hours:&nbsp;<\/strong>24\/7<\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you\u2019ll need to contact your primary care provider first.<\/p>\r\n\r\n<p><strong>In an emergency, you do not need an appointment. Call 911 or walk in.<\/strong><\/p>\r\n\r\n<p><strong>Phone:&nbsp;<\/strong><a href=\"tel: +14123606322\">9<\/a><a href=\"tel: 911\">11<\/a><\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "0b968788-cfb0-41aa-8206-2577105072fa"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "b6717638-7c4b-4b8e-a7ce-c76f37aff4bf"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.b14b30e7-2b21-4ae9-9e57-c93f4901e3b0.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.b14b30e7-2b21-4ae9-9e57-c93f4901e3b0.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "b14b30e7-2b21-4ae9-9e57-c93f4901e3b0"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-05T15:06:28+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Podiatry at Fayette County VA Clinic"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "a6af4eb9-ef34-420e-8a20-e2fba1a5afa2"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-06-14T22:07:27+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-05T15:06:28+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Podiatry at Fayette County VA Clinic | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Podiatry at Fayette County VA Clinic | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Podiatry at Fayette County VA Clinic | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Location and contact information<\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>Phone:&nbsp;<\/strong><a href=\"tel: +14128223000\">412-822-3000<\/a><br \/>\r\n<strong>Hours:&nbsp;<\/strong>Monday \u2013&nbsp;Friday, 8:00 a.m. to 4:30 p.m. ET<\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you\u2019ll need to contact your primary care provider first.<\/p>\r\n\r\n<p><strong>Referral needed?<\/strong>&nbsp;No<br \/>\r\n<strong>Phone:&nbsp;<\/strong><a href=\"tel: +14128223000\">412-822-3000<\/a><\/p>\r\n\r\n<p>&nbsp;<\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "4a987e19-688b-4840-964a-cfefc730fc6c"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "8c838193-be61-48ea-8f1c-a1839b57f1fc"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.b381eb3a-62ce-402f-8799-ce22f61f3e34.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.b381eb3a-62ce-402f-8799-ce22f61f3e34.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "b381eb3a-62ce-402f-8799-ce22f61f3e34"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-05T14:38:27+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Laboratory and pathology at Fayette County VA Clinic"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "a6af4eb9-ef34-420e-8a20-e2fba1a5afa2"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-05-30T23:21:24+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-05T14:38:27+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Laboratory and pathology at Fayette County VA Clinic | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Laboratory and pathology at Fayette County VA Clinic | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Laboratory and pathology at Fayette County VA Clinic | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3><strong>Location and contact information<\/strong><\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>Phone:&nbsp;<\/strong><a href=\"tel: +1412-360-1572\">412-360-1572<\/a><br \/>\r\n<strong>Hours:&nbsp;<\/strong>Monday \u2013&nbsp;Friday, 8:00 a.m. to 4:30 p.m. ET<\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you\u2019ll need to contact your primary care provider first.<\/p>\r\n\r\n<p><strong>Phone:&nbsp;<\/strong><a href=\"tel: +1412-360-1572\">412-360-1572<\/a><\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "4a987e19-688b-4840-964a-cfefc730fc6c"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "04b5f49e-4a46-481c-a494-bd43a8598094"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.b3949e02-0e6a-4a35-b036-4f3749f3321c.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.b3949e02-0e6a-4a35-b036-4f3749f3321c.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "b3949e02-0e6a-4a35-b036-4f3749f3321c"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-05T13:28:57+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Travel reimbursement at Pittsburgh VA Medical Center-University Drive"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "a6af4eb9-ef34-420e-8a20-e2fba1a5afa2"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-06-14T02:20:18+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-05T13:28:57+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Travel reimbursement at Pittsburgh VA Medical Center-University Drive | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Travel reimbursement at Pittsburgh VA Medical Center-University Drive | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Travel reimbursement at Pittsburgh VA Medical Center-University Drive | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Location and contact information<\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>Building 1<\/strong><br \/>\r\nPatient Registration<br \/>\r\n<a data-entity-substitution=\"canonical\" data-entity-type=\"node\" data-entity-uuid=\"71ffee52-a47f-4909-ad7e-21ece5728be3\" href=\"\/node\/783\">Map of University Drive campus<\/a><br \/>\r\n<strong>Phone:&nbsp;<\/strong><a href=\"tel: +14123606993\">412-360-6993<\/a><br \/>\r\n<strong>Hours:&nbsp;<\/strong>Monday \u2013&nbsp;Friday, 24 hours per day<\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you\u2019ll need to contact your primary care provider first.<\/p>\r\n\r\n<p><strong>Referral needed?<\/strong>&nbsp;No<br \/>\r\n<strong>Walk-ins accepted?<\/strong>&nbsp;Yes<br \/>\r\n<strong>Phone:&nbsp;<\/strong><a href=\"tel: +14123606993\">412-360-6993<\/a><\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "0b968788-cfb0-41aa-8206-2577105072fa"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "993ca7e5-e745-4add-890d-66da2f52a52d"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.b49759f3-5655-41b0-b6ec-70be3690bc6d.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.b49759f3-5655-41b0-b6ec-70be3690bc6d.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "b49759f3-5655-41b0-b6ec-70be3690bc6d"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-05T14:42:50+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Minority Veteran care at Fayette County VA Clinic"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-10-30T18:45:29+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-05T14:42:50+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Minority Veteran care at Fayette County VA Clinic | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Minority Veteran care at Fayette County VA Clinic | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Minority Veteran care at Fayette County VA Clinic | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Location and contact information<\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>Minority Veterans Program<\/strong><br \/>\r\n<strong>Phone:<\/strong>&nbsp;<a href=\"tel: +14128223537\">412-822-3537<\/a><br \/>\r\n<strong>Email:<\/strong>&nbsp;<a href=\"mailto:heather.steele@va.gov\">heather.steele@va.gov<\/a><br \/>\r\n<strong>Hours:&nbsp;<\/strong>Monday \u2013&nbsp;Friday, 7:00 a.m.&nbsp;to 3:30 p.m. ET<\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you\u2019ll need to contact your primary care provider first.<\/p>\r\n\r\n<p><strong>Phone:<\/strong>&nbsp;<a href=\"tel: +14128223537\">412-822-3537<\/a><\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "4a987e19-688b-4840-964a-cfefc730fc6c"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "a3dbd92d-9e31-4766-962c-5cb52b8353fe"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.b516b8f9-af49-4402-8a42-5e4428bfdda0.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.b516b8f9-af49-4402-8a42-5e4428bfdda0.json
@@ -1,0 +1,137 @@
+{
+    "uuid": [
+        {
+            "value": "b516b8f9-af49-4402-8a42-5e4428bfdda0"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "regional_health_care_service_des",
+            "target_type": "node_type",
+            "target_uuid": "d2e27d2b-acb1-471b-a628-4c41c3778729"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-09-23T18:24:35+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "fd71292f-3dc7-409d-b0e8-500204cb005a"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Mental health care"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "fd71292f-3dc7-409d-b0e8-500204cb005a"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-05-10T21:46:19+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-09-23T18:24:35+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Mental health care | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Mental health care | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Mental health care | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": "\/mental-health-care",
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Care we provide at VA Pittsburgh&nbsp;<\/h3>\r\n\r\n<p>The Behavioral Health Department offers both inpatient and outpatient services, including telehealth appointments. We provide consultation, evaluation, and treatment for a variety of issues impacting emotional well-being. Our&nbsp;services are confidential and&nbsp;include:<\/p>\r\n\r\n<ul>\r\n\t<li>Psychiatry<\/li>\r\n\t<li>Psychology<\/li>\r\n\t<li>Homeless Veterans services<\/li>\r\n\t<li>Treatment for addictive disorders, including residential rehabilitation treatment programs<\/li>\r\n\t<li>Transition and care management for returning Veterans (OIF\/OEF\/OND)<\/li>\r\n<\/ul>\r\n\r\n<p><a data-entity-substitution=\"canonical\" data-entity-type=\"node\" data-entity-uuid=\"f59ab38a-cc6d-457e-ba3f-dee0d822302b\" href=\"\/node\/806\">Learn more&nbsp;and connect with a care coordinator<\/a><\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_local_health_care_service_": [
+        {
+            "target_type": "node",
+            "target_uuid": "5571a858-a6a4-4e9d-a110-110b1c5d7ebf"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "e62113c9-7c94-48a6-911a-41e63e43b808"
+        }
+    ],
+    "field_region_page": [
+        {
+            "target_type": "node",
+            "target_uuid": "2bddb1a7-6fb1-4503-838d-9c2fcb51c46a"
+        }
+    ],
+    "field_service_name_and_descripti": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "e020dbef-9775-4b91-bc3d-3627a33158dd"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.b655b1c4-5afb-4c04-8857-5b3561b6e449.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.b655b1c4-5afb-4c04-8857-5b3561b6e449.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "b655b1c4-5afb-4c04-8857-5b3561b6e449"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-04T19:47:51+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Intimate partner violence at Belmont County VA Clinic"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-10-30T20:04:29+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-04T19:47:51+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Intimate partner violence at Belmont County VA Clinic | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Intimate partner violence at Belmont County VA Clinic | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Intimate partner violence at Belmont County VA Clinic | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Location and contact information<\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>Intimate Partner Violence Champion<br \/>\r\nPhone: <\/strong><a href=\"tel: +17247096005\">724-<\/a><a href=\"tel: +17246959321\">695-9321<\/a><br \/>\r\n<strong>Hours:&nbsp;<\/strong>Monday \u2013 Friday, 8:00 a.m. to 4:30 p.m. ET<\/p>\r\n\r\n<p class=\"va-address-block\"><strong>National Domestic Violence 24-hour Hotline<\/strong><br \/>\r\n<strong>Phone:<\/strong> <a href=\"tel: +18007997233\">1-800-799-SAFE (7233)<\/a> or <a href=\"tel: +18007873224\">1-800-787-3224 (TTY)<\/a><br \/>\r\n<strong>Hours:<\/strong>&nbsp;24\/7<\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you\u2019ll need to contact your primary care provider first.<\/p>\r\n\r\n<p><strong>Referral needed?&nbsp;<\/strong>No<br \/>\r\n<strong>Phone: <\/strong><a href=\"tel: +17247096005\">724-<\/a><a href=\"tel: +17246959321\">695-9321<\/a><\/p>\r\n\r\n<p>&nbsp;<\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "eac71fd5-260c-4f44-8507-8b803ad2324f"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "e453f2c1-fe99-427f-a256-92fd1f103c25"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.b6717638-7c4b-4b8e-a7ce-c76f37aff4bf.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.b6717638-7c4b-4b8e-a7ce-c76f37aff4bf.json
@@ -1,0 +1,133 @@
+{
+    "uuid": [
+        {
+            "value": "b6717638-7c4b-4b8e-a7ce-c76f37aff4bf"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "regional_health_care_service_des",
+            "target_type": "node_type",
+            "target_uuid": "d2e27d2b-acb1-471b-a628-4c41c3778729"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-09-09T21:08:23+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "8d4a7bed-f4ba-499f-afd4-8e1cbeadfc4a"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Emergency medicine"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "fd71292f-3dc7-409d-b0e8-500204cb005a"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-05-10T21:42:26+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-09-09T21:08:23+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Emergency medicine | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Emergency medicine | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Emergency medicine | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": "\/emergency-medicine",
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Care we provide at VA Pittsburgh<\/h3>\r\n\r\n<p>We treat patients daily for a broad spectrum of emergencies. These include:<\/p>\r\n\r\n<ul>\r\n\t<li>Life-threatening illnesses and injuries&nbsp;that require immediate attention<\/li>\r\n\t<li>Mental health conditions<\/li>\r\n<\/ul>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_local_health_care_service_": [
+        {
+            "target_type": "node",
+            "target_uuid": "af8dcdad-b2e8-41cd-83ee-4945fbd8c9a0"
+        }
+    ],
+    "field_region_page": [
+        {
+            "target_type": "node",
+            "target_uuid": "2bddb1a7-6fb1-4503-838d-9c2fcb51c46a"
+        }
+    ],
+    "field_service_name_and_descripti": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "42b815ca-e751-43ed-b361-9cab0b601fcc"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.b6961ec6-4ab6-41a6-a267-410ccd16e464.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.b6961ec6-4ab6-41a6-a267-410ccd16e464.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "b6961ec6-4ab6-41a6-a267-410ccd16e464"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-09-11T17:36:05+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "8d4a7bed-f4ba-499f-afd4-8e1cbeadfc4a"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Primary care at Belmont County VA Clinic"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "a6af4eb9-ef34-420e-8a20-e2fba1a5afa2"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-06-17T19:36:11+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-05T01:11:20+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Primary care at Belmont County VA Clinic | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Primary care at Belmont County VA Clinic | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Primary care at Belmont County VA Clinic | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Location and contact information<\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>Primary Care Services<br \/>\r\nPhone:&nbsp;<\/strong><a href=\"tel: +17406959321\">740-695-9321<\/a><br \/>\r\n<strong>Hours: <\/strong>Monday \u2013&nbsp;Friday, 8:00 a.m. to 4:30 p.m. ET<\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment.&nbsp;<\/p>\r\n\r\n<p><strong>Referral needed?<\/strong> No<\/p>\r\n\r\n<p><strong>Phone:&nbsp;<\/strong><a href=\"tel: +17406959321\">740-695-9321<\/a><br \/>\r\n<br \/>\r\n<br \/>\r\n<a class=\"usa-button\" data-entity-substitution=\"canonical\" data-entity-type=\"node\" data-entity-uuid=\"4578cb13-d680-426f-8f2d-ff000e990cb3\" href=\"\/node\/37\">Schedule an appointment online<\/a><\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "eac71fd5-260c-4f44-8507-8b803ad2324f"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "c4f23a23-0885-4e1a-b282-48c421fb9203"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.b874472c-c66c-4f88-a789-ba31d33d2e11.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.b874472c-c66c-4f88-a789-ba31d33d2e11.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "b874472c-c66c-4f88-a789-ba31d33d2e11"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-09-10T10:44:03+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "8d4a7bed-f4ba-499f-afd4-8e1cbeadfc4a"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Physical medicine and rehabilitation at H. John Heinz III Department of Veterans Affairs Medical Center"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "a6af4eb9-ef34-420e-8a20-e2fba1a5afa2"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-06-14T21:58:50+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-05T00:58:33+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Physical medicine and rehabilitation at H. John Heinz III Department of Veterans Affairs Medical Center | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Physical medicine and rehabilitation at H. John Heinz III Department of Veterans Affairs Medical Center | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Physical medicine and rehabilitation at H. John Heinz III Department of Veterans Affairs Medical Center | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Location and contact information<\/h3>\r\n\r\n<p class=\"va-address-block\">Building 71<br \/>\r\n1st floor<br \/>\r\n<a data-entity-substitution=\"canonical\" data-entity-type=\"node\" data-entity-uuid=\"a2d3391d-7196-4a3e-bdf5-a71a7b214195\" href=\"\/node\/781\">Map of the Heinz campus<\/a><br \/>\r\n<strong>Phone:&nbsp;<\/strong><a href=\"tel: +14128222111\">412-822-2111<\/a><br \/>\r\n<strong>Hours:&nbsp;<\/strong>Monday \u2013&nbsp;Friday, 8:00 a.m. to 4:30 p.m. ET<\/p>\r\n\r\n<p class=\"va-address-block\">Building 51 (<a href=\"https:\/\/www.pittsburgh.va.gov\/about\/heinz-facility-map.asp\">map<\/a>)<br \/>\r\nGround floor<br \/>\r\n<a data-entity-substitution=\"canonical\" data-entity-type=\"node\" data-entity-uuid=\"a2d3391d-7196-4a3e-bdf5-a71a7b214195\" href=\"\/node\/781\">Map of the Heinz campus<\/a><br \/>\r\n<strong>Phone:&nbsp;<\/strong><a href=\"tel: +14128222111\">412-822-2111<\/a><br \/>\r\n<strong>Hours:&nbsp;<\/strong>Monday \u2013&nbsp;Friday, 8:00 a.m. to 4:30 p.m. ET<\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you\u2019ll need to contact your primary care provider first.<\/p>\r\n\r\n<p><strong>Phone:&nbsp;<\/strong><a href=\"tel: +14128222111\">412-822-2111<\/a><\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "e15ebe41-f7cf-4f2c-a407-3728c341220b"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "4cad2f34-1e07-49b9-a021-dd0d10016149"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.b909349a-9a8a-42f6-8a24-b824048cc845.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.b909349a-9a8a-42f6-8a24-b824048cc845.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "b909349a-9a8a-42f6-8a24-b824048cc845"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-04T20:19:59+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "HIV\/hepatitis at Belmont County VA Clinic"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-10-30T19:35:20+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-04T20:19:59+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "HIV\/hepatitis at Belmont County VA Clinic | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "HIV\/hepatitis at Belmont County VA Clinic | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "HIV\/hepatitis at Belmont County VA Clinic | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3><strong>Location and contact information<\/strong><\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>Suite 215<\/strong><br \/>\r\n<strong>Phone: <\/strong><a href=\"tel: +17247096005\">7<\/a><a href=\"tel: +17406959321\">40-695-9321<\/a><br \/>\r\n<strong>Hours:&nbsp;<\/strong>Monday \u2013&nbsp;Friday, 8:00 a.m. to 4:00 p.m. ET<\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you\u2019ll need to contact your primary care provider first.<\/p>\r\n\r\n<p><strong>Referral needed?<\/strong>&nbsp;Yes<br \/>\r\n<strong>Walk-ins accepted?<\/strong>&nbsp;No<br \/>\r\n<strong>Phone: <\/strong><a href=\"tel: +17247096005\">7<\/a><a href=\"tel: +17406959321\">40-695-9321<\/a><\/p>\r\n\r\n<p>&nbsp;<\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "eac71fd5-260c-4f44-8507-8b803ad2324f"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "02e024f0-e9c8-4d11-8d71-6a4f3e91366d"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.b98ca96d-ce11-42a8-9c09-446922ff7bed.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.b98ca96d-ce11-42a8-9c09-446922ff7bed.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "b98ca96d-ce11-42a8-9c09-446922ff7bed"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-09-10T19:39:10+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "8d4a7bed-f4ba-499f-afd4-8e1cbeadfc4a"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Patient advocates at Washington County VA Clinic "
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "a6af4eb9-ef34-420e-8a20-e2fba1a5afa2"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-06-14T21:06:50+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-09-10T19:39:10+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Patient advocates at Washington County VA Clinic  | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Patient advocates at Washington County VA Clinic  | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Patient advocates at Washington County VA Clinic  | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3 id=\"location-and-contact-informati-633\">Location and contact information<\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>Hours:&nbsp;<\/strong>Monday \u2013 Friday, 8:00 a.m. to 4:30 p.m. ET<\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "a6826998-b7f7-434f-8999-959b1dab0c52"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "85ecc815-a3fc-4978-9e7a-2cfd55dc9b72"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.ba3fd7af-1793-4f16-afb4-868edb12537d.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.ba3fd7af-1793-4f16-afb4-868edb12537d.json
@@ -1,0 +1,133 @@
+{
+    "uuid": [
+        {
+            "value": "ba3fd7af-1793-4f16-afb4-868edb12537d"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "regional_health_care_service_des",
+            "target_type": "node_type",
+            "target_uuid": "d2e27d2b-acb1-471b-a628-4c41c3778729"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-04T18:59:59+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "fd71292f-3dc7-409d-b0e8-500204cb005a"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Returning service member care"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "a8dc1b57-781b-4ae4-8395-feb87b55de1f"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-03-26T16:50:09+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-04T18:59:59+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Returning service member care | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Returning service member care | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Returning service member care | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": "\/returning-service-member-care",
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3 dir=\"LTR\">Care we provide at VA Pittsburgh<\/h3>\r\n\r\n<p dir=\"LTR\">We can help you access service and benefit programs tailored to the needs of returning service members, including:<\/p>\r\n\r\n<ul dir=\"ltr\">\r\n\t<li>Polytrauma care<\/li>\r\n\t<li>Rehabilitation<\/li>\r\n\t<li>Mental health care<\/li>\r\n\t<li>Counseling<\/li>\r\n\t<li>Family benefits counseling<\/li>\r\n\t<li>Referral assistance<\/li>\r\n<\/ul>\r\n\r\n<p dir=\"LTR\"><a data-entity-substitution=\"canonical\" data-entity-type=\"node\" data-entity-uuid=\"da050885-ce47-4512-864c-9c42a57e7fe4\" href=\"\/node\/992\">Learn more and connect with a care coordinator<\/a><\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_local_health_care_service_": [
+        {
+            "target_type": "node",
+            "target_uuid": "c15dd28b-413b-48f6-a1fb-d8683c913e2f"
+        }
+    ],
+    "field_region_page": [
+        {
+            "target_type": "node",
+            "target_uuid": "2bddb1a7-6fb1-4503-838d-9c2fcb51c46a"
+        }
+    ],
+    "field_service_name_and_descripti": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "645020f3-2376-4851-8357-b79151342631"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.bd0e24f1-eae2-43a2-8fc3-dea764d6c87b.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.bd0e24f1-eae2-43a2-8fc3-dea764d6c87b.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "bd0e24f1-eae2-43a2-8fc3-dea764d6c87b"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-04T19:26:05+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Recreation and creative arts therapy at H. John Heinz III Department of Veterans Affairs Medical Center"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "061ad5e6-930a-4a63-b897-b98d90289003"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-07-25T19:09:25+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-05T16:56:30+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Recreation and creative arts therapy at H. John Heinz III Department of Veterans Affairs Medical Center | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Recreation and creative arts therapy at H. John Heinz III Department of Veterans Affairs Medical Center | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Recreation and creative arts therapy at H. John Heinz III Department of Veterans Affairs Medical Center | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Location and contact information<\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>Veterans Recovery Center<br \/>\r\nCommunity Living Center<\/strong><br \/>\r\nAdult Day Health Care Building<br \/>\r\n<a data-entity-substitution=\"canonical\" data-entity-type=\"node\" data-entity-uuid=\"a2d3391d-7196-4a3e-bdf5-a71a7b214195\" href=\"\/node\/781\">Map of Heinz campus<\/a><br \/>\r\n<strong>Phone:<\/strong>&nbsp;<a href=\"tel: +14128223080\">412-822-3080<\/a><br \/>\r\n<strong>Hours:&nbsp;<\/strong>Monday \u2013&nbsp;Friday, 8:00 a.m. \u2013&nbsp;4:30 p.m.<\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you\u2019ll need to contact your primary care provider first.<\/p>\r\n\r\n<p><strong>Phone:<\/strong>&nbsp;<a href=\"tel: +14128223080\">412-822-3080<\/a><\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "e15ebe41-f7cf-4f2c-a407-3728c341220b"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "0a618bda-2a2f-4450-88f2-30d21109d39d"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.be082d1b-5392-47d6-a65b-4927efd83c4e.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.be082d1b-5392-47d6-a65b-4927efd83c4e.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "be082d1b-5392-47d6-a65b-4927efd83c4e"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-04T19:37:44+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Military sexual trauma at Pittsburgh VA Medical Center-University Drive"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "a6af4eb9-ef34-420e-8a20-e2fba1a5afa2"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-06-04T16:10:20+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-04T19:37:44+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Military sexual trauma at Pittsburgh VA Medical Center-University Drive | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Military sexual trauma at Pittsburgh VA Medical Center-University Drive | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Military sexual trauma at Pittsburgh VA Medical Center-University Drive | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Location and contact information&nbsp;<\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>Behavioral&nbsp;Health Services<\/strong><br \/>\r\nConsolidation Building (Building 29)<br \/>\r\n<a data-entity-substitution=\"canonical\" data-entity-type=\"node\" data-entity-uuid=\"71ffee52-a47f-4909-ad7e-21ece5728be3\" href=\"\/node\/783\">Map of University Drive campus<\/a><br \/>\r\n<strong>Phone:&nbsp;<\/strong><a href=\"tel: +1412-360-6600\">412-360-<\/a><a href=\"tel: +1412-360-1040\">1040<\/a><br \/>\r\n<strong>Hours:&nbsp;<\/strong>Monday \u2013&nbsp;Friday, 8:00 a.m. \u2013&nbsp;4:30 p.m. ET<\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you\u2019ll need to contact your primary care provider first.<\/p>\r\n\r\n<p><strong>Phone:&nbsp;<\/strong><a href=\"tel: +1412-360-6600\">412-360-<\/a><a href=\"tel: +1412-360-1040\">1040<\/a><\/p>\r\n\r\n<p>&nbsp;<\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "0b968788-cfb0-41aa-8206-2577105072fa"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "6d59f042-c372-436c-a8ff-7a8f017ad89f"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.c0c47dc3-a90c-44b8-a227-e1fc6f583915.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.c0c47dc3-a90c-44b8-a227-e1fc6f583915.json
@@ -1,0 +1,132 @@
+{
+    "uuid": [
+        {
+            "value": "c0c47dc3-a90c-44b8-a227-e1fc6f583915"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-05T14:58:50+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "revision_log": [
+        {
+            "value": "Bulk operation publish revision"
+        }
+    ],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "My HealtheVet coordinator at Washington County VA Clinic"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-11-05T14:55:12+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-05T14:58:50+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "My HealtheVet coordinator at Washington County VA Clinic | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "My HealtheVet coordinator at Washington County VA Clinic | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "My HealtheVet coordinator at Washington County VA Clinic | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Location and contact information<\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>Hours:<\/strong>&nbsp;Tuesdays&nbsp;9:00 a.m. \u2014&nbsp;1:00 a.m. ET<br \/>\r\n&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;Thursdays 2:00 p.m.&nbsp;\u2014 3:00 p.m. ET<br \/>\r\n&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;Fridays 10:30 a.m.&nbsp;\u2014 11:30 a.m. ET<\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "a6826998-b7f7-434f-8999-959b1dab0c52"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "54d15687-aac6-4457-8560-5d93fe233967"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.c15dd28b-413b-48f6-a1fb-d8683c913e2f.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.c15dd28b-413b-48f6-a1fb-d8683c913e2f.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "c15dd28b-413b-48f6-a1fb-d8683c913e2f"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-09-10T11:10:04+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "8d4a7bed-f4ba-499f-afd4-8e1cbeadfc4a"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Returning service member care at H. John Heinz III Department of Veterans Affairs Medical Center"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "a6af4eb9-ef34-420e-8a20-e2fba1a5afa2"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-06-17T22:33:16+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-04T18:59:59+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Returning service member care at H. John Heinz III Department of Veterans Affairs Medical Center | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Returning service member care at H. John Heinz III Department of Veterans Affairs Medical Center | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Returning service member care at H. John Heinz III Department of Veterans Affairs Medical Center | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Location and contact information<\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>Ambulatory care center<\/strong><br \/>\r\nSecond floor<br \/>\r\n<a data-entity-substitution=\"canonical\" data-entity-type=\"node\" data-entity-uuid=\"a2d3391d-7196-4a3e-bdf5-a71a7b214195\" href=\"\/node\/781\">Map of the Heinz campus<\/a><br \/>\r\n<strong>Phone:<\/strong>&nbsp;<a href=\"tel: +14128222362\">412-822-2362<\/a><br \/>\r\n<strong>Hours:&nbsp;<\/strong><br \/>\r\nMonday, Tuesday, Thursday, and Friday, 8:00 a.m. to&nbsp;4:30 p.m. ET<br \/>\r\nWednesday 4:30 p.m. to 7:00 p.m.<br \/>\r\nClosed weekends<\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you\u2019ll need to contact your primary care provider first.<\/p>\r\n\r\n<p><strong>Phone:&nbsp;<\/strong><a href=\"tel: +14128222363\">412-822-2363<\/a><\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "e15ebe41-f7cf-4f2c-a407-3728c341220b"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "ba3fd7af-1793-4f16-afb4-868edb12537d"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.c1bf3481-50a8-4984-a383-37bdcfbe6b0f.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.c1bf3481-50a8-4984-a383-37bdcfbe6b0f.json
@@ -1,0 +1,137 @@
+{
+    "uuid": [
+        {
+            "value": "c1bf3481-50a8-4984-a383-37bdcfbe6b0f"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "regional_health_care_service_des",
+            "target_type": "node_type",
+            "target_uuid": "d2e27d2b-acb1-471b-a628-4c41c3778729"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-04T20:41:55+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "fd71292f-3dc7-409d-b0e8-500204cb005a"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Orthopedics"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "fd71292f-3dc7-409d-b0e8-500204cb005a"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-05-13T16:21:28+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-04T20:41:55+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Orthopedics | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Orthopedics | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Orthopedics | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": "\/orthopedics",
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Care we provide at VA Pittsburgh<\/h3>\r\n\r\n<p>Our orthopedics specialists use both surgical and nonsurgical means to treat diseases and disorders of the musculoskeletal system. Conditions they address include:<\/p>\r\n\r\n<ul>\r\n\t<li>Musculoskeletal trauma<\/li>\r\n\t<li>Degenerative diseases<\/li>\r\n\t<li>Sports injuries<\/li>\r\n<\/ul>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_local_health_care_service_": [
+        {
+            "target_type": "node",
+            "target_uuid": "fba97a2a-de8f-4846-a384-04a8ec50555b"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "f19cba64-b1b2-48bf-a7a8-da03e1dad5c6"
+        }
+    ],
+    "field_region_page": [
+        {
+            "target_type": "node",
+            "target_uuid": "2bddb1a7-6fb1-4503-838d-9c2fcb51c46a"
+        }
+    ],
+    "field_service_name_and_descripti": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "73a67d7f-ff36-447b-aa5c-84aafd8c01ff"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.c41d704b-0fe8-462d-bf7f-b8a92d842089.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.c41d704b-0fe8-462d-bf7f-b8a92d842089.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "c41d704b-0fe8-462d-bf7f-b8a92d842089"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-05T15:35:57+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Surgery at Pittsburgh VA Medical Center-University Drive"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "a6af4eb9-ef34-420e-8a20-e2fba1a5afa2"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-06-17T23:17:47+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-05T15:35:57+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Surgery at Pittsburgh VA Medical Center-University Drive | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Surgery at Pittsburgh VA Medical Center-University Drive | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Surgery at Pittsburgh VA Medical Center-University Drive | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Where to find us<\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>Surgery service<\/strong><br \/>\r\nMain hospital<br \/>\r\nBuilding 1<br \/>\r\n3 West<br \/>\r\n<a data-entity-substitution=\"canonical\" data-entity-type=\"node\" data-entity-uuid=\"71ffee52-a47f-4909-ad7e-21ece5728be3\" href=\"\/node\/783\">Map of University Drive campus<\/a><br \/>\r\n<strong>Phone:&nbsp;<\/strong><a href=\"tel: +1412-360-6700\">412-360-6700<\/a><br \/>\r\n<strong>Hours:&nbsp;<\/strong>Monday \u2013&nbsp;Friday, 6:00 a.m. to 6:00 p.m. ET<\/p>\r\n\r\n<p class=\"va-address-block\"><strong>Questions or cancelations prior to surgery<\/strong><br \/>\r\nSame Day Surgery Unit<br \/>\r\nBuilding 1<br \/>\r\n3 West<br \/>\r\n<a data-entity-substitution=\"canonical\" data-entity-type=\"node\" data-entity-uuid=\"71ffee52-a47f-4909-ad7e-21ece5728be3\" href=\"\/node\/783\">Map of University Drive campus<\/a><br \/>\r\n<strong>Phone:&nbsp;<\/strong><a href=\"tel: +1412-360-6211\">412-360-6211<\/a><\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you\u2019ll need to contact your primary care provider first.<\/p>\r\n\r\n<p><strong>Phone:&nbsp;<\/strong><a href=\"tel: +1412-360-6700\">412-360-6700<\/a><\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "0b968788-cfb0-41aa-8206-2577105072fa"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "5c2a855e-39b0-4413-8232-1aa143ff5747"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.c57b1ff5-d845-4862-9dfc-427823485e06.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.c57b1ff5-d845-4862-9dfc-427823485e06.json
@@ -1,0 +1,133 @@
+{
+    "uuid": [
+        {
+            "value": "c57b1ff5-d845-4862-9dfc-427823485e06"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "regional_health_care_service_des",
+            "target_type": "node_type",
+            "target_uuid": "d2e27d2b-acb1-471b-a628-4c41c3778729"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-09-23T18:33:50+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "8d4a7bed-f4ba-499f-afd4-8e1cbeadfc4a"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Homeless Veteran care"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "b02c2ff5-dfe1-4542-beec-3fd410a3f267"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-03-22T16:11:43+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-09-23T18:33:50+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Homeless Veteran care | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Homeless Veteran care | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Homeless Veteran care | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": "\/homeless-veteran-care",
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Care we provide at VA Pittsburgh<\/h3>\r\n\r\n<p>We help Veterans who are homeless or at risk of becoming homeless due to financial hardship, unemployment, addiction, depression, or transition from jail. Contact a VA Pittsburgh homeless services care coordinator to get help with:&nbsp;<\/p>\r\n\r\n<ul>\r\n\t<li>Immediate food and shelter, including both&nbsp;transitional and permanent housing<\/li>\r\n\t<li>Job training, life skills development, and education<\/li>\r\n\t<li>Support with justice system navigation and community re-entry from jail<\/li>\r\n\t<li>Financial support to prevent homelessness<\/li>\r\n\t<li>Treatment for addiction and depression<\/li>\r\n\t<li>Health and dental care<\/li>\r\n<\/ul>\r\n\r\n<p><a data-entity-substitution=\"canonical\" data-entity-type=\"node\" data-entity-uuid=\"c0cf9d55-9ac9-4bac-aa21-62d88452f5ae\" href=\"\/node\/801\">Learn more and connect with a care coordinator<\/a><\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_local_health_care_service_": [
+        {
+            "target_type": "node",
+            "target_uuid": "f0c8a0e6-c631-4792-ab16-d7f956923b73"
+        }
+    ],
+    "field_region_page": [
+        {
+            "target_type": "node",
+            "target_uuid": "2bddb1a7-6fb1-4503-838d-9c2fcb51c46a"
+        }
+    ],
+    "field_service_name_and_descripti": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "2366e481-57dd-4026-9292-3a80d7f004ec"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.c88adf39-6ca4-4859-8877-ad6b5706257e.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.c88adf39-6ca4-4859-8877-ad6b5706257e.json
@@ -1,0 +1,141 @@
+{
+    "uuid": [
+        {
+            "value": "c88adf39-6ca4-4859-8877-ad6b5706257e"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "regional_health_care_service_des",
+            "target_type": "node_type",
+            "target_uuid": "d2e27d2b-acb1-471b-a628-4c41c3778729"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-08-27T17:49:53+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "fd71292f-3dc7-409d-b0e8-500204cb005a"
+        }
+    ],
+    "revision_log": [
+        {
+            "value": "Bulk operation publish revision"
+        }
+    ],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Nutrition, food, and dietary"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "a8dc1b57-781b-4ae4-8395-feb87b55de1f"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-03-26T21:25:07+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-05T12:52:48+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Nutrition, food, and dietary | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Nutrition, food, and dietary | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Nutrition, food, and dietary | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": "\/nutrition-food-and-dietary",
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3 dir=\"LTR\">Care we provide at VA Pittsburgh<\/h3>\r\n\r\n<p dir=\"LTR\">We offer information, resources, and counseling on:<\/p>\r\n\r\n<ul>\r\n\t<li>Diabetes<\/li>\r\n\t<li>Gastrointestinal disorders<\/li>\r\n\t<li>Heart disease<\/li>\r\n\t<li>Weight gain or loss<\/li>\r\n\t<li>High or low blood pressure<\/li>\r\n\t<li>Gastrointestinal surgery<\/li>\r\n<\/ul>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_local_health_care_service_": [
+        {
+            "target_type": "node",
+            "target_uuid": "a3e20785-6bc2-44b4-a3d2-a3837a70b5f0"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "644d5e70-1538-4979-8449-f52b4c2a5ca5"
+        }
+    ],
+    "field_region_page": [
+        {
+            "target_type": "node",
+            "target_uuid": "2bddb1a7-6fb1-4503-838d-9c2fcb51c46a"
+        }
+    ],
+    "field_service_name_and_descripti": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "747057bc-2203-4100-ae67-9de02cdeac94"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.c8c43cec-81d2-495b-be81-5129490622c1.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.c8c43cec-81d2-495b-be81-5129490622c1.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "c8c43cec-81d2-495b-be81-5129490622c1"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-05T13:35:58+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Audiology and speech at H. John Heinz III Department of Veterans Affairs Medical Center"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "fd71292f-3dc7-409d-b0e8-500204cb005a"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-05-10T22:16:52+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-05T13:35:58+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Audiology and speech at H. John Heinz III Department of Veterans Affairs Medical Center | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Audiology and speech at H. John Heinz III Department of Veterans Affairs Medical Center | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Audiology and speech at H. John Heinz III Department of Veterans Affairs Medical Center | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Location and contact information<\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>Ambulatory Care Center<\/strong><br \/>\r\nFirst floor<br \/>\r\n<a data-entity-substitution=\"canonical\" data-entity-type=\"node\" data-entity-uuid=\"a2d3391d-7196-4a3e-bdf5-a71a7b214195\" href=\"\/node\/781\">Map of the Heinz campus<\/a><br \/>\r\n<strong>Phone:&nbsp;<\/strong><br \/>\r\n<a href=\"tel: +14123606400\">412-360-6400<\/a><br \/>\r\n<a href=\"tel: +14123606428\">412-360-6428<\/a>&nbsp;<br \/>\r\n<strong>Hours:&nbsp;<\/strong>Monday \u2013&nbsp;Friday, 8:00 a.m. to 4:30 p.m. ET<\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you\u2019ll need to contact your primary care provider first.<\/p>\r\n\r\n<p><strong>Referral needed?<\/strong>&nbsp;No<br \/>\r\n<strong>Phone:&nbsp;<\/strong><a href=\"tel: +14123606400\">412-360-6400<\/a><br \/>\r\n<strong>Phone:&nbsp;<\/strong><a href=\"tel: +14123606428\">412-360-6428<\/a>&nbsp;<\/p>\r\n\r\n<p>&nbsp;<\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "e15ebe41-f7cf-4f2c-a407-3728c341220b"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "a192dca3-0ebd-44a5-8cdb-d70c2d8cc4bc"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.c8ea6d96-9263-4d1d-ac90-c90b55ba13c9.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.c8ea6d96-9263-4d1d-ac90-c90b55ba13c9.json
@@ -1,0 +1,137 @@
+{
+    "uuid": [
+        {
+            "value": "c8ea6d96-9263-4d1d-ac90-c90b55ba13c9"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "regional_health_care_service_des",
+            "target_type": "node_type",
+            "target_uuid": "d2e27d2b-acb1-471b-a628-4c41c3778729"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-08-27T17:49:53+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "fd71292f-3dc7-409d-b0e8-500204cb005a"
+        }
+    ],
+    "revision_log": [
+        {
+            "value": "Bulk operation publish revision"
+        }
+    ],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Gynecology"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "fd71292f-3dc7-409d-b0e8-500204cb005a"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-05-13T16:21:28+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-08-27T17:49:53+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Gynecology | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Gynecology | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Gynecology | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": "\/gynecology",
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Care we provide at VA Pittsburgh<\/h3>\r\n\r\n<p>We provide evaluation and treatment for:<\/p>\r\n\r\n<ul>\r\n\t<li>Abnormal Pap test<\/li>\r\n\t<li>Abnormal uterine bleeding<\/li>\r\n\t<li>Infertility<\/li>\r\n\t<li>Pelvic pain<\/li>\r\n\t<li>Gynecologic cancers<\/li>\r\n<\/ul>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_local_health_care_service_": [
+        {
+            "target_type": "node",
+            "target_uuid": "70151b1a-6176-41b2-9774-a71825d6b1f2"
+        }
+    ],
+    "field_region_page": [
+        {
+            "target_type": "node",
+            "target_uuid": "2bddb1a7-6fb1-4503-838d-9c2fcb51c46a"
+        }
+    ],
+    "field_service_name_and_descripti": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "4c3b2e81-aea0-42d0-9cdd-45d540d546ae"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.cbd42261-56b9-4bd3-8e95-317797682663.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.cbd42261-56b9-4bd3-8e95-317797682663.json
@@ -1,0 +1,133 @@
+{
+    "uuid": [
+        {
+            "value": "cbd42261-56b9-4bd3-8e95-317797682663"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "regional_health_care_service_des",
+            "target_type": "node_type",
+            "target_uuid": "d2e27d2b-acb1-471b-a628-4c41c3778729"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-10-30T21:59:19+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "fd71292f-3dc7-409d-b0e8-500204cb005a"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Ophthalmology"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "fd71292f-3dc7-409d-b0e8-500204cb005a"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-05-10T21:47:51+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-10-30T21:59:19+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Ophthalmology | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Ophthalmology | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Ophthalmology | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": "\/ophthalmology",
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Care we provide at VA Pittsburgh<\/h3>\r\n\r\n<p>We offer&nbsp;comprehensive evaluation of ocular diseases, including subspecialty services, such as the evaluation and treatment&nbsp;for issues related to:<\/p>\r\n\r\n<ul>\r\n\t<li>Retina<\/li>\r\n\t<li>Cornea<\/li>\r\n\t<li>Glaucoma<\/li>\r\n\t<li>Oculoplastics<\/li>\r\n<\/ul>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_local_health_care_service_": [
+        {
+            "target_type": "node",
+            "target_uuid": "97bc639c-1ae1-41d4-ba0b-9513a20ec8ce"
+        }
+    ],
+    "field_region_page": [
+        {
+            "target_type": "node",
+            "target_uuid": "2bddb1a7-6fb1-4503-838d-9c2fcb51c46a"
+        }
+    ],
+    "field_service_name_and_descripti": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "571ba00e-5cc9-4bc2-ae9f-b7c6307c2aea"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.d01200a7-f5fb-4b5d-bc98-5cd1a656bb2f.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.d01200a7-f5fb-4b5d-bc98-5cd1a656bb2f.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "d01200a7-f5fb-4b5d-bc98-5cd1a656bb2f"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-04T19:47:22+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Intimate partner violence at Beaver County VA Clinic"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-10-30T20:03:04+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-04T19:47:22+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Intimate partner violence at Beaver County VA Clinic | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Intimate partner violence at Beaver County VA Clinic | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Intimate partner violence at Beaver County VA Clinic | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Location and contact information<\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>Intimate Partner Violence Champion<br \/>\r\nPhone: <\/strong><a href=\"tel: +17247096005\">724-709-6005<\/a><br \/>\r\n<strong>Hours:&nbsp;<\/strong>Monday \u2013 Friday, 8:00 a.m. to 4:30 p.m. ET<\/p>\r\n\r\n<p class=\"va-address-block\"><strong>National Domestic Violence 24-hour Hotline<\/strong><br \/>\r\n<strong>Phone:<\/strong> <a href=\"tel: +18007997233\">1-800-799-SAFE (7233)<\/a> or <a href=\"tel: +18007873224\">1-800-787-3224 (TTY)<\/a><br \/>\r\n<strong>Hours:<\/strong>&nbsp;24\/7<\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you\u2019ll need to contact your primary care provider first.<\/p>\r\n\r\n<p><strong>Referral needed?&nbsp;<\/strong>No<br \/>\r\n<strong>Phone: <\/strong><a href=\"tel: +17247096005\">724-709-6005<\/a><\/p>\r\n\r\n<p>&nbsp;<\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "a1eabfea-4a7e-4d22-ad09-1d85b884145f"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "e453f2c1-fe99-427f-a256-92fd1f103c25"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.d2461b77-505d-4f8a-9a07-1024cc9bbe3d.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.d2461b77-505d-4f8a-9a07-1024cc9bbe3d.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "d2461b77-505d-4f8a-9a07-1024cc9bbe3d"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-05T14:33:22+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Geriatrics at Pittsburgh VA Medical Center-University Drive"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "a6af4eb9-ef34-420e-8a20-e2fba1a5afa2"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-05-30T22:56:40+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-05T14:33:22+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Geriatrics at Pittsburgh VA Medical Center-University Drive | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Geriatrics at Pittsburgh VA Medical Center-University Drive | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Geriatrics at Pittsburgh VA Medical Center-University Drive | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Location and contact information<\/h3>\r\n\r\n<p class=\"va-address-block\">Geriatric Research Education and Clinical Center (GRECC)<br \/>\r\nResearch Office Building<br \/>\r\nBuilding 30<br \/>\r\n<a data-entity-substitution=\"canonical\" data-entity-type=\"node\" data-entity-uuid=\"71ffee52-a47f-4909-ad7e-21ece5728be3\" href=\"\/node\/783\">Map of University Drive campus<\/a><br \/>\r\n<strong>Phone:&nbsp;<\/strong><a href=\"tel: +14123602915\">412-360-2915<\/a><br \/>\r\n<strong>Hours:&nbsp;<\/strong>Monday \u2013&nbsp;Friday, 8:00 a.m. to 4:30 p.m. ET<\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you\u2019ll need to contact your primary care provider first.<\/p>\r\n\r\n<p><strong>Phone:&nbsp;<\/strong><a href=\"tel: +14123602915\">412-360-2915<\/a><\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "0b968788-cfb0-41aa-8206-2577105072fa"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "ffa5121a-9775-4825-9f9b-27a20c599f1f"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.d616e6d4-2002-4aa9-a678-2797b21849bd.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.d616e6d4-2002-4aa9-a678-2797b21849bd.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "d616e6d4-2002-4aa9-a678-2797b21849bd"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-05T14:42:21+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Minority Veteran care at Beaver County VA Clinic"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-10-30T18:43:32+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-05T14:42:21+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Minority Veteran care at Beaver County VA Clinic | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Minority Veteran care at Beaver County VA Clinic | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Minority Veteran care at Beaver County VA Clinic | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Location and contact information<\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>Minority Veterans Program<\/strong><br \/>\r\n<strong>Phone:<\/strong>&nbsp;<a href=\"tel: +14128223537\">412-822-3537<\/a><br \/>\r\n<strong>Email:<\/strong>&nbsp;<a href=\"mailto:heather.steele@va.gov\">heather.steele@va.gov<\/a><br \/>\r\n<strong>Hours:&nbsp;<\/strong>Monday \u2013&nbsp;Friday, 7:00 a.m.&nbsp;to 3:30 p.m. ET<\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you\u2019ll need to contact your primary care provider first.<\/p>\r\n\r\n<p><strong>Phone:<\/strong>&nbsp;<a href=\"tel: +14128223537\">412-822-3537<\/a><\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "a1eabfea-4a7e-4d22-ad09-1d85b884145f"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "a3dbd92d-9e31-4766-962c-5cb52b8353fe"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.d6a14b35-382e-4df7-bd42-b3572f0727e9.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.d6a14b35-382e-4df7-bd42-b3572f0727e9.json
@@ -1,0 +1,133 @@
+{
+    "uuid": [
+        {
+            "value": "d6a14b35-382e-4df7-bd42-b3572f0727e9"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "regional_health_care_service_des",
+            "target_type": "node_type",
+            "target_uuid": "d2e27d2b-acb1-471b-a628-4c41c3778729"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-09-24T16:24:48+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "8d4a7bed-f4ba-499f-afd4-8e1cbeadfc4a"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Suicide prevention"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "b02c2ff5-dfe1-4542-beec-3fd410a3f267"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-02-28T21:40:45+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-09-24T16:24:48+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Suicide prevention | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Suicide prevention | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Suicide prevention | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": "\/suicide-prevention",
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Care we provide at VA Pittsburgh<\/h3>\r\n\r\n<ul>\r\n\t<li>Suicide prevention care coordinators<\/li>\r\n\t<li>Suicide prevention case managers<\/li>\r\n\t<li>Gun safety locks<\/li>\r\n<\/ul>\r\n\r\n<p><a data-entity-substitution=\"canonical\" data-entity-type=\"node\" data-entity-uuid=\"3bca7853-a18c-4eab-a62c-86cf180f89b2\" href=\"\/node\/996\">Learn more and connect with a care coordinator<\/a><\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_local_health_care_service_": [
+        {
+            "target_type": "node",
+            "target_uuid": "61c521fa-834b-44c2-adb5-7f4124b11188"
+        }
+    ],
+    "field_region_page": [
+        {
+            "target_type": "node",
+            "target_uuid": "2bddb1a7-6fb1-4503-838d-9c2fcb51c46a"
+        }
+    ],
+    "field_service_name_and_descripti": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87529073-31f6-43cd-9527-b34bf63ab640"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.d72934eb-42d0-4413-bcf9-67f4b2bebee5.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.d72934eb-42d0-4413-bcf9-67f4b2bebee5.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "d72934eb-42d0-4413-bcf9-67f4b2bebee5"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-09-10T16:18:14+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "8d4a7bed-f4ba-499f-afd4-8e1cbeadfc4a"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Telehealth at H. John Heinz III Department of Veterans Affairs Medical Center"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "a6af4eb9-ef34-420e-8a20-e2fba1a5afa2"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-06-17T23:37:34+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-05T01:26:21+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Telehealth at H. John Heinz III Department of Veterans Affairs Medical Center | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Telehealth at H. John Heinz III Department of Veterans Affairs Medical Center | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Telehealth at H. John Heinz III Department of Veterans Affairs Medical Center | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Location and contact information<\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>Phone:&nbsp;<\/strong><a href=\"tel: +14128222222\">412-822-2222<\/a><br \/>\r\n<strong>Hours:&nbsp;<\/strong>Monday \u2013&nbsp;Friday, 8:00 a.m. to 4:30 p.m. ET<\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you\u2019ll need to contact your primary care provider first.<\/p>\r\n\r\n<p><strong>Phone:<\/strong> <a href=\"tel: +18664827488\">866-482-7488<\/a><\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "e15ebe41-f7cf-4f2c-a407-3728c341220b"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "7bc4ce20-f573-4ea6-b361-b3060be2e2ea"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.d87ffe54-718b-4882-aa63-2063dbc15864.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.d87ffe54-718b-4882-aa63-2063dbc15864.json
@@ -1,0 +1,132 @@
+{
+    "uuid": [
+        {
+            "value": "d87ffe54-718b-4882-aa63-2063dbc15864"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-04T21:19:44+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "revision_log": [
+        {
+            "value": "Bulk operation publish revision"
+        }
+    ],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Registry exams at Belmont County VA Clinic"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-10-30T18:32:48+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-05T17:00:49+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Registry exams at Belmont County VA Clinic | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Registry exams at Belmont County VA Clinic | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Registry exams at Belmont County VA Clinic | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Location and contact information<\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>Environmental Health Coordinator<\/strong><br \/>\r\nPhone:&nbsp;<a href=\"tel: +14128221707\">412-822-1707<\/a><br \/>\r\n<strong>Email:&nbsp;<\/strong><a href=\"mailto:douglas.turner5@va.gov\">douglas.turner5@va.gov<\/a><\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you\u2019ll need to contact your primary care provider first.<\/p>\r\n\r\n<p><strong>Referral needed?<\/strong>&nbsp;No<br \/>\r\n<strong>Walk-ins accepted?<\/strong>&nbsp;No<br \/>\r\n<strong>Phone:<\/strong>&nbsp;<a href=\"tel: +14128221707\">412-822-1707<\/a><\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "eac71fd5-260c-4f44-8507-8b803ad2324f"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "3e92eaa8-bbf8-4173-84f8-d187b281d548"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.d9936c6b-6c41-4fb5-a975-ae17b0fa4193.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.d9936c6b-6c41-4fb5-a975-ae17b0fa4193.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "d9936c6b-6c41-4fb5-a975-ae17b0fa4193"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-05T14:37:57+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Laboratory and pathology at Beaver County VA Clinic"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "a6af4eb9-ef34-420e-8a20-e2fba1a5afa2"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-05-30T23:21:42+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-05T14:37:57+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Laboratory and pathology at Beaver County VA Clinic | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Laboratory and pathology at Beaver County VA Clinic | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Laboratory and pathology at Beaver County VA Clinic | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3><strong>Location and contact information<\/strong><\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>Phone:&nbsp;<\/strong><a href=\"tel: +1412-360-1572\">412-360-1572<\/a><br \/>\r\n<strong>Hours:&nbsp;<\/strong>Monday \u2013&nbsp;Friday, 8:00 a.m. to 4:30 p.m. ET<\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you\u2019ll need to contact your primary care provider first.<\/p>\r\n\r\n<p><strong>Phone:&nbsp;<\/strong><a href=\"tel: +1412-360-1572\">412-360-1572<\/a><\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "a1eabfea-4a7e-4d22-ad09-1d85b884145f"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "04b5f49e-4a46-481c-a494-bd43a8598094"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.ddabd0e0-0b96-4ffc-816b-25a99338e0f0.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.ddabd0e0-0b96-4ffc-816b-25a99338e0f0.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "ddabd0e0-0b96-4ffc-816b-25a99338e0f0"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-05T13:24:25+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Critical Care at Pittsburgh VA Medical Center-University Drive"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "a6af4eb9-ef34-420e-8a20-e2fba1a5afa2"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-05-30T22:25:07+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-05T13:24:25+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Critical Care at Pittsburgh VA Medical Center-University Drive | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Critical Care at Pittsburgh VA Medical Center-University Drive | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Critical Care at Pittsburgh VA Medical Center-University Drive | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Location and contact information<\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>Main Hospital<\/strong><br \/>\r\nBuilding 1<br \/>\r\n<a data-entity-substitution=\"canonical\" data-entity-type=\"node\" data-entity-uuid=\"71ffee52-a47f-4909-ad7e-21ece5728be3\" href=\"\/node\/783\">Map of University Drive campus<\/a><br \/>\r\n<strong>Phone:&nbsp;<\/strong><br \/>\r\n<a href=\"tel: +14123606215\">412-360-6215<\/a>&nbsp;- 3E Critical Care Unit<br \/>\r\n<a href=\"tel: +14123606219\">412-360-6219<\/a>&nbsp;- 4E Medical ICU<br \/>\r\n<a href=\"tel: +14123606221\">412-360-6221<\/a> - 3A Surgical ICU<br \/>\r\n<a href=\"tel: +14123606217\">412-360-6217<\/a> - 5A Step Down Unit<br \/>\r\n<strong>Hours:&nbsp;<\/strong>24\/7<\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you\u2019ll need to contact your primary care provider first.<\/p>\r\n\r\n<p><strong>Referral needed?<\/strong>&nbsp;No<br \/>\r\n<strong>Walk-ins accepted?<\/strong>&nbsp;No<br \/>\r\n&nbsp;<\/p>\r\n\r\n<p>&nbsp;<\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "0b968788-cfb0-41aa-8206-2577105072fa"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "e65f031a-ad46-47ed-aa0a-9e923bc34f9e"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.ddd4532d-9c31-4f87-af7f-ecbc83116592.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.ddd4532d-9c31-4f87-af7f-ecbc83116592.json
@@ -1,0 +1,137 @@
+{
+    "uuid": [
+        {
+            "value": "ddd4532d-9c31-4f87-af7f-ecbc83116592"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "regional_health_care_service_des",
+            "target_type": "node_type",
+            "target_uuid": "d2e27d2b-acb1-471b-a628-4c41c3778729"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-05T01:21:52+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "fd71292f-3dc7-409d-b0e8-500204cb005a"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Rehabilitation and prosthetics"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "fd71292f-3dc7-409d-b0e8-500204cb005a"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-05-10T22:00:37+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-05T01:21:52+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Rehabilitation and prosthetics | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Rehabilitation and prosthetics | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Rehabilitation and prosthetics | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": "\/rehabilitation-and-prosthetics",
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Care we provide at VA Pittsburgh<\/h3>\r\n\r\n<p>&nbsp;Our prosthetics and sensory aids services include the following:&nbsp;<\/p>\r\n\r\n<ul>\r\n\t<li>Artificial limbs<\/li>\r\n\t<li>Wheelchairs<\/li>\r\n\t<li>Aids for the blind and hearing impaired<\/li>\r\n\t<li>Adaptive equipment for vehicles; modifications to make the home handicapped accessible<\/li>\r\n\t<li>Surgical implants<\/li>\r\n\t<li>Other devices and services for mobility, dignity, and independence<\/li>\r\n<\/ul>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_local_health_care_service_": [
+        {
+            "target_type": "node",
+            "target_uuid": "3f49a39f-3457-4e19-9433-e2d16015d471"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "61516de8-202a-4ee5-859b-8dd5f7ee92ea"
+        }
+    ],
+    "field_region_page": [
+        {
+            "target_type": "node",
+            "target_uuid": "2bddb1a7-6fb1-4503-838d-9c2fcb51c46a"
+        }
+    ],
+    "field_service_name_and_descripti": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "22b27567-f832-47f8-a2e1-1597d622d8b4"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.e15ebe41-f7cf-4f2c-a407-3728c341220b.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.e15ebe41-f7cf-4f2c-a407-3728c341220b.json
@@ -1,0 +1,425 @@
+{
+    "uuid": [
+        {
+            "value": "e15ebe41-f7cf-4f2c-a407-3728c341220b"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_facility",
+            "target_type": "node_type",
+            "target_uuid": "5ecbcf0c-b701-49d5-a47e-08803d42dd80"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-10-22T20:35:34+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "d5b8f9a1-0178-484a-be39-40cb6d91a7a7"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "H. John Heinz III Department of Veterans Affairs Medical Center"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "a8dc1b57-781b-4ae4-8395-feb87b55de1f"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-03-12T20:37:24+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-05T01:31:37+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "VA Pittsburgh Health Care | H.J. Heinz III Campus | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_description": "Learn details about about the H.J. Heinz III Campus, part of the VA Pittsburgh Health Care system, including the services provided here to help you prepare for your visit.",
+            "description": "The Pittsburgh VA H.J. Heinz campus is a medical geriatric community living and progressive care center. Services include hearing care, speech pathology, dental care, primary care, and a pharmacy.",
+            "twitter_cards_title": "H. John Heinz III Department of Veterans Affairs Medical Center | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "keywords": "H.J. Heinz VA medical geriatric community living center",
+            "image_src": "http:\/\/default\/sites\/default\/files\/2019-02\/HJ-heinz-ambulatory-care3_0.jpg",
+            "og_title": "H. John Heinz III Department of Veterans Affairs Medical Center | Veterans Affairs",
+            "og_description": "Learn details about about the H.J. Heinz III Campus, part of the VA Pittsburgh Health Care system, including the services provided here to help you prepare for your visit.",
+            "twitter_cards_image": "http:\/\/default\/sites\/default\/files\/2019-02\/HJ-heinz-ambulatory-care3_0.jpg",
+            "og_image_0": "http:\/\/default\/sites\/default\/files\/2019-02\/HJ-heinz-ambulatory-care3_0.jpg"
+        }
+    },
+    "path": [
+        {
+            "alias": "\/pittsburgh-health-care\/locations\/h-john-heinz-iii-department-of-veterans-affairs-medical-center",
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_address": [
+        {
+            "langcode": null,
+            "country_code": "US",
+            "administrative_area": "PA",
+            "locality": "Pittsburgh",
+            "dependent_locality": null,
+            "postal_code": "15240-1005",
+            "sorting_code": null,
+            "address_line1": "1010 Delafield Road",
+            "address_line2": null,
+            "organization": null,
+            "given_name": null,
+            "additional_name": null,
+            "family_name": null
+        }
+    ],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_description": [
+        {
+            "value": "Learn details about about the H.J. Heinz III Campus, part of the VA Pittsburgh Health Care system, including the services provided here to help you prepare for your visit. "
+        }
+    ],
+    "field_email_subscription": [],
+    "field_facebook": [],
+    "field_facility_classification": [
+        {
+            "value": "1"
+        }
+    ],
+    "field_facility_hours": [
+        {
+            "value": [
+                [
+                    "Mon",
+                    "24\/7"
+                ],
+                [
+                    "Tue",
+                    "24\/7"
+                ],
+                [
+                    "Wed",
+                    "24\/7"
+                ],
+                [
+                    "Thu",
+                    "24\/7"
+                ],
+                [
+                    "Fri",
+                    "24\/7"
+                ],
+                [
+                    "Sat",
+                    "24\/7"
+                ],
+                [
+                    "Sun",
+                    "24\/7"
+                ]
+            ],
+            "format": null,
+            "caption": null
+        }
+    ],
+    "field_facility_locator_api_id": [
+        {
+            "value": "vha_646A4"
+        }
+    ],
+    "field_flickr": [],
+    "field_instagram": [],
+    "field_intro_text": [
+        {
+            "value": "Classified as a Geriatric Center of Excellence, our H.J. Heinz III campus offers transitional care, rehabilitation, dementia and hospice care beds, an ambulatory care center, and many outpatient services."
+        }
+    ],
+    "field_local_health_care_service_": [
+        {
+            "target_type": "node",
+            "target_uuid": "0d73b85c-b637-4527-9e8b-6f78f05a2ab4"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "5571a858-a6a4-4e9d-a110-110b1c5d7ebf"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "88a5e744-5cfb-491a-bf53-ac6c0fc07f4b"
+        },
+        [],
+        [],
+        [],
+        [],
+        {
+            "target_type": "node",
+            "target_uuid": "c8c43cec-81d2-495b-be81-5129490622c1"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "ea7f52c8-203f-4cdb-8437-fd3648b3807f"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "14e57845-110f-4166-a8cd-8bae2d886913"
+        },
+        [],
+        {
+            "target_type": "node",
+            "target_uuid": "36f7cebd-08bd-4b77-a5f8-f4904cf210b6"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "f0c8a0e6-c631-4792-ab16-d7f956923b73"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "9130891f-4884-4d10-a0a0-671730f2cec5"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "2f44780a-d49c-43e6-87c8-ef66eb9f18ff"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "fdb87ac3-cf59-43ba-9908-ff1de484ce63"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "89733fed-7f21-4c29-8e50-003424df1afb"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "a3e20785-6bc2-44b4-a3d2-a3837a70b5f0"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "3d792ced-59f4-4b71-8633-dae36bef86eb"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "a044cafe-b5d0-4aa9-9633-8852790df828"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "f1e75524-194c-4c05-a086-8c8b1248abb8"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "b874472c-c66c-4f88-a789-ba31d33d2e11"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "82fc56d3-e6a6-43e3-98c1-c87e0f8366dd"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "6ef7d829-5a74-4846-be1c-cf45d1e0c46d"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "3ec5cffb-1025-4d98-9ba5-a22cdbc66698"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "3f49a39f-3457-4e19-9433-e2d16015d471"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "c15dd28b-413b-48f6-a1fb-d8683c913e2f"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "28d358e6-3838-40e5-92e1-fd30d33e174d"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "d72934eb-42d0-4413-bcf9-67f4b2bebee5"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "88ad402e-5f72-40af-9c99-5c97f76bbfbb"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "676acdff-d8f1-46c8-8ae5-49457f101c7b"
+        },
+        [],
+        {
+            "target_type": "node",
+            "target_uuid": "bd0e24f1-eae2-43a2-8fc3-dea764d6c87b"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "aac60ec2-0468-49c6-be40-65c8a21b0513"
+        },
+        [],
+        {
+            "target_type": "node",
+            "target_uuid": "6d71dc89-32bd-4c61-932f-68ebad4b04dc"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "2ad0413f-9f1f-4ffe-a35c-5c06030e2873"
+        },
+        [],
+        {
+            "target_type": "node",
+            "target_uuid": "9198779f-53e0-4e22-8160-3e612c39e97a"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "89a107e4-b645-4a01-a19c-10e52d93fd78"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "f19cba64-b1b2-48bf-a7a8-da03e1dad5c6"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "96dc069a-e27e-4b24-bdc6-64f95ed71507"
+        }
+    ],
+    "field_location_services": [
+        {
+            "target_type": "paragraph",
+            "target_uuid": "7f1e7866-8975-4960-af44-eb3ec27090d8"
+        },
+        {
+            "target_type": "paragraph",
+            "target_uuid": "f0d0eb26-72cc-42f0-9198-77636b1ab018"
+        },
+        {
+            "target_type": "paragraph",
+            "target_uuid": "bab7b07c-e3e8-4ca4-a00d-3d968b7ed7c4"
+        },
+        {
+            "target_type": "paragraph",
+            "target_uuid": "640304c8-1975-435e-b710-3536c1140382"
+        },
+        {
+            "target_type": "paragraph",
+            "target_uuid": "e915d298-4eda-456c-a822-49464f8ec1ff"
+        },
+        {
+            "target_type": "paragraph",
+            "target_uuid": "7049fad0-7c40-4535-bca7-74addcf70a34"
+        },
+        {
+            "target_type": "paragraph",
+            "target_uuid": "67ca2715-de10-402b-a53e-c118097bff92"
+        },
+        {
+            "target_type": "paragraph",
+            "target_uuid": "136fe7a5-6706-4a2b-a9f4-7bf807d20b1c"
+        }
+    ],
+    "field_main_location": [
+        {
+            "value": true
+        }
+    ],
+    "field_media": [
+        {
+            "target_type": "media",
+            "target_uuid": "8140b30e-34d1-4bf7-9570-4bdcff5b4f19"
+        }
+    ],
+    "field_mental_health_phone": [
+        {
+            "value": "412-360-6600"
+        }
+    ],
+    "field_meta_tags": [
+        {
+            "value": {
+                "description": "The Pittsburgh VA H.J. Heinz campus is a medical geriatric community living and progressive care center. Services include hearing care, speech pathology, dental care, primary care, and a pharmacy.",
+                "keywords": "H.J. Heinz VA medical geriatric community living center"
+            }
+        }
+    ],
+    "field_meta_title": [
+        {
+            "value": "VA Pittsburgh Health Care | H.J. Heinz III Campus | Veterans Affairs"
+        }
+    ],
+    "field_nickname_for_this_facility": [
+        {
+            "value": "H.J. Heinz III campus"
+        }
+    ],
+    "field_operating_status_facility": [
+        {
+            "value": "normal"
+        }
+    ],
+    "field_operating_status_more_info": [],
+    "field_phone_number": [
+        {
+            "value": "412-360-6000"
+        }
+    ],
+    "field_region_page": [
+        {
+            "target_type": "node",
+            "target_uuid": "2bddb1a7-6fb1-4503-838d-9c2fcb51c46a"
+        }
+    ],
+    "field_twitter": []
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.e1b68b35-f5f7-44ec-9808-9a642d669ce5.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.e1b68b35-f5f7-44ec-9808-9a642d669ce5.json
@@ -1,0 +1,133 @@
+{
+    "uuid": [
+        {
+            "value": "e1b68b35-f5f7-44ec-9808-9a642d669ce5"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "regional_health_care_service_des",
+            "target_type": "node_type",
+            "target_uuid": "d2e27d2b-acb1-471b-a628-4c41c3778729"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-10-31T17:51:06+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "fd71292f-3dc7-409d-b0e8-500204cb005a"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Caregiver support"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "b02c2ff5-dfe1-4542-beec-3fd410a3f267"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-03-22T19:27:55+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-10-31T17:51:06+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Caregiver support | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Caregiver support | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Caregiver support | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": "\/caregiver-support",
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3 dir=\"LTR\">Care we provide at VA Pittsburgh<\/h3>\r\n\r\n<p dir=\"LTR\">If you are a caregiver&nbsp;for a Veteran, you can get support by contacting a VA Pittsburgh caregiver support coordinator.&nbsp;We can help with:<\/p>\r\n\r\n<ul>\r\n\t<li>Progressive needs planning for degenerative conditions<\/li>\r\n\t<li>Matching you with services and benefits&nbsp;<\/li>\r\n\t<li>Connecting you with local resources and programs<\/li>\r\n<\/ul>\r\n\r\n<p><a data-entity-substitution=\"canonical\" data-entity-type=\"node\" data-entity-uuid=\"d0fff516-5df5-4ac6-b59d-c55fdfcfd878\" href=\"\/node\/794\">Learn more and connect with a support coordinator<\/a><\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_local_health_care_service_": [
+        {
+            "target_type": "node",
+            "target_uuid": "14e57845-110f-4166-a8cd-8bae2d886913"
+        }
+    ],
+    "field_region_page": [
+        {
+            "target_type": "node",
+            "target_uuid": "2bddb1a7-6fb1-4503-838d-9c2fcb51c46a"
+        }
+    ],
+    "field_service_name_and_descripti": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "6735bd18-6dd7-4d25-a96d-a517ed478cf0"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.e615f046-866b-44e0-a96b-c84c931a69cc.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.e615f046-866b-44e0-a96b-c84c931a69cc.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "e615f046-866b-44e0-a96b-c84c931a69cc"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-05T13:21:28+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Addiction and substance abuse treatment at Pittsburgh VA Medical Center-University Drive"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "a6af4eb9-ef34-420e-8a20-e2fba1a5afa2"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-06-17T19:40:25+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-05T13:21:28+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Addiction and substance abuse treatment at Pittsburgh VA Medical Center-University Drive | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Addiction and substance abuse treatment at Pittsburgh VA Medical Center-University Drive | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Addiction and substance abuse treatment at Pittsburgh VA Medical Center-University Drive | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3><strong>Location and contact information<\/strong><\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>Center for Treatment of Addictive Disorders (CTAD)<\/strong><br \/>\r\nConsolidation building<br \/>\r\nFirst floor<br \/>\r\nCheck-in area 3<br \/>\r\n<a data-entity-substitution=\"canonical\" data-entity-type=\"node\" data-entity-uuid=\"71ffee52-a47f-4909-ad7e-21ece5728be3\" href=\"\/node\/783\">Map of University Drive campus<\/a><br \/>\r\n<strong>Phone:&nbsp;<\/strong><br \/>\r\n<a href=\"tel: +14123606611\">412-360-6611<\/a> - Residential&nbsp;program<br \/>\r\n<a href=\"tel: +14123606092\">412-360-6092<\/a> - Outpatient program<br \/>\r\n<strong>Hours:&nbsp;<\/strong>Monday&nbsp;\u2013&nbsp;Friday, 8:00 a.m. to 4:30 p.m. ET<\/p>\r\n\r\n<p class=\"va-address-block\"><strong>Opioid Substitution Therapy Clinic<\/strong><br \/>\r\nBuilding 1<br \/>\r\n1st Floor<br \/>\r\n<a data-entity-substitution=\"canonical\" data-entity-type=\"node\" data-entity-uuid=\"71ffee52-a47f-4909-ad7e-21ece5728be3\" href=\"\/node\/783\">Map of University Drive campus<\/a><br \/>\r\n<strong>Phone:<\/strong>&nbsp;<a href=\"tel: +14123603692\">412-360-3692<\/a><br \/>\r\n<strong>Hours:&nbsp;<\/strong>Monday&nbsp;\u2013&nbsp;Friday, 6:00 a.m. to 2:00 p.m. ET<\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you\u2019ll need to contact your primary care provider first.<\/p>\r\n\r\n<p><strong>Phone:<\/strong><a href=\"tel: +14128223000\"><strong>&nbsp;<\/strong><\/a><a href=\"tel: +14128223815\">412-822-3<\/a><a href=\"tel: +14128223000\">000<\/a><\/p>\r\n\r\n<p><br \/>\r\n<a class=\"usa-button\" href=\"https:\/\/www.va.gov\/health-care\/schedule-view-va-appointments\/\">Schedule an appointment online<\/a><\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "0b968788-cfb0-41aa-8206-2577105072fa"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "a502e932-d460-436e-a67b-83eefdef3a7b"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.e62113c9-7c94-48a6-911a-41e63e43b808.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.e62113c9-7c94-48a6-911a-41e63e43b808.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "e62113c9-7c94-48a6-911a-41e63e43b808"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-05T14:40:07+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Mental health care at Pittsburgh VA Medical Center-University Drive"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "fd71292f-3dc7-409d-b0e8-500204cb005a"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-05-06T04:09:26+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-05T14:40:07+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Mental health care at Pittsburgh VA Medical Center-University Drive | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Mental health care at Pittsburgh VA Medical Center-University Drive | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Mental health care at Pittsburgh VA Medical Center-University Drive | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Location and contact information<\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>Behavioral health services<\/strong><br \/>\r\nConsolidation Building<br \/>\r\n<a data-entity-substitution=\"canonical\" data-entity-type=\"node\" data-entity-uuid=\"71ffee52-a47f-4909-ad7e-21ece5728be3\" href=\"\/node\/783\">Map of University Drive campus<\/a><br \/>\r\n<strong>Phone:&nbsp;<\/strong><a href=\"tel: +1412-360-6600\">412-360-6600<\/a><br \/>\r\n<strong>Hours:&nbsp;<\/strong>Monday \u2013 Friday, 8:00 a.m. to 4:30 p.m. ET<br \/>\r\nSome appointments may be available at other hours.<\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you\u2019ll need to contact your primary care provider first.<\/p>\r\n\r\n<p><strong>Phone:&nbsp;<\/strong><a href=\"tel: +1412-360-6600\">412-360-6600<\/a><\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "0b968788-cfb0-41aa-8206-2577105072fa"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "b516b8f9-af49-4402-8a42-5e4428bfdda0"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.e65f031a-ad46-47ed-aa0a-9e923bc34f9e.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.e65f031a-ad46-47ed-aa0a-9e923bc34f9e.json
@@ -1,0 +1,133 @@
+{
+    "uuid": [
+        {
+            "value": "e65f031a-ad46-47ed-aa0a-9e923bc34f9e"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "regional_health_care_service_des",
+            "target_type": "node_type",
+            "target_uuid": "d2e27d2b-acb1-471b-a628-4c41c3778729"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-09-09T21:03:01+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "8d4a7bed-f4ba-499f-afd4-8e1cbeadfc4a"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Critical Care"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "fd71292f-3dc7-409d-b0e8-500204cb005a"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-05-10T21:39:07+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-09-09T21:03:01+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Critical Care | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Critical Care | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Critical Care | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": "\/critical-care",
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Care we provide at VA Pittsburgh<\/h3>\r\n\r\n<ul>\r\n\t<li>Treatment for complications from surgery<\/li>\r\n\t<li>Treatment related to accidents or infections<\/li>\r\n\t<li>Care for severe breathing problems<\/li>\r\n\t<li>A Step Down Unit for patients recently discharged from critical care or who need greater care than a standard medical unit.<\/li>\r\n<\/ul>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_local_health_care_service_": [
+        {
+            "target_type": "node",
+            "target_uuid": "ddabd0e0-0b96-4ffc-816b-25a99338e0f0"
+        }
+    ],
+    "field_region_page": [
+        {
+            "target_type": "node",
+            "target_uuid": "2bddb1a7-6fb1-4503-838d-9c2fcb51c46a"
+        }
+    ],
+    "field_service_name_and_descripti": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "2b43693b-63aa-473b-bfa2-ba944b697513"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.ea7f52c8-203f-4cdb-8437-fd3648b3807f.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.ea7f52c8-203f-4cdb-8437-fd3648b3807f.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "ea7f52c8-203f-4cdb-8437-fd3648b3807f"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-09-10T02:46:04+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "8d4a7bed-f4ba-499f-afd4-8e1cbeadfc4a"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Amputation care at H. John Heinz III Department of Veterans Affairs Medical Center"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "a6af4eb9-ef34-420e-8a20-e2fba1a5afa2"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-05-30T19:31:30+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-04T20:18:42+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Amputation care at H. John Heinz III Department of Veterans Affairs Medical Center | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Amputation care at H. John Heinz III Department of Veterans Affairs Medical Center | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Amputation care at H. John Heinz III Department of Veterans Affairs Medical Center | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Location and contact information<\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>Amputee Clinic<\/strong><br \/>\r\nBuilding 51<br \/>\r\nRoom 1B153<br \/>\r\n<a data-entity-substitution=\"canonical\" data-entity-type=\"node\" data-entity-uuid=\"a2d3391d-7196-4a3e-bdf5-a71a7b214195\" href=\"\/node\/781\">Map of the Heinz campus<\/a><br \/>\r\n<strong>Phone:&nbsp;<\/strong><a href=\"tel: +14128223017\">412-822-3017<\/a><br \/>\r\n<strong>Hours:&nbsp;<\/strong>Monday&nbsp;\u2013&nbsp;Friday, 8:00 a.m. to 4:30 p.m. ET<\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you\u2019ll need to contact your primary care provider first.<\/p>\r\n\r\n<p><strong>Referral needed? <\/strong>No<\/p>\r\n\r\n<p><strong>Phone:&nbsp;<\/strong><a href=\"tel: +14128223017\">412-822-3017<\/a><\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "e15ebe41-f7cf-4f2c-a407-3728c341220b"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "7ab831f3-b998-413d-beb9-c17ccf514514"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.eac71fd5-260c-4f44-8507-8b803ad2324f.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.eac71fd5-260c-4f44-8507-8b803ad2324f.json
@@ -1,0 +1,317 @@
+{
+    "uuid": [
+        {
+            "value": "eac71fd5-260c-4f44-8507-8b803ad2324f"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_facility",
+            "target_type": "node_type",
+            "target_uuid": "5ecbcf0c-b701-49d5-a47e-08803d42dd80"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-10-29T21:20:10+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "efa9900b-7446-41bf-b6a9-a99287ae2235"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Belmont County VA Clinic"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "b02c2ff5-dfe1-4542-beec-3fd410a3f267"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-02-15T20:34:27+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-05T14:51:06+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "VA Pittsburgh Health Care | Belmont County Clinic | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_description": "Learn details about about the Belmont County Outpatient Clinic, part of the VA Pittsburgh Health Care system, to help you prepare for your visit.",
+            "description": "Belmont County Outpatient VA Clinic - where you can receive general medical care, physical exams, laboratory, radiology, dietary and podiatry services.",
+            "twitter_cards_title": "Belmont County VA Clinic | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "keywords": "VA Outpatient Clinic Belmont County",
+            "image_src": "http:\/\/default\/sites\/default\/files\/2019-08\/Belmont_County_CBOC.jpg",
+            "og_title": "Belmont County VA Clinic | Veterans Affairs",
+            "og_description": "Learn details about about the Belmont County Outpatient Clinic, part of the VA Pittsburgh Health Care system, to help you prepare for your visit.",
+            "twitter_cards_image": "http:\/\/default\/sites\/default\/files\/2019-08\/Belmont_County_CBOC.jpg",
+            "og_image_0": "http:\/\/default\/sites\/default\/files\/2019-08\/Belmont_County_CBOC.jpg"
+        }
+    },
+    "path": [
+        {
+            "alias": "\/pittsburgh-health-care\/locations\/belmont-county-va-clinic",
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_address": [
+        {
+            "langcode": null,
+            "country_code": "US",
+            "administrative_area": "OH",
+            "locality": "St. Clairsville",
+            "dependent_locality": null,
+            "postal_code": "43950-1703",
+            "sorting_code": null,
+            "address_line1": "67800 Mall Ring Road, Ohio Valley Mall, Suite 215",
+            "address_line2": null,
+            "organization": null,
+            "given_name": null,
+            "additional_name": null,
+            "family_name": null
+        }
+    ],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_description": [
+        {
+            "value": "Learn details about about the Belmont County Outpatient Clinic, part of the VA Pittsburgh Health Care system, to help you prepare for your visit. "
+        }
+    ],
+    "field_email_subscription": [],
+    "field_facebook": [],
+    "field_facility_classification": [
+        {
+            "value": "3"
+        }
+    ],
+    "field_facility_hours": [
+        {
+            "value": [
+                [
+                    "Mon",
+                    "800AM-430PM"
+                ],
+                [
+                    "Tue",
+                    "800AM-430PM"
+                ],
+                [
+                    "Wed",
+                    "800AM-430PM"
+                ],
+                [
+                    "Thu",
+                    "800AM-430PM"
+                ],
+                [
+                    "Fri",
+                    "800AM-430PM"
+                ],
+                [
+                    "Sat",
+                    "Closed"
+                ],
+                [
+                    "Sun",
+                    "Closed"
+                ]
+            ],
+            "format": null,
+            "caption": null
+        }
+    ],
+    "field_facility_locator_api_id": [
+        {
+            "value": "vha_646GA"
+        }
+    ],
+    "field_flickr": [],
+    "field_instagram": [],
+    "field_intro_text": [
+        {
+            "value": "The Belmont County outpatient clinic offers Veterans general medical care, including physical exams, lab work, x-rays, nutrition counseling, and foot care."
+        }
+    ],
+    "field_local_health_care_service_": [
+        {
+            "target_type": "node",
+            "target_uuid": "9cd25d9b-2590-4c8d-ab91-6ebe860876f4"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "522a27a3-cb38-4f07-8c03-9263015c6b50"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "f3348da9-2977-438a-8831-f9d890b91f49"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "f86833a9-022c-4a4e-bf7e-ad9c36357392"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "b6961ec6-4ab6-41a6-a267-410ccd16e464"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "81664424-6415-4064-b987-64a95a22f2e0"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "d87ffe54-718b-4882-aa63-2063dbc15864"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "444fedd1-b1a2-4d5c-bec5-b5bc9f6317c1"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "b909349a-9a8a-42f6-8a24-b824048cc845"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "1ec72de4-d502-42e6-8e11-75d3cc4bd815"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "b655b1c4-5afb-4c04-8857-5b3561b6e449"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "a92ad77b-0180-4564-a77d-5574cb9678b0"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "67ecbd95-f39c-43c2-a866-5b0c9df56ad9"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "61f79e11-a30b-485c-baeb-3f91aa142a8e"
+        }
+    ],
+    "field_location_services": [
+        {
+            "target_type": "paragraph",
+            "target_uuid": "3784f178-84e1-42e8-9f75-10226773926b"
+        },
+        {
+            "target_type": "paragraph",
+            "target_uuid": "22b42635-d94a-4da5-b4ce-cc6d072be1b7"
+        },
+        {
+            "target_type": "paragraph",
+            "target_uuid": "378f1a29-0d08-456c-89d5-b6307cebc735"
+        }
+    ],
+    "field_main_location": [
+        {
+            "value": false
+        }
+    ],
+    "field_media": [
+        {
+            "target_type": "media",
+            "target_uuid": "d239d448-ff23-4fd5-a348-c83ecf12684d"
+        }
+    ],
+    "field_mental_health_phone": [
+        {
+            "value": "412-360-6600"
+        }
+    ],
+    "field_meta_tags": [
+        {
+            "value": {
+                "description": "Belmont County Outpatient VA Clinic - where you can receive general medical care, physical exams, laboratory, radiology, dietary and podiatry services.",
+                "keywords": "VA Outpatient Clinic Belmont County"
+            }
+        }
+    ],
+    "field_meta_title": [
+        {
+            "value": "VA Pittsburgh Health Care | Belmont County Clinic | Veterans Affairs"
+        }
+    ],
+    "field_nickname_for_this_facility": [
+        {
+            "value": "Belmont County clinic"
+        }
+    ],
+    "field_operating_status_facility": [
+        {
+            "value": "normal"
+        }
+    ],
+    "field_operating_status_more_info": [],
+    "field_phone_number": [
+        {
+            "value": "740-695-9321"
+        }
+    ],
+    "field_region_page": [
+        {
+            "target_type": "node",
+            "target_uuid": "2bddb1a7-6fb1-4503-838d-9c2fcb51c46a"
+        }
+    ],
+    "field_twitter": []
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.ed7ba178-a831-49bd-8a11-9f28ae46da8c.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.ed7ba178-a831-49bd-8a11-9f28ae46da8c.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "ed7ba178-a831-49bd-8a11-9f28ae46da8c"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-04T20:20:26+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "HIV\/hepatitis at Beaver County VA Clinic"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-10-30T19:33:26+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-04T20:20:26+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "HIV\/hepatitis at Beaver County VA Clinic | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "HIV\/hepatitis at Beaver County VA Clinic | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "HIV\/hepatitis at Beaver County VA Clinic | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3><strong>Location and contact information<\/strong><\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>Suite 110<\/strong><br \/>\r\n<strong>Phone: <\/strong><a href=\"tel: +17247096005\">724-709-6005<\/a><br \/>\r\n<strong>Hours:&nbsp;<\/strong>Monday \u2013&nbsp;Friday, 8:00 a.m. to 4:00 p.m. ET<\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you\u2019ll need to contact your primary care provider first.<\/p>\r\n\r\n<p><strong>Referral needed?<\/strong>&nbsp;Yes<br \/>\r\n<strong>Walk-ins accepted?<\/strong>&nbsp;No<br \/>\r\n<strong>Phone: <\/strong><a href=\"tel: +17247096005\">724-709-6005<\/a><\/p>\r\n\r\n<p>&nbsp;<\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "a1eabfea-4a7e-4d22-ad09-1d85b884145f"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "02e024f0-e9c8-4d11-8d71-6a4f3e91366d"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.ef6567c1-7111-431b-8e53-2f3209de506c.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.ef6567c1-7111-431b-8e53-2f3209de506c.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "ef6567c1-7111-431b-8e53-2f3209de506c"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-10-22T18:43:22+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "fd71292f-3dc7-409d-b0e8-500204cb005a"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Primary care at Pittsburgh VA Medical Center-University Drive"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "8bea8773-6a06-4afd-99b5-1dfa7a2192ea"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-05-06T04:05:22+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-05T01:11:20+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Primary care at Pittsburgh VA Medical Center-University Drive | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Primary care at Pittsburgh VA Medical Center-University Drive | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Primary care at Pittsburgh VA Medical Center-University Drive | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Location and contact information<\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>Primary Care Services<\/strong><br \/>\r\nBuilding 1<br \/>\r\n1st Floor, Annex Area<br \/>\r\n<a data-entity-substitution=\"canonical\" data-entity-type=\"node\" data-entity-uuid=\"71ffee52-a47f-4909-ad7e-21ece5728be3\" href=\"\/node\/783\">Map of University Drive campus<\/a><br \/>\r\n<strong>Phone:<\/strong>&nbsp;<a href=\"tel: +14128223000\">412-822-3000<\/a><br \/>\r\n<strong>Hours: <\/strong>Monday \u2013 Friday, 8:00 a.m. to 4:30 p.m. ET<\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment.&nbsp;<\/p>\r\n\r\n<p><strong>Referral needed?<\/strong> No<\/p>\r\n\r\n<p><strong>Phone:<\/strong>&nbsp;<a href=\"tel: +14128223000\">412-822-3000<\/a><\/p>\r\n\r\n<p><a class=\"usa-button\" data-entity-substitution=\"canonical\" data-entity-type=\"node\" data-entity-uuid=\"4578cb13-d680-426f-8f2d-ff000e990cb3\" href=\"\/node\/37\">Schedule an appointment online<\/a><\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "0b968788-cfb0-41aa-8206-2577105072fa"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "c4f23a23-0885-4e1a-b282-48c421fb9203"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.ef6d9811-71ac-42ff-ad23-e5086e6c9b21.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.ef6d9811-71ac-42ff-ad23-e5086e6c9b21.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "ef6d9811-71ac-42ff-ad23-e5086e6c9b21"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-05T15:27:54+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Women Veteran care at Washington County VA Clinic"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "fd71292f-3dc7-409d-b0e8-500204cb005a"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-10-30T19:58:49+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-05T15:27:54+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Women Veteran care at Washington County VA Clinic | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Women Veteran care at Washington County VA Clinic | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Women Veteran care at Washington County VA Clinic | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Location and contact information<\/h3>\r\n\r\n<p class=\"va-address-block\">Crossroads Center<br \/>\r\n<strong>Phone:&nbsp;<\/strong><a href=\"tel:+17242507790\">724-250-7790<\/a><\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you\u2019ll need to contact your primary care provider first.<\/p>\r\n\r\n<p><strong>Phone:&nbsp;<\/strong><a href=\"tel:+17242507790\">724-250-7790<\/a><\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "a6826998-b7f7-434f-8999-959b1dab0c52"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "1fdda7ec-a660-4fa7-86be-ef2421cb4e6f"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.f0c8a0e6-c631-4792-ab16-d7f956923b73.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.f0c8a0e6-c631-4792-ab16-d7f956923b73.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "f0c8a0e6-c631-4792-ab16-d7f956923b73"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-05T14:35:37+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Homeless Veteran care at H. John Heinz III Department of Veterans Affairs Medical Center"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "a6af4eb9-ef34-420e-8a20-e2fba1a5afa2"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-05-30T23:16:38+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-05T14:35:37+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Homeless Veteran care at H. John Heinz III Department of Veterans Affairs Medical Center | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Homeless Veteran care at H. John Heinz III Department of Veterans Affairs Medical Center | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Homeless Veteran care at H. John Heinz III Department of Veterans Affairs Medical Center | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Location and contact information<\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>Health Care for Homeless Veterans Coordinator<\/strong><br \/>\r\nBuilding 69, Veterans Recovery Center<br \/>\r\n<a data-entity-substitution=\"canonical\" data-entity-type=\"node\" data-entity-uuid=\"a2d3391d-7196-4a3e-bdf5-a71a7b214195\" href=\"\/node\/781\">Map of the Heinz campus<\/a><br \/>\r\n<strong>Phone:&nbsp;<\/strong><br \/>\r\n<a href=\"tel: +14128221272\">412-822-1272<\/a><br \/>\r\n<a href=\"tel: +18664827488,221272\">1-866-482-7488, ext. 221272<\/a><br \/>\r\n<strong>Email:&nbsp;<\/strong><a href=\"mailto:mary.pilarski@va.gov\">mary.pilarski@va.gov<\/a><\/p>\r\n\r\n<p class=\"va-address-block\"><strong>National Center for Homeless Veterans<br \/>\r\nPhone:&nbsp;<\/strong><a href=\"tel: +18774243838\">877-424-3838<\/a><br \/>\r\n<strong>Hours:<\/strong> 24\/7<\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you\u2019ll need to contact your primary care provider first.<\/p>\r\n\r\n<p><strong>Phone:&nbsp;<\/strong><a href=\"tel: +14128221272\">412-822-1272<\/a><\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "e15ebe41-f7cf-4f2c-a407-3728c341220b"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "c57b1ff5-d845-4862-9dfc-427823485e06"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.f105e35d-b374-4405-a867-6e2e18f80732.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.f105e35d-b374-4405-a867-6e2e18f80732.json
@@ -1,0 +1,133 @@
+{
+    "uuid": [
+        {
+            "value": "f105e35d-b374-4405-a867-6e2e18f80732"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "regional_health_care_service_des",
+            "target_type": "node_type",
+            "target_uuid": "d2e27d2b-acb1-471b-a628-4c41c3778729"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-04T20:27:26+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "fd71292f-3dc7-409d-b0e8-500204cb005a"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Low vision and blind rehabilitation"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "a8dc1b57-781b-4ae4-8395-feb87b55de1f"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-03-26T20:22:37+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-04T20:27:26+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Low vision and blind rehabilitation | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Low vision and blind rehabilitation | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Low vision and blind rehabilitation | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": "\/low-vision-and-blind-rehabilitation",
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Care we provide at VA Pittsburgh<\/h3>\r\n\r\n<p>Our low vision outpatient clinic can&nbsp;help&nbsp;assess your needs and provide a rehab plan tailored to your personal goals. You will work with a team of specialists and social workers to determine what aids and services are right for you. Clinic services include:<\/p>\r\n\r\n<ul>\r\n\t<li>Comprehensive eye examinations<\/li>\r\n\t<li>Visual skills assessments<\/li>\r\n\t<li>Guidance on developing visual motor and visual perceptual skills<\/li>\r\n\t<li>Training with activities of daily living with vision loss<\/li>\r\n<\/ul>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_local_health_care_service_": [
+        {
+            "target_type": "node",
+            "target_uuid": "fdb87ac3-cf59-43ba-9908-ff1de484ce63"
+        }
+    ],
+    "field_region_page": [
+        {
+            "target_type": "node",
+            "target_uuid": "2bddb1a7-6fb1-4503-838d-9c2fcb51c46a"
+        }
+    ],
+    "field_service_name_and_descripti": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "0e43fb0e-9cfb-4c72-9076-1a7edbc3c8df"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.f12abb98-89c9-4605-b45d-c8e8920cf62d.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.f12abb98-89c9-4605-b45d-c8e8920cf62d.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "f12abb98-89c9-4605-b45d-c8e8920cf62d"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-05T13:12:12+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Radiology\/imaging at Pittsburgh VA Medical Center-University Drive"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "a6af4eb9-ef34-420e-8a20-e2fba1a5afa2"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-06-17T21:51:50+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-05T16:55:48+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Radiology\/imaging at Pittsburgh VA Medical Center-University Drive | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Radiology\/imaging at Pittsburgh VA Medical Center-University Drive | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Radiology\/imaging at Pittsburgh VA Medical Center-University Drive | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Location and contact information<\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>Phone:&nbsp;<\/strong><a href=\"tel: +14128223000\">412-<\/a><a href=\"tel: +14123606105\">360-6105<\/a><br \/>\r\n<strong>Hours:<\/strong>&nbsp;Monday \u2013 Friday, 8:00 a.m. to 4:30 p.m. ET<\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you\u2019ll need to contact your primary care provider first.<\/p>\r\n\r\n<p><strong>Phone:&nbsp;<\/strong><a href=\"tel: +14128223000\">412-<\/a><a href=\"tel: +14123606105\">360-6105<\/a><\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "0b968788-cfb0-41aa-8206-2577105072fa"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "72ff4ca7-0310-4786-b7ff-502486b88efc"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.f19cba64-b1b2-48bf-a7a8-da03e1dad5c6.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.f19cba64-b1b2-48bf-a7a8-da03e1dad5c6.json
@@ -1,0 +1,132 @@
+{
+    "uuid": [
+        {
+            "value": "f19cba64-b1b2-48bf-a7a8-da03e1dad5c6"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-04T21:19:44+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "revision_log": [
+        {
+            "value": "Bulk operation publish revision"
+        }
+    ],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Orthopedics at H. John Heinz III Department of Veterans Affairs Medical Center"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "fd71292f-3dc7-409d-b0e8-500204cb005a"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-11-04T20:38:18+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-04T21:19:44+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Orthopedics at H. John Heinz III Department of Veterans Affairs Medical Center | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Orthopedics at H. John Heinz III Department of Veterans Affairs Medical Center | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Orthopedics at H. John Heinz III Department of Veterans Affairs Medical Center | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 0
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Location and contact information<\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>Orthopedic Non-Surgical Clinic<\/strong><br \/>\r\nHeinz Building 71<br \/>\r\nSecond floor, pod 2<br \/>\r\n<a data-entity-substitution=\"canonical\" data-entity-type=\"node\" data-entity-uuid=\"a2d3391d-7196-4a3e-bdf5-a71a7b214195\" href=\"\/node\/781\">Map of H.J. Heinz III Campus<\/a><br \/>\r\n<strong>Phone:<\/strong>&nbsp;<a href=\"tel: +1412-360-6700\">412-360-6700<\/a><\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you\u2019ll need to contact your primary care provider first.<\/p>\r\n\r\n<p><strong>Phone:<\/strong>&nbsp;<a href=\"tel: +1412-360-6700\">412-360-6700<\/a><\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "e15ebe41-f7cf-4f2c-a407-3728c341220b"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "c1bf3481-50a8-4984-a383-37bdcfbe6b0f"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.f1e75524-194c-4c05-a086-8c8b1248abb8.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.f1e75524-194c-4c05-a086-8c8b1248abb8.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "f1e75524-194c-4c05-a086-8c8b1248abb8"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-05T13:03:04+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Pharmacy at H. John Heinz III Department of Veterans Affairs Medical Center"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "a6af4eb9-ef34-420e-8a20-e2fba1a5afa2"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-06-14T21:32:25+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-05T13:03:04+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Pharmacy at H. John Heinz III Department of Veterans Affairs Medical Center | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Pharmacy at H. John Heinz III Department of Veterans Affairs Medical Center | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Pharmacy at H. John Heinz III Department of Veterans Affairs Medical Center | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Location and contact information<\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>Pharmacy<\/strong><br \/>\r\nBuilding 71<br \/>\r\nFirst Floor<br \/>\r\n<a data-entity-substitution=\"canonical\" data-entity-type=\"node\" data-entity-uuid=\"a2d3391d-7196-4a3e-bdf5-a71a7b214195\" href=\"\/node\/781\">Map of the Heinz campus<\/a><br \/>\r\n<strong>Phone:&nbsp;<\/strong><a href=\"tel: +18664001242\">866-400-1242<\/a><br \/>\r\n<strong>Hours:&nbsp;<\/strong>Mon.&nbsp;\u2013&nbsp;Tues.&nbsp;8:00 a.m. to 4:30 p.m. ET<br \/>\r\n&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; Wednesday&nbsp;8:00 a.m. to 6:30 p.m. ET<br \/>\r\n&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;Thur.&nbsp;\u2013 Fri.&nbsp;8:00 a.m. to 4:30 p.m. ET<\/p>\r\n\r\n<p class=\"va-address-block\"><strong>Prescription refills<\/strong><br \/>\r\nBuilding 71<br \/>\r\nFirst Floor<br \/>\r\n<a data-entity-substitution=\"canonical\" data-entity-type=\"node\" data-entity-uuid=\"a2d3391d-7196-4a3e-bdf5-a71a7b214195\" href=\"\/node\/781\">Map of the Heinz campus<\/a><br \/>\r\n<strong>Phone:&nbsp;<\/strong><a href=\"tel: +14128223140\">412-822-3140<\/a><br \/>\r\n<strong>Hours:<\/strong> Monday \u2013 Friday, 8:00 a.m. to 4:30 p.m. ET<\/p>\r\n\r\n<p class=\"va-address-block\"><strong>Safe medicine disposal drop off location<\/strong><br \/>\r\nBuilding 51<br \/>\r\nCommunity Living Center<br \/>\r\n<a data-entity-substitution=\"canonical\" data-entity-type=\"node\" data-entity-uuid=\"a2d3391d-7196-4a3e-bdf5-a71a7b214195\" href=\"\/node\/781\">Map of the Heinz campus<\/a><br \/>\r\n<strong>Hours:&nbsp;<\/strong>Monday \u2013&nbsp;Friday, 8:00 a.m. to 4:30 p.m. ET<\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you\u2019ll need to contact your primary care provider first.<br \/>\r\n<br \/>\r\n<strong>Walk-ins accepted?<\/strong>&nbsp;No<br \/>\r\n<strong>Phone:&nbsp;<\/strong><a href=\"tel: +18664001242\">866-400-1242<\/a><br \/>\r\n<strong>Phone:&nbsp;<\/strong><a href=\"tel: +14128223140\">412-822-3140<\/a><\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "e15ebe41-f7cf-4f2c-a407-3728c341220b"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "929402f4-2a85-4659-a1bf-900264984903"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.f2151138-ae2f-45c3-9c70-4b4e40a78182.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.f2151138-ae2f-45c3-9c70-4b4e40a78182.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "f2151138-ae2f-45c3-9c70-4b4e40a78182"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-09-11T17:35:49+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "8d4a7bed-f4ba-499f-afd4-8e1cbeadfc4a"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Primary care at Fayette County VA Clinic"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "a6af4eb9-ef34-420e-8a20-e2fba1a5afa2"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-06-17T19:36:41+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-05T01:11:20+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Primary care at Fayette County VA Clinic | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Primary care at Fayette County VA Clinic | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Primary care at Fayette County VA Clinic | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Location and contact information<\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>Primary Care Services<br \/>\r\nPhone:&nbsp;<\/strong><a href=\"tel: +17244394990\">724-439-4990<\/a><br \/>\r\n<strong>Hours: <\/strong>Monday \u2013&nbsp;Friday, 8:00 a.m. to 4:30 p.m. ET<\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment.&nbsp;<\/p>\r\n\r\n<p><strong>Referral needed?<\/strong> No<\/p>\r\n\r\n<p><strong>Phone:&nbsp;<\/strong><a href=\"tel: +17244394990\">724-439-4990<\/a><br \/>\r\n<br \/>\r\n<a class=\"usa-button\" data-entity-substitution=\"canonical\" data-entity-type=\"node\" data-entity-uuid=\"4578cb13-d680-426f-8f2d-ff000e990cb3\" href=\"\/node\/37\">Schedule an appointment online<\/a><\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "4a987e19-688b-4840-964a-cfefc730fc6c"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "c4f23a23-0885-4e1a-b282-48c421fb9203"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.f25b7f27-0320-404a-b116-dc2b21178818.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.f25b7f27-0320-404a-b116-dc2b21178818.json
@@ -1,0 +1,133 @@
+{
+    "uuid": [
+        {
+            "value": "f25b7f27-0320-404a-b116-dc2b21178818"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "regional_health_care_service_des",
+            "target_type": "node_type",
+            "target_uuid": "d2e27d2b-acb1-471b-a628-4c41c3778729"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-09-09T21:49:03+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "8d4a7bed-f4ba-499f-afd4-8e1cbeadfc4a"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Transplant surgery"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "a6af4eb9-ef34-420e-8a20-e2fba1a5afa2"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-06-17T23:40:53+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-09-09T21:49:03+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Transplant surgery | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Transplant surgery | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Transplant surgery | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": "\/transplant-surgery",
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Care we provide at VA Pittsburgh<\/h3>\r\n\r\n<ul>\r\n\t<li>Liver transplants<\/li>\r\n\t<li>Kidney (renal) transplants<\/li>\r\n\t<li>Referrals to other transplant centers<\/li>\r\n<\/ul>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_local_health_care_service_": [
+        {
+            "target_type": "node",
+            "target_uuid": "83e125c4-642c-4c70-849c-48882ebb853d"
+        }
+    ],
+    "field_region_page": [
+        {
+            "target_type": "node",
+            "target_uuid": "2bddb1a7-6fb1-4503-838d-9c2fcb51c46a"
+        }
+    ],
+    "field_service_name_and_descripti": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "e37928d5-30b0-4a20-a486-06ddbdb59873"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.f33134e5-6ced-4e92-8a77-ec6a67913264.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.f33134e5-6ced-4e92-8a77-ec6a67913264.json
@@ -1,0 +1,132 @@
+{
+    "uuid": [
+        {
+            "value": "f33134e5-6ced-4e92-8a77-ec6a67913264"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-04T21:19:44+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "revision_log": [
+        {
+            "value": "Bulk operation publish revision"
+        }
+    ],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Registry exams at Pittsburgh VA Medical Center-University Drive"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-10-30T18:30:30+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-05T17:00:49+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Registry exams at Pittsburgh VA Medical Center-University Drive | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Registry exams at Pittsburgh VA Medical Center-University Drive | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Registry exams at Pittsburgh VA Medical Center-University Drive | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Location and contact information<\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>Environmental Health Coordinator<\/strong><br \/>\r\nPhone:&nbsp;<a href=\"tel: +14128221707\">412-822-1707<\/a><br \/>\r\n<strong>Email:&nbsp;<\/strong><a href=\"mailto:douglas.turner5@va.gov\">douglas.turner5@va.gov<\/a><\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you\u2019ll need to contact your primary care provider first.<\/p>\r\n\r\n<p><strong>Referral needed?<\/strong>&nbsp;No<br \/>\r\n<strong>Walk-ins accepted?<\/strong>&nbsp;No<br \/>\r\n<strong>Phone:<\/strong>&nbsp;<a href=\"tel: +14128221707\">412-822-1707<\/a><\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "0b968788-cfb0-41aa-8206-2577105072fa"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "3e92eaa8-bbf8-4173-84f8-d187b281d548"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.f3348da9-2977-438a-8831-f9d890b91f49.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.f3348da9-2977-438a-8831-f9d890b91f49.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "f3348da9-2977-438a-8831-f9d890b91f49"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-09-10T19:38:45+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "8d4a7bed-f4ba-499f-afd4-8e1cbeadfc4a"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Patient advocates at Belmont County VA Clinic"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "a6af4eb9-ef34-420e-8a20-e2fba1a5afa2"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-06-14T21:04:40+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-09-10T19:38:45+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Patient advocates at Belmont County VA Clinic | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Patient advocates at Belmont County VA Clinic | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Patient advocates at Belmont County VA Clinic | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3 id=\"location-and-contact-informati-633\">Location and contact information<\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>Hours:&nbsp;<\/strong>Monday \u2013 Friday, 8:00 a.m. to 4:30 p.m. ET<\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "eac71fd5-260c-4f44-8507-8b803ad2324f"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "85ecc815-a3fc-4978-9e7a-2cfd55dc9b72"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.f4d32e3c-eee5-4c37-b3f9-4289b632967c.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.f4d32e3c-eee5-4c37-b3f9-4289b632967c.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "f4d32e3c-eee5-4c37-b3f9-4289b632967c"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-05T15:46:29+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "fd71292f-3dc7-409d-b0e8-500204cb005a"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Urology at Pittsburgh VA Medical Center-University Drive"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "fd71292f-3dc7-409d-b0e8-500204cb005a"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-05-13T16:23:41+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-05T15:46:29+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Urology at Pittsburgh VA Medical Center-University Drive | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Urology at Pittsburgh VA Medical Center-University Drive | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Urology at Pittsburgh VA Medical Center-University Drive | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Location and contact information<\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>Main Hospital<\/strong><br \/>\r\nBuilding 1<br \/>\r\n2nd floor, room 2A-201<br \/>\r\n<a data-entity-substitution=\"canonical\" data-entity-type=\"node\" data-entity-uuid=\"71ffee52-a47f-4909-ad7e-21ece5728be3\" href=\"\/node\/783\">Map of University Drive campus<\/a><br \/>\r\n<strong>Phone:&nbsp;<\/strong><a href=\"tel:+14128222222\">412-3<\/a><a href=\"tel:4123606700\">60-6700<\/a><br \/>\r\n<strong>Hours:&nbsp;<\/strong>Monday&nbsp;\u2013 Friday, 8:00 a.m. to 4:30 p.m. ET<\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you\u2019ll need to contact your primary care provider first.<\/p>\r\n\r\n<p><strong>Referral needed? <\/strong>Yes<\/p>\r\n\r\n<p><strong>Walk-ins accepted?<\/strong> No<\/p>\r\n\r\n<p><strong>Phone:&nbsp;<\/strong><a href=\"tel:+14128222222\">412-3<\/a><a href=\"tel:4123606700\">60-6700<\/a><\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "0b968788-cfb0-41aa-8206-2577105072fa"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "fa8d2d15-0e41-4ef0-a606-c0da352fe76d"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.f86833a9-022c-4a4e-bf7e-ad9c36357392.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.f86833a9-022c-4a4e-bf7e-ad9c36357392.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "f86833a9-022c-4a4e-bf7e-ad9c36357392"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-05T15:06:15+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Podiatry at Belmont County VA Clinic"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "a6af4eb9-ef34-420e-8a20-e2fba1a5afa2"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-06-14T22:07:07+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-05T15:06:15+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Podiatry at Belmont County VA Clinic | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Podiatry at Belmont County VA Clinic | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Podiatry at Belmont County VA Clinic | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Location and contact information<\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>Phone:&nbsp;<\/strong><a href=\"tel: +14128223000\">412-822-3000<\/a><br \/>\r\n<strong>Hours:&nbsp;<\/strong>Monday \u2013&nbsp;Friday, 8:00 a.m. to 4:30 p.m. ET<\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you\u2019ll need to contact your primary care provider first.<\/p>\r\n\r\n<p><strong>Referral needed?<\/strong>&nbsp;No<br \/>\r\n<strong>Phone:&nbsp;<\/strong><a href=\"tel: +14128223000\">412-822-3000<\/a><\/p>\r\n\r\n<p>&nbsp;<\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "eac71fd5-260c-4f44-8507-8b803ad2324f"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "8c838193-be61-48ea-8f1c-a1839b57f1fc"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.f88a91dc-918b-40da-a76d-baa3bd19c4ac.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.f88a91dc-918b-40da-a76d-baa3bd19c4ac.json
@@ -1,0 +1,133 @@
+{
+    "uuid": [
+        {
+            "value": "f88a91dc-918b-40da-a76d-baa3bd19c4ac"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "regional_health_care_service_des",
+            "target_type": "node_type",
+            "target_uuid": "d2e27d2b-acb1-471b-a628-4c41c3778729"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-05T17:01:36+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "fd71292f-3dc7-409d-b0e8-500204cb005a"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Spinal cord injury and disorders"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "fd71292f-3dc7-409d-b0e8-500204cb005a"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-05-10T22:01:09+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-05T17:01:36+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Spinal cord injury and disorders | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Spinal cord injury and disorders | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Spinal cord injury and disorders | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": "\/spinal-cord-injury-and-disorders",
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Care we provide at VA Pittsburgh<\/h3>\r\n\r\n<ul>\r\n\t<li>Primary care for spinal-cord-injured patients<\/li>\r\n\t<li>Additional support for spinal-cord-injured patients<\/li>\r\n<\/ul>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_local_health_care_service_": [
+        {
+            "target_type": "node",
+            "target_uuid": "28d358e6-3838-40e5-92e1-fd30d33e174d"
+        }
+    ],
+    "field_region_page": [
+        {
+            "target_type": "node",
+            "target_uuid": "2bddb1a7-6fb1-4503-838d-9c2fcb51c46a"
+        }
+    ],
+    "field_service_name_and_descripti": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "82549624-4c2b-4a7c-886f-39c1278a41e5"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.f9b03ff3-98d9-4ded-93c9-569dd0d85d8b.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.f9b03ff3-98d9-4ded-93c9-569dd0d85d8b.json
@@ -1,0 +1,132 @@
+{
+    "uuid": [
+        {
+            "value": "f9b03ff3-98d9-4ded-93c9-569dd0d85d8b"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-04T21:19:44+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "revision_log": [
+        {
+            "value": "Bulk operation publish revision"
+        }
+    ],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Military sexual trauma at Washington County VA Clinic"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-10-30T21:07:46+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-04T21:19:44+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Military sexual trauma at Washington County VA Clinic | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Military sexual trauma at Washington County VA Clinic | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Military sexual trauma at Washington County VA Clinic | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Location and contact information&nbsp;<\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>Psychology \/ Social Work<\/strong><br \/>\r\n<strong>Phone:<\/strong><a href=\"tel: +17247096005\">&nbsp;7<\/a><a href=\"tel: +17244394990\">24-<\/a><a href=\"tel: +17242507790\">250-7790<\/a><br \/>\r\n<strong>Hours:&nbsp;<\/strong>Monday \u2013&nbsp;Friday, 8:00 a.m. \u2013&nbsp;4:30 p.m. ET<\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you\u2019ll need to contact your primary care provider first.<\/p>\r\n\r\n<p><strong>Phone:&nbsp;<\/strong><a href=\"tel: +17247096005\">7<\/a><a href=\"tel: +17244394990\">24-<\/a><a href=\"tel: +17242507790\">250-7790<\/a><\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "a6826998-b7f7-434f-8999-959b1dab0c52"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "6d59f042-c372-436c-a8ff-7a8f017ad89f"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.fa8d2d15-0e41-4ef0-a606-c0da352fe76d.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.fa8d2d15-0e41-4ef0-a606-c0da352fe76d.json
@@ -1,0 +1,137 @@
+{
+    "uuid": [
+        {
+            "value": "fa8d2d15-0e41-4ef0-a606-c0da352fe76d"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "regional_health_care_service_des",
+            "target_type": "node_type",
+            "target_uuid": "d2e27d2b-acb1-471b-a628-4c41c3778729"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-05T01:35:28+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "fd71292f-3dc7-409d-b0e8-500204cb005a"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Urology"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "fd71292f-3dc7-409d-b0e8-500204cb005a"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-05-13T16:21:28+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-05T01:35:28+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Urology | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Urology | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Urology | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": "\/urology",
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Care we provide at VA Pittsburgh<\/h3>\r\n\r\n<p>We offer various urology procedures, including minimally invasive and robotic procedures for diseases affecting:<\/p>\r\n\r\n<ul>\r\n\t<li>The kidneys<\/li>\r\n\t<li>The bladder<\/li>\r\n\t<li>The urethra&nbsp;<\/li>\r\n\t<li>The male reproductive organs<\/li>\r\n<\/ul>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_local_health_care_service_": [
+        {
+            "target_type": "node",
+            "target_uuid": "f4d32e3c-eee5-4c37-b3f9-4289b632967c"
+        },
+        {
+            "target_type": "node",
+            "target_uuid": "96dc069a-e27e-4b24-bdc6-64f95ed71507"
+        }
+    ],
+    "field_region_page": [
+        {
+            "target_type": "node",
+            "target_uuid": "2bddb1a7-6fb1-4503-838d-9c2fcb51c46a"
+        }
+    ],
+    "field_service_name_and_descripti": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "8a97ad12-57cf-4591-9a5a-171936099fb7"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.fa9fd27d-aa1c-4cc0-b31b-569e779c034d.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.fa9fd27d-aa1c-4cc0-b31b-569e779c034d.json
@@ -1,0 +1,133 @@
+{
+    "uuid": [
+        {
+            "value": "fa9fd27d-aa1c-4cc0-b31b-569e779c034d"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "regional_health_care_service_des",
+            "target_type": "node_type",
+            "target_uuid": "d2e27d2b-acb1-471b-a628-4c41c3778729"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-10-31T19:41:28+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "c0745381-8e20-40da-9540-5a7d2eee1b35"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Vocational rehabilitation and employment programs"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "fd71292f-3dc7-409d-b0e8-500204cb005a"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-05-10T22:02:53+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-10-31T19:41:28+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Vocational rehabilitation and employment programs | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Vocational rehabilitation and employment programs | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Vocational rehabilitation and employment programs | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": "\/vocational-rehabilitation-and-employment-programs",
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Care we provide at VA Pittsburgh<\/h3>\r\n\r\n<p>We help you throughout the employment process, from identifying your skills and abilities to finding and keeping a job. All Veterans enrolled in VA health care are eligible for vocational services. What are vocational services? Programs tailored to your skills, experience, abilities and interests, career counseling, workshops and training, including:<\/p>\r\n\r\n<ul>\r\n\t<li>Skills and abilities testing<\/li>\r\n\t<li>Real-world placements to assess skills, abilities and interests<\/li>\r\n\t<li>Job-search training<\/li>\r\n\t<li>Workplace survival skills<\/li>\r\n\t<li>One-on-one counseling<\/li>\r\n\t<li>Strategies to find and keep a job<\/li>\r\n<\/ul>\r\n\r\n<p><a data-entity-substitution=\"canonical\" data-entity-type=\"node\" data-entity-uuid=\"30d0a3cb-fd75-47c5-944a-932a0a22d22d\" href=\"\/node\/725\">Learn more about VA VR&amp;E programs<\/a><\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_local_health_care_service_": [
+        {
+            "target_type": "node",
+            "target_uuid": "88ad402e-5f72-40af-9c99-5c97f76bbfbb"
+        }
+    ],
+    "field_region_page": [
+        {
+            "target_type": "node",
+            "target_uuid": "2bddb1a7-6fb1-4503-838d-9c2fcb51c46a"
+        }
+    ],
+    "field_service_name_and_descripti": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "f89701d9-68e7-47ae-85e0-42b7ce40f188"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.fba97a2a-de8f-4846-a384-04a8ec50555b.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.fba97a2a-de8f-4846-a384-04a8ec50555b.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "fba97a2a-de8f-4846-a384-04a8ec50555b"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-09-10T14:22:57+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "8d4a7bed-f4ba-499f-afd4-8e1cbeadfc4a"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Orthopedics at Pittsburgh VA Medical Center-University Drive"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "fd71292f-3dc7-409d-b0e8-500204cb005a"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-05-13T16:24:11+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-04T20:30:15+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Orthopedics at Pittsburgh VA Medical Center-University Drive | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Orthopedics at Pittsburgh VA Medical Center-University Drive | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Orthopedics at Pittsburgh VA Medical Center-University Drive | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Location and contact information<\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>Orthopedic surgery<\/strong><br \/>\r\nMain hospital<br \/>\r\nBuilding 1<br \/>\r\n2 West, Surgical clinics<br \/>\r\n6 East Surgical clinics<br \/>\r\n<a data-entity-substitution=\"canonical\" data-entity-type=\"node\" data-entity-uuid=\"71ffee52-a47f-4909-ad7e-21ece5728be3\" href=\"\/node\/783\">Map of University Drive campus<\/a><br \/>\r\n<strong>Phone:<\/strong>&nbsp;<a href=\"tel: +1412-360-6700\">412-360-6700<\/a><\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you\u2019ll need to contact your primary care provider first.<\/p>\r\n\r\n<p><strong>Phone:<\/strong>&nbsp;<a href=\"tel: +1412-360-6700\">412-360-6700<\/a><\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "0b968788-cfb0-41aa-8206-2577105072fa"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "c1bf3481-50a8-4984-a383-37bdcfbe6b0f"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.fc92e5b2-a387-4421-8943-246140fd497f.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.fc92e5b2-a387-4421-8943-246140fd497f.json
@@ -1,0 +1,133 @@
+{
+    "uuid": [
+        {
+            "value": "fc92e5b2-a387-4421-8943-246140fd497f"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "regional_health_care_service_des",
+            "target_type": "node_type",
+            "target_uuid": "d2e27d2b-acb1-471b-a628-4c41c3778729"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-10-30T21:53:45+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "fd71292f-3dc7-409d-b0e8-500204cb005a"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Dental\/oral surgery"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "fd71292f-3dc7-409d-b0e8-500204cb005a"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-05-10T21:39:53+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-10-30T21:53:45+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Dental\/oral surgery | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Dental\/oral surgery | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Dental\/oral surgery | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": "\/dentaloral-surgery",
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Care we provide at VA Pittsburgh<\/h3>\r\n\r\n<p>We offer comprehensive routine and specialized dental care from a wide range of outstanding general dentists and specialists in endodontics, prosthodontics, periodontics, and oral surgery. Our services include:<\/p>\r\n\r\n<ul>\r\n\t<li>Routine exams and dental cleaning<\/li>\r\n\t<li>Comprehensive surgical care including, extractions, implant placement and oral cancer screening<\/li>\r\n\t<li>Routine and advanced prosthodontic care, including fixed bridges, dentures and dental implants&nbsp;<\/li>\r\n\t<li>Routine and advanced periodontal care, including root canals, gum and supporting bone care<\/li>\r\n<\/ul>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_local_health_care_service_": [
+        {
+            "target_type": "node",
+            "target_uuid": "0d73b85c-b637-4527-9e8b-6f78f05a2ab4"
+        }
+    ],
+    "field_region_page": [
+        {
+            "target_type": "node",
+            "target_uuid": "2bddb1a7-6fb1-4503-838d-9c2fcb51c46a"
+        }
+    ],
+    "field_service_name_and_descripti": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "2cfe8251-bda1-47f8-9706-bdcd21cd85dc"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.fdb87ac3-cf59-43ba-9908-ff1de484ce63.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.fdb87ac3-cf59-43ba-9908-ff1de484ce63.json
@@ -1,0 +1,128 @@
+{
+    "uuid": [
+        {
+            "value": "fdb87ac3-cf59-43ba-9908-ff1de484ce63"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_health_service",
+            "target_type": "node_type",
+            "target_uuid": "30801b3d-e2cd-48db-9066-78f7530d34e2"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-11-04T20:21:09+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "fd71292f-3dc7-409d-b0e8-500204cb005a"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Low vision and blind rehabilitation at H. John Heinz III Department of Veterans Affairs Medical Center"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "a6af4eb9-ef34-420e-8a20-e2fba1a5afa2"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-05-31T00:04:33+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-04T20:27:26+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Low vision and blind rehabilitation at H. John Heinz III Department of Veterans Affairs Medical Center | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Low vision and blind rehabilitation at H. John Heinz III Department of Veterans Affairs Medical Center | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Low vision and blind rehabilitation at H. John Heinz III Department of Veterans Affairs Medical Center | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": null,
+            "pid": null,
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Location and contact information<\/h3>\r\n\r\n<p class=\"va-address-block\"><strong>Ambulatory Care Center<\/strong><br \/>\r\nLow vision clinic<br \/>\r\nBuilding 71<br \/>\r\n1st Floor<br \/>\r\n<a data-entity-substitution=\"canonical\" data-entity-type=\"node\" data-entity-uuid=\"a2d3391d-7196-4a3e-bdf5-a71a7b214195\" href=\"\/node\/781\">Map of the Heinz campus<\/a><br \/>\r\n<strong>Phone:<\/strong> <a href=\"tel:412-822-2125\">412-822-2125<\/a><br \/>\r\n<strong>Hours: <\/strong>Monday \u2013 Friday, 8:00 a.m. to 4:30 p.m. ET<\/p>\r\n\r\n<h3>Appointments<\/h3>\r\n\r\n<p>Contact us to schedule, reschedule, or cancel your appointment. If a referral is required, you\u2019ll need to contact your primary care provider first.<\/p>\r\n\r\n<p><strong>Phone:&nbsp;<\/strong><a href=\"tel:412-822-2125\">412-822-2125<\/a><\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_facility_location": [
+        {
+            "target_type": "node",
+            "target_uuid": "e15ebe41-f7cf-4f2c-a407-3728c341220b"
+        }
+    ],
+    "field_regional_health_service": [
+        {
+            "target_type": "node",
+            "target_uuid": "f105e35d-b374-4405-a867-6e2e18f80732"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/node.ffa5121a-9775-4825-9f9b-27a20c599f1f.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.ffa5121a-9775-4825-9f9b-27a20c599f1f.json
@@ -1,0 +1,133 @@
+{
+    "uuid": [
+        {
+            "value": "ffa5121a-9775-4825-9f9b-27a20c599f1f"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "regional_health_care_service_des",
+            "target_type": "node_type",
+            "target_uuid": "d2e27d2b-acb1-471b-a628-4c41c3778729"
+        }
+    ],
+    "revision_timestamp": [
+        {
+            "value": "2019-09-09T21:12:48+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "revision_uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "8d4a7bed-f4ba-499f-afd4-8e1cbeadfc4a"
+        }
+    ],
+    "revision_log": [],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "title": [
+        {
+            "value": "Geriatrics"
+        }
+    ],
+    "uid": [
+        {
+            "target_type": "user",
+            "target_uuid": "fd71292f-3dc7-409d-b0e8-500204cb005a"
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-05-10T21:43:33+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-09-09T21:12:48+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "promote": [
+        {
+            "value": false
+        }
+    ],
+    "sticky": [
+        {
+            "value": false
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "moderation_state": [
+        {
+            "value": "published"
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Geriatrics | Veterans Affairs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "Geriatrics | Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "Geriatrics | Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": "\/geriatrics",
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "menu_link": [],
+    "field_administration": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "field_body": [
+        {
+            "value": "<h3>Care we provide at VA Pittsburgh<\/h3>\r\n\r\n<p>Our Geriatric Evaluation and Management Clinic (GEM)&nbsp;offers outpatient-based comprehensive geriatric assessments&nbsp;and care coordination for you or a senior Veteran in your care.&nbsp;We accept&nbsp;referrals from any doctor. Our team of specialists provides geriatric-specific:<\/p>\r\n\r\n<ul>\r\n\t<li>Medicine and nursing<\/li>\r\n\t<li>Psychology, psychiatry, and social work<\/li>\r\n\t<li>Physical and occupational therapy<\/li>\r\n<\/ul>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "field_local_health_care_service_": [
+        {
+            "target_type": "node",
+            "target_uuid": "d2461b77-505d-4f8a-9a07-1024cc9bbe3d"
+        }
+    ],
+    "field_region_page": [
+        {
+            "target_type": "node",
+            "target_uuid": "2bddb1a7-6fb1-4503-838d-9c2fcb51c46a"
+        }
+    ],
+    "field_service_name_and_descripti": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "0cf2cff8-9012-419c-b8f9-fa625b4ca364"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/paragraph.136fe7a5-6706-4a2b-a9f4-7bf807d20b1c.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/paragraph.136fe7a5-6706-4a2b-a9f4-7bf807d20b1c.json
@@ -1,0 +1,56 @@
+{
+    "uuid": [
+        {
+            "value": "136fe7a5-6706-4a2b-a9f4-7bf807d20b1c"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_facility_servi",
+            "target_type": "paragraphs_type",
+            "target_uuid": "77498b34-84b7-4d01-8650-a3a808ba57f6"
+        }
+    ],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-06-04T21:59:45+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "behavior_settings": [
+        {
+            "value": []
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "field_title": [
+        {
+            "value": "Campus and building maps"
+        }
+    ],
+    "field_wysiwyg": [
+        {
+            "value": "<p dir=\"ltr\">Use these maps to help you get around the campus.<\/p>\r\n\r\n<ul dir=\"ltr\">\r\n\t<li><a href=\"\/pittsburgh-health-care\/hj-heinz-iii-campus-map\">Full H.J. Heinz III campus map<\/a><\/li>\r\n\t<li><a href=\"\/pittsburgh-health-care\/ambulatory-care-center-floor-plans\">Floor plans for the Ambulatory Care Center<\/a><\/li>\r\n<\/ul>\r\n",
+            "format": "rich_text"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/paragraph.1455ec3f-b678-4eec-9fae-9a5a03251bc3.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/paragraph.1455ec3f-b678-4eec-9fae-9a5a03251bc3.json
@@ -1,0 +1,56 @@
+{
+    "uuid": [
+        {
+            "value": "1455ec3f-b678-4eec-9fae-9a5a03251bc3"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_facility_servi",
+            "target_type": "paragraphs_type",
+            "target_uuid": "77498b34-84b7-4d01-8650-a3a808ba57f6"
+        }
+    ],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-08-13T18:45:38+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "behavior_settings": [
+        {
+            "value": []
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "field_title": [
+        {
+            "value": "Lodging for patients and families"
+        }
+    ],
+    "field_wysiwyg": [
+        {
+            "value": "<h4>Nearby hotels<\/h4>\r\n\r\n<p>There is no lodging at the Beaver County outpatient clinic. If you need to travel to the clinic for multiple days, try one of these hotels. When booking, ask if there is a Veteran rate. Many hotels have shuttle vans, so check with the hotel you\u2019re staying at if you need help getting to the clinic.<\/p>\r\n\r\n<ul>\r\n\t<li dir=\"ltr\"><a href=\"https:\/\/www.ihg.com\/holidayinnexpress\/hotels\/us\/en\/monaca\/cshpa\/hoteldetail\">Holiday Inn Express &amp; Suites Center Township<\/a><br \/>\r\n\t<a href=\"tel: +17247285121\">724-728-5121<\/a><\/li>\r\n\t<li dir=\"ltr\"><a href=\"https:\/\/www.choicehotels.com\/pennsylvania\/monaca\/suburban-hotels\/pa777\">Suburban Extended Stay Hotel<\/a><br \/>\r\n\t<a href=\"tel: +1724-888-2090\">724-888-2090<\/a><\/li>\r\n\t<li dir=\"ltr\"><a href=\"https:\/\/www.marriott.com\/hotels\/travel\/pitmo-fairfield-inn-and-suites-monaca\/\">Fairfield Inn &amp; Suites - Monaca<\/a><br \/>\r\n\t<a href=\"tel: +17248882696\">724-888-2696<\/a><\/li>\r\n<\/ul>\r\n",
+            "format": "rich_text"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/paragraph.22b42635-d94a-4da5-b4ce-cc6d072be1b7.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/paragraph.22b42635-d94a-4da5-b4ce-cc6d072be1b7.json
@@ -1,0 +1,56 @@
+{
+    "uuid": [
+        {
+            "value": "22b42635-d94a-4da5-b4ce-cc6d072be1b7"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_facility_servi",
+            "target_type": "paragraphs_type",
+            "target_uuid": "77498b34-84b7-4d01-8650-a3a808ba57f6"
+        }
+    ],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-03-13T18:02:21+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "behavior_settings": [
+        {
+            "value": []
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "field_title": [
+        {
+            "value": "Transportation services and schedules"
+        }
+    ],
+    "field_wysiwyg": [
+        {
+            "value": "<h4 dir=\"ltr\">Van services for Veterans<\/h4>\r\n\r\n<h5 dir=\"ltr\">DAV vans<\/h5>\r\n\r\n<p dir=\"ltr\"><strong>Hours:<\/strong> 8:00 a.m. \u2013 4:30 p.m., individual van schedules vary<\/p>\r\n\r\n<p dir=\"ltr\">We work with Disabled American Veterans and county Veterans Affairs directors to provide transportation for Veterans and authorized caregivers to get to scheduled medical appointments.<\/p>\r\n\r\n<h5 dir=\"ltr\">Non-DAV van services<\/h5>\r\n\r\n<p dir=\"ltr\">Many localities in the region provide other van services to Veterans.<\/p>\r\n\r\n<p dir=\"ltr\"><a href=\"\/pittsburgh-health-care\/dav-vans-transportation-for-veterans\">Learn more about DAV and other the other van services available in your&nbsp;county<\/a><\/p>\r\n\r\n<p dir=\"ltr\">&nbsp;<\/p>\r\n\r\n<h4 dir=\"ltr\">Additional travel options<\/h4>\r\n\r\n<p dir=\"ltr\">See <a href=\"https:\/\/www.pittsburgh.va.gov\/docs\/Transportation_Guidebook_508.pdf\">our printable transportation guide<\/a> for an extensive list of transportation options from across the region, including VA shuttles, taxi companies, and local transit services in many counties. It also includes information on shuttle services to University Drive from other VA facilities in the region, where you can transfer to a Heinz shuttle.<\/p>\r\n\r\n<h4 dir=\"ltr\">Beneficiary travel<\/h4>\r\n\r\n<p dir=\"ltr\">Beneficiary travel benefits include round-trip transportation from your home to the medical center, mileage reimbursement, or special mode transport.&nbsp;<\/p>\r\n\r\n<p dir=\"ltr\"><a href=\"https:\/\/www.pittsburgh.va.gov\/services\/beneficiary-travel.asp\">Find out if you qualify for beneficiary travel benefits<\/a><\/p>\r\n",
+            "format": "rich_text"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/paragraph.2ce8568f-bdf2-4736-be10-fb3a37144a20.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/paragraph.2ce8568f-bdf2-4736-be10-fb3a37144a20.json
@@ -1,0 +1,56 @@
+{
+    "uuid": [
+        {
+            "value": "2ce8568f-bdf2-4736-be10-fb3a37144a20"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_facility_servi",
+            "target_type": "paragraphs_type",
+            "target_uuid": "77498b34-84b7-4d01-8650-a3a808ba57f6"
+        }
+    ],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-02-20T14:04:46+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "behavior_settings": [
+        {
+            "value": []
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "field_title": [
+        {
+            "value": "Dining and retail"
+        }
+    ],
+    "field_wysiwyg": [
+        {
+            "value": "<h4 dir=\"ltr\">Food and drink<\/h4>\r\n\r\n<h5 dir=\"ltr\">Veterans Canteen Service (VCS) Patriot Caf\u00e9<\/h5>\r\n\r\n<p dir=\"ltr\">Serving hot and cold entrees, beverages and desserts.<\/p>\r\n\r\n<p class=\"va-address-block\" dir=\"ltr\"><strong>Ground floor<br \/>\r\nHours<\/strong><br \/>\r\nMonday \u2013 Friday, 7:00 a.m. to 3:30 p.m.<br \/>\r\nClosed weekends<\/p>\r\n\r\n<h5 dir=\"ltr\">VCS Patriot Brew (Starbucks)<\/h5>\r\n\r\n<p dir=\"ltr\">Serving a variety of pastries, light sandwiches and beverages.<\/p>\r\n\r\n<p class=\"va-address-block\" dir=\"ltr\"><strong>First floor<\/strong><br \/>\r\nTo the right of Release of Information.<br \/>\r\n<strong>Hours<\/strong><br \/>\r\nMonday \u2013 Friday, 6:30 a.m. to 7:00 p.m.<br \/>\r\nSaturday, 8:00 a.m. to&nbsp;3:30 p.m.&nbsp;<br \/>\r\nClosed Sunday<\/p>\r\n\r\n<h5 dir=\"ltr\">Vending machines<\/h5>\r\n\r\n<p dir=\"ltr\">Drinks and snacks are available around the clock.<\/p>\r\n\r\n<h4 dir=\"ltr\">Retail<\/h4>\r\n\r\n<h5 dir=\"ltr\">The Patriot Store&nbsp;<\/h5>\r\n\r\n<p dir=\"ltr\">A full-service retail store with such products as electronics, cosmetics, toiletries, and clothing. Purchases are tax-free.<\/p>\r\n\r\n<p class=\"va-address-block\" dir=\"ltr\"><strong>Ground floor<br \/>\r\nHours<\/strong><br \/>\r\nMonday \u2013 Friday, 7:00 a.m. to 7:00 p.m.<br \/>\r\nSaturday, 9:00 a.m. to 3:30 p.m.<br \/>\r\nSunday, 8:30 a.m. to 2:00 p.m.<\/p>\r\n",
+            "format": "rich_text"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/paragraph.32b1d373-a32e-46f3-8329-4f42d95d8fb7.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/paragraph.32b1d373-a32e-46f3-8329-4f42d95d8fb7.json
@@ -1,0 +1,56 @@
+{
+    "uuid": [
+        {
+            "value": "32b1d373-a32e-46f3-8329-4f42d95d8fb7"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_facility_servi",
+            "target_type": "paragraphs_type",
+            "target_uuid": "77498b34-84b7-4d01-8650-a3a808ba57f6"
+        }
+    ],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-06-19T18:21:15+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "behavior_settings": [
+        {
+            "value": []
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "field_title": [
+        {
+            "value": "Parking"
+        }
+    ],
+    "field_wysiwyg": [
+        {
+            "value": "<p><strong>Cost:<\/strong> Free<\/p>\r\n\r\n<p><strong>Wheelchair availability:<\/strong> The Fayette County outpatient clinic has wheelchairs available in the building.<\/p>\r\n",
+            "format": "rich_text"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/paragraph.3784f178-84e1-42e8-9f75-10226773926b.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/paragraph.3784f178-84e1-42e8-9f75-10226773926b.json
@@ -1,0 +1,56 @@
+{
+    "uuid": [
+        {
+            "value": "3784f178-84e1-42e8-9f75-10226773926b"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_facility_servi",
+            "target_type": "paragraphs_type",
+            "target_uuid": "77498b34-84b7-4d01-8650-a3a808ba57f6"
+        }
+    ],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-06-19T19:42:00+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "behavior_settings": [
+        {
+            "value": []
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "field_title": [
+        {
+            "value": "Parking"
+        }
+    ],
+    "field_wysiwyg": [
+        {
+            "value": "<p><strong>Cost:<\/strong> Free<\/p>\r\n\r\n<p><strong>Wheelchair availability:<\/strong> The Belmont County outpatient clinic has wheelchairs available in the building.<\/p>\r\n",
+            "format": "rich_text"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/paragraph.378f1a29-0d08-456c-89d5-b6307cebc735.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/paragraph.378f1a29-0d08-456c-89d5-b6307cebc735.json
@@ -1,0 +1,56 @@
+{
+    "uuid": [
+        {
+            "value": "378f1a29-0d08-456c-89d5-b6307cebc735"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_facility_servi",
+            "target_type": "paragraphs_type",
+            "target_uuid": "77498b34-84b7-4d01-8650-a3a808ba57f6"
+        }
+    ],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-08-13T18:49:06+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "behavior_settings": [
+        {
+            "value": []
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "field_title": [
+        {
+            "value": "Lodging for patients and families"
+        }
+    ],
+    "field_wysiwyg": [
+        {
+            "value": "<h4>Nearby hotels<\/h4>\r\n\r\n<p>There is no lodging at the Belmont County outpatient clinic. If you need to travel to the clinic for multiple days, try one of these hotels. When booking, ask if there is a Veteran rate. Many hotels have shuttle vans, so check with the hotel you\u2019re staying at if you need help getting to the clinic.<\/p>\r\n\r\n<ul>\r\n\t<li><a href=\"https:\/\/www.redroof.com\/property\/oh\/saint-clairsville\/RRI101\">Red Roof Inn St Clairsville - Wheeling West<\/a><br \/>\r\n\t<a href=\"tel: +740695-4057\">740-695-4057<\/a><\/li>\r\n\t<li><a href=\"https:\/\/www.wyndhamhotels.com\/microtel\/saint-clairsville-ohio\/microtel-inn-st-clairsville-oh\/overview?iata=00093785&amp;cid=fe:mt:20170424:yl:pp:MTUS:46440&amp;tel=18885951878&amp;sessionId=1565721280&amp;radius=25&amp;rooms=1&amp;adults=1&amp;children=0&amp;checkInDate=8\/13\/2019&amp;checkOutDate=8\/14\/2019&amp;brand_id=MT&amp;latitude=40.0803199&amp;longitude=-80.90175999999997&amp;referringBrand=MT&amp;useWRPoints=false\">Microtel Inn &amp; Suites by Wyndham St Clairsville<\/a><br \/>\r\n\t<a href=\"tel: +1740-338-4500\">740-338-4500<\/a> or <a href=\"tel: +1-888-595-1878\">1-888-595-1878<\/a><\/li>\r\n\t<li><a href=\"https:\/\/www.ihg.com\/candlewood\/hotels\/us\/en\/st-clairsville\/hlgcw\/hoteldetail\">Candlewood Suites St Clairsville<\/a><br \/>\r\n\t<a href=\"tel: +1740695-9200\">740-695-9200<\/a><\/li>\r\n<\/ul>\r\n",
+            "format": "rich_text"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/paragraph.49172c9a-f504-4f7d-8da6-87627b35a8d8.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/paragraph.49172c9a-f504-4f7d-8da6-87627b35a8d8.json
@@ -1,0 +1,56 @@
+{
+    "uuid": [
+        {
+            "value": "49172c9a-f504-4f7d-8da6-87627b35a8d8"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_facility_servi",
+            "target_type": "paragraphs_type",
+            "target_uuid": "77498b34-84b7-4d01-8650-a3a808ba57f6"
+        }
+    ],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-03-13T18:19:00+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "behavior_settings": [
+        {
+            "value": []
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "field_title": [
+        {
+            "value": "Transportation services and schedules"
+        }
+    ],
+    "field_wysiwyg": [
+        {
+            "value": "<h4 dir=\"ltr\">Van services for Veterans<\/h4>\r\n\r\n<h5 dir=\"ltr\">DAV vans<\/h5>\r\n\r\n<p dir=\"ltr\"><strong>Hours:<\/strong> 8:00 a.m. \u2013 4:30 p.m., individual van schedules vary<\/p>\r\n\r\n<p dir=\"ltr\">We work with Disabled American Veterans and county Veterans Affairs directors to provide transportation for Veterans and authorized caregivers to get to scheduled medical appointments.<\/p>\r\n\r\n<h5 dir=\"ltr\">Non-DAV van services<\/h5>\r\n\r\n<p dir=\"ltr\">Many localities in the region provide other van services to Veterans.<\/p>\r\n\r\n<p dir=\"ltr\"><a href=\"\/pittsburgh-health-care\/dav-vans-transportation-for-veterans\">Learn more about DAV and the other van services available in your&nbsp;county<\/a><\/p>\r\n\r\n<p dir=\"ltr\">&nbsp;<\/p>\r\n\r\n<h4 dir=\"ltr\"><strong>Local transit services<\/strong><\/h4>\r\n\r\n<p dir=\"ltr\">Beaver County Transit Authority offers regular transit service in the area.<\/p>\r\n\r\n<p dir=\"ltr\"><a href=\"https:\/\/bcta.com\/how-to-ride\/\">Regular bus service<\/a><br \/>\r\n<a href=\"https:\/\/bcta.com\/programs\/dart\/\">DART service<\/a>, for people with limited mobility<\/p>\r\n\r\n<p dir=\"ltr\"><a href=\"http:\/\/www.beavercountypa.gov\/Depts\/EMS\/Pages\/EMSServices.aspx\">Non-emergency ambulance services<\/a><\/p>\r\n\r\n<h4 dir=\"ltr\">Additional travel options<\/h4>\r\n\r\n<p dir=\"ltr\">See <a href=\"https:\/\/www.pittsburgh.va.gov\/docs\/Transportation_Guidebook_508.pdf\">our printable transportation guide<\/a> for an extensive list of transportation options from across the region, including VA shuttles, taxi companies, and local transit services in many counties. It also includes information on shuttle services to University Drive from other VA facilities in the region, where you can transfer to a Heinz shuttle.<\/p>\r\n\r\n<h4 dir=\"ltr\">Beneficiary travel<\/h4>\r\n\r\n<p dir=\"ltr\">Beneficiary travel benefits include round-trip transportation from your home to the medical center, mileage reimbursement, or special mode transport.&nbsp;<\/p>\r\n\r\n<p dir=\"ltr\"><a href=\"https:\/\/www.pittsburgh.va.gov\/services\/beneficiary-travel.asp\">Find out if you qualify for beneficiary travel benefits<\/a><\/p>\r\n",
+            "format": "rich_text"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/paragraph.640304c8-1975-435e-b710-3536c1140382.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/paragraph.640304c8-1975-435e-b710-3536c1140382.json
@@ -1,0 +1,56 @@
+{
+    "uuid": [
+        {
+            "value": "640304c8-1975-435e-b710-3536c1140382"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_facility_servi",
+            "target_type": "paragraphs_type",
+            "target_uuid": "77498b34-84b7-4d01-8650-a3a808ba57f6"
+        }
+    ],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-03-12T22:07:56+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "behavior_settings": [
+        {
+            "value": []
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "field_title": [
+        {
+            "value": "Lodging for patients and families"
+        }
+    ],
+    "field_wysiwyg": [
+        {
+            "value": "<p dir=\"ltr\">Visitors are not permitted to stay overnight in the medical center itself. Here are some other options.<\/p>\r\n\r\n<h4 dir=\"ltr\"><strong>Accommodations solely for Veterans and families<\/strong><\/h4>\r\n\r\n<h5 dir=\"ltr\"><strong>VA Hoptel and lodging program<\/strong><\/h5>\r\n\r\n<p dir=\"ltr\">Temporary overnight lodging for eligible Veterans for outpatient medical procedures.<\/p>\r\n\r\n<p dir=\"ltr\"><a href=\"https:\/\/www.pittsburgh.va.gov\/services\/hoptel-program.asp\"><strong>More info<\/strong><\/a><br \/>\r\n<strong>Phone:<\/strong>&nbsp;<a href=\"tel: +14123606233\">412-360-6233<\/a><\/p>\r\n\r\n<h5 dir=\"ltr\"><strong>Fisher House<\/strong><\/h5>\r\n\r\n<p dir=\"ltr\">A place for visiting families to stay, free of charge, while their loved ones receive inpatient medical care.<\/p>\r\n\r\n<p dir=\"ltr\"><strong>More info:<\/strong>&nbsp;<a href=\"http:\/\/www.pittsburghfisherhouse.org\/\">http:\/\/www.pittsburghfisherhouse.org\/<\/a><br \/>\r\n<strong>Phone:<\/strong>&nbsp;<a href=\"tel: +14123602032\">412-360-2032<\/a><\/p>\r\n\r\n<h4 dir=\"ltr\"><strong>Family House<\/strong><\/h4>\r\n\r\n<p dir=\"ltr\">A special home away from home for patients and\/or families who travel to Pittsburgh for treatment of serious or life-threatening illnesses. Family House has four locations in the area.<\/p>\r\n\r\n<p dir=\"ltr\"><strong>More info:&nbsp;<\/strong><a href=\"http:\/\/www.familyhouse.org\/\">http:\/\/www.familyhouse.org\/<\/a><br \/>\r\n<strong>Phone:<\/strong>&nbsp;<a href=\"tel: +14126477777\">412-647-7777<\/a><\/p>\r\n\r\n<h4 dir=\"ltr\"><strong>Nearby hotels<\/strong><\/h4>\r\n\r\n<p dir=\"ltr\">When booking, ask for the hospital rate. Many hotels have shuttle service to VA hospitals. Check with the hotel you\u2019re staying at.<\/p>\r\n\r\n<ul>\r\n\t<li dir=\"ltr\">\r\n\t<p dir=\"ltr\"><a href=\"https:\/\/hamptoninn3.hilton.com\/en\/hotels\/pennsylvania\/hampton-inn-and-suites-pittsburgh-harmarville-PITHAHX\/index.html\">Hampton Inn &amp; Suites Harmarville<\/a><br \/>\r\n\t<a href=\"tel: +1412-423-1100\">412-423-1100<\/a> or <a href=\"tel: +1-800-426-7866\">1-800-426-7866<\/a><\/p>\r\n\t<\/li>\r\n<\/ul>\r\n\r\n<ul>\r\n\t<li dir=\"ltr\">\r\n\t<p dir=\"ltr\"><a href=\"https:\/\/hamptoninn3.hilton.com\/en\/hotels\/pennsylvania\/hampton-inn-and-suites-pittsburgh-harmarville-PITHAHX\/index.html\">Holiday Inn Express Harmarville<\/a><br \/>\r\n\t<a href=\"tel: +1-877-410-6667\">1-877-410-6667<\/a><\/p>\r\n\t<\/li>\r\n<\/ul>\r\n\r\n<ul>\r\n\t<li dir=\"ltr\">\r\n\t<p dir=\"ltr\"><a href=\"https:\/\/www.marriott.com\/hotels\/travel\/pitne-towneplace-suites-pittsburgh-harmarville\/?scid=45f93f1b-bd77-45c9-8dab-83b6a417f6fe\">TownePlace Suites Harmarville<\/a><br \/>\r\n\t<a href=\"tel: +1412-423-1900\">412-423-1900<\/a> or <a href=\"tel: +1-800-721-7033\">1-800-721-7033<\/a><\/p>\r\n\t<\/li>\r\n<\/ul>\r\n\r\n<h4 dir=\"ltr\"><strong>Visit Pittsburgh<\/strong><\/h4>\r\n\r\n<p dir=\"ltr\">The official tourism and promotion agency for Pittsburgh and Allegheny County has up-to-date listings for area hotels, as well as activities, transportation, restaurants, shops and more. <a href=\"http:\/\/www.visitpittsburgh.com\/\">http:\/\/www.visitpittsburgh.com\/<\/a><\/p>\r\n",
+            "format": "rich_text"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/paragraph.67ca2715-de10-402b-a53e-c118097bff92.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/paragraph.67ca2715-de10-402b-a53e-c118097bff92.json
@@ -1,0 +1,56 @@
+{
+    "uuid": [
+        {
+            "value": "67ca2715-de10-402b-a53e-c118097bff92"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_facility_servi",
+            "target_type": "paragraphs_type",
+            "target_uuid": "77498b34-84b7-4d01-8650-a3a808ba57f6"
+        }
+    ],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-08-13T17:18:14+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "behavior_settings": [
+        {
+            "value": []
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "field_title": [
+        {
+            "value": "Chaplain services and chapels"
+        }
+    ],
+    "field_wysiwyg": [
+        {
+            "value": "<p dir=\"ltr\"><strong>Building 51<\/strong>&nbsp;<br \/>\r\nFirst floor<br \/>\r\n<strong>Hours:<\/strong> 24\/7<\/p>\r\n\r\n<h4 dir=\"ltr\">Chaplains<\/h4>\r\n\r\n<p dir=\"ltr\">When you\u2019re admitted, you can request or decline visits by a VA chaplain. Our chaplains provide spiritual, pastoral, and emotional care for you and your family, in accordance with your own beliefs and practices. This includes locating clergy or religious leaders in the community for needs that our chaplain staff cannot meet.<\/p>\r\n\r\n<h4 dir=\"ltr\">Interfaith chapel<\/h4>\r\n\r\n<p dir=\"ltr\">The chapel is open to anyone at any time for quiet meditation and reflection. The chapel also hosts regularly scheduled&nbsp;services for many denominations. Services are recorded and broadcast at H.J. Heinz on channel 75.<\/p>\r\n\r\n<p dir=\"ltr\"><a class=\"usa-button usa-button-secondary\" data-entity-substitution=\"canonical\" data-entity-type=\"node\" data-entity-uuid=\"1d014daa-80cd-46f6-952d-ad1b488a561a\" href=\"\/node\/779\">Learn&nbsp;how to request&nbsp;chaplain services&nbsp;during your stay at VA Pittsburgh.<\/a><\/p>\r\n",
+            "format": "rich_text"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/paragraph.7049fad0-7c40-4535-bca7-74addcf70a34.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/paragraph.7049fad0-7c40-4535-bca7-74addcf70a34.json
@@ -1,0 +1,56 @@
+{
+    "uuid": [
+        {
+            "value": "7049fad0-7c40-4535-bca7-74addcf70a34"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_facility_servi",
+            "target_type": "paragraphs_type",
+            "target_uuid": "77498b34-84b7-4d01-8650-a3a808ba57f6"
+        }
+    ],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-08-13T17:15:32+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "behavior_settings": [
+        {
+            "value": []
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "field_title": [
+        {
+            "value": "Library"
+        }
+    ],
+    "field_wysiwyg": [
+        {
+            "value": "<p dir=\"ltr\">Veterans have access to traditional library services at H.J. Heinz:<\/p>\r\n\r\n<ul>\r\n\t<li dir=\"ltr\">Newspapers, books and magazines<\/li>\r\n\t<li dir=\"ltr\">Internet access<\/li>\r\n\t<li dir=\"ltr\">Assistance with researching and reference<\/li>\r\n\t<li dir=\"ltr\">Borrowing books<\/li>\r\n\t<li dir=\"ltr\">Veteran and family consumer health materials<\/li>\r\n<\/ul>\r\n\r\n<p class=\"va-address-block\" dir=\"ltr\"><strong>Building 51<\/strong><br \/>\r\nNear the Recreation Hall<br \/>\r\n<strong>Phone:<\/strong> <a href=\"tel: +14128221748\">412-822-1748<\/a><br \/>\r\n<strong>Hours:<\/strong> Monday \u2013 Friday, 8:00 a.m. to 4:30 p.m.<\/p>\r\n",
+            "format": "rich_text"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/paragraph.70f4e892-3f51-44c9-a2c0-b6f57852f6c6.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/paragraph.70f4e892-3f51-44c9-a2c0-b6f57852f6c6.json
@@ -1,0 +1,56 @@
+{
+    "uuid": [
+        {
+            "value": "70f4e892-3f51-44c9-a2c0-b6f57852f6c6"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_facility_servi",
+            "target_type": "paragraphs_type",
+            "target_uuid": "77498b34-84b7-4d01-8650-a3a808ba57f6"
+        }
+    ],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-06-04T23:28:46+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "behavior_settings": [
+        {
+            "value": []
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "field_title": [
+        {
+            "value": "Campus and building maps"
+        }
+    ],
+    "field_wysiwyg": [
+        {
+            "value": "<p dir=\"ltr\">Use these maps to help you get around the campus.<\/p>\r\n\r\n<ul dir=\"ltr\">\r\n\t<li><a data-entity-substitution=\"canonical\" data-entity-type=\"node\" data-entity-uuid=\"71ffee52-a47f-4909-ad7e-21ece5728be3\" href=\"\/node\/783\">Full University Drive campus map<\/a><\/li>\r\n\t<li><a href=\"\/pittsburgh-health-care\/consolidation-building-floor-plans\">Floor plans for the consolidation building<\/a><\/li>\r\n<\/ul>\r\n",
+            "format": "rich_text"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/paragraph.7241348a-14a8-4b7a-8c2a-69b99a6c476b.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/paragraph.7241348a-14a8-4b7a-8c2a-69b99a6c476b.json
@@ -1,0 +1,56 @@
+{
+    "uuid": [
+        {
+            "value": "7241348a-14a8-4b7a-8c2a-69b99a6c476b"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_facility_servi",
+            "target_type": "paragraphs_type",
+            "target_uuid": "77498b34-84b7-4d01-8650-a3a808ba57f6"
+        }
+    ],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-02-20T13:55:16+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "behavior_settings": [
+        {
+            "value": []
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "field_title": [
+        {
+            "value": "Visitor hours and information"
+        }
+    ],
+    "field_wysiwyg": [
+        {
+            "value": "<h4 dir=\"ltr\"><strong>Hours<\/strong><\/h4>\r\n\r\n<p dir=\"ltr\"><strong>Lobby entrance:<\/strong> 24 hours a day, 7 days a week<br \/>\r\n<strong>General visiting:<\/strong> No set hours for most departments, please visit when it's most convenient for you and the patient. Exceptions are listed below.<\/p>\r\n\r\n<h5 dir=\"ltr\">Behavioral health inpatient wards<\/h5>\r\n\r\n<p dir=\"ltr\">1:00 p.m. to 2:00 p.m. and 6:00 p.m. to 7:30 p.m., 7 days a week<\/p>\r\n\r\n<h5 dir=\"ltr\">Critical care<\/h5>\r\n\r\n<p dir=\"ltr\">Visiting hours are individualized to meet the needs of the patient, family, and caregivers.<\/p>\r\n\r\n<h5 dir=\"ltr\">Post-anesthesia recovery<\/h5>\r\n\r\n<p dir=\"ltr\">Generally, visitors are not permitted. The doctor or nurse may make an exception.<\/p>\r\n\r\n<h4 dir=\"ltr\">Visitor policies<\/h4>\r\n\r\n<p dir=\"ltr\">Children younger than 16 must be supervised by an adult, and bedside visits are limited to 15 minutes. Some units, like the dialysis unit, may require the doctor\u2019s permission for children younger than 16 years old.<\/p>\r\n\r\n<p dir=\"ltr\">In most cases, visitors may bring candy, fruit, and other food items that have&nbsp;been cleared by the nursing staff as appropriate for the patient's diet. Fresh fruit and flowers are not permitted in the critical care center, and visitors are not permitted to eat or drink in the units.<\/p>\r\n\r\n<p dir=\"ltr\"><a href=\"https:\/\/www.va.gov\/pittsburgh-health-care\/policies\/#visitation-policy\">See&nbsp;VA Pittsburgh's full visitation policy<\/a><\/p>\r\n",
+            "format": "rich_text"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/paragraph.7e6fe218-4890-4ed5-ab9e-5df64229f7d1.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/paragraph.7e6fe218-4890-4ed5-ab9e-5df64229f7d1.json
@@ -1,0 +1,56 @@
+{
+    "uuid": [
+        {
+            "value": "7e6fe218-4890-4ed5-ab9e-5df64229f7d1"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_facility_servi",
+            "target_type": "paragraphs_type",
+            "target_uuid": "77498b34-84b7-4d01-8650-a3a808ba57f6"
+        }
+    ],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-06-19T18:28:45+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "behavior_settings": [
+        {
+            "value": []
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "field_title": [
+        {
+            "value": "Parking"
+        }
+    ],
+    "field_wysiwyg": [
+        {
+            "value": "<p><strong>Cost:<\/strong> Free<\/p>\r\n\r\n<p><strong>Wheelchair availability:<\/strong> The Beaver County outpatient clinic has wheelchairs available in the building.<\/p>\r\n",
+            "format": "rich_text"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/paragraph.7f1e7866-8975-4960-af44-eb3ec27090d8.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/paragraph.7f1e7866-8975-4960-af44-eb3ec27090d8.json
@@ -1,0 +1,56 @@
+{
+    "uuid": [
+        {
+            "value": "7f1e7866-8975-4960-af44-eb3ec27090d8"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_facility_servi",
+            "target_type": "paragraphs_type",
+            "target_uuid": "77498b34-84b7-4d01-8650-a3a808ba57f6"
+        }
+    ],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-06-19T15:29:49+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "behavior_settings": [
+        {
+            "value": []
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "field_title": [
+        {
+            "value": "Parking"
+        }
+    ],
+    "field_wysiwyg": [
+        {
+            "value": "<p><strong>Cost:<\/strong> Free<\/p>\r\n\r\n<p><strong>Wheelchair availability:<\/strong> H.J. Heinz III Campus has wheelchairs upon arrival for patients who need them to access the building.<\/p>\r\n",
+            "format": "rich_text"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/paragraph.979bce27-fb3e-4d0f-aa83-abe4338e774e.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/paragraph.979bce27-fb3e-4d0f-aa83-abe4338e774e.json
@@ -1,0 +1,56 @@
+{
+    "uuid": [
+        {
+            "value": "979bce27-fb3e-4d0f-aa83-abe4338e774e"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_facility_servi",
+            "target_type": "paragraphs_type",
+            "target_uuid": "77498b34-84b7-4d01-8650-a3a808ba57f6"
+        }
+    ],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-08-13T17:34:23+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "behavior_settings": [
+        {
+            "value": []
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "field_title": [
+        {
+            "value": "Library"
+        }
+    ],
+    "field_wysiwyg": [
+        {
+            "value": "<p dir=\"ltr\">Veterans have access to traditional library services at University Drive:<\/p>\r\n\r\n<ul>\r\n\t<li>Newspapers, books and magazines<\/li>\r\n\t<li>Internet access<\/li>\r\n\t<li>Assistance with researching and reference<\/li>\r\n\t<li>Borrowing books<\/li>\r\n\t<li>Veteran and family consumer health materials<\/li>\r\n<\/ul>\r\n\r\n<p class=\"va-address-block\" dir=\"ltr\"><strong>Consolidation building<\/strong><br \/>\r\n2nd floor<br \/>\r\n<strong>Phone:<\/strong> 412-360-3054<br \/>\r\n<strong>Hours:<\/strong> Monday \u2013 Friday, 8:00 a.m. to 4:30 p.m.<\/p>\r\n",
+            "format": "rich_text"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/paragraph.a0a57c48-86e4-4d9d-8a33-df479aacb882.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/paragraph.a0a57c48-86e4-4d9d-8a33-df479aacb882.json
@@ -1,0 +1,56 @@
+{
+    "uuid": [
+        {
+            "value": "a0a57c48-86e4-4d9d-8a33-df479aacb882"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_facility_servi",
+            "target_type": "paragraphs_type",
+            "target_uuid": "77498b34-84b7-4d01-8650-a3a808ba57f6"
+        }
+    ],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-03-13T18:32:40+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "behavior_settings": [
+        {
+            "value": []
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "field_title": [
+        {
+            "value": "Transportation services and schedules"
+        }
+    ],
+    "field_wysiwyg": [
+        {
+            "value": "<h4 dir=\"ltr\">Van services for Veterans<\/h4>\r\n\r\n<h5 dir=\"ltr\">DAV vans<\/h5>\r\n\r\n<p dir=\"ltr\"><strong>Hours:<\/strong> 8:00 a.m. \u2013 4:30 p.m., individual van schedules vary<\/p>\r\n\r\n<p dir=\"ltr\">We work with Disabled American Veterans and county Veterans Affairs directors to provide transportation for Veterans and authorized caregivers to get to scheduled medical appointments.<\/p>\r\n\r\n<h5 dir=\"ltr\">Non-DAV van services<\/h5>\r\n\r\n<p dir=\"ltr\">Many localities in the region provide other van services to Veterans.<\/p>\r\n\r\n<p dir=\"ltr\"><a href=\"\/pittsburgh-health-care\/dav-vans-transportation-for-veterans\">Learn more about DAV and&nbsp;the other van services available in your&nbsp;county<\/a><\/p>\r\n\r\n<p dir=\"ltr\">&nbsp;<\/p>\r\n\r\n<h4 dir=\"ltr\">Local transportation services<\/h4>\r\n\r\n<p dir=\"ltr\">Fayette Area Coordinated Transportation offers regular transit service in the area.<\/p>\r\n\r\n<p dir=\"ltr\"><a href=\"https:\/\/www.factbus.com\/schedules.htm\">Regular bus service<\/a><br \/>\r\n<a href=\"https:\/\/www.factbus.com\/sharedride.htm\">Shared Ride service<\/a>, for people with limited mobility<\/p>\r\n\r\n<p dir=\"ltr\"><a href=\"https:\/\/www.fcema.org\/nonemergency.php#EMS\">Non-emergency ambulance services<\/a>&nbsp;for Fayette County<\/p>\r\n\r\n<h4 dir=\"ltr\">Additional travel options<\/h4>\r\n\r\n<p dir=\"ltr\">See <a href=\"https:\/\/www.pittsburgh.va.gov\/docs\/Transportation_Guidebook_508.pdf\">our printable transportation guide<\/a> for an extensive list of transportation options from across the region, including VA shuttles, taxi companies, and local transit services in many counties. It also includes information on shuttle services to University Drive from other VA facilities in the region, where you can transfer to a Heinz shuttle.<\/p>\r\n\r\n<h4 dir=\"ltr\">Beneficiary travel<\/h4>\r\n\r\n<p dir=\"ltr\">Beneficiary travel benefits include round-trip transportation from your home to the medical center, mileage reimbursement, or special mode transport.&nbsp;<\/p>\r\n\r\n<p dir=\"ltr\"><a href=\"https:\/\/www.pittsburgh.va.gov\/services\/beneficiary-travel.asp\">Find out if you qualify for beneficiary travel benefits<\/a><\/p>\r\n",
+            "format": "rich_text"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/paragraph.a73e09d2-6b2e-446c-92c1-09752128d37c.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/paragraph.a73e09d2-6b2e-446c-92c1-09752128d37c.json
@@ -1,0 +1,56 @@
+{
+    "uuid": [
+        {
+            "value": "a73e09d2-6b2e-446c-92c1-09752128d37c"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_facility_servi",
+            "target_type": "paragraphs_type",
+            "target_uuid": "77498b34-84b7-4d01-8650-a3a808ba57f6"
+        }
+    ],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-03-13T18:43:34+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "behavior_settings": [
+        {
+            "value": []
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "field_title": [
+        {
+            "value": "Transportation services and schedules"
+        }
+    ],
+    "field_wysiwyg": [
+        {
+            "value": "<h4 dir=\"ltr\">Van services for Veterans<\/h4>\r\n\r\n<h5 dir=\"ltr\">DAV vans<\/h5>\r\n\r\n<p dir=\"ltr\"><strong>Hours:<\/strong> 8:00 a.m. \u2013 4:30 p.m., individual van schedules vary<\/p>\r\n\r\n<p dir=\"ltr\">We work with Disabled American Veterans and county Veterans Affairs directors to provide transportation for Veterans and authorized caregivers to get to scheduled medical appointments.<\/p>\r\n\r\n<h5 dir=\"ltr\">Non-DAV van services<\/h5>\r\n\r\n<p dir=\"ltr\">Many localities in the region provide other van services to Veterans.<\/p>\r\n\r\n<p dir=\"ltr\"><a href=\"\/pittsburgh-health-care\/dav-vans-transportation-for-veterans\">Learn more about DAV and the other van services available in your&nbsp;county<\/a><\/p>\r\n\r\n<p dir=\"ltr\">&nbsp;<\/p>\r\n\r\n<h4 dir=\"ltr\">Local transportation services<\/h4>\r\n\r\n<p dir=\"ltr\">Freedom Transit offers regular transit service in the area.<\/p>\r\n\r\n<p dir=\"ltr\"><a href=\"https:\/\/freedom-transit.org\/fixed-route-fares-Washington-County-PA.htm\">Regular bus service<\/a><br \/>\r\n<a href=\"https:\/\/freedom-transit.org\/shared-ride-transportation-programs-Washington-County-PA.htm\">Shared Ride service<\/a><br \/>\r\n<a href=\"https:\/\/freedom-transit.org\/ADA-paratransit-services-Washington-County-PA.htm\">Paratransit service<\/a><\/p>\r\n\r\n<h4 dir=\"ltr\">Additional travel options<\/h4>\r\n\r\n<p dir=\"ltr\">See <a href=\"https:\/\/www.pittsburgh.va.gov\/docs\/Transportation_Guidebook_508.pdf\">our printable transportation guide<\/a> for an extensive list of transportation options from across the region, including VA shuttles, taxi companies, and local transit services in many counties. It also includes information on shuttle services to University Drive from other VA facilities in the region, where you can transfer to a Heinz shuttle.<\/p>\r\n\r\n<h4 dir=\"ltr\">Beneficiary travel<\/h4>\r\n\r\n<p dir=\"ltr\">Beneficiary travel benefits include round-trip transportation from your home to the medical center, mileage reimbursement, or special mode transport.&nbsp;<\/p>\r\n\r\n<p dir=\"ltr\"><a href=\"https:\/\/www.pittsburgh.va.gov\/services\/beneficiary-travel.asp\">Find out if you qualify for beneficiary travel benefits<\/a><\/p>\r\n",
+            "format": "rich_text"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/paragraph.bab7b07c-e3e8-4ca4-a00d-3d968b7ed7c4.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/paragraph.bab7b07c-e3e8-4ca4-a00d-3d968b7ed7c4.json
@@ -1,0 +1,56 @@
+{
+    "uuid": [
+        {
+            "value": "bab7b07c-e3e8-4ca4-a00d-3d968b7ed7c4"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_facility_servi",
+            "target_type": "paragraphs_type",
+            "target_uuid": "77498b34-84b7-4d01-8650-a3a808ba57f6"
+        }
+    ],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-03-12T21:22:51+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "behavior_settings": [
+        {
+            "value": []
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "field_title": [
+        {
+            "value": "Visitor hours and information"
+        }
+    ],
+    "field_wysiwyg": [
+        {
+            "value": "<h4 dir=\"ltr\">Hours<\/h4>\r\n\r\n<p dir=\"ltr\"><strong>Lobby entrance: <\/strong>The front lobby of Building 51 and the rear lobby of Building 50 are both open 4:30 a.m. to 8:30 p.m.&nbsp;<br \/>\r\n<strong>General visiting: <\/strong>8:30 a.m. to 8:30 p.m. Exceptions are listed below.<\/p>\r\n\r\n<h5 dir=\"ltr\"><strong>Community living center<\/strong><\/h5>\r\n\r\n<p dir=\"ltr\">We offer flexible visiting hours and encourage you to discuss special circumstances like parties or overnight stays with your care team in advance.<\/p>\r\n\r\n<h4 dir=\"ltr\"><strong>Visitor policies<\/strong><\/h4>\r\n\r\n<p dir=\"ltr\">We look forward to meeting your family and loved ones. Here are a few helpful tips to make their next visit go smoothly:<\/p>\r\n\r\n<ul>\r\n\t<li dir=\"ltr\">\r\n\t<p dir=\"ltr\">Guests can purchase meals to enjoy with patients when they visit. Please give your care team at least two days\u2019 advance notice. You or your guest must pay the Agent Cashier in advance. Specify how many extra meals you need and when you would like them served.<\/p>\r\n\t<\/li>\r\n<\/ul>\r\n\r\n<ul>\r\n\t<li dir=\"ltr\">\r\n\t<p dir=\"ltr\">Guests who bring their own meals will have access to silverware and a microwave, if needed.<\/p>\r\n\t<\/li>\r\n<\/ul>\r\n\r\n<ul>\r\n\t<li dir=\"ltr\">\r\n\t<p dir=\"ltr\">Family members or loved ones who are sick should postpone their visit.<\/p>\r\n\t<\/li>\r\n\t<li dir=\"ltr\">\r\n\t<p dir=\"ltr\">Please use proper hand hygiene. Use hand sanitizer when available and wash hands as appropriate throughout the visit.<\/p>\r\n\t<\/li>\r\n<\/ul>\r\n\r\n<p dir=\"ltr\"><a href=\"https:\/\/www.va.gov\/pittsburgh-health-care\/policies\/#visitation-policy\">See&nbsp;VA Pittsburgh's full visitation policy<\/a><\/p>\r\n",
+            "format": "rich_text"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/paragraph.bea4655c-f1e8-4cd1-a5f3-208d808d7911.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/paragraph.bea4655c-f1e8-4cd1-a5f3-208d808d7911.json
@@ -1,0 +1,56 @@
+{
+    "uuid": [
+        {
+            "value": "bea4655c-f1e8-4cd1-a5f3-208d808d7911"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_facility_servi",
+            "target_type": "paragraphs_type",
+            "target_uuid": "77498b34-84b7-4d01-8650-a3a808ba57f6"
+        }
+    ],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-02-20T14:02:06+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "behavior_settings": [
+        {
+            "value": []
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "field_title": [
+        {
+            "value": "Lodging for patients and families"
+        }
+    ],
+    "field_wysiwyg": [
+        {
+            "value": "<p dir=\"ltr\">Visitors are not permitted to stay overnight in the medical center itself. Here are some other options.<\/p>\r\n\r\n<h4 dir=\"ltr\"><strong>Accommodations solely&nbsp;for Veterans and families<\/strong><\/h4>\r\n\r\n<h5 dir=\"ltr\"><strong>VA Hoptel and lodging program<\/strong><\/h5>\r\n\r\n<p dir=\"ltr\">Temporary overnight lodging for eligible Veterans for outpatient medical procedures.<\/p>\r\n\r\n<p dir=\"ltr\"><a href=\"https:\/\/www.pittsburgh.va.gov\/services\/hoptel-program.asp\"><strong>More info<\/strong><\/a><br \/>\r\n<strong>Phone:<\/strong>&nbsp;<a href=\"tel: +14123606233\">412-360-6233<\/a><\/p>\r\n\r\n<h5 dir=\"ltr\"><strong>Fisher House<\/strong><\/h5>\r\n\r\n<p dir=\"ltr\">A place for visiting families to stay, free of charge, while their loved ones receive inpatient medical care.<\/p>\r\n\r\n<p dir=\"ltr\"><strong>More info:<\/strong>&nbsp;<a href=\"http:\/\/www.pittsburghfisherhouse.org\/\">http:\/\/www.pittsburghfisherhouse.org\/<\/a><br \/>\r\n<strong>Phone:<\/strong>&nbsp;<a href=\"tel: +14123602032\">412-360-2032<\/a><\/p>\r\n\r\n<h4 dir=\"ltr\"><strong>Family House<\/strong><\/h4>\r\n\r\n<p dir=\"ltr\">A special home away from home for patients and\/or families who travel to Pittsburgh for treatment of serious or life-threatening illnesses. Family House has four locations in the area.<\/p>\r\n\r\n<p dir=\"ltr\"><strong>More info:&nbsp;<\/strong><a href=\"http:\/\/www.familyhouse.org\/\">http:\/\/www.familyhouse.org\/<\/a><br \/>\r\n<strong>Phone:<\/strong>&nbsp;<a href=\"tel: +14126477777\">412-647-7777<\/a><\/p>\r\n\r\n<h4 dir=\"ltr\">Nearby hotels<\/h4>\r\n\r\n<p dir=\"ltr\">When booking, ask for the hospital rate. Many hotels have shuttle service to VA hospitals. Check with the hotel you\u2019re staying at.<\/p>\r\n\r\n<ul>\r\n\t<li dir=\"ltr\">\r\n\t<p dir=\"ltr\"><a href=\"https:\/\/www.marriott.com\/hotels\/travel\/pitok-courtyard-pittsburgh-shadyside\">Courtyard by Marriott, Shadyside<\/a><br \/>\r\n\t<a href=\"tel: +1412-683-3113\">412-683-3113<\/a> or <a href=\"tel: +1-800-228-9290\">1-800-228-9290<\/a><\/p>\r\n\t<\/li>\r\n\t<li dir=\"ltr\">\r\n\t<p dir=\"ltr\"><a href=\"http:\/\/hamptoninn3.hilton.com\/en\/hotels\/pennsylvania\/hampton-inn-pittsburgh-university-medical-center-PITOKHX\/index.html\">Hampton Inn, University Center<\/a><br \/>\r\n\t<a href=\"tel: +1412-329-4969\">412-329-4969<\/a> or <a href=\"tel: +1-800-426-7866\">1-800-426-7866<\/a><\/p>\r\n\t<\/li>\r\n\t<li dir=\"ltr\">\r\n\t<p dir=\"ltr\"><a href=\"http:\/\/www.qualityinn.com\/hotel-pittsburgh-pennsylvania-PA369\">Quality Inn, University Center<\/a><br \/>\r\n\t<a href=\"tel: +1412-683-6100\">412-683-6100<\/a> or <a href=\"tel: +1-877-424-6423\">1-877-424-6423<\/a><\/p>\r\n\t<\/li>\r\n\t<li dir=\"ltr\">\r\n\t<p dir=\"ltr\"><a href=\"http:\/\/www.shadysideinn.com\/\">Shadyside Inn All Suites Hotel<\/a><br \/>\r\n\t<a href=\"tel: +1412-441-4444\">412-441-4444<\/a> or <a href=\"tel: +1-800-767-8483\">1-800-767-8483<\/a><\/p>\r\n\t<\/li>\r\n<\/ul>\r\n\r\n<h4 dir=\"ltr\"><strong>Visit Pittsburgh<\/strong><\/h4>\r\n\r\n<p dir=\"ltr\">The official tourism and promotion agency for Pittsburgh and Allegheny County has up-to-date listings for area hotels, as well as activities, transportation, restaurants, shops and more. <a href=\"http:\/\/www.visitpittsburgh.com\/\">http:\/\/www.visitpittsburgh.com\/<\/a><\/p>\r\n",
+            "format": "rich_text"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/paragraph.c92943d7-33a0-40c9-951c-2d070f46a7d1.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/paragraph.c92943d7-33a0-40c9-951c-2d070f46a7d1.json
@@ -1,0 +1,56 @@
+{
+    "uuid": [
+        {
+            "value": "c92943d7-33a0-40c9-951c-2d070f46a7d1"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_facility_servi",
+            "target_type": "paragraphs_type",
+            "target_uuid": "77498b34-84b7-4d01-8650-a3a808ba57f6"
+        }
+    ],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-06-19T18:51:14+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "behavior_settings": [
+        {
+            "value": []
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "field_title": [
+        {
+            "value": "Parking"
+        }
+    ],
+    "field_wysiwyg": [
+        {
+            "value": "<p><strong>Cost:<\/strong> Free with validation. Ask clinic staff to validate your parking ticket.<\/p>\r\n\r\n<p>The parking entrance is on Franklin Street.<\/p>\r\n\r\n<p>The garage is adjacent to the building. To get to the clinic from the garage, use the skywalk located on the garage's 4th floor. The clinic is on the 2nd floor of the building.<\/p>\r\n\r\n<p><strong>Wheelchair availability:<\/strong> The Washington County outpatient clinic has wheelchairs available in the building.<\/p>\r\n",
+            "format": "rich_text"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/paragraph.d0a9d603-e89a-43ca-bd45-c255861d836b.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/paragraph.d0a9d603-e89a-43ca-bd45-c255861d836b.json
@@ -1,0 +1,56 @@
+{
+    "uuid": [
+        {
+            "value": "d0a9d603-e89a-43ca-bd45-c255861d836b"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_facility_servi",
+            "target_type": "paragraphs_type",
+            "target_uuid": "77498b34-84b7-4d01-8650-a3a808ba57f6"
+        }
+    ],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-08-13T18:55:44+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "behavior_settings": [
+        {
+            "value": []
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "field_title": [
+        {
+            "value": "Lodging for patients and families"
+        }
+    ],
+    "field_wysiwyg": [
+        {
+            "value": "<h4>Nearby hotels<\/h4>\r\n\r\n<p>There is no lodging at the Fayette&nbsp;County outpatient clinic. If you need to travel to the clinic for multiple days, try one of these hotels. When booking, ask if there is a Veteran rate. Many hotels have shuttle vans, so check with the hotel you\u2019re staying at if you need help getting to the clinic.<\/p>\r\n\r\n<ul>\r\n\t<li dir=\"ltr\"><a href=\"https:\/\/www.hilton.com\/en\/hotels\/untpahx-hampton-uniontown\/\">Hampton Inn Uniontown<\/a><br \/>\r\n\t<a href=\"tel: ++1-724-430-1000\">724-430-1000<\/a><\/li>\r\n\t<li dir=\"ltr\"><a href=\"https:\/\/www.choicehotels.com\/pennsylvania\/uniontown\/comfort-suites-hotels\/pa654\/rates\">Comfort Suites<\/a><br \/>\r\n\t<a href=\"tel: +1724-550-4700\">724-550-4700<\/a><\/li>\r\n\t<li dir=\"ltr\"><a href=\"https:\/\/hiltongardeninn3.hilton.com\/en\/hotels\/pennsylvania\/hilton-garden-inn-uniontown-MGWUNGI\/index.html\">Hilton Garden Inn Uniontown<\/a><br \/>\r\n\t<a href=\"tel: +1-724-434-7200\">724-434-7200<\/a><\/li>\r\n<\/ul>\r\n",
+            "format": "rich_text"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/paragraph.dd090d59-0fe5-4c5e-ba46-443443b9e56e.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/paragraph.dd090d59-0fe5-4c5e-ba46-443443b9e56e.json
@@ -1,0 +1,56 @@
+{
+    "uuid": [
+        {
+            "value": "dd090d59-0fe5-4c5e-ba46-443443b9e56e"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_facility_servi",
+            "target_type": "paragraphs_type",
+            "target_uuid": "77498b34-84b7-4d01-8650-a3a808ba57f6"
+        }
+    ],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-06-19T18:13:38+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "behavior_settings": [
+        {
+            "value": []
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "field_title": [
+        {
+            "value": "Parking"
+        }
+    ],
+    "field_wysiwyg": [
+        {
+            "value": "<p><strong>Cost:<\/strong> Free<\/p>\r\n\r\n<p>On the busiest days, we require the use of our free valet service. To account for this, please allow extra time before your appointment.<\/p>\r\n\r\n<p><strong>Wheelchair availability:<\/strong> Pittsburgh VA Medical Center-University Drive has wheelchairs available upon arrival for patients who need them to access the building.<\/p>\r\n",
+            "format": "rich_text"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/paragraph.e915d298-4eda-456c-a822-49464f8ec1ff.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/paragraph.e915d298-4eda-456c-a822-49464f8ec1ff.json
@@ -1,0 +1,56 @@
+{
+    "uuid": [
+        {
+            "value": "e915d298-4eda-456c-a822-49464f8ec1ff"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_facility_servi",
+            "target_type": "paragraphs_type",
+            "target_uuid": "77498b34-84b7-4d01-8650-a3a808ba57f6"
+        }
+    ],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-03-12T22:37:20+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "behavior_settings": [
+        {
+            "value": []
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "field_title": [
+        {
+            "value": "Dining and retail"
+        }
+    ],
+    "field_wysiwyg": [
+        {
+            "value": "<h4 dir=\"ltr\">Food and drink<\/h4>\r\n\r\n<h5 dir=\"ltr\">Veterans Canteen Service (VCS) Patriot Caf\u00e9<\/h5>\r\n\r\n<p dir=\"ltr\">Serves hot and cold entrees, beverages and desserts.<\/p>\r\n\r\n<p class=\"va-address-block\" dir=\"ltr\"><strong>Building 51<\/strong><br \/>\r\nFirst floor<br \/>\r\n<strong>Hours<\/strong><br \/>\r\nMonday \u2013 Friday, 7:00 a.m. to 3:30 p.m.<br \/>\r\nClosed weekends<\/p>\r\n\r\n<h5 dir=\"ltr\">VCS Patriot Brew (Starbucks)<\/h5>\r\n\r\n<p dir=\"ltr\">Serves a variety of pastries, light sandwiches and beverages.<\/p>\r\n\r\n<p class=\"va-address-block\" dir=\"ltr\"><strong>Ambulatory Care Center<\/strong><br \/>\r\nFirst floor<br \/>\r\n<strong>Hours<\/strong><br \/>\r\nMonday \u2013 Friday, 6:30 a.m. to 7:00 p.m.<br \/>\r\nSaturday, 8:00 a.m. to 3:30 p.m.&nbsp;<br \/>\r\nClosed Sunday<\/p>\r\n\r\n<h5 dir=\"ltr\">Stars &amp; Stripes Caf\u00e9<\/h5>\r\n\r\n<p dir=\"ltr\">This Veteran-run enterprise serves&nbsp;gourmet coffees, teas, real fruit smoothies, danishes and homemade biscotti.<\/p>\r\n\r\n<p dir=\"ltr\"><strong>Location:<\/strong> Administration building lobby, and Building 50 front entrance<\/p>\r\n\r\n<h5 dir=\"ltr\">Vending machines<\/h5>\r\n\r\n<p dir=\"ltr\">Drinks and snacks are available around the clock.<\/p>\r\n\r\n<h4 dir=\"ltr\">Retail<\/h4>\r\n\r\n<h5 dir=\"ltr\">VCS Patriot Store&nbsp;<\/h5>\r\n\r\n<p dir=\"ltr\">A full-service retail store with such products as electronics, cosmetics, toiletries, and clothing. Purchases are tax-free.<\/p>\r\n\r\n<p class=\"va-address-block\" dir=\"ltr\"><strong>Ground floor<\/strong><br \/>\r\n<strong>Hours<\/strong><br \/>\r\nMonday \u2013 Friday, 7:00 a.m. to 4:00 p.m.<br \/>\r\nSaturday, 9:00 a.m. to 3:30 p.m.<br \/>\r\nClosed Sunday<\/p>\r\n",
+            "format": "rich_text"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/paragraph.ea40834e-b567-4da5-981e-848b43d8b69a.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/paragraph.ea40834e-b567-4da5-981e-848b43d8b69a.json
@@ -1,0 +1,56 @@
+{
+    "uuid": [
+        {
+            "value": "ea40834e-b567-4da5-981e-848b43d8b69a"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_facility_servi",
+            "target_type": "paragraphs_type",
+            "target_uuid": "77498b34-84b7-4d01-8650-a3a808ba57f6"
+        }
+    ],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-08-13T17:34:29+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "behavior_settings": [
+        {
+            "value": []
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "field_title": [
+        {
+            "value": "Chaplain services and chapels"
+        }
+    ],
+    "field_wysiwyg": [
+        {
+            "value": "<p class=\"va-address-block\" dir=\"ltr\"><strong>Building 29<\/strong><br \/>\r\nSecond floor<br \/>\r\n<strong>Hours:<\/strong> 24\/7<\/p>\r\n\r\n<h4 dir=\"ltr\">Chaplains<\/h4>\r\n\r\n<p dir=\"ltr\">When you\u2019re admitted, you can request or decline visits by a VA chaplain. Our chaplains provide spiritual, pastoral, and emotional care for you and your family, in accordance with your own beliefs and practices. This includes locating clergy or religious leaders in the community for needs that our chaplain staff cannot meet.<\/p>\r\n\r\n<h4 dir=\"ltr\">Interfaith chapel<\/h4>\r\n\r\n<p dir=\"ltr\">The chapel is open to anyone at any time for quiet meditation and reflection. The chapel also hosts regularly scheduled&nbsp;services for many denominations.&nbsp;Services are recorded and broadcast at University Drive on channel 81.<\/p>\r\n\r\n<p dir=\"ltr\"><a class=\"usa-button usa-button-secondary\" data-entity-substitution=\"canonical\" data-entity-type=\"node\" data-entity-uuid=\"1d014daa-80cd-46f6-952d-ad1b488a561a\" href=\"\/node\/779\">Learn&nbsp;how to request&nbsp;chaplain services&nbsp;during your stay at VA Pittsburgh.<\/a><\/p>\r\n",
+            "format": "rich_text"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/paragraph.f0d0eb26-72cc-42f0-9198-77636b1ab018.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/paragraph.f0d0eb26-72cc-42f0-9198-77636b1ab018.json
@@ -1,0 +1,56 @@
+{
+    "uuid": [
+        {
+            "value": "f0d0eb26-72cc-42f0-9198-77636b1ab018"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_facility_servi",
+            "target_type": "paragraphs_type",
+            "target_uuid": "77498b34-84b7-4d01-8650-a3a808ba57f6"
+        }
+    ],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-03-12T22:28:04+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "behavior_settings": [
+        {
+            "value": []
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "field_title": [
+        {
+            "value": "Transportation services, schedules, and benefits"
+        }
+    ],
+    "field_wysiwyg": [
+        {
+            "value": "<h4 dir=\"ltr\"><strong>Van services for Veterans<\/strong><\/h4>\r\n\r\n<h5 dir=\"ltr\"><strong>DAV vans<\/strong><\/h5>\r\n\r\n<p dir=\"ltr\"><strong>Hours:<\/strong> 8:00 a.m. \u2013 4:30 p.m., individual van schedules vary<\/p>\r\n\r\n<p dir=\"ltr\">We work with Disabled American Veterans and county Veterans Affairs directors to provide transportation for Veterans and authorized caregivers to get to scheduled medical appointments.<\/p>\r\n\r\n<h5 dir=\"ltr\">Non-DAV van services<\/h5>\r\n\r\n<p dir=\"ltr\">Many localities in the region provide other van services to Veterans.<\/p>\r\n\r\n<p dir=\"ltr\"><a href=\"\/pittsburgh-health-care\/dav-vans-transportation-for-veterans\">Learn more about DAV and the other van services available in your&nbsp;county<\/a><\/p>\r\n\r\n<h4 dir=\"ltr\"><strong>Shuttle service at H.J. Heinz<\/strong><\/h4>\r\n\r\n<p dir=\"ltr\"><strong>Cost:<\/strong>&nbsp;Free<br \/>\r\n<strong>Schedule:<\/strong>&nbsp;Monday through Friday, except holidays<br \/>\r\n<a href=\"\/pittsburgh-health-care\/shuttle-schedule\/\">See complete shuttle schedule<\/a>&nbsp;<\/p>\r\n\r\n<h5 dir=\"ltr\">Shuttle routes serving this location<\/h5>\r\n\r\n<p dir=\"ltr\">University Drive campus \u2013 Heinz<\/p>\r\n\r\n<h4 dir=\"ltr\"><strong>Local&nbsp;transit services<\/strong><\/h4>\r\n\r\n<h5 dir=\"ltr\">Port Authority of Allegheny County<\/h5>\r\n\r\n<p dir=\"ltr\"><a href=\"https:\/\/www.portauthority.org\/inside-Port-Authority\/rider-info\/how-to-ride\/how-to-ride-the-bus\/\">Bus<\/a><br \/>\r\n<a href=\"https:\/\/www.portauthority.org\/inside-Port-Authority\/rider-info\/how-to-ride\/how-to-ride-the-light-rail-system\/\">Light rail<\/a><br \/>\r\n<a href=\"https:\/\/www.portauthority.org\/inside-Port-Authority\/rider-info\/accessibility\/access-paratransit\/\">ACCESS paratransit<\/a>, serving people with limited mobility<\/p>\r\n\r\n<h5 dir=\"ltr\">Other services<\/h5>\r\n\r\n<p dir=\"ltr\">Paratransit service (p.r.n. Health Service)\u2013 <a href=\"tel: +14128242181\">412-824-2181<\/a> or <a href=\"tel: +18008608222\">1-800-860-8222<\/a><br \/>\r\n<br \/>\r\nTranscare ambulance \u2013 <a href=\"tel: +14123730200\">412-373-0200<\/a><\/p>\r\n\r\n<h4 dir=\"ltr\"><strong>Additional travel options<\/strong><\/h4>\r\n\r\n<p dir=\"ltr\"><a href=\"https:\/\/www.pittsburgh.va.gov\/docs\/Transportation_Guidebook_508.pdf\">Our printable transportation guide<\/a> has an extensive list of transportation options from across the region, including VA shuttles, taxi companies, and local transit services in many counties. It also includes information on shuttle services to University Drive from other VA facilities in the region, where you can transfer to a Heinz shuttle.<\/p>\r\n\r\n<h4 dir=\"ltr\"><strong>Beneficiary travel<\/strong><\/h4>\r\n\r\n<p dir=\"ltr\">Beneficiary travel benefits include round-trip transportation from your home to the medical center, mileage reimbursement, or special mode transport.&nbsp;<\/p>\r\n\r\n<p dir=\"ltr\"><a href=\"https:\/\/www.pittsburgh.va.gov\/services\/beneficiary-travel.asp\">Find out if you qualify for beneficiary travel benefits<\/a><\/p>\r\n",
+            "format": "rich_text"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/paragraph.f7f422cd-cf36-4463-a7c8-997d2218f0ba.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/paragraph.f7f422cd-cf36-4463-a7c8-997d2218f0ba.json
@@ -1,0 +1,56 @@
+{
+    "uuid": [
+        {
+            "value": "f7f422cd-cf36-4463-a7c8-997d2218f0ba"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "type": [
+        {
+            "target_id": "health_care_local_facility_servi",
+            "target_type": "paragraphs_type",
+            "target_uuid": "77498b34-84b7-4d01-8650-a3a808ba57f6"
+        }
+    ],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "created": [
+        {
+            "value": "2019-02-20T13:53:13+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "behavior_settings": [
+        {
+            "value": []
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "revision_translation_affected": [
+        {
+            "value": true
+        }
+    ],
+    "field_title": [
+        {
+            "value": "Transportation services and schedules"
+        }
+    ],
+    "field_wysiwyg": [
+        {
+            "value": "<h4 dir=\"ltr\">Van services for Veterans<\/h4>\r\n\r\n<h5 dir=\"ltr\">DAV vans<\/h5>\r\n\r\n<p dir=\"ltr\"><strong>Hours:<\/strong> 8:00 a.m. \u2013 4:30 p.m., individual van schedules vary<\/p>\r\n\r\n<p dir=\"ltr\">We work with Disabled American Veterans and county Veterans Affairs directors to provide transportation for Veterans and authorized caregivers to get to scheduled medical appointments.<\/p>\r\n\r\n<h5 dir=\"ltr\">Non-DAV van services<\/h5>\r\n\r\n<p dir=\"ltr\">Many localities in the region provide other van services to Veterans.<\/p>\r\n\r\n<p dir=\"ltr\"><a href=\"\/pittsburgh-health-care\/dav-vans-transportation-for-veterans\">Learn more about DAV and the other van services available in your&nbsp;county<\/a><\/p>\r\n\r\n<h4 dir=\"ltr\"><strong>Shuttle service at University Drive<\/strong><\/h4>\r\n\r\n<p dir=\"ltr\"><strong>Cost:<\/strong>&nbsp;Free<br \/>\r\n<strong>Schedule:<\/strong>&nbsp;Monday through Friday, except holidays<br \/>\r\n<a href=\"\/pittsburgh-health-care\/shuttle-schedule\/\">See complete shuttle schedule<\/a><\/p>\r\n\r\n<h5 dir=\"ltr\">Shuttle routes serving this location<\/h5>\r\n\r\n<p dir=\"ltr\">University Drive \u2013 Heinz<br \/>\r\nUniversity Drive \u2013 Federal Building<br \/>\r\nUniversity Drive \u2013 Fisher House<\/p>\r\n\r\n<h4 dir=\"ltr\">Local transportation services<\/h4>\r\n\r\n<h5 dir=\"ltr\">Port Authority of Allegheny County<\/h5>\r\n\r\n<p dir=\"ltr\"><a href=\"https:\/\/www.portauthority.org\/inside-Port-Authority\/rider-info\/how-to-ride\/how-to-ride-the-bus\/\">Bus<\/a><br \/>\r\n<a href=\"https:\/\/www.portauthority.org\/inside-Port-Authority\/rider-info\/how-to-ride\/how-to-ride-the-light-rail-system\/\">Light rail<\/a><br \/>\r\n<a href=\"https:\/\/www.portauthority.org\/inside-Port-Authority\/rider-info\/accessibility\/access-paratransit\/\">ACCESS paratransit<\/a>, serving people with limited mobility<\/p>\r\n\r\n<h5 dir=\"ltr\">Other services<\/h5>\r\n\r\n<p dir=\"ltr\">Paratransit service (p.r.n. Health Service): <a href=\"tel: +1412-824-2181\">412-824-2181<\/a> or <a href=\"tel: +1-800-860-8222\">1-800-860-8222<\/a><\/p>\r\n\r\n<p dir=\"ltr\">Transcare ambulance: <a href=\"tel: +1412-373-0200\">412-373-0200<\/a><\/p>\r\n\r\n<h4 dir=\"ltr\">Additional travel options<\/h4>\r\n\r\n<p dir=\"ltr\">See <a href=\"https:\/\/www.pittsburgh.va.gov\/docs\/Transportation_Guidebook_508.pdf\">our printable transportation guide<\/a> for an extensive list of transportation options from across the region, including VA shuttles, taxi companies, and local transit services in many counties. It also includes information on shuttle services to University Drive from other VA facilities in the region.<\/p>\r\n\r\n<h4 dir=\"ltr\">Beneficiary travel<\/h4>\r\n\r\n<p dir=\"ltr\">Beneficiary travel benefits include round-trip transportation from your home to the medical center, mileage reimbursement, or special mode transport.&nbsp;<\/p>\r\n\r\n<p dir=\"ltr\"><a href=\"https:\/\/www.pittsburgh.va.gov\/services\/beneficiary-travel.asp\">Find out if you qualify for beneficiary travel benefits<\/a><\/p>\r\n",
+            "format": "rich_text"
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/taxonomy_term.0cf2cff8-9012-419c-b8f9-fa625b4ca364.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/taxonomy_term.0cf2cff8-9012-419c-b8f9-fa625b4ca364.json
@@ -1,0 +1,94 @@
+{
+    "uuid": [
+        {
+            "value": "0cf2cff8-9012-419c-b8f9-fa625b4ca364"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "vid": [
+        {
+            "target_id": "health_care_service_taxonomy",
+            "target_type": "taxonomy_vocabulary",
+            "target_uuid": "1ae4c52e-f750-44eb-9e53-e10234617743"
+        }
+    ],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "name": [
+        {
+            "value": "Geriatrics"
+        }
+    ],
+    "description": [
+        {
+            "value": "<p>As you age, we offer a range of medical and support services to help you stay as healthy, active and independent as possible. We also offer help to family members and caregivers who may support you.<\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "weight": [
+        {
+            "value": 4
+        }
+    ],
+    "parent": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "c09b9c29-0ba1-4ed9-9b30-28807263e294"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-10-30T16:02:46+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Geriatrics | Veterans Affairs",
+            "canonical_url": "http:\/\/default\/health-care\/geriatrics",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "description": "As you age, we offer a range of medical and support services to help you stay as healthy, active and independent as possible. We also offer help to family members and caregivers who may support you.",
+            "twitter_cards_title": "| Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "| Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": "\/health-care\/geriatrics",
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "field_also_known_as": [
+        {
+            "value": "Older adult care, senior care"
+        }
+    ],
+    "field_commonly_treated_condition": [
+        {
+            "value": "memory problems, sleep problems, falls, bone loss, weight loss"
+        }
+    ],
+    "field_health_service_api_id": [],
+    "field_owner": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "0e30e74c-76b9-4c25-aa12-745086f02e37"
+        }
+    ],
+    "field_vha_healthservice_stopcode": []
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/taxonomy_term.0e43fb0e-9cfb-4c72-9076-1a7edbc3c8df.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/taxonomy_term.0e43fb0e-9cfb-4c72-9076-1a7edbc3c8df.json
@@ -1,0 +1,90 @@
+{
+    "uuid": [
+        {
+            "value": "0e43fb0e-9cfb-4c72-9076-1a7edbc3c8df"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "vid": [
+        {
+            "target_id": "health_care_service_taxonomy",
+            "target_type": "taxonomy_vocabulary",
+            "target_uuid": "1ae4c52e-f750-44eb-9e53-e10234617743"
+        }
+    ],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "name": [
+        {
+            "value": "Low vision and blind rehabilitation"
+        }
+    ],
+    "description": [
+        {
+            "value": "<p>We offer advanced vision care and blind rehabilitation services to help you live independently. These may include vision-enhancing devices and technology as well as visual skills and related training.<\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "weight": [
+        {
+            "value": 23
+        }
+    ],
+    "parent": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "1b15f183-be97-4371-b3f6-a15e0d8913cf"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-10-30T16:52:40+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Low vision and blind rehabilitation | Veterans Affairs",
+            "canonical_url": "http:\/\/default\/health-care\/low-vision-and-blind-rehabilitation",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "description": "We offer advanced vision care and blind rehabilitation services to help you live independently. These may include vision-enhancing devices and technology as well as visual skills and related training.",
+            "twitter_cards_title": "| Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "| Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": "\/health-care\/low-vision-and-blind-rehabilitation",
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "field_also_known_as": [],
+    "field_commonly_treated_condition": [
+        {
+            "value": "macular degeneration, diabetic eye disease, glaucoma,  corneal diseases, retinitis pigmentosa, uveitis, stroke and injury-related vision loss"
+        }
+    ],
+    "field_health_service_api_id": [],
+    "field_owner": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "0e30e74c-76b9-4c25-aa12-745086f02e37"
+        }
+    ],
+    "field_vha_healthservice_stopcode": []
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/taxonomy_term.157c46b3-6307-444c-96cc-20323c67077c.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/taxonomy_term.157c46b3-6307-444c-96cc-20323c67077c.json
@@ -1,0 +1,90 @@
+{
+    "uuid": [
+        {
+            "value": "157c46b3-6307-444c-96cc-20323c67077c"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "vid": [
+        {
+            "target_id": "health_care_service_taxonomy",
+            "target_type": "taxonomy_vocabulary",
+            "target_uuid": "1ae4c52e-f750-44eb-9e53-e10234617743"
+        }
+    ],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "name": [
+        {
+            "value": "Physical medicine and rehabilitation"
+        }
+    ],
+    "description": [
+        {
+            "value": "<p>If you\u2019re living with a traumatic brain injury, amputation or other disability, our specialists offer support to help you improve your independence and quality of life, manage pain&nbsp;and stay healthy.<\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "weight": [
+        {
+            "value": 36
+        }
+    ],
+    "parent": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "1b15f183-be97-4371-b3f6-a15e0d8913cf"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-10-31T21:24:25+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Physical medicine and rehabilitation | Veterans Affairs",
+            "canonical_url": "http:\/\/default\/health-care\/physical-medicine-and-rehabilitation",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "description": "If you\u2019re living with a traumatic brain injury, amputation or other disability, our specialists offer support to help you improve your independence and quality of life, manage pain\u00a0and stay healthy.",
+            "twitter_cards_title": "| Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "| Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": "\/health-care\/physical-medicine-and-rehabilitation",
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "field_also_known_as": [],
+    "field_commonly_treated_condition": [
+        {
+            "value": "pain, stroke, brain injury, neuromuscular disorders, musculoskeletal problems, sports injuries, spinal cord injuries"
+        }
+    ],
+    "field_health_service_api_id": [],
+    "field_owner": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "0e30e74c-76b9-4c25-aa12-745086f02e37"
+        }
+    ],
+    "field_vha_healthservice_stopcode": []
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/taxonomy_term.22b27567-f832-47f8-a2e1-1597d622d8b4.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/taxonomy_term.22b27567-f832-47f8-a2e1-1597d622d8b4.json
@@ -1,0 +1,90 @@
+{
+    "uuid": [
+        {
+            "value": "22b27567-f832-47f8-a2e1-1597d622d8b4"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "vid": [
+        {
+            "target_id": "health_care_service_taxonomy",
+            "target_type": "taxonomy_vocabulary",
+            "target_uuid": "1ae4c52e-f750-44eb-9e53-e10234617743"
+        }
+    ],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "name": [
+        {
+            "value": "Rehabilitation and prosthetics"
+        }
+    ],
+    "description": [
+        {
+            "value": "<p>We provide and help you use medical aids, hearing aids, state-of-the-art adaptive home equipment&nbsp;and other equipment to help you preserve and increase your mobility and independence.<\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "weight": [
+        {
+            "value": 44
+        }
+    ],
+    "parent": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "1b15f183-be97-4371-b3f6-a15e0d8913cf"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-05T21:27:27+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Rehabilitation and prosthetics | Veterans Affairs",
+            "canonical_url": "http:\/\/default\/health-care\/rehabilitation-and-prosthetics",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "description": "We provide and help you use medical aids, hearing aids, state-of-the-art adaptive home equipment\u00a0and other equipment to help you preserve and increase your mobility and independence.",
+            "twitter_cards_title": "| Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "| Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": "\/health-care\/rehabilitation-and-prosthetics",
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "field_also_known_as": [
+        {
+            "value": "Prosthetics, orthotics and medical equipment"
+        }
+    ],
+    "field_commonly_treated_condition": [],
+    "field_health_service_api_id": [],
+    "field_owner": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "0e30e74c-76b9-4c25-aa12-745086f02e37"
+        }
+    ],
+    "field_vha_healthservice_stopcode": []
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/taxonomy_term.2366e481-57dd-4026-9292-3a80d7f004ec.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/taxonomy_term.2366e481-57dd-4026-9292-3a80d7f004ec.json
@@ -1,0 +1,90 @@
+{
+    "uuid": [
+        {
+            "value": "2366e481-57dd-4026-9292-3a80d7f004ec"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "vid": [
+        {
+            "target_id": "health_care_service_taxonomy",
+            "target_type": "taxonomy_vocabulary",
+            "target_uuid": "1ae4c52e-f750-44eb-9e53-e10234617743"
+        }
+    ],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "name": [
+        {
+            "value": "Homeless Veteran care"
+        }
+    ],
+    "description": [
+        {
+            "value": "<p>If you\u2019re homeless or at risk of becoming homeless, we can help. We offer many programs and services, including free health care. And we can help you connect with resources in your community.<\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "weight": [
+        {
+            "value": 3
+        }
+    ],
+    "parent": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "ba3209fc-81f2-4608-81d5-10caa4f057f9"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-05T21:47:35+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Homeless Veteran care | Veterans Affairs",
+            "canonical_url": "http:\/\/default\/health-care\/homeless-veteran-care",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "description": "If you\u2019re homeless or at risk of becoming homeless, we can help. We offer many programs and services, including free health care. And we can help you connect with resources in your community.",
+            "twitter_cards_title": "| Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "| Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": "\/health-care\/homeless-veteran-care",
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "field_also_known_as": [
+        {
+            "value": "Transitional and supportive housing, HUD-VASH"
+        }
+    ],
+    "field_commonly_treated_condition": [],
+    "field_health_service_api_id": [],
+    "field_owner": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "0e30e74c-76b9-4c25-aa12-745086f02e37"
+        }
+    ],
+    "field_vha_healthservice_stopcode": []
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/taxonomy_term.2acc2da7-84dc-4cfe-af86-68a87d0f9861.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/taxonomy_term.2acc2da7-84dc-4cfe-af86-68a87d0f9861.json
@@ -1,0 +1,86 @@
+{
+    "uuid": [
+        {
+            "value": "2acc2da7-84dc-4cfe-af86-68a87d0f9861"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "vid": [
+        {
+            "target_id": "health_care_service_taxonomy",
+            "target_type": "taxonomy_vocabulary",
+            "target_uuid": "1ae4c52e-f750-44eb-9e53-e10234617743"
+        }
+    ],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "name": [
+        {
+            "value": "Psychology"
+        }
+    ],
+    "description": [
+        {
+            "value": "<p>If you\u2019re struggling with a mental health problem\u2014or just need to talk with someone\u2014we can help. We offer treatment and support such as therapy, alternative treatments&nbsp;and medications when needed.<\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "weight": [
+        {
+            "value": 3
+        }
+    ],
+    "parent": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "184678e9-7458-426d-8baa-116f3902d6ef"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-10-30T16:09:31+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Psychology | Veterans Affairs",
+            "canonical_url": "http:\/\/default\/health-care\/psychology",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "description": "If you\u2019re struggling with a mental health problem\u2014or just need to talk with someone\u2014we can help. We offer treatment and support such as therapy, alternative treatments\u00a0and medications when needed.",
+            "twitter_cards_title": "| Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "| Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": "\/health-care\/psychology",
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "field_also_known_as": [],
+    "field_commonly_treated_condition": [],
+    "field_health_service_api_id": [],
+    "field_owner": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "0e30e74c-76b9-4c25-aa12-745086f02e37"
+        }
+    ],
+    "field_vha_healthservice_stopcode": []
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/taxonomy_term.2b43693b-63aa-473b-bfa2-ba944b697513.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/taxonomy_term.2b43693b-63aa-473b-bfa2-ba944b697513.json
@@ -1,0 +1,86 @@
+{
+    "uuid": [
+        {
+            "value": "2b43693b-63aa-473b-bfa2-ba944b697513"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "vid": [
+        {
+            "target_id": "health_care_service_taxonomy",
+            "target_type": "taxonomy_vocabulary",
+            "target_uuid": "1ae4c52e-f750-44eb-9e53-e10234617743"
+        }
+    ],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "name": [
+        {
+            "value": "Critical care"
+        }
+    ],
+    "description": [
+        {
+            "value": "<p>If you or a Veteran you care about has a life-threatening injury, infection, illness or breathing problem, we offer comprehensive care and constant monitoring in our intensive care units (ICUs).<\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "weight": [
+        {
+            "value": 10
+        }
+    ],
+    "parent": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "1b15f183-be97-4371-b3f6-a15e0d8913cf"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-10-30T16:31:32+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Critical care | Veterans Affairs",
+            "canonical_url": "http:\/\/default\/health-care\/critical-care",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "description": "If you or a Veteran you care about has a life-threatening injury, infection, illness or breathing problem, we offer comprehensive care and constant monitoring in our intensive care units (ICUs).",
+            "twitter_cards_title": "| Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "| Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": "\/health-care\/critical-care",
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "field_also_known_as": [],
+    "field_commonly_treated_condition": [],
+    "field_health_service_api_id": [],
+    "field_owner": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "0e30e74c-76b9-4c25-aa12-745086f02e37"
+        }
+    ],
+    "field_vha_healthservice_stopcode": []
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/taxonomy_term.2cfe8251-bda1-47f8-9706-bdcd21cd85dc.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/taxonomy_term.2cfe8251-bda1-47f8-9706-bdcd21cd85dc.json
@@ -1,0 +1,94 @@
+{
+    "uuid": [
+        {
+            "value": "2cfe8251-bda1-47f8-9706-bdcd21cd85dc"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "vid": [
+        {
+            "target_id": "health_care_service_taxonomy",
+            "target_type": "taxonomy_vocabulary",
+            "target_uuid": "1ae4c52e-f750-44eb-9e53-e10234617743"
+        }
+    ],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "name": [
+        {
+            "value": "Dental\/oral surgery"
+        }
+    ],
+    "description": [
+        {
+            "value": "<p>If you\u2019re eligible for VA dental care, we provide dental screenings, cleanings, X-rays&nbsp;and fillings. We also provide specialty dental procedures like root canal, restorations&nbsp;and dentures.<\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "weight": [
+        {
+            "value": 11
+        }
+    ],
+    "parent": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "1b15f183-be97-4371-b3f6-a15e0d8913cf"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-10-30T16:33:05+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Dental\/oral surgery | Veterans Affairs",
+            "canonical_url": "http:\/\/default\/health-care\/dentaloral-surgery",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "description": "If you\u2019re eligible for VA dental care, we provide dental screenings, cleanings, X-rays\u00a0and fillings. We also provide specialty dental procedures like root canal, restorations\u00a0and dentures.",
+            "twitter_cards_title": "| Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "| Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": "\/health-care\/dentaloral-surgery",
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "field_also_known_as": [
+        {
+            "value": "Mouth, teeth, gum and oral care"
+        }
+    ],
+    "field_commonly_treated_condition": [
+        {
+            "value": "teeth cleaning, fillings, restorations, root canal, bridges, dental implants, dentures "
+        }
+    ],
+    "field_health_service_api_id": [],
+    "field_owner": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "0e30e74c-76b9-4c25-aa12-745086f02e37"
+        }
+    ],
+    "field_vha_healthservice_stopcode": []
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/taxonomy_term.374d18b8-c4e8-45b3-a6b0-be6e60509294.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/taxonomy_term.374d18b8-c4e8-45b3-a6b0-be6e60509294.json
@@ -1,0 +1,84 @@
+{
+    "uuid": [
+        {
+            "value": "374d18b8-c4e8-45b3-a6b0-be6e60509294"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "vid": [
+        {
+            "target_id": "health_care_service_taxonomy",
+            "target_type": "taxonomy_vocabulary",
+            "target_uuid": "1ae4c52e-f750-44eb-9e53-e10234617743"
+        }
+    ],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "name": [
+        {
+            "value": "Other services"
+        }
+    ],
+    "description": [
+        {
+            "value": null,
+            "format": null
+        }
+    ],
+    "weight": [
+        {
+            "value": 95
+        }
+    ],
+    "parent": [
+        {
+            "target_id": null
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-09-10T19:18:15+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Other services | Veterans Affairs",
+            "canonical_url": "http:\/\/default\/health-care\/other-services",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "| Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "| Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": "\/health-care\/other-services",
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "field_also_known_as": [],
+    "field_commonly_treated_condition": [],
+    "field_health_service_api_id": [],
+    "field_owner": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "e5820ec7-83b0-4d03-8ebf-ed50fa8cc211"
+        }
+    ],
+    "field_vha_healthservice_stopcode": []
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/taxonomy_term.42b815ca-e751-43ed-b361-9cab0b601fcc.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/taxonomy_term.42b815ca-e751-43ed-b361-9cab0b601fcc.json
@@ -1,0 +1,90 @@
+{
+    "uuid": [
+        {
+            "value": "42b815ca-e751-43ed-b361-9cab0b601fcc"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "vid": [
+        {
+            "target_id": "health_care_service_taxonomy",
+            "target_type": "taxonomy_vocabulary",
+            "target_uuid": "1ae4c52e-f750-44eb-9e53-e10234617743"
+        }
+    ],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "name": [
+        {
+            "value": "Emergency care"
+        }
+    ],
+    "description": [
+        {
+            "value": "<p>In an emergency, call 911 or go to the nearest VA or non-VA emergency room. We provide immediate treatment for serious, life-threatening health emergencies such as severe chest pain, seizures, heavy uncontrollable bleeding&nbsp;or moderate to severe burns.<\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "weight": [
+        {
+            "value": 2
+        }
+    ],
+    "parent": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "c09b9c29-0ba1-4ed9-9b30-28807263e294"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-10-25T17:12:58+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Emergency care | Veterans Affairs",
+            "canonical_url": "http:\/\/default\/health-care\/emergency-care",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "description": "In an emergency, call 911 or go to the nearest VA or non-VA emergency room. We provide immediate treatment for serious, life-threatening health emergencies such as severe chest pain, seizures, heavy uncontrollable bleeding\u00a0or moderate to severe burns.",
+            "twitter_cards_title": "| Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "| Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": "\/health-care\/emergency-care",
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "field_also_known_as": [
+        {
+            "value": "Emergency room"
+        }
+    ],
+    "field_commonly_treated_condition": [],
+    "field_health_service_api_id": [],
+    "field_owner": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "0e30e74c-76b9-4c25-aa12-745086f02e37"
+        }
+    ],
+    "field_vha_healthservice_stopcode": []
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/taxonomy_term.4c3b2e81-aea0-42d0-9cdd-45d540d546ae.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/taxonomy_term.4c3b2e81-aea0-42d0-9cdd-45d540d546ae.json
@@ -1,0 +1,94 @@
+{
+    "uuid": [
+        {
+            "value": "4c3b2e81-aea0-42d0-9cdd-45d540d546ae"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "vid": [
+        {
+            "target_id": "health_care_service_taxonomy",
+            "target_type": "taxonomy_vocabulary",
+            "target_uuid": "1ae4c52e-f750-44eb-9e53-e10234617743"
+        }
+    ],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "name": [
+        {
+            "value": "Gynecology"
+        }
+    ],
+    "description": [
+        {
+            "value": "<p>Our specialists offer reproductive health care services for women Veterans, including contraception, pregnancy care and fertility treatment.<\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "weight": [
+        {
+            "value": 5
+        }
+    ],
+    "parent": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "c09b9c29-0ba1-4ed9-9b30-28807263e294"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-10-30T16:00:48+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Gynecology | Veterans Affairs",
+            "canonical_url": "http:\/\/default\/health-care\/gynecology",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "description": "Our specialists offer reproductive health care services for women Veterans, including contraception, pregnancy care and fertility treatment.",
+            "twitter_cards_title": "| Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "| Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": "\/health-care\/gynecology",
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "field_also_known_as": [
+        {
+            "value": "Reproductive and maternal health, women's health"
+        }
+    ],
+    "field_commonly_treated_condition": [],
+    "field_health_service_api_id": [
+        {
+            "value": "gynecology"
+        }
+    ],
+    "field_owner": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "0e30e74c-76b9-4c25-aa12-745086f02e37"
+        }
+    ],
+    "field_vha_healthservice_stopcode": []
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/taxonomy_term.571ba00e-5cc9-4bc2-ae9f-b7c6307c2aea.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/taxonomy_term.571ba00e-5cc9-4bc2-ae9f-b7c6307c2aea.json
@@ -1,0 +1,98 @@
+{
+    "uuid": [
+        {
+            "value": "571ba00e-5cc9-4bc2-ae9f-b7c6307c2aea"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "vid": [
+        {
+            "target_id": "health_care_service_taxonomy",
+            "target_type": "taxonomy_vocabulary",
+            "target_uuid": "1ae4c52e-f750-44eb-9e53-e10234617743"
+        }
+    ],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "name": [
+        {
+            "value": "Ophthalmology"
+        }
+    ],
+    "description": [
+        {
+            "value": "<p>Our ophthalmology specialists diagnose and provide medical and surgical care for conditions that affect your eyes\u2014like cataracts, glaucoma, macular degeneration and diabetic retinopathy.&nbsp;<\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "weight": [
+        {
+            "value": 29
+        }
+    ],
+    "parent": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "1b15f183-be97-4371-b3f6-a15e0d8913cf"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-10-30T17:00:06+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Ophthalmology | Veterans Affairs",
+            "canonical_url": "http:\/\/default\/health-care\/ophthalmology",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "description": "Our ophthalmology specialists diagnose and provide medical and surgical care for conditions that affect your eyes\u2014like cataracts, glaucoma, macular degeneration and diabetic retinopathy.\u00a0",
+            "twitter_cards_title": "| Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "| Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": "\/health-care\/ophthalmology",
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "field_also_known_as": [
+        {
+            "value": "Eye and vision care"
+        }
+    ],
+    "field_commonly_treated_condition": [
+        {
+            "value": "cataracts, glaucoma, macular degeneration, diabetic eye disease"
+        }
+    ],
+    "field_health_service_api_id": [
+        {
+            "value": "ophthalmology"
+        }
+    ],
+    "field_owner": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "0e30e74c-76b9-4c25-aa12-745086f02e37"
+        }
+    ],
+    "field_vha_healthservice_stopcode": []
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/taxonomy_term.5fe3592a-7766-4ff1-a2df-2cdf6a992683.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/taxonomy_term.5fe3592a-7766-4ff1-a2df-2cdf6a992683.json
@@ -1,0 +1,86 @@
+{
+    "uuid": [
+        {
+            "value": "5fe3592a-7766-4ff1-a2df-2cdf6a992683"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "vid": [
+        {
+            "target_id": "health_care_service_taxonomy",
+            "target_type": "taxonomy_vocabulary",
+            "target_uuid": "1ae4c52e-f750-44eb-9e53-e10234617743"
+        }
+    ],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "name": [
+        {
+            "value": "Surgery"
+        }
+    ],
+    "description": [
+        {
+            "value": "<p>If you are having surgery, we&nbsp;make sure that your procedure and follow-up care are safe and high-quality.<\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "weight": [
+        {
+            "value": 49
+        }
+    ],
+    "parent": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "1b15f183-be97-4371-b3f6-a15e0d8913cf"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-05T21:33:37+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Surgery | Veterans Affairs",
+            "canonical_url": "http:\/\/default\/health-care\/surgery",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "description": "If you are having surgery, we\u00a0make sure that your procedure and follow-up care are safe and high-quality.",
+            "twitter_cards_title": "| Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "| Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": "\/health-care\/surgery",
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "field_also_known_as": [],
+    "field_commonly_treated_condition": [],
+    "field_health_service_api_id": [],
+    "field_owner": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "0e30e74c-76b9-4c25-aa12-745086f02e37"
+        }
+    ],
+    "field_vha_healthservice_stopcode": []
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/taxonomy_term.603b9ef3-2516-4acc-ae25-ad1fc2ec6291.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/taxonomy_term.603b9ef3-2516-4acc-ae25-ad1fc2ec6291.json
@@ -1,0 +1,90 @@
+{
+    "uuid": [
+        {
+            "value": "603b9ef3-2516-4acc-ae25-ad1fc2ec6291"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "vid": [
+        {
+            "target_id": "health_care_service_taxonomy",
+            "target_type": "taxonomy_vocabulary",
+            "target_uuid": "1ae4c52e-f750-44eb-9e53-e10234617743"
+        }
+    ],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "name": [
+        {
+            "value": "My HealtheVet coordinator"
+        }
+    ],
+    "description": [
+        {
+            "value": "<p>Your My HealtheVet coordinator can help you start using the VA online portal to manage your appointments and records, refill prescriptions, view your lab and test results&nbsp;and communicate with your health care team.<\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "weight": [
+        {
+            "value": 0
+        }
+    ],
+    "parent": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "374d18b8-c4e8-45b3-a6b0-be6e60509294"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-05T22:00:30+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "My HealtheVet coordinator | Veterans Affairs",
+            "canonical_url": "http:\/\/default\/health-care\/my-healthevet-coordinator",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "description": "Your My HealtheVet coordinator can help you start using the VA online portal to manage your appointments and records, refill prescriptions, view your lab and test results\u00a0and communicate with your health care team.",
+            "twitter_cards_title": "| Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "| Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": "\/health-care\/my-healthevet-coordinator",
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "field_also_known_as": [
+        {
+            "value": "VA.gov website"
+        }
+    ],
+    "field_commonly_treated_condition": [],
+    "field_health_service_api_id": [],
+    "field_owner": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "0e30e74c-76b9-4c25-aa12-745086f02e37"
+        }
+    ],
+    "field_vha_healthservice_stopcode": []
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/taxonomy_term.645020f3-2376-4851-8357-b79151342631.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/taxonomy_term.645020f3-2376-4851-8357-b79151342631.json
@@ -1,0 +1,90 @@
+{
+    "uuid": [
+        {
+            "value": "645020f3-2376-4851-8357-b79151342631"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "vid": [
+        {
+            "target_id": "health_care_service_taxonomy",
+            "target_type": "taxonomy_vocabulary",
+            "target_uuid": "1ae4c52e-f750-44eb-9e53-e10234617743"
+        }
+    ],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "name": [
+        {
+            "value": "Returning service member care"
+        }
+    ],
+    "description": [
+        {
+            "value": "<p>If you\u2019re returning from military service, we can help you readjust to civilian life and get started with VA health care. We can also help connect you with&nbsp;programs like mental health services and education and career counseling.<\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "weight": [
+        {
+            "value": 10
+        }
+    ],
+    "parent": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "ba3209fc-81f2-4608-81d5-10caa4f057f9"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-05T21:55:15+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Returning service member care | Veterans Affairs",
+            "canonical_url": "http:\/\/default\/health-care\/returning-service-member-care",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "description": "If you\u2019re returning from military service, we can help you readjust to civilian life and get started with VA health care. We can also help connect you with\u00a0programs like mental health services and education and career counseling.",
+            "twitter_cards_title": "| Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "| Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": "\/health-care\/returning-service-member-care",
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "field_also_known_as": [
+        {
+            "value": "Post-9\/11 Veterans (OEF, OIF, OND) transition and care management services"
+        }
+    ],
+    "field_commonly_treated_condition": [],
+    "field_health_service_api_id": [],
+    "field_owner": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "0e30e74c-76b9-4c25-aa12-745086f02e37"
+        }
+    ],
+    "field_vha_healthservice_stopcode": []
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/taxonomy_term.6735bd18-6dd7-4d25-a96d-a517ed478cf0.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/taxonomy_term.6735bd18-6dd7-4d25-a96d-a517ed478cf0.json
@@ -1,0 +1,86 @@
+{
+    "uuid": [
+        {
+            "value": "6735bd18-6dd7-4d25-a96d-a517ed478cf0"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "vid": [
+        {
+            "target_id": "health_care_service_taxonomy",
+            "target_type": "taxonomy_vocabulary",
+            "target_uuid": "1ae4c52e-f750-44eb-9e53-e10234617743"
+        }
+    ],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "name": [
+        {
+            "value": "Caregiver support"
+        }
+    ],
+    "description": [
+        {
+            "value": "<p>If you are&nbsp;caring for a Veteran with serious illness or disabilities, we can help you support them\u2014and take care of yourself. You may qualify for services like training, counseling&nbsp;or respite care when you need a break.<\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "weight": [
+        {
+            "value": 1
+        }
+    ],
+    "parent": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "ba3209fc-81f2-4608-81d5-10caa4f057f9"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-05T21:46:48+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Caregiver support | Veterans Affairs",
+            "canonical_url": "http:\/\/default\/health-care\/caregiver-support",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "description": "If you are\u00a0caring for a Veteran with serious illness or disabilities, we can help you support them\u2014and take care of yourself. You may qualify for services like training, counseling\u00a0or respite care when you need a break.",
+            "twitter_cards_title": "| Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "| Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": "\/health-care\/caregiver-support",
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "field_also_known_as": [],
+    "field_commonly_treated_condition": [],
+    "field_health_service_api_id": [],
+    "field_owner": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "0e30e74c-76b9-4c25-aa12-745086f02e37"
+        }
+    ],
+    "field_vha_healthservice_stopcode": []
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/taxonomy_term.6fe1da43-4b95-41f4-a343-c773b3c90297.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/taxonomy_term.6fe1da43-4b95-41f4-a343-c773b3c90297.json
@@ -1,0 +1,98 @@
+{
+    "uuid": [
+        {
+            "value": "6fe1da43-4b95-41f4-a343-c773b3c90297"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "vid": [
+        {
+            "target_id": "health_care_service_taxonomy",
+            "target_type": "taxonomy_vocabulary",
+            "target_uuid": "1ae4c52e-f750-44eb-9e53-e10234617743"
+        }
+    ],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "name": [
+        {
+            "value": "Audiology and speech"
+        }
+    ],
+    "description": [
+        {
+            "value": "<p>We diagnose and treat conditions affecting your hearing, speech&nbsp;or balance. These include hearing loss, tinnitus (noise or ringing the ears) and dizziness\u2014also speech, language, voice&nbsp;or swallowing disorders.<\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "weight": [
+        {
+            "value": 3
+        }
+    ],
+    "parent": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "1b15f183-be97-4371-b3f6-a15e0d8913cf"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-10-30T16:23:35+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Audiology and speech | Veterans Affairs",
+            "canonical_url": "http:\/\/default\/health-care\/audiology-and-speech",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "description": "We diagnose and treat conditions affecting your hearing, speech\u00a0or balance. These include hearing loss, tinnitus (noise or ringing the ears) and dizziness\u2014also speech, language, voice\u00a0or swallowing disorders.",
+            "twitter_cards_title": "| Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "| Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": "\/health-care\/audiology-and-speech",
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "field_also_known_as": [
+        {
+            "value": "Hearing, speech and balance"
+        }
+    ],
+    "field_commonly_treated_condition": [
+        {
+            "value": "tinnitus, vertigo, hearing loss, vestibular conditions, swallowing conditions"
+        }
+    ],
+    "field_health_service_api_id": [
+        {
+            "value": "audiology"
+        }
+    ],
+    "field_owner": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "0e30e74c-76b9-4c25-aa12-745086f02e37"
+        }
+    ],
+    "field_vha_healthservice_stopcode": []
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/taxonomy_term.73a67d7f-ff36-447b-aa5c-84aafd8c01ff.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/taxonomy_term.73a67d7f-ff36-447b-aa5c-84aafd8c01ff.json
@@ -1,0 +1,98 @@
+{
+    "uuid": [
+        {
+            "value": "73a67d7f-ff36-447b-aa5c-84aafd8c01ff"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "vid": [
+        {
+            "target_id": "health_care_service_taxonomy",
+            "target_type": "taxonomy_vocabulary",
+            "target_uuid": "1ae4c52e-f750-44eb-9e53-e10234617743"
+        }
+    ],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "name": [
+        {
+            "value": "Orthopedics"
+        }
+    ],
+    "description": [
+        {
+            "value": "<p>Our orthopedists offer advanced care and treatment for issues related to muscles, bones&nbsp;and joints, including arthritis, disorders of the muscles and bones, tendon and ligament repair&nbsp;and joint replacement.<\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "weight": [
+        {
+            "value": 31
+        }
+    ],
+    "parent": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "1b15f183-be97-4371-b3f6-a15e0d8913cf"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-10-31T20:58:02+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Orthopedics | Veterans Affairs",
+            "canonical_url": "http:\/\/default\/health-care\/orthopedics",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "description": "Our orthopedists offer advanced care and treatment for issues related to muscles, bones\u00a0and joints, including arthritis, disorders of the muscles and bones, tendon and ligament repair\u00a0and joint replacement.",
+            "twitter_cards_title": "| Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "| Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": "\/health-care\/orthopedics",
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "field_also_known_as": [
+        {
+            "value": "Bones, muscles and joints"
+        }
+    ],
+    "field_commonly_treated_condition": [
+        {
+            "value": "arthritis, musculoskeletal disorders, tendon and ligament repair, joint replacement"
+        }
+    ],
+    "field_health_service_api_id": [
+        {
+            "value": "orthopedics"
+        }
+    ],
+    "field_owner": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "0e30e74c-76b9-4c25-aa12-745086f02e37"
+        }
+    ],
+    "field_vha_healthservice_stopcode": []
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/taxonomy_term.73d2fb6b-d074-42c0-a513-4d26d03ff8a0.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/taxonomy_term.73d2fb6b-d074-42c0-a513-4d26d03ff8a0.json
@@ -1,0 +1,86 @@
+{
+    "uuid": [
+        {
+            "value": "73d2fb6b-d074-42c0-a513-4d26d03ff8a0"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "vid": [
+        {
+            "target_id": "health_care_service_taxonomy",
+            "target_type": "taxonomy_vocabulary",
+            "target_uuid": "1ae4c52e-f750-44eb-9e53-e10234617743"
+        }
+    ],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "name": [
+        {
+            "value": "Recreation and creative arts therapy"
+        }
+    ],
+    "description": [
+        {
+            "value": "<p>We offer a wide range of activities (arts and crafts, games, sports, exercise) that we can adapt to your needs.<\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "weight": [
+        {
+            "value": 8
+        }
+    ],
+    "parent": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "ba3209fc-81f2-4608-81d5-10caa4f057f9"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-09-06T23:30:53+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Recreation and creative arts therapy | Veterans Affairs",
+            "canonical_url": "http:\/\/default\/health-care\/recreation-and-creative-arts-therapy",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "description": "We offer a wide range of activities (arts and crafts, games, sports, exercise) that we can adapt to your needs.",
+            "twitter_cards_title": "| Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "| Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": "\/health-care\/recreation-and-creative-arts-therapy",
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "field_also_known_as": [],
+    "field_commonly_treated_condition": [],
+    "field_health_service_api_id": [],
+    "field_owner": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "c20f3989-e93e-49bd-8c95-ad3821042a02"
+        }
+    ],
+    "field_vha_healthservice_stopcode": []
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/taxonomy_term.747057bc-2203-4100-ae67-9de02cdeac94.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/taxonomy_term.747057bc-2203-4100-ae67-9de02cdeac94.json
@@ -1,0 +1,86 @@
+{
+    "uuid": [
+        {
+            "value": "747057bc-2203-4100-ae67-9de02cdeac94"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "vid": [
+        {
+            "target_id": "health_care_service_taxonomy",
+            "target_type": "taxonomy_vocabulary",
+            "target_uuid": "1ae4c52e-f750-44eb-9e53-e10234617743"
+        }
+    ],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "name": [
+        {
+            "value": "Nutrition, food, and dietary"
+        }
+    ],
+    "description": [
+        {
+            "value": "<p>Our nutrition experts work closely with you and your care team to help make sure you\u2019re getting the nutrition you need to get and stay as healthy as possible.<\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "weight": [
+        {
+            "value": 28
+        }
+    ],
+    "parent": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "1b15f183-be97-4371-b3f6-a15e0d8913cf"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-10-30T16:58:56+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Nutrition, food, and dietary | Veterans Affairs",
+            "canonical_url": "http:\/\/default\/health-care\/nutrition-food-and-dietary",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "description": "Our nutrition experts work closely with you and your care team to help make sure you\u2019re getting the nutrition you need to get and stay as healthy as possible.",
+            "twitter_cards_title": "| Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "| Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": "\/health-care\/nutrition-food-and-dietary",
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "field_also_known_as": [],
+    "field_commonly_treated_condition": [],
+    "field_health_service_api_id": [],
+    "field_owner": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "0e30e74c-76b9-4c25-aa12-745086f02e37"
+        }
+    ],
+    "field_vha_healthservice_stopcode": []
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/taxonomy_term.82549624-4c2b-4a7c-886f-39c1278a41e5.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/taxonomy_term.82549624-4c2b-4a7c-886f-39c1278a41e5.json
@@ -1,0 +1,86 @@
+{
+    "uuid": [
+        {
+            "value": "82549624-4c2b-4a7c-886f-39c1278a41e5"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "vid": [
+        {
+            "target_id": "health_care_service_taxonomy",
+            "target_type": "taxonomy_vocabulary",
+            "target_uuid": "1ae4c52e-f750-44eb-9e53-e10234617743"
+        }
+    ],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "name": [
+        {
+            "value": "Spinal cord injury and disorders"
+        }
+    ],
+    "description": [
+        {
+            "value": "<p>If you have a spinal cord injury or disorder, our specialists provide coordinated care throughout your life. We work to help you achieve your goals for independence, productivity&nbsp;and quality of life.<\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "weight": [
+        {
+            "value": 48
+        }
+    ],
+    "parent": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "1b15f183-be97-4371-b3f6-a15e0d8913cf"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-05T21:32:19+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Spinal cord injury and disorders | Veterans Affairs",
+            "canonical_url": "http:\/\/default\/health-care\/spinal-cord-injury-and-disorders",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "description": "If you have a spinal cord injury or disorder, our specialists provide coordinated care throughout your life. We work to help you achieve your goals for independence, productivity\u00a0and quality of life.",
+            "twitter_cards_title": "| Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "| Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": "\/health-care\/spinal-cord-injury-and-disorders",
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "field_also_known_as": [],
+    "field_commonly_treated_condition": [],
+    "field_health_service_api_id": [],
+    "field_owner": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "0e30e74c-76b9-4c25-aa12-745086f02e37"
+        }
+    ],
+    "field_vha_healthservice_stopcode": []
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/taxonomy_term.87529073-31f6-43cd-9527-b34bf63ab640.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/taxonomy_term.87529073-31f6-43cd-9527-b34bf63ab640.json
@@ -1,0 +1,90 @@
+{
+    "uuid": [
+        {
+            "value": "87529073-31f6-43cd-9527-b34bf63ab640"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "vid": [
+        {
+            "target_id": "health_care_service_taxonomy",
+            "target_type": "taxonomy_vocabulary",
+            "target_uuid": "1ae4c52e-f750-44eb-9e53-e10234617743"
+        }
+    ],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "name": [
+        {
+            "value": "Suicide prevention"
+        }
+    ],
+    "description": [
+        {
+            "value": "<p>Call our Veterans Crisis Line at 800-273-8255 (select 1) for free, private help anytime 24\/7. Our local suicide prevention coordinators can also connect you with ongoing counseling and services.<\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "weight": [
+        {
+            "value": 6
+        }
+    ],
+    "parent": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "184678e9-7458-426d-8baa-116f3902d6ef"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-10-30T16:13:52+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Suicide prevention | Veterans Affairs",
+            "canonical_url": "http:\/\/default\/health-care\/suicide-prevention",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "description": "Call our Veterans Crisis Line at 800-273-8255 (select 1) for free, private help anytime 24\/7. Our local suicide prevention coordinators can also connect you with ongoing counseling and services.",
+            "twitter_cards_title": "| Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "| Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": "\/health-care\/suicide-prevention",
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "field_also_known_as": [
+        {
+            "value": "Veterans Crisis Line"
+        }
+    ],
+    "field_commonly_treated_condition": [],
+    "field_health_service_api_id": [],
+    "field_owner": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "0e30e74c-76b9-4c25-aa12-745086f02e37"
+        }
+    ],
+    "field_vha_healthservice_stopcode": []
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/taxonomy_term.87832236-1e54-4ce3-8141-8dec27c8a9a7.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/taxonomy_term.87832236-1e54-4ce3-8141-8dec27c8a9a7.json
@@ -1,0 +1,108 @@
+{
+    "uuid": [
+        {
+            "value": "87832236-1e54-4ce3-8141-8dec27c8a9a7"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "vid": [
+        {
+            "target_id": "administration",
+            "target_type": "taxonomy_vocabulary",
+            "target_uuid": "645055c5-e567-4683-b6db-459ce04522ce"
+        }
+    ],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "name": [
+        {
+            "value": "VA Pittsburgh health care"
+        }
+    ],
+    "description": [
+        {
+            "value": null,
+            "format": null
+        }
+    ],
+    "weight": [
+        {
+            "value": 6
+        }
+    ],
+    "parent": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "62ba5bc4-5bf3-4888-a2bb-0489ead0c76f"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-09-26T01:08:39+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "VA Pittsburgh health care | Veterans Affairs",
+            "canonical_url": "http:\/\/default\/section\/veterans-health-administration\/vha-facilities\/va-pittsburgh-health-care",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "twitter_cards_title": "| Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "| Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": "\/section\/veterans-health-administration\/vha-facilities\/va-pittsburgh-health-care",
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "field_acronym": [],
+    "field_description": [],
+    "field_email_updates_link_text": [],
+    "field_email_updates_url": [],
+    "field_intro_text": [],
+    "field_link": [],
+    "field_metatags": [],
+    "field_social_media_links": [
+        {
+            "platform": null,
+            "value": null,
+            "platform_values": {
+                "facebook": {
+                    "value": ""
+                },
+                "instagram": {
+                    "value": ""
+                },
+                "linkedin": {
+                    "value": ""
+                },
+                "twitter": {
+                    "value": ""
+                },
+                "youtube": {
+                    "value": ""
+                },
+                "youtube_channel": {
+                    "value": ""
+                }
+            }
+        }
+    ]
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/taxonomy_term.8a97ad12-57cf-4591-9a5a-171936099fb7.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/taxonomy_term.8a97ad12-57cf-4591-9a5a-171936099fb7.json
@@ -1,0 +1,98 @@
+{
+    "uuid": [
+        {
+            "value": "8a97ad12-57cf-4591-9a5a-171936099fb7"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "vid": [
+        {
+            "target_id": "health_care_service_taxonomy",
+            "target_type": "taxonomy_vocabulary",
+            "target_uuid": "1ae4c52e-f750-44eb-9e53-e10234617743"
+        }
+    ],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "name": [
+        {
+            "value": "Urology"
+        }
+    ],
+    "description": [
+        {
+            "value": "<p>We offer understanding and advanced care and treatment to Veterans with conditions that affect the male urinary and reproductive systems and the female urinary system.&nbsp;<\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "weight": [
+        {
+            "value": 53
+        }
+    ],
+    "parent": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "1b15f183-be97-4371-b3f6-a15e0d8913cf"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-05T21:37:06+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Urology | Veterans Affairs",
+            "canonical_url": "http:\/\/default\/health-care\/urology",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "description": "We offer understanding and advanced care and treatment to Veterans with conditions that affect the male urinary and reproductive systems and the female urinary system.\u00a0",
+            "twitter_cards_title": "| Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "| Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": "\/health-care\/urology",
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "field_also_known_as": [
+        {
+            "value": "Male and female urinary tract and male reproductive system"
+        }
+    ],
+    "field_commonly_treated_condition": [
+        {
+            "value": "prostate cancer, erectile dysfunction, urinary disorders"
+        }
+    ],
+    "field_health_service_api_id": [
+        {
+            "value": "urology"
+        }
+    ],
+    "field_owner": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "0e30e74c-76b9-4c25-aa12-745086f02e37"
+        }
+    ],
+    "field_vha_healthservice_stopcode": []
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/taxonomy_term.b2264cc5-bdcc-48fb-b9c8-9f036656690c.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/taxonomy_term.b2264cc5-bdcc-48fb-b9c8-9f036656690c.json
@@ -1,0 +1,98 @@
+{
+    "uuid": [
+        {
+            "value": "b2264cc5-bdcc-48fb-b9c8-9f036656690c"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "vid": [
+        {
+            "target_id": "health_care_service_taxonomy",
+            "target_type": "taxonomy_vocabulary",
+            "target_uuid": "1ae4c52e-f750-44eb-9e53-e10234617743"
+        }
+    ],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "name": [
+        {
+            "value": "Dermatology"
+        }
+    ],
+    "description": [
+        {
+            "value": "<p>Our dermatologists offer expert treatment for a range of conditions that affect your skin, hair&nbsp;and nails\u2014from acne to psoriasis to skin cancer. We also offer skin cancer screening and education.<\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "weight": [
+        {
+            "value": 12
+        }
+    ],
+    "parent": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "1b15f183-be97-4371-b3f6-a15e0d8913cf"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-10-30T16:39:30+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Dermatology | Veterans Affairs",
+            "canonical_url": "http:\/\/default\/health-care\/dermatology",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "description": "Our dermatologists offer expert treatment for a range of conditions that affect your skin, hair\u00a0and nails\u2014from acne to psoriasis to skin cancer. We also offer skin cancer screening and education.",
+            "twitter_cards_title": "| Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "| Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": "\/health-care\/dermatology",
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "field_also_known_as": [
+        {
+            "value": "Skin conditions and diseases"
+        }
+    ],
+    "field_commonly_treated_condition": [
+        {
+            "value": "psoriasis, eczema, skin cancer, acne, rosacea, allergic skin diseases, ulcers"
+        }
+    ],
+    "field_health_service_api_id": [
+        {
+            "value": "dermatology"
+        }
+    ],
+    "field_owner": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "0e30e74c-76b9-4c25-aa12-745086f02e37"
+        }
+    ],
+    "field_vha_healthservice_stopcode": []
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/taxonomy_term.ba71e44c-f5b4-46c2-ada4-dc908281dbea.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/taxonomy_term.ba71e44c-f5b4-46c2-ada4-dc908281dbea.json
@@ -1,0 +1,94 @@
+{
+    "uuid": [
+        {
+            "value": "ba71e44c-f5b4-46c2-ada4-dc908281dbea"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "vid": [
+        {
+            "target_id": "health_care_service_taxonomy",
+            "target_type": "taxonomy_vocabulary",
+            "target_uuid": "1ae4c52e-f750-44eb-9e53-e10234617743"
+        }
+    ],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "name": [
+        {
+            "value": "Nephrology, renal and kidney"
+        }
+    ],
+    "description": [
+        {
+            "value": "<p>Our specialists offer you advanced care for kidney-related diseases&nbsp;like chronic kidney disease, high blood pressure and fluid and electrolyte problems. We also provide dialysis and related support. &nbsp;<\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "weight": [
+        {
+            "value": 25
+        }
+    ],
+    "parent": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "1b15f183-be97-4371-b3f6-a15e0d8913cf"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-10-30T16:55:20+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Nephrology, renal and kidney | Veterans Affairs",
+            "canonical_url": "http:\/\/default\/health-care\/nephrology-renal-and-kidney",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "description": "Our specialists offer you advanced care for kidney-related diseases\u00a0like chronic kidney disease, high blood pressure and fluid and electrolyte problems. We also provide dialysis and related support. \u00a0",
+            "twitter_cards_title": "| Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "| Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": "\/health-care\/nephrology-renal-and-kidney",
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "field_also_known_as": [
+        {
+            "value": "Dialysis and hypertension"
+        }
+    ],
+    "field_commonly_treated_condition": [
+        {
+            "value": "dialysis, kidney disease, high blood pressure"
+        }
+    ],
+    "field_health_service_api_id": [],
+    "field_owner": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "0e30e74c-76b9-4c25-aa12-745086f02e37"
+        }
+    ],
+    "field_vha_healthservice_stopcode": []
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/taxonomy_term.c6670e19-6527-4cd5-9fb5-6f6cc62abd71.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/taxonomy_term.c6670e19-6527-4cd5-9fb5-6f6cc62abd71.json
@@ -1,0 +1,90 @@
+{
+    "uuid": [
+        {
+            "value": "c6670e19-6527-4cd5-9fb5-6f6cc62abd71"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "vid": [
+        {
+            "target_id": "health_care_service_taxonomy",
+            "target_type": "taxonomy_vocabulary",
+            "target_uuid": "1ae4c52e-f750-44eb-9e53-e10234617743"
+        }
+    ],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "name": [
+        {
+            "value": "Telehealth"
+        }
+    ],
+    "description": [
+        {
+            "value": "<p>With VA telehealth, you can get care from your health providers without having to travel. Get checkups and treatment, talk about your care&nbsp;and more\u2014from home or elsewhere.<\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "weight": [
+        {
+            "value": 1
+        }
+    ],
+    "parent": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "374d18b8-c4e8-45b3-a6b0-be6e60509294"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-05T22:01:27+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Telehealth | Veterans Affairs",
+            "canonical_url": "http:\/\/default\/health-care\/telehealth",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "description": "With VA telehealth, you can get care from your health providers without having to travel. Get checkups and treatment, talk about your care\u00a0and more\u2014from home or elsewhere.",
+            "twitter_cards_title": "| Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "| Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": "\/health-care\/telehealth",
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "field_also_known_as": [
+        {
+            "value": "Video visits, remote care, care by telephone"
+        }
+    ],
+    "field_commonly_treated_condition": [],
+    "field_health_service_api_id": [],
+    "field_owner": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "0e30e74c-76b9-4c25-aa12-745086f02e37"
+        }
+    ],
+    "field_vha_healthservice_stopcode": []
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/taxonomy_term.ca88c56c-eaec-4570-9370-e783510b602a.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/taxonomy_term.ca88c56c-eaec-4570-9370-e783510b602a.json
@@ -1,0 +1,90 @@
+{
+    "uuid": [
+        {
+            "value": "ca88c56c-eaec-4570-9370-e783510b602a"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "vid": [
+        {
+            "target_id": "health_care_service_taxonomy",
+            "target_type": "taxonomy_vocabulary",
+            "target_uuid": "1ae4c52e-f750-44eb-9e53-e10234617743"
+        }
+    ],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "name": [
+        {
+            "value": "Pharmacy"
+        }
+    ],
+    "description": [
+        {
+            "value": "<p>Our specialists provide a full range of services to help you get and understand your prescription medicines and supplies. You can refill VA prescriptions online, by phone or by mail.<\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "weight": [
+        {
+            "value": 6
+        }
+    ],
+    "parent": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "c09b9c29-0ba1-4ed9-9b30-28807263e294"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-10-30T16:01:16+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Pharmacy | Veterans Affairs",
+            "canonical_url": "http:\/\/default\/health-care\/pharmacy",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "description": "Our specialists provide a full range of services to help you get and understand your prescription medicines and supplies. You can refill VA prescriptions online, by phone or by mail.",
+            "twitter_cards_title": "| Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "| Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": "\/health-care\/pharmacy",
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "field_also_known_as": [
+        {
+            "value": "Prescriptions, Rx, medications, pharmacist consultation"
+        }
+    ],
+    "field_commonly_treated_condition": [],
+    "field_health_service_api_id": [],
+    "field_owner": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "0e30e74c-76b9-4c25-aa12-745086f02e37"
+        }
+    ],
+    "field_vha_healthservice_stopcode": []
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/taxonomy_term.d657ae30-f9de-48f0-8a2f-c776a5252443.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/taxonomy_term.d657ae30-f9de-48f0-8a2f-c776a5252443.json
@@ -1,0 +1,86 @@
+{
+    "uuid": [
+        {
+            "value": "d657ae30-f9de-48f0-8a2f-c776a5252443"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "vid": [
+        {
+            "target_id": "health_care_service_taxonomy",
+            "target_type": "taxonomy_vocabulary",
+            "target_uuid": "1ae4c52e-f750-44eb-9e53-e10234617743"
+        }
+    ],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "name": [
+        {
+            "value": "Amputation care"
+        }
+    ],
+    "description": [
+        {
+            "value": "<p>If you face or have had an amputation, our team will support you with thoughtful, compassionate care.<\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "weight": [
+        {
+            "value": 1
+        }
+    ],
+    "parent": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "1b15f183-be97-4371-b3f6-a15e0d8913cf"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-10-30T16:16:36+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Amputation care | Veterans Affairs",
+            "canonical_url": "http:\/\/default\/health-care\/amputation-care",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "description": "If you face or have had an amputation, our team will support you with thoughtful, compassionate care.",
+            "twitter_cards_title": "| Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "| Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": "\/health-care\/amputation-care",
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "field_also_known_as": [],
+    "field_commonly_treated_condition": [],
+    "field_health_service_api_id": [],
+    "field_owner": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "0e30e74c-76b9-4c25-aa12-745086f02e37"
+        }
+    ],
+    "field_vha_healthservice_stopcode": []
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/taxonomy_term.df6f3c6c-cd45-4f0c-9c89-affe932043a6.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/taxonomy_term.df6f3c6c-cd45-4f0c-9c89-affe932043a6.json
@@ -1,0 +1,90 @@
+{
+    "uuid": [
+        {
+            "value": "df6f3c6c-cd45-4f0c-9c89-affe932043a6"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "vid": [
+        {
+            "target_id": "health_care_service_taxonomy",
+            "target_type": "taxonomy_vocabulary",
+            "target_uuid": "1ae4c52e-f750-44eb-9e53-e10234617743"
+        }
+    ],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "name": [
+        {
+            "value": "Addiction and substance abuse treatment"
+        }
+    ],
+    "description": [
+        {
+            "value": "<p>We can help you overcome substance use problems from unhealthy alcohol use to life-threatening addiction. We match our services\u2014like counseling, group therapy or medication\u2014to your specific needs.<\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "weight": [
+        {
+            "value": 0
+        }
+    ],
+    "parent": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "184678e9-7458-426d-8baa-116f3902d6ef"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-10-30T16:05:36+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Addiction and substance abuse treatment | Veterans Affairs",
+            "canonical_url": "http:\/\/default\/health-care\/addiction-and-substance-abuse-treatment",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "description": "We can help you overcome substance use problems from unhealthy alcohol use to life-threatening addiction. We match our services\u2014like counseling, group therapy or medication\u2014to your specific needs.",
+            "twitter_cards_title": "| Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "| Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": "\/health-care\/addiction-and-substance-abuse-treatment",
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "field_also_known_as": [
+        {
+            "value": "Drug and alcohol treatment and rehabilitation"
+        }
+    ],
+    "field_commonly_treated_condition": [],
+    "field_health_service_api_id": [],
+    "field_owner": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "0e30e74c-76b9-4c25-aa12-745086f02e37"
+        }
+    ],
+    "field_vha_healthservice_stopcode": []
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/taxonomy_term.e020dbef-9775-4b91-bc3d-3627a33158dd.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/taxonomy_term.e020dbef-9775-4b91-bc3d-3627a33158dd.json
@@ -1,0 +1,98 @@
+{
+    "uuid": [
+        {
+            "value": "e020dbef-9775-4b91-bc3d-3627a33158dd"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "vid": [
+        {
+            "target_id": "health_care_service_taxonomy",
+            "target_type": "taxonomy_vocabulary",
+            "target_uuid": "1ae4c52e-f750-44eb-9e53-e10234617743"
+        }
+    ],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "name": [
+        {
+            "value": "Mental health care"
+        }
+    ],
+    "description": [
+        {
+            "value": "<p>If you\u2019re struggling with issues like PTSD, depression, grief, anger or trauma, we offer counseling and other support. All VA health care facilities offer same-day help. You may qualify even without enrolling in VA health care.<\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "weight": [
+        {
+            "value": 1
+        }
+    ],
+    "parent": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "184678e9-7458-426d-8baa-116f3902d6ef"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-10-30T16:07:34+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Mental health care | Veterans Affairs",
+            "canonical_url": "http:\/\/default\/health-care\/mental-health-care-0",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "description": "If you\u2019re struggling with issues like PTSD, depression, grief, anger or trauma, we offer counseling and other support. All VA health care facilities offer same-day help. You may qualify even without enrolling in VA health care.",
+            "twitter_cards_title": "| Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "| Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": "\/health-care\/mental-health-care-0",
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "field_also_known_as": [
+        {
+            "value": "Behavioral health"
+        }
+    ],
+    "field_commonly_treated_condition": [
+        {
+            "value": "addiction, depression, anxiety, trauma, PTSD, bipolar disorder, schizophrenia, OCD "
+        }
+    ],
+    "field_health_service_api_id": [
+        {
+            "value": "mentalHealth"
+        }
+    ],
+    "field_owner": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "0e30e74c-76b9-4c25-aa12-745086f02e37"
+        }
+    ],
+    "field_vha_healthservice_stopcode": []
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/taxonomy_term.e37928d5-30b0-4a20-a486-06ddbdb59873.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/taxonomy_term.e37928d5-30b0-4a20-a486-06ddbdb59873.json
@@ -1,0 +1,86 @@
+{
+    "uuid": [
+        {
+            "value": "e37928d5-30b0-4a20-a486-06ddbdb59873"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "vid": [
+        {
+            "target_id": "health_care_service_taxonomy",
+            "target_type": "taxonomy_vocabulary",
+            "target_uuid": "1ae4c52e-f750-44eb-9e53-e10234617743"
+        }
+    ],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "name": [
+        {
+            "value": "Transplant surgery"
+        }
+    ],
+    "description": [
+        {
+            "value": "<p>We are experts in life-saving transplants, including kidney, liver, heart, lung, small bowel, bone marrow&nbsp;and stem cell.<\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "weight": [
+        {
+            "value": 52
+        }
+    ],
+    "parent": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "1b15f183-be97-4371-b3f6-a15e0d8913cf"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-05T21:36:17+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Transplant surgery | Veterans Affairs",
+            "canonical_url": "http:\/\/default\/health-care\/transplant-surgery",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "description": "We are experts in life-saving transplants, including kidney, liver, heart, lung, small bowel, bone marrow\u00a0and stem cell.",
+            "twitter_cards_title": "| Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "| Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": "\/health-care\/transplant-surgery",
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "field_also_known_as": [],
+    "field_commonly_treated_condition": [],
+    "field_health_service_api_id": [],
+    "field_owner": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "0e30e74c-76b9-4c25-aa12-745086f02e37"
+        }
+    ],
+    "field_vha_healthservice_stopcode": []
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/taxonomy_term.e5d2d0df-ab4c-424f-b108-5f735fc320d5.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/taxonomy_term.e5d2d0df-ab4c-424f-b108-5f735fc320d5.json
@@ -1,0 +1,86 @@
+{
+    "uuid": [
+        {
+            "value": "e5d2d0df-ab4c-424f-b108-5f735fc320d5"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "vid": [
+        {
+            "target_id": "health_care_service_taxonomy",
+            "target_type": "taxonomy_vocabulary",
+            "target_uuid": "1ae4c52e-f750-44eb-9e53-e10234617743"
+        }
+    ],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "name": [
+        {
+            "value": "Travel reimbursement"
+        }
+    ],
+    "description": [
+        {
+            "value": "<p>If you have to travel far for care, we may be able to reimburse (repay) you for travel expenses. We can also help arrange transportation for getting to and from your VA appointment.<\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "weight": [
+        {
+            "value": 2
+        }
+    ],
+    "parent": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "374d18b8-c4e8-45b3-a6b0-be6e60509294"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-05T22:02:55+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Travel reimbursement | Veterans Affairs",
+            "canonical_url": "http:\/\/default\/health-care\/travel-reimbursement",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "description": "If you have to travel far for care, we may be able to reimburse (repay) you for travel expenses. We can also help arrange transportation for getting to and from your VA appointment.",
+            "twitter_cards_title": "| Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "| Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": "\/health-care\/travel-reimbursement",
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "field_also_known_as": [],
+    "field_commonly_treated_condition": [],
+    "field_health_service_api_id": [],
+    "field_owner": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "0e30e74c-76b9-4c25-aa12-745086f02e37"
+        }
+    ],
+    "field_vha_healthservice_stopcode": []
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/taxonomy_term.e93e002b-25d8-4f00-ad39-945ae41a182c.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/taxonomy_term.e93e002b-25d8-4f00-ad39-945ae41a182c.json
@@ -1,0 +1,86 @@
+{
+    "uuid": [
+        {
+            "value": "e93e002b-25d8-4f00-ad39-945ae41a182c"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "vid": [
+        {
+            "target_id": "health_care_service_taxonomy",
+            "target_type": "taxonomy_vocabulary",
+            "target_uuid": "1ae4c52e-f750-44eb-9e53-e10234617743"
+        }
+    ],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "name": [
+        {
+            "value": "Psychiatry"
+        }
+    ],
+    "description": [
+        {
+            "value": "<p>If you\u2019re struggling with a mental health problem\u2014or just need to talk with someone\u2014we can help. We offer treatment and support such as therapy, alternative treatments&nbsp;&nbsp;and medications when needed.<\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "weight": [
+        {
+            "value": 4
+        }
+    ],
+    "parent": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "184678e9-7458-426d-8baa-116f3902d6ef"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-10-30T16:12:07+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Psychiatry | Veterans Affairs",
+            "canonical_url": "http:\/\/default\/health-care\/psychiatry",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "description": "If you\u2019re struggling with a mental health problem\u2014or just need to talk with someone\u2014we can help. We offer treatment and support such as therapy, alternative treatments\u00a0\u00a0and medications when needed.",
+            "twitter_cards_title": "| Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "| Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": "\/health-care\/psychiatry",
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "field_also_known_as": [],
+    "field_commonly_treated_condition": [],
+    "field_health_service_api_id": [],
+    "field_owner": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "0e30e74c-76b9-4c25-aa12-745086f02e37"
+        }
+    ],
+    "field_vha_healthservice_stopcode": []
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/taxonomy_term.eb25f62a-778b-429d-a67f-075e98a46b52.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/taxonomy_term.eb25f62a-778b-429d-a67f-075e98a46b52.json
@@ -1,0 +1,98 @@
+{
+    "uuid": [
+        {
+            "value": "eb25f62a-778b-429d-a67f-075e98a46b52"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "vid": [
+        {
+            "target_id": "health_care_service_taxonomy",
+            "target_type": "taxonomy_vocabulary",
+            "target_uuid": "1ae4c52e-f750-44eb-9e53-e10234617743"
+        }
+    ],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "name": [
+        {
+            "value": "Optometry"
+        }
+    ],
+    "description": [
+        {
+            "value": "<p>Our optometrists offer you routine eye exams, preventive vision testing&nbsp;and treatment for conditions like glaucoma. We also provide prescriptions for eyeglasses and other assistive devices.<\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "weight": [
+        {
+            "value": 30
+        }
+    ],
+    "parent": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "1b15f183-be97-4371-b3f6-a15e0d8913cf"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-10-30T17:04:09+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Optometry | Veterans Affairs",
+            "canonical_url": "http:\/\/default\/health-care\/optometry",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "description": "Our optometrists offer you routine eye exams, preventive vision testing\u00a0and treatment for conditions like glaucoma. We also provide prescriptions for eyeglasses and other assistive devices.",
+            "twitter_cards_title": "| Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "| Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": "\/health-care\/optometry",
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "field_also_known_as": [
+        {
+            "value": "Vision care, corrective lenses and eyeglasses"
+        }
+    ],
+    "field_commonly_treated_condition": [
+        {
+            "value": "vision exams, prescription eyeglasses, contact lenses"
+        }
+    ],
+    "field_health_service_api_id": [
+        {
+            "value": "optometry"
+        }
+    ],
+    "field_owner": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "0e30e74c-76b9-4c25-aa12-745086f02e37"
+        }
+    ],
+    "field_vha_healthservice_stopcode": []
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/taxonomy_term.f4eb738f-cafb-428b-9f32-160bfa083367.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/taxonomy_term.f4eb738f-cafb-428b-9f32-160bfa083367.json
@@ -1,0 +1,94 @@
+{
+    "uuid": [
+        {
+            "value": "f4eb738f-cafb-428b-9f32-160bfa083367"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "vid": [
+        {
+            "target_id": "health_care_service_taxonomy",
+            "target_type": "taxonomy_vocabulary",
+            "target_uuid": "1ae4c52e-f750-44eb-9e53-e10234617743"
+        }
+    ],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "name": [
+        {
+            "value": "Wheelchair and mobility"
+        }
+    ],
+    "description": [
+        {
+            "value": "<p>We provide support and assistive devices, including wheelchairs, scooters, walkers&nbsp;and canes, to help you preserve and increase your mobility.<\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "weight": [
+        {
+            "value": 55
+        }
+    ],
+    "parent": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "1b15f183-be97-4371-b3f6-a15e0d8913cf"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-05T21:38:46+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Wheelchair and mobility | Veterans Affairs",
+            "canonical_url": "http:\/\/default\/health-care\/wheelchair-and-mobility",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "description": "We provide support and assistive devices, including wheelchairs, scooters, walkers\u00a0and canes, to help you preserve and increase your mobility.",
+            "twitter_cards_title": "| Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "| Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": "\/health-care\/wheelchair-and-mobility",
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "field_also_known_as": [
+        {
+            "value": "Wheelchairs, scooters and custom seating"
+        }
+    ],
+    "field_commonly_treated_condition": [
+        {
+            "value": "lightweight manual "
+        }
+    ],
+    "field_health_service_api_id": [],
+    "field_owner": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "0e30e74c-76b9-4c25-aa12-745086f02e37"
+        }
+    ],
+    "field_vha_healthservice_stopcode": []
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/taxonomy_term.f750bca5-c4d7-424b-af63-70de3479c24c.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/taxonomy_term.f750bca5-c4d7-424b-af63-70de3479c24c.json
@@ -1,0 +1,86 @@
+{
+    "uuid": [
+        {
+            "value": "f750bca5-c4d7-424b-af63-70de3479c24c"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "vid": [
+        {
+            "target_id": "health_care_service_taxonomy",
+            "target_type": "taxonomy_vocabulary",
+            "target_uuid": "1ae4c52e-f750-44eb-9e53-e10234617743"
+        }
+    ],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "name": [
+        {
+            "value": "PTSD treatment"
+        }
+    ],
+    "description": [
+        {
+            "value": "<p>If you have symptoms of PTSD after a traumatic event, we can help. We offer assessment and treatment support such as private counseling, group therapy and medication. It\u2019s never too late to get help.<\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "weight": [
+        {
+            "value": 5
+        }
+    ],
+    "parent": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "184678e9-7458-426d-8baa-116f3902d6ef"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-10-30T16:11:04+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "PTSD treatment | Veterans Affairs",
+            "canonical_url": "http:\/\/default\/health-care\/ptsd-treatment",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "description": "If you have symptoms of PTSD after a traumatic event, we can help. We offer assessment and treatment support such as private counseling, group therapy and medication. It\u2019s never too late to get help.",
+            "twitter_cards_title": "| Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "| Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": "\/health-care\/ptsd-treatment",
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "field_also_known_as": [],
+    "field_commonly_treated_condition": [],
+    "field_health_service_api_id": [],
+    "field_owner": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "0e30e74c-76b9-4c25-aa12-745086f02e37"
+        }
+    ],
+    "field_vha_healthservice_stopcode": []
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/taxonomy_term.f89701d9-68e7-47ae-85e0-42b7ce40f188.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/taxonomy_term.f89701d9-68e7-47ae-85e0-42b7ce40f188.json
@@ -1,0 +1,90 @@
+{
+    "uuid": [
+        {
+            "value": "f89701d9-68e7-47ae-85e0-42b7ce40f188"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "vid": [
+        {
+            "target_id": "health_care_service_taxonomy",
+            "target_type": "taxonomy_vocabulary",
+            "target_uuid": "1ae4c52e-f750-44eb-9e53-e10234617743"
+        }
+    ],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "name": [
+        {
+            "value": "Vocational rehabilitation and employment programs"
+        }
+    ],
+    "description": [
+        {
+            "value": "<p>We&nbsp;can help you reach your job and career goals with one-on-one support, counseling&nbsp;and training. Many graduates of our programs go on to work here at VA.<\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "weight": [
+        {
+            "value": 3
+        }
+    ],
+    "parent": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "374d18b8-c4e8-45b3-a6b0-be6e60509294"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-11-05T22:03:29+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Vocational rehabilitation and employment programs | Veterans Affairs",
+            "canonical_url": "http:\/\/default\/health-care\/vocational-rehabilitation-and-employment-programs",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "description": "We\u00a0can help you reach your job and career goals with one-on-one support, counseling\u00a0and training. Many graduates of our programs go on to work here at VA.",
+            "twitter_cards_title": "| Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "| Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": "\/health-care\/vocational-rehabilitation-and-employment-programs",
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "field_also_known_as": [
+        {
+            "value": "Job and career training programs"
+        }
+    ],
+    "field_commonly_treated_condition": [],
+    "field_health_service_api_id": [],
+    "field_owner": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "0e30e74c-76b9-4c25-aa12-745086f02e37"
+        }
+    ],
+    "field_vha_healthservice_stopcode": []
+}

--- a/src/site/stages/build/process-cms-exports/tests/entities/taxonomy_term.fc8527c3-7ded-47b3-a24c-d54821b23765.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/taxonomy_term.fc8527c3-7ded-47b3-a24c-d54821b23765.json
@@ -1,0 +1,98 @@
+{
+    "uuid": [
+        {
+            "value": "fc8527c3-7ded-47b3-a24c-d54821b23765"
+        }
+    ],
+    "langcode": [
+        {
+            "value": "en"
+        }
+    ],
+    "vid": [
+        {
+            "target_id": "health_care_service_taxonomy",
+            "target_type": "taxonomy_vocabulary",
+            "target_uuid": "1ae4c52e-f750-44eb-9e53-e10234617743"
+        }
+    ],
+    "status": [
+        {
+            "value": true
+        }
+    ],
+    "name": [
+        {
+            "value": "Cardiology"
+        }
+    ],
+    "description": [
+        {
+            "value": "<p>Our cardiology specialists offer advanced treatment and care for conditions affecting your heart and blood vessels, including heart disease, stroke, heart rhythm disorders and high blood pressure.&nbsp;<\/p>\r\n",
+            "format": "rich_text"
+        }
+    ],
+    "weight": [
+        {
+            "value": 6
+        }
+    ],
+    "parent": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "1b15f183-be97-4371-b3f6-a15e0d8913cf"
+        }
+    ],
+    "changed": [
+        {
+            "value": "2019-10-30T16:27:17+00:00",
+            "format": "Y-m-d\\TH:i:sP"
+        }
+    ],
+    "default_langcode": [
+        {
+            "value": true
+        }
+    ],
+    "metatag": {
+        "value": {
+            "title": "Cardiology | Veterans Affairs",
+            "canonical_url": "http:\/\/default\/health-care\/cardiology",
+            "twitter_cards_type": "summary_large_image",
+            "og_site_name": "Veterans Affairs",
+            "description": "Our cardiology specialists offer advanced treatment and care for conditions affecting your heart and blood vessels, including heart disease, stroke, heart rhythm disorders and high blood pressure.\u00a0",
+            "twitter_cards_title": "| Veterans Affairs",
+            "twitter_cards_site": "@DeptVetAffairs",
+            "og_title": "| Veterans Affairs"
+        }
+    },
+    "path": [
+        {
+            "alias": "\/health-care\/cardiology",
+            "langcode": "en",
+            "pathauto": 1
+        }
+    ],
+    "field_also_known_as": [
+        {
+            "value": "Heart and circulation"
+        }
+    ],
+    "field_commonly_treated_condition": [
+        {
+            "value": "heart disease, high blood pressure, heart rhythm disorders, angina, vascular diseases"
+        }
+    ],
+    "field_health_service_api_id": [
+        {
+            "value": "cardiology"
+        }
+    ],
+    "field_owner": [
+        {
+            "target_type": "taxonomy_term",
+            "target_uuid": "0e30e74c-76b9-4c25-aa12-745086f02e37"
+        }
+    ],
+    "field_vha_healthservice_stopcode": []
+}


### PR DESCRIPTION
## Description
Herein lies the (mostly "useless") test data for https://github.com/department-of-veterans-affairs/vets-website/pull/11584.

If anybody has a better idea than adding 30k+ of JSON files when most of them will end up being unused because of reasons, I'm all :ear: & :eyes: 

The only way I can think of to get around this involves hooking up the entity expansion logic into the transformers. Even then, I don't think that would work, because if we called a `loadAndTransform(entity.childEntityReference)` from a transformer, it would still run the normal transformer on the child entity, which would in turn still load up all the same entities. We'd need to have some kind of separate logic in the transformer that said like, "If the parent is [this], then only return [this]. Otherwise, return [all this]." And that's gross.