### PR TITLE
Add aria controls attribute for calendar div

### DIFF
--- a/src/applications/vaos/components/calendar/CalendarCell.jsx
+++ b/src/applications/vaos/components/calendar/CalendarCell.jsx
@@ -84,6 +84,9 @@ const CalendarCell = ({
       style={{ height: isCurrentlySelected ? optionsHeight : 'auto' }}
     >
       <button
+        aria-controls={
+          isCurrentlySelected ? `vaos-options-container-${date}` : undefined
+        }
         className="vaos-calendar__calendar-day-button"
         id={`date-cell-${date}`}
         onClick={() => onClick(date)}

--- a/src/applications/vaos/components/calendar/CalendarOptions.jsx
+++ b/src/applications/vaos/components/calendar/CalendarOptions.jsx
@@ -46,7 +46,11 @@ export default function CalendarOptions({
     );
 
     return (
-      <div className="vaos-calendar__options-container" ref={optionsHeightRef}>
+      <div
+        className="vaos-calendar__options-container"
+        id={`vaos-options-container-${currentlySelectedDate}`}
+        ref={optionsHeightRef}
+      >
         <fieldset>
           <legend className="vads-u-visibility--screen-reader">
             {additionalOptions.legend ||


### PR DESCRIPTION
## Description
This adds some `aria-controls` markup to the calendar to improve JAWS usability.

## Testing done
Local testing

## Acceptance criteria
- [ ] aria-controls is set up correctly

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
