### PR TITLE
bradl3yC - 7054 - Correct address val analytics payload

### DIFF
--- a/src/platform/user/profile/vet360/actions/transactions.js
+++ b/src/platform/user/profile/vet360/actions/transactions.js
@@ -247,8 +247,6 @@ export const validateAddress = (
       ...confirmedSuggestions[0],
     };
 
-    const selectedAddressId = confirmedSuggestions.length > 0 ? '0' : null;
-
     // always select first address as default if there are any
     let selectedAddress = confirmedSuggestions[0];
 
@@ -261,6 +259,11 @@ export const validateAddress = (
     // to show the modal because the only time we will skip the modal is if one
     // and only one confirmed address came back from the API
     const showModal = showAddressValidationModal(suggestedAddresses);
+
+    let selectedAddressId = null;
+    if (showModal) {
+      selectedAddressId = confirmedSuggestions.length > 0 ? '0' : 'userEntered';
+    }
 
     // push data to dataLayer for analytics
     recordEvent({

--- a/src/platform/user/profile/vet360/components/base/Vet360EditModal.jsx
+++ b/src/platform/user/profile/vet360/components/base/Vet360EditModal.jsx
@@ -19,7 +19,7 @@ export default class Vet360EditModal extends React.Component {
     hasValidationError: PropTypes.func,
     isEmpty: PropTypes.bool.isRequired,
     onCancel: PropTypes.func.isRequired,
-    onChange: PropTypes.func.isRequired,
+    onChangeFormDataAndSchemas: PropTypes.func.isRequired,
     onDelete: PropTypes.func.isRequired,
     onSubmit: PropTypes.func.isRequired,
     render: PropTypes.func.isRequired,


### PR DESCRIPTION
## Description
Currently the analytics output is showing more suggested addresses used than were presented - this should not be possible.  It is being caused by an incorrect value in redux state being set.  That has been corrected and now the payload to analytics has been corrected as well.

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
