### PR TITLE
Update VAOS messages for no DS and CC states

### DIFF
--- a/src/applications/vaos/containers/AppointmentsPage.jsx
+++ b/src/applications/vaos/containers/AppointmentsPage.jsx
@@ -25,6 +25,8 @@ import {
   vaosCancel,
   vaosRequests,
   vaosPastAppts,
+  vaosDirectScheduling,
+  vaosCommunityCare,
   isWelcomeModalDismissed,
 } from '../utils/selectors';
 import { scrollAndFocus } from '../utils/scrollAndFocus';
@@ -63,6 +65,8 @@ export class AppointmentsPage extends Component {
       showCancelButton,
       showScheduleButton,
       showPastAppointments,
+      showCommunityCare,
+      showDirectScheduling,
     } = this.props;
     const {
       future,
@@ -205,10 +209,33 @@ export class AppointmentsPage extends Component {
                 <h2 className="vads-u-font-size--h3 vads-u-margin-y--0">
                   Create a new appointment
                 </h2>
-                <p className="vads-u-margin-top--1">
-                  Schedule an appointment at a VA medical center, clinic, or
-                  Community Care facility.
-                </p>
+                {showCommunityCare &&
+                  showDirectScheduling && (
+                    <p className="vads-u-margin-top--1">
+                      Schedule an appointment at a VA medical center, clinic, or
+                      Community Care facility.
+                    </p>
+                  )}
+                {!showCommunityCare &&
+                  !showDirectScheduling && (
+                    <p className="vads-u-margin-top--1">
+                      Send a request to schedule an appointment at a VA medical
+                      center or clinic.
+                    </p>
+                  )}
+                {showCommunityCare &&
+                  !showDirectScheduling && (
+                    <p className="vads-u-margin-top--1">
+                      Send a request to schedule an appointment at a VA medical
+                      center, clinic, or Community Care facility.
+                    </p>
+                  )}
+                {!showCommunityCare &&
+                  showDirectScheduling && (
+                    <p className="vads-u-margin-top--1">
+                      Schedule an appointment at a VA medical center or clinic.
+                    </p>
+                  )}
                 <Link
                   id="new-appointment"
                   className="usa-button vads-u-font-weight--bold vads-u-font-size--md"
@@ -270,6 +297,8 @@ function mapStateToProps(state) {
     showCancelButton: vaosCancel(state),
     showPastAppointments: vaosPastAppts(state),
     showScheduleButton: vaosRequests(state),
+    showCommunityCare: vaosCommunityCare(state),
+    showDirectScheduling: vaosDirectScheduling(state),
     isWelcomeModalDismissed: isWelcomeModalDismissed(state),
   };
 }

--- a/src/platform/site-wide/cta-widget/components/messages/VAOnlineScheduling.jsx
+++ b/src/platform/site-wide/cta-widget/components/messages/VAOnlineScheduling.jsx
@@ -9,11 +9,18 @@ const alertText = (
   </p>
 );
 
-const VAOnlineScheduling = () => {
+const noCCAlertText = (
+  <p>
+    You’ll be able to manage and see all your appointments in one place on
+    VA.gov. You can also schedule or cancel some VA appointments online.
+  </p>
+);
+
+const VAOnlineScheduling = ({ isCommunityCareEnabled }) => {
   const content = {
     heading:
       'Go to the VA appointments tool to view, schedule, or cancel your appointment online',
-    alertText,
+    alertText: isCommunityCareEnabled ? alertText : noCCAlertText,
     primaryButtonText: 'Go to your VA appointments',
     primaryButtonHandler: () => {
       window.location =

--- a/src/platform/site-wide/cta-widget/index.js
+++ b/src/platform/site-wide/cta-widget/index.js
@@ -133,7 +133,14 @@ export class CallToActionWidget extends React.Component {
         return this.getMviErrorContent();
       }
 
-      return <VAOnlineScheduling appId={this.props.appId} />;
+      return (
+        <VAOnlineScheduling
+          appId={this.props.appId}
+          isCommunityCareEnabled={
+            this.props.featureToggles.vaOnlineSchedulingCommunityCare
+          }
+        />
+      );
     }
 
     return null;


### PR DESCRIPTION
## Description
This updates a couple messages to be accurate now that we've turned off DS and CC. We're really only using the first two, but thought I would set up the others just in case.

## Testing done
Local testing

## Screenshots

CTA
![Screen Shot 2020-03-24 at 10 18 27 AM](https://user-images.githubusercontent.com/634932/77435680-faf52000-6db8-11ea-88b7-cb9d6f88c133.png)

DS is off, CC is off
![Screen Shot 2020-03-24 at 10 04 18 AM](https://user-images.githubusercontent.com/634932/77435494-c1241980-6db8-11ea-875e-615bc409ee4b.png)

DS is on, CC is off
![Screen Shot 2020-03-24 at 10 04 52 AM](https://user-images.githubusercontent.com/634932/77435493-c08b8300-6db8-11ea-94c6-1db6fe8578e7.png)

DS is off, CC is on
![Screen Shot 2020-03-24 at 10 21 09 AM](https://user-images.githubusercontent.com/634932/77435873-3263cc80-6db9-11ea-89f0-e0546418ad46.png)

## Acceptance criteria
- [ ] Messages are correct

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
