### PR TITLE
[Development] Remove emailUI class

### DIFF
--- a/src/platform/forms-system/src/js/definitions/email.js
+++ b/src/platform/forms-system/src/js/definitions/email.js
@@ -11,7 +11,6 @@ export default function uiSchema(title = 'Email address') {
       required: 'Please enter an email address',
     },
     'ui:options': {
-      widgetClassNames: 'va-input-medium-large',
       inputType: 'email',
     },
   };


### PR DESCRIPTION
## Description

The class name added to email inputs created by the email ui schema in `src/platform/forms-system/src/js/definitions/email.js` is limiting the width of the input

![Screen Shot 2020-03-16 at 9 49 37 AM](https://user-images.githubusercontent.com/136959/76770527-15514d00-676c-11ea-8cd4-45a6a8fff475.png)

The class name `va-input-medium-large` sets the max-width to `18rem`. Removing it restores the full-width input

![Screen Shot 2020-03-16 at 9 50 38 AM](https://user-images.githubusercontent.com/136959/76770765-69f4c800-676c-11ea-8881-5114530fc17a.png)

## Testing done

Local unit tests

## Screenshots

See above

## Acceptance criteria
- [x] Email inputs created with the provided uiSchema will be full width

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
