### PR TITLE
Wait for build on content refresh Jenkins job

### DIFF
--- a/Jenkinsfile.content
+++ b/Jenkinsfile.content
@@ -8,17 +8,18 @@ node('vetsgov-general-purpose') {
   }
 
   def jobFailed = false
+  def refStatusState
   while({
+    echo "checking build status..."
     refStatusState = getGithubCommitState("vets-website", ref)
     if ("${refStatusState}" == "SUCCESS") {
       return false
-    } else if ("${refStatusStatue}" == "PENDING") {
+    } else if ("${refStatusState}" == "PENDING") {
       sleep 60
       return true
-    } else {
-      jobFailed = true
-      return false
     }
+    jobFailed = true
+    return false
   }()) continue
 
   if (jobFailed) {

--- a/Jenkinsfile.content
+++ b/Jenkinsfile.content
@@ -7,8 +7,21 @@ node('vetsgov-general-purpose') {
     ref = getLatestGitRef("vets-website", branch: "master")
   }
 
-  refStatusState = getGithubCommitState("vets-website", ref)
-  if ("${refStatusState}" != "SUCCESS") {
+  def jobFailed = false
+  while({
+    refStatusState = getGithubCommitState("vets-website", ref)
+    if ("${refStatusState}" == "SUCCESS") {
+      return false
+    } else if ("${refStatusStatue}" == "PENDING") {
+      sleep 60
+      return true
+    } else {
+      jobFailed = true
+      return false
+    }
+  }()) continue
+
+  if (jobFailed) {
     message = "Web content refresh on ${params.env} aborted due to '${refStatusState}' status on vets-website commit ${ref}."
     echo "${message}"
     slackSend(message: "${message}",


### PR DESCRIPTION
## Description
Instead of simply exiting the build if the commit status is not "SUCCESS", we wait for a commit status that is either "SUCCESS" or "ERROR" and exit or continue appropriately.

ref: https://github.com/department-of-veterans-affairs/va.gov-team/issues/4988

## Testing done
Tested the logic in a separate isolated Jenkins job.