### PR TITLE
Kelsonic 5856 downtime messaging

### DIFF
--- a/src/platform/site-wide/announcements/components/Downtime.jsx
+++ b/src/platform/site-wide/announcements/components/Downtime.jsx
@@ -1,0 +1,38 @@
+// Dependencies.
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import moment from 'moment';
+import PromoBanner, {
+  PROMO_BANNER_TYPES,
+} from '@department-of-veterans-affairs/formation-react/PromoBanner';
+
+class Downtime extends Component {
+  static propTypes = {
+    announcement: PropTypes.shape({
+      startsAt: PropTypes.object.isRequired,
+      expiresAt: PropTypes.object.isRequired,
+    }).isRequired,
+    dismiss: PropTypes.func.isRequired,
+  };
+
+  render() {
+    const {
+      announcement: { expiresAt },
+      dismiss,
+    } = this.props;
+
+    // Derive the message.
+    const formattedExpiresAt = moment(expiresAt).format('MMM Do [at] h:mm a z');
+    const message = `We're doing work on VA.gov. If you have trouble using online tools, check back after ${formattedExpiresAt}.`;
+
+    return (
+      <PromoBanner
+        onClose={dismiss}
+        render={() => <div>{message}</div>}
+        type={PROMO_BANNER_TYPES.announcement}
+      />
+    );
+  }
+}
+
+export default Downtime;

--- a/src/platform/site-wide/announcements/components/Downtime.jsx
+++ b/src/platform/site-wide/announcements/components/Downtime.jsx
@@ -9,8 +9,7 @@ import PromoBanner, {
 class Downtime extends Component {
   static propTypes = {
     announcement: PropTypes.shape({
-      startsAt: PropTypes.object.isRequired,
-      expiresAt: PropTypes.object.isRequired,
+      expiresAt: PropTypes.string.isRequired,
     }).isRequired,
     dismiss: PropTypes.func.isRequired,
   };

--- a/src/platform/site-wide/announcements/components/PreDowntime.jsx
+++ b/src/platform/site-wide/announcements/components/PreDowntime.jsx
@@ -9,8 +9,7 @@ import PromoBanner, {
 class PreDowntime extends Component {
   static propTypes = {
     announcement: PropTypes.shape({
-      startsAt: PropTypes.object.isRequired,
-      expiresAt: PropTypes.object.isRequired,
+      downtimeStartsAt: PropTypes.string.isRequired,
     }).isRequired,
     dismiss: PropTypes.func.isRequired,
   };
@@ -27,13 +26,13 @@ class PreDowntime extends Component {
 
   render() {
     const {
-      announcement: { startsAt },
+      announcement: { downtimeStartsAt },
       dismiss,
     } = this.props;
 
     // Derive the message.
     const now = moment();
-    const minutesRemaining = moment(startsAt).diff(now, 'minutes');
+    const minutesRemaining = moment(downtimeStartsAt).diff(now, 'minutes');
     const message = `Scheduled maintenance starts in ${minutesRemaining} minutes. If you’re filling out a form, sign in or create an account to save your work.`;
 
     return (

--- a/src/platform/site-wide/announcements/components/PreDowntime.jsx
+++ b/src/platform/site-wide/announcements/components/PreDowntime.jsx
@@ -1,0 +1,49 @@
+// Dependencies.
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import moment from 'moment';
+import PromoBanner, {
+  PROMO_BANNER_TYPES,
+} from '@department-of-veterans-affairs/formation-react/PromoBanner';
+
+class PreDowntime extends Component {
+  static propTypes = {
+    announcement: PropTypes.shape({
+      startsAt: PropTypes.object.isRequired,
+      expiresAt: PropTypes.object.isRequired,
+    }).isRequired,
+    dismiss: PropTypes.func.isRequired,
+  };
+
+  componentWillMount() {
+    // Set an interval to update the time.
+    this.rerenderInterval = setInterval(() => this.forceUpdate(), 60000);
+  }
+
+  componentWillUnmount() {
+    // Prevent memory leaks by clearing timeouts.
+    clearInterval(this.rerenderInterval);
+  }
+
+  render() {
+    const {
+      announcement: { startsAt },
+      dismiss,
+    } = this.props;
+
+    // Derive the message.
+    const now = moment();
+    const minutesRemaining = moment(startsAt).diff(now, 'minutes');
+    const message = `Scheduled maintenance starts in ${minutesRemaining} minutes. If you’re filling out a form, sign in or create an account to save your work.`;
+
+    return (
+      <PromoBanner
+        onClose={dismiss}
+        render={() => <div>{message}</div>}
+        type={PROMO_BANNER_TYPES.announcement}
+      />
+    );
+  }
+}
+
+export default PreDowntime;

--- a/src/platform/site-wide/announcements/components/PreDowntime.jsx
+++ b/src/platform/site-wide/announcements/components/PreDowntime.jsx
@@ -14,9 +14,27 @@ class PreDowntime extends Component {
     dismiss: PropTypes.func.isRequired,
   };
 
+  constructor(props) {
+    super(props);
+
+    // Derive minutes remaining.
+    const now = moment();
+    const minutesRemaining = moment(props?.announcement?.downtimeStartsAt).diff(
+      now,
+      'minutes',
+    );
+
+    this.state = {
+      minutesRemaining,
+    };
+  }
+
   componentWillMount() {
     // Set an interval to update the time.
-    this.rerenderInterval = setInterval(() => this.forceUpdate(), 60000);
+    this.rerenderInterval = setInterval(
+      () => this.updateMinutesRemaining(),
+      60000,
+    );
   }
 
   componentWillUnmount() {
@@ -24,15 +42,24 @@ class PreDowntime extends Component {
     clearInterval(this.rerenderInterval);
   }
 
-  render() {
+  updateMinutesRemaining = () => {
     const {
       announcement: { downtimeStartsAt },
-      dismiss,
     } = this.props;
 
-    // Derive the message.
+    // Derive minutes remaining.
     const now = moment();
     const minutesRemaining = moment(downtimeStartsAt).diff(now, 'minutes');
+
+    // Update minutes remaining in state.
+    this.setState({ minutesRemaining });
+  };
+
+  render() {
+    const { minutesRemaining } = this.state;
+    const { dismiss } = this.props;
+
+    // Derive the message.
     const message = `Scheduled maintenance starts in ${minutesRemaining} minutes. If you’re filling out a form, sign in or create an account to save your work.`;
 
     return (

--- a/src/platform/site-wide/announcements/components/PrePreDowntime.jsx
+++ b/src/platform/site-wide/announcements/components/PrePreDowntime.jsx
@@ -9,21 +9,23 @@ import PromoBanner, {
 class PrePreDowntime extends Component {
   static propTypes = {
     announcement: PropTypes.shape({
-      startsAt: PropTypes.object.isRequired,
-      expiresAt: PropTypes.object.isRequired,
+      downtimeStartsAt: PropTypes.string.isRequired,
+      downtimeExpiresAt: PropTypes.string.isRequired,
     }).isRequired,
     dismiss: PropTypes.func.isRequired,
   };
 
   render() {
     const {
-      announcement: { startsAt, expiresAt },
+      announcement: { downtimeStartsAt, downtimeExpiresAt },
       dismiss,
     } = this.props;
 
     // Derive the message.
-    const formattedStartsAt = moment(startsAt).format('MMM Do [at] h:mm a');
-    const formattedExpiresAt = moment(expiresAt).format('h:mm a z');
+    const formattedStartsAt = moment(downtimeStartsAt).format(
+      'MMM Do [at] h:mm a',
+    );
+    const formattedExpiresAt = moment(downtimeExpiresAt).format('h:mm a z');
     const message = `We'll be doing site maintenance on ${formattedStartsAt} until ${formattedExpiresAt}. You won’t be able to sign in or use some tools during this time.`;
 
     return (

--- a/src/platform/site-wide/announcements/components/PrePreDowntime.jsx
+++ b/src/platform/site-wide/announcements/components/PrePreDowntime.jsx
@@ -1,0 +1,39 @@
+// Dependencies.
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import moment from 'moment';
+import PromoBanner, {
+  PROMO_BANNER_TYPES,
+} from '@department-of-veterans-affairs/formation-react/PromoBanner';
+
+class PrePreDowntime extends Component {
+  static propTypes = {
+    announcement: PropTypes.shape({
+      startsAt: PropTypes.object.isRequired,
+      expiresAt: PropTypes.object.isRequired,
+    }).isRequired,
+    dismiss: PropTypes.func.isRequired,
+  };
+
+  render() {
+    const {
+      announcement: { startsAt, expiresAt },
+      dismiss,
+    } = this.props;
+
+    // Derive the message.
+    const formattedStartsAt = moment(startsAt).format('MMM Do [at] h:mm a');
+    const formattedExpiresAt = moment(expiresAt).format('h:mm a z');
+    const message = `We'll be doing site maintenance on ${formattedStartsAt} until ${formattedExpiresAt}. You won’t be able to sign in or use some tools during this time.`;
+
+    return (
+      <PromoBanner
+        onClose={dismiss}
+        render={() => <div>{message}</div>}
+        type={PROMO_BANNER_TYPES.announcement}
+      />
+    );
+  }
+}
+
+export default PrePreDowntime;

--- a/src/platform/site-wide/announcements/config/index.js
+++ b/src/platform/site-wide/announcements/config/index.js
@@ -18,6 +18,9 @@ const config = {
       component: PrePreDowntime,
       startsAt: '2020-02-29 09:00',
       expiresAt: '2020-02-29 20:00',
+      // The following key-value pairs are just used as props, not in selectors.js.
+      downtimeStartsAt: '2020-02-29 21:00',
+      downtimeExpiresAt: '2020-02-29 21:30',
     },
     {
       name: 'pre-downtime',
@@ -25,6 +28,8 @@ const config = {
       component: PreDowntime,
       startsAt: '2020-02-29 20:00',
       expiresAt: '2020-02-29 21:00',
+      // The following key-value pairs are just used as props, not in selectors.js.
+      downtimeStartsAt: '2020-02-29 21:00',
     },
     {
       name: 'downtime',

--- a/src/platform/site-wide/announcements/config/index.js
+++ b/src/platform/site-wide/announcements/config/index.js
@@ -1,14 +1,38 @@
 // Relative imports.
+import Downtime from '../components/Downtime';
 import ExploreVAModal from '../components/ExploreVAModal';
 import FindVABenefitsIntro from '../components/FindVABenefitsIntro';
 import PersonalizationBanner from '../components/PersonalizationBanner';
+import PreDowntime from '../components/PreDowntime';
+import PrePreDowntime from '../components/PrePreDowntime';
 import Profile360Intro from '../components/Profile360Intro';
+import VAMCWelcomeModal, { VAMC_PATHS } from '../components/VAMCWelcomeModal';
 import VAPlusVetsModal from '../components/VAPlusVetsModal';
 import WelcomeToNewVAModal from '../components/WelcomeToNewVAModal';
-import VAMCWelcomeModal, { VAMC_PATHS } from '../components/VAMCWelcomeModal';
 
 const config = {
   announcements: [
+    {
+      name: 'pre-pre-downtime',
+      paths: /(.)/,
+      component: PrePreDowntime,
+      startsAt: '2020-02-29 09:00',
+      expiresAt: '2020-02-29 20:00',
+    },
+    {
+      name: 'pre-downtime',
+      paths: /(.)/,
+      component: PreDowntime,
+      startsAt: '2020-02-29 20:00',
+      expiresAt: '2020-02-29 21:00',
+    },
+    {
+      name: 'downtime',
+      paths: /(.)/,
+      component: Downtime,
+      startsAt: '2020-02-29 21:00',
+      expiresAt: '2020-02-29 21:30',
+    },
     {
       name: 'brand-consolidation-va-plus-vets',
       paths: /(.)/,

--- a/src/platform/site-wide/announcements/config/index.js
+++ b/src/platform/site-wide/announcements/config/index.js
@@ -1,3 +1,5 @@
+// Node modules.
+import moment from 'moment';
 // Relative imports.
 import Downtime from '../components/Downtime';
 import ExploreVAModal from '../components/ExploreVAModal';
@@ -10,33 +12,37 @@ import VAMCWelcomeModal, { VAMC_PATHS } from '../components/VAMCWelcomeModal';
 import VAPlusVetsModal from '../components/VAPlusVetsModal';
 import WelcomeToNewVAModal from '../components/WelcomeToNewVAModal';
 
+// Derive when downtime will start and expire.
+const downtimeStartAtDate = moment('2020-02-29 21:00');
+const downtimeExpiresAtDate = moment('2020-02-29 21:30');
+
 const config = {
   announcements: [
     {
       name: 'pre-pre-downtime',
       paths: /(.)/,
       component: PrePreDowntime,
-      startsAt: '2020-02-29 09:00',
-      expiresAt: '2020-02-29 20:00',
+      startsAt: downtimeStartAtDate.clone().subtract(12, 'hours'),
+      expiresAt: downtimeStartAtDate.clone().subtract(1, 'hours'),
       // The following key-value pairs are just used as props, not in selectors.js.
-      downtimeStartsAt: '2020-02-29 21:00',
-      downtimeExpiresAt: '2020-02-29 21:30',
+      downtimeStartsAt: downtimeStartAtDate.toISOString(),
+      downtimeExpiresAt: downtimeExpiresAtDate.toISOString(),
     },
     {
       name: 'pre-downtime',
       paths: /(.)/,
       component: PreDowntime,
-      startsAt: '2020-02-29 20:00',
-      expiresAt: '2020-02-29 21:00',
+      startsAt: downtimeStartAtDate.clone().subtract(1, 'hours'),
+      expiresAt: downtimeStartAtDate.toISOString(),
       // The following key-value pairs are just used as props, not in selectors.js.
-      downtimeStartsAt: '2020-02-29 21:00',
+      downtimeStartsAt: downtimeStartAtDate.toISOString(),
     },
     {
       name: 'downtime',
       paths: /(.)/,
       component: Downtime,
-      startsAt: '2020-02-29 21:00',
-      expiresAt: '2020-02-29 21:30',
+      startsAt: downtimeStartAtDate.toISOString(),
+      expiresAt: downtimeExpiresAtDate.toISOString(),
     },
     {
       name: 'brand-consolidation-va-plus-vets',

--- a/src/platform/site-wide/announcements/config/index.js
+++ b/src/platform/site-wide/announcements/config/index.js
@@ -13,8 +13,10 @@ import VAPlusVetsModal from '../components/VAPlusVetsModal';
 import WelcomeToNewVAModal from '../components/WelcomeToNewVAModal';
 
 // Derive when downtime will start and expire.
-const downtimeStartAtDate = moment('2020-02-29 21:00');
-const downtimeExpiresAtDate = moment('2020-02-29 21:30');
+const downtimeStartAtDate = moment.utc('2020-03-01 2:00').local();
+const downtimeExpiresAtDate = moment.utc('2020-03-01 2:30').local();
+
+console.log('downtimeStartAtDate', downtimeStartAtDate);
 
 const config = {
   announcements: [

--- a/src/platform/site-wide/announcements/config/index.js
+++ b/src/platform/site-wide/announcements/config/index.js
@@ -16,8 +16,6 @@ import WelcomeToNewVAModal from '../components/WelcomeToNewVAModal';
 const downtimeStartAtDate = moment.utc('2020-03-01 2:00').local();
 const downtimeExpiresAtDate = moment.utc('2020-03-01 2:30').local();
 
-console.log('downtimeStartAtDate', downtimeStartAtDate);
-
 const config = {
   announcements: [
     {

--- a/src/platform/site-wide/announcements/selectors.js
+++ b/src/platform/site-wide/announcements/selectors.js
@@ -3,14 +3,56 @@ import moment from 'moment';
 // Relative imports.
 import _config from './config';
 
-// Checks if the announcement has expired.
-const isExpiredAnnouncement = announcement => {
-  if (!announcement.expiresAt) return true;
+// Checks if the announcement has started.
+const isStarted = announcement => {
+  const { startsAt } = announcement;
+  console.log('Name: ', announcement.name);
 
-  const expiresAtDate = moment(announcement.expiresAt);
+  // Assume announcement is valid if startsAt was NOT provided.
+  if (!startsAt) {
+    console.log('does not have startsAt', announcement.startsAt);
+    return true;
+  }
+
+  // Derive if the announcement has started.
+  const startsAtDate = moment(startsAt);
+  const hasStarted = moment().isSameOrAfter(startsAtDate);
+
+  // Announcement has not started.
+  if (!hasStarted) {
+    console.log('has NOT started', startsAtDate.format('YYYY-MM-DD h:mm a'));
+    return false;
+  }
+
+  // Announcement has started.
+  console.log('has started', startsAtDate.format('YYYY-MM-DD h:mm a'));
+  return true;
+};
+
+// Checks if the announcement has expired.
+const isNotExpired = announcement => {
+  const { expiresAt } = announcement;
+  console.log('Name: ', announcement.name);
+
+  // Assume announcement is valid if expiresAt was NOT provided.
+  if (!expiresAt) {
+    console.log('does not have expiresAt', announcement.expiresAt);
+    return true;
+  }
+
+  // Derive if the announcement has expired.
+  const expiresAtDate = moment(expiresAt);
   const hasExpired = moment().isSameOrAfter(expiresAtDate);
 
-  return !hasExpired;
+  // Announcement has not expired.
+  if (!hasExpired) {
+    console.log('has NOT expired', expiresAtDate.format('YYYY-MM-DD h:mm a'));
+    return true;
+  }
+
+  // Announcement has expired.
+  console.log('has expired', expiresAtDate.format('YYYY-MM-DD h:mm a'));
+  return false;
 };
 
 export const selectAnnouncement = (
@@ -24,7 +66,8 @@ export const selectAnnouncement = (
   if (announcements.isInitialized) {
     announcement = config.announcements
       .filter(a => !a.disabled)
-      .filter(isExpiredAnnouncement)
+      .filter(isStarted)
+      .filter(isNotExpired)
       .filter(a => !announcements.dismissed.includes(a.name))
       .find(a => a.paths.test(path));
   }

--- a/src/platform/site-wide/announcements/selectors.js
+++ b/src/platform/site-wide/announcements/selectors.js
@@ -6,11 +6,9 @@ import _config from './config';
 // Checks if the announcement has started.
 const isStarted = announcement => {
   const { startsAt } = announcement;
-  console.log('Name: ', announcement.name);
 
   // Assume announcement is valid if startsAt was NOT provided.
   if (!startsAt) {
-    console.log('does not have startsAt', announcement.startsAt);
     return true;
   }
 
@@ -20,23 +18,19 @@ const isStarted = announcement => {
 
   // Announcement has not started.
   if (!hasStarted) {
-    console.log('has NOT started', startsAtDate.format('YYYY-MM-DD h:mm a'));
     return false;
   }
 
   // Announcement has started.
-  console.log('has started', startsAtDate.format('YYYY-MM-DD h:mm a'));
   return true;
 };
 
 // Checks if the announcement has expired.
 const isNotExpired = announcement => {
   const { expiresAt } = announcement;
-  console.log('Name: ', announcement.name);
 
   // Assume announcement is valid if expiresAt was NOT provided.
   if (!expiresAt) {
-    console.log('does not have expiresAt', announcement.expiresAt);
     return true;
   }
 
@@ -46,12 +40,10 @@ const isNotExpired = announcement => {
 
   // Announcement has not expired.
   if (!hasExpired) {
-    console.log('has NOT expired', expiresAtDate.format('YYYY-MM-DD h:mm a'));
     return true;
   }
 
   // Announcement has expired.
-  console.log('has expired', expiresAtDate.format('YYYY-MM-DD h:mm a'));
   return false;
 };
 

--- a/src/platform/site-wide/announcements/tests/components/Downtime.unit.spec.jsx
+++ b/src/platform/site-wide/announcements/tests/components/Downtime.unit.spec.jsx
@@ -1,0 +1,37 @@
+// Dependencies.
+import React from 'react';
+import moment from 'moment';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+import sinon from 'sinon';
+// Relative imports.
+import Downtime from '../../components/Downtime';
+
+describe('Downtime Messaging <Downtime />', () => {
+  it('should render', () => {
+    // Derive props.
+    const downtimeExpiresAt = moment()
+      .add(1, 'hours')
+      .add(30, 'minutes')
+      .toISOString();
+    const dismiss = sinon.stub();
+    const props = {
+      announcement: { downtimeExpiresAt },
+      dismiss,
+    };
+
+    // Shallow render the component.
+    const wrapper = shallow(<Downtime {...props} />);
+
+    // Find the component.
+    const promoBannerComponent = wrapper.find('PromoBanner');
+
+    // Call `dismiss` props.
+    promoBannerComponent.props().onClose();
+
+    // Test `dismiss` prop.
+    expect(dismiss.called).to.be.true;
+
+    wrapper.unmount();
+  });
+});

--- a/src/platform/site-wide/announcements/tests/components/PreDowntime.unit.spec.jsx
+++ b/src/platform/site-wide/announcements/tests/components/PreDowntime.unit.spec.jsx
@@ -1,0 +1,43 @@
+// Dependencies.
+import React from 'react';
+import moment from 'moment';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+import sinon from 'sinon';
+// Relative imports.
+import PreDowntime from '../../components/PreDowntime';
+
+describe('Downtime Messaging <PreDowntime />', () => {
+  it('should render', () => {
+    // Derive props.
+    const downtimeStartsAt = moment()
+      .add(1, 'hour')
+      .toISOString();
+    const dismiss = sinon.stub();
+    const props = {
+      announcement: { downtimeStartsAt },
+      dismiss,
+    };
+
+    // Shallow render the component.
+    const wrapper = shallow(<PreDowntime {...props} />);
+
+    // Find the component.
+    const promoBannerComponent = wrapper.find('PromoBanner');
+
+    // Call `dismiss` props.
+    promoBannerComponent.props().onClose();
+
+    // Test `dismiss` prop.
+    expect(dismiss.called).to.be.true;
+
+    // Derive minutesRemaining.
+    const minutesRemaining = wrapper.state().minutesRemaining;
+
+    // Test `minutesRemaining` state. This should almost always be 59.
+    expect(minutesRemaining).to.be.at.least(58);
+    expect(minutesRemaining).to.be.at.most(60);
+
+    wrapper.unmount();
+  });
+});

--- a/src/platform/site-wide/announcements/tests/components/PrePreDowntime.unit.spec.jsx
+++ b/src/platform/site-wide/announcements/tests/components/PrePreDowntime.unit.spec.jsx
@@ -1,0 +1,40 @@
+// Dependencies.
+import React from 'react';
+import moment from 'moment';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+import sinon from 'sinon';
+// Relative imports.
+import PrePreDowntime from '../../components/PrePreDowntime';
+
+describe('Downtime Messaging <PrePreDowntime />', () => {
+  it('should render', () => {
+    // Derive props.
+    const downtimeStartsAt = moment()
+      .add(1, 'hour')
+      .toISOString();
+    const downtimeExpiresAt = moment()
+      .add(1, 'hours')
+      .add(30, 'minutes')
+      .toISOString();
+    const dismiss = sinon.stub();
+    const props = {
+      announcement: { downtimeStartsAt, downtimeExpiresAt },
+      dismiss,
+    };
+
+    // Shallow render the component.
+    const wrapper = shallow(<PrePreDowntime {...props} />);
+
+    // Find the component.
+    const promoBannerComponent = wrapper.find('PromoBanner');
+
+    // Call `dismiss` props.
+    promoBannerComponent.props().onClose();
+
+    // Test `dismiss` prop.
+    expect(dismiss.called).to.be.true;
+
+    wrapper.unmount();
+  });
+});

--- a/src/platform/site-wide/announcements/tests/selectors.unit.spec.js
+++ b/src/platform/site-wide/announcements/tests/selectors.unit.spec.js
@@ -49,6 +49,17 @@ describe('selectAnnouncement', () => {
           paths: /^(\/unique-route\/)$/,
           expiresAt: '2019-11-11',
         },
+        {
+          name: 'dummy8',
+          paths: /^(\/unique-route-2\/)$/,
+          startsAt: '2022-11-11',
+        },
+        {
+          name: 'dummy9',
+          paths: /^(\/unique-route-3\/)$/,
+          startsAt: '2019-11-11',
+          expiresAt: '2022-11-11',
+        },
       ],
     };
   });
@@ -120,5 +131,25 @@ describe('selectAnnouncement', () => {
     );
 
     expect(result).to.be.undefined;
+  });
+
+  it('filters announcements that have not started yet', () => {
+    const result = selectors.selectAnnouncement(
+      state,
+      config,
+      '/unique-route-2/',
+    );
+
+    expect(result).to.be.undefined;
+  });
+
+  it('includes announcements where `startsAt` <= now <= `expiresAt`', () => {
+    const result = selectors.selectAnnouncement(
+      state,
+      config,
+      '/unique-route-3/',
+    );
+
+    expect(result).to.not.be.undefined;
   });
 });


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/5856

This PR implements configurable downtime messaging.

It includes:
1. Dismissable promo banner downtime messaging 12 hours beforehand.
2. Dismissable promo banner downtime messaging 1 hour beforehand that ticks.
3. Dismissable promo banner downtime messaging during downtime.
4. **Only 2 loc** that will need to be updated for future downtime messaging.

**WARNING:** This PR does **NOT** include support for timezones as using `moment-timezone` was deemed as bloating the build (for good reason, too). **What should I use instead of `moment-timezone` to support timezones? Any suggestions welcome and greatly appreciated!!**

## Testing done
Locally. Changed my OS time to test each of the 3 promo banners listed above, including pre-12 hours beforehand and post-downtime states. All worked with flying colors! 🎉 

## Screenshots
Let me know if you want them and I'll add them. 🙂 

## Acceptance criteria
1. Dismissable promo banner downtime messaging 12 hours beforehand.
2. Dismissable promo banner downtime messaging 1 hour beforehand that ticks.
3. Dismissable promo banner downtime messaging during downtime.
4. **Only 2 loc** that will need to be updated for future downtime messaging.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
