### PR TITLE
VACMS-1296 listings entity reference field swap

### DIFF
--- a/src/site/components/events_list.drupal.liquid
+++ b/src/site/components/events_list.drupal.liquid
@@ -1,10 +1,8 @@
 {% assign timezone = "America/New_York" %}
 <div class="events-listing events-show">
   {% assign count = 0 %}
-  {% assign eventsArray = fieldOffice.entity.reverseFieldOfficeNode.entities %}
-  {% if outreachSidebar.name == 'Outreach and events' %}
-    {% assign eventsArray = reverseFieldOfficeNode.entities %}
-  {% endif %}
+  {% assign eventsArray = reverseFieldListingNode.entities %}
+
   {% assign sortedEventsArray = eventsArray | eventSorter %}
   {% for event in sortedEventsArray %}
     {% if event.title.length %}

--- a/src/site/stages/build/drupal/graphql/eventListingPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/eventListingPage.graphql.js
@@ -11,7 +11,7 @@ module.exports = `
     title
     fieldIntroText
     entityId
-    reverseFieldOfficeNode(limit: 500, filter: {conditions: [{field: "status", value: "1", operator: EQUAL}, {field: "type", value: "event"}]}, sort: {field: "changed", direction: DESC}) {
+    reverseFieldListingNode(limit: 500, filter: {conditions: [{field: "status", value: "1", operator: EQUAL}, {field: "type", value: "event"}]}, sort: {field: "changed", direction: DESC}) {
         entities {
           ... on NodeEvent {
             title
@@ -53,42 +53,6 @@ module.exports = `
           entityLabel
           title
           fieldNicknameForThisFacility
-        }
-        reverseFieldOfficeNode(limit: 500, filter: {conditions: [{field: "type", value: "event"}, {field: "status", value: "1", operator: EQUAL}]}, sort: {field: "changed", direction: DESC}) {
-            entities {
-              ... on NodeEvent {
-                title
-                fieldFeatured
-                entityUrl {
-                  path
-                }
-                uid {
-                  targetId
-                  ... on FieldNodeUid {
-                    entity {
-                      name
-                      timezone
-                    }
-                  }
-                }
-                fieldDate {
-                  startDate
-                  value
-                  endDate
-                  endValue
-                }
-                fieldDescription
-                fieldLocationHumanreadable
-                fieldFacilityLocation {
-                  entity {
-                    title
-                    entityUrl {
-                      path
-                    }
-                  }
-                }
-            }
-          }
         }
       }
     }

--- a/src/site/stages/build/drupal/graphql/pressReleasesListingPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/pressReleasesListingPage.graphql.js
@@ -8,53 +8,48 @@ module.exports = `
  fragment pressReleasesListingPage on NodePressReleasesListing {
     ${entityElementsFromPages}
     fieldIntroText
-    fieldOffice {
-      entity {
-        title
-        reverseFieldOfficeNode(limit: 500, filter: {conditions: [{field: "type", value: "press_release"}, {field: "status", value: "1", operator: EQUAL}]}) {
-          entities {
-            ... on NodePressRelease {
-              entityId
-              title
-              fieldReleaseDate {
-                value
+    reverseFieldListingNode(limit: 500, filter: {conditions: [{field: "type", value: "press_release"}, {field: "status", value: "1", operator: EQUAL}]}) {
+      entities {
+        ... on NodePressRelease {
+          entityId
+          title
+          fieldReleaseDate {
+            value
+          }
+          entityUrl {
+            path
+          }
+          uid {
+            targetId
+            ... on FieldNodeUid {
+              entity {
+                name
+                timezone
               }
-              entityUrl {
-                path
-              }
-              uid {
-                targetId
-                ... on FieldNodeUid {
-                  entity {
-                    name
-                    timezone
-                  }
-                }
-              }
-              promote
-              created
-              fieldOffice {
-                entity {
-                  ... on NodeHealthCareRegionPage {
-                    entityLabel
-                    entityUrl {
-                      ... on EntityCanonicalUrl {
-                        breadcrumb {
-                          url {
-                            path
-                            routed
-                          }
-                          text
-                        }
-                        path
-                      }
-                    }
-                  }
-                }
-              }
-              fieldIntroText
             }
           }
+          promote
+          created
+          fieldOffice {
+            entity {
+              ... on NodeHealthCareRegionPage {
+                entityLabel
+                entityUrl {
+                  ... on EntityCanonicalUrl {
+                    breadcrumb {
+                      url {
+                        path
+                        routed
+                      }
+                      text
+                    }
+                    path
+                  }
+                }
+              }
+            }
+          }
+          fieldIntroText
         }
       }
     }

--- a/src/site/stages/build/drupal/graphql/storyListingPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/storyListingPage.graphql.js
@@ -8,77 +8,72 @@ module.exports = `
  fragment storyListingPage on NodeStoryListing {
     ${entityElementsFromPages}
     fieldIntroText
-    fieldOffice {
-      entity {
-        title
-        reverseFieldOfficeNode(limit: 500, filter: {conditions: [{field: "type", value: "news_story"}, {field: "status", value: "1", operator: EQUAL}]}) {
-          entities {
-            ... on NodeNewsStory {
-              entityId
-              title
-              fieldFeatured
-              entityUrl {
-                path
-              }
-              uid {
-                targetId
-                ... on FieldNodeUid {
-                  entity {
-                    name
-                    timezone
-                  }
-                }
-              }
-              promote
-              created
-              fieldOffice {
-                entity {
-                  ... on NodeHealthCareRegionPage {
-                    entityLabel
-                    entityUrl {
-                      ... on EntityCanonicalUrl {
-                        breadcrumb {
-                          url {
-                            path
-                            routed
-                          }
-                          text
-                        }
-                        path
-                      }
-                    }
-                  }
-                }
-              }
-              fieldAuthor {
-                entity {
-                  ...on NodePersonProfile {
-                    title
-                    fieldDescription
-                  }
-                }
-              }
-              fieldImageCaption
-              fieldIntroText
-              fieldMedia {
-                entity {
-                  ... on MediaImage {
-                    image {
-                      alt
-                      title
-                      derivative(style: _21MEDIUMTHUMBNAIL) {
-                        url
-                        width
-                        height
-                      }
-                    }
-                  }
-                }
-              }
-              fieldFullStory {
-                processed
+    reverseFieldListingNode(limit: 500, filter: {conditions: [{field: "type", value: "news_story"}, {field: "status", value: "1", operator: EQUAL}]}) {
+      entities {
+        ... on NodeNewsStory {
+          entityId
+          title
+          fieldFeatured
+          entityUrl {
+            path
+          }
+          uid {
+            targetId
+            ... on FieldNodeUid {
+              entity {
+                name
+                timezone
               }
             }
+          }
+          promote
+          created
+          fieldOffice {
+            entity {
+              ... on NodeHealthCareRegionPage {
+                entityLabel
+                entityUrl {
+                  ... on EntityCanonicalUrl {
+                    breadcrumb {
+                      url {
+                        path
+                        routed
+                      }
+                      text
+                    }
+                    path
+                  }
+                }
+              }
+            }
+          }
+          fieldAuthor {
+            entity {
+              ...on NodePersonProfile {
+                title
+                fieldDescription
+              }
+            }
+          }
+          fieldImageCaption
+          fieldIntroText
+          fieldMedia {
+            entity {
+              ... on MediaImage {
+                image {
+                  alt
+                  title
+                  derivative(style: _21MEDIUMTHUMBNAIL) {
+                    url
+                    width
+                    height
+                  }
+                }
+              }
+            }
+          }
+          fieldFullStory {
+            processed
           }
         }
       }
@@ -86,6 +81,7 @@ module.exports = `
     fieldOffice {
       targetId
       entity {
+        title
         ... on NodeHealthCareRegionPage {
           entityLabel
           title

--- a/src/site/stages/build/drupal/metalsmith-drupal.js
+++ b/src/site/stages/build/drupal/metalsmith-drupal.js
@@ -89,10 +89,10 @@ function pipeDrupalPagesIntoMetalsmith(contentData, files) {
         addGetUpdatesFields(pageCompiled, pages);
         break;
       case 'event_listing':
-        pageCompiled.allEventTeasers = pageCompiled.fieldOffice.entity
-          .reverseFieldOfficeNode.entities.length
-          ? pageCompiled.fieldOffice.entity.reverseFieldOfficeNode
-          : pageCompiled.reverseFieldOfficeNode;
+        pageCompiled.allEventTeasers = pageCompiled.reverseFieldListingNode
+          .entities.length
+          ? pageCompiled.reverseFieldListingNode
+          : '';
         addPager(
           pageCompiled,
           files,

--- a/src/site/stages/build/drupal/metalsmith-drupal.js
+++ b/src/site/stages/build/drupal/metalsmith-drupal.js
@@ -102,8 +102,7 @@ function pipeDrupalPagesIntoMetalsmith(contentData, files) {
         );
         break;
       case 'story_listing':
-        pageCompiled.allNewsStoryTeasers =
-          page.fieldOffice.entity.reverseFieldOfficeNode;
+        pageCompiled.allNewsStoryTeasers = page.reverseFieldListingNode;
         addPager(
           pageCompiled,
           files,

--- a/src/site/stages/build/drupal/metalsmith-drupal.js
+++ b/src/site/stages/build/drupal/metalsmith-drupal.js
@@ -89,10 +89,7 @@ function pipeDrupalPagesIntoMetalsmith(contentData, files) {
         addGetUpdatesFields(pageCompiled, pages);
         break;
       case 'event_listing':
-        pageCompiled.allEventTeasers = pageCompiled.reverseFieldListingNode
-          .entities.length
-          ? pageCompiled.reverseFieldListingNode
-          : '';
+        pageCompiled.allEventTeasers = pageCompiled.reverseFieldListingNode;
         addPager(
           pageCompiled,
           files,
@@ -112,8 +109,7 @@ function pipeDrupalPagesIntoMetalsmith(contentData, files) {
         );
         break;
       case 'press_releases_listing':
-        pageCompiled.allPressReleaseTeasers =
-          page.fieldOffice.entity.reverseFieldOfficeNode;
+        pageCompiled.allPressReleaseTeasers = page.reverseFieldListingNode;
         addPager(
           pageCompiled,
           files,
@@ -127,7 +123,7 @@ function pipeDrupalPagesIntoMetalsmith(contentData, files) {
           pageCompiled.fieldOffice.entity.reverseFieldRegionPageNode.entities,
         );
         break;
-      case 'leaderships_listing':
+      case 'leadership_listing':
         pageCompiled.allStaffProfiles = page.fieldLeadership;
         addPager(
           pageCompiled,


### PR DESCRIPTION
## Description
On 4 listing entity types (event_listing, story_listing, press_releases_listing, publication_listing), we are using a lookup for child entities via field_office. This pr replaces field_office with a reverse field lookup to use a field on the child entities entitled field_listing.

## Testing done
Visual and build

## Acceptance criteria
- [x] /outreach-and-events/outreach-materials/, /outreach-and-events/events/, /pittsburgh-health-care/events/, /pittsburgh-health-care/events/past-events, /pittsburgh-health-care/news-releases, /pittsburgh-health-care/stories are not broken, and have content listings.
