### PR TITLE
Add workflow to report a child has stopped attending school

### DIFF
--- a/src/applications/disability-benefits/new-686/config/chapters/report-child-stopped-attending-school/child-information/childInformation.js
+++ b/src/applications/disability-benefits/new-686/config/chapters/report-child-stopped-attending-school/child-information/childInformation.js
@@ -41,15 +41,14 @@ export const uiSchema = {
       'ui:options': { widgetClassNames: 'form-select-medium' },
     },
   },
-  dateChildLeftSchool: Object.assign(
-    {},
-    currentOrPastDateUI('When did child stop attending school?'),
-    {
+  dateChildLeftSchool: {
+    ...currentOrPastDateUI('When did child stop attending school?'),
+    ...{
       'ui:required': formData =>
         isChapterFieldRequired(
           formData,
           'reportChild18OrOlderIsNotAttendingSchool',
         ),
     },
-  ),
+  },
 };

--- a/src/applications/disability-benefits/new-686/config/chapters/report-child-stopped-attending-school/child-information/childInformation.js
+++ b/src/applications/disability-benefits/new-686/config/chapters/report-child-stopped-attending-school/child-information/childInformation.js
@@ -1,5 +1,6 @@
 import currentOrPastDateUI from 'platform/forms-system/src/js/definitions/currentOrPastDate';
 
+import { isChapterFieldRequired } from '../../taskWizard/wizard/helpers';
 import { genericSchemas } from '../../../generic-schema';
 import { validateName } from '../../../utilities';
 
@@ -7,7 +8,6 @@ const { fullName, date } = genericSchemas;
 
 export const schema = {
   type: 'object',
-  required: ['childNoLongerAtSchoolName', 'dateChildLeftSchool'],
   properties: {
     childNoLongerAtSchoolName: fullName,
     dateChildLeftSchool: date,
@@ -18,11 +18,21 @@ export const uiSchema = {
   childNoLongerAtSchoolName: {
     'ui:validations': [validateName],
     first: {
+      'ui:required': formData =>
+        isChapterFieldRequired(
+          formData,
+          'reportChild18OrOlderIsNotAttendingSchool',
+        ),
       'ui:title': 'Child’s first name',
       'ui:errorMessages': { required: 'Please enter a first name' },
     },
     middle: { 'ui:title': 'Child’s middle name' },
     last: {
+      'ui:required': formData =>
+        isChapterFieldRequired(
+          formData,
+          'reportChild18OrOlderIsNotAttendingSchool',
+        ),
       'ui:title': 'Child’s last name',
       'ui:errorMessages': { required: 'Please enter a last name' },
     },
@@ -31,7 +41,15 @@ export const uiSchema = {
       'ui:options': { widgetClassNames: 'form-select-medium' },
     },
   },
-  dateChildLeftSchool: currentOrPastDateUI(
-    'When did child stop attending school?',
+  dateChildLeftSchool: Object.assign(
+    {},
+    currentOrPastDateUI('When did child stop attending school?'),
+    {
+      'ui:required': formData =>
+        isChapterFieldRequired(
+          formData,
+          'reportChild18OrOlderIsNotAttendingSchool',
+        ),
+    },
   ),
 };

--- a/src/applications/disability-benefits/new-686/config/chapters/report-child-stopped-attending-school/child-information/childInformation.js
+++ b/src/applications/disability-benefits/new-686/config/chapters/report-child-stopped-attending-school/child-information/childInformation.js
@@ -1,0 +1,37 @@
+import currentOrPastDateUI from 'platform/forms-system/src/js/definitions/currentOrPastDate';
+
+import { genericSchemas } from '../../../generic-schema';
+import { validateName } from '../../../utilities';
+
+const { fullName, date } = genericSchemas;
+
+export const schema = {
+  type: 'object',
+  required: ['childNoLongerAtSchoolName', 'dateChildLeftSchool'],
+  properties: {
+    childNoLongerAtSchoolName: fullName,
+    dateChildLeftSchool: date,
+  },
+};
+
+export const uiSchema = {
+  childNoLongerAtSchoolName: {
+    'ui:validations': [validateName],
+    first: {
+      'ui:title': 'Child’s first name',
+      'ui:errorMessages': { required: 'Please enter a first name' },
+    },
+    middle: { 'ui:title': 'Child’s middle name' },
+    last: {
+      'ui:title': 'Child’s last name',
+      'ui:errorMessages': { required: 'Please enter a last name' },
+    },
+    suffix: {
+      'ui:title': 'Child’s suffix',
+      'ui:options': { widgetClassNames: 'form-select-medium' },
+    },
+  },
+  dateChildLeftSchool: currentOrPastDateUI(
+    'When did child stop attending school?',
+  ),
+};

--- a/src/applications/disability-benefits/new-686/config/chapters/report-child-stopped-attending-school/index.js
+++ b/src/applications/disability-benefits/new-686/config/chapters/report-child-stopped-attending-school/index.js
@@ -1,0 +1,3 @@
+import * as reportChildStoppedAttendingSchool from './child-information/childInformation';
+
+export { reportChildStoppedAttendingSchool };

--- a/src/applications/disability-benefits/new-686/config/chapters/taskWizard/wizard/helpers.js
+++ b/src/applications/disability-benefits/new-686/config/chapters/taskWizard/wizard/helpers.js
@@ -3,3 +3,6 @@ export const validateAtLeastOneSelected = (errors, fieldData) => {
     errors.addError('Please select at least one option');
   }
 };
+
+export const isChapterFieldRequired = (formData, option) =>
+  formData[`view:selectable686Options`][option];

--- a/src/applications/disability-benefits/new-686/config/form.js
+++ b/src/applications/disability-benefits/new-686/config/form.js
@@ -5,6 +5,7 @@ import ConfirmationPage from '../containers/ConfirmationPage';
 import { formerSpouseInformation } from './chapters/report-divorce';
 import { deceasedDependentInformation } from './chapters/report-dependent-death';
 import { reportChildMarriage } from './chapters/report-marriage-of-child';
+import { reportChildStoppedAttendingSchool } from './chapters/report-child-stopped-attending-school';
 import { wizard } from './chapters/taskWizard';
 import {
   veteranInformation,
@@ -87,6 +88,19 @@ const formConfig = {
           path: '686-report-marriage-of-child',
           uiSchema: reportChildMarriage.uiSchema,
           schema: reportChildMarriage.schema,
+        },
+      },
+    },
+    reportChildStoppedAttendingSchool: {
+      title:
+        'Information needed to report a child 18-23 years old stopped attending school',
+      pages: {
+        childNoLongerInSchool: {
+          title:
+            'Information needed to report a child 18-23 years old stopped attending school',
+          path: 'report-child-stopped-attending-school',
+          uiSchema: reportChildStoppedAttendingSchool.uiSchema,
+          schema: reportChildStoppedAttendingSchool.schema,
         },
       },
     },

--- a/src/applications/disability-benefits/new-686/tests/config/reportChildStoppedAttendingSchool.unit.spec.jsx
+++ b/src/applications/disability-benefits/new-686/tests/config/reportChildStoppedAttendingSchool.unit.spec.jsx
@@ -1,0 +1,147 @@
+import React from 'react';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { mount } from 'enzyme';
+
+import {
+  DefinitionTester,
+  fillData,
+} from 'platform/testing/unit/schemaform-utils.jsx';
+import formConfig from '../../config/form';
+
+describe('686 report a child has stopped attending school', () => {
+  const {
+    schema,
+    uiSchema,
+  } = formConfig.chapters.reportChildStoppedAttendingSchool.pages.childNoLongerInSchool;
+
+  it('should render', () => {
+    const form = mount(
+      <DefinitionTester
+        schema={schema}
+        uiSchema={uiSchema}
+        definitions={formConfig.defaultDefinitions}
+      />,
+    );
+    expect(form.find('input').length).to.equal(4);
+    form.unmount();
+  });
+
+  it('should not submit an empty form', () => {
+    const onSubmit = sinon.spy();
+    const form = mount(
+      <DefinitionTester
+        schema={schema}
+        uiSchema={uiSchema}
+        definitions={formConfig.defaultDefinitions}
+        onSubmit={onSubmit}
+      />,
+    );
+    form.find('form').simulate('submit');
+    expect(form.find('.usa-input-error').length).to.equal(3);
+    expect(onSubmit.called).to.be.false;
+    form.unmount();
+  });
+
+  // empty last name
+  it('should not submit a form with an incomplete name', () => {
+    const onSubmit = sinon.spy();
+    const form = mount(
+      <DefinitionTester
+        schema={schema}
+        uiSchema={uiSchema}
+        definitions={formConfig.defaultDefinitions}
+      />,
+    );
+    fillData(form, 'input#root_childNoLongerAtSchoolName_first', 'john');
+    const month = form.find('select#root_dateChildLeftSchoolMonth');
+    const day = form.find('select#root_dateChildLeftSchoolDay');
+    month.simulate('change', {
+      target: { value: '1' },
+    });
+    day.simulate('change', {
+      target: { value: '1' },
+    });
+    fillData(form, 'input#root_dateChildLeftSchoolYear', '2010');
+    form.find('form').simulate('submit');
+    expect(form.find('.usa-input-error').length).to.equal(1);
+    expect(onSubmit.called).to.be.false;
+    form.unmount();
+  });
+
+  // empty date
+  it('should not submit a form without a date', () => {
+    const onSubmit = sinon.spy();
+    const form = mount(
+      <DefinitionTester
+        schema={schema}
+        uiSchema={uiSchema}
+        definitions={formConfig.defaultDefinitions}
+        onSubmit={onSubmit}
+      />,
+    );
+    fillData(form, 'input#root_childNoLongerAtSchoolName_first', 'john');
+    fillData(form, 'input#root_childNoLongerAtSchoolName_last', 'doe');
+    form.find('form').simulate('submit');
+    expect(form.find('.usa-input-error').length).to.equal(1);
+    expect(onSubmit.called).to.be.false;
+    form.unmount();
+  });
+
+  it('should submit a valid form without a suffix or middle name', () => {
+    const onSubmit = sinon.spy();
+    const form = mount(
+      <DefinitionTester
+        schema={schema}
+        uiSchema={uiSchema}
+        definitions={formConfig.defaultDefinitions}
+        onSubmit={onSubmit}
+      />,
+    );
+    fillData(form, 'input#root_childNoLongerAtSchoolName_first', 'john');
+    fillData(form, 'input#root_childNoLongerAtSchoolName_last', 'doe');
+    const month = form.find('select#root_dateChildLeftSchoolMonth');
+    const day = form.find('select#root_dateChildLeftSchoolDay');
+    month.simulate('change', {
+      target: { value: '1' },
+    });
+    day.simulate('change', {
+      target: { value: '1' },
+    });
+    fillData(form, 'input#root_dateChildLeftSchoolYear', '2010');
+    form.find('form').simulate('submit');
+    expect(onSubmit.called).to.be.true;
+    form.unmount();
+  });
+
+  it('should submit a valid form with a suffix and middle name', () => {
+    const onSubmit = sinon.spy();
+    const form = mount(
+      <DefinitionTester
+        schema={schema}
+        uiSchema={uiSchema}
+        definitions={formConfig.defaultDefinitions}
+        onSubmit={onSubmit}
+      />,
+    );
+    fillData(form, 'input#root_childNoLongerAtSchoolName_first', 'john');
+    fillData(form, 'input#root_childNoLongerAtSchoolName_middle', 'jeffrey');
+    fillData(form, 'input#root_childNoLongerAtSchoolName_last', 'doe');
+    const suffix = form.find('select#root_childNoLongerAtSchoolName_suffix');
+    suffix.simulate('change', {
+      target: { value: 'II' },
+    });
+    const month = form.find('select#root_dateChildLeftSchoolMonth');
+    const day = form.find('select#root_dateChildLeftSchoolDay');
+    month.simulate('change', {
+      target: { value: '1' },
+    });
+    day.simulate('change', {
+      target: { value: '1' },
+    });
+    fillData(form, 'input#root_dateChildLeftSchoolYear', '2010');
+    form.find('form').simulate('submit');
+    expect(onSubmit.called).to.be.true;
+    form.unmount();
+  });
+});

--- a/src/applications/disability-benefits/new-686/tests/config/reportChildStoppedAttendingSchool.unit.spec.jsx
+++ b/src/applications/disability-benefits/new-686/tests/config/reportChildStoppedAttendingSchool.unit.spec.jsx
@@ -15,11 +15,18 @@ describe('686 report a child has stopped attending school', () => {
     uiSchema,
   } = formConfig.chapters.reportChildStoppedAttendingSchool.pages.childNoLongerInSchool;
 
+  const formData = {
+    'view:selectable686Options': {
+      reportChild18OrOlderIsNotAttendingSchool: true,
+    },
+  };
+
   it('should render', () => {
     const form = mount(
       <DefinitionTester
         schema={schema}
         uiSchema={uiSchema}
+        data={formData}
         definitions={formConfig.defaultDefinitions}
       />,
     );
@@ -33,6 +40,7 @@ describe('686 report a child has stopped attending school', () => {
       <DefinitionTester
         schema={schema}
         uiSchema={uiSchema}
+        data={formData}
         definitions={formConfig.defaultDefinitions}
         onSubmit={onSubmit}
       />,
@@ -50,6 +58,7 @@ describe('686 report a child has stopped attending school', () => {
       <DefinitionTester
         schema={schema}
         uiSchema={uiSchema}
+        data={formData}
         definitions={formConfig.defaultDefinitions}
       />,
     );
@@ -76,6 +85,7 @@ describe('686 report a child has stopped attending school', () => {
       <DefinitionTester
         schema={schema}
         uiSchema={uiSchema}
+        data={formData}
         definitions={formConfig.defaultDefinitions}
         onSubmit={onSubmit}
       />,
@@ -94,6 +104,7 @@ describe('686 report a child has stopped attending school', () => {
       <DefinitionTester
         schema={schema}
         uiSchema={uiSchema}
+        data={formData}
         definitions={formConfig.defaultDefinitions}
         onSubmit={onSubmit}
       />,
@@ -120,6 +131,7 @@ describe('686 report a child has stopped attending school', () => {
       <DefinitionTester
         schema={schema}
         uiSchema={uiSchema}
+        data={formData}
         definitions={formConfig.defaultDefinitions}
         onSubmit={onSubmit}
       />,


### PR DESCRIPTION
## Description
[Original Ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/4910)

This pull request adds a 686c workflow for reporting that a child has stopped attending school. Since the workflow was relatively simple, this pull request also includes the unit tests for the new component. 

## Testing done
- local, all unit tests pass.

## Screenshots
<img width="809" alt="Screen Shot 2020-02-26 at 2 39 25 PM" src="https://user-images.githubusercontent.com/15097156/75395199-b607c780-58a6-11ea-9e25-d69a6b7f61db.png">
<img width="670" alt="Screen Shot 2020-02-26 at 2 39 57 PM" src="https://user-images.githubusercontent.com/15097156/75395208-bd2ed580-58a6-11ea-8377-a7a272d09187.png">
<img width="638" alt="Screen Shot 2020-02-26 at 2 40 23 PM" src="https://user-images.githubusercontent.com/15097156/75395218-c324b680-58a6-11ea-9f4a-627082395989.png">
<img width="432" alt="Screen Shot 2020-02-26 at 2 40 43 PM" src="https://user-images.githubusercontent.com/15097156/75395236-cd46b500-58a6-11ea-9085-4b028c478948.png">
![Screen Shot 2020-02-26 at 2 40 54 PM](https://user-images.githubusercontent.com/15097156/75395249-d46dc300-58a6-11ea-8085-8dea7a452b99.png)


## Acceptance criteria
- [x] unit tests pass

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
