### PR TITLE
Update html for list items and fix sleep care back button

### DIFF
--- a/src/applications/vaos/components/AddToCalendar.jsx
+++ b/src/applications/vaos/components/AddToCalendar.jsx
@@ -47,7 +47,7 @@ export default function AddToCalendar({
     <a
       href={`data:text/calendar;charset=utf-8,${encodeURIComponent(text)}`}
       download={filename}
-      aria-label={`Add to calendar on ${formattedDate}`}
+      aria-label={`Add ${formattedDate} appointment to your calendar`}
       className="va-button-link vads-u-margin-right--4 vads-u-flex--0"
     >
       Add to calendar

--- a/src/applications/vaos/components/AddToCalendar.jsx
+++ b/src/applications/vaos/components/AddToCalendar.jsx
@@ -35,7 +35,7 @@ export default function AddToCalendar({
     return (
       <button
         onClick={onClick}
-        aria-label={`Add to calendar on ${formattedDate}`}
+        aria-label={`Add ${formattedDate} appointment to your calendar`}
         className="va-button-link vads-u-margin-right--4 vads-u-flex--0"
       >
         Add to calendar

--- a/src/applications/vaos/components/AppointmentRequestListItem.jsx
+++ b/src/applications/vaos/components/AppointmentRequestListItem.jsx
@@ -62,19 +62,19 @@ export default class AppointmentRequestListItem extends React.Component {
 
     return (
       <li
-        aria-labelledby={`card-${index}`}
+        aria-labelledby={`card-${index} card-${index}-status`}
         data-request-id={appointment.id}
         className={itemClasses}
       >
         <div className="vaos-form__title vads-u-font-size--sm vads-u-font-weight--normal vads-u-font-family--sans">
           {getAppointmentTypeHeader(appointment)}
         </div>
-        <h2
+        <h3
           id={`card-${index}`}
           className="vads-u-font-size--h3 vads-u-margin-y--0"
         >
           {sentenceCase(appointment.appointmentType)} appointment
-        </h2>
+        </h3>
         <div className="vads-u-display--flex vads-u-justify-content--space-between vads-u-margin-top--2">
           <div className="vads-u-margin-right--1">
             {canceled ? (
@@ -86,10 +86,10 @@ export default class AppointmentRequestListItem extends React.Component {
           <span className="vads-u-font-weight--bold vads-u-flex--1">
             <div className="vaos-appts__status-text vads-u-font-size--base vads-u-font-family--sans">
               {canceled ? (
-                'Canceled'
+                <span id={`card-${index}-status`}>Canceled</span>
               ) : (
                 <>
-                  <strong>Pending</strong>{' '}
+                  <strong id={`card-${index}-status`}>Pending</strong>{' '}
                   <div className="vads-u-font-weight--normal">
                     The time and date of this appointment are still to be
                     determined.

--- a/src/applications/vaos/components/ConfirmedAppointmentListItem.jsx
+++ b/src/applications/vaos/components/ConfirmedAppointmentListItem.jsx
@@ -54,13 +54,19 @@ export default function ConfirmedAppointmentListItem({
   );
 
   return (
-    <li aria-labelledby={`card-${index}`} className={itemClasses}>
-      <div className="vaos-form__title vads-u-font-size--sm vads-u-font-weight--normal vads-u-font-family--sans">
+    <li
+      aria-labelledby={`card-${index}-type card-${index}-state`}
+      className={itemClasses}
+    >
+      <div
+        id={`card-${index}-type`}
+        className="vaos-form__title vads-u-font-size--sm vads-u-font-weight--normal vads-u-font-family--sans"
+      >
         {getAppointmentTypeHeader(appointment)}
       </div>
-      <h2 className="vaos-appts__date-time vads-u-font-size--lg vads-u-margin-x--0">
+      <h3 className="vaos-appts__date-time vads-u-font-size--h3 vads-u-margin-x--0">
         {getAppointmentDateTime(appointment)}
-      </h2>
+      </h3>
       <div className="vads-u-margin-top--2">
         {canceled ? (
           <i className="fas fa-exclamation-circle" />
@@ -68,11 +74,10 @@ export default function ConfirmedAppointmentListItem({
           <i className="fas fa-check-circle" />
         )}
         <span
-          id={`card-${index}`}
+          id={`card-${index}-state`}
           className="vads-u-font-weight--bold vads-u-margin-left--1 vads-u-display--inline-block"
         >
           {canceled ? 'Canceled' : 'Confirmed'}
-          <span className="sr-only"> appointment</span>
         </span>
       </div>
 

--- a/src/applications/vaos/containers/DateTimeSelectPage.jsx
+++ b/src/applications/vaos/containers/DateTimeSelectPage.jsx
@@ -165,8 +165,8 @@ export class DateTimeSelectPage extends React.Component {
             this.validate(newData);
             this.props.onCalendarChange(newData);
           }}
-          onClickNext={getAppointmentSlots}
-          onClickPrev={getAppointmentSlots}
+          onClickNext={this.props.getAppointmentSlots}
+          onClickPrev={this.props.getAppointmentSlots}
           minDate={moment()
             .add(1, 'days')
             .format('YYYY-MM-DD')}

--- a/src/applications/vaos/newAppointmentFlow.js
+++ b/src/applications/vaos/newAppointmentFlow.js
@@ -193,18 +193,14 @@ export default {
               }
             }
           }
-
-          dispatch(updateFacilityType(FACILITY_TYPES.VAMC));
-          return 'vaFacility';
         } catch (e) {
           captureError(e);
           Sentry.captureMessage(
             'Community Care eligibility check failed with errors',
           );
-          dispatch(updateFacilityType(FACILITY_TYPES.VAMC));
-          return 'vaFacility';
         }
       }
+
       dispatch(updateFacilityType(FACILITY_TYPES.VAMC));
       return 'vaFacility';
     },
@@ -260,7 +256,9 @@ export default {
       let nextState = 'typeOfCare';
       const communityCareEnabled = vaosCommunityCare(state);
 
-      if (
+      if (isSleepCare(state)) {
+        nextState = 'typeOfSleepCare';
+      } else if (
         communityCareEnabled &&
         isCCEligible(state) &&
         getTypeOfCare(getFormData(state))?.ccId !== undefined

--- a/src/applications/vaos/tests/components/AddToCalendar.unit.spec.jsx
+++ b/src/applications/vaos/tests/components/AddToCalendar.unit.spec.jsx
@@ -86,7 +86,7 @@ describe('VAOS <AddToCalendar>', () => {
 
     it('should have an aria label', () => {
       expect(link.props()['aria-label']).to.equal(
-        `Add to calendar on January 2, 2020`,
+        `Add January 2, 2020 appointment to your calendar`,
       );
     });
 
@@ -122,7 +122,7 @@ describe('VAOS <AddToCalendar>', () => {
 
     it('should have an aria label', () => {
       expect(link.props()['aria-label']).to.equal(
-        `Add to calendar on January 2, 2020`,
+        `Add January 2, 2020 appointment to your calendar`,
       );
     });
 
@@ -190,7 +190,7 @@ describe('VAOS <AddToCalendar>', () => {
 
     it('should have an aria label', () => {
       expect(link.props()['aria-label']).to.equal(
-        `Add to calendar on March 12, 2020`,
+        `Add March 12, 2020 appointment to your calendar`,
       );
     });
   });
@@ -231,7 +231,7 @@ describe('VAOS <AddToCalendar>', () => {
 
     it('should have an aria label', () => {
       expect(button.props()['aria-label']).to.equal(
-        `Add to calendar on January 2, 2020`,
+        `Add January 2, 2020 appointment to your calendar`,
       );
     });
 

--- a/src/applications/vaos/tests/components/ConfirmedAppointmentListItem.unit.spec.jsx
+++ b/src/applications/vaos/tests/components/ConfirmedAppointmentListItem.unit.spec.jsx
@@ -74,10 +74,10 @@ describe('VAOS <ConfirmedAppointmentListItem> Regular Appointment', () => {
     ).to.contain('Confirmed');
   });
 
-  it('should have an h2 with date', () => {
+  it('should have an h3 with date', () => {
     expect(
       tree
-        .find('h2')
+        .find('h3')
         .text()
         .trim(),
     ).to.contain('December 11, 2019');
@@ -140,10 +140,10 @@ describe('VAOS <ConfirmedAppointmentListItem> Community Care Appointment', () =>
     ).to.contain('Confirmed');
   });
 
-  it('should have an h2 with date', () => {
+  it('should have an h3 with date', () => {
     expect(
       tree
-        .find('h2')
+        .find('h3')
         .text()
         .trim(),
     ).to.contain('May 22, 2019 at 10:00 a.m.');
@@ -267,10 +267,10 @@ describe('VAOS <ConfirmedAppointmentListItem> Canceled Appointment', () => {
     ).to.contain('Canceled');
   });
 
-  it('should have an h2 with date', () => {
+  it('should have an h3 with date', () => {
     expect(
       tree
-        .find('h2')
+        .find('h3')
         .text()
         .trim(),
     ).to.contain('December 11, 2019');

--- a/src/applications/vaos/tests/newAppointmentFlow.unit.spec.js
+++ b/src/applications/vaos/tests/newAppointmentFlow.unit.spec.js
@@ -460,6 +460,25 @@ describe('VAOS newAppointmentFlow', () => {
         const nextState = newAppointmentFlow.vaFacility.previous(state);
         expect(nextState).to.equal('typeOfCare');
       });
+      it('should be typeOfSleepCare page when back button selected along sleep care flow', () => {
+        const state = {
+          ...defaultState,
+          newAppointment: {
+            ...defaultState.newAppointment,
+            data: {
+              typeOfCareId: 'SLEEP',
+              vaParent: '983',
+              vaFacility: '983',
+              facilityType: FACILITY_TYPES.VAMC,
+            },
+            hasCCEnabledSystems: false,
+            isCCEligible: true,
+          },
+        };
+
+        const nextState = newAppointmentFlow.vaFacility.previous(state);
+        expect(nextState).to.equal('typeOfSleepCare');
+      });
       // testing eyecare flow
       it('should be typeOfEyeCare page when back button selected along Ophthalmology flow', () => {
         const state = {


### PR DESCRIPTION
## Description
This addresses two issues:
1. Makes suggested a11y related updates on list items (https://github.com/department-of-veterans-affairs/va.gov-team/issues/6106)
2. Fixes back button issue in the sleep care flow (https://github.com/department-of-veterans-affairs/va.gov-team/issues/6684)
3. Fixes an issue with appointment slots not being fetched

## Testing done
Local and unit testing

## Acceptance criteria
- [ ] Sleep care back button works
- [ ] HTML for list items is updated

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
