### PR TITLE
VAMC template handling for null wait time data

### DIFF
--- a/src/applications/static-pages/facilities/FacilityAppointmentWaitTimesWidget.jsx
+++ b/src/applications/static-pages/facilities/FacilityAppointmentWaitTimesWidget.jsx
@@ -40,7 +40,7 @@ export class FacilityAppointmentWaitTimesWidget extends React.Component {
     const service = this.props.service.split('(')[0];
     const serviceExists = facility.access.health[_.camelCase(service)];
     // check if this health service has a wait time associated with it
-    if (serviceExists) {
+    if (serviceExists && (serviceExists.new || serviceExists.established)) {
       return (
         <div>
           <h3>Average number of days to get an appointment</h3>
@@ -54,30 +54,36 @@ export class FacilityAppointmentWaitTimesWidget extends React.Component {
           </p>
           <div className="usa-grid-full">
             <div className="vads-u-display--flex">
-              <div className="facility-satisfaction-tile vads-u-background-color--gray-lightest vads-u-padding-x--2 vads-u-padding-top--1 vads-u-padding-bottom--1p5 vads-u-margin-right--1">
-                <p className="vads-u-margin--0">New patient</p>
-                <p
-                  id={`facility-${_.camelCase(service)}-new-patient-wait-time`}
-                  className="vads-u-font-size--lg vads-u-font-weight--bold vads-u-margin--0 vads-u-font-family--serif"
-                >
-                  {this.appointmentWaitTime(facility.access.health, service)}
-                </p>
-              </div>
-              <div className="facility-satisfaction-tile vads-u-background-color--gray-lightest vads-u-padding-x--2 vads-u-padding-top--1 vads-u-padding-bottom--1p5">
-                <p className="vads-u-margin--0">Existing patient</p>
-                <p
-                  id={`facility-${_.camelCase(
-                    service,
-                  )}-existing-patient-wait-time`}
-                  className="vads-u-font-size--lg vads-u-font-weight--bold vads-u-margin--0 vads-u-font-family--serif"
-                >
-                  {this.appointmentWaitTime(
-                    facility.access.health,
-                    service,
-                    true,
-                  )}
-                </p>
-              </div>
+              {serviceExists.new && (
+                <div className="facility-satisfaction-tile vads-u-background-color--gray-lightest vads-u-padding-x--2 vads-u-padding-top--1 vads-u-padding-bottom--1p5 vads-u-margin-right--1">
+                  <p className="vads-u-margin--0">New patient</p>
+                  <p
+                    id={`facility-${_.camelCase(
+                      service,
+                    )}-new-patient-wait-time`}
+                    className="vads-u-font-size--lg vads-u-font-weight--bold vads-u-margin--0 vads-u-font-family--serif"
+                  >
+                    {this.appointmentWaitTime(facility.access.health, service)}
+                  </p>
+                </div>
+              )}
+              {serviceExists.established && (
+                <div className="facility-satisfaction-tile vads-u-background-color--gray-lightest vads-u-padding-x--2 vads-u-padding-top--1 vads-u-padding-bottom--1p5">
+                  <p className="vads-u-margin--0">Existing patient</p>
+                  <p
+                    id={`facility-${_.camelCase(
+                      service,
+                    )}-existing-patient-wait-time`}
+                    className="vads-u-font-size--lg vads-u-font-weight--bold vads-u-margin--0 vads-u-font-family--serif"
+                  >
+                    {this.appointmentWaitTime(
+                      facility.access.health,
+                      service,
+                      true,
+                    )}
+                  </p>
+                </div>
+              )}
             </div>
             <div className="vads-l-row">
               <p


### PR DESCRIPTION
## Description
issue https://github.com/department-of-veterans-affairs/va.gov-team/issues/5188

## Testing done


## Screenshots


## Acceptance criteria
- [x] If wait time data is available for Existing Patients, but not for New Patients, then only the content block for Existing Patients is displayed.
- [x] If wait time data is available for New Patients, but not for Existing Patients, then only the content block for New Patients is displayed.
- [x] If data is not available for either Existing or New, the entire content block should not display.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
