### PR TITLE
Add welcome modal to VAOS

### DIFF
--- a/src/applications/vaos/containers/AppointmentsPage.jsx
+++ b/src/applications/vaos/containers/AppointmentsPage.jsx
@@ -22,7 +22,7 @@ import {
   getCancelInfo,
   vaosCancel,
   vaosRequests,
-  isWelcomeModalDimissed,
+  isWelcomeModalDismissed,
 } from '../utils/selectors';
 import { scrollAndFocus } from '../utils/scrollAndFocus';
 
@@ -30,7 +30,7 @@ const pageTitle = 'VA appointments';
 
 export class AppointmentsPage extends Component {
   componentDidMount() {
-    if (this.props.isWelcomeModalDimissed) {
+    if (this.props.isWelcomeModalDismissed) {
       scrollAndFocus();
     }
     this.props.fetchFutureAppointments();
@@ -39,8 +39,8 @@ export class AppointmentsPage extends Component {
 
   componentDidUpdate(prevProps) {
     if (
-      this.props.isWelcomeModalDimissed &&
-      !prevProps.isWelcomeModalDimissed
+      this.props.isWelcomeModalDismissed &&
+      !prevProps.isWelcomeModalDismissed
     ) {
       scrollAndFocus();
     }
@@ -238,7 +238,7 @@ function mapStateToProps(state) {
     cancelInfo: getCancelInfo(state),
     showCancelButton: vaosCancel(state),
     showScheduleButton: vaosRequests(state),
-    isWelcomeModalDimissed: isWelcomeModalDimissed(state),
+    isWelcomeModalDismissed: isWelcomeModalDismissed(state),
   };
 }
 

--- a/src/applications/vaos/containers/AppointmentsPage.jsx
+++ b/src/applications/vaos/containers/AppointmentsPage.jsx
@@ -18,14 +18,19 @@ import {
 import { getAppointmentType, getRealFacilityId } from '../utils/appointment';
 import { FETCH_STATUS, APPOINTMENT_TYPES, GA_PREFIX } from '../utils/constants';
 import CancelAppointmentModal from '../components/CancelAppointmentModal';
-import { getCancelInfo, vaosCancel, vaosRequests } from '../utils/selectors';
+import {
+  getCancelInfo,
+  vaosCancel,
+  vaosRequests,
+  isWelcomeModalDimissed,
+} from '../utils/selectors';
 import { scrollAndFocus } from '../utils/scrollAndFocus';
 
 const pageTitle = 'VA appointments';
 
 export class AppointmentsPage extends Component {
   componentDidMount() {
-    if (this.props.welcomeModalDismissed) {
+    if (this.props.isWelcomeModalDimissed) {
       scrollAndFocus();
     }
     this.props.fetchFutureAppointments();
@@ -33,7 +38,10 @@ export class AppointmentsPage extends Component {
   }
 
   componentDidUpdate(prevProps) {
-    if (this.props.welcomeModalDismissed && !prevProps.welcomeModalDismissed) {
+    if (
+      this.props.isWelcomeModalDimissed &&
+      !prevProps.isWelcomeModalDimissed
+    ) {
       scrollAndFocus();
     }
   }
@@ -232,9 +240,7 @@ function mapStateToProps(state) {
     cancelInfo: getCancelInfo(state),
     showCancelButton: vaosCancel(state),
     showScheduleButton: vaosRequests(state),
-    welcomeModalDismissed: state.announcements.dismissed.some(
-      announcement => announcement === 'welcome-to-new-vaos',
-    ),
+    isWelcomeModalDimissed: isWelcomeModalDimissed(state),
   };
 }
 

--- a/src/applications/vaos/containers/AppointmentsPage.jsx
+++ b/src/applications/vaos/containers/AppointmentsPage.jsx
@@ -25,9 +25,17 @@ const pageTitle = 'VA appointments';
 
 export class AppointmentsPage extends Component {
   componentDidMount() {
-    scrollAndFocus();
+    if (this.props.welcomeModalDismissed) {
+      scrollAndFocus();
+    }
     this.props.fetchFutureAppointments();
     document.title = `${pageTitle} | Veterans Affairs`;
+  }
+
+  componentDidUpdate(prevProps) {
+    if (this.props.welcomeModalDismissed && !prevProps.welcomeModalDismissed) {
+      scrollAndFocus();
+    }
   }
 
   recordStartEvent() {
@@ -176,7 +184,9 @@ export class AppointmentsPage extends Component {
         <Breadcrumbs />
         <div className="vads-l-row">
           <div className="vads-l-col--12 medium-screen:vads-l-col--8 vads-u-margin-bottom--2">
-            <h1 className="vads-u-flex--1">{pageTitle}</h1>
+            <h1 id="appointments-list-header" className="vads-u-flex--1">
+              {pageTitle}
+            </h1>
             {showScheduleButton && (
               <div className="vads-u-padding-y--3 vads-u-border-top--1px vads-u-border-bottom--1px vads-u-border-color--gray-lighter">
                 <h2 className="vads-u-font-size--h3 vads-u-margin-y--0">
@@ -222,6 +232,9 @@ function mapStateToProps(state) {
     cancelInfo: getCancelInfo(state),
     showCancelButton: vaosCancel(state),
     showScheduleButton: vaosRequests(state),
+    welcomeModalDismissed: state.announcements.dismissed.some(
+      announcement => announcement === 'welcome-to-new-vaos',
+    ),
   };
 }
 

--- a/src/applications/vaos/containers/AppointmentsPage.jsx
+++ b/src/applications/vaos/containers/AppointmentsPage.jsx
@@ -192,9 +192,7 @@ export class AppointmentsPage extends Component {
         <Breadcrumbs />
         <div className="vads-l-row">
           <div className="vads-l-col--12 medium-screen:vads-l-col--8 vads-u-margin-bottom--2">
-            <h1 id="appointments-list-header" className="vads-u-flex--1">
-              {pageTitle}
-            </h1>
+            <h1 className="vads-u-flex--1">{pageTitle}</h1>
             {showScheduleButton && (
               <div className="vads-u-padding-y--3 vads-u-border-top--1px vads-u-border-bottom--1px vads-u-border-color--gray-lighter">
                 <h2 className="vads-u-font-size--h3 vads-u-margin-y--0">

--- a/src/applications/vaos/reducers/appointments.js
+++ b/src/applications/vaos/reducers/appointments.js
@@ -36,7 +36,6 @@ const initialState = {
   facilityData: {},
   requestMessages: {},
   systemClinicToFacilityMap: {},
-  welcomeModelOpen: false,
 };
 
 export default function appointmentsReducer(state = initialState, action) {

--- a/src/applications/vaos/reducers/appointments.js
+++ b/src/applications/vaos/reducers/appointments.js
@@ -36,6 +36,7 @@ const initialState = {
   facilityData: {},
   requestMessages: {},
   systemClinicToFacilityMap: {},
+  welcomeModelOpen: false,
 };
 
 export default function appointmentsReducer(state = initialState, action) {

--- a/src/applications/vaos/tests/containers/AppointmentsPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/containers/AppointmentsPage.unit.spec.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { expect } from 'chai';
 import sinon from 'sinon';
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 import { FETCH_STATUS } from '../../utils/constants';
 
 import { AppointmentsPage } from '../../containers/AppointmentsPage';
@@ -213,5 +213,37 @@ describe('VAOS <AppointmentsPage>', () => {
     expect(tree.find('h1').text()).to.equal(pageTitle);
     expect(document.title).contain(pageTitle);
     tree.unmount();
+  });
+
+  it('should focus if modal is dismissed', () => {
+    const defaultProps = {
+      appointments: {
+        future: [],
+        futureStatus: FETCH_STATUS.succeeded,
+        facilityData: {},
+      },
+      isWelcomeModalDismissed: false,
+    };
+
+    const fetchFutureAppointments = sinon.spy();
+    const div = document.createElement('div');
+    document.body.appendChild(div);
+
+    const tree = mount(
+      <AppointmentsPage
+        fetchFutureAppointments={fetchFutureAppointments}
+        {...defaultProps}
+      />,
+      {
+        attachTo: div,
+      },
+    );
+
+    expect(document.activeElement.nodeName).to.not.equal('H1');
+    tree.setProps({ isWelcomeModalDismissed: true });
+    expect(document.activeElement.nodeName).to.equal('H1');
+
+    tree.unmount();
+    div.remove();
   });
 });

--- a/src/applications/vaos/tests/e2e/00.appointment-list.e2e.spec.js
+++ b/src/applications/vaos/tests/e2e/00.appointment-list.e2e.spec.js
@@ -9,6 +9,15 @@ module.exports = E2eHelpers.createE2eTest(client => {
   VAOSHelpers.initAppointmentListMock(token);
   E2eHelpers.overrideVetsGovApi(client);
 
+  // init announcements
+  client.execute(() => {
+    // window.localStorage.clear();
+    window.localStorage.setItem(
+      'DISMISSED_ANNOUNCEMENTS',
+      '["welcome-to-new-vaos"]',
+    );
+  });
+
   Auth.logIn(
     token,
     client,

--- a/src/applications/vaos/tests/utils/selectors.unit.spec.js
+++ b/src/applications/vaos/tests/utils/selectors.unit.spec.js
@@ -16,6 +16,7 @@ import {
   getTypeOfCare,
   getCancelInfo,
   getCCEType,
+  isWelcomeModalDismissed,
 } from '../../utils/selectors';
 
 describe('VAOS selectors', () => {
@@ -401,6 +402,24 @@ describe('VAOS selectors', () => {
       };
       const cceType = getCCEType(state);
       expect(cceType).to.equal('Audiology');
+    });
+  });
+  describe('isWelcomeModalDismissed', () => {
+    it('should return dismissed if key is in list', () => {
+      const state = {
+        announcements: {
+          dismissed: ['welcome-to-new-vaos'],
+        },
+      };
+      expect(isWelcomeModalDismissed(state)).to.be.true;
+    });
+    it('should not return dismissed if key is not in list', () => {
+      const state = {
+        announcements: {
+          dismissed: ['welcome-to-new-va'],
+        },
+      };
+      expect(isWelcomeModalDismissed(state)).to.be.false;
     });
   });
 });

--- a/src/applications/vaos/utils/selectors.js
+++ b/src/applications/vaos/utils/selectors.js
@@ -286,7 +286,7 @@ export const vaosDirectScheduling = state =>
   toggleValues(state).vaOnlineSchedulingDirect;
 export const selectFeatureToggleLoading = state => toggleValues(state).loading;
 
-export const isWelcomeModalDimissed = state =>
+export const isWelcomeModalDismissed = state =>
   state.announcements.dismissed.some(
     announcement => announcement === 'welcome-to-new-vaos',
   );

--- a/src/applications/vaos/utils/selectors.js
+++ b/src/applications/vaos/utils/selectors.js
@@ -285,3 +285,8 @@ export const vaosCommunityCare = state =>
 export const vaosDirectScheduling = state =>
   toggleValues(state).vaOnlineSchedulingDirect;
 export const selectFeatureToggleLoading = state => toggleValues(state).loading;
+
+export const isWelcomeModalDimissed = state =>
+  state.announcements.dismissed.some(
+    announcement => announcement === 'welcome-to-new-vaos',
+  );

--- a/src/platform/site-wide/announcements/components/WelcomeVAOSModal.jsx
+++ b/src/platform/site-wide/announcements/components/WelcomeVAOSModal.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import Modal from '@department-of-veterans-affairs/formation-react/Modal';
+
+export default function WelcomeVAOSModal({ dismiss }) {
+  return (
+    <Modal visible onClose={dismiss} id="modal-announcement">
+      <div className="announcement-heading-brand-consolidation">
+        <img
+          className="announcement-brand-consolidation-logo"
+          src="/img/design/logo/va-logo.png"
+          alt="VA.gov"
+        />
+      </div>
+      <h1
+        id="modal-announcement-title"
+        className="vads-u-font-size--h3 announcement-title"
+      >
+        Welcome to the new VA online scheduling tool on VA.gov
+      </h1>
+      <p>
+        This tool has been redesigned with Veteran feedback. You may use this
+        tool to schedule, request, and cancel some VA or community care
+        appointments.
+      </p>
+      <p>
+        If you need it, you will find a link to the mobile online scheduling
+        tool in the footer.
+      </p>
+      <button type="button" onClick={dismiss}>
+        Continue to the new VA online scheduling tool
+      </button>
+    </Modal>
+  );
+}

--- a/src/platform/site-wide/announcements/components/WelcomeVAOSModal.jsx
+++ b/src/platform/site-wide/announcements/components/WelcomeVAOSModal.jsx
@@ -11,10 +11,7 @@ export default function WelcomeVAOSModal({ dismiss }) {
           alt="VA.gov"
         />
       </div>
-      <h1
-        id="modal-announcement-title"
-        className="vads-u-font-size--h3 announcement-title"
-      >
+      <h1 className="vads-u-font-size--h3 vads-u-margin-top--2">
         Welcome to the new VA online scheduling tool on VA.gov
       </h1>
       <p>

--- a/src/platform/site-wide/announcements/components/WelcomeVAOSModal.jsx
+++ b/src/platform/site-wide/announcements/components/WelcomeVAOSModal.jsx
@@ -12,19 +12,19 @@ export default function WelcomeVAOSModal({ dismiss }) {
         />
       </div>
       <h1 className="vads-u-font-size--h3 vads-u-margin-top--2">
-        Welcome to the new VA online scheduling tool on VA.gov
+        Welcome to the new VA.gov online scheduling tool
       </h1>
       <p>
-        This tool has been redesigned with Veteran feedback. You may use this
-        tool to schedule, request, and cancel some VA or community care
-        appointments.
+        The VA appointments tool has been redesigned based on feedback from
+        Veterans like you. You can now view, schedule, and cancel all your
+        appointments in one place on VA.gov.
       </p>
       <p>
-        If you need it, you will find a link to the mobile online scheduling
-        tool in the footer.
+        If you want to go back to the old appointments tool, you’ll find a link
+        to that scheduling tool at the bottom of the page in the new tool.
       </p>
       <button type="button" onClick={dismiss}>
-        Continue to the new VA online scheduling tool
+        Continue to your VA appointments
       </button>
     </Modal>
   );

--- a/src/platform/site-wide/announcements/config/index.js
+++ b/src/platform/site-wide/announcements/config/index.js
@@ -11,6 +11,7 @@ import Profile360Intro from '../components/Profile360Intro';
 import VAMCWelcomeModal, { VAMC_PATHS } from '../components/VAMCWelcomeModal';
 import VAPlusVetsModal from '../components/VAPlusVetsModal';
 import WelcomeToNewVAModal from '../components/WelcomeToNewVAModal';
+import WelcomeVAOSModal from '../components/WelcomeVAOSModal';
 
 // Derive when downtime will start and expire.
 const downtimeStartAtDate = moment.utc('2020-03-01T02:00:00.000Z').local();
@@ -63,6 +64,11 @@ const config = {
       name: 'welcome-to-new-va',
       paths: /^\/$/,
       component: WelcomeToNewVAModal,
+    },
+    {
+      name: 'welcome-to-new-vaos',
+      paths: /^\/health-care\/schedule-view-va-appointments\/appointments\/$/,
+      component: WelcomeVAOSModal,
     },
     {
       name: 'pittsburgh-vamc',

--- a/src/platform/site-wide/announcements/tests/components/WelcomeVAOSModal.unit.spec.jsx
+++ b/src/platform/site-wide/announcements/tests/components/WelcomeVAOSModal.unit.spec.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { expect } from 'chai';
+import { mount } from 'enzyme';
+import sinon from 'sinon';
+
+import WelcomeVAOSModal from '../../components/WelcomeVAOSModal';
+
+describe('Announcements <WelcomeVAOSModal>', () => {
+  it('renders', () => {
+    const dismiss = sinon.spy();
+
+    const tree = mount(<WelcomeVAOSModal dismiss={dismiss} />);
+
+    expect(tree.text()).to.contain(
+      'Welcome to the new VA online scheduling tool on VA.gov',
+    );
+
+    tree
+      .find('button')
+      .at(1)
+      .props()
+      .onClick();
+    expect(dismiss.called).to.be.true;
+
+    tree.unmount();
+  });
+});

--- a/src/platform/site-wide/announcements/tests/components/WelcomeVAOSModal.unit.spec.jsx
+++ b/src/platform/site-wide/announcements/tests/components/WelcomeVAOSModal.unit.spec.jsx
@@ -12,7 +12,7 @@ describe('Announcements <WelcomeVAOSModal>', () => {
     const tree = mount(<WelcomeVAOSModal dismiss={dismiss} />);
 
     expect(tree.text()).to.contain(
-      'Welcome to the new VA online scheduling tool on VA.gov',
+      'Welcome to the new VA.gov online scheduling tool',
     );
 
     tree


### PR DESCRIPTION
## Description
This adds a welcome modal to VAOS, using the announcement functionality.

## Testing done
Local testing

## Screenshots
![Screen Shot 2020-03-05 at 11 30 24 AM](https://user-images.githubusercontent.com/634932/76002596-d94cfb00-5ed4-11ea-9c9a-686efe9d73b5.png)

## Acceptance criteria
- [ ] Modal works

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
