### PR TITLE
Removing unused graphql fields and adding checks for field presence.

### DIFF
--- a/src/site/layouts/health_care_region_page.drupal.liquid
+++ b/src/site/layouts/health_care_region_page.drupal.liquid
@@ -264,6 +264,7 @@ Example data:
           </div>
 
           <!-- Stories -->
+          {% if newsStoryTeasers.entities.length %}
           <section>
             <h2
               class="vads-u-margin-bottom--3 medium-screen:vads-u-margin-top--5">
@@ -278,8 +279,10 @@ Example data:
                 class="fa fa-chevron-right va-l-font-size--12px"></i>
             </a>
           </section>
+          {% endif %}
 
           <!-- Events -->
+          {% if eventTeasers.entities.length %}
           <section>
             <h2
               class="vads-u-margin-top--4 vads-u-margin-bottom--2 medium-screen:vads-u-margin-bottom--2p5">
@@ -299,6 +302,7 @@ Example data:
                 class="fa fa-chevron-right va-l-font-size--12px"></i>
             </a>
           </section>
+          {% endif %}
 
           <!-- Social Links -->
           {% if fieldFacebook != empty || fieldFlickr != empty || fieldInstagram != empty || fieldTwitter != empty || fieldEmailSubscription != empty %}

--- a/src/site/layouts/news_story.drupal.liquid
+++ b/src/site/layouts/news_story.drupal.liquid
@@ -142,7 +142,7 @@ Example data:
                             {{ fieldFullStory.processed }}
                         </div>
                     </div>
-                    <a onClick="recordEvent({ event: 'nav-secondary-button-click' });" class="vads-u-display--block vads-u-margin-bottom--7" href="{{ fieldOffice.entity.entityUrl.path }}/stories">See all stories</a>
+                    <a onClick="recordEvent({ event: 'nav-secondary-button-click' });" class="vads-u-display--block vads-u-margin-bottom--7" href="{{ fieldListing.entity.entityUrl.path }}">See all stories</a>
                 </article>
             </div>
         {% endif %}

--- a/src/site/stages/build/drupal/graphql/eventPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/eventPage.graphql.js
@@ -70,10 +70,5 @@ module.exports = `
     }
     fieldEventRegistrationrequired
     fieldAdditionalInformationAbo {processed}
-    fieldOffice {
-      entity {
-        entityLabel
-      }
-    }
  }
 `;

--- a/src/site/stages/build/drupal/graphql/file-fragments/outreachAssets.graphql.js
+++ b/src/site/stages/build/drupal/graphql/file-fragments/outreachAssets.graphql.js
@@ -9,9 +9,6 @@ module.exports = `
         fieldFormat
         fieldBenefits
         fieldDescription
-        fieldOffice {
-          targetId
-        }
         fieldMedia {
           entity {
             ... on MediaImage {

--- a/src/site/stages/build/drupal/graphql/newStoryPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/newStoryPage.graphql.js
@@ -9,25 +9,6 @@ module.exports = `
     ${entityElementsFromPages}
     promote
     created
-    fieldOffice {
-      entity {
-        ... on NodeHealthCareRegionPage {
-          entityLabel
-          entityUrl {
-            ... on EntityCanonicalUrl {
-              breadcrumb {
-                url {
-                  path
-                  routed
-                }
-                text
-              }
-              path
-            }
-          }
-        }
-      }
-    }
     fieldAuthor {
       entity {
         ...on NodePersonProfile {
@@ -50,6 +31,13 @@ module.exports = `
               height
             }
           }
+        }
+      }
+    }
+    fieldListing {
+      entity {
+        entityUrl {
+          path
         }
       }
     }

--- a/src/site/stages/build/drupal/graphql/pressReleasePage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/pressReleasePage.graphql.js
@@ -18,11 +18,11 @@ module.exports = `
             entity {
               ...on File {
                 filename
-                url         
+                url
               }
             }
           }
-        }      
+        }
       }
     }
     fieldAddress {
@@ -53,34 +53,24 @@ module.exports = `
             entity {
               ...on File {
                 filename
-                url          
+                url
               }
             }
           }
-        }   
-        
-        ...on MediaImage {        
-          image {          
+        }
+
+        ...on MediaImage {
+          image {
             alt
             url
           }
         }
-        
+
         ...on MediaVideo {
-          fieldMediaVideoEmbedField        
+          fieldMediaVideoEmbedField
         }
-        
+
       }
     }
-    fieldOffice {
-      entity {
-        ...on NodeHealthCareRegionPage {
-          entityLabel
-          fieldPressReleaseBlurb {
-            processed
-          }
-        }
-      }
-    }  
   }
 `;

--- a/src/site/stages/build/drupal/graphql/pressReleasesListingPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/pressReleasesListingPage.graphql.js
@@ -33,25 +33,6 @@ module.exports = `
               }
               promote
               created
-              fieldOffice {
-                entity {
-                  ... on NodeHealthCareRegionPage {
-                    entityLabel
-                    entityUrl {
-                      ... on EntityCanonicalUrl {
-                        breadcrumb {
-                          url {
-                            path
-                            routed
-                          }
-                          text
-                        }
-                        path
-                      }
-                    }
-                  }
-                }
-              }
               fieldIntroText
             }
           }

--- a/src/site/stages/build/drupal/graphql/storyListingPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/storyListingPage.graphql.js
@@ -31,25 +31,6 @@ module.exports = `
               }
               promote
               created
-              fieldOffice {
-                entity {
-                  ... on NodeHealthCareRegionPage {
-                    entityLabel
-                    entityUrl {
-                      ... on EntityCanonicalUrl {
-                        breadcrumb {
-                          url {
-                            path
-                            routed
-                          }
-                          text
-                        }
-                        path
-                      }
-                    }
-                  }
-                }
-              }
               fieldAuthor {
                 entity {
                   ...on NodePersonProfile {


### PR DESCRIPTION
## Description
Removes legacy usage of field_office, and adds item existence checks before outputting text in a couple of places. Issue with legacy usage of field_office was discovered during build of https://github.com/department-of-veterans-affairs/va.gov-cms/pull/1353

## Testing done
Successful local Metalsmith build completion.
