### PR TITLE
Updated GIBCT caution flag modal content

### DIFF
--- a/src/applications/gi/containers/Modals.jsx
+++ b/src/applications/gi/containers/Modals.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import * as actions from '../actions';
 import Modal from '@department-of-veterans-affairs/formation-react/Modal';
+import environment from 'platform/utilities/environment';
 
 export class Modals extends React.Component {
   calcBeneficiaryLocationQuestionContent = () => (
@@ -655,6 +656,17 @@ export class Modals extends React.Component {
           or legal scrutiny to this program. VA will display other categories of
           caution flags in future versions of the GI Bill Comparison Tool.
         </p>
+        {!environment.isProduction() && (
+          <p>
+            <a
+              href="https://www.benefits.va.gov/gibill/comparison_tool/about_this_tool.asp#phoenix"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Suspension of VA Benefits to Five Schools for Deceptive Practices
+            </a>
+          </p>
+        )}
         <p>
           <a
             href="https://studentaid.ed.gov/sa/about/data-center/school/hcm"


### PR DESCRIPTION
## Description
Added an additional link to the caution flag "Learn more about these warnings" modal

https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/6848

## Testing done
Tested locally and QA reviewed

## Screenshots
![image](https://user-images.githubusercontent.com/41960449/76989911-82f0ab00-691d-11ea-9e1e-2f8d5590650d.png)

## Acceptance criteria
- [x] In the "Cautionary information" section of the Profile Page, a user selects the "Learn more about these warnings" link.
  - a. A modal appears and includes following link to "Suspension of VA Benefits to Five Schools for Deceptive Practices", which is included above "heightened cash monitoring" in the modal: https://www.benefits.va.gov/gibill/comparison_tool/about_this_tool.asp#phoenix

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
