### PR TITLE
Send system id instead of facility id in slots service

### DIFF
--- a/src/applications/vaos/actions/newAppointment.js
+++ b/src/applications/vaos/actions/newAppointment.js
@@ -14,6 +14,7 @@ import {
   getNewAppointment,
   getFormData,
   getSystemFromParent,
+  getSystemFromChosenFacility,
 } from '../utils/selectors';
 import {
   getSystemIdentifiers,
@@ -445,7 +446,9 @@ export function openClinicPage(page, uiSchema, schema) {
 
 export function getAppointmentSlots(startDate, endDate) {
   return async (dispatch, getState) => {
-    const newAppointment = getNewAppointment(getState());
+    const state = getState();
+    const systemId = getSystemFromChosenFacility(state);
+    const newAppointment = getNewAppointment(state);
     const availableSlots = newAppointment.availableSlots || [];
     const { data } = newAppointment;
 
@@ -479,7 +482,7 @@ export function getAppointmentSlots(startDate, endDate) {
               .format('YYYY-MM-DD');
 
         const response = await getAvailableSlots(
-          data.vaFacility,
+          systemId,
           data.typeOfCareId,
           data.clinicId,
           startDateString,

--- a/src/applications/vaos/tests/actions/newAppointment.unit.spec.js
+++ b/src/applications/vaos/tests/actions/newAppointment.unit.spec.js
@@ -768,8 +768,15 @@ describe('VAOS newAppointment actions', () => {
         newAppointment: {
           data: {
             preferredDate: '2019-01-01',
+            vaFacility: '983GC',
+            vaParent: '983A6',
+            typeOfCareId: '323',
+            clinicId: '1234',
           },
           fetchedAppointmentSlotMonths: [],
+          facilities: {
+            '323_983A6': [{ institutionCode: '983GC', rootStationCode: '983' }],
+          },
         },
       };
       const getState = () => state;
@@ -812,8 +819,15 @@ describe('VAOS newAppointment actions', () => {
         newAppointment: {
           data: {
             preferredDate: '2019-01-01',
+            vaFacility: '983GC',
+            vaParent: '983A6',
+            typeOfCareId: '323',
+            clinicId: '1234',
           },
           fetchedAppointmentSlotMonths: [],
+          facilities: {
+            '323_983A6': [{ institutionCode: '983GC', rootStationCode: '983' }],
+          },
         },
       };
       const getState = () => state;
@@ -830,6 +844,9 @@ describe('VAOS newAppointment actions', () => {
       );
       await thunk(dispatch, getState);
 
+      expect(global.fetch.firstCall.args[0]).to.contain(
+        '/facilities/983/available_appointments?type_of_care_id=323&clinic_ids[]=1234',
+      );
       expect(dispatch.firstCall.args[0].type).to.equal(
         FORM_CALENDAR_FETCH_SLOTS,
       );


### PR DESCRIPTION
## Description
We should be sending the site id, not the facility id, in the url for the appointment slots

## Testing done
Local and unit testing

## Acceptance criteria
- [ ] URL has the correct id

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
