### PR TITLE
Add polyfill for element.matches

### DIFF
--- a/package.json
+++ b/package.json
@@ -244,6 +244,7 @@
     "cookie-parser": "^1.4.3",
     "core-js": "^2.5.7",
     "downshift": "^1.22.5",
+    "element-matches-polyfill": "^1.0.0",
     "express": "^4.14.0",
     "express-http-proxy": "^1.5.1",
     "fast-levenshtein": "^2.0.6",

--- a/src/platform/polyfills/preESModulesPolyfills.js
+++ b/src/platform/polyfills/preESModulesPolyfills.js
@@ -8,11 +8,12 @@
 
 // This section is for custom polyfills that we need
 import 'classlist-polyfill'; // DOM element classList support.
+import 'element-matches-polyfill'; // DOM element .matches support.
 
 /*
  * This section is all of the core-js polyfills we need.
  *
- * To recreate this list: 
+ * To recreate this list:
  *
  * 1. Switch the list of browsers in babelrc to the full, older list
  * 2. Set debug to true in babelrc

--- a/yarn.lock
+++ b/yarn.lock
@@ -4479,6 +4479,11 @@ element-closest@^3.0.1:
   resolved "https://registry.yarnpkg.com/element-closest/-/element-closest-3.0.2.tgz#3814a69a84f30e48e63eaf57341f4dbf4227d2aa"
   integrity sha512-JxKQiJKX0Zr5Q2/bCaTx8P+UbfyMET1OQd61qu5xQFeWr1km3fGaxelSJtnfT27XQ5Uoztn2yIyeamAc/VX13g==
 
+element-matches-polyfill@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/element-matches-polyfill/-/element-matches-polyfill-1.0.0.tgz#3d97b361c9f8101ed1ce8bb450cef874dadda283"
+  integrity sha512-6xnaB9NpWYmSgWP1/njuCanX1nopjVZRvSivd9cX7cfURGdldeT46g+3ph1pfNNiiPvHLjfhUk/8HXQkbcu7ng==
+
 elliptic@^6.0.0:
   version "6.4.0"
   resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.4.0.tgz#cac9af8762c85836187003c8dfe193e5e2eae5df"


### PR DESCRIPTION
## Description
A long shot at figuring out whatever is going on over at https://github.com/department-of-veterans-affairs/va.gov-team/issues/6155.

There seems to be an error with the injected header on https://www.oprm.va.gov/ using IE11 on a government-issued laptop.

## Testing done
I can't because I am on a contractor Mac. But you should be able to test this by -

1. Use your government-issued laptop
1. Run the website locally with - `npm run watch -- --entry=proxy-rewrite --local-proxy-rewrite`
1. Using IE11, navigate to http://localhost:3001/?target=https://www.oprm.va.gov
1. Check for visual or console errors

## Screenshots
N/A

## Acceptance criteria
- [ ] Header isn't broken on oprm.va.gov

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
