### PR TITLE
Add original claims as a back end service for accessing the 526 form

### DIFF
--- a/src/applications/disability-benefits/all-claims/containers/RequiredServicesGate.jsx
+++ b/src/applications/disability-benefits/all-claims/containers/RequiredServicesGate.jsx
@@ -6,16 +6,26 @@ import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 import RequiredLoginView from '../../../../platform/user/authorization/components/RequiredLoginView';
 import backendServices from '../../../../platform/user/profile/constants/backendServices';
 
+import environment from 'platform/utilities/environment';
+
 export function RequiredServicesGate({ user, location, children }) {
   // Short-circuit the check on the intro page
   if (location.pathname === '/introduction') {
     return children;
   }
 
-  if (
-    user.login.currentlyLoggedIn &&
-    !user.profile.services.includes(backendServices.FORM526)
-  ) {
+  const currentlyLoggedIn = user.login.currentlyLoggedIn;
+  const userProfileServices = user.profile.services;
+  let missingInformation = !userProfileServices.includes(
+    backendServices.FORM526,
+  );
+  if (missingInformation && !environment.isProduction()) {
+    missingInformation = !userProfileServices.includes(
+      backendServices.ORIGINAL_CLAIMS,
+    );
+  }
+
+  if (currentlyLoggedIn && missingInformation) {
     return (
       <div className="usa-grid full-page-alert">
         <AlertBox
@@ -28,12 +38,16 @@ export function RequiredServicesGate({ user, location, children }) {
     );
   }
 
+  let serviceRequired = backendServices.FORM526;
+  if (!environment.isProduction()) {
+    serviceRequired = [
+      backendServices.FORM526,
+      backendServices.ORIGINAL_CLAIMS,
+    ];
+  }
+
   return (
-    <RequiredLoginView
-      serviceRequired={backendServices.FORM526}
-      user={user}
-      verify
-    >
+    <RequiredLoginView serviceRequired={serviceRequired} user={user} verify>
       {children}
     </RequiredLoginView>
   );

--- a/src/platform/user/profile/constants/backendServices.js
+++ b/src/platform/user/profile/constants/backendServices.js
@@ -7,6 +7,7 @@ export default {
   EDUCATION_BENEFITS: 'edu-benefits',
   EVSS_CLAIMS: 'evss-claims',
   FORM526: 'form526', // like EVSS_CLAIMS, but must also include BIRLS ID
+  ORIGINAL_CLAIMS: 'original-claims',
   APPEALS_STATUS: 'appeals-status',
   USER_PROFILE: 'user-profile',
   ID_CARD: 'id-card',


### PR DESCRIPTION
## Description
This is written to only impact staging. This PR enables users to begin the 526 form if they are marked as being able to do an original-claim by the back end. A separate PR exists to remove the UI gating question regarding original claims.

## Acceptance criteria
- [ ] Only in staging, users can access the 526 form with the form526 OR original-claims back end service