### PR TITLE
526: Handle rated disabilities in treatment facilities properly

### DIFF
--- a/src/applications/disability-benefits/all-claims/submit-transformer.js
+++ b/src/applications/disability-benefits/all-claims/submit-transformer.js
@@ -75,9 +75,13 @@ export function transformProviderFacilities(providerFacilities) {
  * Returns an array of disabilities pulled from ratedDisabilities, newDisabilities, newPrimaryDisabilities and newSecondaryDisabilities
  * @param {object} formData
  */
-function getDisabilities(formData) {
+function getDisabilities(formData, includeDisabilityActionTypeNone = true) {
   // Assumes we have only selected conditions at this point
-  const claimedConditions = formData.ratedDisabilities || [];
+  const claimedConditions = (formData.ratedDisabilities || []).filter(
+    ratedDisability =>
+      includeDisabilityActionTypeNone ||
+      ratedDisability.disabilityActionType !== disabilityActionTypes.NONE,
+  );
 
   // Depending on where this is called in the transformation flow, we have to use different key names.
   // This assumes newDisabilities is removed after it's split out into its primary and secondary counterparts.
@@ -99,9 +103,12 @@ function getDisabilityName(disability) {
   return name && name.trim();
 }
 
-function getClaimedConditionNames(formData) {
-  return getDisabilities(formData).map(disability =>
-    getDisabilityName(disability),
+function getClaimedConditionNames(
+  formData,
+  includeDisabilityActionTypeNone = true,
+) {
+  return getDisabilities(formData, includeDisabilityActionTypeNone).map(
+    disability => getDisabilityName(disability),
   );
 }
 
@@ -380,7 +387,7 @@ export function transform(formConfig, form) {
         'treatedDisabilityNames',
         transformRelatedDisabilities(
           facility.treatedDisabilityNames,
-          getClaimedConditionNames(formData),
+          getClaimedConditionNames(formData, false),
         ),
         facility,
       ),

--- a/src/applications/disability-benefits/all-claims/tests/data/transformed-data/secondary-new-test.json
+++ b/src/applications/disability-benefits/all-claims/tests/data/transformed-data/secondary-new-test.json
@@ -39,7 +39,7 @@
           "city": "Bigcity",
           "state": "AK"
         },
-        "treatedDisabilityNames": ["Diabetes mellitus0", "De-selected", "knee replacement"]
+        "treatedDisabilityNames": ["knee replacement"]
       }
     ],
     "ratedDisabilities": [


### PR DESCRIPTION
## Description
This pull request properly handles rated disabilities on submission of the 526 form. The behavior has been adjusted to not include rated disabilities with an action code of "NONE" in the list of treated disability names attached to a VA treatment facility. In theory, this situation shouldn't be possible because of how the form flow is set up. In practice, it is possible for users to cause this situation if data is manipulated backwards on the review page. For example: a user marks a rated disability as worsening, then adds that same disability to a treatment center, then, on the review page, un-marks that disability as worsening but doesn't remove the disability from the treatment center. This is then handled on submit by removing that disability from the treatment center list.

## Acceptance criteria
- [ ] Rated disabilities with an action type of "NONE" are removed from treatment center disability arrays on submit