### PR TITLE
Revert 2 redirects

### DIFF
--- a/src/applications/proxy-rewrite/redirects/crossDomainRedirects.json
+++ b/src/applications/proxy-rewrite/redirects/crossDomainRedirects.json
@@ -541,16 +541,6 @@
   },
   {
     "domain": "www.benefits.va.gov",
-    "src": "/compensation/special_Benefit_Allowances_2018.asp",
-    "dest": "/disability/compensation-rates/special-benefit-allowance-rates/"
-  },
-  {
-    "domain": "www.benefits.va.gov",
-    "src": "/compensation/sb2018.asp",
-    "dest": "/disability/compensation-rates/birth-defect-rates/"
-  },
-  {
-    "domain": "www.benefits.va.gov",
     "src": "/compensation/claimexam.asp",
     "dest": "/disability/va-claim-exam/"
   },


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/6902

This PR implements 2 redirects:

Redirect back to URL  |  Current URL
---  |  ---
https://www.benefits.va.gov/compensation/special_Benefit_Allowances_2018.asp | https://www.va.gov/disability/compensation-rates/special-benefit-allowance-rates/
https://www.benefits.va.gov/compensation/sb2018.asp | https://www.va.gov/disability/compensation-rates/birth-defect-rates/

## Testing done
N/A

## Screenshots
N/A

## Acceptance criteria
- [x] Revert the above 2 redirects.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
