### PR TITLE
Update help content for VAOS

### DIFF
--- a/src/applications/vaos/components/NeedHelp.jsx
+++ b/src/applications/vaos/components/NeedHelp.jsx
@@ -11,13 +11,14 @@ export default function NeedHelp() {
         For help scheduling a VA or Community Care appointment, or if you have
         questions about enrollment or eligibility, please call{' '}
         <a href="tel:8774705947">877-470-5947</a> (if you have hearing loss,
-        call TTY: 711). We’re here Monday &ndash; Friday, 8 a.m. to 8 p.m. ET.
+        call TTY: 711). We’re here Monday &ndash; Friday, 8:00 a.m. to 8:00 p.m.
+        ET.
       </p>
       <p className="vads-u-margin-top--0">
         For questions about joining a VA Video Connect appointment, please call{' '}
         <a href="tel:8666513180">866-651-3180</a> (if you have hearing loss,
-        call TTY: 711). We’re here Monday &ndash; Saturday, 7 a.m. to 11 p.m.
-        ET.
+        call TTY: 711). We’re here Monday &ndash; Saturday, 7:00 a.m. to 11:00
+        p.m. ET.
       </p>
       <p className="vads-u-margin-top--0">
         <a

--- a/src/applications/vaos/components/NeedHelp.jsx
+++ b/src/applications/vaos/components/NeedHelp.jsx
@@ -8,49 +8,35 @@ export default function NeedHelp() {
       </h2>
       <hr className="vads-u-margin-y--1p5 vads-u-border-color--primary" />
       <p className="vads-u-margin-top--0">
-        For help scheduling an appointment, or if you have questions about
-        enrollment or eligibility, please call:
+        For help scheduling a VA or Community Care appointment, or if you have
+        questions about enrollment or eligibility, please call{' '}
+        <a href="tel:8774705947">877-470-5947</a> (if you have hearing loss,
+        call TTY: 711). We’re here Monday &ndash; Friday, 8 a.m. to 8 p.m. ET.
       </p>
-      <div className="vads-u-display--flex">
-        <ul className="usa-unstyled-list vads-u-flex--1">
-          <li>VA facility and Community Care appointments:</li>
-          <li>
-            <a href="tel:8772228387" className="vads-u-font-weight--bold">
-              877-222-8387
-            </a>
-          </li>
-          <li>
-            TTY:{' '}
-            <a href="tel:8008778339" className="vads-u-font-weight--bold">
-              800-877-8339
-            </a>
-          </li>
-          <li>Monday &ndash; Friday, 8:00 a.m. &ndash; 8:00 p.m. ET</li>
-        </ul>
-        <ul className="usa-unstyled-list vads-u-padding-left--4">
-          <li>VA Video Connect appointments:</li>
-          <li>
-            <a href="tel:8772228387" className="vads-u-font-weight--bold">
-              877-222-8387
-            </a>
-          </li>
-          <li>
-            TTY:{' '}
-            <a href="tel:8008778339" className="vads-u-font-weight--bold">
-              800-877-8339
-            </a>
-          </li>
-          <li>Monday &ndash; Friday, 8:00 a.m. &ndash; 8:00 p.m. ET</li>
-        </ul>
-      </div>
-      <a
-        href="https://veteran.apps.va.gov/feedback-web/v1/?appId=85870ADC-CC55-405E-9AC3-976A92BBBBEE"
-        className="vads-u-display--block vads-u-margin-top--2"
-        target="_blank"
-        rel="noopener noreferrer"
-      >
-        Leave feedback for this application
-      </a>
+      <p className="vads-u-margin-top--0">
+        For questions about joining a VA Video Connect appointment, please call{' '}
+        <a href="tel:8666513180">866-651-3180</a> (if you have hearing loss,
+        call TTY: 711). We’re here Monday &ndash; Saturday, 7 a.m. to 11 p.m.
+        ET.
+      </p>
+      <p className="vads-u-margin-top--0">
+        <a
+          href="https://veteran.apps.va.gov/feedback-web/v1/?appId=85870ADC-CC55-405E-9AC3-976A92BBBBEE"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Leave feedback for this application
+        </a>
+      </p>
+      <p>
+        <a
+          href="https://veteran.mobile.va.gov/var/v4/"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Go back to the old VA appointment tool
+        </a>
+      </p>
     </div>
   );
 }

--- a/src/applications/vaos/components/NeedHelp.jsx
+++ b/src/applications/vaos/components/NeedHelp.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import recordEvent from 'platform/monitoring/record-event';
 
 export default function NeedHelp() {
   return (
@@ -34,6 +35,9 @@ export default function NeedHelp() {
           href="https://veteran.mobile.va.gov/var/v4/"
           target="_blank"
           rel="noopener noreferrer"
+          onClick={() =>
+            recordEvent({ event: 'vaos-return-to-legacy-link-clicked' })
+          }
         >
           Go back to the old VA appointment tool
         </a>

--- a/src/applications/vaos/containers/AppointmentsPage.jsx
+++ b/src/applications/vaos/containers/AppointmentsPage.jsx
@@ -20,6 +20,7 @@ import { FETCH_STATUS, APPOINTMENT_TYPES, GA_PREFIX } from '../utils/constants';
 import CancelAppointmentModal from '../components/CancelAppointmentModal';
 import { getCancelInfo, vaosCancel, vaosRequests } from '../utils/selectors';
 import { scrollAndFocus } from '../utils/scrollAndFocus';
+import NeedHelp from '../components/NeedHelp';
 
 const pageTitle = 'VA appointments';
 
@@ -200,6 +201,7 @@ export class AppointmentsPage extends Component {
               Upcoming appointments
             </h2>
             {content}
+            <NeedHelp />
           </div>
         </div>
         <CancelAppointmentModal

--- a/src/applications/vaos/tests/components/NeedHelp.unit.spec.jsx
+++ b/src/applications/vaos/tests/components/NeedHelp.unit.spec.jsx
@@ -9,28 +9,20 @@ describe('VAOS <NeedHelp>', () => {
     const tree = shallow(<NeedHelp />);
 
     expect(tree.find('h2').text()).to.contain('Need help?');
-    expect(tree.hasClass('vads-u-margin-top--9')).to.equal(true);
+    expect(tree.hasClass('vads-u-margin-top--9')).be.true;
 
     const links = tree.find('a');
-    expect(links.length).to.equal(5);
-    expect(links.at(0).props().href).to.equal('tel:8772228387');
-    expect(links.at(0).text()).to.equal('877-222-8387');
-    expect(links.at(1).props().href).to.equal('tel:8008778339');
-    expect(links.at(1).text()).to.equal('800-877-8339');
-    expect(links.at(2).props().href).to.equal('tel:8772228387');
-    expect(links.at(2).text()).to.equal('877-222-8387');
-    expect(links.at(3).props().href).to.equal('tel:8008778339');
-    expect(links.at(3).text()).to.equal('800-877-8339');
-    expect(links.at(4).props().href).to.equal(
+    expect(links.length).to.equal(4);
+    expect(links.at(0).props().href).to.equal('tel:8774705947');
+    expect(links.at(0).text()).to.equal('877-470-5947');
+    expect(links.at(1).props().href).to.equal('tel:8666513180');
+    expect(links.at(1).text()).to.equal('866-651-3180');
+    expect(links.at(2).props().href).to.equal(
       'https://veteran.apps.va.gov/feedback-web/v1/?appId=85870ADC-CC55-405E-9AC3-976A92BBBBEE',
     );
-    expect(links.at(4).text()).to.equal('Leave feedback for this application');
-    tree.unmount();
-  });
-  it('should render extra margin space', () => {
-    const tree = shallow(<NeedHelp />);
-
-    expect(tree.hasClass('vads-u-margin-top--9')).to.equal(true);
+    expect(links.at(3).props().href).to.equal(
+      'https://veteran.mobile.va.gov/var/v4/',
+    );
     tree.unmount();
   });
 });


### PR DESCRIPTION
## Description
This is still tentative, but these are the help component text updates that we know of right now. Numbers may change. I've also added the footer to the bottom of the appointments page.

## Testing done
Local testing

## Screenshots
![Screen Shot 2020-03-04 at 4 15 14 PM](https://user-images.githubusercontent.com/634932/75923595-693a6880-5e33-11ea-94c0-2a022e4dd083.png)

## Acceptance criteria
- [ ] Help content looks correct

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
