### PR TITLE
re-enable review instances

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -98,27 +98,27 @@ node('vetsgov-general-purpose') {
   commonStages.archiveAll(dockerContainer, ref);
   commonStages.cacheDrupalContent(dockerContainer, envsUsingDrupalCache);
 
-//  stage('Review') {
-//    if (commonStages.shouldBail()) {
-//      currentBuild.result = 'ABORTED'
-//      return
-//    }
-//
-//    try {
-//      if (!commonStages.isReviewable()) {
-//        return
-//      }
-//      build job: 'deploys/vets-review-instance-deploy', parameters: [
-//        stringParam(name: 'devops_branch', value: 'master'),
-//        stringParam(name: 'api_branch', value: 'master'),
-//        stringParam(name: 'web_branch', value: env.BRANCH_NAME),
-//        stringParam(name: 'source_repo', value: 'vets-website'),
-//      ], wait: false
-//    } catch (error) {
-//      commonStages.slackNotify()
-//      throw error
-//    }
-//  }
+  stage('Review') {
+    if (commonStages.shouldBail()) {
+      currentBuild.result = 'ABORTED'
+      return
+    }
+
+    try {
+      if (!commonStages.isReviewable()) {
+        return
+      }
+      build job: 'deploys/vets-review-instance-deploy', parameters: [
+        stringParam(name: 'devops_branch', value: 'master'),
+        stringParam(name: 'api_branch', value: 'master'),
+        stringParam(name: 'web_branch', value: env.BRANCH_NAME),
+        stringParam(name: 'source_repo', value: 'vets-website'),
+      ], wait: false
+    } catch (error) {
+      commonStages.slackNotify()
+      throw error
+    }
+  }
 
   stage('Deploy dev or staging') {
     try {


### PR DESCRIPTION
## Description

Looks like this was a temporary measure when a job was disabled or failing to start some time ago, and just no one turned them back on.

## Testing done

This very PR should trigger a new one if it works correctly.

## Screenshots


## Acceptance criteria

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable - I'm updating this so I don't have to fix documentation that says they're enabled 🚀
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub) https://github.com/department-of-veterans-affairs/va.gov-team/issues/4617
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
