### PR TITLE
7281: Update link for 'Suspension of VA Benefits to Five Schools for Deceptive Practices

### DIFF
--- a/src/applications/gi/containers/Modals.jsx
+++ b/src/applications/gi/containers/Modals.jsx
@@ -659,7 +659,7 @@ export class Modals extends React.Component {
         {!environment.isProduction() && (
           <p>
             <a
-              href="https://www.benefits.va.gov/gibill/comparison_tool/about_this_tool.asp#phoenix"
+              href="https://www.benefits.va.gov/gibill/comparison_tool/about_this_tool.asp#suspension"
               target="_blank"
               rel="noopener noreferrer"
             >


### PR DESCRIPTION
## Description

As a user of the GI Bill Comparison Tool, I need to understand all of the caution flags an institution can have so that I can make the best decision regarding how to use my education benefits.

[Originating Issue](https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/7281)

## Testing done
Testing passes locally

## Screenshots
N/A

## Acceptance criteria
- [x] In the "Cautionary information" section of the Profile Page, a user selects the "Learn more about these warnings" link.
a. A modal appears and includes following link to "Suspension of VA Benefits to Five Schools for Deceptive Practices", which is included above "heightened cash monitoring" in the modal: https://www.benefits.va.gov/gibill/comparison_tool/about_this_tool.asp#suspension

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
