### PR TITLE
[Development] Show errors in review

### DIFF
--- a/src/platform/forms-system/src/js/actions.js
+++ b/src/platform/forms-system/src/js/actions.js
@@ -13,6 +13,7 @@ export const SET_SUBMISSION = 'SET_SUBMISSION';
 export const SET_SUBMITTED = 'SET_SUBMITTED';
 export const OPEN_REVIEW_CHAPTER = 'OPEN_REVIEW_CHAPTER';
 export const CLOSE_REVIEW_CHAPTER = 'CLOSE_REVIEW_CHAPTER';
+export const SET_FORM_ERRORS = 'SET_FORM_ERRORS';
 
 export function closeReviewChapter(closedChapter, pageKeys = []) {
   return {
@@ -75,6 +76,13 @@ export function setViewedPages(pageKeys) {
   return {
     type: SET_VIEWED_PAGES,
     pageKeys,
+  };
+}
+
+export function setFormErrors(errors) {
+  return {
+    type: SET_FORM_ERRORS,
+    data: errors,
   };
 }
 

--- a/src/platform/forms-system/src/js/review/ArrayField.jsx
+++ b/src/platform/forms-system/src/js/review/ArrayField.jsx
@@ -38,6 +38,16 @@ class ArrayField extends React.Component {
     this.scrollToRow = this.scrollToRow.bind(this);
     this.isLocked = this.isLocked.bind(this);
   }
+
+  componentDidMount() {
+    const { formContext, arrayData = [], editing } = this.props;
+    // Automatically add a new item when editing & no data
+    // called when the review page error link is used
+    if (editing && arrayData.length === 0 && formContext?.onReviewPage) {
+      this.handleAdd();
+    }
+  }
+
   /* eslint-disable-next-line camelcase */
   UNSAFE_componentWillReceiveProps(newProps) {
     if (newProps.arrayData !== this.props.arrayData) {

--- a/src/platform/forms-system/src/js/review/ReviewCollapsibleChapter.jsx
+++ b/src/platform/forms-system/src/js/review/ReviewCollapsibleChapter.jsx
@@ -74,6 +74,7 @@ export default class ReviewCollapsibleChapter extends React.Component {
       form,
       formContext,
       pageKeys,
+      checkValidation,
       showUnviewedPageWarning,
       viewedPages,
     } = this.props;
@@ -197,6 +198,7 @@ export default class ReviewCollapsibleChapter extends React.Component {
                       <ProgressButton
                         submitButton
                         onButtonClick={() => {
+                          checkValidation();
                           focusOnChange(
                             `${page.pageKey}${
                               typeof page.index === 'number' ? page.index : ''
@@ -215,6 +217,7 @@ export default class ReviewCollapsibleChapter extends React.Component {
                       pageKey={page.pageKey}
                       pageTitle={page.title}
                       arrayData={_.get(arrayField.path, form.data)}
+                      editing={editing}
                       formData={form.data}
                       appStateData={page.appStateData}
                       formContext={formContext}
@@ -264,7 +267,11 @@ export default class ReviewCollapsibleChapter extends React.Component {
                 {chapterTitle || ''}
               </button>
               {showUnviewedPageWarning && (
-                <span className="schemaform-review-chapter-warning-icon" />
+                <span
+                  role="presentation"
+                  aria-hidden="true"
+                  className="schemaform-review-chapter-warning-icon"
+                />
               )}
             </div>
             <div id={`collapsible-${this.id}`}>{pageContent}</div>

--- a/src/platform/forms-system/src/js/review/SubmitButtons.jsx
+++ b/src/platform/forms-system/src/js/review/SubmitButtons.jsx
@@ -21,6 +21,7 @@ export default function SubmitButtons(props) {
     renderErrorMessage,
     submission,
     formConfig,
+    formErrors = {},
   } = props;
 
   const appType = formConfig?.customText?.appType || APP_TYPE_DEFAULT;
@@ -66,6 +67,7 @@ export default function SubmitButtons(props) {
       <ValidationError
         appType={appType}
         formConfig={formConfig}
+        formErrors={formErrors}
         onBack={onBack}
         onSubmit={onSubmit}
       />

--- a/src/platform/forms-system/src/js/review/submit-states/ValidationError.jsx
+++ b/src/platform/forms-system/src/js/review/submit-states/ValidationError.jsx
@@ -1,24 +1,107 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
+import environment from 'platform/utilities/environment';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+
 import Back from './Back';
 import ProgressButton from '../../components/ProgressButton';
-import PropTypes from 'prop-types';
 import { Column, Row } from 'platform/forms/components/common/grid';
 import ErrorMessage from 'platform/forms/components/common/alerts/ErrorMessage';
 import PreSubmitSection from 'platform/forms/components/review/PreSubmitSection';
+import { focusAndScrollToReviewElement } from '../../utilities/ui';
+import { openReviewChapter, setEditMode } from '../../actions';
 
-export default function ValidationError(props) {
-  const { appType, formConfig, onBack, onSubmit, testId } = props;
+import { VA_FORM_IDS } from 'platform/forms/constants';
+
+function ValidationError(props) {
+  const { appType, formConfig, onBack, onSubmit, testId, formErrors } = props;
+
+  const errors = formErrors?.errors || [];
+  const errorsLen = errors.length;
+  const [hadErrors, setHadErrors] = useState(false);
+
+  useEffect(() => {
+    // Move focus
+    const errorFocus = document.querySelector('.error-message-focus');
+    if (errorFocus && !errorFocus.classList.contains('has-focused')) {
+      // focus on legend immediately above error links
+      errorFocus.focus();
+      errorFocus.classList.add('has-focused');
+    }
+  });
+
+  // check if we're using form 526 (will make this globally apply later)
+  const isForm526 = formConfig.formId === VA_FORM_IDS.FORM_21_526EZ;
+  // error links need evaluation & testing before production
+  const renderErrors =
+    errorsLen > 0 && isForm526 && !environment.isProduction();
+
+  if (!hadErrors && errorsLen > 0) {
+    setHadErrors(true);
+  }
+
+  const resolved = hadErrors && errorsLen === 0;
+
+  const errorTitle = resolved
+    ? `The information in your ${appType} now appears to be valid`
+    : `We’re sorry. Some information in your ${appType} is missing or
+      not valid.`;
+
+  const errorMessage = resolved ? (
+    `please try resubmitting your ${appType} now.`
+  ) : (
+    <>
+      {renderErrors && (
+        <fieldset>
+          <legend
+            className="error-message-focus vads-u-font-size--base"
+            tabIndex={-1}
+          >
+            The following required
+            {errorsLen === 1 ? ' item is ' : ' items are '}
+            preventing submission:
+          </legend>
+          <ul className="vads-u-margin-left--3">
+            {errors.map(error => (
+              <li key={error.name} className="error-message-list-item">
+                {error.chapterKey ? (
+                  <a
+                    href="#"
+                    className="error-message-list-link"
+                    onClick={event => {
+                      event.preventDefault();
+                      props.openReviewChapter(error.chapterKey);
+                      props.setEditMode(
+                        error.pageKey,
+                        true, // enable edit mode
+                        error.index || null,
+                      );
+                      // props.formContext.onError();
+                      focusAndScrollToReviewElement(error);
+                    }}
+                  >
+                    {error.message}
+                  </a>
+                ) : (
+                  error.message
+                )}
+              </li>
+            ))}
+          </ul>
+        </fieldset>
+      )}
+      <p>
+        Please check each section of your {appType} to make sure you’ve filled
+        out all the information that is required.
+      </p>
+    </>
+  );
 
   return (
     <>
       <Row>
         <Column role="alert" testId={testId}>
-          <ErrorMessage
-            active
-            title={`We’re sorry. Some information in your ${appType} is missing or not valid.`}
-            message={`Please check each section of your ${appType} to make sure you’ve
-              filled out all the information that is required.`}
-          />
+          <ErrorMessage active title={errorTitle} message={errorMessage} />
         </Column>
       </Row>
       <PreSubmitSection formConfig={formConfig} />
@@ -41,9 +124,23 @@ export default function ValidationError(props) {
   );
 }
 
+const mapDispatchToProps = {
+  openReviewChapter,
+  setEditMode,
+};
+
 ValidationError.propTypes = {
   appType: PropTypes.string,
   formConfig: PropTypes.object,
   onBack: PropTypes.func,
   onSubmit: PropTypes.func,
+  openReviewChapter: PropTypes.func,
+  setEditMode: PropTypes.func,
 };
+
+export default connect(
+  state => state,
+  mapDispatchToProps,
+)(ValidationError);
+
+export { ValidationError };

--- a/src/platform/forms-system/src/js/review/submit-states/ValidationError.jsx
+++ b/src/platform/forms-system/src/js/review/submit-states/ValidationError.jsx
@@ -106,7 +106,9 @@ function ValidationError(props) {
     <>
       <Row>
         <Column role="alert" testId={testId}>
-          <ErrorMessage active title={errorTitle} message={errorMessage} />
+          <ErrorMessage active title={errorTitle}>
+            {errorMessage}
+          </ErrorMessage>
         </Column>
       </Row>
       <PreSubmitSection formConfig={formConfig} />

--- a/src/platform/forms-system/src/js/review/submit-states/ValidationError.jsx
+++ b/src/platform/forms-system/src/js/review/submit-states/ValidationError.jsx
@@ -47,6 +47,11 @@ function ValidationError(props) {
     : `We’re sorry. Some information in your ${appType} is missing or
       not valid.`;
 
+  // "enum values:" may be followed by a very long list (e.g. all countries)
+  const enumValues = /(enum\svalues:.+)$/g;
+  const processMessage = message =>
+    message.replace(enumValues, 'the available values');
+
   const errorMessage = resolved ? (
     `please try resubmitting your ${appType} now.`
   ) : (
@@ -80,10 +85,10 @@ function ValidationError(props) {
                       focusAndScrollToReviewElement(error);
                     }}
                   >
-                    {error.message}
+                    {processMessage(error.message)}
                   </a>
                 ) : (
-                  error.message
+                  processMessage(error.message)
                 )}
               </li>
             ))}

--- a/src/platform/forms-system/src/js/state/helpers.js
+++ b/src/platform/forms-system/src/js/state/helpers.js
@@ -638,6 +638,7 @@ export function createInitialState(formConfig) {
       viewedPages: new Set(),
     },
     trackingPrefix: formConfig.trackingPrefix,
+    formErrors: {},
   };
 
   const pageAndDataState = createFormPageList(formConfig).reduce(

--- a/src/platform/forms-system/src/js/state/reducers.js
+++ b/src/platform/forms-system/src/js/state/reducers.js
@@ -9,6 +9,7 @@ import {
   SET_SUBMISSION,
   SET_SUBMITTED,
   SET_VIEWED_PAGES,
+  SET_FORM_ERRORS,
 } from '../actions';
 
 import { recalculateSchemaAndData } from '../state/helpers';
@@ -76,4 +77,8 @@ export default {
 
     return _.set('reviewPageView.viewedPages', viewedPages, state);
   },
+  [SET_FORM_ERRORS]: (state, { data = {} }) => ({
+    ...state,
+    formErrors: data,
+  }),
 };

--- a/src/platform/forms-system/src/js/utilities/data/reduceErrors.js
+++ b/src/platform/forms-system/src/js/utilities/data/reduceErrors.js
@@ -1,0 +1,195 @@
+import numberToWords from './numberToWords';
+// Process JSON-schema error messages for viewing
+
+// Convert array zero-baed number `test[0]` into a word `first test`
+const replaceNumberWithWord = (_, word, number) => {
+  const num = parseFloat(number);
+  return `${
+    isNaN(num) || !isFinite(num) ? number : numberToWords(num + 1)
+  } ${word}`;
+};
+
+// Make hard-coded jsonschema validation error messages _more_ readable. E.g.
+// * Changes`requires property "someCamelCasedProperty1"` is changed to
+//   `Some camel cased property 1`
+// * Array type properties need to get special treatment,
+//   `"instance.newDisabilities[0] requires property "cause"` is modified into
+//   `First new disabilities cause`.
+// Both of these methods use the schema property name, which also isn't ideal,
+// Sadly, the form validator is external to react-jsonschema-form and doesn't
+// collect the error messages. Also we can't use the title because the uiSchema
+// may have an empty title and/or empty or really long description. Also, we
+// would have to detect & process the title as either a string or React
+// component
+const formatErrors = message =>
+  message
+    .replace(/(requires property|instance\.?)\s*/g, '')
+    .replace(/(view:|ui:|")/g, '')
+    .replace(/(\w+)\[(\d+)\]/, replaceNumberWithWord)
+    // Change camel case variable names into something readable.
+    .replace(/[A-Z]/g, str => ` ${str.toLowerCase()}`)
+    // Separate numbers (e.g. "address1" -> "address 1")
+    .replace(/([a-z])(\d)/g, '$1 $2')
+    // "zip" code replaced with "postal" code in content, but not property names
+    .replace(/zip\s(code)?/i, 'postal code')
+    // Make abbreviations upper case
+    .replace(/\b(va|pow)\b/g, str => ` ${str.toUpperCase()} `)
+    .trim()
+    .replace(/^./, str => str.toUpperCase());
+
+// min/max length or item errors may show up as duplicates
+const errorExists = (acc, name) => acc.find(obj => obj.name === name);
+
+// Keys to ignore within the pageList objects & pageList schema
+const ignoreKeys = [
+  'title',
+  'path',
+  'depends',
+  'schema',
+  'chapterTitle',
+  'chapterKey',
+  'pageKey',
+  'type',
+  'required',
+  'initialData',
+];
+
+export const isIgnoredSchemaKey = key =>
+  key.startsWith('ui:') || ignoreKeys.includes(key);
+
+// Find the chapter and page name that contains the property (name) which is
+// used to build a link that will expand the associated accordion when clicked
+const getPropertyInfo = (pageList = [], name, instance = '') => {
+  const findPageIndex = (obj, insideInstance = instance === '') => {
+    if (obj && typeof obj === 'object') {
+      return Object.keys(obj).findIndex(key => {
+        if (isIgnoredSchemaKey(key)) {
+          return false;
+        }
+        if (insideInstance && name === key && obj[name]) {
+          return true;
+        }
+        return findPageIndex(obj[key], insideInstance || key === instance) > -1;
+      });
+    }
+    return -1;
+  };
+  return pageList.find(page => findPageIndex(page) > -1) || {};
+};
+
+/**
+ * @typedef Form~errors
+ * @type {object[]}
+ * @property {string} name - form element name from uiSchema
+ * @property {number|null} index - if the value is an array, this is the index
+ * @property {string} message - processed error message
+ * @property {string} chapterKey - the chapter the element is associated with
+ * @property {string} pageKey - the page within the chapter the element is
+ *   associated with
+ */
+/**
+ * @typedef Form~rawErrors - list of raw errors that are output from jsonschema
+ *   validator
+ * @type {object}
+ * @property {string} property
+ * @property {string} message
+ * @property {string} name
+ * @property {string|number} argument - element name or index in array
+ * @property {object} schema - ignored
+ * @property {string} stack - error message used in processing
+ * @property {string[]} __errors - may contain multiple error messages for one
+ *   element
+ *
+ * There are four types of hardcoded validation error messages:
+ *
+ * min/max: {
+    property: 'instance.someProperty',
+    message: 'does not meet minimum length of 1',
+    name: 'minItems',
+    argument: 1,
+    schema: {...},
+    stack: 'instance.someProperty does not meet minimum length of 1'
+  }
+  * required: {
+    property: 'instance',
+    message: 'requires property "someProperty"',
+    name: 'required',
+    argument: 'someProperty',
+    schema: {...},
+    stack: 'instance requires property "someProperty"'
+  }
+  * array: {
+    property: 'instance.newDisabilities[0]',
+    message: 'requires property "cause"',
+    name: 'required',
+    argument: 'cause',
+    schema: {...},
+    stack: 'instance.newDisabilities[0] requires property "cause"'
+  }
+  * non-empty "__errors" array: {
+    __errors: ['error message']
+  }
+*/
+/**
+ * @typedef Form~formErrors
+ * @type {object}
+ * @property {Form~rawErrors}
+ * @property {Form~errors}
+ */
+/**
+ * Process rawErrors from jsonschema validator into a more friendly list
+ * @param {Form~formErrors} errors
+ * @param {object[]} pageList - list of all form pages from `form.pages`
+ */
+export const reduceErrors = (errors, pageList) =>
+  errors.reduce((acc, error) => {
+    const findErrors = (key, err) => {
+      if (typeof err === 'object') {
+        if (err.message) {
+          const property = err.property.replace(/instance\.?/, '') || '';
+          const instance = property.replace(/(\[\d+\])/, '');
+          const name = err.name === 'required' ? err.argument : instance;
+          /*
+           * There may be multiple errors for the same property, e.g.
+           * `contestedIssues` in form 996. It can have a custom message
+           * "Please select a contested issue" and a minItem error
+           * "Does not meet minimum length of 1"; there's no need to confuse
+           * anyone and show both
+          */
+          if (!errorExists(acc, name)) {
+            const { chapterKey = '', pageKey = '' } = getPropertyInfo(
+              pageList,
+              err.argument,
+              err.property.startsWith('instance.') ? instance : '',
+            );
+            acc.push({
+              name,
+              // property may be `array[0]`; we need to extract out the `[0]`
+              index: property.match(/\[(\d+)\]/)?.[1] || null,
+              message: formatErrors(err.stack),
+              chapterKey,
+              pageKey,
+            });
+          }
+          return null;
+        }
+        if (err.__errors && err.__errors.length && !errorExists(acc, key)) {
+          const { chapterKey = '', pageKey = '' } = getPropertyInfo(
+            pageList,
+            key,
+          );
+          acc.push({
+            name: key,
+            index: null,
+            message: err.__errors.map(e => formatErrors(e)).join('. '),
+            chapterKey,
+            pageKey,
+          });
+        }
+        Object.keys(err).forEach(sub => findErrors(sub, err[sub]));
+      }
+      return null;
+    };
+    findErrors('', error);
+    return acc;
+  }, []);

--- a/src/platform/forms-system/src/js/utilities/ui/index.js
+++ b/src/platform/forms-system/src/js/utilities/ui/index.js
@@ -1,10 +1,12 @@
 import Scroll from 'react-scroll';
 
+export const $ = selectorOrElement =>
+  typeof selectorOrElement === 'string'
+    ? document.querySelector(selectorOrElement)
+    : selectorOrElement;
+
 export function focusElement(selectorOrElement, options) {
-  const el =
-    typeof selectorOrElement === 'string'
-      ? document.querySelector(selectorOrElement)
-      : selectorOrElement;
+  const el = $(selectorOrElement);
 
   if (el) {
     if (el.tabIndex === 0) {
@@ -17,16 +19,70 @@ export function focusElement(selectorOrElement, options) {
   }
 }
 
+// List from https://html.spec.whatwg.org/dev/dom.html#interactive-content
+const focusableElements = [
+  '[href]',
+  'button',
+  'details',
+  'input:not([type="hidden"])',
+  'select',
+  'textarea',
+  /* focusable, but not tabbable */
+  '[tabindex]:not([tabindex="-1"])',
+  /* label removed from list, because you can't programmically focus it
+   * unless it has a tabindex of 0 or -1; clicking on it shifts focus to the
+   * associated focusable form element
+   */
+  // 'label[for]',
+  /* focusable elements not used in our form system */
+  // 'audio[controls]',
+  // 'embed',
+  // 'iframe',
+  // 'img[usemap]',
+  // 'object[usemap]',
+  // 'video[controls]',
+];
+/**
+ * Find all the focusable elements within a block
+ * @param {HTMLElement|node} block - wrapping element
+ * @return {HTMLElement[]}
+ */
+export const getFocusableElements = block =>
+  block
+    ? [...block?.querySelectorAll(focusableElements.join(','))].filter(
+        // Ignore disabled & hidden elements
+        // This does not check the element's visibility or opacity
+        el => !el.disabled && el.offsetWidth > 0 && el.offsetHeight > 0,
+      )
+    : [];
+
+const scrollElementName = 'ScrollElement';
+
 // Set focus on target _after_ the content has been updated
 export function focusOnChange(name, target = '.edit-btn') {
   setTimeout(() => {
-    const selector = `[name="${name}ScrollElement"]`;
+    const selector = `[name="${name}${scrollElementName}"]`;
     const el = document.querySelector(selector);
     // nextElementSibling = page form
     const focusTarget = el?.nextElementSibling?.querySelector(target);
     focusElement(focusTarget);
   });
 }
+
+export const scrollToElement = name => {
+  if (name) {
+    const el =
+      typeof name === 'string' && name.includes('name=') ? $(name) : name;
+    Scroll.scroller.scrollTo(
+      el, // pass a string key + 'ScrollElement' or DOM element
+      window.Forms.scroll || {
+        duration: 500,
+        delay: 2,
+        smooth: true,
+      },
+    );
+  }
+};
 
 export function setGlobalScroll() {
   window.Forms = window.Forms || {
@@ -50,7 +106,7 @@ export function getScrollOptions(additionalOptions) {
 }
 
 export function scrollToFirstError() {
-  const errorEl = document.querySelector('.usa-input-error, .input-error-date');
+  const errorEl = $('.usa-input-error, .input-error-date');
   if (errorEl) {
     // document.body.scrollTop doesn’t work with all browsers, so we’ll cover them all like so:
     const currentPosition =
@@ -68,3 +124,66 @@ export function scrollToFirstError() {
     focusElement(errorEl);
   }
 }
+
+/**
+ * @typedef FormUtility~findTargetOptions
+ * @type {object}
+ * @property {boolean} getLabel - if true, return label vs actual element
+ */
+/**
+ * Find the wrapping accordion header, or the label of a specific element inside
+ * the accordion
+ * @param {Form~errors} error - single error from `form.formErrors.errors`
+ * @param {FormUtility~findTargetOptions}
+ * @return {HTMLElement} - either the form element or associated label
+ */
+const findTarget = (error, { getLabel = true } = {}) => {
+  // index value indicates an array instance (saved as a string, e.g. '0')
+  const propertyKey = `${error.pageKey}${error.index || ''}`;
+  const el = $(`[name="${propertyKey}${scrollElementName}"]`);
+  if (error.pageKey === error.chapterKey) {
+    return el;
+  }
+  // Find all visible elements within the form
+  const form = el?.closest('.form-review-panel-page')?.querySelector('form');
+  const formElement = getFocusableElements(form)
+    // narrow down search to a matching id (if possible)
+    .filter(
+      elm =>
+        // ID may not match in an array block (e.g. 526 servicePeriods)
+        (error.index || '') === '' ? elm.id.includes(`_${error.name}`) : true,
+    )?.[0];
+  return getLabel
+    ? formElement
+        ?.closest('.schemaform-field-template')
+        ?.querySelector('legend, label')
+    : formElement;
+};
+
+/**
+ * Focus on the review form accordion chapter, or form element; then scroll
+ * to that element. Code is within a setTimeout since it is difficult to add a
+ * ref or call this function within the componentDidMount function (both within
+ * the rjsf library)
+ * The error object is created by ../utilities/data/reduceErrors.js
+ * @param {Form~errors} error - single error from `form.formErrors.errors`
+ */
+export const focusAndScrollToReviewElement = (error = {}) => {
+  if (error.name) {
+    // Ensure DOM updates
+    setTimeout(() => {
+      const el = findTarget(error);
+      if (el) {
+        if (error.pageKey === error.chapterKey) {
+          // Focus on accordion header (pageKey title is hidden)
+          focusElement(el);
+          scrollToElement(`chapter${error.chapterKey}${scrollElementName}`);
+        } else {
+          focusElement(el);
+          // label/legend with id OR div before an array (table) wrapper
+          scrollToElement(el.id || `topOfTable_${error.name}`);
+        }
+      }
+    });
+  }
+};

--- a/src/platform/forms-system/test/js/actions.unit.spec.js
+++ b/src/platform/forms-system/test/js/actions.unit.spec.js
@@ -14,6 +14,8 @@ import {
   SET_SUBMITTED,
   submitForm,
   uploadFile,
+  setFormErrors,
+  SET_FORM_ERRORS,
 } from '../../src/js/actions';
 
 describe('Schemaform actions:', () => {
@@ -513,6 +515,14 @@ describe('Schemaform actions:', () => {
         name: 'jpg',
         errorMessage: 'Internal Server Error',
       });
+    });
+  });
+  describe('setFormErrors', () => {
+    it('should return action', () => {
+      const data = { test: 'foo' };
+      const action = setFormErrors(data);
+      expect(action.data).to.equal(data);
+      expect(action.type).to.equal(SET_FORM_ERRORS);
     });
   });
 });

--- a/src/platform/forms-system/test/js/review/ArrayField.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/review/ArrayField.unit.spec.jsx
@@ -158,6 +158,71 @@ describe('Schemaform review <ArrayField>', () => {
       'Add Another Item name',
     );
   });
+
+  it('should call handleAdd in edit mode with no data', done => {
+    const schema = {
+      type: 'array',
+      items: [
+        {
+          type: 'object',
+          properties: {
+            field: {
+              type: 'string',
+            },
+          },
+        },
+        {
+          type: 'object',
+          properties: {
+            field: {
+              type: 'string',
+            },
+          },
+        },
+      ],
+      additionalItems: {
+        type: 'object',
+        properties: {
+          field: {
+            type: 'string',
+          },
+        },
+      },
+    };
+    const uiSchema = {
+      'ui:title': 'List of things',
+      items: {},
+      'ui:options': {
+        viewField: f => f,
+        itemName: 'Item name',
+      },
+    };
+    const tree = SkinDeep.shallowRender(
+      <ArrayField
+        pageKey="page1"
+        arrayData={[]}
+        path={['thingList']}
+        schema={schema}
+        uiSchema={uiSchema}
+        idSchema={{}}
+        registry={registry}
+        formContext={{ onReviewPage: true }}
+        editing
+        pageTitle=""
+        requiredSchema={requiredSchema}
+      />,
+    );
+    setTimeout(() => {
+      // componenetDidMount not called?!
+      tree.getMountedInstance().componentDidMount();
+      expect(tree.everySubTree('h5')[0].text()).to.equal('New Item name');
+      expect(tree.everySubTree('button')[2].text()).to.equal(
+        'Add Another Item name',
+      );
+      done();
+    }, 0);
+  });
+
   it('should render array warning', () => {
     // If it's a BasicArrayField with a set minItems, make sure it doesn't break
     //  if no items are found; it should render a validation warning instead.

--- a/src/platform/forms-system/test/js/review/SubmitButtons.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/review/SubmitButtons.unit.spec.jsx
@@ -9,7 +9,6 @@ import GenericError from '../../../src/js/review/submit-states/GenericError';
 import Pending from '../../../src/js/review/submit-states/Pending';
 import Submitted from '../../../src/js/review/submit-states/Submitted';
 import ThrottledError from '../../../src/js/review/submit-states/ThrottledError';
-import ValidationError from '../../../src/js/review/submit-states/ValidationError';
 
 describe('Schemaform review: <SubmitButtons>', () => {
   let formConfig;
@@ -84,10 +83,7 @@ describe('Schemaform review: <SubmitButtons>', () => {
     const tree = SkinDeep.shallowRender(
       <SubmitButtons submission={submission} formConfig={formConfig} />,
     );
-
-    expect(tree.everySubTree('ValidationError')[0].type).to.equal(
-      ValidationError,
-    );
+    expect(tree.everySubTree('Connect(ValidationError)')).to.exist;
   });
 
   it('renders throttled error', () => {

--- a/src/platform/forms-system/test/js/review/submit-states/ValidationError.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/review/submit-states/ValidationError.unit.spec.jsx
@@ -9,6 +9,7 @@ import createCommonStore from 'platform/startup/store';
 import createSchemaFormReducer from 'platform/forms-system/src/js/state';
 import reducers from 'platform/forms-system/src/js/state/reducers';
 
+import { VA_FORM_IDS } from 'platform/forms/constants';
 import ValidationError from '../../../../src/js/review/submit-states/ValidationError';
 
 const createForm = options => ({
@@ -206,6 +207,64 @@ describe('Schemaform review: <ValidationError />', () => {
       ),
     ).to.not.be.null;
     expect(tree.getByTestId('12345')).to.have.attribute('role', 'alert');
+
+    tree.unmount();
+  });
+
+  it('has the expected list of errors', () => {
+    const formErrors = {
+      errors: [
+        {
+          name: 'test',
+          message: 'Missing test',
+          chapterKey: 'Test',
+          index: 0,
+        },
+        { name: 'zip', message: 'Zip', chapterKey: 'Zip', pageKey: 'zip' },
+        // No chapter -> no link to open accordion
+        { name: 'empty', message: 'Property not found', chapterKey: '' },
+      ],
+    };
+
+    const onBack = sinon.spy();
+    const onSubmit = sinon.spy();
+
+    const form = createForm();
+    const formConfig = getFormConfig();
+
+    formConfig.formId = VA_FORM_IDS.FORM_21_526EZ;
+
+    const formReducer = createformReducer({
+      formConfig: form,
+    });
+
+    const store = createStore();
+    store.injectReducer('form', formReducer);
+
+    const tree = render(
+      <Provider store={store}>
+        <ValidationError
+          appType="test"
+          formConfig={formConfig}
+          formErrors={formErrors}
+          onBack={onBack}
+          onSubmit={onSubmit}
+          testId={'12345'}
+        />
+      </Provider>,
+    );
+
+    expect(
+      tree.getByText(
+        'We’re sorry. Some information in your test is missing or not valid.',
+      ),
+    ).to.not.be.null;
+    expect(
+      tree.getByText('The following required items are preventing submission:'),
+    ).to.not.be.null;
+    expect(tree.getByText('Missing test')).to.not.be.null;
+    expect(tree.getByText('Zip')).to.not.be.null;
+    expect(tree.getByText('Property not found')).to.not.be.null;
 
     tree.unmount();
   });

--- a/src/platform/forms-system/test/js/state/index.unit.spec.js
+++ b/src/platform/forms-system/test/js/state/index.unit.spec.js
@@ -8,6 +8,7 @@ import {
   SET_PRE_SUBMIT,
   SET_SUBMISSION,
   SET_SUBMITTED,
+  SET_FORM_ERRORS,
 } from '../../../src/js/actions';
 
 import createSchemaFormReducer from '../../../src/js/state';
@@ -232,6 +233,22 @@ describe('schemaform createSchemaFormReducer', () => {
 
       expect(state.submission.status).to.equal('applicationSubmitted');
       expect(state.submission.response).to.eql({ field: 'test' });
+    });
+    it('should set form errors', () => {
+      const data = {
+        rawErrors: ['raw error'],
+        errors: ['error'],
+      };
+      const state = reducer(
+        {
+          formErrors: {},
+        },
+        {
+          type: SET_FORM_ERRORS,
+          data,
+        },
+      );
+      expect(state.formErrors).to.equal(data);
     });
   });
 });

--- a/src/platform/forms-system/test/js/utilities/reduceErrors.unit.spec.js
+++ b/src/platform/forms-system/test/js/utilities/reduceErrors.unit.spec.js
@@ -1,0 +1,438 @@
+import { expect } from 'chai';
+
+import { reduceErrors } from '../../../src/js/utilities/data/reduceErrors';
+
+// Portions copied from form 996 & 526
+const pageList = [
+  {
+    pageKey: 'introduction',
+    path: '/introduction',
+  },
+  {
+    title: 'Veteran information',
+    path: '/veteran-information',
+    uiSchema: {},
+    schema: {
+      type: 'object',
+      properties: {},
+    },
+    chapterKey: 'veteranDetails',
+    pageKey: 'veteranInformation',
+  },
+  {
+    title: 'Contested issues',
+    path: '/contested-issues',
+    uiSchema: {
+      'ui:title': ' ',
+      contestedIssues: {
+        'ui:title': ' ',
+        'ui:description': '',
+        'ui:field': 'StringField',
+        'ui:options': {},
+      },
+      'view:contestedIssuesAlert': {},
+      'view:disabilitiesExplanation': {
+        'ui:description': '',
+      },
+    },
+    schema: {},
+    initialData: {
+      primaryPhone: '1234556789',
+      emailAddress: 'vet@vet.com',
+    },
+    chapterTitle: 'Contested issues',
+    chapterKey: 'contestedIssues',
+    pageKey: 'contestedIssues',
+  },
+  {
+    title: 'Military service history',
+    path: '/review-veteran-details/military-service-history',
+    uiSchema: {
+      serviceInformation: {
+        servicePeriods: {
+          'ui:title': '',
+          'ui:description': '',
+          'ui:options': {},
+          items: {
+            serviceBranch: {},
+            dateRange: {},
+            'ui:options': {},
+          },
+        },
+      },
+    },
+    schema: {},
+    chapterKey: 'veteranDetails',
+    pageKey: 'militaryHistory',
+  },
+  {
+    title: 'Retirement pay',
+    path: '/retirement-pay',
+    uiSchema: {
+      'view:hasMilitaryRetiredPay': {
+        'ui:title': '',
+        'ui:widget': 'yesNo',
+        'ui:options': {},
+      },
+      militaryRetiredPayBranch: {
+        'ui:title': '',
+        'ui:options': {},
+      },
+    },
+    schema: {},
+    chapterKey: 'veteranDetails',
+    pageKey: 'retirementPay',
+  },
+  {
+    title: 'Training pay',
+    path: '/training-pay',
+    uiSchema: {
+      hasTrainingPay: {},
+    },
+    schema: {},
+    chapterKey: 'veteranDetails',
+    pageKey: 'trainingPay',
+  },
+  {
+    title: 'New disabilities',
+    path: '/new-disabilities',
+    uiSchema: {
+      'view:newDisabilities': {
+        'ui:title': '',
+        'ui:validations': [],
+      },
+      'view:noSelectedAlert': {},
+    },
+    schema: {},
+    chapterTitle: 'Disabilities',
+    chapterKey: 'disabilities',
+    pageKey: 'newDisabilities',
+  },
+  {
+    title: 'Prisoner of war (POW)',
+    path: '/pow',
+    uiSchema: {
+      'ui:title': '',
+      'view:powStatus': {},
+      'view:isPow': {
+        confinements: {},
+        powDisabilities: {},
+      },
+    },
+    schema: {},
+    chapterTitle: 'Disabilities',
+    chapterKey: 'disabilities',
+    pageKey: 'prisonerOfWar',
+  },
+  {
+    title: 'Veteran contact information',
+    path: '/contact-information',
+    uiSchema: {
+      'ui:title': 'Contact information',
+      phoneAndEmail: {
+        'ui:title': 'Phone & email',
+        primaryPhone: {},
+        emailAddress: {},
+      },
+      mailingAddress: {
+        'ui:title': 'Mailing address',
+        country: {},
+        addressLine1: {},
+        addressLine2: {},
+        addressLine3: {},
+        city: {},
+        state: {},
+        zipCode: {},
+      },
+      'view:contactInfoDescription': {},
+    },
+    schema: {},
+    chapterTitle: 'Additional information',
+    chapterKey: 'additionalInformation',
+    pageKey: 'contactInformation',
+  },
+  {
+    title: 'Housing situation',
+    path: '/housing-situation',
+    uiSchema: {
+      homelessOrAtRisk: {},
+      'view:isHomeless': {
+        'ui:options': {},
+        homelessHousingSituation: {},
+        otherHomelessHousing: {},
+        needToLeaveHousing: {},
+      },
+      'view:isAtRisk': {
+        'ui:options': {},
+        atRiskHousingSituation: {},
+        otherAtRiskHousing: {},
+      },
+      homelessnessContact: {
+        name: {},
+        phoneNumber: {},
+      },
+    },
+    schema: {},
+    chapterTitle: 'Additional information',
+    chapterKey: 'additionalInformation',
+    pageKey: 'homelessOrAtRisk',
+  },
+  {
+    path: '/new-disabilities/follow-up/:index',
+    showPagePerItem: true,
+    arrayPath: 'newDisabilities',
+    uiSchema: {
+      'ui:title': 'Disability details',
+      newDisabilities: {
+        items: {
+          cause: {
+            'ui:title': {},
+            'ui:widget': 'radio',
+            'ui:options': {},
+          },
+          primaryDescription: {
+            'ui:title': '',
+            'ui:widget': 'textarea',
+            'ui:options': {},
+            'ui:validations': [],
+          },
+          'view:secondaryFollowUp': {
+            'ui:options': {},
+            causedByDisability: {
+              'ui:title': '',
+              'ui:options': {},
+            },
+            causedByDisabilityDescription: {},
+          },
+          'view:worsenedFollowUp': {
+            'ui:options': {},
+            worsenedDescription: {},
+            worsenedEffects: {},
+          },
+          'view:vaFollowUp': {
+            'ui:options': {},
+            vaMistreatmentDescription: {},
+            vaMistreatmentLocation: {},
+            vaMistreatmentDate: {},
+          },
+        },
+      },
+    },
+    schema: {},
+    chapterTitle: 'Disabilities',
+    chapterKey: 'disabilities',
+    pageKey: 'newDisabilityFollowUp',
+  },
+];
+
+const rawErrors = [
+  {},
+  {
+    contestedIssues: {
+      __errors: ['Please select a contested issue'],
+    },
+  },
+  {
+    'view:hasAlternateName': {
+      __errors: [],
+    },
+    alternateNames: {
+      __errors: [],
+    },
+    uiSchema: {
+      primaryPhone: {}, // ignored since it's not the correct instance
+    },
+  },
+  {
+    property: 'instance',
+    message: 'requires property "view:hasMilitaryRetiredPay"',
+    schema: {},
+    name: 'required',
+    argument: 'view:hasMilitaryRetiredPay',
+    stack: 'instance requires property "view:hasMilitaryRetiredPay"',
+  },
+  {
+    property: 'instance',
+    message: 'requires property "hasTrainingPay"',
+    schema: {},
+    name: 'required',
+    argument: 'hasTrainingPay',
+    stack: 'instance requires property "hasTrainingPay"',
+  },
+  {},
+  {
+    property: 'instance',
+    message: 'requires property "view:newDisabilities"',
+    schema: {},
+    name: 'required',
+    argument: 'view:newDisabilities',
+    stack: 'instance requires property "view:newDisabilities"',
+  },
+  {
+    property: 'instance',
+    message: 'requires property "view:powStatus"',
+    schema: {},
+    name: 'required',
+    argument: 'view:powStatus',
+    stack: 'instance requires property "view:powStatus"',
+  },
+  {
+    property: 'instance.phoneAndEmail',
+    message: 'requires property "primaryPhone"',
+    schema: {},
+    name: 'required',
+    argument: 'primaryPhone',
+    stack: 'instance.phoneAndEmail requires property "primaryPhone"',
+  },
+  {
+    property: 'instance.phoneAndEmail',
+    message: 'requires property "emailAddress"',
+    schema: {},
+    name: 'required',
+    argument: 'emailAddress',
+    stack: 'instance.phoneAndEmail requires property "emailAddress"',
+  },
+  {
+    property: 'instance.mailingAddress',
+    message: 'requires property "city"',
+    schema: {},
+    name: 'required',
+    argument: 'city',
+    stack: 'instance.mailingAddress requires property "city"',
+  },
+  {
+    property: 'instance.mailingAddress',
+    message: 'requires property "addressLine1"',
+    schema: {},
+    name: 'required',
+    argument: 'addressLine1',
+    stack: 'instance.mailingAddress requires property "addressLine1"',
+  },
+  {
+    'view:bankAccount': {
+      __errors: [],
+      bankAccountType: {
+        __errors: [],
+      },
+      bankAccountNumber: {
+        __errors: [],
+      },
+      bankRoutingNumber: {
+        __errors: [],
+      },
+      bankName: {
+        __errors: [],
+      },
+    },
+  },
+  {
+    property: 'instance',
+    message: 'requires property "homelessOrAtRisk"',
+    schema: {},
+    name: 'required',
+    argument: 'homelessOrAtRisk',
+    stack: 'instance requires property "homelessOrAtRisk"',
+  },
+  {
+    isTerminallyIll: {
+      __errors: [],
+    },
+    'view:terminallyIllInfo': {
+      __errors: [],
+    },
+  },
+  {
+    property: 'instance.newDisabilities[0]',
+    message: 'requires property "cause"',
+    schema: {},
+    name: 'required',
+    argument: 'cause',
+    stack: 'instance.newDisabilities[0] requires property "cause"',
+  },
+];
+
+const result = [
+  {
+    name: 'contestedIssues',
+    message: 'Please select a contested issue',
+    chapterKey: 'contestedIssues',
+    pageKey: 'contestedIssues',
+    index: null,
+  },
+  {
+    name: 'view:hasMilitaryRetiredPay',
+    message: 'Has military retired pay',
+    chapterKey: 'veteranDetails',
+    pageKey: 'retirementPay',
+    index: null,
+  },
+  {
+    name: 'hasTrainingPay',
+    message: 'Has training pay',
+    chapterKey: 'veteranDetails',
+    pageKey: 'trainingPay',
+    index: null,
+  },
+  {
+    name: 'view:newDisabilities',
+    message: 'New disabilities',
+    chapterKey: 'disabilities',
+    pageKey: 'newDisabilities',
+    index: null,
+  },
+  {
+    name: 'view:powStatus',
+    message: 'POW  status',
+    chapterKey: 'disabilities',
+    pageKey: 'prisonerOfWar',
+    index: null,
+  },
+  {
+    name: 'primaryPhone',
+    message: 'Phone and email primary phone',
+    chapterKey: 'additionalInformation',
+    pageKey: 'contactInformation',
+    index: null,
+  },
+  {
+    name: 'emailAddress',
+    message: 'Phone and email email address',
+    chapterKey: 'additionalInformation',
+    pageKey: 'contactInformation',
+    index: null,
+  },
+  {
+    name: 'city',
+    message: 'Mailing address city',
+    chapterKey: 'additionalInformation',
+    pageKey: 'contactInformation',
+    index: null,
+  },
+  {
+    name: 'addressLine1',
+    message: 'Mailing address address line 1',
+    chapterKey: 'additionalInformation',
+    pageKey: 'contactInformation',
+    index: null,
+  },
+  {
+    name: 'homelessOrAtRisk',
+    message: 'Homeless or at risk',
+    chapterKey: 'additionalInformation',
+    pageKey: 'homelessOrAtRisk',
+    index: null,
+  },
+  {
+    name: 'cause',
+    message: 'First new disabilities cause',
+    chapterKey: 'disabilities',
+    pageKey: 'newDisabilityFollowUp',
+    index: '0',
+  },
+];
+
+describe('Process form validation errors', () => {
+  it('should process the JSON schema form errors into', () => {
+    expect(reduceErrors(rawErrors, pageList)).to.eql(result);
+  });
+});

--- a/src/platform/forms/components/common/alerts/ErrorMessage.jsx
+++ b/src/platform/forms/components/common/alerts/ErrorMessage.jsx
@@ -22,8 +22,7 @@ function ErrorMessage(props) {
           <p className="schemaform-warning-header">
             <strong>{title}</strong>
           </p>
-          {message}
-          <p />
+          <p>{message}</p>
           {children}
         </div>
       </div>

--- a/src/platform/forms/components/common/alerts/ErrorMessage.jsx
+++ b/src/platform/forms/components/common/alerts/ErrorMessage.jsx
@@ -22,7 +22,8 @@ function ErrorMessage(props) {
           <p className="schemaform-warning-header">
             <strong>{title}</strong>
           </p>
-          <p>{message}</p>
+          {message}
+          <p />
           {children}
         </div>
       </div>

--- a/src/platform/forms/save-in-progress/reducers.js
+++ b/src/platform/forms/save-in-progress/reducers.js
@@ -132,6 +132,7 @@ export function createSaveInProgressInitialState(formConfig, initialState) {
     prefillTransformer: formConfig.prefillTransformer,
     trackingPrefix: formConfig.trackingPrefix,
     additionalRoutes: formConfig.additionalRoutes,
+    formErrors: formConfig.formErrors,
   });
 }
 


### PR DESCRIPTION
## Description

This is a global form change that shows the user any form errors on the review page after attempting to submit the form.

These changes will not be shown in production until it has been review throughly.

Original ticket: https://github.com/department-of-veterans-affairs/va.gov-team/issues/2138
Original PR: https://github.com/department-of-veterans-affairs/vets-website/pull/11564 (split into smaller PRs)

**WIP**: Things that still need to be done, or fixed (so far)

* <details><summary>Some dynamic required fields.</summary>
  I think this problem is mostly due to issues with the `schema`, but I haven't searched for, or attempted to fix them all. 

  For example, if you test form 526 (see instructions above). Use the "Please select at least one type of supporting evidence" link. The accordion & section will open in edit mode. Select any (or all) of the 3 checkboxes. The error in the alert will disappear, with no new errors, and the sections that were checked will remain visible with a warning icon.</details>

* <details><summary>Missing some dynamic error updates</summary>
  The list of errors do not always update dynamically. This may or may not be due to the schema; I could get this error to show if I made the code search for and include all undefined arrays, but then non-required array entries would be added to the error list.
    
  For example:
  
    * In form 526, use the "New disabilities" error link.
    * After choosing "Yes" and using "Update page", a "New condition" section will appear; but it will not be included in the error list. 
    * Now use the "New condition" edit button and add an entry like "GERD"
    * Use "Update" to save the entry.
    * Now scroll down to the error list. No mention of the condition is listed  _until_ you press the "Submit application" button.
    * You will now see a "First new disabilities cause" error link appear.
  </details>
* <details><summary>Show error messages in edit mode</summary>

  Normally, error messages are not visible until the form element has been focused and blurred, or if the user tries to update or submit the page while the form element is visible. @jenstrickland recommended to make the form errors visible when the page is opened in edit mode. I haven't been able to programmatically make the form errors visible. I have tried:

  * Initially called `props.formContext.onError()` which forced _all_ form errors to show up; now I can't remember where I got the `formContext` that included that function. Either way, showing _all_ errors isn't ideal. 
  * Calling `onBlur` on the element itself - no change; but I think we would first need access to the internal `touched` value.
  * Calling `props.formContext.onBlur(elementID)` - function not accessible from the `RoutedSavableReviewPage` (grandparent component of the SubmitButtons component where the error links code lives)
  </details>

* <details><summary>Add e2e unit tests</summary>
  Once these changes are nearly finalized, e2e tests will be added.</details>

## How to test

* You'll need to have the local server & vets-api running
* <details><summary>For the HLR page:</summary>

  <!-- leave a blank line above -->
  * No need to log in - this page is still a WIP
  * Go to http://localhost:3001/decision-reviews/higher-level-review/request-higher-level-review-form-20-0996/review-and-submit
  * Check the "I have read and accept..." checkbox
  * Press "Submit application" button
  * You should now be focused on the error alert box

    <details><summary>Screenshot</summary>

    <!-- leave a blank line above -->
    ![Screen Shot 2020-03-02 at 9 45 33 AM](https://user-images.githubusercontent.com/136959/75692106-abfd1480-5c6a-11ea-8219-293525f4d471.png)
    </details>
  * The "Schedule times" link won't work because I need to fix the schema's dynamic requirement method. I didn't change it so I could demo examples of broken links.
 </details>

* <details><summary>For form 526EZ:</summary>

  <!-- leave a blank line above -->
  * Log in to user 228
  * Go straight to http://localhost:3001/disability/file-disability-claim-form-21-526ez/review-and-submit
  * Click "Continue" on the ITF page
  * Check the "I have read and accept..." checkbox
  * Press "Submit application" button
  * You should now be focused on the error alert box

    <details><summary>Screenshot</summary>

    <!-- leave a blank line above -->
    ![Screen Shot 2020-03-02 at 9 54 40 AM](https://user-images.githubusercontent.com/136959/75692919-de5b4180-5c6b-11ea-8198-30d8485721a8.png)
    </details>
  </details>

* Other forms haven't been tested (yet)

## Testing done

- Local unit tests
- Tests for new/modified components

## Screenshots

The list of interactive errors links in the alert box

* <details><summary>HLR</summary>

  <!-- leave a blank line above -->
  ![Screen Shot 2020-03-02 at 10 13 52 AM](https://user-images.githubusercontent.com/136959/75694772-b15c5e00-5c6e-11ea-8145-19716dacd474.png)

  Note: the "Scheduled times" link will not focus on any form elements, at least until the "Informal conference choice" is made. This was left in place to show that some form errors are due to the structure of the `uiSchema` ; a simple change to the `uiSchema` will prevent this "extra" link from showing up.
  </details>

* <details><summary>Form 526</summary>

  <!-- leave a blank line above -->
  ![Screen Shot 2020-03-02 at 10 14 06 AM](https://user-images.githubusercontent.com/136959/75694833-c638f180-5c6e-11ea-976b-e1fcb8bb1796.png)
  </details>

## Acceptance criteria
- [ ] Form error links only show up in local, staging & dev environments
- [ ] Error links scroll to the associated page form & focus on the label/legend immediately above the form element (input, radio, etc)
- [ ] After updating, the item is removed from the error list
- [ ] After all items have been handled, the error list message will change to inform the user to try submitting again

## Definition of done
- [x] Events are logged appropriately; error messages are already logged to Sentry.
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
