### PR TITLE
Convert phone form to use SchemaForm

### DIFF
--- a/src/platform/user/profile/vet360/components/PhoneField/PhoneField.jsx
+++ b/src/platform/user/profile/vet360/components/PhoneField/PhoneField.jsx
@@ -1,15 +1,75 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import pickBy from 'lodash/pickBy';
+import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 
 import { API_ROUTES, FIELD_NAMES, PHONE_TYPE, USA } from 'vet360/constants';
 
 import { isValidPhone } from 'platform/forms/validations';
+import PhoneNumberWidget from 'platform/forms-system/src/js/widgets/PhoneNumberWidget';
 
 import Vet360ProfileField from 'vet360/containers/Vet360ProfileField';
 
 import PhoneEditModal from './PhoneEditModal';
 import PhoneView from './PhoneView';
+
+const formSchema = {
+  type: 'object',
+  properties: {
+    'view:noInternationalNumbers': {
+      type: 'object',
+      properties: {},
+    },
+    inputPhoneNumber: {
+      type: 'string',
+      pattern: '^\\d{10}$',
+    },
+    extension: {
+      type: 'string',
+      pattern: '^\\s*[a-zA-Z0-9]{1,10}\\s*$',
+    },
+    isTextPermitted: {
+      type: 'boolean',
+    },
+  },
+  required: ['inputPhoneNumber'],
+};
+
+const uiSchema = {
+  'view:noInternationalNumbers': {
+    'ui:description': () => (
+      <AlertBox isVisible status="info" className="vads-u-margin-bottom--3">
+        <p>
+          We can only support U.S. phone numbers right now. If you have an
+          international number, please check back later.
+        </p>
+      </AlertBox>
+    ),
+  },
+  inputPhoneNumber: {
+    'ui:widget': PhoneNumberWidget,
+    'ui:options': {
+      inputType: 'tel',
+    },
+    'ui:title': 'Number',
+    'ui:errorMessages': {
+      pattern: 'Please enter a valid phone number.',
+    },
+  },
+  extension: {
+    'ui:title': 'Extension',
+    'ui:errorMessages': {
+      pattern: 'Please enter a valid extension.',
+    },
+  },
+  isTextPermitted: {
+    'ui:title':
+      'Send me text message (SMS) reminders for my VA health care appointments',
+    'ui:options': {
+      hideIf: formData => !formData['view:showSMSCheckbox'],
+    },
+  },
+};
 
 export default class PhoneField extends React.Component {
   static propTypes = {
@@ -60,7 +120,8 @@ export default class PhoneField extends React.Component {
     };
   }
 
-  convertCleanDataToPayload(cleanData, fieldName) {
+  convertCleanDataToPayload(data, fieldName) {
+    const cleanData = this.convertNextValueToCleanData(data);
     return pickBy(
       {
         id: cleanData.id,
@@ -88,6 +149,8 @@ export default class PhoneField extends React.Component {
         convertCleanDataToPayload={this.convertCleanDataToPayload}
         Content={PhoneView}
         EditModal={PhoneEditModal}
+        formSchema={formSchema}
+        uiSchema={uiSchema}
       />
     );
   }


### PR DESCRIPTION
## Description
Much like my two previous PRs (https://github.com/department-of-veterans-affairs/vets-website/pull/11601, https://github.com/department-of-veterans-affairs/vets-website/pull/11642) to convert profile forms to use a SchemaForm, this does the same for 

## Testing done
Local, making sure the payload matches the existing implementation.

## Screenshots
<img width="434" alt="new" src="https://user-images.githubusercontent.com/20728956/74255507-cfa1f000-4ca6-11ea-8758-8aaca6990d21.png">

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs