### PR TITLE
Apirequest update claims status

### DIFF
--- a/src/applications/claims-status/actions/index.jsx
+++ b/src/applications/claims-status/actions/index.jsx
@@ -154,10 +154,8 @@ export function pollRequest({
   shouldSucceed,
   target,
 }) {
-  return request(
-    target,
-    null,
-    response => {
+  return request(target)
+    .then(response => {
       if (shouldSucceed(response)) {
         onSuccess(response);
         return;
@@ -177,9 +175,8 @@ export function pollRequest({
         shouldSucceed,
         target,
       });
-    },
-    error => onError(error),
-  );
+    })
+    .catch(error => onError(error));
 }
 
 export function getSyncStatus(claimsAsyncResponse) {

--- a/src/applications/claims-status/actions/index.jsx
+++ b/src/applications/claims-status/actions/index.jsx
@@ -149,12 +149,11 @@ export function pollRequest({
   onError,
   onSuccess,
   pollingInterval,
-  request = apiRequest,
   shouldFail,
   shouldSucceed,
   target,
 }) {
-  return request(target)
+  return apiRequest(target)
     .then(response => {
       if (shouldSucceed(response)) {
         onSuccess(response);
@@ -170,7 +169,7 @@ export function pollRequest({
         onError,
         onSuccess,
         pollingInterval,
-        request,
+        apiRequest,
         shouldFail,
         shouldSucceed,
         target,

--- a/src/applications/claims-status/actions/index.jsx
+++ b/src/applications/claims-status/actions/index.jsx
@@ -104,11 +104,9 @@ export function fetchAppealsSuccess(response) {
 export function getAppealsV2() {
   return dispatch => {
     dispatch({ type: FETCH_APPEALS_PENDING });
-    return apiRequest(
-      '/appeals',
-      null,
-      appeals => dispatch(fetchAppealsSuccess(appeals)),
-      response => {
+    return apiRequest('/appeals')
+      .then(appeals => dispatch(fetchAppealsSuccess(appeals)))
+      .catch(response => {
         const status = getErrorStatus(response);
         const action = { type: '' };
         switch (status) {
@@ -133,8 +131,7 @@ export function getAppealsV2() {
           Sentry.captureException(`vets_appeals_v2_err_get_appeals ${status}`);
         });
         return dispatch(action);
-      },
-    );
+      });
   };
 }
 

--- a/src/applications/claims-status/tests/actions.unit.spec.js
+++ b/src/applications/claims-status/tests/actions.unit.spec.js
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
+import { mockApiRequest, resetFetch } from 'platform/testing/unit/helpers';
 
 import {
   ADD_FILE,
@@ -446,28 +447,27 @@ describe('Actions', () => {
 
   describe('pollClaimStatus', () => {
     describe('apiRequest response handler', () => {
-      it('should call onSuccess when shouldSucceed returns true', () => {
-        const apiRequestSpy = sinon.spy();
+      beforeEach(() => mockApiRequest({}));
+      afterEach(resetFetch);
+      it('should call onSuccess when shouldSucceed returns true', async () => {
         const mockResponse = {};
         const onSuccessSpy = sinon.spy();
         const onErrorSpy = sinon.spy();
         const shouldSucceedStub = sinon.stub();
         shouldSucceedStub.returns(true);
 
-        pollRequest({
+        await pollRequest({
           onError: onErrorSpy,
           onSuccess: onSuccessSpy,
-          request: apiRequestSpy,
           shouldSucceed: shouldSucceedStub,
+          target: '/test',
         });
-        apiRequestSpy.firstCall.args[2](mockResponse);
 
         expect(onSuccessSpy.calledOnce).to.be.true;
         expect(onErrorSpy.called).to.be.false;
         expect(shouldSucceedStub.firstCall.args[0]).to.eql(mockResponse);
       });
-      it('should call onError when shouldSuccess return false shouldFail returns true', () => {
-        const apiRequestSpy = sinon.spy();
+      it('should call onError when shouldSuccess return false and shouldFail returns true', async () => {
         const mockResponse = {};
         const onErrorSpy = sinon.spy();
         const onSuccessSpy = sinon.spy();
@@ -476,14 +476,13 @@ describe('Actions', () => {
         shouldSucceedStub.returns(false);
         shouldFailStub.returns(true);
 
-        pollRequest({
+        await pollRequest({
           onError: onErrorSpy,
           onSuccess: onSuccessSpy,
-          request: apiRequestSpy,
           shouldFail: shouldFailStub,
           shouldSucceed: shouldSucceedStub,
+          target: '/test',
         });
-        apiRequestSpy.firstCall.args[2](mockResponse);
 
         expect(onSuccessSpy.calledOnce).to.be.false;
         expect(onErrorSpy.calledOnce).to.be.true;

--- a/src/applications/claims-status/tests/actions.unit.spec.js
+++ b/src/applications/claims-status/tests/actions.unit.spec.js
@@ -445,12 +445,6 @@ describe('Actions', () => {
   });
 
   describe('pollClaimStatus', () => {
-    it('should call apiRequest', () => {
-      const apiRequestSpy = sinon.spy();
-
-      pollRequest({ request: apiRequestSpy });
-      expect(apiRequestSpy.calledOnce).to.be.true;
-    });
     describe('apiRequest response handler', () => {
       it('should call onSuccess when shouldSucceed returns true', () => {
         const apiRequestSpy = sinon.spy();


### PR DESCRIPTION
## Description
The `apiRequest` helper is being modified to have CSRF protection (#11958).  The helper still allows for some inconsistent usage, so this is an effort to eliminate those opportunities in order to simplify it and make it easier to use across different applications.

[This PR comment](https://github.com/department-of-veterans-affairs/vets-website/pull/10845#issuecomment-540692196) documents why these changes are being made.  Removing the callback arguments and relying instead on a promise chain is one small piece of improving the helper.

## Testing done

Local unit testing

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
