### PR TITLE
Adjust Data layer push for search performance analytics

### DIFF
--- a/src/applications/facility-locator/actions/index.js
+++ b/src/applications/facility-locator/actions/index.js
@@ -116,7 +116,7 @@ const fetchLocations = async (
       page,
     );
     // Record event as soon as API return results
-    if (data && data.length > 0) {
+    if (data.data && data.data.length > 0) {
       recordEvent({ event: 'fl-search-results' });
     }
     if (data.errors) {

--- a/src/applications/facility-locator/actions/index.js
+++ b/src/applications/facility-locator/actions/index.js
@@ -16,6 +16,7 @@ import { LocationType, BOUNDING_RADIUS } from '../constants';
 import { ccLocatorEnabled } from '../config';
 
 import mbxGeo from '@mapbox/mapbox-sdk/services/geocoding';
+import recordEvent from '../../../platform/monitoring/record-event';
 
 const mbxClient = mbxGeo(mapboxClient);
 /**
@@ -114,6 +115,10 @@ const fetchLocations = async (
       serviceType,
       page,
     );
+    // Record event as soon as API return results
+    if (data && data.length > 0) {
+      recordEvent({ event: 'fl-search-results' });
+    }
     if (data.errors) {
       dispatch({ type: SEARCH_FAILED, error: data.errors });
     } else {

--- a/src/applications/facility-locator/components/ResultsList.jsx
+++ b/src/applications/facility-locator/components/ResultsList.jsx
@@ -15,7 +15,6 @@ import { updateSearchQuery, searchWithBounds } from '../actions';
 
 import SearchResult from './SearchResult';
 import DelayedRender from 'platform/utilities/ui/DelayedRender';
-import recordEvent from '../../../platform/monitoring/record-event';
 
 const TIMEOUTS = new Set(['408', '504', '503']);
 
@@ -25,10 +24,6 @@ class ResultsList extends Component {
     this.searchResultTitle = React.createRef();
   }
   shouldComponentUpdate(nextProps) {
-    // Record event
-    if (nextProps.results.length > 0) {
-      recordEvent({ event: 'fl-search-results' });
-    }
     return (
       nextProps.results !== this.props.results ||
       nextProps.inProgress !== this.props.inProgress


### PR DESCRIPTION
## Description
issue: https://github.com/department-of-veterans-affairs/va.gov-team/issues/6443

## Acceptance criteria
- [x]  Perform dataLayer push ONCE each time all new search results are returned

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
