### PR TITLE
bradl3yC - 5865 - screen reader reading previous modal twice

### DIFF
--- a/src/applications/personalization/profile360/sass/profile-360.scss
+++ b/src/applications/personalization/profile360/sass/profile-360.scss
@@ -83,6 +83,6 @@ input.usa-only-phone {
   padding: 0 5px;
 
   .address-validation-input {
-    height: 100%;
+    height: 75%;
   }
 }

--- a/src/platform/user/profile/vet360/containers/AddressValidationModal.jsx
+++ b/src/platform/user/profile/vet360/containers/AddressValidationModal.jsx
@@ -159,13 +159,14 @@ class AddressValidationModal extends React.Component {
               zipCode && <span>{` ${city}, ${stateCode} ${zipCode}`}</span>}
             {isAddressFromUser &&
               showEditLink && (
-                <a
+                <button
+                  className="va-button-link"
                   onClick={() =>
                     this.props.openModal(addressValidationType, addressFromUser)
                   }
                 >
                   Edit Address
-                </a>
+                </button>
               )}
           </div>
         </label>

--- a/src/platform/user/profile/vet360/containers/Vet360ProfileField.jsx
+++ b/src/platform/user/profile/vet360/containers/Vet360ProfileField.jsx
@@ -193,7 +193,6 @@ class Vet360ProfileField extends React.Component {
       <div
         className="vet360-profile-field"
         aria-atomic="false"
-        aria-live="polite"
         data-field-name={fieldName}
       >
         <Vet360ProfileFieldHeading

--- a/src/platform/user/profile/vet360/reducers/index.js
+++ b/src/platform/user/profile/vet360/reducers/index.js
@@ -215,6 +215,7 @@ export default function vet360(state = initialState, action) {
     case ADDRESS_VALIDATION_INITIALIZE:
       return {
         ...state,
+        modal: null,
         addressValidation: {
           ...initialAddressValidationState,
         },

--- a/src/platform/user/profile/vet360/tests/reducers/index.unit.spec.js
+++ b/src/platform/user/profile/vet360/tests/reducers/index.unit.spec.js
@@ -460,6 +460,7 @@ describe('vet360 reducer', () => {
         fieldTransactionMap: {
           mailingAddress: { isPending: true },
         },
+        modal: null,
       };
       expect(vet360(state, action)).to.eql(expectedState);
     });


### PR DESCRIPTION
## Description
- [x] - remove aria-live from modal field inputs

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
