### PR TITLE
Restore Direct Deposit 2FA message

### DIFF
--- a/src/applications/personalization/profile360/containers/PaymentInformation.jsx
+++ b/src/applications/personalization/profile360/containers/PaymentInformation.jsx
@@ -32,7 +32,7 @@ import {
   directDepositAccountInformation,
   directDepositAddressIsSetUp,
   directDepositInformation,
-  directDepositIsBlocked,
+  directDepositIsBlocked as directDepositIsBlockedSelector,
   directDepositIsSetUp as directDepositIsSetUpSelector,
 } from '../selectors';
 
@@ -167,13 +167,10 @@ class PaymentInformation extends React.Component {
       paymentInformation,
       paymentAccount,
       shouldShowDirectDeposit,
+      directDepositIsBlocked,
     } = this.props;
 
     let content = null;
-
-    if (!shouldShowDirectDeposit) {
-      return content;
-    }
 
     if (isLoading) {
       return <LoadingIndicator message="Loading payment information..." />;
@@ -183,6 +180,12 @@ class PaymentInformation extends React.Component {
       content = <PaymentInformation2FARequired />;
     } else if (paymentInformation.error) {
       content = <LoadFail information="payment" />;
+    } else if (directDepositIsBlocked) {
+      // TODO: soon we will show an alert telling the user that they are blocked
+      // from the direct deposit feature
+      return content;
+    } else if (!shouldShowDirectDeposit) {
+      return content;
     } else {
       content = (
         <>
@@ -281,7 +284,6 @@ const isEvssAvailable = createIsServiceAvailableSelector(
 const mapStateToProps = state => {
   const directDepositIsSetUp = directDepositIsSetUpSelector(state);
   const isEligible = isEvssAvailable(state);
-  const isNotBlocked = !directDepositIsBlocked(state);
   const isEligibleToSignUp = directDepositAddressIsSetUp(state);
 
   return {
@@ -296,10 +298,9 @@ const mapStateToProps = state => {
     paymentAccount: directDepositAccountInformation(state),
     paymentInformation: directDepositInformation(state),
     paymentInformationUiState: state.vaProfile.paymentInformationUiState,
+    directDepositIsBlocked: directDepositIsBlockedSelector(state),
     shouldShowDirectDeposit:
-      isEligible &&
-      isNotBlocked &&
-      (directDepositIsSetUp || isEligibleToSignUp),
+      isEligible && (directDepositIsSetUp || isEligibleToSignUp),
   };
 };
 

--- a/src/applications/personalization/profile360/containers/PaymentInformation.jsx
+++ b/src/applications/personalization/profile360/containers/PaymentInformation.jsx
@@ -108,7 +108,7 @@ const recordProfileNavEvent = (customProps = {}) => {
 class PaymentInformation extends React.Component {
   static propTypes = {
     isLoading: PropTypes.bool.isRequired,
-    isEligible: PropTypes.bool.isRequired,
+    isEvssAvailable: PropTypes.bool.isRequired,
     multifactorEnabled: PropTypes.bool.isRequired,
     fetchPaymentInformation: PropTypes.func.isRequired,
     editModalToggled: PropTypes.func.isRequired,
@@ -130,7 +130,7 @@ class PaymentInformation extends React.Component {
   };
 
   componentDidMount() {
-    if (this.props.isEligible && this.props.multifactorEnabled) {
+    if (this.props.isEvssAvailable && this.props.multifactorEnabled) {
       this.props.fetchPaymentInformation();
     }
   }
@@ -277,21 +277,21 @@ class PaymentInformation extends React.Component {
   }
 }
 
-const isEvssAvailable = createIsServiceAvailableSelector(
+const isEvssAvailableSelector = createIsServiceAvailableSelector(
   backendServices.EVSS_CLAIMS,
 );
 
 const mapStateToProps = state => {
   const directDepositIsSetUp = directDepositIsSetUpSelector(state);
-  const isEligible = isEvssAvailable(state);
+  const isEvssAvailable = isEvssAvailableSelector(state);
   const isEligibleToSignUp = directDepositAddressIsSetUp(state);
 
   return {
     directDepositIsSetUp,
-    isEligible,
+    isEvssAvailable,
     isEligibleToSignUp,
     isLoading:
-      isEligible &&
+      isEvssAvailable &&
       isMultifactorEnabled(state) &&
       !directDepositInformation(state),
     multifactorEnabled: isMultifactorEnabled(state),
@@ -300,7 +300,7 @@ const mapStateToProps = state => {
     paymentInformationUiState: state.vaProfile.paymentInformationUiState,
     directDepositIsBlocked: directDepositIsBlockedSelector(state),
     shouldShowDirectDeposit:
-      isEligible && (directDepositIsSetUp || isEligibleToSignUp),
+      isEvssAvailable && (directDepositIsSetUp || isEligibleToSignUp),
   };
 };
 

--- a/src/applications/personalization/profile360/selectors.js
+++ b/src/applications/personalization/profile360/selectors.js
@@ -28,13 +28,5 @@ export const directDepositAddressIsSetUp = state => {
 export const directDepositIsBlocked = state => {
   const controlInfo =
     directDepositInformation(state)?.responses?.[0]?.controlInformation || {};
-  // If all of these flags are not strictly equal to `true` we want to block
-  // access to the direct deposit feature. ie, we want to err on the side of
-  // blocking people from accessing direct deposit rather than err on the side
-  // of letting people have access to the feature.
-  return (
-    controlInfo.isCompetentIndicator !== true ||
-    controlInfo.noFiduciaryAssignedIndicator !== true ||
-    controlInfo.notDeceasedIndicator !== true
-  );
+  return controlInfo.canUpdateAddress !== true;
 };

--- a/src/applications/personalization/profile360/tests/containers/PaymentInformation.unit.spec.jsx
+++ b/src/applications/personalization/profile360/tests/containers/PaymentInformation.unit.spec.jsx
@@ -40,6 +40,7 @@ describe('<PaymentInformation/>', () => {
       ],
     },
     shouldShowDirectDeposit: true,
+    directDepositIsBlocked: false,
   };
 
   it('renders', () => {
@@ -59,6 +60,24 @@ describe('<PaymentInformation/>', () => {
     const wrapper = shallow(<PaymentInformation {...props} />);
     expect(wrapper.text()).to.be.empty;
     expect(fetchPaymentInformation.called).to.be.false;
+    wrapper.unmount();
+  });
+
+  it('does not render if the user is blocked from accessing direct deposit', () => {
+    const fetchPaymentInformation = sinon.spy();
+    const props = {
+      ...defaultProps,
+      fetchPaymentInformation,
+      // `false` because the GET payment_information endpoint will not populate
+      // the account number when the controlInformation indicates that they are
+      // blocked from accessing the direct deposit feature
+      directDepositIsSetUp: false,
+      shouldShowDirectDeposit: true,
+      directDepositIsBlocked: true,
+    };
+    const wrapper = shallow(<PaymentInformation {...props} />);
+    expect(fetchPaymentInformation.called).to.be.true;
+    expect(wrapper.text()).to.be.empty;
     wrapper.unmount();
   });
 
@@ -83,8 +102,14 @@ describe('<PaymentInformation/>', () => {
   });
 
   it('renders a prompt to enable 2FA is the user does not have it enabled already', () => {
-    const props = { ...defaultProps, multifactorEnabled: false };
+    const fetchPaymentInformation = sinon.spy();
+    const props = {
+      ...defaultProps,
+      fetchPaymentInformation,
+      multifactorEnabled: false,
+    };
     const wrapper = shallow(<PaymentInformation {...props} />);
+    expect(fetchPaymentInformation.called).to.be.false;
     expect(wrapper.find('PaymentInformation2FARequired')).to.have.lengthOf(1);
     wrapper.unmount();
   });

--- a/src/applications/personalization/profile360/tests/containers/PaymentInformation.unit.spec.jsx
+++ b/src/applications/personalization/profile360/tests/containers/PaymentInformation.unit.spec.jsx
@@ -21,7 +21,7 @@ describe('<PaymentInformation/>', () => {
     directDepositIsSetUp: true,
     multifactorEnabled: true,
     isLoading: false,
-    isEligible: true,
+    isEvssAvailable: true,
     isEligibleToSignUp: true,
     fetchPaymentInformation() {},
     savePaymentInformation() {},
@@ -54,7 +54,7 @@ describe('<PaymentInformation/>', () => {
     const props = {
       ...defaultProps,
       fetchPaymentInformation,
-      isEligible: false,
+      isEvssAvailable: false,
       shouldShowDirectDeposit: false,
     };
     const wrapper = shallow(<PaymentInformation {...props} />);

--- a/src/applications/personalization/profile360/tests/selectors.unit.spec.js
+++ b/src/applications/personalization/profile360/tests/selectors.unit.spec.js
@@ -118,16 +118,14 @@ describe('profile360 selectors', () => {
   });
 
   describe('directDepositIsBlocked', () => {
-    it('returns `false` if the isCompetentIndicator, noFiduciaryAssignedIndicator, and notDeceasedIndicator flags are all `true`', () => {
+    it('returns `false` if the `canUpdateAddress` flag is `true`', () => {
       const state = {
         vaProfile: {
           paymentInformation: {
             responses: [
               {
                 controlInformation: {
-                  isCompetentIndicator: true,
-                  noFiduciaryAssignedIndicator: true,
-                  notDeceasedIndicator: true,
+                  canUpdateAddress: true,
                 },
               },
             ],
@@ -136,7 +134,7 @@ describe('profile360 selectors', () => {
       };
       expect(selectors.directDepositIsBlocked(state)).to.be.false;
     });
-    it('returns `true` if the control information is not set', () => {
+    it('returns `true` if the `paymentInformation.controlInformation` is not set', () => {
       const state = {
         vaProfile: {
           paymentInformation: {
@@ -146,48 +144,14 @@ describe('profile360 selectors', () => {
       };
       expect(selectors.directDepositIsBlocked(state)).to.be.true;
     });
-    it('returns `true` if the `isCompetentIndicator` is not true', () => {
+    it('returns `true` if the `canUpdateAddress` flag is not `true`', () => {
       const state = {
         vaProfile: {
           paymentInformation: {
             responses: [
               {
                 controlInformation: {
-                  isCompetentIndicator: null,
-                  noFiduciaryAssignedIndicator: true,
-                },
-              },
-            ],
-          },
-        },
-      };
-      expect(selectors.directDepositIsBlocked(state)).to.be.true;
-    });
-    it('returns `true` if the `noFiduciaryAssignedIndicator` is not true', () => {
-      const state = {
-        vaProfile: {
-          paymentInformation: {
-            responses: [
-              {
-                controlInformation: {
-                  isCompetentIndicator: true,
-                },
-              },
-            ],
-          },
-        },
-      };
-      expect(selectors.directDepositIsBlocked(state)).to.be.true;
-    });
-    it('returns `true` if the `notDeceasedIndicator` is not true', () => {
-      const state = {
-        vaProfile: {
-          paymentInformation: {
-            responses: [
-              {
-                controlInformation: {
-                  isCompetentIndicator: true,
-                  noFiduciaryAssignedIndicator: true,
+                  canUpdateAddress: null,
                 },
               },
             ],


### PR DESCRIPTION
## Description
In a previous PR we'd inadvertently prevented the "set up 2FA" message from ever appearing. This restores it.

This also fixes a bug I just discovered the prevented the loading indicator from ever appearing and also simplifies the `directDepositIsBlocked` selector logic

## Testing done
Local + unit tests

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs