### PR TITLE
Move location of AddressValidationModal in component tree

### DIFF
--- a/src/platform/user/profile/vet360/components/AddressField/AddressField.jsx
+++ b/src/platform/user/profile/vet360/components/AddressField/AddressField.jsx
@@ -14,6 +14,7 @@ import {
 import Vet360ProfileField from 'vet360/containers/Vet360ProfileField';
 
 import AddressEditModal from './AddressEditModal';
+import AddressValidationModal from '../../containers/AddressValidationModal';
 import AddressView from './AddressView';
 
 import { getFormSchema, getUiSchema } from './address-schemas';
@@ -164,6 +165,7 @@ export default class AddressField extends React.Component {
         deleteDisabled={this.props.deleteDisabled}
         Content={AddressView}
         EditModal={AddressEditModal}
+        ValidationModal={AddressValidationModal}
         formSchema={getFormSchema(this.props.fieldName)}
         uiSchema={getUiSchema(this.props.fieldName)}
       />

--- a/src/platform/user/profile/vet360/containers/AddressValidationModal.jsx
+++ b/src/platform/user/profile/vet360/containers/AddressValidationModal.jsx
@@ -5,7 +5,6 @@ import { bindActionCreators } from 'redux';
 import Modal from '@department-of-veterans-affairs/formation-react/Modal';
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 import LoadingButton from 'platform/site-wide/loading-button/LoadingButton';
-import { selectCurrentlyOpenEditModal } from '../selectors';
 import {
   openModal,
   createTransaction,
@@ -181,7 +180,6 @@ class AddressValidationModal extends React.Component {
 
   render() {
     const {
-      isAddressValidationModalVisible,
       addressValidationType,
       suggestedAddresses,
       addressFromUser,
@@ -217,7 +215,7 @@ class AddressValidationModal extends React.Component {
         }
         id="address-validation-warning"
         onClose={resetDataAndCloseModal}
-        visible={isAddressValidationModalVisible}
+        visible
       >
         <AlertBox
           className="vads-u-margin-bottom--1"
@@ -264,8 +262,6 @@ const mapStateToProps = state => {
     analyticsSectionName: VET360.ANALYTICS_FIELD_MAP[addressValidationType],
     isLoading:
       state.vet360.fieldTransactionMap[addressValidationType]?.isPending,
-    isAddressValidationModalVisible:
-      selectCurrentlyOpenEditModal(state) === 'addressValidation',
     addressValidationError:
       state.vet360.addressValidation.addressValidationError,
     suggestedAddresses: state.vet360.addressValidation.suggestedAddresses,
@@ -294,7 +290,6 @@ const mapDispatchToProps = dispatch => ({
 
 AddressValidationModal.propTypes = {
   analyticsSectionName: PropTypes.string,
-  isAddressValidationModalVisible: PropTypes.bool.isRequired,
   addressValidationError: PropTypes.bool.isRequired,
   suggestedAddresses: PropTypes.array.isRequired,
   confirmedSuggestions: PropTypes.arrayOf(

--- a/src/platform/user/profile/vet360/containers/InitializeVet360ID.jsx
+++ b/src/platform/user/profile/vet360/containers/InitializeVet360ID.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import AddressValidationModal from './AddressValidationModal';
-import environment from 'platform/utilities/environment';
+// import AddressValidationModal from './AddressValidationModal';
 
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 
@@ -18,7 +17,10 @@ import {
   refreshTransaction,
 } from '../actions';
 
-import { selectVet360InitializationStatus } from '../selectors';
+import {
+  selectVet360InitializationStatus,
+  // vaProfileUseAddressValidation,
+} from '../selectors';
 
 import TransactionPending from '../components/base/Vet360TransactionPending';
 
@@ -66,7 +68,7 @@ class InitializeVet360ID extends React.Component {
       case VET360_INITIALIZATION_STATUS.INITIALIZED:
         return (
           <div>
-            {!environment.isProduction() && <AddressValidationModal />}
+            {/* {this.props.useAddressValidation && <AddressValidationModal />} */}
             {this.props.children}
           </div>
         );
@@ -109,6 +111,7 @@ const mapStateToProps = state => {
     status,
     transaction,
     transactionRequest,
+    // useAddressValidation: vaProfileUseAddressValidation(state),
   };
 };
 

--- a/src/platform/user/profile/vet360/containers/InitializeVet360ID.jsx
+++ b/src/platform/user/profile/vet360/containers/InitializeVet360ID.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { connect } from 'react-redux';
-// import AddressValidationModal from './AddressValidationModal';
 
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 
@@ -17,10 +16,7 @@ import {
   refreshTransaction,
 } from '../actions';
 
-import {
-  selectVet360InitializationStatus,
-  // vaProfileUseAddressValidation,
-} from '../selectors';
+import { selectVet360InitializationStatus } from '../selectors';
 
 import TransactionPending from '../components/base/Vet360TransactionPending';
 
@@ -66,12 +62,7 @@ class InitializeVet360ID extends React.Component {
   render() {
     switch (this.props.status) {
       case VET360_INITIALIZATION_STATUS.INITIALIZED:
-        return (
-          <div>
-            {/* {this.props.useAddressValidation && <AddressValidationModal />} */}
-            {this.props.children}
-          </div>
-        );
+        return <>{this.props.children}</>;
 
       case VET360_INITIALIZATION_STATUS.INITIALIZATION_FAILURE:
         return (
@@ -111,7 +102,6 @@ const mapStateToProps = state => {
     status,
     transaction,
     transactionRequest,
-    // useAddressValidation: vaProfileUseAddressValidation(state),
   };
 };
 

--- a/src/platform/user/profile/vet360/containers/Vet360ProfileField.jsx
+++ b/src/platform/user/profile/vet360/containers/Vet360ProfileField.jsx
@@ -240,7 +240,7 @@ class Vet360ProfileField extends React.Component {
   }
 }
 
-const mapStateToProps = (state, ownProps) => {
+export const mapStateToProps = (state, ownProps) => {
   const { fieldName } = ownProps;
   const { transaction, transactionRequest } = selectVet360Transaction(
     state,
@@ -251,6 +251,11 @@ const mapStateToProps = (state, ownProps) => {
   const useAddressValidation = vaProfileUseAddressValidation(state);
   const addressValidationType =
     state.vet360.addressValidation.addressValidationType;
+  const showValidationModal =
+    useAddressValidation &&
+    ownProps.ValidationModal &&
+    addressValidationType === fieldName &&
+    selectCurrentlyOpenEditModal(state) === 'addressValidation';
 
   return {
     analyticsSectionName: VET360.ANALYTICS_FIELD_MAP[fieldName],
@@ -258,11 +263,7 @@ const mapStateToProps = (state, ownProps) => {
     fieldName,
     field: selectEditedFormField(state, fieldName),
     isEditing: selectCurrentlyOpenEditModal(state) === fieldName,
-    showValidationModal:
-      useAddressValidation &&
-      ownProps.ValidationModal &&
-      addressValidationType === fieldName &&
-      selectCurrentlyOpenEditModal(state) === 'addressValidation',
+    showValidationModal: !!showValidationModal,
     isEmpty,
     transaction,
     transactionRequest,

--- a/src/platform/user/profile/vet360/containers/Vet360ProfileField.jsx
+++ b/src/platform/user/profile/vet360/containers/Vet360ProfileField.jsx
@@ -184,6 +184,8 @@ class Vet360ProfileField extends React.Component {
       isEmpty,
       Content,
       EditModal,
+      ValidationModal,
+      showValidationModal,
       title,
       transaction,
       transactionRequest,
@@ -211,6 +213,7 @@ class Vet360ProfileField extends React.Component {
           {title}
         </Vet360ProfileFieldHeading>
         {isEditing && <EditModal {...childProps} />}
+        {showValidationModal && <ValidationModal />}
         <Vet360Transaction
           id={`${fieldName}-transaction-status`}
           title={title}
@@ -246,6 +249,8 @@ const mapStateToProps = (state, ownProps) => {
   const data = selectVet360Field(state, fieldName);
   const isEmpty = !data;
   const useAddressValidation = vaProfileUseAddressValidation(state);
+  const addressValidationType =
+    state.vet360.addressValidation.addressValidationType;
 
   return {
     analyticsSectionName: VET360.ANALYTICS_FIELD_MAP[fieldName],
@@ -253,6 +258,11 @@ const mapStateToProps = (state, ownProps) => {
     fieldName,
     field: selectEditedFormField(state, fieldName),
     isEditing: selectCurrentlyOpenEditModal(state) === fieldName,
+    showValidationModal:
+      useAddressValidation &&
+      ownProps.ValidationModal &&
+      addressValidationType === fieldName &&
+      selectCurrentlyOpenEditModal(state) === 'addressValidation',
     isEmpty,
     transaction,
     transactionRequest,
@@ -290,6 +300,7 @@ Vet360ProfileFieldContainer.propTypes = {
   fieldName: PropTypes.oneOf(Object.values(VET360.FIELD_NAMES)).isRequired,
   Content: PropTypes.func.isRequired,
   EditModal: PropTypes.func.isRequired,
+  ValidationModal: PropTypes.func,
   title: PropTypes.string.isRequired,
   apiRoute: PropTypes.oneOf(Object.values(VET360.API_ROUTES)).isRequired,
   convertNextValueToCleanData: PropTypes.func.isRequired,


### PR DESCRIPTION
## Description
This is an attempt to fix the JAWS/IE11 screenreader issue described in https://github.com/department-of-veterans-affairs/va.gov-team/issues/5865

I moved the location of the AddressValidationModal component from waaaaaay up in the component chain to a better(?) home right alongside the EditModal component. I have no idea if this will make JAWS happy, but it does resolve an issue with a bunch of console errors popping up alongside the address validation modal.

## Testing done
Local (address validation still works as normal) + unit tests

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs