### PR TITLE
Hide the direct deposit component if ineligible

### DIFF
--- a/src/applications/personalization/profile360/components/ProfileView.jsx
+++ b/src/applications/personalization/profile360/components/ProfileView.jsx
@@ -24,6 +24,7 @@ import MVIError from './MVIError';
 import {
   directDepositIsSetUp,
   directDepositAddressIsSetUp,
+  directDepositIsBlocked,
   profileShowReceiveTextNotifications,
 } from 'applications/personalization/profile360/selectors';
 
@@ -189,9 +190,11 @@ class ProfileView extends React.Component {
 }
 
 function mapStateToProps(state) {
+  const directDepositIsAllowed = !directDepositIsBlocked(state);
   return {
     showDirectDepositLink:
-      directDepositIsSetUp(state) || directDepositAddressIsSetUp(state),
+      directDepositIsAllowed &&
+      (directDepositIsSetUp(state) || directDepositAddressIsSetUp(state)),
     showReceiveTextNotifications: profileShowReceiveTextNotifications(state),
   };
 }

--- a/src/applications/personalization/profile360/components/ProfileView.jsx
+++ b/src/applications/personalization/profile360/components/ProfileView.jsx
@@ -2,8 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
-import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
-
 import DowntimeNotification, {
   externalServices,
   externalServiceStatus,
@@ -17,8 +15,8 @@ import Hero from './Hero';
 import ContactInformation from './ContactInformation';
 import PersonalInformation from './PersonalInformation';
 import MilitaryInformation from './MilitaryInformation';
-// import PaymentInformation from '../containers/PaymentInformation';
-// import PaymentInformationTOCItem from '../containers/PaymentInformationTOCItem';
+import PaymentInformation from '../containers/PaymentInformation';
+import PaymentInformationTOCItem from '../containers/PaymentInformationTOCItem';
 
 import IdentityVerification from './IdentityVerification';
 import MVIError from './MVIError';
@@ -29,15 +27,14 @@ import {
   profileShowReceiveTextNotifications,
 } from 'applications/personalization/profile360/selectors';
 
-const ProfileTOC = ({ militaryInformation }) => (
-  // const ProfileTOC = ({ militaryInformation, showDirectDepositLink }) => (
+const ProfileTOC = ({ militaryInformation, showDirectDepositLink }) => (
   <>
     <h2 className="vads-u-font-size--h3">On this page</h2>
     <ul>
       <li>
         <a href="#contact-information">Contact information</a>
       </li>
-      {/* {showDirectDepositLink && <PaymentInformationTOCItem />} */}
+      {showDirectDepositLink && <PaymentInformationTOCItem />}
       <li>
         <a href="#personal-information">Personal information</a>
       </li>
@@ -92,7 +89,7 @@ class ProfileView extends React.Component {
       fetchPersonalInformation,
       profile: { hero, personalInformation, militaryInformation },
       downtimeData: { appTitle },
-      // showDirectDepositLink,
+      showDirectDepositLink,
       showReceiveTextNotifications,
     } = this.props;
 
@@ -113,14 +110,6 @@ class ProfileView extends React.Component {
           >
             <div>
               <Vet360TransactionReporter />
-              <AlertBox
-                headline="We're making some updates to the direct deposit tool"
-                status="warning"
-                className="vads-u-margin-bottom--2"
-              >
-                We’re sorry it’s not working right now. Please check back on
-                Monday Feb. 24, 2020.
-              </AlertBox>
               <Hero
                 fetchHero={fetchHero}
                 hero={hero}
@@ -128,16 +117,16 @@ class ProfileView extends React.Component {
               />
               <ProfileTOC
                 militaryInformation={militaryInformation}
-                // showDirectDepositLink={showDirectDepositLink}
+                showDirectDepositLink={showDirectDepositLink}
               />
               <div id="contact-information" />
               <ContactInformation
                 showReceiveTextNotifications={showReceiveTextNotifications}
               />
-              {/* <>
+              <>
                 <div id="direct-deposit" />
                 <PaymentInformation />
-              </> */}
+              </>
               <div id="personal-information" />
               <PersonalInformation
                 fetchPersonalInformation={fetchPersonalInformation}

--- a/src/applications/personalization/profile360/containers/PaymentInformation.jsx
+++ b/src/applications/personalization/profile360/containers/PaymentInformation.jsx
@@ -32,6 +32,7 @@ import {
   directDepositAccountInformation,
   directDepositAddressIsSetUp,
   directDepositInformation,
+  directDepositIsBlocked,
   directDepositIsSetUp as directDepositIsSetUpSelector,
 } from '../selectors';
 
@@ -280,6 +281,7 @@ const isEvssAvailable = createIsServiceAvailableSelector(
 const mapStateToProps = state => {
   const directDepositIsSetUp = directDepositIsSetUpSelector(state);
   const isEligible = isEvssAvailable(state);
+  const isNotBlocked = !directDepositIsBlocked(state);
   const isEligibleToSignUp = directDepositAddressIsSetUp(state);
 
   return {
@@ -295,7 +297,9 @@ const mapStateToProps = state => {
     paymentInformation: directDepositInformation(state),
     paymentInformationUiState: state.vaProfile.paymentInformationUiState,
     shouldShowDirectDeposit:
-      isEligible && (directDepositIsSetUp || isEligibleToSignUp),
+      isEligible &&
+      isNotBlocked &&
+      (directDepositIsSetUp || isEligibleToSignUp),
   };
 };
 

--- a/src/applications/personalization/profile360/selectors.js
+++ b/src/applications/personalization/profile360/selectors.js
@@ -24,3 +24,17 @@ export const directDepositAddressIsSetUp = state => {
     addressInfo?.stateCode
   );
 };
+
+export const directDepositIsBlocked = state => {
+  const controlInfo =
+    directDepositInformation(state)?.responses?.[0]?.controlInformation || {};
+  // If all of these flags are not strictly equal to `true` we want to block
+  // access to the direct deposit feature. ie, we want to err on the side of
+  // blocking people from accessing direct deposit rather than err on the side
+  // of letting people have access to the feature.
+  return (
+    controlInfo.isCompetentIndicator !== true ||
+    controlInfo.noFiduciaryAssignedIndicator !== true ||
+    controlInfo.notDeceasedIndicator !== true
+  );
+};

--- a/src/applications/personalization/profile360/tests/selectors.unit.spec.js
+++ b/src/applications/personalization/profile360/tests/selectors.unit.spec.js
@@ -116,4 +116,85 @@ describe('profile360 selectors', () => {
       expect(selectors.directDepositAddressIsSetUp(state)).to.be.false;
     });
   });
+
+  describe('directDepositIsBlocked', () => {
+    it('returns `false` if the isCompetentIndicator, noFiduciaryAssignedIndicator, and notDeceasedIndicator flags are all `true`', () => {
+      const state = {
+        vaProfile: {
+          paymentInformation: {
+            responses: [
+              {
+                controlInformation: {
+                  isCompetentIndicator: true,
+                  noFiduciaryAssignedIndicator: true,
+                  notDeceasedIndicator: true,
+                },
+              },
+            ],
+          },
+        },
+      };
+      expect(selectors.directDepositIsBlocked(state)).to.be.false;
+    });
+    it('returns `true` if the control information is not set', () => {
+      const state = {
+        vaProfile: {
+          paymentInformation: {
+            responses: [{ paymentInformation: {} }],
+          },
+        },
+      };
+      expect(selectors.directDepositIsBlocked(state)).to.be.true;
+    });
+    it('returns `true` if the `isCompetentIndicator` is not true', () => {
+      const state = {
+        vaProfile: {
+          paymentInformation: {
+            responses: [
+              {
+                controlInformation: {
+                  isCompetentIndicator: null,
+                  noFiduciaryAssignedIndicator: true,
+                },
+              },
+            ],
+          },
+        },
+      };
+      expect(selectors.directDepositIsBlocked(state)).to.be.true;
+    });
+    it('returns `true` if the `noFiduciaryAssignedIndicator` is not true', () => {
+      const state = {
+        vaProfile: {
+          paymentInformation: {
+            responses: [
+              {
+                controlInformation: {
+                  isCompetentIndicator: true,
+                },
+              },
+            ],
+          },
+        },
+      };
+      expect(selectors.directDepositIsBlocked(state)).to.be.true;
+    });
+    it('returns `true` if the `notDeceasedIndicator` is not true', () => {
+      const state = {
+        vaProfile: {
+          paymentInformation: {
+            responses: [
+              {
+                controlInformation: {
+                  isCompetentIndicator: true,
+                  noFiduciaryAssignedIndicator: true,
+                },
+              },
+            ],
+          },
+        },
+      };
+      expect(selectors.directDepositIsBlocked(state)).to.be.true;
+    });
+  });
 });


### PR DESCRIPTION
**NOTE: unit tests for the component itself do not currently exist so I'm adding those as a follow up PR but we need to get this out ASAP to restore the Direct Deposit feature to eligible users; we completely removed it late on Friday.**

Only render the component if the user is not flagged as: deceased, incompetent, or having a fiduciary.

## Description
There are new conditions where we should hide the Direct Deposit feature from users. This PR adjusts the logic to render the component only if certain flags from the PPIU service have been set to `true`. The component will err on the side of being secure and _not_ render anything unless three indicator flags have been explicitly set to `true`.

## Testing done
Local + unit tests. I hacked the vets-api code locally to return different responses from `GET ppiu/payment_information` to make sure the FE was handing different cases correctly.

## Screenshots
N/A

## Acceptance criteria
- [ ] the DD component does not render anything unless all three indicator flags are `true`.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs