### PR TITLE
[Due 3/10] Disability Legacy URLs based on rewriting work

### DIFF
--- a/src/applications/proxy-rewrite/redirects/crossDomainRedirects.json
+++ b/src/applications/proxy-rewrite/redirects/crossDomainRedirects.json
@@ -523,5 +523,50 @@
     "domain": "www.benefits.va.gov",
     "src": "/gibill/careerscope.asp",
     "dest": "/careers-employment/careerscope-skills-assessment/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/compensation/rates-index.asp",
+    "dest": "/disability/compensation-rates/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/compensation/resources-rates-read-compAndSMC.asp",
+    "dest": "/disability/compensation-rates/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/compensation/read_rates.asp",
+    "dest": "/disability/compensation-rates/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/compensation/resources_comp01.asp",
+    "dest": "/disability/compensation-rates/veteran-rates/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/compensation/resources_comp02.asp",
+    "dest": "/disability/compensation-rates/special-monthly-compensation-rates/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/compensation/special_Benefit_Allowances_2018.asp",
+    "dest": "/disability/compensation-rates/special-benefit-allowance-rates/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/compensation/sb2018.asp",
+    "dest": "/disability/compensation-rates/birth-defect-rates/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/compensation/claimexam.asp",
+    "dest": "/disability/va-claim-exam/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/compensation/add-dependents.asp",
+    "dest": "/disability/add-remove-dependent/"
   }
 ]


### PR DESCRIPTION
## Description
Implements a bunch of redirects per ticket.

| Src | dest |
| -- | -- |
https://www.benefits.va.gov/compensation/rates-index.asp | https://www.va.gov/disability/compensation-rates/
https://www.benefits.va.gov/compensation/resources-rates-read-compAndSMC.asp | https://www.va.gov/disability/compensation-rates/
https://www.benefits.va.gov/compensation/read_rates.asp | https://www.va.gov/disability/compensation-rates/
https://www.benefits.va.gov/compensation/resources_comp01.asp | https://www.va.gov/disability/compensation-rates/veteran-rates/
https://www.benefits.va.gov/compensation/resources_comp02.asp | https://www.va.gov/disability/compensation-rates/special-monthly-compensation-rates/
https://www.benefits.va.gov/compensation/special_Benefit_Allowances_2018.asp | https://www.va.gov/disability/compensation-rates/special-benefit-allowance-rates/
https://www.benefits.va.gov/compensation/sb2018.asp | https://www.va.gov/disability/compensation-rates/birth-defect-rates/
https://www.benefits.va.gov/compensation/claimexam.asp | https://www.va.gov/disability/va-claim-exam/
https://benefits.va.gov/compensation/add-dependents.asp | https://www.va.gov/disability/add-remove-dependent/



Ticket - https://github.com/department-of-veterans-affairs/va.gov-team/issues/6087

## Screenshots
N/A

## Acceptance criteria
- [ ] Redirects are implemented on the scheduled date

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
