### PR TITLE
Disable Cerner facilities on facility selection page

### DIFF
--- a/src/applications/vaos/components/SystemsRadioWidget.jsx
+++ b/src/applications/vaos/components/SystemsRadioWidget.jsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { getCernerPortalLink } from '../utils/appointment';
+
+/*
+ * This is a copy of the form system RadioWidget, but with custom
+ * code to disable certain options. This isn't currently supported by the
+ * form system.
+ */
+export default function SystemsRadioWidget({
+  options,
+  value,
+  onChange,
+  id,
+  formContext,
+}) {
+  const { enumOptions, labels = {} } = options;
+  const cernerFacilities = formContext.cernerFacilities;
+
+  return (
+    <div>
+      {enumOptions.map((option, i) => {
+        const checked = option.value === value;
+        const isCerner = cernerFacilities.some(facilityId =>
+          option.value.startsWith(facilityId),
+        );
+        const radioButton = (
+          <div className="form-radio-buttons" key={option.value}>
+            <input
+              type="radio"
+              checked={checked}
+              id={`${id}_${i}`}
+              name={`${id}`}
+              value={option.value}
+              disabled={isCerner}
+              onChange={_ => onChange(option.value)}
+            />
+            <label htmlFor={`${id}_${i}`}>
+              {labels[option.value] || option.label}
+              {isCerner && (
+                <>
+                  <br />
+                  <strong>
+                    To schedule a VA appointment at this location, go to{' '}
+                    <a
+                      href={getCernerPortalLink()}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      My VA Health
+                    </a>
+                  </strong>
+                  .
+                </>
+              )}
+            </label>
+          </div>
+        );
+
+        return radioButton;
+      })}
+    </div>
+  );
+}

--- a/src/applications/vaos/containers/VAFacilityPage.jsx
+++ b/src/applications/vaos/containers/VAFacilityPage.jsx
@@ -8,6 +8,7 @@ import FormButtons from '../components/FormButtons';
 import EligibilityCheckMessage from '../components/EligibilityCheckMessage';
 import SingleFacilityEligibilityCheckMessage from '../components/SingleFacilityEligibilityCheckMessage';
 import ErrorMessage from '../components/ErrorMessage';
+import SystemsRadioWidget from '../components/SystemsRadioWidget';
 import { scrollAndFocus } from '../utils/scrollAndFocus';
 
 import {
@@ -39,7 +40,7 @@ const initialSchema = {
 
 const uiSchema = {
   vaParent: {
-    'ui:widget': 'radio',
+    'ui:widget': SystemsRadioWidget,
     'ui:title':
       'You’re registered at the following VA medical centers. Please let us know where you would like to have your appointment.',
   },
@@ -118,6 +119,7 @@ export class VAFacilityPage extends React.Component {
       hasDataFetchingError,
       hasEligibilityError,
       parentOfChosenFacility,
+      cernerFacilities,
     } = this.props;
 
     const notEligibleAtChosenFacility =
@@ -219,6 +221,7 @@ export class VAFacilityPage extends React.Component {
             typeOfCare,
             facilityDetailsStatus,
             parentDetails,
+            cernerFacilities,
           }}
           data={data}
         >

--- a/src/applications/vaos/tests/components/SystemsRadioWidget.unit.spec.jsx
+++ b/src/applications/vaos/tests/components/SystemsRadioWidget.unit.spec.jsx
@@ -1,0 +1,150 @@
+import React from 'react';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { shallow } from 'enzyme';
+
+import SystemsRadioWidget from '../../components/SystemsRadioWidget';
+
+describe('Schemaform <SystemsRadioWidget>', () => {
+  it('should render', () => {
+    const onChange = sinon.spy();
+    const enumOptions = [
+      {
+        label: 'Testing',
+        value: '1',
+      },
+      {
+        label: 'Testing2',
+        value: '2',
+      },
+    ];
+    const tree = shallow(
+      <SystemsRadioWidget
+        value
+        onChange={onChange}
+        options={{ enumOptions }}
+        formContext={{ cernerFacilities: [] }}
+      />,
+    );
+    expect(tree.find('input').length).to.equal(2);
+    expect(
+      tree
+        .find('label')
+        .at(0)
+        .text(),
+    ).to.equal('Testing');
+    expect(
+      tree
+        .find('label')
+        .at(1)
+        .text(),
+    ).to.equal('Testing2');
+    tree.unmount();
+  });
+  it('should render label from options', () => {
+    const onChange = sinon.spy();
+    const enumOptions = [
+      {
+        label: 'Testing',
+        value: '1',
+      },
+      {
+        label: 'Testing2',
+        value: '2',
+      },
+    ];
+    const labels = {
+      1: 'Other',
+    };
+    const tree = shallow(
+      <SystemsRadioWidget
+        value
+        onChange={onChange}
+        options={{ enumOptions, labels }}
+        formContext={{ cernerFacilities: [] }}
+      />,
+    );
+    expect(
+      tree
+        .find('label')
+        .at(0)
+        .text(),
+    ).to.equal('Other');
+    expect(
+      tree
+        .find('label')
+        .at(1)
+        .text(),
+    ).to.equal('Testing2');
+    tree.unmount();
+  });
+  it('should handle change', () => {
+    const onChange = sinon.spy();
+    const enumOptions = [
+      {
+        label: 'Testing',
+        value: '1',
+      },
+      {
+        label: 'Testing2',
+        value: '2',
+      },
+    ];
+    const tree = shallow(
+      <SystemsRadioWidget
+        value
+        onChange={onChange}
+        options={{ enumOptions }}
+        formContext={{ cernerFacilities: [] }}
+      />,
+    );
+    tree
+      .find('input')
+      .at(0)
+      .props()
+      .onChange();
+    expect(onChange.calledWith('1')).to.be.true;
+    tree.unmount();
+  });
+  it('should disable Cerner facilities', () => {
+    const onChange = sinon.spy();
+    const enumOptions = [
+      {
+        label: 'Testing',
+        value: '983',
+      },
+      {
+        label: 'Testing2',
+        value: '984',
+      },
+    ];
+    const tree = shallow(
+      <SystemsRadioWidget
+        value
+        onChange={onChange}
+        options={{ enumOptions }}
+        formContext={{ cernerFacilities: ['984'] }}
+      />,
+    );
+
+    expect(
+      tree
+        .find('input')
+        .at(0)
+        .props().disabled,
+    ).to.be.false;
+    expect(
+      tree
+        .find('input')
+        .at(1)
+        .props().disabled,
+    ).to.be.true;
+    expect(
+      tree
+        .find('label')
+        .at(1)
+        .text(),
+    ).to.contain('To schedule a VA appointment at this location');
+    tree.unmount();
+  });
+});

--- a/src/applications/vaos/tests/containers/VAFacilityPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/containers/VAFacilityPage.unit.spec.jsx
@@ -29,6 +29,7 @@ describe('VAOS <VAFacilityPage>', () => {
         loadingParentFacilities
         data={defaultData}
         openFacilityPage={openFormPage}
+        cernerFacilities={[]}
       />,
     );
 
@@ -44,6 +45,7 @@ describe('VAOS <VAFacilityPage>', () => {
         data={defaultData}
         noValidVAParentFacilities
         openFacilityPage={openFormPage}
+        cernerFacilities={[]}
       />,
     );
 
@@ -59,6 +61,7 @@ describe('VAOS <VAFacilityPage>', () => {
         singleValidVALocation
         data={{}}
         openFacilityPage={openFormPage}
+        cernerFacilities={[]}
       />,
     );
 
@@ -76,6 +79,7 @@ describe('VAOS <VAFacilityPage>', () => {
         singleValidVALocation
         data={{}}
         openFacilityPage={openFormPage}
+        cernerFacilities={[]}
       />,
     );
 
@@ -103,6 +107,7 @@ describe('VAOS <VAFacilityPage>', () => {
         loadingFacilities
         schema={schema}
         openFacilityPage={openFormPage}
+        cernerFacilities={[]}
       />,
     );
 
@@ -126,6 +131,7 @@ describe('VAOS <VAFacilityPage>', () => {
         noValidVAParentFacilities
         schema={schema}
         openFacilityPage={openFormPage}
+        cernerFacilities={[]}
       />,
     );
 
@@ -141,6 +147,7 @@ describe('VAOS <VAFacilityPage>', () => {
         data={{}}
         schema={defaultSchema}
         openFacilityPage={openFormPage}
+        cernerFacilities={[]}
       />,
     );
 
@@ -158,6 +165,7 @@ describe('VAOS <VAFacilityPage>', () => {
         schema={defaultSchema}
         openFacilityPage={openFormPage}
         routeToNextAppointmentPage={routeToNextAppointmentPage}
+        cernerFacilities={[]}
       />,
     );
 
@@ -182,6 +190,7 @@ describe('VAOS <VAFacilityPage>', () => {
           vaParent: '983',
           vaFacility: '983',
         }}
+        cernerFacilities={[]}
       />,
     );
 
@@ -207,6 +216,7 @@ describe('VAOS <VAFacilityPage>', () => {
           vaParent: '983',
           vaFacility: '983',
         }}
+        cernerFacilities={[]}
       />,
     );
 
@@ -234,6 +244,7 @@ describe('VAOS <VAFacilityPage>', () => {
           vaParent: '983',
           vaFacility: '983',
         }}
+        cernerFacilities={[]}
       />,
     );
 
@@ -252,6 +263,7 @@ describe('VAOS <VAFacilityPage>', () => {
         data={{}}
         schema={defaultSchema}
         openFacilityPage={openFormPage}
+        cernerFacilities={[]}
       />,
     );
 
@@ -267,6 +279,7 @@ describe('VAOS <VAFacilityPage>', () => {
         data={defaultData}
         hasDataFetchingError
         openFacilityPage={openFormPage}
+        cernerFacilities={[]}
       />,
     );
 
@@ -284,6 +297,7 @@ describe('VAOS <VAFacilityPage>', () => {
         schema={defaultSchema}
         hasEligibilityError
         openFacilityPage={openFormPage}
+        cernerFacilities={[]}
       />,
     );
 

--- a/src/applications/vaos/tests/utils/selectors.unit.spec.js
+++ b/src/applications/vaos/tests/utils/selectors.unit.spec.js
@@ -17,6 +17,7 @@ import {
   getCancelInfo,
   getCCEType,
   isWelcomeModalDismissed,
+  selectIsCernerOnlyPatient,
 } from '../../utils/selectors';
 
 describe('VAOS selectors', () => {
@@ -83,6 +84,11 @@ describe('VAOS selectors', () => {
   describe('getFacilityPageInfo', () => {
     it('should return typeOfCare string and begin loading parentFacilities', () => {
       const state = {
+        user: {
+          profile: {
+            facilities: [],
+          },
+        },
         newAppointment: {
           pages: {},
           data: {
@@ -103,6 +109,11 @@ describe('VAOS selectors', () => {
     });
     it('should return eligibility error flag', () => {
       const state = {
+        user: {
+          profile: {
+            facilities: [],
+          },
+        },
         newAppointment: {
           pages: {},
           data: {
@@ -120,6 +131,34 @@ describe('VAOS selectors', () => {
 
       const newState = getFacilityPageInfo(state);
       expect(newState.hasEligibilityError).to.be.true;
+    });
+    it('should return Cerner facilities', () => {
+      const state = {
+        user: {
+          profile: {
+            facilities: [
+              { facilityId: '123', isCerner: true },
+              { facilityId: '124', isCerner: false },
+            ],
+          },
+        },
+        newAppointment: {
+          pages: {},
+          data: {
+            typeOfCareId: '160',
+            facilityType: 'vamc',
+            vaParent: '983',
+          },
+          facilities: {},
+          eligibility: {},
+          parentFacilities: [{}],
+          facilityDetails: {},
+          eligibilityStatus: 'failed',
+        },
+      };
+
+      const newState = getFacilityPageInfo(state);
+      expect(newState.cernerFacilities).to.deep.equal(['123']);
     });
   });
 
@@ -463,6 +502,31 @@ describe('VAOS selectors', () => {
         },
       };
       expect(isWelcomeModalDismissed(state)).to.be.false;
+    });
+  });
+  describe('selectIsCernerOnlyPatient', () => {
+    it('should return true if Cerner only', () => {
+      const state = {
+        user: {
+          profile: {
+            facilities: [{ facilityId: '123', isCerner: true }],
+          },
+        },
+      };
+      expect(selectIsCernerOnlyPatient(state)).to.be.true;
+    });
+    it('should return false if not Cerner only', () => {
+      const state = {
+        user: {
+          profile: {
+            facilities: [
+              { facilityId: '123', isCerner: true },
+              { facilityId: '124', isCerner: false },
+            ],
+          },
+        },
+      };
+      expect(selectIsCernerOnlyPatient(state)).to.be.false;
     });
   });
 });

--- a/src/applications/vaos/utils/appointment.jsx
+++ b/src/applications/vaos/utils/appointment.jsx
@@ -570,3 +570,11 @@ DTEND:${endDate}
 END:VEVENT
 END:VCALENDAR`;
 }
+
+export function getCernerPortalLink() {
+  if (environment.isProduction()) {
+    return 'http://patientportal.myhealth.va.gov/';
+  }
+
+  return 'http://ehrm-va-test.patientportal.us.healtheintent.com/';
+}

--- a/src/applications/vaos/utils/selectors.js
+++ b/src/applications/vaos/utils/selectors.js
@@ -37,6 +37,11 @@ export function getFormPageInfo(state, pageKey) {
   };
 }
 
+export const selectFacilities = state =>
+  selectPatientFacilities(state)?.filter(
+    f => !f.facilityId.startsWith('742'),
+  ) || null;
+
 const AUDIOLOGY = '203';
 const SLEEP_CARE = 'SLEEP';
 const EYE_CARE = 'EYE';
@@ -214,6 +219,10 @@ export function getFacilityPageInfo(state) {
     typeOfCare: getTypeOfCare(data)?.name,
     parentDetails: newAppointment?.facilityDetails[data.vaParent],
     parentOfChosenFacility: getParentOfChosenFacility(state),
+    cernerFacilities:
+      selectFacilities(state)
+        ?.filter(f => f.isCerner)
+        .map(f => f.facilityId) || [],
   };
 }
 
@@ -320,9 +329,8 @@ export const isWelcomeModalDismissed = state =>
     announcement => announcement === 'welcome-to-new-vaos',
   );
 
-export const selectFacilities = state =>
-  selectPatientFacilities(state)?.filter(
-    f => !f.facilityId.startsWith('742'),
-  ) || null;
 export const selectSystemIds = state =>
   selectFacilities(state)?.map(f => f.facilityId) || null;
+
+export const selectIsCernerOnlyPatient = state =>
+  !!selectFacilities(state)?.every(f => f.isCerner);


### PR DESCRIPTION
## Description
This disables Cerner facilities on the facility selection page.

## Testing done
Local and unit testing

## Screenshots
![Screen Shot 2020-03-24 at 4 40 54 PM](https://user-images.githubusercontent.com/634932/77575292-b7c6aa00-6ea9-11ea-9d73-319b3b92db61.png)


## Acceptance criteria
- [ ] System is not selectable

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
