### PR TITLE
Use eligible facilities list when auto-populating facility choice

### DIFF
--- a/src/applications/vaos/actions/newAppointment.js
+++ b/src/applications/vaos/actions/newAppointment.js
@@ -281,10 +281,12 @@ export function openFacilityPage(page, uiSchema, schema) {
         );
       }
 
-      const eligibilityDataNeeded = !!facilityId || facilities?.length === 1;
+      const eligibleFacilities = getEligibleFacilities(facilities);
+      const eligibilityDataNeeded =
+        !!facilityId || eligibleFacilities?.length === 1;
 
       if (eligibilityDataNeeded && !facilityId) {
-        facilityId = facilities[0].institutionCode;
+        facilityId = eligibleFacilities[0].institutionCode;
       }
 
       const eligibilityChecks =
@@ -292,7 +294,9 @@ export function openFacilityPage(page, uiSchema, schema) {
 
       if (eligibilityDataNeeded && !eligibilityChecks) {
         eligibilityData = await getEligibilityData(
-          facilities.find(facility => facility.institutionCode === facilityId),
+          eligibleFacilities.find(
+            facility => facility.institutionCode === facilityId,
+          ),
           typeOfCareId,
           systemId,
           directSchedulingEnabled,

--- a/src/applications/vaos/tests/actions/newAppointment.unit.spec.js
+++ b/src/applications/vaos/tests/actions/newAppointment.unit.spec.js
@@ -396,6 +396,48 @@ describe('VAOS newAppointment actions', () => {
       expect(firstAction.eligibilityData).to.not.be.null;
     });
 
+    it('should fetch eligibility info if only one supported facility', async () => {
+      setFetchJSONResponse(global.fetch, clinics);
+      const dispatch = sinon.spy();
+      const previousState = {
+        ...defaultState,
+        newAppointment: {
+          ...defaultState.newAppointment,
+          data: {
+            ...defaultState.newAppointment.data,
+            vaParent: '983',
+          },
+          facilities: {
+            '323_983': [
+              {
+                institutionCode: '983',
+                rootStationCode: '983',
+                parentStationCode: '983',
+                requestSupported: false,
+                directSchedulingSupported: false,
+              },
+              {
+                institutionCode: '983GC',
+                rootStationCode: '983',
+                parentStationCode: '983',
+                requestSupported: true,
+                directSchedulingSupported: false,
+              },
+            ],
+          },
+        },
+      };
+
+      const getState = () => previousState;
+
+      const thunk = openFacilityPage('vaFacility', {}, defaultSchema);
+      await thunk(dispatch, getState);
+      const firstAction = dispatch.firstCall.args[0];
+      expect(firstAction.type).to.equal(FORM_PAGE_FACILITY_OPEN_SUCCEEDED);
+
+      expect(firstAction.eligibilityData).to.not.be.null;
+    });
+
     it('should skip eligibility request and succeed if facility list is empty', async () => {
       setFetchJSONResponse(global.fetch, { data: [] });
       const dispatch = sinon.spy();

--- a/src/applications/vaos/utils/eligibility.js
+++ b/src/applications/vaos/utils/eligibility.js
@@ -187,7 +187,7 @@ export function isEligible(eligibilityChecks) {
 }
 
 export function getEligibleFacilities(facilities) {
-  return facilities.filter(
+  return facilities?.filter(
     facility => facility.requestSupported || facility.directSchedulingSupported,
   );
 }

--- a/src/applications/vaos/utils/error.js
+++ b/src/applications/vaos/utils/error.js
@@ -1,5 +1,6 @@
 import * as Sentry from '@sentry/browser';
 import { recordVaosError } from './events';
+import environment from 'platform/utilities/environment';
 
 export function captureError(err, skipRecordEvent) {
   let eventErrorKey;
@@ -20,5 +21,10 @@ export function captureError(err, skipRecordEvent) {
 
   if (!skipRecordEvent) {
     recordVaosError(eventErrorKey);
+  }
+
+  if (!environment.isProduction()) {
+    // eslint-disable-next-line no-console
+    console.error(err);
   }
 }


### PR DESCRIPTION
## Description
This fixes one sequence of events where you can get to the va facility page with only one supported facility, but not see any eligibility issues for that facility. Which leads to a user getting stuck and a not eligible error in Sentry.

This seems to happen when a user has one registered system that has only one child facility that supports requests (or DS) and there's an eligibility error for that facility (request limit, etc).

## Testing done
Local testing

## Acceptance criteria
- [ ] Users don't get stuck

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
