### PR TITLE
Gate new profile-2 app

### DIFF
--- a/src/applications/personalization/account/containers/AccountApp.jsx
+++ b/src/applications/personalization/account/containers/AccountApp.jsx
@@ -16,7 +16,6 @@ class AccountApp extends React.Component {
     return (
       <div>
         <RequiredLoginView
-          authRequired={1}
           serviceRequired={backendServices.USER_PROFILE}
           user={this.props.user}
         >

--- a/src/applications/personalization/connected-accounts/containers/ConnectedAcctApp.jsx
+++ b/src/applications/personalization/connected-accounts/containers/ConnectedAcctApp.jsx
@@ -57,7 +57,6 @@ class ConnectedAcctApp extends React.Component {
     return (
       <div>
         <RequiredLoginView
-          authRequired={1}
           serviceRequired={backendServices.USER_PROFILE}
           user={this.props.user}
         >

--- a/src/applications/personalization/profile-2/components/ProfileWrapper.jsx
+++ b/src/applications/personalization/profile-2/components/ProfileWrapper.jsx
@@ -1,9 +1,14 @@
 import React from 'react';
+import { connect } from 'react-redux';
+
+import RequiredLoginView from 'platform/user/authorization/components/RequiredLoginView';
+import backendServices from 'platform/user/profile/constants/backendServices';
+
 import ProfileHeader from './ProfileHeader';
 import ProfileSideNav from './ProfileSideNav';
 
-const ProfileWrapper = ({ children }) => (
-  <>
+const ProfileWrapper = ({ children, user }) => (
+  <RequiredLoginView serviceRequired={backendServices.USER_PROFILE} user={user}>
     <ProfileHeader />
     <div className="usa-grid usa-grid-full">
       <div className="usa-width-one-fourth">
@@ -11,7 +16,13 @@ const ProfileWrapper = ({ children }) => (
       </div>
       <div className="usa-width-three-fourths">{children}</div>
     </div>
-  </>
+  </RequiredLoginView>
 );
 
-export default ProfileWrapper;
+const mapStateToProps = state => ({
+  user: state.user,
+});
+
+export { ProfileWrapper };
+
+export default connect(mapStateToProps)(ProfileWrapper);

--- a/src/applications/personalization/profile-2/sass/profile-2.scss
+++ b/src/applications/personalization/profile-2/sass/profile-2.scss
@@ -2,6 +2,9 @@
 @import "../../../../platform/forms/sass/m-schemaform";
 
 nav.profile-side-nav {
+  ul {
+    padding: 0;
+  }
   li {
     list-style: none;
   }

--- a/src/applications/personalization/profile360/containers/VAProfileApp.jsx
+++ b/src/applications/personalization/profile360/containers/VAProfileApp.jsx
@@ -21,7 +21,6 @@ class VAProfileApp extends React.Component {
     return (
       <div>
         <RequiredLoginView
-          authRequired={1}
           serviceRequired={backendServices.USER_PROFILE}
           user={this.props.user}
           loginUrl={this.props.loginUrl}

--- a/src/applications/personalization/profile360/containers/VAProfileApp.jsx
+++ b/src/applications/personalization/profile360/containers/VAProfileApp.jsx
@@ -23,8 +23,6 @@ class VAProfileApp extends React.Component {
         <RequiredLoginView
           serviceRequired={backendServices.USER_PROFILE}
           user={this.props.user}
-          loginUrl={this.props.loginUrl}
-          verifyUrl={this.props.verifyUrl}
         >
           <ProfileView
             profile={this.props.profile}

--- a/src/applications/personalization/rated-disabilities/containers/RatedDisabilitiesApp.jsx
+++ b/src/applications/personalization/rated-disabilities/containers/RatedDisabilitiesApp.jsx
@@ -44,8 +44,6 @@ class RatedDisabilitiesApp extends React.Component {
         <RequiredLoginView
           serviceRequired={backendServices.USER_PROFILE}
           user={this.props.user}
-          loginUrl={this.props.loginUrl}
-          verifyUrl={this.props.verifyUrl}
         >
           <DowntimeNotification
             appTitle="Rated Disabilities"

--- a/src/applications/personalization/rated-disabilities/containers/RatedDisabilitiesApp.jsx
+++ b/src/applications/personalization/rated-disabilities/containers/RatedDisabilitiesApp.jsx
@@ -42,7 +42,6 @@ class RatedDisabilitiesApp extends React.Component {
           </Breadcrumbs>
         </div>
         <RequiredLoginView
-          authRequired={1}
           serviceRequired={backendServices.USER_PROFILE}
           user={this.props.user}
           loginUrl={this.props.loginUrl}

--- a/src/applications/personalization/view-dependents/containers/ViewDependentsApp.jsx
+++ b/src/applications/personalization/view-dependents/containers/ViewDependentsApp.jsx
@@ -13,7 +13,6 @@ class ViewDependentsApp extends Component {
   render() {
     return (
       <RequiredLoginView
-        authRequired={1}
         serviceRequired={backendServices.USER_PROFILE}
         user={this.props.user}
         loginUrl={this.props.loginUrl}

--- a/src/applications/personalization/view-dependents/containers/ViewDependentsApp.jsx
+++ b/src/applications/personalization/view-dependents/containers/ViewDependentsApp.jsx
@@ -15,8 +15,6 @@ class ViewDependentsApp extends Component {
       <RequiredLoginView
         serviceRequired={backendServices.USER_PROFILE}
         user={this.props.user}
-        loginUrl={this.props.loginUrl}
-        verifyUrl={this.props.verifyUrl}
       >
         <ViewDependentsLayout
           loading={this.props.loading}


### PR DESCRIPTION
## Description
Gate the profile-2 app to only allow logged-in users.
Also removed some old props.

## Testing done
Local

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs