### PR TITLE
Fix hidden form validation errors

### DIFF
--- a/src/platform/user/profile/vet360/components/PhoneField/PhoneEditModal.jsx
+++ b/src/platform/user/profile/vet360/components/PhoneField/PhoneEditModal.jsx
@@ -77,6 +77,7 @@ class PhoneEditModal extends React.Component {
           this.props.data.phoneNumber
         }`,
         extension: this.props.data.extension || '',
+        isTextPermitted: this.props.data.isTextPermitted || false,
         'view:showSMSCheckbox': this.props.showSMSCheckbox,
       };
     } else {

--- a/src/platform/user/profile/vet360/util/local-vet360.js
+++ b/src/platform/user/profile/vet360/util/local-vet360.js
@@ -28,7 +28,7 @@ export const mockContactInformation = {
     id: 123,
     isInternational: false,
     isTextable: true,
-    isTextPermitted: false,
+    isTextPermitted: null,
     isTty: true,
     isVoicemailable: true,
     phoneNumber: '5551234',


### PR DESCRIPTION
## Description
Form submission was getting blocked because VA Profile was giving us `null` as the value for `isTextPermitted` which led to the form failing validation.

## Testing done
Local. It was easy to replicate the issue locally by more accurately mocking the initial data we get back from VA Profile.

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs