### PR TITLE
bradl3yC - 6715 - Add spinner when using suggested address

### DIFF
--- a/src/platform/user/profile/vet360/actions/transactions.js
+++ b/src/platform/user/profile/vet360/actions/transactions.js
@@ -34,6 +34,7 @@ export const ADDRESS_VALIDATION_CONFIRM = 'ADDRESS_VALIDATION_CONFIRM';
 export const ADDRESS_VALIDATION_ERROR = 'ADDRESS_VALIDATION_ERROR';
 export const ADDRESS_VALIDATION_RESET = 'ADDRESS_VALIDATION_RESET';
 export const ADDRESS_VALIDATION_INITIALIZE = 'ADDRESS_VALIDATION_INITIALIZE';
+export const ADDRESS_VALIDATION_UPDATE = 'ADDRESS_VALIDATION_UPDATE';
 
 export function clearTransactionStatus() {
   return {
@@ -306,6 +307,10 @@ export const updateValidationKeyAndSave = (
   payload,
   analyticsSectionName,
 ) => async dispatch => {
+  dispatch({
+    type: ADDRESS_VALIDATION_UPDATE,
+    fieldName,
+  });
   try {
     const addressPayload = { address: addCountryCodeIso3ToAddress(payload) };
     const options = {

--- a/src/platform/user/profile/vet360/reducers/index.js
+++ b/src/platform/user/profile/vet360/reducers/index.js
@@ -16,6 +16,7 @@ import {
   ADDRESS_VALIDATION_RESET,
   UPDATE_SELECTED_ADDRESS,
   ADDRESS_VALIDATION_INITIALIZE,
+  ADDRESS_VALIDATION_UPDATE,
 } from '../actions';
 
 import { isFailedTransaction } from '../util/transactions';
@@ -271,6 +272,15 @@ export default function vet360(state = initialState, action) {
       return {
         ...state,
         addressValidation: { ...initialAddressValidationState },
+      };
+
+    case ADDRESS_VALIDATION_UPDATE:
+      return {
+        ...state,
+        fieldTransactionMap: {
+          ...state.fieldTransactionMap,
+          [action.fieldName]: { isPending: true },
+        },
       };
 
     case UPDATE_SELECTED_ADDRESS:

--- a/src/platform/user/profile/vet360/tests/actions/transactions.unit.spec.js
+++ b/src/platform/user/profile/vet360/tests/actions/transactions.unit.spec.js
@@ -1,9 +1,11 @@
 import {
   resetAddressValidation,
   validateAddress,
+  updateValidationKeyAndSave,
   ADDRESS_VALIDATION_CONFIRM,
   ADDRESS_VALIDATION_INITIALIZE,
   ADDRESS_VALIDATION_RESET,
+  ADDRESS_VALIDATION_UPDATE,
 } from '../../actions/transactions';
 import sinon from 'sinon';
 import { expect } from 'chai';
@@ -113,6 +115,23 @@ describe('validateAddress', () => {
           id: 123,
         },
       ]);
+    });
+  });
+});
+
+describe('updateValidationKeyAndSave', () => {
+  it('verify return data', () => {
+    const dispatch = sinon.spy();
+    return updateValidationKeyAndSave(
+      route,
+      method,
+      fieldName,
+      payload,
+      analyticsSectionName,
+    )(dispatch).then(() => {
+      expect(dispatch.firstCall.args[0].type).to.equal(
+        ADDRESS_VALIDATION_UPDATE,
+      );
     });
   });
 });

--- a/src/platform/user/profile/vet360/tests/reducers/index.unit.spec.js
+++ b/src/platform/user/profile/vet360/tests/reducers/index.unit.spec.js
@@ -6,6 +6,7 @@ import {
   ADDRESS_VALIDATION_RESET,
   UPDATE_SELECTED_ADDRESS,
   ADDRESS_VALIDATION_INITIALIZE,
+  ADDRESS_VALIDATION_UPDATE,
 } from '../../actions';
 
 describe('vet360 reducer', () => {
@@ -465,6 +466,26 @@ describe('vet360 reducer', () => {
         fieldTransactionMap: {
           mailingAddress: { isPending: true },
         },
+      };
+      expect(vet360(state, action)).to.eql(expectedState);
+    });
+  });
+
+  describe('ADDRESS_VALIDATION_UPDATE action', () => {
+    it('sets inProgress to true', () => {
+      const expectedState = {
+        fieldTransactionMap: {
+          mailingAddress: { isPending: true },
+        },
+      };
+      const state = {
+        fieldTransactionMap: {
+          mailingAddress: { isPending: false },
+        },
+      };
+      const action = {
+        type: ADDRESS_VALIDATION_UPDATE,
+        fieldName: 'mailingAddress',
       };
       expect(vet360(state, action)).to.eql(expectedState);
     });


### PR DESCRIPTION
## Description
Using a suggested address will call back out to address validation API to update the validation key.  While this is happening, we need to display a spinner.

## Testing done
Added a unit test

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
