### PR TITLE
[Templates] Switch <aside> to <div>

### DIFF
--- a/src/site/components/navigation-links-list.html
+++ b/src/site/components/navigation-links-list.html
@@ -29,7 +29,7 @@ See https://help.shopify.com/themes/liquid/tags/theme-tags#include
 
 <div class="row">
   <div class="usa-content columns">
-    <aside class="va-nav-linkslist {% if isRelated %}va-nav-linkslist--related{% endif %}">
+    <div class="va-nav-linkslist {% if isRelated %}va-nav-linkslist--related{% endif %}">
     {% for group in linklist %}
 
       {% comment %}
@@ -66,6 +66,6 @@ See https://help.shopify.com/themes/liquid/tags/theme-tags#include
     {% if link.heading != empty %}
       </section>
     {% endif %}
-    </aside>
+    </div>
   </div>
 </div>

--- a/src/site/layouts/page.drupal.liquid
+++ b/src/site/layouts/page.drupal.liquid
@@ -54,9 +54,9 @@
         {% if fieldRelatedLinks != empty %}
         <div class="row">
           <div class="usa-content columns">
-            <aside class="va-nav-linkslist va-nav-linkslist--related">
+            <div class="va-nav-linkslist va-nav-linkslist--related">
               {% include 'src/site/paragraphs/list_of_link_teasers.drupal.liquid' entity = fieldRelatedLinks.entity %}
-            </aside>
+            </div>
           </div>
         </div>
         {%  endif %}


### PR DESCRIPTION
## Description
This PR swaps out the `aside` element with a `div` in the Related Links sections.

https://github.com/department-of-veterans-affairs/va.gov-team/issues/6379

## Testing done
Visually checked the element after changing to div

## Screenshots

<details>
<summary>Aside element</summary>

![image](https://user-images.githubusercontent.com/1915775/77187345-b3198480-6aaa-11ea-957a-9fa2d02bf04b.png)

</details>

## Acceptance criteria
- [x] Landmark is not ignored by screenreader

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
