### PR TITLE
Update announcements.json

### DIFF
--- a/src/applications/static-pages/school-resources/constants/announcements.json
+++ b/src/applications/static-pages/school-resources/constants/announcements.json
@@ -1,5 +1,12 @@
 [
   {    
+    "name": "Rescheduled COVID-19 Webinars for State Approving Agencies and School Certifying Officials are Full to Capacity",
+    "url": "https://www.benefits.va.gov/gibill/#20200318",
+    "date": "2020-03-18",
+    "displayStartDate": "2020-03-18",
+    "displayEndDate": "2020-04-18"
+  },
+  {    
     "name": "Webinar on March 20 – Office Hours – For State Certifying Officials (SCOs) to Discuss COVID-19 Impact",
     "url": "https://www.benefits.va.gov/gibill/#20200317",
     "date": "2020-03-17",

--- a/src/applications/static-pages/school-resources/constants/announcements.json
+++ b/src/applications/static-pages/school-resources/constants/announcements.json
@@ -1,6 +1,13 @@
 [
   {    
-    "name": "Rescheduled COVID-19 Webinars for State Approving Agencies and School Certifying Officials are Full to Capacity",
+    "name": "Yellow Ribbon Program Open Season for the 2020-2021 Academic Year",
+    "url": "https://www.benefits.va.gov/gibill/#20200319",
+    "date": "2020-03-19",
+    "displayStartDate": "2020-03-19",
+    "displayEndDate": "2020-04-19"
+  },
+  {    
+    "name": "Rescheduled COVID-19 Webinars for SAAs and SCOs are Full to Capacity",
     "url": "https://www.benefits.va.gov/gibill/#20200318",
     "date": "2020-03-18",
     "displayStartDate": "2020-03-18",


### PR DESCRIPTION
Added Rescheduled COVID-19 Webinars for State Approving Agencies and School Certifying Officials are Full to Capacity Announcement

## Description


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
