### PR TITLE
[GIBS] Fix width of app container

### DIFF
--- a/src/applications/post-911-gib-status/containers/Post911GIBStatusApp.jsx
+++ b/src/applications/post-911-gib-status/containers/Post911GIBStatusApp.jsx
@@ -48,11 +48,7 @@ class Post911GIBStatusApp extends React.Component {
           dependencies={[externalServices.evss]}
         >
           <AppContent>
-            <div className="row">
-              <div className="small-12 columns">
-                <Main>{this.props.children}</Main>
-              </div>
-            </div>
+            <Main>{this.props.children}</Main>
           </AppContent>
         </DowntimeNotification>
       </RequiredLoginView>

--- a/src/applications/post-911-gib-status/containers/StatusPage.jsx
+++ b/src/applications/post-911-gib-status/containers/StatusPage.jsx
@@ -48,34 +48,39 @@ class StatusPage extends React.Component {
     }
 
     return (
-      <div className="gib-info">
-        <FormTitle title="Post-9/11 GI Bill Statement of Benefits" />
-        {introText}
-        {printButton}
-        <UserInfoSection enrollmentData={enrollmentData} />
-        <h4>How can I see my Post-9/11 GI Bill benefit payments?</h4>
-        <div>
-          If you've received education benefit payments through this program,{' '}
-          <a
-            target="_blank"
-            rel="noopener noreferrer"
-            href="https://www.ebenefits.va.gov/ebenefits/about/feature?feature=payment-history"
-            onClick={() =>
-              recordEvent({
-                event: 'nav-ebenefits-click',
-              })
-            }
-          >
-            you can see your payment history on eBenefits
-          </a>
-          .
-        </div>
-        <EnrollmentHistory enrollmentData={enrollmentData} />
-        <div className="feature help-desk">
-          <h2>Need help?</h2>
-          <div>
-            Call 888-GI-BILL-1 (<a href="tel:+18884424551">888-442-4551</a>
-            ), Monday &#8211; Friday, 8:00 a.m. &#8211; 7:00 p.m. ET
+      <div className="gib-info vads-l-grid-container large-screen:vads-u-padding-x--0">
+        <div className="vads-l-row">
+          <div className="medium-screen:vads-l-col--9">
+            <FormTitle title="Post-9/11 GI Bill Statement of Benefits" />
+            {introText}
+            {printButton}
+            <UserInfoSection enrollmentData={enrollmentData} />
+            <h4>How can I see my Post-9/11 GI Bill benefit payments?</h4>
+            <div>
+              If you've received education benefit payments through this
+              program,{' '}
+              <a
+                target="_blank"
+                rel="noopener noreferrer"
+                href="https://www.ebenefits.va.gov/ebenefits/about/feature?feature=payment-history"
+                onClick={() =>
+                  recordEvent({
+                    event: 'nav-ebenefits-click',
+                  })
+                }
+              >
+                you can see your payment history on eBenefits
+              </a>
+              .
+            </div>
+            <EnrollmentHistory enrollmentData={enrollmentData} />
+            <div className="feature help-desk">
+              <h2>Need help?</h2>
+              <div>
+                Call 888-GI-BILL-1 (<a href="tel:+18884424551">888-442-4551</a>
+                ), Monday &#8211; Friday, 8:00 a.m. &#8211; 7:00 p.m. ET
+              </div>
+            </div>
           </div>
         </div>
       </div>

--- a/src/applications/post-911-gib-status/sass/post-911-gib-status.scss
+++ b/src/applications/post-911-gib-status/sass/post-911-gib-status.scss
@@ -93,7 +93,7 @@ $formation-image-path: "~@department-of-veterans-affairs/formation/assets/img";
       a {
         text-decoration: none;
         &:after {
-          content: " (https://vets.gov" attr(href) ")";
+          content: " (https://www.va.gov" attr(href) ")";
         }
       }
 


### PR DESCRIPTION
## Description
This PR adjusts the width of the Post-9/11 GI Bill Statement of Benefits app, which appears to be rendering using the full-width of the screen instead of the typical three-fourths width.

Related to https://github.com/department-of-veterans-affairs/va.gov-team/issues/6756

## Testing done
Logged in and looked at the app

## Screenshots

<details>
<summary>Desktop</summary>

![image](https://user-images.githubusercontent.com/1915775/77546777-be8df680-6e82-11ea-92a1-fb4cac697b3f.png)

</details>

<details>
<summary>Mobile</summary>

![image](https://user-images.githubusercontent.com/1915775/77546949-eed59500-6e82-11ea-85b2-585ebc557e20.png)

</details>

## Acceptance criteria
- [x] Width is consistent with rest of website

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
