### PR TITLE
Fix failing VAOS tests on master

### DIFF
--- a/src/applications/vaos/tests/components/calendar/CalendarWidget.unit.spec.jsx
+++ b/src/applications/vaos/tests/components/calendar/CalendarWidget.unit.spec.jsx
@@ -18,7 +18,7 @@ const getOptionsByDate = () => [
   },
   {
     date: '2020-03-05',
-    datetime: '2020-03-05-24T09:00:00-05:00',
+    datetime: '2020-03-05T09:00:00-05:00',
   },
 ];
 
@@ -158,6 +158,7 @@ describe('VAOS <CalendarWidget>', () => {
     beforeEach(() => {
       tree = mount(
         <CalendarWidget
+          monthsToShowAtOnce={2}
           minDate={moment().format('YYYY-MM-DD')}
           onChange={state => {
             tree.setProps(state);
@@ -221,6 +222,7 @@ describe('VAOS <CalendarWidget>', () => {
       tree = mount(
         // No weekend dates and date must be equal or after current date!
         <CalendarWidget
+          monthsToShowAtOnce={2}
           minDate={moment().format('YYYY-MM-DD')}
           onChange={state => {
             tree.setProps(state);
@@ -345,6 +347,7 @@ describe('VAOS <CalendarWidget>', () => {
       tree = mount(
         // No weekend dates and date must be equal or after current date!
         <CalendarWidget
+          monthsToShowAtOnce={2}
           minDate={moment().format('YYYY-MM-DD')}
           onChange={state => {
             tree.setProps(state);


### PR DESCRIPTION
## Description
It's the end of the month and some of our calendar widget tests are failing because there are dates to select this month.

## Testing done
Unit tests

## Acceptance criteria
- [ ] Tests pass

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
