### PR TITLE
bradl3yC - 6470 - Manage focus of profile section post validate and save

### DIFF
--- a/src/platform/user/profile/vet360/containers/Vet360ProfileField.jsx
+++ b/src/platform/user/profile/vet360/containers/Vet360ProfileField.jsx
@@ -45,7 +45,15 @@ class Vet360ProfileField extends React.Component {
   };
 
   componentDidUpdate(prevProps) {
-    if (prevProps.transaction && !this.props.transaction) {
+    const { transaction, showValidationModal, isEditing } = prevProps;
+    const modalOpenInPrevProps =
+      transaction || showValidationModal || isEditing;
+    const modalIsClosed =
+      !this.props.transaction ||
+      !this.props.showValidationModal ||
+      !this.props.isEditing;
+
+    if (modalOpenInPrevProps && modalIsClosed) {
       focusElement(`button#${this.props.fieldName}-edit-link`);
     }
     if (!prevProps.transaction && this.props.transaction) {

--- a/src/platform/user/profile/vet360/containers/Vet360ProfileField.jsx
+++ b/src/platform/user/profile/vet360/containers/Vet360ProfileField.jsx
@@ -49,8 +49,8 @@ class Vet360ProfileField extends React.Component {
     const modalOpenInPrevProps =
       transaction || showValidationModal || isEditing;
     const modalIsClosed =
-      !this.props.transaction ||
-      !this.props.showValidationModal ||
+      !this.props.transaction &&
+      !this.props.showValidationModal &&
       !this.props.isEditing;
 
     if (modalOpenInPrevProps && modalIsClosed) {


### PR DESCRIPTION
## Description
```
Log into test user 56's /profile
Click the Edit button for mailing address
Enter a nonsense address, or a valid, overridable address
Press the Update button
Press the Edit it or Edit address button from the validation modal
Enter a further nonsense address, or update your valid overridable address
Press the Update button again
Press the Cancel button from the second validation modal
Verify the focus is on the Edit button for mailing address 
```

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
