### PR TITLE
CT 116: Add SCO Contact Details to all non VETTEC profile pages #5362

### DIFF
--- a/src/applications/gi/components/profile/ContactInformation.jsx
+++ b/src/applications/gi/components/profile/ContactInformation.jsx
@@ -2,10 +2,10 @@ import _ from 'lodash';
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { VetTecScoContact } from './VetTecScoContact';
+import { ScoContact } from './ScoContact';
 import { phoneInfo } from '../../utils/helpers';
 
-export const VetTecContactInformation = ({ institution }) => {
+export const ContactInformation = ({ institution }) => {
   const firstProgram = _.get(institution, 'programs[0]', {});
 
   const versionedSchoolCertifyingOfficials = _.get(
@@ -136,10 +136,10 @@ export const VetTecContactInformation = ({ institution }) => {
         <div className="vads-l-col--9">
           <div className="vads-l-grid-container--full">
             <ul
-              className="vads-l-row vettec-sco-list vads-u-margin--0 primary-sco-list"
+              className="vads-l-row sco-list vads-u-margin--0 primary-sco-list"
               aria-labelledby="primary-contact-header"
             >
-              {primarySCOs.map((sco, index) => VetTecScoContact(sco, index))}
+              {primarySCOs.map((sco, index) => ScoContact(sco, index))}
             </ul>
           </div>
         </div>
@@ -160,10 +160,10 @@ export const VetTecContactInformation = ({ institution }) => {
         <div className="vads-l-col--9">
           <div className="vads-l-grid-container--full">
             <ul
-              className="vads-l-row vettec-sco-list vads-u-margin--0 secondary-sco-list"
+              className="vads-l-row sco-list vads-u-margin--0 secondary-sco-list"
               aria-labelledby="secondary-contact-header"
             >
-              {secondarySCOs.map((sco, index) => VetTecScoContact(sco, index))}
+              {secondarySCOs.map((sco, index) => ScoContact(sco, index))}
             </ul>
           </div>
         </div>
@@ -191,8 +191,8 @@ export const VetTecContactInformation = ({ institution }) => {
   );
 };
 
-VetTecContactInformation.propTypes = {
+ContactInformation.propTypes = {
   institution: PropTypes.object,
 };
 
-export default VetTecContactInformation;
+export default ContactInformation;

--- a/src/applications/gi/components/profile/InstitutionProfile.jsx
+++ b/src/applications/gi/components/profile/InstitutionProfile.jsx
@@ -11,6 +11,7 @@ import CautionaryInformation from './CautionaryInformation';
 import AdditionalInformation from './AdditionalInformation';
 import environment from 'platform/utilities/environment';
 import SchoolLocationsOld from './SchoolLocationsOld';
+import ContactInformation from './ContactInformation';
 
 export class InstitutionProfile extends React.Component {
   static propTypes = {
@@ -84,6 +85,11 @@ export class InstitutionProfile extends React.Component {
                 onShowModal={showModal}
               />
             </AccordionItem>
+            {!environment.isProduction() && (
+              <AccordionItem button="Contact details">
+                <ContactInformation institution={profile.attributes} />
+              </AccordionItem>
+            )}
             <AccordionItem button="Additional information">
               <AdditionalInformation
                 institution={profile.attributes}

--- a/src/applications/gi/components/profile/ScoContact.jsx
+++ b/src/applications/gi/components/profile/ScoContact.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-export const VetTecScoContact = (sco, index) => {
+export const ScoContact = (sco, index) => {
   if (sco) {
     const key = `${sco.firstName}.${sco.lastName}.${index}`;
     return (

--- a/src/applications/gi/components/vet-tec/VetTecApprovedPrograms.jsx
+++ b/src/applications/gi/components/vet-tec/VetTecApprovedPrograms.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import recordEvent from 'platform/monitoring/record-event';
-import VetTecContactInformation from './VetTecContactInformation';
+import ContactInformation from '../profile/ContactInformation';
 import { calculatorInputChange } from '../../actions';
 import { formatCurrency, isPresent } from '../../utils/helpers';
 
@@ -125,7 +125,7 @@ class VetTecApprovedPrograms extends React.Component {
   }
 }
 
-VetTecContactInformation.propTypes = {
+ContactInformation.propTypes = {
   institution: PropTypes.object,
   preSelectedProgram: PropTypes.string,
 };

--- a/src/applications/gi/components/vet-tec/VetTecInstitutionProfile.jsx
+++ b/src/applications/gi/components/vet-tec/VetTecInstitutionProfile.jsx
@@ -6,7 +6,7 @@ import VetTecApplicationProcess from './VetTecApplicationProcess';
 import VetTecApprovedPrograms from './VetTecApprovedPrograms';
 import VetTecCalculator from './VetTecCalculator';
 import VetTecHeadingSummary from './VetTecHeadingSummary';
-import VetTecContactInformation from './VetTecContactInformation';
+import ContactInformation from '../profile/ContactInformation';
 import { renderVetTecLogo } from '../../utils/render';
 import classNames from 'classnames';
 import VetTecVeteranPrograms from './VetTecVeteranPrograms';
@@ -42,7 +42,7 @@ const VetTecInstitutionProfile = ({
           <VetTecApplicationProcess institution={institution} />
         </AccordionItem>
         <AccordionItem button="Contact details">
-          <VetTecContactInformation institution={institution} />
+          <ContactInformation institution={institution} />
         </AccordionItem>
         <AccordionItem button="Additional information">
           <VetTecAdditionalInformation

--- a/src/applications/gi/sass/partials/_gi-profile-page.scss
+++ b/src/applications/gi/sass/partials/_gi-profile-page.scss
@@ -273,4 +273,8 @@
       display: none;
     }
   }
+
+  .sco-list {
+    list-style: none;
+  }
 }

--- a/src/applications/gi/sass/partials/_gi-vet-tec.scss
+++ b/src/applications/gi/sass/partials/_gi-vet-tec.scss
@@ -30,8 +30,4 @@
       display: none !important;
     }
   }
-
-  .vettec-sco-list {
-    list-style: none;
-  }
 }

--- a/src/applications/gi/tests/components/ContactInformation.unit.spec.jsx
+++ b/src/applications/gi/tests/components/ContactInformation.unit.spec.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
 
-import VetTecContactInformation from '../../components/vet-tec/VetTecContactInformation';
+import ContactInformation from '../../components/profile/ContactInformation';
 
 const institution = {
   versionedSchoolCertifyingOfficials: [
@@ -53,28 +53,22 @@ const institution = {
   ],
 };
 
-describe('<VetTecContactInformation>', () => {
+describe('<ContactInformation>', () => {
   it('should render', () => {
-    const wrapper = shallow(
-      <VetTecContactInformation institution={institution} />,
-    );
+    const wrapper = shallow(<ContactInformation institution={institution} />);
     const vdom = wrapper.html();
     expect(vdom).to.not.be.undefined;
     wrapper.unmount();
   });
 
   it('should display primary SCOs', () => {
-    const wrapper = shallow(
-      <VetTecContactInformation institution={institution} />,
-    );
+    const wrapper = shallow(<ContactInformation institution={institution} />);
     expect(wrapper.find('.primary-sco-list li').length).to.eq(2);
     wrapper.unmount();
   });
 
   it('should display secondary SCOs', () => {
-    const wrapper = shallow(
-      <VetTecContactInformation institution={institution} />,
-    );
+    const wrapper = shallow(<ContactInformation institution={institution} />);
     expect(wrapper.find('.secondary-sco-list li').length).to.eq(2);
     wrapper.unmount();
   });

--- a/src/applications/gi/tests/components/ScoContact.unit.spec.jsx
+++ b/src/applications/gi/tests/components/ScoContact.unit.spec.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
 
-import { VetTecScoContact } from '../../components/vet-tec/VetTecScoContact';
+import { ScoContact } from '../../components/profile/ScoContact';
 
 const sco = {
   facilityCode: '2V000203',
@@ -17,20 +17,20 @@ const sco = {
   email: 'VABENEFITS@GALVANIZE.COM',
 };
 
-describe('<VetTecScoContact>', () => {
+describe('<ScoContact>', () => {
   it('should render', () => {
-    const wrapper = shallow(<VetTecScoContact />);
+    const wrapper = shallow(<ScoContact />);
     const vdom = wrapper.html();
     expect(vdom).to.not.be.undefined;
     wrapper.unmount();
   });
 
   it('return null when no sco is supplied', () => {
-    expect(VetTecScoContact()).to.be.null;
+    expect(ScoContact()).to.be.null;
   });
 
   it('return the contact information for an SCO', () => {
-    const wrapper = shallow(VetTecScoContact(sco, 0));
+    const wrapper = shallow(ScoContact(sco, 0));
 
     expect(wrapper.text().includes('MARTIN INDIATSI')).to.be.true;
     expect(wrapper.text().includes('SCHOOL CERTIFYING OFFICIAL')).to.be.true;


### PR DESCRIPTION
## Description
https://github.com/department-of-veterans-affairs/va.gov-team/issues/5362

As a Comparison Tool user, I need the SCO Contact Details displayed on all institution profile pages so that I know who to contact at that institution.

## Testing done
- local testing

## Screenshots
<img width="1019" alt="Screen Shot 2020-02-07 at 3 53 04 PM" src="https://user-images.githubusercontent.com/1094999/74065936-071d4d80-49c4-11ea-9196-a2b1e5bfe24b.png">


## Acceptance criteria
- [ ] 1. A "School certifying officials" sub-section is in the "Contact Details" section on the profile page.
- [ ] 2. In the "School certifying officials" sub-section, SCOs are grouped by type: Primary & Secondary.
- [ ] 3. The SCO Full Name is displayed on all profile pages.
- [ ] 4. The SCO Title is displayed on all profile pages.
- [ ] 5. The SCOs are displayed in alphabetical order by last name from left to right, top to bottom for each type (primary, secondary)

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
