### PR TITLE
Add CSRF protection via Headers for API requests

### DIFF
--- a/src/platform/utilities/api/index.js
+++ b/src/platform/utilities/api/index.js
@@ -103,7 +103,7 @@ export function apiRequest(resource, optionalSettings = {}, success, error) {
       }
 
       // Get CSRF Token from header
-      const csrfToken = response.headers;
+      const csrfToken = response.headers.get('X-CSRF-Token');
       // eslint-disable-next-line no-console
       console.log(csrfToken);
       if (csrfToken) {

--- a/src/platform/utilities/api/index.js
+++ b/src/platform/utilities/api/index.js
@@ -101,7 +101,8 @@ export function apiRequest(resource, optionalSettings = {}, success, error) {
 
       // Get CSRF Token from API header
       const csrfToken = response.headers.get('X-CSRF-Token');
-      if (csrfToken) {
+
+      if (csrfToken && !csrfTokenStored) {
         localStorage.setItem('csrfToken', csrfToken);
       }
 

--- a/src/platform/utilities/api/index.js
+++ b/src/platform/utilities/api/index.js
@@ -97,6 +97,19 @@ export function apiRequest(resource, optionalSettings = {}, success, error) {
         ? response.json()
         : Promise.resolve(response);
 
+      for (const value of response.headers.values()) {
+        // eslint-disable-next-line no-console
+        console.log(value);
+      }
+
+      // Get CSRF Token from header
+      const csrfToken = response.headers;
+      // eslint-disable-next-line no-console
+      console.log(csrfToken);
+      if (csrfToken) {
+        localStorage.setItem('csrfToken', csrfToken);
+      }
+
       if (response.ok || response.status === 304) {
         return data;
       }

--- a/src/platform/utilities/api/index.js
+++ b/src/platform/utilities/api/index.js
@@ -102,7 +102,7 @@ export function apiRequest(resource, optionalSettings = {}, success, error) {
       // Get CSRF Token from API header
       const csrfToken = response.headers.get('X-CSRF-Token');
 
-      if (csrfToken && !csrfTokenStored) {
+      if (csrfToken && csrfToken !== csrfTokenStored) {
         localStorage.setItem('csrfToken', csrfToken);
       }
 

--- a/src/platform/utilities/api/index.js
+++ b/src/platform/utilities/api/index.js
@@ -49,6 +49,7 @@ function isJson(response) {
 export function apiRequest(resource, optionalSettings = {}, success, error) {
   const baseUrl = `${environment.API_URL}/v0`;
   const url = resource[0] === '/' ? [baseUrl, resource].join('') : resource;
+  const csrfTokenStored = localStorage.getItem('csrfToken');
 
   if (success) {
     // eslint-disable-next-line no-console
@@ -70,6 +71,7 @@ export function apiRequest(resource, optionalSettings = {}, success, error) {
     headers: {
       'X-Key-Inflection': 'camel',
       'Source-App-Name': window.appName,
+      'X-CSRF-Token': csrfTokenStored,
     },
   };
 
@@ -97,15 +99,8 @@ export function apiRequest(resource, optionalSettings = {}, success, error) {
         ? response.json()
         : Promise.resolve(response);
 
-      for (const value of response.headers.values()) {
-        // eslint-disable-next-line no-console
-        console.log(value);
-      }
-
-      // Get CSRF Token from header
+      // Get CSRF Token from API header
       const csrfToken = response.headers.get('X-CSRF-Token');
-      // eslint-disable-next-line no-console
-      console.log(csrfToken);
       if (csrfToken) {
         localStorage.setItem('csrfToken', csrfToken);
       }


### PR DESCRIPTION
## Description

This PR complements the implementation done by the backend team to prevent a CSRF attack when submitting a form using our API (`vets-api`).

An HTTP header (`X-CSRF-Token`) is expected from the API. This header will be stores in the `localStorage` and resubmitted with its contents throughout the HTTP header for every API call.

Backend implementation can be found [here](https://github.com/department-of-veterans-affairs/vets-api/pull/3982)

## Epics

- [Main Ticket](https://github.com/department-of-veterans-affairs/va.gov-team-sensitive/issues/42)
- [FE Ticket # 62](https://github.com/department-of-veterans-affairs/va.gov-team-sensitive/issues/62)
- [BE Ticket # 61](https://github.com/department-of-veterans-affairs/va.gov-team-sensitive/issues/61)

## Testing done
Locally

## Screenshots

<details><summary>Response Headers from API</summary>

![Screen Shot 2020-03-25 at 3 42 40 PM](https://user-images.githubusercontent.com/55560129/77782000-ecaf3a00-702c-11ea-9706-4dbe83400cd4.png)

</details>

<details><summary>Request Headers</summary>

![Screen Shot 2020-03-25 at 3 43 14 PM](https://user-images.githubusercontent.com/55560129/77782013-f5077500-702c-11ea-9094-5d17d2b95877.png)

</details>

## Acceptance criteria
- [x] Grab `X-CSRF-Token` from headers
- [x] Submit `X-CSRF-Token` contents throughout the HTTP header
- [x] Review instance testing