### PR TITLE
[Development] Update HLR scheduled times review block

### DIFF
--- a/src/applications/disability-benefits/996/containers/ScheduleTimesReviewField.jsx
+++ b/src/applications/disability-benefits/996/containers/ScheduleTimesReviewField.jsx
@@ -18,7 +18,7 @@ export default function ScheduleTimesReviewField(props) {
   const timeSlot = informalConferenceTimeAllLabels?.[children?.props.name];
 
   return (
-    <div className="review-row">
+    <div className="review-row scheduled-time">
       <dt>{label}</dt>
       <dd>{timeSlot}</dd>
     </div>

--- a/src/applications/disability-benefits/996/content/InformalConference.jsx
+++ b/src/applications/disability-benefits/996/content/InformalConference.jsx
@@ -62,10 +62,10 @@ export const InformalConferenceTimes = ({ isRep }) => (
 );
 
 export const informalConferenceTimeAllLabels = {
-  time0800to1000: '8:00 a.m. - 10:00 a.m. ET',
-  time1000to1200: '10:00 a.m. - 12:00 p.m. ET',
-  time1230to1400: '12:30 p.m. - 2:00 p.m. ET',
-  time1400to1630: '2:00 p.m. - 4:30 p.m. ET',
+  time0800to1000: '8:00 a.m. to 10:00 a.m. ET',
+  time1000to1200: '10:00 a.m. to 12:00 p.m. ET',
+  time1230to1400: '12:30 p.m. to 2:00 p.m. ET',
+  time1400to1630: '2:00 p.m. to 4:30 p.m. ET',
 };
 
 // These labels are hidden on the review page
@@ -77,7 +77,7 @@ export const InformalConferenceTimeLabels = key => (
 
 export const InformalConferenceAvailability = contact => (
   <span className="time-contact" role="presentation">
-    {contact === 'me' ? 'Your' : 'Representative’s'} availability
+    {contact === 'me' ? 'My' : 'Representative’s'} availability for scheduling
   </span>
 );
 

--- a/src/applications/disability-benefits/996/sass/0996-higher-level-review.scss
+++ b/src/applications/disability-benefits/996/sass/0996-higher-level-review.scss
@@ -221,18 +221,6 @@ article[data-location="opt-out-of-old-appeals"] {
   }
 }
 
-/* Step 2c */
-article[data-location^="contested-issues/"] {
-  /* Add space above AdditionalInfo block */
-  .form-expanding-group {
-    margin-top: 2em;
-  }
-
-  .usa-input-error label {
-    font-weight: bold;
-  }
-}
-
 /* Step 3 */
 /* Informal conference */
 article[data-location="request-informal-conference"] {
@@ -274,6 +262,18 @@ article[data-location="review-and-submit"] {
   /* checkbox group "Required" lable (added to */
   #root_scheduleTimes-label {
     display: none;
+  }
+
+  /* tweak second entry */
+  .scheduled-time + .scheduled-time {
+    padding-top: 0;
+    margin-top: -0.5rem;
+    border-top-width: 0;
+
+    /* hide duplicate label */
+    .time-contact {
+      display: none;
+    }
   }
 }
 


### PR DESCRIPTION
## Description

Updating the design of the Higher-Level Review informal conference time block.

Multiple selections are added in separate rows; but with some CSS, this PR hides the label and separating border

Design: https://vsateams.invisionapp.com/share/W5U21BDFTQK#/screens/404689832
Realted issue: https://github.com/department-of-veterans-affairs/va.gov-team/issues/6402

## Testing done

Local unit tests

## Screenshots

<details><summary>Before (2 times selected)</summary>

<!-- leave a blank line above -->
![Screen Shot 2020-03-18 at 2 57 37 PM](https://user-images.githubusercontent.com/136959/77002923-65760e00-692a-11ea-86bd-bd600dd401f7.png)
</details>
<details>
<summary>After (2 times selected)</summary>

<!-- leave a blank line above -->
![Screen Shot 2020-03-18 at 2 49 09 PM](https://user-images.githubusercontent.com/136959/77002989-83437300-692a-11ea-8c80-3da1c06e3ad4.png)
</details>

<details>
<summary>After (1 time selected)</summary>

<!-- leave a blank line above -->
![Screen Shot 2020-03-18 at 2 52 09 PM](https://user-images.githubusercontent.com/136959/77003042-97877000-692a-11ea-824e-14d58513a1d6.png)
</details>

## Acceptance criteria
- [ ] Review page informal conference times block matches the design

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
