### PR TITLE
pin vale version for now during install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest
 RUN chmod +x /cc-test-reporter
 
 # Install vale for plain language linting
-RUN curl -sfL https://install.goreleaser.com/github.com/ValeLint/vale.sh | sh -s latest \
+RUN curl -sfL https://install.goreleaser.com/github.com/ValeLint/vale.sh | sh -s v1.7.1 \
   && export PATH="./bin:$PATH" \
   && vale -v
 


### PR DESCRIPTION
## Description

The install of `latest` is just exiting 1 during installation right now and it's breaking all builds. Looks like this version was released yesterday according to the releases list. https://github.com/errata-ai/vale/releases

They switched to 2.0 which shows some breaking changes. I think this should relieve enough pressure to let us get to 2.0 without having everything broken due to the `latest` string being passed here.

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
