### PR TITLE
Remove lodash-fp and full lodash imports from personalization apps

### DIFF
--- a/src/applications/personalization/dashboard/containers/AppointmentsWidget.jsx
+++ b/src/applications/personalization/dashboard/containers/AppointmentsWidget.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import moment from 'moment';
 
-import { startCase } from 'lodash';
+import startCase from 'lodash/startCase';
 
 import { fetchAppointments } from '../../appointments/actions';
 

--- a/src/applications/personalization/dashboard/helpers.jsx
+++ b/src/applications/personalization/dashboard/helpers.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import * as Sentry from '@sentry/browser';
-import { isPlainObject } from 'lodash';
+import isPlainObject from 'lodash/isPlainObject';
 
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 

--- a/src/applications/personalization/dashboard/reducers/folders.js
+++ b/src/applications/personalization/dashboard/reducers/folders.js
@@ -1,5 +1,5 @@
-import _ from 'lodash';
-import set from 'lodash/fp/set';
+import kebabCase from 'lodash/kebabCase';
+import set from 'platform/utilities/data/set';
 
 import { FETCH_FOLDER_SUCCESS, LOADING_FOLDER } from '../utils/constants';
 
@@ -28,7 +28,7 @@ const initialState = {
   },
 };
 
-const folderKey = folderName => _.kebabCase(folderName);
+const folderKey = folderName => kebabCase(folderName);
 
 export default function folders(state = initialState, action) {
   switch (action.type) {

--- a/src/applications/personalization/dashboard/reducers/prescriptions.js
+++ b/src/applications/personalization/dashboard/reducers/prescriptions.js
@@ -1,5 +1,4 @@
-import assign from 'lodash/fp/assign';
-import set from 'lodash/fp/set';
+import set from 'platform/utilities/data/set';
 
 const initialState = {
   currentItem: null,
@@ -69,7 +68,7 @@ export default function prescriptions(state = initialState, action) {
         };
       }
 
-      return assign(state, newState);
+      return Object.assign({}, state, newState);
     }
 
     default:

--- a/src/applications/personalization/preferences/containers/PreferencesWidget.jsx
+++ b/src/applications/personalization/preferences/containers/PreferencesWidget.jsx
@@ -3,7 +3,7 @@ import { Link } from 'react-router';
 import { connect } from 'react-redux';
 import ReactCSSTransitionGroup from 'react-transition-group/CSSTransitionGroup';
 import moment from 'moment';
-import { isEmpty } from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 
 import LoadingIndicator from '@department-of-veterans-affairs/formation-react/LoadingIndicator';
 

--- a/src/applications/personalization/preferences/containers/SetPreferences.jsx
+++ b/src/applications/personalization/preferences/containers/SetPreferences.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Link, withRouter } from 'react-router';
 import { connect } from 'react-redux';
-import { isEqual } from 'lodash';
+import isEqual from 'lodash/isEqual';
 
 import LoadingIndicator from '@department-of-veterans-affairs/formation-react/LoadingIndicator';
 

--- a/src/applications/personalization/preferences/helpers.jsx
+++ b/src/applications/personalization/preferences/helpers.jsx
@@ -1,4 +1,4 @@
-import { isEqual } from 'lodash';
+import isEqual from 'lodash/isEqual';
 
 import deduplicate from 'platform/utilities/data/deduplicate';
 import localStorage from 'platform/utilities/storage/localStorage';

--- a/src/applications/personalization/preferences/reducers/index.js
+++ b/src/applications/personalization/preferences/reducers/index.js
@@ -1,4 +1,4 @@
-import _ from 'lodash/fp';
+import set from 'platform/utilities/data/set';
 import get from 'platform/utilities/data/get';
 
 import { LOADING_STATES, PREFERENCE_CODES } from '../constants';
@@ -120,7 +120,7 @@ export default function preferences(state = initialState, action) {
       return newState;
     }
     case SET_DISMISSED_DASHBOARD_PREFERENCE_BENEFIT_ALERTS: {
-      return _.set(`dismissedBenefitAlerts`, action.value, state);
+      return set(`dismissedBenefitAlerts`, action.value, state);
     }
     case RESTORE_PREVIOUS_USER_PREFERENCES: {
       return {

--- a/src/applications/personalization/profile360/components/MilitaryInformation.jsx
+++ b/src/applications/personalization/profile360/components/MilitaryInformation.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { some } from 'lodash';
+import some from 'lodash/some';
 
 import DowntimeNotification, {
   externalServices,


### PR DESCRIPTION
## Description
This PR removes full lodash imports from personalization apps.

cc @bradl3yC 

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
