### PR TITLE
do not show covid19 banner to VISN8 patients

### DIFF
--- a/src/applications/personalization/dashboard/covid-19.jsx
+++ b/src/applications/personalization/dashboard/covid-19.jsx
@@ -119,11 +119,8 @@ const testingFacilities = [
   { name: 'zzzFakeTestFacility 2', id: '984' },
 ];
 
-const eligibleFacilities = [
-  ...visn8Facilities,
-  ...visn23Facilities,
-  ...testingFacilities,
-];
+// 2020-03-24: removed VISN8 facilities from eligibleFacilities
+const eligibleFacilities = [...visn23Facilities, ...testingFacilities];
 
 /**
  * This filters the list of VISN8 facilities and returns just a set of

--- a/src/applications/personalization/dashboard/tests/containers/DashboardApp.unit.spec.jsx
+++ b/src/applications/personalization/dashboard/tests/containers/DashboardApp.unit.spec.jsx
@@ -127,15 +127,25 @@ describe('mapStateToProps', () => {
     },
   });
   describe('showCOVID19Alert', () => {
-    it('is set to true when the user is a patient in an eligible health care system', () => {
+    it('is set to true when the user is a patient in a VISN23 health care system', () => {
       const state = defaultState();
       state.user.profile.facilities = [
         { facilityId: 'abc' },
         { facilityId: '123' },
-        { facilityId: '672' }, // this facility is eligible for health chat
+        { facilityId: '656' }, // St. Cloud VA is in VISN23
       ];
       const props = mapStateToProps(state);
       expect(props.showCOVID19Alert).to.be.true;
+    });
+    it('is set to false when the user is a patient in a VISN8 health care system', () => {
+      const state = defaultState();
+      state.user.profile.facilities = [
+        { facilityId: 'abc' },
+        { facilityId: '123' },
+        { facilityId: '548' }, // West Palm Beach is in VISN8
+      ];
+      const props = mapStateToProps(state);
+      expect(props.showCOVID19Alert).to.be.false;
     });
     it('is set to false when the user is not a patient in an eligible health care system', () => {
       const state = defaultState();
@@ -150,10 +160,21 @@ describe('mapStateToProps', () => {
       state.user.profile.facilities = [
         { facilityId: 'abc' },
         { facilityId: '123' },
-        { facilityId: '672' }, // this facility is eligible for health chat
+        { facilityId: '656' }, // St. Cloud VA is in VISN23
       ];
       const props = mapStateToProps(state);
-      expect(props.vaHealthChatEligibleSystemId).to.equal('672');
+      expect(props.vaHealthChatEligibleSystemId).to.equal('656');
+    });
+    it('is set to null when the user is not a patient in an eligible health care system', () => {
+      const state = defaultState();
+      state.user.profile.facilities = [
+        { facilityId: 'abc' },
+        { facilityId: '123' },
+        { facilityId: '548' }, // West Palm Beach is in VISN8
+      ];
+      state.user.profile.facilities = [{ facilityId: 'abc' }];
+      const props = mapStateToProps(state);
+      expect(props.vaHealthChatEligibleSystemId).to.be.null;
     });
     it('is set to null when the user is not a patient in an eligible health care system', () => {
       const state = defaultState();


### PR DESCRIPTION
## Description
At least for the time being we are not showing the COVID19 banner to veterans who are patients in VISN8 systems. We are only showing it to patients in VISN23 facilities. I thought it seemed smarted to leave the VISN8 code in place and simply update the set of eligible facilities rather than totally remove that code. I also updated/expanded the unit tests to make sure we show it for VISN23 systems and don't show it for VISN8 systems

## Testing done
Local + unit tests

## Screenshots
N/A nothing new here

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs