### PR TITLE
Show error on facility page when there's an error in eligibility services

### DIFF
--- a/src/applications/vaos/api/index.js
+++ b/src/applications/vaos/api/index.js
@@ -317,13 +317,14 @@ export function getAvailableClinics(facilityId, typeOfCareId, systemId) {
 export function getPacTeam(systemId) {
   let promise;
   if (USE_MOCK_DATA) {
-    if (systemId.includes('983')) {
-      promise = import('./pact.json').then(
-        module => (module.default ? module.default : module),
-      );
-    } else {
-      promise = Promise.resolve({ data: [] });
-    }
+    promise = Promise.reject();
+    // if (systemId.includes('983')) {
+    //   promise = import('./pact.json').then(
+    //     module => (module.default ? module.default : module),
+    //   );
+    // } else {
+    //   promise = Promise.resolve({ data: [] });
+    // }
   } else {
     promise = apiRequest(`/vaos/systems/${systemId}/pact`);
   }

--- a/src/applications/vaos/api/index.js
+++ b/src/applications/vaos/api/index.js
@@ -317,14 +317,13 @@ export function getAvailableClinics(facilityId, typeOfCareId, systemId) {
 export function getPacTeam(systemId) {
   let promise;
   if (USE_MOCK_DATA) {
-    promise = Promise.reject();
-    // if (systemId.includes('983')) {
-    //   promise = import('./pact.json').then(
-    //     module => (module.default ? module.default : module),
-    //   );
-    // } else {
-    //   promise = Promise.resolve({ data: [] });
-    // }
+    if (systemId.includes('983')) {
+      promise = import('./pact.json').then(
+        module => (module.default ? module.default : module),
+      );
+    } else {
+      promise = Promise.resolve({ data: [] });
+    }
   } else {
     promise = apiRequest(`/vaos/systems/${systemId}/pact`);
   }

--- a/src/applications/vaos/containers/VAFacilityPage.jsx
+++ b/src/applications/vaos/containers/VAFacilityPage.jsx
@@ -112,6 +112,7 @@ export class VAFacilityPage extends React.Component {
       facilityDetailsStatus,
       systemDetails,
       hasDataFetchingError,
+      hasEligibilityError,
     } = this.props;
 
     const notEligibleAtChosenFacility =
@@ -191,7 +192,10 @@ export class VAFacilityPage extends React.Component {
     }
 
     const disableSubmitButton =
-      loadingFacilities || noValidVAFacilities || notEligibleAtChosenFacility;
+      loadingFacilities ||
+      noValidVAFacilities ||
+      notEligibleAtChosenFacility ||
+      hasEligibilityError;
 
     return (
       <div>
@@ -224,6 +228,7 @@ export class VAFacilityPage extends React.Component {
             pageChangeInProgress={loadingEligibility || pageChangeInProgress}
           />
         </SchemaForm>
+        {hasEligibilityError && <ErrorMessage />}
       </div>
     );
   }

--- a/src/applications/vaos/containers/VAFacilityPage.jsx
+++ b/src/applications/vaos/containers/VAFacilityPage.jsx
@@ -222,13 +222,13 @@ export class VAFacilityPage extends React.Component {
               <EligibilityCheckMessage eligibility={eligibility} />
             </div>
           )}
+          {hasEligibilityError && <ErrorMessage />}
           <FormButtons
             onBack={this.goBack}
             disabled={disableSubmitButton}
             pageChangeInProgress={loadingEligibility || pageChangeInProgress}
           />
         </SchemaForm>
-        {hasEligibilityError && <ErrorMessage />}
       </div>
     );
   }

--- a/src/applications/vaos/tests/containers/VAFacilityPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/containers/VAFacilityPage.unit.spec.jsx
@@ -257,4 +257,37 @@ describe('VAOS <VAFacilityPage>', () => {
     expect(document.title).contain(pageTitle);
     form.unmount();
   });
+
+  it('should render data fetching error', () => {
+    const openFormPage = sinon.spy();
+    const form = shallow(
+      <VAFacilityPage
+        data={defaultData}
+        hasDataFetchingError
+        openFacilityPage={openFormPage}
+      />,
+    );
+
+    expect(form.find('LoadingIndicator').exists()).to.be.false;
+    expect(form.find('SchemaForm').exists()).to.be.false;
+    expect(form.find('ErrorMessage').exists()).to.be.true;
+    form.unmount();
+  });
+
+  it('should render eligibility error', () => {
+    const openFormPage = sinon.spy();
+    const form = shallow(
+      <VAFacilityPage
+        data={defaultData}
+        schema={defaultSchema}
+        hasEligibilityError
+        openFacilityPage={openFormPage}
+      />,
+    );
+
+    expect(form.find('LoadingIndicator').exists()).to.be.false;
+    expect(form.find('SchemaForm').exists()).to.be.true;
+    expect(form.find('ErrorMessage').exists()).to.be.true;
+    form.unmount();
+  });
 });

--- a/src/applications/vaos/tests/utils/selectors.unit.spec.js
+++ b/src/applications/vaos/tests/utils/selectors.unit.spec.js
@@ -100,6 +100,26 @@ describe('VAOS selectors', () => {
       expect(newState.typeOfCare).to.equal('Pharmacy');
       expect(newState.loadingSystems).to.be.true;
     });
+    it('should return eligibility error flag', () => {
+      const state = {
+        newAppointment: {
+          pages: {},
+          data: {
+            typeOfCareId: '160',
+            facilityType: 'vamc',
+            vaSystem: '983',
+          },
+          facilities: {},
+          eligibility: {},
+          systems: [{}],
+          facilityDetails: {},
+          eligibilityStatus: 'failed',
+        },
+      };
+
+      const newState = getFacilityPageInfo(state);
+      expect(newState.hasEligibilityError).to.be.true;
+    });
   });
 
   describe('getChosenFacilityInfo', () => {

--- a/src/applications/vaos/utils/selectors.js
+++ b/src/applications/vaos/utils/selectors.js
@@ -168,8 +168,9 @@ export function getFacilityPageInfo(state) {
     facilityDetailsStatus: newAppointment.facilityDetailsStatus,
     hasDataFetchingError:
       newAppointment.systemsStatus === FETCH_STATUS.failed ||
-      newAppointment.childFacilitiesStatus === FETCH_STATUS.failed ||
-      newAppointment.elibilityStatus === FETCH_STATUS.failed,
+      newAppointment.childFacilitiesStatus === FETCH_STATUS.failed,
+    hasEligibilityError:
+      newAppointment.eligibilityStatus === FETCH_STATUS.failed,
     typeOfCare: getTypeOfCare(data)?.name,
     systemDetails: newAppointment?.facilityDetails[data.vaSystem],
   };


### PR DESCRIPTION
## Description
We should be showing an error when there's a problem with the eligibility services, but we are not, due to a typo. I've fixed the typo and moved the message so that we don't yank all the info on the page away from the user when the checks fail.

## Testing done
Local testing

## Screenshots
![Screen Shot 2020-02-03 at 2 11 20 PM](https://user-images.githubusercontent.com/634932/73682934-52b3bc80-468f-11ea-9a85-40876e712097.png)


## Acceptance criteria
- [ ] Error message is displayed

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
