### PR TITLE
CT: Fix spacing in Search Results Filters

### DIFF
--- a/src/applications/gi/components/CheckboxGroup.jsx
+++ b/src/applications/gi/components/CheckboxGroup.jsx
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import _ from 'lodash';
+import environment from 'platform/utilities/environment';
 
 /**
  * A checkbox group with a label.
@@ -54,7 +55,13 @@ class CheckboxGroup extends React.Component {
       <div className={this.props.errorMessage ? 'usa-input-error' : ''}>
         <fieldset>
           <div>
-            <span id={`${this.inputId}-legend`} className="gibct-legend">
+            {/*  prod flag for bah-7186 */}
+            <span
+              id={`${this.inputId}-legend`}
+              className={
+                environment.isProduction() ? 'gibct-legend-old' : 'gibct-legend'
+              }
+            >
               {this.props.label}
             </span>
             {this.renderOptions()}

--- a/src/applications/gi/components/RadioButtons.jsx
+++ b/src/applications/gi/components/RadioButtons.jsx
@@ -5,6 +5,7 @@ import _ from 'lodash';
 import ToolTip from './ToolTip';
 import ExpandingGroup from '@department-of-veterans-affairs/formation-react/ExpandingGroup';
 import { SMALL_SCREEN_WIDTH } from '../constants';
+import environment from 'platform/utilities/environment';
 
 /**
  * A radio button group with a label.
@@ -139,7 +140,10 @@ class RadioButtons extends React.Component {
     if (this.props.required) {
       requiredSpan = <span className="form-required-span">*</span>;
     }
-
+    // prod flag for bah-7186
+    const gibctLegendStyle = environment.isProduction()
+      ? 'gibct-legend-old'
+      : 'gibct-legend';
     return (
       <div className={this.props.errorMessage ? 'usa-input-error' : ''}>
         <fieldset>
@@ -149,7 +153,7 @@ class RadioButtons extends React.Component {
               className={
                 this.props.errorMessage
                   ? 'usa-input-error-label'
-                  : 'gibct-legend'
+                  : gibctLegendStyle
               }
             >
               {this.props.label}

--- a/src/applications/gi/components/search/InstitutionSearchForm.jsx
+++ b/src/applications/gi/components/search/InstitutionSearchForm.jsx
@@ -4,13 +4,21 @@ import EligibilityForm from './EligibilityForm';
 import InstitutionFilterForm from './InstitutionFilterForm';
 import KeywordSearch from './KeywordSearch';
 import OnlineClassesFilter from './OnlineClassesFilter';
+import environment from 'platform/utilities/environment';
 
 class InstitutionSearchForm extends React.Component {
   render() {
     return (
       <div className="row">
         <div className={this.props.filtersClass}>
-          <div className="filters-sidebar-inner">
+          {/* prod flag for bah-7186 */}
+          <div
+            className={
+              environment.isProduction()
+                ? 'filters-sidebar-inner-old'
+                : 'filters-sidebar-inner'
+            }
+          >
             {this.props.search.filterOpened && <h1>Filter your search</h1>}
             <h2>Keywords</h2>
             <KeywordSearch

--- a/src/applications/gi/sass/gi.scss
+++ b/src/applications/gi/sass/gi.scss
@@ -90,7 +90,7 @@
 }
 
 .gibct-legend {
-  margin-top: 3rem;
+  margin-top: 1rem;
   display: block;
   font-weight: inherit;
   font-size: inherit;

--- a/src/applications/gi/sass/gi.scss
+++ b/src/applications/gi/sass/gi.scss
@@ -89,6 +89,17 @@
   }
 }
 
+.gibct-legend-old {
+  margin-top: 3rem;
+  display: block;
+  font-weight: inherit;
+  font-size: inherit;
+  color: inherit;
+  line-height: inherit;
+  max-width: 46rem;
+  padding-bottom: 0;
+}
+
 .gibct-legend {
   margin-top: 1rem;
   display: block;

--- a/src/applications/gi/sass/partials/_gi-search-page.scss
+++ b/src/applications/gi/sass/partials/_gi-search-page.scss
@@ -35,6 +35,9 @@
     @include media-maxwidth($small-screen) {
       padding-bottom: 8rem;
     }
+    h2 {
+      margin-top: 0;
+    }
   }
 
   .filter-button,

--- a/src/applications/gi/sass/partials/_gi-search-page.scss
+++ b/src/applications/gi/sass/partials/_gi-search-page.scss
@@ -40,6 +40,12 @@
     }
   }
 
+  .filters-sidebar-inner-old {
+    @include media-maxwidth($small-screen) {
+      padding-bottom: 8rem;
+    }
+  }
+
   .filter-button,
   .results-button {
     display: none;


### PR DESCRIPTION
## Description
https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/7186

Changed margin sizes so headers fit the  DEPO styling standards.

## Testing done
Dev tested.

## Screenshots
Before:
![image](https://user-images.githubusercontent.com/48804654/77557912-afae4080-6e90-11ea-81a1-466fffdfc28c.png)

After:
![image](https://user-images.githubusercontent.com/48804654/77557926-b50b8b00-6e90-11ea-921d-265210fb742c.png)


## Acceptance criteria
- [x] The spacing between "Institution details" subhead and "Type of institution" label is reduced so that it matches the spacing between the "Keywords" subhead and "City, school, or employer" label.
- [x] The spacing for the first header in filter fields is lined up with the first search results card. This includes vettec search results filter.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
