### PR TITLE
Consolidate and update generic error messages

### DIFF
--- a/src/applications/vaos/components/EligibilityCheckMessage.jsx
+++ b/src/applications/vaos/components/EligibilityCheckMessage.jsx
@@ -1,16 +1,10 @@
 import React from 'react';
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
+import ErrorMessage from './ErrorMessage';
 
 export default function EligibilityCheckMessage({ eligibility }) {
   if (eligibility.requestFailed) {
-    return (
-      <div aria-atomic="true" aria-live="assertive">
-        <AlertBox status="error" headline="Sorry, something went wrong">
-          Sorry, we’re having trouble verifying that you can make an appointment
-          at this facility. Please try another facility.
-        </AlertBox>
-      </div>
-    );
+    return <ErrorMessage />;
   }
   if (!eligibility.requestSupported) {
     return (
@@ -63,12 +57,5 @@ export default function EligibilityCheckMessage({ eligibility }) {
     );
   }
 
-  return (
-    <div aria-atomic="true" aria-live="assertive">
-      <AlertBox status="error" headline="Sorry, something went wrong">
-        Sorry, we're having trouble verifying that you can make an appointment
-        at this facility. Please try another facility.
-      </AlertBox>
-    </div>
-  );
+  return <ErrorMessage />;
 }

--- a/src/applications/vaos/components/ErrorMessage.jsx
+++ b/src/applications/vaos/components/ErrorMessage.jsx
@@ -5,8 +5,8 @@ import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 export default function ErrorMessage() {
   return (
     <div aria-atomic="true" aria-live="assertive">
-      <AlertBox status="error" headline="Sorry, something went wrong">
-        We’re sorry, we ran into an error. Please try again later.
+      <AlertBox status="error" headline="We’re sorry. We’ve run into a problem">
+        Something went wrong on our end. Please try again later.
       </AlertBox>
     </div>
   );

--- a/src/applications/vaos/components/SingleFacilityEligibilityCheckMessage.jsx
+++ b/src/applications/vaos/components/SingleFacilityEligibilityCheckMessage.jsx
@@ -1,18 +1,12 @@
 import React from 'react';
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
+import ErrorMessage from './ErrorMessage';
 
 export default function VAFacilityInfoMessage({ facility, eligibility }) {
   let message;
 
   if (eligibility.requestFailed) {
-    return (
-      <div aria-atomic="true" aria-live="assertive">
-        <AlertBox status="error" headline="Sorry, something went wrong">
-          Sorry, we’re having trouble verifying that you can make an appointment
-          at a facility.
-        </AlertBox>
-      </div>
-    );
+    return <ErrorMessage />;
   }
 
   if (!eligibility.requestPastVisit) {
@@ -38,14 +32,7 @@ export default function VAFacilityInfoMessage({ facility, eligibility }) {
       </>
     );
   } else {
-    return (
-      <div aria-atomic="true" aria-live="assertive">
-        <AlertBox status="error" headline="Sorry, something went wrong">
-          Sorry, we’re having trouble verifying that you can make an appointment
-          at a facility.
-        </AlertBox>
-      </div>
-    );
+    return <ErrorMessage />;
   }
 
   return (

--- a/src/applications/vaos/containers/RegistrationCheck.jsx
+++ b/src/applications/vaos/containers/RegistrationCheck.jsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import LoadingIndicator from '@department-of-veterans-affairs/formation-react/LoadingIndicator';
-import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 
 import Breadcrumbs from '../components/Breadcrumbs';
 import { FETCH_STATUS } from '../utils/constants';
 import { checkRegistration } from '../actions/registration';
 import NoRegistrationMessage from '../components/NoRegistrationMessage';
+import ErrorMessage from '../components/ErrorMessage';
 
 export class RegistrationCheck extends React.Component {
   componentDidMount() {
@@ -29,12 +29,7 @@ export class RegistrationCheck extends React.Component {
 
     let errorMessage;
     if (status === FETCH_STATUS.failed) {
-      errorMessage = (
-        <AlertBox status="error" headline="Sorry, something went wrong">
-          We’re sorry, we ran into an error when trying to find your VA medical
-          facility registrations. Please try again later.
-        </AlertBox>
-      );
+      errorMessage = <ErrorMessage />;
     } else {
       errorMessage = <NoRegistrationMessage />;
     }

--- a/src/applications/vaos/tests/actions/newAppointment.unit.spec.js
+++ b/src/applications/vaos/tests/actions/newAppointment.unit.spec.js
@@ -181,8 +181,8 @@ describe('VAOS newAppointment actions', () => {
   });
 
   describe('fetchFacilityDetails', () => {
-    mockFetch();
     it('should fetch facility details', async () => {
+      mockFetch();
       setFetchJSONResponse(global.fetch, {});
       const dispatch = sinon.spy();
       const thunk = fetchFacilityDetails('123');
@@ -195,7 +195,6 @@ describe('VAOS newAppointment actions', () => {
         FORM_FETCH_FACILITY_DETAILS_SUCCEEDED,
       );
     });
-    resetFetch();
   });
 
   describe('openFacilityPage', () => {

--- a/src/applications/vaos/tests/components/EligibilityCheckMessage.unit.spec.jsx
+++ b/src/applications/vaos/tests/components/EligibilityCheckMessage.unit.spec.jsx
@@ -42,7 +42,7 @@ describe('VAOS <EligibilityCheckMessage>', () => {
 
     const tree = mount(<EligibilityCheckMessage eligibility={eligibility} />);
 
-    expect(tree.text()).to.contain('trouble verifying');
+    expect(tree.text()).to.contain('Something went wrong');
     expect(tree.find('[aria-atomic="true"]').exists()).to.be.true;
     tree.unmount();
   });
@@ -71,7 +71,7 @@ describe('VAOS <EligibilityCheckMessage>', () => {
 
     const tree = mount(<EligibilityCheckMessage eligibility={eligibility} />);
 
-    expect(tree.text()).to.contain('having trouble');
+    expect(tree.text()).to.contain('Something went wrong');
     expect(tree.find('AlertBox').props().status).to.equal('error');
     expect(tree.find('[aria-atomic="true"]').exists()).to.be.true;
     tree.unmount();

--- a/src/applications/vaos/tests/components/SingleFacilityEligibilityCheckMessage.unit.spec.jsx
+++ b/src/applications/vaos/tests/components/SingleFacilityEligibilityCheckMessage.unit.spec.jsx
@@ -60,7 +60,7 @@ describe('VAOS <SingleFacilityEligibilityCheckMessage>', () => {
       />,
     );
 
-    expect(tree.text()).to.contain('trouble verifying');
+    expect(tree.text()).to.contain('Something went wrong');
     expect(tree.find('AlertBox').props().status).to.equal('error');
     expect(tree.find('[aria-atomic="true"]').exists()).to.be.true;
     tree.unmount();
@@ -102,7 +102,7 @@ describe('VAOS <SingleFacilityEligibilityCheckMessage>', () => {
       />,
     );
 
-    expect(tree.text()).to.contain('trouble verifying');
+    expect(tree.text()).to.contain('Something went wrong');
     expect(tree.find('AlertBox').props().status).to.equal('error');
     expect(tree.find('[aria-atomic="true"]').exists()).to.be.true;
     tree.unmount();

--- a/src/applications/vaos/tests/containers/RegistrationCheck.unit.spec.jsx
+++ b/src/applications/vaos/tests/containers/RegistrationCheck.unit.spec.jsx
@@ -31,7 +31,7 @@ describe('VAOS <RegistrationCheck>', () => {
     );
 
     expect(tree.find('LoadingIndicator').exists()).to.be.false;
-    expect(tree.find('AlertBox').exists()).to.be.true;
+    expect(tree.find('ErrorMessage').exists()).to.be.true;
     tree.unmount();
   });
 


### PR DESCRIPTION
## Description
This consolidates some of our generic error messages into a single component with the updated copy from the content team.

## Testing done
Local testing

## Screenshots
![Screen Shot 2020-03-03 at 2 07 36 PM](https://user-images.githubusercontent.com/634932/75810312-5b63e500-5d58-11ea-8c68-dbd1d6e6527d.png)

## Acceptance criteria
- [ ] Generic error message copy updated

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
