### PR TITLE
bradl3yC - 6278 - address validation error handdling

### DIFF
--- a/src/platform/user/profile/vet360/actions/transactions.js
+++ b/src/platform/user/profile/vet360/actions/transactions.js
@@ -203,85 +203,83 @@ export const validateAddress = (
     },
   };
 
-  const transaction = isVet360Configured()
-    ? () => apiRequest('/profile/address_validation', options)
-    : () => localVet360.addressValidationSuccess();
-
-  transaction()
-    .then(response => {
-      const { addresses, validationKey } = response;
-      const suggestedAddresses = addresses
-        // sort highest confidence score to lowest confidence score
-        .sort(
-          (firstAddress, secondAddress) =>
-            secondAddress.addressMetaData?.confidenceScore -
-            firstAddress.addressMetaData?.confidenceScore,
-        )
-        // add the address type, POU, and original id to each suggestion
-        .map(address => ({
-          addressMetaData: { ...address.addressMetaData },
-          ...inferAddressType(address.address),
-          addressPou:
-            fieldName === FIELD_NAMES.MAILING_ADDRESS
-              ? ADDRESS_POU.CORRESPONDENCE
-              : ADDRESS_POU.RESIDENCE,
-          id: payload.id || null,
-        }));
-      const confirmedSuggestions = suggestedAddresses.filter(
-        suggestion =>
-          suggestion.addressMetaData?.deliveryPointValidation === CONFIRMED,
-      );
-      const payloadWithSuggestedAddress = {
-        ...confirmedSuggestions[0],
-      };
-
-      const selectedAddressId = confirmedSuggestions.length > 0 ? '0' : null;
-
-      // always select first address as default if there are any
-      let selectedAddress = confirmedSuggestions[0];
-
-      if (!confirmedSuggestions.length && validationKey) {
-        // if there are no confirmed suggestions and user can override, fall back to submitted address
-        selectedAddress = userEnteredAddress.address;
-      }
-
-      // we use the unfiltered list of suggested addresses to determine if we need
-      // to show the modal because the only time we will skip the modal is if one
-      // and only one confirmed address came back from the API
-      const showModal = showAddressValidationModal(suggestedAddresses);
-
-      // show the modal if the API doesn't find a single solid match for the address
-      if (showModal) {
-        return dispatch({
-          type: ADDRESS_VALIDATION_CONFIRM,
-          addressFromUser: userEnteredAddress.address, // need to use the address with iso3 code added to it
-          addressValidationType: fieldName,
-          selectedAddress,
-          suggestedAddresses,
-          selectedAddressId,
-          validationKey,
-          confirmedSuggestions,
-        });
-      }
-      // otherwise just send the first suggestion to the API
-      return dispatch(
-        createTransaction(
-          route,
-          method,
-          fieldName,
-          payloadWithSuggestedAddress,
-          analyticsSectionName,
-        ),
-      );
-    })
-    .catch(() =>
-      dispatch({
-        type: ADDRESS_VALIDATION_ERROR,
-        addressValidationType: fieldName,
-        addressValidationError: true,
-        addressFromUser: { ...payload },
-      }),
+  try {
+    const response = isVet360Configured()
+      ? await apiRequest('/profile/address_validation', options)
+      : await localVet360.addressValidationSuccess();
+    const { addresses, validationKey } = response;
+    const suggestedAddresses = addresses
+      // sort highest confidence score to lowest confidence score
+      .sort(
+        (firstAddress, secondAddress) =>
+          secondAddress.addressMetaData?.confidenceScore -
+          firstAddress.addressMetaData?.confidenceScore,
+      )
+      // add the address type, POU, and original id to each suggestion
+      .map(address => ({
+        addressMetaData: { ...address.addressMetaData },
+        ...inferAddressType(address.address),
+        addressPou:
+          fieldName === FIELD_NAMES.MAILING_ADDRESS
+            ? ADDRESS_POU.CORRESPONDENCE
+            : ADDRESS_POU.RESIDENCE,
+        id: payload.id || null,
+      }));
+    const confirmedSuggestions = suggestedAddresses.filter(
+      suggestion =>
+        suggestion.addressMetaData?.deliveryPointValidation === CONFIRMED,
     );
+    const payloadWithSuggestedAddress = {
+      ...confirmedSuggestions[0],
+    };
+
+    const selectedAddressId = confirmedSuggestions.length > 0 ? '0' : null;
+
+    // always select first address as default if there are any
+    let selectedAddress = confirmedSuggestions[0];
+
+    if (!confirmedSuggestions.length && validationKey) {
+      // if there are no confirmed suggestions and user can override, fall back to submitted address
+      selectedAddress = userEnteredAddress.address;
+    }
+
+    // we use the unfiltered list of suggested addresses to determine if we need
+    // to show the modal because the only time we will skip the modal is if one
+    // and only one confirmed address came back from the API
+    const showModal = showAddressValidationModal(suggestedAddresses);
+
+    // show the modal if the API doesn't find a single solid match for the address
+    if (showModal) {
+      return dispatch({
+        type: ADDRESS_VALIDATION_CONFIRM,
+        addressFromUser: userEnteredAddress.address, // need to use the address with iso3 code added to it
+        addressValidationType: fieldName,
+        selectedAddress,
+        suggestedAddresses,
+        selectedAddressId,
+        validationKey,
+        confirmedSuggestions,
+      });
+    }
+    // otherwise just send the first suggestion to the API
+    return dispatch(
+      createTransaction(
+        route,
+        method,
+        fieldName,
+        payloadWithSuggestedAddress,
+        analyticsSectionName,
+      ),
+    );
+  } catch (error) {
+    return dispatch({
+      type: ADDRESS_VALIDATION_ERROR,
+      addressValidationError: true,
+      addressFromUser: { ...payload },
+      fieldName,
+      error,
+    });
+  }
 };
 
 export const updateValidationKeyAndSave = (

--- a/src/platform/user/profile/vet360/components/base/Vet360EditModal.jsx
+++ b/src/platform/user/profile/vet360/components/base/Vet360EditModal.jsx
@@ -125,11 +125,13 @@ export default class Vet360EditModal extends React.Component {
         <Modal id="profile-edit-modal" onClose={onCancel} visible={isFormReady}>
           <h3>Edit {title.toLowerCase()}</h3>
           {error && (
-            <Vet360EditModalErrorMessage
-              title={title}
-              error={error}
-              clearErrors={clearErrors}
-            />
+            <div className="vads-u-margin-bottom--1">
+              <Vet360EditModalErrorMessage
+                title={title}
+                error={error}
+                clearErrors={clearErrors}
+              />
+            </div>
           )}
           {isFormReady && render(actionButtons, this.onSubmitSchemaForm)}
         </Modal>

--- a/src/platform/user/profile/vet360/reducers/index.js
+++ b/src/platform/user/profile/vet360/reducers/index.js
@@ -251,16 +251,21 @@ export default function vet360(state = initialState, action) {
         ...state,
         fieldTransactionMap: {
           ...state.fieldTransactionMap,
-          [action.addressValidationType]: { isPending: false },
+          [action.fieldName]: {
+            ...state.fieldTransactionMap[action.fieldName],
+            isPending: false,
+            isFailed: true,
+            error: action.error,
+          },
         },
         addressValidation: {
           ...initialAddressValidationState,
           addressValidationError: action.addressValidationError,
-          addressValidationType: action.addressValidationType,
+          addressValidationType: action.fieldName,
           validationKey: action.validationKey || null,
           addressFromUser: action.addressFromUser,
         },
-        modal: 'addressValidation',
+        modal: action.fieldName,
       };
 
     case ADDRESS_VALIDATION_RESET:

--- a/src/platform/user/profile/vet360/tests/reducers/index.unit.spec.js
+++ b/src/platform/user/profile/vet360/tests/reducers/index.unit.spec.js
@@ -323,9 +323,10 @@ describe('vet360 reducer', () => {
       };
       const action = {
         type: 'ADDRESS_VALIDATION_ERROR',
-        addressValidationError: true,
-        addressValidationType: 'mailingAddress',
         addressFromUser: { street: '987 main' },
+        addressValidationError: true,
+        fieldName: 'mailingAddress',
+        error: 'Foo',
       };
       const expectedState = {
         ...state,
@@ -340,9 +341,13 @@ describe('vet360 reducer', () => {
           validationKey: null,
         },
         fieldTransactionMap: {
-          mailingAddress: { isPending: false },
+          mailingAddress: {
+            isPending: false,
+            isFailed: true,
+            error: 'Foo',
+          },
         },
-        modal: 'addressValidation',
+        modal: 'mailingAddress',
       };
       expect(vet360(state, action)).to.eql(expectedState);
     });


### PR DESCRIPTION
## Description
Previously, if the address validation API returned a 400/500, the address validation model would re-open and give the user the ability to edit their address.  This behavior was not ideal and did not give any indication that an error occurred.

The new behavior will reopen the address modal that resulted in an error (either home address or mailing address) and display an error in an alert box.

## Testing done


## Screenshots
### Result:
![Screen Shot 2020-02-28 at 1 42 12 PM](https://user-images.githubusercontent.com/6165421/75577518-24c45c80-5a30-11ea-83fa-f472a9a398d6.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
