### PR TITLE
lodash resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -294,5 +294,8 @@
     "vanilla-lazyload": "^8.17.0",
     "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#53c351b16a1130c959bb54e3d52df290dc9aa64f",
     "whatwg-fetch": "^2.0.3"
+  },
+  "resolutions": {
+    "**/lodash": "^4.17.15"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9061,18 +9061,10 @@ lodash.zip@^4.2.0:
   resolved "https://registry.yarnpkg.com/lodash.zip/-/lodash.zip-4.2.0.tgz#ec6662e4896408ed4ab6c542a3990b72cc080020"
   integrity sha1-7GZi5IlkCO1KtsVCo5kLcswIACA=
 
-"lodash@>=3.5 <5", lodash@^4.0.0, lodash@^4.13.1, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.2, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.3.0, lodash@^4.6.1:
+lodash@4.17.15, "lodash@>=3.5 <5", lodash@^2.4.1, lodash@^4.0.0, lodash@^4.13.1, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.2, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.3.0, lodash@^4.6.1, lodash@~4.16.4:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
-
-lodash@^2.4.1:
-  version "2.4.2"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-2.4.2.tgz#fadd834b9683073da179b3eae6d9c0d15053f73e"
-
-lodash@~4.16.4:
-  version "4.16.6"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.16.6.tgz#d22c9ac660288f3843e16ba7d2b5d06cca27d777"
 
 log-symbols@^2.1.0, log-symbols@^2.2.0:
   version "2.2.0"


### PR DESCRIPTION
## Description
`Resolutions` is used for cases like we are having where the dependencies don't upgrade the dependency needed to be upgraded. Since those sub-dependencies are locked (`package-lock.json`), we can't modify them manually. However, with `resolutions` we can override it.

This PR will upgrade `lodash` sub-dependencies to `^4.17.15`.

### Documentation
[Selective dependency resolutions](https://classic.yarnpkg.com/en/docs/selective-version-resolutions/)

## Github Security Issue
https://github.com/department-of-veterans-affairs/vets-website/network/alert/yarn.lock/lodash/open

![Screen Shot 2020-03-10 at 10 53 39 AM](https://user-images.githubusercontent.com/55560129/76325389-9e283e80-62bd-11ea-95a3-d6afa8c820c0.png)

## Testing done
Locally

## Acceptance criteria
- [ x] Upgrade `lodash` to version `4.17.12` or later to fix vulnerability
