### PR TITLE
Conditionally hide state and city

### DIFF
--- a/src/applications/yellow-ribbon/containers/SearchForm/index.jsx
+++ b/src/applications/yellow-ribbon/containers/SearchForm/index.jsx
@@ -162,7 +162,7 @@ export class SearchForm extends Component {
             >
               <option value="">- Select -</option>
               {map(
-                [{ label: 'United States of America', value: 'USA' }],
+                [{ label: 'United States', value: 'USA' }],
                 countryOption => (
                   <option
                     key={countryOption?.value}

--- a/src/applications/yellow-ribbon/containers/SearchForm/index.jsx
+++ b/src/applications/yellow-ribbon/containers/SearchForm/index.jsx
@@ -166,41 +166,48 @@ export class SearchForm extends Component {
           </select>
         </div>
 
-        {/* State Field */}
-        <label htmlFor="yr-search-state" className="vads-u-margin-top--3">
-          State or Territory
-        </label>
-        <div className="vads-u-flex--1">
-          <select
-            name="yr-search-state"
-            onChange={onStateChange('state')}
-            value={state}
-          >
-            <option value="">- Select -</option>
-            {map(STATES, provincialState => (
-              <option key={provincialState?.code} value={provincialState?.code}>
-                {provincialState?.label}
-              </option>
-            ))}
-          </select>
-        </div>
+        {country && (
+          <>
+            {/* State Field */}
+            <label htmlFor="yr-search-state" className="vads-u-margin-top--3">
+              State or Territory
+            </label>
+            <div className="vads-u-flex--1">
+              <select
+                name="yr-search-state"
+                onChange={onStateChange('state')}
+                value={state}
+              >
+                <option value="">- Select -</option>
+                {map(STATES, provincialState => (
+                  <option
+                    key={provincialState?.code}
+                    value={provincialState?.code}
+                  >
+                    {provincialState?.label}
+                  </option>
+                ))}
+              </select>
+            </div>
 
-        {/* City Field */}
-        <label
-          htmlFor="yr-search-city"
-          className="vads-u-margin-top--1 vads-u-margin--0"
-        >
-          City
-        </label>
-        <div className="vads-u-flex--1">
-          <input
-            className="usa-input"
-            name="yr-search-city"
-            onChange={onStateChange('city')}
-            type="text"
-            value={city}
-          />
-        </div>
+            {/* City Field */}
+            <label
+              htmlFor="yr-search-city"
+              className="vads-u-margin-top--3 vads-u-margin--0"
+            >
+              City
+            </label>
+            <div className="vads-u-flex--1">
+              <input
+                className="usa-input"
+                name="yr-search-city"
+                onChange={onStateChange('city')}
+                type="text"
+                value={city}
+              />
+            </div>
+          </>
+        )}
 
         {/* Unlimited Contribution Amount */}
         <ErrorableCheckbox

--- a/src/applications/yellow-ribbon/containers/SearchForm/index.jsx
+++ b/src/applications/yellow-ribbon/containers/SearchForm/index.jsx
@@ -3,6 +3,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import URLSearchParams from 'url-search-params';
+import classNames from 'classnames';
 import map from 'lodash/map';
 // Relative imports.
 import ErrorableCheckbox from '@department-of-veterans-affairs/formation-react/ErrorableCheckbox';
@@ -144,70 +145,79 @@ export class SearchForm extends Component {
           />
         </div>
 
-        {/* Country Field */}
-        <label htmlFor="yr-search-country" className="vads-u-margin-top--3">
-          Country
-        </label>
-        <div className="vads-u-flex--1">
-          <select
-            name="yr-search-country"
-            onChange={onStateChange('country')}
-            value={country}
-          >
-            <option value="">- Select -</option>
-            {map(
-              [{ label: 'United States of America', value: 'USA' }],
-              countryOption => (
-                <option key={countryOption?.value} value={countryOption?.value}>
-                  {countryOption?.label}
-                </option>
-              ),
-            )}
-          </select>
-        </div>
-
-        {country && (
-          <>
-            {/* State Field */}
-            <label htmlFor="yr-search-state" className="vads-u-margin-top--3">
-              State or Territory
-            </label>
-            <div className="vads-u-flex--1">
-              <select
-                name="yr-search-state"
-                onChange={onStateChange('state')}
-                value={state}
-              >
-                <option value="">- Select -</option>
-                {map(STATES, provincialState => (
-                  <option
-                    key={provincialState?.code}
-                    value={provincialState?.code}
-                  >
-                    {provincialState?.label}
-                  </option>
-                ))}
-              </select>
-            </div>
-
-            {/* City Field */}
-            <label
-              htmlFor="yr-search-city"
-              className="vads-u-margin-top--3 vads-u-margin--0"
+        <div
+          className={classNames('form-expanding-group', {
+            'form-expanding-group-open': country,
+          })}
+        >
+          {/* Country Field */}
+          <label htmlFor="yr-search-country" className="vads-u-margin-top--3">
+            Country
+          </label>
+          <div className="vads-u-flex--1">
+            <select
+              name="yr-search-country"
+              onChange={onStateChange('country')}
+              value={country}
             >
-              City
-            </label>
-            <div className="vads-u-flex--1">
-              <input
-                className="usa-input"
-                name="yr-search-city"
-                onChange={onStateChange('city')}
-                type="text"
-                value={city}
-              />
-            </div>
-          </>
-        )}
+              <option value="">- Select -</option>
+              {map(
+                [{ label: 'United States of America', value: 'USA' }],
+                countryOption => (
+                  <option
+                    key={countryOption?.value}
+                    value={countryOption?.value}
+                  >
+                    {countryOption?.label}
+                  </option>
+                ),
+              )}
+            </select>
+          </div>
+
+          {country && (
+            <>
+              {/* State Field */}
+              <label htmlFor="yr-search-state" className="vads-u-margin-top--3">
+                State or Territory
+              </label>
+              <div className="vads-u-flex--1">
+                <select
+                  name="yr-search-state"
+                  onChange={onStateChange('state')}
+                  value={state}
+                >
+                  <option value="">- Select -</option>
+                  {map(STATES, provincialState => (
+                    <option
+                      key={provincialState?.code}
+                      value={provincialState?.code}
+                    >
+                      {provincialState?.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
+
+              {/* City Field */}
+              <label
+                htmlFor="yr-search-city"
+                className="vads-u-margin-top--3 vads-u-margin--0"
+              >
+                City
+              </label>
+              <div className="vads-u-flex--1">
+                <input
+                  className="usa-input"
+                  name="yr-search-city"
+                  onChange={onStateChange('city')}
+                  type="text"
+                  value={city}
+                />
+              </div>
+            </>
+          )}
+        </div>
 
         {/* Unlimited Contribution Amount */}
         <ErrorableCheckbox

--- a/src/applications/yellow-ribbon/containers/SearchForm/index.unit.spec.jsx
+++ b/src/applications/yellow-ribbon/containers/SearchForm/index.unit.spec.jsx
@@ -12,8 +12,8 @@ describe('Yellow Ribbon container <SearchForm>', () => {
     const input = tree.find('input');
     const select = tree.find('select');
 
-    expect(input.length).to.be.equal(2);
-    expect(select.length).to.be.equal(2);
+    expect(input.length).to.be.equal(1);
+    expect(select.length).to.be.equal(1);
     tree.unmount();
   });
 


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/6668

This PR conditionally renders `state` and `city` fields based on whether there's a value for `country`.

## Testing done


## Screenshots
Without `country` value:

![image](https://user-images.githubusercontent.com/12773166/77190218-76e02700-6a9e-11ea-96bc-b10ca55255ce.png)

With `country` value:

![image](https://user-images.githubusercontent.com/12773166/77200683-b152bf80-6ab0-11ea-8dfb-63d8c3bbbb42.png)

## Acceptance criteria
- [x] conditionally render `state` and `city` fields based on whether there's a value for `country`

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
