### PR TITLE
[Development] Change all references of "zip" to "postal"

### DIFF
--- a/src/applications/facility-locator/components/ResultsList.jsx
+++ b/src/applications/facility-locator/components/ResultsList.jsx
@@ -158,7 +158,8 @@ class ResultsList extends Component {
           ref={this.searchResultTitle}
         >
           No facilities found. Please try entering a different search term
-          (Street, City, State or Zip) and click search to find facilities.
+          (Street, City, State or Postal code) and click search to find
+          facilities.
         </div>
       );
     }

--- a/src/applications/facility-locator/components/SearchControls.jsx
+++ b/src/applications/facility-locator/components/SearchControls.jsx
@@ -128,7 +128,7 @@ class SearchControls extends Component {
                     htmlFor="street-city-state-zip"
                     id="street-city-state-zip-label"
                   >
-                    Search by city, state or ZIP Code
+                    Search by city, state or postal Code
                   </label>
                   <input
                     id="street-city-state-zip"
@@ -137,7 +137,7 @@ class SearchControls extends Component {
                     type="text"
                     onChange={this.handleQueryChange}
                     value={currentQuery.searchString}
-                    title="Your location: Street, City, State or Zip"
+                    title="Your location: Street, City, State or Postal code"
                     required
                   />
                 </div>

--- a/src/applications/facility-locator/manifest.json
+++ b/src/applications/facility-locator/manifest.json
@@ -6,7 +6,7 @@
   "template": {
     "title": "Find VA Locations",
     "layout": "page-react.html",
-    "description": "Find a VA medical center, clinic, hospital, national cemetery, or VA regional office near you. You can search by city, state, zip code, or service. You'll get wait times and directions.",
+    "description": "Find a VA medical center, clinic, hospital, national cemetery, or VA regional office near you. You can search by city, state, postal code, or service. You'll get wait times and directions.",
     "keywords": "VA location by zip code, VA clinic, VA near me"
   }
 }

--- a/src/applications/gi/components/profile/CalculatorForm.jsx
+++ b/src/applications/gi/components/profile/CalculatorForm.jsx
@@ -78,7 +78,7 @@ class CalculatorForm extends React.Component {
       this.isFullZipcode(event.value);
       this.setState({ invalidZip: '' });
     } else if (event.dirty && this.props.inputs.beneficiaryZIP.length < 5) {
-      this.setState({ invalidZip: 'Zip code must be a 5-digit number' });
+      this.setState({ invalidZip: 'Postal code must be a 5-digit number' });
     }
   };
 
@@ -661,8 +661,8 @@ class CalculatorForm extends React.Component {
 
       if (!inputs.classesOutsideUS) {
         const label = this.isCountryInternational()
-          ? "If you're taking classes in the U.S., enter the location's zip code"
-          : "Please enter the zip code where you'll take your classes";
+          ? "If you're taking classes in the U.S., enter the location's postal code"
+          : "Please enter the postal code where you'll take your classes";
 
         amountInput = (
           <div>
@@ -679,7 +679,7 @@ class CalculatorForm extends React.Component {
 
         zipcodeLocation = (
           <p aria-live="polite" aria-atomic="true">
-            <span className="sr-only">Your zip code is located in</span>
+            <span className="sr-only">Your postal code is located in</span>
             <strong>{inputs.housingAllowanceCity}</strong>
           </p>
         );

--- a/src/applications/gi/containers/Modals.jsx
+++ b/src/applications/gi/containers/Modals.jsx
@@ -169,8 +169,8 @@ export class Modals extends React.Component {
         <p>
           If you attend your training program in person, your housing stipend
           will be equal to the monthly military Basic Allowance for Housing
-          (BAH) for an E-5 with dependents. This is based on the zip code where
-          you attend your training.
+          (BAH) for an E-5 with dependents. This is based on the postal code
+          where you attend your training.
         </p>
         <p>
           If you participate in an online program, your stipend will be half of

--- a/src/applications/gi/reducers/calculator.js
+++ b/src/applications/gi/reducers/calculator.js
@@ -169,7 +169,7 @@ export default function(state = INITIAL_STATE, action) {
       // institution and zipcode_rates endpoints both return this generic error
       const errorMessage =
         error.message === 'Record not found'
-          ? 'No rates for this zip code found. Try another zip code'
+          ? 'No rates for this postal code found. Try another postal code'
           : 'Something went wrong. Try again';
 
       // response mismatch - do nothing
@@ -244,7 +244,7 @@ export default function(state = INITIAL_STATE, action) {
         beneficiaryZIP !== '' &&
         !beneficiaryZIPRegExTester.exec(beneficiaryZIP)
       ) {
-        beneficiaryZIPError = 'Zip code must be a 5-digit number';
+        beneficiaryZIPError = 'Postal code must be a 5-digit number';
       } else {
         beneficiaryZIPError = '';
       }

--- a/src/applications/gi/tests/components/CalculatorForm.unit.spec.jsx
+++ b/src/applications/gi/tests/components/CalculatorForm.unit.spec.jsx
@@ -59,7 +59,7 @@ describe('<CalculatorForm>', () => {
       .text();
     tree.unmount();
 
-    expect(errorMessage).to.equal('Error Zip code must be a 5-digit number');
+    expect(errorMessage).to.equal('Error Postal code must be a 5-digit number');
   });
 });
 

--- a/src/applications/gi/tests/reducers/calculator.unit.spec.js
+++ b/src/applications/gi/tests/reducers/calculator.unit.spec.js
@@ -85,7 +85,7 @@ describe('calculator reducer', () => {
 
       const expectedState = {
         beneficiaryZIPError:
-          'No rates for this zip code found. Try another zip code',
+          'No rates for this postal code found. Try another postal code',
         beneficiaryZIPFetched: '',
         beneficiaryLocationBah: null,
         beneficiaryLocationGrandfatheredBah: null,
@@ -283,7 +283,7 @@ describe('calculator reducer', () => {
       };
 
       const expectedState = {
-        beneficiaryZIPError: 'Zip code must be a 5-digit number',
+        beneficiaryZIPError: 'Postal code must be a 5-digit number',
         beneficiaryZIP: '1dd',
         beneficiaryZIPFetched: '',
         beneficiaryLocationBah: null,
@@ -311,7 +311,7 @@ describe('calculator reducer', () => {
       };
 
       const expectedState = {
-        beneficiaryZIPError: 'Zip code must be a 5-digit number',
+        beneficiaryZIPError: 'Postal code must be a 5-digit number',
         beneficiaryZIP: '1111111',
         beneficiaryZIPFetched: '',
         beneficiaryLocationBah: null,

--- a/src/applications/letters/components/Address.jsx
+++ b/src/applications/letters/components/Address.jsx
@@ -152,7 +152,7 @@ class Address extends React.Component {
             <ErrorableTextInput
               errorMessage={errorMessages.zipCode}
               additionalClass="usa-input-medium"
-              label={'Zip code'}
+              label={'Postal code'}
               name="postalCode"
               autocomplete="postal-code"
               value={this.props.address.zipCode}

--- a/src/applications/letters/utils/validations.js
+++ b/src/applications/letters/utils/validations.js
@@ -45,7 +45,7 @@ export const postalCodeValidations = [
   // Require zip for US addresses
   (postalCode, fullAddress) => {
     if (fullAddress.countryName === 'USA' && !postalCode) {
-      return 'Please enter a Zip code';
+      return 'Please enter a postal code';
     }
 
     return true;
@@ -53,7 +53,7 @@ export const postalCodeValidations = [
   // Check for valid US zip codes
   (postalCode, fullAddress) => {
     if (fullAddress.countryName === 'USA' && !isValidUSZipCode(postalCode)) {
-      return 'Please enter a valid Zip code';
+      return 'Please enter a valid postal code';
     }
 
     return true;

--- a/src/applications/vaos/utils/address.js
+++ b/src/applications/vaos/utils/address.js
@@ -145,7 +145,7 @@ export function uiSchema(label = '') {
       'ui:title': 'State',
     },
     postalCode: {
-      'ui:title': 'ZIP code',
+      'ui:title': 'Postal code',
       'ui:options': {
         widgetClassNames: 'usa-input-medium',
       },

--- a/src/platform/user/profile/vet360/components/AddressField/AddressField.jsx
+++ b/src/platform/user/profile/vet360/components/AddressField/AddressField.jsx
@@ -66,9 +66,9 @@ export const convertNextValueToCleanData = value => {
 const validateZipCode = zipCode => {
   let result = '';
   if (!zipCode) {
-    result = 'Zip code is required';
+    result = 'Postal code is required';
   } else if (!zipCode.match(/\d{5}/)) {
-    result = 'Zip code must be 5 digits';
+    result = 'Postal code must be 5 digits';
   }
   return result;
 };

--- a/src/platform/user/profile/vet360/components/AddressField/AddressForm.jsx
+++ b/src/platform/user/profile/vet360/components/AddressField/AddressForm.jsx
@@ -236,7 +236,7 @@ class AddressForm extends React.Component {
           <ErrorableTextInput
             errorMessage={errorMessages.zipCode}
             additionalClass="usa-input-medium"
-            label={'Zip code'}
+            label={'Postal code'}
             name="postalCode"
             charMax={5}
             autocomplete="postal-code"


### PR DESCRIPTION
## Description

This PR changes all references of "zip" to "postal" because zip code is a U.S. specific name.

## Testing done

Unit tests; no update needed since only content was changed

## Screenshots

None

## Acceptance criteria
- [ ] Change "zip" to "postal" in content & error messages

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
