### PR TITLE
Remove moment-timezone from announcement selector and from moment-setup

### DIFF
--- a/src/platform/site-wide/announcements/selectors.js
+++ b/src/platform/site-wide/announcements/selectors.js
@@ -1,5 +1,5 @@
 // Node modules.
-import moment from 'moment-timezone';
+import moment from 'moment';
 // Relative imports.
 import _config from './config';
 
@@ -7,10 +7,8 @@ import _config from './config';
 const isExpiredAnnouncement = announcement => {
   if (!announcement.expiresAt) return true;
 
-  const expiresAtDate = moment.tz(announcement.expiresAt, 'America/New_York');
-  const hasExpired = moment()
-    .tz('America/New_York')
-    .isSameOrAfter(expiresAtDate);
+  const expiresAtDate = moment(announcement.expiresAt);
+  const hasExpired = moment().isSameOrAfter(expiresAtDate);
 
   return !hasExpired;
 };

--- a/src/platform/site-wide/moment-setup.js
+++ b/src/platform/site-wide/moment-setup.js
@@ -1,5 +1,4 @@
 import moment from 'moment';
-import momentTimezone from 'moment-timezone';
 
 // Derive moment options.
 const options = {
@@ -27,4 +26,3 @@ const options = {
 
 // Called at startup so that the formatting applied under updateLocale occur site-wide.
 moment.updateLocale('en', options);
-momentTimezone.updateLocale('en', options);


### PR DESCRIPTION
## Description
This PR removes `moment-timezone` from announcement code and from the `moment-setup` file.

## Testing done


## Screenshots


## Acceptance criteria
- [x] Remove `moment-timezone` from the Downtime Notification alert code that was introduced.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
