### PR TITLE
1995-STEM: "Based on you responses" should be "Based on your responses"

### DIFF
--- a/src/applications/edu-benefits/1995/containers/StemEligibilityView.jsx
+++ b/src/applications/edu-benefits/1995/containers/StemEligibilityView.jsx
@@ -140,6 +140,11 @@ export class StemEligibilityView extends React.Component {
       <div className={divClassName}>
         <fieldset className="schemaform-field-template schemaform-first-field">
           <legend className={legendClassName}>
+            <div className="sr-only">
+              {this.renderIsEdithNourseRogersScholarshipCheck()}
+              {this.renderExhaustionOfBenefitsCheck()}
+              {this.renderIsEnrolledStemCheck()}
+            </div>
             Since it appears you're not eligible for the scholarship, would you
             still like to apply and let us determine your eligibility?
             <span className="schemaform-required-span">(*Required)</span>

--- a/src/applications/edu-benefits/1995/containers/StemEligibilityView.jsx
+++ b/src/applications/edu-benefits/1995/containers/StemEligibilityView.jsx
@@ -220,9 +220,11 @@ export class StemEligibilityView extends React.Component {
     return (
       <div>
         <div className="vads-u-background-color--gray-lightest vads-u-padding-y--1 vads-u-padding-x--2">
-          {this.renderChecks()}
-          {this.renderDetermineEligibility()}
-          {this.renderExploreOtherBenefits()}
+          <ul>
+            {this.renderChecks()}
+            {this.renderDetermineEligibility()}
+            {this.renderExploreOtherBenefits()}
+          </ul>
         </div>
         {this.renderContinueApplication()}
       </div>

--- a/src/applications/edu-benefits/1995/containers/StemEligibilityView.jsx
+++ b/src/applications/edu-benefits/1995/containers/StemEligibilityView.jsx
@@ -140,13 +140,6 @@ export class StemEligibilityView extends React.Component {
       <div className={divClassName}>
         <fieldset className="schemaform-field-template schemaform-first-field">
           <legend className={legendClassName}>
-            <div className="sr-only">
-              <ul>
-                {this.renderIsEdithNourseRogersScholarshipCheck()}
-                {this.renderExhaustionOfBenefitsCheck()}
-                {this.renderIsEnrolledStemCheck()}
-              </ul>
-            </div>
             Since it appears you're not eligible for the scholarship, would you
             still like to apply and let us determine your eligibility?
             <span className="schemaform-required-span">(*Required)</span>

--- a/src/applications/edu-benefits/1995/containers/StemEligibilityView.jsx
+++ b/src/applications/edu-benefits/1995/containers/StemEligibilityView.jsx
@@ -89,7 +89,7 @@ export class StemEligibilityView extends React.Component {
     <div>
       <p className="vads-u-margin-bottom--1">
         <span className="vads-u-font-family--serif heading-level-4">
-          Based on you responses, it appears you're not eligible.
+          Based on your responses, it appears you're not eligible.
         </span>
         <br />
         <br />

--- a/src/applications/edu-benefits/1995/containers/StemEligibilityView.jsx
+++ b/src/applications/edu-benefits/1995/containers/StemEligibilityView.jsx
@@ -141,9 +141,11 @@ export class StemEligibilityView extends React.Component {
         <fieldset className="schemaform-field-template schemaform-first-field">
           <legend className={legendClassName}>
             <div className="sr-only">
-              {this.renderIsEdithNourseRogersScholarshipCheck()}
-              {this.renderExhaustionOfBenefitsCheck()}
-              {this.renderIsEnrolledStemCheck()}
+              <ul>
+                {this.renderIsEdithNourseRogersScholarshipCheck()}
+                {this.renderExhaustionOfBenefitsCheck()}
+                {this.renderIsEnrolledStemCheck()}
+              </ul>
             </div>
             Since it appears you're not eligible for the scholarship, would you
             still like to apply and let us determine your eligibility?
@@ -220,11 +222,9 @@ export class StemEligibilityView extends React.Component {
     return (
       <div>
         <div className="vads-u-background-color--gray-lightest vads-u-padding-y--1 vads-u-padding-x--2">
-          <ul>
-            {this.renderChecks()}
-            {this.renderDetermineEligibility()}
-            {this.renderExploreOtherBenefits()}
-          </ul>
+          {this.renderChecks()}
+          {this.renderDetermineEligibility()}
+          {this.renderExploreOtherBenefits()}
         </div>
         {this.renderContinueApplication()}
       </div>


### PR DESCRIPTION
## Description
A typographical error is present on the "Rogers STEM Scholarship eligibility" page of the 1995-STEM form. "You" in the header of the box indicating why a user is not eligible should be "your". See screenshot below

https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/6393

## Testing done
Local testing 
## Screenshots


<img width="580" alt="Screen Shot 2020-03-06 at 7 53 10 AM" src="https://user-images.githubusercontent.com/50601724/76085299-c0e5ea80-5f7f-11ea-8abe-a94b7e8d3e24.png">


## Acceptance criteria
- [x] Text reads `your` and not `you`

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
