### PR TITLE
Hide podiatry when CC is off

### DIFF
--- a/src/applications/vaos/actions/newAppointment.js
+++ b/src/applications/vaos/actions/newAppointment.js
@@ -15,6 +15,7 @@ import {
   getFormData,
   getSystemFromParent,
   getSystemFromChosenFacility,
+  vaosCommunityCare,
 } from '../utils/selectors';
 import {
   getSystemIdentifiers,
@@ -194,6 +195,7 @@ export function openTypeOfCarePage(page, uiSchema, schema) {
     const email = selectVet360EmailAddress(state);
     const homePhone = selectVet360HomePhoneString(state);
     const mobilePhone = selectVet360MobilePhoneString(state);
+    const showCommunityCare = vaosCommunityCare(state);
 
     const phoneNumber = mobilePhone || homePhone;
     dispatch({
@@ -203,6 +205,7 @@ export function openTypeOfCarePage(page, uiSchema, schema) {
       schema,
       email,
       phoneNumber,
+      showCommunityCare,
     });
   };
 }

--- a/src/applications/vaos/containers/TypeOfCarePage.jsx
+++ b/src/applications/vaos/containers/TypeOfCarePage.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { connect } from 'react-redux';
 import SchemaForm from 'platform/forms-system/src/js/components/SchemaForm';
 
-import { TYPES_OF_CARE } from '../utils/constants';
 import { scrollAndFocus } from '../utils/scrollAndFocus';
 import { getLongTermAppointmentHistory } from '../api';
 import FormButtons from '../components/FormButtons';
@@ -17,19 +16,12 @@ import {
 } from '../actions/newAppointment.js';
 import { getFormPageInfo, getNewAppointment } from '../utils/selectors';
 
-const sortedCare = TYPES_OF_CARE.sort(
-  (careA, careB) =>
-    careA.name.toLowerCase() > careB.name.toLowerCase() ? 1 : -1,
-);
-
 const initialSchema = {
   type: 'object',
   required: ['typeOfCareId'],
   properties: {
     typeOfCareId: {
       type: 'string',
-      enum: sortedCare.map(care => care.id || care.ccId),
-      enumNames: sortedCare.map(care => care.label || care.name),
     },
   },
 };
@@ -77,13 +69,17 @@ export class TypeOfCarePage extends React.Component {
       showToCUnavailableModal,
     } = this.props;
 
+    if (!schema) {
+      return null;
+    }
+
     return (
       <div>
         <h1 className="vads-u-font-size--h2">{pageTitle}</h1>
         <SchemaForm
           name="Type of care"
           title="Type of care"
-          schema={schema || initialSchema}
+          schema={schema}
           uiSchema={uiSchema}
           onSubmit={this.goForward}
           onChange={this.onChange}

--- a/src/applications/vaos/reducers/newAppointment.js
+++ b/src/applications/vaos/reducers/newAppointment.js
@@ -62,6 +62,8 @@ import {
   REASON_MAX_CHARS,
   FETCH_STATUS,
   PURPOSE_TEXT,
+  TYPES_OF_CARE,
+  PODIATRY_ID,
 } from '../utils/constants';
 
 import { getTypeOfCare } from '../utils/selectors';
@@ -220,9 +222,26 @@ export default function formReducer(state = initialState, action) {
         email: state.data.email || action.email,
       };
 
+      const sortedCare = TYPES_OF_CARE.filter(
+        typeOfCare => typeOfCare.id !== PODIATRY_ID || action.showCommunityCare,
+      ).sort(
+        (careA, careB) =>
+          careA.name.toLowerCase() > careB.name.toLowerCase() ? 1 : -1,
+      );
+      const initialSchema = {
+        ...action.schema,
+        properties: {
+          typeOfCareId: {
+            type: 'string',
+            enum: sortedCare.map(care => care.id || care.ccId),
+            enumNames: sortedCare.map(care => care.label || care.name),
+          },
+        },
+      };
+
       const { data, schema } = setupFormData(
         prefilledData,
-        action.schema,
+        initialSchema,
         action.uiSchema,
       );
 

--- a/src/applications/vaos/tests/containers/TypeOfCarePage.unit.spec.jsx
+++ b/src/applications/vaos/tests/containers/TypeOfCarePage.unit.spec.jsx
@@ -7,7 +7,19 @@ import { mockFetch, setFetchJSONResponse } from 'platform/testing/unit/helpers';
 
 import { selectRadio } from 'platform/testing/unit/schemaform-utils.jsx';
 import { TypeOfCarePage } from '../../containers/TypeOfCarePage';
+import { TYPES_OF_CARE } from '../../utils/constants';
 
+const initialSchema = {
+  type: 'object',
+  required: ['typeOfCareId'],
+  properties: {
+    typeOfCareId: {
+      type: 'string',
+      enum: TYPES_OF_CARE.map(care => care.id || care.ccId),
+      enumNames: TYPES_OF_CARE.map(care => care.label || care.name),
+    },
+  },
+};
 describe('VAOS <TypeOfCarePage>', () => {
   it('should render', () => {
     const openTypeOfCarePage = sinon.spy();
@@ -17,6 +29,7 @@ describe('VAOS <TypeOfCarePage>', () => {
       <TypeOfCarePage
         openTypeOfCarePage={openTypeOfCarePage}
         updateFormData={updateFormData}
+        schema={initialSchema}
         data={{}}
       />,
     );
@@ -34,6 +47,7 @@ describe('VAOS <TypeOfCarePage>', () => {
     const form = mount(
       <TypeOfCarePage
         openTypeOfCarePage={openTypeOfCarePage}
+        schema={initialSchema}
         router={router}
         data={{}}
       />,
@@ -59,6 +73,7 @@ describe('VAOS <TypeOfCarePage>', () => {
       <TypeOfCarePage
         openTypeOfCarePage={openTypeOfCarePage}
         updateFormData={updateFormData}
+        schema={initialSchema}
         router={router}
         data={{}}
       />,
@@ -78,6 +93,7 @@ describe('VAOS <TypeOfCarePage>', () => {
     const form = mount(
       <TypeOfCarePage
         openTypeOfCarePage={openTypeOfCarePage}
+        schema={initialSchema}
         routeToNextAppointmentPage={routeToNextAppointmentPage}
         data={{ typeOfCareId: '323' }}
       />,
@@ -90,26 +106,6 @@ describe('VAOS <TypeOfCarePage>', () => {
     form.unmount();
   });
 
-  it('should list type of care in alphabetical order', () => {
-    const openTypeOfCarePage = sinon.spy();
-    const updateFormData = sinon.spy();
-
-    const form = mount(
-      <TypeOfCarePage
-        openTypeOfCarePage={openTypeOfCarePage}
-        updateFormData={updateFormData}
-        data={{}}
-      />,
-    );
-    expect(
-      form
-        .find('label')
-        .at(0)
-        .text(),
-    ).to.contain('Amputation care');
-    form.unmount();
-  });
-
   it('document title should match h1 text', () => {
     const openTypeOfCarePage = sinon.spy();
     const updateFormData = sinon.spy();
@@ -118,6 +114,7 @@ describe('VAOS <TypeOfCarePage>', () => {
     const form = mount(
       <TypeOfCarePage
         openTypeOfCarePage={openTypeOfCarePage}
+        schema={initialSchema}
         updateFormData={updateFormData}
         data={{}}
       />,

--- a/src/applications/vaos/tests/reducers/newAppointment.unit.spec.js
+++ b/src/applications/vaos/tests/reducers/newAppointment.unit.spec.js
@@ -1001,6 +1001,7 @@ describe('VAOS reducer: newAppointment', () => {
       uiSchema: {},
       phoneNumber: '123456789',
       email: 'test@va.gov',
+      showCommunityCare: true,
     };
 
     const newState = newAppointmentReducer(currentState, action);
@@ -1008,6 +1009,40 @@ describe('VAOS reducer: newAppointment', () => {
     expect(newState.pages.test).not.to.be.undefined;
     expect(newState.data.phoneNumber).to.equal(action.phoneNumber);
     expect(newState.data.email).to.equal(action.email);
+    expect(
+      newState.pages.test.properties.typeOfCareId.enumNames.some(label =>
+        label.toLowerCase().includes('podiatry'),
+      ),
+    ).to.be.true;
+    expect(newState.pages.test.properties.typeOfCareId.enumNames[0]).to.contain(
+      'Amputation care',
+    );
+  });
+
+  it('should hide podiatry from care list if community care is disabled', () => {
+    const currentState = {
+      data: {},
+      pages: {},
+    };
+    const action = {
+      type: FORM_TYPE_OF_CARE_PAGE_OPENED,
+      page: 'test',
+      schema: {
+        type: 'object',
+        properties: {},
+      },
+      uiSchema: {},
+      phoneNumber: '123456789',
+      email: 'test@va.gov',
+      showCommunityCare: false,
+    };
+
+    const newState = newAppointmentReducer(currentState, action);
+    expect(
+      newState.pages.test.properties.typeOfCareId.enumNames.some(label =>
+        label.toLowerCase().includes('podiatry'),
+      ),
+    ).to.be.false;
   });
 
   it('should set ToC modal to show', () => {

--- a/src/applications/vaos/utils/constants.js
+++ b/src/applications/vaos/utils/constants.js
@@ -52,6 +52,7 @@ export const REASON_ADDITIONAL_INFO_TITLES = {
     'Please provide any additional details you’d like to share with your provider about this appointment.',
 };
 
+export const PODIATRY_ID = 'tbd-podiatry';
 export const TYPES_OF_CARE = [
   {
     id: '323',
@@ -101,7 +102,7 @@ export const TYPES_OF_CARE = [
     cceType: 'Nutrition',
   },
   {
-    id: 'tbd-podiatry',
+    id: PODIATRY_ID,
     name: 'Podiatry',
     label: 'Podiatry (only available online for Community Care appointments)',
     ccId: 'CCPOD',


### PR DESCRIPTION
## Description
This removes Podiatry from the type of care list when CC is not enabled.

## Testing done
Local and unit testing

## Screenshots
![Screen Shot 2020-03-18 at 3 40 22 PM](https://user-images.githubusercontent.com/634932/77000492-dfa89180-692e-11ea-8254-592d0d46d57e.png)


## Acceptance criteria
- [ ] Podiatry is no longer there

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
