### PR TITLE
VACMS-1219: Adding missed graphql field for new release.

### DIFF
--- a/src/site/stages/build/drupal/graphql/pressReleasesListingPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/pressReleasesListingPage.graphql.js
@@ -16,6 +16,9 @@ module.exports = `
             ... on NodePressRelease {
               entityId
               title
+              fieldReleaseDate {
+                value
+              }
               entityUrl {
                 path
               }


### PR DESCRIPTION
## Description
Broken dates for list items, here: `/pittsburgh-health-care/news-releases/`

## Testing done
 - Visual

## Screenshots
![image](https://user-images.githubusercontent.com/2404547/76527266-516f6f80-6445-11ea-8bb7-b488dda790ac.png)

## Acceptance criteria
- [ ] Dates appear for individual news listings, here `/pittsburgh-health-care/news-releases/`
