### PR TITLE
Added sonarjs/max-switch-cases to testing stage

### DIFF
--- a/circle.eslint.json
+++ b/circle.eslint.json
@@ -1,6 +1,7 @@
 {
   "rules": {
     "sonarjs/no-extra-arguments": 2,
-    "sonarjs/no-identical-expressions": 2
+    "sonarjs/no-identical-expressions": 2,
+    "sonarjs/max-switch-cases": [2, 40]
   }
 }


### PR DESCRIPTION
## Description
`max-switch-cases` rule from SonarJS has been added to the testing stage in CircleCI (`circle.esint.json`)

This rule has currently 3 errors in the existing code. After reviewing all the 3 errors, the multiple case statements are necessary. Therefore, I raised the threshold of 30 (by default) to 40.

## Errors status by ownership

### `Frontend` team
3/3 errors were fixed/disabled by increasing the threshold

## Testing done
Locally

## Acceptance criteria
- [x] `Frontend` team errors need to be fixed
