### PR TITLE
add init system to docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends gconf-service l
                                                 libxrandr2 libxrender1 libxss1 libxtst6 ca-certificates \
                                                 fonts-liberation libappindicator1 libnss3 lsb-release xdg-utils \
                                                 x11vnc x11-xkb-utils xfonts-100dpi xfonts-75dpi xfonts-scalable \
-                                                xfonts-cyrillic x11-apps xvfb xauth wget netcat \
+                                                xfonts-cyrillic x11-apps xvfb xauth wget netcat dumb-init \
   && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
   && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
   && apt-get update \
@@ -40,3 +40,5 @@ RUN mkdir -p /application
 WORKDIR /application
 
 USER vets-website
+
+ENTRYPOINT ["/usr/bin/dumb-init", "--"]

--- a/docker-compose.review.yml
+++ b/docker-compose.review.yml
@@ -8,7 +8,8 @@ services:
     command: script/review-entrypoint.sh
     environment:
       API_URL: ${API_URL:-http://localhost:3000}
-      WEB_HOST: ${WEB_HOST:-localhost:3001}
+      WEB_HOST: ${WEB_HOST:-localhost}
+      WEB_PORT: ${WEB_PORT:-3001}
     expose:
       - 3001
     image: vets-website:${IMAGE_TAG:-latest}

--- a/docker-compose.review.yml
+++ b/docker-compose.review.yml
@@ -8,6 +8,7 @@ services:
     command: script/review-entrypoint.sh
     environment:
       API_URL: ${API_URL:-http://localhost:3000}
+      WEB_HOST: ${WEB_HOST:-localhost:3001}
     expose:
       - 3001
     image: vets-website:${IMAGE_TAG:-latest}

--- a/script/review-entrypoint.sh
+++ b/script/review-entrypoint.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 set -e
 yarn install --production=false
-npm run build -- --buildtype localhost --api='${API_URL}' --host='${WEB_HOST}'
+npm run build -- --buildtype localhost --api='${API_URL}' --host='${WEB_HOST}' --port='${WEB_PORT}'
 npm run heroku-serve -- build/localhost -p 3001

--- a/script/review-entrypoint.sh
+++ b/script/review-entrypoint.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 set -e
 yarn install --production=false
-npm run build -- --buildtype localhost --api='${API_URL}'
+npm run build -- --buildtype localhost --api='${API_URL}' --host='${WEB_HOST}'
 npm run heroku-serve -- build/localhost -p 3001


### PR DESCRIPTION
## Description

Fixes a couple of issues with the review instance implementation:

1) the Docker process didn't have a proper init, so issuing a restart would result in a 10s timeout from Docker and a SIGKILL being sent to the process. I believe this is the cause of an occasional busted up yarn cache directory which was resulting in failed builds but have been unable to reproduce it consistently so far
2) the build process wasn't getting all of the right options and was ending up with links scattered throughout to `localhost:3001`

ref: https://github.com/department-of-veterans-affairs/va.gov-team/issues/5883

## Testing done

Tested in review instances, needs https://github.com/department-of-veterans-affairs/devops/pull/6384 to work.

## Screenshots


## Acceptance criteria

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
