### PR TITLE
Remove lodash-fp from find va forms

### DIFF
--- a/src/applications/find-va-forms/api/index.js
+++ b/src/applications/find-va-forms/api/index.js
@@ -1,6 +1,6 @@
 // Dependencies.
 import appendQuery from 'append-query';
-import { orderBy } from 'lodash';
+import sortBy from 'lodash/sortBy';
 // Relative imports.
 import STUBBED_RESPONSE from '../constants/STUBBED_RESPONSE';
 import { apiRequest } from '../../../platform/utilities/api';
@@ -30,7 +30,7 @@ export const fetchFormsApi = async (query, options = {}) => {
   const normalizedForms = normalizeFormsForTable(forms);
 
   // Sort the forms by 'id' and 'asc' by default.
-  const sortedForms = orderBy(normalizedForms, 'id', 'asc');
+  const sortedForms = sortBy(normalizedForms, 'id');
 
   return sortedForms;
 };

--- a/src/applications/find-va-forms/containers/SearchResults.jsx
+++ b/src/applications/find-va-forms/containers/SearchResults.jsx
@@ -6,7 +6,8 @@ import LoadingIndicator from '@department-of-veterans-affairs/formation-react/Lo
 import Pagination from '@department-of-veterans-affairs/formation-react/Pagination';
 import SortableTable from '@department-of-veterans-affairs/formation-react/SortableTable';
 import { connect } from 'react-redux';
-import { orderBy, slice } from 'lodash';
+import orderBy from 'lodash/orderBy';
+import slice from 'lodash/slice';
 // Relative imports.
 import { updatePaginationAction, updateResultsAction } from '../actions';
 

--- a/src/applications/find-va-forms/tests/containers/SearchResults.unit.spec.jsx
+++ b/src/applications/find-va-forms/tests/containers/SearchResults.unit.spec.jsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
-import { times } from 'lodash';
+import times from 'lodash/times';
 // Relative imports.
 import {
   SearchResults,


### PR DESCRIPTION
## Description
This pull request removes full lodash imports from `find-va-forms`.
cc @bradl3yC 

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
