### PR TITLE
Parse int posCode before check

### DIFF
--- a/src/applications/facility-locator/components/ProviderServiceDescription.jsx
+++ b/src/applications/facility-locator/components/ProviderServiceDescription.jsx
@@ -8,9 +8,9 @@ const providerName = (query, posCodes) => {
       name = facilityTypes.cc_pharmacy.toUpperCase();
       break;
     case 'urgent_care':
-      if (posCodes && parseInt(posCodes, 0) === 17) {
+      if (posCodes && parseInt(posCodes, 10) === 17) {
         name = ccUrgentCareLabels.WalkIn;
-      } else if (posCodes && parseInt(posCodes, 0) === 20) {
+      } else if (posCodes && parseInt(posCodes, 10) === 20) {
         name = ccUrgentCareLabels.UrgentCare;
       } else {
         name = facilityTypes.urgent_care.toUpperCase();

--- a/src/applications/facility-locator/components/ProviderServiceDescription.jsx
+++ b/src/applications/facility-locator/components/ProviderServiceDescription.jsx
@@ -8,9 +8,9 @@ const providerName = (query, posCodes) => {
       name = facilityTypes.cc_pharmacy.toUpperCase();
       break;
     case 'urgent_care':
-      if (posCodes && posCodes === 17) {
+      if (posCodes && parseInt(posCodes, 0) === 17) {
         name = ccUrgentCareLabels.WalkIn;
-      } else if (posCodes && posCodes === 20) {
+      } else if (posCodes && parseInt(posCodes, 0) === 20) {
         name = ccUrgentCareLabels.UrgentCare;
       } else {
         name = facilityTypes.urgent_care.toUpperCase();

--- a/src/applications/facility-locator/constants/mock-facilities-data.js
+++ b/src/applications/facility-locator/constants/mock-facilities-data.js
@@ -278,6 +278,7 @@ export const facilityData = (facility, service) => {
                 state: 'TX',
                 zip: '78757',
               },
+              posCodes: '17',
               email: null,
               phone: null,
               fax: null,


### PR DESCRIPTION
## Description
issue: https://github.com/department-of-veterans-affairs/va.gov-team/issues/5896

## Testing done
Locally

## Screenshots


## Acceptance criteria
- [x] Display label should match posCodes 17 or 20

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
