### PR TITLE
Scheduled downtime without moment-timezone

### DIFF
--- a/src/platform/monitoring/DowntimeNotification/config/scheduledDowntimeWindow.js
+++ b/src/platform/monitoring/DowntimeNotification/config/scheduledDowntimeWindow.js
@@ -1,6 +1,7 @@
-import moment from 'moment-timezone';
+import moment from 'moment';
 
+// Times should always have Eastern time offset.
 export default {
-  downtimeStart: moment.tz('2020-02-29 21:00', 'America/New_York'),
-  downtimeEnd: moment.tz('2020-02-29 21:30', 'America/New_York'),
+  downtimeStart: moment.parseZone('2020-02-29T21:00:00-05:00'),
+  downtimeEnd: moment.parseZone('2020-02-29T21:30:00-05:00'),
 };

--- a/src/platform/monitoring/DowntimeNotification/util/helpers.js
+++ b/src/platform/monitoring/DowntimeNotification/util/helpers.js
@@ -103,6 +103,12 @@ export function getSoonestDowntime(serviceMap, serviceNames) {
     }, null);
 }
 
+/**
+ * Determines whether there is a global downtime in progress
+ * @param {object} downtimeWindow Optional arg to set arbitrary downtime
+ * @returns {boolean} true if the current time is within the downtime window,
+ *     false if not
+ */
 export const isGlobalDowntimeInProgress = (
   downtimeWindow = scheduledDowntimeWindow,
 ) => {

--- a/src/platform/utilities/date/index.js
+++ b/src/platform/utilities/date/index.js
@@ -102,6 +102,13 @@ const LONG_FORM_MONTHS = [
   monthIndices.JUL,
 ];
 
+/**
+ * Formats the given date-time into a string that is intended for use in
+ * downtime notifications
+ *
+ * @param {string} dateTime The date-time as a moment or string in Eastern time
+ * @returns {string} The formatted date-time string
+ */
 export const formatDowntime = dateTime => {
   const dtMoment = moment.parseZone(dateTime);
   const dtHour = dtMoment.hour();


### PR DESCRIPTION
## Description
Doesn't seem like there is a dependency on the date-time being in the `moment.tz` format, so replacing it to reduce the burden on performance.

## Testing done
Local testing to see that the message stiil appears.

## Acceptance criteria
- [ ] `moment-timezone` should not be used unless necessary.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
