### PR TITLE
Fix null timezone bug on confirmation page using direct schedule

### DIFF
--- a/src/applications/vaos/components/ConfirmationDirectScheduleInfo.jsx
+++ b/src/applications/vaos/components/ConfirmationDirectScheduleInfo.jsx
@@ -16,9 +16,10 @@ export default function ConfirmationDirectScheduleInfo({
   clinic,
   pageTitle,
   appointmentLength,
+  systemId,
 }) {
   const dateTime = data.calendarData.selectedDates[0].datetime;
-  const timezone = getTimezoneBySystemId(data.vaSystem);
+  const timezone = getTimezoneBySystemId(systemId);
   const momentDate = timezone
     ? moment(dateTime).tz(timezone.timezone, true)
     : moment(dateTime);
@@ -38,7 +39,7 @@ export default function ConfirmationDirectScheduleInfo({
         </div>
         <h2 className="vaos-appts__date-time vads-u-font-size--lg vads-u-margin-x--0">
           {momentDate.format('MMMM D, YYYY [at] hh:mm a')}
-          {` ${getTimezoneAbbrBySystemId(data.vaSystem)}`}
+          {` ${getTimezoneAbbrBySystemId(systemId)}`}
         </h2>
         <div className="vads-u-margin-top--2">
           <i className="fas fa-check-circle" />

--- a/src/applications/vaos/containers/ConfirmationPage.jsx
+++ b/src/applications/vaos/containers/ConfirmationPage.jsx
@@ -8,7 +8,7 @@ import {
   getFlowType,
   getChosenClinicInfo,
   getChosenFacilityDetails,
-  getSystemFromParent,
+  getSystemFromChosenFacility,
 } from '../utils/selectors';
 import {
   closeConfirmationPage,
@@ -102,7 +102,7 @@ function mapStateToProps(state) {
     clinic: getChosenClinicInfo(state),
     flowType: getFlowType(state),
     appointmentLength: getAppointmentLength(state),
-    systemId: getSystemFromParent(state, data?.vaParent),
+    systemId: getSystemFromChosenFacility(state),
   };
 }
 

--- a/src/applications/vaos/containers/ConfirmationPage.jsx
+++ b/src/applications/vaos/containers/ConfirmationPage.jsx
@@ -8,6 +8,7 @@ import {
   getFlowType,
   getChosenClinicInfo,
   getChosenFacilityDetails,
+  getSystemFromParent,
 } from '../utils/selectors';
 import {
   closeConfirmationPage,
@@ -50,6 +51,7 @@ export class ConfirmationPage extends React.Component {
       clinic,
       flowType,
       appointmentLength,
+      systemId,
     } = this.props;
     const isDirectSchedule = flowType === FLOW_TYPES.DIRECT;
 
@@ -62,6 +64,7 @@ export class ConfirmationPage extends React.Component {
             clinic={clinic}
             pageTitle={this.pageTitle}
             appointmentLength={appointmentLength}
+            systemId={systemId}
           />
         )}
         {!isDirectSchedule && (
@@ -91,12 +94,15 @@ ConfirmationPage.propTypes = {
 };
 
 function mapStateToProps(state) {
+  const data = getFormData(state);
+
   return {
-    data: getFormData(state),
+    data,
     facilityDetails: getChosenFacilityDetails(state),
     clinic: getChosenClinicInfo(state),
     flowType: getFlowType(state),
     appointmentLength: getAppointmentLength(state),
+    systemId: getSystemFromParent(state, data?.vaParent),
   };
 }
 

--- a/src/applications/vaos/tests/components/AddToCalendar.unit.spec.jsx
+++ b/src/applications/vaos/tests/components/AddToCalendar.unit.spec.jsx
@@ -147,7 +147,6 @@ describe('VAOS <AddToCalendar>', () => {
         },
       },
       data: {
-        vaSystem: '983',
         calendarData: {
           selectedDates: [
             {
@@ -156,10 +155,11 @@ describe('VAOS <AddToCalendar>', () => {
           ],
         },
       },
+      systemId: '983',
     };
 
     const dateTime = props.data.calendarData.selectedDates[0].dateTime;
-    const timezone = getTimezoneBySystemId(props.data.vaSystem);
+    const timezone = getTimezoneBySystemId(props.systemId);
     const momentDate = timezone
       ? moment(dateTime).tz(timezone.timezone, true)
       : moment(dateTime);

--- a/src/applications/vaos/tests/components/ConfirmationDirectScheduleInfo.unit.spec.jsx
+++ b/src/applications/vaos/tests/components/ConfirmationDirectScheduleInfo.unit.spec.jsx
@@ -35,7 +35,7 @@ describe('VAOS <ConfirmationDirectScheduleInfo>', () => {
       <ConfirmationDirectScheduleInfo {...props} pageTitle={pageTitle} />,
     );
 
-    expect(tree.text()).to.contain('December 20, 2019 at 10:00 a.m.');
+    expect(tree.text()).to.contain('December 20, 2019 at 10:00 a.m. MT');
 
     expect(tree.find('h1').text()).to.equal(pageTitle);
 

--- a/src/applications/vaos/tests/components/ConfirmationDirectScheduleInfo.unit.spec.jsx
+++ b/src/applications/vaos/tests/components/ConfirmationDirectScheduleInfo.unit.spec.jsx
@@ -23,11 +23,11 @@ describe('VAOS <ConfirmationDirectScheduleInfo>', () => {
         },
       },
       data: {
-        vaSystem: '983',
         calendarData: {
           selectedDates: [{ datetime: '2019-12-20T10:00:00' }],
         },
       },
+      systemId: '983',
     };
     const pageTitle = 'Your appointment has been scheduled';
 


### PR DESCRIPTION
## Description
Fixes timezone display on confirmation page of a direct schedule appointment.  This component was previously using `data.vaSystem` but we updated the state to use `data.vaParent` instead, so systemId was missing.  This PR provides the proper `systemId` in order to get the timezone.

## Testing done
Local and unit

## Screenshots
<img width="678" alt="Screen Shot 2020-02-25 at 12 33 54 PM" src="https://user-images.githubusercontent.com/786704/75285323-453fad00-57cb-11ea-95d0-102c976ca707.png">


## Acceptance criteria
- [ ] Timezone displays properly on confirmation page when direct scheduling

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
