### PR TITLE
7280: Removal of production flag for 6848 and 7281

### DIFF
--- a/src/applications/gi/containers/Modals.jsx
+++ b/src/applications/gi/containers/Modals.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { connect } from 'react-redux';
 import * as actions from '../actions';
 import Modal from '@department-of-veterans-affairs/formation-react/Modal';
-import environment from 'platform/utilities/environment';
 
 export class Modals extends React.Component {
   calcBeneficiaryLocationQuestionContent = () => (
@@ -656,17 +655,16 @@ export class Modals extends React.Component {
           or legal scrutiny to this program. VA will display other categories of
           caution flags in future versions of the GI Bill Comparison Tool.
         </p>
-        {!environment.isProduction() && (
-          <p>
-            <a
-              href="https://www.benefits.va.gov/gibill/comparison_tool/about_this_tool.asp#suspension"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              Suspension of VA Benefits to Five Schools for Deceptive Practices
-            </a>
-          </p>
-        )}
+        <p>
+          <a
+            href="https://www.benefits.va.gov/gibill/comparison_tool/about_this_tool.asp#suspension"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Suspension of VA Benefits to Five Schools for Deceptive Practices
+          </a>
+        </p>
+
         <p>
           <a
             href="https://studentaid.ed.gov/sa/about/data-center/school/hcm"


### PR DESCRIPTION
## Description
As a developer, I need to remove the prod flag for the updates the Learn More caution flag content in Comparison Tool so that the updates are available in the production environment.

Content for both 6848 and 7281 were both behind a single production flag which is being removed in this pull request.

[Originating Issue](https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/7280)

For:
- [6848](https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/6848)
- [7281](https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/7281)

## Testing done
Content shows in all environments based off of local testing

## Screenshots
N/A

## Acceptance criteria
- [x] 1. The functionality in 6848 and 7281 is available in the production environment.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
