### PR TITLE
[Find Forms] Make 'Revision date' not required

### DIFF
--- a/src/applications/find-va-forms/containers/SearchResults.jsx
+++ b/src/applications/find-va-forms/containers/SearchResults.jsx
@@ -40,7 +40,7 @@ export class SearchResults extends Component {
         // Original form data key-value pairs.
         formName: PropTypes.string.isRequired,
         id: PropTypes.string.isRequired,
-        lastRevisionOn: PropTypes.number.isRequired,
+        lastRevisionOn: PropTypes.number,
         pages: PropTypes.number.isRequired,
         sha256: PropTypes.string.isRequired,
         title: PropTypes.string.isRequired,

--- a/src/applications/find-va-forms/helpers/index.js
+++ b/src/applications/find-va-forms/helpers/index.js
@@ -24,7 +24,7 @@ export const normalizeFormsForTable = forms =>
       // Overridden form values.
       id,
       type: form.type,
-      lastRevisionOn: lastRevisionOn && lastRevisionOn.unix(),
+      lastRevisionOn: lastRevisionOn?.unix(),
       // JSX Labels.
       idLabel,
       titleLabel: title,

--- a/src/applications/find-va-forms/helpers/index.js
+++ b/src/applications/find-va-forms/helpers/index.js
@@ -8,10 +8,9 @@ export const normalizeFormsForTable = forms =>
     const id = form?.id;
     const downloadURL = form?.attributes?.url || '';
     const title = form?.attributes?.title || '';
-    const lastRevisionOn = moment(
-      form?.attributes?.lastRevisionOn,
-      'YYYY-MM-DD',
-    );
+    const lastRevisionOn =
+      form?.attributes?.lastRevisionOn &&
+      moment(form.attributes.lastRevisionOn, 'YYYY-MM-DD');
 
     // Derive the ID field.
     const idLabel = (
@@ -25,10 +24,12 @@ export const normalizeFormsForTable = forms =>
       // Overridden form values.
       id,
       type: form.type,
-      lastRevisionOn: lastRevisionOn.unix(),
+      lastRevisionOn: lastRevisionOn && lastRevisionOn.unix(),
       // JSX Labels.
       idLabel,
       titleLabel: title,
-      lastRevisionOnLabel: lastRevisionOn.format('MM-DD-YYYY'),
+      lastRevisionOnLabel: lastRevisionOn
+        ? lastRevisionOn.format('MM-DD-YYYY')
+        : 'N/A',
     };
   });


### PR DESCRIPTION
## Description
`Revision date` is now nullable, so we need to check for `null` values before passing it into the forms table.

Related to https://github.com/department-of-veterans-affairs/va.gov-team/issues/6050

## Testing done
1. Visit /find-va-forms-beta/?q=health+care
1. Under the `Revision date` column, bbserve `N/A` is used for null values instead of `Invalid date`.

## Screenshots
![image](https://user-images.githubusercontent.com/1915775/75183656-f9303200-5710-11ea-9d40-7c941726edef.png)


## Acceptance criteria
- [x] `Invalid date` no longer shows in the table results

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
