### PR TITLE
wipe out payment info when modal opens

### DIFF
--- a/src/applications/personalization/profile360/components/PaymentInformationEditModal.jsx
+++ b/src/applications/personalization/profile360/components/PaymentInformationEditModal.jsx
@@ -81,6 +81,12 @@ class PaymentInformationEditModal extends React.Component {
     formData: {},
   };
 
+  componentDidUpdate = prevProps => {
+    if (this.props.isEditing && !prevProps.isEditing) {
+      this.setState({ formData: {} });
+    }
+  };
+
   onSubmit = event => {
     event.preventDefault();
 

--- a/src/applications/personalization/profile360/tests/components/PaymentInformationEditModal.unit.spec.jsx
+++ b/src/applications/personalization/profile360/tests/components/PaymentInformationEditModal.unit.spec.jsx
@@ -99,4 +99,24 @@ describe('<PaymentInformationEditModal/>', () => {
     expect(onSubmit.called).to.be.false;
     wrapper.unmount();
   });
+
+  it('clears its state when the modal opens', () => {
+    const props = set('isEditing', false, defaultProps);
+    const wrapper = shallow(<PaymentInformationEditModal {...props} />);
+
+    wrapper.setState({
+      formData: {
+        accountNumber: '123456',
+        routingNumber: '123456789',
+        accountType: ACCOUNT_TYPES_OPTIONS.checking,
+      },
+    });
+    wrapper.setProps({ isEditing: true });
+
+    const state = wrapper.state();
+
+    expect(state).to.deep.equal({ formData: {} });
+
+    wrapper.unmount();
+  });
 });


### PR DESCRIPTION
## Description
This fixes an issue, described [here](https://github.com/department-of-veterans-affairs/va.gov-team/issues/5816#issuecomment-587485594), where data entered in the direct deposit edit modal would persist when the modal was closed and reopened.

## Testing done
Local + new unit tests

## Screenshots
n/a

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs