### PR TITLE
Reduce font size for error message

### DIFF
--- a/src/applications/find-va-forms/containers/SearchResults.jsx
+++ b/src/applications/find-va-forms/containers/SearchResults.jsx
@@ -155,7 +155,7 @@ export class SearchResults extends Component {
         vads-u-margin-top--1p5 vads-u-font-weight--normal"
         >
           No results were found for "<strong>{query}</strong>
-          ". Try using fewer words or broadening your search. If you&apos;re
+          ." Try using fewer words or broadening your search. If you&apos;re
           looking for non-VA forms, go to the{' '}
           <a
             href="https://www.gsa.gov/reference/forms"

--- a/src/applications/find-va-forms/containers/SearchResults.jsx
+++ b/src/applications/find-va-forms/containers/SearchResults.jsx
@@ -150,7 +150,7 @@ export class SearchResults extends Component {
     // Show no results found message.
     if (!results.length) {
       return (
-        <h2 className="vads-u-font-size--lg vads-u-margin-top--1p5 vads-u-font-weight--normal">
+        <h2 className="vads-u-font-size--sm vads-u-margin-top--1p5 vads-u-font-weight--normal">
           No results were found for "<strong>{query}</strong>
           ". Try using fewer words or broadening your search. If you&apos;re
           looking for non-VA forms, go to the{' '}

--- a/src/applications/find-va-forms/containers/SearchResults.jsx
+++ b/src/applications/find-va-forms/containers/SearchResults.jsx
@@ -150,7 +150,10 @@ export class SearchResults extends Component {
     // Show no results found message.
     if (!results.length) {
       return (
-        <h2 className="vads-u-font-size--sm vads-u-margin-top--1p5 vads-u-font-weight--normal">
+        <h2
+          className="vads-u-font-size--base vads-u-line-height--3 vads-u-font-family--sans
+        vads-u-margin-top--1p5 vads-u-font-weight--normal"
+        >
           No results were found for "<strong>{query}</strong>
           ". Try using fewer words or broadening your search. If you&apos;re
           looking for non-VA forms, go to the{' '}


### PR DESCRIPTION
## Description
This PR reduces the font size for the no results error message on find-va-forms.

## Testing done


## Screenshots
https://github.com/department-of-veterans-affairs/va.gov-team/issues/5709#issuecomment-585778517

## Acceptance criteria
- [x] Reduce font size

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
