### PR TITLE
Update HLR form entry path

### DIFF
--- a/src/applications/disability-benefits/996/constants.js
+++ b/src/applications/disability-benefits/996/constants.js
@@ -1,6 +1,6 @@
 // Same as "rootUrl" in manifest.json
 export const BASE_URL =
-  '/disability-benefits/apply/form-0996-higher-level-review';
+  '/decision-reviews/higher-level-review/request-higher-level-review-form-20-0996';
 
 export const FORM_URL = 'https://www.vba.va.gov/pubs/forms/VBA-20-0996-ARE.pdf';
 

--- a/src/applications/disability-benefits/996/containers/ConfirmationPage.jsx
+++ b/src/applications/disability-benefits/996/containers/ConfirmationPage.jsx
@@ -67,7 +67,7 @@ export class ConfirmationPage extends React.Component {
         <p>
           When your review is complete, VA will mail you a decision packet that
           includes details about the decision on your case.{' '}
-          <a href="https://www.va.gov/decision-reviews/after-you-request-review/">
+          <a href="/decision-reviews/after-you-request-review/">
             Learn more about what happens after you request a review
           </a>
           .

--- a/src/applications/disability-benefits/996/manifest.json
+++ b/src/applications/disability-benefits/996/manifest.json
@@ -2,20 +2,28 @@
   "appName": "Request for Higher-Level Review",
   "entryFile": "./form-entry.jsx",
   "entryName": "0996-higher-level-review",
-  "rootUrl": "/disability-benefits/apply/form-0996-higher-level-review",
+  "rootUrl": "/decision-reviews/higher-level-review/request-higher-level-review-form-20-0996",
   "production": false,
   "template": {
     "title": "Request a Higher-Level Review",
     "heading": "Request a Higher-Level Review",
     "display_title": "Request a Higher-Level Review",
     "layout": "page-react.html",
-    "description": "Apply online to request a higher-level review.",
+    "description": "Apply online to request a Higher-Level Review.",
     "includeBreadcrumbs": true,
     "vagovprod": false,
     "breadcrumbs_override": [
       {
+        "name": "VA decision review and appeals",
+        "path": "decision-reviews"
+      },
+      {
+        "name": "Higher-Level Review",
+        "path": "decision-reviews/higher-level-review/"
+      },
+      {
         "name": "Request a Higher-Level Review",
-        "path": "disability-benefits/apply/form-0996-higher-level-review"
+        "path": "decision-reviews/higher-level-review/request-higher-level-review-form-20-0996"
       }
     ]
   }


### PR DESCRIPTION
## Description

Update Higher-Level Review form entry URL per IA recommendation in https://github.com/department-of-veterans-affairs/va.gov-team/issues/4718; also update the breadcrumbs.

Previous relative URL: `/disability-benefits/apply/form-0996-higher-level-review`
New relative URL: `/decision-reviews/higher-level-review/request-higher-level-review-form-20-0996`

There is no need to start a redirect request process because this form isn't live in production.

## Testing done

Local unit tests

## Screenshots

N/A

## Acceptance criteria

- [ ] HLR form path has been updated
- [ ] Updated breadcrumbs
- [ ] Interested parties have been informed of the update (will `@here` in our Slack channel. 

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
