### PR TITLE
Add margin-top to Disability Rating Calculator

### DIFF
--- a/src/applications/disability-benefits/disability-rating-calculator/components/DisabilityRatingCalculator.jsx
+++ b/src/applications/disability-benefits/disability-rating-calculator/components/DisabilityRatingCalculator.jsx
@@ -135,7 +135,7 @@ export default class DisabilityRatingCalculator extends React.Component {
     const ratings = getRatings(disabilities);
 
     return (
-      <div className="disability-calculator vads-u-padding-y--4 vads-u-background-color--gray-lightest">
+      <div className="disability-calculator vads-u-padding-y--4 vads-u-margin-top--4 vads-u-background-color--gray-lightest">
         <div className="vads-u-padding-x--4">
           <h2 className="vads-u-margin-top--0">
             VA combined disability rating calculator


### PR DESCRIPTION
## Description
This PR adds some to the calculator widget visible at http://preview-prod.vfs.va.gov/preview?nodeId=866, so that it doesn't touch the sign-in box.

Ticket - https://github.com/department-of-veterans-affairs/va.gov-team/issues/3767
https://dsva.slack.com/archives/C52CL1PKQ/p1580930652319300

## Testing done
Added the CSS class to the calculator in the Drupal preview using dev tools

## Screenshots
![image](https://user-images.githubusercontent.com/1915775/73973271-42e6e300-48f0-11ea-979a-969a48f4f6d9.png)


## Acceptance criteria
- [ ] Gray boxes don't touch

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
