### PR TITLE
[Homepage] Remove section heading from anayltics

### DIFF
--- a/src/site/layouts/home.drupal.liquid
+++ b/src/site/layouts/home.drupal.liquid
@@ -14,13 +14,12 @@
         <div class="hub-links-container" data-e2e="bucket">
           <h2 class="heading-level-3 hub-links-title"><i class="icon-large-baseline icon-heading hub-icon-{{ card.label | downcase | replace: ' ', '-' }} hub-color-{{ card.label | downcase | replace: ' ', '-' }}"></i>{{ card.label }}</h2>
           <ul class="hub-links-list">
-            {% assign cardLabel = card.label %}
             {% for link in card.links %}
               <li>
                 <a href="{{ link.url.path }}"
                   onclick="recordEvent({
                     event: 'nav-zone-one',
-                    'nav-path': '{{ cardLabel }}->{% if link.url.path != empty %}{{ link.url.path }}{% else %}{{ link.label }}{% endif %}',
+                    'nav-path': '->{% if link.url.path != empty %}{{ link.url.path }}{% else %}{{ link.label }}{% endif %}',
                   });"
                   >
                   {{ link.label }}


### PR DESCRIPTION
## Description
Follow up to https://github.com/department-of-veterans-affairs/vets-website/pull/12018

The section heading shouldn't be included in our event capture. 

## Testing done
Looked at page source to confirm event is corrected

## Screenshots
![image](https://user-images.githubusercontent.com/1915775/77767577-abf8f600-7017-11ea-89a5-cd9b26c83e0d.png)


## Acceptance criteria
- [x] No section heading in event

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
