### PR TITLE
Add bah-code-reviewers for gi and 1995

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -19,3 +19,6 @@ src/platform/user/profile/vet360 @department-of-veterans-affairs/vsa-frontend
 src/applications/vaos @department-of-veterans-affairs/vfs-vaos
 # Facilities team
 src/applications/facility-locator/ @department-of-veterans-affairs/facility-locator-frontend
+# Booz Allen Team
+vets-website/src/applications/gi @department-of-veterans-affairs/bah-code-reviewers
+vets-website/src/applications/edu-benefits/1995 @department-of-veterans-affairs/bah-code-reviewers


### PR DESCRIPTION
## Description
Add BAH team to gi and 1995

## Testing done


## Screenshots


## Acceptance criteria
- [X]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
