### PR TITLE
Fix VAOS tests that fail in evenings

### DIFF
--- a/src/applications/vaos/tests/components/AddToCalendar.unit.spec.jsx
+++ b/src/applications/vaos/tests/components/AddToCalendar.unit.spec.jsx
@@ -1,13 +1,10 @@
 import React from 'react';
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
-import moment from '../../utils/moment-tz';
 
 import AddToCalendar from '../../components/AddToCalendar';
 
 describe('VAOS <AddToCalendar>', () => {
-  const now = new Date();
-
   const facility = {
     address: {
       physical: {
@@ -20,7 +17,7 @@ describe('VAOS <AddToCalendar>', () => {
   };
 
   const communityCareAppointment = {
-    appointmentTime: now,
+    appointmentTime: '01/02/2020 13:45:00',
     timeZone: '-04:00 EDT',
     address: {
       street: '',
@@ -30,18 +27,9 @@ describe('VAOS <AddToCalendar>', () => {
     },
   };
 
-  const communityCareAppointmentRequest = {
-    appointmentTime: now,
-    typeOfCareId: 'CC',
-    timeZone: '-04:00 EDT',
-  };
-
-  const vaAppointmentRequest = {
-    optionDate1: ' ',
-  };
-
   const vaAppointment = {
     clinicId: ' ',
+    startDate: '2020-01-02T16:00:00Z',
     vdsAppointments: [
       {
         appointmentLength: '',
@@ -76,38 +64,7 @@ describe('VAOS <AddToCalendar>', () => {
 
     it('should have an aria label', () => {
       expect(link.props()['aria-label']).to.equal(
-        `Add to calendar on ${moment(now).format('MMMM D, YYYY')}`,
-      );
-    });
-
-    tree.unmount();
-  });
-
-  describe('Add community care appointment request to calendar', () => {
-    const tree = shallow(
-      <AddToCalendar
-        appointment={communityCareAppointmentRequest}
-        facility={facility}
-      />,
-    );
-
-    const link = tree.find('a');
-
-    it('should render', () => {
-      expect(tree.exists()).to.be.true;
-    });
-
-    it('should contain valid ICS end command', () => {
-      expect(link.props().href).to.contain(encodeURIComponent('END:VCALENDAR'));
-    });
-
-    it('should download ICS commands to a file named "Community_Care.ics"', () => {
-      expect(link.props().download).to.equal('Community_Care.ics');
-    });
-
-    it('should have an aria label', () => {
-      expect(link.props()['aria-label']).to.equal(
-        `Add to calendar on ${moment(now).format('MMMM D, YYYY')}`,
+        `Add to calendar on January 2, 2020`,
       );
     });
 
@@ -135,35 +92,7 @@ describe('VAOS <AddToCalendar>', () => {
 
     it('should have an aria label', () => {
       expect(link.props()['aria-label']).to.equal(
-        `Add to calendar on ${moment(now).format('MMMM D, YYYY')}`,
-      );
-    });
-
-    tree.unmount();
-  });
-
-  describe('Add VA appointment request to calendar', () => {
-    const tree = shallow(
-      <AddToCalendar appointment={vaAppointmentRequest} facility={facility} />,
-    );
-
-    const link = tree.find('a');
-
-    it('should render', () => {
-      expect(tree.exists()).to.be.true;
-    });
-
-    it('should contain valid ICS end command', () => {
-      expect(link.props().href).to.contain(encodeURIComponent('END:VCALENDAR'));
-    });
-
-    it('should download ICS commands to a file named "VA_Appointment.ics"', () => {
-      expect(link.props().download).to.equal('VA_Appointment.ics');
-    });
-
-    it('should have an aria label', () => {
-      expect(link.props()['aria-label']).to.equal(
-        `Add to calendar on ${moment(now).format('MMMM D, YYYY')}`,
+        `Add to calendar on January 2, 2020`,
       );
     });
 

--- a/src/applications/vaos/tests/utils/appointment.unit.spec.jsx
+++ b/src/applications/vaos/tests/utils/appointment.unit.spec.jsx
@@ -506,9 +506,9 @@ describe('VAOS appointment helpers', () => {
       expect(
         getAppointmentDate({
           ...communityCareAppointment,
-          appointmentTime: now,
+          appointmentTime: '01/02/2020 13:45:00',
         }),
-      ).to.equal(now.format('MMMM D, YYYY'));
+      ).to.equal('January 2, 2020');
     });
   });
 


### PR DESCRIPTION
## Description
Some of the VAOS tests were written while we were setting the moment locale with moment-timezone. When that was removed, they started failing, I think due to moment and Date object mismatches? Not exactly sure, but these changes fix them.

I've also removed some tests that aren't necessary for this component.

## Testing done
Switched my local date and timezone to generate test failures and verified fixes in that time range

## Acceptance criteria
- [ ] Tests stop failing in the evenings

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
