### PR TITLE
Remove past appts messaging

### DIFF
--- a/src/applications/vaos/containers/AppointmentsPage.jsx
+++ b/src/applications/vaos/containers/AppointmentsPage.jsx
@@ -61,7 +61,6 @@ export class AppointmentsPage extends Component {
       cancelInfo,
       showCancelButton,
       showScheduleButton,
-      showPastAppointments,
     } = this.props;
     const {
       future,
@@ -224,25 +223,6 @@ export class AppointmentsPage extends Component {
             <h2 className="vads-u-font-size--h3 vads-u-margin-bottom--2">
               Upcoming appointments
             </h2>
-            {!showPastAppointments && (
-              <p>
-                To view past appointments you’ve made through My HealtheVet, go
-                to the{' '}
-                <a
-                  href="https://veteran.mobile.va.gov/var/v4/"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  onClick={() =>
-                    recordEvent({
-                      event: 'vaos-past-appointments-legacy-link-clicked',
-                    })
-                  }
-                >
-                  old appointments tool
-                </a>
-                .
-              </p>
-            )}
             {content}
             <NeedHelp />
           </div>

--- a/src/applications/vaos/tests/containers/AppointmentsPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/containers/AppointmentsPage.unit.spec.jsx
@@ -276,34 +276,4 @@ describe('VAOS <AppointmentsPage>', () => {
     );
     tree.unmount();
   });
-
-  it('should fire a GA event when clicking past appointments link', () => {
-    const defaultProps = {
-      appointments: {
-        future: [],
-        futureStatus: FETCH_STATUS.succeeded,
-        facilityData: {},
-      },
-    };
-
-    const startNewAppointmentFlow = sinon.spy();
-    const fetchFutureAppointments = sinon.spy();
-    const tree = shallow(
-      <AppointmentsPage
-        {...defaultProps}
-        showScheduleButton
-        fetchFutureAppointments={fetchFutureAppointments}
-        startNewAppointmentFlow={startNewAppointmentFlow}
-      />,
-    );
-
-    tree
-      .find('a')
-      .at(0)
-      .simulate('click');
-    expect(global.window.dataLayer[0].event).to.equal(
-      'vaos-past-appointments-legacy-link-clicked',
-    );
-    tree.unmount();
-  });
 });

--- a/src/platform/site-wide/announcements/components/WelcomeVAOSModal.jsx
+++ b/src/platform/site-wide/announcements/components/WelcomeVAOSModal.jsx
@@ -20,9 +20,8 @@ export default function WelcomeVAOSModal({ dismiss }) {
         appointments in one place on VA.gov.
       </p>
       <p>
-        To view your past appointments, you can go back to the old appointments
-        tool. You’ll find a link to it at the bottom of the page in the new
-        tool.
+        If you want to go back to the old appointments tool, you’ll find a link
+        to that scheduling tool at the bottom of the page in the new tool.
       </p>
       <button type="button" onClick={dismiss}>
         Continue to your VA appointments


### PR DESCRIPTION
## Description
Past appointments are in MHV, not the legacy tool, so this messaging is wrong and I need to do some discovery to fix it.

## Testing done
Unit testing

## Acceptance criteria
- [ ] Messages removed

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
