### PR TITLE
bradl3yC - 6156 - Add focus back to edit link after transaction

### DIFF
--- a/src/platform/user/profile/vet360/components/base/Vet360ProfileFieldHeading.jsx
+++ b/src/platform/user/profile/vet360/components/base/Vet360ProfileFieldHeading.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-function Vet360ProfileFieldHeading({ children, onEditClick }) {
+function Vet360ProfileFieldHeading({ children, onEditClick, fieldName }) {
   return (
     <div>
       <h3 style={{ display: 'inline-block' }}>{children}</h3>{' '}
@@ -11,6 +11,7 @@ function Vet360ProfileFieldHeading({ children, onEditClick }) {
           type="button"
           data-action="edit"
           onClick={onEditClick}
+          id={fieldName}
           className="va-button-link va-profile-btn"
         >
           Edit

--- a/src/platform/user/profile/vet360/components/base/Vet360ProfileFieldHeading.jsx
+++ b/src/platform/user/profile/vet360/components/base/Vet360ProfileFieldHeading.jsx
@@ -11,7 +11,7 @@ function Vet360ProfileFieldHeading({ children, onEditClick, fieldName }) {
           type="button"
           data-action="edit"
           onClick={onEditClick}
-          id={fieldName}
+          id={`${fieldName}-edit-link`}
           className="va-button-link va-profile-btn"
         >
           Edit

--- a/src/platform/user/profile/vet360/containers/Vet360ProfileField.jsx
+++ b/src/platform/user/profile/vet360/containers/Vet360ProfileField.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import { focusElement } from 'platform/utilities/ui';
 
 import recordEvent from 'platform/monitoring/record-event';
 
@@ -45,12 +46,7 @@ class Vet360ProfileField extends React.Component {
 
   componentDidUpdate(prevProps) {
     if (prevProps.transaction && !this.props.transaction) {
-      const editButton = document.querySelector(
-        `button#${this.props.fieldName}-edit-link`,
-      );
-      if (editButton) {
-        editButton.focus();
-      }
+      focusElement(`button#${this.props.fieldName}-edit-link`);
     }
   }
 

--- a/src/platform/user/profile/vet360/containers/Vet360ProfileField.jsx
+++ b/src/platform/user/profile/vet360/containers/Vet360ProfileField.jsx
@@ -43,6 +43,12 @@ class Vet360ProfileField extends React.Component {
     transactionRequest: PropTypes.object,
   };
 
+  componentDidUpdate(prevProps) {
+    if (prevProps.transaction && !this.props.transaction) {
+      document.querySelector(`button#${this.props.fieldName}`).focus();
+    }
+  }
+
   onAdd = () => {
     this.captureEvent('add-link');
     this.openEditModal();
@@ -196,6 +202,7 @@ class Vet360ProfileField extends React.Component {
       <div className="vet360-profile-field" data-field-name={fieldName}>
         <Vet360ProfileFieldHeading
           onEditClick={this.isEditLinkVisible() ? this.onEdit : null}
+          fieldName={fieldName}
         >
           {title}
         </Vet360ProfileFieldHeading>

--- a/src/platform/user/profile/vet360/containers/Vet360ProfileField.jsx
+++ b/src/platform/user/profile/vet360/containers/Vet360ProfileField.jsx
@@ -45,7 +45,12 @@ class Vet360ProfileField extends React.Component {
 
   componentDidUpdate(prevProps) {
     if (prevProps.transaction && !this.props.transaction) {
-      document.querySelector(`button#${this.props.fieldName}`).focus();
+      const editButton = document.querySelector(
+        `button#${this.props.fieldName}`,
+      );
+      if (editButton) {
+        editButton.focus();
+      }
     }
   }
 

--- a/src/platform/user/profile/vet360/containers/Vet360ProfileField.jsx
+++ b/src/platform/user/profile/vet360/containers/Vet360ProfileField.jsx
@@ -46,7 +46,7 @@ class Vet360ProfileField extends React.Component {
   componentDidUpdate(prevProps) {
     if (prevProps.transaction && !this.props.transaction) {
       const editButton = document.querySelector(
-        `button#${this.props.fieldName}`,
+        `button#${this.props.fieldName}-edit-link`,
       );
       if (editButton) {
         editButton.focus();


### PR DESCRIPTION
## Description
After using address validation modal and successfully updating an address, the focus was returning to the body and not the edit button.  This is due to the edit link being removed from the DOM during the transaction.  

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
