### PR TITLE
disable programmatic scrolling when a modal is open

### DIFF
--- a/src/platform/forms-system/src/js/utilities/ui/index.js
+++ b/src/platform/forms-system/src/js/utilities/ui/index.js
@@ -40,6 +40,7 @@ export function getScrollOptions(additionalOptions) {
 }
 
 export function scrollToFirstError() {
+  const body = document.querySelector('body');
   const errorEl = document.querySelector('.usa-input-error, .input-error-date');
   if (errorEl) {
     // document.body.scrollTop doesn’t work with all browsers, so we’ll cover them all like so:
@@ -49,7 +50,12 @@ export function scrollToFirstError() {
       document.body.scrollTop ||
       0;
     const position = errorEl.getBoundingClientRect().top + currentPosition;
-    Scroll.animateScroll.scrollTo(position - 10, getScrollOptions());
+    // Don't animate the scrolling if there is an open modal on the page. This
+    // prevents the page behind the modal from scrolling if there is an error in
+    // modal's form.
+    if (!body.classList.contains('modal-open')) {
+      Scroll.animateScroll.scrollTo(position - 10, getScrollOptions());
+    }
     focusElement(errorEl);
   }
 }

--- a/src/platform/forms-system/src/js/utilities/ui/index.js
+++ b/src/platform/forms-system/src/js/utilities/ui/index.js
@@ -40,7 +40,6 @@ export function getScrollOptions(additionalOptions) {
 }
 
 export function scrollToFirstError() {
-  const body = document.querySelector('body');
   const errorEl = document.querySelector('.usa-input-error, .input-error-date');
   if (errorEl) {
     // document.body.scrollTop doesn’t work with all browsers, so we’ll cover them all like so:
@@ -53,7 +52,7 @@ export function scrollToFirstError() {
     // Don't animate the scrolling if there is an open modal on the page. This
     // prevents the page behind the modal from scrolling if there is an error in
     // modal's form.
-    if (!body.classList.contains('modal-open')) {
+    if (!document.body.classList.contains('modal-open')) {
       Scroll.animateScroll.scrollTo(position - 10, getScrollOptions());
     }
     focusElement(errorEl);


### PR DESCRIPTION
note: I'm skipping VSA review since this change is to platform code.

## Description
Disables auto-scrolling to the first form error when form submission fails only if there is a modal open.

## Testing done
Local, also confirming the scrolling to errors works like normal when there isn't a modal open

## Screenshots


## Acceptance criteria
- [x] main page does not scroll behind the modal when there's an error in the modal's form (can be tested on the Profile edit address modal)
- [x] scrolling to the first error works like normal if there is no modal open (can be tested here when logged out http://localhost:3001/health-care/apply/application/id-form)

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs