### PR TITLE
Add in optional application query param for login endpoint

### DIFF
--- a/src/applications/login/containers/SignInApp.jsx
+++ b/src/applications/login/containers/SignInApp.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 
 import ExternalServicesError from 'platform/monitoring/external-services/ExternalServicesError';
-// import recordEvent from 'platform/monitoring/record-event';
+import recordEvent from 'platform/monitoring/record-event';
 import SubmitSignInForm from 'platform/static-data/SubmitSignInForm';
 import { login, signup } from 'platform/user/authentication/utilities';
 import environment from 'platform/utilities/environment';
@@ -12,8 +12,7 @@ import LogoutAlert from '../components/LogoutAlert';
 import downtimeBanners from '../utilities/downtimeBanners';
 
 function loginHandler(loginType, application = null) {
-  // TODO add separate login tracking for this page
-  //   recordEvent({ event: `login-attempted-${loginType}` });
+  recordEvent({ event: `login-attempted-${loginType}` });
   login(loginType, 'v1', application);
 }
 

--- a/src/applications/login/containers/SignInApp.jsx
+++ b/src/applications/login/containers/SignInApp.jsx
@@ -11,15 +11,11 @@ import environment from 'platform/utilities/environment';
 import LogoutAlert from '../components/LogoutAlert';
 import downtimeBanners from '../utilities/downtimeBanners';
 
-const loginHandler = loginType => () => {
+function loginHandler(loginType, application = null) {
   // TODO add separate login tracking for this page
   //   recordEvent({ event: `login-attempted-${loginType}` });
-  login(loginType, 'v1', 'cerner');
-};
-
-const handleDsLogon = loginHandler('dslogon');
-const handleMhv = loginHandler('mhv');
-const handleIdMe = loginHandler('idme');
+  login(loginType, 'v1', application);
+}
 
 const vaGovFullDomain = environment.BASE_URL;
 
@@ -59,7 +55,9 @@ class SignInPage extends React.Component {
 
   render() {
     const { globalDowntime } = this.state;
-    const loggedOut = this.props.location.query.auth === 'logged_out';
+    const { query } = this.props.location;
+    const loggedOut = query.auth === 'logged_out';
+    const application = query.application;
 
     return (
       <main className="login">
@@ -105,7 +103,7 @@ class SignInPage extends React.Component {
                     <button
                       disabled={globalDowntime}
                       className="dslogon"
-                      onClick={handleDsLogon}
+                      onClick={() => loginHandler('dslogon', application)}
                     >
                       <img
                         alt="DS Logon"
@@ -116,7 +114,7 @@ class SignInPage extends React.Component {
                     <button
                       disabled={globalDowntime}
                       className="mhv"
-                      onClick={handleMhv}
+                      onClick={() => loginHandler('mhv', application)}
                     >
                       <img
                         alt="My HealtheVet"
@@ -127,7 +125,7 @@ class SignInPage extends React.Component {
                     <button
                       disabled={globalDowntime}
                       className="usa-button-primary va-button-primary"
-                      onClick={handleIdMe}
+                      onClick={() => loginHandler('idme', application)}
                     >
                       <img
                         alt="ID.me"

--- a/src/applications/login/containers/SignInApp.jsx
+++ b/src/applications/login/containers/SignInApp.jsx
@@ -14,7 +14,7 @@ import downtimeBanners from '../utilities/downtimeBanners';
 const loginHandler = loginType => () => {
   // TODO add separate login tracking for this page
   //   recordEvent({ event: `login-attempted-${loginType}` });
-  login(loginType, 'v1');
+  login(loginType, 'v1', 'cerner');
 };
 
 const handleDsLogon = loginHandler('dslogon');

--- a/src/platform/user/authentication/utilities.js
+++ b/src/platform/user/authentication/utilities.js
@@ -8,13 +8,15 @@ export const authnSettings = {
   RETURN_URL: 'authReturnUrl',
 };
 
-function sessionTypeUrl(type, version = 'v0') {
+function sessionTypeUrl(type = '', version = 'v0', application = null) {
   const SESSIONS_URI =
     version === 'v1'
       ? `${environment.API_URL}/v1/sessions`
       : `${environment.API_URL}/sessions`;
 
-  return `${SESSIONS_URI}/${type}/new`;
+  return `${SESSIONS_URI}/${type}/new${
+    application ? `?application=${application}` : ''
+  }`;
 }
 
 const SIGNUP_URL = sessionTypeUrl('signup');
@@ -22,14 +24,14 @@ const MFA_URL = sessionTypeUrl('mfa');
 const VERIFY_URL = sessionTypeUrl('verify');
 const LOGOUT_URL = sessionTypeUrl('slo');
 
-const loginUrl = (policy, version) => {
+const loginUrl = (policy, version, application) => {
   switch (policy) {
     case 'mhv':
-      return sessionTypeUrl('mhv', version);
+      return sessionTypeUrl('mhv', version, application);
     case 'dslogon':
-      return sessionTypeUrl('dslogon', version);
+      return sessionTypeUrl('dslogon', version, application);
     default:
-      return sessionTypeUrl('idme', version);
+      return sessionTypeUrl('idme', version, application);
   }
 };
 
@@ -82,8 +84,11 @@ function redirect(redirectUrl, clickedEvent) {
   }
 }
 
-export function login(policy, version = 'v0') {
-  return redirect(loginUrl(policy, version), 'login-link-clicked-modal');
+export function login(policy, version = 'v0', application = null) {
+  return redirect(
+    loginUrl(policy, version, application),
+    'login-link-clicked-modal',
+  );
 }
 
 export function mfa() {


### PR DESCRIPTION
## Description

Closes  department-of-veterans-affairs/va.gov-team#4440

Client-side changes to complement department-of-veterans-affairs/vets-api#4042 . This PR adds in an `application` param to the login utility function. This is so we can add an application query param to the new sessions endpoint, to redirect to an external application upon successful authentication (redirect happens via `vets-api`).

## Testing done

Manual verification with up-to-date changes from `vets-api

## Acceptance criteria
- [ ] hitting `/sessions/{type}/new?application=myvahealth` results in the expected redirect

## Definition of done
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
