### PR TITLE
change margin to 8px for caution flags

### DIFF
--- a/src/applications/gi/tests/utils/render.unit.spec.js
+++ b/src/applications/gi/tests/utils/render.unit.spec.js
@@ -21,7 +21,7 @@ describe('renderSchoolClosingAlert', () => {
         schoolClosingOn: '2019-05-06',
       }),
     );
-    expect(tree.find('.usa-alert-text').text()).to.equal('School has closed.');
+    expect(tree.find('.usa-alert-text').text()).to.equal('School has closed');
     tree.unmount();
   });
   it('should not render an alert', () => {

--- a/src/applications/gi/utils/render.jsx
+++ b/src/applications/gi/utils/render.jsx
@@ -15,7 +15,7 @@ export const renderSchoolClosingAlert = result => {
       if (currentDate > schoolClosingDate) {
         return (
           <AlertBox
-            className="vads-u-margin-top--0p5"
+            className="vads-u-margin-top--1"
             headline="School closed"
             content={<p>School has closed.</p>}
             isVisible={!!schoolClosing}
@@ -26,7 +26,7 @@ export const renderSchoolClosingAlert = result => {
     }
     return (
       <AlertBox
-        className="vads-u-margin-top--0p5"
+        className="vads-u-margin-top--1"
         content={<p>A campus at this school will be closing soon</p>}
         headline="A campus is closing soon"
         isVisible={!!schoolClosing}
@@ -37,7 +37,7 @@ export const renderSchoolClosingAlert = result => {
 
   return (
     <AlertBox
-      className="vads-u-margin-top--0p5"
+      className="vads-u-margin-top--1"
       content={<p>Upcoming campus closure</p>}
       headline="School closure"
       isVisible={!!schoolClosing}
@@ -79,7 +79,7 @@ export const renderCautionAlert = result => {
   if (!environment.isProduction()) {
     return (
       <AlertBox
-        className="vads-u-margin-top--1 "
+        className="vads-u-margin-top--1"
         content={renderReasons(cautionFlags)}
         headline={
           cautionFlags.length > 1

--- a/src/applications/gi/utils/render.jsx
+++ b/src/applications/gi/utils/render.jsx
@@ -17,7 +17,7 @@ export const renderSchoolClosingAlert = result => {
           <AlertBox
             className="vads-u-margin-top--1"
             headline="School closed"
-            content={<p>School has closed.</p>}
+            content={<p>School has closed</p>}
             isVisible={!!schoolClosing}
             status="warning"
           />

--- a/src/applications/gi/utils/render.jsx
+++ b/src/applications/gi/utils/render.jsx
@@ -79,7 +79,7 @@ export const renderCautionAlert = result => {
   if (!environment.isProduction()) {
     return (
       <AlertBox
-        className="vads-u-margin-top--0p5"
+        className="vads-u-margin-top--1 "
         content={renderReasons(cautionFlags)}
         headline={
           cautionFlags.length > 1
@@ -93,6 +93,7 @@ export const renderCautionAlert = result => {
   }
   return (
     <AlertBox
+      className="vads-u-margin-top--1"
       content={<p>This school has cautionary warnings</p>}
       headline="Caution"
       isVisible={cautionFlags.length > 0}


### PR DESCRIPTION
## Description
https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/7294

Margin for caution flags must be 8px
## Testing done
Dev tested.

## Screenshots


## Acceptance criteria
- [x] margin between alerts is 8px.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
