### PR TITLE
Add smooth scrolling to jump links site-wide

### DIFF
--- a/src/applications/static-pages/smoothScrollJumpLinks.js
+++ b/src/applications/static-pages/smoothScrollJumpLinks.js
@@ -41,7 +41,7 @@ export default () => {
     }
 
     // Update the URL hash to equal the href since we did `event.preventDefault()` above.
-    // WARNING: Do not update window.location.hash, otherwise it will autoscroll without 'smooth' behavior.
+    // WARNING: Do not update window.location.hash directly, otherwise it will autoscroll without 'smooth' behavior.
     history.pushState({}, '', href);
   });
 };

--- a/src/applications/static-pages/smoothScrollJumpLinks.js
+++ b/src/applications/static-pages/smoothScrollJumpLinks.js
@@ -1,0 +1,47 @@
+export default () => {
+  document.addEventListener('click', event => {
+    // Derive element properties.
+    const element = event?.target;
+    const tagName = element?.tagName;
+    const href = element?.attributes?.href?.value;
+
+    // Escape early if it's not an anchor tag.
+    if (tagName !== 'A') {
+      return;
+    }
+
+    // Escape early if it does not contain an href.
+    if (!href) {
+      return;
+    }
+
+    // Escape early if it's not a jump-link.
+    if (!href.startsWith('#')) {
+      return;
+    }
+
+    // Derive the jump element.
+    const jumpElementID = href.replace('#', '');
+    const jumpElement = document.getElementById(jumpElementID);
+
+    // Escape early if no jump element was found.
+    if (!jumpElement) {
+      return;
+    }
+
+    // Prevent immediately jumping.
+    event.preventDefault();
+
+    // Smooth scroll to the element (Browser compatibility: https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView).
+    jumpElement.scrollIntoView({ behavior: 'smooth' });
+
+    // Escape early if the hash is already up-to-date.
+    if (window.location.hash === href) {
+      return;
+    }
+
+    // Update the URL hash to equal the href since we did `event.preventDefault()` above.
+    // WARNING: Do not update window.location.hash, otherwise it will autoscroll without 'smooth' behavior.
+    history.pushState({}, '', href);
+  });
+};

--- a/src/applications/static-pages/static-pages-entry.js
+++ b/src/applications/static-pages/static-pages-entry.js
@@ -12,6 +12,7 @@ import createFacilityPage from './facilities/createFacilityPage';
 import widgetTypes from './widgetTypes';
 import subscribeAdditionalInfoEvents from './subscribeAdditionalInfoEvents';
 import subscribeAccordionEvents from './subscribeAccordionEvents';
+import smoothScrollJumpLinks from './smoothScrollJumpLinks';
 import createApplicationStatus from './createApplicationStatus';
 import createCallToActionWidget from './createCallToActionWidget';
 import createMyVALoginWidget from './createMyVALoginWidget';
@@ -62,6 +63,9 @@ Sentry.withScope(scope => {
 subscribeAdditionalInfoEvents();
 
 subscribeAccordionEvents();
+
+// Smooth scroll to jump links.
+smoothScrollJumpLinks();
 
 createApplicationStatus(store, {
   formId: VA_FORM_IDS.FORM_21P_527EZ,


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/2199

This PR updates jump links on all browsers except IE and Edge to have smooth scrolling.

## Testing done


## Screenshots
https://dsva.slack.com/archives/C52CL1PKQ/p1581108531467900

## Acceptance criteria
- [x] Make jump links smooth scroll site-wide.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
