### PR TITLE
Improvements to the app coverage script

### DIFF
--- a/script/app-coverage-report.js
+++ b/script/app-coverage-report.js
@@ -39,15 +39,12 @@ const printCoverage = coverageResults => {
 const generateCoverage = (rootDir, coverageSummary) => {
   // Get application manifests & entry names
   const manifests = getAppManifests(path.join(__dirname, '../'));
-  const entryNames = manifests.map(manifest => manifest.entryName);
 
   // Set initial coverage object
   const initialCoverage = Object.assign(
-    ...entryNames.map(entryName => ({
+    ...manifests.map(({ entryName, entryFile }) => ({
       [entryName]: {
-        path: manifests
-          .find(obj => obj.entryName === entryName)
-          .entryFile.replace(rootDir, ''),
+        path: entryFile.replace(rootDir, ''),
         lines: { total: 0, covered: 0, pct: 0 },
         statements: { total: 0, covered: 0, pct: 0 },
         functions: { total: 0, covered: 0, pct: 0 },
@@ -58,16 +55,14 @@ const generateCoverage = (rootDir, coverageSummary) => {
 
   // Iterate through coverages that are under src/applications
   return Object.keys(coverageSummary)
-    .filter(fullPath => fullPath.replace(rootDir, '').split(path.sep)[0])
+    .filter(fullPath => fullPath.includes('src/applications'))
     .reduce((acc, fullCoveragePath) => {
       // Find coverage if it exists by checking if the path of the coverage result file
       // includes an application path, e.g. 'vre/chapter36/'
       const coverageItem = Object.values(acc).find(appCov =>
-        fullCoveragePath
-          .replace(rootDir, '')
-          .includes(
-            `${appCov.path.substring(0, appCov.path.lastIndexOf('/'))}/`,
-          ),
+        fullCoveragePath.includes(
+          `${appCov.path.substring(0, appCov.path.lastIndexOf('/'))}/`,
+        ),
       );
 
       // Average coverageResult with respective coverageItem segment if present

--- a/script/app-coverage-report.js
+++ b/script/app-coverage-report.js
@@ -3,18 +3,32 @@
 const fs = require('fs');
 const path = require('path');
 const Table = require('cli-table');
+const {
+  getAppManifests,
+} = require('../src/site/stages/build/webpack/manifest-helpers');
 
 const printCoverage = coverageResults => {
   // Create a new table with headers
   const coverageTable = new Table({
-    head: ['Application', 'Lines', 'Functions', 'Statements', 'Branches'],
+    head: [
+      'Application (src/applications)',
+      'Lines',
+      'Functions',
+      'Statements',
+      'Branches',
+    ],
   });
 
   // Add each app coverage result to the table
   Object.keys(coverageResults).forEach(key => {
     if (key !== 'total') {
+      const appLocation = `${coverageResults[key].path.substr(
+        0,
+        coverageResults[key].path.lastIndexOf('/'),
+      )}`;
+
       coverageTable.push({
-        [key]: [
+        [appLocation]: [
           `${coverageResults[key].lines.pct}%`,
           `${coverageResults[key].functions.pct}%`,
           `${coverageResults[key].statements.pct}%`,
@@ -27,34 +41,67 @@ const printCoverage = coverageResults => {
   console.log(coverageTable.toString());
 };
 
-const generateCoverage = (rootDir, coverageSummary) =>
-  Object.keys(coverageSummary).reduce((acc, coverageResult) => {
+const generateCoverage = (rootDir, coverageSummary) => {
+  // Get application manifests & entry names
+  const manifests = getAppManifests(path.join(__dirname, '../'));
+  const entryNames = manifests.map(manifest => manifest.entryName);
+
+  // Set initial coverage object
+  const initialCoverage = Object.assign(
+    ...entryNames.map(entryName => ({
+      [entryName]: {
+        path: manifests
+          .find(obj => obj.entryName === entryName)
+          .entryFile.replace(rootDir, ''),
+        lines: { total: 0, covered: 0, skipped: 0, pct: 0 },
+        statements: { total: 0, covered: 0, skipped: 0, pct: 0 },
+        functions: { total: 0, covered: 0, skipped: 0, pct: 0 },
+        branches: { total: 0, covered: 0, skipped: 0, pct: 0 },
+      },
+    })),
+  );
+
+  return Object.keys(coverageSummary).reduce((acc, coverageResult) => {
     const appName = coverageResult.replace(rootDir, '').split(path.sep)[0];
-    // If appName exists, add coverageResult to overall coverage
+
     if (appName) {
-      if (acc[appName]) {
+      // Find coverage if it exists by checking if the path of the coverage result file
+      // includes an application path, e.g. 'vre/chapter36/'
+      const resultFilePath = coverageResult.replace(rootDir, '');
+      const coverageItem = Object.values(acc).find(appCov =>
+        resultFilePath.includes(
+          `${appCov.path.substring(0, appCov.path.lastIndexOf('/'))}/`,
+        ),
+      );
+
+      // Get key of coverageItem
+      const coverageKey = Object.keys(acc).find(
+        key => acc[key] === coverageItem,
+      );
+
+      // Update coverage
+      if (acc[coverageKey]) {
         // Average coverageResult with respective acc segment if present
         // Each 'seg' represents coverage by line, function, statement, and branch
-        Object.keys(acc[appName]).forEach(seg => {
-          acc[appName][seg].total += coverageSummary[coverageResult][seg].total;
-          acc[appName][seg].covered +=
-            coverageSummary[coverageResult][seg].covered;
-          acc[appName][seg].skipped +=
-            coverageSummary[coverageResult][seg].skipped;
-          acc[appName][seg].pct = (
-            (acc[appName][seg].covered / acc[appName][seg].total) *
-            100
-          ).toFixed(2);
-        });
-      } else {
-        // Create new coverageResult entry
-        Object.assign(acc, {
-          [appName]: coverageSummary[coverageResult],
+        Object.keys(acc[coverageKey]).forEach(seg => {
+          if (seg !== 'path') {
+            acc[coverageKey][seg].total +=
+              coverageSummary[coverageResult][seg].total;
+            acc[coverageKey][seg].covered +=
+              coverageSummary[coverageResult][seg].covered;
+            acc[coverageKey][seg].skipped +=
+              coverageSummary[coverageResult][seg].skipped;
+            acc[coverageKey][seg].pct = (
+              (acc[coverageKey][seg].covered / acc[coverageKey][seg].total) *
+                100 || 0
+            ).toFixed(2);
+          }
         });
       }
     }
     return acc;
-  }, {});
+  }, initialCoverage);
+};
 
 // Root directory of application folders
 const applicationDir = path.join(__dirname, '../src/applications/');
@@ -65,8 +112,8 @@ if (fs.existsSync(path.join(__dirname, '../coverage/coverage-summary.json'))) {
     fs.readFileSync(path.join(__dirname, '../coverage/coverage-summary.json')),
   );
   // Generate and print coverage
-  const appCoverage = generateCoverage(applicationDir, coverageSummaryJson);
-  printCoverage(appCoverage);
+  const appCoverages = generateCoverage(applicationDir, coverageSummaryJson);
+  printCoverage(appCoverages);
 } else {
   console.log('./coverage/coverage-summary.json not found.');
 }

--- a/script/app-coverage-report.js
+++ b/script/app-coverage-report.js
@@ -21,7 +21,7 @@ const printCoverage = coverageResults => {
 
   // Add each app coverage result to the table
   Object.values(coverageResults).forEach(cov => {
-    const appLocation = `${cov.path.substr(0, cov.path.lastIndexOf('/'))}`;
+    const appLocation = cov.path.substr(0, cov.path.lastIndexOf('/'));
 
     coverageTable.push({
       [appLocation]: [


### PR DESCRIPTION
## Description
This pull request updates the app coverage script to accurately display each application's coverage. This is a second draft of https://github.com/department-of-veterans-affairs/vets-website/pull/11768.

Changes include using the `manifest.json` files to determine applications, and displaying full paths of applications in the output.


## Testing done


## Screenshots
<img width="582" alt="Screen Shot 2020-03-13 at 8 17 55 AM" src="https://user-images.githubusercontent.com/9042882/76634243-4549e780-6503-11ea-8816-f4d269fa8e58.png">
<img width="582" alt="Screen Shot 2020-03-13 at 8 18 26 AM" src="https://user-images.githubusercontent.com/9042882/76634353-61e61f80-6503-11ea-9612-25ae69531614.png">


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
