### PR TITLE
Keep bad clinic data out Redux state

### DIFF
--- a/src/applications/vaos/reducers/newAppointment.js
+++ b/src/applications/vaos/reducers/newAppointment.js
@@ -314,11 +314,14 @@ export default function formReducer(state = initialState, action) {
           ...state.eligibility,
           [`${data.vaFacility}_${action.typeOfCareId}`]: facilityEligibility,
         };
-        clinics = {
-          ...state.clinics,
-          [`${data.vaFacility}_${action.typeOfCareId}`]: action.eligibilityData
-            .clinics,
-        };
+
+        if (!action.eligibilityData.clinics?.directFailed) {
+          clinics = {
+            ...state.clinics,
+            [`${data.vaFacility}_${action.typeOfCareId}`]: action
+              .eligibilityData.clinics,
+          };
+        }
       }
 
       return {
@@ -445,14 +448,19 @@ export default function formReducer(state = initialState, action) {
         action.typeOfCareId,
         action.eligibilityData,
       );
+      let clinics = state.clinics;
 
-      return {
-        ...state,
-        clinics: {
+      if (!action.eligibilityData.clinics?.directFailed) {
+        clinics = {
           ...state.clinics,
           [`${state.data.vaFacility}_${action.typeOfCareId}`]: action
             .eligibilityData.clinics,
-        },
+        };
+      }
+
+      return {
+        ...state,
+        clinics,
         eligibility: {
           ...state.eligibility,
           [`${state.data.vaFacility}_${action.typeOfCareId}`]: eligibility,

--- a/src/applications/vaos/tests/reducers/newAppointment.unit.spec.js
+++ b/src/applications/vaos/tests/reducers/newAppointment.unit.spec.js
@@ -251,6 +251,24 @@ describe('VAOS reducer: newAppointment', () => {
       );
     });
 
+    it('should not set clinics when it failed', () => {
+      const action = {
+        ...defaultOpenPageAction,
+        parentFacilities: parentFacilitiesParsed.slice(0, 1),
+        facilities: facilities983Parsed.slice(0, 1),
+        eligibilityData: {
+          clinics: { directFailed: true },
+          requestPastVisit: {},
+          directPastVisit: {},
+          requestLimits: {},
+        },
+      };
+
+      const newState = newAppointmentReducer(defaultState, action);
+
+      expect(newState.clinics).to.be.undefined;
+    });
+
     it('should set error when failed', () => {
       const currentState = {
         ...defaultState,
@@ -435,6 +453,33 @@ describe('VAOS reducer: newAppointment', () => {
         action.eligibilityData.clinics,
       );
       expect(newState.eligibility['983_323']).to.not.be.undefined;
+    });
+
+    it('should not set clinic info if failed', () => {
+      const action = {
+        type: FORM_ELIGIBILITY_CHECKS_SUCCEEDED,
+        typeOfCareId: '323',
+        eligibilityData: {
+          clinics: { directFailed: true },
+          directPastVisit: {},
+          requestPastVisit: {},
+          requestLimits: {},
+        },
+      };
+      const state = {
+        ...defaultState,
+        facilities: {
+          '323_983': facilities983Parsed,
+        },
+        parentFacilities: parentFacilitiesParsed,
+        data: {
+          ...defaultState.data,
+          vaFacility: '983',
+        },
+      };
+
+      const newState = newAppointmentReducer(state, action);
+      expect(newState.clinics).to.be.undefined;
     });
 
     it('should set error state', () => {


### PR DESCRIPTION
## Description
When the clinic call fails, we put an error object in that property in our eligibility data. We then were adding that to the Redux state. This is not what we want to do, we instead want to leave the clinics state empty for that facility and type of care.

## Testing done
Local testing

## Acceptance criteria
- [ ] Review page doesn't error out when clinics call fails

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
