### PR TITLE
CT: Improve error messaging when there is a timeout#6662

### DIFF
--- a/src/applications/gi/actions/index.js
+++ b/src/applications/gi/actions/index.js
@@ -208,15 +208,25 @@ export function fetchInstitutionSearchResults(query = {}) {
     dispatch({ type: SEARCH_STARTED, query });
 
     return fetch(url, api.settings)
-      .then(res => res.json())
-      .then(
-        payload =>
-          withPreview(dispatch, {
-            type: INSTITUTION_SEARCH_SUCCEEDED,
-            payload,
-          }),
-        err => dispatch({ type: SEARCH_FAILED, err }),
-      );
+      .then(res => {
+        if (res.ok) {
+          return res.json();
+        }
+
+        throw new Error(res.statusText);
+      })
+      .then(payload =>
+        withPreview(dispatch, {
+          type: INSTITUTION_SEARCH_SUCCEEDED,
+          payload,
+        }),
+      )
+      .catch(err => {
+        dispatch({
+          type: FETCH_PROFILE_FAILED,
+          payload: err.message,
+        });
+      });
   };
 }
 
@@ -230,12 +240,25 @@ export function fetchProgramSearchResults(query = {}) {
     dispatch({ type: SEARCH_STARTED, query });
 
     return fetch(url, api.settings)
-      .then(res => res.json())
-      .then(
-        payload =>
-          withPreview(dispatch, { type: PROGRAM_SEARCH_SUCCEEDED, payload }),
-        err => dispatch({ type: SEARCH_FAILED, err }),
-      );
+      .then(res => {
+        if (res.ok) {
+          return res.json();
+        }
+
+        throw new Error(res.statusText);
+      })
+      .then(payload =>
+        withPreview(dispatch, {
+          type: PROGRAM_SEARCH_SUCCEEDED,
+          payload,
+        }),
+      )
+      .catch(err => {
+        dispatch({
+          type: SEARCH_FAILED,
+          payload: err.message,
+        });
+      });
   };
 }
 

--- a/src/applications/gi/actions/index.js
+++ b/src/applications/gi/actions/index.js
@@ -96,16 +96,24 @@ function withPreview(dispatch, action) {
 export function fetchConstants(version) {
   const queryString = version ? `?version=${version}` : '';
   const url = `${api.url}/calculator_constants${queryString}`;
-
   return dispatch => {
     dispatch({ type: FETCH_CONSTANTS_STARTED });
     return fetch(url, api.settings)
-      .then(res => res.json())
-      .then(
-        payload =>
-          withPreview(dispatch, { type: FETCH_CONSTANTS_SUCCEEDED, payload }),
-        err => dispatch({ type: FETCH_CONSTANTS_FAILED, err }),
-      );
+      .then(res => {
+        if (res.ok) {
+          return res.json();
+        }
+        throw new Error(res.statusText);
+      })
+      .then(payload => {
+        withPreview(dispatch, { type: FETCH_CONSTANTS_SUCCEEDED, payload });
+      })
+      .catch(err => {
+        dispatch({
+          type: FETCH_CONSTANTS_FAILED,
+          payload: err.message,
+        });
+      });
   };
 }
 
@@ -243,10 +251,7 @@ export function fetchProfile(facilityCode, version) {
         if (res.ok) {
           return res.json();
         }
-
-        return res.json().then(errors => {
-          throw new Error(errors);
-        });
+        throw new Error(res.statusText);
       })
       .then(institution => {
         const { AVGVABAH, AVGDODBAH } = getState().constants.constants;
@@ -260,7 +265,10 @@ export function fetchProfile(facilityCode, version) {
         });
       })
       .catch(err => {
-        dispatch({ type: FETCH_PROFILE_FAILED, err });
+        dispatch({
+          type: FETCH_PROFILE_FAILED,
+          payload: err.message,
+        });
       });
   };
 }

--- a/src/applications/gi/actions/index.js
+++ b/src/applications/gi/actions/index.js
@@ -223,7 +223,7 @@ export function fetchInstitutionSearchResults(query = {}) {
       )
       .catch(err => {
         dispatch({
-          type: FETCH_PROFILE_FAILED,
+          type: SEARCH_FAILED,
           payload: err.message,
         });
       });

--- a/src/applications/gi/components/ErrorMessage.jsx
+++ b/src/applications/gi/components/ErrorMessage.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+export const ErrorMessage = () => (
+  <div className="backenderror">
+    <h3 className="backend-error-bold"> We’ve run into a problem. </h3>
+
+    <div className="backend-error vads-u-padding-bottom--5">
+      We're sorry. Something went wrong on our end. Please try again or check
+      back soon.
+    </div>
+  </div>
+);
+
+export default ErrorMessage;

--- a/src/applications/gi/components/ServiceError.jsx
+++ b/src/applications/gi/components/ServiceError.jsx
@@ -5,8 +5,8 @@ export const ServiceError = () => (
     <h3 className="backend-error-bold"> We’ve run into a problem. </h3>
 
     <div className="backend-error vads-u-padding-bottom--5">
-      We're sorry. Something went wrong on our end. Please try again or check
-      back soon.
+      We're sorry. Something went wrong on our end. Please refresh this page or
+      check back soon.
     </div>
   </div>
 );

--- a/src/applications/gi/components/ServiceError.jsx
+++ b/src/applications/gi/components/ServiceError.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-export const ErrorMessage = () => (
+export const ServiceError = () => (
   <div className="backenderror">
     <h3 className="backend-error-bold"> We’ve run into a problem. </h3>
 
@@ -11,4 +11,4 @@ export const ErrorMessage = () => (
   </div>
 );
 
-export default ErrorMessage;
+export default ServiceError;

--- a/src/applications/gi/containers/GiBillApp.jsx
+++ b/src/applications/gi/containers/GiBillApp.jsx
@@ -11,6 +11,7 @@ import Modals from '../containers/Modals';
 import PreviewBanner from '../components/heading/PreviewBanner';
 import GiBillBreadcrumbs from '../components/heading/GiBillBreadcrumbs';
 import AboutThisTool from '../components/content/AboutThisTool';
+import ErrorMessage from '../components/ErrorMessage';
 
 const Disclaimer = () => (
   <div className="row disclaimer">
@@ -103,8 +104,9 @@ export class GiBillApp extends React.Component {
               facilityCode={facilityCode}
               location={this.props.location}
             />
+
             <DowntimeNotification appTitle={'GI Bill Comparison Tool'}>
-              {content}
+              {constants.error ? <ErrorMessage /> : content}
             </DowntimeNotification>
             <AboutThisTool />
             <Disclaimer />

--- a/src/applications/gi/containers/GiBillApp.jsx
+++ b/src/applications/gi/containers/GiBillApp.jsx
@@ -12,6 +12,7 @@ import PreviewBanner from '../components/heading/PreviewBanner';
 import GiBillBreadcrumbs from '../components/heading/GiBillBreadcrumbs';
 import AboutThisTool from '../components/content/AboutThisTool';
 import ErrorMessage from '../components/ErrorMessage';
+import environment from 'platform/utilities/environment';
 
 const Disclaimer = () => (
   <div className="row disclaimer">
@@ -106,7 +107,11 @@ export class GiBillApp extends React.Component {
             />
 
             <DowntimeNotification appTitle={'GI Bill Comparison Tool'}>
-              {constants.error ? <ErrorMessage /> : content}
+              {constants.error && !environment.isProduction() ? (
+                <ErrorMessage />
+              ) : (
+                content
+              )}
             </DowntimeNotification>
             <AboutThisTool />
             <Disclaimer />

--- a/src/applications/gi/containers/GiBillApp.jsx
+++ b/src/applications/gi/containers/GiBillApp.jsx
@@ -11,7 +11,7 @@ import Modals from '../containers/Modals';
 import PreviewBanner from '../components/heading/PreviewBanner';
 import GiBillBreadcrumbs from '../components/heading/GiBillBreadcrumbs';
 import AboutThisTool from '../components/content/AboutThisTool';
-import ErrorMessage from '../components/ErrorMessage';
+import ServiceError from '../components/ServiceError';
 import environment from 'platform/utilities/environment';
 
 const Disclaimer = () => (
@@ -108,7 +108,7 @@ export class GiBillApp extends React.Component {
 
             <DowntimeNotification appTitle={'GI Bill Comparison Tool'}>
               {constants.error && !environment.isProduction() ? (
-                <ErrorMessage />
+                <ServiceError />
               ) : (
                 content
               )}

--- a/src/applications/gi/containers/ProfilePage.jsx
+++ b/src/applications/gi/containers/ProfilePage.jsx
@@ -8,6 +8,7 @@ import { getScrollOptions, focusElement } from 'platform/utilities/ui';
 import { fetchProfile, setPageTitle, showModal } from '../actions';
 import VetTecInstitutionProfile from '../components/vet-tec/VetTecInstitutionProfile';
 import InstitutionProfile from '../components/profile/InstitutionProfile';
+import ErrorMessage from '../components/ErrorMessage';
 
 const { Element: ScrollElement, scroller } = Scroll;
 
@@ -86,8 +87,11 @@ export class ProfilePage extends React.Component {
     }
 
     return (
-      <ScrollElement name="profilePage" className="profile-page">
-        {content}
+      <ScrollElement
+        name="profilePage"
+        className="profile-page vads-u-padding-top--3"
+      >
+        {profile.error ? <ErrorMessage /> : content}
       </ScrollElement>
     );
   }

--- a/src/applications/gi/containers/ProfilePage.jsx
+++ b/src/applications/gi/containers/ProfilePage.jsx
@@ -8,8 +8,8 @@ import { getScrollOptions, focusElement } from 'platform/utilities/ui';
 import { fetchProfile, setPageTitle, showModal } from '../actions';
 import VetTecInstitutionProfile from '../components/vet-tec/VetTecInstitutionProfile';
 import InstitutionProfile from '../components/profile/InstitutionProfile';
-import ErrorMessage from '../components/ErrorMessage';
 import environment from 'platform/utilities/environment';
+import ServiceError from '../components/ServiceError';
 
 const { Element: ScrollElement, scroller } = Scroll;
 
@@ -93,7 +93,7 @@ export class ProfilePage extends React.Component {
         className="profile-page vads-u-padding-top--3"
       >
         {profile.error && !environment.isProduction() ? (
-          <ErrorMessage />
+          <ServiceError />
         ) : (
           content
         )}

--- a/src/applications/gi/containers/ProfilePage.jsx
+++ b/src/applications/gi/containers/ProfilePage.jsx
@@ -9,6 +9,7 @@ import { fetchProfile, setPageTitle, showModal } from '../actions';
 import VetTecInstitutionProfile from '../components/vet-tec/VetTecInstitutionProfile';
 import InstitutionProfile from '../components/profile/InstitutionProfile';
 import ErrorMessage from '../components/ErrorMessage';
+import environment from 'platform/utilities/environment';
 
 const { Element: ScrollElement, scroller } = Scroll;
 
@@ -91,7 +92,11 @@ export class ProfilePage extends React.Component {
         name="profilePage"
         className="profile-page vads-u-padding-top--3"
       >
-        {profile.error ? <ErrorMessage /> : content}
+        {profile.error && !environment.isProduction() ? (
+          <ErrorMessage />
+        ) : (
+          content
+        )}
       </ScrollElement>
     );
   }

--- a/src/applications/gi/containers/SearchPage.jsx
+++ b/src/applications/gi/containers/SearchPage.jsx
@@ -4,7 +4,7 @@ import { withRouter } from 'react-router';
 import Scroll from 'react-scroll';
 import _ from 'lodash';
 import classNames from 'classnames';
-import environment from '../../../platform/utilities/environment';
+import environment from 'platform/utilities/environment';
 
 import {
   clearAutocompleteSuggestions,

--- a/src/applications/gi/containers/SearchPage.jsx
+++ b/src/applications/gi/containers/SearchPage.jsx
@@ -25,7 +25,7 @@ import Pagination from '@department-of-veterans-affairs/formation-react/Paginati
 import { getScrollOptions, focusElement } from 'platform/utilities/ui';
 import SearchResult from '../components/search/SearchResult';
 import InstitutionSearchForm from '../components/search/InstitutionSearchForm';
-import ErrorMessage from '../components/ErrorMessage';
+import ServiceError from '../components/ServiceError';
 
 const { Element: ScrollElement, scroller } = Scroll;
 
@@ -279,7 +279,7 @@ export class SearchPage extends React.Component {
       <ScrollElement name="searchPage" className="search-page">
         {/* /CT 116 */}
         {search.error && !environment.isProduction() ? (
-          <ErrorMessage />
+          <ServiceError />
         ) : (
           this.renderInstitutionSearchForm(searchResults, filtersClass)
         )}

--- a/src/applications/gi/containers/SearchPage.jsx
+++ b/src/applications/gi/containers/SearchPage.jsx
@@ -4,6 +4,7 @@ import { withRouter } from 'react-router';
 import Scroll from 'react-scroll';
 import _ from 'lodash';
 import classNames from 'classnames';
+import environment from '../../../platform/utilities/environment';
 
 import {
   clearAutocompleteSuggestions,
@@ -24,6 +25,7 @@ import Pagination from '@department-of-veterans-affairs/formation-react/Paginati
 import { getScrollOptions, focusElement } from 'platform/utilities/ui';
 import SearchResult from '../components/search/SearchResult';
 import InstitutionSearchForm from '../components/search/InstitutionSearchForm';
+import ErrorMessage from '../components/ErrorMessage';
 
 const { Element: ScrollElement, scroller } = Scroll;
 
@@ -276,7 +278,11 @@ export class SearchPage extends React.Component {
     return (
       <ScrollElement name="searchPage" className="search-page">
         {/* /CT 116 */}
-        {this.renderInstitutionSearchForm(searchResults, filtersClass)}
+        {search.error && !environment.isProduction() ? (
+          <ErrorMessage />
+        ) : (
+          this.renderInstitutionSearchForm(searchResults, filtersClass)
+        )}
       </ScrollElement>
     );
   }

--- a/src/applications/gi/containers/VetTecSearchPage.jsx
+++ b/src/applications/gi/containers/VetTecSearchPage.jsx
@@ -23,6 +23,8 @@ import { getScrollOptions, focusElement } from 'platform/utilities/ui';
 import VetTecProgramSearchResult from '../components/vet-tec/VetTecProgramSearchResult';
 import VetTecSearchForm from '../components/vet-tec/VetTecSearchForm';
 import { renderVetTecLogo } from '../utils/render';
+import environment from 'platform/utilities/environment';
+import ServiceError from '../components/ServiceError';
 
 const { Element: ScrollElement, scroller } = Scroll;
 
@@ -248,42 +250,47 @@ export class VetTecSearchPage extends React.Component {
 
     return (
       <ScrollElement name="searchPage" className="search-page">
-        <div>
-          <div className="vads-u-display--block single-column-display-none  vettec-logo-container">
-            {renderVetTecLogo(classNames('vettec-logo'))}
-          </div>
-          <div className="vads-l-row vads-u-justify-content--space-between vads-u-align-items--flex-end vads-u-margin-top--neg3">
-            <div className="vads-l-col--9 search-results-count">
-              {this.renderSearchResultsHeader(this.props.search)}
+        {search.error && !environment.isProduction() ? (
+          <ServiceError />
+        ) : (
+          <div>
+            <div className="vads-u-display--block single-column-display-none  vettec-logo-container">
+              {renderVetTecLogo(classNames('vettec-logo'))}
             </div>
-            <div className="vads-l-col--3">
-              <div className="vads-u-display--none single-column-display-block vettec-logo-container">
-                {renderVetTecLogo(classNames('vettec-logo'))}
+            <div className="vads-l-row vads-u-justify-content--space-between vads-u-align-items--flex-end vads-u-margin-top--neg3">
+              <div className="vads-l-col--9 search-results-count">
+                {this.renderSearchResultsHeader(this.props.search)}
+              </div>
+              <div className="vads-l-col--3">
+                <div className="vads-u-display--none single-column-display-block vettec-logo-container">
+                  {renderVetTecLogo(classNames('vettec-logo'))}
+                </div>
               </div>
             </div>
+
+            <VetTecSearchForm
+              filtersClass={filtersClass}
+              search={this.props.search}
+              autocomplete={this.props.autocomplete}
+              location={this.props.location}
+              clearAutocompleteSuggestions={
+                this.props.clearAutocompleteSuggestions
+              }
+              fetchAutocompleteSuggestions={this.autocomplete}
+              handleFilterChange={this.handleFilterChange}
+              handleProviderFilterChange={this.handleProviderFilterChange}
+              updateAutocompleteSearchTerm={
+                this.props.updateAutocompleteSearchTerm
+              }
+              filters={filters}
+              toggleFilter={this.props.toggleFilter}
+              searchResults={searchResults}
+              eligibility={this.props.eligibility}
+              showModal={this.props.showModal}
+              eligibilityChange={this.props.eligibilityChange}
+            />
           </div>
-          <VetTecSearchForm
-            filtersClass={filtersClass}
-            search={this.props.search}
-            autocomplete={this.props.autocomplete}
-            location={this.props.location}
-            clearAutocompleteSuggestions={
-              this.props.clearAutocompleteSuggestions
-            }
-            fetchAutocompleteSuggestions={this.autocomplete}
-            handleFilterChange={this.handleFilterChange}
-            handleProviderFilterChange={this.handleProviderFilterChange}
-            updateAutocompleteSearchTerm={
-              this.props.updateAutocompleteSearchTerm
-            }
-            filters={filters}
-            toggleFilter={this.props.toggleFilter}
-            searchResults={searchResults}
-            eligibility={this.props.eligibility}
-            showModal={this.props.showModal}
-            eligibilityChange={this.props.eligibilityChange}
-          />
-        </div>
+        )}
       </ScrollElement>
     );
   }

--- a/src/applications/gi/reducers/constants.js
+++ b/src/applications/gi/reducers/constants.js
@@ -37,6 +37,7 @@ export default function(state = INITIAL_STATE, action) {
         constants,
         version: camelPayload.meta.version,
         inProgress: false,
+        error: null,
       };
     default:
       return state;

--- a/src/applications/gi/reducers/constants.js
+++ b/src/applications/gi/reducers/constants.js
@@ -8,6 +8,7 @@ import camelCaseKeysRecursive from 'camelcase-keys-recursive';
 
 const INITIAL_STATE = {
   inProgress: false,
+  error: null,
   version: {},
 };
 
@@ -23,6 +24,7 @@ export default function(state = INITIAL_STATE, action) {
         ...state,
         ...action.err,
         inProgress: false,
+        error: action.payload,
       };
     case FETCH_CONSTANTS_SUCCEEDED:
       const camelPayload = camelCaseKeysRecursive(action.payload);

--- a/src/applications/gi/reducers/profile.js
+++ b/src/applications/gi/reducers/profile.js
@@ -11,6 +11,7 @@ const INITIAL_STATE = {
   attributes: {},
   version: {},
   inProgress: false,
+  error: null,
 };
 
 export default function(state = INITIAL_STATE, action) {
@@ -25,6 +26,7 @@ export default function(state = INITIAL_STATE, action) {
         ...state,
         ...action.err,
         inProgress: false,
+        error: action.payload,
       };
     case FETCH_PROFILE_SUCCEEDED:
       const camelPayload = camelCaseKeysRecursive(action.payload);

--- a/src/applications/gi/reducers/profile.js
+++ b/src/applications/gi/reducers/profile.js
@@ -44,6 +44,7 @@ export default function(state = INITIAL_STATE, action) {
         attributes,
         version,
         inProgress: false,
+        error: null,
       };
     default:
       return state;

--- a/src/applications/gi/reducers/search.js
+++ b/src/applications/gi/reducers/search.js
@@ -37,6 +37,7 @@ const INITIAL_STATE = {
     totalPages: 1,
   },
   inProgress: false,
+  error: null,
   filterOpened: false,
 };
 
@@ -82,6 +83,7 @@ export default function(state = INITIAL_STATE, action) {
         ...state,
         ...action.err,
         inProgress: false,
+        error: action.payload,
       };
     case INSTITUTION_SEARCH_SUCCEEDED:
       const camelPayload = camelCaseKeysRecursive(action.payload);

--- a/src/applications/gi/reducers/search.js
+++ b/src/applications/gi/reducers/search.js
@@ -99,6 +99,7 @@ export default function(state = INITIAL_STATE, action) {
         count: camelPayload.meta.count,
         version: camelPayload.meta.version,
         inProgress: false,
+        error: null,
       };
     case PROGRAM_SEARCH_SUCCEEDED:
       const programCamelPayload = camelCaseKeysRecursive(action.payload);

--- a/src/applications/gi/tests/actions/index.unit.spec.js
+++ b/src/applications/gi/tests/actions/index.unit.spec.js
@@ -176,9 +176,8 @@ describe('fetchProfile', () => {
     ).to.be.true;
 
     setTimeout(() => {
-      const { type, err } = dispatch.secondCall.args[0];
+      const { type, payload } = dispatch.secondCall.args[0];
       expect(type).to.eql(FETCH_PROFILE_FAILED);
-      expect(err instanceof Error).to.be.true;
       done();
     }, 0);
   });

--- a/src/applications/gi/tests/actions/index.unit.spec.js
+++ b/src/applications/gi/tests/actions/index.unit.spec.js
@@ -1,6 +1,8 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
+
 import {
+  mockApiRequest,
   mockFetch,
   resetFetch,
   setFetchJSONFailure as setFetchFailure,
@@ -18,8 +20,14 @@ import {
   FETCH_PROFILE_SUCCEEDED,
   fetchInstitutionAutocompleteSuggestions,
   fetchProgramAutocompleteSuggestions,
+  fetchConstants,
+  fetchInstitutionSearchResults,
   AUTOCOMPLETE_SUCCEEDED,
   AUTOCOMPLETE_FAILED,
+  FETCH_CONSTANTS_STARTED,
+  FETCH_CONSTANTS_FAILED,
+  SEARCH_STARTED,
+  SEARCH_FAILED,
 } from '../../actions/index';
 
 describe('beneficiaryZIPCodeChanged', () => {
@@ -319,5 +327,52 @@ describe('institution program autocomplete', () => {
       expect(err instanceof Error).to.be.true;
       done();
     }, 0);
+  });
+});
+
+describe('institution search', () => {
+  beforeEach(() => mockFetch());
+
+  it('should dispatch a failure action', done => {
+    const payload = 'Service Unavailable';
+    setFetchFailure(global.fetch.onFirstCall(), payload);
+
+    const dispatch = sinon.spy();
+
+    mockApiRequest(payload, false);
+    fetchInstitutionSearchResults()(dispatch)
+      .then(() => {
+        expect(dispatch.firstCall.args[0].type).to.equal(SEARCH_STARTED);
+        expect(dispatch.secondCall.args[0].type).to.equal(SEARCH_FAILED);
+        expect(payload).to.eql('Service Unavailable');
+        done();
+      })
+      .catch(done);
+  });
+});
+
+describe('constants', () => {
+  beforeEach(() => mockFetch());
+
+  it('should dispatch a failure action', done => {
+    const payload = 'Service Unavailable';
+    setFetchFailure(global.fetch.onFirstCall(), payload);
+
+    const dispatch = sinon.spy();
+
+    mockApiRequest(payload, false);
+
+    fetchConstants()(dispatch)
+      .then(() => {
+        expect(dispatch.firstCall.args[0].type).to.equal(
+          FETCH_CONSTANTS_STARTED,
+        );
+        expect(dispatch.secondCall.args[0].type).to.equal(
+          FETCH_CONSTANTS_FAILED,
+        );
+        expect(payload).to.eql('Service Unavailable');
+        done();
+      })
+      .catch(done);
   });
 });

--- a/src/applications/gi/tests/actions/index.unit.spec.js
+++ b/src/applications/gi/tests/actions/index.unit.spec.js
@@ -2,7 +2,6 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 
 import {
-  mockApiRequest,
   mockFetch,
   resetFetch,
   setFetchJSONFailure as setFetchFailure,
@@ -334,20 +333,24 @@ describe('institution search', () => {
   beforeEach(() => mockFetch());
 
   it('should dispatch a failure action', done => {
-    const payload = 'Service Unavailable';
-    setFetchFailure(global.fetch.onFirstCall(), payload);
+    const error = { test: 'test' };
+    setFetchFailure(global.fetch.onFirstCall(), error);
 
     const dispatch = sinon.spy();
 
-    mockApiRequest(payload, false);
-    fetchInstitutionSearchResults()(dispatch)
-      .then(() => {
-        expect(dispatch.firstCall.args[0].type).to.equal(SEARCH_STARTED);
-        expect(dispatch.secondCall.args[0].type).to.equal(SEARCH_FAILED);
-        expect(payload).to.eql('Service Unavailable');
-        done();
-      })
-      .catch(done);
+    fetchInstitutionSearchResults('@@', {})(dispatch);
+
+    expect(dispatch.firstCall.args[0].type).to.equal(SEARCH_STARTED);
+
+    setTimeout(() => {
+      const { payload } = dispatch.secondCall.args[0];
+
+      expect(dispatch.secondCall.args[0]).to.eql({
+        type: SEARCH_FAILED,
+        payload: payload,
+      });
+      done();
+    }, 0);
   });
 });
 
@@ -355,24 +358,23 @@ describe('constants', () => {
   beforeEach(() => mockFetch());
 
   it('should dispatch a failure action', done => {
-    const payload = 'Service Unavailable';
-    setFetchFailure(global.fetch.onFirstCall(), payload);
+    const error = { test: 'test' };
+    setFetchFailure(global.fetch.onFirstCall(), error);
 
     const dispatch = sinon.spy();
 
-    mockApiRequest(payload, false);
+    fetchConstants('test')(dispatch);
 
-    fetchConstants()(dispatch)
-      .then(() => {
-        expect(dispatch.firstCall.args[0].type).to.equal(
-          FETCH_CONSTANTS_STARTED,
-        );
-        expect(dispatch.secondCall.args[0].type).to.equal(
-          FETCH_CONSTANTS_FAILED,
-        );
-        expect(payload).to.eql('Service Unavailable');
-        done();
-      })
-      .catch(done);
+    expect(dispatch.firstCall.args[0].type).to.equal(FETCH_CONSTANTS_STARTED);
+
+    setTimeout(() => {
+      const { payload } = dispatch.secondCall.args[0];
+
+      expect(dispatch.secondCall.args[0]).to.eql({
+        type: FETCH_CONSTANTS_FAILED,
+        payload: payload,
+      });
+      done();
+    }, 0);
   });
 });

--- a/src/applications/gi/tests/actions/index.unit.spec.js
+++ b/src/applications/gi/tests/actions/index.unit.spec.js
@@ -176,7 +176,7 @@ describe('fetchProfile', () => {
     ).to.be.true;
 
     setTimeout(() => {
-      const { type, payload } = dispatch.secondCall.args[0];
+      const { type } = dispatch.secondCall.args[0];
       expect(type).to.eql(FETCH_PROFILE_FAILED);
       done();
     }, 0);

--- a/src/applications/gi/tests/actions/index.unit.spec.js
+++ b/src/applications/gi/tests/actions/index.unit.spec.js
@@ -347,7 +347,7 @@ describe('institution search', () => {
 
       expect(dispatch.secondCall.args[0]).to.eql({
         type: SEARCH_FAILED,
-        payload: payload,
+        payload,
       });
       done();
     }, 0);
@@ -372,7 +372,7 @@ describe('constants', () => {
 
       expect(dispatch.secondCall.args[0]).to.eql({
         type: FETCH_CONSTANTS_FAILED,
-        payload: payload,
+        payload,
       });
       done();
     }, 0);

--- a/src/applications/gi/tests/containers/GiBillApp.unit.spec.js
+++ b/src/applications/gi/tests/containers/GiBillApp.unit.spec.js
@@ -42,4 +42,19 @@ describe('<GiBillApp>', () => {
     );
     expect(tree.subTree('LoadingIndicator')).to.be.ok;
   });
+
+  it('should render error message when constants fail', () => {
+    const errorProps = {
+      ...defaultProps,
+      constants: {
+        ...defaultProps.constants,
+        inProgress: true,
+        error: 'Service Unavailable',
+      },
+    };
+    const tree = SkinDeep.shallowRender(
+      <GiBillApp {...errorProps} location={location} params={params} />,
+    );
+    expect(tree.subTree('ErrorMessage')).to.be.ok;
+  });
 });

--- a/src/applications/gi/tests/containers/GiBillApp.unit.spec.js
+++ b/src/applications/gi/tests/containers/GiBillApp.unit.spec.js
@@ -55,6 +55,6 @@ describe('<GiBillApp>', () => {
     const tree = SkinDeep.shallowRender(
       <GiBillApp {...errorProps} location={location} params={params} />,
     );
-    expect(tree.subTree('ErrorMessage')).to.be.ok;
+    expect(tree.subTree('ServiceError')).to.be.ok;
   });
 });

--- a/src/applications/gi/tests/containers/ProfilePage.unit.spec.js
+++ b/src/applications/gi/tests/containers/ProfilePage.unit.spec.js
@@ -44,4 +44,13 @@ describe('<ProfilePage>', () => {
     expect(vdom).to.not.be.undefined;
     expect(tree.subTree('LoadingIndicator')).to.be.ok;
   });
+
+  it('should show error message when profile failed', () => {
+    const errorProps = {
+      ...defaultProps,
+      profile: { inProgress: true, error: 'Service Unavailable' },
+    };
+    const tree = SkinDeep.shallowRender(<ProfilePage {...errorProps} />);
+    expect(tree.subTree('ErrorMessage')).to.be.ok;
+  });
 });

--- a/src/applications/gi/tests/containers/ProfilePage.unit.spec.js
+++ b/src/applications/gi/tests/containers/ProfilePage.unit.spec.js
@@ -51,6 +51,6 @@ describe('<ProfilePage>', () => {
       profile: { inProgress: true, error: 'Service Unavailable' },
     };
     const tree = SkinDeep.shallowRender(<ProfilePage {...errorProps} />);
-    expect(tree.subTree('ErrorMessage')).to.be.ok;
+    expect(tree.subTree('ServiceError')).to.be.ok;
   });
 });

--- a/src/applications/gi/tests/containers/SearchPage.unit.spec.js
+++ b/src/applications/gi/tests/containers/SearchPage.unit.spec.js
@@ -4,6 +4,7 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import { mount, shallow } from 'enzyme';
 import { Provider } from 'react-redux';
+import { SkinDeep } from 'skin-deep';
 
 import createCommonStore from '../../../../platform/startup/store';
 import { SearchPage } from '../../containers/SearchPage';
@@ -70,6 +71,24 @@ describe('<SearchPage>', () => {
     expect(defaultProps.setPageTitle.called).to.be.true;
     tree.unmount();
   });
+});
+
+it('should render error message', () => {
+  const props = {
+    ...defaultProps,
+    search: {
+      ...defaultProps.search,
+      inProgress: true,
+      error: 'Service Unavailable',
+    },
+  };
+  const tree = mount(
+    <Provider store={defaultStore}>
+      <SearchPage {...props} />
+    </Provider>,
+  );
+
+  expect(tree.find('ErrorMessage')).to.be.ok;
 });
 
 describe('<SearchPage> functions', () => {

--- a/src/applications/gi/tests/containers/SearchPage.unit.spec.js
+++ b/src/applications/gi/tests/containers/SearchPage.unit.spec.js
@@ -87,7 +87,7 @@ it('should render error message', () => {
     </Provider>,
   );
 
-  expect(tree.find('ErrorMessage')).to.be.ok;
+  expect(tree.find('ServiceError')).to.be.ok;
   tree.unmount();
 });
 

--- a/src/applications/gi/tests/containers/SearchPage.unit.spec.js
+++ b/src/applications/gi/tests/containers/SearchPage.unit.spec.js
@@ -4,7 +4,6 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import { mount, shallow } from 'enzyme';
 import { Provider } from 'react-redux';
-import { SkinDeep } from 'skin-deep';
 
 import createCommonStore from '../../../../platform/startup/store';
 import { SearchPage } from '../../containers/SearchPage';
@@ -89,6 +88,7 @@ it('should render error message', () => {
   );
 
   expect(tree.find('ErrorMessage')).to.be.ok;
+  tree.unmount();
 });
 
 describe('<SearchPage> functions', () => {

--- a/src/applications/gi/tests/reducers/constants.unit.spec.js
+++ b/src/applications/gi/tests/reducers/constants.unit.spec.js
@@ -18,15 +18,15 @@ describe('constants reducer', () => {
 
   it('should handle fetch failed', () => {
     const state = constantsReducer(
-      { inProgress: true, error: 'Status Unavailible' },
+      { inProgress: true },
       {
         type: 'FETCH_CONSTANTS_FAILED',
-        payload: 'Status Unavailible',
+        payload: 'Service Unavailible',
       },
     );
 
     expect(state.inProgress).to.eql(false);
-    expect(state.error).to.eql('Status Unavailible');
+    expect(state.error).to.eql('Service Unavailible');
   });
 
   it('should handle fetch succeeded', () => {

--- a/src/applications/gi/tests/reducers/constants.unit.spec.js
+++ b/src/applications/gi/tests/reducers/constants.unit.spec.js
@@ -21,12 +21,12 @@ describe('constants reducer', () => {
       { inProgress: true },
       {
         type: 'FETCH_CONSTANTS_FAILED',
-        payload: 'Service Unavailible',
+        payload: 'Service Unavailable',
       },
     );
 
     expect(state.inProgress).to.eql(false);
-    expect(state.error).to.eql('Service Unavailible');
+    expect(state.error).to.eql('Service Unavailable');
   });
 
   it('should handle fetch succeeded', () => {

--- a/src/applications/gi/tests/reducers/constants.unit.spec.js
+++ b/src/applications/gi/tests/reducers/constants.unit.spec.js
@@ -18,17 +18,15 @@ describe('constants reducer', () => {
 
   it('should handle fetch failed', () => {
     const state = constantsReducer(
-      { inProgress: true },
+      { inProgress: true, error: 'Status Unavailible' },
       {
         type: 'FETCH_CONSTANTS_FAILED',
-        err: {
-          errorMessage: 'error',
-        },
+        payload: 'Status Unavailible',
       },
     );
 
     expect(state.inProgress).to.eql(false);
-    expect(state.errorMessage).to.eql('error');
+    expect(state.error).to.eql('Status Unavailible');
   });
 
   it('should handle fetch succeeded', () => {

--- a/src/applications/gi/tests/reducers/profile.unit.spec.js
+++ b/src/applications/gi/tests/reducers/profile.unit.spec.js
@@ -19,16 +19,14 @@ describe('profile reducer', () => {
 
   it('should handle profile fetch failure', () => {
     const state = profileReducer(
-      { inProgress: true },
+      { inProgress: true, error: 'Status Unavailible' },
       {
         type: 'FETCH_PROFILE_FAILED',
-        err: {
-          errorMessage: 'error',
-        },
+        payload: 'Status Unavailible',
       },
     );
 
-    expect(state.errorMessage).to.eql('error');
+    expect(state.error).to.eql('Status Unavailible');
     expect(state.inProgress).to.eql(false);
   });
 

--- a/src/applications/gi/tests/reducers/profile.unit.spec.js
+++ b/src/applications/gi/tests/reducers/profile.unit.spec.js
@@ -19,14 +19,14 @@ describe('profile reducer', () => {
 
   it('should handle profile fetch failure', () => {
     const state = profileReducer(
-      { inProgress: true, error: 'Status Unavailible' },
+      { inProgress: true },
       {
         type: 'FETCH_PROFILE_FAILED',
-        payload: 'Status Unavailible',
+        payload: 'Service Unavailible',
       },
     );
 
-    expect(state.error).to.eql('Status Unavailible');
+    expect(state.error).to.eql('Service Unavailible');
     expect(state.inProgress).to.eql(false);
   });
 

--- a/src/applications/gi/tests/reducers/profile.unit.spec.js
+++ b/src/applications/gi/tests/reducers/profile.unit.spec.js
@@ -22,11 +22,11 @@ describe('profile reducer', () => {
       { inProgress: true },
       {
         type: 'FETCH_PROFILE_FAILED',
-        payload: 'Service Unavailible',
+        payload: 'Service Unavailable',
       },
     );
 
-    expect(state.error).to.eql('Service Unavailible');
+    expect(state.error).to.eql('Service Unavailable');
     expect(state.inProgress).to.eql(false);
   });
 

--- a/src/applications/gi/tests/reducers/search.unit.spec.js
+++ b/src/applications/gi/tests/reducers/search.unit.spec.js
@@ -27,7 +27,7 @@ describe('search reducer', () => {
 
   it('should set correct state on failure', () => {
     const state = searchReducer(
-      { inProgress: true, error: 'Service Unavailible' },
+      { inProgress: true },
       {
         type: 'SEARCH_FAILED',
         payload: 'Service Unavailible',

--- a/src/applications/gi/tests/reducers/search.unit.spec.js
+++ b/src/applications/gi/tests/reducers/search.unit.spec.js
@@ -30,12 +30,12 @@ describe('search reducer', () => {
       { inProgress: true },
       {
         type: 'SEARCH_FAILED',
-        payload: 'Service Unavailible',
+        payload: 'Service Unavailable',
       },
     );
 
     expect(state.inProgress).to.eql(false);
-    expect(state.error).to.eql('Service Unavailible');
+    expect(state.error).to.eql('Service Unavailable');
   });
 
   it('should set correct state on institution search success', () => {

--- a/src/applications/gi/tests/reducers/search.unit.spec.js
+++ b/src/applications/gi/tests/reducers/search.unit.spec.js
@@ -27,17 +27,15 @@ describe('search reducer', () => {
 
   it('should set correct state on failure', () => {
     const state = searchReducer(
-      { inProgress: true },
+      { inProgress: true, error: 'Service Unavailible' },
       {
         type: 'SEARCH_FAILED',
-        err: {
-          errorMessage: 'error message',
-        },
+        payload: 'Service Unavailible',
       },
     );
 
     expect(state.inProgress).to.eql(false);
-    expect(state.errorMessage).to.eql('error message');
+    expect(state.error).to.eql('Service Unavailible');
   });
 
   it('should set correct state on institution search success', () => {


### PR DESCRIPTION
## Description
The GI Bill Comparison Tool currently handles an outage or timeout of the GIDS service by endlessly spinning, so this story seeks to provide those using the CT with an error message letting them know what they need to do.

https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/6662

## Testing done
Local testing completed

## Screenshots
Landing:
![Screen Shot 2020-03-18 at 11 48 26 PM](https://user-images.githubusercontent.com/50601724/77030746-05a55480-6976-11ea-9516-0f899e0807ce.png)
Search:
![Screen Shot 2020-03-18 at 11 47 35 PM](https://user-images.githubusercontent.com/50601724/77030762-1786f780-6976-11ea-91f9-fd42414261eb.png)

Profile:
![Screen Shot 2020-03-19 at 7 27 53 AM](https://user-images.githubusercontent.com/50601724/77062929-35bf1880-69b3-11ea-8145-42bfd189a8d5.png)



## Acceptance criteria
- [x] When the GI Bill Comparison Tool experiences an outage or timeout of the GIDS service, the following alert is displayed: We’re sorry. Something went wrong on our end. Please refresh this page or try again later.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs