### PR TITLE
[Homepage] Fix for analytics bug

### DIFF
--- a/src/site/layouts/home.drupal.liquid
+++ b/src/site/layouts/home.drupal.liquid
@@ -14,12 +14,13 @@
         <div class="hub-links-container" data-e2e="bucket">
           <h2 class="heading-level-3 hub-links-title"><i class="icon-large-baseline icon-heading hub-icon-{{ card.label | downcase | replace: ' ', '-' }} hub-color-{{ card.label | downcase | replace: ' ', '-' }}"></i>{{ card.label }}</h2>
           <ul class="hub-links-list">
+            {% assign cardLabel = card.label %}
             {% for link in card.links %}
               <li>
                 <a href="{{ link.url.path }}"
                   onclick="recordEvent({
                     event: 'nav-zone-one',
-                    'nav-path': '{{ card.label }}->{% if link.url.path != empty %}{{ link.url.path }}{% else %}{{ link.label }}{% endif %}',
+                    'nav-path': '{{ cardLabel }}->{% if link.url.path != empty %}{{ link.url.path }}{% else %}{{ link.label }}{% endif %}',
                   });"
                   >
                   {{ link.label }}

--- a/src/site/layouts/home.drupal.liquid
+++ b/src/site/layouts/home.drupal.liquid
@@ -15,7 +15,16 @@
           <h2 class="heading-level-3 hub-links-title"><i class="icon-large-baseline icon-heading hub-icon-{{ card.label | downcase | replace: ' ', '-' }} hub-color-{{ card.label | downcase | replace: ' ', '-' }}"></i>{{ card.label }}</h2>
           <ul class="hub-links-list">
             {% for link in card.links %}
-              <li><a data-nav-path="{{ card.label }}->{% if link.url.path != empty %}{{ link.url.path }}{% else %}{{ link.label }}{% endif %}" href="{{ link.url.path }}">{{ link.label }}</a></li>
+              <li>
+                <a href="{{ link.url.path }}"
+                  onclick="recordEvent({
+                    event: 'nav-zone-one',
+                    'nav-path': '{{ card.label }}->{% if link.url.path != empty %}{{ link.url.path }}{% else %}{{ link.label }}{% endif %}',
+                  });"
+                  >
+                  {{ link.label }}
+                </a>
+              </li>
             {% endfor %}
           </ul>
         </div>
@@ -117,21 +126,6 @@
   </section>
 
 </main>
-
-<script type="text/javascript">
-  var hubLinksList = document.getElementsByClassName('hub-links-list');
-
-  for (var i=0; i < hubLinksList.length; i++) {
-    hubLinksList[i].addEventListener('click', function(e) {
-      var linkData = e.target.dataset;
-
-      recordEvent({
-        event: 'nav-zone-one',
-        'nav-path': linkData.navPath,
-      });
-    });
-  }
-</script>
 
 {% include "src/site/includes/footer.html" %}
 {% include "src/site/includes/debug.drupal.liquid" %}


### PR DESCRIPTION
## Description
We have a GA event on the homepage that is firing sometimes with empty values. For some reason, the event listener wasn't tied directly to the anchor tag, so clicking space around the tag would trigger the event. This PR fixes that by just attaching the `onclick` event directly to the anchor tag.

https://github.com/department-of-veterans-affairs/va.gov-team/issues/727

## Testing done
- Clicked around the anchor tag on the homepage confirming that the event only triggers on a direct click

## Screenshots
Google Analytics Debugger

![image](https://user-images.githubusercontent.com/1915775/77666610-899fa380-6f57-11ea-9d27-52ef0266f284.png)


## Acceptance criteria
- [ ] Correct GTM event is captured only when event occurs
 
## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
