### PR TITLE
bradl3yC - 5505 - IE11 cannot select inputs - specific click area

### DIFF
--- a/src/applications/personalization/profile360/sass/profile-360.scss
+++ b/src/applications/personalization/profile360/sass/profile-360.scss
@@ -75,3 +75,8 @@ input.usa-only-phone {
 .no-wrap {
   white-space: nowrap;
 }
+
+.address-validation-input {
+  max-height: 125px;
+  height: 100%;
+}

--- a/src/applications/personalization/profile360/sass/profile-360.scss
+++ b/src/applications/personalization/profile360/sass/profile-360.scss
@@ -76,7 +76,13 @@ input.usa-only-phone {
   white-space: nowrap;
 }
 
-.address-validation-input {
-  max-height: 125px;
-  height: 100%;
+.address-validation-container {
+  overflow: hidden;
+  position: relative;
+  width: 100%;
+  padding: 0 5px;
+
+  .address-validation-input {
+    height: 100%;
+  }
 }

--- a/src/platform/user/profile/vet360/containers/AddressValidationModal.jsx
+++ b/src/platform/user/profile/vet360/containers/AddressValidationModal.jsx
@@ -132,7 +132,7 @@ class AddressValidationModal extends React.Component {
     return (
       <div
         key={id}
-        className="vads-u-display--flex vads-u-flex-direction--column vads-u-justify-content--center vads-u-margin-bottom--1p5"
+        className="vads-u-margin-bottom--1p5 address-validation-container"
       >
         {isFirstOptionOrEnabled &&
           hasConfirmedSuggestions && (

--- a/src/platform/user/profile/vet360/containers/AddressValidationModal.jsx
+++ b/src/platform/user/profile/vet360/containers/AddressValidationModal.jsx
@@ -137,6 +137,7 @@ class AddressValidationModal extends React.Component {
         {isFirstOptionOrEnabled &&
           hasConfirmedSuggestions && (
             <input
+              className="address-validation-input"
               type="radio"
               name={id}
               onChange={


### PR DESCRIPTION
## Description
The height of the input was not the same as the label - IE11 also does not respect ```justify-content: center```  This should make the input the same size as the label making the entire area clickable to select the radio button

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
