### PR TITLE
6014 686 add spouse unit tests p1

### DIFF
--- a/src/applications/disability-benefits/new-686/config/chapters/report-add-a-spouse/spouse-information/spouseInformation.js
+++ b/src/applications/disability-benefits/new-686/config/chapters/report-add-a-spouse/spouse-information/spouseInformation.js
@@ -65,9 +65,11 @@ export const uiSchema = {
   isSpouseVeteran: {
     'ui:title': 'Is your spouse a veteran?',
     'ui:widget': 'yesNo',
+    'ui:required': formData => isChapterFieldRequired(formData, 'addSpouse'),
   },
   spouseVAFileNumber: {
     'ui:title': 'Spouse’s VA file number',
+    'ui:errorMessages': { pattern: 'Please enter a valid VA File number' },
     'ui:options': {
       widgetClassNames: 'usa-input-medium',
       expandUnder: 'isSpouseVeteran',
@@ -75,6 +77,7 @@ export const uiSchema = {
   },
   spouseServiceNumber: {
     'ui:title': 'Spouse’s service number',
+    'ui:errorMessages': { pattern: 'Please enter a valid Service Number' },
     'ui:options': {
       widgetClassNames: 'usa-input-medium',
       expandUnder: 'isSpouseVeteran',

--- a/src/applications/disability-benefits/new-686/tests/config/currentMarriageInformation.unit.spec.jsx
+++ b/src/applications/disability-benefits/new-686/tests/config/currentMarriageInformation.unit.spec.jsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { mount } from 'enzyme';
+import { changeDropdown } from '../helpers/index.js';
+import {
+  DefinitionTester,
+  fillData,
+  selectRadio,
+} from 'platform/testing/unit/schemaform-utils.jsx';
+
+import formConfig from '../../config/form';
+
+describe('686 current marriage information', () => {
+  const {
+    schema,
+    uiSchema,
+  } = formConfig.chapters.addSpouse.pages.currentMarriageInformation;
+
+  const formData = {
+    'view:selectable686Options': {
+      addSpouse: true,
+    },
+  };
+
+  it('should render', () => {
+    const form = mount(
+      <DefinitionTester
+        schema={schema}
+        uiSchema={uiSchema}
+        definitions={formConfig.defaultDefinitions}
+        data={formData}
+      />,
+    );
+    expect(form.find('input').length).to.equal(8);
+    form.unmount();
+  });
+
+  it('should not submit without all required fields', () => {
+    const onSubmit = sinon.spy();
+    const form = mount(
+      <DefinitionTester
+        schema={schema}
+        uiSchema={uiSchema}
+        definitions={formConfig.defaultDefinitions}
+        data={formData}
+        onSubmit={onSubmit}
+      />,
+    );
+    form.find('form').simulate('submit');
+    expect(form.find('.usa-input-error').length).to.equal(4);
+    expect(onSubmit.called).to.be.false;
+    form.unmount();
+  });
+
+  it('should submit with all required fields', () => {
+    const onSubmit = sinon.spy();
+    const form = mount(
+      <DefinitionTester
+        schema={schema}
+        uiSchema={uiSchema}
+        definitions={formConfig.defaultDefinitions}
+        data={formData}
+        onSubmit={onSubmit}
+      />,
+    );
+    changeDropdown(form, 'select#root_dateOfMarriageMonth', 1);
+    changeDropdown(form, 'select#root_dateOfMarriageDay', 1);
+    fillData(form, 'input#root_dateOfMarriageYear', '2010');
+    fillData(form, 'input#root_locationOfMarriage_state', 'California');
+    fillData(form, 'input#root_locationOfMarriage_city', 'Los Angeles');
+    selectRadio(form, 'root_marriageType', 'CEREMONIAL');
+    form.find('form').simulate('submit');
+    expect(form.find('.usa-input-error').length).to.equal(0);
+    expect(onSubmit.called).to.be.true;
+    form.unmount();
+  });
+});

--- a/src/applications/disability-benefits/new-686/tests/config/currentSpouseInformation.unit.spec.jsx
+++ b/src/applications/disability-benefits/new-686/tests/config/currentSpouseInformation.unit.spec.jsx
@@ -1,0 +1,103 @@
+import React from 'react';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { mount } from 'enzyme';
+import { changeDropdown } from '../helpers/index.js';
+import {
+  DefinitionTester,
+  fillData,
+  selectRadio,
+} from 'platform/testing/unit/schemaform-utils.jsx';
+
+import formConfig from '../../config/form';
+
+describe('686 current spouse information', () => {
+  const {
+    schema,
+    uiSchema,
+  } = formConfig.chapters.addSpouse.pages.spouseNameInformation;
+
+  const formData = {
+    'view:selectable686Options': {
+      addSpouse: true,
+    },
+  };
+
+  const onSubmit = sinon.spy();
+
+  it('should render', () => {
+    const form = mount(
+      <DefinitionTester
+        schema={schema}
+        uiSchema={uiSchema}
+        definitions={formConfig.defaultDefinitions}
+        data={formData}
+      />,
+    );
+    expect(form.find('input').length).to.equal(7);
+    form.unmount();
+  });
+
+  it('should not submit without required fields', () => {
+    const form = mount(
+      <DefinitionTester
+        schema={schema}
+        uiSchema={uiSchema}
+        definitions={formConfig.defaultDefinitions}
+        data={formData}
+        onSubmit={onSubmit}
+      />,
+    );
+    form.find('form').simulate('submit');
+    expect(form.find('.usa-input-error').length).to.equal(5);
+    expect(onSubmit.called).to.be.false;
+    form.unmount();
+  });
+
+  it('should submit with valid information for non-veteran spouse', () => {
+    const form = mount(
+      <DefinitionTester
+        schema={schema}
+        uiSchema={uiSchema}
+        definitions={formConfig.defaultDefinitions}
+        data={formData}
+        onSubmit={onSubmit}
+      />,
+    );
+    fillData(form, 'input#root_spouseFullName_first', 'Jane');
+    fillData(form, 'input#root_spouseFullName_last', 'Doe');
+    fillData(form, 'input#root_spouseSSN', '123-12-1234');
+    changeDropdown(form, 'select#root_spouseDOBMonth', 1);
+    changeDropdown(form, 'select#root_spouseDOBDay', 1);
+    fillData(form, 'input#root_spouseDOBYear', '1991');
+    selectRadio(form, 'root_isSpouseVeteran', 'N');
+    form.find('form').simulate('submit');
+    expect(form.find('.usa-input-error').length).to.equal(0);
+    expect(onSubmit.called).to.be.true;
+    form.unmount();
+  });
+
+  it('should submit with valid information for a veteran spouse', () => {
+    const form = mount(
+      <DefinitionTester
+        schema={schema}
+        uiSchema={uiSchema}
+        definitions={formConfig.defaultDefinitions}
+        data={formData}
+        onSubmit={onSubmit}
+      />,
+    );
+    fillData(form, 'input#root_spouseFullName_first', 'Jane');
+    fillData(form, 'input#root_spouseFullName_last', 'Doe');
+    fillData(form, 'input#root_spouseSSN', '123-12-1234');
+    changeDropdown(form, 'select#root_spouseDOBMonth', 1);
+    changeDropdown(form, 'select#root_spouseDOBDay', 1);
+    fillData(form, 'input#root_spouseDOBYear', '1991');
+    selectRadio(form, 'root_isSpouseVeteran', 'Y');
+    fillData(form, 'input#root_spouseVAFileNumber', '123455');
+    form.find('form').simulate('submit');
+    expect(form.find('.usa-input-error').length).to.equal(0);
+    expect(onSubmit.called).to.be.true;
+    form.unmount();
+  });
+});

--- a/src/applications/disability-benefits/new-686/tests/config/currentSpouseInformation.unit.spec.jsx
+++ b/src/applications/disability-benefits/new-686/tests/config/currentSpouseInformation.unit.spec.jsx
@@ -23,8 +23,6 @@ describe('686 current spouse information', () => {
     },
   };
 
-  const onSubmit = sinon.spy();
-
   it('should render', () => {
     const form = mount(
       <DefinitionTester
@@ -39,6 +37,7 @@ describe('686 current spouse information', () => {
   });
 
   it('should not submit without required fields', () => {
+    const onSubmit = sinon.spy();
     const form = mount(
       <DefinitionTester
         schema={schema}
@@ -55,6 +54,7 @@ describe('686 current spouse information', () => {
   });
 
   it('should submit with valid information for non-veteran spouse', () => {
+    const onSubmit = sinon.spy();
     const form = mount(
       <DefinitionTester
         schema={schema}
@@ -78,6 +78,7 @@ describe('686 current spouse information', () => {
   });
 
   it('should submit with valid information for a veteran spouse', () => {
+    const onSubmit = sinon.spy();
     const form = mount(
       <DefinitionTester
         schema={schema}

--- a/src/applications/disability-benefits/new-686/tests/config/doesLiveWithSpouse.unit.spec.jsx
+++ b/src/applications/disability-benefits/new-686/tests/config/doesLiveWithSpouse.unit.spec.jsx
@@ -1,0 +1,122 @@
+import React from 'react';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { mount } from 'enzyme';
+import { changeDropdown } from '../helpers/index.js';
+import {
+  DefinitionTester,
+  fillData,
+  selectRadio,
+} from 'platform/testing/unit/schemaform-utils.jsx';
+
+import formConfig from '../../config/form';
+
+describe('686 current marriage co-habitation status', () => {
+  const {
+    schema,
+    uiSchema,
+  } = formConfig.chapters.addSpouse.pages.doesLiveWithSpouse;
+
+  const formData = {
+    'view:selectable686Options': {
+      addSpouse: true,
+    },
+  };
+
+  it('should render', () => {
+    const form = mount(
+      <DefinitionTester
+        schema={schema}
+        uiSchema={uiSchema}
+        definitions={formConfig.defaultDefinitions}
+        data={formData}
+      />,
+    );
+    expect(form.find('input').length).to.equal(2);
+    form.unmount();
+  });
+
+  it('should submit when spouse and veteran live together', () => {
+    const onSubmit = sinon.spy();
+    const form = mount(
+      <DefinitionTester
+        schema={schema}
+        uiSchema={uiSchema}
+        definitions={formConfig.defaultDefinitions}
+        data={formData}
+        onSubmit={onSubmit}
+      />,
+    );
+    selectRadio(form, 'root_spouseDoesLiveWithVeteran', 'Y');
+    form.find('form').simulate('submit');
+    expect(form.find('.usa-input-error').length).to.equal(0);
+    expect(onSubmit.called).to.be.true;
+    form.unmount();
+  });
+
+  it('should require spouse address if they live apart', () => {
+    const onSubmit = sinon.spy();
+    const form = mount(
+      <DefinitionTester
+        schema={schema}
+        uiSchema={uiSchema}
+        definitions={formConfig.defaultDefinitions}
+        data={formData}
+        onSubmit={onSubmit}
+      />,
+    );
+    selectRadio(form, 'root_spouseDoesLiveWithVeteran', 'N');
+    form.find('form').simulate('submit');
+    expect(form.find('.usa-input-error').length).to.equal(6);
+    expect(onSubmit.called).to.be.false;
+    form.unmount();
+  });
+
+  it('should submit when spouse lives apart with all necessary information', () => {
+    const onSubmit = sinon.spy();
+    const form = mount(
+      <DefinitionTester
+        schema={schema}
+        uiSchema={uiSchema}
+        definitions={formConfig.defaultDefinitions}
+        data={formData}
+        onSubmit={onSubmit}
+      />,
+    );
+    selectRadio(form, 'root_spouseDoesLiveWithVeteran', 'N');
+    fillData(
+      form,
+      'input#root_currentSpouseReasonForSeparation',
+      'This is an explanation',
+    );
+    changeDropdown(
+      form,
+      'select#root_currentSpouseAddress_currentSpouseCountry',
+      'United States',
+    );
+    fillData(
+      form,
+      'input#root_currentSpouseAddress_currentSpouseStreet',
+      '123 Back St',
+    );
+    fillData(
+      form,
+      'input#root_currentSpouseAddress_currentSpouseCity',
+      'SomeCity',
+    );
+    fillData(
+      form,
+      'input#root_currentSpouseAddress_currentSpouseState',
+      'SomeState',
+    );
+    fillData(
+      form,
+      'input#root_currentSpouseAddress_currentSpousePostalCode',
+      '12345',
+    );
+    form.find('form').simulate('submit');
+    expect(form.find('.usa-input-error').length).to.equal(0);
+    expect(onSubmit.called).to.be.true;
+    form.unmount();
+  });
+});


### PR DESCRIPTION
## Description
[Original ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/6014)

This pull request adds unit tests for the first three pages of the `add a spouse` workflow for the 686. It is directly related to [this pull request](https://github.com/department-of-veterans-affairs/vets-website/pull/11791) that was merged in previously. 

## Testing done
- local, all new unit tests pass.

## Screenshots
- Spouse Information:
![Screen Shot 2020-03-03 at 12 08 26 PM](https://user-images.githubusercontent.com/15097156/75815906-11273780-5d49-11ea-9c22-58e97427a3c7.png)
- Marriage Information:
![Screen Shot 2020-03-03 at 12 08 06 PM](https://user-images.githubusercontent.com/15097156/75815948-213f1700-5d49-11ea-8f65-3c48870d8d36.png)
- Marriage habitation Information:
![Screen Shot 2020-03-03 at 12 07 47 PM](https://user-images.githubusercontent.com/15097156/75815990-3320ba00-5d49-11ea-8eec-296c58e2ad32.png)


## Acceptance criteria
- [x] all unit tests pass.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
