### PR TITLE
Use SchemaForm for Direct Deposit modal

### DIFF
--- a/src/applications/personalization/profile360/components/PaymentInformationEditModal.jsx
+++ b/src/applications/personalization/profile360/components/PaymentInformationEditModal.jsx
@@ -9,6 +9,8 @@ import ErrorableSelect from '@department-of-veterans-affairs/formation-react/Err
 import LoadingButton from 'platform/site-wide/loading-button/LoadingButton';
 
 import { focusElement } from 'platform/utilities/ui';
+import environment from 'platform/utilities/environment';
+import SchemaForm from 'platform/forms-system/src/js/components/SchemaForm';
 
 import {
   getAccountNumberErrorMessage,
@@ -19,6 +21,51 @@ import { ACCOUNT_TYPES_OPTIONS } from '../constants';
 
 import PaymentInformationEditModalError from './PaymentInformationEditModalError';
 
+const useNewForm = !environment.isProduction();
+
+const schema = {
+  type: 'object',
+  properties: {
+    routingNumber: {
+      type: 'string',
+      pattern: '^\\d{9}$',
+    },
+    accountNumber: {
+      type: 'string',
+      pattern: '^\\d{1,17}$',
+    },
+    accountType: {
+      type: 'string',
+      enum: Object.values(ACCOUNT_TYPES_OPTIONS),
+    },
+  },
+  required: ['accountNumber', 'routingNumber', 'accountType'],
+};
+
+const uiSchema = {
+  routingNumber: {
+    'ui:title':
+      'Routing number (Your 9-digit routing number will update your bank’s name)',
+    'ui:errorMessages': {
+      pattern: 'Please enter the bank’s 9-digit routing number.',
+      required: 'Please enter the bank’s 9-digit routing number.',
+    },
+  },
+  accountNumber: {
+    'ui:title': 'Account number (No more than 17 digits)',
+    'ui:errorMessages': {
+      pattern: 'Please enter your account number.',
+      required: 'Please enter your account number.',
+    },
+  },
+  accountType: {
+    'ui:title': 'Account type',
+    'ui:errorMessages': {
+      required: 'Please select the type that best describes the account.',
+    },
+  },
+};
+
 class PaymentInformationEditModal extends React.Component {
   static propTypes = {
     fields: PropTypes.object,
@@ -28,6 +75,10 @@ class PaymentInformationEditModal extends React.Component {
     onSubmit: PropTypes.func.isRequired,
     editModalFieldChanged: PropTypes.func.isRequired,
     responseError: PropTypes.object,
+  };
+
+  state = {
+    formData: {},
   };
 
   onSubmit = event => {
@@ -104,6 +155,15 @@ class PaymentInformationEditModal extends React.Component {
     });
   };
 
+  formSubmit = ({ formData }) => {
+    this.props.onSubmit({
+      financialInstitutionName: 'Hidden form field',
+      financialInstitutionRoutingNumber: formData.routingNumber,
+      accountNumber: formData.accountNumber,
+      accountType: formData.accountType,
+    });
+  };
+
   render() {
     const {
       financialInstitutionRoutingNumber: routingNumber,
@@ -135,55 +195,86 @@ class PaymentInformationEditModal extends React.Component {
           alt="On a personal check, find your bank's 9-digit routing number listed along the bottom-left edge, and your account number listed beside that."
         />
 
-        <form onSubmit={this.onSubmit}>
-          <ErrorableTextInput
-            label="Routing number (Your 9-digit routing number will update your bank’s name)"
-            name="routing-number"
-            field={routingNumber.field}
-            errorMessage={routingNumber.errorMessage}
-            onValueChange={this.onRoutingNumberChanged}
-            required
-            charMax={9}
-          />
+        {!useNewForm && (
+          <form onSubmit={this.onSubmit}>
+            <ErrorableTextInput
+              label="Routing number (Your 9-digit routing number will update your bank’s name)"
+              name="routing-number"
+              field={routingNumber.field}
+              errorMessage={routingNumber.errorMessage}
+              onValueChange={this.onRoutingNumberChanged}
+              required
+              charMax={9}
+            />
 
-          <ErrorableTextInput
-            label="Account number (No more than 17 digits)"
-            name="account-number"
-            field={accountNumber.field}
-            errorMessage={accountNumber.errorMessage}
-            onValueChange={this.onAccountNumberChanged}
-            required
-            charMax={17}
-          />
+            <ErrorableTextInput
+              label="Account number (No more than 17 digits)"
+              name="account-number"
+              field={accountNumber.field}
+              errorMessage={accountNumber.errorMessage}
+              onValueChange={this.onAccountNumberChanged}
+              required
+              charMax={17}
+            />
 
-          <ErrorableSelect
-            label="Account type"
-            name="account-type"
-            value={accountType.value}
-            errorMessage={accountType.errorMessage}
-            onValueChange={this.onAccountTypeChanged}
-            options={Object.values(ACCOUNT_TYPES_OPTIONS)}
-            includeBlankOption
-            required
-          />
+            <ErrorableSelect
+              label="Account type"
+              name="account-type"
+              value={accountType.value}
+              errorMessage={accountType.errorMessage}
+              onValueChange={this.onAccountTypeChanged}
+              options={Object.values(ACCOUNT_TYPES_OPTIONS)}
+              includeBlankOption
+              required
+            />
 
-          <LoadingButton
-            type="submit"
-            className="usa-button-primary vads-u-width--full small-screen:vads-u-width--auto"
-            isLoading={this.props.isSaving}
+            <LoadingButton
+              type="submit"
+              className="usa-button-primary vads-u-width--full small-screen:vads-u-width--auto"
+              isLoading={this.props.isSaving}
+            >
+              Update
+            </LoadingButton>
+
+            <button
+              type="button"
+              disabled={this.props.isSaving}
+              className="usa-button-secondary"
+              onClick={this.props.onClose}
+            >
+              Cancel
+            </button>
+          </form>
+        )}
+
+        {useNewForm && (
+          <SchemaForm
+            name="Direct Deposit Information"
+            title="Direct Deposit Information"
+            schema={schema}
+            uiSchema={uiSchema}
+            onSubmit={this.formSubmit}
+            onChange={formData => this.setState({ formData })}
+            data={this.state.formData}
           >
-            Update
-          </LoadingButton>
+            <LoadingButton
+              type="submit"
+              className="usa-button-primary vads-u-margin-top--0 vads-u-width--full small-screen:vads-u-width--auto"
+              isLoading={this.props.isSaving}
+            >
+              Update
+            </LoadingButton>
 
-          <button
-            type="button"
-            disabled={this.props.isSaving}
-            className="usa-button-secondary"
-            onClick={this.props.onClose}
-          >
-            Cancel
-          </button>
-        </form>
+            <button
+              type="button"
+              disabled={this.props.isSaving}
+              className="usa-button-secondary"
+              onClick={this.props.onClose}
+            >
+              Cancel
+            </button>
+          </SchemaForm>
+        )}
       </Modal>
     );
   }

--- a/src/applications/personalization/profile360/tests/components/PaymentInformationEditModal.unit.spec.jsx
+++ b/src/applications/personalization/profile360/tests/components/PaymentInformationEditModal.unit.spec.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { mount, shallow } from 'enzyme';
 import { expect } from 'chai';
 import sinon from 'sinon';
 
@@ -54,20 +54,18 @@ describe('<PaymentInformationEditModal/>', () => {
   it('submits', () => {
     const onSubmit = sinon.spy();
 
-    let props = set('fields.accountNumber.field.value', '123456', defaultProps);
-    props = set(
-      'fields.financialInstitutionRoutingNumber.field.value',
-      '123456789',
-      props,
-    );
-    props = set('onSubmit', onSubmit, props);
+    const props = set('onSubmit', onSubmit, defaultProps);
 
-    const wrapper = shallow(<PaymentInformationEditModal {...props} />);
-    const event = {
-      preventDefault() {},
-    };
+    const wrapper = mount(<PaymentInformationEditModal {...props} />);
+    wrapper.setState({
+      formData: {
+        accountNumber: '123456',
+        routingNumber: '123456789',
+        accountType: ACCOUNT_TYPES_OPTIONS.checking,
+      },
+    });
 
-    wrapper.find('form').simulate('submit', event);
+    wrapper.find('form').simulate('submit');
 
     expect(onSubmit.called).to.be.true;
 
@@ -86,19 +84,18 @@ describe('<PaymentInformationEditModal/>', () => {
   it('does not submit when input is invalid', () => {
     const onSubmit = sinon.spy();
 
-    let props = set(
-      'fields.accountNumber.field.value',
-      'INVALID',
-      defaultProps,
-    );
-    props = set('onSubmit', onSubmit, props);
+    const props = set('onSubmit', onSubmit, defaultProps);
 
-    const wrapper = shallow(<PaymentInformationEditModal {...props} />);
-    const event = {
-      preventDefault() {},
-    };
+    const wrapper = mount(<PaymentInformationEditModal {...props} />);
+    wrapper.setState({
+      formData: {
+        accountNumber: 'invalid',
+        routingNumber: '123456789',
+        accountType: ACCOUNT_TYPES_OPTIONS.checking,
+      },
+    });
 
-    wrapper.find('form').simulate('submit', event);
+    wrapper.find('form').simulate('submit');
     expect(onSubmit.called).to.be.false;
     wrapper.unmount();
   });


### PR DESCRIPTION
## Description
Make a new SchemaForm-based form for editing direct deposit bank info.

## Testing done
Local

## Screenshots
![image](https://user-images.githubusercontent.com/20728956/74575771-190b6d00-4f3d-11ea-85ae-eccc6cb31b1e.png)


## Acceptance criteria
- [ ] new form works more or less identically to the existing form

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs