### PR TITLE
fix DD set up 2FA link

### DIFF
--- a/src/applications/personalization/profile360/components/PaymentInformation2FARequired.jsx
+++ b/src/applications/personalization/profile360/components/PaymentInformation2FARequired.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 
+import { mfa } from 'platform/user/authentication/utilities';
+
 export default function PaymentInformation2FARequired() {
   return (
     <AlertBox
@@ -20,9 +22,9 @@ export default function PaymentInformation2FARequired() {
           make sure that no one but you can access your account—even if they get
           your password.
         </p>
-        <a className="usa-button-primary va-button-primary" href="/account">
+        <button className="usa-button-primary va-button-primary" onClick={mfa}>
           Set up 2-factor authentication
-        </a>
+        </button>
       </>
     </AlertBox>
   );


### PR DESCRIPTION
## Description
Use the existing `mfa` helper to handle setting up two-factor auth

## Testing done
Local

## Screenshots
![direct-deposit-set-up-2fa](https://user-images.githubusercontent.com/20728956/75472792-e607a700-5948-11ea-9fc5-81e6b8601cb9.gif)

## Acceptance criteria
- [ ] users are sent directly into the 2FA setup flow
- [ ] the button looks the same as before

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs