### PR TITLE
Removed subTitle double check

### DIFF
--- a/src/applications/facility-locator/components/search-results/LocationPhoneLink.jsx
+++ b/src/applications/facility-locator/components/search-results/LocationPhoneLink.jsx
@@ -24,7 +24,7 @@ const renderPhoneNumber = (
       {!isCCProvider && phone.replace(re, '$1-$2-$3 $4$5').replace(/x$/, '')}
       <br />
       {from === 'FacilityDetail' && <i className="fa fa-fw" />}
-      {subTitle && subTitle}
+      {subTitle}
       {isCCProvider &&
         ` ${phone.replace(re, '$1-$2-$3 $4$5').replace(/x$/, '')}`}
       {from === 'FacilityDetail' ? (


### PR DESCRIPTION
## Description

`no-identical-expressions` rule from SonarJS has been added to the testing stage in CircleCI (circle.esint.json)

This change should help the code to be in compliance with the rule and removes the errors from `additional-linting` CircleCI check.

## Testing done
Locally

## Screenshots

<img width="597" alt="Screen Shot 2020-03-24 at 3 05 05 PM" src="https://user-images.githubusercontent.com/55560129/77466794-30adff00-6de1-11ea-86de-88e952d38af7.png">
