### PR TITLE
Remove full lodash imports from yellow-ribbon

### DIFF
--- a/src/applications/yellow-ribbon/components/ComparisonBanner/index.jsx
+++ b/src/applications/yellow-ribbon/components/ComparisonBanner/index.jsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { isEmpty } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 
 export const ComparisonBanner = ({ schoolIDs }) => {
   // Do not render if there are no selected schoolIDs.

--- a/src/applications/yellow-ribbon/components/SearchResult/index.jsx
+++ b/src/applications/yellow-ribbon/components/SearchResult/index.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
-import { includes } from 'lodash';
+import includes from 'lodash/includes';
 // Relative imports.
 import { capitalize } from '../../helpers';
 import {

--- a/src/applications/yellow-ribbon/containers/SearchForm/index.jsx
+++ b/src/applications/yellow-ribbon/containers/SearchForm/index.jsx
@@ -3,7 +3,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import URLSearchParams from 'url-search-params';
-import { map } from 'lodash';
+import map from 'lodash/map';
 // Relative imports.
 import STATES from '../../constants/STATES.json';
 import { fetchResultsThunk } from '../../actions';

--- a/src/applications/yellow-ribbon/containers/SearchResults/index.jsx
+++ b/src/applications/yellow-ribbon/containers/SearchResults/index.jsx
@@ -5,7 +5,7 @@ import LoadingIndicator from '@department-of-veterans-affairs/formation-react/Lo
 import Pagination from '@department-of-veterans-affairs/formation-react/Pagination';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { map } from 'lodash';
+import map from 'lodash/map';
 // Relative imports.
 import SearchResult from '../../components/SearchResult';
 import scrollToTop from 'platform/utilities/ui/scrollToTop';

--- a/src/applications/yellow-ribbon/containers/SearchResults/index.unit.spec.jsx
+++ b/src/applications/yellow-ribbon/containers/SearchResults/index.unit.spec.jsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
-import { times } from 'lodash';
+import times from 'lodash/times';
 // Relative imports.
 import { SearchResults } from './index';
 

--- a/src/applications/yellow-ribbon/containers/YellowRibbonApp/index.unit.spec.jsx
+++ b/src/applications/yellow-ribbon/containers/YellowRibbonApp/index.unit.spec.jsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
-import { times } from 'lodash';
+import times from 'lodash/times';
 // Relative imports.
 import { YellowRibbonApp } from './index';
 

--- a/src/applications/yellow-ribbon/helpers/index.js
+++ b/src/applications/yellow-ribbon/helpers/index.js
@@ -1,5 +1,7 @@
 // Node modules.
-import { map, startCase, toLower } from 'lodash';
+import map from 'lodash/map';
+import startCase from 'lodash/startCase';
+import toLower from 'lodash/toLower';
 
 export const capitalize = str => startCase(toLower(str));
 

--- a/src/applications/yellow-ribbon/reducers/index.js
+++ b/src/applications/yellow-ribbon/reducers/index.js
@@ -1,5 +1,7 @@
 // Dependencies
-import { concat, filter, pick } from 'lodash';
+import concat from 'lodash/concat';
+import filter from 'lodash/filter';
+import pick from 'lodash/pick';
 // Relative imports.
 import {
   ADD_SCHOOL_TO_COMPARE,


### PR DESCRIPTION
## Description
This pull request is for removing full `lodash` imports from yellow-ribbon.

Tagging @bradl3yC 


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
