### PR TITLE
[Development] Show 526 max length street address restriction

### DIFF
--- a/src/applications/disability-benefits/all-claims/pages/contactInformation.js
+++ b/src/applications/disability-benefits/all-claims/pages/contactInformation.js
@@ -1,5 +1,3 @@
-import React from 'react';
-
 // import _ from '../../../../platform/utilities/data';
 // import merge from 'lodash/merge';
 import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json';
@@ -7,10 +5,8 @@ import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json';
 // import dateRangeUI from 'platform/forms-system/src/js/definitions/dateRange';
 import phoneUI from 'platform/forms-system/src/js/definitions/phone';
 import emailUI from 'platform/forms-system/src/js/definitions/email';
-import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 
 import ReviewCardField from '../components/ReviewCardField';
-import { checkMaxInputLength } from '../validations';
 
 import {
   contactInfoDescription,
@@ -31,7 +27,7 @@ import {
 import { ADDRESS_PATHS } from '../constants';
 
 const {
-  // mailingAddress,
+  mailingAddress,
   // forwardingAddress,
   phoneAndEmail,
 } = fullSchema.properties;
@@ -50,36 +46,13 @@ export const uiSchema = {
   },
   mailingAddress: {
     ...addressUISchema(ADDRESS_PATHS.mailingAddress, 'Mailing address', true),
-    'ui:order': [
-      'country',
-      'addressLine1',
-      'view:addressLine1MaxLengthAlert',
-      'addressLine2',
-      'addressLine3',
-      'city',
-      'state',
-      'zipCode',
-    ],
     addressLine1: {
       'ui:title': 'Street address',
+      'ui:description': `20 characters maximum. If you have a longer address,
+         use the second address box below`,
       'ui:errorMessages': {
         pattern: 'Please enter a valid street address',
         required: 'Please enter a street address',
-      },
-      'ui:validations': [checkMaxInputLength],
-    },
-    'view:addressLine1MaxLengthAlert': {
-      'ui:title': ' ',
-      'ui:description': (
-        <AlertBox
-          headline="Warning alert"
-          content="Please enter no more than 20 characters in this field"
-          status="warning"
-        />
-      ),
-      'ui:options': {
-        hideIf: formData => formData.mailingAddress.addressLine1?.length < 20,
-        expandUnder: 'addressLine1',
       },
     },
   },
@@ -142,17 +115,11 @@ export const uiSchema = {
   },
 };
 
-const modifiedMailingAddress = { ...fullSchema.definitions.address };
-modifiedMailingAddress.properties['view:addressLine1MaxLengthAlert'] = {
-  type: 'object',
-  properties: {},
-};
-
 export const schema = {
   type: 'object',
   properties: {
     phoneAndEmail,
-    mailingAddress: modifiedMailingAddress,
+    mailingAddress,
     // 'view:hasForwardingAddress': {
     //   type: 'boolean',
     // },

--- a/src/applications/disability-benefits/all-claims/pages/contactInformation.js
+++ b/src/applications/disability-benefits/all-claims/pages/contactInformation.js
@@ -1,3 +1,5 @@
+import React from 'react';
+
 // import _ from '../../../../platform/utilities/data';
 // import merge from 'lodash/merge';
 import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json';
@@ -5,8 +7,10 @@ import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json';
 // import dateRangeUI from 'platform/forms-system/src/js/definitions/dateRange';
 import phoneUI from 'platform/forms-system/src/js/definitions/phone';
 import emailUI from 'platform/forms-system/src/js/definitions/email';
+import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 
 import ReviewCardField from '../components/ReviewCardField';
+import { checkMaxInputLength } from '../validations';
 
 import {
   contactInfoDescription,
@@ -27,7 +31,7 @@ import {
 import { ADDRESS_PATHS } from '../constants';
 
 const {
-  mailingAddress,
+  // mailingAddress,
   // forwardingAddress,
   phoneAndEmail,
 } = fullSchema.properties;
@@ -44,11 +48,41 @@ export const uiSchema = {
     primaryPhone: phoneUI('Phone number'),
     emailAddress: emailUI(),
   },
-  mailingAddress: addressUISchema(
-    ADDRESS_PATHS.mailingAddress,
-    'Mailing address',
-    true,
-  ),
+  mailingAddress: {
+    ...addressUISchema(ADDRESS_PATHS.mailingAddress, 'Mailing address', true),
+    'ui:order': [
+      'country',
+      'addressLine1',
+      'view:addressLine1MaxLengthAlert',
+      'addressLine2',
+      'addressLine3',
+      'city',
+      'state',
+      'zipCode',
+    ],
+    addressLine1: {
+      'ui:title': 'Street address',
+      'ui:errorMessages': {
+        pattern: 'Please enter a valid street address',
+        required: 'Please enter a street address',
+      },
+      'ui:validations': [checkMaxInputLength],
+    },
+    'view:addressLine1MaxLengthAlert': {
+      'ui:title': ' ',
+      'ui:description': (
+        <AlertBox
+          headline="Warning alert"
+          content="Please enter no more than 20 characters in this field"
+          status="warning"
+        />
+      ),
+      'ui:options': {
+        hideIf: formData => formData.mailingAddress.addressLine1?.length < 20,
+        expandUnder: 'addressLine1',
+      },
+    },
+  },
   // 'view:hasForwardingAddress': {
   //   'ui:title': 'My address will be changing soon.',
   // },
@@ -108,11 +142,17 @@ export const uiSchema = {
   },
 };
 
+const modifiedMailingAddress = { ...fullSchema.definitions.address };
+modifiedMailingAddress.properties['view:addressLine1MaxLengthAlert'] = {
+  type: 'object',
+  properties: {},
+};
+
 export const schema = {
   type: 'object',
   properties: {
     phoneAndEmail,
-    mailingAddress,
+    mailingAddress: modifiedMailingAddress,
     // 'view:hasForwardingAddress': {
     //   type: 'boolean',
     // },

--- a/src/applications/disability-benefits/all-claims/pages/contactInformation.js
+++ b/src/applications/disability-benefits/all-claims/pages/contactInformation.js
@@ -47,11 +47,8 @@ export const uiSchema = {
   mailingAddress: {
     ...addressUISchema(ADDRESS_PATHS.mailingAddress, 'Mailing address', true),
     addressLine1: {
-      'ui:title': 'Street address',
-      'ui:description': `20 characters maximum. If you have a longer address,
-         use the second address box below`,
+      'ui:title': 'Street address (20 characters maximum)',
       'ui:errorMessages': {
-        pattern: 'Please enter a valid street address',
         required: 'Please enter a street address',
       },
     },

--- a/src/applications/disability-benefits/all-claims/pages/contactInformation.js
+++ b/src/applications/disability-benefits/all-claims/pages/contactInformation.js
@@ -52,6 +52,12 @@ export const uiSchema = {
         required: 'Please enter a street address',
       },
     },
+    addressLine2: {
+      'ui:title': 'Street address (20 characters maximum)',
+    },
+    addressLine3: {
+      'ui:title': 'Street address (20 characters maximum)',
+    },
   },
   // 'view:hasForwardingAddress': {
   //   'ui:title': 'My address will be changing soon.',

--- a/src/applications/disability-benefits/all-claims/validations.js
+++ b/src/applications/disability-benefits/all-claims/validations.js
@@ -288,3 +288,11 @@ export const requireNewDisability = (err, fieldData, formData) => {
     err.addError('');
   }
 };
+
+export const checkMaxInputLength = (err, fieldData, gg, schema) => {
+  if (fieldData.length >= schema.maxLength) {
+    err.addError(
+      `Please enter no more than ${schema.maxLength} characters in this field`,
+    );
+  }
+};

--- a/src/applications/disability-benefits/all-claims/validations.js
+++ b/src/applications/disability-benefits/all-claims/validations.js
@@ -288,11 +288,3 @@ export const requireNewDisability = (err, fieldData, formData) => {
     err.addError('');
   }
 };
-
-export const checkMaxInputLength = (err, fieldData, gg, schema) => {
-  if (fieldData.length >= schema.maxLength) {
-    err.addError(
-      `Please enter no more than ${schema.maxLength} characters in this field`,
-    );
-  }
-};


### PR DESCRIPTION
## Description

Users are unaware of the 20 character limitation of the street address in form 526. To make them more aware, we will add a description stating this limitation. The current form systems does not show warning messages, nor will it show an error message if the `maxLength` of the input is set. This was the next best alternative.

Discussions:
- main issue: https://github.com/department-of-veterans-affairs/va.gov-team/issues/5225
- Slack: https://dsva.slack.com/archives/C0NGDDXME/p1582213355120200

## Testing done

Local unit tests

## Screenshots

Before this change

![Screen Shot 2020-02-20 at 5 22 51 PM](https://user-images.githubusercontent.com/136959/74989320-aa7b5300-5405-11ea-862d-7982d7744e31.png)

No warning or message after entering 20 characters. Typing additional characters does nothing inside the input

After

![Screen Shot 2020-02-24 at 1 03 30 PM](https://user-images.githubusercontent.com/136959/75182598-5e325a80-5706-11ea-9137-406ae945f72d.png)

![Screen Shot 2020-02-24 at 1 44 08 PM](https://user-images.githubusercontent.com/136959/75185695-262e1600-570c-11ea-8f77-ec707f6dbf0a.png)

Same behavior as before, but at least there is a message

## Acceptance criteria
- [ ] Users should be aware of the text limitation
- [ ] Screenreader users are aware of this limitation

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
