### PR TITLE
[Development] Remove jump link in form 526

### DIFF
--- a/src/applications/disability-benefits/all-claims/content/summaryOfDisabilities.jsx
+++ b/src/applications/disability-benefits/all-claims/content/summaryOfDisabilities.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import { Link } from 'react-router';
+// import { Link } from 'react-router';
 
 import { capitalizeEachWord, isDisabilityPtsd } from '../utils';
 import { ptsdTypeEnum } from './ptsdTypeInfo';
-import formConfig from '../config/form';
+// import formConfig from '../config/form';
 import { NULL_CONDITION_STRING } from '../constants';
 
 const mapDisabilityName = (disabilityName, formData, index) => {
@@ -52,17 +52,18 @@ export const SummaryOfDisabilitiesDescription = ({ formData }) => {
   const selectedDisabilitiesList = ratedDisabilityNames
     .concat(newDisabilityNames)
     .map((name, i) => mapDisabilityName(name, formData, i));
-  const orientationPath =
-    formConfig?.chapters.disabilities.pages.disabilitiesOrientation.path || '/';
+  // const orientationPath =
+  //   formConfig?.chapters.disabilities.pages.disabilitiesOrientation.path || '/';
 
   return (
     <>
       <p>
         Below is the list of disabilities you’re claiming in this application.
-        If a disability is missing from the list, please{' '}
-        <Link aria-label="Add missing disabilities" to={orientationPath}>
+        If a disability is missing from the list, please go back to the
+        beginning of this step and add it
+        {/* <Link aria-label="Add missing disabilities" to={orientationPath}>
           go back and add it
-        </Link>
+        </Link> */}
         .
       </p>
       <ul>{selectedDisabilitiesList}</ul>


### PR DESCRIPTION
## Description

Temporarily remove the link that jumps from one step to another in form 526. Use of this link isn't updating a saved state (see https://github.com/department-of-veterans-affairs/va.gov-team/issues/6068 for details), so we will temporarily remove it until that issue has been determined & resolved.

## Testing done

Local unit tests

## Screenshots

Before

![](https://user-images.githubusercontent.com/136959/74983208-33d95800-53fb-11ea-8d56-6dd99eed184e.png)

After
![Screen Shot 2020-02-21 at 9 58 59 AM](https://user-images.githubusercontent.com/136959/75050528-c2001d80-5491-11ea-8089-6d15f10d8671.png)

## Acceptance criteria
- [ ] Troublesome link was removed

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
