### PR TITLE
bradl3yC - Set focus back to edit link when modals unmount

### DIFF
--- a/src/platform/user/profile/vet360/components/AddressField/AddressEditModal.jsx
+++ b/src/platform/user/profile/vet360/components/AddressField/AddressEditModal.jsx
@@ -23,7 +23,7 @@ const useNewAddressForm = !environment.isProduction();
 
 class AddressEditModal extends React.Component {
   componentWillUnmount() {
-    focusElement(`button#${this.props.modal}-edit-link`);
+    focusElement(`#${this.props.fieldName}-edit-link`);
   }
 
   onBlur = field => {
@@ -175,7 +175,6 @@ class AddressEditModal extends React.Component {
 }
 
 const mapStateToProps = state => ({
-  modal: state.vet360.modal,
   modalData: state.vet360?.modalData,
 });
 

--- a/src/platform/user/profile/vet360/components/AddressField/AddressEditModal.jsx
+++ b/src/platform/user/profile/vet360/components/AddressField/AddressEditModal.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import pickBy from 'lodash/pickBy';
+import { focusElement } from 'platform/utilities/ui';
 
 import {
   ADDRESS_FORM_VALUES,
@@ -21,6 +22,10 @@ import environment from 'platform/utilities/environment';
 const useNewAddressForm = !environment.isProduction();
 
 class AddressEditModal extends React.Component {
+  componentWillUnmount() {
+    focusElement(`button#${this.props.modal}-edit-link`);
+  }
+
   onBlur = field => {
     this.props.onChange(this.props.field.value, field);
   };
@@ -170,6 +175,7 @@ class AddressEditModal extends React.Component {
 }
 
 const mapStateToProps = state => ({
+  modal: state.vet360.modal,
   modalData: state.vet360?.modalData,
 });
 

--- a/src/platform/user/profile/vet360/components/base/Vet360Transaction.jsx
+++ b/src/platform/user/profile/vet360/components/base/Vet360Transaction.jsx
@@ -20,6 +20,7 @@ export default class Vet360Transaction extends React.Component {
 
   render() {
     const {
+      id,
       children,
       refreshTransaction,
       title,
@@ -37,11 +38,13 @@ export default class Vet360Transaction extends React.Component {
       <div className={classes}>
         {hasError && <Vet360TransactionInlineErrorMessage {...this.props} />}
         {transaction && isPendingTransaction(transaction) ? (
-          <Vet360TransactionPending
-            title={title}
-            refreshTransaction={refreshTransaction}
-            method={method}
-          />
+          <div id={id}>
+            <Vet360TransactionPending
+              title={title}
+              refreshTransaction={refreshTransaction}
+              method={method}
+            />
+          </div>
         ) : (
           children
         )}

--- a/src/platform/user/profile/vet360/containers/AddressValidationModal.jsx
+++ b/src/platform/user/profile/vet360/containers/AddressValidationModal.jsx
@@ -14,12 +14,17 @@ import {
   closeModal,
   resetAddressValidation as resetAddressValidationAction,
 } from '../actions';
+import { focusElement } from 'platform/utilities/ui';
 import { getValidationMessageKey } from '../../utilities';
 import { ADDRESS_VALIDATION_MESSAGES } from '../../constants/addressValidationMessages';
 
 import * as VET360 from '../constants';
 
 class AddressValidationModal extends React.Component {
+  componentWillUnmount() {
+    focusElement(`button#${this.props.addressValidationType}-edit-link`);
+  }
+
   onChangeHandler = (address, selectedAddressId) => _event => {
     this.props.updateSelectedAddress(address, selectedAddressId);
   };

--- a/src/platform/user/profile/vet360/containers/AddressValidationModal.jsx
+++ b/src/platform/user/profile/vet360/containers/AddressValidationModal.jsx
@@ -22,7 +22,7 @@ import * as VET360 from '../constants';
 
 class AddressValidationModal extends React.Component {
   componentWillUnmount() {
-    focusElement(`button#${this.props.addressValidationType}-edit-link`);
+    focusElement(`#${this.props.addressValidationType}-edit-link`);
   }
 
   onChangeHandler = (address, selectedAddressId) => _event => {

--- a/src/platform/user/profile/vet360/containers/Vet360ProfileField.jsx
+++ b/src/platform/user/profile/vet360/containers/Vet360ProfileField.jsx
@@ -48,6 +48,9 @@ class Vet360ProfileField extends React.Component {
     if (prevProps.transaction && !this.props.transaction) {
       focusElement(`button#${this.props.fieldName}-edit-link`);
     }
+    if (!prevProps.transaction && this.props.transaction) {
+      focusElement(`div#${this.props.fieldName}-transaction-status`);
+    }
   }
 
   onAdd = () => {
@@ -209,6 +212,7 @@ class Vet360ProfileField extends React.Component {
         </Vet360ProfileFieldHeading>
         {isEditing && <EditModal {...childProps} />}
         <Vet360Transaction
+          id={`${fieldName}-transaction-status`}
           title={title}
           transaction={transaction}
           transactionRequest={transactionRequest}


### PR DESCRIPTION
## Description
When transitioning from edit modal -> validation modal -> back to edit modal, focus is being lost as the component unmounts and its set to the body.  This is causing the screen readers to re-read certain elements in IE11

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
