### PR TITLE
[SCREENREADER] Review: shift focus to edit button after editing

### DIFF
--- a/src/platform/forms-system/src/js/components/FieldTemplate.jsx
+++ b/src/platform/forms-system/src/js/components/FieldTemplate.jsx
@@ -84,12 +84,17 @@ export default function FieldTemplate(props) {
     (isFieldGroup || !!showFieldLabel) && !useLabelElement;
 
   const labelElement = useFieldsetLegend ? (
-    <legend id={`${id}-label`} className={labelClassNames}>
+    <legend id={`${id}-label`} className={labelClassNames} tabIndex="-1">
       {label}
       {requiredSpan}
     </legend>
   ) : (
-    <label id={`${id}-label`} className={labelClassNames} htmlFor={id}>
+    <label
+      id={`${id}-label`}
+      className={labelClassNames}
+      htmlFor={id}
+      tabIndex="-1"
+    >
       {label}
       {requiredSpan}
     </label>

--- a/src/platform/forms-system/src/js/components/FieldTemplate.jsx
+++ b/src/platform/forms-system/src/js/components/FieldTemplate.jsx
@@ -84,17 +84,12 @@ export default function FieldTemplate(props) {
     (isFieldGroup || !!showFieldLabel) && !useLabelElement;
 
   const labelElement = useFieldsetLegend ? (
-    <legend id={`${id}-label`} className={labelClassNames} tabIndex="-1">
+    <legend id={`${id}-label`} className={labelClassNames}>
       {label}
       {requiredSpan}
     </legend>
   ) : (
-    <label
-      id={`${id}-label`}
-      className={labelClassNames}
-      htmlFor={id}
-      tabIndex="-1"
-    >
+    <label id={`${id}-label`} className={labelClassNames} htmlFor={id}>
       {label}
       {requiredSpan}
     </label>

--- a/src/platform/forms-system/src/js/review/ReviewCollapsibleChapter.jsx
+++ b/src/platform/forms-system/src/js/review/ReviewCollapsibleChapter.jsx
@@ -5,7 +5,7 @@ import _ from 'lodash/fp'; // eslint-disable-line no-restricted-imports
 import classNames from 'classnames';
 
 import ProgressButton from '../components/ProgressButton';
-import { focusElement, focusOnChange } from '../utilities/ui';
+import { focusElement, focusOnChange, getScrollOptions } from '../utilities/ui';
 import SchemaForm from '../components/SchemaForm';
 import { getArrayFields, getNonArraySchema } from '../helpers';
 import ArrayField from './ArrayField';
@@ -57,14 +57,7 @@ export default class ReviewCollapsibleChapter extends React.Component {
   };
 
   scrollToPage(key) {
-    scroller.scrollTo(
-      `${key}ScrollElement`,
-      window.Forms.scroll || {
-        duration: 500,
-        delay: 2,
-        smooth: true,
-      },
-    );
+    scroller.scrollTo(`${key}ScrollElement`, getScrollOptions({ offset: -40 }));
   }
 
   shouldHideExpandedPageTitle = (expandedPages, chapterTitle, pageTitle) =>

--- a/src/platform/forms-system/src/js/review/ReviewCollapsibleChapter.jsx
+++ b/src/platform/forms-system/src/js/review/ReviewCollapsibleChapter.jsx
@@ -5,7 +5,7 @@ import _ from 'lodash/fp'; // eslint-disable-line no-restricted-imports
 import classNames from 'classnames';
 
 import ProgressButton from '../components/ProgressButton';
-import { focusElement } from '../utilities/ui';
+import { focusElement, focusOnChange } from '../utilities/ui';
 import SchemaForm from '../components/SchemaForm';
 import { getArrayFields, getNonArraySchema } from '../helpers';
 import ArrayField from './ArrayField';
@@ -201,6 +201,13 @@ export default class ReviewCollapsibleChapter extends React.Component {
                     ) : (
                       <ProgressButton
                         submitButton
+                        onButtonClick={() => {
+                          focusOnChange(
+                            `${page.pageKey}${
+                              typeof page.index === 'number' ? page.index : ''
+                            }`,
+                          );
+                        }}
                         buttonText="Update page"
                         buttonClass="usa-button-primary"
                       />

--- a/src/platform/forms-system/src/js/review/ReviewCollapsibleChapter.jsx
+++ b/src/platform/forms-system/src/js/review/ReviewCollapsibleChapter.jsx
@@ -5,7 +5,7 @@ import _ from 'lodash/fp'; // eslint-disable-line no-restricted-imports
 import classNames from 'classnames';
 
 import ProgressButton from '../components/ProgressButton';
-import { focusElement, focusOnChange, getScrollOptions } from '../utilities/ui';
+import { focusOnChange, getScrollOptions } from '../utilities/ui';
 import SchemaForm from '../components/SchemaForm';
 import { getArrayFields, getNonArraySchema } from '../helpers';
 import ArrayField from './ArrayField';
@@ -35,8 +35,9 @@ export default class ReviewCollapsibleChapter extends React.Component {
   }
 
   focusOnPage(key) {
-    const pageDiv = document.querySelector(`#${key.replace(/:/g, '\\:')}`);
-    focusElement(pageDiv);
+    const name = `${key.replace(/:/g, '\\:')}`;
+    // legend & label target array type form elements
+    focusOnChange(name, 'p, legend, label');
   }
 
   handleEdit(key, editing, index = null) {

--- a/src/platform/forms-system/src/js/utilities/ui/index.js
+++ b/src/platform/forms-system/src/js/utilities/ui/index.js
@@ -1,4 +1,3 @@
-import _ from 'lodash/fp'; // eslint-disable-line no-restricted-imports
 import Scroll from 'react-scroll';
 
 export function focusElement(selectorOrElement, options, testDom) {
@@ -49,7 +48,7 @@ export function getScrollOptions(additionalOptions) {
     delay: 0,
     smooth: true,
   };
-  return _.merge({}, defaults, globals.scroll, additionalOptions);
+  return Object.assign({}, defaults, globals.scroll, additionalOptions);
 }
 
 export function scrollToFirstError() {

--- a/src/platform/forms-system/src/js/utilities/ui/index.js
+++ b/src/platform/forms-system/src/js/utilities/ui/index.js
@@ -17,15 +17,15 @@ export function focusElement(selectorOrElement, options, testDom) {
   }
 }
 
-// Retrun focus to edit button _after_ the content has been updated
-export function focusOnChange(name, testDom) {
+// Set focus on target _after_ the content has been updated
+export function focusOnChange(name, target = '.edit-btn', testDom) {
   setTimeout(() => {
     const selector = `[name="${name}ScrollElement"]`;
     const el = (testDom || document).querySelector(selector);
     // nextElementSibling = page form
-    const target = el?.nextElementSibling?.querySelector('.edit-btn');
-    if (target) {
-      focusElement(target);
+    const focusTarget = el?.nextElementSibling?.querySelector(target);
+    if (focusTarget) {
+      focusElement(focusTarget);
     }
   });
 }

--- a/src/platform/forms-system/src/js/utilities/ui/index.js
+++ b/src/platform/forms-system/src/js/utilities/ui/index.js
@@ -1,9 +1,9 @@
 import Scroll from 'react-scroll';
 
-export function focusElement(selectorOrElement, options, testDom) {
+export function focusElement(selectorOrElement, options) {
   const el =
     typeof selectorOrElement === 'string'
-      ? (testDom || document).querySelector(selectorOrElement)
+      ? (window.Forms.document || document).querySelector(selectorOrElement)
       : selectorOrElement;
 
   if (el) {
@@ -18,15 +18,13 @@ export function focusElement(selectorOrElement, options, testDom) {
 }
 
 // Set focus on target _after_ the content has been updated
-export function focusOnChange(name, target = '.edit-btn', testDom) {
+export function focusOnChange(name, target = '.edit-btn') {
   setTimeout(() => {
     const selector = `[name="${name}ScrollElement"]`;
-    const el = (testDom || document).querySelector(selector);
+    const el = (window.Forms.document || document).querySelector(selector);
     // nextElementSibling = page form
     const focusTarget = el?.nextElementSibling?.querySelector(target);
-    if (focusTarget) {
-      focusElement(focusTarget);
-    }
+    focusElement(focusTarget);
   });
 }
 

--- a/src/platform/forms-system/src/js/utilities/ui/index.js
+++ b/src/platform/forms-system/src/js/utilities/ui/index.js
@@ -18,16 +18,15 @@ export function focusElement(selectorOrElement, options, testDom) {
   }
 }
 
-// Focus on review row _after_ the content has been updated
+// Retrun focus to edit button _after_ the content has been updated
 export function focusOnChange(name, testDom) {
   setTimeout(() => {
     const selector = `[name="${name}ScrollElement"]`;
     const el = (testDom || document).querySelector(selector);
     // nextElementSibling = page form
-    const targets = el?.nextElementSibling?.querySelectorAll('.review-row');
-    if (targets) {
-      targets.forEach(target => target.setAttribute('tabindex', '0'));
-      focusElement(targets[0]);
+    const target = el?.nextElementSibling?.querySelector('.edit-btn');
+    if (target) {
+      focusElement(target);
     }
   });
 }

--- a/src/platform/forms-system/src/js/utilities/ui/index.js
+++ b/src/platform/forms-system/src/js/utilities/ui/index.js
@@ -1,10 +1,10 @@
 import _ from 'lodash/fp'; // eslint-disable-line no-restricted-imports
 import Scroll from 'react-scroll';
 
-export function focusElement(selectorOrElement, options) {
+export function focusElement(selectorOrElement, options, testDom) {
   const el =
     typeof selectorOrElement === 'string'
-      ? document.querySelector(selectorOrElement)
+      ? (testDom || document).querySelector(selectorOrElement)
       : selectorOrElement;
 
   if (el) {
@@ -19,9 +19,10 @@ export function focusElement(selectorOrElement, options) {
 }
 
 // Focus on review row _after_ the content has been updated
-export function focusOnChange(name) {
+export function focusOnChange(name, testDom) {
   setTimeout(() => {
-    const el = document.querySelector(`[name="${name}ScrollElement"]`);
+    const selector = `[name="${name}ScrollElement"]`;
+    const el = (testDom || document).querySelector(selector);
     // nextElementSibling = page form
     const targets = el?.nextElementSibling?.querySelectorAll('.review-row');
     if (targets) {

--- a/src/platform/forms-system/src/js/utilities/ui/index.js
+++ b/src/platform/forms-system/src/js/utilities/ui/index.js
@@ -18,6 +18,19 @@ export function focusElement(selectorOrElement, options) {
   }
 }
 
+// Focus on review row _after_ the content has been updated
+export function focusOnChange(name) {
+  setTimeout(() => {
+    const el = document.querySelector(`[name="${name}ScrollElement"]`);
+    // nextElementSibling = page form
+    const targets = el?.nextElementSibling?.querySelectorAll('.review-row');
+    if (targets) {
+      targets.forEach(target => target.setAttribute('tabindex', '0'));
+      focusElement(targets[0]);
+    }
+  });
+}
+
 export function setGlobalScroll() {
   window.Forms = window.Forms || {
     scroll: {

--- a/src/platform/forms-system/src/js/utilities/ui/index.js
+++ b/src/platform/forms-system/src/js/utilities/ui/index.js
@@ -3,7 +3,7 @@ import Scroll from 'react-scroll';
 export function focusElement(selectorOrElement, options) {
   const el =
     typeof selectorOrElement === 'string'
-      ? (window.Forms.document || document).querySelector(selectorOrElement)
+      ? document.querySelector(selectorOrElement)
       : selectorOrElement;
 
   if (el) {
@@ -21,7 +21,7 @@ export function focusElement(selectorOrElement, options) {
 export function focusOnChange(name, target = '.edit-btn') {
   setTimeout(() => {
     const selector = `[name="${name}ScrollElement"]`;
-    const el = (window.Forms.document || document).querySelector(selector);
+    const el = document.querySelector(selector);
     // nextElementSibling = page form
     const focusTarget = el?.nextElementSibling?.querySelector(target);
     focusElement(focusTarget);

--- a/src/platform/forms-system/test/js/utilities/ui.unit.spec.js
+++ b/src/platform/forms-system/test/js/utilities/ui.unit.spec.js
@@ -75,8 +75,9 @@ describe('focus on change', () => {
     );
 
     const dom = findDOMNode(tree);
-    const focused = sinon.stub(dom.querySelector('.edit-btn'), 'focus');
-    focusOnChange('test', dom);
+    const target = '.edit-btn';
+    const focused = sinon.stub(dom.querySelector(target), 'focus');
+    focusOnChange('test', target, dom);
 
     // setTimeout used by focusOnChange function
     setTimeout(() => {

--- a/src/platform/forms-system/test/js/utilities/ui.unit.spec.js
+++ b/src/platform/forms-system/test/js/utilities/ui.unit.spec.js
@@ -15,7 +15,7 @@ describe('focus on element', () => {
       </div>,
     );
     const dom = findDOMNode(tree);
-    window.Forms.document = dom;
+    global.document = dom;
     const focused = sinon.stub(dom.querySelector('button'), 'focus');
     focusElement('button', {});
     expect(focused.calledOnce).to.be.true;
@@ -76,7 +76,7 @@ describe('focus on change', () => {
     );
 
     const dom = findDOMNode(tree);
-    window.Forms.document = dom;
+    global.document = dom;
     const target = '.edit-btn';
     const focused = sinon.stub(dom.querySelector(target), 'focus');
     focusOnChange('test', target);

--- a/src/platform/forms-system/test/js/utilities/ui.unit.spec.js
+++ b/src/platform/forms-system/test/js/utilities/ui.unit.spec.js
@@ -35,7 +35,7 @@ describe('focus on element', () => {
 });
 
 describe('focus on change', () => {
-  it('should focus on review row after updating a review form', done => {
+  it('should focus on edit button after updating a review form', done => {
     const pages = [
       {
         title: '',
@@ -49,10 +49,15 @@ describe('focus on change', () => {
         test: {
           title: '',
           schema: {
-            type: 'boolean',
+            type: 'object',
+            properties: {
+              test2: {
+                type: 'boolean',
+              },
+            },
           },
           uiSchema: {},
-          // editMode: true,
+          editMode: false,
         },
       },
       data: {},
@@ -70,7 +75,7 @@ describe('focus on change', () => {
     );
 
     const dom = findDOMNode(tree);
-    const focused = sinon.stub(dom.querySelector('.review-row'), 'focus');
+    const focused = sinon.stub(dom.querySelector('.edit-btn'), 'focus');
     focusOnChange('test', dom);
 
     // setTimeout used by focusOnChange function

--- a/src/platform/forms-system/test/js/utilities/ui.unit.spec.js
+++ b/src/platform/forms-system/test/js/utilities/ui.unit.spec.js
@@ -15,8 +15,9 @@ describe('focus on element', () => {
       </div>,
     );
     const dom = findDOMNode(tree);
+    window.Forms.document = dom;
     const focused = sinon.stub(dom.querySelector('button'), 'focus');
-    focusElement('button', {}, dom);
+    focusElement('button', {});
     expect(focused.calledOnce).to.be.true;
   });
 
@@ -75,9 +76,10 @@ describe('focus on change', () => {
     );
 
     const dom = findDOMNode(tree);
+    window.Forms.document = dom;
     const target = '.edit-btn';
     const focused = sinon.stub(dom.querySelector(target), 'focus');
-    focusOnChange('test', target, dom);
+    focusOnChange('test', target);
 
     // setTimeout used by focusOnChange function
     setTimeout(() => {

--- a/src/platform/forms-system/test/js/utilities/ui.unit.spec.js
+++ b/src/platform/forms-system/test/js/utilities/ui.unit.spec.js
@@ -1,0 +1,82 @@
+import React from 'react';
+import { findDOMNode } from 'react-dom';
+import ReactTestUtils from 'react-dom/test-utils';
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import { focusElement, focusOnChange } from '../../../src/js/utilities/ui';
+import ReviewCollapsibleChapter from '../../../src/js/review/ReviewCollapsibleChapter';
+
+describe('focus on element', () => {
+  it('should focus on element based on selector string', () => {
+    const tree = ReactTestUtils.renderIntoDocument(
+      <div>
+        <button />
+      </div>,
+    );
+    const dom = findDOMNode(tree);
+    const focused = sinon.stub(dom.querySelector('button'), 'focus');
+    focusElement('button', {}, dom);
+    expect(focused.calledOnce).to.be.true;
+  });
+
+  it('should focus on element passed to the function', () => {
+    const tree = ReactTestUtils.renderIntoDocument(
+      <div>
+        <button />
+      </div>,
+    );
+    const dom = findDOMNode(tree);
+    const button = dom.querySelector('button');
+    const focused = sinon.stub(button, 'focus');
+    focusElement(button);
+    expect(focused.calledOnce).to.be.true;
+  });
+});
+
+describe('focus on change', () => {
+  it('should focus on review row after updating a review form', done => {
+    const pages = [
+      {
+        title: '',
+        pageKey: 'test',
+      },
+    ];
+    const chapterKey = 'test';
+    const chapter = {};
+    const form = {
+      pages: {
+        test: {
+          title: '',
+          schema: {
+            type: 'boolean',
+          },
+          uiSchema: {},
+          // editMode: true,
+        },
+      },
+      data: {},
+    };
+
+    const tree = ReactTestUtils.renderIntoDocument(
+      <ReviewCollapsibleChapter
+        viewedPages={new Set()}
+        expandedPages={pages}
+        chapterKey={chapterKey}
+        chapterFormConfig={chapter}
+        form={form}
+        open
+      />,
+    );
+
+    const dom = findDOMNode(tree);
+    const focused = sinon.stub(dom.querySelector('.review-row'), 'focus');
+    focusOnChange('test', dom);
+
+    // setTimeout used by focusOnChange function
+    setTimeout(() => {
+      expect(focused.calledOnce).to.be.true;
+      done();
+    }, 0);
+  });
+});

--- a/src/platform/forms/sass/_m-schemaform.scss
+++ b/src/platform/forms/sass/_m-schemaform.scss
@@ -424,7 +424,9 @@ legend.schemaform-label.schemaform-file-label {
 /* hide outline on focused <p> inside review form; recommendation from:
  * https://github.com/department-of-veterans-affairs/vets-website/pull/11847#discussion_r391864665
 */
-.form-review-panel-page p[tabIndex] {
+.form-review-panel-page p[tabIndex],
+.form-review-panel-page legend[tabIndex],
+.form-review-panel-page label[tabIndex] {
   outline: none;
 }
 

--- a/src/platform/forms/sass/_m-schemaform.scss
+++ b/src/platform/forms/sass/_m-schemaform.scss
@@ -421,6 +421,13 @@ legend.schemaform-label.schemaform-file-label {
   width: 100%;
 }
 
+/* hide outline on focused <p> inside review form; recommendation from:
+ * https://github.com/department-of-veterans-affairs/vets-website/pull/11847#discussion_r391864665
+*/
+.form-review-panel-page p[tabIndex] {
+  outline: none;
+}
+
 .schemaform-review-array-warning {
   margin: -1em -0.8em 0;
   border: 2px solid $color-gold-lightest;


### PR DESCRIPTION
## Description

On any form review page, once a user opens an accordion and edits an entry, focus becomes lost. 

This PR:

- Shifts the focus to the ~first review row so that the screen reader can let the veteran know that the change has been applied~ back to the edit button.

Changes not implemented:
- ~A `tabindex` of `0` is added to each review row to allow tabbing through the edited page entries; these are cleared if the user closes and reopens the accordion~.
- ~On pages with more than one entry, e.g. a mailing address block, the first review row entry will always be focused (see screenshot). This isn't ideal, but the form doesn't keep track of the changes made within a page.~

## Testing done

Local unit tests
Added unit tests for `focusElement` and `focusOnChange` functions

## Screenshots

![Screen Shot 2020-03-12 at 1 20 39 PM](https://user-images.githubusercontent.com/136959/76554734-5b549b00-6464-11ea-915e-ca1620131b10.png)

## Acceptance criteria
- [ ] Focus is added to the ~review row~ edit button of the page that was recently edited.
- ~The user can <kbd>Tab</kbd> through the rows of the page so the screenreader can read off each entry. The user can then make sure that their changes have been applied.~

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
