### PR TITLE
Don't show "Practice in" text if data doesn't exist

### DIFF
--- a/src/applications/vaos/components/review/PreferredProviderSection.jsx
+++ b/src/applications/vaos/components/review/PreferredProviderSection.jsx
@@ -24,8 +24,12 @@ export default function PreferredProviderSection(props) {
             </div>
           </div>
           <span>
-            {props.data.communityCareProvider.practiceName}
-            <br />
+            {!!props.data.communityCareProvider.practiceName && (
+              <>
+                {props.data.communityCareProvider.practiceName}
+                <br />
+              </>
+            )}
             {props.data.communityCareProvider.firstName} &nbsp;
             {props.data.communityCareProvider.lastName}
             <br />
@@ -36,6 +40,11 @@ export default function PreferredProviderSection(props) {
             {props.data.communityCareProvider.address.city}, &nbsp;
             {props.data.communityCareProvider.address.state} &nbsp;
             {props.data.communityCareProvider.address.postalCode}
+            <br />
+            <br />
+            {props.vaCityState && (
+              <>Closest VA health system: {props.vaCityState}</>
+            )}
           </span>
         </>
       )}
@@ -67,7 +76,9 @@ export default function PreferredProviderSection(props) {
               )?.value
             }
             <br />
-            Practice in {props.vaCityState}
+            {props.vaCityState && (
+              <>Closest VA health system: {props.vaCityState}</>
+            )}
           </span>
         </>
       )}


### PR DESCRIPTION
## Description
We're showing some label text when there's no actual data for it to display. I've made sure it's hidden when there's no data and also updated the text to be more accurate.

## Testing done
Local testing

## Screenshots
![Screen Shot 2020-02-03 at 10 26 52 AM](https://user-images.githubusercontent.com/634932/73665939-fee5ab00-466f-11ea-8144-07ed93219e39.png)


## Acceptance criteria
- [x] No hanging "Practice in" text

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
