### PR TITLE
Make calendar link work in IE11

### DIFF
--- a/src/applications/vaos/components/AddToCalendar.jsx
+++ b/src/applications/vaos/components/AddToCalendar.jsx
@@ -6,21 +6,15 @@ import {
   generateICS,
 } from '../utils/appointment';
 
-function generateCalendarEntry(appointment, facility) {
+export default function AddToCalendar({ appointment, facility }) {
   const title = getAppointmentTypeHeader(appointment);
   const filename = `${title.replace(/\s/g, '_')}.ics`;
-
   const text = generateICS(appointment, facility);
 
-  return { text, filename };
-}
-
-export default function AddToCalendar({ appointment, facility }) {
   // IE11 doesn't support the download attribute, so this creates a button
   // and uses an ms blob save api
   if (window.navigator.msSaveOrOpenBlob) {
     const onClick = () => {
-      const { text, filename } = generateCalendarEntry(appointment, facility);
       const blob = new Blob([text], { type: 'text/calendar;charset=utf-8;' });
       window.navigator.msSaveOrOpenBlob(blob, filename);
     };
@@ -36,11 +30,9 @@ export default function AddToCalendar({ appointment, facility }) {
     );
   }
 
-  const { text, filename } = generateCalendarEntry(appointment, facility);
-
   return (
     <a
-      href={`data:text/calendar;charset=utf8,${encodeURIComponent(text)}`}
+      href={`data:text/calendar;charset=utf-8,${encodeURIComponent(text)}`}
       download={filename}
       aria-label={`Add to calendar on ${getAppointmentDate(appointment)}`}
       className="va-button-link vads-u-margin-right--4 vads-u-flex--0"

--- a/src/applications/vaos/components/AddToCalendar.jsx
+++ b/src/applications/vaos/components/AddToCalendar.jsx
@@ -6,23 +6,46 @@ import {
   generateICS,
 } from '../utils/appointment';
 
-export default class AddToCalendar extends React.Component {
-  render() {
-    const { appointment, facility } = this.props;
+function generateCalendarEntry(appointment, facility) {
+  const title = getAppointmentTypeHeader(appointment);
+  const filename = `${title.replace(/\s/g, '_')}.ics`;
 
-    const title = getAppointmentTypeHeader(appointment);
-    const filename = `${title.replace(/\s/g, '_')}.ics`;
+  const text = generateICS(appointment, facility);
 
-    const text = generateICS(appointment, facility);
+  return { text, filename };
+}
+
+export default function AddToCalendar({ appointment, facility }) {
+  // IE11 doesn't support the download attribute, so this creates a button
+  // and uses an ms blob save api
+  if (window.navigator.msSaveOrOpenBlob) {
+    const onClick = () => {
+      const { text, filename } = generateCalendarEntry(appointment, facility);
+      const blob = new Blob([text], { type: 'text/calendar;charset=utf-8;' });
+      window.navigator.msSaveOrOpenBlob(blob, filename);
+    };
+
     return (
-      <a
-        href={`data:text/calendar;charset=utf8,${encodeURIComponent(text)}`}
-        download={filename}
+      <button
+        onClick={onClick}
         aria-label={`Add to calendar on ${getAppointmentDate(appointment)}`}
-        className="va-button-link  vads-u-margin-right--4 vads-u-flex--0"
+        className="va-button-link vads-u-margin-right--4 vads-u-flex--0"
       >
         Add to calendar
-      </a>
+      </button>
     );
   }
+
+  const { text, filename } = generateCalendarEntry(appointment, facility);
+
+  return (
+    <a
+      href={`data:text/calendar;charset=utf8,${encodeURIComponent(text)}`}
+      download={filename}
+      aria-label={`Add to calendar on ${getAppointmentDate(appointment)}`}
+      className="va-button-link vads-u-margin-right--4 vads-u-flex--0"
+    >
+      Add to calendar
+    </a>
+  );
 }

--- a/src/applications/vaos/containers/VAOSApp.jsx
+++ b/src/applications/vaos/containers/VAOSApp.jsx
@@ -55,14 +55,7 @@ export class VAOSApp extends React.Component {
     }
 
     return (
-      <RequiredLoginView
-        authRequired={1}
-        serviceRequired={[
-          backendServices.USER_PROFILE,
-          backendServices.FACILITIES,
-        ]}
-        user={user}
-      >
+      <>
         {loadingFeatureToggles && (
           <div className="vads-l-grid-container vads-u-padding-x--2p5 large-screen:vads-u-padding-x--0 vads-u-padding-bottom--2p5">
             <div className="vads-l-row">
@@ -82,7 +75,7 @@ export class VAOSApp extends React.Component {
             </DowntimeNotification>
           )}
         {!loadingFeatureToggles && !showApplication && <AppUnavailable />}
-      </RequiredLoginView>
+      </>
     );
   }
 }

--- a/src/applications/vaos/containers/VAOSApp.jsx
+++ b/src/applications/vaos/containers/VAOSApp.jsx
@@ -55,7 +55,14 @@ export class VAOSApp extends React.Component {
     }
 
     return (
-      <>
+      <RequiredLoginView
+        authRequired={1}
+        serviceRequired={[
+          backendServices.USER_PROFILE,
+          backendServices.FACILITIES,
+        ]}
+        user={user}
+      >
         {loadingFeatureToggles && (
           <div className="vads-l-grid-container vads-u-padding-x--2p5 large-screen:vads-u-padding-x--0 vads-u-padding-bottom--2p5">
             <div className="vads-l-row">
@@ -75,7 +82,7 @@ export class VAOSApp extends React.Component {
             </DowntimeNotification>
           )}
         {!loadingFeatureToggles && !showApplication && <AppUnavailable />}
-      </>
+      </RequiredLoginView>
     );
   }
 }

--- a/src/applications/vaos/tests/components/AddToCalendar.unit.spec.jsx
+++ b/src/applications/vaos/tests/components/AddToCalendar.unit.spec.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { expect } from 'chai';
+import sinon from 'sinon';
 import { shallow } from 'enzyme';
 import moment from '../../utils/moment-tz';
 
@@ -163,6 +164,39 @@ describe('VAOS <AddToCalendar>', () => {
 
     it('should have an aria label', () => {
       expect(link.props()['aria-label']).to.equal(
+        `Add to calendar on ${moment(now).format('MMMM D, YYYY')}`,
+      );
+    });
+
+    tree.unmount();
+  });
+
+  describe('Add appointment request to calendar in IE', () => {
+    Object.defineProperty(window.navigator, 'msSaveOrOpenBlob', {
+      value: sinon.spy(),
+    });
+    const tree = shallow(
+      <AddToCalendar appointment={vaAppointmentRequest} facility={facility} />,
+    );
+
+    const button = tree.find('button');
+
+    it('should render', () => {
+      expect(button.exists()).to.be.true;
+    });
+
+    it('should download ICS file on click', async () => {
+      Object.defineProperty(window.navigator, 'msSaveOrOpenBlob', {
+        value: sinon.spy(),
+      });
+      button.props().onClick();
+      const filename = window.navigator.msSaveOrOpenBlob.firstCall.args[1];
+      expect(window.navigator.msSaveOrOpenBlob.called).to.be.true;
+      expect(filename).to.equal('VA_Appointment.ics');
+    });
+
+    it('should have an aria label', () => {
+      expect(button.props()['aria-label']).to.equal(
         `Add to calendar on ${moment(now).format('MMMM D, YYYY')}`,
       );
     });

--- a/src/applications/vaos/tests/components/AddToCalendar.unit.spec.jsx
+++ b/src/applications/vaos/tests/components/AddToCalendar.unit.spec.jsx
@@ -172,6 +172,7 @@ describe('VAOS <AddToCalendar>', () => {
   });
 
   describe('Add appointment request to calendar in IE', () => {
+    const oldValue = window.navigator.msSaveOrOpenBlob;
     Object.defineProperty(window.navigator, 'msSaveOrOpenBlob', {
       value: sinon.spy(),
     });
@@ -202,5 +203,8 @@ describe('VAOS <AddToCalendar>', () => {
     });
 
     tree.unmount();
+    Object.defineProperty(window.navigator, 'msSaveOrOpenBlob', {
+      value: oldValue,
+    });
   });
 });

--- a/src/applications/vaos/tests/components/AddToCalendar.unit.spec.jsx
+++ b/src/applications/vaos/tests/components/AddToCalendar.unit.spec.jsx
@@ -175,6 +175,7 @@ describe('VAOS <AddToCalendar>', () => {
     const oldValue = window.navigator.msSaveOrOpenBlob;
     Object.defineProperty(window.navigator, 'msSaveOrOpenBlob', {
       value: sinon.spy(),
+      writable: true,
     });
     const tree = shallow(
       <AddToCalendar appointment={vaAppointmentRequest} facility={facility} />,
@@ -205,6 +206,7 @@ describe('VAOS <AddToCalendar>', () => {
     tree.unmount();
     Object.defineProperty(window.navigator, 'msSaveOrOpenBlob', {
       value: oldValue,
+      writable: true,
     });
   });
 });


### PR DESCRIPTION
## Description
IE11 doesn't support the download attribute, so we need to use a browser specific blob save method.

## Testing done
Local and IE testing

## Acceptance criteria
- [ ] ICS file saves in IE11

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
