### PR TITLE
Remove lodash-fp and full lodash imports from platform/site-wide

### DIFF
--- a/src/platform/site-wide/mega-menu/reducers/index.js
+++ b/src/platform/site-wide/mega-menu/reducers/index.js
@@ -1,5 +1,3 @@
-// import _ from 'lodash/fp';
-
 import {
   TOGGLE_PANEL_OPEN,
   UPDATE_CURRENT_SECTION,

--- a/src/platform/site-wide/side-nav/components/DuplicateLineLabel.js
+++ b/src/platform/site-wide/side-nav/components/DuplicateLineLabel.js
@@ -2,7 +2,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { get } from 'lodash';
+import get from 'lodash/get';
 // Relative
 import { NavItemPropTypes } from '../prop-types';
 import LabelText from './LabelText';

--- a/src/platform/site-wide/side-nav/components/ExpandCollapseIcon.js
+++ b/src/platform/site-wide/side-nav/components/ExpandCollapseIcon.js
@@ -2,7 +2,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { get } from 'lodash';
+import get from 'lodash/get';
 // Relative
 import { NavItemPropTypes } from '../prop-types';
 

--- a/src/platform/site-wide/side-nav/components/LabelText.js
+++ b/src/platform/site-wide/side-nav/components/LabelText.js
@@ -1,6 +1,6 @@
 // Dependencies
 import React from 'react';
-import { get } from 'lodash';
+import get from 'lodash/get';
 // Relative
 import { NavItemPropTypes } from '../prop-types';
 

--- a/src/platform/site-wide/side-nav/components/NavItem.js
+++ b/src/platform/site-wide/side-nav/components/NavItem.js
@@ -1,7 +1,7 @@
 // Dependencies
 import React from 'react';
 import PropTypes from 'prop-types';
-import { get } from 'lodash';
+import get from 'lodash/get';
 // Relative
 import DuplicateLineLabel from './DuplicateLineLabel';
 import NavItemRow from './NavItemRow';

--- a/src/platform/site-wide/side-nav/components/NavItemRow.js
+++ b/src/platform/site-wide/side-nav/components/NavItemRow.js
@@ -2,7 +2,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { get } from 'lodash';
+import get from 'lodash/get';
 // Relative
 import ExpandCollapseIcon from './ExpandCollapseIcon';
 import LabelText from './LabelText';

--- a/src/platform/site-wide/side-nav/components/SideNav.js
+++ b/src/platform/site-wide/side-nav/components/SideNav.js
@@ -1,7 +1,11 @@
 // Dependencies
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { find, filter, get, map, orderBy } from 'lodash';
+import find from 'lodash/find';
+import filter from 'lodash/filter';
+import get from 'lodash/get';
+import map from 'lodash/map';
+import sortBy from 'lodash/sortBy';
 // Relative
 import NavItem from './NavItem';
 
@@ -52,11 +56,12 @@ class SideNav extends Component {
     // Derive the items to render.
     const filteredNavItems = filter(
       navItemsLookup,
+      // eslint-disable-next-line lodash/matches-prop-shorthand,lodash/matches-shorthand
       item => item.parentID === parentID,
     );
 
     // Sort the items by `order`.
-    const sortedNavItems = orderBy(filteredNavItems, 'order', 'asc');
+    const sortedNavItems = sortBy(filteredNavItems, 'order');
 
     return map(sortedNavItems, (item, index) => (
       <NavItem

--- a/src/platform/site-wide/side-nav/helpers.js
+++ b/src/platform/site-wide/side-nav/helpers.js
@@ -1,5 +1,10 @@
 // Dependencies
-import { each, get, isEmpty, set, trimEnd, uniqueId } from 'lodash';
+import forEach from 'lodash/forEach';
+import get from 'lodash/get';
+import isEmpty from 'lodash/isEmpty';
+import set from 'lodash/set';
+import trimEnd from 'lodash/trimEnd';
+import uniqueId from 'lodash/uniqueId';
 
 /* Recursive function that expands all `parentID`s.
   @param {Object}, options:
@@ -55,7 +60,7 @@ const deriveNavItemsLookup = options => {
   // Determine if the nav items are top-level.
   const isTopNavItem = depth < 2;
 
-  each(items, (item, index) => {
+  forEach(items, (item, index) => {
     // Derive item properties.
     const description = get(item, 'description', '');
     const href = get(item, 'url.path', '');

--- a/src/platform/site-wide/side-nav/tests/components/DuplicateLineLabel.unit.spec.js
+++ b/src/platform/site-wide/side-nav/tests/components/DuplicateLineLabel.unit.spec.js
@@ -2,7 +2,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import { expect } from 'chai';
-import { uniqueId } from 'lodash';
+import uniqueId from 'lodash/uniqueId';
 // Relative
 import DuplicateLineLabel from '../../components/DuplicateLineLabel';
 

--- a/src/platform/site-wide/side-nav/tests/components/ExpandCollapseIcon.unit.spec.js
+++ b/src/platform/site-wide/side-nav/tests/components/ExpandCollapseIcon.unit.spec.js
@@ -2,7 +2,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import { expect } from 'chai';
-import { uniqueId } from 'lodash';
+import uniqueId from 'lodash/uniqueId';
 // Relative
 import ExpandCollapseIcon from '../../components/ExpandCollapseIcon';
 

--- a/src/platform/site-wide/side-nav/tests/components/LabelText.unit.spec.js
+++ b/src/platform/site-wide/side-nav/tests/components/LabelText.unit.spec.js
@@ -2,7 +2,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import { expect } from 'chai';
-import { uniqueId } from 'lodash';
+import uniqueId from 'lodash/uniqueId';
 // Relative
 import LabelText from '../../components/LabelText';
 

--- a/src/platform/site-wide/side-nav/tests/components/NavItem.unit.spec.js
+++ b/src/platform/site-wide/side-nav/tests/components/NavItem.unit.spec.js
@@ -2,7 +2,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import { expect } from 'chai';
-import { uniqueId } from 'lodash';
+import uniqueId from 'lodash/uniqueId';
 // Relative
 import NavItem from '../../components/NavItem';
 

--- a/src/platform/site-wide/side-nav/tests/components/NavItemRow.unit.spec.js
+++ b/src/platform/site-wide/side-nav/tests/components/NavItemRow.unit.spec.js
@@ -2,7 +2,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import { expect } from 'chai';
-import { uniqueId } from 'lodash';
+import uniqueId from 'lodash/uniqueId';
 // Relative
 import NavItemRow from '../../components/NavItemRow';
 

--- a/src/platform/site-wide/side-nav/tests/components/SideNav.unit.spec.js
+++ b/src/platform/site-wide/side-nav/tests/components/SideNav.unit.spec.js
@@ -2,7 +2,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import { expect } from 'chai';
-import { uniqueId } from 'lodash';
+import uniqueId from 'lodash/uniqueId';
 // Relative
 import SideNav from '../../components/SideNav';
 

--- a/src/platform/site-wide/user-nav/selectors.js
+++ b/src/platform/site-wide/user-nav/selectors.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { createSelector } from 'reselect';
-import { startCase, toLower } from 'lodash';
+import startCase from 'lodash/startCase';
+import toLower from 'lodash/toLower';
 
 import localStorage from '../../utilities/storage/localStorage';
 import { selectProfile } from '../../user/selectors';

--- a/src/platform/site-wide/user-nav/tests/selectors.unit.spec.js
+++ b/src/platform/site-wide/user-nav/tests/selectors.unit.spec.js
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { set } from 'lodash/fp';
+import set from 'platform/utilities/data/set';
 
 import localStorage from '../../../utilities/storage/localStorage';
 import { selectUserGreeting } from '../selectors';

--- a/src/platform/site-wide/va-footer/helpers.jsx
+++ b/src/platform/site-wide/va-footer/helpers.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import orderBy from 'lodash/orderBy';
+import sortBy from 'lodash/sortBy';
 import groupBy from 'lodash/groupBy';
 import { replaceDomainsInData } from '../../utilities/environment/stagingDomains';
 
@@ -62,7 +63,7 @@ function generateSuperLinks(groupedList) {
 
   return (
     <ul>
-      {orderBy(groupedList.bottom_rail, 'order', 'asc').map(link => (
+      {sortBy(groupedList.bottom_rail, 'order').map(link => (
         <li key={`${link.order}`}>
           <a
             href={link.href}


### PR DESCRIPTION
## Description
This PR removes full lodash imports from `platform/site-wide`.

cc @bradl3yC 

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
