### PR TITLE
bradl3yC - 6213 - Google analytics FE work address validation

### DIFF
--- a/src/platform/user/profile/vet360/actions/transactions.js
+++ b/src/platform/user/profile/vet360/actions/transactions.js
@@ -206,7 +206,7 @@ export const validateAddress = (
   try {
     const response = isVet360Configured()
       ? await apiRequest('/profile/address_validation', options)
-      : await localVet360.addressValidationError();
+      : await localVet360.addressValidationSuccess();
     const { addresses, validationKey } = response;
     const suggestedAddresses = addresses
       // sort highest confidence score to lowest confidence score

--- a/src/platform/user/profile/vet360/actions/transactions.js
+++ b/src/platform/user/profile/vet360/actions/transactions.js
@@ -249,7 +249,7 @@ export const validateAddress = (
     const showModal = showAddressValidationModal(suggestedAddresses);
 
     // push data to dataLayer for analytics
-    window.dataLayer.push({
+    recordEvent({
       event: 'profile-navigation',
       'profile-action': 'update-button',
       'profile-section': analyticsSectionName,
@@ -283,7 +283,7 @@ export const validateAddress = (
       ),
     );
   } catch (error) {
-    window.dataLayer.push({
+    recordEvent({
       event: 'profile-edit-failure',
       'profile-action': 'address-suggestion-failure',
       'profile-section': analyticsSectionName,

--- a/src/platform/user/profile/vet360/actions/transactions.js
+++ b/src/platform/user/profile/vet360/actions/transactions.js
@@ -3,6 +3,7 @@ import { refreshProfile } from 'platform/user/profile/actions';
 import recordEvent from 'platform/monitoring/record-event';
 import { inferAddressType } from 'applications/letters/utils/helpers';
 import { showAddressValidationModal } from '../../utilities';
+import kebabCase from 'lodash/kebabCase';
 
 import localVet360, { isVet360Configured } from '../util/local-vet360';
 import { CONFIRMED } from '../../constants/addressValidationMessages';
@@ -248,6 +249,18 @@ export const validateAddress = (
     // and only one confirmed address came back from the API
     const showModal = showAddressValidationModal(suggestedAddresses);
 
+    // push data to dataLayer for analytics
+
+    window.dataLayer.push({
+      event: 'profile-navigation',
+      'profile-action': 'update-button',
+      'profile-section': kebabCase(fieldName),
+      'profile-addressValidationAlertShown': showModal ? 'yes' : 'no',
+      'profile-addressSuggestionProvided': confirmedSuggestions.length
+        ? 'yes'
+        : 'no',
+    });
+
     // show the modal if the API doesn't find a single solid match for the address
     if (showModal) {
       return dispatch({
@@ -272,6 +285,12 @@ export const validateAddress = (
       ),
     );
   } catch (error) {
+    window.dataLayer.push({
+      event: 'profile-edit-failure',
+      'profile-action': 'address-suggestion-failure',
+      'profile-section': kebabCase(fieldName),
+    });
+
     return dispatch({
       type: ADDRESS_VALIDATION_ERROR,
       addressValidationError: true,

--- a/src/platform/user/profile/vet360/actions/transactions.js
+++ b/src/platform/user/profile/vet360/actions/transactions.js
@@ -249,7 +249,6 @@ export const validateAddress = (
     const showModal = showAddressValidationModal(suggestedAddresses);
 
     // push data to dataLayer for analytics
-
     window.dataLayer.push({
       event: 'profile-navigation',
       'profile-action': 'update-button',

--- a/src/platform/user/profile/vet360/actions/transactions.js
+++ b/src/platform/user/profile/vet360/actions/transactions.js
@@ -3,7 +3,6 @@ import { refreshProfile } from 'platform/user/profile/actions';
 import recordEvent from 'platform/monitoring/record-event';
 import { inferAddressType } from 'applications/letters/utils/helpers';
 import { showAddressValidationModal } from '../../utilities';
-import kebabCase from 'lodash/kebabCase';
 
 import localVet360, { isVet360Configured } from '../util/local-vet360';
 import { CONFIRMED } from '../../constants/addressValidationMessages';
@@ -207,7 +206,7 @@ export const validateAddress = (
   try {
     const response = isVet360Configured()
       ? await apiRequest('/profile/address_validation', options)
-      : await localVet360.addressValidationSuccess();
+      : await localVet360.addressValidationError();
     const { addresses, validationKey } = response;
     const suggestedAddresses = addresses
       // sort highest confidence score to lowest confidence score
@@ -254,7 +253,7 @@ export const validateAddress = (
     window.dataLayer.push({
       event: 'profile-navigation',
       'profile-action': 'update-button',
-      'profile-section': kebabCase(fieldName),
+      'profile-section': analyticsSectionName,
       'profile-addressValidationAlertShown': showModal ? 'yes' : 'no',
       'profile-addressSuggestionProvided': confirmedSuggestions.length
         ? 'yes'
@@ -288,7 +287,7 @@ export const validateAddress = (
     window.dataLayer.push({
       event: 'profile-edit-failure',
       'profile-action': 'address-suggestion-failure',
-      'profile-section': kebabCase(fieldName),
+      'profile-section': analyticsSectionName,
     });
 
     return dispatch({

--- a/src/platform/user/profile/vet360/containers/AddressValidationModal.jsx
+++ b/src/platform/user/profile/vet360/containers/AddressValidationModal.jsx
@@ -16,7 +16,6 @@ import {
 import { focusElement } from 'platform/utilities/ui';
 import { getValidationMessageKey } from '../../utilities';
 import { ADDRESS_VALIDATION_MESSAGES } from '../../constants/addressValidationMessages';
-import kebabCase from 'lodash/kebabCase';
 
 import * as VET360 from '../constants';
 
@@ -36,6 +35,7 @@ class AddressValidationModal extends React.Component {
       addressValidationType,
       selectedAddress,
       selectedAddressId,
+      analyticsSectionName,
     } = this.props;
 
     const payload = {
@@ -49,7 +49,7 @@ class AddressValidationModal extends React.Component {
 
     window.dataLayer.push({
       event: 'profile-transaction',
-      'profile-section': 'home-address',
+      'profile-section': analyticsSectionName,
       'profile-addressSuggestionUsed': suggestedAddressSelected ? 'yes' : 'no',
     });
 
@@ -73,11 +73,15 @@ class AddressValidationModal extends React.Component {
   };
 
   onEditClick = () => {
-    const { addressValidationType, addressFromUser } = this.props;
+    const {
+      addressValidationType,
+      addressFromUser,
+      analyticsSectionName,
+    } = this.props;
     window.dataLayer.push({
       event: 'profile-navigation',
       'profile-action': 'edit-link',
-      'profile-section': kebabCase(addressValidationType),
+      'profile-section': analyticsSectionName,
     });
     this.props.openModal(addressValidationType, addressFromUser);
   };

--- a/src/platform/user/profile/vet360/containers/AddressValidationModal.jsx
+++ b/src/platform/user/profile/vet360/containers/AddressValidationModal.jsx
@@ -60,7 +60,7 @@ class AddressValidationModal extends React.Component {
         method,
         addressValidationType,
         payload,
-        this.props.analyticsSectionName,
+        analyticsSectionName,
       );
     } else {
       this.props.createTransaction(
@@ -68,7 +68,7 @@ class AddressValidationModal extends React.Component {
         method,
         addressValidationType,
         payload,
-        this.props.analyticsSectionName,
+        analyticsSectionName,
       );
     }
   };

--- a/src/platform/user/profile/vet360/containers/AddressValidationModal.jsx
+++ b/src/platform/user/profile/vet360/containers/AddressValidationModal.jsx
@@ -16,6 +16,7 @@ import {
 import { focusElement } from 'platform/utilities/ui';
 import { getValidationMessageKey } from '../../utilities';
 import { ADDRESS_VALIDATION_MESSAGES } from '../../constants/addressValidationMessages';
+import recordEvent from 'platform/monitoring/record-event';
 
 import * as VET360 from '../constants';
 
@@ -47,7 +48,7 @@ class AddressValidationModal extends React.Component {
 
     const method = payload.id ? 'PUT' : 'POST';
 
-    window.dataLayer.push({
+    recordEvent({
       event: 'profile-transaction',
       'profile-section': analyticsSectionName,
       'profile-addressSuggestionUsed': suggestedAddressSelected ? 'yes' : 'no',
@@ -78,7 +79,7 @@ class AddressValidationModal extends React.Component {
       addressFromUser,
       analyticsSectionName,
     } = this.props;
-    window.dataLayer.push({
+    recordEvent({
       event: 'profile-navigation',
       'profile-action': 'edit-link',
       'profile-section': analyticsSectionName,

--- a/src/platform/user/profile/vet360/containers/AddressValidationModal.jsx
+++ b/src/platform/user/profile/vet360/containers/AddressValidationModal.jsx
@@ -16,6 +16,7 @@ import {
 import { focusElement } from 'platform/utilities/ui';
 import { getValidationMessageKey } from '../../utilities';
 import { ADDRESS_VALIDATION_MESSAGES } from '../../constants/addressValidationMessages';
+import kebabCase from 'lodash/kebabCase';
 
 import * as VET360 from '../constants';
 
@@ -42,9 +43,17 @@ class AddressValidationModal extends React.Component {
       validationKey,
     };
 
+    const suggestedAddressSelected = selectedAddressId !== 'userEntered';
+
     const method = payload.id ? 'PUT' : 'POST';
 
-    if (selectedAddressId !== 'userEntered') {
+    window.dataLayer.push({
+      event: 'profile-transaction',
+      'profile-section': 'home-address',
+      'profile-addressSuggestionUsed': suggestedAddressSelected ? 'yes' : 'no',
+    });
+
+    if (suggestedAddressSelected) {
       this.props.updateValidationKeyAndSave(
         VET360.API_ROUTES.ADDRESSES,
         method,
@@ -63,13 +72,21 @@ class AddressValidationModal extends React.Component {
     }
   };
 
+  onEditClick = () => {
+    const { addressValidationType, addressFromUser } = this.props;
+    window.dataLayer.push({
+      event: 'profile-navigation',
+      'profile-action': 'edit-link',
+      'profile-section': kebabCase(addressValidationType),
+    });
+    this.props.openModal(addressValidationType, addressFromUser);
+  };
+
   renderPrimaryButton = () => {
     const {
       addressValidationError,
-      addressValidationType,
       validationKey,
       isLoading,
-      addressFromUser,
       confirmedSuggestions,
     } = this.props;
 
@@ -88,12 +105,7 @@ class AddressValidationModal extends React.Component {
       (!confirmedSuggestions.length && !validationKey)
     ) {
       return (
-        <button
-          className="usa-button-primary"
-          onClick={() =>
-            this.props.openModal(addressValidationType, addressFromUser)
-          }
-        >
+        <button className="usa-button-primary" onClick={this.onEditClick}>
           Edit Address
         </button>
       );
@@ -110,8 +122,6 @@ class AddressValidationModal extends React.Component {
     const {
       validationKey,
       addressValidationError,
-      addressValidationType,
-      addressFromUser,
       selectedAddressId,
       confirmedSuggestions,
     } = this.props;
@@ -163,12 +173,7 @@ class AddressValidationModal extends React.Component {
               zipCode && <span>{` ${city}, ${stateCode} ${zipCode}`}</span>}
             {isAddressFromUser &&
               showEditLink && (
-                <button
-                  className="va-button-link"
-                  onClick={() =>
-                    this.props.openModal(addressValidationType, addressFromUser)
-                  }
-                >
+                <button className="va-button-link" onClick={this.onEditClick}>
                   Edit Address
                 </button>
               )}
@@ -222,11 +227,7 @@ class AddressValidationModal extends React.Component {
           status="warning"
           headline={addressValidationMessage.headline}
         >
-          <addressValidationMessage.ModalText
-            editFunction={() =>
-              this.props.openModal(addressValidationType, addressFromUser)
-            }
-          />
+          <addressValidationMessage.ModalText editFunction={this.onEditClick} />
         </AlertBox>
         <form onSubmit={this.onSubmit}>
           <span className="vads-u-font-weight--bold">You entered:</span>


### PR DESCRIPTION
## Description
Add dataLayer pushes to each of the interactions with address validation

## Testing done


## Screenshots

### User updates address - address validation modal is shown with suggestions
![Screen Shot 2020-03-06 at 10 14 51 AM](https://user-images.githubusercontent.com/6165421/76096648-6c993580-5f94-11ea-9ac7-8cf3492e64b5.png)

### Saved address via validation modal using OVERRIDE
![Screen Shot 2020-03-06 at 10 30 54 AM](https://user-images.githubusercontent.com/6165421/76097375-9acb4500-5f95-11ea-9551-f06d548be052.png)

### Saved address via validation modal using SUGGESTED ADDRESS
![Screen Shot 2020-03-06 at 10 31 55 AM](https://user-images.githubusercontent.com/6165421/76097445-b8001380-5f95-11ea-8c1f-25321b04ed7a.png)

### Edit address link clicked
![Screen Shot 2020-03-06 at 10 32 58 AM](https://user-images.githubusercontent.com/6165421/76097530-e41b9480-5f95-11ea-8b4d-d9a7d8e41ead.png)

### Address validation error
![Screen Shot 2020-03-06 at 10 33 57 AM](https://user-images.githubusercontent.com/6165421/76097624-06adad80-5f96-11ea-88b4-27e0e6c147a5.png)



## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
