### PR TITLE
Update Sign in Modal Ds Logon banner text.

### DIFF
--- a/src/platform/user/authentication/components/SignInModal.jsx
+++ b/src/platform/user/authentication/components/SignInModal.jsx
@@ -94,7 +94,11 @@ class SignInModal extends React.Component {
           [EXTERNAL_SERVICES.dslogon],
           'You may have trouble signing in with DS Logon',
           'warning',
-          "We’re sorry. We’re working to fix some problems with our DS Logon sign in process. You can sign in to VA.gov with an existing ID.me account or you can create an account and verify your identity through ID.me. Learn how to create an account through ID.me. If you continue to have trouble, please call the DS Logon help desk at (800) 538-9552.",
+          <>
+            <p>We’re sorry. We’re working to fix some problems with our DS Logon sign in process. You can sign in to VA.gov with an existing ID.me account or you can create an account and verify your identity through ID.me.</p>
+            <p><a href="...">Learn how to create an account through ID.me.</a></p>
+            <p>If you continue to have trouble, please call the DS Logon help desk at (800) 538-9552.</p>
+          </>,
         )}
         {this.downtimeBanner(
           [EXTERNAL_SERVICES.mhv],

--- a/src/platform/user/authentication/components/SignInModal.jsx
+++ b/src/platform/user/authentication/components/SignInModal.jsx
@@ -108,7 +108,7 @@ class SignInModal extends React.Component {
             </p>
             <p>
               If you continue to have trouble, please call the DS Logon help
-              desk at <a href="tel:+18005389552">(800) 538-9552</a> .
+              desk at <a href="tel:+18005389552">(800) 538-9552</a>.
             </p>
           </>,
         )}

--- a/src/platform/user/authentication/components/SignInModal.jsx
+++ b/src/platform/user/authentication/components/SignInModal.jsx
@@ -96,8 +96,8 @@ class SignInModal extends React.Component {
           'warning',
           <>
             <p>We’re sorry. We’re working to fix some problems with our DS Logon sign in process. You can sign in to VA.gov with an existing ID.me account or you can create an account and verify your identity through ID.me.</p>
-            <p><a href="...">Learn how to create an account through ID.me.</a></p>
-            <p>If you continue to have trouble, please call the DS Logon help desk at (800) 538-9552.</p>
+            <p><a href="/sign-in-faq">Learn how to create an account through ID.me.</a></p>
+            <p>If you continue to have trouble, please call the DS Logon help desk at <a href="tel:+18005389552">(800) 538-9552</a> .</p>
           </>,
         )}
         {this.downtimeBanner(

--- a/src/platform/user/authentication/components/SignInModal.jsx
+++ b/src/platform/user/authentication/components/SignInModal.jsx
@@ -94,7 +94,7 @@ class SignInModal extends React.Component {
           [EXTERNAL_SERVICES.dslogon],
           'You may have trouble signing in with DS Logon',
           'warning',
-          'We’re sorry. We’re working to fix some problems with our DS Logon sign in process. If you’d like to sign in to VA.gov with your DS Logon account, please check back later.',
+          "We’re sorry. We’re working to fix some problems with our DS Logon sign in process. You can sign in to VA.gov with an existing ID.me account or you can create an account and verify your identity through ID.me. Learn how to create an account through ID.me. If you continue to have trouble, please call the DS Logon help desk at (800) 538-9552.",
         )}
         {this.downtimeBanner(
           [EXTERNAL_SERVICES.mhv],

--- a/src/platform/user/authentication/components/SignInModal.jsx
+++ b/src/platform/user/authentication/components/SignInModal.jsx
@@ -95,9 +95,21 @@ class SignInModal extends React.Component {
           'You may have trouble signing in with DS Logon',
           'warning',
           <>
-            <p>We’re sorry. We’re working to fix some problems with our DS Logon sign in process. You can sign in to VA.gov with an existing ID.me account or you can create an account and verify your identity through ID.me.</p>
-            <p><a href="/sign-in-faq">Learn how to create an account through ID.me.</a></p>
-            <p>If you continue to have trouble, please call the DS Logon help desk at <a href="tel:+18005389552">(800) 538-9552</a> .</p>
+            <p>
+              We’re sorry. We’re working to fix some problems with our DS Logon
+              sign in process. You can sign in to VA.gov with an existing ID.me
+              account or you can create an account and verify your identity
+              through ID.me.
+            </p>
+            <p>
+              <a href="/sign-in-faq">
+                Learn how to create an account through ID.me.
+              </a>
+            </p>
+            <p>
+              If you continue to have trouble, please call the DS Logon help
+              desk at <a href="tel:+18005389552">(800) 538-9552</a> .
+            </p>
           </>,
         )}
         {this.downtimeBanner(


### PR DESCRIPTION
## Description

DS logon is regularly out for extended periods of time (~31 hours last week), and can be a [generally frustrating experience for veterans](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/identity-personalization/login/ds-logon/research/research_brief.md).

we could make it clear to veterans that they can log in with id.me or create a new id.me account and their "stuff" will still be there (presuming they have verified their identity).  



## Testing done


## Screenshots

<img width="1017" alt="Screen Shot 2020-02-05 at 2 56 36 PM" src="https://user-images.githubusercontent.com/19188/73878266-444cd880-4828-11ea-8788-359643e60303.png">

## Acceptance criteria
- [x] text is present

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs

I was testing by setting the [backend_statuses_controller action](https://github.com/department-of-veterans-affairs/vets-api/blob/master/app/controllers/v0/backend_statuses_controller.rb#L9) to

````
    def index
     # statuses = ExternalServicesRedis::Status.new.fetch_or_cache
data = <<EOM
{"data":{"id":"","type":"pagerduty_external_services_responses","attributes":{"reported_at":"2020-02-05T18:26:38.000+00:00","statuses":[{"service":"DS Logon","service_id":"dslogon","status":"incident","last_incident_timestamp":"2020-02-05T17:45:26.000+00:00"}]}}}
EOM
      render json: data
    end
````
