### PR TITLE
Remove caregiver from static heroku build

### DIFF
--- a/script/heroku-postbuild.sh
+++ b/script/heroku-postbuild.sh
@@ -11,4 +11,4 @@ git clone --depth=1 https://github.com/department-of-veterans-affairs/vagov-cont
 cd ${vagov_apps_dir}
 
 # build the site as usual
-npm run build --  --entry static-pages,caregivers --content-directory ${vagov_content_dir}/pages
+npm run build --  --entry static-pages --content-directory ${vagov_content_dir}/pages


### PR DESCRIPTION
## Description
Forgot to remove this line of code before merging my last PR


## Screenshots


## Acceptance criteria
- [ ] Remove caregivers from static heroku build

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
