### PR TITLE
7117: Prod flag removal for 6803

### DIFF
--- a/src/applications/gi/components/CheckboxGroup.jsx
+++ b/src/applications/gi/components/CheckboxGroup.jsx
@@ -1,7 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import _ from 'lodash';
-import environment from 'platform/utilities/environment';
 
 /**
  * A checkbox group with a label.
@@ -55,13 +54,7 @@ class CheckboxGroup extends React.Component {
       <div className={this.props.errorMessage ? 'usa-input-error' : ''}>
         <fieldset>
           <div>
-            {/*  prod flag for bah-7186 */}
-            <span
-              id={`${this.inputId}-legend`}
-              className={
-                environment.isProduction() ? 'gibct-legend-old' : 'gibct-legend'
-              }
-            >
+            <span id={`${this.inputId}-legend`} className={'gibct-legend'}>
               {this.props.label}
             </span>
             {this.renderOptions()}

--- a/src/applications/gi/components/RadioButtons.jsx
+++ b/src/applications/gi/components/RadioButtons.jsx
@@ -5,7 +5,6 @@ import _ from 'lodash';
 import ToolTip from './ToolTip';
 import ExpandingGroup from '@department-of-veterans-affairs/formation-react/ExpandingGroup';
 import { SMALL_SCREEN_WIDTH } from '../constants';
-import environment from 'platform/utilities/environment';
 
 /**
  * A radio button group with a label.
@@ -140,10 +139,7 @@ class RadioButtons extends React.Component {
     if (this.props.required) {
       requiredSpan = <span className="form-required-span">*</span>;
     }
-    // prod flag for bah-7186
-    const gibctLegendStyle = environment.isProduction()
-      ? 'gibct-legend-old'
-      : 'gibct-legend';
+
     return (
       <div className={this.props.errorMessage ? 'usa-input-error' : ''}>
         <fieldset>
@@ -153,7 +149,7 @@ class RadioButtons extends React.Component {
               className={
                 this.props.errorMessage
                   ? 'usa-input-error-label'
-                  : gibctLegendStyle
+                  : 'gibct-legend'
               }
             >
               {this.props.label}

--- a/src/applications/gi/components/profile/CautionaryInformation.jsx
+++ b/src/applications/gi/components/profile/CautionaryInformation.jsx
@@ -1,10 +1,8 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import recordEvent from 'platform/monitoring/record-event';
-import AlertBox from '../AlertBox';
 import CautionFlagDetails from './CautionFlagDetails';
 import SchoolClosingDetails from './SchoolClosingDetails';
-import environment from 'platform/utilities/environment';
 
 const TableRow = ({ description, thisCampus, allCampuses }) => {
   if (!thisCampus && !allCampuses) return null;
@@ -36,7 +34,7 @@ const ListRow = ({ description, value }) => {
 };
 
 export class CautionaryInformation extends React.Component {
-  renderNewCautionFlags = () => {
+  renderCautionFlags = () => {
     const it = this.props.institution;
     if (!it.schoolClosing && it.cautionFlags.length === 0) {
       return null;
@@ -88,35 +86,6 @@ export class CautionaryInformation extends React.Component {
     if (!it.complaints) {
       return null;
     }
-
-    // If Ashford, show specific link.
-    const schoolSpecificLink = (it.facilityCode === '21007103' ||
-      it.website === 'http://www.ashford.edu') && (
-      <a
-        href="https://www.benefits.va.gov/gibill/comparison_tool/about_this_tool.asp#AshfordSAA"
-        target="_blank"
-        rel="noopener noreferrer"
-      >
-        More information on Ashford University
-      </a>
-    );
-
-    const flagContent = (
-      <div>
-        <p>
-          {it.cautionFlagReason} {schoolSpecificLink}
-        </p>
-        <p>
-          <button
-            type="button"
-            className="va-button-link learn-more-button"
-            onClick={this.props.onShowModal.bind(this, 'cautionInfo')}
-          >
-            Learn more about these warnings
-          </button>
-        </p>
-      </div>
-    );
 
     const allCampusesLink = (
       <a
@@ -179,22 +148,10 @@ export class CautionaryInformation extends React.Component {
 
     return (
       <div className="cautionary-information">
-        {// #6805 prod flag
-        environment.isProduction() ? (
-          <div className="caution-flag">
-            <AlertBox
-              content={flagContent}
-              isVisible={!!it.cautionFlag}
-              status="warning"
-            />
-          </div>
-        ) : (
-          this.renderNewCautionFlags()
-        )}
+        {this.renderCautionFlags()}
 
         <div className="student-complaints">
-          {// #6805 prod flag
-          !environment.isProduction() && <h3>Student feedback</h3>}
+          <h3>Student feedback</h3>
 
           <div className="link-header">
             <h3>

--- a/src/applications/gi/components/profile/HeadingSummary.jsx
+++ b/src/applications/gi/components/profile/HeadingSummary.jsx
@@ -2,13 +2,11 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import _ from 'lodash';
 
-import AlertBox from '../AlertBox';
 import AdditionalResources from '../content/AdditionalResources';
 import { formatNumber, locationInfo } from '../../utils/helpers';
 import { ariaLabels } from '../../constants';
 import CautionFlagHeading from './CautionFlagHeading';
 import SchoolClosingHeading from './SchoolClosingHeading';
-import environment from 'platform/utilities/environment';
 
 const IconWithInfo = ({ icon, children, present }) => {
   if (!present) return null;
@@ -42,54 +40,15 @@ class HeadingSummary extends React.Component {
       <div className="heading row">
         <div className="usa-width-two-thirds medium-8 small-12 column">
           <h1 tabIndex={-1}>{it.name}</h1>
-          {// #6805 prod flag
-          environment.isProduction() ? (
-            <AlertBox
-              content={
-                <p>
-                  Are you enrolled in this school?{' '}
-                  <a
-                    href="https://www.benefits.va.gov/GIBILL/FGIB/Restoration.asp"
-                    rel="noopener noreferrer"
-                    target="_blank"
-                  >
-                    Find out if you qualify to have your benefits restored.
-                  </a>
-                </p>
-              }
-              headline="This school is closing soon"
-              isVisible={!!it.schoolClosing}
-              status="warning"
-            />
-          ) : (
-            <SchoolClosingHeading
-              schoolClosing={it.schoolClosing}
-              schoolClosingOn={it.schoolClosingOn}
-            />
-          )}
+          <SchoolClosingHeading
+            schoolClosing={it.schoolClosing}
+            schoolClosingOn={it.schoolClosingOn}
+          />
           <div className="caution-flag">
-            {// #6805 prod flag
-            environment.isProduction() ? (
-              <AlertBox
-                content={
-                  <a href="#viewWarnings" onClick={this.props.onViewWarnings}>
-                    View cautionary information about this school
-                  </a>
-                }
-                headline={
-                  <h2 className="vads-u-font-size--h3 usa-alert-heading">
-                    This school has cautionary warnings
-                  </h2>
-                }
-                isVisible={!!it.cautionFlag}
-                status="warning"
-              />
-            ) : (
-              <CautionFlagHeading
-                cautionFlags={it.cautionFlags}
-                onViewWarnings={this.props.onViewWarnings}
-              />
-            )}
+            <CautionFlagHeading
+              cautionFlags={it.cautionFlags}
+              onViewWarnings={this.props.onViewWarnings}
+            />
           </div>
           <div className="column">
             <p>

--- a/src/applications/gi/components/search/InstitutionFilterForm.jsx
+++ b/src/applications/gi/components/search/InstitutionFilterForm.jsx
@@ -9,7 +9,6 @@ import {
   getStateNameForCode,
   sortOptionsByStateName,
 } from '../../utils/helpers';
-import environment from 'platform/utilities/environment';
 import CautionaryWarningsFilter from './CautionaryWarningsFilter';
 
 class InstitutionFilterForm extends React.Component {
@@ -150,15 +149,13 @@ class InstitutionFilterForm extends React.Component {
         {this.renderCategoryFilter()}
         {this.renderCountryFilter()}
         {this.renderStateFilter()}
-        {environment.isProduction() ? (
-          ''
-        ) : (
+        {
           <CautionaryWarningsFilter
             excludeCautionFlags={this.props.filters.excludeCautionFlags}
             onChange={this.handleCheckboxChange}
             showModal={this.props.showModal}
           />
-        )}
+        }
         {this.renderProgramFilters()}
         {this.renderTypeFilter()}
       </div>

--- a/src/applications/gi/components/search/InstitutionSearchForm.jsx
+++ b/src/applications/gi/components/search/InstitutionSearchForm.jsx
@@ -4,7 +4,6 @@ import EligibilityForm from './EligibilityForm';
 import InstitutionFilterForm from './InstitutionFilterForm';
 import KeywordSearch from './KeywordSearch';
 import OnlineClassesFilter from './OnlineClassesFilter';
-import environment from 'platform/utilities/environment';
 
 class InstitutionSearchForm extends React.Component {
   render() {

--- a/src/applications/gi/components/search/InstitutionSearchForm.jsx
+++ b/src/applications/gi/components/search/InstitutionSearchForm.jsx
@@ -11,14 +11,7 @@ class InstitutionSearchForm extends React.Component {
     return (
       <div className="row">
         <div className={this.props.filtersClass}>
-          {/* prod flag for bah-7186 */}
-          <div
-            className={
-              environment.isProduction()
-                ? 'filters-sidebar-inner-old'
-                : 'filters-sidebar-inner'
-            }
-          >
+          <div className={'filters-sidebar-inner'}>
             {this.props.search.filterOpened && <h1>Filter your search</h1>}
             <h2>Keywords</h2>
             <KeywordSearch

--- a/src/applications/gi/components/search/SearchResult.jsx
+++ b/src/applications/gi/components/search/SearchResult.jsx
@@ -8,7 +8,6 @@ import {
   renderCautionAlert,
   renderSchoolClosingAlert,
 } from '../../utils/render';
-import environment from 'platform/utilities/environment';
 
 export class SearchResult extends React.Component {
   estimate = ({ qualifier, value }) => {
@@ -32,7 +31,6 @@ export class SearchResult extends React.Component {
       state,
       country,
       studentCount,
-      cautionFlag,
       cautionFlags,
     } = this.props;
 
@@ -43,14 +41,6 @@ export class SearchResult extends React.Component {
       pathname: `profile/${facilityCode}`,
       query: version ? { version } : {},
     };
-
-    // Prod flags for 7183
-    const searchResultContentClassnamesLeft = environment.isProduction()
-      ? 'small-12 usa-width-seven-twelfths medium-7 columns'
-      : 'small-12  medium-6 large-7 columns';
-    const searchResultContentClassnamesRight = environment.isProduction()
-      ? 'small-12 usa-width-five-twelfths medium-5 columns estimated-benefits'
-      : 'small-12 medium-6 large-5 columns estimated-benefits';
 
     return (
       <div className="search-result">
@@ -68,16 +58,16 @@ export class SearchResult extends React.Component {
                 </h2>
               </div>
             </div>
-            {(schoolClosing || cautionFlag) && (
+            {(schoolClosing || cautionFlags.length > 0) && (
               <div className="row alert-row">
                 <div className="small-12 columns">
                   {renderSchoolClosingAlert({ schoolClosing, schoolClosingOn })}
-                  {renderCautionAlert({ cautionFlag, cautionFlags })}
+                  {renderCautionAlert({ cautionFlags })}
                 </div>
               </div>
             )}
             <div className="row">
-              <div className={searchResultContentClassnamesLeft}>
+              <div className={'small-12  medium-6 large-7 columns'}>
                 <div style={{ position: 'relative', bottom: 0 }}>
                   <p className="locality" id={`location-${facilityCode}`}>
                     {locationInfo(city, state, country)}
@@ -87,7 +77,11 @@ export class SearchResult extends React.Component {
                   </p>
                 </div>
               </div>
-              <div className={searchResultContentClassnamesRight}>
+              <div
+                className={
+                  'small-12 medium-6 large-5 columns estimated-benefits'
+                }
+              >
                 <h3>You may be eligible for up to:</h3>
                 <div className="row">
                   <div className="columns">

--- a/src/applications/gi/components/vet-tec/VetTecProgramSearchResult.jsx
+++ b/src/applications/gi/components/vet-tec/VetTecProgramSearchResult.jsx
@@ -30,8 +30,6 @@ class VetTecProgramSearchResult extends React.Component {
       ? formatCurrency(tuitionAmount)
       : 'TBD';
 
-    const cautionFlag = cautionFlags && cautionFlags.length > 0;
-
     const displayHours =
       lengthInHours === '0' ? 'TBD' : `${lengthInHours} hours`;
 
@@ -63,11 +61,11 @@ class VetTecProgramSearchResult extends React.Component {
                 {renderPreferredProviderFlag(this.props.result)}
               </div>
             </div>
-            {(schoolClosing || cautionFlag) && (
+            {(schoolClosing || cautionFlags.length > 0) && (
               <div className="row alert-row">
                 <div className="small-12 columns">
                   {renderSchoolClosingAlert({ schoolClosing, schoolClosingOn })}
-                  {renderCautionAlert({ cautionFlag, cautionFlags })}
+                  {renderCautionAlert({ cautionFlags })}
                 </div>
               </div>
             )}

--- a/src/applications/gi/components/vet-tec/VetTecSearchForm.jsx
+++ b/src/applications/gi/components/vet-tec/VetTecSearchForm.jsx
@@ -6,7 +6,6 @@ import { addAllOption, getStateNameForCode } from '../../utils/helpers';
 import PropTypes from 'prop-types';
 import Dropdown from '../Dropdown';
 import VetTecFilterBy from './VetTecFilterBy';
-import environment from 'platform/utilities/environment';
 import CautionaryWarningsFilter from '../search/CautionaryWarningsFilter';
 
 class VetTecSearchForm extends React.Component {
@@ -157,15 +156,13 @@ class VetTecSearchForm extends React.Component {
 
             {this.renderCountryFilter()}
             {this.renderStateFilter()}
-            {environment.isProduction() ? (
-              ''
-            ) : (
+            {
               <CautionaryWarningsFilter
                 excludeCautionFlags={this.props.filters.excludeCautionFlags}
                 onChange={this.handleCheckboxChange}
                 showModal={this.props.showModal}
               />
-            )}
+            }
             {this.renderFilterBy()}
           </div>
           <div className="results-button">

--- a/src/applications/gi/containers/SearchPage.jsx
+++ b/src/applications/gi/containers/SearchPage.jsx
@@ -4,7 +4,6 @@ import { withRouter } from 'react-router';
 import Scroll from 'react-scroll';
 import _ from 'lodash';
 import classNames from 'classnames';
-import environment from 'platform/utilities/environment';
 
 import {
   clearAutocompleteSuggestions,
@@ -161,20 +160,15 @@ export class SearchPage extends React.Component {
       pagination: { currentPage, totalPages },
     } = search;
 
-    // Prod flag for 7183
-    const resultsClass = environment.isProduction()
-      ? classNames(
-          'search-results',
-          'small-12',
-          'usa-width-three-fourths medium-9',
-          'columns',
-          {
-            opened: !search.filterOpened,
-          },
-        )
-      : classNames('search-results', 'small-12', 'medium-9', 'columns', {
-          opened: !search.filterOpened,
-        });
+    const resultsClass = classNames(
+      'search-results',
+      'small-12',
+      'medium-9',
+      'columns',
+      {
+        opened: !search.filterOpened,
+      },
+    );
 
     let searchResults;
 

--- a/src/applications/gi/sass/gi.scss
+++ b/src/applications/gi/sass/gi.scss
@@ -1,18 +1,17 @@
-@import "~@department-of-veterans-affairs/formation/sass/shared-variables";
-@import "~@department-of-veterans-affairs/formation/sass/modules/m-modal";
+@import '~@department-of-veterans-affairs/formation/sass/shared-variables';
+@import '~@department-of-veterans-affairs/formation/sass/modules/m-modal';
 
-@import "~@department-of-veterans-affairs/formation/sass/modules/va-pagination";
+@import '~@department-of-veterans-affairs/formation/sass/modules/va-pagination';
 
-@import "partials/gi-vet-tec";
-@import "partials/gi-preview-banner";
-@import "partials/gi-autocomplete";
-@import "partials/gi-modal";
-@import "partials/gi-landing-page";
-@import "partials/gi-search-page";
-@import "partials/gi-profile-page";
+@import 'partials/gi-vet-tec';
+@import 'partials/gi-preview-banner';
+@import 'partials/gi-autocomplete';
+@import 'partials/gi-modal';
+@import 'partials/gi-landing-page';
+@import 'partials/gi-search-page';
+@import 'partials/gi-profile-page';
 
 .gi-app {
-
   div.military-status-info {
     font-size: 0.9em;
     padding: 1em;
@@ -51,10 +50,10 @@
         line-height: 1.2rem;
       }
 
-      a.link{
+      a.link {
         @include media-maxwidth($small-screen) {
           margin-left: 1rem;
-          padding: .5rem;
+          padding: 0.5rem;
         }
       }
     }
@@ -70,14 +69,14 @@
   }
 
   select.hide-arrows {
-    background-image: none
+    background-image: none;
   }
 
   .search-result {
     i.fa {
       background: initial;
       color: initial;
-   }
+    }
   }
 
   .benefit-notification {
@@ -87,17 +86,6 @@
   h1:focus {
     outline: none;
   }
-}
-
-.gibct-legend-old {
-  margin-top: 3rem;
-  display: block;
-  font-weight: inherit;
-  font-size: inherit;
-  color: inherit;
-  line-height: inherit;
-  max-width: 46rem;
-  padding-bottom: 0;
 }
 
 .gibct-legend {

--- a/src/applications/gi/sass/partials/_gi-search-page.scss
+++ b/src/applications/gi/sass/partials/_gi-search-page.scss
@@ -40,12 +40,6 @@
     }
   }
 
-  .filters-sidebar-inner-old {
-    @include media-maxwidth($small-screen) {
-      padding-bottom: 8rem;
-    }
-  }
-
   .filter-button,
   .results-button {
     display: none;
@@ -192,12 +186,12 @@
 
   .usa-alert {
     background-color: $color-white;
-    padding: .5em 1em;
+    padding: 0.5em 1em;
     margin-top: 1em;
   }
 
   .usa-alert-text {
-    margin-top: .25em;
+    margin-top: 0.25em;
   }
 
   .alert-row {
@@ -211,5 +205,4 @@
   .usa-alert-heading {
     font-size: 1em;
   }
-
 }

--- a/src/applications/gi/utils/render.jsx
+++ b/src/applications/gi/utils/render.jsx
@@ -1,45 +1,31 @@
 import React from 'react';
 import AlertBox from '../components/AlertBox';
-import environment from 'platform/utilities/environment';
 
 export const renderSchoolClosingAlert = result => {
   const { schoolClosing, schoolClosingOn } = result;
 
   if (!schoolClosing) return null;
-  // Prod flag for 6803
-  // prod flag for bah-7020
-  if (!environment.isProduction()) {
-    if (schoolClosingOn) {
-      const currentDate = new Date();
-      const schoolClosingDate = new Date(schoolClosingOn);
-      if (currentDate > schoolClosingDate) {
-        return (
-          <AlertBox
-            className="vads-u-margin-top--1"
-            headline="School closed"
-            content={<p>School has closed</p>}
-            isVisible={!!schoolClosing}
-            status="warning"
-          />
-        );
-      }
-    }
-    return (
-      <AlertBox
-        className="vads-u-margin-top--1"
-        content={<p>School will be closing soon</p>}
-        headline="School closing"
-        isVisible={!!schoolClosing}
-        status="warning"
-      />
-    );
-  }
 
+  if (schoolClosingOn) {
+    const currentDate = new Date();
+    const schoolClosingDate = new Date(schoolClosingOn);
+    if (currentDate > schoolClosingDate) {
+      return (
+        <AlertBox
+          className="vads-u-margin-top--1"
+          headline="School closed"
+          content={<p>School has closed</p>}
+          isVisible={!!schoolClosing}
+          status="warning"
+        />
+      );
+    }
+  }
   return (
     <AlertBox
       className="vads-u-margin-top--1"
-      content={<p>Upcoming campus closure</p>}
-      headline="School closure"
+      content={<p>School will be closing soon</p>}
+      headline="School closing"
       isVisible={!!schoolClosing}
       status="warning"
     />
@@ -47,50 +33,38 @@ export const renderSchoolClosingAlert = result => {
 };
 
 export const renderCautionAlert = result => {
-  const { cautionFlag, cautionFlags } = result;
+  const { cautionFlags } = result;
 
-  // Prod flag for 6803
-  if (!environment.isProduction()) {
-    const validFlags = [...cautionFlags]
-      .filter(flag => flag.title)
-      .sort((a, b) => (a.title.toLowerCase() < b.title.toLowerCase() ? -1 : 1));
+  const validFlags = [...cautionFlags]
+    .filter(flag => flag.title)
+    .sort((a, b) => (a.title.toLowerCase() < b.title.toLowerCase() ? -1 : 1));
 
-    return (
-      <AlertBox
-        className="vads-u-margin-top--1"
-        content={
-          <React.Fragment>
-            {validFlags.length === 1 && <p>{validFlags[0].title}</p>}
-            {validFlags.length > 1 && (
-              <ul className="vads-u-margin-top--0">
-                {validFlags.map(flag => (
-                  <li
-                    className="vads-u-margin-y--0p25 vads-u-margin-left--1p5"
-                    key={flag.id}
-                  >
-                    {flag.title}
-                  </li>
-                ))}
-              </ul>
-            )}
-          </React.Fragment>
-        }
-        headline={
-          validFlags.length > 1
-            ? 'This school has cautionary warnings'
-            : 'This school has a cautionary warning'
-        }
-        isVisible={validFlags.length > 0}
-        status="warning"
-      />
-    );
-  }
   return (
     <AlertBox
       className="vads-u-margin-top--1"
-      content={<p>This school has cautionary warnings</p>}
-      headline="Caution"
-      isVisible={cautionFlag}
+      content={
+        <React.Fragment>
+          {validFlags.length === 1 && <p>{validFlags[0].title}</p>}
+          {validFlags.length > 1 && (
+            <ul className="vads-u-margin-top--0">
+              {validFlags.map(flag => (
+                <li
+                  className="vads-u-margin-y--0p25 vads-u-margin-left--1p5"
+                  key={flag.id}
+                >
+                  {flag.title}
+                </li>
+              ))}
+            </ul>
+          )}
+        </React.Fragment>
+      }
+      headline={
+        validFlags.length > 1
+          ? 'This school has cautionary warnings'
+          : 'This school has a cautionary warning'
+      }
+      isVisible={validFlags.length > 0}
       status="warning"
     />
   );


### PR DESCRIPTION
## Description
As a developer, I need to remove the prod flag for the Caution Flag updates on the CT Search Results so that they are available in the production environment.

[Originating Issue](https://github.com/department-of-veterans-affairs/va.gov-team/issues/7117)

## Testing done
Testing passes locally

## Screenshots
![image.png](https://images.zenhubusercontent.com/5c98dce9c64b93000145b07f/fcedb116-4c2f-4a0c-885c-9ab0bdfb674a)

![image](https://user-images.githubusercontent.com/48804834/77351441-2a058600-6d14-11ea-98da-35d378b61e83.png)


## Acceptance criteria
- [x] The functionality in [6803](https://github.com/department-of-veterans-affairs/va.gov-team/issues/6803) is available in the production environment.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
