### PR TITLE
VAOS Analytics Fixes

### DIFF
--- a/src/applications/vaos/actions/newAppointment.js
+++ b/src/applications/vaos/actions/newAppointment.js
@@ -131,9 +131,6 @@ export function openFormPage(page, uiSchema, schema) {
 }
 
 export function startNewAppointmentFlow() {
-  recordEvent({
-    event: `${GA_PREFIX}-schedule-new-appointment-started`,
-  });
   return {
     type: STARTED_NEW_APPOINTMENT_FLOW,
   };
@@ -647,7 +644,7 @@ export function submitAppointmentOrRequest(router) {
         });
         router.push('/new-appointment/confirmation');
       } catch (error) {
-        captureError(error);
+        captureError(error, true);
         dispatch({
           type: FORM_SUBMIT_FAILED,
         });
@@ -693,11 +690,6 @@ export function submitAppointmentOrRequest(router) {
         } catch (error) {
           // These are ancillary updates, the request went through if the first submit
           // succeeded
-          recordEvent({
-            event: `${GA_PREFIX}-${eventType}-submission-failed`,
-            flow,
-            ...additionalEventData,
-          });
           captureError(error);
         }
 
@@ -712,7 +704,7 @@ export function submitAppointmentOrRequest(router) {
         });
         router.push('/new-appointment/confirmation');
       } catch (error) {
-        captureError(error);
+        captureError(error, true);
         dispatch({
           type: FORM_SUBMIT_FAILED,
         });

--- a/src/applications/vaos/actions/newAppointment.js
+++ b/src/applications/vaos/actions/newAppointment.js
@@ -610,15 +610,19 @@ export function submitAppointmentOrRequest(router) {
       type: FORM_SUBMIT,
     });
 
-    if (newAppointment.flowType === FLOW_TYPES.DIRECT) {
-      const additionalEventData = {
-        typeOfCare,
-        flow: GA_FLOWS.DIRECT,
-      };
+    const additionalEventData = {
+      typeOfCare,
+      'health-TypeOfCare': typeOfCare,
+      'health-ReasonForAppointment': newAppointment?.data?.reasonForAppointment,
+      'health-ReasonAdditionalInfo': newAppointment?.data?.reasonAdditionalInfo,
+    };
 
+    if (newAppointment.flowType === FLOW_TYPES.DIRECT) {
       recordEvent({
         event: `${GA_PREFIX}-direct-submission`,
         ...additionalEventData,
+        'health-flow': GA_FLOWS.DIRECT,
+        flow: GA_FLOWS.DIRECT,
       });
 
       try {
@@ -659,13 +663,10 @@ export function submitAppointmentOrRequest(router) {
       const isCommunityCare =
         newAppointment.data.facilityType === FACILITY_TYPES.COMMUNITY_CARE;
       const eventType = isCommunityCare ? 'community-care' : 'request';
-      const additionalEventData = {
-        typeOfCare,
-        flow: isCommunityCare ? GA_FLOWS.CC_REQUEST : GA_FLOWS.VA_REQUEST,
-      };
 
       recordEvent({
         event: `${GA_PREFIX}-${eventType}-submission`,
+        flow: isCommunityCare ? GA_FLOWS.CC_REQUEST : GA_FLOWS.VA_REQUEST,
         ...additionalEventData,
       });
 

--- a/src/applications/vaos/containers/ConfirmationPage.jsx
+++ b/src/applications/vaos/containers/ConfirmationPage.jsx
@@ -75,7 +75,15 @@ export class ConfirmationPage extends React.Component {
           />
         )}
         <div className="vads-u-margin-y--2">
-          <Link to="/" className="usa-button vads-u-padding-right--2">
+          <Link
+            to="/"
+            className="usa-button vads-u-padding-right--2"
+            onClick={() => {
+              recordEvent({
+                event: `${GA_PREFIX}-view-your-appointments-button-clicked`,
+              });
+            }}
+          >
             View your appointments
           </Link>
           <Link

--- a/src/applications/vaos/tests/actions/newAppointment.unit.spec.js
+++ b/src/applications/vaos/tests/actions/newAppointment.unit.spec.js
@@ -1120,10 +1120,6 @@ describe('VAOS newAppointment actions', () => {
       expect(dispatch.firstCall.args[0].type).to.equal(FORM_SUBMIT);
       expect(dispatch.secondCall.args[0].type).to.equal(FORM_SUBMIT_FAILED);
       expect(global.window.dataLayer[1]).to.deep.equal({
-        event: 'vaos-error',
-        'error-key': 'vaos_server_error',
-      });
-      expect(global.window.dataLayer[2]).to.deep.equal({
         event: 'vaos-request-submission-failed',
         flow: 'va-request',
         'health-TypeOfCare': 'Primary care',

--- a/src/applications/vaos/tests/actions/newAppointment.unit.spec.js
+++ b/src/applications/vaos/tests/actions/newAppointment.unit.spec.js
@@ -974,12 +974,14 @@ describe('VAOS newAppointment actions', () => {
       expect(dispatch.secondCall.args[0].type).to.equal(FORM_SUBMIT_SUCCEEDED);
       expect(global.window.dataLayer[0]).to.deep.equal({
         event: 'vaos-request-submission',
-        typeOfCare: 'Primary care',
+        'health-TypeOfCare': 'Primary care',
+        'health-ReasonForAppointment': 'routine-follow-up',
         flow: 'va-request',
       });
       expect(global.window.dataLayer[1]).to.deep.equal({
         event: 'vaos-request-submission-successful',
-        typeOfCare: 'Primary care',
+        'health-TypeOfCare': 'Primary care',
+        'health-ReasonForAppointment': 'routine-follow-up',
         flow: 'va-request',
       });
       expect(router.push.called).to.be.true;
@@ -1094,6 +1096,7 @@ describe('VAOS newAppointment actions', () => {
               selectedDates: [],
             },
             reasonForAppointment: 'routine-follow-up',
+            reasonAdditionalInfo: 'test',
             bestTimeToCall: [],
           },
           facilities: {
@@ -1117,9 +1120,14 @@ describe('VAOS newAppointment actions', () => {
       expect(dispatch.firstCall.args[0].type).to.equal(FORM_SUBMIT);
       expect(dispatch.secondCall.args[0].type).to.equal(FORM_SUBMIT_FAILED);
       expect(global.window.dataLayer[1]).to.deep.equal({
+        event: 'vaos-error',
+        'error-key': 'vaos_server_error',
+      });
+      expect(global.window.dataLayer[2]).to.deep.equal({
         event: 'vaos-request-submission-failed',
-        typeOfCare: 'Primary care',
         flow: 'va-request',
+        'health-TypeOfCare': 'Primary care',
+        'health-ReasonForAppointment': 'routine-follow-up',
       });
       expect(router.push.called).to.be.false;
     });

--- a/src/applications/vaos/utils/eligibility.js
+++ b/src/applications/vaos/utils/eligibility.js
@@ -7,7 +7,7 @@ import { recordVaosError } from './events';
 
 function createErrorHandler(directOrRequest, errorKey) {
   return data => {
-    captureError(data);
+    captureError(data, true);
     recordVaosError(errorKey);
     return { [`${directOrRequest}Failed`]: true };
   };

--- a/src/applications/vaos/utils/error.js
+++ b/src/applications/vaos/utils/error.js
@@ -1,19 +1,25 @@
 import * as Sentry from '@sentry/browser';
 import { recordVaosError } from './events';
 
-export function captureError(err) {
+export function captureError(err, skipRecordEvent) {
+  let eventErrorKey;
+
   if (err instanceof Error) {
     Sentry.captureException(err);
-    recordVaosError(err.message);
+    eventErrorKey = err.message;
   } else {
     Sentry.withScope(scope => {
       scope.setExtra('error', err);
       const message = `vaos_server_error${
         err?.[0]?.title ? `: ${err?.[0]?.title}` : ''
       }`;
-      recordVaosError(message);
+      eventErrorKey = message;
       // the apiRequest helper returns the errors array, instead of an exception
       Sentry.captureMessage(message);
     });
+  }
+
+  if (!skipRecordEvent) {
+    recordVaosError(eventErrorKey);
   }
 }

--- a/src/applications/vaos/utils/error.js
+++ b/src/applications/vaos/utils/error.js
@@ -1,13 +1,19 @@
 import * as Sentry from '@sentry/browser';
+import { recordVaosError } from './events';
 
 export function captureError(err) {
   if (err instanceof Error) {
     Sentry.captureException(err);
+    recordVaosError(err.message);
   } else {
     Sentry.withScope(scope => {
       scope.setExtra('error', err);
+      const message = `vaos_server_error${
+        err?.[0]?.title ? `: ${err?.[0]?.title}` : ''
+      }`;
+      recordVaosError(message);
       // the apiRequest helper returns the errors array, instead of an exception
-      Sentry.captureMessage(`vaos_server_error: ${err?.[0]?.title}`);
+      Sentry.captureMessage(message);
     });
   }
 }


### PR DESCRIPTION
## Description
This ticket adds some missing additional info to submission events with `-health` prefix.  Also records a `vaos-error` any time we use the `captureError()` handler, as per @nedierecel's recommendation, which would help us cross-check the Sentry errors.

FYI, I added a `skipRecordEvent` parameter to `captureError()` in the case where we are already recording an event and want to prevent duplicates.

## Testing done
Local and unit

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
