### PR TITLE
Fix inconsistent focus on h1 in VAOS pages

### DIFF
--- a/src/applications/vaos/components/NewAppointmentLayout.jsx
+++ b/src/applications/vaos/components/NewAppointmentLayout.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router';
 import Breadcrumbs from './Breadcrumbs';
-import { scrollAndFocus } from '../utils/scrollAndFocus';
 import NeedHelp from '../components/NeedHelp';
 
 export default class NewAppointmentLayout extends React.Component {
@@ -10,7 +9,6 @@ export default class NewAppointmentLayout extends React.Component {
       window.History.scrollRestoration = 'manual';
     }
 
-    scrollAndFocus();
     window.addEventListener('beforeunload', this.onBeforeUnload);
 
     // We don't want people to start in the middle of the form, so redirect them when they jump
@@ -24,8 +22,6 @@ export default class NewAppointmentLayout extends React.Component {
     if (this.props.location.pathname.endsWith('confirmation')) {
       this.removeBeforeUnloadHook();
     }
-
-    scrollAndFocus();
   }
 
   componentWillUnmount() {

--- a/src/applications/vaos/containers/AppointmentsPage.jsx
+++ b/src/applications/vaos/containers/AppointmentsPage.jsx
@@ -60,7 +60,7 @@ export class AppointmentsPage extends Component {
     if (loading) {
       content = (
         <div className="vads-u-margin-y--8">
-          <LoadingIndicator setFocus message="Loading your appointments..." />
+          <LoadingIndicator message="Loading your appointments..." />
         </div>
       );
     } else if (hasAppointments) {

--- a/src/applications/vaos/containers/ClinicChoicePage.jsx
+++ b/src/applications/vaos/containers/ClinicChoicePage.jsx
@@ -50,7 +50,7 @@ const pageKey = 'clinicChoice';
 export class ClinicChoicePage extends React.Component {
   componentDidMount() {
     this.props.openClinicPage(pageKey, uiSchema, initialSchema);
-    scrollAndFocus('.loading-indicator');
+    scrollAndFocus();
   }
 
   componentDidUpdate(oldProps) {

--- a/src/applications/vaos/containers/ClinicChoicePage.jsx
+++ b/src/applications/vaos/containers/ClinicChoicePage.jsx
@@ -50,6 +50,7 @@ const pageKey = 'clinicChoice';
 export class ClinicChoicePage extends React.Component {
   componentDidMount() {
     this.props.openClinicPage(pageKey, uiSchema, initialSchema);
+    scrollAndFocus('.loading-indicator');
   }
 
   componentDidUpdate(oldProps) {

--- a/src/applications/vaos/containers/CommunityCarePreferencesPage.jsx
+++ b/src/applications/vaos/containers/CommunityCarePreferencesPage.jsx
@@ -15,6 +15,7 @@ import {
   routeToPreviousAppointmentPage,
 } from '../actions/newAppointment.js';
 import { getFormPageInfo } from '../utils/selectors';
+import { scrollAndFocus } from '../utils/scrollAndFocus';
 
 const initialSchema = {
   type: 'object',
@@ -127,6 +128,7 @@ export class CommunityCarePreferencesPage extends React.Component {
       initialSchema,
     );
     document.title = `${pageTitle}  | Veterans Affairs`;
+    scrollAndFocus();
   }
 
   goBack = () => {

--- a/src/applications/vaos/containers/ConfirmationPage.jsx
+++ b/src/applications/vaos/containers/ConfirmationPage.jsx
@@ -9,6 +9,7 @@ import {
   getChosenClinicInfo,
   getChosenFacilityDetails,
 } from '../utils/selectors';
+import { scrollAndFocus } from '../utils/scrollAndFocus';
 import {
   closeConfirmationPage,
   fetchFacilityDetails,
@@ -38,6 +39,7 @@ export class ConfirmationPage extends React.Component {
     ) {
       this.props.fetchFacilityDetails(this.props.data.vaFacility);
     }
+    scrollAndFocus();
   }
 
   componentWillUnmount() {

--- a/src/applications/vaos/containers/ContactInfoPage.jsx
+++ b/src/applications/vaos/containers/ContactInfoPage.jsx
@@ -12,6 +12,7 @@ import {
   routeToPreviousAppointmentPage,
 } from '../actions/newAppointment.js';
 import { getFormPageInfo } from '../utils/selectors';
+import { scrollAndFocus } from '../utils/scrollAndFocus';
 
 const initialSchema = {
   type: 'object',
@@ -100,6 +101,7 @@ export class ContactInfoPage extends React.Component {
   componentDidMount() {
     this.props.openFormPage(pageKey, uiSchema, initialSchema);
     document.title = `${pageTitle} | Veterans Affairs`;
+    scrollAndFocus();
   }
 
   goBack = () => {

--- a/src/applications/vaos/containers/DateTimeRequestPage.jsx
+++ b/src/applications/vaos/containers/DateTimeRequestPage.jsx
@@ -7,7 +7,6 @@ import {
   routeToNextAppointmentPage,
   routeToPreviousAppointmentPage,
 } from '../actions/newAppointment.js';
-import { focusElement } from 'platform/utilities/ui';
 import { scrollAndFocus } from '../utils/scrollAndFocus';
 import FormButtons from '../components/FormButtons';
 import CalendarWidget from '../components/calendar/CalendarWidget';
@@ -38,8 +37,8 @@ export class DateTimeRequestPage extends React.Component {
   }
 
   componentDidMount() {
-    focusElement('h1.vads-u-font-size--h2');
     document.title = `${pageTitle} | Veterans Affairs`;
+    scrollAndFocus();
   }
 
   componentDidUpdate(prevProps, prevState) {

--- a/src/applications/vaos/containers/DateTimeSelectPage.jsx
+++ b/src/applications/vaos/containers/DateTimeSelectPage.jsx
@@ -9,7 +9,6 @@ import {
   routeToPreviousAppointmentPage,
   startRequestAppointmentFlow,
 } from '../actions/newAppointment.js';
-import { focusElement } from 'platform/utilities/ui';
 import { scrollAndFocus } from '../utils/scrollAndFocus';
 import FormButtons from '../components/FormButtons';
 import { getDateTimeSelect } from '../utils/selectors';
@@ -53,7 +52,6 @@ export class DateTimeSelectPage extends React.Component {
   }
 
   componentDidMount() {
-    focusElement('h1.vads-u-font-size--h2');
     const { preferredDate } = this.props;
     this.props.getAppointmentSlots(
       moment(preferredDate)
@@ -65,6 +63,7 @@ export class DateTimeSelectPage extends React.Component {
         .format('YYYY-MM-DD'),
     );
     document.title = `${pageTitle} | Veterans Affairs`;
+    scrollAndFocus();
   }
 
   componentDidUpdate(prevProps, prevState) {

--- a/src/applications/vaos/containers/PreferredDatePage.jsx
+++ b/src/applications/vaos/containers/PreferredDatePage.jsx
@@ -10,6 +10,7 @@ import {
   routeToPreviousAppointmentPage,
 } from '../actions/newAppointment.js';
 import { getPreferredDate } from '../utils/selectors';
+import { scrollAndFocus } from '../utils/scrollAndFocus';
 import AdditionalInfo from '@department-of-veterans-affairs/formation-react/AdditionalInfo';
 
 const initialSchema = {
@@ -38,6 +39,7 @@ export class PreferredDatePage extends React.Component {
   componentDidMount() {
     this.props.openFormPage(pageKey, uiSchema, initialSchema);
     document.title = `${pageTitle}  | Veterans Affairs`;
+    scrollAndFocus();
   }
 
   goBack = () => {

--- a/src/applications/vaos/containers/ReasonForAppointmentPage.jsx
+++ b/src/applications/vaos/containers/ReasonForAppointmentPage.jsx
@@ -10,6 +10,7 @@ import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 import SchemaForm from 'platform/forms-system/src/js/components/SchemaForm';
 import FormButtons from '../components/FormButtons';
 import { getFormPageInfo } from '../utils/selectors';
+import { scrollAndFocus } from '../utils/scrollAndFocus';
 import { PURPOSE_TEXT } from '../utils/constants';
 import TextareaWidget from '../components/TextareaWidget';
 
@@ -50,6 +51,7 @@ export class ReasonForAppointmentPage extends React.Component {
   componentDidMount() {
     document.title = `${pageTitle} | Veterans Affairs`;
     this.props.openReasonForAppointment(pageKey, uiSchema, initialSchema);
+    scrollAndFocus();
   }
 
   goBack = () => {

--- a/src/applications/vaos/containers/ReviewPage.jsx
+++ b/src/applications/vaos/containers/ReviewPage.jsx
@@ -10,6 +10,7 @@ import {
   getChosenVACityState,
 } from '../utils/selectors';
 import { FLOW_TYPES, FETCH_STATUS } from '../utils/constants';
+import { scrollAndFocus } from '../utils/scrollAndFocus';
 import ReviewDirectScheduleInfo from '../components/review/ReviewDirectScheduleInfo';
 import ReviewRequestInfo from '../components/review/ReviewRequestInfo';
 import LoadingButton from 'platform/site-wide/loading-button/LoadingButton';
@@ -20,6 +21,7 @@ const pageTitle = 'Review your appointment details';
 export class ReviewPage extends React.Component {
   componentDidMount() {
     document.title = `${pageTitle} | Veterans Affairs`;
+    scrollAndFocus();
   }
 
   render() {

--- a/src/applications/vaos/containers/TypeOfAudiologyCarePage.jsx
+++ b/src/applications/vaos/containers/TypeOfAudiologyCarePage.jsx
@@ -9,6 +9,7 @@ import {
   routeToPreviousAppointmentPage,
 } from '../actions/newAppointment.js';
 import { getFormPageInfo } from '../utils/selectors';
+import { scrollAndFocus } from '../utils/scrollAndFocus';
 
 const initialSchema = {
   type: 'object',
@@ -64,6 +65,7 @@ const pageKey = 'audiologyCareType';
 export class TypeOfAudiologyCarePage extends React.Component {
   componentDidMount() {
     this.props.openFormPage(pageKey, uiSchema, initialSchema);
+    scrollAndFocus();
   }
 
   goBack = () => {

--- a/src/applications/vaos/containers/TypeOfCarePage.jsx
+++ b/src/applications/vaos/containers/TypeOfCarePage.jsx
@@ -15,7 +15,6 @@ import {
   showTypeOfCareUnavailableModal,
   hideTypeOfCareUnavailableModal,
 } from '../actions/newAppointment.js';
-import { loadApplication } from '../actions/registration';
 import { getFormPageInfo, getNewAppointment } from '../utils/selectors';
 
 const sortedCare = TYPES_OF_CARE.sort(
@@ -49,8 +48,7 @@ export class TypeOfCarePage extends React.Component {
   componentDidMount() {
     this.props.openTypeOfCarePage(pageKey, uiSchema, initialSchema);
     document.title = `${pageTitle} | Veterans Affairs`;
-    scrollAndFocus(this.props.isInitialLoad ? 'body' : 'h1');
-    this.props.loadApplication();
+    scrollAndFocus();
   }
 
   onChange = newData => {
@@ -122,7 +120,6 @@ const mapDispatchToProps = {
   routeToPreviousAppointmentPage,
   showTypeOfCareUnavailableModal,
   hideTypeOfCareUnavailableModal,
-  loadApplication,
 };
 
 export default connect(

--- a/src/applications/vaos/containers/TypeOfCarePage.jsx
+++ b/src/applications/vaos/containers/TypeOfCarePage.jsx
@@ -3,6 +3,7 @@ import { connect } from 'react-redux';
 import SchemaForm from 'platform/forms-system/src/js/components/SchemaForm';
 
 import { TYPES_OF_CARE } from '../utils/constants';
+import { scrollAndFocus } from '../utils/scrollAndFocus';
 import { getLongTermAppointmentHistory } from '../api';
 import FormButtons from '../components/FormButtons';
 import TypeOfCareUnavailableModal from '../components/TypeOfCareUnavailableModal';
@@ -14,6 +15,7 @@ import {
   showTypeOfCareUnavailableModal,
   hideTypeOfCareUnavailableModal,
 } from '../actions/newAppointment.js';
+import { loadApplication } from '../actions/registration';
 import { getFormPageInfo, getNewAppointment } from '../utils/selectors';
 
 const sortedCare = TYPES_OF_CARE.sort(
@@ -47,6 +49,8 @@ export class TypeOfCarePage extends React.Component {
   componentDidMount() {
     this.props.openTypeOfCarePage(pageKey, uiSchema, initialSchema);
     document.title = `${pageTitle} | Veterans Affairs`;
+    scrollAndFocus(this.props.isInitialLoad ? 'body' : 'h1');
+    this.props.loadApplication();
   }
 
   onChange = newData => {
@@ -118,6 +122,7 @@ const mapDispatchToProps = {
   routeToPreviousAppointmentPage,
   showTypeOfCareUnavailableModal,
   hideTypeOfCareUnavailableModal,
+  loadApplication,
 };
 
 export default connect(

--- a/src/applications/vaos/containers/TypeOfFacilityPage.jsx
+++ b/src/applications/vaos/containers/TypeOfFacilityPage.jsx
@@ -10,6 +10,7 @@ import {
   routeToPreviousAppointmentPage,
 } from '../actions/newAppointment.js';
 import { getFormPageInfo } from '../utils/selectors';
+import { scrollAndFocus } from '../utils/scrollAndFocus';
 
 const initialSchema = {
   type: 'object',
@@ -61,6 +62,7 @@ export class TypeOfFacilityPage extends React.Component {
   componentDidMount() {
     this.props.openFormPage(pageKey, uiSchema, initialSchema);
     document.title = `${pageTitle} | Veterans Affairs`;
+    scrollAndFocus();
   }
 
   goBack = () => {

--- a/src/applications/vaos/containers/TypeOfSleepCarePage.jsx
+++ b/src/applications/vaos/containers/TypeOfSleepCarePage.jsx
@@ -9,6 +9,7 @@ import {
   routeToPreviousAppointmentPage,
 } from '../actions/newAppointment.js';
 import { getFormPageInfo } from '../utils/selectors';
+import { scrollAndFocus } from '../utils/scrollAndFocus';
 import { TYPES_OF_SLEEP_CARE } from '../utils/constants';
 
 const initialSchema = {
@@ -65,6 +66,7 @@ export class TypeOfSleepCarePage extends React.Component {
   componentDidMount() {
     this.props.openFormPage(pageKey, uiSchema, initialSchema);
     document.title = `${pageTitle} | Veterans Affairs`;
+    scrollAndFocus();
   }
 
   goBack = () => {

--- a/src/applications/vaos/containers/TypeOfVisitPage.jsx
+++ b/src/applications/vaos/containers/TypeOfVisitPage.jsx
@@ -10,6 +10,7 @@ import {
 } from '../actions/newAppointment.js';
 import { getFormPageInfo } from '../utils/selectors';
 import { TYPE_OF_VISIT } from '../utils/constants';
+import { scrollAndFocus } from '../utils/scrollAndFocus';
 
 const initialSchema = {
   type: 'object',
@@ -38,6 +39,7 @@ export class TypeOfVisitPage extends React.Component {
   componentDidMount() {
     this.props.openFormPage(pageKey, uiSchema, initialSchema);
     document.title = `${pageTitle} | Veterans Affairs`;
+    scrollAndFocus();
   }
 
   goBack = () => {

--- a/src/applications/vaos/containers/VAFacilityPage.jsx
+++ b/src/applications/vaos/containers/VAFacilityPage.jsx
@@ -84,9 +84,18 @@ const title = <h1 className="vads-u-font-size--h2">{pageTitle}</h1>;
 
 export class VAFacilityPage extends React.Component {
   componentDidMount() {
-    scrollAndFocus();
     this.props.openFacilityPage(pageKey, uiSchema, initialSchema);
     document.title = `${pageTitle} | Veterans Affairs`;
+    scrollAndFocus();
+  }
+
+  componentDidUpdate(prevProps) {
+    if (
+      prevProps.loadingParentFacilities &&
+      !this.props.loadingParentFacilities
+    ) {
+      scrollAndFocus();
+    }
   }
 
   goBack = () => {

--- a/src/applications/vaos/containers/VAFacilityPage.jsx
+++ b/src/applications/vaos/containers/VAFacilityPage.jsx
@@ -89,15 +89,6 @@ export class VAFacilityPage extends React.Component {
     scrollAndFocus();
   }
 
-  componentDidUpdate(prevProps) {
-    if (
-      prevProps.loadingParentFacilities &&
-      !this.props.loadingParentFacilities
-    ) {
-      scrollAndFocus();
-    }
-  }
-
   goBack = () => {
     this.props.routeToPreviousAppointmentPage(this.props.router, pageKey);
   };


### PR DESCRIPTION
## Description
Due to some missed loading states and NewAppointmentLayout not being a reliable place to detect page changes, our pages weren't always focusing on the h1 element after loading. This should fix that.

## Testing done
Local testing

## Acceptance criteria
- [ ] Focus works

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
