### PR TITLE
Remove double messaging on Files tab for Claim Status Tool

### DIFF
--- a/src/applications/claims-status/actions/index.jsx
+++ b/src/applications/claims-status/actions/index.jsx
@@ -56,12 +56,23 @@ export const SET_FIELDS_DIRTY = 'SET_FIELD_DIRTY';
 export const SHOW_CONSOLIDATED_MODAL = 'SHOW_CONSOLIDATED_MODAL';
 export const SET_LAST_PAGE = 'SET_LAST_PAGE';
 export const SET_NOTIFICATION = 'SET_NOTIFICATION';
+export const SET_ADDITIONAL_EVIDENCE_NOTIFICATION =
+  'SET_ADDITIONAL_EVIDENCE_NOTIFICATION';
 export const CLEAR_NOTIFICATION = 'CLEAR_NOTIFICATION';
+export const CLEAR_ADDITIONAL_EVIDENCE_NOTIFICATION =
+  'CLEAR_ADDITIONAL_EVIDENCE_NOTIFICATION';
 export const HIDE_30_DAY_NOTICE = 'HIDE_30_DAY_NOTICE';
 
 export function setNotification(message) {
   return {
     type: SET_NOTIFICATION,
+    message,
+  };
+}
+
+export function setAdditionalEvidenceNotification(message) {
+  return {
+    type: SET_ADDITIONAL_EVIDENCE_NOTIFICATION,
     message,
   };
 }
@@ -324,6 +335,12 @@ export function clearNotification() {
   };
 }
 
+export function clearAdditionalEvidenceNotification() {
+  return {
+    type: CLEAR_ADDITIONAL_EVIDENCE_NOTIFICATION,
+  };
+}
+
 export function submitFiles(claimId, trackedItem, files) {
   let filesComplete = 0;
   let bytesComplete = 0;
@@ -337,6 +354,7 @@ export function submitFiles(claimId, trackedItem, files) {
 
   return dispatch => {
     dispatch(clearNotification());
+    dispatch(clearAdditionalEvidenceNotification());
     dispatch({
       type: SET_UPLOADING,
       uploading: true,
@@ -399,7 +417,7 @@ export function submitFiles(claimId, trackedItem, files) {
                   type: SET_UPLOAD_ERROR,
                 });
                 dispatch(
-                  setNotification({
+                  setAdditionalEvidenceNotification({
                     title: 'Error uploading files',
                     body:
                       'There was an error uploading your files. Please try again',

--- a/src/applications/claims-status/containers/AdditionalEvidencePage.jsx
+++ b/src/applications/claims-status/containers/AdditionalEvidencePage.jsx
@@ -19,7 +19,7 @@ import {
   getClaimDetail,
   setFieldsDirty,
   resetUploads,
-  clearNotification,
+  clearAdditionalEvidenceNotification,
 } from '../actions/index.jsx';
 
 const scrollToError = () => {
@@ -54,7 +54,7 @@ class AdditionalEvidencePage extends React.Component {
   }
   componentWillUnmount() {
     if (!this.props.uploadComplete) {
-      this.props.clearNotification();
+      this.props.clearAdditionalEvidenceNotification();
     }
   }
   goToFilesPage() {
@@ -135,7 +135,7 @@ function mapStateToProps(state) {
     uploadField: claimsState.uploads.uploadField,
     showMailOrFax: claimsState.uploads.showMailOrFax,
     lastPage: claimsState.routing.lastPage,
-    message: claimsState.notifications.message,
+    message: claimsState.notifications.additionalEvidenceMessage,
   };
 }
 
@@ -149,7 +149,7 @@ const mapDispatchToProps = {
   getClaimDetail,
   setFieldsDirty,
   resetUploads,
-  clearNotification,
+  clearAdditionalEvidenceNotification,
 };
 
 export default withRouter(

--- a/src/applications/claims-status/reducers/notifications.js
+++ b/src/applications/claims-status/reducers/notifications.js
@@ -1,9 +1,15 @@
 import _ from 'lodash/fp';
 
-import { CLEAR_NOTIFICATION, SET_NOTIFICATION } from '../actions/index.jsx';
+import {
+  CLEAR_NOTIFICATION,
+  SET_NOTIFICATION,
+  CLEAR_ADDITIONAL_EVIDENCE_NOTIFICATION,
+  SET_ADDITIONAL_EVIDENCE_NOTIFICATION,
+} from '../actions/index.jsx';
 
 const initialState = {
   message: null,
+  additionalEvidenceMessage: null,
 };
 
 export default function notificationsReducer(state = initialState, action) {
@@ -12,6 +18,10 @@ export default function notificationsReducer(state = initialState, action) {
       return _.set('message', action.message, state);
     case CLEAR_NOTIFICATION:
       return _.set('message', null, state);
+    case SET_ADDITIONAL_EVIDENCE_NOTIFICATION:
+      return _.set('additionalEvidenceMessage', action.message, state);
+    case CLEAR_ADDITIONAL_EVIDENCE_NOTIFICATION:
+      return _.set('additionalEvidenceMessage', null, state);
     default:
       return state;
   }

--- a/src/applications/claims-status/tests/actions.unit.spec.js
+++ b/src/applications/claims-status/tests/actions.unit.spec.js
@@ -10,6 +10,8 @@ import {
   changePage,
   CLEAR_NOTIFICATION,
   clearNotification,
+  CLEAR_ADDITIONAL_EVIDENCE_NOTIFICATION,
+  clearAdditionalEvidenceNotification,
   FETCH_APPEALS,
   GET_CLAIM_DETAIL,
   getAppeals,
@@ -29,9 +31,11 @@ import {
   SET_FIELDS_DIRTY,
   SET_LAST_PAGE,
   SET_NOTIFICATION,
+  SET_ADDITIONAL_EVIDENCE_NOTIFICATION,
   setFieldsDirty,
   setLastPage,
   setNotification,
+  setAdditionalEvidenceNotification,
   setUnavailable,
   SHOW_CONSOLIDATED_MODAL,
   SHOW_MAIL_OR_FAX,
@@ -63,6 +67,16 @@ describe('Actions', () => {
 
       expect(action).to.eql({
         type: SET_NOTIFICATION,
+        message: 'Testing',
+      });
+    });
+  });
+  describe('setAdditionalEvidenceNotification', () => {
+    it('should return the correct action object', () => {
+      const action = setAdditionalEvidenceNotification('Testing');
+
+      expect(action).to.eql({
+        type: SET_ADDITIONAL_EVIDENCE_NOTIFICATION,
         message: 'Testing',
       });
     });
@@ -121,6 +135,15 @@ describe('Actions', () => {
 
       expect(action).to.eql({
         type: CLEAR_NOTIFICATION,
+      });
+    });
+  });
+  describe('clearAdditionalEvidenceNotification', () => {
+    it('should return the correct action object', () => {
+      const action = clearAdditionalEvidenceNotification();
+
+      expect(action).to.eql({
+        type: CLEAR_ADDITIONAL_EVIDENCE_NOTIFICATION,
       });
     });
   });

--- a/src/applications/claims-status/tests/components/AdditionalEvidencePage.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/AdditionalEvidencePage.unit.spec.jsx
@@ -45,19 +45,21 @@ describe('<AdditionalEvidencePage>', () => {
       body: 'test',
       type: 'error',
     };
-    const clearNotification = sinon.spy();
+    const clearAdditionalEvidenceNotification = sinon.spy();
 
     const tree = SkinDeep.shallowRender(
       <AdditionalEvidencePage
         params={params}
         claim={claim}
-        clearNotification={clearNotification}
+        clearAdditionalEvidenceNotification={
+          clearAdditionalEvidenceNotification
+        }
         message={message}
       />,
     );
     expect(tree.subTree('Notification')).not.to.be.false;
     tree.getMountedInstance().componentWillUnmount();
-    expect(clearNotification.called).to.be.true;
+    expect(clearAdditionalEvidenceNotification.called).to.be.true;
   });
   it('should not clear notification after completed upload', () => {
     const claim = {
@@ -69,20 +71,22 @@ describe('<AdditionalEvidencePage>', () => {
       body: 'test',
       type: 'error',
     };
-    const clearNotification = sinon.spy();
+    const clearAdditionalEvidenceNotification = sinon.spy();
 
     const tree = SkinDeep.shallowRender(
       <AdditionalEvidencePage
         params={params}
         claim={claim}
         uploadComplete
-        clearNotification={clearNotification}
+        clearAdditionalEvidenceNotification={
+          clearAdditionalEvidenceNotification
+        }
         message={message}
       />,
     );
     expect(tree.subTree('Notification')).not.to.be.false;
     tree.getMountedInstance().componentWillUnmount();
-    expect(clearNotification.called).to.be.false;
+    expect(clearAdditionalEvidenceNotification.called).to.be.false;
   });
   it('should handle submit files', () => {
     const files = [];


### PR DESCRIPTION
## Description
In the claim status tool, when viewing a single claim/appeal on the Files tab, messages that appear on the screen for the veteran currently appear in double locations. The linked ticket has a screenshot example of this. For messages relating to file uploading, the messaging has been adjusted to **only** appear under the Additional Evidence header. All other messaging now **only** appears at the top of the page. There is now no situation where messages appear in both locations.

## Acceptance criteria
- [ ] No double messaging on the Files tab in the Claim Status Tool