### PR TITLE
Use profileSchemaForms feature flag

### DIFF
--- a/src/applications/personalization/profile360/components/PaymentInformationEditModal.jsx
+++ b/src/applications/personalization/profile360/components/PaymentInformationEditModal.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
 
 import set from 'platform/utilities/data/set';
 
@@ -9,8 +10,9 @@ import ErrorableSelect from '@department-of-veterans-affairs/formation-react/Err
 import LoadingButton from 'platform/site-wide/loading-button/LoadingButton';
 
 import { focusElement } from 'platform/utilities/ui';
-import environment from 'platform/utilities/environment';
 import SchemaForm from 'platform/forms-system/src/js/components/SchemaForm';
+
+import { profileUseSchemaForms } from 'vet360/selectors';
 
 import {
   getAccountNumberErrorMessage,
@@ -20,8 +22,6 @@ import {
 import { ACCOUNT_TYPES_OPTIONS } from '../constants';
 
 import PaymentInformationEditModalError from './PaymentInformationEditModalError';
-
-const useNewForm = !environment.isProduction();
 
 const schema = {
   type: 'object',
@@ -201,7 +201,7 @@ class PaymentInformationEditModal extends React.Component {
           alt="On a personal check, find your bank's 9-digit routing number listed along the bottom-left edge, and your account number listed beside that."
         />
 
-        {!useNewForm && (
+        {!this.props.useSchemaForm && (
           <form onSubmit={this.onSubmit}>
             <ErrorableTextInput
               label="Routing number (Your 9-digit routing number will update your bank’s name)"
@@ -253,7 +253,7 @@ class PaymentInformationEditModal extends React.Component {
           </form>
         )}
 
-        {useNewForm && (
+        {this.props.useSchemaForm && (
           <SchemaForm
             name="Direct Deposit Information"
             title="Direct Deposit Information"
@@ -286,4 +286,10 @@ class PaymentInformationEditModal extends React.Component {
   }
 }
 
-export default PaymentInformationEditModal;
+const mapStateToProps = state => ({
+  useSchemaForm: profileUseSchemaForms(state),
+});
+
+export { PaymentInformationEditModal };
+
+export default connect(mapStateToProps)(PaymentInformationEditModal);

--- a/src/applications/personalization/profile360/tests/components/PaymentInformationEditModal.unit.spec.jsx
+++ b/src/applications/personalization/profile360/tests/components/PaymentInformationEditModal.unit.spec.jsx
@@ -6,7 +6,7 @@ import sinon from 'sinon';
 import set from 'platform/utilities/data/set';
 
 import { ACCOUNT_TYPES_OPTIONS } from '../../constants';
-import PaymentInformationEditModal from '../../components/PaymentInformationEditModal';
+import { PaymentInformationEditModal } from '../../components/PaymentInformationEditModal';
 
 describe('<PaymentInformationEditModal/>', () => {
   const defaultProps = {
@@ -36,6 +36,7 @@ describe('<PaymentInformationEditModal/>', () => {
     onSubmit() {},
     editModalFieldChanged() {},
     responseError: null,
+    useSchemaForm: true,
   };
 
   it('renders', () => {

--- a/src/platform/user/profile/vet360/components/AddressField/AddressEditModal.jsx
+++ b/src/platform/user/profile/vet360/components/AddressField/AddressEditModal.jsx
@@ -14,12 +14,10 @@ import {
 import Vet360EditModal from '../base/Vet360EditModal';
 
 import CopyMailingAddress from 'vet360/containers/CopyMailingAddress';
+import { profileUseSchemaForms } from 'vet360/selectors';
+
 import AddressForm from './AddressForm';
 import ContactInfoForm from '../ContactInfoForm';
-
-import environment from 'platform/utilities/environment';
-
-const useNewAddressForm = !environment.isProduction();
 
 class AddressEditModal extends React.Component {
   componentWillUnmount() {
@@ -116,7 +114,7 @@ class AddressEditModal extends React.Component {
 
   copyMailingAddress = mailingAddress => {
     const newAddressValue = { ...this.props.field.value, ...mailingAddress };
-    if (useNewAddressForm) {
+    if (this.props.useSchemaForm) {
       this.props.onChangeFormDataAndSchemas(
         this.transformInitialFormValues(newAddressValue),
         this.props.field.formSchema,
@@ -133,10 +131,10 @@ class AddressEditModal extends React.Component {
         <CopyMailingAddress
           convertNextValueToCleanData={this.props.convertNextValueToCleanData}
           copyMailingAddress={this.copyMailingAddress}
-          useNewAddressForm={useNewAddressForm}
+          useNewAddressForm={this.props.useSchemaForm}
         />
       )}
-      {useNewAddressForm && (
+      {this.props.useSchemaForm && (
         <ContactInfoForm
           formData={this.props.field.value}
           formSchema={this.props.field.formSchema}
@@ -147,7 +145,7 @@ class AddressEditModal extends React.Component {
           {formButtons}
         </ContactInfoForm>
       )}
-      {!useNewAddressForm && (
+      {!this.props.useSchemaForm && (
         <AddressForm
           isMailingAddress={this.getIsMailingAddress()}
           address={this.props.field.value}
@@ -165,9 +163,9 @@ class AddressEditModal extends React.Component {
     return (
       <Vet360EditModal
         getInitialFormValues={this.getInitialFormValues}
-        onBlur={useNewAddressForm ? null : this.onBlur}
+        onBlur={this.props.useSchemaForm ? null : this.onBlur}
         render={this.renderForm}
-        useSchemaForm={useNewAddressForm}
+        useSchemaForm={this.props.useSchemaForm}
         {...this.props}
       />
     );
@@ -176,6 +174,7 @@ class AddressEditModal extends React.Component {
 
 const mapStateToProps = state => ({
   modalData: state.vet360?.modalData,
+  useSchemaForm: profileUseSchemaForms(state),
 });
 
 export default connect(mapStateToProps)(AddressEditModal);

--- a/src/platform/user/profile/vet360/components/EmailField/EmailEditModal.jsx
+++ b/src/platform/user/profile/vet360/components/EmailField/EmailEditModal.jsx
@@ -1,15 +1,15 @@
 import React from 'react';
+import { connect } from 'react-redux';
+
 import ErrorableTextInput from '@department-of-veterans-affairs/formation-react/ErrorableTextInput';
+
+import { profileUseSchemaForms } from 'vet360/selectors';
 
 import Vet360EditModal from '../base/Vet360EditModal';
 
 import ContactInfoForm from '../ContactInfoForm';
 
-import environment from 'platform/utilities/environment';
-
-const useNewForm = !environment.isProduction();
-
-export default class EmailEditModal extends React.Component {
+class EmailEditModal extends React.Component {
   onChange = ({ value: emailAddress, dirty }) => {
     const newFieldValue = { ...this.props.field.value, emailAddress };
     this.props.onChange(newFieldValue, dirty);
@@ -30,7 +30,7 @@ export default class EmailEditModal extends React.Component {
 
   renderForm = (formButtons, onSubmit) => (
     <>
-      {useNewForm && (
+      {this.props.useSchemaForm && (
         <ContactInfoForm
           formData={this.props.field.value}
           formSchema={this.props.field.formSchema}
@@ -41,7 +41,7 @@ export default class EmailEditModal extends React.Component {
           {formButtons}
         </ContactInfoForm>
       )}
-      {!useNewForm && (
+      {!this.props.useSchemaForm && (
         <ErrorableTextInput
           autoFocus
           label="Email Address"
@@ -60,10 +60,16 @@ export default class EmailEditModal extends React.Component {
       <Vet360EditModal
         getInitialFormValues={this.getInitialFormValues}
         render={this.renderForm}
-        onBlur={useNewForm ? null : this.onBlur}
-        useSchemaForm={useNewForm}
+        onBlur={this.props.useSchemaForm ? null : this.onBlur}
+        useSchemaForm={this.props.useSchemaForm}
         {...this.props}
       />
     );
   }
 }
+
+const mapStateToProps = state => ({
+  useSchemaForm: profileUseSchemaForms(state),
+});
+
+export default connect(mapStateToProps)(EmailEditModal);

--- a/src/platform/user/profile/vet360/components/PhoneField/PhoneEditModal.jsx
+++ b/src/platform/user/profile/vet360/components/PhoneField/PhoneEditModal.jsx
@@ -10,13 +10,11 @@ import Vet360EditModal from '../base/Vet360EditModal';
 import { isEnrolledInVAHealthCare as isEnrolledInVAHealthCareSelector } from 'applications/hca/selectors';
 
 import { FIELD_NAMES } from 'vet360/constants';
+import { profileUseSchemaForms } from 'vet360/selectors';
 
 import { profileShowReceiveTextNotifications } from 'applications/personalization/profile360/selectors';
 
 import ContactInfoForm from '../ContactInfoForm';
-import environment from 'platform/utilities/environment';
-
-const useNewForm = !environment.isProduction();
 
 class PhoneTextInput extends ErrorableTextInput {
   // componentDidMount() {
@@ -137,7 +135,7 @@ class PhoneEditModal extends React.Component {
   );
 
   renderForm = (formButtons, onSubmit) => {
-    if (!useNewForm) {
+    if (!this.props.useSchemaForm) {
       return this.renderOldForm();
     }
     return (
@@ -158,8 +156,8 @@ class PhoneEditModal extends React.Component {
       <Vet360EditModal
         getInitialFormValues={this.getInitialFormValues}
         render={this.renderForm}
-        onBlur={useNewForm ? null : this.onBlur}
-        useSchemaForm={useNewForm}
+        onBlur={this.props.useSchemaForm ? null : this.onBlur}
+        useSchemaForm={this.props.useSchemaForm}
         {...this.props}
       />
     );
@@ -179,6 +177,7 @@ export function mapStateToProps(state, ownProps) {
     showReceiveTextNotifications,
     isEnrolledInVAHealthCare,
     showSMSCheckbox,
+    useSchemaForm: profileUseSchemaForms(state),
   };
 }
 

--- a/src/platform/user/profile/vet360/selectors.js
+++ b/src/platform/user/profile/vet360/selectors.js
@@ -139,3 +139,7 @@ export function selectVet360InitializationStatus(state) {
 export function vaProfileUseAddressValidation(state) {
   return toggleValues(state)[FEATURE_FLAG_NAMES.vaProfileAddressValidation];
 }
+
+export function profileUseSchemaForms(state) {
+  return toggleValues(state)[FEATURE_FLAG_NAMES.profileSchemaForms];
+}

--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -1,6 +1,7 @@
 const FEATURE_FLAG_NAMES = Object.freeze({
   facilityLocatorShowCommunityCares: 'facilityLocatorShowCommunityCares',
   profileShowReceiveTextNotifications: 'profileShowReceiveTextNotifications',
+  profileSchemaForms: 'profileSchemaForms',
   vaOnlineScheduling: 'vaOnlineScheduling',
   vaOnlineSchedulingCancel: 'vaOnlineSchedulingCancel',
   vaOnlineSchedulingRequests: 'vaOnlineSchedulingRequests',


### PR DESCRIPTION
## Description
Use a new feature flag, instead of environment helpers, to gate the new SchemaForm-based profile forms

## Testing done
Local

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs