### PR TITLE
Refactor new appointment flow tests

### DIFF
--- a/src/applications/vaos/newAppointmentFlow.js
+++ b/src/applications/vaos/newAppointmentFlow.js
@@ -63,6 +63,13 @@ export default {
   home: {
     url: '/',
   },
+  typeOfAppointment: {
+    url: '/new-appointment',
+    // Temporary stub for typeOfAppointment which will eventually be first step
+    // Next will direct to type of care or provider once both flows are complete
+    next: 'typeOfFacility',
+    previous: 'home',
+  },
   typeOfCare: {
     url: '/new-appointment',
     async next(state, dispatch) {

--- a/src/applications/vaos/newAppointmentFlow.js
+++ b/src/applications/vaos/newAppointmentFlow.js
@@ -63,13 +63,6 @@ export default {
   home: {
     url: '/',
   },
-  typeOfAppointment: {
-    url: '/new-appointment',
-    // Temporary stub for typeOfAppointment which will eventually be first step
-    // Next will direct to type of care or provider once both flows are complete
-    next: 'typeOfFacility',
-    previous: 'home',
-  },
   typeOfCare: {
     url: '/new-appointment',
     async next(state, dispatch) {
@@ -167,15 +160,8 @@ export default {
       if (eligibilityStatus.direct) {
         let appointments = null;
 
-        // If we can't get the history, then continue anyway
-        // and we'll show the full clinic list
         try {
           appointments = await getLongTermAppointmentHistory();
-        } catch (error) {
-          captureError(error);
-        }
-
-        if (appointments) {
           const clinics = getClinicsForChosenFacility(state);
           const hasMatchingClinics = clinics.some(
             clinic =>
@@ -190,9 +176,8 @@ export default {
             dispatch(startDirectScheduleFlow(appointments));
             return 'clinicChoice';
           }
-        } else {
-          dispatch(startDirectScheduleFlow(appointments));
-          return 'clinicChoice';
+        } catch (error) {
+          captureError(error);
         }
       }
 

--- a/src/applications/vaos/tests/newAppointmentFlow.unit.spec.js
+++ b/src/applications/vaos/tests/newAppointmentFlow.unit.spec.js
@@ -100,7 +100,7 @@ describe('VAOS newAppointmentFlow', () => {
         resetFetch();
       });
 
-      it('should be the requestDateTime page if CC support and typeOfCare is podiatry', async () => {
+      it('should be requestDateTime if CC support and typeOfCare is podiatry', async () => {
         mockFetch();
         setFetchJSONResponse(global.fetch, systems);
         setFetchJSONResponse(global.fetch.onCall(1), supportedSites);

--- a/src/applications/vaos/tests/newAppointmentFlow.unit.spec.js
+++ b/src/applications/vaos/tests/newAppointmentFlow.unit.spec.js
@@ -5,6 +5,7 @@ import {
   resetFetch,
   mockFetch,
   setFetchJSONResponse,
+  setFetchJSONFailure,
 } from 'platform/testing/unit/helpers';
 
 import past from '../api/past.json';
@@ -15,71 +16,224 @@ import newAppointmentFlow from '../newAppointmentFlow';
 import { FACILITY_TYPES, FLOW_TYPES } from '../utils/constants';
 
 describe('VAOS newAppointmentFlow', () => {
-  describe('type of appointment page', () => {
-    expect(newAppointmentFlow.typeOfAppointment.next).to.equal(
-      'typeOfFacility',
-    );
-    expect(newAppointmentFlow.typeOfAppointment.previous).to.equal('home');
+  describe('typeOfCare page', () => {
+    describe('next page', () => {
+      it('should be vaFacility page if no systems have CC support', async () => {
+        mockFetch();
+        setFetchJSONResponse(global.fetch, {
+          data: [{ attributes: { assigningAuthority: 'dfn-000' } }],
+        });
+
+        const state = {
+          featureToggles: {
+            loading: false,
+            vaOnlineSchedulingDirect: true,
+            vaOnlineSchedulingCommunityCare: true,
+          },
+          newAppointment: {
+            data: {
+              typeOfCareId: '323',
+            },
+          },
+        };
+
+        const dispatch = sinon.spy();
+        const nextState = await newAppointmentFlow.typeOfCare.next(
+          state,
+          dispatch,
+        );
+        expect(nextState).to.equal('vaFacility');
+        resetFetch();
+      });
+
+      it('should be vaFacility page if CC check has an error', async () => {
+        mockFetch();
+        setFetchJSONResponse(global.fetch, systems);
+        setFetchJSONResponse(global.fetch.onCall(1), supportedSites);
+        setFetchJSONFailure(global.fetch.onCall(2), {});
+        const state = {
+          featureToggles: {
+            loading: false,
+            vaOnlineSchedulingDirect: true,
+            vaOnlineSchedulingCommunityCare: true,
+          },
+          newAppointment: {
+            data: {
+              typeOfCareId: 'tbd-podiatry',
+            },
+          },
+        };
+
+        const dispatch = sinon.spy();
+        const nextState = await newAppointmentFlow.typeOfCare.next(
+          state,
+          dispatch,
+        );
+        expect(nextState).to.equal('vaFacility');
+        resetFetch();
+      });
+
+      it('should be the current page if no CC support and typeOfCare is podiatry', async () => {
+        mockFetch();
+        setFetchJSONResponse(global.fetch, {
+          data: [{ attributes: { assigningAuthority: 'dfn-000' } }],
+        });
+        const state = {
+          featureToggles: {
+            loading: false,
+            vaOnlineSchedulingDirect: true,
+            vaOnlineSchedulingCommunityCare: true,
+          },
+          newAppointment: {
+            data: {
+              typeOfCareId: 'tbd-podiatry',
+            },
+          },
+        };
+
+        const dispatch = sinon.spy();
+        const nextState = await newAppointmentFlow.typeOfCare.next(
+          state,
+          dispatch,
+        );
+        expect(nextState).to.equal('typeOfCare');
+        resetFetch();
+      });
+
+      it('should be the requestDateTime page if CC support and typeOfCare is podiatry', async () => {
+        mockFetch();
+        setFetchJSONResponse(global.fetch, systems);
+        setFetchJSONResponse(global.fetch.onCall(1), supportedSites);
+        setFetchJSONResponse(global.fetch.onCall(2), {
+          data: {
+            attributes: { eligible: true },
+          },
+        });
+        const state = {
+          featureToggles: {
+            loading: false,
+            vaOnlineSchedulingDirect: true,
+            vaOnlineSchedulingCommunityCare: true,
+          },
+          newAppointment: {
+            data: {
+              typeOfCareId: 'tbd-podiatry',
+            },
+          },
+        };
+
+        const dispatch = sinon.spy();
+        const nextState = await newAppointmentFlow.typeOfCare.next(
+          state,
+          dispatch,
+        );
+        expect(nextState).to.equal('requestDateTime');
+        resetFetch();
+      });
+
+      it('should be typeOfSleepCare if sleep care chosen', async () => {
+        const dispatch = sinon.spy();
+        const state = {
+          featureToggles: {
+            loading: false,
+            vaOnlineSchedulingDirect: true,
+            vaOnlineSchedulingCommunityCare: true,
+          },
+          newAppointment: {
+            data: {
+              typeOfCareId: 'SLEEP',
+            },
+          },
+        };
+
+        const nextState = await newAppointmentFlow.typeOfCare.next(
+          state,
+          dispatch,
+        );
+        expect(nextState).to.equal('typeOfSleepCare');
+      });
+
+      it('should be typeOfFacility page if site has CC support', async () => {
+        mockFetch();
+        setFetchJSONResponse(global.fetch, systems);
+        setFetchJSONResponse(global.fetch.onCall(1), supportedSites);
+        setFetchJSONResponse(global.fetch.onCall(2), {
+          data: {
+            attributes: { eligible: true },
+          },
+        });
+        const state = {
+          featureToggles: {
+            loading: false,
+            vaOnlineSchedulingDirect: true,
+            vaOnlineSchedulingCommunityCare: true,
+          },
+          newAppointment: {
+            data: {
+              typeOfCareId: '323',
+            },
+          },
+        };
+
+        const dispatch = sinon.spy();
+        const nextState = await newAppointmentFlow.typeOfCare.next(
+          state,
+          dispatch,
+        );
+        expect(nextState).to.equal('typeOfFacility');
+
+        resetFetch();
+      });
+    });
   });
 
-  describe('type of facility page', () => {
-    it('next should choose audiology decision page if CC and audiology chosen', () => {
-      const state = {
-        newAppointment: {
-          data: {
-            facilityType: FACILITY_TYPES.COMMUNITY_CARE,
-            typeOfCareId: '203',
+  describe('typeOfFacility page', () => {
+    describe('next page', () => {
+      it('should be audiologyCareType if CC supported and audiology chosen', () => {
+        const state = {
+          newAppointment: {
+            data: {
+              facilityType: FACILITY_TYPES.COMMUNITY_CARE,
+              typeOfCareId: '203',
+            },
           },
-        },
-      };
+        };
 
-      const nextState = newAppointmentFlow.typeOfFacility.next(state);
-      expect(nextState).to.equal('audiologyCareType');
-    });
+        const nextState = newAppointmentFlow.typeOfFacility.next(state);
+        expect(nextState).to.equal('audiologyCareType');
+      });
 
-    it('next should choose date page if CC chosen', () => {
-      const state = {
-        newAppointment: {
-          data: {
-            facilityType: FACILITY_TYPES.COMMUNITY_CARE,
-            typeOfCareId: '320',
+      it('should be requestDateTime if CC is chosen', () => {
+        const state = {
+          newAppointment: {
+            data: {
+              facilityType: FACILITY_TYPES.COMMUNITY_CARE,
+              typeOfCareId: '320',
+            },
           },
-        },
-      };
+        };
 
-      const nextState = newAppointmentFlow.typeOfFacility.next(state);
-      expect(nextState).to.equal('requestDateTime');
-    });
+        const nextState = newAppointmentFlow.typeOfFacility.next(state);
+        expect(nextState).to.equal('requestDateTime');
+      });
 
-    it('next should choose audiology options page if CC and audiology is chosen', () => {
-      const state = {
-        newAppointment: {
-          data: {
-            facilityType: FACILITY_TYPES.COMMUNITY_CARE,
-            typeOfCareId: '203',
+      it('should be vaFacility page if they chose VA', () => {
+        const state = {
+          newAppointment: {
+            data: {
+              facilityType: 'va',
+              typeOfCareId: '203',
+            },
           },
-        },
-      };
+        };
 
-      const nextState = newAppointmentFlow.typeOfFacility.next(state);
-      expect(nextState).to.equal('audiologyCareType');
-    });
-
-    it('next should choose va facility page if not CC', () => {
-      const state = {
-        newAppointment: {
-          data: {
-            facilityType: 'va',
-            typeOfCareId: '203',
-          },
-        },
-      };
-
-      const nextState = newAppointmentFlow.typeOfFacility.next(state);
-      expect(nextState).to.equal('vaFacility');
+        const nextState = newAppointmentFlow.typeOfFacility.next(state);
+        expect(nextState).to.equal('vaFacility');
+      });
     });
   });
-  describe('va facility page', () => {
+
+  describe('vaFacility page', () => {
     const defaultState = {
       featureToggles: {
         loading: false,
@@ -106,487 +260,447 @@ describe('VAOS newAppointmentFlow', () => {
         },
       },
     };
-    it('next should choose clinic choice page if eligible', async () => {
-      mockFetch();
-      setFetchJSONResponse(global.fetch, past);
-      const state = {
-        ...defaultState,
-        newAppointment: {
-          ...defaultState.newAppointment,
-          eligibility: {
-            '983_323': {
-              directSupported: true,
-              directPastVisit: true,
-              directPACT: true,
-              directClinics: true,
+    describe('next page', () => {
+      it('should be clinicChoice page if eligible', async () => {
+        mockFetch();
+        setFetchJSONResponse(global.fetch, past);
+        const state = {
+          ...defaultState,
+          newAppointment: {
+            ...defaultState.newAppointment,
+            eligibility: {
+              '983_323': {
+                directSupported: true,
+                directPastVisit: true,
+                directPACT: true,
+                directClinics: true,
+              },
             },
           },
-        },
-      };
-      const dispatch = sinon.spy();
+        };
+        const dispatch = sinon.spy();
 
-      const nextState = await newAppointmentFlow.vaFacility.next(
-        state,
-        dispatch,
-      );
-      expect(dispatch.firstCall.args[0].type).to.equal(
-        'newAppointment/START_DIRECT_SCHEDULE_FLOW',
-      );
-      expect(nextState).to.equal('clinicChoice');
+        const nextState = await newAppointmentFlow.vaFacility.next(
+          state,
+          dispatch,
+        );
+        expect(dispatch.firstCall.args[0].type).to.equal(
+          'newAppointment/START_DIRECT_SCHEDULE_FLOW',
+        );
+        expect(nextState).to.equal('clinicChoice');
 
-      resetFetch();
-    });
-    it('next should direct to request flow if not direct eligible', async () => {
-      const state = {
-        ...defaultState,
-        newAppointment: {
-          ...defaultState.newAppointment,
-          eligibility: {
-            '983_323': {
-              directSupported: true,
-              directPastVisit: false,
-              directPACT: true,
-              directClinics: true,
-              requestSupported: true,
-              requestPastVisit: true,
-              requestLimit: true,
+        resetFetch();
+      });
+      it('should be requestDateTime page if past appointments request errors', async () => {
+        mockFetch();
+        setFetchJSONFailure(global.fetch, {});
+        const state = {
+          ...defaultState,
+          newAppointment: {
+            ...defaultState.newAppointment,
+            eligibility: {
+              '983_323': {
+                directSupported: true,
+                directPastVisit: true,
+                directPACT: true,
+                directClinics: true,
+                requestSupported: true,
+                requestPastVisit: true,
+                requestLimit: true,
+              },
             },
           },
-        },
-      };
-      const dispatch = sinon.spy();
+        };
+        const dispatch = sinon.spy();
 
-      const nextState = await newAppointmentFlow.vaFacility.next(
-        state,
-        dispatch,
-      );
-      expect(nextState).to.equal('requestDateTime');
-    });
+        const nextState = await newAppointmentFlow.vaFacility.next(
+          state,
+          dispatch,
+        );
+        expect(dispatch.firstCall.args[0].type).to.equal(
+          'newAppointment/START_REQUEST_APPOINTMENT_FLOW',
+        );
+        expect(nextState).to.equal('requestDateTime');
 
-    it('should return to type of care page if none of user Systems is cc enabled', () => {
-      const state = {
-        ...defaultState,
-        newAppointment: {
-          ...defaultState.newAppointment,
-          data: {
-            typeOfCareId: '323',
-            vaParent: '983',
-            vaFacility: '983',
-            facilityType: FACILITY_TYPES.VAMC,
+        resetFetch();
+      });
+      it('should throw error if not eligible for requests or direct', async () => {
+        const state = {
+          ...defaultState,
+          newAppointment: {
+            ...defaultState.newAppointment,
+            eligibility: {
+              '983_323': {
+                directSupported: false,
+                directPastVisit: true,
+                directPACT: true,
+                directClinics: true,
+                requestSupported: false,
+                requestPastVisit: true,
+                requestLimit: true,
+              },
+            },
           },
-          hasCCEnabledSystems: false,
-        },
-      };
-      const nextState = newAppointmentFlow.vaFacility.previous(state);
-      expect(nextState).to.equal('typeOfCare');
-    });
+        };
+        const dispatch = sinon.spy();
 
-    it('should return to typeOfFacility if user is CC eligible ', () => {
-      const state = {
-        ...defaultState,
-        newAppointment: {
-          ...defaultState.newAppointment,
-          data: {
-            typeOfCareId: '323',
-            vaParent: '983',
-            vaFacility: '983',
-            facilityType: FACILITY_TYPES.VAMC,
+        try {
+          await newAppointmentFlow.vaFacility.next(state, dispatch);
+          // Should throw an error above
+          expect(false).to.be.true;
+        } catch (e) {
+          expect(e.message).to.equal(
+            'Veteran not eligible for direct scheduling or requests',
+          );
+        }
+      });
+      it('should be requestDateTime if not direct eligible', async () => {
+        const state = {
+          ...defaultState,
+          newAppointment: {
+            ...defaultState.newAppointment,
+            eligibility: {
+              '983_323': {
+                directSupported: true,
+                directPastVisit: false,
+                directPACT: true,
+                directClinics: true,
+                requestSupported: true,
+                requestPastVisit: true,
+                requestLimit: true,
+              },
+            },
           },
-          ccEnabledSystems: ['983'],
-          isCCEligible: true,
-        },
-      };
+        };
+        const dispatch = sinon.spy();
 
-      const nextState = newAppointmentFlow.vaFacility.previous(state);
-      expect(nextState).to.equal('typeOfFacility');
+        const nextState = await newAppointmentFlow.vaFacility.next(
+          state,
+          dispatch,
+        );
+        expect(nextState).to.equal('requestDateTime');
+      });
     });
 
-    it('should return to typeOfCare if user is not CC eligible ', () => {
-      const state = {
-        ...defaultState,
-        newAppointment: {
-          ...defaultState.newAppointment,
-          data: {
-            typeOfCareId: '323',
-            vaParent: '983',
-            vaFacility: '983',
-            facilityType: FACILITY_TYPES.VAMC,
+    describe('previous page', () => {
+      it('should be typeOfCare page if no user systems are CC eligibile', () => {
+        const state = {
+          ...defaultState,
+          newAppointment: {
+            ...defaultState.newAppointment,
+            data: {
+              typeOfCareId: '323',
+              vaParent: '983',
+              vaFacility: '983',
+              facilityType: FACILITY_TYPES.VAMC,
+            },
+            hasCCEnabledSystems: false,
           },
-          ccEnabledSystems: ['983'],
-          isCCEligible: false,
-        },
-      };
-
-      const nextState = newAppointmentFlow.vaFacility.previous(state);
-      expect(nextState).to.equal('typeOfCare');
-    });
-
-    it('should return to typeOfCare if selected type of care is not CC eligible', () => {
-      const state = {
-        ...defaultState,
-        newAppointment: {
-          ...defaultState.newAppointment,
-          data: {
-            typeOfCareId: '502',
-            vaParent: '983',
-            vaFacility: '983',
-            facilityType: FACILITY_TYPES.VAMC,
-          },
-          ccEnabledSystems: ['983'],
-          isCCEligible: true,
-        },
-      };
-
-      const nextState = newAppointmentFlow.vaFacility.previous(state);
-      expect(nextState).to.equal('typeOfCare');
-    });
-  });
-  describe('request date/time page', () => {
-    it('should go to CC preferences page if CC', () => {
-      const state = {
-        newAppointment: {
-          data: {
-            facilityType: FACILITY_TYPES.COMMUNITY_CARE,
-          },
-        },
-      };
-
-      const nextState = newAppointmentFlow.requestDateTime.next(state);
-
-      expect(nextState).to.equal('ccPreferences');
-    });
-    it('should go to reason for appt if not cc', () => {
-      const state = {
-        newAppointment: {
-          data: {
-            facilityType: FACILITY_TYPES.VAMC,
-          },
-        },
-      };
-
-      const nextState = newAppointmentFlow.requestDateTime.next(state);
-
-      expect(nextState).to.equal('reasonForAppointment');
-    });
-    it('should go back to type of facility page if CC', () => {
-      const state = {
-        newAppointment: {
-          data: {
-            facilityType: FACILITY_TYPES.COMMUNITY_CARE,
-          },
-        },
-      };
-
-      const nextState = newAppointmentFlow.requestDateTime.previous(state);
-
-      expect(nextState).to.equal('typeOfFacility');
-    });
-    it('should go back to audiology preferences page if type of care is audiology', () => {
-      const state = {
-        newAppointment: {
-          data: {
-            facilityType: FACILITY_TYPES.COMMUNITY_CARE,
-            typeOfCareId: '203',
-          },
-        },
-      };
-
-      const nextState = newAppointmentFlow.requestDateTime.previous(state);
-
-      expect(nextState).to.equal('audiologyCareType');
-    });
-    it('should go back to va facility page if not cc', () => {
-      const state = {
-        newAppointment: {
-          data: {
-            facilityType: FACILITY_TYPES.VAMC,
-          },
-        },
-      };
-
-      const nextState = newAppointmentFlow.requestDateTime.previous(state);
-
-      expect(nextState).to.equal('vaFacility');
-    });
-  });
-  describe('clinic choice page', () => {
-    it('should go to next direct schedule page if user chose a clinic', () => {
-      const state = {
-        newAppointment: {
-          data: {
-            clinicId: '123',
-          },
-        },
-      };
-
-      const nextState = newAppointmentFlow.clinicChoice.next(state);
-
-      expect(nextState).to.equal('preferredDate');
-    });
-
-    it('should go to request date page if user chose a different clinic', () => {
-      const state = {
-        newAppointment: {
-          data: {
-            clinicId: 'NONE',
-          },
-        },
-      };
-      const dispatch = sinon.spy();
-
-      const nextState = newAppointmentFlow.clinicChoice.next(state, dispatch);
-
-      expect(nextState).to.equal('requestDateTime');
-      expect(dispatch.called).to.be.true;
-    });
-  });
-
-  describe('preferred date page', () => {
-    it('should go to select date page', () => {
-      expect(newAppointmentFlow.preferredDate.next).to.equal('selectDateTime');
-    });
-
-    it('should go back to to clinic choice page', () => {
-      expect(newAppointmentFlow.preferredDate.previous).to.equal(
-        'clinicChoice',
-      );
-    });
-  });
-
-  describe('reason for appointment page', () => {
-    it('should go visit page if not CC', () => {
-      const state = {
-        newAppointment: {
-          data: {
-            facilityType: FACILITY_TYPES.VAMC,
-          },
-        },
-      };
-
-      const nextState = newAppointmentFlow.reasonForAppointment.next(state);
-      expect(nextState).to.equal('visitType');
-    });
-
-    it('should go contact info page if CC', () => {
-      const state = {
-        newAppointment: {
-          data: {
-            facilityType: FACILITY_TYPES.COMMUNITY_CARE,
-          },
-        },
-      };
-
-      const nextState = newAppointmentFlow.reasonForAppointment.next(state);
-      expect(nextState).to.equal('contactInfo');
-    });
-
-    it('should go back to ccPreferences if community care', () => {
-      const state = {
-        newAppointment: {
-          data: {
-            facilityType: FACILITY_TYPES.COMMUNITY_CARE,
-          },
-          flowType: FLOW_TYPES.DIRECT,
-        },
-      };
-
-      const nextState = newAppointmentFlow.reasonForAppointment.previous(state);
-      expect(nextState).to.equal('ccPreferences');
-    });
-
-    it('should go back to selectDateTime if direct schedule', () => {
-      const state = {
-        newAppointment: {
-          data: {
-            facilityType: FACILITY_TYPES.VAMC,
-          },
-          flowType: FLOW_TYPES.DIRECT,
-        },
-      };
-
-      const nextState = newAppointmentFlow.reasonForAppointment.previous(state);
-
-      expect(nextState).to.equal('selectDateTime');
-    });
-
-    it('should go back to requestDateTime if request flow', () => {
-      const state = {
-        newAppointment: {
-          data: {
-            facilityType: FACILITY_TYPES.VAMC,
-          },
-          flowType: FLOW_TYPES.REQUEST,
-        },
-      };
-
-      const nextState = newAppointmentFlow.reasonForAppointment.previous(state);
-
-      expect(nextState).to.equal('requestDateTime');
-    });
-  });
-  describe('type of care page', () => {
-    it('next should be vaFacility page if no systems have CC support', async () => {
-      mockFetch();
-      setFetchJSONResponse(global.fetch, {
-        data: [{ attributes: { assigningAuthority: 'dfn-000' } }],
+        };
+        const nextState = newAppointmentFlow.vaFacility.previous(state);
+        expect(nextState).to.equal('typeOfCare');
       });
 
-      const state = {
-        featureToggles: {
-          loading: false,
-          vaOnlineSchedulingDirect: true,
-          vaOnlineSchedulingCommunityCare: true,
-        },
-        newAppointment: {
-          data: {
-            typeOfCareId: '372',
+      it('should be typeOfFacility if user is CC eligible ', () => {
+        const state = {
+          ...defaultState,
+          newAppointment: {
+            ...defaultState.newAppointment,
+            data: {
+              typeOfCareId: '323',
+              vaParent: '983',
+              vaFacility: '983',
+              facilityType: FACILITY_TYPES.VAMC,
+            },
+            ccEnabledSystems: ['983'],
+            isCCEligible: true,
           },
-        },
-      };
+        };
 
-      const dispatch = sinon.spy();
-      const nextState = await newAppointmentFlow.typeOfCare.next(
-        state,
-        dispatch,
-      );
-      expect(nextState).to.equal('vaFacility');
-      resetFetch();
-    });
-
-    it('next should stay on typeOfCare page if no CC support and typeOfCare is podiatry', async () => {
-      mockFetch();
-      setFetchJSONResponse(global.fetch, {
-        data: [{ attributes: { assigningAuthority: 'dfn-000' } }],
+        const nextState = newAppointmentFlow.vaFacility.previous(state);
+        expect(nextState).to.equal('typeOfFacility');
       });
-      const state = {
-        featureToggles: {
-          loading: false,
-          vaOnlineSchedulingDirect: true,
-          vaOnlineSchedulingCommunityCare: true,
-        },
-        newAppointment: {
-          data: {
-            typeOfCareId: 'tbd-podiatry',
+
+      it('should be typeOfCare if user if user has CC enabled systems but is not CC eligible', () => {
+        const state = {
+          ...defaultState,
+          newAppointment: {
+            ...defaultState.newAppointment,
+            data: {
+              typeOfCareId: '323',
+              vaParent: '983',
+              vaFacility: '983',
+              facilityType: FACILITY_TYPES.VAMC,
+            },
+            ccEnabledSystems: ['983'],
+            isCCEligible: false,
           },
-        },
-      };
+        };
 
-      const dispatch = sinon.spy();
-      const nextState = await newAppointmentFlow.typeOfCare.next(
-        state,
-        dispatch,
-      );
-      expect(nextState).to.equal('typeOfCare');
-      resetFetch();
-    });
-
-    it('next should go to requestDateTime page if CC support and typeOfCare is podiatry', async () => {
-      mockFetch();
-      setFetchJSONResponse(global.fetch, systems);
-      setFetchJSONResponse(global.fetch.onCall(1), supportedSites);
-      setFetchJSONResponse(global.fetch.onCall(2), {
-        data: {
-          attributes: { eligible: true },
-        },
+        const nextState = newAppointmentFlow.vaFacility.previous(state);
+        expect(nextState).to.equal('typeOfCare');
       });
-      const state = {
-        featureToggles: {
-          loading: false,
-          vaOnlineSchedulingDirect: true,
-          vaOnlineSchedulingCommunityCare: true,
-        },
-        newAppointment: {
-          data: {
-            typeOfCareId: 'tbd-podiatry',
+
+      it('should be typeOfCare if selected type of care is not CC eligible', () => {
+        const state = {
+          ...defaultState,
+          newAppointment: {
+            ...defaultState.newAppointment,
+            data: {
+              typeOfCareId: '502',
+              vaParent: '983',
+              vaFacility: '983',
+              facilityType: FACILITY_TYPES.VAMC,
+            },
+            ccEnabledSystems: ['983'],
+            isCCEligible: true,
           },
-        },
-      };
+        };
 
-      const dispatch = sinon.spy();
-      const nextState = await newAppointmentFlow.typeOfCare.next(
-        state,
-        dispatch,
-      );
-      expect(nextState).to.equal('requestDateTime');
-      resetFetch();
-    });
-
-    it('should choose Sleep care page', async () => {
-      const dispatch = sinon.spy();
-      const state = {
-        featureToggles: {
-          loading: false,
-          vaOnlineSchedulingDirect: true,
-          vaOnlineSchedulingCommunityCare: true,
-        },
-        newAppointment: {
-          data: {
-            typeOfCareId: 'SLEEP',
-          },
-        },
-      };
-
-      const nextState = await newAppointmentFlow.typeOfCare.next(
-        state,
-        dispatch,
-      );
-      expect(nextState).to.equal('typeOfSleepCare');
-    });
-
-    it('next should be type of facility page if CC support', async () => {
-      mockFetch();
-      setFetchJSONResponse(global.fetch, systems);
-      setFetchJSONResponse(global.fetch.onCall(1), supportedSites);
-      setFetchJSONResponse(global.fetch.onCall(2), {
-        data: {
-          attributes: { eligible: true },
-        },
+        const nextState = newAppointmentFlow.vaFacility.previous(state);
+        expect(nextState).to.equal('typeOfCare');
       });
-      const state = {
-        featureToggles: {
-          loading: false,
-          vaOnlineSchedulingDirect: true,
-          vaOnlineSchedulingCommunityCare: true,
-        },
-        newAppointment: {
-          data: {
-            typeOfCareId: '323',
-          },
-        },
-      };
-
-      const dispatch = sinon.spy();
-      const nextState = await newAppointmentFlow.typeOfCare.next(
-        state,
-        dispatch,
-      );
-      expect(nextState).to.equal('typeOfFacility');
-
-      resetFetch();
     });
   });
-  describe('contact info page', () => {
-    it('should return to choose visit type page', () => {
-      const state = {
-        newAppointment: {
-          data: {},
-        },
-      };
-      expect(newAppointmentFlow.contactInfo.previous(state)).to.equal(
-        'visitType',
-      );
-    });
-    it('should return to choose CC provider page', () => {
-      const state = {
-        newAppointment: {
-          data: {
-            facilityType: FACILITY_TYPES.COMMUNITY_CARE,
+
+  describe('requestDateTime page', () => {
+    describe('next page', () => {
+      it('should be ccPreferences if in the CC flow', () => {
+        const state = {
+          newAppointment: {
+            data: {
+              facilityType: FACILITY_TYPES.COMMUNITY_CARE,
+            },
           },
-        },
-      };
-      expect(newAppointmentFlow.contactInfo.previous(state)).to.equal(
-        'ccPreferences',
-      );
+        };
+
+        const nextState = newAppointmentFlow.requestDateTime.next(state);
+
+        expect(nextState).to.equal('ccPreferences');
+      });
+      it('should be reasonForAppointment if in the VA flow', () => {
+        const state = {
+          newAppointment: {
+            data: {
+              facilityType: FACILITY_TYPES.VAMC,
+            },
+          },
+        };
+
+        const nextState = newAppointmentFlow.requestDateTime.next(state);
+
+        expect(nextState).to.equal('reasonForAppointment');
+      });
+    });
+    describe('previous page', () => {
+      it('should be typeOfFacility if in the CC flow', () => {
+        const state = {
+          newAppointment: {
+            data: {
+              facilityType: FACILITY_TYPES.COMMUNITY_CARE,
+            },
+          },
+        };
+
+        const nextState = newAppointmentFlow.requestDateTime.previous(state);
+
+        expect(nextState).to.equal('typeOfFacility');
+      });
+      it('should be audiologyCareType if user chose audiology', () => {
+        const state = {
+          newAppointment: {
+            data: {
+              facilityType: FACILITY_TYPES.COMMUNITY_CARE,
+              typeOfCareId: '203',
+            },
+          },
+        };
+
+        const nextState = newAppointmentFlow.requestDateTime.previous(state);
+
+        expect(nextState).to.equal('audiologyCareType');
+      });
+      it('should be vaFacility if in the VA flow', () => {
+        const state = {
+          newAppointment: {
+            data: {
+              facilityType: FACILITY_TYPES.VAMC,
+            },
+          },
+        };
+
+        const nextState = newAppointmentFlow.requestDateTime.previous(state);
+
+        expect(nextState).to.equal('vaFacility');
+      });
+      it('should be typeOfCare if in the CC flow and user chose podiatry', () => {
+        const state = {
+          newAppointment: {
+            data: {
+              facilityType: FACILITY_TYPES.COMMUNITY_CARE,
+              typeOfCareId: 'tbd-podiatry',
+            },
+          },
+        };
+
+        const nextState = newAppointmentFlow.requestDateTime.previous(state);
+
+        expect(nextState).to.equal('typeOfCare');
+      });
+    });
+  });
+
+  describe('clinicChoicePage', () => {
+    describe('next page', () => {
+      it('should be preferredDate if user chose a clinic', () => {
+        const state = {
+          newAppointment: {
+            data: {
+              clinicId: '123',
+            },
+          },
+        };
+
+        const nextState = newAppointmentFlow.clinicChoice.next(state);
+
+        expect(nextState).to.equal('preferredDate');
+      });
+
+      it('should be requestDateTime if user chose that they need a different clinic', () => {
+        const state = {
+          newAppointment: {
+            data: {
+              clinicId: 'NONE',
+            },
+          },
+        };
+        const dispatch = sinon.spy();
+
+        const nextState = newAppointmentFlow.clinicChoice.next(state, dispatch);
+
+        expect(nextState).to.equal('requestDateTime');
+        expect(dispatch.called).to.be.true;
+      });
+    });
+  });
+
+  describe('reasonForAppointment page', () => {
+    describe('next page', () => {
+      it('should be visitType if in the VA flow', () => {
+        const state = {
+          newAppointment: {
+            data: {
+              facilityType: FACILITY_TYPES.VAMC,
+            },
+          },
+        };
+
+        const nextState = newAppointmentFlow.reasonForAppointment.next(state);
+        expect(nextState).to.equal('visitType');
+      });
+
+      it('should be contactInfo if in the CC flow', () => {
+        const state = {
+          newAppointment: {
+            data: {
+              facilityType: FACILITY_TYPES.COMMUNITY_CARE,
+            },
+          },
+        };
+
+        const nextState = newAppointmentFlow.reasonForAppointment.next(state);
+        expect(nextState).to.equal('contactInfo');
+      });
+    });
+
+    describe('previous page', () => {
+      it('should be ccPreferences if in CC flow', () => {
+        const state = {
+          newAppointment: {
+            data: {
+              facilityType: FACILITY_TYPES.COMMUNITY_CARE,
+            },
+            flowType: FLOW_TYPES.DIRECT,
+          },
+        };
+
+        const nextState = newAppointmentFlow.reasonForAppointment.previous(
+          state,
+        );
+        expect(nextState).to.equal('ccPreferences');
+      });
+
+      it('should be selectDateTime if in the direct schedule flow', () => {
+        const state = {
+          newAppointment: {
+            data: {
+              facilityType: FACILITY_TYPES.VAMC,
+            },
+            flowType: FLOW_TYPES.DIRECT,
+          },
+        };
+
+        const nextState = newAppointmentFlow.reasonForAppointment.previous(
+          state,
+        );
+
+        expect(nextState).to.equal('selectDateTime');
+      });
+
+      it('should be requestDateTime if in request flow', () => {
+        const state = {
+          newAppointment: {
+            data: {
+              facilityType: FACILITY_TYPES.VAMC,
+            },
+            flowType: FLOW_TYPES.REQUEST,
+          },
+        };
+
+        const nextState = newAppointmentFlow.reasonForAppointment.previous(
+          state,
+        );
+
+        expect(nextState).to.equal('requestDateTime');
+      });
+    });
+  });
+
+  describe('contactInfo page', () => {
+    describe('previous page', () => {
+      it('should be visitType if in VA request flow', () => {
+        const state = {
+          newAppointment: {
+            data: {},
+          },
+        };
+        expect(newAppointmentFlow.contactInfo.previous(state)).to.equal(
+          'visitType',
+        );
+      });
+      it('should be visitType if in direct schedule flow', () => {
+        const state = {
+          newAppointment: {
+            data: {},
+            flowType: FLOW_TYPES.DIRECT,
+          },
+        };
+        expect(newAppointmentFlow.contactInfo.previous(state)).to.equal(
+          'reasonForAppointment',
+        );
+      });
+      it('should be ccPreferences if in CC flow', () => {
+        const state = {
+          newAppointment: {
+            data: {
+              facilityType: FACILITY_TYPES.COMMUNITY_CARE,
+            },
+          },
+        };
+        expect(newAppointmentFlow.contactInfo.previous(state)).to.equal(
+          'ccPreferences',
+        );
+      });
     });
   });
 });


### PR DESCRIPTION
## Description
This PR looks bigger than it is. What I have done:

1. Move type of care test block to the start of the file, to better follow the order in the newAppointmentFlow.js file
2. Grouped tests for each page into "next page" and "previous page" blocks
3. Added a few new tests to cover missed cases
4. Removed any tests that were not testing next/previous functions, because we're just rewriting config data in a test.

## Testing done
Unit tests?

## Acceptance criteria
- [ ] Tests pass

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
