### PR TITLE
fix bug with PhoneNumberWidget

### DIFF
--- a/src/platform/forms-system/src/js/widgets/PhoneNumberWidget.jsx
+++ b/src/platform/forms-system/src/js/widgets/PhoneNumberWidget.jsx
@@ -7,9 +7,12 @@ import TextWidget from './TextWidget';
  * instead
  */
 export default class PhoneNumberWidget extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = { val: props.value };
+  state = { val: this.props.value, firstUpdate: true };
+
+  componentDidUpdate(prevProps) {
+    if (this.state.firstUpdate && this.props.value !== prevProps.value) {
+      this.handleChange(this.props.value);
+    }
   }
 
   handleChange = val => {
@@ -18,7 +21,7 @@ export default class PhoneNumberWidget extends React.Component {
       stripped = val.replace(/[ \-()x+]/g, '');
     }
 
-    this.setState({ val }, () => {
+    this.setState({ val, firstUpdate: false }, () => {
       this.props.onChange(stripped);
     });
   };


### PR DESCRIPTION
## Description
This addresses a [weird bug](https://github.com/department-of-veterans-affairs/va.gov-team/issues/5963) which uncovered the fact that the `PhoneNumberWidget` does not properly pass its `value` prop down to its child `TextWidget` if the `value` prop changes after the component has rendered.

## Testing done
Local. This fixes the bug where a phone edit modal would show the last-entered data in the input field instead of the phone number on file if the user had canceled out of the modal.

## Screenshots
![ScreenFlow](https://user-images.githubusercontent.com/20728956/75801422-f98f8500-5d2f-11ea-99be-81d22c0491ee.gif)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs