### PR TITLE
Removed buildOptions from injectLocalBundle

### DIFF
--- a/src/applications/proxy-rewrite/local-proxy-rewrite.js
+++ b/src/applications/proxy-rewrite/local-proxy-rewrite.js
@@ -60,7 +60,7 @@ function fallbackToTeamSiteServer(buildOptions) {
 }
 
 function setupLocalProxyRewrite(devServer, buildOptions) {
-  devServer.use(injectLocalBundle(buildOptions));
+  devServer.use(injectLocalBundle());
   devServer.use(fallbackToTeamSiteServer(buildOptions));
 }
 


### PR DESCRIPTION
## Description

`no-extra-arguments` rule from SonarJS has been added to the testing stage in CircleCI (circle.esint.json)

This change should help the code to be in compliance with the rule and removes the errors from `additional-linting` CircleCI check.

`buildOptions` was removed from the `injectLocalBundle()` function. It doesn't seem to be used inside the function

## Testing done
Locally

## Screenshots

<img width="696" alt="Screen Shot 2020-03-24 at 9 24 40 AM" src="https://user-images.githubusercontent.com/55560129/77430735-03962800-6db2-11ea-8302-9a1159dd4b07.png">

