### PR TITLE
change text for school closed flag

### DIFF
--- a/src/applications/gi/tests/utils/render.unit.spec.js
+++ b/src/applications/gi/tests/utils/render.unit.spec.js
@@ -21,9 +21,7 @@ describe('renderSchoolClosingAlert', () => {
         schoolClosingOn: '2019-05-06',
       }),
     );
-    expect(tree.find('.usa-alert-text').text()).to.equal(
-      "This campus has closed. Visit the school's website to learn more.",
-    );
+    expect(tree.find('.usa-alert-text').text()).to.equal('School has closed.');
     tree.unmount();
   });
   it('should not render an alert', () => {

--- a/src/applications/gi/utils/render.jsx
+++ b/src/applications/gi/utils/render.jsx
@@ -15,6 +15,7 @@ export const renderSchoolClosingAlert = result => {
       if (currentDate > schoolClosingDate) {
         return (
           <AlertBox
+            className="vads-u-margin-top--0p5"
             headline="School closed"
             content={<p>School has closed.</p>}
             isVisible={!!schoolClosing}
@@ -36,6 +37,7 @@ export const renderSchoolClosingAlert = result => {
 
   return (
     <AlertBox
+      className="vads-u-margin-top--0p5"
       content={<p>Upcoming campus closure</p>}
       headline="School closure"
       isVisible={!!schoolClosing}

--- a/src/applications/gi/utils/render.jsx
+++ b/src/applications/gi/utils/render.jsx
@@ -15,13 +15,8 @@ export const renderSchoolClosingAlert = result => {
       if (currentDate > schoolClosingDate) {
         return (
           <AlertBox
-            headline="This campus has closed"
-            content={
-              <p>
-                This campus has closed. Visit the school's website to learn
-                more.
-              </p>
-            }
+            headline="School closed"
+            content={<p>School has closed.</p>}
             isVisible={!!schoolClosing}
             status="warning"
           />


### PR DESCRIPTION
## Description
https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/7020

Changing text in the alert. 

## Testing done
Dev tested.

## Screenshots
![image](https://user-images.githubusercontent.com/48804654/77693085-2a08be80-6f7e-11ea-85df-5cda556e86a8.png)



## Acceptance criteria
- [x] When the school closure date associated with a school closing flag passes, the language on the Search Results page is updated to state:
Header: "School closed"
Subtext: "School has closed."

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
