### PR TITLE
[CMS Preview] Fix for number callouts being empty

### DIFF
--- a/src/site/stages/build/drupal/graphql/page.graphql.js
+++ b/src/site/stages/build/drupal/graphql/page.graphql.js
@@ -20,6 +20,7 @@ const ALERT_PARAGRAPH = '... alertParagraph';
 const TABLE = '... table';
 const DOWNLOADABLE_FILE_PARAGRAPH = '... downloadableFile';
 const MEDIA_PARAGRAPH = '... embeddedImage';
+const NUMBER_CALLOUT = '... numberCallout';
 
 const fieldAministrationKey = 'FieldNodePageFieldAdministration';
 
@@ -52,6 +53,7 @@ module.exports = `
         ${ALERT_PARAGRAPH}
         ${DOWNLOADABLE_FILE_PARAGRAPH}
         ${MEDIA_PARAGRAPH}
+        ${NUMBER_CALLOUT}
       }
     }
     ${FIELD_ALERT}


### PR DESCRIPTION
## Description
This PR fixes an issue where the Number Callout content model renders as an empty gray panel from the CMS preview server. I think this could also happen during the website build, but since it doesn't show correctly from the Preview server, we never tried it.

https://github.com/department-of-veterans-affairs/va.gov-team/issues/6099

## Testing done
Locally, made sure that existing number callouts aren't broken while running the website. I can't test this easily, because there isn't a page in the CMS dev environment where I can replicate this.

## Screenshots
![image](https://user-images.githubusercontent.com/1915775/76774118-e6da6e80-6779-11ea-97f9-0bf2b329da77.png)

## Acceptance criteria
- [x] Number callouts render okay from CMS preview

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
