### PR TITLE
526: Require conditions to have content

### DIFF
--- a/src/applications/disability-benefits/all-claims/pages/addDisabilities.js
+++ b/src/applications/disability-benefits/all-claims/pages/addDisabilities.js
@@ -68,6 +68,7 @@ export const uiSchema = {
           },
           // autoSuggest schema doesn't have any default validations as long as { `freeInput: true` }
           'ui:validations': [validateDisabilityName],
+          'ui:required': () => true,
         },
       ),
       'view:descriptionInfo': {


### PR DESCRIPTION
## Description
Currently, in the 526 form, users can enter blank conditions. This PR removes this ability and requires users to enter at least one character for their condition. This is because it is required upstream for the condition to at least have something for the disability name.

## Screenshots
![image](https://user-images.githubusercontent.com/53942725/77003908-8fccc900-6934-11ea-900f-6e865fecc0e4.png)

## Acceptance criteria
- [ ] Users are required to enter at least one character for conditions in the 526 form