### PR TITLE
analytics tracking for exhaustionOfBenefitsAfterPursuingTeachingCert radio button

### DIFF
--- a/src/applications/edu-benefits/1995/submitForm.js
+++ b/src/applications/edu-benefits/1995/submitForm.js
@@ -6,6 +6,9 @@ const submitForm = (form, formConfig) => {
   const body = formConfig.transformForSubmit
     ? formConfig.transformForSubmit(formConfig, form)
     : transformForSubmit(formConfig, form);
+  const exhaustedAllBenefits =
+    form.data['view:exhaustionOfBenefits'] === true ||
+    form.data['view:exhaustionOfBenefitsAfterPursuingTeachingCert'] === true;
   const eventData = {
     benefitsUsedRecently: form.data.benefit,
     'edu-stemApplicant': form.data.isEdithNourseRogersScholarship
@@ -16,9 +19,7 @@ const submitForm = (form, formConfig) => {
     activeDuty: form.data.isActiveDuty ? 'Yes' : 'No',
     calledActiveDuty: form.data.isActiveDuty ? 'Yes' : 'No',
     preferredContactMethod: form.data.preferredContactMethod,
-    'edu-exhaustedAllBenefits': form.data['view:exhaustionOfBenefits']
-      ? 'Yes'
-      : 'No',
+    'edu-exhaustedAllBenefits': exhaustedAllBenefits ? 'Yes' : 'No',
   };
 
   const submitUrl = display1995StemFlow(form.data)


### PR DESCRIPTION
## Description
https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/6092

Added in google analytics tracking for the `exhaustionOfBenefitsAfterPursuingTeachingCert` radio button input field. 

## Testing done
Dev tested


## Screenshots

## Acceptance criteria
- [x] Both exhaustionOfBenefitsAfterPursuingTeachingCert and exhaustionOfBenefits are tracked as `edu-exhaustedAllBenefits` event.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
