### PR TITLE
SonarJs enforcing rules batch 1

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -61,6 +61,20 @@
     "react/no-deprecated": 2,
     "react/no-direct-mutation-state": 2,
 
+    /* || sonarJS plugin || */
+    "sonarjs/no-all-duplicated-branches": 2,
+    "sonarjs/no-element-overwrite": 2,
+    "sonarjs/no-identical-conditions": 2,
+    "sonarjs/no-one-iteration-loop": 2,
+    "sonarjs/no-use-of-empty-return-value": 2,
+    "sonarjs/no-collection-size-mischeck": 2,
+    "sonarjs/no-redundant-jump": 2,
+    "sonarjs/no-same-line-conditional": 2,
+    "sonarjs/no-useless-catch": 2,
+    "sonarjs/prefer-object-literal": 2,
+    "sonarjs/prefer-single-boolean-return": 2,
+    "sonarjs/prefer-while": 2,
+
     /* || airbnb plugin || */
     // this is the airbnb default, minus for..of
     "no-restricted-syntax": [

--- a/circle.eslint.json
+++ b/circle.eslint.json
@@ -1,16 +1,3 @@
 {
-  "rules": {
-    "sonarjs/no-all-duplicated-branches": 2,
-    "sonarjs/no-element-overwrite": 2,
-    "sonarjs/no-identical-conditions": 2,
-    "sonarjs/no-one-iteration-loop": 2,
-    "sonarjs/no-use-of-empty-return-value": 2,
-    "sonarjs/no-collection-size-mischeck": 2,
-    "sonarjs/no-redundant-jump": 2,
-    "sonarjs/no-same-line-conditional": 2,
-    "sonarjs/no-useless-catch": 2,
-    "sonarjs/prefer-object-literal": 2,
-    "sonarjs/prefer-single-boolean-return": 2,
-    "sonarjs/prefer-while": 2
-  }
+  "rules": {}
 }


### PR DESCRIPTION
## Description
After placing these SonarJS rules in the testing stage during the Sprint 21. We are moving them to be forced into the `.eslintrc` file.

## Testing done
Locally

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
