### PR TITLE
Add link to MHV for past appointments

### DIFF
--- a/src/applications/vaos/containers/AppointmentsPage.jsx
+++ b/src/applications/vaos/containers/AppointmentsPage.jsx
@@ -5,6 +5,7 @@ import { Link } from 'react-router';
 import LoadingIndicator from '@department-of-veterans-affairs/formation-react/LoadingIndicator';
 import recordEvent from 'platform/monitoring/record-event';
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
+import environment from 'platform/utilities/environment';
 import Breadcrumbs from '../components/Breadcrumbs';
 import ConfirmedAppointmentListItem from '../components/ConfirmedAppointmentListItem';
 import AppointmentRequestListItem from '../components/AppointmentRequestListItem';
@@ -61,6 +62,7 @@ export class AppointmentsPage extends Component {
       cancelInfo,
       showCancelButton,
       showScheduleButton,
+      showPastAppointments,
     } = this.props;
     const {
       future,
@@ -223,6 +225,26 @@ export class AppointmentsPage extends Component {
             <h2 className="vads-u-font-size--h3 vads-u-margin-bottom--2">
               Upcoming appointments
             </h2>
+            {!showPastAppointments && (
+              <p>
+                To view past appointments you've made,{' '}
+                <a
+                  href={`https://${
+                    !environment.isProduction() ? 'mhv-syst' : 'www'
+                  }.myhealth.va.gov/mhv-portal-web/appointments`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  onClick={() =>
+                    recordEvent({
+                      event: 'vaos-past-appointments-legacy-link-clicked',
+                    })
+                  }
+                >
+                  go to My HealtheVet
+                </a>
+                .
+              </p>
+            )}
             {content}
             <NeedHelp />
           </div>

--- a/src/applications/vaos/containers/AppointmentsPage.jsx
+++ b/src/applications/vaos/containers/AppointmentsPage.jsx
@@ -227,7 +227,7 @@ export class AppointmentsPage extends Component {
             </h2>
             {!showPastAppointments && (
               <p>
-                To view past appointments you've made,{' '}
+                To view past appointments you’ve made,{' '}
                 <a
                   href={`https://${
                     !environment.isProduction() ? 'mhv-syst' : 'www'

--- a/src/applications/vaos/tests/containers/AppointmentsPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/containers/AppointmentsPage.unit.spec.jsx
@@ -276,4 +276,34 @@ describe('VAOS <AppointmentsPage>', () => {
     );
     tree.unmount();
   });
+
+  it('should fire a GA event when clicking past appointments link', () => {
+    const defaultProps = {
+      appointments: {
+        future: [],
+        futureStatus: FETCH_STATUS.succeeded,
+        facilityData: {},
+      },
+    };
+
+    const startNewAppointmentFlow = sinon.spy();
+    const fetchFutureAppointments = sinon.spy();
+    const tree = shallow(
+      <AppointmentsPage
+        {...defaultProps}
+        showScheduleButton
+        fetchFutureAppointments={fetchFutureAppointments}
+        startNewAppointmentFlow={startNewAppointmentFlow}
+      />,
+    );
+
+    tree
+      .find('a')
+      .at(0)
+      .simulate('click');
+    expect(global.window.dataLayer[0].event).to.equal(
+      'vaos-past-appointments-legacy-link-clicked',
+    );
+    tree.unmount();
+  });
 });


### PR DESCRIPTION
## Description
This adds back the past appointments link, this time pointing correctly to MHV.

## Testing done
Local testing

## Screenshots
![Screen Shot 2020-03-18 at 11 21 02 AM](https://user-images.githubusercontent.com/634932/76976700-b7a73700-690a-11ea-8e93-92efa330fdd9.png)

## Acceptance criteria
- [ ] link displays

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
