### PR TITLE
Set build script to allow *.ci.cms.va.gov domains in addition to *.cms.va.gov.

### DIFF
--- a/src/site/stages/build/drupal/assets.js
+++ b/src/site/stages/build/drupal/assets.js
@@ -57,7 +57,7 @@ function updateAttr(attr, doc, client) {
     const srcAttr = item.attr(attr);
 
     const siteURI = srcAttr.match(
-      /https?:\/\/([a-z0-9]+[.])*cms[.]va[.]gov/,
+      /https?:\/\/([a-zA-Z0-9]+[.])*cms[.]va[.]gov/,
     )[0];
     // *.ci.cms.va.gov ENVs don't have AWS URLs.
     const newAssetPath = convertAssetPath(srcAttr);

--- a/src/site/stages/build/drupal/assets.js
+++ b/src/site/stages/build/drupal/assets.js
@@ -29,10 +29,10 @@ function replacePathInData(data, replacer) {
   return current;
 }
 
-function convertAssetPath(drupalInstance, url) {
+function convertAssetPath(url) {
   // After this path are other folders in the image paths,
   // but it's hard to tell if we can strip them, so I'm leaving them alone
-  const withoutHost = url.replace(`${drupalInstance}/sites/default/files/`, '');
+  const withoutHost = url.replace(/^.*\/sites\/.*\/files\//, '');
   const path = withoutHost.split('?', 2)[0];
 
   // This is sort of naive, but we'd like to have images in the img folder
@@ -47,6 +47,7 @@ function convertAssetPath(drupalInstance, url) {
   return `/files/${path}`;
 }
 
+// @todo Explain _why_ this function is needed.
 function updateAttr(attr, doc, client) {
   const assetsToDownload = [];
   const usingAWS = !!PUBLIC_URLS[client.getSiteUri()];
@@ -56,16 +57,17 @@ function updateAttr(attr, doc, client) {
     const srcAttr = item.attr(attr);
 
     const siteURI = srcAttr.match(
-      /http[s]{0,1}:\/\/[^.]*[.]{0,1}cms\.va\.gov/,
+      /https?:\/\/([a-z0-9]+[.])*cms[.]va[.]gov/,
     )[0];
-    const awsURI = Object.entries(PUBLIC_URLS).find(
-      entry => entry[1] === siteURI,
-    )[0];
+    // *.ci.cms.va.gov ENVs don't have AWS URLs.
+    const newAssetPath = convertAssetPath(srcAttr);
+    const awsURI = usingAWS
+      ? Object.entries(PUBLIC_URLS).find(entry => entry[1] === siteURI)[0]
+      : null;
 
-    const newAssetPath = convertAssetPath(siteURI, srcAttr);
     assetsToDownload.push({
-      // urls in WYSIWYG content won't be the aws urls, they'll be cms urls
-      // this means we need to replace them with the aws urls if we're on jenkins
+      // URLs in WYSIWYG content won't be the AWS URLs, they'll be CMS URLs.
+      // This means we need to replace them with the AWS URLs if we're on Jenkins.
       src: usingAWS ? srcAttr.replace(siteURI, awsURI) : srcAttr,
       dest: newAssetPath,
     });
@@ -80,8 +82,8 @@ function convertDrupalFilesToLocal(drupalData, files, options) {
   const client = getDrupalClient(options);
 
   return replacePathInData(drupalData, (data, key) => {
-    if (data.startsWith(`${client.getSiteUri()}/sites/default/files`)) {
-      const newPath = convertAssetPath(client.getSiteUri(), data);
+    if (data.match(/^.*\/sites\/.*\/files\//)) {
+      const newPath = convertAssetPath(data);
       const decodedFileName = decodeURIComponent(newPath).substring(1);
       // eslint-disable-next-line no-param-reassign
       files[decodedFileName] = {


### PR DESCRIPTION
## Description
This fixes
https://github.com/department-of-veterans-affairs/va.gov-cms/issues/878. This is a follow up to https://github.com/department-of-veterans-affairs/vets-website/pull/10077 by @jbalboni. 

## Testing done
Tested locally. 

## Screenshots
This new data output by the CMS was causing the script to try to swap out the href on *cms.va.gov links (which included *.ci.cms.va.gov) but further logic only looked at *.cms.va.gov). Both regexes should match now. 

![image](https://user-images.githubusercontent.com/1504756/73881342-fc708600-4814-11ea-883a-a7aaa9c99783.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs