### PR TITLE
bradl3yC - 5866 - Screen reader re-reading previous modal

### DIFF
--- a/src/platform/user/profile/vet360/containers/AddressValidationModal.jsx
+++ b/src/platform/user/profile/vet360/containers/AddressValidationModal.jsx
@@ -11,7 +11,7 @@ import {
   createTransaction,
   updateSelectedAddress,
   updateValidationKeyAndSave,
-  closeModal as closeAddressValidationModal,
+  closeModal,
   resetAddressValidation as resetAddressValidationAction,
 } from '../actions';
 import { getValidationMessageKey } from '../../utilities';
@@ -86,9 +86,10 @@ class AddressValidationModal extends React.Component {
       return (
         <button
           className="usa-button-primary"
-          onClick={() =>
-            this.props.openModal(addressValidationType, addressFromUser)
-          }
+          onClick={() => {
+            this.props.closeModal();
+            this.props.openModal(addressValidationType, addressFromUser);
+          }}
         >
           Edit Address
         </button>
@@ -150,7 +151,7 @@ class AddressValidationModal extends React.Component {
           htmlFor={id}
           className="vads-u-margin-top--2 vads-u-display--flex vads-u-align-items--center"
         >
-          <div className="vads-u-display--flex vads-u-flex-direction--column">
+          <div className="vads-u-display--flex vads-u-flex-direction--column vads-u-padding-bottom--0p5">
             {addressLine1 && <span>{addressLine1}</span>}
             {addressLine2 && <span>{` ${addressLine2}`}</span>}
             {addressLine3 && <span>{` ${addressLine3}`}</span>}
@@ -161,9 +162,13 @@ class AddressValidationModal extends React.Component {
               showEditLink && (
                 <button
                   className="va-button-link"
-                  onClick={() =>
-                    this.props.openModal(addressValidationType, addressFromUser)
-                  }
+                  onClick={() => {
+                    this.props.closeModal();
+                    this.props.openModal(
+                      addressValidationType,
+                      addressFromUser,
+                    );
+                  }}
                 >
                   Edit Address
                 </button>
@@ -182,14 +187,13 @@ class AddressValidationModal extends React.Component {
       addressFromUser,
       validationKey,
       addressValidationError,
-      closeModal,
       resetAddressValidation,
       confirmedSuggestions,
     } = this.props;
 
     const resetDataAndCloseModal = () => {
       resetAddressValidation();
-      closeModal();
+      this.props.closeModal();
     };
 
     const validationMessageKey = getValidationMessageKey(
@@ -277,7 +281,7 @@ const mapStateToProps = state => {
 const mapDispatchToProps = dispatch => ({
   ...bindActionCreators(
     {
-      closeModal: closeAddressValidationModal,
+      closeModal,
       openModal,
       updateSelectedAddress,
       updateValidationKeyAndSave,


### PR DESCRIPTION
## Description
- [x] - close modal before opening the next 

## Testing done


## Screenshots
![Screen Shot 2020-02-25 at 4 34 18 PM](https://user-images.githubusercontent.com/6165421/75289632-b2b00580-57ec-11ea-9499-c76e52fa6a75.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
