### PR TITLE
fix repeated dash in hours of operation & special string cases

### DIFF
--- a/src/applications/facility-locator/tests/helpers.unit.spec.js
+++ b/src/applications/facility-locator/tests/helpers.unit.spec.js
@@ -172,7 +172,7 @@ describe('Validate ID Strings for Breadcrumb', () => {
 
   it('formatOperatingHours should convert API hour (without colon) to a human readable hour', () => {
     const operatingHours = '800 AM - 430 PM';
-    const expected = '8:00a.m. - 4:30p.m.';
+    const expected = '8:00 a.m. - 4:30 p.m.';
 
     const result = formatOperatingHours(operatingHours);
 
@@ -209,6 +209,33 @@ describe('Validate ID Strings for Breadcrumb', () => {
   it('formatOperatingHours should return "Closed" if format is "Closed"', () => {
     const operatingHours = 'Closed';
     const expected = 'Closed';
+
+    const result = formatOperatingHours(operatingHours);
+
+    expect(result).to.eq(expected);
+  });
+
+  it('formatOperatingHours should return "By Appointment Only" if format is "By Appointment Only"', () => {
+    const operatingHours = 'By Appointment Only';
+    const expected = 'By Appointment Only';
+
+    const result = formatOperatingHours(operatingHours);
+
+    expect(result).to.eq(expected);
+  });
+
+  it('formatOperatingHours should return "24/7" if format is "24/7"', () => {
+    const operatingHours = '24/7';
+    const expected = '24/7';
+
+    const result = formatOperatingHours(operatingHours);
+
+    expect(result).to.eq(expected);
+  });
+
+  it('formatOperatingHours should return "Sunrise - Sunset" if format is "Sunrise - Sunset"', () => {
+    const operatingHours = 'Sunrise - Sunset';
+    const expected = 'Sunrise - Sunset';
 
     const result = formatOperatingHours(operatingHours);
 

--- a/src/applications/facility-locator/utils/helpers.js
+++ b/src/applications/facility-locator/utils/helpers.js
@@ -119,7 +119,14 @@ export const formatOperatingHours = operatingHours => {
   // Remove all whitespace.
   const sanitizedOperatingHours = operatingHours.replace(/ /g, '');
 
-  if (sanitizedOperatingHours.search(/Sunrise-Sunset/i) === 0) {
+  if (sanitizedOperatingHours.search(/AM-PM/i) === 0) {
+    return operatingHours;
+  }
+
+  if (
+    sanitizedOperatingHours.search(/Sunrise-Sunset/i) === 0 ||
+    sanitizedOperatingHours.search(/Sunrise-Sundown/i) === 0
+  ) {
     return operatingHours;
   }
 
@@ -127,7 +134,19 @@ export const formatOperatingHours = operatingHours => {
     return sanitizedOperatingHours;
   }
 
-  if (sanitizedOperatingHours.search(/ByAppointmentOnly/i) === 0) {
+  if (
+    sanitizedOperatingHours.search(/ByAppointmentOnly/i) === 0 ||
+    sanitizedOperatingHours.search(/AppointmentsOnly/i) === 0 ||
+    sanitizedOperatingHours.search(/PleaseCallforHours/i) === 0 ||
+    sanitizedOperatingHours.search(
+      /3rdThursdayeverymonth,pleasecallforhours./i,
+    ) === 0 ||
+    sanitizedOperatingHours.search(/2ndand4thWeds.eachmonth.Callforhours./i) ===
+      0 ||
+    sanitizedOperatingHours.search(
+      /LastMondayeverymonth,pleasecallforhours./i,
+    ) === 0
+  ) {
     return operatingHours;
   }
 


### PR DESCRIPTION
## Description
issue: https://github.com/department-of-veterans-affairs/va.gov-team/issues/7236

## Testing done
Locally

## Screenshots
<img width="1089" alt="Screen Shot 2020-03-25 at 5 59 40 PM" src="https://user-images.githubusercontent.com/100468/77664272-117fb080-6f4c-11ea-92c6-5efa46f009ab.png">
<img width="1104" alt="Screen Shot 2020-03-25 at 5 59 53 PM" src="https://user-images.githubusercontent.com/100468/77664289-15abce00-6f4c-11ea-85df-967750a1e2f0.png">
<img width="1144" alt="Screen Shot 2020-03-25 at 6 00 05 PM" src="https://user-images.githubusercontent.com/100468/77664298-18a6be80-6f4c-11ea-8e6c-90cea4242258.png">
<img width="1162" alt="Screen Shot 2020-03-25 at 6 00 18 PM" src="https://user-images.githubusercontent.com/100468/77664304-1a708200-6f4c-11ea-8cae-5344cd432375.png">
<img width="1115" alt="Screen Shot 2020-03-25 at 6 00 48 PM" src="https://user-images.githubusercontent.com/100468/77664314-1cd2dc00-6f4c-11ea-9d9d-4b8f8bd75797.png">
<img width="1164" alt="Screen Shot 2020-03-25 at 6 02 16 PM" src="https://user-images.githubusercontent.com/100468/77664328-20666300-6f4c-11ea-9e3b-1fec67a13270.png">
<img width="1222" alt="Screen Shot 2020-03-26 at 10 40 30 AM" src="https://user-images.githubusercontent.com/100468/77665884-3ffe8b00-6f4e-11ea-8b9e-8026f7386541.png">
<img width="1105" alt="Screen Shot 2020-03-26 at 11 30 01 AM" src="https://user-images.githubusercontent.com/100468/77671181-39274680-6f55-11ea-9325-87b0c896e0a6.png">
<img width="1191" alt="Screen Shot 2020-03-26 at 11 29 44 AM" src="https://user-images.githubusercontent.com/100468/77671164-34629280-6f55-11ea-8e7a-502e767c54de.png">
<img width="1147" alt="Screen Shot 2020-03-26 at 11 47 15 AM" src="https://user-images.githubusercontent.com/100468/77673808-aa1c2d80-6f58-11ea-84e3-1ae7587fbac8.png">
<img width="1234" alt="Screen Shot 2020-03-26 at 11 52 41 AM" src="https://user-images.githubusercontent.com/100468/77673815-ad171e00-6f58-11ea-80b6-5b24382ecc53.png">
<img width="1261" alt="Screen Shot 2020-03-26 at 2 03 55 PM" src="https://user-images.githubusercontent.com/100468/77686341-cf199c00-6f6a-11ea-9e49-5c2b9db1fddb.png">
<img width="1209" alt="Screen Shot 2020-03-26 at 2 06 35 PM" src="https://user-images.githubusercontent.com/100468/77686514-14d66480-6f6b-11ea-9fe0-7d5a74cec118.png">


## Acceptance criteria
- [x]  Hours of operation should be displayed as they are provided via API. Field can be number, string or combination. 24/7 should be expressed as single value, not as open - close.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
