### PR TITLE
bradl3yC - 6511 - Revert breaking UX change to modal open and close behavior

### DIFF
--- a/src/platform/user/profile/vet360/containers/AddressValidationModal.jsx
+++ b/src/platform/user/profile/vet360/containers/AddressValidationModal.jsx
@@ -86,10 +86,9 @@ class AddressValidationModal extends React.Component {
       return (
         <button
           className="usa-button-primary"
-          onClick={() => {
-            this.props.closeModal();
-            this.props.openModal(addressValidationType, addressFromUser);
-          }}
+          onClick={() =>
+            this.props.openModal(addressValidationType, addressFromUser)
+          }
         >
           Edit Address
         </button>
@@ -162,13 +161,9 @@ class AddressValidationModal extends React.Component {
               showEditLink && (
                 <button
                   className="va-button-link"
-                  onClick={() => {
-                    this.props.closeModal();
-                    this.props.openModal(
-                      addressValidationType,
-                      addressFromUser,
-                    );
-                  }}
+                  onClick={() =>
+                    this.props.openModal(addressValidationType, addressFromUser)
+                  }
                 >
                   Edit Address
                 </button>
@@ -225,10 +220,9 @@ class AddressValidationModal extends React.Component {
           headline={addressValidationMessage.headline}
         >
           <addressValidationMessage.ModalText
-            editFunction={() => {
-              this.props.closeModal();
-              this.props.openModal(addressValidationType, addressFromUser);
-            }}
+            editFunction={() =>
+              this.props.openModal(addressValidationType, addressFromUser)
+            }
           />
         </AlertBox>
         <form onSubmit={this.onSubmit}>

--- a/src/platform/user/profile/vet360/reducers/index.js
+++ b/src/platform/user/profile/vet360/reducers/index.js
@@ -222,7 +222,6 @@ export default function vet360(state = initialState, action) {
           ...state.fieldTransactionMap,
           [action.fieldName]: { isPending: true },
         },
-        modal: null,
       };
 
     case ADDRESS_VALIDATION_CONFIRM:

--- a/src/platform/user/profile/vet360/tests/reducers/index.unit.spec.js
+++ b/src/platform/user/profile/vet360/tests/reducers/index.unit.spec.js
@@ -465,7 +465,6 @@ describe('vet360 reducer', () => {
         fieldTransactionMap: {
           mailingAddress: { isPending: true },
         },
-        modal: null,
       };
       expect(vet360(state, action)).to.eql(expectedState);
     });


### PR DESCRIPTION
## Description
During the course of trying to fix screen readers being able to properly translate the address validation modal, a change was introduced to explicitly close one modal before transitioning to the next.  This caused a breaking change to the UX where there is no visual cues that any transactions were in flight / waiting on a response

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
