### PR TITLE
pre-check "lives on military base" checkbox

### DIFF
--- a/src/platform/user/profile/vet360/components/AddressField/AddressEditModal.jsx
+++ b/src/platform/user/profile/vet360/components/AddressField/AddressEditModal.jsx
@@ -71,7 +71,7 @@ class AddressEditModal extends React.Component {
         internationalPostalCode: data.internationalPostalCode,
         zipCode: data.zipCode,
         province: data.province,
-        addressPou: data.Pou,
+        addressPou: data.addressPou,
       },
       e => !!e,
     );
@@ -92,13 +92,16 @@ class AddressEditModal extends React.Component {
   };
 
   /**
-   * Helper function that:
-   * - totally removes data fields that are not set
-   * - sets the form data's `view:livesOnMilitaryBase` prop to `true` if this is
+   * Helper function that calls other helpers to:
+   * - totally remove data fields that are not set
+   * - set the form data's `view:livesOnMilitaryBase` prop to `true` if this is
    *   an overseas military mailing address
+   *
+   * If the argument is not an object this function will simply return whatever
+   * was passed to it.
    */
   transformInitialFormValues = initialFormValues => {
-    if (!initialFormValues) {
+    if (!(initialFormValues instanceof Object)) {
       return initialFormValues;
     }
     let transformedData = this.removeEmptyKeys(initialFormValues);


### PR DESCRIPTION
## Description
I had an error in my code that stripped the `addressPou` value from initial form data so the checkbox wasn't getting selected when the modal first popped up

## Testing done
Local

## Screenshots
GIF showing that the checkbox is selected when editing a military base
![prechecked](https://user-images.githubusercontent.com/20728956/73986946-cce47b00-48f3-11ea-904f-983a555e8ebf.gif)

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs