### PR TITLE
Add updateUiSchema form system helper

### DIFF
--- a/src/platform/forms-system/src/js/state/helpers.js
+++ b/src/platform/forms-system/src/js/state/helpers.js
@@ -349,6 +349,53 @@ export function updateSchemaFromUiSchema(
   return currentSchema;
 }
 
+/**
+ * A helper that returns a new uiSchema based on the input uiSchema and formData
+ * @param {Object} uiSchema - The uiSchema to update
+ * @param {Object} formData - The form data to based uiSchema updates on
+ * @returns {Object} The new uiSchema object
+ */
+export function updateUiSchema(uiSchema, formData) {
+  let currentUiSchema = uiSchema;
+
+  if (typeof currentUiSchema === 'object') {
+    const newUiSchema = Object.keys(currentUiSchema).reduce((current, next) => {
+      const nextProp = updateUiSchema(current[next], formData);
+
+      if (current[next] !== nextProp) {
+        return { ...current, [next]: nextProp };
+      }
+
+      return current;
+    }, currentUiSchema);
+
+    if (newUiSchema !== uiSchema) {
+      currentUiSchema = newUiSchema;
+    }
+  }
+
+  const uiSchemaUpdater = uiSchema['ui:options']?.updateUiSchema;
+
+  if (!uiSchemaUpdater) {
+    return currentUiSchema;
+  }
+
+  const newUiSchemaProps = uiSchemaUpdater(formData);
+
+  const updatedUiSchema = Object.keys(newUiSchemaProps).reduce(
+    (current, next) => {
+      if (newUiSchemaProps[next] !== uiSchema[next]) {
+        return { ...current, [next]: newUiSchemaProps[next] };
+      }
+
+      return current;
+    },
+    uiSchema,
+  );
+
+  return updatedUiSchema;
+}
+
 export function replaceRefSchemas(schema, definitions, path = '') {
   // this can happen if you import a field that doesn’t exist from a schema
   if (!schema) {

--- a/src/platform/forms-system/test/js/state/helpers.unit.spec.js
+++ b/src/platform/forms-system/test/js/state/helpers.unit.spec.js
@@ -1,10 +1,12 @@
 import { expect } from 'chai';
+import sinon from 'sinon';
 
 import {
   updateRequiredFields,
   setHiddenFields,
   removeHiddenData,
   updateSchemaFromUiSchema,
+  updateUiSchema,
   updateItemsSchema,
   replaceRefSchemas,
 } from '../../../src/js/state/helpers';
@@ -411,6 +413,52 @@ describe('Schemaform formState:', () => {
       expect(newData[0]).to.eql({ field: 'test' });
     });
   });
+  describe('updateUiSchema', () => {
+    describe('if no updateUiSchema are set', () => {
+      it('should return the input uiSchema', () => {
+        const data = {
+          first: 'Pat',
+        };
+        const uiSchema = {
+          first: {
+            'ui:title': 'First Name',
+          },
+        };
+        const newUiSchema = updateUiSchema(uiSchema, data);
+        expect(newUiSchema).to.deep.equal(uiSchema);
+      });
+    });
+    describe('if a ui:options.updateUiSchema is set', () => {
+      const updateUiSchemaStub = sinon
+        .stub()
+        .callsFake(() => ({ 'ui:title': 'FIRST NAME' }));
+      const data = {
+        first: 'Pat',
+      };
+      const uiSchema = {
+        first: {
+          'ui:title': 'First Name',
+          'ui:options': {
+            updateUiSchema: updateUiSchemaStub,
+          },
+        },
+      };
+      let newUiSchema;
+      beforeEach(() => {
+        newUiSchema = updateUiSchema(uiSchema, data);
+      });
+      it('should call the updateUiSchema function', () => {
+        expect(updateUiSchemaStub.called).to.be.true;
+      });
+      it('should return the updated uiSchema', () => {
+        expect(newUiSchema.first['ui:title']).to.equal('FIRST NAME');
+        expect(newUiSchema.first['ui:options']).to.deep.equal({
+          updateUiSchema: updateUiSchemaStub,
+        });
+      });
+    });
+  });
+
   describe('updateSchemaFromUiSchema', () => {
     it('should update schema', () => {
       const schema = {


### PR DESCRIPTION
## Description
This helper allows you to update the uiSchema as the form data changes. It works just like the ui:options.updateSchema callback. I'm using this on the revised profile address form so that the country dropdown can be disabled when the user has selected that they live on a military base outside of the US. (Disabling is done via `ui:disabled` on the uiSchema)

GIF of an example using the new updateUiSchema handler to disable a select field:
![disable](https://user-images.githubusercontent.com/20728956/73680777-bdee9600-4671-11ea-836e-b77241d2eead.gif)

## Testing done
Local + new unit tests

## Acceptance criteria
- [ ] updating the uiSchema on the fly works
- [ ] it doesn't break anything else

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs