### PR TITLE
Fix undefined system param

### DIFF
--- a/src/applications/vaos/actions/newAppointment.js
+++ b/src/applications/vaos/actions/newAppointment.js
@@ -254,7 +254,9 @@ export function openFacilityPage(page, uiSchema, schema) {
         parentId = parentFacilities[0].institutionCode;
       }
 
-      const systemId = getSystemFromParent(getState(), parentId);
+      const systemId = parentFacilities?.find(
+        parent => parent.institutionCode === parentId,
+      ).rootStationCode;
       facilities =
         newAppointment.facilities[`${typeOfCareId}_${parentId}`] || null;
 

--- a/src/applications/vaos/actions/newAppointment.js
+++ b/src/applications/vaos/actions/newAppointment.js
@@ -256,7 +256,7 @@ export function openFacilityPage(page, uiSchema, schema) {
 
       const systemId = parentFacilities?.find(
         parent => parent.institutionCode === parentId,
-      ).rootStationCode;
+      )?.rootStationCode;
       facilities =
         newAppointment.facilities[`${typeOfCareId}_${parentId}`] || null;
 

--- a/src/applications/vaos/tests/actions/newAppointment.unit.spec.js
+++ b/src/applications/vaos/tests/actions/newAppointment.unit.spec.js
@@ -277,10 +277,6 @@ describe('VAOS newAppointment actions', () => {
       const thunk = openFacilityPage('vaFacility', {}, defaultSchema);
       await thunk(dispatch, getState);
 
-      expect(dispatch.firstCall.args[0].type).to.equal(
-        FORM_PAGE_FACILITY_OPEN_SUCCEEDED,
-      );
-
       const succeededAction = dispatch.firstCall.args[0];
       expect(succeededAction).to.deep.equal({
         type: FORM_PAGE_FACILITY_OPEN_SUCCEEDED,

--- a/src/applications/vaos/tests/actions/newAppointment.unit.spec.js
+++ b/src/applications/vaos/tests/actions/newAppointment.unit.spec.js
@@ -265,7 +265,9 @@ describe('VAOS newAppointment actions', () => {
     it('should fetch parentFacilities and child facilities if single parent', async () => {
       setFetchJSONResponse(global.fetch, systemIdentifiers);
       setFetchJSONResponse(global.fetch.onCall(1), {
-        data: parentFacilities.data.slice(0, 1),
+        data: parentFacilities.data.filter(
+          parent => parent.attributes.institutionCode === '983',
+        ),
       });
       setFetchJSONResponse(global.fetch.onCall(2), facilities983);
       const dispatch = sinon.spy();

--- a/src/applications/vaos/tests/actions/newAppointment.unit.spec.js
+++ b/src/applications/vaos/tests/actions/newAppointment.unit.spec.js
@@ -262,6 +262,37 @@ describe('VAOS newAppointment actions', () => {
       });
     });
 
+    it('should fetch parentFacilities and child facilities if single parent', async () => {
+      setFetchJSONResponse(global.fetch, systemIdentifiers);
+      setFetchJSONResponse(global.fetch.onCall(1), {
+        data: parentFacilities.data.slice(0, 1),
+      });
+      setFetchJSONResponse(global.fetch.onCall(2), facilities983);
+      const dispatch = sinon.spy();
+      const state = set('newAppointment.parentFacilities', null, defaultState);
+      const getState = () => state;
+
+      const thunk = openFacilityPage('vaFacility', {}, defaultSchema);
+      await thunk(dispatch, getState);
+
+      expect(dispatch.firstCall.args[0].type).to.equal(
+        FORM_PAGE_FACILITY_OPEN_SUCCEEDED,
+      );
+
+      const succeededAction = dispatch.firstCall.args[0];
+      expect(succeededAction).to.deep.equal({
+        type: FORM_PAGE_FACILITY_OPEN_SUCCEEDED,
+        schema: defaultSchema,
+        page: 'vaFacility',
+        uiSchema: {},
+        parentFacilities: parentFacilitiesParsed.slice(0, 1),
+        facilities: facilities983Parsed,
+        eligibilityData: null,
+        typeOfCareId: defaultState.newAppointment.data.typeOfCareId,
+      });
+      expect(global.fetch.thirdCall.args[0]).to.contain('/systems/983/');
+    });
+
     it('should send fail action if a fetch fails', async () => {
       setFetchJSONFailure(global.fetch, {});
       const dispatch = sinon.spy();


### PR DESCRIPTION
## Description
We're trying to pull the system from parent facilities in the Redux state, before they're actually in that state, when opening the facility page for a single system patient.

## Testing done
Local and unit testing.

## Acceptance criteria
- [ ] System is sent properly

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
