### PR TITLE
Update error message when there's no results

### DIFF
--- a/src/applications/find-va-forms/containers/SearchResults.jsx
+++ b/src/applications/find-va-forms/containers/SearchResults.jsx
@@ -153,7 +153,7 @@ export class SearchResults extends Component {
         <h2 className="vads-u-font-size--lg vads-u-margin-top--1p5 vads-u-font-weight--normal">
           No results were found for "<strong>{query}</strong>
           ". Try using fewer words or broadening your search. If you&apos;re
-          looking non-VA forms, go to the{' '}
+          looking for non-VA forms, go to the{' '}
           <a
             href="https://www.gsa.gov/reference/forms"
             rel="noopener noreferrer"

--- a/src/applications/find-va-forms/containers/SearchResults.jsx
+++ b/src/applications/find-va-forms/containers/SearchResults.jsx
@@ -151,7 +151,17 @@ export class SearchResults extends Component {
     if (!results.length) {
       return (
         <h2 className="vads-u-font-size--lg vads-u-margin-top--1p5 vads-u-font-weight--normal">
-          No results found for "<strong>{query}</strong>"
+          No results were found for "<strong>{query}</strong>
+          ". Try using fewer words or broadening your search. If you&apos;re
+          looking non-VA forms, go to the{' '}
+          <a
+            href="https://www.gsa.gov/reference/forms"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            GSA Forms Library
+          </a>
+          .
         </h2>
       );
     }


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/5709

This PR updates the error message text on find-va-forms.

## Testing done
N/A

## Screenshots
![image](https://user-images.githubusercontent.com/12773166/74377445-1ffd7880-4da1-11ea-919b-3e2c39168955.png)

## Acceptance criteria
- [x] Update text for error message text when no forms are found on find-va-forms.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
