### PR TITLE
Add missing GA event to track SSO

### DIFF
--- a/src/applications/disability-benefits/wizard/pages/bdd.jsx
+++ b/src/applications/disability-benefits/wizard/pages/bdd.jsx
@@ -1,6 +1,9 @@
 import React from 'react';
+import { connect } from 'react-redux';
 import moment from 'moment';
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
+import { isLoggedIn as isLoggedInSelector } from 'platform/user/selectors';
+import recordEvent from 'platform/monitoring/record-event';
 import { pageNames } from './pageList';
 import { EBEN_526_URL, BDD_INFO_URL } from '../../constants';
 
@@ -13,39 +16,51 @@ const oneHundredEightyDays = moment()
   .add(180, 'd')
   .format(dateFormat);
 
-const alertContent = (
-  <>
-    <p>
-      <strong>
-        If your separation date is between {ninetyDays} and{' '}
-        {oneHundredEightyDays}
-      </strong>{' '}
-      (90 and 180 days from today), you can file a disability claim through the
-      Benefits Delivery at Discharge (BDD) program.
-    </p>
-    <p>
-      <strong>If your separation date is before {ninetyDays},</strong> you can’t
-      file a BDD claim, but you can still begin the process of filing your claim
-      on eBenefits.
-    </p>
-    <a href={EBEN_526_URL} className="usa-button-primary va-button-primary">
-      Go to eBenefits
-    </a>
-    <p>
-      <a href={BDD_INFO_URL}>Learn more about the BDD program</a>
-    </p>
-  </>
-);
+function alertContent(isLoggedIn) {
+  return (
+    <>
+      <p>
+        <strong>
+          If your separation date is between {ninetyDays} and{' '}
+          {oneHundredEightyDays}
+        </strong>{' '}
+        (90 and 180 days from today), you can file a disability claim through
+        the Benefits Delivery at Discharge (BDD) program.
+      </p>
+      <p>
+        <strong>If your separation date is before {ninetyDays},</strong> you
+        can’t file a BDD claim, but you can still begin the process of filing
+        your claim on eBenefits.
+      </p>
+      <a
+        href={EBEN_526_URL}
+        className="usa-button-primary va-button-primary"
+        onClick={() =>
+          isLoggedIn && recordEvent({ event: 'nav-ebenefits-click' })
+        }
+      >
+        Go to eBenefits
+      </a>
+      <p>
+        <a href={BDD_INFO_URL}>Learn more about the BDD program</a>
+      </p>
+    </>
+  );
+}
 
-const BDDPage = () => (
+const BDDPage = ({ isLoggedIn }) => (
   <AlertBox
     status="error"
     headline="You’ll need to file a claim on eBenefits"
-    content={alertContent}
+    content={alertContent(isLoggedIn)}
   />
 );
 
+const mapStateToProps = state => ({
+  isLoggedIn: isLoggedInSelector(state),
+});
+
 export default {
   name: pageNames.bdd,
-  component: BDDPage,
+  component: connect(mapStateToProps)(BDDPage),
 };


### PR DESCRIPTION
## Description

The SSO project recently added GA tracking to count eBenefit navigations. This addresses a missed case.

## Testing done

Manually confirmed the `isLoggedIn` flag works as expected. 

## Acceptance criteria
- [ ] Adds missing GA event tag

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
