### PR TITLE
Remove outdated security exceptions

### DIFF
--- a/script/security-check.js
+++ b/script/security-check.js
@@ -9,10 +9,6 @@ const { spawn } = require('child_process');
 const packageJSON = require('../package.json');
 
 const exceptionSet = new Set([
-  'https://npmjs.com/advisories/577',
-  'https://npmjs.com/advisories/157',
-  'https://npmjs.com/advisories/788',
-  'https://npmjs.com/advisories/813',
   'https://npmjs.com/advisories/996',
   'https://npmjs.com/advisories/1488',
 ]);


### PR DESCRIPTION
## Description

While doing some investigation for #11834 I discovered that some old exceptions are no longer needed and can be removed.


## Testing done

Ran `yarn security-check` locally.


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
