### PR TITLE
Add downtime messaging promo banners for saturday

### DIFF
--- a/src/platform/site-wide/announcements/components/ScheduledMaintenance.jsx
+++ b/src/platform/site-wide/announcements/components/ScheduledMaintenance.jsx
@@ -1,0 +1,118 @@
+// Dependencies.
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import moment from 'moment-timezone';
+import PromoBanner, {
+  PROMO_BANNER_TYPES,
+} from '@department-of-veterans-affairs/formation-react/PromoBanner';
+
+class ScheduledMaintenance extends Component {
+  static propTypes = {
+    announcement: PropTypes.shape({
+      downtimeStartsAt: PropTypes.object.isRequired,
+      expiresAt: PropTypes.object.isRequired,
+    }).isRequired,
+    dismiss: PropTypes.func.isRequired,
+  };
+
+  static deriveMessage(downtimeStartsAt, expiresAt, component) {
+    // Derive the timestamp for the present.
+    const now = moment().tz('America/New_York');
+
+    // No message if the announcement has expired (This shouldn't ever be run.)
+    if (now.isAfter(expiresAt)) {
+      return '';
+    }
+
+    // MESSAGE 3: if there is scheduled maintenance *in progress*.
+    if (now.isAfter(downtimeStartsAt)) {
+      return `We're doing work on VA.gov. If you have trouble using online tools, check back after ${expiresAt.format(
+        'MMM Do [at] h:mm a z',
+      )}.`;
+    }
+
+    // Derive cloned downtimeStartsAt since moment mutates with .subtract... :(
+    const clonedDowntimeStartsAt = downtimeStartsAt.clone();
+
+    // MESSAGE 2: if scheduled maintenance *is really about to* happen.
+    if (now.isAfter(clonedDowntimeStartsAt.subtract(60, 'minutes'))) {
+      // Update in a few seconds to update the minute number on the UI.
+      if (component) {
+        component.refreshIn(60000);
+      }
+
+      return `Scheduled maintenance starts in ${downtimeStartsAt.diff(
+        now,
+        'minutes',
+      )} minutes. If you’re filling out a form, sign in or create an account to save your work.`;
+    }
+
+    // Derive cloned downtimeStartsAt since moment mutates with .subtract... :(
+    const cloned2DowntimeStartsAt = downtimeStartsAt.clone();
+
+    // MESSAGE 1: if scheduled maintenance *is about to* happen.
+    if (now.isAfter(cloned2DowntimeStartsAt.subtract(12, 'hours'))) {
+      return `We'll be doing site maintenance on ${downtimeStartsAt.format(
+        'MMM Do [at] h:mm a',
+      )} until ${expiresAt.format(
+        'h:mm a z',
+      )}. You won’t be able to sign in or use some tools during this time.`;
+    }
+
+    // No message if scheduled maintenance is not about to happen.
+    return '';
+  }
+
+  componentWillUnmount() {
+    // Prevent memory leaks by clearing timeouts.
+    clearTimeout(this.rerenderTimeout);
+  }
+
+  refreshIn = milliseconds => {
+    clearTimeout(this.rerenderTimeout);
+    this.rerenderTimeout = setTimeout(() => {
+      this.forceUpdate();
+    }, milliseconds);
+  };
+
+  render() {
+    const {
+      announcement: { downtimeStartsAt, expiresAt },
+      dismiss,
+    } = this.props;
+
+    // Derive the timestamp for the present.
+    const now = moment().tz('America/New_York');
+
+    // Do not render if it's after the expiration date.
+    if (now.isAfter(expiresAt)) {
+      return null;
+    }
+
+    // Derive cloned downtimeStartsAt since moment mutates with .subtract... :(
+    const clonedDowntimeStartsAt = downtimeStartsAt.clone();
+
+    // Do not render if it's before scheduled maintenance.
+    if (now.isBefore(clonedDowntimeStartsAt.subtract(12, 'hours'))) {
+      return null;
+    }
+
+    return (
+      <PromoBanner
+        onClose={dismiss}
+        render={() => (
+          <div>
+            {ScheduledMaintenance.deriveMessage(
+              downtimeStartsAt,
+              expiresAt,
+              this,
+            )}
+          </div>
+        )}
+        type={PROMO_BANNER_TYPES.announcement}
+      />
+    );
+  }
+}
+
+export default ScheduledMaintenance;

--- a/src/platform/site-wide/announcements/config/index.js
+++ b/src/platform/site-wide/announcements/config/index.js
@@ -1,11 +1,37 @@
+// Node modules.
+import moment from 'moment-timezone';
 // Relative imports.
 import ExploreVAModal from '../components/ExploreVAModal';
 import FindVABenefitsIntro from '../components/FindVABenefitsIntro';
 import PersonalizationBanner from '../components/PersonalizationBanner';
 import Profile360Intro from '../components/Profile360Intro';
+import ScheduledMaintenance from '../components/ScheduledMaintenance';
 import VAPlusVetsModal from '../components/VAPlusVetsModal';
 import WelcomeToNewVAModal from '../components/WelcomeToNewVAModal';
 import VAMCWelcomeModal, { VAMC_PATHS } from '../components/VAMCWelcomeModal';
+
+const scheduledMaintenance = {
+  name: 'scheduled-maintenance',
+  paths: /(.)/,
+  component: ScheduledMaintenance,
+  // This is just used as a prop and not in selectors.
+  downtimeStartsAt: moment.tz('2020-02-15 21:00', 'America/New_York'),
+  expiresAt: moment.tz('2020-02-15 21:30', 'America/New_York'),
+};
+
+const scheduledMaintenanceMessage = ScheduledMaintenance.deriveMessage(
+  scheduledMaintenance.downtimeStartsAt,
+  scheduledMaintenance.expiresAt,
+);
+
+// The scheduled maintenance announcement has three different states, each of which should be separately dismissible
+// This spoofs it by deriving the announcement's name property in the config.
+if (scheduledMaintenanceMessage) {
+  const stateId = scheduledMaintenanceMessage.slice(1, 10);
+  scheduledMaintenance.name = `scheduled-maintenance-${stateId}`;
+} else {
+  scheduledMaintenance.disabled = true;
+}
 
 const config = {
   announcements: [
@@ -16,6 +42,7 @@ const config = {
       disabled: !VAPlusVetsModal.isEnabled(),
       showEverytime: true,
     },
+    scheduledMaintenance,
     {
       name: 'explore-va',
       paths: /(.)/,

--- a/src/platform/site-wide/announcements/selectors.js
+++ b/src/platform/site-wide/announcements/selectors.js
@@ -1,5 +1,5 @@
 // Node modules.
-import moment from 'moment';
+import moment from 'moment-timezone';
 // Relative imports.
 import _config from './config';
 
@@ -7,8 +7,10 @@ import _config from './config';
 const isExpiredAnnouncement = announcement => {
   if (!announcement.expiresAt) return true;
 
-  const expiresAtDate = moment(announcement.expiresAt);
-  const hasExpired = moment().isSameOrAfter(expiresAtDate);
+  const expiresAtDate = moment.tz(announcement.expiresAt, 'America/New_York');
+  const hasExpired = moment()
+    .tz('America/New_York')
+    .isSameOrAfter(expiresAtDate);
 
   return !hasExpired;
 };

--- a/src/platform/site-wide/moment-setup.js
+++ b/src/platform/site-wide/moment-setup.js
@@ -1,4 +1,5 @@
 import moment from 'moment';
+import momentTimezone from 'moment-timezone';
 
 // Derive moment options.
 const options = {
@@ -26,3 +27,4 @@ const options = {
 
 // Called at startup so that the formatting applied under updateLocale occur site-wide.
 moment.updateLocale('en', options);
+momentTimezone.updateLocale('en', options);


### PR DESCRIPTION
## Description
This PR adds downtime messaging promo banners for Saturday's downtime.

Related ticket with all details: https://github.com/department-of-veterans-affairs/va.gov-team/issues/5856

**NOTE:** I am not happy with this PR but it's needed for Saturday's downtime. My plan is to immediately start a follow-up PR that will refactor this code so that we can just update 3-6 loc anytime there's scheduled `vets-api` downtime.

This PR is a combo of these 2 old PRs:
https://github.com/department-of-veterans-affairs/vets-website/pull/11630
https://github.com/department-of-veterans-affairs/vets-website/pull/11464

## Testing done


## Screenshots
https://dsva.slack.com/archives/C52CL1PKQ/p1581627140135100

## Acceptance criteria
- [x] Add downtime notifications for saturday

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
