### PR TITLE
Add Additional GA Events for VAOS

### DIFF
--- a/src/applications/vaos/actions/appointments.js
+++ b/src/applications/vaos/actions/appointments.js
@@ -1,7 +1,8 @@
 import moment from 'moment';
 import * as Sentry from '@sentry/browser';
-import { FETCH_STATUS } from '../utils/constants';
-import { getMomentConfirmedDate } from '../utils/appointment';
+import { FETCH_STATUS, GA_PREFIX } from '../utils/constants';
+import { getMomentConfirmedDate, isCommunityCare } from '../utils/appointment';
+import recordEvent from 'platform/monitoring/record-event';
 
 import {
   getConfirmedAppointments,
@@ -235,14 +236,25 @@ const SUBMITTED_REQUEST = 'Submitted';
 const CANCELLED_REQUEST = 'Cancelled';
 export function confirmCancelAppointment() {
   return async (dispatch, getState) => {
+    const appointment = getState().appointments.appointmentToCancel;
+    const isPendingRequest = appointment.status === SUBMITTED_REQUEST;
+    const eventPrefix = `${GA_PREFIX}-cancel-appointment-submission`;
+    const additionalEventdata = {
+      appointmentType: isPendingRequest ? 'pending' : 'confirmed',
+      facilityType: isCommunityCare(appointment) ? 'cc' : 'va',
+    };
+
     try {
+      recordEvent({
+        event: eventPrefix,
+        ...additionalEventdata,
+      });
+
       dispatch({
         type: CANCEL_APPOINTMENT_CONFIRMED,
       });
 
-      const appointment = getState().appointments.appointmentToCancel;
-
-      if (appointment.status === SUBMITTED_REQUEST) {
+      if (isPendingRequest) {
         await updateRequest({
           ...appointment,
           status: CANCELLED_REQUEST,
@@ -287,10 +299,20 @@ export function confirmCancelAppointment() {
       dispatch({
         type: CANCEL_APPOINTMENT_CONFIRMED_SUCCEEDED,
       });
+
+      recordEvent({
+        event: `${eventPrefix}-succeeded`,
+        ...additionalEventdata,
+      });
     } catch (e) {
       captureError(e);
       dispatch({
         type: CANCEL_APPOINTMENT_CONFIRMED_FAILED,
+      });
+
+      recordEvent({
+        event: `${eventPrefix}-failed`,
+        ...additionalEventdata,
       });
     }
   };

--- a/src/applications/vaos/actions/appointments.js
+++ b/src/applications/vaos/actions/appointments.js
@@ -301,7 +301,7 @@ export function confirmCancelAppointment() {
       });
 
       recordEvent({
-        event: `${eventPrefix}-succeeded`,
+        event: `${eventPrefix}-successful`,
         ...additionalEventdata,
       });
     } catch (e) {

--- a/src/applications/vaos/actions/newAppointment.js
+++ b/src/applications/vaos/actions/newAppointment.js
@@ -592,16 +592,25 @@ async function buildPreferencesDataAndUpdate(newAppointment) {
 
 export function submitAppointmentOrRequest(router) {
   return async (dispatch, getState) => {
-    const newAppointment = getState().newAppointment;
+    const state = getState();
+    const newAppointment = getNewAppointment(state);
+    const typeOfCare = getTypeOfCare(getFormData(state))?.name;
 
     dispatch({
       type: FORM_SUBMIT,
     });
 
     if (newAppointment.flowType === FLOW_TYPES.DIRECT) {
+      const additionalEventData = {
+        typeOfCare,
+        flow: 'direct',
+      };
+
       recordEvent({
         event: `${GA_PREFIX}-direct-submission`,
+        ...additionalEventData,
       });
+
       try {
         const appointmentBody = transformFormToAppointment(getState());
         await submitAppointment(appointmentBody);
@@ -620,6 +629,7 @@ export function submitAppointmentOrRequest(router) {
 
         recordEvent({
           event: `${GA_PREFIX}-direct-submission-successful`,
+          ...additionalEventData,
         });
         router.push('/new-appointment/confirmation');
       } catch (error) {
@@ -629,15 +639,21 @@ export function submitAppointmentOrRequest(router) {
         });
         recordEvent({
           event: `${GA_PREFIX}-direct-submission-failed`,
+          ...additionalEventData,
         });
       }
     } else {
       const isCommunityCare =
         newAppointment.data.facilityType === FACILITY_TYPES.COMMUNITY_CARE;
       const eventType = isCommunityCare ? 'community-care' : 'request';
+      const additionalEventData = {
+        typeOfCare,
+        flow: isCommunityCare ? 'cc-request' : 'va-request',
+      };
 
       recordEvent({
         event: `${GA_PREFIX}-${eventType}-submission`,
+        ...additionalEventData,
       });
 
       try {
@@ -670,6 +686,7 @@ export function submitAppointmentOrRequest(router) {
 
         recordEvent({
           event: `${GA_PREFIX}-${eventType}-submission-successful`,
+          ...additionalEventData,
         });
         router.push('/new-appointment/confirmation');
       } catch (error) {
@@ -679,6 +696,7 @@ export function submitAppointmentOrRequest(router) {
         });
         recordEvent({
           event: `${GA_PREFIX}-${eventType}-submission-failed`,
+          ...additionalEventData,
         });
       }
     }

--- a/src/applications/vaos/actions/newAppointment.js
+++ b/src/applications/vaos/actions/newAppointment.js
@@ -27,7 +27,12 @@ import {
   submitAppointment,
   sendRequestMessage,
 } from '../api';
-import { FACILITY_TYPES, FLOW_TYPES, GA_PREFIX } from '../utils/constants';
+import {
+  FACILITY_TYPES,
+  FLOW_TYPES,
+  GA_PREFIX,
+  GA_FLOWS,
+} from '../utils/constants';
 import {
   transformFormToVARequest,
   transformFormToCCRequest,
@@ -608,7 +613,7 @@ export function submitAppointmentOrRequest(router) {
     if (newAppointment.flowType === FLOW_TYPES.DIRECT) {
       const additionalEventData = {
         typeOfCare,
-        flow: 'direct',
+        flow: GA_FLOWS.DIRECT,
       };
 
       recordEvent({
@@ -653,7 +658,7 @@ export function submitAppointmentOrRequest(router) {
       const eventType = isCommunityCare ? 'community-care' : 'request';
       const additionalEventData = {
         typeOfCare,
-        flow: isCommunityCare ? 'cc-request' : 'va-request',
+        flow: isCommunityCare ? GA_FLOWS.CC_REQUEST : GA_FLOWS.VA_REQUEST,
       };
 
       recordEvent({

--- a/src/applications/vaos/actions/newAppointment.js
+++ b/src/applications/vaos/actions/newAppointment.js
@@ -38,6 +38,7 @@ import {
 import {
   getEligibilityData,
   getEligibleFacilities,
+  recordEligibilityGAEvents,
 } from '../utils/eligibility';
 
 import { captureError } from '../utils/error';
@@ -289,6 +290,8 @@ export function openFacilityPage(page, uiSchema, schema) {
           systemId,
           directSchedulingEnabled,
         );
+
+        recordEligibilityGAEvents(eligibilityData, typeOfCareId, systemId);
       }
 
       dispatch({
@@ -381,6 +384,8 @@ export function updateFacilityPageData(page, uiSchema, data) {
           systemId,
           directSchedulingEnabled,
         );
+
+        recordEligibilityGAEvents(eligibilityData, typeOfCareId, systemId);
 
         dispatch({
           type: FORM_ELIGIBILITY_CHECKS_SUCCEEDED,

--- a/src/applications/vaos/containers/AppointmentsPage.jsx
+++ b/src/applications/vaos/containers/AppointmentsPage.jsx
@@ -3,6 +3,7 @@ import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router';
 import LoadingIndicator from '@department-of-veterans-affairs/formation-react/LoadingIndicator';
+import recordEvent from 'platform/monitoring/record-event';
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 import Breadcrumbs from '../components/Breadcrumbs';
 import ConfirmedAppointmentListItem from '../components/ConfirmedAppointmentListItem';
@@ -16,7 +17,7 @@ import {
   startNewAppointmentFlow,
 } from '../actions/appointments';
 import { getAppointmentType, getRealFacilityId } from '../utils/appointment';
-import { FETCH_STATUS, APPOINTMENT_TYPES } from '../utils/constants';
+import { FETCH_STATUS, APPOINTMENT_TYPES, GA_PREFIX } from '../utils/constants';
 import CancelAppointmentModal from '../components/CancelAppointmentModal';
 import { getCancelInfo, vaosCancel, vaosRequests } from '../utils/selectors';
 import { scrollAndFocus } from '../utils/scrollAndFocus';
@@ -29,6 +30,12 @@ export class AppointmentsPage extends Component {
     scrollAndFocus();
     this.props.fetchFutureAppointments();
     document.title = `${pageTitle} | Veterans Affairs`;
+  }
+
+  recordStartEvent() {
+    recordEvent({
+      event: `${GA_PREFIX}-schedule-appointment-button-clicked`,
+    });
   }
 
   render() {
@@ -140,7 +147,10 @@ export class AppointmentsPage extends Component {
                 id="new-appointment"
                 className="va-button-link vads-u-font-weight--bold vads-u-font-size--md"
                 to="/new-appointment"
-                onClick={this.props.startNewAppointmentFlow}
+                onClick={() => {
+                  this.recordStartEvent();
+                  this.props.startNewAppointmentFlow();
+                }}
               >
                 Schedule an appointment
               </Link>
@@ -184,7 +194,10 @@ export class AppointmentsPage extends Component {
                   id="new-appointment"
                   className="usa-button vads-u-font-weight--bold vads-u-font-size--md"
                   to="/new-appointment"
-                  onClick={this.props.startNewAppointmentFlow}
+                  onClick={() => {
+                    this.recordStartEvent();
+                    this.props.startNewAppointmentFlow();
+                  }}
                 >
                   Schedule an appointment
                 </Link>

--- a/src/applications/vaos/containers/ConfirmationPage.jsx
+++ b/src/applications/vaos/containers/ConfirmationPage.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Link } from 'react-router';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import recordEvent from 'platform/monitoring/record-event';
 import {
   getAppointmentLength,
   getFormData,
@@ -15,7 +16,7 @@ import {
   startNewAppointmentFlow,
   fetchFacilityDetails,
 } from '../actions/newAppointment';
-import { FLOW_TYPES, FACILITY_TYPES } from '../utils/constants';
+import { FLOW_TYPES, FACILITY_TYPES, GA_PREFIX } from '../utils/constants';
 import ConfirmationDirectScheduleInfo from '../components/ConfirmationDirectScheduleInfo';
 import ConfirmationRequestInfo from '../components/ConfirmationRequestInfo';
 
@@ -80,7 +81,11 @@ export class ConfirmationPage extends React.Component {
           <Link
             to="new-appointment"
             className="usa-button"
-            onClick={this.props.startNewAppointmentFlow}
+            onClick={() =>
+              recordEvent({
+                event: `${GA_PREFIX}-schedule-another-appointment-button-clicked`,
+              })
+            }
           >
             New appointment
           </Link>

--- a/src/applications/vaos/containers/ConfirmationPage.jsx
+++ b/src/applications/vaos/containers/ConfirmationPage.jsx
@@ -81,11 +81,12 @@ export class ConfirmationPage extends React.Component {
           <Link
             to="new-appointment"
             className="usa-button"
-            onClick={() =>
+            onClick={() => {
               recordEvent({
                 event: `${GA_PREFIX}-schedule-another-appointment-button-clicked`,
-              })
-            }
+              });
+              this.props.startNewAppointmentFlow();
+            }}
           >
             New appointment
           </Link>

--- a/src/applications/vaos/containers/ReviewPage.jsx
+++ b/src/applications/vaos/containers/ReviewPage.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
+import recordEvent from 'platform/monitoring/record-event';
 import {
   getFormData,
   getFlowType,
@@ -9,7 +10,7 @@ import {
   getChosenClinicInfo,
   getChosenVACityState,
 } from '../utils/selectors';
-import { FLOW_TYPES, FETCH_STATUS } from '../utils/constants';
+import { FLOW_TYPES, FETCH_STATUS, GA_PREFIX } from '../utils/constants';
 import { scrollAndFocus } from '../utils/scrollAndFocus';
 import ReviewDirectScheduleInfo from '../components/review/ReviewDirectScheduleInfo';
 import ReviewRequestInfo from '../components/review/ReviewRequestInfo';
@@ -58,7 +59,12 @@ export class ReviewPage extends React.Component {
           <LoadingButton
             disabled={submitStatus === FETCH_STATUS.succeeded}
             isLoading={submitStatus === FETCH_STATUS.loading}
-            onClick={() => this.props.submitAppointmentOrRequest(router)}
+            onClick={() => {
+              recordEvent({
+                event: `${GA_PREFIX}-schedule-another-appointment-button-clicked`,
+              });
+              this.props.submitAppointmentOrRequest(router);
+            }}
             className="usa-button usa-button-primary"
           >
             {isDirectSchedule ? 'Confirm appointment' : 'Request appointment'}

--- a/src/applications/vaos/containers/ReviewPage.jsx
+++ b/src/applications/vaos/containers/ReviewPage.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
-import recordEvent from 'platform/monitoring/record-event';
 import {
   getFormData,
   getFlowType,
@@ -10,7 +9,7 @@ import {
   getChosenClinicInfo,
   getChosenVACityState,
 } from '../utils/selectors';
-import { FLOW_TYPES, FETCH_STATUS, GA_PREFIX } from '../utils/constants';
+import { FLOW_TYPES, FETCH_STATUS } from '../utils/constants';
 import { scrollAndFocus } from '../utils/scrollAndFocus';
 import ReviewDirectScheduleInfo from '../components/review/ReviewDirectScheduleInfo';
 import ReviewRequestInfo from '../components/review/ReviewRequestInfo';
@@ -60,9 +59,6 @@ export class ReviewPage extends React.Component {
             disabled={submitStatus === FETCH_STATUS.succeeded}
             isLoading={submitStatus === FETCH_STATUS.loading}
             onClick={() => {
-              recordEvent({
-                event: `${GA_PREFIX}-schedule-another-appointment-button-clicked`,
-              });
               this.props.submitAppointmentOrRequest(router);
             }}
             className="usa-button usa-button-primary"

--- a/src/applications/vaos/containers/ReviewPage.jsx
+++ b/src/applications/vaos/containers/ReviewPage.jsx
@@ -58,9 +58,7 @@ export class ReviewPage extends React.Component {
           <LoadingButton
             disabled={submitStatus === FETCH_STATUS.succeeded}
             isLoading={submitStatus === FETCH_STATUS.loading}
-            onClick={() => {
-              this.props.submitAppointmentOrRequest(router);
-            }}
+            onClick={() => this.props.submitAppointmentOrRequest(router)}
             className="usa-button usa-button-primary"
           >
             {isDirectSchedule ? 'Confirm appointment' : 'Request appointment'}

--- a/src/applications/vaos/newAppointmentFlow.js
+++ b/src/applications/vaos/newAppointmentFlow.js
@@ -24,6 +24,7 @@ import {
   updateCCEnabledSystems,
   updateCCEligibility,
 } from './actions/newAppointment';
+import { recordVaosError } from './utils/events';
 
 const AUDIOLOGY = '203';
 const SLEEP_CARE = 'SLEEP';
@@ -183,7 +184,9 @@ export default {
             dispatch(startDirectScheduleFlow(appointments));
             return 'clinicChoice';
           }
+          recordVaosError('direct-no-matching-past-clinics-failure');
         } catch (error) {
+          recordVaosError('direct-no-matching-past-clinics-error');
           captureError(error);
         }
       }

--- a/src/applications/vaos/tests/actions/appointments.unit.spec.js
+++ b/src/applications/vaos/tests/actions/appointments.unit.spec.js
@@ -281,7 +281,7 @@ describe('VAOS actions: appointments', () => {
       });
 
       expect(global.window.dataLayer[1]).to.deep.equal({
-        event: 'vaos-cancel-appointment-submission-succeeded',
+        event: 'vaos-cancel-appointment-submission-successful',
         appointmentType: 'confirmed',
         facilityType: 'va',
       });

--- a/src/applications/vaos/tests/actions/appointments.unit.spec.js
+++ b/src/applications/vaos/tests/actions/appointments.unit.spec.js
@@ -212,18 +212,6 @@ describe('VAOS actions: appointments', () => {
   });
 
   describe('cancel appointment', () => {
-    const oldWindow = global.window;
-
-    beforeEach(() => {
-      global.window = {
-        dataLayer: [],
-      };
-    });
-
-    afterEach(() => {
-      global.window = oldWindow;
-    });
-
     it('should return cancel appointment action', () => {
       const appointment = {};
       const action = cancelAppointment(appointment);

--- a/src/applications/vaos/tests/actions/appointments.unit.spec.js
+++ b/src/applications/vaos/tests/actions/appointments.unit.spec.js
@@ -212,6 +212,18 @@ describe('VAOS actions: appointments', () => {
   });
 
   describe('cancel appointment', () => {
+    const oldWindow = global.window;
+
+    beforeEach(() => {
+      global.window = {
+        dataLayer: [],
+      };
+    });
+
+    afterEach(() => {
+      global.window = oldWindow;
+    });
+
     it('should return cancel appointment action', () => {
       const appointment = {};
       const action = cancelAppointment(appointment);
@@ -261,6 +273,18 @@ describe('VAOS actions: appointments', () => {
       expect(dispatch.secondCall.args[0]).to.deep.equal({
         type: CANCEL_APPOINTMENT_CONFIRMED_SUCCEEDED,
       });
+
+      expect(global.window.dataLayer[0]).to.deep.equal({
+        event: 'vaos-cancel-appointment-submission',
+        appointmentType: 'confirmed',
+        facilityType: 'va',
+      });
+
+      expect(global.window.dataLayer[1]).to.deep.equal({
+        event: 'vaos-cancel-appointment-submission-succeeded',
+        appointmentType: 'confirmed',
+        facilityType: 'va',
+      });
       expect(
         JSON.parse(global.fetch.secondCall.args[1].body).cancelReason,
       ).to.equal('4');
@@ -291,6 +315,7 @@ describe('VAOS actions: appointments', () => {
       expect(dispatch.secondCall.args[0]).to.deep.equal({
         type: CANCEL_APPOINTMENT_CONFIRMED_SUCCEEDED,
       });
+
       expect(
         JSON.parse(global.fetch.secondCall.args[1].body).cancelReason,
       ).to.equal('5');
@@ -342,6 +367,12 @@ describe('VAOS actions: appointments', () => {
       );
       expect(dispatch.secondCall.args[0]).to.deep.equal({
         type: CANCEL_APPOINTMENT_CONFIRMED_FAILED,
+      });
+
+      expect(global.window.dataLayer[1]).to.deep.equal({
+        event: 'vaos-cancel-appointment-submission-failed',
+        appointmentType: 'confirmed',
+        facilityType: 'va',
       });
     });
 

--- a/src/applications/vaos/tests/actions/newAppointment.unit.spec.js
+++ b/src/applications/vaos/tests/actions/newAppointment.unit.spec.js
@@ -925,6 +925,10 @@ describe('VAOS newAppointment actions', () => {
   });
 
   describe('form submit', () => {
+    beforeEach(() => {
+      mockFetch();
+    });
+
     afterEach(() => {
       resetFetch();
     });

--- a/src/applications/vaos/tests/actions/newAppointment.unit.spec.js
+++ b/src/applications/vaos/tests/actions/newAppointment.unit.spec.js
@@ -925,12 +925,18 @@ describe('VAOS newAppointment actions', () => {
   });
 
   describe('form submit', () => {
+    const oldWindow = global.window;
+
     beforeEach(() => {
       mockFetch();
+      global.window = {
+        dataLayer: [],
+      };
     });
 
     afterEach(() => {
       resetFetch();
+      global.window = oldWindow;
     });
 
     it('should send VA request', async () => {
@@ -974,6 +980,16 @@ describe('VAOS newAppointment actions', () => {
 
       expect(dispatch.firstCall.args[0].type).to.equal(FORM_SUBMIT);
       expect(dispatch.secondCall.args[0].type).to.equal(FORM_SUBMIT_SUCCEEDED);
+      expect(global.window.dataLayer[0]).to.deep.equal({
+        event: 'vaos-request-submission',
+        typeOfCare: 'Primary care',
+        flow: 'va-request',
+      });
+      expect(global.window.dataLayer[1]).to.deep.equal({
+        event: 'vaos-request-submission-successful',
+        typeOfCare: 'Primary care',
+        flow: 'va-request',
+      });
       expect(router.push.called).to.be.true;
     });
 
@@ -1108,6 +1124,11 @@ describe('VAOS newAppointment actions', () => {
 
       expect(dispatch.firstCall.args[0].type).to.equal(FORM_SUBMIT);
       expect(dispatch.secondCall.args[0].type).to.equal(FORM_SUBMIT_FAILED);
+      expect(global.window.dataLayer[1]).to.deep.equal({
+        event: 'vaos-request-submission-failed',
+        typeOfCare: 'Primary care',
+        flow: 'va-request',
+      });
       expect(router.push.called).to.be.false;
     });
 

--- a/src/applications/vaos/tests/actions/newAppointment.unit.spec.js
+++ b/src/applications/vaos/tests/actions/newAppointment.unit.spec.js
@@ -925,18 +925,8 @@ describe('VAOS newAppointment actions', () => {
   });
 
   describe('form submit', () => {
-    const oldWindow = global.window;
-
-    beforeEach(() => {
-      mockFetch();
-      global.window = {
-        dataLayer: [],
-      };
-    });
-
     afterEach(() => {
       resetFetch();
-      global.window = oldWindow;
     });
 
     it('should send VA request', async () => {

--- a/src/applications/vaos/tests/containers/AppointmentsPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/containers/AppointmentsPage.unit.spec.jsx
@@ -214,4 +214,43 @@ describe('VAOS <AppointmentsPage>', () => {
     expect(document.title).contain(pageTitle);
     tree.unmount();
   });
+
+  it('should fire a GA event when clicking schedule new appointment button', () => {
+    const oldWindow = global.window;
+    beforeEach(() => {
+      global.window = {
+        dataLayer: [],
+      };
+    });
+
+    afterEach(() => {
+      global.window = oldWindow;
+    });
+
+    const defaultProps = {
+      appointments: {
+        future: [],
+        futureStatus: FETCH_STATUS.succeeded,
+        facilityData: {},
+      },
+    };
+
+    const fetchFutureAppointments = sinon.spy();
+    const tree = shallow(
+      <AppointmentsPage
+        {...defaultProps}
+        showScheduleButton
+        fetchFutureAppointments={fetchFutureAppointments}
+      />,
+    );
+
+    tree
+      .find('Link')
+      .at(0)
+      .simulate('click');
+    expect(global.window.dataLayer[0].event).to.equal(
+      'vaos-schedule-appointment-button-clicked',
+    );
+    tree.unmount();
+  });
 });

--- a/src/applications/vaos/tests/containers/AppointmentsPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/containers/AppointmentsPage.unit.spec.jsx
@@ -216,17 +216,6 @@ describe('VAOS <AppointmentsPage>', () => {
   });
 
   it('should fire a GA event when clicking schedule new appointment button', () => {
-    const oldWindow = global.window;
-    beforeEach(() => {
-      global.window = {
-        dataLayer: [],
-      };
-    });
-
-    afterEach(() => {
-      global.window = oldWindow;
-    });
-
     const defaultProps = {
       appointments: {
         future: [],
@@ -235,12 +224,14 @@ describe('VAOS <AppointmentsPage>', () => {
       },
     };
 
+    const startNewAppointmentFlow = sinon.spy();
     const fetchFutureAppointments = sinon.spy();
     const tree = shallow(
       <AppointmentsPage
         {...defaultProps}
         showScheduleButton
         fetchFutureAppointments={fetchFutureAppointments}
+        startNewAppointmentFlow={startNewAppointmentFlow}
       />,
     );
 

--- a/src/applications/vaos/tests/containers/ConfirmationPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/containers/ConfirmationPage.unit.spec.jsx
@@ -75,21 +75,11 @@ describe('VAOS <ConfirmationPage>', () => {
   });
 
   it('should render view/schedule appointment buttons and fire GA event on click', () => {
-    const oldWindow = global.window;
-    beforeEach(() => {
-      global.window = {
-        dataLayer: [],
-      };
-    });
-
-    afterEach(() => {
-      global.window = oldWindow;
-    });
-
     const flowType = FLOW_TYPES.DIRECT;
     const closeConfirmationPage = sinon.spy();
     const data = {};
     const fetchFacilityDetails = sinon.spy();
+    const startNewAppointmentFlow = sinon.spy();
 
     const tree = shallow(
       <ConfirmationPage
@@ -97,6 +87,7 @@ describe('VAOS <ConfirmationPage>', () => {
         closeConfirmationPage={closeConfirmationPage}
         flowType={flowType}
         data={data}
+        startNewAppointmentFlow={startNewAppointmentFlow}
       />,
     );
 

--- a/src/applications/vaos/tests/containers/ConfirmationPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/containers/ConfirmationPage.unit.spec.jsx
@@ -73,4 +73,39 @@ describe('VAOS <ConfirmationPage>', () => {
 
     tree.unmount();
   });
+
+  it('should render view/schedule appointment buttons and fire GA event on click', () => {
+    const oldWindow = global.window;
+    beforeEach(() => {
+      global.window = {
+        dataLayer: [],
+      };
+    });
+
+    afterEach(() => {
+      global.window = oldWindow;
+    });
+
+    const flowType = FLOW_TYPES.DIRECT;
+    const closeConfirmationPage = sinon.spy();
+    const data = {};
+    const fetchFacilityDetails = sinon.spy();
+
+    const tree = shallow(
+      <ConfirmationPage
+        fetchFacilityDetails={fetchFacilityDetails}
+        closeConfirmationPage={closeConfirmationPage}
+        flowType={flowType}
+        data={data}
+      />,
+    );
+
+    const LinkButtons = tree.find('Link');
+    expect(LinkButtons.length).to.equal(2);
+    LinkButtons.at(1).simulate('click');
+    expect(global.window.dataLayer[0].event).to.equal(
+      'vaos-schedule-another-appointment-button-clicked',
+    );
+    tree.unmount();
+  });
 });

--- a/src/applications/vaos/tests/utils/eligibility.unit.spec.js
+++ b/src/applications/vaos/tests/utils/eligibility.unit.spec.js
@@ -13,6 +13,7 @@ import {
   isEligible,
   getEligibilityChecks,
   getEligibilityData,
+  recordEligibilityGAEvents,
 } from '../../utils/eligibility';
 
 describe('VAOS scheduling eligibility logic', () => {
@@ -242,6 +243,94 @@ describe('VAOS scheduling eligibility logic', () => {
 
       expect(direct).to.be.false;
       expect(request).to.be.true;
+    });
+  });
+
+  describe('GA Events', () => {
+    const oldWindow = global.window;
+
+    beforeEach(() => {
+      global.window = {
+        dataLayer: [],
+      };
+    });
+
+    afterEach(() => {
+      global.window = oldWindow;
+    });
+
+    it('should record error events with fetch failures', async () => {
+      mockFetch();
+      setFetchJSONFailure(global.fetch.onCall(0), { errors: [{}] });
+      setFetchJSONFailure(global.fetch.onCall(1), { errors: [{}] });
+      setFetchJSONFailure(global.fetch.onCall(2), { errors: [{}] });
+      setFetchJSONFailure(global.fetch.onCall(3), { errors: [{}] });
+      setFetchJSONFailure(global.fetch.onCall(4), { errors: [{}] });
+      await getEligibilityData(
+        {
+          institutionCode: '983',
+          directSchedulingSupported: true,
+          requestSupported: true,
+        },
+        '323',
+        '983',
+        true,
+      );
+      expect(global.window.dataLayer.length).to.equal(5);
+      resetFetch();
+    });
+
+    it('should record failure events when ineligible', () => {
+      recordEligibilityGAEvents(
+        {
+          pacTeam: [],
+          clinics: [],
+          directSupported: true,
+          requestSupported: true,
+          directPastVisit: {
+            durationInMonths: 12,
+            hasVisitedInPastMonths: false,
+          },
+          requestPastVisit: {
+            requestFailed: false,
+          },
+          requestLimits: {
+            requestLimit: 1,
+            numberOfRequests: 1,
+          },
+        },
+        '323',
+        '983',
+      );
+
+      expect(global.window.dataLayer.length).to.equal(5);
+    });
+
+    it('should not record failure events when ineligible', () => {
+      recordEligibilityGAEvents(
+        {
+          pacTeam: [{ facilityId: '983' }],
+          clinics: [{}],
+          directSupported: true,
+          requestSupported: true,
+          directPastVisit: {
+            durationInMonths: 12,
+            hasVisitedInPastMonths: true,
+          },
+          requestPastVisit: {
+            requestFailed: false,
+            hasVisitedInPastMonths: true,
+          },
+          requestLimits: {
+            requestLimit: 1,
+            numberOfRequests: 0,
+          },
+        },
+        '323',
+        '983',
+      );
+
+      expect(global.window.dataLayer.length).to.equal(0);
     });
   });
 });

--- a/src/applications/vaos/tests/utils/eligibility.unit.spec.js
+++ b/src/applications/vaos/tests/utils/eligibility.unit.spec.js
@@ -247,18 +247,6 @@ describe('VAOS scheduling eligibility logic', () => {
   });
 
   describe('GA Events', () => {
-    const oldWindow = global.window;
-
-    beforeEach(() => {
-      global.window = {
-        dataLayer: [],
-      };
-    });
-
-    afterEach(() => {
-      global.window = oldWindow;
-    });
-
     it('should record error events with fetch failures', async () => {
       mockFetch();
       setFetchJSONFailure(global.fetch.onCall(0), { errors: [{}] });

--- a/src/applications/vaos/utils/constants.js
+++ b/src/applications/vaos/utils/constants.js
@@ -279,4 +279,10 @@ export const CALENDAR_INDICATOR_TYPES = {
 export const DISABLED_LIMIT_VALUE = 0;
 export const PRIMARY_CARE = '323';
 export const MENTAL_HEALTH = '502';
+
 export const GA_PREFIX = 'vaos';
+export const GA_FLOWS = {
+  DIRECT: 'direct',
+  VA_REQUEST: 'va-request',
+  CC_REQUEST: 'cc-request',
+};

--- a/src/applications/vaos/utils/eligibility.js
+++ b/src/applications/vaos/utils/eligibility.js
@@ -231,7 +231,7 @@ export function getEligibleFacilities(facilities) {
  * Record Google Analytics events based on results of eligibility checks.
  * Error keys ending with 'error' represent a failure in fetching info for the check,
  * while keys ending with 'failure' signify that the user didn't meet the condition
- * of the check
+ * of the check.
  */
 export function recordEligibilityGAEvents(
   eligibilityData,

--- a/src/applications/vaos/utils/eligibility.js
+++ b/src/applications/vaos/utils/eligibility.js
@@ -9,13 +9,17 @@ import {
   getAvailableClinics,
 } from '../api';
 
+function recordVaosError(errorKey) {
+  recordEvent({
+    event: 'vaos-error',
+    'error-key': errorKey,
+  });
+}
+
 function createErrorHandler(directOrRequest, errorKey) {
   return data => {
     captureError(data);
-    recordEvent({
-      event: 'vaos-error',
-      'error-key': errorKey,
-    });
+    recordVaosError(errorKey);
     return { [`${directOrRequest}Failed`]: true };
   };
 }
@@ -242,17 +246,11 @@ export function recordEligibilityGAEvents(
 ) {
   if (!hasRequestFailed(eligibilityData)) {
     if (!isUnderRequestLimit(eligibilityData)) {
-      recordEvent({
-        event: 'vaos-error',
-        'error-key': 'request-exceeded-outstanding-requests-failure',
-      });
+      recordVaosError('request-exceeded-outstanding-requests-failure');
     }
 
     if (!hasVisitedInPastMonthsRequest(eligibilityData)) {
-      recordEvent({
-        event: 'vaos-error',
-        'error-key': 'request-past-visits-failure',
-      });
+      recordVaosError('request-past-visits-failure');
     }
   }
 
@@ -260,27 +258,18 @@ export function recordEligibilityGAEvents(
 
   if (directSchedulingEnabled && !hasRequestFailed(eligibilityData)) {
     if (!hasVisitedInPastMonthsDirect(eligibilityData)) {
-      recordEvent({
-        event: 'vaos-error',
-        'error-key': 'direct-check-past-visits-failure',
-      });
+      recordVaosError('direct-check-past-visits-failure');
     }
 
     if (!eligibilityData.clinics?.length) {
-      recordEvent({
-        event: 'vaos-error',
-        'error-key': 'direct-available-clinics-failure',
-      });
+      recordVaosError('direct-available-clinics-failure');
     }
 
     if (
       typeOfCareId === PRIMARY_CARE &&
       !hasPACTeamIfPrimaryCare(eligibilityData, typeOfCareId, systemId)
     ) {
-      recordEvent({
-        event: 'vaos-error',
-        'error-key': 'direct-pac-team-failure',
-      });
+      recordVaosError('direct-pac-team-failure');
     }
   }
 }

--- a/src/applications/vaos/utils/eligibility.js
+++ b/src/applications/vaos/utils/eligibility.js
@@ -1,5 +1,4 @@
 import { PRIMARY_CARE, DISABLED_LIMIT_VALUE } from '../utils/constants';
-import recordEvent from 'platform/monitoring/record-event';
 import { captureError } from '../utils/error';
 
 import {
@@ -9,12 +8,7 @@ import {
   getAvailableClinics,
 } from '../api';
 
-function recordVaosError(errorKey) {
-  recordEvent({
-    event: 'vaos-error',
-    'error-key': errorKey,
-  });
-}
+import { recordVaosError } from './events';
 
 function createErrorHandler(directOrRequest, errorKey) {
   return data => {

--- a/src/applications/vaos/utils/eligibility.js
+++ b/src/applications/vaos/utils/eligibility.js
@@ -9,16 +9,15 @@ import {
   getAvailableClinics,
 } from '../api';
 
-function handleDirectError(data) {
-  captureError(data);
-
-  return { directFailed: true };
-}
-
-function handleRequestError(data) {
-  captureError(data);
-
-  return { requestFailed: true };
+function createErrorHandler(directOrRequest, errorKey) {
+  return data => {
+    captureError(data);
+    recordEvent({
+      event: 'vaos-error',
+      'error-key': errorKey,
+    });
+    return { [`${directOrRequest}Failed`]: true };
+  };
 }
 
 /*
@@ -41,54 +40,33 @@ export async function getEligibilityData(
   const facilityId = facility.institutionCode;
   const eligibilityChecks = [
     checkPastVisits(systemId, facilityId, typeOfCareId, 'request').catch(
-      error => {
-        handleRequestError(error);
-        recordEvent({
-          event: 'vaos-error',
-          'error-key': 'request-past-visits-error',
-        });
-      },
+      createErrorHandler('request', 'request-check-past-visits-error'),
     ),
-    getRequestLimits(facilityId, typeOfCareId).catch(error => {
-      handleRequestError(error);
-      recordEvent({
-        event: 'vaos-error',
-        'error-key': 'request-exceeded-outstanding-requests-error',
-      });
-    }),
+    getRequestLimits(facilityId, typeOfCareId).catch(
+      createErrorHandler(
+        'request',
+        'request-exceeded-outstanding-requests-error',
+      ),
+    ),
   ];
 
   if (facility.directSchedulingSupported && isDirectScheduleEnabled) {
     eligibilityChecks.push(
       checkPastVisits(systemId, facilityId, typeOfCareId, 'direct').catch(
-        error => {
-          handleDirectError(error);
-          recordEvent({
-            event: 'vaos-error',
-            'error-key': 'direct-check-past-visits-error',
-          });
-        },
+        createErrorHandler('direct', 'direct-check-past-visits-error'),
       ),
     );
     eligibilityChecks.push(
-      getAvailableClinics(facilityId, typeOfCareId, systemId).catch(error => {
-        handleDirectError(error);
-        recordEvent({
-          event: 'vaos-error',
-          'error-key': 'direct-available-clinics-error',
-        });
-      }),
+      getAvailableClinics(facilityId, typeOfCareId, systemId).catch(
+        createErrorHandler('direct', 'direct-available-clinics-error'),
+      ),
     );
 
     if (typeOfCareId === PRIMARY_CARE) {
       eligibilityChecks.push(
-        getPacTeam(systemId).catch(error => {
-          handleDirectError(error);
-          recordEvent({
-            event: 'vaos-error',
-            'error-key': 'direct-pac-team-error',
-          });
-        }),
+        getPacTeam(systemId).catch(
+          createErrorHandler('direct', 'direct-pac-team-error'),
+        ),
       );
     }
   }
@@ -152,6 +130,18 @@ function isUnderRequestLimit(eligibilityData) {
   );
 }
 
+function isDirectSchedulingEnabled(eligibilityData) {
+  return typeof eligibilityData.directPastVisit !== 'undefined';
+}
+
+function hasRequestFailed(eligibilityData) {
+  return Object.values(eligibilityData).some(result => result.requestFailed);
+}
+
+function hasDirectFailed(eligibilityData) {
+  return Object.values(eligibilityData).some(result => result.directFailed);
+}
+
 /*
  * This function takes the data from the eligibility related services and 
  * decides if each check we need to make passes or fails. It also checks for
@@ -162,18 +152,13 @@ function isUnderRequestLimit(eligibilityData) {
 export function getEligibilityChecks(systemId, typeOfCareId, eligibilityData) {
   // If we're missing this property, it means no DS checks were made
   // because it's disabled
-  const directSchedulingEnabled =
-    typeof eligibilityData.directPastVisit !== 'undefined';
+  const directSchedulingEnabled = isDirectSchedulingEnabled(eligibilityData);
 
   let eligibilityChecks = {
     requestSupported: eligibilityData.requestSupported,
-    requestFailed: Object.values(eligibilityData).some(
-      result => result.requestFailed,
-    ),
+    requestFailed: hasRequestFailed(eligibilityData),
     directSupported: eligibilityData.directSupported,
-    directFailed: Object.values(eligibilityData).some(
-      result => result.directFailed,
-    ),
+    directFailed: hasDirectFailed(eligibilityData),
   };
 
   if (!eligibilityChecks.requestFailed) {
@@ -184,20 +169,6 @@ export function getEligibilityChecks(systemId, typeOfCareId, eligibilityData) {
       requestLimit: isUnderRequestLimit(eligibilityData),
       requestLimitValue: eligibilityData.requestLimits.requestLimit,
     };
-
-    if (!isUnderRequestLimit) {
-      recordEvent({
-        event: 'vaos-error',
-        'error-key': 'request-exceeded-outstanding-requests-failure',
-      });
-    }
-
-    if (!hasVisitedInPastMonthsRequest(eligibilityData)) {
-      recordEvent({
-        event: 'vaos-error',
-        'error-key': 'request-past-visits-failure',
-      });
-    }
   }
 
   if (!eligibilityChecks.directFailed) {
@@ -215,34 +186,6 @@ export function getEligibilityChecks(systemId, typeOfCareId, eligibilityData) {
       directClinics:
         directSchedulingEnabled && !!eligibilityData.clinics.length,
     };
-
-    if (
-      directSchedulingEnabled &&
-      !hasVisitedInPastMonthsDirect(eligibilityData)
-    ) {
-      recordEvent({
-        event: 'vaos-error',
-        'error-key': 'direct-check-past-visits-failure',
-      });
-    }
-
-    if (directSchedulingEnabled && !eligibilityData.clinics?.length) {
-      recordEvent({
-        event: 'vaos-error',
-        'error-key': 'direct-available-clinics-failure',
-      });
-    }
-
-    if (
-      directSchedulingEnabled &&
-      typeOfCareId === PRIMARY_CARE &&
-      !hasPACTeamIfPrimaryCare(eligibilityData, typeOfCareId, systemId)
-    ) {
-      recordEvent({
-        event: 'vaos-error',
-        'error-key': 'direct-pac-team-failure',
-      });
-    }
   }
 
   return eligibilityChecks;
@@ -284,4 +227,60 @@ export function getEligibleFacilities(facilities) {
   return facilities.filter(
     facility => facility.requestSupported || facility.directSchedulingSupported,
   );
+}
+
+/**
+ * Record Google Analytics events based on results of eligibility checks.
+ * Error keys ending with 'error' represent a failure in fetching info for the check,
+ * while keys ending with 'failure' signify that the user didn't meet the condition
+ * of the check
+ */
+export function recordEligibilityGAEvents(
+  eligibilityData,
+  typeOfCareId,
+  systemId,
+) {
+  if (!hasRequestFailed(eligibilityData)) {
+    if (!isUnderRequestLimit(eligibilityData)) {
+      recordEvent({
+        event: 'vaos-error',
+        'error-key': 'request-exceeded-outstanding-requests-failure',
+      });
+    }
+
+    if (!hasVisitedInPastMonthsRequest(eligibilityData)) {
+      recordEvent({
+        event: 'vaos-error',
+        'error-key': 'request-past-visits-failure',
+      });
+    }
+  }
+
+  const directSchedulingEnabled = isDirectSchedulingEnabled(eligibilityData);
+
+  if (directSchedulingEnabled && !hasRequestFailed(eligibilityData)) {
+    if (!hasVisitedInPastMonthsDirect(eligibilityData)) {
+      recordEvent({
+        event: 'vaos-error',
+        'error-key': 'direct-check-past-visits-failure',
+      });
+    }
+
+    if (!eligibilityData.clinics?.length) {
+      recordEvent({
+        event: 'vaos-error',
+        'error-key': 'direct-available-clinics-failure',
+      });
+    }
+
+    if (
+      typeOfCareId === PRIMARY_CARE &&
+      !hasPACTeamIfPrimaryCare(eligibilityData, typeOfCareId, systemId)
+    ) {
+      recordEvent({
+        event: 'vaos-error',
+        'error-key': 'direct-pac-team-failure',
+      });
+    }
+  }
 }

--- a/src/applications/vaos/utils/eligibility.js
+++ b/src/applications/vaos/utils/eligibility.js
@@ -109,9 +109,9 @@ function hasVisitedInPastMonthsDirect(eligibilityData) {
 
 function hasVisitedInPastMonthsRequest(eligibilityData) {
   return (
-    eligibilityData.requestPastVisit.durationInMonths ===
+    eligibilityData.requestPastVisit?.durationInMonths ===
       DISABLED_LIMIT_VALUE ||
-    eligibilityData.requestPastVisit.hasVisitedInPastMonths
+    eligibilityData.requestPastVisit?.hasVisitedInPastMonths
   );
 }
 
@@ -124,9 +124,9 @@ function hasPACTeamIfPrimaryCare(eligibilityData, typeOfCareId, systemId) {
 
 function isUnderRequestLimit(eligibilityData) {
   return (
-    eligibilityData.requestLimits.requestLimit === DISABLED_LIMIT_VALUE ||
-    eligibilityData.requestLimits.numberOfRequests <
-      eligibilityData.requestLimits.requestLimit
+    eligibilityData.requestLimits?.requestLimit === DISABLED_LIMIT_VALUE ||
+    eligibilityData.requestLimits?.numberOfRequests <
+      eligibilityData.requestLimits?.requestLimit
   );
 }
 
@@ -135,11 +135,11 @@ function isDirectSchedulingEnabled(eligibilityData) {
 }
 
 function hasRequestFailed(eligibilityData) {
-  return Object.values(eligibilityData).some(result => result.requestFailed);
+  return Object.values(eligibilityData).some(result => result?.requestFailed);
 }
 
 function hasDirectFailed(eligibilityData) {
-  return Object.values(eligibilityData).some(result => result.directFailed);
+  return Object.values(eligibilityData).some(result => result?.directFailed);
 }
 
 /*

--- a/src/applications/vaos/utils/events.js
+++ b/src/applications/vaos/utils/events.js
@@ -1,0 +1,8 @@
+import recordEvent from 'platform/monitoring/record-event';
+
+export function recordVaosError(errorKey) {
+  recordEvent({
+    event: 'vaos-error',
+    'error-key': errorKey,
+  });
+}


### PR DESCRIPTION
## Description
Add the following GA events throughout the app:

- 'schedule appointment' button clicked on homepage
  - `vaos-schedule-appointment-button-clicked`
- 'New Appointment' on confirmation page
  - `vaos-schedule-another-appointment-button-clicked`
- 'submit request/appointment' button clicked
  - `vaos-community-care-submission`
  - `vaos-direct-submission`
  - `vaos-request-submission`
  - As additional data, capture type of care and flow (VA Req, CC Req, DS)
    - `{ typeOfCare: ‘Primary Care’, flow: ‘direct’}`
- Form submission succeeded
  - `vaos-community-care-submission-successful`
  - `vaos-direct-submission-successful`
  - `vaos-request-submission-successful`
  - As additional data, capture type of care and flow (VA Req, CC Req, DS)
    - `{ typeOfCare: ‘Primary Care’, flow: ‘direct’}`
- Form submission failed 
  - `vaos-community-care-submission-failed`
  - `vaos-direct-submission-failed`
  - `vaos-request-submission-failed`
  - As additional data, capture type of care and flow (VA Req, CC Req, DS)
    - `{ typeOfCare: ‘Primary Care’, flow: ‘direct’}`
- ~~'return to legacy VAOS' link clicked~~ (will be covered in https://github.com/department-of-veterans-affairs/vets-website/pull/11813)
	- `vaos-return-to-legacy-link-clicked`
	    - `{ typeOfCare: ‘Primary Care’, flow: ‘direct’}`
- 'Cancel' link clicked
  - `vaos-cancel-appointment-submission`
  - As additional data, capture confirmed vs pending & whether VA or CC
    - `{ appointmentType: ‘pending’, facilityType: ‘va’}`
- 'Cancel' succeeded
  - `vaos-cancel-appointment-submission-successful`
  - As additional data, capture confirmed vs pending & whether VA or CC
    - `{ appointmentType: ‘confirmed’, facilityType: ‘va’}`
- 'Cancel' failed
  - `vaos-cancel-appointment-submission-failed`
  - As additional data, capture confirmed vs pending & whether VA or CC
    - `{ appointmentType: ‘pending’, facilityType: ‘va’}`

Also added `vaos-error` events and set the `error-key` for error/failure states for the errors below:

- Exceeded outstanding requests limit/errored
  - `request-exceeded-outstanding-requests-failure`
  - `request-exceeded-outstanding-requests-error`
- Doesn't meet requests past visits requirement/errored
  - `request-past-visits-failure`
  - `request-past-visits-error`
- Doesn't meet direct schedule past visits requirement/errored
  - `direct-check-past-visits-failure`
  - `direct-check-past-visits-error`
- Doesn't have any available clinics/errored
  - `direct-available-clinics-failure`
  - `direct-available-clinics-error`
- Doesn't have any clinics available that match past clinics/errored
  - @jbalboni I'm not sure exactly where to put the event for this.  Can you point me in the right direction?
- Doesn't have active PACT members/errored
  - `direct-pac-team-failure`
  - `direct-pac-team-error`

## Testing done
Local and unit

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
