### PR TITLE
[CMS template] Fix for empty heading

### DIFF
--- a/src/site/paragraphs/list_of_link_teasers.drupal.liquid
+++ b/src/site/paragraphs/list_of_link_teasers.drupal.liquid
@@ -15,11 +15,13 @@
     {% assign ulClass = "va-nav-linkslist-list" %}
 {% endif %}
 <section class="{{ entity.parentFieldName }}">
-    <{{ header }}
-        {% if entity.fieldTitle != empty %}id="{{ entity.fieldTitle | hashReference }}"{% endif %}
-        class="{{ headerClass }}">
-        {{ entity.fieldTitle }}
-    </{{ header }}>
+    {% if entity.fieldTitle != empty %}
+      <{{ header }}
+          id="{{ entity.fieldTitle | hashReference }}"
+          class="{{ headerClass }}">
+          {{ entity.fieldTitle }}
+      </{{ header }}>
+    {% endif %}
     <ul class="{{ ulClass }}">
         {% for linkTeaser in entity.fieldVaParagraphs %}
             {% include "src/site/paragraphs/linkTeaser.drupal.liquid" linkTeaser = linkTeaser.entity parentFieldName = parentFieldName boldTitle = boldTitle %}


### PR DESCRIPTION
## Description
This PR fixes an issue where there are empty heading tags on pages like `/disability/after-you-file-claim/`.

https://github.com/department-of-veterans-affairs/va.gov-team/issues/6371

## Testing done
Looked at page source after template change

## Screenshots
<details><summary>Issue</summary>

![image](https://user-images.githubusercontent.com/1915775/77185412-c119d600-6aa7-11ea-9e18-a46e0a46a3b4.png)


</details>

<details><summary>Fixed</summary>

![image](https://user-images.githubusercontent.com/1915775/77185581-08a06200-6aa8-11ea-80e8-f178d4ee470b.png)


</details>

## Acceptance criteria
- [x] No more empty heading

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
