### PR TITLE
Fix Inverted boolean

### DIFF
--- a/src/applications/gi/selectors/calculator.js
+++ b/src/applications/gi/selectors/calculator.js
@@ -278,7 +278,7 @@ const getDerivedValues = createSelector(
     );
 
     // Determine kicker benefit level - getKickerBenefit
-    if (!(inputs.kickerEligible === 'yes')) {
+    if (inputs.kickerEligible !== 'yes') {
       kickerBenefit = 0;
     } else {
       kickerBenefit = +inputs.kickerAmount;


### PR DESCRIPTION
## Description

`no-inverted-boolean-check` rule from SonarJS has been added to the testing stage in CircleCI (circle.esint.json)

This change should help the code to be in compliance with the rule and removes the errors from `additional-linting` CircleCI check.

## Testing done
Locally

## Screenshots

<img width="621" alt="Screen Shot 2020-03-31 at 1 40 07 PM" src="https://user-images.githubusercontent.com/55560129/78057708-2a75d080-7355-11ea-9fcc-51f92865fec6.png">

