### PR TITLE
Fix bugs with new edit phone number modal

### DIFF
--- a/src/platform/user/profile/vet360/components/PhoneField/PhoneEditModal.jsx
+++ b/src/platform/user/profile/vet360/components/PhoneField/PhoneEditModal.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import { merge } from 'lodash';
 
 import ErrorableTextInput from '@department-of-veterans-affairs/formation-react/ErrorableTextInput';
 import ErrorableCheckbox from '@department-of-veterans-affairs/formation-react/ErrorableCheckbox';
@@ -72,12 +71,14 @@ class PhoneEditModal extends React.Component {
     let defaultFieldValue;
 
     if (this.props.data) {
-      defaultFieldValue = merge(this.props.data, {
-        inputPhoneNumber:
-          this.props.data &&
-          [this.props.data.areaCode, this.props.data.phoneNumber].join(''),
+      defaultFieldValue = {
+        ...this.props.data,
+        inputPhoneNumber: `${this.props.data.areaCode}${
+          this.props.data.phoneNumber
+        }`,
+        extension: this.props.data.extension || '',
         'view:showSMSCheckbox': this.props.showSMSCheckbox,
-      });
+      };
     } else {
       defaultFieldValue = {
         countryCode: '1',
@@ -85,6 +86,7 @@ class PhoneEditModal extends React.Component {
         inputPhoneNumber: '',
         isTextable: false,
         isTextPermitted: false,
+        'view:showSMSCheckbox': this.props.showSMSCheckbox,
       };
     }
 

--- a/src/platform/user/profile/vet360/components/PhoneField/PhoneField.jsx
+++ b/src/platform/user/profile/vet360/components/PhoneField/PhoneField.jsx
@@ -26,7 +26,7 @@ const formSchema = {
     },
     extension: {
       type: 'string',
-      pattern: '^\\s*[a-zA-Z0-9]{1,10}\\s*$',
+      pattern: '^\\s*[a-zA-Z0-9]{0,10}\\s*$',
     },
     isTextPermitted: {
       type: 'boolean',


### PR DESCRIPTION
## Description
This addresses an issue where users could get weird form validation errors if they didn't enter a phone number extension. The issue is described here: https://github.com/department-of-veterans-affairs/va.gov-team/issues/5118#issuecomment-585415841

## Testing done
Local

## Screenshots


## Acceptance criteria
- [ ] There is never a situation where a user is unable to leave the extension field blank.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs