### PR TITLE
Include drupal cache fetch (review instances)

### DIFF
--- a/script/review-entrypoint.sh
+++ b/script/review-entrypoint.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 set -e
 yarn install --production=false
+npm run fetch-drupal-cache
 npm run build -- --buildtype localhost --api='${API_URL}' --host='${WEB_HOST}' --port='${WEB_PORT}'
 npm run heroku-serve -- build/localhost -p 3001


### PR DESCRIPTION
## Description
Adds the fetch of drupal content to review instance build process. 

## Testing done
Added the line in this PR and ran review instance build(s) locally from my laptop.

## Screenshots
![image](https://user-images.githubusercontent.com/56260532/76885408-91738f80-6855-11ea-8432-d24d64bde73d.png)

## Acceptance criteria
- [x] Review instance building with latest drupal content. 

## Relates
- https://app.zenhub.com/workspaces/vsp-5cedc9cce6e3335dc5a49fc4/issues/department-of-veterans-affairs/va.gov-team/6084

## Depends on
- https://github.com/department-of-veterans-affairs/devops/pull/6533 (needs to be merged before this)

## Definition of done
- [x] Events are logged appropriately - n/a
- [x] Documentation has been updated, if applicable - n/a
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
