### PR TITLE
Add VAOS team members to codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,3 +10,6 @@ src/applications/proxy-rewrite/redirects/crossDomainRedirects.json @department-o
 src/applications/find-va-forms @department-of-veterans-affairs/vsa-frontend
 src/platform/site-wide @department-of-veterans-affairs/vsa-frontend
 src/applications/yellow-ribbon @department-of-veterans-affairs/vsa-frontend
+
+# Other
+src/applications/vaos @department-of-veterans-affairs/vfs-vaos


### PR DESCRIPTION
## Description
Adds a VAOS team to our application folder

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
