### PR TITLE
Add overseas address functionality to 526

### DIFF
--- a/src/applications/disability-benefits/all-claims/tests/pages/contactInformation.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/contactInformation.unit.spec.jsx
@@ -39,8 +39,8 @@ describe('Disability benefits 526EZ contact information', () => {
 
     // country
     expect(form.find('select').length).to.equal(1);
-    // street 1, 2, 3, city, phone, email, fwding address checkbox
-    expect(form.find('input').length).to.equal(6);
+    // street 1, 2, 3, city, phone, email, and overseas address checkbox
+    expect(form.find('input').length).to.equal(7);
     form.unmount();
   });
 
@@ -62,8 +62,8 @@ describe('Disability benefits 526EZ contact information', () => {
 
     // country, state
     expect(form.find('select').length).to.equal(2);
-    // street 1, 2, 3, city, zip, phone, email, fwding address checkbox
-    expect(form.find('input').length).to.equal(7);
+    // street 1, 2, 3, city, zip, phone, email, and overseas address checkbox
+    expect(form.find('input').length).to.equal(8);
     form.unmount();
   });
 
@@ -85,8 +85,8 @@ describe('Disability benefits 526EZ contact information', () => {
 
     // country
     expect(form.find('select').length).to.equal(1);
-    // street 1, 2, 3, city, phone, email, fwding address checkbox
-    expect(form.find('input').length).to.equal(6);
+    // street 1, 2, 3, city, phone, email, and overseas address checkbox
+    expect(form.find('input').length).to.equal(7);
     form.unmount();
   });
 

--- a/src/applications/disability-benefits/all-claims/tests/pages/contactInformation.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/contactInformation.unit.spec.jsx
@@ -204,6 +204,33 @@ describe('Disability benefits 526EZ contact information', () => {
     form.unmount();
   });
 
+  it('disables the country dropdown when overseas address is checked', () => {
+    const form = mount(
+      <DefinitionTester
+        definitions={formConfig.defaultDefinitions}
+        schema={schema}
+        data={{
+          mailingAddress: {
+            'view:livesOnMilitaryBase': true,
+            country: 'USA',
+          },
+          phoneAndEmail: {},
+        }}
+        formData={{}}
+        uiSchema={uiSchema}
+      />,
+    );
+
+    // country
+    expect(
+      form
+        .find('select')
+        .at(0)
+        .prop('disabled'),
+    ).to.be.true;
+    form.unmount();
+  });
+
   // it('expands forwarding address fields when forwarding address checked', () => {
   //   const form = mount(
   //     <DefinitionTester


### PR DESCRIPTION
## Description
The user profile has been updated to support indicating that the user lives on an overseas military base. This PR adds this functionality to the 526 form.

## Screenshots
![image](https://user-images.githubusercontent.com/53942725/76436477-a8fed400-638e-11ea-966a-1578851cf4d2.png)

![image](https://user-images.githubusercontent.com/53942725/76436518-b7e58680-638e-11ea-818f-c2d518d80ac7.png)

## Acceptance criteria
- [ ] Added checkbox to indicate overseas military base
- [ ] Checkbox has helper text label and field
- [ ] When checkbox is checked, country is disabled and set to USA
- [ ] When checkbox is checked, City changes to APO/FPO/DOP
- [ ] When checkbox is checked, the State field is limited to AA, AE, and AP