### PR TITLE
Suppress display for number of search results

### DIFF
--- a/src/applications/facility-locator/containers/VAMap.jsx
+++ b/src/applications/facility-locator/containers/VAMap.jsx
@@ -489,7 +489,7 @@ class VAMap extends Component {
       selectedResult,
       showCommunityCares,
       results,
-      pagination: { currentPage, totalPages, totalEntries },
+      pagination: { currentPage, totalPages },
     } = this.props;
     const facilityLocatorMarkers = this.renderFacilityMarkers();
     const externalLink =
@@ -595,7 +595,7 @@ class VAMap extends Component {
       currentQuery,
       showCommunityCares,
       results,
-      pagination: { currentPage, totalPages, totalEntries },
+      pagination: { currentPage, totalPages },
     } = this.props;
     const coords = this.props.currentQuery.position;
     const position = [coords.latitude, coords.longitude];

--- a/src/applications/facility-locator/containers/VAMap.jsx
+++ b/src/applications/facility-locator/containers/VAMap.jsx
@@ -506,7 +506,7 @@ class VAMap extends Component {
             showCommunityCares={showCommunityCares}
             isMobile
           />
-          <div ref={this.searchResultTitle}>
+          {/* <div ref={this.searchResultTitle}>
             {results.length > 0 ? (
               <p className="search-result-title">
                 <strong>{totalEntries} results</strong>
@@ -520,7 +520,8 @@ class VAMap extends Component {
             ) : (
               <br />
             )}
-          </div>
+          </div> */}
+          <br />
           <Tabs onSelect={this.centerMap}>
             <TabList>
               <Tab className="small-6 tab">View List</Tab>
@@ -614,7 +615,7 @@ class VAMap extends Component {
             showCommunityCares={showCommunityCares}
           />
         </div>
-        <div ref={this.searchResultTitle} style={{ paddingLeft: '15px' }}>
+        {/* <div ref={this.searchResultTitle} style={{ paddingLeft: '15px' }}>
           {results.length > 0 ? (
             <p className="search-result-title">
               <strong>{totalEntries} results</strong>
@@ -626,9 +627,10 @@ class VAMap extends Component {
               <strong>“{this.props.currentQuery.context}”</strong>
             </p>
           ) : (
-            <br />
+            <br >
           )}
-        </div>
+        </div> */}
+        <br />
         <div className="row">
           <div
             className="columns usa-width-one-third medium-4 small-12"


### PR DESCRIPTION
## Description
Issue: https://github.com/department-of-veterans-affairs/va.gov-team/issues/6775

## Testing done
Locally

## Screenshots
<img width="734" alt="Screen Shot 2020-03-11 at 2 00 25 PM" src="https://user-images.githubusercontent.com/100468/76457577-0e5ebf00-63a7-11ea-8960-266720bfe6c5.png">
<img width="1134" alt="Screen Shot 2020-03-11 at 2 00 39 PM" src="https://user-images.githubusercontent.com/100468/76457585-11f24600-63a7-11ea-9224-0722efba5cab.png">


## Acceptance criteria
- [x] Hide the results summary for every facility type search,

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
