### PR TITLE
[Redirects] Revert some Rates redirects

### DIFF
--- a/src/applications/proxy-rewrite/redirects/crossDomainRedirects.json
+++ b/src/applications/proxy-rewrite/redirects/crossDomainRedirects.json
@@ -526,6 +526,26 @@
   },
   {
     "domain": "www.benefits.va.gov",
+    "src": "/compensation/resources-rates-read-compAndSMC.asp",
+    "dest": "/disability/compensation-rates/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/compensation/read_rates.asp",
+    "dest": "/disability/compensation-rates/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/compensation/resources_comp01.asp",
+    "dest": "/disability/compensation-rates/veteran-rates/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/compensation/special_Benefit_Allowances_2018.asp",
+    "dest": "/disability/compensation-rates/special-benefit-allowance-rates/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
     "src": "/compensation/sb2018.asp",
     "dest": "/disability/compensation-rates/birth-defect-rates/"
   },

--- a/src/applications/proxy-rewrite/redirects/crossDomainRedirects.json
+++ b/src/applications/proxy-rewrite/redirects/crossDomainRedirects.json
@@ -526,36 +526,6 @@
   },
   {
     "domain": "www.benefits.va.gov",
-    "src": "/compensation/rates-index.asp",
-    "dest": "/disability/compensation-rates/"
-  },
-  {
-    "domain": "www.benefits.va.gov",
-    "src": "/compensation/resources-rates-read-compAndSMC.asp",
-    "dest": "/disability/compensation-rates/"
-  },
-  {
-    "domain": "www.benefits.va.gov",
-    "src": "/compensation/read_rates.asp",
-    "dest": "/disability/compensation-rates/"
-  },
-  {
-    "domain": "www.benefits.va.gov",
-    "src": "/compensation/resources_comp01.asp",
-    "dest": "/disability/compensation-rates/veteran-rates/"
-  },
-  {
-    "domain": "www.benefits.va.gov",
-    "src": "/compensation/resources_comp02.asp",
-    "dest": "/disability/compensation-rates/special-monthly-compensation-rates/"
-  },
-  {
-    "domain": "www.benefits.va.gov",
-    "src": "/compensation/special_Benefit_Allowances_2018.asp",
-    "dest": "/disability/compensation-rates/special-benefit-allowance-rates/"
-  },
-  {
-    "domain": "www.benefits.va.gov",
     "src": "/compensation/sb2018.asp",
     "dest": "/disability/compensation-rates/birth-defect-rates/"
   },


### PR DESCRIPTION
## Description
These pages were redirected on 3/10 but displays the incorrect special
monthly rates and is causing confusion.

Ticket - https://github.com/department-of-veterans-affairs/va.gov-team/issues/6833
Related to https://github.com/department-of-veterans-affairs/va.gov-team/issues/6087

## Screenshots
N/A

## Acceptance criteria
- [ ] Redirects are reverted

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
