### PR TITLE
Temporary facility id fix

### DIFF
--- a/src/applications/vaos/containers/VAOSApp.jsx
+++ b/src/applications/vaos/containers/VAOSApp.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 
 import LoadingIndicator from '@department-of-veterans-affairs/formation-react/LoadingIndicator';
-import { selectUser, selectPatientFacilities } from 'platform/user/selectors';
+import { selectUser } from 'platform/user/selectors';
 import backendServices from 'platform/user/profile/constants/backendServices';
 import RequiredLoginView from 'platform/user/authorization/components/RequiredLoginView';
 import DowntimeNotification, {
@@ -14,6 +14,7 @@ import { captureError } from '../utils/error';
 import {
   vaosApplication,
   selectFeatureToggleLoading,
+  selectFacilities,
 } from '../utils/selectors';
 import NoRegistrationMessage from '../components/NoRegistrationMessage';
 import AppUnavailable from '../components/AppUnavailable';
@@ -105,7 +106,7 @@ function mapStateToProps(state) {
     user: selectUser(state),
     showApplication: vaosApplication(state),
     loadingFeatureToggles: selectFeatureToggleLoading(state),
-    sites: selectPatientFacilities(state),
+    sites: selectFacilities(state),
   };
 }
 

--- a/src/applications/vaos/utils/selectors.js
+++ b/src/applications/vaos/utils/selectors.js
@@ -315,5 +315,9 @@ export const isWelcomeModalDismissed = state =>
     announcement => announcement === 'welcome-to-new-vaos',
   );
 
+export const selectFacilities = state =>
+  selectPatientFacilities(state)?.filter(
+    f => !f.facilityId.startsWith('742'),
+  ) || null;
 export const selectSystemIds = state =>
-  selectPatientFacilities(state)?.map(f => f.facilityId) || null;
+  selectFacilities(state)?.map(f => f.facilityId) || null;


### PR DESCRIPTION
## Description
This bad id is sneaking into our facilities list, this excludes it for now until we can figure out how to get it excluded on the backend.

This is the real fix, but I'm not sure how well I understand what all is going on, so I don't expect that one to make it to prod today: https://github.com/department-of-veterans-affairs/devops/pull/6570

## Acceptance criteria
- [ ] Id is removed

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
