### PR TITLE
Fixes format for facilities operating hours

### DIFF
--- a/src/applications/facility-locator/tests/helpers.unit.spec.js
+++ b/src/applications/facility-locator/tests/helpers.unit.spec.js
@@ -171,8 +171,8 @@ describe('Validate ID Strings for Breadcrumb', () => {
   });
 
   it('formatOperatingHours should convert API hour (without colon) to a human readable hour', () => {
-    const operatingHours = '800AM-430PM';
-    const expected = '8:00 a.m. - 4:30 p.m.';
+    const operatingHours = '800 AM - 430 PM';
+    const expected = '8:00a.m. - 4:30p.m.';
 
     const result = formatOperatingHours(operatingHours);
 

--- a/src/applications/facility-locator/tests/helpers.unit.spec.js
+++ b/src/applications/facility-locator/tests/helpers.unit.spec.js
@@ -172,7 +172,7 @@ describe('Validate ID Strings for Breadcrumb', () => {
 
   it('formatOperatingHours should convert API hour (without colon) to a human readable hour', () => {
     const operatingHours = '800AM-430PM';
-    const expected = '8:00a.m. - 4:30p.m.';
+    const expected = '8:00 a.m. - 4:30 p.m.';
 
     const result = formatOperatingHours(operatingHours);
 
@@ -181,7 +181,7 @@ describe('Validate ID Strings for Breadcrumb', () => {
 
   it('formatOperatingHours should convert API hour (with colon) to a human readable hour', () => {
     const operatingHours = '8:00AM-4:30PM';
-    const expected = '8:00a.m. - 4:30p.m.';
+    const expected = '8:00 a.m. - 4:30 p.m.';
 
     const result = formatOperatingHours(operatingHours);
 
@@ -189,8 +189,8 @@ describe('Validate ID Strings for Breadcrumb', () => {
   });
 
   it('formatOperatingHours should return the original string a time is invalid', () => {
-    const operatingHours = 'By Appointment only';
-    const expected = 'By Appointment only';
+    const operatingHours = '8:00am-Sunset';
+    const expected = '8:00 a.m. - Sunset';
 
     const result = formatOperatingHours(operatingHours);
 

--- a/src/applications/facility-locator/utils/helpers.js
+++ b/src/applications/facility-locator/utils/helpers.js
@@ -146,10 +146,10 @@ export const formatOperatingHours = operatingHours => {
 
   // Attempt to format the hours based on 'h:mmA' if theere's a colon.
   if (includes(openingHour, ':')) {
-    formattedOpeningHour = moment(openingHour, 'h:mmA').format('h:mma');
+    formattedOpeningHour = moment(openingHour, 'h:mmA').format('h:mm a');
   }
   if (includes(closingHour, ':')) {
-    formattedClosingHour = moment(closingHour, 'h:mmA').format('h:mma');
+    formattedClosingHour = moment(closingHour, 'h:mmA').format('h:mm a');
   }
 
   // Return original string if invalid date.
@@ -160,19 +160,6 @@ export const formatOperatingHours = operatingHours => {
   // Return original string if invalid date.
   if (formattedClosingHour.search(/Invalid date/i) === 0) {
     formattedClosingHour = closingHour;
-  }
-  // Add space in between time and format
-  if (
-    formattedOpeningHour.match(/a.m./g) &&
-    formattedOpeningHour.match(/a.m./g).length > 0
-  ) {
-    formattedOpeningHour = formattedOpeningHour.replace(/a.m./g, ' a.m.');
-  }
-  if (
-    formattedClosingHour.match(/p.m./g) &&
-    formattedClosingHour.match(/p.m./g).length > 0
-  ) {
-    formattedClosingHour = formattedClosingHour.replace(/p.m./g, ' p.m.');
   }
 
   // Derive the formatted operating hours.

--- a/src/applications/facility-locator/utils/helpers.js
+++ b/src/applications/facility-locator/utils/helpers.js
@@ -116,6 +116,8 @@ export const validateIdString = (urlObj, urlPrefixString) => {
  */
 export const formatOperatingHours = operatingHours => {
   if (!operatingHours) return operatingHours;
+  console.log({operatingHours})
+
   // Remove all whitespace.
   const sanitizedOperatingHours = replace(operatingHours, ' ', '');
 
@@ -151,13 +153,32 @@ export const formatOperatingHours = operatingHours => {
     formattedClosingHour = moment(closingHour, 'h:mmA').format('h:mma');
   }
 
-  // Derive the formatted operating hours.
-  const formattedOperatingHours = `${formattedOpeningHour} - ${formattedClosingHour}`;
+  // Return original string if invalid date.
+  if (formattedOpeningHour.search(/Invalid date/i) === 0) {
+    formattedOpeningHour = operatingHours;
+  }
 
   // Return original string if invalid date.
-  if (formattedOperatingHours.search(/Invalid date/i) === 0) {
-    return operatingHours;
+  if (formattedClosingHour.search(/Invalid date/i) === 0) {
+    formattedClosingHour = closingHour;
   }
+  // Add space in between time and format
+  if (
+    formattedOpeningHour.match(/a.m./g) &&
+    formattedOpeningHour.match(/a.m./g).length > 0
+  ) {
+    formattedOpeningHour = formattedOpeningHour.replace(/a.m./g, ' a.m.');
+  }
+  if (
+    formattedClosingHour.match(/p.m./g) &&
+    formattedClosingHour.match(/p.m./g).length > 0
+  ) {
+    formattedClosingHour = formattedClosingHour.replace(/p.m./g, ' p.m.');
+  }
+
+
+  // Derive the formatted operating hours.
+  const formattedOperatingHours = `${formattedOpeningHour} - ${formattedClosingHour}`;
 
   // Return the formatted operating hours.
   return formattedOperatingHours;

--- a/src/applications/facility-locator/utils/helpers.js
+++ b/src/applications/facility-locator/utils/helpers.js
@@ -116,7 +116,6 @@ export const validateIdString = (urlObj, urlPrefixString) => {
  */
 export const formatOperatingHours = operatingHours => {
   if (!operatingHours) return operatingHours;
-  console.log({operatingHours})
 
   // Remove all whitespace.
   const sanitizedOperatingHours = replace(operatingHours, ' ', '');
@@ -175,7 +174,6 @@ export const formatOperatingHours = operatingHours => {
   ) {
     formattedClosingHour = formattedClosingHour.replace(/p.m./g, ' p.m.');
   }
-
 
   // Derive the formatted operating hours.
   const formattedOperatingHours = `${formattedOpeningHour} - ${formattedClosingHour}`;


### PR DESCRIPTION
## Description

issues:

https://github.com/department-of-veterans-affairs/va.gov-team/issues/4000

https://github.com/department-of-veterans-affairs/va.gov-team/issues/3541

## Testing done
Locally, updated test cases


## Screenshots
<img width="1095" alt="Screen Shot 2020-03-03 at 11 56 56 AM" src="https://user-images.githubusercontent.com/100468/75804741-2484d380-5d46-11ea-9f89-eba5f7b022fe.png">

<img width="1108" alt="Screen Shot 2020-03-03 at 11 57 09 AM" src="https://user-images.githubusercontent.com/100468/75804806-3d8d8480-5d46-11ea-8d48-ff1e16e88636.png">


## Acceptance criteria
- [x] Add a space between the time and "a.m." and "p.m."
- [x] Actual Hours or String needs to be shown.


## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
