### PR TITLE
[Find Forms] Add some focus-handling

### DIFF
--- a/src/applications/find-va-forms/containers/SearchForm.jsx
+++ b/src/applications/find-va-forms/containers/SearchForm.jsx
@@ -5,6 +5,7 @@ import { connect } from 'react-redux';
 import URLSearchParams from 'url-search-params';
 // Relative imports.
 import { fetchFormsThunk } from '../actions';
+import { focusElement } from 'platform/utilities/ui';
 
 export class SearchForm extends Component {
   static propTypes = {
@@ -46,6 +47,8 @@ export class SearchForm extends Component {
   onSubmitHandler = event => {
     event.preventDefault();
     this.props.fetchFormsThunk(this.state.query);
+
+    focusElement('form[name="find-va-form"] button[type="submit"]');
   };
 
   render() {

--- a/src/applications/find-va-forms/containers/SearchForm.jsx
+++ b/src/applications/find-va-forms/containers/SearchForm.jsx
@@ -5,7 +5,6 @@ import { connect } from 'react-redux';
 import URLSearchParams from 'url-search-params';
 // Relative imports.
 import { fetchFormsThunk } from '../actions';
-import { focusElement } from 'platform/utilities/ui';
 
 export class SearchForm extends Component {
   static propTypes = {
@@ -47,8 +46,6 @@ export class SearchForm extends Component {
   onSubmitHandler = event => {
     event.preventDefault();
     this.props.fetchFormsThunk(this.state.query);
-
-    focusElement('form[name="find-va-form"] button[type="submit"]');
   };
 
   render() {

--- a/src/applications/find-va-forms/containers/SearchForm.jsx
+++ b/src/applications/find-va-forms/containers/SearchForm.jsx
@@ -53,6 +53,7 @@ export class SearchForm extends Component {
 
   render() {
     const { onSubmitHandler, onQueryChange } = this;
+    const { fetching } = this.props;
     const { query } = this.state;
 
     return (
@@ -78,6 +79,7 @@ export class SearchForm extends Component {
             <button
               className="usa-button vads-u-margin--0 vads-u-margin-y--1"
               type="submit"
+              disabled={fetching}
             >
               Search
             </button>

--- a/src/applications/find-va-forms/containers/SearchResults.jsx
+++ b/src/applications/find-va-forms/containers/SearchResults.jsx
@@ -201,8 +201,8 @@ export class SearchResults extends Component {
           className="vads-u-font-size--lg vads-u-margin-top--1p5 vads-u-font-weight--normal"
           data-forms-focus
         >
-          Displaying {startLabel} - {lastLabel} out of {results.length} results
-          for "<strong>{query}</strong>"
+          Displaying {startLabel} &ndash; {lastLabel} out of {results.length}{' '}
+          results for "<strong>{query}</strong>"
         </h2>
 
         {/* Table of Forms */}

--- a/src/applications/find-va-forms/containers/SearchResults.jsx
+++ b/src/applications/find-va-forms/containers/SearchResults.jsx
@@ -196,8 +196,8 @@ export class SearchResults extends Component {
     return (
       <>
         <h2
-          data-forms-focus
           className="vads-u-font-size--lg vads-u-margin-top--1p5 vads-u-font-weight--normal"
+          data-forms-focus
         >
           Displaying {startLabel} - {lastLabel} out of {results.length} results
           for "<strong>{query}</strong>"

--- a/src/applications/find-va-forms/containers/SearchResults.jsx
+++ b/src/applications/find-va-forms/containers/SearchResults.jsx
@@ -8,6 +8,9 @@ import SortableTable from '@department-of-veterans-affairs/formation-react/Sorta
 import { connect } from 'react-redux';
 import orderBy from 'lodash/orderBy';
 import slice from 'lodash/slice';
+
+import { focusElement } from 'platform/utilities/ui';
+
 // Relative imports.
 import { updatePaginationAction, updateResultsAction } from '../actions';
 
@@ -65,6 +68,14 @@ export class SearchResults extends Component {
       selectedFieldLabel: 'idLabel',
       selectedFieldOrder: ASCENDING,
     };
+  }
+
+  componentDidUpdate(previousProps) {
+    const justRefreshed = previousProps.fetching && !this.props.fetching;
+
+    if (justRefreshed) {
+      focusElement('[data-forms-focus]');
+    }
   }
 
   onHeaderClick = (fieldLabel, order) => {
@@ -129,7 +140,7 @@ export class SearchResults extends Component {
 
     // Show loading indicator if we are fetching.
     if (fetching) {
-      return <LoadingIndicator message="Loading search results..." />;
+      return <LoadingIndicator setFocus message="Loading search results..." />;
     }
 
     // Show the error alert box if there was an error.
@@ -154,6 +165,7 @@ export class SearchResults extends Component {
         <h2
           className="vads-u-font-size--base vads-u-line-height--3 vads-u-font-family--sans
         vads-u-margin-top--1p5 vads-u-font-weight--normal"
+          data-forms-focus
         >
           No results were found for "<strong>{query}</strong>
           ." Try using fewer words or broadening your search. If you&apos;re
@@ -183,7 +195,10 @@ export class SearchResults extends Component {
 
     return (
       <>
-        <h2 className="vads-u-font-size--lg vads-u-margin-top--1p5 vads-u-font-weight--normal">
+        <h2
+          data-forms-focus
+          className="vads-u-font-size--lg vads-u-margin-top--1p5 vads-u-font-weight--normal"
+        >
           Displaying {startLabel} - {lastLabel} out of {results.length} results
           for "<strong>{query}</strong>"
         </h2>

--- a/src/applications/find-va-forms/containers/SearchResults.jsx
+++ b/src/applications/find-va-forms/containers/SearchResults.jsx
@@ -105,6 +105,8 @@ export class SearchResults extends Component {
 
     // Update the page and the new start index.
     updatePagination(page, startIndex);
+
+    focusElement('[data-forms-focus]');
   };
 
   sortResults = (fieldLabel, selectedFieldOrder = ASCENDING) => {


### PR DESCRIPTION
## Description
This PR adds some accessibility improvements into `/find-forms`.

1. While results are loading, set browser focus to the loading indicator
1. Once results are done loading, set browser focus to the results heading
1. When the result page changes, focus back to the results heading

We'll probably have to follow up to this by removing the gold outline that appears around focused elements. 

https://github.com/department-of-veterans-affairs/va.gov-team/issues/7096

## Testing done
Used the page locally, confirming support

## Screenshots

<details>

<summary>Right after a search is done loading</summary>

![image](https://user-images.githubusercontent.com/1915775/77775471-f59b0e00-7022-11ea-8c25-3bbc37f3094f.png)

</details>

## Acceptance criteria
- [ ] Focus works correctly on `/find-forms`.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
