### PR TITLE
fix `copy mailing address` bugs

### DIFF
--- a/src/platform/user/profile/vet360/components/AddressField/AddressEditModal.jsx
+++ b/src/platform/user/profile/vet360/components/AddressField/AddressEditModal.jsx
@@ -113,7 +113,7 @@ class AddressEditModal extends React.Component {
     const newAddressValue = { ...this.props.field.value, ...mailingAddress };
     if (useNewAddressForm) {
       this.props.onChangeFormDataAndSchemas(
-        newAddressValue,
+        this.transformInitialFormValues(newAddressValue),
         this.props.field.formSchema,
         this.props.field.uiSchema,
       );

--- a/src/platform/user/profile/vet360/containers/CopyMailingAddress.jsx
+++ b/src/platform/user/profile/vet360/containers/CopyMailingAddress.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import isEqual from 'lodash/isEqual';
 import pick from 'lodash/pick';
+import pickBy from 'lodash/pickBy';
 
 import { isEmptyAddress } from 'platform/forms/address/helpers';
 
@@ -68,7 +69,7 @@ export function mapStateToProps(state, ownProps) {
     }
     if (useNewAddressForm) {
       return isEqual(
-        pick(mailingAddress, ADDRESS_PROPS),
+        pickBy(pick(mailingAddress, ADDRESS_PROPS), e => !!e),
         pick(residentialAddress, ADDRESS_PROPS),
       );
     }

--- a/src/platform/user/profile/vet360/tests/containers/CopyMailingAddress.unit.spec.jsx
+++ b/src/platform/user/profile/vet360/tests/containers/CopyMailingAddress.unit.spec.jsx
@@ -91,5 +91,77 @@ describe('<CopyMailingAddress/>', () => {
       const result = mapStateToProps(state, ownProps);
       expect(result.checked).to.be.true;
     });
+
+    describe('when using new address form', () => {
+      beforeEach(() => {
+        // this is real data from staging
+        state.user.profile.vet360[FIELD_NAMES.MAILING_ADDRESS] = {
+          addressLine1: '36320 Coronado Dr',
+          addressLine2: null,
+          addressLine3: null,
+          addressPou: 'CORRESPONDENCE',
+          addressType: 'DOMESTIC',
+          city: 'Fremont',
+          countryName: 'United States',
+          countryCodeIso2: 'US',
+          countryCodeIso3: 'USA',
+          countryCodeFips: null,
+          countyCode: '06001',
+          countyName: 'Alameda County',
+          createdAt: '2019-10-04T17:52:48.000Z',
+          effectiveEndDate: null,
+          effectiveStartDate: '2020-03-04T18:33:56.000Z',
+          id: 104273,
+          internationalPostalCode: null,
+          province: null,
+          sourceDate: '2020-03-04T18:33:56.000Z',
+          sourceSystemUser: null,
+          stateCode: 'CA',
+          transactionId: '17a5fa0c-36be-4ce0-960d-b06d3b297ebe',
+          updatedAt: '2020-03-04T18:33:57.000Z',
+          validationKey: null,
+          vet360Id: '139281',
+          zipCode: '94536',
+          zipCodeSuffix: '5537',
+        };
+      });
+
+      it('returns `checked` as `true` when addresses are equal', () => {
+        // This is real data from staging
+        state.vet360.formFields[FIELD_NAMES.RESIDENTIAL_ADDRESS] = {
+          value: {
+            id: 145184,
+            addressLine1: '36320 Coronado Dr',
+            addressType: 'DOMESTIC',
+            city: 'Fremont',
+            countryName: 'United States',
+            stateCode: 'CA',
+            zipCode: '94536',
+            addressPou: 'RESIDENCE/CHOICE',
+          },
+        };
+
+        const result = mapStateToProps(state, { useNewAddressForm: true });
+        expect(result.checked).to.be.true;
+      });
+
+      it('returns `checked` as `false` when addresses are not equal', () => {
+        state.vet360.formFields[FIELD_NAMES.RESIDENTIAL_ADDRESS] = {
+          value: {
+            id: 145184,
+            addressLine1: '123 Main St.',
+            addressType: 'DOMESTIC',
+            city: 'Fremont',
+            countryName: 'United States',
+            stateCode: 'CA',
+            zipCode: '94536',
+            addressPou: 'RESIDENCE/CHOICE',
+          },
+        };
+
+        const result = mapStateToProps(state, { useNewAddressForm: true });
+        expect(result.checked).to.be.false;
+      });
+    });
   });
 });


### PR DESCRIPTION
## Description
Adds proper cleanup up address data when copying a mailing address to use it as a residential address and when comparing the two types of addresses to see if they are the same.

## Testing done
confirmed locally that:
- clicking the checkbox uses the mailing address as the residential address and attempting to save the new address does not result in form validation errors
- the checkbox is prechecked when you open the residential address edit modal when the residential address is already the same as the mailing address

## Screenshots
**Copying and saving works**
![copy-and-save](https://user-images.githubusercontent.com/20728956/75811711-c5bd5b00-5d41-11ea-8fd9-6a7bd911d509.gif)

**The checkbox is preselected when it should be**
![preselected](https://user-images.githubusercontent.com/20728956/75811693-bb02c600-5d41-11ea-8d65-979811db9aa2.gif)

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs