### PR TITLE
Create app specific unit test coverage report

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "test:accessibility:docker": "docker-compose -p accessibility up -d && docker-compose -p accessibility run --rm --entrypoint=npm -e BABEL_ENV=test -e BUILDTYPE=vagovprod vets-website --no-color run nightwatch:docker -- --env=accessibility && docker-compose -p accessibility stop",
     "test:best-practice": "./script/run-nightwatch.sh --env bestpractice",
     "test:coverage": "./script/run-coverage.sh",
+    "test:coverage-apps": "npm run test:coverage && node script/app-coverage-report.js",
     "test:puppeteer": "./script/run-puppeteer-tests.sh",
     "test:puppeteer:docker": "IN_DOCKER=true jest -c=config/jest-puppeteer.config.js",
     "test:sauce": "./script/run-nightwatch.sh --sauce",

--- a/script/app-coverage-report.js
+++ b/script/app-coverage-report.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-console */
+
 const fs = require('fs');
 const path = require('path');
 const Table = require('cli-table');
@@ -22,7 +24,7 @@ const printCoverage = coverageResults => {
     }
   });
 
-  console.log(coverageTable.toString()); // eslint-disable-line
+  console.log(coverageTable.toString());
 };
 
 const generateCoverage = (rootDir, coverageSummary) =>
@@ -57,9 +59,14 @@ const generateCoverage = (rootDir, coverageSummary) =>
 // Root directory of application folders
 const applicationDir = path.join(__dirname, '../src/applications/');
 
-const coverageSummaryJson = JSON.parse(
-  fs.readFileSync(path.join(__dirname, '../coverage/coverage-summary.json')),
-);
-
-const appCoverage = generateCoverage(applicationDir, coverageSummaryJson);
-printCoverage(appCoverage);
+// Check if coverage-summary.json exists before generating coverage
+if (fs.existsSync(path.join(__dirname, '../coverage/coverage-summary.json'))) {
+  const coverageSummaryJson = JSON.parse(
+    fs.readFileSync(path.join(__dirname, '../coverage/coverage-summary.json')),
+  );
+  // Generate and print coverage
+  const appCoverage = generateCoverage(applicationDir, coverageSummaryJson);
+  printCoverage(appCoverage);
+} else {
+  console.log('./coverage/coverage-summary.json not found.');
+}

--- a/script/app-coverage-report.js
+++ b/script/app-coverage-report.js
@@ -1,0 +1,77 @@
+const fs = require('fs');
+const path = require('path');
+const Table = require('cli-table');
+
+const camelCase = str =>
+  // Convert string to camel case
+  str
+    .replace(
+      /(?:^\w|[A-Z]|\b\w)/g,
+      (word, index) => (index === 0 ? word.toLowerCase() : word.toUpperCase()),
+    )
+    .replace(/-|\s/g, '');
+
+const printCoverage = coverageResults => {
+  // Create a new table with headers
+  const coverageTable = new Table({
+    head: ['Application', 'Lines', 'Functions', 'Statements', 'Branches'],
+  });
+
+  // Add each app coverage result to the table
+  Object.keys(coverageResults).forEach(key => {
+    if (key !== 'total') {
+      coverageTable.push({
+        [key]: [
+          `${coverageResults[key].lines.pct}%`,
+          `${coverageResults[key].functions.pct}%`,
+          `${coverageResults[key].statements.pct}%`,
+          `${coverageResults[key].branches.pct}%`,
+        ],
+      });
+    }
+  });
+
+  /* eslint-disable no-console */
+  console.log(coverageTable.toString());
+};
+
+const generateCoverageReport = (rootDir, coverageSummary) => {
+  const appCoverages = {};
+
+  // Iterate through each coverage result
+  Object.keys(coverageSummary).forEach(key => {
+    // Extract the application name from the coverage result & store in camel case
+    const appName = camelCase(key.replace(rootDir, '').split(path.sep)[0]);
+    const coverageResult = coverageSummary[key];
+
+    // If there is an app name, add result to overall coverage
+    if (appName) {
+      // Average coverageResult with respective appCoverage segment if present
+      if (appCoverages[appName]) {
+        Object.keys(appCoverages[appName]).forEach(seg => {
+          appCoverages[appName][seg].total += coverageResult[seg].total;
+          appCoverages[appName][seg].covered += coverageResult[seg].covered;
+          appCoverages[appName][seg].skipped += coverageResult[seg].skipped;
+          appCoverages[appName][seg].pct = (
+            (appCoverages[appName][seg].covered /
+              appCoverages[appName][seg].total) *
+            100
+          ).toFixed(2);
+        });
+      } else {
+        // Create new appCoverage entry
+        Object.assign(appCoverages, { [appName]: coverageResult });
+      }
+    }
+  });
+  printCoverage(appCoverages);
+};
+
+// Root directory of application folders
+const applicationDir = path.join(__dirname, '../src/applications/');
+
+const coverageSummaryJson = JSON.parse(
+  fs.readFileSync(path.join(__dirname, '../coverage/coverage-summary.json')),
+);
+
+generateCoverageReport(applicationDir, coverageSummaryJson);

--- a/script/run-coverage.sh
+++ b/script/run-coverage.sh
@@ -10,7 +10,7 @@ fi
 
 # No test specified; run coverage on all of them
 if [[ -z "$1" ]] || [[ $1 == -* ]]; then
-  NODE_ENV=test $NYC --all --reporter=lcov --reporter=text mocha --reporter mocha-junit-reporter --no-color --opts src/platform/testing/unit/mocha.opts --recursive '{src,test}/**/*.unit.spec.js?(x)' src/platform/testing/unit/helper.js "$@"
+  NODE_ENV=test $NYC --all --reporter=lcov --reporter=text --reporter=json-summary mocha --reporter mocha-junit-reporter --no-color --opts src/platform/testing/unit/mocha.opts --recursive '{src,test}/**/*.unit.spec.js?(x)' src/platform/testing/unit/helper.js "$@"
   exit $?
 fi
 

--- a/script/run-coverage.sh
+++ b/script/run-coverage.sh
@@ -14,4 +14,4 @@ if [[ -z "$1" ]] || [[ $1 == -* ]]; then
   exit $?
 fi
 
-NODE_ENV=test $NYC --reporter=lcov --reporter=text mocha --reporter mocha-junit-reporter --no-color --opts src/platform/testing/unit/mocha.opts src/platform/testing/unit/helper.js --recursive "$@"
+NODE_ENV=test $NYC --reporter=lcov --reporter=text --reporter=json-summary mocha --reporter mocha-junit-reporter --no-color --opts src/platform/testing/unit/mocha.opts src/platform/testing/unit/helper.js --recursive "$@"

--- a/script/run-isolated-tests.sh
+++ b/script/run-isolated-tests.sh
@@ -32,8 +32,10 @@ echo
 # When only one app has been modified, run its tests and platform's tests.
 if [ $NUM_APPS_CHANGED -eq 1 ]; then
   yarn test:coverage "{src/platform,$APP_SUBPATHS_CHANGED}/**/*.unit.spec.js?(x)"
+  node ./script/app-coverage-report.js
   exit $?
 fi
 
 # Run tests for platform and all apps that have changes.
 echo $APP_SUBPATHS_CHANGED | sed 's/ /,/g' | xargs -I '$' yarn test:coverage '{src/platform,$}/**/*.unit.spec.js?(x)'
+node ./script/app-coverage-report.js


### PR DESCRIPTION
## Description
This PR creates an application unit test coverage report. Each application's unit test coverage information is averaged out, and displayed by running `npm run test:coverage-apps`.

The [`json-summary`](https://istanbul.js.org/docs/advanced/alternative-reporters/#json-summary) reporter has been added to the `run-coverage.sh` script. This generates the `./coverage/coverage-summary.json` report that lists each file's coverage.

The added script in this PR, `app-coverage-report.js`, takes the information from `coverage-summary.json`, sorts it by application, and takes the average of the test coverages for each application's files. 

## Testing done


## Screenshots
<img width="484" alt="Screen Shot 2020-02-25 at 5 18 44 PM" src="https://user-images.githubusercontent.com/9042882/75302556-0a516f80-57f3-11ea-8e96-ad2cab54cced.png">

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
