### PR TITLE
Update form errors & schema

### DIFF
--- a/src/applications/disability-benefits/996/constants.js
+++ b/src/applications/disability-benefits/996/constants.js
@@ -23,6 +23,7 @@ export const errorMessages = {
   informalConferenceContactPhone: 'Please provide a number',
   informalConferenceTimesMin: 'You can choose up to two time periods',
   informalConferenceTimesMax: 'You can choose up to two time periods',
+  contestedIssue: 'Please select a contested issue',
   contestedIssueCommentLength:
     'Please enter no more than 400 characters in this field',
 };

--- a/src/applications/disability-benefits/996/pages/contestedIssueFollowup.js
+++ b/src/applications/disability-benefits/996/pages/contestedIssueFollowup.js
@@ -43,6 +43,8 @@ const contestedIssueFollowup = {
     properties: {
       contestedIssues: {
         type: 'array',
+        minItems: 1,
+        maxItems: 100,
         items: {
           type: 'object',
           properties: {

--- a/src/applications/disability-benefits/996/validations/index.js
+++ b/src/applications/disability-benefits/996/validations/index.js
@@ -35,9 +35,9 @@ export const checkDateRange = (errors, { from = '', to = '' } = {}) => {
 
 export const requireRatedDisability = (err, fieldData /* , formData */) => {
   if (!fieldData.some(entry => entry['view:selected'])) {
-    // The actual validation error is displayed as an alert field, so we don't
-    // need to add an error message here.
-    err.addError('');
+    // The actual validation error is displayed as an alert field. The message
+    // here will be shown on the review page
+    err.addError(errorMessages.contestedIssue);
   }
 };
 

--- a/src/applications/disability-benefits/all-claims/pages/militaryHistory.js
+++ b/src/applications/disability-benefits/all-claims/pages/militaryHistory.js
@@ -54,6 +54,7 @@ export const schema = {
   type: 'object',
   properties: {
     serviceInformation: {
+      required: ['servicePeriods'], // required in fullSchema
       type: 'object',
       properties: {
         servicePeriods:

--- a/src/applications/disability-benefits/all-claims/validations.js
+++ b/src/applications/disability-benefits/all-claims/validations.js
@@ -241,7 +241,7 @@ export const isWithinServicePeriod = (errors, fieldData, formData) => {
       errors.from.addError(
         getPOWValidationMessage(servicePeriods.map(period => period.dateRange)),
       );
-      errors.to.addError('');
+      errors.to.addError('Please provide your service periods');
     }
   }
 };
@@ -263,8 +263,9 @@ export const validateDisabilityName = (err, fieldData) => {
 
 export const requireDisability = (err, fieldData, formData) => {
   if (!hasClaimedConditions(formData)) {
-    // The actual validation error is displayed as an alert field, so we don't need to add an error message here.
-    err.addError('');
+    // The actual validation error is displayed as an alert field. The message
+    // here will be shown on the review page
+    err.addError('Please select a disability');
   }
 };
 
@@ -273,8 +274,9 @@ export const requireDisability = (err, fieldData, formData) => {
  */
 export const requireRatedDisability = (err, fieldData, formData) => {
   if (increaseOnly(formData) && !claimingRated(formData)) {
-    // The actual validation error is displayed as an alert field, so we don't need to add an error message here.
-    err.addError('');
+    // The actual validation error is displayed as an alert field. The message
+    // here will be shown on the review page
+    err.addError('Please selected a rated disability');
   }
 };
 
@@ -284,7 +286,8 @@ export const requireRatedDisability = (err, fieldData, formData) => {
  */
 export const requireNewDisability = (err, fieldData, formData) => {
   if (!claimingRated(formData) && !fieldData) {
-    // The actual validation error is displayed as an alert field, so we don't need to add an error message here.
-    err.addError('');
+    // The actual validation error is displayed as an alert field. The message
+    // here will be shown on the review page
+    err.addError('No rated disability selected. Please add a new one');
   }
 };


### PR DESCRIPTION
## Description

As part of a new update to show form errors, this PR adds missing (empty) error messages and updates the schema of the HLR and 526 forms to match the full schema.

## Testing done

Local unit tests

## Screenshots

N/A - there are no visual indicators of this change

## Acceptance criteria
- [x] Empty error messages included
- [x] Schema update to match form schema

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
