### PR TITLE
Add more tests for confirmed item and confirmation page

### DIFF
--- a/src/applications/vaos/tests/components/ConfirmationRequestInfo.unit.spec.jsx
+++ b/src/applications/vaos/tests/components/ConfirmationRequestInfo.unit.spec.jsx
@@ -121,4 +121,153 @@ describe('VAOS <ConfirmationRequestInfo>', () => {
 
     tree.unmount();
   });
+
+  it('should render CC request without provider', () => {
+    const data = {
+      facilityType: 'communityCare',
+      distanceWillingToTravel: '25',
+      preferredLanguage: 'english',
+      visitType: 'office',
+      bestTimeToCall: {
+        morning: true,
+        afternoon: true,
+      },
+      hasCommunityCareProvider: false,
+      calendarData: {
+        selectedDates: [{ date: '2019-12-20', optionTime: 'AM' }],
+      },
+    };
+    const facilityDetails = {
+      name: 'CHYSHR-Sidney VA Clinic',
+      address: {
+        physical: {
+          zip: '82001-5356',
+          city: 'Cheyenne',
+          state: 'WY',
+          address1: '2360 East Pershing Boulevard',
+          address2: null,
+          address3: null,
+        },
+      },
+    };
+
+    const pageTitle = 'Your appointment request has been submitted';
+    const tree = mount(
+      <ConfirmationRequestInfo
+        data={data}
+        facilityDetails={facilityDetails}
+        vaCityState="Cheyenne, WY"
+        pageTitle={pageTitle}
+      />,
+    );
+
+    const text = tree.text();
+    const heading = tree.find('h1');
+
+    expect(text).to.contain('Community Care');
+    expect(text).not.to.contain('CHYSHR-Sidney VA Clinic');
+    expect(text).to.contain('No preference');
+
+    expect(tree.find('AlertBox').exists()).to.be.true;
+    expect(tree.find('h1').exists()).to.be.true;
+    expect(heading.exists()).to.be.true;
+    expect(heading.text()).to.equal(pageTitle);
+
+    tree.unmount();
+  });
+
+  it('should render single time', () => {
+    const data = {
+      visitType: 'office',
+      bestTimeToCall: {
+        evening: true,
+      },
+      calendarData: {
+        selectedDates: [{ date: '2019-12-20', optionTime: 'AM' }],
+      },
+    };
+    const facilityDetails = {
+      name: 'CHYSHR-Sidney VA Clinic',
+      address: {
+        physical: {
+          zip: '82001-5356',
+          city: 'Cheyenne',
+          state: 'WY',
+          address1: '2360 East Pershing Boulevard',
+          address2: null,
+          address3: null,
+        },
+      },
+    };
+    const pageTitle = 'Your appointment request has been submitted';
+
+    const tree = mount(
+      <ConfirmationRequestInfo
+        data={data}
+        facilityDetails={facilityDetails}
+        pageTitle={pageTitle}
+      />,
+    );
+
+    tree
+      .find('AdditionalInfo')
+      .find('button')
+      .simulate('click');
+    tree.setProps();
+
+    const text = tree.text();
+
+    expect(text).to.contain('Evening');
+    expect(text).to.contain('Show less');
+
+    tree.unmount();
+  });
+
+  it('should render message for all times', () => {
+    const data = {
+      visitType: 'office',
+      bestTimeToCall: {
+        evening: true,
+        morning: true,
+        afternoon: true,
+      },
+      calendarData: {
+        selectedDates: [{ date: '2019-12-20', optionTime: 'AM' }],
+      },
+    };
+    const facilityDetails = {
+      name: 'CHYSHR-Sidney VA Clinic',
+      address: {
+        physical: {
+          zip: '82001-5356',
+          city: 'Cheyenne',
+          state: 'WY',
+          address1: '2360 East Pershing Boulevard',
+          address2: null,
+          address3: null,
+        },
+      },
+    };
+    const pageTitle = 'Your appointment request has been submitted';
+
+    const tree = mount(
+      <ConfirmationRequestInfo
+        data={data}
+        facilityDetails={facilityDetails}
+        pageTitle={pageTitle}
+      />,
+    );
+
+    tree
+      .find('AdditionalInfo')
+      .find('button')
+      .simulate('click');
+    tree.setProps();
+
+    const text = tree.text();
+
+    expect(text).to.contain('Anytime during the day');
+
+    tree.unmount();
+  });
 });

--- a/src/applications/vaos/tests/components/ConfirmedAppointmentListItem.unit.spec.jsx
+++ b/src/applications/vaos/tests/components/ConfirmedAppointmentListItem.unit.spec.jsx
@@ -1,8 +1,10 @@
 import React from 'react';
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
+import sinon from 'sinon';
 import moment from 'moment';
 
+import { APPOINTMENT_TYPES } from '../../utils/constants';
 import ConfirmedAppointmentListItem from '../../components/ConfirmedAppointmentListItem';
 
 describe('VAOS <ConfirmedAppointmentListItem> Regular Appointment', () => {
@@ -44,12 +46,15 @@ describe('VAOS <ConfirmedAppointmentListItem> Regular Appointment', () => {
       main: '307-778-7550',
     },
   };
+  const cancelAppointment = sinon.spy();
 
   let tree;
 
   beforeEach(() => {
     tree = shallow(
       <ConfirmedAppointmentListItem
+        showCancelButton
+        cancelAppointment={cancelAppointment}
         appointment={appointment}
         facility={facility}
       />,
@@ -93,6 +98,18 @@ describe('VAOS <ConfirmedAppointmentListItem> Regular Appointment', () => {
 
   it('should not show booking note', () => {
     expect(tree.text()).not.to.contain('Booking note');
+  });
+
+  it('should show cancel link', () => {
+    expect(tree.text()).to.contain('Cancel appointment');
+  });
+
+  it('should cancel appointment', () => {
+    tree
+      .find('button')
+      .props()
+      .onClick();
+    expect(cancelAppointment.called).to.be.true;
   });
 });
 
@@ -182,5 +199,97 @@ describe('VAOS <ConfirmedAppointmentListItem> Video Appointment', () => {
   it('should show booking note', () => {
     expect(tree.text()).to.contain('Booking note');
     expect(tree.text()).to.contain('My reason isn’t listed');
+  });
+});
+
+describe('VAOS <ConfirmedAppointmentListItem> Canceled Appointment', () => {
+  const appointment = {
+    appointmentType: 'Testing',
+    startDate: '2019-12-11T16:00:00Z',
+    facilityId: '983',
+    clinicId: '123',
+    vvsAppointments: [],
+    vdsAppointments: [
+      {
+        appointmentLength: '60',
+        appointmentTime: '2019-12-11T16:00:00Z',
+        clinic: {
+          name: 'C&P BEV AUDIO FTC1',
+          askForCheckIn: false,
+          facilityCode: '983',
+        },
+        patientId: '7216691',
+        type: 'REGULAR',
+        currentStatus: 'NO-SHOW',
+        bookingNote: 'Booking note',
+      },
+    ],
+  };
+  const facility = {
+    address: {
+      mailing: {},
+      physical: {
+        zip: '82001-5356',
+        city: 'Cheyenne',
+        state: 'WY',
+        address1: '2360 East Pershing Boulevard',
+        address2: null,
+        address3: null,
+      },
+    },
+    phone: {
+      main: '307-778-7550',
+    },
+  };
+
+  let tree;
+
+  beforeEach(() => {
+    tree = shallow(
+      <ConfirmedAppointmentListItem
+        appointment={appointment}
+        type={APPOINTMENT_TYPES.vaAppointment}
+        facility={facility}
+      />,
+    );
+  });
+
+  afterEach(() => {
+    tree.unmount();
+  });
+
+  it('should have a status of "canceled"', () => {
+    expect(
+      tree
+        .find('span')
+        .at(2)
+        .text(),
+    ).to.contain('Canceled');
+  });
+
+  it('should have an h2 with date', () => {
+    expect(
+      tree
+        .find('h2')
+        .text()
+        .trim(),
+    ).to.contain('December 11, 2019');
+  });
+
+  it('should display clinic name', () => {
+    expect(
+      tree
+        .find('dt')
+        .first()
+        .text(),
+    ).to.contain('C&P BEV AUDIO FTC1');
+  });
+
+  it('should show facility address', () => {
+    expect(tree.find('FacilityAddress').exists()).to.be.true;
+  });
+
+  it('should not show booking note', () => {
+    expect(tree.text()).not.to.contain('Booking note');
   });
 });


### PR DESCRIPTION
## Description
This adds some more unit tests to cover gaps in a couple VAOS components.

## Testing done
Unit testing

## Acceptance criteria
- [ ] Tests pass

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
