### PR TITLE
Centralize number to words conversion

### DIFF
--- a/src/applications/disability-benefits/686/helpers.jsx
+++ b/src/applications/disability-benefits/686/helpers.jsx
@@ -3,6 +3,8 @@ import React from 'react';
 import moment from 'moment';
 import { transformForSubmit } from 'platform/forms-system/src/js/helpers';
 // import { apiRequest } from '../../../platform/utilities/api';
+import numberToWords from 'platform/forms-system/src/js/utilities/data/numberToWords';
+import titleCase from 'platform/utilities/data/titleCase';
 
 export const childRelationshipStatusLabels = {
   biological: 'Biological',
@@ -14,19 +16,6 @@ export const separationReasons = {
   DEATH: 'Death',
   DIVORCE: 'Divorce',
   OTHER: 'Other',
-};
-
-const numberToWords = {
-  0: 'First',
-  1: 'Second',
-  2: 'Third',
-  3: 'Fourth',
-  4: 'Fifth',
-  5: 'Sixth',
-  6: 'Seventh',
-  7: 'Eighth',
-  8: 'Ninth',
-  9: 'Tenth',
 };
 
 const militaryStates = [
@@ -117,11 +106,8 @@ export function isNotLivingWithParent(form, index) {
 }
 
 export function getMarriageTitle(index) {
-  const marriageNumber = numberToWords[index];
-
-  return marriageNumber
-    ? `${marriageNumber} marriage`
-    : `Marriage ${index + 1}`;
+  const marriageNumber = numberToWords(index + 1);
+  return `${titleCase(marriageNumber)} marriage`;
 }
 
 export function getMarriageTitleWithCurrent(form, index) {
@@ -132,11 +118,8 @@ export function getMarriageTitleWithCurrent(form, index) {
   return getMarriageTitle(index);
 }
 export function getSpouseMarriageTitle(index) {
-  const marriageNumber = numberToWords[index];
-
-  return marriageNumber
-    ? `Spouse’s ${marriageNumber.toLowerCase()} marriage`
-    : `Spouse marriage ${index + 1}`;
+  const marriageNumber = numberToWords(index + 1);
+  return `Spouse’s ${marriageNumber} marriage`;
 }
 
 export function calculateChildAge(form, index) {

--- a/src/applications/disability-benefits/686/tests/config/marriageHistory.unit.spec.jsx
+++ b/src/applications/disability-benefits/686/tests/config/marriageHistory.unit.spec.jsx
@@ -76,9 +76,10 @@ describe('686 marriage history', () => {
     const pageTitle = marriageHistory.title;
     it('uses word for index', () => {
       expect(pageTitle({}, { pagePerItemIndex: 0 })).to.equal('First marriage');
-    });
-    it('uses number when at index ten or greater', () => {
-      expect(pageTitle({}, { pagePerItemIndex: 10 })).to.equal('Marriage 11');
+      expect(pageTitle({}, { pagePerItemIndex: 10 })).to.equal(
+        'Eleventh marriage',
+      );
+      expect(pageTitle({}, { pagePerItemIndex: 49 })).to.equal('50th marriage');
     });
   });
 

--- a/src/applications/disability-benefits/all-claims/config/781/index.js
+++ b/src/applications/disability-benefits/all-claims/config/781/index.js
@@ -30,19 +30,8 @@ import {
   wantsHelpWithPrivateRecordsSecondary,
   wantsHelpRequestingStatementsSecondary,
 } from '../../utils';
-
-const numberToWords = {
-  0: 'First',
-  1: 'Second',
-  2: 'Third',
-  3: 'Fourth',
-  4: 'Fifth',
-  5: 'Sixth',
-  6: 'Seventh',
-  7: 'Eighth',
-  8: 'Ninth',
-  9: 'Tenth',
-};
+import numberToWords from 'platform/forms-system/src/js/utilities/data/numberToWords';
+import titleCase from 'platform/utilities/data/titleCase';
 
 const REVIEW_TITLE_TOKEN = '[index]';
 
@@ -50,10 +39,13 @@ const REVIEW_TITLE_TOKEN = '[index]';
  * This removes "First " from the title if there is only one incident.
  *
  * @param {string} [title] Displayed as the section summary header.
- * If contains REVIEW_TITLE_TOKEN and there is more than one incident, replaces REVIEW_TITLE_TOKEN with numberToWords[index].toLowerCase().
- * If does not contain REVIEW_TITLE_TOKEN appends numberToWords[index] to front of title.
+ * If contains REVIEW_TITLE_TOKEN and there is more than one incident, replaces
+ *   REVIEW_TITLE_TOKEN with numberToWords(index).
+ * If does not contain REVIEW_TITLE_TOKEN appends a capitalized
+ *   numberToWords(index + 1) to front of title.
  * @param {int} index Index of numberToWords
- * @param {string} formType Indicates what type of form is calling function; 781, 781a
+ * @param {string} formType Indicates what type of form is calling function;
+ *   781, 781a
  * @returns {object} title
  */
 const setReviewTitle = (title, index, formType) => formData => {
@@ -68,14 +60,16 @@ const setReviewTitle = (title, index, formType) => formData => {
     if (title.search(REVIEW_TITLE_TOKEN) > 0) {
       formattedTitle = title.replace(
         REVIEW_TITLE_TOKEN,
-        ` ${numberToWords[index].toLowerCase()} `,
+        ` ${numberToWords(index + 1)} `,
       );
     } else {
-      // If does not contain REVIEW_TITLE_TOKEN put numberToWords[index] at start of title
-      formattedTitle = `${numberToWords[index]} ${title}`;
+      // If does not contain REVIEW_TITLE_TOKEN put numberToWords(index + 1) at
+      // start of title
+      formattedTitle = `${titleCase(numberToWords(index + 1))} ${title}`;
     }
   } else {
-    formattedTitle = title.replace(REVIEW_TITLE_TOKEN, ' '); // can do this without a search check
+    // can do this without a search check
+    formattedTitle = title.replace(REVIEW_TITLE_TOKEN, ' ');
   }
 
   return formattedTitle;
@@ -316,9 +310,9 @@ export function createFormConfig781a(iterations) {
       },
       // 9. SUPPORTING DOCUMENTS UPLOAD
       [`secondaryUploadSourcesChoice${index}`]: {
-        title: `${
-          numberToWords[index]
-        } 781a PTSD Upload Supporting Sources Choice`,
+        title: `${titleCase(
+          numberToWords(index + 1),
+        )} 781a PTSD Upload Supporting Sources Choice`,
         path: `disabilities/ptsd-secondary-upload-supporting-sources-choice-${index}`,
         depends: isAnswering781aQuestions(index),
         uiSchema: secondaryUploadSourcesChoice.uiSchema(index),

--- a/src/applications/pensions/helpers.jsx
+++ b/src/applications/pensions/helpers.jsx
@@ -4,6 +4,8 @@ import moment from 'moment';
 import environment from 'platform/utilities/environment';
 import { fetchAndUpdateSessionExpiration as fetch } from 'platform/utilities/api';
 import { transformForSubmit } from 'platform/forms-system/src/js/helpers';
+import numberToWords from 'platform/forms-system/src/js/utilities/data/numberToWords';
+import titleCase from 'platform/utilities/data/titleCase';
 
 function replacer(key, value) {
   // if the containing object has a name, we’re in the national guard object
@@ -173,31 +175,14 @@ export function isMarried(form = {}) {
   return ['Married', 'Separated'].includes(form.maritalStatus);
 }
 
-const numberToWords = {
-  0: 'First',
-  1: 'Second',
-  2: 'Third',
-  3: 'Fourth',
-  4: 'Fifth',
-  5: 'Sixth',
-  6: 'Seventh',
-  7: 'Eighth',
-  8: 'Ninth',
-  9: 'Tenth',
-};
-
 export function getMarriageTitle(index) {
-  const desc = numberToWords[index];
-
-  return desc ? `${desc} marriage` : `Marriage ${index + 1}`;
+  const desc = numberToWords(index + 1);
+  return `${titleCase(desc)} marriage`;
 }
 
 export function getSpouseMarriageTitle(index) {
-  const desc = numberToWords[index];
-
-  return desc
-    ? `Spouse’s ${desc.toLowerCase()} marriage`
-    : `Spouse marriage ${index + 1}`;
+  const desc = numberToWords(index + 1);
+  return `Spouse’s ${desc} marriage`;
 }
 
 export function getMarriageTitleWithCurrent(form, index) {

--- a/src/applications/pensions/tests/components/SpouseMarriageTitle.unit.spec.jsx
+++ b/src/applications/pensions/tests/components/SpouseMarriageTitle.unit.spec.jsx
@@ -12,11 +12,18 @@ describe('Pensions SpouseMarriageTitle', () => {
 
     expect(tree.text()).to.contain('Spouse’s first marriage');
   });
-  it('should render marriage title with number value', () => {
+  it('should render eleventh marriage title', () => {
     const tree = SkinDeep.shallowRender(
       <SpouseMarriageTitle id="id" formContext={{ pagePerItemIndex: 10 }} />,
     );
 
-    expect(tree.text()).to.contain('Spouse marriage 11');
+    expect(tree.text()).to.contain('Spouse’s eleventh marriage');
+  });
+  it('should render 50th marriage title', () => {
+    const tree = SkinDeep.shallowRender(
+      <SpouseMarriageTitle id="id" formContext={{ pagePerItemIndex: 49 }} />,
+    );
+
+    expect(tree.text()).to.contain('Spouse’s 50th marriage');
   });
 });

--- a/src/applications/pensions/tests/config/marriageHistory.unit.spec.jsx
+++ b/src/applications/pensions/tests/config/marriageHistory.unit.spec.jsx
@@ -77,7 +77,12 @@ describe('Pensions marriage history', () => {
       expect(pageTitle({}, { pagePerItemIndex: 0 })).to.equal('First marriage');
     });
     it('uses number when at index ten or greater', () => {
-      expect(pageTitle({}, { pagePerItemIndex: 10 })).to.equal('Marriage 11');
+      expect(pageTitle({}, { pagePerItemIndex: 10 })).to.equal(
+        'Eleventh marriage',
+      );
+    });
+    it('uses word for index', () => {
+      expect(pageTitle({}, { pagePerItemIndex: 49 })).to.equal('50th marriage');
     });
   });
 

--- a/src/applications/pensions/tests/config/spouseMarriageHistory.unit.spec.jsx
+++ b/src/applications/pensions/tests/config/spouseMarriageHistory.unit.spec.jsx
@@ -64,10 +64,11 @@ describe('Pensions spouse marriage history', () => {
       expect(pageTitle({}, { pagePerItemIndex: 0 })).to.equal(
         'Spouse’s first marriage',
       );
-    });
-    it('uses number when at index ten or greater', () => {
       expect(pageTitle({}, { pagePerItemIndex: 10 })).to.equal(
-        'Spouse marriage 11',
+        'Spouse’s eleventh marriage',
+      );
+      expect(pageTitle({}, { pagePerItemIndex: 49 })).to.equal(
+        'Spouse’s 50th marriage',
       );
     });
   });

--- a/src/platform/forms-system/src/js/utilities/data/numberToWords.js
+++ b/src/platform/forms-system/src/js/utilities/data/numberToWords.js
@@ -1,0 +1,79 @@
+const ordinals = {
+  1: 'first',
+  2: 'second',
+  3: 'third',
+  4: 'fourth',
+  5: 'fifth',
+  6: 'sixth',
+  7: 'seventh',
+  8: 'eighth',
+  9: 'ninth',
+  10: 'tenth',
+  11: 'eleventh',
+  12: 'twelveth',
+  13: 'thirteenth',
+  14: 'fourteenth',
+  15: 'fifteenth',
+  16: 'sixteenth',
+  17: 'seventeenth',
+  18: 'eighteenth',
+  19: 'nineteenth',
+  20: 'twentieth',
+  30: 'thirtieth',
+  // add more as needed
+};
+
+const tens = {
+  20: 'twenty',
+  30: 'thirty',
+  // add more as needed
+};
+
+const endings = {
+  1: 'st',
+  2: 'nd',
+  3: 'rd',
+};
+
+/**
+ * Limited version of a converter of numbers to words. Returns:
+ *  Ordinal names of numbers from 1 to 39 from a one-based index, e.g.
+ *   `21` becomes `twenty-first`
+ *   `39' becomes `thirty-nineth`
+ *  Ignores fractional part of valid numbers
+ *  Numbers > 39 & < 100 get an 'st', 'nd', 'rd' or 'th' ending, e.g. `40th`
+ *
+ * @param {number|string} value
+ * @return {string|number} Will return original param if invalid or out-of-range
+ */
+export default function numberToWords(value) {
+  const string = value?.toString();
+  const number = parseFloat(string);
+
+  if (
+    !value ||
+    isNaN(value) ||
+    isNaN(string) ||
+    // ignore fractions
+    number % 1 > 0 ||
+    // limit range
+    number < 1 ||
+    !isFinite(number)
+  ) {
+    return value;
+  }
+
+  if (number <= 20) {
+    return ordinals[number];
+  }
+  const remainder = number % 10;
+  const tensValue = parseInt(number / 10, 10) * 10;
+
+  if (!remainder) {
+    // return original number if words aren't set up
+    return ordinals[number] || `${number}th`;
+  }
+  return tens[tensValue]
+    ? `${tens[tensValue]}-${ordinals[number - tensValue]}`
+    : `${number}${endings[remainder] || 'th'}`;
+}

--- a/src/platform/forms-system/test/js/utilities/numberToWords.unit.spec.js
+++ b/src/platform/forms-system/test/js/utilities/numberToWords.unit.spec.js
@@ -1,0 +1,81 @@
+import { expect } from 'chai';
+
+import numberToWords from '../../../src/js/utilities/data/numberToWords';
+
+describe('Convert numbers to words', () => {
+  it('should return the original value for non-numbers', () => {
+    expect(numberToWords('')).to.eql('');
+    expect(numberToWords()).to.be.undefined;
+    expect(numberToWords(null)).to.be.null;
+    expect(numberToWords(NaN)).to.be.NaN;
+    expect(numberToWords('foo')).to.eql('foo');
+    expect(numberToWords('bar 1')).to.eql('bar 1');
+    expect(numberToWords('1 baz')).to.eql('1 baz');
+    expect(numberToWords(true)).to.eql(true);
+    expect(numberToWords(false)).to.eql(false);
+  });
+
+  it('should return the original value for out of range numbers & fractions', () => {
+    expect(numberToWords(-1)).to.eql(-1);
+    expect(numberToWords(0)).to.eql(0);
+    expect(numberToWords(0.5)).to.eql(0.5);
+    expect(numberToWords(1.5)).to.eql(1.5);
+    expect(numberToWords(Infinity)).to.eql(Infinity);
+  });
+
+  it('should return preset values of numbers less than 21', () => {
+    expect(numberToWords(1)).to.eql('first');
+    expect(numberToWords(2)).to.eql('second');
+    expect(numberToWords(3)).to.eql('third');
+    expect(numberToWords(4)).to.eql('fourth');
+    expect(numberToWords(5)).to.eql('fifth');
+    expect(numberToWords(6)).to.eql('sixth');
+    expect(numberToWords(7)).to.eql('seventh');
+    expect(numberToWords(8)).to.eql('eighth');
+    expect(numberToWords(9)).to.eql('ninth');
+    expect(numberToWords(10)).to.eql('tenth');
+    expect(numberToWords(11)).to.eql('eleventh');
+    expect(numberToWords(12)).to.eql('twelveth');
+    expect(numberToWords(13)).to.eql('thirteenth');
+    expect(numberToWords(14)).to.eql('fourteenth');
+    expect(numberToWords(15)).to.eql('fifteenth');
+    expect(numberToWords(16)).to.eql('sixteenth');
+    expect(numberToWords(17)).to.eql('seventeenth');
+    expect(numberToWords(18)).to.eql('eighteenth');
+    expect(numberToWords(19)).to.eql('nineteenth');
+    expect(numberToWords(20)).to.eql('twentieth');
+  });
+
+  it('should generate numbers between 21 and 40', () => {
+    expect(numberToWords(21)).to.eql('twenty-first');
+    expect(numberToWords(22)).to.eql('twenty-second');
+    expect(numberToWords(23)).to.eql('twenty-third');
+    expect(numberToWords(24)).to.eql('twenty-fourth');
+    expect(numberToWords(25)).to.eql('twenty-fifth');
+    expect(numberToWords(26)).to.eql('twenty-sixth');
+    expect(numberToWords(27)).to.eql('twenty-seventh');
+    expect(numberToWords(28)).to.eql('twenty-eighth');
+    expect(numberToWords(29)).to.eql('twenty-ninth');
+    expect(numberToWords(30)).to.eql('thirtieth');
+    expect(numberToWords(31)).to.eql('thirty-first');
+    expect(numberToWords(32)).to.eql('thirty-second');
+    expect(numberToWords(33)).to.eql('thirty-third');
+    expect(numberToWords(34)).to.eql('thirty-fourth');
+    expect(numberToWords(35)).to.eql('thirty-fifth');
+    expect(numberToWords(36)).to.eql('thirty-sixth');
+    expect(numberToWords(37)).to.eql('thirty-seventh');
+    expect(numberToWords(38)).to.eql('thirty-eighth');
+    expect(numberToWords(39)).to.eql('thirty-ninth');
+  });
+
+  it('should add an appropriate suffix to numbers >= 40', () => {
+    expect(numberToWords(40)).to.eql('40th');
+    expect(numberToWords(41)).to.eql('41st');
+    expect(numberToWords(42)).to.eql('42nd');
+    expect(numberToWords(43)).to.eql('43rd');
+    expect(numberToWords(44)).to.eql('44th');
+    expect(numberToWords(99)).to.eql('99th');
+    expect(numberToWords(100)).to.eql('100th');
+    expect(numberToWords(1003)).to.eql('1003rd');
+  });
+});


### PR DESCRIPTION
## Description

Multiple forms are using separate `numberToWords` objects. The object cross-references a **zero-based number index** into a cardinal word (e.g. `0` becomes `first`, and `9` returns `tenth`). 

```js
const numberToWords = {
  0: 'First',
  1: 'Second',
  2: 'Third',
  // ...
  9: 'Tenth',
};
```

All current implementations have a limit of 10 definitions. When `10` is used, _most_ implementations check for the `undefined` returned value; one implementation does not.

This update creates a function that accepts a **one-based number index** & returns ordinal words. A maximum of `40` words has been set;  passing this value will return `40th`. This maximum can be incremented by values of 10 by adding a new entry into the `ordinals` object in the `platform/forms-system/src/js/utilities/data/numberToWords.js` file. 

```js
// New function
numberToWords(3) // third
numberToWords(22) // twenty-second
numberToWords(39) // thiry-ninth
numberToWords(43) // 43rd
numberToWords(99) // 99th
```

This change is associated with https://github.com/department-of-veterans-affairs/va.gov-team/issues/2138, because it will be needed to improve form error handling

## Testing done

- Added unit tests for the new `numberToWords` function.
- Updated unit tests for forms 686, all-claims & pensions implementations.

## Screenshots

N/A

## Acceptance criteria

- [x] `numberToWords` function returns expected values
- [x] New function replaces previous implementation without issues 

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
