### PR TITLE
Use a real feature flag for address validation

### DIFF
--- a/src/platform/user/profile/vet360/containers/Vet360ProfileField.jsx
+++ b/src/platform/user/profile/vet360/containers/Vet360ProfileField.jsx
@@ -7,7 +7,6 @@ import recordEvent from 'platform/monitoring/record-event';
 import * as VET360 from '../constants';
 
 import { isPendingTransaction } from '../util/transactions';
-import environment from 'platform/utilities/environment';
 
 import {
   createTransaction,
@@ -24,6 +23,7 @@ import {
   selectVet360Transaction,
   selectCurrentlyOpenEditModal,
   selectEditedFormField,
+  vaProfileUseAddressValidation,
 } from '../selectors';
 
 import Vet360ProfileFieldHeading from '../components/base/Vet360ProfileFieldHeading';
@@ -108,10 +108,7 @@ class Vet360ProfileField extends React.Component {
 
     const method = payload.id ? 'PUT' : 'POST';
 
-    if (
-      this.props.fieldName.toLowerCase().includes('address') &&
-      !environment.isProduction()
-    ) {
+    if (this.props.useAddressValidation) {
       this.props.validateAddress(
         this.props.apiRoute,
         method,
@@ -238,6 +235,7 @@ const mapStateToProps = (state, ownProps) => {
   );
   const data = selectVet360Field(state, fieldName);
   const isEmpty = !data;
+  const useAddressValidation = vaProfileUseAddressValidation(state);
 
   return {
     analyticsSectionName: VET360.ANALYTICS_FIELD_MAP[fieldName],
@@ -248,6 +246,7 @@ const mapStateToProps = (state, ownProps) => {
     isEmpty,
     transaction,
     transactionRequest,
+    useAddressValidation,
   };
 };
 

--- a/src/platform/user/profile/vet360/selectors.js
+++ b/src/platform/user/profile/vet360/selectors.js
@@ -1,4 +1,6 @@
 import backendServices from 'platform/user/profile/constants/backendServices';
+import FEATURE_FLAG_NAMES from 'platform/utilities/feature-toggles/featureFlagNames';
+import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
 
 import { VET360_INITIALIZATION_STATUS, INIT_VET360_ID } from './constants';
 
@@ -132,4 +134,8 @@ export function selectVet360InitializationStatus(state) {
     transaction,
     transactionRequest,
   };
+}
+
+export function vaProfileUseAddressValidation(state) {
+  return toggleValues(state)[FEATURE_FLAG_NAMES.vaProfileAddressValidation];
 }

--- a/src/platform/user/profile/vet360/tests/selectors.unit.spec.js
+++ b/src/platform/user/profile/vet360/tests/selectors.unit.spec.js
@@ -340,3 +340,24 @@ describe('selectVet360InitializationStatus', () => {
     );
   });
 });
+
+describe('vaProfileUseAddressValidation', () => {
+  it('returns `true` if the feature flag is set', () => {
+    expect(
+      selectors.vaProfileUseAddressValidation({
+        featureToggles: {
+          vaProfileAddressValidation: true,
+        },
+      }),
+    ).to.be.true;
+  });
+  it('returns `undefined` if the feature flag is not set', () => {
+    expect(
+      selectors.vaProfileUseAddressValidation({
+        featureToggles: {
+          anotherFeatureFlag: true,
+        },
+      }),
+    ).to.be.undefined;
+  });
+});

--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -7,6 +7,7 @@ const FEATURE_FLAG_NAMES = Object.freeze({
   vaOnlineSchedulingCommunityCare: 'vaOnlineSchedulingCommunityCare',
   vaOnlineSchedulingDirect: 'vaOnlineSchedulingDirect',
   vaGlobalDowntimeNotification: 'vaGlobalDowntimeNotification',
+  vaProfileAddressValidation: 'vaProfileAddressValidation',
 });
 
 module.exports = FEATURE_FLAG_NAMES;


### PR DESCRIPTION
## Description
This switches to using a real feature flag for the address validation feature so that we can test it with a small number of selected users on prod before a full rollout.

## Testing done
Tested locally after adding the feature flag to the API (https://github.com/department-of-veterans-affairs/vets-api/pull/3922). Also confirmed that exposing the feature to only a single user works as expected.

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs