### PR TITLE
VACMS-971: Fixing timeformatting display on events.

### DIFF
--- a/src/site/components/events_list.drupal.liquid
+++ b/src/site/components/events_list.drupal.liquid
@@ -1,3 +1,4 @@
+{% assign timezone = "America/New_York" %}
 <div class="events-listing events-show">
   {% assign count = 0 %}
   {% assign eventsArray = fieldOffice.entity.reverseFieldOfficeNode.entities %}
@@ -6,46 +7,52 @@
   {% endif %}
   {% assign sortedEventsArray = eventsArray | eventSorter %}
   {% for event in sortedEventsArray %}
-  {% if event.title.length %}
-  {% assign count = count | plus:1 %}
-  <div class="vads-u-margin-bottom--2">
-    <h4><a href="{{event.entityUrl.path}}">{{event.title}}</a></h4>
-    <p>{{event.fieldDescription}}</p>
-    <div class="usa-grid usa-grid-full">
-      {% if event.fieldDate.value %}
-      <div class="usa-width-one-sixth">
-        <strong>When:</strong>
+    {% if event.title.length %}
+      {% assign count = count | plus:1 %}
+      <div class="vads-u-margin-bottom--2">
+        <h4>
+          <a href="{{event.entityUrl.path}}">{{event.title}}</a>
+        </h4>
+        <p>{{event.fieldDescription}}</p>
+        {% if event.fieldDate.startDate and event.fieldDate.value %}
+          <div class="usa-grid usa-grid-full">
+            <div class="usa-width-one-sixth">
+              <strong>When:</strong>
+            </div>
+            <div class="usa-width-five-sixths">
+              <span>{{ event.fieldDate.value | humanizeDate }}</span><br>
+              <span>{{ event.fieldDate.startDate | timeZone: timezone, "h:mm A"}}
+                {% if event.fieldDate.endDate %}
+                  –
+                  {{ event.fieldDate.endDate | timeZone: timezone, "h:mm A" }} ET</span>
+              {% endif %}
+            </div>
+          </div>
+        {% endif %}
+        <div class="usa-grid usa-grid-full">
+          {% if event.fieldFacilityLocation.entity.entityUrl.path %}
+            <div class="usa-width-one-sixth">
+              <strong>Where:</strong>
+            </div>
+            <div class="usa-width-five-sixths">
+              <p>
+                <a href="{{event.fieldFacilityLocation.entity.entityUrl.path}}">{{event.fieldFacilityLocation.entity.title}}</a>
+              </p>
+            </div>
+          {% endif %}
+        </div>
       </div>
-      <div class="usa-width-five-sixths">
-        <span>{{ event.fieldDate.value | humanizeDate }}</span><br>
-        <span>{{ event.fieldDate.value | humanizeTime }} –
-          {{ event.fieldDate.endValue | humanizeTime }}</span>
-      </div>
-      {% endif %}
-    </div>
-    <div class="usa-grid usa-grid-full">
-      {% if event.fieldFacilityLocation.entity.entityUrl.path %}
-      <div class="usa-width-one-sixth">
-        <strong>Where:</strong>
-      </div>
-      <div class="usa-width-five-sixths">
-        <p><a
-            href="{{event.fieldFacilityLocation.entity.entityUrl.path}}">{{event.fieldFacilityLocation.entity.title}}</a>
-        </p>
-      </div>
-      {% endif %}
-    </div>
-  </div>
-  {% endif %}
+    {% endif %}
   {% endfor %}
   {% if count == 0 %}
-  <div class="vads-u-margin-bottom--2">
-    <div>
-      <p>
-        <i>We're sorry, there are no events to display at this time. Check back regularly
-        for new event listings.</i>
-      </p>
+    <div class="vads-u-margin-bottom--2">
+      <div>
+        <p>
+          <i>We're sorry, there are no events to display at this time. Check back
+                      regularly
+                      for new event listings.</i>
+        </p>
+      </div>
     </div>
-  </div>
   {% endif %}
 </div>

--- a/src/site/layouts/event.drupal.liquid
+++ b/src/site/layouts/event.drupal.liquid
@@ -77,9 +77,12 @@ Example data:
 {% include "src/site/includes/breadcrumbs.drupal.liquid" with hideHomeBreadcrumb = true %}
 
 {% assign timezone = "America/New_York" %}
+{% comment %}
+Ultimately, we will allow check to use user timezone.
 {% if uid.entity.timezone != empty %}
-  {% assign timezone = uid.entity.timezone %}
+{% assign timezone = uid.entity.timezone %}
 {% endif %}
+{% endcomment %}
 
 {% assign start_date_no_time = fieldDate.startDate | timeZone: timezone, "dddd, MMM D" %}
 {% assign end_date_no_time = fieldDate.endValue | timeZone: timezone, "dddd, MMM D" %}

--- a/src/site/teasers/event.drupal.liquid
+++ b/src/site/teasers/event.drupal.liquid
@@ -28,9 +28,12 @@ Example data:
 {% if node != empty %}
 
     {% assign timezone = "America/New_York" %}
-    {% if node.uid.entity.timezone != empty %}
-        {% assign timezone = uid.entity.timezone %}
+    {% comment %}
+    Ultimately, we will allow check to use user timezone.
+    {% if uid.entity.timezone != empty %}
+    {% assign timezone = uid.entity.timezone %}
     {% endif %}
+    {% endcomment %}
 
     {% assign start_date_no_time = node.fieldDate.startDate | timeZone: timezone, "dddd, MMM D" %}
     {% assign end_date_no_time = node.fieldDate.endDate | timeZone: timezone , "dddd, MMM D" %}

--- a/src/site/teasers/event_featured.drupal.liquid
+++ b/src/site/teasers/event_featured.drupal.liquid
@@ -29,9 +29,12 @@ views",
 {% if node != empty %}
 
   {% assign timezone = "America/New_York" %}
-  {% if node.uid.entity.timezone != empty %}
-    {% assign timezone = uid.entity.timezone %}
+  {% comment %}
+  Ultimately, we will allow check to use user timezone.
+  {% if uid.entity.timezone != empty %}
+  {% assign timezone = uid.entity.timezone %}
   {% endif %}
+  {% endcomment %}
 
 {% assign start_date_no_time = node.fieldDate.startDate | timeZone: timezone, "dddd, MMM D" %}
 {% assign end_date_no_time = node.fieldDate.endDate | timeZone: timezone , "dddd, MMM D" %}


### PR DESCRIPTION
## Description
Different times are being output on listing pages and event pages. Formatting differences are okay, but we are seeing different times. This pr fixes.

## Testing done
Visual

## Screenshots
![image](https://user-images.githubusercontent.com/2404547/74373933-6ce64c80-4dab-11ea-8106-47e46af4323b.png)

## Acceptance criteria
- [ ] Go to `outreach-and-events/events/` and scroll down to `Leesburg, Virginia Community Veterans Engagement Board` - note the `When` time
- [ ] Follow link to event, and visually verify that the time is the same, e.g., both list and detail page have the same start and end times (disregard minor formatting differences)
