### PR TITLE
Add personalization/ and disability-benefits/ to VSA codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,6 +11,7 @@ src/applications/find-va-forms @department-of-veterans-affairs/vsa-frontend
 src/platform/site-wide @department-of-veterans-affairs/vsa-frontend
 src/applications/yellow-ribbon @department-of-veterans-affairs/vsa-frontend
 src/applications/personalization @department-of-veterans-affairs/vsa-frontend
+src/applications/disability-benefits @department-of-veterans-affairs/vsa-frontend
 
 # Other
 src/applications/vaos @department-of-veterans-affairs/vfs-vaos

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,6 +9,7 @@
 src/applications/proxy-rewrite/redirects/crossDomainRedirects.json @department-of-veterans-affairs/vsa-frontend
 src/applications/find-va-forms @department-of-veterans-affairs/vsa-frontend
 src/platform/site-wide @department-of-veterans-affairs/vsa-frontend
+src/applications/yellow-ribbon @department-of-veterans-affairs/vsa-frontend
 src/applications/personalization @department-of-veterans-affairs/vsa-frontend
 
 # Other

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,7 +12,7 @@ src/platform/site-wide @department-of-veterans-affairs/vsa-frontend
 src/applications/yellow-ribbon @department-of-veterans-affairs/vsa-frontend
 src/applications/personalization @department-of-veterans-affairs/vsa-frontend
 src/applications/disability-benefits @department-of-veterans-affairs/vsa-frontend
-src/platform/user/profile/vet360/ @department-of-veterans-affairs/vsa-frontend
+src/platform/user/profile/vet360 @department-of-veterans-affairs/vsa-frontend
 
 # Other
 src/applications/vaos @department-of-veterans-affairs/vfs-vaos

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,7 +9,7 @@
 src/applications/proxy-rewrite/redirects/crossDomainRedirects.json @department-of-veterans-affairs/vsa-frontend
 src/applications/find-va-forms @department-of-veterans-affairs/vsa-frontend
 src/platform/site-wide @department-of-veterans-affairs/vsa-frontend
-src/applications/yellow-ribbon @department-of-veterans-affairs/vsa-frontend
+src/applications/personalization @department-of-veterans-affairs/vsa-frontend
 
 # Other
 src/applications/vaos @department-of-veterans-affairs/vfs-vaos

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,7 +12,7 @@ src/platform/site-wide @department-of-veterans-affairs/vsa-frontend
 src/applications/yellow-ribbon @department-of-veterans-affairs/vsa-frontend
 src/applications/personalization @department-of-veterans-affairs/vsa-frontend
 src/applications/disability-benefits @department-of-veterans-affairs/vsa-frontend
-src/platform/user/profile/vet360/
+src/platform/user/profile/vet360/ @department-of-veterans-affairs/vsa-frontend
 
 # Other
 src/applications/vaos @department-of-veterans-affairs/vfs-vaos

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,6 +12,7 @@ src/platform/site-wide @department-of-veterans-affairs/vsa-frontend
 src/applications/yellow-ribbon @department-of-veterans-affairs/vsa-frontend
 src/applications/personalization @department-of-veterans-affairs/vsa-frontend
 src/applications/disability-benefits @department-of-veterans-affairs/vsa-frontend
+src/platform/user/profile/vet360/
 
 # Other
 src/applications/vaos @department-of-veterans-affairs/vfs-vaos


### PR DESCRIPTION
## Description
Assigns some code directories to the VSA GH Group in the codeowners file.

## Testing done
N/A

## Screenshots
N/A

## Acceptance criteria
- [x] VSA team members can merge with approval from only a VSA team member

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
