### PR TITLE
[Development] Add hide empty review uiSchema option

### DIFF
--- a/src/platform/forms-system/src/js/review/ReviewFieldTemplate.jsx
+++ b/src/platform/forms-system/src/js/review/ReviewFieldTemplate.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-
 /*
  * This is the template for each field (which in the schema library means label + widget)
  */
@@ -16,9 +15,27 @@ export default function ReviewFieldTemplate(props) {
     return children;
   }
 
-  return uiSchema?.['ui:reviewField'] ? (
-    uiSchema['ui:reviewField'](props)
-  ) : (
+  // `hideEmptyValueInReview` option is ignored if a 'ui:reviewField' is defined
+  // The custom reviewField should handle empty values
+  if (uiSchema?.['ui:reviewField']) {
+    return uiSchema['ui:reviewField'](props);
+  }
+
+  if (uiSchema?.['ui:options']?.hideEmptyValueInReview) {
+    let value = children;
+    if (typeof children !== 'undefined') {
+      if ('props' in children) {
+        value = children.props.formData;
+      } else if ('value' in children) {
+        value = children.value;
+      }
+    }
+    if (typeof value === 'undefined' || value === null || value === '') {
+      return null;
+    }
+  }
+
+  return (
     <div className="review-row">
       <dt>
         {label}

--- a/src/platform/forms-system/test/js/review/ReviewFieldTemplate.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/review/ReviewFieldTemplate.unit.spec.jsx
@@ -3,6 +3,7 @@ import { expect } from 'chai';
 import SkinDeep from 'skin-deep';
 
 import ReviewFieldTemplate from '../../../src/js/review/ReviewFieldTemplate';
+import StringField from '../../../src/js/review/StringField';
 
 describe('Schemaform ReviewFieldTemplate', () => {
   it('should render review row', () => {
@@ -104,5 +105,82 @@ describe('Schemaform ReviewFieldTemplate', () => {
 
     expect(tree.everySubTree('.review-row')).to.be.empty;
     expect(tree.everySubTree('.test-child').length).to.equal(1);
+  });
+
+  const hideEmptyUiSchema = {
+    'ui:title': 'Label',
+    'ui:reviewWidget': () => <span />,
+    'ui:options': {
+      hideEmptyValueInReview: true,
+    },
+  };
+  it('should render children with content when hideEmptyValueInReview is set', () => {
+    const schema = { type: 'string' };
+    const tree = SkinDeep.shallowRender(
+      <ReviewFieldTemplate schema={schema} uiSchema={hideEmptyUiSchema}>
+        <StringField
+          schema={schema}
+          uiSchema={hideEmptyUiSchema}
+          formData={'1234'}
+        />
+      </ReviewFieldTemplate>,
+    );
+
+    expect(tree.everySubTree('.review-row')).to.not.be.empty;
+    expect(tree.subTree('dt').text()).to.equal('Label');
+    expect(tree.dive(['StringField']).props.formData).to.equal('1234');
+  });
+  it('should hide review row with empty value & hideEmptyValueInReview is set', () => {
+    const schema = { type: 'string' };
+    const tree = SkinDeep.shallowRender(
+      <ReviewFieldTemplate schema={schema} uiSchema={hideEmptyUiSchema}>
+        <StringField
+          schema={schema}
+          uiSchema={hideEmptyUiSchema}
+          formData={''}
+        />
+      </ReviewFieldTemplate>,
+    );
+
+    expect(tree.everySubTree('.review-row')).to.be.empty;
+  });
+  it('should hide review row with empty value & hideEmptyValueInReview is set', () => {
+    const schema = { type: 'string' };
+    const tree = SkinDeep.shallowRender(
+      <ReviewFieldTemplate schema={schema} uiSchema={hideEmptyUiSchema}>
+        <StringField
+          schema={schema}
+          uiSchema={hideEmptyUiSchema}
+          formData={null}
+        />
+      </ReviewFieldTemplate>,
+    );
+
+    expect(tree.everySubTree('.review-row')).to.be.empty;
+  });
+  it('should render reviewWidget with empty value & hideEmptyValueInReview is set', () => {
+    const schema = { type: 'string' };
+    const uiSchema = {
+      'ui:title': 'Label',
+      'ui:reviewWidget': () => <span />,
+      'ui:reviewField': () => (
+        <dl className="review-row">
+          <dt>Test</dt>
+          <dd>123</dd>
+        </dl>
+      ),
+      'ui:options': {
+        hideEmptyValueInReview: true,
+      },
+    };
+    const tree = SkinDeep.shallowRender(
+      <ReviewFieldTemplate schema={schema} uiSchema={uiSchema}>
+        <StringField schema={schema} uiSchema={uiSchema} formData={''} />
+      </ReviewFieldTemplate>,
+    );
+
+    expect(tree.everySubTree('.review-row')).to.not.be.empty;
+    expect(tree.subTree('dt').text()).to.equal('Test');
+    expect(tree.subTree('dd').text()).to.equal('123'); // ignore formData
   });
 });


### PR DESCRIPTION
## Description

Added an option to hide empty review row entries.

In certain cases, it is better to hide empty review field entries, e.g. an empty "street address line 3" or am empty name suffix. Removal of the row will match newer design requirements, and likely improve screenreader accessibility (labels with empty values will not be read aloud)

## Testing done

Local unit tests
Added new unit tests for this addition

## Screenshots

Before (or option not set)

![](https://user-images.githubusercontent.com/136959/76772291-a32e3780-676e-11ea-8436-8c27e68ba885.png)

Option set - hidden Street address lines 2 & 3

![Screen Shot 2020-03-16 at 5 07 29 PM](https://user-images.githubusercontent.com/136959/76803788-aa723700-67a8-11ea-8a54-b4b5771ff5fa.png)

Entries are still available upon editing

![Screen Shot 2020-03-16 at 4 44 00 PM](https://user-images.githubusercontent.com/136959/76802774-69792300-67a6-11ea-8003-cf996b9ff53f.png)

## Acceptance criteria
- [ ] Designated review rows will be hidden if the form value is empty (empty string, `null` or `undefined`) when the `hideEmptyValueInReview` option is set to `true`.

## Definition of done
- [ ] Events are logged appropriately
- [x] Documentation has been updated, if applicable (https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/pull/222)
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
