### PR TITLE
6219 686 spouse marriage history part II

### DIFF
--- a/src/applications/disability-benefits/new-686/components/SpouseViewField.jsx
+++ b/src/applications/disability-benefits/new-686/components/SpouseViewField.jsx
@@ -4,7 +4,7 @@ export default function SpouseViewField({ formData }) {
   const { first, middle, last, suffix } = formData.spouseFormerPartnerName;
 
   return (
-    <div>
+    <div className="vads-u-padding--2">
       <strong>
         {first} {middle && `${middle} `}
         {last}

--- a/src/applications/disability-benefits/new-686/components/SpouseViewField.jsx
+++ b/src/applications/disability-benefits/new-686/components/SpouseViewField.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+export default function SpouseViewField({ formData }) {
+  const { first, middle, last, suffix } = formData.spouseFormerPartnerName;
+
+  return (
+    <div>
+      <strong>
+        {first} {middle && `${middle} `}
+        {last}
+        {suffix && `, ${suffix}`}
+      </strong>
+      <br />
+    </div>
+  );
+}

--- a/src/applications/disability-benefits/new-686/config/chapters/report-add-a-spouse/current-marriage-information/currentMarriageInformation.js
+++ b/src/applications/disability-benefits/new-686/config/chapters/report-add-a-spouse/current-marriage-information/currentMarriageInformation.js
@@ -39,7 +39,7 @@ export const uiSchema = {
     },
     city: {
       'ui:required': formData => isChapterFieldRequired(formData, 'addSpouse'),
-      'ui:title': 'City (or APO/FPO/DPO)',
+      'ui:title': 'City or county',
     },
   },
   marriageType: {

--- a/src/applications/disability-benefits/new-686/config/chapters/report-add-a-spouse/current-spouse-marriage-history-details/currentSpouseMarriageHistoryDetails.js
+++ b/src/applications/disability-benefits/new-686/config/chapters/report-add-a-spouse/current-spouse-marriage-history-details/currentSpouseMarriageHistoryDetails.js
@@ -1,6 +1,7 @@
 import currentOrPastDateUI from 'platform/forms-system/src/js/definitions/currentOrPastDate';
 
 import { genericSchemas } from '../../../generic-schema';
+import { spouseTitle } from './helpers';
 
 const { date, genericLocation, genericTextInput } = genericSchemas;
 
@@ -39,7 +40,7 @@ export const schema = {
 export const uiSchema = {
   spouseMarriageHistory: {
     items: {
-      'ui:title': 'Placeholder for now',
+      'ui:title': spouseTitle,
       marriageStartDate: {
         ...currentOrPastDateUI('Date of marriage'),
         ...{

--- a/src/applications/disability-benefits/new-686/config/chapters/report-add-a-spouse/current-spouse-marriage-history-details/currentSpouseMarriageHistoryDetails.js
+++ b/src/applications/disability-benefits/new-686/config/chapters/report-add-a-spouse/current-spouse-marriage-history-details/currentSpouseMarriageHistoryDetails.js
@@ -1,7 +1,7 @@
 import currentOrPastDateUI from 'platform/forms-system/src/js/definitions/currentOrPastDate';
 
 import { genericSchemas } from '../../../generic-schema';
-import { spouseTitle } from './helpers';
+import { SpouseTitle } from './helpers';
 
 const { date, genericLocation, genericTextInput } = genericSchemas;
 
@@ -40,21 +40,21 @@ export const schema = {
 export const uiSchema = {
   spouseMarriageHistory: {
     items: {
-      'ui:title': spouseTitle,
+      'ui:title': SpouseTitle,
       marriageStartDate: {
         ...currentOrPastDateUI('Date of marriage'),
         ...{
-          'ui:required': formData => formData.spouseWasMarriedBefore === true,
+          'ui:required': formData => formData.spouseWasMarriedBefore,
         },
       },
       marriageStartLocation: {
         'ui:title': 'Where did this marriage take place?',
         state: {
-          'ui:required': formData => formData.spouseWasMarriedBefore === true,
+          'ui:required': formData => formData.spouseWasMarriedBefore,
           'ui:title': 'State (or country if outside the U.S.)',
         },
         city: {
-          'ui:required': formData => formData.spouseWasMarriedBefore === true,
+          'ui:required': formData => formData.spouseWasMarriedBefore,
           'ui:title': 'City or county',
         },
       },
@@ -74,17 +74,17 @@ export const uiSchema = {
       marriageEndDate: {
         ...currentOrPastDateUI('When did marriage end?'),
         ...{
-          'ui:required': formData => formData.spouseWasMarriedBefore === true,
+          'ui:required': formData => formData.spouseWasMarriedBefore,
         },
       },
       marriageEndLocation: {
         'ui:title': 'Where did this marriage end?',
         state: {
-          'ui:required': formData => formData.spouseWasMarriedBefore === true,
+          'ui:required': formData => formData.spouseWasMarriedBefore,
           'ui:title': 'State (or country if outside the U.S.)',
         },
         city: {
-          'ui:required': formData => formData.spouseWasMarriedBefore === true,
+          'ui:required': formData => formData.spouseWasMarriedBefore,
           'ui:title': 'City or county',
         },
       },

--- a/src/applications/disability-benefits/new-686/config/chapters/report-add-a-spouse/current-spouse-marriage-history-details/currentSpouseMarriageHistoryDetails.js
+++ b/src/applications/disability-benefits/new-686/config/chapters/report-add-a-spouse/current-spouse-marriage-history-details/currentSpouseMarriageHistoryDetails.js
@@ -1,0 +1,92 @@
+import currentOrPastDateUI from 'platform/forms-system/src/js/definitions/currentOrPastDate';
+
+import { genericSchemas } from '../../../generic-schema';
+
+const { date, genericLocation, genericTextInput } = genericSchemas;
+
+const reasonMarriageEndedSchema = {
+  type: 'string',
+  enum: ['DIVORCE', 'DEATH', 'ANNULMENT', 'OTHER'],
+  enumNames: ['Divorce', 'Death', 'Annulment', 'Other'],
+};
+
+const reasonMarriageEndedUISchema = {
+  'ui:required': formData => formData.spouseWasMarriedBefore === true,
+  'ui:title': 'Why did marriage end?',
+  'ui:widget': 'radio',
+};
+
+export const schema = {
+  type: 'object',
+  properties: {
+    spouseMarriageHistory: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          marriageStartDate: date,
+          marriageStartLocation: genericLocation,
+          reasonMarriageEnded: reasonMarriageEndedSchema,
+          reasonMarriageEndedOther: genericTextInput,
+          marriageEndDate: date,
+          marriageEndLocation: genericLocation,
+        },
+      },
+    },
+  },
+};
+
+export const uiSchema = {
+  spouseMarriageHistory: {
+    items: {
+      'ui:title': 'Placeholder for now',
+      marriageStartDate: {
+        ...currentOrPastDateUI('Date of marriage'),
+        ...{
+          'ui:required': formData => formData.spouseWasMarriedBefore === true,
+        },
+      },
+      marriageStartLocation: {
+        'ui:title': 'Where did this marriage take place?',
+        state: {
+          'ui:required': formData => formData.spouseWasMarriedBefore === true,
+          'ui:title': 'State (or country if outside the U.S.)',
+        },
+        city: {
+          'ui:required': formData => formData.spouseWasMarriedBefore === true,
+          'ui:title': 'City or county',
+        },
+      },
+      reasonMarriageEnded: reasonMarriageEndedUISchema,
+      reasonMarriageEndedOther: {
+        'ui:required': (formData, index) =>
+          formData.spouseMarriageHistory[`${index}`].reasonMarriageEnded ===
+          'OTHER',
+        'ui:title': 'Please give a brief explanation',
+        'ui:options': {
+          expandUnder: 'reasonMarriageEnded',
+          expandUnderCondition: 'OTHER',
+          keepInPageOnReview: true,
+          widgetClassNames: 'vads-u-margin-y--0',
+        },
+      },
+      marriageEndDate: {
+        ...currentOrPastDateUI('When did marriage end?'),
+        ...{
+          'ui:required': formData => formData.spouseWasMarriedBefore === true,
+        },
+      },
+      marriageEndLocation: {
+        'ui:title': 'Where did this marriage end?',
+        state: {
+          'ui:required': formData => formData.spouseWasMarriedBefore === true,
+          'ui:title': 'State (or country if outside the U.S.)',
+        },
+        city: {
+          'ui:required': formData => formData.spouseWasMarriedBefore === true,
+          'ui:title': 'City or county',
+        },
+      },
+    },
+  },
+};

--- a/src/applications/disability-benefits/new-686/config/chapters/report-add-a-spouse/current-spouse-marriage-history-details/helpers.jsx
+++ b/src/applications/disability-benefits/new-686/config/chapters/report-add-a-spouse/current-spouse-marriage-history-details/helpers.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-export function spouseTitle({ formData }) {
+export function SpouseTitle({ formData }) {
   return (
     <div>
       <h4 className="vads-u-border-color--link-default vads-u-border-bottom--2px vads-u-margin-top--0 vads-u-padding-bottom--0p5">

--- a/src/applications/disability-benefits/new-686/config/chapters/report-add-a-spouse/current-spouse-marriage-history-details/helpers.jsx
+++ b/src/applications/disability-benefits/new-686/config/chapters/report-add-a-spouse/current-spouse-marriage-history-details/helpers.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+export function spouseTitle({ formData }) {
+  return (
+    <div>
+      <h4 className="vads-u-border-color--link-default vads-u-border-bottom--2px vads-u-margin-top--0 vads-u-padding-bottom--0p5">
+        {formData.spouseFormerPartnerName.first}{' '}
+        {formData.spouseFormerPartnerName.last}
+      </h4>
+    </div>
+  );
+}

--- a/src/applications/disability-benefits/new-686/config/chapters/report-add-a-spouse/current-spouse-marriage-history/currentSpouseMarriageHistory.js
+++ b/src/applications/disability-benefits/new-686/config/chapters/report-add-a-spouse/current-spouse-marriage-history/currentSpouseMarriageHistory.js
@@ -35,6 +35,12 @@ export const uiSchema = {
       expandUnder: 'spouseWasMarriedBefore',
       expandUnderCondition: true,
       keepInPageOnReview: true,
+      // ui:required doesn't play well with expandUnder, possibly because the markup isn't added to the dom until the expandUnder condition is met.
+      // Because of this, a user can progress past the below fields, even if they're technically mandatory.
+      // Using updateSchema and ensuring at least one item needs to be in the array causes the validations to fire properly.
+      updateSchema: () => ({
+        minItems: 1,
+      }),
     },
     items: {
       spouseFormerPartnerName: {
@@ -43,6 +49,7 @@ export const uiSchema = {
         first: {
           'ui:title': 'Former spouse’s first name',
           'ui:errorMessages': { required: 'Please enter a first name' },
+          'ui:required': formData => formData.spouseWasMarriedBefore === true,
         },
         middle: {
           'ui:title': 'Former spouse’s middle name',
@@ -50,6 +57,7 @@ export const uiSchema = {
         last: {
           'ui:title': 'Former spouse’s last name',
           'ui:errorMessages': { required: 'Please enter a last name' },
+          'ui:required': formData => formData.spouseWasMarriedBefore === true,
         },
         suffix: {
           'ui:title': 'Former spouse’s suffix',

--- a/src/applications/disability-benefits/new-686/config/chapters/report-add-a-spouse/current-spouse-marriage-history/currentSpouseMarriageHistory.js
+++ b/src/applications/disability-benefits/new-686/config/chapters/report-add-a-spouse/current-spouse-marriage-history/currentSpouseMarriageHistory.js
@@ -11,7 +11,7 @@ export const schema = {
     spouseWasMarriedBefore: {
       type: 'boolean',
     },
-    spouseFormerMarriages: {
+    spouseMarriageHistory: {
       type: 'array',
       items: {
         type: 'object',
@@ -29,7 +29,7 @@ export const uiSchema = {
     'ui:widget': 'yesNo',
     'ui:required': formData => isChapterFieldRequired(formData, 'addSpouse'),
   },
-  spouseFormerMarriages: {
+  spouseMarriageHistory: {
     'ui:options': {
       viewField: SpouseViewField,
       expandUnder: 'spouseWasMarriedBefore',

--- a/src/applications/disability-benefits/new-686/config/chapters/report-add-a-spouse/current-spouse-marriage-history/currentSpouseMarriageHistory.js
+++ b/src/applications/disability-benefits/new-686/config/chapters/report-add-a-spouse/current-spouse-marriage-history/currentSpouseMarriageHistory.js
@@ -1,0 +1,61 @@
+import { isChapterFieldRequired } from '../../../helpers';
+import { genericSchemas } from '../../../generic-schema';
+import { validateName } from '../../../utilities';
+import SpouseViewField from '../../../../components/SpouseViewField';
+
+const { fullName } = genericSchemas;
+
+export const schema = {
+  type: 'object',
+  properties: {
+    spouseWasMarriedBefore: {
+      type: 'boolean',
+    },
+    spouseFormerMarriages: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          spouseFormerPartnerName: fullName,
+        },
+      },
+    },
+  },
+};
+
+export const uiSchema = {
+  spouseWasMarriedBefore: {
+    'ui:title': 'Was your spouse married before?',
+    'ui:widget': 'yesNo',
+    'ui:required': formData => isChapterFieldRequired(formData, 'addSpouse'),
+  },
+  spouseFormerMarriages: {
+    'ui:options': {
+      viewField: SpouseViewField,
+      expandUnder: 'spouseWasMarriedBefore',
+      expandUnderCondition: true,
+      keepInPageOnReview: true,
+    },
+    items: {
+      spouseFormerPartnerName: {
+        'ui:title': 'Former spouse’s information',
+        'ui:validations': [validateName],
+        first: {
+          'ui:title': 'Former spouse’s first name',
+          'ui:errorMessages': { required: 'Please enter a first name' },
+        },
+        middle: {
+          'ui:title': 'Former spouse’s middle name',
+        },
+        last: {
+          'ui:title': 'Former spouse’s last name',
+          'ui:errorMessages': { required: 'Please enter a last name' },
+        },
+        suffix: {
+          'ui:title': 'Former spouse’s suffix',
+          'ui:options': { widgetClassNames: 'form-select-medium' },
+        },
+      },
+    },
+  },
+};

--- a/src/applications/disability-benefits/new-686/config/chapters/report-add-a-spouse/index.js
+++ b/src/applications/disability-benefits/new-686/config/chapters/report-add-a-spouse/index.js
@@ -2,10 +2,12 @@ import * as spouseInformation from './spouse-information/spouseInformation';
 import * as currentMarriageInformation from './current-marriage-information/currentMarriageInformation';
 import * as doesLiveWithSpouse from './does-live-with-spouse/doesLiveWithSpouse';
 import * as spouseMarriageHistory from './current-spouse-marriage-history/currentSpouseMarriageHistory';
+import * as spouseMarriageHistoryDetails from './current-spouse-marriage-history-details/currentSpouseMarriageHistoryDetails';
 
 export {
   spouseInformation,
   currentMarriageInformation,
   doesLiveWithSpouse,
   spouseMarriageHistory,
+  spouseMarriageHistoryDetails,
 };

--- a/src/applications/disability-benefits/new-686/config/chapters/report-add-a-spouse/index.js
+++ b/src/applications/disability-benefits/new-686/config/chapters/report-add-a-spouse/index.js
@@ -1,5 +1,11 @@
 import * as spouseInformation from './spouse-information/spouseInformation';
 import * as currentMarriageInformation from './current-marriage-information/currentMarriageInformation';
 import * as doesLiveWithSpouse from './does-live-with-spouse/doesLiveWithSpouse';
+import * as spouseMarriageHistory from './current-spouse-marriage-history/currentSpouseMarriageHistory';
 
-export { spouseInformation, currentMarriageInformation, doesLiveWithSpouse };
+export {
+  spouseInformation,
+  currentMarriageInformation,
+  doesLiveWithSpouse,
+  spouseMarriageHistory,
+};

--- a/src/applications/disability-benefits/new-686/config/form.js
+++ b/src/applications/disability-benefits/new-686/config/form.js
@@ -10,6 +10,7 @@ import {
   currentMarriageInformation,
   doesLiveWithSpouse,
   spouseInformation,
+  spouseMarriageHistory,
 } from './chapters/report-add-a-spouse';
 import { wizard } from './chapters/taskWizard';
 import {
@@ -86,6 +87,12 @@ const formConfig = {
           path: 'current-marriage-address',
           uiSchema: doesLiveWithSpouse.uiSchema,
           schema: doesLiveWithSpouse.schema,
+        },
+        spouseMarriageHistory: {
+          title: 'Information needed to add your spouse',
+          path: 'current-spouse-marriage-history',
+          uiSchema: spouseMarriageHistory.uiSchema,
+          schema: spouseMarriageHistory.schema,
         },
       },
     },

--- a/src/applications/disability-benefits/new-686/config/form.js
+++ b/src/applications/disability-benefits/new-686/config/form.js
@@ -11,6 +11,7 @@ import {
   doesLiveWithSpouse,
   spouseInformation,
   spouseMarriageHistory,
+  spouseMarriageHistoryDetails,
 } from './chapters/report-add-a-spouse';
 import { wizard } from './chapters/taskWizard';
 import {
@@ -93,6 +94,14 @@ const formConfig = {
           path: 'current-spouse-marriage-history',
           uiSchema: spouseMarriageHistory.uiSchema,
           schema: spouseMarriageHistory.schema,
+        },
+        spouseMarriageHistoryDetails: {
+          title: 'Information needed to add your spouse',
+          path: 'current-spouse-marriage-history/:index',
+          showPagePerItem: true,
+          arrayPath: 'spouseMarriageHistory',
+          uiSchema: spouseMarriageHistoryDetails.uiSchema,
+          schema: spouseMarriageHistoryDetails.schema,
         },
       },
     },


### PR DESCRIPTION
## Description
[Original Ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/6219)

This pull request adds pages 4 & 5 to the `add spouse` workflow of the 686. Specifically, it allows a user to report any past marriages their spouse may have had in keeping with the requirements found on the paper version of the 686. 

Unit tests will be added in a separate pull request.

## Testing done
- local

## Screenshots
![Screen Shot 2020-03-05 at 9 34 55 AM](https://user-images.githubusercontent.com/15097156/76010268-79038c80-5ec7-11ea-99dd-e6e2a9cbe587.png)
![Screen Shot 2020-03-05 at 9 43 50 AM](https://user-images.githubusercontent.com/15097156/76010279-7f920400-5ec7-11ea-8e22-3927010adb52.png)
![Screen Shot 2020-03-05 at 9 50 25 AM](https://user-images.githubusercontent.com/15097156/76010305-8882d580-5ec7-11ea-8fe6-6da549a32609.png)
![Screen Shot 2020-03-05 at 9 50 48 AM](https://user-images.githubusercontent.com/15097156/76010326-8fa9e380-5ec7-11ea-82de-42a012ff25b3.png)
![Screen Shot 2020-03-05 at 9 51 28 AM](https://user-images.githubusercontent.com/15097156/76010338-95072e00-5ec7-11ea-9fe5-f0764868a32e.png)


## Acceptance criteria
- [x] pages have been added.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
