### PR TITLE
GI Bill Comparison Tool - Remove unused code

### DIFF
--- a/src/applications/gi/containers/LandingPage.jsx
+++ b/src/applications/gi/containers/LandingPage.jsx
@@ -52,13 +52,12 @@ export class LandingPage extends React.Component {
 
   search = value => {
     const { location } = this.props;
-    const { category, vetTecProvider } = this.props.filters;
+    const { category } = this.props.filters;
 
     const query = {
       name: value,
       version: location.query.version,
-      category: vetTecProvider ? null : category,
-      vetTecProvider,
+      category,
     };
 
     _.forEach(query, (val, key) => {
@@ -68,7 +67,7 @@ export class LandingPage extends React.Component {
     });
 
     if (isVetTecSelected(this.props.filters)) {
-      delete query.vetTecProvider;
+      delete query.category;
       this.props.router.push({ pathname: 'program-search', query });
     } else {
       this.props.router.push({ pathname: 'search', query });
@@ -86,12 +85,8 @@ export class LandingPage extends React.Component {
       'gibct-form-value': value,
     });
 
-    if (field === 'category') {
-      filters.vetTecProvider = value === 'vettec';
-
-      if (filters.vetTecProvider) {
-        this.props.updateAutocompleteSearchTerm('');
-      }
+    if (field === 'category' && value === 'vettec') {
+      this.props.updateAutocompleteSearchTerm('');
     }
     filters[field] = value;
 
@@ -108,17 +103,6 @@ export class LandingPage extends React.Component {
 
     const eligibility = { ...this.props.eligibility };
     eligibility[field] = value;
-
-    if (
-      this.props.filters.category === 'vettec' &&
-      !this.shouldDisplayTypeOfInstitution(eligibility)
-    ) {
-      this.props.institutionFilterChange({
-        ...this.props.filters,
-        category: 'school',
-        vetTecProvider: false,
-      });
-    }
 
     this.props.eligibilityChange(e);
   };

--- a/src/applications/gi/containers/SearchPage.jsx
+++ b/src/applications/gi/containers/SearchPage.jsx
@@ -23,11 +23,7 @@ import LoadingIndicator from '@department-of-veterans-affairs/formation-react/Lo
 import Pagination from '@department-of-veterans-affairs/formation-react/Pagination';
 import { getScrollOptions, focusElement } from 'platform/utilities/ui';
 import SearchResult from '../components/search/SearchResult';
-import VetTecProgramSearchResult from '../components/vet-tec/VetTecProgramSearchResult';
 import InstitutionSearchForm from '../components/search/InstitutionSearchForm';
-import VetTecSearchForm from '../components/vet-tec/VetTecSearchForm';
-import { isVetTecSelected } from '../utils/helpers';
-import { renderVetTecLogo } from '../utils/render';
 
 const { Element: ScrollElement, scroller } = Scroll;
 
@@ -76,7 +72,6 @@ export class SearchPage extends React.Component {
       'stemIndicator',
       'priorityEnrollment',
       'independentStudy',
-      'vetTecProvider',
       'preferredProvider',
     ];
 
@@ -106,12 +101,7 @@ export class SearchPage extends React.Component {
     });
 
     this.props.institutionFilterChange(institutionFilter);
-
-    if (isVetTecSelected(institutionFilter)) {
-      this.props.fetchProgramSearchResults(query);
-    } else {
-      this.props.fetchInstitutionSearchResults(query);
-    }
+    this.props.fetchInstitutionSearchResults(query);
   };
 
   handlePageSelect = page => {
@@ -151,7 +141,7 @@ export class SearchPage extends React.Component {
   };
 
   searchResults = () => {
-    const { search, filters } = this.props;
+    const { search } = this.props;
     const {
       pagination: { currentPage, totalPages },
     } = search;
@@ -188,43 +178,31 @@ export class SearchPage extends React.Component {
         <div className={resultsClass}>
           {filterButton}
           <div>
-            {search.results.map(result => {
-              if (isVetTecSelected(filters)) {
-                return (
-                  <VetTecProgramSearchResult
-                    version={this.props.location.query.version}
-                    key={`${result.facilityCode}-${result.description}`}
-                    result={result}
-                    constants={this.props.constants}
-                  />
-                );
-              }
-              return (
-                <SearchResult
-                  version={this.props.location.query.version}
-                  key={result.facilityCode}
-                  name={result.name}
-                  facilityCode={result.facilityCode}
-                  type={result.type}
-                  city={result.city}
-                  state={result.state}
-                  zip={result.zip}
-                  country={result.country}
-                  cautionFlag={result.cautionFlag}
-                  studentCount={result.studentCount}
-                  bah={result.bah}
-                  dodBah={result.dodBah}
-                  schoolClosing={result.schoolClosing}
-                  tuitionInState={result.tuitionInState}
-                  tuitionOutOfState={result.tuitionOutOfState}
-                  books={result.books}
-                  studentVeteran={result.studentVeteran}
-                  yr={result.yr}
-                  poe={result.poe}
-                  eightKeys={result.eightKeys}
-                />
-              );
-            })}
+            {search.results.map(result => (
+              <SearchResult
+                version={this.props.location.query.version}
+                key={result.facilityCode}
+                name={result.name}
+                facilityCode={result.facilityCode}
+                type={result.type}
+                city={result.city}
+                state={result.state}
+                zip={result.zip}
+                country={result.country}
+                cautionFlag={result.cautionFlag}
+                studentCount={result.studentCount}
+                bah={result.bah}
+                dodBah={result.dodBah}
+                schoolClosing={result.schoolClosing}
+                tuitionInState={result.tuitionInState}
+                tuitionOutOfState={result.tuitionOutOfState}
+                books={result.books}
+                studentVeteran={result.studentVeteran}
+                yr={result.yr}
+                poe={result.poe}
+                eightKeys={result.eightKeys}
+              />
+            ))}
           </div>
 
           <Pagination
@@ -244,42 +222,6 @@ export class SearchPage extends React.Component {
       {!search.inProgress &&
         `${(search.count || 0).toLocaleString()} Search Results`}
     </h1>
-  );
-
-  renderVetTecSearchForm = (searchResults, filtersClass) => (
-    <div>
-      <div className="vads-u-display--block small-screen:vads-u-display--none vettec-logo-container">
-        {renderVetTecLogo(classNames('vettec-logo'))}
-      </div>
-      <div className="vads-l-row vads-u-justify-content--space-between vads-u-align-items--flex-end">
-        <div className="vads-l-col--10 search-results-count">
-          {this.renderSearchResultsHeader(this.props.search)}
-        </div>
-        <div className="vads-l-col--2">
-          <div className="vads-u-display--none small-screen:vads-u-display--block vettec-logo-container">
-            {renderVetTecLogo(classNames('vettec-logo'))}
-          </div>
-        </div>
-      </div>
-      <VetTecSearchForm
-        filtersClass={filtersClass}
-        search={this.props.search}
-        autocomplete={this.props.autocomplete}
-        location={this.props.location}
-        clearAutocompleteSuggestions={this.props.clearAutocompleteSuggestions}
-        fetchAutocompleteSuggestions={
-          this.props.fetchProgramAutocompleteSuggestions
-        }
-        handleFilterChange={this.handleFilterChange}
-        updateAutocompleteSearchTerm={this.props.updateAutocompleteSearchTerm}
-        filters={this.props.filters}
-        toggleFilter={this.props.toggleFilter}
-        searchResults={searchResults}
-        eligibility={this.props.eligibility}
-        showModal={this.props.showModal}
-        eligibilityChange={this.props.eligibilityChange}
-      />
-    </div>
   );
 
   renderInstitutionSearchForm = (searchResults, filtersClass) => (
@@ -309,7 +251,7 @@ export class SearchPage extends React.Component {
   );
 
   render() {
-    const { search, filters } = this.props;
+    const { search } = this.props;
 
     const filtersClass = classNames(
       'filters-sidebar',
@@ -317,7 +259,6 @@ export class SearchPage extends React.Component {
       'usa-width-one-fourth',
       'medium-3',
       'columns',
-      'mobile-vettec-logo',
       { opened: search.filterOpened },
     );
 
@@ -326,9 +267,7 @@ export class SearchPage extends React.Component {
     return (
       <ScrollElement name="searchPage" className="search-page">
         {/* /CT 116 */}
-        {isVetTecSelected(filters)
-          ? this.renderVetTecSearchForm(searchResults, filtersClass)
-          : this.renderInstitutionSearchForm(searchResults, filtersClass)}
+        {this.renderInstitutionSearchForm(searchResults, filtersClass)}
       </ScrollElement>
     );
   }

--- a/src/applications/gi/reducers/filter.js
+++ b/src/applications/gi/reducers/filter.js
@@ -11,7 +11,6 @@ const INITIAL_STATE = Object.freeze({
   eightKeysToVeteranSuccess: false,
   stemIndicator: false,
   typeName: 'ALL',
-  vetTecProvider: false,
   preferredProvider: false,
   provider: [],
 });

--- a/src/applications/gi/selectors/search.js
+++ b/src/applications/gi/selectors/search.js
@@ -6,12 +6,5 @@ export const calculateFilters = filters => {
     };
   }
 
-  if (filters.vetTecProvider) {
-    return {
-      ...filters,
-      category: 'vettec',
-    };
-  }
-
   return filters;
 };

--- a/src/applications/gi/tests/containers/ProfilePage.unit.spec.js
+++ b/src/applications/gi/tests/containers/ProfilePage.unit.spec.js
@@ -22,7 +22,6 @@ describe('<ProfilePage>', () => {
       profile: {
         ...defaultProps.profile,
         attributes: {
-          vetTecProvider: true,
           type: 'FOR PROFIT',
         },
       },

--- a/src/applications/gi/tests/containers/ProfilePage.unit.spec.js
+++ b/src/applications/gi/tests/containers/ProfilePage.unit.spec.js
@@ -9,11 +9,11 @@ import reducer from '../../reducers';
 const defaultProps = createCommonStore(reducer).getState();
 
 describe('<ProfilePage>', () => {
-  it('should render', () => {
-    const tree = SkinDeep.shallowRender(<ProfilePage {...defaultProps} />);
-    const vdom = tree.getRenderOutput();
-    expect(vdom).to.not.be.undefined;
-  });
+  // it('should render', () => {
+  //   const tree = SkinDeep.shallowRender(<ProfilePage {...defaultProps} />);
+  //   const vdom = tree.getRenderOutput();
+  //   expect(vdom).to.not.be.undefined;
+  // });
 
   it('should render VET TEC institution', () => {
     const vetTecProps = {
@@ -23,6 +23,7 @@ describe('<ProfilePage>', () => {
         ...defaultProps.profile,
         attributes: {
           type: 'FOR PROFIT',
+          vetTecProvider: true,
         },
       },
       params: {
@@ -33,14 +34,14 @@ describe('<ProfilePage>', () => {
     expect(tree.subTree('VetTecInstitutionProfile')).to.be.ok;
   });
 
-  it('should show LoadingState when profile is fetching', () => {
-    const inProgressProps = {
-      ...defaultProps,
-      profile: { inProgress: true },
-    };
-    const tree = SkinDeep.shallowRender(<ProfilePage {...inProgressProps} />);
-    const vdom = tree.getRenderOutput();
-    expect(vdom).to.not.be.undefined;
-    expect(tree.subTree('LoadingIndicator')).to.be.ok;
-  });
+  // it('should show LoadingState when profile is fetching', () => {
+  //   const inProgressProps = {
+  //     ...defaultProps,
+  //     profile: { inProgress: true },
+  //   };
+  //   const tree = SkinDeep.shallowRender(<ProfilePage {...inProgressProps} />);
+  //   const vdom = tree.getRenderOutput();
+  //   expect(vdom).to.not.be.undefined;
+  //   expect(tree.subTree('LoadingIndicator')).to.be.ok;
+  // });
 });

--- a/src/applications/gi/tests/containers/ProfilePage.unit.spec.js
+++ b/src/applications/gi/tests/containers/ProfilePage.unit.spec.js
@@ -9,11 +9,11 @@ import reducer from '../../reducers';
 const defaultProps = createCommonStore(reducer).getState();
 
 describe('<ProfilePage>', () => {
-  // it('should render', () => {
-  //   const tree = SkinDeep.shallowRender(<ProfilePage {...defaultProps} />);
-  //   const vdom = tree.getRenderOutput();
-  //   expect(vdom).to.not.be.undefined;
-  // });
+  it('should render', () => {
+    const tree = SkinDeep.shallowRender(<ProfilePage {...defaultProps} />);
+    const vdom = tree.getRenderOutput();
+    expect(vdom).to.not.be.undefined;
+  });
 
   it('should render VET TEC institution', () => {
     const vetTecProps = {
@@ -34,14 +34,14 @@ describe('<ProfilePage>', () => {
     expect(tree.subTree('VetTecInstitutionProfile')).to.be.ok;
   });
 
-  // it('should show LoadingState when profile is fetching', () => {
-  //   const inProgressProps = {
-  //     ...defaultProps,
-  //     profile: { inProgress: true },
-  //   };
-  //   const tree = SkinDeep.shallowRender(<ProfilePage {...inProgressProps} />);
-  //   const vdom = tree.getRenderOutput();
-  //   expect(vdom).to.not.be.undefined;
-  //   expect(tree.subTree('LoadingIndicator')).to.be.ok;
-  // });
+  it('should show LoadingState when profile is fetching', () => {
+    const inProgressProps = {
+      ...defaultProps,
+      profile: { inProgress: true },
+    };
+    const tree = SkinDeep.shallowRender(<ProfilePage {...inProgressProps} />);
+    const vdom = tree.getRenderOutput();
+    expect(vdom).to.not.be.undefined;
+    expect(tree.subTree('LoadingIndicator')).to.be.ok;
+  });
 });

--- a/src/applications/gi/tests/containers/SearchPage.unit.spec.js
+++ b/src/applications/gi/tests/containers/SearchPage.unit.spec.js
@@ -84,7 +84,6 @@ describe('<SearchPage> functions', () => {
       'stemIndicator',
       'priorityEnrollment',
       'independentStudy',
-      'vetTecProvider',
       'preferredProvider',
     ];
 
@@ -126,7 +125,6 @@ describe('<SearchPage> functions', () => {
       stemIndicator: 'false',
       priorityEnrollment: 'false',
       independentStudy: 'false',
-      vetTecProvider: 'false',
       preferredProvider: 'false',
       version: '94ed39bf-f816-4b12-b3ce-a8241c2325b7',
       category: 'school',

--- a/src/applications/gi/tests/utils/helpers.unit.spec.js
+++ b/src/applications/gi/tests/utils/helpers.unit.spec.js
@@ -31,9 +31,6 @@ describe('GIBCT helpers:', () => {
     it('should recognize VET TEC', () => {
       expect(isVetTecSelected({ category: 'vettec' })).to.be.true;
     });
-    it('should recognize vetTecProvider flag', () => {
-      expect(isVetTecSelected({ vetTecProvider: true })).to.be.true;
-    });
   });
 
   describe('addAllOption', () => {

--- a/src/applications/gi/utils/helpers.js
+++ b/src/applications/gi/utils/helpers.js
@@ -8,8 +8,7 @@ export const formatNumber = value => {
 
 export const formatCurrency = value => `$${formatNumber(Math.round(+value))}`;
 
-export const isVetTecSelected = filters =>
-  filters.category === 'vettec' || filters.vetTecProvider;
+export const isVetTecSelected = filters => filters.category === 'vettec';
 
 export const addAllOption = options => [
   { value: 'ALL', label: 'ALL' },


### PR DESCRIPTION
## Description
There was previously one route for searching both VET TEC and non-VET TEC institutions, with a `vetTecProvider` query param that was used to conditionally load components, but a new route was added for VET TEC institutions that used VET TEC specific search components.  The conditional logic using the `vetTecProvider` prop can now be removed.

https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/5343

## Testing done
Tested locally and QA reviewed

## Screenshots
N/A

## Acceptance criteria
- [x] Existing VET TEC search functionality is not impacted by the removal.
- [x] All dead VET TEC search code is removed from the vets-website repository.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
