### PR TITLE
Disable pharmacy option search on Facility Locator

### DIFF
--- a/script/heroku-postbuild.sh
+++ b/script/heroku-postbuild.sh
@@ -11,4 +11,4 @@ git clone --depth=1 https://github.com/department-of-veterans-affairs/vagov-cont
 cd ${vagov_apps_dir}
 
 # build the site as usual
-npm run build --  --entry static-pages,facilities --content-directory ${vagov_content_dir}/pages
+npm run build --  --entry static-pages --content-directory ${vagov_content_dir}/pages

--- a/script/heroku-postbuild.sh
+++ b/script/heroku-postbuild.sh
@@ -11,4 +11,4 @@ git clone --depth=1 https://github.com/department-of-veterans-affairs/vagov-cont
 cd ${vagov_apps_dir}
 
 # build the site as usual
-npm run build --  --entry static-pages --content-directory ${vagov_content_dir}/pages
+npm run build --  --entry static-pages,facilities --content-directory ${vagov_content_dir}/pages

--- a/src/applications/facility-locator/constants/index.js
+++ b/src/applications/facility-locator/constants/index.js
@@ -1,5 +1,3 @@
-import FEATURE_FLAG_NAMES from 'platform/utilities/feature-toggles/featureFlagNames';
-
 /**
  * Enum for the type attribute of a Facility/Provider search result
  */
@@ -45,29 +43,14 @@ export const PinNames = {
 /**
  * Defines the options available for the Location Type Dropdown
  */
-let locOptions;
-
-if (FEATURE_FLAG_NAMES.facilitiesPpmsSuppressPharmacies) {
-  locOptions = [
-    LocationType.HEALTH,
-    LocationType.URGENT_CARE,
-    LocationType.CC_PROVIDER,
-    LocationType.BENEFITS,
-    LocationType.CEMETARY,
-    LocationType.VET_CENTER,
-  ];
-} else {
-  locOptions = [
-    LocationType.HEALTH,
-    LocationType.URGENT_CARE,
-    LocationType.URGENT_CARE_FARMACIES,
-    LocationType.CC_PROVIDER,
-    LocationType.BENEFITS,
-    LocationType.CEMETARY,
-    LocationType.VET_CENTER,
-  ];
-}
-export const LOCATION_OPTIONS = locOptions;
+export const LOCATION_OPTIONS = [
+  LocationType.HEALTH,
+  LocationType.URGENT_CARE,
+  LocationType.CC_PROVIDER,
+  LocationType.BENEFITS,
+  LocationType.CEMETARY,
+  LocationType.VET_CENTER,
+];
 
 /**
  * Defines the ± change in bounding box size for the map when changing zoom

--- a/src/applications/facility-locator/constants/index.js
+++ b/src/applications/facility-locator/constants/index.js
@@ -1,3 +1,5 @@
+import FEATURE_FLAG_NAMES from 'platform/utilities/feature-toggles/featureFlagNames';
+
 /**
  * Enum for the type attribute of a Facility/Provider search result
  */
@@ -43,15 +45,29 @@ export const PinNames = {
 /**
  * Defines the options available for the Location Type Dropdown
  */
-export const LOCATION_OPTIONS = [
-  LocationType.HEALTH,
-  LocationType.URGENT_CARE,
-  LocationType.URGENT_CARE_FARMACIES,
-  LocationType.CC_PROVIDER,
-  LocationType.BENEFITS,
-  LocationType.CEMETARY,
-  LocationType.VET_CENTER,
-];
+let locOptions;
+
+if (FEATURE_FLAG_NAMES.facilitiesPpmsSuppressPharmacies) {
+  locOptions = [
+    LocationType.HEALTH,
+    LocationType.URGENT_CARE,
+    LocationType.CC_PROVIDER,
+    LocationType.BENEFITS,
+    LocationType.CEMETARY,
+    LocationType.VET_CENTER,
+  ];
+} else {
+  locOptions = [
+    LocationType.HEALTH,
+    LocationType.URGENT_CARE,
+    LocationType.URGENT_CARE_FARMACIES,
+    LocationType.CC_PROVIDER,
+    LocationType.BENEFITS,
+    LocationType.CEMETARY,
+    LocationType.VET_CENTER,
+  ];
+}
+export const LOCATION_OPTIONS = locOptions;
 
 /**
  * Defines the ± change in bounding box size for the map when changing zoom


### PR DESCRIPTION
## Description
Issue: https://github.com/department-of-veterans-affairs/va.gov-team/issues/6809

## Testing done
Locally, heroku

## Acceptance criteria
- [x]  Temporarily prevent Urgent care pharmacies (in VA's network) from being displayed in the VA facility type drop down

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
