### PR TITLE
[HCA] Correct phone number

### DIFF
--- a/src/applications/claims-status/components/appeals-v2/AppealHelpSidebar.jsx
+++ b/src/applications/claims-status/components/appeals-v2/AppealHelpSidebar.jsx
@@ -22,7 +22,7 @@ const vhaVersion = (
     <p>Call Health Care Benefits</p>
     <p className="help-phone-number">
       <a className="help-phone-number-link" href="tel:1-877-222-8387">
-        877-222-VETS (8387)
+        877-222-8387
       </a>
     </p>
     <p>Monday - Friday, 8:00am - 8:00pm ET</p>

--- a/src/applications/claims-status/components/appeals-v2/AppealHelpSidebar.jsx
+++ b/src/applications/claims-status/components/appeals-v2/AppealHelpSidebar.jsx
@@ -22,7 +22,7 @@ const vhaVersion = (
     <p>Call Health Care Benefits</p>
     <p className="help-phone-number">
       <a className="help-phone-number-link" href="tel:1-877-222-8387">
-        877-222-8387
+        877-222-VETS (8387)
       </a>
     </p>
     <p>Monday - Friday, 8:00am - 8:00pm ET</p>

--- a/src/applications/disability-benefits/all-claims/content/unemployabilityDisabilities.jsx
+++ b/src/applications/disability-benefits/all-claims/content/unemployabilityDisabilities.jsx
@@ -48,8 +48,7 @@ export const helpDescription = (
     <p>
       <strong>Please note:</strong> If you expect to see something that isn’t
       included in this list or if you have other questions about your claim,
-      contact: 877-222-VETS (877-222-8387), Monday – Friday, 8:00 a.m. – 8:00
-      p.m. ET.
+      contact: 877-222-8387, Monday – Friday, 8:00 a.m. – 8:00 p.m. ET.
     </p>
   </div>
 );

--- a/src/applications/hca/components/DowntimeMessage.jsx
+++ b/src/applications/hca/components/DowntimeMessage.jsx
@@ -18,11 +18,10 @@ export default function DowntimeMessage({ isAfterSteps }) {
           fix a few things. We’ll be back up as soon as we can.
         </p>
         <p>
-          In the meantime, you can call 877-222-VETS (
-          <a href="tel:+18772228387">877-222-8387</a>
-          ), Monday &#8211; Friday, 8:00 a.m. &#8211; 8:00 p.m. (
-          <abbr title="eastern time">ET</abbr>) and press 2 to complete this
-          application over the phone.
+          In the meantime, you can call{' '}
+          <a href="tel:+18772228387">877-222-8387</a>, Monday &#8211; Friday,
+          8:00 a.m. &#8211; 8:00 p.m. (<abbr title="eastern time">ET</abbr>) and
+          press 2 to complete this application over the phone.
         </p>
       </div>
     </AlertBox>

--- a/src/applications/hca/components/ErrorMessage.jsx
+++ b/src/applications/hca/components/ErrorMessage.jsx
@@ -3,8 +3,8 @@ import React from 'react';
 export default function ErrorMessage() {
   return (
     <p>
-      If you’d like to complete this form by phone, please call 877-222-VETS (
-      <a href="tel:+18772228387">877-222-8387</a>) and press 2, Monday &#8211;
+      If you’d like to complete this form by phone, please call{' '}
+      <a href="tel:+18772228387">877-222-8387</a> and press 2, Monday &#8211;
       Friday, 8:00 a.m. &#8211; 8:00 p.m. ET.
     </p>
   );

--- a/src/applications/hca/components/HCASubwayMap.jsx
+++ b/src/applications/hca/components/HCASubwayMap.jsx
@@ -98,9 +98,8 @@ export default function HCASubwayMap() {
             <p>
               We process health care claims within a week. If more than a week
               has passed since you submitted your application and you haven’t
-              heard back, please don’t apply again. Call us at 877-222-VETS (
-              <a href="tel:+18772228387">877-222-8387</a>
-              ).
+              heard back, please don’t apply again. Call us at
+              <a href="tel:+18772228387">877-222-8387</a>.
             </p>
           </li>
           <li className="process-step list-four">

--- a/src/applications/hca/components/HCASubwayMap.jsx
+++ b/src/applications/hca/components/HCASubwayMap.jsx
@@ -98,7 +98,7 @@ export default function HCASubwayMap() {
             <p>
               We process health care claims within a week. If more than a week
               has passed since you submitted your application and you haven’t
-              heard back, please don’t apply again. Call us at
+              heard back, please don’t apply again. Call us at{' '}
               <a href="tel:+18772228387">877-222-8387</a>.
             </p>
           </li>

--- a/src/applications/hca/containers/ConfirmationPage.jsx
+++ b/src/applications/hca/containers/ConfirmationPage.jsx
@@ -90,9 +90,8 @@ export class ConfirmationPage extends React.Component {
           </p>
           <p>
             Please don’t apply again. Instead, please call our toll-free hotline
-            at 877-222-VETS
-            <br />(<a href="tel:+18772228387">877-222-8387</a>
-            ). We’re here Monday through Friday, 8:00 am to 8:00 pm ET.
+            at <a href="tel:+18772228387">877-222-8387</a>. We’re here Monday
+            through Friday, 8:00 am to 8:00 pm ET.
           </p>
           <h4 className="confirmation-guidance-heading">
             How can I check the status of my application?
@@ -159,9 +158,8 @@ export class ConfirmationPage extends React.Component {
             What if I have more questions?
           </h4>
           <p className="confirmation-guidance-message">
-            Please call 877-222-VETS (
-            <a href="tel:+18772228387">877-222-8387</a>) and select 2. We're
-            here Monday through Friday, 8:00 a.m. to 8:00 p.m. ET.
+            Please call <a href="tel:+18772228387">877-222-8387</a> and select
+            2. We're here Monday through Friday, 8:00 a.m. to 8:00 p.m. ET.
           </p>
         </div>
       </div>

--- a/src/applications/hca/containers/IntroductionPage.jsx
+++ b/src/applications/hca/containers/IntroductionPage.jsx
@@ -59,10 +59,9 @@ const VerificationRequiredAlert = () => (
             </a>
           </li>
           <li>
-            Or call us at
-            <a href="tel:+18772228387">877-222-8387</a>. If you have hearing
-            loss, call TTY: 800-877-8339. We’re here Monday through Friday, 8:00
-            a.m. to 8:00 p.m. ET.
+            Or call us at <a href="tel:+18772228387">877-222-8387</a>. If you
+            have hearing loss, call TTY: 800-877-8339. We’re here Monday through
+            Friday, 8:00 a.m. to 8:00 p.m. ET.
           </li>
         </ul>
         <p>

--- a/src/applications/hca/containers/IntroductionPage.jsx
+++ b/src/applications/hca/containers/IntroductionPage.jsx
@@ -59,10 +59,10 @@ const VerificationRequiredAlert = () => (
             </a>
           </li>
           <li>
-            Or call us at 877-222-VETS (
-            <a href="tel:+18772228387">877-222-8387</a>
-            ). If you have hearing loss, call TTY: 800-877-8339. We’re here
-            Monday through Friday, 8:00 a.m. to 8:00 p.m. ET.
+            Or call us at
+            <a href="tel:+18772228387">877-222-8387</a>. If you have hearing
+            loss, call TTY: 800-877-8339. We’re here Monday through Friday, 8:00
+            a.m. to 8:00 p.m. ET.
           </li>
         </ul>
         <p>

--- a/src/applications/hca/manifest.json
+++ b/src/applications/hca/manifest.json
@@ -11,7 +11,7 @@
     "body_class": "page-healthcare",
     "in_maintenance": false,
     "maintenance_line1": "We’re sorry. The health care application is currently down while we fix a few things. We’ll be back up as soon as we can.",
-    "maintenance_line2": "In the meantime, you can call 1-877-222-VETS (<a href=\"tel:+18772228387\">1-877-222-8387</a>), Monday &#8211; Friday, 8:00 a.m. &#8211; 8:00 p.m. (<abbr title=\"eastern time\">ET</abbr>) and press 2 to complete this application over the phone.",
+    "maintenance_line2": "In the meantime, you can call <a href=\"tel:+18772228387\">1-877-222-8387</a>, Monday &#8211; Friday, 8:00 a.m. &#8211; 8:00 p.m. (<abbr title=\"eastern time\">ET</abbr>) and press 2 to complete this application over the phone.",
     "collection": "healthCare",
     "spoke": "Get benefits",
     "order": 4,

--- a/src/applications/letters/utils/helpers.jsx
+++ b/src/applications/letters/utils/helpers.jsx
@@ -189,10 +189,9 @@ export const letterContent = {
       insurance requirements under the Affordable Care Act (ACA). To prove that
       you’re enrolled in the VA health care system, you must have IRS Form
       1095-B from VA to show what months you were covered by a VA health care
-      plan. If you’ve lost your IRS Form 1095-B, please call 877-222-VETS (
-      <a href="tel:+18772228387">877-222-8387</a>
-      ), Monday &#8211; Friday, 8:00 a.m. &#8211; 8:00 p.m. ET to request
-      another copy.
+      plan. If you’ve lost your IRS Form 1095-B, please call{' '}
+      <a href="tel:+18772228387">877-222-8387</a>, Monday &#8211; Friday, 8:00
+      a.m. &#8211; 8:00 p.m. ET to request another copy.
     </div>
   ),
   service_verification: serviceVerificationLetterContent,

--- a/src/applications/pre-need/containers/ConfirmationPage.jsx
+++ b/src/applications/pre-need/containers/ConfirmationPage.jsx
@@ -94,11 +94,11 @@ class ConfirmationPage extends React.Component {
           <h4 className="confirmation-guidance-heading">Need help?</h4>
           <div>
             <p className="confirmation-guidance-message">
-              If you have questions, please call 877-222-VETS (
+              If you have questions, please call{' '}
               <a className="help-phone-number-link" href="tel:1-877-222-8387">
                 877-222-8387
               </a>
-              ), Monday through Friday, 8:00 a.m. to 8:00 p.m. ET.
+              , Monday through Friday, 8:00 a.m. to 8:00 p.m. ET.
             </p>
           </div>
         </div>

--- a/src/applications/vre/chapter31/containers/ConfirmationPage.jsx
+++ b/src/applications/vre/chapter31/containers/ConfirmationPage.jsx
@@ -91,8 +91,7 @@ class ConfirmationPage extends React.Component {
         <div className="confirmation-guidance-container">
           <h4 className="confirmation-guidance-heading">Need help?</h4>
           <p className="confirmation-guidance-message">
-            If you have questions, please call 877-222-VETS (877-222-8387) and
-            press 2,
+            If you have questions, please call 877-222-8387 and press 2,
             <br />
             Monday — Friday, 8:00 a.m. — 8:00 p.m. ET.
           </p>


### PR DESCRIPTION
## Description
Remove the VETS vanity number across the website per this ticket, https://github.com/department-of-veterans-affairs/va.gov-team/issues/6159.

## Testing done
Looked at HCA introduction page

## Screenshots
http://localhost:3001/health-care/apply/application/introduction

![image](https://user-images.githubusercontent.com/1915775/75690007-28debd00-5c70-11ea-957c-542d38f27e41.png)


## Acceptance criteria
- [ ] Vanity number is removed from HCA

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
