### PR TITLE
[Development] Remove HLR intro page redirect

### DIFF
--- a/src/applications/disability-benefits/996/components/IntroductionPage.jsx
+++ b/src/applications/disability-benefits/996/components/IntroductionPage.jsx
@@ -10,17 +10,8 @@ import CallToActionWidget from 'platform/site-wide/cta-widget';
 import { toggleLoginModal } from 'platform/site-wide/user-nav/actions';
 import { focusElement } from 'platform/utilities/ui';
 
-import { BASE_URL } from '../constants';
-
 class IntroductionPage extends React.Component {
   componentDidMount() {
-    if (
-      !this.hasSavedForm() &&
-      !window.location.pathname.endsWith('/introduction')
-    ) {
-      window.location.replace(`${BASE_URL}/introduction`);
-    }
-
     focusElement('.va-nav-breadcrumbs-list');
   }
 


### PR DESCRIPTION
## Description

Currently, a logged-in user will get stuck on the HLR introduction page (https://staging.va.gov/decision-reviews/higher-level-review/request-higher-level-review-form-20-0996/).

This PR removes the code that is likely causing this endless loop redirect 

## Testing done

Local unit tests

## Screenshots

N/A

## Acceptance criteria
- [ ] A user can log in to the HLR form (user 228) and progress past the introduction page

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
