### PR TITLE
Add supported facility related events

### DIFF
--- a/src/applications/vaos/actions/newAppointment.js
+++ b/src/applications/vaos/actions/newAppointment.js
@@ -48,6 +48,8 @@ import {
   recordEligibilityGAEvents,
 } from '../utils/eligibility';
 
+import { recordEligibilityFailure } from '../utils/events';
+
 import { captureError } from '../utils/error';
 
 import {
@@ -289,6 +291,10 @@ export function openFacilityPage(page, uiSchema, schema) {
         facilityId = eligibleFacilities[0].institutionCode;
       }
 
+      if (!eligibleFacilities?.length) {
+        recordEligibilityFailure('supported-facilities');
+      }
+
       const eligibilityChecks =
         newAppointment.eligibility[`${facilityId}_${typeOfCareId}`] || null;
 
@@ -353,6 +359,7 @@ export function updateFacilityPageData(page, uiSchema, data) {
         // If no available facilities, fetch system details to display contact info
         if (!availableFacilities?.length) {
           dispatch(fetchFacilityDetails(data.vaParent));
+          recordEligibilityFailure('supported-facilities');
         }
 
         dispatch({

--- a/src/applications/vaos/containers/TypeOfCarePage.jsx
+++ b/src/applications/vaos/containers/TypeOfCarePage.jsx
@@ -18,6 +18,7 @@ import {
   getFormPageInfo,
   getNewAppointment,
   selectIsCernerOnlyPatient,
+  vaosDirectScheduling,
 } from '../utils/selectors';
 
 const initialSchema = {
@@ -52,7 +53,9 @@ export class TypeOfCarePage extends React.Component {
     // kick off the past appointments fetch, which takes a while
     // This could get called multiple times, but the function is memoized
     // and returns the previous promise if it eixsts
-    getLongTermAppointmentHistory();
+    if (this.props.showDirectScheduling) {
+      getLongTermAppointmentHistory();
+    }
 
     this.props.updateFormData(pageKey, uiSchema, newData);
   };
@@ -111,6 +114,7 @@ function mapStateToProps(state) {
     ...formInfo,
     showToCUnavailableModal: newAppointment.showTypeOfCareUnavailableModal,
     isCernerOnlyPatient: selectIsCernerOnlyPatient(state),
+    showDirectScheduling: vaosDirectScheduling(state),
   };
 }
 

--- a/src/applications/vaos/newAppointmentFlow.js
+++ b/src/applications/vaos/newAppointmentFlow.js
@@ -217,10 +217,6 @@ export default {
     async next(state, dispatch) {
       const eligibilityStatus = getEligibilityStatus(state);
 
-      if (!eligibilityStatus.direct && !eligibilityStatus.request) {
-        recordEligibilityFailure();
-      }
-
       if (eligibilityStatus.direct) {
         let appointments = null;
 

--- a/src/applications/vaos/tests/newAppointmentFlow.unit.spec.js
+++ b/src/applications/vaos/tests/newAppointmentFlow.unit.spec.js
@@ -392,11 +392,6 @@ describe('VAOS newAppointmentFlow', () => {
           // Should throw an error above
           expect(false).to.be.true;
         } catch (e) {
-          expect(
-            global.window.dataLayer.filter(
-              event => event.event === 'vaos-eligibility-failed',
-            ).length,
-          ).to.equal(1);
           expect(e.message).to.equal(
             'Veteran not eligible for direct scheduling or requests',
           );

--- a/src/applications/vaos/tests/utils/eligibility.unit.spec.js
+++ b/src/applications/vaos/tests/utils/eligibility.unit.spec.js
@@ -46,6 +46,7 @@ describe('VAOS scheduling eligibility logic', () => {
         'requestPastVisit',
         'requestLimits',
         'directSupported',
+        'directEnabled',
         'requestSupported',
         'directPastVisit',
         'clinics',
@@ -67,6 +68,7 @@ describe('VAOS scheduling eligibility logic', () => {
         'requestPastVisit',
         'requestLimits',
         'directSupported',
+        'directEnabled',
         'requestSupported',
         'directPastVisit',
         'clinics',
@@ -89,6 +91,7 @@ describe('VAOS scheduling eligibility logic', () => {
         'requestPastVisit',
         'requestLimits',
         'directSupported',
+        'directEnabled',
         'requestSupported',
         'directPastVisit',
         'clinics',
@@ -272,6 +275,7 @@ describe('VAOS scheduling eligibility logic', () => {
         {
           pacTeam: [],
           clinics: [],
+          directEnabled: true,
           directSupported: true,
           requestSupported: true,
           directPastVisit: {
@@ -294,6 +298,36 @@ describe('VAOS scheduling eligibility logic', () => {
           e.event.startsWith('vaos-eligibility-'),
         ).length,
       ).to.equal(4);
+    });
+
+    it('should record only supported failure events', () => {
+      recordEligibilityGAEvents(
+        {
+          pacTeam: [],
+          clinics: [],
+          directEnabled: true,
+          directSupported: false,
+          requestSupported: false,
+          directPastVisit: {
+            durationInMonths: 12,
+            hasVisitedInPastMonths: false,
+          },
+          requestPastVisit: {
+            requestFailed: false,
+          },
+          requestLimits: {
+            requestLimit: 1,
+            numberOfRequests: 1,
+          },
+        },
+        '323',
+        '983',
+      );
+      expect(
+        global.window.dataLayer.filter(e =>
+          e.event.startsWith('vaos-eligibility-'),
+        ).length,
+      ).to.equal(2);
     });
 
     it('should not record failure events when ineligible', () => {

--- a/src/applications/vaos/utils/eligibility.js
+++ b/src/applications/vaos/utils/eligibility.js
@@ -199,7 +199,7 @@ export function getEligibleFacilities(facilities) {
  * of the check.
  */
 export function recordEligibilityGAEvents(eligibilityData) {
-  if (eligibilityData.requestSupported && !hasRequestFailed(eligibilityData)) {
+  if (eligibilityData.requestSupported && !eligibilityData.requestFailed) {
     if (!isUnderRequestLimit(eligibilityData)) {
       recordEligibilityFailure('request-exceeded-outstanding-requests');
     }
@@ -216,7 +216,7 @@ export function recordEligibilityGAEvents(eligibilityData) {
   if (
     eligibilityData.directEnabled &&
     eligibilityData.directSupported &&
-    !hasDirectFailed(eligibilityData)
+    !eligibilityData.directFailed
   ) {
     if (!hasVisitedInPastMonthsDirect(eligibilityData)) {
       recordEligibilityFailure('direct-check-past-visits');

--- a/src/applications/vaos/utils/eligibility.js
+++ b/src/applications/vaos/utils/eligibility.js
@@ -81,8 +81,9 @@ export async function getEligibilityData(
 
 function hasVisitedInPastMonthsDirect(eligibilityData) {
   return (
-    eligibilityData.directPastVisit.durationInMonths === DISABLED_LIMIT_VALUE ||
-    eligibilityData.directPastVisit.hasVisitedInPastMonths
+    eligibilityData.directPastVisit?.durationInMonths ===
+      DISABLED_LIMIT_VALUE ||
+    eligibilityData.directPastVisit?.hasVisitedInPastMonths
   );
 }
 


### PR DESCRIPTION
## Description
This adds a couple new events to record if a user is getting stopped in the flow because a facility isn't enabled for requests or direct scheduling

## Testing done
Local testing

## Acceptance criteria
- [ ] Events fired as expected

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
