### PR TITLE
VACMS-1220 events sorting et

### DIFF
--- a/src/platform/site-wide/sass/shame.scss
+++ b/src/platform/site-wide/sass/shame.scss
@@ -579,3 +579,8 @@ img[data-srcset] {
 .operating-status-title {
   margin: auto;
 }
+
+.clearfix-text {
+  display: block;
+  clear: both;
+}

--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -237,26 +237,21 @@ module.exports = function registerFilters() {
     item ? item.sort((a, b) => a.entityId - b.entityId) : undefined;
 
   liquid.filters.eventSorter = item => {
-    const sorted = item.sort((a, b) => {
-      const aTime = Math.floor(
-        new Date(a.fieldDate.startDate).getTime() / 1000,
-      );
-      const bTime = Math.floor(
-        new Date(b.fieldDate.startDate).getTime() / 1000,
-      );
-      // Sort order needs to be oldest first.
-      const sorter = aTime - bTime;
-      return sorter;
-    });
+    const sorted =
+      item !== null
+        ? item.sort((a, b) => {
+            const aTime = Math.floor(
+              new Date(a.fieldDate.startDate).getTime() / 1000,
+            );
+            const bTime = Math.floor(
+              new Date(b.fieldDate.startDate).getTime() / 1000,
+            );
+            // Sort order needs to be oldest first.
+            const sorter = aTime - bTime;
+            return sorter;
+          })
+        : '';
     return sorted;
-  };
-
-  liquid.filters.pastPresent = (items, url) => {
-    const isPast = value =>
-      moment().diff(value.fieldDate.startDate, 'days') >= 1;
-    const isCurrent = value => !isPast(value);
-    const filter = url.split('/').includes('past-events') ? isPast : isCurrent;
-    return items.filter(filter);
   };
 
   // Find the current path in an array of nested link arrays and then return it's depth + it's parent and children

--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -238,19 +238,12 @@ module.exports = function registerFilters() {
 
   liquid.filters.eventSorter = item => {
     const sorted =
-      item !== null
-        ? item.sort((a, b) => {
-            const aTime = Math.floor(
-              new Date(a.fieldDate.startDate).getTime() / 1000,
-            );
-            const bTime = Math.floor(
-              new Date(b.fieldDate.startDate).getTime() / 1000,
-            );
-            // Sort order needs to be oldest first.
-            const sorter = aTime - bTime;
-            return sorter;
-          })
-        : '';
+      item &&
+      item.sort((a, b) => {
+        const start1 = moment(a.fieldDate.startDate);
+        const start2 = moment(b.fieldDate.startDate);
+        return start1.isAfter(start2);
+      });
     return sorted;
   };
 

--- a/src/site/layouts/event_listing.drupal.liquid
+++ b/src/site/layouts/event_listing.drupal.liquid
@@ -55,11 +55,11 @@
 
               {% assign numItems = pagedItems | size %}
               {% if numItems < 1 %}
-                <div>No events at this time.</div>
+                <div class="clearfix-text">No events at this time.</div>
               {% endif %}
               {% for event in pagedItems %}
                 {% if featuredUrl != event.entityUrl.path %}
-                  <div class="usa-width-two-thirds">
+                  <div class="clearfix-text">
                     {% include "src/site/teasers/event.drupal.liquid" with node = event %}
                   </div>
                 {% endif %}

--- a/src/site/layouts/event_listing.drupal.liquid
+++ b/src/site/layouts/event_listing.drupal.liquid
@@ -53,19 +53,18 @@
                 {% endif %}
               {% endfor %}
 
-              {% assign sortedEventsArray = pagedItems | eventSorter | pastPresent: path %}
-              {% assign numItems = sortedEventsArray | size %}
+              {% assign numItems = pagedItems | size %}
               {% if numItems < 1 %}
                 <div>No events at this time.</div>
               {% endif %}
-              {% for event in sortedEventsArray %}
+              {% for event in pagedItems %}
                 {% if featuredUrl != event.entityUrl.path %}
                   <div class="usa-width-two-thirds">
                     {% include "src/site/teasers/event.drupal.liquid" with node = event %}
                   </div>
                 {% endif %}
               {% endfor %}
-              {% include "src/site/includes/pagination.drupal.liquid" with numItems %}
+              {% include "src/site/includes/pagination.drupal.liquid" %}
 
             </div>
           </div>

--- a/src/site/layouts/leadership_listing.drupal.liquid
+++ b/src/site/layouts/leadership_listing.drupal.liquid
@@ -49,7 +49,7 @@ Example data:
                 <article class="usa-content">
                     <h1 class="vads-u-margin-bottom--3">{{ title }}</h1>
                         {% if fieldIntroText %}
-                        <div class="va-introtext vads-u-margin-bottom--0">
+                        <div class="va-introtext vads-u-padding-bottom--2p5">
                             {{ fieldIntroText }}
                         </div>
                         {% endif %}

--- a/src/site/layouts/locations_listing.drupal.liquid
+++ b/src/site/layouts/locations_listing.drupal.liquid
@@ -35,7 +35,7 @@
                         {% endfor %}
 
                         {% if mainFacility == false and fieldOffice.entity.otherFacilities.entities == false %}
-                        <div>No locations at this time.</div>
+                        <div class="clearfix-text">No locations at this time.</div>
                         {% endif %}
 
                         {% if fieldOffice.entity.fieldOtherVaLocations != empty and fieldOffice.entity.fieldOtherVaLocations.length %}

--- a/src/site/layouts/press_releases_listing.drupal.liquid
+++ b/src/site/layouts/press_releases_listing.drupal.liquid
@@ -81,7 +81,7 @@ larger space in the Fayette Plaza at 627 Pittsburgh Road, Suite 2, Uniontown,
             {% endfor %}
 
             {% if pagedItems == false %}
-            <div>No news releases at this time.</div>
+            <div class="clearfix-text">No news releases at this time.</div>
             {% endif %}
 
             {% include "src/site/includes/pagination.drupal.liquid" %}

--- a/src/site/layouts/story_listing.drupal.liquid
+++ b/src/site/layouts/story_listing.drupal.liquid
@@ -80,7 +80,7 @@ Example data:
           {% endfor %}
 
           {% if pagedItems == false %}
-          <div>No stories at this time.</div>
+          <div class="clearfix-text">No stories at this time.</div>
           {% endif %}
 
           {% include "src/site/includes/pagination.drupal.liquid" %}

--- a/src/site/stages/build/drupal/health-care-region.js
+++ b/src/site/stages/build/drupal/health-care-region.js
@@ -282,12 +282,8 @@ function itemSorter(items = [], field, reverse = false, stale = true) {
   let sorted = items.entities.sort((a, b) => {
     const start1 = moment(a[field].value);
     const start2 = moment(b[field].value);
-    return start1.isAfter(start2);
+    return reverse ? start2 - start1 : start1 - start2;
   });
-
-  if (reverse) {
-    sorted = sorted.reverse();
-  }
 
   if (stale) {
     sorted = sorted.filter(item => moment(item[field].value).isAfter(moment()));

--- a/src/site/stages/build/drupal/health-care-region.js
+++ b/src/site/stages/build/drupal/health-care-region.js
@@ -272,36 +272,29 @@ function addGetUpdatesFields(page, pages) {
 /**
  * Sorts items from oldest to newest, removing expired items.
  *
- * @param {items} object The items object.
+ * @param {items} array The items array.
  * @param {field} string The target date field.
  * @param {reverse} bool Sorting order set to default false.
  * @param {stale} bool Remove expired date items set to default false.
  * @return Filtered array of sorted items.
  */
-function itemSorter(items, field, reverse = false, stale = true) {
-  const dateFiltered = [];
-  const sorted =
-    items !== null
-      ? items.entities.sort((a, b) => {
-          const aTime = Math.floor(new Date(a[field].value).getTime() / 1000);
-          const bTime = Math.floor(new Date(b[field].value).getTime() / 1000);
-          // Sort order.
-          const sorter = reverse ? bTime - aTime : aTime - bTime;
-          return sorter;
-        })
-      : '';
-  // Remove expired items.
-  sorted.forEach(element => {
-    if (
-      element[field] &&
-      new Date(element[field].value).valueOf() > new Date().valueOf()
-    ) {
-      dateFiltered.push(element);
-    }
+function itemSorter(items = [], field, reverse = false, stale = true) {
+  let sorted = items.entities.sort((a, b) => {
+    const start1 = moment(a[field].value);
+    const start2 = moment(b[field].value);
+    return start1.isAfter(start2);
   });
-  return stale ? dateFiltered : sorted;
-}
 
+  if (reverse) {
+    sorted = sorted.reverse();
+  }
+
+  if (stale) {
+    sorted = sorted.filter(item => moment(item[field].value).isAfter(moment()));
+  }
+
+  return sorted;
+}
 /**
  * Add pagers to cms content listing pages.
  *

--- a/src/site/stages/build/drupal/page.js
+++ b/src/site/stages/build/drupal/page.js
@@ -77,7 +77,7 @@ function paginatePages(page, files, field, layout, ariaLabel, perPage) {
     pagedPage.pagedItems = pagedEntities[pageNum];
     const innerPages = [];
 
-    if (pagedEntities.length > 1) {
+    if (pagedEntities.length > 0) {
       // add page numbers
       const numPageLinks = 3;
       let start;


### PR DESCRIPTION
## Description
Events sorting is all over the place. This pr fixes this - sort order is set to occurring soonest down to occurring latest, and removes events that have already occurred. Also fixes news items sort order to show most recent items first

## Testing done
Visual

## Screenshots
![image](https://user-images.githubusercontent.com/2404547/76972535-19fd3900-6905-11ea-8755-9f56abc370c6.png)

## Acceptance criteria
- [ ] Go to `pittsburgh-health-care/events/` and visually verify that events are sorted in soonest to occur first order, and expired events are removed.
- [ ] Go to `pittsburgh-health-care/news-releases/` and visually verify that news items sort order to show most recent items first.