### PR TITLE
gracefully handle ppiu/payment_information error data

### DIFF
--- a/src/applications/personalization/profile360/selectors.js
+++ b/src/applications/personalization/profile360/selectors.js
@@ -8,13 +8,13 @@ export const directDepositInformation = state =>
   state.vaProfile?.paymentInformation;
 
 export const directDepositAccountInformation = state =>
-  directDepositInformation(state)?.responses[0]?.paymentAccount;
+  directDepositInformation(state)?.responses?.[0]?.paymentAccount;
 
 export const directDepositIsSetUp = state =>
   !!directDepositAccountInformation(state)?.accountNumber;
 
 export const directDepositAddressInformation = state =>
-  directDepositInformation(state)?.responses[0]?.paymentAddress;
+  directDepositInformation(state)?.responses?.[0]?.paymentAddress;
 
 export const directDepositAddressIsSetUp = state => {
   const addressInfo = directDepositAddressInformation(state);

--- a/src/applications/personalization/profile360/tests/selectors.unit.spec.js
+++ b/src/applications/personalization/profile360/tests/selectors.unit.spec.js
@@ -38,6 +38,25 @@ describe('profile360 selectors', () => {
         '';
       expect(selectors.directDepositIsSetUp(state)).to.be.false;
     });
+    it('returns `false` when the payment info endpoint failed to get data', () => {
+      state = {
+        vaProfile: {
+          paymentInformation: {
+            errors: [
+              {
+                title: 'Bad Gateway',
+                detail:
+                  'Received an an invalid response from the upstream server',
+                code: 'EVSS502',
+                source: 'EVSS::PPIU::Service',
+                status: '502',
+              },
+            ],
+          },
+        },
+      };
+      expect(selectors.directDepositIsSetUp(state)).to.be.false;
+    });
   });
 
   describe('directDepositAddressIsSetUp selector', () => {
@@ -74,6 +93,26 @@ describe('profile360 selectors', () => {
     it('returns `false` if the state is missing', () => {
       state.vaProfile.paymentInformation.responses[0].paymentAddress.stateCode =
         '';
+      expect(selectors.directDepositAddressIsSetUp(state)).to.be.false;
+    });
+
+    it('returns `false` when the payment info endpoint failed to get data', () => {
+      state = {
+        vaProfile: {
+          paymentInformation: {
+            errors: [
+              {
+                title: 'Bad Gateway',
+                detail:
+                  'Received an an invalid response from the upstream server',
+                code: 'EVSS502',
+                source: 'EVSS::PPIU::Service',
+                status: '502',
+              },
+            ],
+          },
+        },
+      };
       expect(selectors.directDepositAddressIsSetUp(state)).to.be.false;
     });
   });


### PR DESCRIPTION
## Description
Our selectors would blow up the Profile if the call to `GET ppiu/payment_information` failed. This fixes the errors in optional chaining that led to the crashes.

## Testing done
Local (faked an error response from vets-api) + unit tests

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs