### PR TITLE
Remove original claims UI gating for 526

### DIFF
--- a/src/applications/disability-benefits/wizard/pages/start.jsx
+++ b/src/applications/disability-benefits/wizard/pages/start.jsx
@@ -1,9 +1,15 @@
 import React from 'react';
 import ErrorableRadioButtons from '@department-of-veterans-affairs/formation-react/ErrorableRadioButtons';
 import { pageNames } from './pageList';
+import environment from 'platform/utilities/environment';
+
+let pageNameYes = pageNames.originalClaim;
+if (!environment.isProduction()) {
+  pageNameYes = pageNames.appeals;
+}
 
 const options = [
-  { value: pageNames.originalClaim, label: 'Yes' },
+  { value: pageNameYes, label: 'Yes' },
   { value: pageNames.bdd, label: 'No' },
 ];
 


### PR DESCRIPTION
## Description
This is written to only impact staging. This PR removes step 2 of the gating for the 526 form. Step 2 is the question regarding original claims. 

## Acceptance criteria
- [ ] Only in staging, step 2 is removed from the gating questions for the 526 form