### PR TITLE
Fix text (grammar) on facility locator page detail

### DIFF
--- a/src/applications/facility-locator/containers/FacilityDetail.jsx
+++ b/src/applications/facility-locator/containers/FacilityDetail.jsx
@@ -71,7 +71,7 @@ class FacilityDetail extends Component {
           phone.main && (
             <p className="p1">
               Planning to visit? Please call first as information on this page
-              change.
+              may change.
             </p>
           )}
       </div>


### PR DESCRIPTION
## Description

issue: https://github.com/department-of-veterans-affairs/va.gov-team/issues/3907

## Testing done
Review instance 

<img width="767" alt="Screen Shot 2020-03-19 at 6 27 44 PM" src="https://user-images.githubusercontent.com/100468/77123899-659c0980-6a0f-11ea-906d-320770143e5a.png">


## Acceptance criteria
- [x] Text should say: "Planning to visit? Please call first as information on this page may change." (insert the word "may")

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
