### PR TITLE
Hotfix for 526 disappearing UI on review page

### DIFF
--- a/src/applications/disability-benefits/all-claims/pages/contactInformation.js
+++ b/src/applications/disability-benefits/all-claims/pages/contactInformation.js
@@ -66,7 +66,7 @@ const uiOrder = [
   'state',
   'zipCode',
 ];
-// livesOnMilitaryBase is automatically being dropped on
+// livesOnMilitaryBaseInfo is automatically being dropped on
 // the review page so this adjusts ui:order appropriately
 if (window.location.href.includes('review-and-submit')) {
   uiOrder.splice(uiOrder.indexOf('view:livesOnMilitaryBaseInfo'), 1);

--- a/src/applications/disability-benefits/all-claims/pages/contactInformation.js
+++ b/src/applications/disability-benefits/all-claims/pages/contactInformation.js
@@ -55,6 +55,32 @@ const mailingAddress = merge(fullSchema.definitions.address, {
   },
 });
 
+let uiOrder = [
+  'view:livesOnMilitaryBase',
+  'view:livesOnMilitaryBaseInfo',
+  'country',
+  'addressLine1',
+  'addressLine2',
+  'addressLine3',
+  'city',
+  'state',
+  'zipCode',
+];
+// livesOnMilitaryBase is automatically being dropped on
+// the review page so this adjusts ui:order appropriately
+if (window.location.href.includes('review-and-submit')) {
+  uiOrder = [
+    'view:livesOnMilitaryBase',
+    'country',
+    'addressLine1',
+    'addressLine2',
+    'addressLine3',
+    'city',
+    'state',
+    'zipCode',
+  ];
+}
+
 const countryEnum = fullSchema.definitions.country.enum;
 const citySchema = fullSchema.definitions.address.properties.city;
 
@@ -72,17 +98,7 @@ export const uiSchema = {
   },
   mailingAddress: {
     ...addressUISchema(ADDRESS_PATHS.mailingAddress, 'Mailing address', true),
-    'ui:order': [
-      'view:livesOnMilitaryBase',
-      'view:livesOnMilitaryBaseInfo',
-      'country',
-      'addressLine1',
-      'addressLine2',
-      'addressLine3',
-      'city',
-      'state',
-      'zipCode',
-    ],
+    'ui:order': uiOrder,
     'view:livesOnMilitaryBase': {
       'ui:title':
         'I live on a United States military base outside of the United States',

--- a/src/applications/disability-benefits/all-claims/pages/contactInformation.js
+++ b/src/applications/disability-benefits/all-claims/pages/contactInformation.js
@@ -55,7 +55,7 @@ const mailingAddress = merge(fullSchema.definitions.address, {
   },
 });
 
-let uiOrder = [
+const uiOrder = [
   'view:livesOnMilitaryBase',
   'view:livesOnMilitaryBaseInfo',
   'country',
@@ -69,16 +69,7 @@ let uiOrder = [
 // livesOnMilitaryBase is automatically being dropped on
 // the review page so this adjusts ui:order appropriately
 if (window.location.href.includes('review-and-submit')) {
-  uiOrder = [
-    'view:livesOnMilitaryBase',
-    'country',
-    'addressLine1',
-    'addressLine2',
-    'addressLine3',
-    'city',
-    'state',
-    'zipCode',
-  ];
+  uiOrder.splice(uiOrder.indexOf('view:livesOnMilitaryBaseInfo'), 1);
 }
 
 const countryEnum = fullSchema.definitions.country.enum;


### PR DESCRIPTION
## Description
This is a quick fix for an issue with 526 where UI disappears on the review page when accordions are clicked because of a the 'ui:order' containing extraneous properties.

## Acceptance criteria
- [ ] Review page doesn't disappear when accordions are clicked
