### PR TITLE
[CMS] Change H3 to H2

### DIFF
--- a/src/site/layouts/landing_page.drupal.liquid
+++ b/src/site/layouts/landing_page.drupal.liquid
@@ -22,7 +22,7 @@
           <p>{{ fieldIntroText }}</p>
         </div>
         {% if fieldSpokes != empty and fieldSpokes.length > 1 %}
-        <h3>On this page</h3>
+        <h2 class="vads-u-margin-bottom--2 vads-u-font-size--lg">On this page</h2>
         <ul>
           {% for spoke in fieldSpokes %}
           <li>


### PR DESCRIPTION
## Description
This PR fixes a 508 issue on pages like `/disability/` where the `On this page` heading should be an h2, not an h3.

https://github.com/department-of-veterans-affairs/va.gov-team/issues/6338

## Testing done
Inspected the element on `/disability/`

## Screenshots
<details><summary>inspector</summary>

![image](https://user-images.githubusercontent.com/1915775/77173079-5b245300-6a95-11ea-8e9c-e47bb511e031.png)

</details>

## Acceptance criteria
- [ ] Markup is semantic

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
