### PR TITLE
Update times to be iso format

### DIFF
--- a/src/platform/site-wide/announcements/components/Downtime.jsx
+++ b/src/platform/site-wide/announcements/components/Downtime.jsx
@@ -21,8 +21,8 @@ class Downtime extends Component {
     } = this.props;
 
     // Derive the message.
-    const formattedExpiresAt = moment(expiresAt).format('MMM Do [at] h:mm a z');
-    const message = `We're doing work on VA.gov. If you have trouble using online tools, check back after ${formattedExpiresAt}.`;
+    const formattedExpiresAt = moment(expiresAt).format('MMM D [at] h:mm a');
+    const message = `We're doing work on VA.gov. If you have trouble using online tools, check back after ${formattedExpiresAt}`;
 
     return (
       <PromoBanner

--- a/src/platform/site-wide/announcements/components/PrePreDowntime.jsx
+++ b/src/platform/site-wide/announcements/components/PrePreDowntime.jsx
@@ -23,10 +23,10 @@ class PrePreDowntime extends Component {
 
     // Derive the message.
     const formattedStartsAt = moment(downtimeStartsAt).format(
-      'MMM Do [at] h:mm a',
+      'MMM D [at] h:mm a',
     );
-    const formattedExpiresAt = moment(downtimeExpiresAt).format('h:mm a z');
-    const message = `We'll be doing site maintenance on ${formattedStartsAt} until ${formattedExpiresAt}. You won’t be able to sign in or use some tools during this time.`;
+    const formattedExpiresAt = moment(downtimeExpiresAt).format('h:mm a');
+    const message = `We'll be doing site maintenance on ${formattedStartsAt} until ${formattedExpiresAt} You won’t be able to sign in or use some tools during this time.`;
 
     return (
       <PromoBanner

--- a/src/platform/site-wide/announcements/config/index.js
+++ b/src/platform/site-wide/announcements/config/index.js
@@ -13,8 +13,8 @@ import VAPlusVetsModal from '../components/VAPlusVetsModal';
 import WelcomeToNewVAModal from '../components/WelcomeToNewVAModal';
 
 // Derive when downtime will start and expire.
-const downtimeStartAtDate = moment.utc('2020-03-01 2:00').local();
-const downtimeExpiresAtDate = moment.utc('2020-03-01 2:30').local();
+const downtimeStartAtDate = moment.utc('2020-03-01T02:00:00.000Z').local();
+const downtimeExpiresAtDate = moment.utc('2020-03-01T02:30:00.000Z').local();
 
 const config = {
   announcements: [


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/6108

Current Behavior: It shows in production right now on Safari.

Desired Behavior: It should only show in production on Feb 29 at 9am ET until Feb 29 at 9:30pm ET.

This PR implements the above behavior due to a date format issue with `moment`.

## Testing done
Tested on both Chrome and Safari locally by checking for the downtime notification:

1. More than 12 hours before Feb 29 @ 9pm EST.
2. Between 12 hours and 1 hour before Feb 29 @ 9pm EST.
3. Between 1 hour and Feb 29 @9pm EST.
4. Between Feb 29 @ 9pm EST to 9:30pm EST.
5. After Feb 29 @9:30pm EST.

## Screenshots
N/A

## Acceptance criteria
- [x] Fix downtime notifications.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
