### PR TITLE
HOLD Update VAOS calendar validation to only show post-submit

### DIFF
--- a/src/applications/vaos/api/index.js
+++ b/src/applications/vaos/api/index.js
@@ -298,7 +298,7 @@ export function getClinicInstitutions(systemId, clinicIds) {
 export function getAvailableClinics(facilityId, typeOfCareId, systemId) {
   let promise;
   if (USE_MOCK_DATA) {
-    if (facilityId === '983A6') {
+    if (facilityId === '983') {
       promise = import('./clinicList983.json').then(
         module => (module.default ? module.default : module),
       );

--- a/src/applications/vaos/tests/containers/DateTimeRequestPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/containers/DateTimeRequestPage.unit.spec.jsx
@@ -101,4 +101,34 @@ describe('VAOS <DateTimeRequestPage>', () => {
     expect(document.title).contain(pageTitle);
     form.unmount();
   });
+
+  it('should validate after change', () => {
+    const openFormPage = sinon.spy();
+    const updateFormData = sinon.spy();
+    const routeToNextAppointmentPage = sinon.spy();
+
+    const form = mount(
+      <DateTimeRequestPage
+        openFormPage={openFormPage}
+        updateFormData={updateFormData}
+        data={{
+          calendarData: {
+            selectedDates: [{ date: '2019-10-30', optionTime: 'AM' }],
+          },
+        }}
+        routeToNextAppointmentPage={routeToNextAppointmentPage}
+      />,
+    );
+
+    form
+      .find('SchemaForm')
+      .props()
+      .onChange({});
+    form.setProps({ data: {} });
+
+    form.find('form').simulate('submit');
+    expect(routeToNextAppointmentPage.called).to.be.false;
+    expect(form.find('.usa-input-error-message').exists()).to.be.true;
+    form.unmount();
+  });
 });

--- a/src/applications/vaos/tests/containers/DateTimeSelectPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/containers/DateTimeSelectPage.unit.spec.jsx
@@ -145,4 +145,54 @@ describe('VAOS <DateTimeSelectPage>', () => {
     expect(document.title).to.contain(pageTitle);
     form.unmount();
   });
+
+  it('should run validation after change', () => {
+    const openFormPage = sinon.spy();
+    const getAppointmentSlots = sinon.spy();
+    const updateFormData = sinon.spy();
+    const routeToNextAppointmentPage = sinon.spy();
+
+    const form = mount(
+      <DateTimeSelectPage
+        openFormPage={openFormPage}
+        getAppointmentSlots={getAppointmentSlots}
+        updateFormData={updateFormData}
+        data={{}}
+        availableDates={availableDates}
+        facilityId="123"
+        availableSlots={availableSlots}
+        routeToNextAppointmentPage={routeToNextAppointmentPage}
+        loadingStatus={FETCH_STATUS.succeeded}
+      />,
+    );
+
+    form.find('form').simulate('submit');
+    expect(routeToNextAppointmentPage.called).to.be.false;
+    expect(form.find('.usa-input-error-message').exists()).to.be.true;
+
+    form
+      .find('SchemaForm')
+      .props()
+      .onChange({
+        calendarData: {
+          selectedDates: [
+            { date: '2019-10-30', datetime: '2019-10-30T10:00:00-07:00' },
+          ],
+        },
+      });
+    form.setProps({
+      data: {
+        calendarData: {
+          selectedDates: [
+            { date: '2019-10-30', datetime: '2019-10-30T10:00:00-07:00' },
+          ],
+        },
+      },
+    });
+
+    form.find('form').simulate('submit');
+    expect(routeToNextAppointmentPage.called).to.be.true;
+
+    form.unmount();
+  });
 });


### PR DESCRIPTION
## Description
There's a bug where deselecting a date displayed the validation error. This PR updates the validation on both calendar pages to follow our typical form validation pattern, but without the blur logic. So:

1. No validation errors show before attempting to submit
2. After trying to submit, changes to calendar data will immediately show or hide a validation error

I made the same changes on both calendar pages to be consistent.

## Testing done
Local testing

## Acceptance criteria
- [ ] Validation message displays appropriately

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
