### PR TITLE
Execute data push to measure search performance

### DIFF
--- a/src/applications/facility-locator/components/ResultsList.jsx
+++ b/src/applications/facility-locator/components/ResultsList.jsx
@@ -15,6 +15,7 @@ import { updateSearchQuery, searchWithBounds } from '../actions';
 
 import SearchResult from './SearchResult';
 import DelayedRender from 'platform/utilities/ui/DelayedRender';
+import recordEvent from '../../../platform/monitoring/record-event';
 
 const TIMEOUTS = new Set(['408', '504', '503']);
 
@@ -24,6 +25,10 @@ class ResultsList extends Component {
     this.searchResultTitle = React.createRef();
   }
   shouldComponentUpdate(nextProps) {
+    // Record event
+    if (nextProps.results.length > 0) {
+      recordEvent({ event: 'fl-search-results' });
+    }
     return (
       nextProps.results !== this.props.results ||
       nextProps.inProgress !== this.props.inProgress


### PR DESCRIPTION
## Description

issue: https://github.com/department-of-veterans-affairs/va.gov-team/issues/4026

## Testing done


## Screenshots


## Acceptance criteria
- [x]  perform dataLayer push each time search results are returned

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
