### PR TITLE
Add instructions for JAWS on calendar buttons

### DIFF
--- a/src/applications/vaos/components/calendar/CalendarCell.jsx
+++ b/src/applications/vaos/components/calendar/CalendarCell.jsx
@@ -87,9 +87,7 @@ const CalendarCell = ({
         aria-controls={
           isCurrentlySelected ? `vaos-options-container-${date}` : undefined
         }
-        aria-describedby={`vaos-calendar-instructions-${momentDate.format(
-          'MM',
-        )}`}
+        aria-describedby={`vaos-calendar-instructions-${momentDate.month()}`}
         className="vaos-calendar__calendar-day-button"
         id={`date-cell-${date}`}
         onClick={() => onClick(date)}

--- a/src/applications/vaos/components/calendar/CalendarCell.jsx
+++ b/src/applications/vaos/components/calendar/CalendarCell.jsx
@@ -87,7 +87,9 @@ const CalendarCell = ({
         aria-controls={
           isCurrentlySelected ? `vaos-options-container-${date}` : undefined
         }
-        aria-describedby="vaos-calendar-instructions"
+        aria-describedby={`vaos-calendar-instructions-${momentDate.format(
+          'MM',
+        )}`}
         className="vaos-calendar__calendar-day-button"
         id={`date-cell-${date}`}
         onClick={() => onClick(date)}

--- a/src/applications/vaos/components/calendar/CalendarCell.jsx
+++ b/src/applications/vaos/components/calendar/CalendarCell.jsx
@@ -87,6 +87,7 @@ const CalendarCell = ({
         aria-controls={
           isCurrentlySelected ? `vaos-options-container-${date}` : undefined
         }
+        aria-describedby="vaos-calendar-instructions"
         className="vaos-calendar__calendar-day-button"
         id={`date-cell-${date}`}
         onClick={() => onClick(date)}

--- a/src/applications/vaos/components/calendar/CalendarWidget.jsx
+++ b/src/applications/vaos/components/calendar/CalendarWidget.jsx
@@ -306,7 +306,10 @@ export default class CalendarWidget extends Component {
         >
           {month.format('MMMM YYYY')}
         </h2>
-        <div className="sr-only" id="vaos-calendar-instructions">
+        <div
+          className="sr-only"
+          id={`vaos-calendar-instructions-${month.format('MM')}`}
+        >
           Press the Enter key to expand the day you want to schedule an
           appointment. Then press the Tab key or form shortcut key to select an
           appointment time.

--- a/src/applications/vaos/components/calendar/CalendarWidget.jsx
+++ b/src/applications/vaos/components/calendar/CalendarWidget.jsx
@@ -306,6 +306,11 @@ export default class CalendarWidget extends Component {
         >
           {month.format('MMMM YYYY')}
         </h2>
+        <div className="sr-only" id="vaos-calendar-instructions">
+          Press the Enter key to expand the day you want to schedule an
+          appointment. Then press the Tab key or form shortcut key to select an
+          appointment time.
+        </div>
 
         {index === 0 && (
           <CalendarNavigation

--- a/src/applications/vaos/components/calendar/CalendarWidget.jsx
+++ b/src/applications/vaos/components/calendar/CalendarWidget.jsx
@@ -308,7 +308,7 @@ export default class CalendarWidget extends Component {
         </h2>
         <div
           className="sr-only"
-          id={`vaos-calendar-instructions-${month.format('MM')}`}
+          id={`vaos-calendar-instructions-${month.month()}`}
         >
           Press the Enter key to expand the day you want to schedule an
           appointment. Then press the Tab key or form shortcut key to select an


### PR DESCRIPTION
## Description
This adds some descriptive instructions to the calendar widget, based on an issue Trevor filed.

## Testing done
Local testing

## Acceptance criteria
- [ ] decribedby is set up correctly

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
