### PR TITLE
fix bug with adding a new residential address

### DIFF
--- a/src/platform/user/profile/vet360/components/AddressField/AddressEditModal.jsx
+++ b/src/platform/user/profile/vet360/components/AddressField/AddressEditModal.jsx
@@ -98,6 +98,9 @@ class AddressEditModal extends React.Component {
    *   an overseas military mailing address
    */
   transformInitialFormValues = initialFormValues => {
+    if (!initialFormValues) {
+      return initialFormValues;
+    }
     let transformedData = this.removeEmptyKeys(initialFormValues);
     transformedData = this.selectLivesOnMilitaryBaseCheckbox(transformedData);
     return transformedData;


### PR DESCRIPTION
## Description
A null value was getting passed to an object transformation helper, causing a crash. This skips running the object transformation helpers if the data is not set.

## Testing done
Local

## Screenshots


## Acceptance criteria
- [ ] You can add a new residential address

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs