### PR TITLE
Letters app: only request letters when user has a valid address

### DIFF
--- a/src/applications/letters/containers/Main.jsx
+++ b/src/applications/letters/containers/Main.jsx
@@ -4,7 +4,7 @@ import { connect } from 'react-redux';
 import LoadingIndicator from '@department-of-veterans-affairs/formation-react/LoadingIndicator';
 import { systemDownMessage } from '../../../platform/static-data/error-messages';
 import { AVAILABILITY_STATUSES } from '../utils/constants';
-import { recordsNotFound } from '../utils/helpers';
+import { recordsNotFound, isAddressEmpty } from '../utils/helpers';
 
 import { getLetterListAndBSLOptions } from '../actions/letters';
 
@@ -19,7 +19,9 @@ const {
 
 export class Main extends React.Component {
   componentDidMount() {
-    this.props.getLetterListAndBSLOptions();
+    if (!this.props.emptyAddress) {
+      this.props.getLetterListAndBSLOptions();
+    }
   }
 
   appAvailability(lettersAvailability) {
@@ -67,6 +69,7 @@ function mapStateToProps(state) {
       serviceInfo: letterState.serviceInfo,
     },
     optionsAvailable: letterState.optionsAvailable,
+    emptyAddress: isAddressEmpty(state.user.profile.vet360.mailingAddress),
   };
 }
 


### PR DESCRIPTION
## Description
Currently, we are requesting letters from the back end even when the user does not have a valid address. This is causing errors, so this PR changes the code to only make the request if the user has an address.

## Acceptance criteria
- [ ] The component only requests for letters if the user has a valid address