### PR TITLE
Rename standalone sign-in subroute, update login redirect

### DIFF
--- a/src/applications/login/manifest.json
+++ b/src/applications/login/manifest.json
@@ -2,7 +2,7 @@
   "appName": "Login Page",
   "entryFile": "./app-entry.jsx",
   "entryName": "login-page",
-  "rootUrl": "/login",
+  "rootUrl": "/sign-in",
   "production": false,
   "template": {
     "vagovprod": false,

--- a/src/platform/user/authentication/utilities.js
+++ b/src/platform/user/authentication/utilities.js
@@ -67,7 +67,11 @@ function redirectWithGAClientId(redirectUrl) {
 
 function redirect(redirectUrl, clickedEvent) {
   // Keep track of the URL to return to after auth operation.
-  sessionStorage.setItem(authnSettings.RETURN_URL, window.location);
+  // If the user is coming via the standalone sign-in, redirect to the home page.
+  const returnUrl = window.location.href.includes('sign-in')
+    ? window.location.origin
+    : window.location;
+  sessionStorage.setItem(authnSettings.RETURN_URL, returnUrl);
   recordEvent({ event: clickedEvent });
 
   if (redirectUrl.includes('idme')) {

--- a/src/platform/user/authentication/utilities.js
+++ b/src/platform/user/authentication/utilities.js
@@ -68,9 +68,10 @@ function redirectWithGAClientId(redirectUrl) {
 function redirect(redirectUrl, clickedEvent) {
   // Keep track of the URL to return to after auth operation.
   // If the user is coming via the standalone sign-in, redirect to the home page.
-  const returnUrl = window.location.href.includes('sign-in')
-    ? window.location.origin
-    : window.location;
+  const returnUrl =
+    window.location.pathname === '/sign-in/'
+      ? window.location.origin
+      : window.location;
   sessionStorage.setItem(authnSettings.RETURN_URL, returnUrl);
   recordEvent({ event: clickedEvent });
 

--- a/src/platform/user/tests/authentication/utilities.unit.spec.js
+++ b/src/platform/user/tests/authentication/utilities.unit.spec.js
@@ -25,6 +25,7 @@ const fakeWindow = () => {
       set: value => {
         global.window.location = value;
       },
+      href: '',
     },
   };
 };
@@ -60,5 +61,10 @@ describe('authentication URL helpers', () => {
   it('should redirect for verify', () => {
     verify();
     expect(global.window.location).to.include('/sessions/verify/new');
+  });
+
+  it('should redirect for SSO', () => {
+    login('idme', 'v1');
+    expect(global.window.location).to.include('/v1/sessions/idme/new');
   });
 });

--- a/src/platform/user/tests/authentication/utilities.unit.spec.js
+++ b/src/platform/user/tests/authentication/utilities.unit.spec.js
@@ -25,7 +25,7 @@ const fakeWindow = () => {
       set: value => {
         global.window.location = value;
       },
-      href: '',
+      pathname: '',
     },
   };
 };


### PR DESCRIPTION
## Description

Two updates:

1. This renames the standalone login page route from "/login" to "/sign-in".
2. Redirects to the home page upon successful login via SSOe/vets-api. This potentially will need to change in future updates when the page has more target use cases that require to be more aware of different navigational states.

## Testing done

Manually logged in via the existing (modal) and the new to make sure both function as expected

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
