### PR TITLE
Show better error message if the appointment slots call fails

### DIFF
--- a/src/applications/vaos/actions/newAppointment.js
+++ b/src/applications/vaos/actions/newAppointment.js
@@ -726,6 +726,13 @@ export function submitAppointmentOrRequest(router) {
   };
 }
 
+export function requestAppointmentDateChoice(router) {
+  return dispatch => {
+    dispatch(startRequestAppointmentFlow());
+    router.replace('/new-appointment/request-date');
+  };
+}
+
 export function routeToPageInFlow(flow, router, current, action) {
   return async (dispatch, getState) => {
     dispatch({

--- a/src/applications/vaos/api/index.js
+++ b/src/applications/vaos/api/index.js
@@ -403,16 +403,15 @@ export function getAvailableSlots(
   let promise;
 
   if (USE_MOCK_DATA) {
-    promise = Promise.reject();
-    // promise = new Promise(resolve => {
-    //   setTimeout(() => {
-    //     import('./slots.json').then(module => {
-    //       const response = module.default ? module.default : module;
-    //       response.data[0].attributes.appointmentTimeSlot = generateMockSlots();
-    //       resolve(response);
-    //     });
-    //   }, 500);
-    // });
+    promise = new Promise(resolve => {
+      setTimeout(() => {
+        import('./slots.json').then(module => {
+          const response = module.default ? module.default : module;
+          response.data[0].attributes.appointmentTimeSlot = generateMockSlots();
+          resolve(response);
+        });
+      }, 500);
+    });
   } else {
     promise = apiRequest(
       `/vaos/facilities/${facilityId}/available_appointments?type_of_care_id=${typeOfCareId}&clinic_ids[]=${clinicId}&start_date=${startDate}&end_date=${endDate}`,

--- a/src/applications/vaos/api/index.js
+++ b/src/applications/vaos/api/index.js
@@ -403,15 +403,16 @@ export function getAvailableSlots(
   let promise;
 
   if (USE_MOCK_DATA) {
-    promise = new Promise(resolve => {
-      setTimeout(() => {
-        import('./slots.json').then(module => {
-          const response = module.default ? module.default : module;
-          response.data[0].attributes.appointmentTimeSlot = generateMockSlots();
-          resolve(response);
-        });
-      }, 500);
-    });
+    promise = Promise.reject();
+    // promise = new Promise(resolve => {
+    //   setTimeout(() => {
+    //     import('./slots.json').then(module => {
+    //       const response = module.default ? module.default : module;
+    //       response.data[0].attributes.appointmentTimeSlot = generateMockSlots();
+    //       resolve(response);
+    //     });
+    //   }, 500);
+    // });
   } else {
     promise = apiRequest(
       `/vaos/facilities/${facilityId}/available_appointments?type_of_care_id=${typeOfCareId}&clinic_ids[]=${clinicId}&start_date=${startDate}&end_date=${endDate}`,

--- a/src/applications/vaos/components/WaitTimeAlert.jsx
+++ b/src/applications/vaos/components/WaitTimeAlert.jsx
@@ -4,7 +4,7 @@ import moment from 'moment';
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 import { Link } from 'react-router';
 import { MENTAL_HEALTH } from '../utils/constants';
-import { getStagingId } from '../utils/appointment';
+import { getRealFacilityId } from '../utils/appointment';
 import newAppointmentFlow from '../newAppointmentFlow';
 
 export const WaitTimeAlert = ({
@@ -97,7 +97,7 @@ export const WaitTimeAlert = ({
                   </>
                 )}
                 <a
-                  href={`/find-locations/facility/vha_${getStagingId(
+                  href={`/find-locations/facility/vha_${getRealFacilityId(
                     facilityId,
                   )}`}
                   rel="noopener noreferrer"

--- a/src/applications/vaos/components/calendar/CalendarWidget.jsx
+++ b/src/applications/vaos/components/calendar/CalendarWidget.jsx
@@ -258,7 +258,7 @@ export default class CalendarWidget extends Component {
   };
 
   render() {
-    const { loadingStatus, validationError } = this.props;
+    const { loadingStatus, validationError, loadingErrorMessage } = this.props;
     const { maxMonth, months } = this.state;
     const showError = validationError?.length > 0;
 
@@ -268,12 +268,7 @@ export default class CalendarWidget extends Component {
     });
 
     if (loadingStatus === FETCH_STATUS.failed) {
-      return (
-        <p>
-          There was a problem loading appointment availability. Please try again
-          later.
-        </p>
-      );
+      return loadingErrorMessage;
     }
 
     return (

--- a/src/applications/vaos/containers/DateTimeSelectPage.jsx
+++ b/src/applications/vaos/containers/DateTimeSelectPage.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import moment from 'moment';
+import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 
 import {
   getAppointmentSlots,
@@ -8,6 +9,7 @@ import {
   routeToNextAppointmentPage,
   routeToPreviousAppointmentPage,
   startRequestAppointmentFlow,
+  requestAppointmentDateChoice,
 } from '../actions/newAppointment.js';
 import { scrollAndFocus } from '../utils/scrollAndFocus';
 import FormButtons from '../components/FormButtons';
@@ -15,6 +17,7 @@ import { getDateTimeSelect } from '../utils/selectors';
 import CalendarWidget from '../components/calendar/CalendarWidget';
 import WaitTimeAlert from '../components/WaitTimeAlert';
 import { FETCH_STATUS } from '../utils/constants';
+import { getRealFacilityId } from '../utils/appointment';
 
 const pageKey = 'selectDateTime';
 const pageTitle = 'Tell us the date and time you’d like your appointment';
@@ -42,6 +45,32 @@ export function getOptionsByDate(selectedDate, availableSlots = []) {
 
   return options;
 }
+
+function ErrorMessage({ facilityId, startRequestFlow }) {
+  return (
+    <div aria-atomic="true" aria-live="assertive">
+      <AlertBox
+        status="error"
+        headline="We’ve run into a problem when trying to find available appointment times"
+      >
+        To schedule this appointment, you can{' '}
+        <button onClick={startRequestFlow} className="va-button-link">
+          submit a request for a VA appointment
+        </button>{' '}
+        or{' '}
+        <a
+          href={`/find-locations/facility/vha_${getRealFacilityId(facilityId)}`}
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          call your local VA medical center
+        </a>
+        .
+      </AlertBox>
+    </div>
+  );
+}
+
 export class DateTimeSelectPage extends React.Component {
   constructor(props) {
     super(props);
@@ -161,6 +190,12 @@ export class DateTimeSelectPage extends React.Component {
               getOptionsByDate(selectedDate, availableSlots),
           }}
           loadingStatus={appointmentSlotsStatus}
+          loadingErrorMessage={
+            <ErrorMessage
+              facilityId={facilityId}
+              startRequestFlow={this.props.requestAppointmentDateChoice}
+            />
+          }
           onChange={newData => {
             this.validate(newData);
             this.props.onCalendarChange(newData);
@@ -181,6 +216,7 @@ export class DateTimeSelectPage extends React.Component {
         <FormButtons
           onBack={this.goBack}
           onSubmit={this.goForward}
+          disabled={appointmentSlotsStatus === FETCH_STATUS.failed}
           pageChangeInProgress={pageChangeInProgress}
         />
       </div>
@@ -198,6 +234,7 @@ const mapDispatchToProps = {
   routeToNextAppointmentPage,
   routeToPreviousAppointmentPage,
   startRequestAppointmentFlow,
+  requestAppointmentDateChoice,
 };
 
 export default connect(

--- a/src/applications/vaos/containers/DateTimeSelectPage.jsx
+++ b/src/applications/vaos/containers/DateTimeSelectPage.jsx
@@ -122,6 +122,10 @@ export class DateTimeSelectPage extends React.Component {
     }
   };
 
+  startRequestFlow = () => {
+    this.props.requestAppointmentDateChoice(this.props.router);
+  };
+
   validate = data => {
     if (this.userSelectedSlot(data)) {
       this.setState({ validationError: null });
@@ -193,7 +197,7 @@ export class DateTimeSelectPage extends React.Component {
           loadingErrorMessage={
             <ErrorMessage
               facilityId={facilityId}
-              startRequestFlow={this.props.requestAppointmentDateChoice}
+              startRequestFlow={this.startRequestFlow}
             />
           }
           onChange={newData => {

--- a/src/applications/vaos/containers/ReviewPage.jsx
+++ b/src/applications/vaos/containers/ReviewPage.jsx
@@ -11,7 +11,7 @@ import {
   getChosenFacilityDetails,
 } from '../utils/selectors';
 import { FLOW_TYPES, FETCH_STATUS } from '../utils/constants';
-import { getStagingId } from '../utils/appointment';
+import { getRealFacilityId } from '../utils/appointment';
 import { scrollAndFocus } from '../utils/scrollAndFocus';
 import ReviewDirectScheduleInfo from '../components/review/ReviewDirectScheduleInfo';
 import ReviewRequestInfo from '../components/review/ReviewRequestInfo';
@@ -88,7 +88,7 @@ export class ReviewPage extends React.Component {
                     <a
                       target="_blank"
                       rel="noopener noreferrer"
-                      href={`/find-locations/facility/vha_${getStagingId(
+                      href={`/find-locations/facility/vha_${getRealFacilityId(
                         data.vaFacility || data.communityCareSystemId,
                       )}`}
                     >

--- a/src/applications/vaos/tests/actions/newAppointment.unit.spec.js
+++ b/src/applications/vaos/tests/actions/newAppointment.unit.spec.js
@@ -24,6 +24,7 @@ import {
   onCalendarChange,
   hideTypeOfCareUnavailableModal,
   startNewAppointmentFlow,
+  requestAppointmentDateChoice,
   FORM_PAGE_OPENED,
   FORM_DATA_UPDATED,
   FORM_PAGE_CHANGE_STARTED,
@@ -53,6 +54,7 @@ import {
   FORM_CALENDAR_FETCH_SLOTS_FAILED,
   FORM_CALENDAR_DATA_CHANGED,
   FORM_HIDE_TYPE_OF_CARE_UNAVAILABLE_MODAL,
+  START_REQUEST_APPOINTMENT_FLOW,
 } from '../../actions/newAppointment';
 import {
   FORM_SUBMIT_SUCCEEDED,
@@ -1192,33 +1194,50 @@ describe('VAOS newAppointment actions', () => {
     });
   });
 
-  it('should open type of care page and pull contact info to prefill', () => {
-    const state = {
-      user: {
-        profile: {
-          vet360: {
-            email: {
-              emailAddress: 'test@va.gov',
-            },
-            homePhone: {
-              areaCode: '503',
-              extension: '0000',
-              phoneNumber: '2222222',
+  describe('openTypeOfCarePage', () => {
+    it('should open type of care page and pull contact info to prefill', () => {
+      const state = {
+        user: {
+          profile: {
+            vet360: {
+              email: {
+                emailAddress: 'test@va.gov',
+              },
+              homePhone: {
+                areaCode: '503',
+                extension: '0000',
+                phoneNumber: '2222222',
+              },
             },
           },
         },
-      },
-    };
-    const getState = () => state;
-    const dispatch = sinon.spy();
+      };
+      const getState = () => state;
+      const dispatch = sinon.spy();
 
-    const thunk = openTypeOfCarePage('typeOfCare', {}, {});
-    thunk(dispatch, getState);
+      const thunk = openTypeOfCarePage('typeOfCare', {}, {});
+      thunk(dispatch, getState);
 
-    expect(dispatch.firstCall.args[0].type).to.equal(
-      FORM_TYPE_OF_CARE_PAGE_OPENED,
-    );
-    expect(dispatch.firstCall.args[0].phoneNumber).to.equal('5032222222');
-    expect(dispatch.firstCall.args[0].email).to.equal('test@va.gov');
+      expect(dispatch.firstCall.args[0].type).to.equal(
+        FORM_TYPE_OF_CARE_PAGE_OPENED,
+      );
+      expect(dispatch.firstCall.args[0].phoneNumber).to.equal('5032222222');
+      expect(dispatch.firstCall.args[0].email).to.equal('test@va.gov');
+    });
+  });
+  describe('requestAppointmentDateChoice', () => {
+    it('should start request flow and route to request date page', () => {
+      const router = {
+        replace: sinon.spy(),
+      };
+      const dispatch = sinon.spy();
+
+      requestAppointmentDateChoice(router)(dispatch);
+
+      expect(dispatch.firstCall.args[0]).to.deep.equal({
+        type: START_REQUEST_APPOINTMENT_FLOW,
+      });
+      expect(router.replace.called).to.be.true;
+    });
   });
 });

--- a/src/applications/vaos/tests/components/calendar/CalendarWidget.unit.spec.jsx
+++ b/src/applications/vaos/tests/components/calendar/CalendarWidget.unit.spec.jsx
@@ -71,11 +71,14 @@ describe('VAOS <CalendarWidget>', () => {
     const tree = shallow(
       <CalendarWidget
         monthsToShowAtOnce={2}
+        loadingErrorMessage={
+          <div>There was a problem loading appointment availability</div>
+        }
         loadingStatus={FETCH_STATUS.failed}
       />,
     );
     expect(tree.text()).to.contain(
-      'There was a problem loading appointment availability. Please try again later.',
+      'There was a problem loading appointment availability',
     );
     tree.unmount();
   });

--- a/src/applications/vaos/tests/containers/DateTimeSelectPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/containers/DateTimeSelectPage.unit.spec.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { expect } from 'chai';
 import sinon from 'sinon';
-import { mount } from 'enzyme';
+import { mount, shallow } from 'enzyme';
 import moment from 'moment';
 
 import {
@@ -225,5 +225,39 @@ describe('VAOS <DateTimeSelectPage>', () => {
     expect(options[1].label.props.children[4].props.children).to.equal(
       srMeridiem(dateTime1),
     );
+  });
+
+  it('should render error message if slots call fails', () => {
+    const getAppointmentSlots = sinon.spy();
+    const onCalendarChange = sinon.spy();
+    const requestAppointmentDateChoice = sinon.spy();
+
+    const form = mount(
+      <DateTimeSelectPage
+        availableDates={availableDates}
+        availableSlots={availableSlots}
+        data={{ calendarData: {} }}
+        facilityId="123"
+        getAppointmentSlots={getAppointmentSlots}
+        appointmentSlotsStatus={FETCH_STATUS.failed}
+        onCalendarChange={onCalendarChange}
+        requestAppointmentDateChoice={requestAppointmentDateChoice}
+      />,
+    );
+
+    const message = shallow(
+      form.find('CalendarWidget').props().loadingErrorMessage,
+    );
+    message
+      .find('button')
+      .props()
+      .onClick();
+
+    expect(message.find('AlertBox').exists()).to.be.true;
+    expect(message.find('a').props().href).to.contain('vha_123');
+    expect(requestAppointmentDateChoice.called).to.be.true;
+
+    form.unmount();
+    message.unmount();
   });
 });

--- a/src/applications/vaos/tests/utils/appointment.unit.spec.jsx
+++ b/src/applications/vaos/tests/utils/appointment.unit.spec.jsx
@@ -25,7 +25,6 @@ import {
   getRealFacilityId,
   getRequestDateOptions,
   getRequestTimeToCall,
-  getStagingId,
   getVideoVisitLink,
   hasInstructions,
   isCommunityCare,
@@ -141,13 +140,6 @@ describe('VAOS appointment helpers', () => {
     };
     it('should be true', () => {
       expect(getVideoVisitLink(appt)).to.equal('https://va.gov');
-    });
-  });
-
-  describe('getStagingId', () => {
-    it('should return the staging id for not production environemnts', () => {
-      expect(getStagingId('983')).to.equal('442');
-      expect(getStagingId('984')).to.equal('984');
     });
   });
 

--- a/src/applications/vaos/utils/appointment.jsx
+++ b/src/applications/vaos/utils/appointment.jsx
@@ -47,14 +47,6 @@ export function getVideoVisitLink(appt) {
   return appt.vvsAppointments[0]?.patients?.[0]?.virtualMeetingRoom?.url;
 }
 
-export function getStagingId(facilityId) {
-  if (!environment.isProduction() && facilityId?.startsWith('983')) {
-    return facilityId.replace('983', '442');
-  }
-
-  return facilityId;
-}
-
 export function titleCase(str) {
   return str
     .toLowerCase()
@@ -186,7 +178,7 @@ export function getAppointmentLocation(appt, facility) {
 
   return (
     <a
-      href={`/find-locations/facility/vha_${getStagingId(facilityId)}`}
+      href={`/find-locations/facility/vha_${getRealFacilityId(facilityId)}`}
       rel="noopener noreferrer"
       target="_blank"
     >

--- a/src/applications/vaos/utils/appointment.jsx
+++ b/src/applications/vaos/utils/appointment.jsx
@@ -13,6 +13,14 @@ import {
   stripDST,
 } from './timezone';
 
+export function getRealFacilityId(facilityId) {
+  if (!environment.isProduction() && facilityId) {
+    return facilityId.replace('983', '442').replace('984', '552');
+  }
+
+  return facilityId;
+}
+
 export function getAppointmentType(appt) {
   if (appt.typeOfCareId?.startsWith('CC')) {
     return APPOINTMENT_TYPES.ccRequest;
@@ -367,14 +375,6 @@ export function sortFutureRequests(a, b) {
 
 export function sortMessages(a, b) {
   return moment(a.attributes.date).isBefore(b.attributes.date) ? -1 : 1;
-}
-
-export function getRealFacilityId(facilityId) {
-  if (!environment.isProduction() && facilityId) {
-    return facilityId.replace('983', '442').replace('984', '552');
-  }
-
-  return facilityId;
 }
 
 export function getAppointmentInstructions(appt) {


### PR DESCRIPTION
## Description
This improves the error message if the appointment slots call fails

## Testing done
Local testing

## Screenshots
![Screen Shot 2020-03-19 at 2 46 11 PM](https://user-images.githubusercontent.com/634932/77106034-e26dba00-69f4-11ea-8320-ac30a3b08ccc.png)


## Acceptance criteria
- [ ] Error message alert displays with the ability to go to the request flow or contact VA

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
