### PR TITLE
[SCREENREADER] Move review page alert directly below accordions

### DIFF
--- a/src/platform/forms-system/src/js/review/SubmitButtons.jsx
+++ b/src/platform/forms-system/src/js/review/SubmitButtons.jsx
@@ -1,10 +1,17 @@
 import React from 'react';
 import moment from 'moment';
+
 import ProgressButton from '../components/ProgressButton';
 import { timeFromNow } from '../utilities/date';
 
 export default function SubmitButtons(props) {
-  const { onBack, onSubmit, submission, renderErrorMessage } = props;
+  const {
+    preSubmitBlock,
+    onBack,
+    onSubmit,
+    submission,
+    renderErrorMessage,
+  } = props;
   let submitButton;
   let submitMessage;
   if (submission.status === false) {
@@ -129,10 +136,11 @@ export default function SubmitButtons(props) {
     }
 
     return (
-      <div>
+      <>
         <div className="row">
           <div className="small-12 medium-12 columns">{submitMessage}</div>
         </div>
+        {preSubmitBlock}
         <div className="row form-progress-buttons schemaform-back-buttons">
           <div className="small-6 usa-width-one-half medium-6 columns">
             <a href="/">
@@ -141,11 +149,15 @@ export default function SubmitButtons(props) {
           </div>
           {submitButton}
         </div>
-      </div>
+      </>
     );
   }
   return (
-    <div>
+    <>
+      <div className="row">
+        <div className="columns">{submitMessage}</div>
+      </div>
+      {preSubmitBlock}
       <div className="row form-progress-buttons">
         <div className="small-6 medium-5 columns">
           <ProgressButton
@@ -160,9 +172,6 @@ export default function SubmitButtons(props) {
           <div className="hidden">&nbsp;</div>
         </div>
       </div>
-      <div className="row">
-        <div className="columns">{submitMessage}</div>
-      </div>
-    </div>
+    </>
   );
 }

--- a/src/platform/forms-system/src/js/review/SubmitController.jsx
+++ b/src/platform/forms-system/src/js/review/SubmitController.jsx
@@ -84,22 +84,25 @@ class SubmitController extends React.Component {
       renderErrorMessage,
     } = this.props;
     const preSubmit = this.getPreSubmit(formConfig);
+    // Render inside SubmitButtons so the alert is _above_ the submit button;
+    // helps with accessibility
+    const PreSubmitBlock = (
+      <PreSubmitSection
+        preSubmitInfo={preSubmit}
+        onChange={value => this.props.setPreSubmit(preSubmit.field, value)}
+        checked={form.data[preSubmit.field] || false}
+        showError={showPreSubmitError}
+      />
+    );
 
     return (
-      <div>
-        <PreSubmitSection
-          preSubmitInfo={preSubmit}
-          onChange={value => this.props.setPreSubmit(preSubmit.field, value)}
-          checked={form.data[preSubmit.field] || false}
-          showError={showPreSubmitError}
-        />
-        <SubmitButtons
-          onBack={this.goBack}
-          onSubmit={this.handleSubmit}
-          submission={form.submission}
-          renderErrorMessage={renderErrorMessage}
-        />
-      </div>
+      <SubmitButtons
+        onBack={this.goBack}
+        onSubmit={this.handleSubmit}
+        submission={form.submission}
+        renderErrorMessage={renderErrorMessage}
+        preSubmitBlock={PreSubmitBlock}
+      />
     );
   }
 }


### PR DESCRIPTION
## Description

To improve accessibility for the screenreader, this PR will move the form submission alert _above_ the pre submit privacy policy check & submit application buttons. Previously the alert was below the submit button.

This recommendation was part of the original ticket - https://github.com/department-of-veterans-affairs/va.gov-team/issues/2138 - which recommends adding clickable form error links within this alert.

## Testing done

Local unit tests

## Screenshots

**Before:**
![](https://user-images.githubusercontent.com/136959/66862223-1c262a80-ef56-11e9-8027-4feb26079be9.png)

**After:**
![Screen Shot 2020-03-02 at 9 12 41 AM](https://user-images.githubusercontent.com/136959/75688982-08116a00-5c66-11ea-84a4-0fbf654dc022.png)

## Acceptance criteria
- [ ] The form alert is moved above the submit button

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
