### PR TITLE
Fix display phone number bug on cc providers result card

### DIFF
--- a/src/applications/facility-locator/components/search-results/LocationPhoneLink.jsx
+++ b/src/applications/facility-locator/components/search-results/LocationPhoneLink.jsx
@@ -9,6 +9,7 @@ const renderPhoneNumber = (
   icon = 'fw',
   altPhone,
   from,
+  isCCProvider,
 ) => {
   if (!phone) {
     return null;
@@ -20,11 +21,12 @@ const renderPhoneNumber = (
     <div>
       {from === 'FacilityDetail' && <i className={`fa fa-${icon}`} />}
       {title && <strong>{title}: </strong>}
-      {phone.replace(re, '$1-$2-$3 $4$5').replace(/x$/, '')}
+      {!isCCProvider && phone.replace(re, '$1-$2-$3 $4$5').replace(/x$/, '')}
       <br />
       {from === 'FacilityDetail' && <i className="fa fa-fw" />}
       {subTitle && subTitle}
-
+      {isCCProvider &&
+        ` ${phone.replace(re, '$1-$2-$3 $4$5').replace(/x$/, '')}`}
       {from === 'FacilityDetail' ? (
         <a
           href={`tel:${phone.replace(/[ ]?x/, '')}`}


### PR DESCRIPTION
## Description

issue: https://github.com/department-of-veterans-affairs/va.gov-team/issues/5692

## Testing done
Locally

## Screenshots
<img width="998" alt="Screen Shot 2020-03-23 at 11 36 19 AM" src="https://user-images.githubusercontent.com/100468/77343326-827e5880-6cff-11ea-975d-d78f37ab138c.png">



## Acceptance criteria
- [x] When Facility type = Community providers (in VA's network) + Service type, any cards displayed in results will have phone numbers if included in the data.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
