### PR TITLE
Add CSRF protection for API requests

### DIFF
--- a/src/platform/utilities/api/index.js
+++ b/src/platform/utilities/api/index.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 import environment from '../environment';
 import localStorage from '../storage/localStorage';
 import { checkAndUpdateSSOeSession } from './ssoHelpers';
+import Cookies from 'js-cookie';
 
 export function fetchAndUpdateSessionExpiration(...args) {
   // Only replace with custom fetch if not stubbed for unit testing
@@ -49,6 +50,7 @@ function isJson(response) {
 export function apiRequest(resource, optionalSettings = {}, success, error) {
   const baseUrl = `${environment.API_URL}/v0`;
   const url = resource[0] === '/' ? [baseUrl, resource].join('') : resource;
+  const csrfToken = Cookies.get('X-CSRF-Token');
 
   if (success) {
     // eslint-disable-next-line no-console
@@ -70,6 +72,7 @@ export function apiRequest(resource, optionalSettings = {}, success, error) {
     headers: {
       'X-Key-Inflection': 'camel',
       'Source-App-Name': window.appName,
+      'X-CSRF-Token': csrfToken,
     },
   };
 


### PR DESCRIPTION
## Description

This PR complements the implementation done by the backend team to prevent a CSRF attack when submitting a form using our API (`vets-api`).

A cookie is expected from the API. This cookie needs to be created and resubmitted with its contents throughout the HTTP header for every API call.

Backend implementation can be found [here](https://github.com/department-of-veterans-affairs/vets-api/pull/3982)

## Epics

- [Main Ticket](https://github.com/department-of-veterans-affairs/va.gov-team-sensitive/issues/42)
- [FE Ticket # 62](https://github.com/department-of-veterans-affairs/va.gov-team-sensitive/issues/62)
- [BE Ticket # 61](https://github.com/department-of-veterans-affairs/va.gov-team-sensitive/issues/61)

## Testing done
Locally

## Screenshots

<details><summary>Response Headers from API</summary>

<!-- leave a blank line above -->
![Response Headers](https://user-images.githubusercontent.com/55560129/77185213-6bddc480-6aa7-11ea-8c64-abf42f3d9851.png)
</details>

<details><summary>X-CSRF-Token Cookie created</summary>

<!-- leave a blank line above -->
![X-CSRF-Token Cookie](https://user-images.githubusercontent.com/55560129/77185287-8ca61a00-6aa7-11ea-97a2-e83cfcce658b.png)
</details>

<details><summary>Request Headers</summary>

<!-- leave a blank line above -->
![Request Headers](https://user-images.githubusercontent.com/55560129/77185476-dc84e100-6aa7-11ea-905e-683e687846c7.png)
</details>

## Acceptance criteria
- [x] Create `X-CSRF-Token` Cookie
- [x] Submit `X-CSRF-Token` contents throughout the HTTP header
- [ ] Review instance testing