### PR TITLE
Add SSO announcement info modal

### DIFF
--- a/src/platform/site-wide/announcements/README.md
+++ b/src/platform/site-wide/announcements/README.md
@@ -40,7 +40,7 @@ The Announcement entry point uses React to bind to an element above the footer o
 ## E2E Tests
 Announcements are disabled during E2E tests for two reasons -
 
-1. Philosophically, because they change overtime while E2E tests should run consistently.
+1. Philosophically, because they change over time, while E2E tests should run consistently.
 2. Functionally, because it is likely that announcements will use "position: fixed" in their style, which will interrupt Nightwatch's browser focus while tests are running and break things.
 
 The helper for disabling announcements is named `disableAnnouncements` and is located in `platform/testing/e2e/helpers.js`.

--- a/src/platform/site-wide/announcements/components/SingleSignOnInfoModal.jsx
+++ b/src/platform/site-wide/announcements/components/SingleSignOnInfoModal.jsx
@@ -3,7 +3,7 @@ import Modal from '@department-of-veterans-affairs/formation-react/Modal';
 import { hasSessionSSO } from 'platform/user/profile/utilities';
 
 export default function SingleSignOnInfoModal({ dismiss, isLoggedIn }) {
-  if (!isLoggedIn && !hasSessionSSO()) return null;
+  if (!isLoggedIn || !hasSessionSSO()) return null;
 
   return (
     <Modal visible onClose={dismiss} id="modal-announcment">

--- a/src/platform/site-wide/announcements/components/SingleSignOnInfoModal.jsx
+++ b/src/platform/site-wide/announcements/components/SingleSignOnInfoModal.jsx
@@ -11,7 +11,7 @@ export default function SingleSignOnInfoModal({ dismiss, isLoggedIn }) {
         Sign in once to access the VA sites you use most
       </h1>
       <p>
-        Now when you sign into VA.gov, we'll also sign you into MyHealtheVet ,
+        Now when you sign into VA.gov, we’ll also sign you into MyHealtheVet,
         eBenefits, and other VA sites.
       </p>
       <p>
@@ -30,10 +30,6 @@ export default function SingleSignOnInfoModal({ dismiss, isLoggedIn }) {
       <button type="button" onClick={dismiss}>
         Continue to VA.gov
       </button>
-      <p>
-        Get answers to{' '}
-        <a href="/sign-in-faq">frequently asked questions about singing in</a>.
-      </p>
     </Modal>
   );
 }

--- a/src/platform/site-wide/announcements/components/SingleSignOnInfoModal.jsx
+++ b/src/platform/site-wide/announcements/components/SingleSignOnInfoModal.jsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import Modal from '@department-of-veterans-affairs/formation-react/Modal';
+import { hasSessionSSO } from 'platform/user/profile/utilities';
+
+export default function SingleSignOnInfoModal({ dismiss, isLoggedIn }) {
+  if (!isLoggedIn && !hasSessionSSO()) return null;
+
+  return (
+    <Modal visible onClose={dismiss} id="modal-announcment">
+      <h1 className="vads-u-font-size--h3 vads-u-margin-top--2">
+        Sign in once to access the VA sites you use most
+      </h1>
+      <p>
+        Now when you sign into VA.gov, we'll also sign you into MyHealtheVet ,
+        eBenefits, and other VA sites.
+      </p>
+      <p>
+        <strong>With a single sign on, you can:</strong>
+      </p>
+      <ul>
+        <li>
+          Track and manage your VA benefits and services with just one username
+          and password
+        </li>
+        <li>
+          Access the VA sites you use most without having to sign in each time
+        </li>
+        <li>Sign out of VA.gov and be signed out of other VA sites</li>
+      </ul>
+      <button type="button" onClick={dismiss}>
+        Continue to VA.gov
+      </button>
+      <p>
+        Get answers to{' '}
+        <a href="/sign-in-faq">frequently asked questions about singing in</a>.
+      </p>
+    </Modal>
+  );
+}

--- a/src/platform/site-wide/announcements/config/index.js
+++ b/src/platform/site-wide/announcements/config/index.js
@@ -67,11 +67,6 @@ const config = {
       component: WelcomeToNewVAModal,
     },
     {
-      name: 'single-sign-on-intro',
-      paths: /(.)/,
-      component: SingleSignOnInfoModal,
-    },
-    {
       name: 'welcome-to-new-vaos',
       paths: /^\/health-care\/schedule-view-va-appointments\/appointments\/$/,
       component: WelcomeVAOSModal,
@@ -98,6 +93,11 @@ const config = {
       name: 'personalization',
       paths: /(.)/,
       component: PersonalizationBanner,
+    },
+    {
+      name: 'single-sign-on-intro',
+      paths: /(.)/,
+      component: SingleSignOnInfoModal,
     },
   ],
 };

--- a/src/platform/site-wide/announcements/config/index.js
+++ b/src/platform/site-wide/announcements/config/index.js
@@ -8,6 +8,7 @@ import PersonalizationBanner from '../components/PersonalizationBanner';
 import PreDowntime from '../components/PreDowntime';
 import PrePreDowntime from '../components/PrePreDowntime';
 import Profile360Intro from '../components/Profile360Intro';
+import SingleSignOnInfoModal from '../components/SingleSignOnInfoModal';
 import VAMCWelcomeModal, { VAMC_PATHS } from '../components/VAMCWelcomeModal';
 import VAPlusVetsModal from '../components/VAPlusVetsModal';
 import WelcomeToNewVAModal from '../components/WelcomeToNewVAModal';
@@ -64,6 +65,11 @@ const config = {
       name: 'welcome-to-new-va',
       paths: /^\/$/,
       component: WelcomeToNewVAModal,
+    },
+    {
+      name: 'single-sign-on-intro',
+      paths: /^\/$/,
+      component: SingleSignOnInfoModal,
     },
     {
       name: 'welcome-to-new-vaos',

--- a/src/platform/site-wide/announcements/config/index.js
+++ b/src/platform/site-wide/announcements/config/index.js
@@ -90,14 +90,14 @@ const config = {
       relatedAnnouncements: ['personalization'],
     },
     {
-      name: 'personalization',
-      paths: /(.)/,
-      component: PersonalizationBanner,
-    },
-    {
       name: 'single-sign-on-intro',
       paths: /(.)/,
       component: SingleSignOnInfoModal,
+    },
+    {
+      name: 'personalization',
+      paths: /(.)/,
+      component: PersonalizationBanner,
     },
   ],
 };

--- a/src/platform/site-wide/announcements/config/index.js
+++ b/src/platform/site-wide/announcements/config/index.js
@@ -68,7 +68,7 @@ const config = {
     },
     {
       name: 'single-sign-on-intro',
-      paths: /^\/$/,
+      paths: /(.)/,
       component: SingleSignOnInfoModal,
     },
     {

--- a/src/platform/site-wide/announcements/tests/components/SingleSignOnInfoModal.unit.spec.jsx
+++ b/src/platform/site-wide/announcements/tests/components/SingleSignOnInfoModal.unit.spec.jsx
@@ -7,26 +7,6 @@ import localStorage from 'platform/utilities/storage/localStorage';
 import SingleSignOnInfoModal from '../../components/SingleSignOnInfoModal';
 
 describe('Announcements <SingleSignOnInfoModal>', () => {
-  it('renders for logged in SSO users', () => {
-    localStorage.setItem('hasSessionSSO', true);
-    const dismiss = sinon.spy();
-
-    const tree = mount(<SingleSignOnInfoModal isLoggedIn dismiss={dismiss} />);
-
-    expect(tree.text()).to.contain(
-      'Sign in once to access the VA sites you use most',
-    );
-
-    tree
-      .find('button')
-      .at(1)
-      .props()
-      .onClick();
-    expect(dismiss.called).to.be.true;
-
-    tree.unmount();
-  });
-
   it('does not render for users that are logged in but without SSO', () => {
     localStorage.setItem('hasSessionSSO', false);
     const tree = mount(<SingleSignOnInfoModal isLoggedIn />);
@@ -37,5 +17,34 @@ describe('Announcements <SingleSignOnInfoModal>', () => {
   });
   afterEach(() => {
     localStorage.clear();
+  });
+
+  it('renders for logged in SSO users', () => {
+    localStorage.setItem('hasSessionSSO', true);
+    const dismiss = sinon.spy();
+
+    const tree = mount(<SingleSignOnInfoModal isLoggedIn dismiss={dismiss} />);
+
+    expect(tree.text()).to.contain(
+      'Sign in once to access the VA sites you use most',
+    );
+
+    tree.unmount();
+  });
+
+  it('closes when the dismiss handler is fired', () => {
+    localStorage.setItem('hasSessionSSO', true);
+    const dismiss = sinon.spy();
+
+    const tree = mount(<SingleSignOnInfoModal isLoggedIn dismiss={dismiss} />);
+
+    tree
+      .find('button')
+      .at(1)
+      .props()
+      .onClick();
+    expect(dismiss.called).to.be.true;
+
+    tree.unmount();
   });
 });

--- a/src/platform/site-wide/announcements/tests/components/SingleSignOnInfoModal.unit.spec.jsx
+++ b/src/platform/site-wide/announcements/tests/components/SingleSignOnInfoModal.unit.spec.jsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { expect } from 'chai';
+import { mount } from 'enzyme';
+import sinon from 'sinon';
+
+import localStorage from 'platform/utilities/storage/localStorage';
+import SingleSignOnInfoModal from '../../components/SingleSignOnInfoModal';
+
+describe('Announcements <SingleSignOnInfoModal>', () => {
+  it('renders for logged in SSO users', () => {
+    localStorage.setItem('hasSessionSSO', true);
+    const dismiss = sinon.spy();
+
+    const tree = mount(<SingleSignOnInfoModal isLoggedIn dismiss={dismiss} />);
+
+    expect(tree.text()).to.contain(
+      'Sign in once to access the VA sites you use most',
+    );
+
+    tree
+      .find('button')
+      .at(1)
+      .props()
+      .onClick();
+    expect(dismiss.called).to.be.true;
+
+    tree.unmount();
+  });
+
+  it('does not render for users that are logged in but without SSO', () => {
+    localStorage.setItem('hasSessionSSO', false);
+    const tree = mount(<SingleSignOnInfoModal isLoggedIn />);
+
+    expect(tree.html()).to.equal(null);
+
+    tree.unmount();
+  });
+  afterEach(() => {
+    localStorage.clear();
+  });
+});

--- a/src/platform/site-wide/announcements/tests/components/SingleSignOnInfoModal.unit.spec.jsx
+++ b/src/platform/site-wide/announcements/tests/components/SingleSignOnInfoModal.unit.spec.jsx
@@ -7,15 +7,16 @@ import localStorage from 'platform/utilities/storage/localStorage';
 import SingleSignOnInfoModal from '../../components/SingleSignOnInfoModal';
 
 describe('Announcements <SingleSignOnInfoModal>', () => {
+  afterEach(() => {
+    localStorage.clear();
+  });
+
   it('does not render for users that are logged in but without SSO', () => {
     const tree = mount(<SingleSignOnInfoModal isLoggedIn />);
 
     expect(tree.html()).to.equal(null);
 
     tree.unmount();
-  });
-  afterEach(() => {
-    localStorage.clear();
   });
 
   it('renders for logged in SSO users', () => {

--- a/src/platform/site-wide/announcements/tests/components/SingleSignOnInfoModal.unit.spec.jsx
+++ b/src/platform/site-wide/announcements/tests/components/SingleSignOnInfoModal.unit.spec.jsx
@@ -8,7 +8,6 @@ import SingleSignOnInfoModal from '../../components/SingleSignOnInfoModal';
 
 describe('Announcements <SingleSignOnInfoModal>', () => {
   it('does not render for users that are logged in but without SSO', () => {
-    localStorage.setItem('hasSessionSSO', false);
     const tree = mount(<SingleSignOnInfoModal isLoggedIn />);
 
     expect(tree.html()).to.equal(null);

--- a/src/platform/user/profile/utilities/index.js
+++ b/src/platform/user/profile/utilities/index.js
@@ -131,7 +131,8 @@ export function mapRawUserDataToState(json) {
 // as a trigger to properly update any components that subscribe to it.
 export const hasSession = () => localStorage.getItem('hasSession');
 
-export const hasSessionSSO = () => localStorage.getItem('hasSessionSSO');
+export const hasSessionSSO = () =>
+  localStorage.getItem('hasSessionSSO') === 'true';
 
 export async function setupProfileSession(userProfile) {
   const { firstName, signIn } = userProfile;

--- a/src/platform/user/profile/utilities/index.js
+++ b/src/platform/user/profile/utilities/index.js
@@ -131,8 +131,7 @@ export function mapRawUserDataToState(json) {
 // as a trigger to properly update any components that subscribe to it.
 export const hasSession = () => localStorage.getItem('hasSession');
 
-export const hasSessionSSO = () =>
-  localStorage.getItem('hasSessionSSO') === 'true';
+export const hasSessionSSO = () => localStorage.getItem('hasSessionSSO');
 
 export async function setupProfileSession(userProfile) {
   const { firstName, signIn } = userProfile;

--- a/src/platform/utilities/api/ssoHelpers.js
+++ b/src/platform/utilities/api/ssoHelpers.js
@@ -36,7 +36,7 @@ export function ssoKeepAliveSession() {
         localStorage.setItem('sessionExpirationSSO', expirationTime);
         localStorage.setItem('hasSessionSSO', true);
       } else {
-        localStorage.setItem('hasSessionSSO', false);
+        localStorage.removeItem('hasSessionSSO');
       }
     })
     .catch(err => {


### PR DESCRIPTION
## Description

Closes  department-of-veterans-affairs/va.gov-team#5828

This adds a notification modal for users the first time they log into VA.gov with an SSO-enabled session.

## Testing done

Because the SSO session flag is dependent on a call that is blocked by CORS locally, this will need to be manually checked again on dev/staging.

## Screenshots

<details>
<summary>Desktop</summary>

![Screenshot_2020-03-20 VA gov Home Veterans Affairs](https://user-images.githubusercontent.com/13280995/77207640-e6b6d780-6ac7-11ea-81ba-36cd1f46cd00.png)


</details>

<details>
<summary>Mobile</summary>

![Screenshot_2020-03-20 VA gov Home Veterans Affairs(2)](https://user-images.githubusercontent.com/13280995/77207674-f9c9a780-6ac7-11ea-9efd-80222cbf47dc.png)

</details>

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
