### PR TITLE
Claim Status Tool: Default to using status if status.type is undefined

### DIFF
--- a/src/applications/claims-status/utils/appeals-v2-helpers.jsx
+++ b/src/applications/claims-status/utils/appeals-v2-helpers.jsx
@@ -281,7 +281,7 @@ function getHearingType(type) {
 export function getStatusContents(appeal, name = {}) {
   const { status, aoj, programArea } = appeal.attributes;
   const appealType = appeal.type;
-  const statusType = status.type;
+  const statusType = status.type || status;
   const details = status.details || {};
   const amaDocket = _.get(appeal, 'attributes.docket.type');
   const aojDescription = getAojDescription(aoj);


### PR DESCRIPTION
## Description
The claim status tool uses the function `getStatusContents` to determine what title and description to display based on a giant switch statement that checks the status of the claim/appeal. We ran into a seemingly one-off situation where a user viewed a claim and received the `default` case for the switch statement. This could happen in a couple scenarios:

1. The status being checked is not in our list of `STATUS_TYPES`
2. The variable being checked is `undefined` due to the status being a string and not an object

This PR handles the latter situation. The function checks `appeal.attributes.status.type`, but based on some test data we looked at, we think status come across as a string sometimes and not an object. In this situation, we look at just `appeals.attributes.status`.

## Acceptance criteria
- [ ] `getStatusContents` falls back to `appeal.attributes.status` when `appeal.attributes.status.type` is `undefined`