### PR TITLE
Reset `page` to 1 on new search

### DIFF
--- a/src/applications/yellow-ribbon/actions/index.js
+++ b/src/applications/yellow-ribbon/actions/index.js
@@ -66,25 +66,30 @@ export const fetchResultsThunk = (options = {}) => async dispatch => {
   const perPage = options?.perPage || 10;
   const state = options?.state || null;
 
-  const fetchOptions = {
+  const queryParamsLookup = {
     city,
     contributionAmount,
-    hideFetchingState,
     name,
     numberOfStudents,
     state,
   };
 
   // Change the `fetching` state in our store.
-  dispatch(fetchResultsAction(fetchOptions));
+  dispatch(
+    fetchResultsAction({
+      ...queryParamsLookup,
+      hideFetchingState,
+      page,
+    }),
+  );
 
   // Derive the current query params.
   const queryParams = new URLSearchParams(location.search);
 
   // Set/Delete query params.
-  Object.keys(fetchOptions).forEach(key => {
+  Object.keys(queryParamsLookup).forEach(key => {
     // Derive the value.
-    const value = fetchOptions[key];
+    const value = queryParamsLookup[key];
 
     // Set the query param.
     if (value) {

--- a/src/applications/yellow-ribbon/actions/index.unit.spec.js
+++ b/src/applications/yellow-ribbon/actions/index.unit.spec.js
@@ -107,7 +107,6 @@ describe('Yellow Ribbon actions', () => {
       const dispatch = () => {};
       const thunk = fetchResultsThunk({
         city: 'boulder',
-        country: 'usa',
         hideFetchingState: false,
         history: mockedHistory,
         location: mockedLocation,
@@ -154,6 +153,7 @@ describe('Yellow Ribbon actions', () => {
             hideFetchingState: false,
             name: 'university',
             numberOfStudents: 'unlimited',
+            page: 1,
             state: 'CO',
           },
           type: FETCH_RESULTS,

--- a/src/applications/yellow-ribbon/components/SearchResult/index.jsx
+++ b/src/applications/yellow-ribbon/components/SearchResult/index.jsx
@@ -148,7 +148,7 @@ export const SearchResult = ({ school, schoolIDs }) => (
 SearchResult.propTypes = {
   school: PropTypes.shape({
     city: PropTypes.string.isRequired,
-    insturl: PropTypes.number,
+    insturl: PropTypes.string,
     id: PropTypes.string.isRequired,
     name: PropTypes.string.isRequired,
     state: PropTypes.string.isRequired,

--- a/src/applications/yellow-ribbon/components/SearchResult/index.unit.spec.jsx
+++ b/src/applications/yellow-ribbon/components/SearchResult/index.unit.spec.jsx
@@ -11,7 +11,6 @@ describe('Yellow Ribbon <SearchResult>', () => {
       school: {
         city: 'Los Angeles',
         contributionAmount: '500',
-        country: 'USA',
         degreeLevel: 'All',
         divisionProfessionalSchool: 'All',
         facilityCode: '21115805',

--- a/src/applications/yellow-ribbon/containers/SearchForm/index.jsx
+++ b/src/applications/yellow-ribbon/containers/SearchForm/index.jsx
@@ -93,6 +93,7 @@ export class SearchForm extends Component {
       contributionAmount,
       name,
       numberOfStudents,
+      page: 1,
       state,
     });
   };

--- a/src/applications/yellow-ribbon/containers/SearchForm/index.unit.spec.jsx
+++ b/src/applications/yellow-ribbon/containers/SearchForm/index.unit.spec.jsx
@@ -23,7 +23,7 @@ describe('Yellow Ribbon container <SearchForm>', () => {
     global.window = {
       location: {
         search:
-          '?contributionAmount=unlimited&city=boulder&country=usa&name=university&numberOfStudents=unlimited&state=co',
+          '?contributionAmount=unlimited&city=boulder&name=university&numberOfStudents=unlimited&state=co',
       },
     };
 

--- a/src/applications/yellow-ribbon/containers/SearchResults/index.jsx
+++ b/src/applications/yellow-ribbon/containers/SearchResults/index.jsx
@@ -39,7 +39,6 @@ export class SearchResults extends Component {
     // Derive the state values from our query params.
     const city = queryParams.get('city') || '';
     const contributionAmount = queryParams.get('contributionAmount') || '';
-    const country = queryParams.get('country') || '';
     const name = queryParams.get('name') || '';
     const numberOfStudents = queryParams.get('numberOfStudents') || '';
     const state = queryParams.get('state') || '';
@@ -51,7 +50,6 @@ export class SearchResults extends Component {
     fetchResults({
       city,
       contributionAmount,
-      country,
       hideFetchingState: true,
       name,
       numberOfStudents,

--- a/src/applications/yellow-ribbon/containers/SearchResults/index.unit.spec.jsx
+++ b/src/applications/yellow-ribbon/containers/SearchResults/index.unit.spec.jsx
@@ -54,7 +54,6 @@ describe('Yellow Ribbon container <SearchResults>', () => {
         'Warning or Equivalent-Factors Affecting Academic Quality (Concerns about issues affecting academic quality)',
       city: 'ABILENE',
       closure109: null,
-      country: 'USA',
       createdAt: '2019-12-11T17:31:21.000Z',
       distanceLearning: true,
       dodBah: 1062,

--- a/src/applications/yellow-ribbon/reducers/index.js
+++ b/src/applications/yellow-ribbon/reducers/index.js
@@ -13,17 +13,11 @@ import {
 } from '../constants';
 
 const initialState = {
-  city: '',
-  contributionAmount: '',
-  country: '',
   error: '',
   fetching: false,
-  name: '',
-  numberOfStudents: '',
   page: 1,
   perPage: 10,
   results: undefined,
-  state: '',
   totalResults: undefined,
   // For comparing:
   schoolIDs: [],
@@ -45,14 +39,9 @@ export const yellowRibbonReducer = (state = initialState, action) => {
     case FETCH_RESULTS: {
       return {
         ...state,
-        city: action?.options?.city || '',
-        contributionAmount: action?.options?.contributionAmount || '',
-        country: action?.options?.country || '',
         error: '',
         fetching: !action?.options?.hideFetchingState,
-        name: action?.options?.name || '',
-        numberOfStudents: action?.options?.numberOfStudents || '',
-        state: action?.options?.state || '',
+        page: action?.options?.page || state?.page,
       };
     }
     case FETCH_RESULTS_FAILURE: {

--- a/src/applications/yellow-ribbon/reducers/index.unit.spec.js
+++ b/src/applications/yellow-ribbon/reducers/index.unit.spec.js
@@ -10,19 +10,13 @@ describe('Yellow Ribbon reducer', () => {
     const result = yellowRibbonReducer(undefined, emptyAction);
 
     expect(result).to.be.deep.equal({
-      city: '',
-      contributionAmount: '',
-      country: '',
       error: '',
       fetching: false,
-      name: '',
-      numberOfStudents: '',
       page: 1,
       perPage: 10,
       results: undefined,
       schoolIDs: [],
       schoolsLookup: {},
-      state: '',
       totalResults: undefined,
     });
   });
@@ -32,7 +26,6 @@ describe('Yellow Ribbon reducer', () => {
       type: FETCH_RESULTS,
       options: {
         city: 'boulder',
-        country: 'usa',
         hideFetchingState: true,
         name: 'university',
         state: 'CO',
@@ -41,19 +34,13 @@ describe('Yellow Ribbon reducer', () => {
     const state = yellowRibbonReducer(undefined, action);
 
     expect(state).to.be.deep.equal({
-      city: 'boulder',
-      contributionAmount: '',
-      country: 'usa',
       error: '',
       fetching: false,
-      name: 'university',
-      numberOfStudents: '',
       page: 1,
       perPage: 10,
       results: undefined,
       schoolIDs: [],
       schoolsLookup: {},
-      state: 'CO',
       totalResults: undefined,
     });
   });


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/7173

This PR fixes a bug where a new search would remain on the previous search's page number.

## Testing done
Updated unit tests.

## Screenshots
N/A

## Acceptance criteria
- [x] The Displaying x of xx results reflects the correct number of cards that are displaying

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
