### PR TITLE
Always set facility type for non-CC types

### DIFF
--- a/src/applications/vaos/containers/DateTimeRequestPage.jsx
+++ b/src/applications/vaos/containers/DateTimeRequestPage.jsx
@@ -117,7 +117,7 @@ export class DateTimeRequestPage extends React.Component {
             .add(5, 'days')
             .format('YYYY-MM-DD')}
           maxDate={moment()
-            .add(395, 'days')
+            .add(120, 'days')
             .format('YYYY-MM-DD')}
           currentlySelectedDate={currentlySelectedDate}
           selectedDates={selectedDates}

--- a/src/applications/vaos/newAppointmentFlow.js
+++ b/src/applications/vaos/newAppointmentFlow.js
@@ -80,14 +80,13 @@ export default {
   typeOfCare: {
     url: '/new-appointment',
     async next(state, dispatch) {
-      let nextState = 'vaFacility';
       const communityCareEnabled = vaosCommunityCare(state);
 
       if (isSleepCare(state)) {
         dispatch(updateFacilityType(FACILITY_TYPES.VAMC));
-        nextState = 'typeOfSleepCare';
+        return 'typeOfSleepCare';
       } else if (isEyeCare(state)) {
-        nextState = 'typeOfEyeCare';
+        return 'typeOfEyeCare';
       } else if (isCommunityCare(state)) {
         try {
           if (communityCareEnabled) {
@@ -121,20 +120,16 @@ export default {
             dispatch(showTypeOfCareUnavailableModal());
             return 'typeOfCare';
           }
-
-          dispatch(updateFacilityType(FACILITY_TYPES.VAMC));
-          return 'vaFacility';
         } catch (e) {
           captureError(e);
           Sentry.captureMessage(
             'Community Care eligibility check failed with errors',
           );
-          dispatch(updateFacilityType(FACILITY_TYPES.VAMC));
-          return 'vaFacility';
         }
       }
 
-      return nextState;
+      dispatch(updateFacilityType(FACILITY_TYPES.VAMC));
+      return 'vaFacility';
     },
     previous: 'home',
   },


### PR DESCRIPTION
## Description
We're not always setting the facility type for types of care that aren't CC eligible and don't have disambiguation pages. This results in missing info on the review page.

## Testing done
Local testing

## Acceptance criteria
- [ ] facility type is always set

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
