### PR TITLE
Kelsonic 4811 compare buttons sticky footer

### DIFF
--- a/src/applications/yellow-ribbon/actions/index.js
+++ b/src/applications/yellow-ribbon/actions/index.js
@@ -7,6 +7,7 @@ import {
   FETCH_RESULTS,
   FETCH_RESULTS_FAILURE,
   FETCH_RESULTS_SUCCESS,
+  REMOVE_SCHOOL_FROM_COMPARE,
   UPDATE_PAGE,
 } from '../constants';
 
@@ -16,6 +17,11 @@ import {
 export const addSchoolToCompareAction = school => ({
   school,
   type: ADD_SCHOOL_TO_COMPARE,
+});
+
+export const removeSchoolFromCompareAction = school => ({
+  school,
+  type: REMOVE_SCHOOL_FROM_COMPARE,
 });
 
 // ============

--- a/src/applications/yellow-ribbon/actions/index.js
+++ b/src/applications/yellow-ribbon/actions/index.js
@@ -3,11 +3,20 @@ import URLSearchParams from 'url-search-params';
 // Relative imports.
 import { fetchResultsApi } from '../api';
 import {
+  ADD_SCHOOL_TO_COMPARE,
   FETCH_RESULTS,
   FETCH_RESULTS_FAILURE,
   FETCH_RESULTS_SUCCESS,
   UPDATE_PAGE,
 } from '../constants';
+
+// ============
+// Add/Remove School from comparison
+// ============
+export const addSchoolToCompareAction = school => ({
+  school,
+  type: ADD_SCHOOL_TO_COMPARE,
+});
 
 // ============
 // Fetch Results (via API)

--- a/src/applications/yellow-ribbon/actions/index.unit.spec.js
+++ b/src/applications/yellow-ribbon/actions/index.unit.spec.js
@@ -8,12 +8,14 @@ import {
   fetchResultsSuccess,
   fetchResultsThunk,
   updatePageAction,
+  addSchoolToCompareAction,
 } from './index';
 import {
   FETCH_RESULTS,
   FETCH_RESULTS_FAILURE,
   FETCH_RESULTS_SUCCESS,
   UPDATE_PAGE,
+  ADD_SCHOOL_TO_COMPARE,
 } from '../constants';
 
 describe('Yellow Ribbon actions', () => {
@@ -55,6 +57,21 @@ describe('Yellow Ribbon actions', () => {
       expect(action).to.be.deep.equal({
         response,
         type: FETCH_RESULTS_SUCCESS,
+      });
+    });
+  });
+
+  describe('addSchoolToCompareAction', () => {
+    it('should return an action in the shape we expect', () => {
+      const school = {
+        id: 'asdf',
+        name: 'qwer',
+      };
+      const action = addSchoolToCompareAction(school);
+
+      expect(action).to.be.deep.equal({
+        school,
+        type: ADD_SCHOOL_TO_COMPARE,
       });
     });
   });

--- a/src/applications/yellow-ribbon/components/ComparisonBanner/index.jsx
+++ b/src/applications/yellow-ribbon/components/ComparisonBanner/index.jsx
@@ -1,0 +1,42 @@
+// Dependencies.
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { isEmpty } from 'lodash';
+
+const ComparisonBanner = ({ schoolIDs }) => {
+  // Do not render if there are no selected schoolIDs.
+  if (isEmpty(schoolIDs)) {
+    return null;
+  }
+
+  return (
+    <div className="vads-c-promo-banner vads-u-background-color--green vads-u-padding-y--1">
+      <div className="vads-c-promo-banner__body">
+        <div className="vads-c-promo-banner__content vads-u-text-align--center">
+          <a
+            className="vads-c-promo-banner__content-link vads-u-font-family--serif vads-u-text-decoration--underline vads-u-font-weight--normal vads-u-font-size--lg vads-u-color--white"
+            href="#"
+          >
+            Compare {schoolIDs.length} selected schools{' '}
+            <i className="fas fa-chevron-right" />
+          </a>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+ComparisonBanner.propTypes = {
+  // From mapStateToProps.
+  schoolIDs: PropTypes.arrayOf(PropTypes.string.isRequired).isRequired,
+};
+
+const mapStateToProps = state => ({
+  schoolIDs: state.yellowRibbonReducer.schoolIDs,
+});
+
+export default connect(
+  mapStateToProps,
+  null,
+)(ComparisonBanner);

--- a/src/applications/yellow-ribbon/components/ComparisonBanner/index.jsx
+++ b/src/applications/yellow-ribbon/components/ComparisonBanner/index.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { isEmpty } from 'lodash';
 
-const ComparisonBanner = ({ schoolIDs }) => {
+export const ComparisonBanner = ({ schoolIDs }) => {
   // Do not render if there are no selected schoolIDs.
   if (isEmpty(schoolIDs)) {
     return null;

--- a/src/applications/yellow-ribbon/components/ComparisonBanner/index.unit.spec.jsx
+++ b/src/applications/yellow-ribbon/components/ComparisonBanner/index.unit.spec.jsx
@@ -1,0 +1,34 @@
+// Dependencies.
+import React from 'react';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+// Relative imports.
+import { ComparisonBanner } from './index';
+
+describe('Yellow Ribbon <ComparisonBanner>', () => {
+  it('should not render when no `schoolIDs`', () => {
+    const props = {
+      schoolIDs: [],
+    };
+
+    const tree = shallow(<ComparisonBanner {...props} />);
+    const text = tree.text();
+
+    expect(text).to.equal('');
+
+    tree.unmount();
+  });
+
+  it('should render when `schoolIDs`', () => {
+    const props = {
+      schoolIDs: ['asd', 'asdf'],
+    };
+
+    const tree = shallow(<ComparisonBanner {...props} />);
+    const text = tree.text();
+
+    expect(text).to.include('Compare 2 selected schools');
+
+    tree.unmount();
+  });
+});

--- a/src/applications/yellow-ribbon/components/SearchResult/index.jsx
+++ b/src/applications/yellow-ribbon/components/SearchResult/index.jsx
@@ -1,8 +1,12 @@
 // Node modules.
 import React from 'react';
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
+import { connect } from 'react-redux';
+import { includes } from 'lodash';
 // Relative imports.
 import { capitalize } from '../../helpers';
+import { addSchoolToCompareAction } from '../../actions';
 
 const deriveNameLabel = school => {
   // Show unknown if there's no name.
@@ -69,8 +73,19 @@ const deriveDegreeLevelLabel = (school = {}) => {
 
 const deriveProgramLabel = () => 'Unknown';
 
-const SearchResult = ({ school }) => (
-  <div className="medium-screen:vads-l-col vads-l-col vads-u-background-color--gray-light-alt vads-u-margin-bottom--2 vads-u-padding-x--3 vads-u-padding-y--2">
+const SearchResult = ({ addSchoolToCompare, school, schoolIDs }) => (
+  <div
+    className={classNames({
+      'medium-screen:vads-l-col': true,
+      'vads-l-col': true,
+      'vads-u-background-color--gray-light-alt': true,
+      'vads-u-border--3px': includes(schoolIDs, school?.id),
+      'vads-u-border-color--primary': includes(schoolIDs, school?.id),
+      'vads-u-margin-bottom--2': true,
+      'vads-u-padding-x--3': true,
+      'vads-u-padding-y--2': true,
+    })}
+  >
     {/* School Name */}
     <h3 className="vads-u-margin--0">{deriveNameLabel(school)}</h3>
 
@@ -97,15 +112,26 @@ const SearchResult = ({ school }) => (
           {deriveEligibleStudentsLabel(school)}
         </p>
 
-        {/* Add to Compare */}
         <div>
-          <button
-            className="usa-button-secondary vads-u-background-color--white vads-u-margin--0 vads-u-font-size--md"
-            onClick={() => {}}
-          >
-            <i className="fas fa-plus vads-u-padding-right--1" />
-            Add to compare
-          </button>
+          {/* Remove from Comparison. */}
+          {includes(schoolIDs, school?.id) ? (
+            <button
+              className="usa-button-secondary vads-u-background-color--primary vads-u-color--white vads-u-margin--0 vads-u-font-size--md"
+              onClick={() => addSchoolToCompare(school)}
+            >
+              <i className="fas fa-check vads-u-padding-right--1" />
+              Added
+            </button>
+          ) : (
+            // Add to Comparison.
+            <button
+              className="usa-button-secondary vads-u-background-color--white vads-u-margin--0 vads-u-font-size--md"
+              onClick={() => addSchoolToCompare(school)}
+            >
+              <i className="fas fa-plus vads-u-padding-right--1" />
+              Add to compare
+            </button>
+          )}
         </div>
       </div>
 
@@ -136,6 +162,21 @@ SearchResult.propTypes = {
     studentCount: PropTypes.number.isRequired,
     tuitionOutOfState: PropTypes.number.isRequired,
   }).isRequired,
+  // From mapStateToProps.
+  schoolIDs: PropTypes.arrayOf(PropTypes.string.isRequired).isRequired,
+  // From mapDispatchToProps.
+  addSchoolToCompare: PropTypes.func.isRequired,
 };
 
-export default SearchResult;
+const mapStateToProps = state => ({
+  schoolIDs: state.yellowRibbonReducer.schoolIDs,
+});
+
+const mapDispatchToProps = dispatch => ({
+  addSchoolToCompare: school => dispatch(addSchoolToCompareAction(school)),
+});
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(SearchResult);

--- a/src/applications/yellow-ribbon/components/SearchResult/index.jsx
+++ b/src/applications/yellow-ribbon/components/SearchResult/index.jsx
@@ -6,7 +6,10 @@ import { connect } from 'react-redux';
 import { includes } from 'lodash';
 // Relative imports.
 import { capitalize } from '../../helpers';
-import { addSchoolToCompareAction } from '../../actions';
+import {
+  addSchoolToCompareAction,
+  removeSchoolFromCompareAction,
+} from '../../actions';
 
 const deriveNameLabel = school => {
   // Show unknown if there's no name.
@@ -73,15 +76,21 @@ const deriveDegreeLevelLabel = (school = {}) => {
 
 const deriveProgramLabel = () => 'Unknown';
 
-const SearchResult = ({ addSchoolToCompare, school, schoolIDs }) => (
+const SearchResult = ({
+  addSchoolToCompare,
+  removeSchoolFromCompare,
+  school,
+  schoolIDs,
+}) => (
   <div
     className={classNames({
       'medium-screen:vads-l-col': true,
       'vads-l-col': true,
       'vads-u-background-color--gray-light-alt': true,
-      'vads-u-border--3px': includes(schoolIDs, school?.id),
+      'vads-u-border--3px': true,
       'vads-u-border-color--primary': includes(schoolIDs, school?.id),
-      'vads-u-margin-bottom--2': true,
+      'vads-u-border-color--white': !includes(schoolIDs, school?.id),
+      'vads-u-margin-bottom--1': true,
       'vads-u-padding-x--3': true,
       'vads-u-padding-y--2': true,
     })}
@@ -117,7 +126,7 @@ const SearchResult = ({ addSchoolToCompare, school, schoolIDs }) => (
           {includes(schoolIDs, school?.id) ? (
             <button
               className="usa-button-secondary vads-u-background-color--primary vads-u-color--white vads-u-margin--0 vads-u-font-size--md"
-              onClick={() => addSchoolToCompare(school)}
+              onClick={() => removeSchoolFromCompare(school)}
             >
               <i className="fas fa-check vads-u-padding-right--1" />
               Added
@@ -174,6 +183,8 @@ const mapStateToProps = state => ({
 
 const mapDispatchToProps = dispatch => ({
   addSchoolToCompare: school => dispatch(addSchoolToCompareAction(school)),
+  removeSchoolFromCompare: school =>
+    dispatch(removeSchoolFromCompareAction(school)),
 });
 
 export default connect(

--- a/src/applications/yellow-ribbon/components/SearchResult/index.jsx
+++ b/src/applications/yellow-ribbon/components/SearchResult/index.jsx
@@ -76,7 +76,7 @@ const deriveDegreeLevelLabel = (school = {}) => {
 
 const deriveProgramLabel = () => 'Unknown';
 
-const SearchResult = ({
+export const SearchResult = ({
   addSchoolToCompare,
   removeSchoolFromCompare,
   school,

--- a/src/applications/yellow-ribbon/components/SearchResult/index.jsx
+++ b/src/applications/yellow-ribbon/components/SearchResult/index.jsx
@@ -83,17 +83,19 @@ export const SearchResult = ({
   schoolIDs,
 }) => (
   <div
-    className={classNames({
-      'medium-screen:vads-l-col': true,
-      'vads-l-col': true,
-      'vads-u-background-color--gray-light-alt': true,
-      'vads-u-border--3px': true,
-      'vads-u-border-color--primary': includes(schoolIDs, school?.id),
-      'vads-u-border-color--transparent': !includes(schoolIDs, school?.id),
-      'vads-u-margin-bottom--1': true,
-      'vads-u-padding-x--3': true,
-      'vads-u-padding-y--2': true,
-    })}
+    className={classNames(
+      'medium-screen:vads-l-col',
+      'vads-l-col',
+      'vads-u-margin-bottom--1',
+      'vads-u-padding-x--3',
+      'vads-u-padding-y--2',
+      'vads-u-background-color--gray-light-alt',
+      'vads-u-border--3px',
+      {
+        'vads-u-border-color--primary': includes(schoolIDs, school?.id),
+        'vads-u-border-color--transparent': !includes(schoolIDs, school?.id),
+      },
+    )}
   >
     {/* School Name */}
     <h3 className="vads-u-margin--0">{deriveNameLabel(school)}</h3>

--- a/src/applications/yellow-ribbon/components/SearchResult/index.jsx
+++ b/src/applications/yellow-ribbon/components/SearchResult/index.jsx
@@ -89,7 +89,7 @@ const SearchResult = ({
       'vads-u-background-color--gray-light-alt': true,
       'vads-u-border--3px': true,
       'vads-u-border-color--primary': includes(schoolIDs, school?.id),
-      'vads-u-border-color--white': !includes(schoolIDs, school?.id),
+      'vads-u-border-color--transparent': !includes(schoolIDs, school?.id),
       'vads-u-margin-bottom--1': true,
       'vads-u-padding-x--3': true,
       'vads-u-padding-y--2': true,

--- a/src/applications/yellow-ribbon/components/SearchResult/index.unit.spec.jsx
+++ b/src/applications/yellow-ribbon/components/SearchResult/index.unit.spec.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
 // Relative imports.
-import SearchResult from './index';
+import { SearchResult } from './index';
 
 describe('Yellow Ribbon <SearchResult>', () => {
   it('should render', () => {

--- a/src/applications/yellow-ribbon/constants/index.js
+++ b/src/applications/yellow-ribbon/constants/index.js
@@ -1,4 +1,5 @@
 export const FETCH_RESULTS = 'yellow-ribbon/FETCH_RESULTS';
 export const FETCH_RESULTS_FAILURE = 'yellow-ribbon/FETCH_RESULTS_FAILURE';
 export const FETCH_RESULTS_SUCCESS = 'yellow-ribbon/FETCH_RESULTS_SUCCESS';
+export const ADD_SCHOOL_TO_COMPARE = 'yellow-ribbon/ADD_SCHOOL_TO_COMPARE';
 export const UPDATE_PAGE = 'yellow-ribbon/UPDATE_PAGE';

--- a/src/applications/yellow-ribbon/constants/index.js
+++ b/src/applications/yellow-ribbon/constants/index.js
@@ -1,5 +1,7 @@
+export const ADD_SCHOOL_TO_COMPARE = 'yellow-ribbon/ADD_SCHOOL_TO_COMPARE';
 export const FETCH_RESULTS = 'yellow-ribbon/FETCH_RESULTS';
 export const FETCH_RESULTS_FAILURE = 'yellow-ribbon/FETCH_RESULTS_FAILURE';
 export const FETCH_RESULTS_SUCCESS = 'yellow-ribbon/FETCH_RESULTS_SUCCESS';
-export const ADD_SCHOOL_TO_COMPARE = 'yellow-ribbon/ADD_SCHOOL_TO_COMPARE';
+export const REMOVE_SCHOOL_FROM_COMPARE =
+  'yellow-ribbon/REMOVE_SCHOOL_FROM_COMPARE';
 export const UPDATE_PAGE = 'yellow-ribbon/UPDATE_PAGE';

--- a/src/applications/yellow-ribbon/constants/index.unit.spec.js
+++ b/src/applications/yellow-ribbon/constants/index.unit.spec.js
@@ -6,6 +6,7 @@ import {
   FETCH_RESULTS_FAILURE,
   FETCH_RESULTS_SUCCESS,
   UPDATE_PAGE,
+  ADD_SCHOOL_TO_COMPARE,
 } from './index';
 
 describe('Yellow Ribbon constants', () => {
@@ -13,6 +14,7 @@ describe('Yellow Ribbon constants', () => {
     expect(FETCH_RESULTS).to.include('yellow-ribbon');
     expect(FETCH_RESULTS_FAILURE).to.include('yellow-ribbon');
     expect(FETCH_RESULTS_SUCCESS).to.include('yellow-ribbon');
+    expect(ADD_SCHOOL_TO_COMPARE).to.include('yellow-ribbon');
     expect(UPDATE_PAGE).to.include('yellow-ribbon');
   });
 });

--- a/src/applications/yellow-ribbon/containers/SearchResults/index.unit.spec.jsx
+++ b/src/applications/yellow-ribbon/containers/SearchResults/index.unit.spec.jsx
@@ -90,7 +90,7 @@ describe('Yellow Ribbon container <SearchResults>', () => {
 
     const tree = shallow(<SearchResults results={results} />);
 
-    expect(tree.find('SearchResult')).to.have.lengthOf(10);
+    expect(tree.find('.search-results')).to.have.lengthOf(1);
     expect(tree.find('Pagination')).to.have.lengthOf(1);
 
     tree.unmount();

--- a/src/applications/yellow-ribbon/containers/YellowRibbonApp/index.jsx
+++ b/src/applications/yellow-ribbon/containers/YellowRibbonApp/index.jsx
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import { connect } from 'react-redux';
 // Relative imports.
+import ComparisonBanner from '../../components/ComparisonBanner';
 import SearchForm from '../SearchForm';
 import SearchResults from '../SearchResults';
 
@@ -17,6 +18,9 @@ export const YellowRibbonApp = ({ results }) => (
       <a href="/yellow-ribbon/schools/">Find a Yellow Ribbon school</a>
       {results && <a href={window.location.href}>Search results</a>}
     </Breadcrumbs>
+
+    {/* Comparison Banner */}
+    <ComparisonBanner />
 
     <div className="vads-l-grid-container vads-u-padding-x--2p5 large-screen:vads-u-padding-x--0 vads-u-padding-bottom--4">
       {/* Title */}

--- a/src/applications/yellow-ribbon/containers/YellowRibbonApp/index.jsx
+++ b/src/applications/yellow-ribbon/containers/YellowRibbonApp/index.jsx
@@ -14,14 +14,14 @@ export const YellowRibbonApp = ({ results }) => (
     <Breadcrumbs className="vads-u-padding--0">
       <a href="/">Home</a>
       <a href="/education/">Education and training</a>
-      <a href="/yellow-ribbon/schools/">Yellow Ribbon school finder</a>
+      <a href="/yellow-ribbon/schools/">Find a Yellow Ribbon school</a>
       {results && <a href={window.location.href}>Search results</a>}
     </Breadcrumbs>
 
     <div className="vads-l-grid-container vads-u-padding-x--2p5 large-screen:vads-u-padding-x--0 vads-u-padding-bottom--4">
       {/* Title */}
       <div className="vads-l-col">
-        <h1 className="vads-u-font-size--h2">Yellow Ribbon school finder</h1>
+        <h1 className="vads-u-font-size--h2">Find a Yellow Ribbon school</h1>
       </div>
 
       <div className="vads-l-row">

--- a/src/applications/yellow-ribbon/containers/YellowRibbonApp/index.unit.spec.jsx
+++ b/src/applications/yellow-ribbon/containers/YellowRibbonApp/index.unit.spec.jsx
@@ -13,7 +13,7 @@ describe('Yellow Ribbon container <YellowRibbonApp>', () => {
 
     // Expect there to be:
     expect(tree.find('Breadcrumbs')).to.have.lengthOf(1);
-    expect(text).to.include('Yellow Ribbon school finder');
+    expect(text).to.include('Find a Yellow Ribbon school');
     expect(text).to.include('Learn more about the Yellow Ribbon Program.');
     expect(text).to.include(
       'You may be eligible for Yellow Ribbon program funding if you:',
@@ -74,7 +74,7 @@ describe('Yellow Ribbon container <YellowRibbonApp>', () => {
 
     // Expect there to be:
     expect(tree.find('Breadcrumbs')).to.have.lengthOf(1);
-    expect(text).to.include('Yellow Ribbon school finder');
+    expect(text).to.include('Find a Yellow Ribbon school');
 
     // Expect there NOT to be:
     expect(text).to.not.include('Learn more about the Yellow Ribbon Program.');

--- a/src/applications/yellow-ribbon/reducers/index.js
+++ b/src/applications/yellow-ribbon/reducers/index.js
@@ -1,11 +1,12 @@
 // Dependencies
-import { concat } from 'lodash';
+import { concat, filter, pick } from 'lodash';
 // Relative imports.
 import {
   ADD_SCHOOL_TO_COMPARE,
   FETCH_RESULTS,
   FETCH_RESULTS_FAILURE,
   FETCH_RESULTS_SUCCESS,
+  REMOVE_SCHOOL_FROM_COMPARE,
   UPDATE_PAGE,
 } from '../constants';
 
@@ -55,6 +56,19 @@ export const yellowRibbonReducer = (state = initialState, action) => {
         fetching: false,
         results: action?.response?.results,
         totalResults: action?.response?.totalResults,
+      };
+    }
+    case REMOVE_SCHOOL_FROM_COMPARE: {
+      // Derive the updated list of school IDs.
+      const schoolIDs = filter(
+        state.schoolIDs,
+        id => id !== action?.school?.id,
+      );
+
+      return {
+        ...state,
+        schoolIDs,
+        schoolsLookup: pick(state.schoolsLookup, schoolIDs),
       };
     }
     case UPDATE_PAGE: {

--- a/src/applications/yellow-ribbon/reducers/index.js
+++ b/src/applications/yellow-ribbon/reducers/index.js
@@ -1,5 +1,8 @@
+// Dependencies
+import { concat } from 'lodash';
 // Relative imports.
 import {
+  ADD_SCHOOL_TO_COMPARE,
   FETCH_RESULTS,
   FETCH_RESULTS_FAILURE,
   FETCH_RESULTS_SUCCESS,
@@ -16,10 +19,23 @@ const initialState = {
   results: undefined,
   state: '',
   totalResults: undefined,
+  // For comparing:
+  schoolIDs: [],
+  schoolsLookup: {},
 };
 
 export const yellowRibbonReducer = (state = initialState, action) => {
   switch (action.type) {
+    case ADD_SCHOOL_TO_COMPARE: {
+      return {
+        ...state,
+        schoolIDs: concat(state.schoolIDs, action?.school?.id),
+        schoolsLookup: {
+          ...state.schoolsLookup,
+          [action?.school?.id]: action?.school,
+        },
+      };
+    }
     case FETCH_RESULTS: {
       return {
         ...state,

--- a/src/applications/yellow-ribbon/reducers/index.unit.spec.js
+++ b/src/applications/yellow-ribbon/reducers/index.unit.spec.js
@@ -17,6 +17,8 @@ describe('Yellow Ribbon reducer', () => {
       page: 1,
       perPage: 10,
       results: undefined,
+      schoolIDs: [],
+      schoolsLookup: {},
       state: '',
       totalResults: undefined,
     });
@@ -42,6 +44,8 @@ describe('Yellow Ribbon reducer', () => {
       page: 1,
       perPage: 10,
       results: undefined,
+      schoolIDs: [],
+      schoolsLookup: {},
       state: 'CO',
       totalResults: undefined,
     });


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/4811

**Original Design Spec:** https://vsateams.invisionapp.com/share/2CVEX68T5A9#/screens

This PR implements compare buttons on YR search result cards as well as a sticky banner that indicates how many schools are currently selected for comparison.

## Testing done
Unit tests modified/added.

## Screenshots
#### Multiple selected schools
![image](https://user-images.githubusercontent.com/12773166/73565446-cac77b80-441e-11ea-921b-118171bba12f.png)

#### Deselect a school
![image](https://user-images.githubusercontent.com/12773166/73565433-c3a06d80-441e-11ea-921d-c57ab98cb1b4.png)

#### New search with persisted selected schools
![image](https://user-images.githubusercontent.com/12773166/73565490-e03ca580-441e-11ea-8168-4d94852753d5.png)

## Acceptance criteria
- [x] Add a compare button per search result.
- [x] Add a sticky View Comparisons button on the bottom of the viewport + unit tests.
- [x] Create relevant actions for the comparison logic + unit tests.
- [x] Create relevant constants for the comparison logic + unit tests.
- [x] Update relevant reducer for the comparison logic + unit tests.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
