### PR TITLE
Generate mock appointment slots

### DIFF
--- a/src/applications/vaos/api/index.js
+++ b/src/applications/vaos/api/index.js
@@ -1,6 +1,7 @@
 import moment from 'moment';
 import { apiRequest } from 'platform/utilities/api';
 import environment from 'platform/utilities/environment';
+import { generateMockSlots } from '../utils/calendar';
 
 function getStagingId(facilityId) {
   if (!environment.isProduction() && facilityId.startsWith('983')) {
@@ -402,9 +403,11 @@ export function getAvailableSlots(
   if (USE_MOCK_DATA) {
     promise = new Promise(resolve => {
       setTimeout(() => {
-        import('./slots.json').then(module =>
-          resolve(module.default ? module.default : module),
-        );
+        import('./slots.json').then(module => {
+          const response = module.default ? module.default : module;
+          response.data[0].attributes.appointmentTimeSlot = generateMockSlots();
+          resolve(response);
+        });
       }, 500);
     });
   } else {

--- a/src/applications/vaos/utils/calendar.js
+++ b/src/applications/vaos/utils/calendar.js
@@ -135,3 +135,32 @@ export function removeDateOptionPairFromSelectedArray(
       (d.date === dateObj.date && d[fieldName] !== dateObj[fieldName]),
   );
 }
+
+function randomInt(min, max) {
+  return Math.floor(Math.random() * (max - min + 1) + min);
+}
+
+export function generateMockSlots() {
+  const slots = [];
+  const today = moment();
+  const minuteSlots = ['00:00', '20:00', '40:00'];
+
+  while (slots.length < 300) {
+    const daysToAdd = randomInt(1, 365);
+    const date = today
+      .clone()
+      .add(daysToAdd, 'day')
+      .format('YYYY-MM-DD');
+    const hour = `0${randomInt(9, 16)}`.slice(-2);
+    const minutes = minuteSlots[Math.floor(Math.random() * minuteSlots.length)];
+    const startDateTime = `${date}T${hour}:${minutes}.000+00:00`;
+    slots.push({
+      startDateTime,
+      bookingStatus: '1',
+      remainingAllowedOverBookings: '3',
+      availability: true,
+    });
+  }
+
+  return slots;
+}


### PR DESCRIPTION
## Description
Generates slots up to 365 days in the future so we don't need to keep updating `slots.json`

## Testing done
Local

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
