### PR TITLE
MFA and Verify links to use SSOe feature flag

### DIFF
--- a/src/applications/personalization/account/components/MultifactorMessage.jsx
+++ b/src/applications/personalization/account/components/MultifactorMessage.jsx
@@ -1,54 +1,49 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import PropTypes from 'prop-types';
 
 import { ssoe } from 'platform/user/authentication/selectors';
 import { mfa } from 'platform/user/authentication/utilities';
 import recordEvent from 'platform/monitoring/record-event';
 
-export class MultifactorMessage extends React.Component {
-  mfaHandler = () => {
-    recordEvent({ event: 'multifactor-link-clicked' });
-    mfa(this.props.useSSOe ? 'v1' : 'v0');
-  };
-
-  render() {
-    if (this.props.multifactor) {
-      return (
-        <>
-          <h3>Account security</h3>
-          <p>
-            <i className="fa fa-check-circle" /> You've added an extra layer of
-            security to your account with 2-factor authentication.
-          </p>
-        </>
-      );
-    }
-
-    return (
-      <>
-        <h4>Want to make your account more secure?</h4>
-        <p>
-          Add an extra layer of security (called 2-factor authentication). This
-          helps to make sure only you can access your account—even if someone
-          gets your password.
-        </p>
-        <button className="usa-button-primary" onClick={this.mfaHandler}>
-          Set up 2-factor authentication
-        </button>
-      </>
-    );
-  }
+function mfaHandler(useSSOe) {
+  recordEvent({ event: 'multifactor-link-clicked' });
+  mfa(useSSOe ? 'v1' : 'v0');
 }
 
-MultifactorMessage.propTypes = {
-  mulitfactor: PropTypes.bool,
-};
+export function MultifactorMessage({ multifactor, useSSOe }) {
+  if (multifactor) {
+    return (
+      <div>
+        <h3>Account security</h3>
+        <p>
+          <i className="fa fa-check-circle" /> You've added an extra layer of
+          security to your account with 2-factor authentication.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <h4>Want to make your account more secure?</h4>
+      <p>
+        Add an extra layer of security (called 2-factor authentication). This
+        helps to make sure only you can access your account—even if someone gets
+        your password.
+      </p>
+      <button
+        className="usa-button-primary"
+        onClick={() => mfaHandler(useSSOe)}
+      >
+        Set up 2-factor authentication
+      </button>
+    </div>
+  );
+}
 
 function mapStateToProps(state) {
   return {
     useSSOe: ssoe(state),
   };
 }
-
 export default connect(mapStateToProps)(MultifactorMessage);

--- a/src/applications/personalization/account/components/MultifactorMessage.jsx
+++ b/src/applications/personalization/account/components/MultifactorMessage.jsx
@@ -2,9 +2,9 @@ import React from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 
-import { ssoe } from '../../../../platform/user/authentication/selectors';
-import { mfa } from '../../../../platform/user/authentication/utilities';
-import recordEvent from '../../../../platform/monitoring/record-event';
+import { ssoe } from 'platform/user/authentication/selectors';
+import { mfa } from 'platform/user/authentication/utilities';
+import recordEvent from 'platform/monitoring/record-event';
 
 export class MultifactorMessage extends React.Component {
   mfaHandler = () => {

--- a/src/applications/personalization/account/components/MultifactorMessage.jsx
+++ b/src/applications/personalization/account/components/MultifactorMessage.jsx
@@ -7,10 +7,10 @@ import { mfa } from '../../../../platform/user/authentication/utilities';
 import recordEvent from '../../../../platform/monitoring/record-event';
 
 export class MultifactorMessage extends React.Component {
-  mfaHandler() {
+  mfaHandler = () => {
     recordEvent({ event: 'multifactor-link-clicked' });
     mfa(this.props.useSSOe ? 'v1' : 'v0');
-  }
+  };
 
   render() {
     if (this.props.multifactor) {

--- a/src/applications/personalization/account/components/MultifactorMessage.jsx
+++ b/src/applications/personalization/account/components/MultifactorMessage.jsx
@@ -1,36 +1,54 @@
 import React from 'react';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+
+import { ssoe } from '../../../../platform/user/authentication/selectors';
 import { mfa } from '../../../../platform/user/authentication/utilities';
 import recordEvent from '../../../../platform/monitoring/record-event';
 
-function recordAnalyticEvent() {
-  recordEvent({ event: 'multifactor-link-clicked' });
-  mfa();
-}
-
-export default function MultifactorMessage({ multifactor }) {
-  if (multifactor) {
-    return (
-      <div>
-        <h3>Account security</h3>
-        <p>
-          <i className="fa fa-check-circle" /> You've added an extra layer of
-          security to your account with 2-factor authentication.
-        </p>
-      </div>
-    );
+export class MultifactorMessage extends React.Component {
+  mfaHandler() {
+    recordEvent({ event: 'multifactor-link-clicked' });
+    mfa(this.props.useSSOe ? 'v1' : 'v0');
   }
 
-  return (
-    <div>
-      <h4>Want to make your account more secure?</h4>
-      <p>
-        Add an extra layer of security (called 2-factor authentication). This
-        helps to make sure only you can access your account—even if someone gets
-        your password.
-      </p>
-      <button className="usa-button-primary" onClick={recordAnalyticEvent}>
-        Set up 2-factor authentication
-      </button>
-    </div>
-  );
+  render() {
+    if (this.props.multifactor) {
+      return (
+        <>
+          <h3>Account security</h3>
+          <p>
+            <i className="fa fa-check-circle" /> You've added an extra layer of
+            security to your account with 2-factor authentication.
+          </p>
+        </>
+      );
+    }
+
+    return (
+      <>
+        <h4>Want to make your account more secure?</h4>
+        <p>
+          Add an extra layer of security (called 2-factor authentication). This
+          helps to make sure only you can access your account—even if someone
+          gets your password.
+        </p>
+        <button className="usa-button-primary" onClick={this.mfaHandler}>
+          Set up 2-factor authentication
+        </button>
+      </>
+    );
+  }
 }
+
+MultifactorMessage.propTypes = {
+  mulitfactor: PropTypes.bool,
+};
+
+function mapStateToProps(state) {
+  return {
+    useSSOe: ssoe(state),
+  };
+}
+
+export default connect(mapStateToProps)(MultifactorMessage);

--- a/src/applications/personalization/profile360/components/PaymentInformation2FARequired.jsx
+++ b/src/applications/personalization/profile360/components/PaymentInformation2FARequired.jsx
@@ -7,41 +7,39 @@ import { ssoe } from 'platform/user/authentication/selectors';
 import { mfa } from 'platform/user/authentication/utilities';
 import recordEvent from 'platform/monitoring/record-event';
 
-export class PaymentInformation2FARequired extends React.Component {
-  mfaHandler = () => {
-    recordEvent({ event: 'multifactor-link-clicked' });
-    mfa(this.props.useSSOe ? 'v1' : 'v0');
-  };
+function mfaHandler(useSSOe) {
+  recordEvent({ event: 'multifactor-link-clicked' });
+  mfa(useSSOe ? 'v1' : 'v0');
+}
 
-  render() {
-    return (
-      <AlertBox
-        status="success"
-        isVisible
-        headline="You’ll need to set up 2-factor authentication before you can edit your direct deposit information."
-      >
-        <>
-          <p>
-            We require this to help protect your bank account information and
-            prevent fraud.
-          </p>
-          <p>
-            Authentication gives you an extra layer of security by letting you
-            into your account only after you’ve signed in with a password and a
-            6-digit code sent directly to your mobile or home phone. This helps
-            to make sure that no one but you can access your account—even if
-            they get your password.
-          </p>
-          <button
-            className="usa-button-primary va-button-primary"
-            onClick={this.mfaHandler}
-          >
-            Set up 2-factor authentication
-          </button>
-        </>
-      </AlertBox>
-    );
-  }
+export function PaymentInformation2FARequired({ useSSOe }) {
+  return (
+    <AlertBox
+      status="success"
+      isVisible
+      headline="You’ll need to set up 2-factor authentication before you can edit your direct deposit information."
+    >
+      <>
+        <p>
+          We require this to help protect your bank account information and
+          prevent fraud.
+        </p>
+        <p>
+          Authentication gives you an extra layer of security by letting you
+          into your account only after you’ve signed in with a password and a
+          6-digit code sent directly to your mobile or home phone. This helps to
+          make sure that no one but you can access your account—even if they get
+          your password.
+        </p>
+        <button
+          className="usa-button-primary va-button-primary"
+          onClick={() => mfaHandler(useSSOe)}
+        >
+          Set up 2-factor authentication
+        </button>
+      </>
+    </AlertBox>
+  );
 }
 
 function mapStateToProps(state) {

--- a/src/applications/personalization/profile360/components/PaymentInformation2FARequired.jsx
+++ b/src/applications/personalization/profile360/components/PaymentInformation2FARequired.jsx
@@ -1,31 +1,53 @@
 import React from 'react';
+import { connect } from 'react-redux';
+
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 
+import { ssoe } from 'platform/user/authentication/selectors';
 import { mfa } from 'platform/user/authentication/utilities';
+import recordEvent from 'platform/monitoring/record-event';
 
-export default function PaymentInformation2FARequired() {
-  return (
-    <AlertBox
-      status="success"
-      isVisible
-      headline="You’ll need to set up 2-factor authentication before you can edit your direct deposit information."
-    >
-      <>
-        <p>
-          We require this to help protect your bank account information and
-          prevent fraud.
-        </p>
-        <p>
-          Authentication gives you an extra layer of security by letting you
-          into your account only after you’ve signed in with a password and a
-          6-digit code sent directly to your mobile or home phone. This helps to
-          make sure that no one but you can access your account—even if they get
-          your password.
-        </p>
-        <button className="usa-button-primary va-button-primary" onClick={mfa}>
-          Set up 2-factor authentication
-        </button>
-      </>
-    </AlertBox>
-  );
+export class PaymentInformation2FARequired extends React.Component {
+  mfaHandler() {
+    recordEvent({ event: 'multifactor-link-clicked' });
+    mfa(this.props.useSSOe ? 'v1' : 'v0');
+  }
+
+  render() {
+    return (
+      <AlertBox
+        status="success"
+        isVisible
+        headline="You’ll need to set up 2-factor authentication before you can edit your direct deposit information."
+      >
+        <>
+          <p>
+            We require this to help protect your bank account information and
+            prevent fraud.
+          </p>
+          <p>
+            Authentication gives you an extra layer of security by letting you
+            into your account only after you’ve signed in with a password and a
+            6-digit code sent directly to your mobile or home phone. This helps
+            to make sure that no one but you can access your account—even if
+            they get your password.
+          </p>
+          <button
+            className="usa-button-primary va-button-primary"
+            onClick={this.mfaHandler}
+          >
+            Set up 2-factor authentication
+          </button>
+        </>
+      </AlertBox>
+    );
+  }
 }
+
+function mapStateToProps(state) {
+  return {
+    useSSOe: ssoe(state),
+  };
+}
+
+export default connect(mapStateToProps)(PaymentInformation2FARequired);

--- a/src/applications/personalization/profile360/components/PaymentInformation2FARequired.jsx
+++ b/src/applications/personalization/profile360/components/PaymentInformation2FARequired.jsx
@@ -8,10 +8,10 @@ import { mfa } from 'platform/user/authentication/utilities';
 import recordEvent from 'platform/monitoring/record-event';
 
 export class PaymentInformation2FARequired extends React.Component {
-  mfaHandler() {
+  mfaHandler = () => {
     recordEvent({ event: 'multifactor-link-clicked' });
     mfa(this.props.useSSOe ? 'v1' : 'v0');
-  }
+  };
 
   render() {
     return (

--- a/src/applications/personalization/profile360/tests/containers/PaymentInformation.unit.spec.jsx
+++ b/src/applications/personalization/profile360/tests/containers/PaymentInformation.unit.spec.jsx
@@ -8,6 +8,7 @@ import set from 'platform/utilities/data/set';
 import { PaymentInformation } from '../../containers/PaymentInformation';
 import ProfileFieldHeading from 'vet360/components/base/Vet360ProfileFieldHeading';
 import PaymentInformationEditModal from '../../components/PaymentInformationEditModal';
+import PaymentInformation2FARequired from '../../components/PaymentInformation2FARequired';
 import DowntimeNotification from 'platform/monitoring/DowntimeNotification';
 
 describe('<PaymentInformation/>', () => {
@@ -110,7 +111,7 @@ describe('<PaymentInformation/>', () => {
     };
     const wrapper = shallow(<PaymentInformation {...props} />);
     expect(fetchPaymentInformation.called).to.be.false;
-    expect(wrapper.find('PaymentInformation2FARequired')).to.have.lengthOf(1);
+    expect(wrapper.find(PaymentInformation2FARequired)).to.have.lengthOf(1);
     wrapper.unmount();
   });
 

--- a/src/applications/validate-mhv-account/containers/VerifyIdentity.jsx
+++ b/src/applications/validate-mhv-account/containers/VerifyIdentity.jsx
@@ -6,31 +6,28 @@ import MessageTemplate from './../components/MessageTemplate';
 import { ssoe } from 'platform/user/authentication/selectors';
 import { verify } from 'platform/user/authentication/utilities';
 
-export class VerifyIdentity extends React.Component {
-  render() {
-    const authVersion = this.props.useSSOe ? 'v1' : 'v0';
+export function VerifyIdentity({ useSSOe }) {
+  const authVersion = useSSOe ? 'v1' : 'v0';
+  const content = {
+    heading: 'Verify your identity to access health tools',
+    body: (
+      <>
+        <p>
+          We take your privacy seriously, and we’re committed to protecting your
+          information. You’ll need to verify your identity before we can give
+          you access to your personal health information.
+        </p>
+        <button
+          onClick={() => verify(authVersion)}
+          className="usa-button-primary va-button-primary"
+        >
+          Verify your identity
+        </button>
+      </>
+    ),
+  };
 
-    const content = {
-      heading: 'Verify your identity to access health tools',
-      body: (
-        <>
-          <p>
-            We take your privacy seriously, and we’re committed to protecting
-            your information. You’ll need to verify your identity before we can
-            give you access to your personal health information.
-          </p>
-          <button
-            onClick={() => verify(authVersion)}
-            className="usa-button-primary va-button-primary"
-          >
-            Verify your identity
-          </button>
-        </>
-      ),
-    };
-
-    return <MessageTemplate content={content} />;
-  }
+  return <MessageTemplate content={content} />;
 }
 
 function mapStateToProps(state) {

--- a/src/applications/validate-mhv-account/containers/VerifyIdentity.jsx
+++ b/src/applications/validate-mhv-account/containers/VerifyIdentity.jsx
@@ -3,15 +3,13 @@ import { connect } from 'react-redux';
 
 import MessageTemplate from './../components/MessageTemplate';
 
-import { ssoe } from '../../../platform/user/authentication/selectors';
-import { verify } from '../../../platform/user/authentication/utilities';
+import { ssoe } from 'platform/user/authentication/selectors';
+import { verify } from 'platform/user/authentication/utilities';
 
 export class VerifyIdentity extends React.Component {
-  verifyHandler = () => {
-    verify(this.props.useSSOe ? 'v1' : 'v0');
-  };
-
   render() {
+    const authVersion = this.props.useSSOe ? 'v1' : 'v0';
+
     const content = {
       heading: 'Verify your identity to access health tools',
       body: (
@@ -22,7 +20,7 @@ export class VerifyIdentity extends React.Component {
             give you access to your personal health information.
           </p>
           <button
-            onClick={this.verifyHandler}
+            onClick={() => verify(authVersion)}
             className="usa-button-primary va-button-primary"
           >
             Verify your identity

--- a/src/applications/validate-mhv-account/containers/VerifyIdentity.jsx
+++ b/src/applications/validate-mhv-account/containers/VerifyIdentity.jsx
@@ -7,9 +7,9 @@ import { ssoe } from '../../../platform/user/authentication/selectors';
 import { verify } from '../../../platform/user/authentication/utilities';
 
 export class VerifyIdentity extends React.Component {
-  verifyHandler() {
+  verifyHandler = () => {
     verify(this.props.useSSOe ? 'v1' : 'v0');
-  }
+  };
 
   render() {
     const content = {

--- a/src/applications/validate-mhv-account/containers/VerifyIdentity.jsx
+++ b/src/applications/validate-mhv-account/containers/VerifyIdentity.jsx
@@ -1,28 +1,44 @@
 import React from 'react';
+import { connect } from 'react-redux';
+
 import MessageTemplate from './../components/MessageTemplate';
+
+import { ssoe } from '../../../platform/user/authentication/selectors';
 import { verify } from '../../../platform/user/authentication/utilities';
 
-const VerifyIdentity = () => {
-  const content = {
-    heading: 'Verify your identity to access health tools',
-    body: (
-      <>
-        <p>
-          We take your privacy seriously, and we’re committed to protecting your
-          information. You’ll need to verify your identity before we can give
-          you access to your personal health information.
-        </p>
-        <button
-          onClick={verify}
-          className="usa-button-primary va-button-primary"
-        >
-          Verify your identity
-        </button>
-      </>
-    ),
+export class VerifyIdentity extends React.Component {
+  verifyHandler() {
+    verify(this.props.useSSOe ? 'v1' : 'v0');
+  }
+
+  render() {
+    const content = {
+      heading: 'Verify your identity to access health tools',
+      body: (
+        <>
+          <p>
+            We take your privacy seriously, and we’re committed to protecting
+            your information. You’ll need to verify your identity before we can
+            give you access to your personal health information.
+          </p>
+          <button
+            onClick={this.verifyHandler}
+            className="usa-button-primary va-button-primary"
+          >
+            Verify your identity
+          </button>
+        </>
+      ),
+    };
+
+    return <MessageTemplate content={content} />;
+  }
+}
+
+function mapStateToProps(state) {
+  return {
+    useSSOe: ssoe(state),
   };
+}
 
-  return <MessageTemplate content={content} />;
-};
-
-export default VerifyIdentity;
+export default connect(mapStateToProps)(VerifyIdentity);

--- a/src/applications/verify/containers/VerifyApp.jsx
+++ b/src/applications/verify/containers/VerifyApp.jsx
@@ -4,12 +4,12 @@ import URLSearchParams from 'url-search-params';
 
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 import LoadingIndicator from '@department-of-veterans-affairs/formation-react/LoadingIndicator';
-import recordEvent from '../../../platform/monitoring/record-event';
+import recordEvent from 'platform/monitoring/record-event';
 
-import { ssoe } from '../../../platform/user/authentication/selectors';
-import { verify } from '../../../platform/user/authentication/utilities';
-import { hasSession } from '../../../platform/user/profile/utilities';
-import SubmitSignInForm from '../../../platform/static-data/SubmitSignInForm';
+import { ssoe } from 'platform/user/authentication/selectors';
+import { verify } from 'platform/user/authentication/utilities';
+import { hasSession } from 'platform/user/profile/utilities';
+import SubmitSignInForm from 'platform/static-data/SubmitSignInForm';
 
 export class VerifyApp extends React.Component {
   constructor(props) {
@@ -48,12 +48,9 @@ export class VerifyApp extends React.Component {
     }
   }
 
-  verifyHandler = () => {
-    verify(this.props.useSSOe ? 'v1' : 'v0');
-  };
-
   render() {
     const { profile } = this.props;
+    const authVersion = this.props.useSSOe ? 'v1' : 'v0';
 
     if (profile.loading) {
       return <LoadingIndicator message="Loading the application..." />;
@@ -85,7 +82,7 @@ export class VerifyApp extends React.Component {
                 </p>
                 <button
                   className="usa-button-primary va-button-primary"
-                  onClick={this.verifyHandler}
+                  onClick={() => verify(authVersion)}
                 >
                   <img alt="ID.me" src="/img/signin/idme-icon-white.svg" />
                   <strong> Verify with ID.me</strong>

--- a/src/applications/verify/containers/VerifyApp.jsx
+++ b/src/applications/verify/containers/VerifyApp.jsx
@@ -5,6 +5,8 @@ import URLSearchParams from 'url-search-params';
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 import LoadingIndicator from '@department-of-veterans-affairs/formation-react/LoadingIndicator';
 import recordEvent from '../../../platform/monitoring/record-event';
+
+import { ssoe } from '../../../platform/user/authentication/selectors';
 import { verify } from '../../../platform/user/authentication/utilities';
 import { hasSession } from '../../../platform/user/profile/utilities';
 import SubmitSignInForm from '../../../platform/static-data/SubmitSignInForm';
@@ -46,6 +48,10 @@ export class VerifyApp extends React.Component {
     }
   }
 
+  verifyHandler() {
+    verify(this.props.useSSOe ? 'v1' : 'v0');
+  }
+
   render() {
     const { profile } = this.props;
 
@@ -79,7 +85,7 @@ export class VerifyApp extends React.Component {
                 </p>
                 <button
                   className="usa-button-primary va-button-primary"
-                  onClick={verify}
+                  onClick={this.verifyHandler}
                 >
                   <img alt="ID.me" src="/img/signin/idme-icon-white.svg" />
                   <strong> Verify with ID.me</strong>
@@ -119,6 +125,7 @@ const mapStateToProps = state => {
   return {
     login: userState.login,
     profile: userState.profile,
+    useSSOe: ssoe(state),
   };
 };
 

--- a/src/applications/verify/containers/VerifyApp.jsx
+++ b/src/applications/verify/containers/VerifyApp.jsx
@@ -48,9 +48,9 @@ export class VerifyApp extends React.Component {
     }
   }
 
-  verifyHandler() {
+  verifyHandler = () => {
     verify(this.props.useSSOe ? 'v1' : 'v0');
-  }
+  };
 
   render() {
     const { profile } = this.props;

--- a/src/platform/site-wide/cta-widget/components/messages/mvi/NotAuthorized.jsx
+++ b/src/platform/site-wide/cta-widget/components/messages/mvi/NotAuthorized.jsx
@@ -4,7 +4,7 @@ import CallToActionAlert from '../../CallToActionAlert';
 import { verify } from 'platform/user/authentication/utilities';
 
 function NotAuthorized({ useSSOe }) {
-  const version = useSSOe ? 'v1' : 'v0';
+  const authVersion = useSSOe ? 'v1' : 'v0';
 
   const content = {
     heading: 'Verify your identity to access more VA.gov tools and features',
@@ -15,7 +15,10 @@ function NotAuthorized({ useSSOe }) {
           track your claims, refill your prescriptions, and download your VA
           benefit letters.
         </p>
-        <button className="usa-button-primary" onClick={() => verify(version)}>
+        <button
+          className="usa-button-primary"
+          onClick={() => verify(authVersion)}
+        >
           Verify Your Identity
         </button>
         <p>

--- a/src/platform/site-wide/cta-widget/components/messages/mvi/NotAuthorized.jsx
+++ b/src/platform/site-wide/cta-widget/components/messages/mvi/NotAuthorized.jsx
@@ -3,11 +3,9 @@ import React from 'react';
 import CallToActionAlert from '../../CallToActionAlert';
 import { verify } from 'platform/user/authentication/utilities';
 
-const verifyHandler = () => {
-  verify(this.props.useSSOe ? 'v1' : 'v0');
-};
-
 function NotAuthorized({ useSSOe }) {
+  const version = useSSOe ? 'v1' : 'v0';
+
   const content = {
     heading: 'Verify your identity to access more VA.gov tools and features',
     alertText: (
@@ -17,10 +15,7 @@ function NotAuthorized({ useSSOe }) {
           track your claims, refill your prescriptions, and download your VA
           benefit letters.
         </p>
-        <button
-          className="usa-button-primary"
-          onClick={() => verifyHandler(useSSOe)}
-        >
+        <button className="usa-button-primary" onClick={() => verify(version)}>
           Verify Your Identity
         </button>
         <p>

--- a/src/platform/site-wide/cta-widget/components/messages/mvi/NotAuthorized.jsx
+++ b/src/platform/site-wide/cta-widget/components/messages/mvi/NotAuthorized.jsx
@@ -7,9 +7,9 @@ import { ssoe } from 'platform/user/authentication/selectors';
 import { verify } from 'platform/user/authentication/utilities';
 
 export class NotAuthorized extends React.Component {
-  verifyHandler() {
+  verifyHandler = () => {
     verify(this.props.useSSOe ? 'v1' : 'v0');
-  }
+  };
 
   render() {
     const content = {

--- a/src/platform/site-wide/cta-widget/components/messages/mvi/NotAuthorized.jsx
+++ b/src/platform/site-wide/cta-widget/components/messages/mvi/NotAuthorized.jsx
@@ -1,31 +1,47 @@
 import React from 'react';
+import { connect } from 'react-redux';
+
 import CallToActionAlert from '../../CallToActionAlert';
+
+import { ssoe } from 'platform/user/authentication/selectors';
 import { verify } from 'platform/user/authentication/utilities';
 
-const NotAuthorized = () => {
-  const content = {
-    heading: 'Verify your identity to access more VA.gov tools and features',
-    alertText: (
-      <>
-        <p>
-          When you verify your identity, you can use VA.gov to do things like
-          track your claims, refill your prescriptions, and download your VA
-          benefit letters.
-        </p>
-        <button className="usa-button-primary" onClick={verify}>
-          Verify Your Identity
-        </button>
-        <p>
-          <a href="/sign-in-faq/#how-to-verify">
-            Learn about how to verify your identity
-          </a>
-        </p>
-      </>
-    ),
-    status: 'info',
+export class NotAuthorized extends React.Component {
+  verifyHandler() {
+    verify(this.props.useSSOe ? 'v1' : 'v0');
+  }
+
+  render() {
+    const content = {
+      heading: 'Verify your identity to access more VA.gov tools and features',
+      alertText: (
+        <>
+          <p>
+            When you verify your identity, you can use VA.gov to do things like
+            track your claims, refill your prescriptions, and download your VA
+            benefit letters.
+          </p>
+          <button className="usa-button-primary" onClick={this.verifyHandler}>
+            Verify Your Identity
+          </button>
+          <p>
+            <a href="/sign-in-faq/#how-to-verify">
+              Learn about how to verify your identity
+            </a>
+          </p>
+        </>
+      ),
+      status: 'info',
+    };
+
+    return <CallToActionAlert {...content} />;
+  }
+}
+
+function mapStateToProps(state) {
+  return {
+    useSSOe: ssoe(state),
   };
+}
 
-  return <CallToActionAlert {...content} />;
-};
-
-export default NotAuthorized;
+export default connect(mapStateToProps)(NotAuthorized);

--- a/src/platform/site-wide/cta-widget/components/messages/mvi/NotAuthorized.jsx
+++ b/src/platform/site-wide/cta-widget/components/messages/mvi/NotAuthorized.jsx
@@ -1,47 +1,39 @@
 import React from 'react';
-import { connect } from 'react-redux';
 
 import CallToActionAlert from '../../CallToActionAlert';
-
-import { ssoe } from 'platform/user/authentication/selectors';
 import { verify } from 'platform/user/authentication/utilities';
 
-export class NotAuthorized extends React.Component {
-  verifyHandler = () => {
-    verify(this.props.useSSOe ? 'v1' : 'v0');
+const verifyHandler = () => {
+  verify(this.props.useSSOe ? 'v1' : 'v0');
+};
+
+function NotAuthorized({ useSSOe }) {
+  const content = {
+    heading: 'Verify your identity to access more VA.gov tools and features',
+    alertText: (
+      <>
+        <p>
+          When you verify your identity, you can use VA.gov to do things like
+          track your claims, refill your prescriptions, and download your VA
+          benefit letters.
+        </p>
+        <button
+          className="usa-button-primary"
+          onClick={() => verifyHandler(useSSOe)}
+        >
+          Verify Your Identity
+        </button>
+        <p>
+          <a href="/sign-in-faq/#how-to-verify">
+            Learn about how to verify your identity
+          </a>
+        </p>
+      </>
+    ),
+    status: 'info',
   };
 
-  render() {
-    const content = {
-      heading: 'Verify your identity to access more VA.gov tools and features',
-      alertText: (
-        <>
-          <p>
-            When you verify your identity, you can use VA.gov to do things like
-            track your claims, refill your prescriptions, and download your VA
-            benefit letters.
-          </p>
-          <button className="usa-button-primary" onClick={this.verifyHandler}>
-            Verify Your Identity
-          </button>
-          <p>
-            <a href="/sign-in-faq/#how-to-verify">
-              Learn about how to verify your identity
-            </a>
-          </p>
-        </>
-      ),
-      status: 'info',
-    };
-
-    return <CallToActionAlert {...content} />;
-  }
+  return <CallToActionAlert {...content} />;
 }
 
-function mapStateToProps(state) {
-  return {
-    useSSOe: ssoe(state),
-  };
-}
-
-export default connect(mapStateToProps)(NotAuthorized);
+export default NotAuthorized;

--- a/src/platform/site-wide/cta-widget/index.js
+++ b/src/platform/site-wide/cta-widget/index.js
@@ -174,7 +174,7 @@ export class CallToActionWidget extends React.Component {
         return (
           <MFA
             serviceDescription={this._serviceDescription}
-            primaryButtonHandler={mfa}
+            primaryButtonHandler={this.mfaHandler}
           />
         );
       }
@@ -372,9 +372,18 @@ export class CallToActionWidget extends React.Component {
     }
   };
 
+  authVersion() {
+    return this.props.useSSOe ? 'v1' : 'v0';
+  }
+
   signOut = () => {
     recordEvent({ event: 'logout-link-clicked-createcta-mhv' });
-    logout(this.props.useSSOe ? 'v1' : 'v0');
+    logout(this.authVersion());
+  };
+
+  mfaHandler = () => {
+    recordEvent({ event: 'multifactor-link-clicked' });
+    mfa(this.authVersion());
   };
 
   render() {

--- a/src/platform/site-wide/cta-widget/index.js
+++ b/src/platform/site-wide/cta-widget/index.js
@@ -7,7 +7,6 @@ import URLSearchParams from 'url-search-params';
 import LoadingIndicator from '@department-of-veterans-affairs/formation-react/LoadingIndicator';
 import { toggleLoginModal } from 'platform/site-wide/user-nav/actions';
 import { ssoe } from 'platform/user/authentication/selectors';
-
 import { logout, verify, mfa } from 'platform/user/authentication/utilities';
 import recordEvent from 'platform/monitoring/record-event';
 import {

--- a/src/platform/site-wide/cta-widget/index.js
+++ b/src/platform/site-wide/cta-widget/index.js
@@ -7,6 +7,7 @@ import URLSearchParams from 'url-search-params';
 import LoadingIndicator from '@department-of-veterans-affairs/formation-react/LoadingIndicator';
 import { toggleLoginModal } from 'platform/site-wide/user-nav/actions';
 import { ssoe } from 'platform/user/authentication/selectors';
+
 import { logout, verify, mfa } from 'platform/user/authentication/utilities';
 import recordEvent from 'platform/monitoring/record-event';
 import {
@@ -124,7 +125,7 @@ export class CallToActionWidget extends React.Component {
       return (
         <Verify
           serviceDescription={this._serviceDescription}
-          primaryButtonHandler={verify}
+          primaryButtonHandler={this.verifyHandler}
         />
       );
     }
@@ -225,7 +226,7 @@ export class CallToActionWidget extends React.Component {
         return (
           <Verify
             serviceDescription={this._serviceDescription}
-            primaryButtonHandler={verify}
+            primaryButtonHandler={this.verifyHandler}
           />
         );
 
@@ -384,6 +385,10 @@ export class CallToActionWidget extends React.Component {
   mfaHandler = () => {
     recordEvent({ event: 'multifactor-link-clicked' });
     mfa(this.authVersion());
+  };
+
+  verifyHandler = () => {
+    verify(this.authVersion());
   };
 
   render() {

--- a/src/platform/site-wide/cta-widget/index.js
+++ b/src/platform/site-wide/cta-widget/index.js
@@ -198,7 +198,7 @@ export class CallToActionWidget extends React.Component {
   getMviErrorContent = () => {
     switch (this.props.mviStatus) {
       case 'NOT_AUTHORIZED':
-        return <NotAuthorized />;
+        return <NotAuthorized useSSOe={this.props.useSSOe} />;
       case 'NOT_FOUND':
         return <NotFound />;
       default:

--- a/src/platform/site-wide/cta-widget/tests/index.unit.spec.js
+++ b/src/platform/site-wide/cta-widget/tests/index.unit.spec.js
@@ -286,6 +286,7 @@ describe('<CallToActionWidget>', () => {
         <CallToActionWidget
           fetchMHVAccount={d => d}
           isLoggedIn
+          useSSOe
           appId="rx"
           profile={{
             loading: false,

--- a/src/platform/site-wide/cta-widget/tests/index.unit.spec.js
+++ b/src/platform/site-wide/cta-widget/tests/index.unit.spec.js
@@ -286,7 +286,6 @@ describe('<CallToActionWidget>', () => {
         <CallToActionWidget
           fetchMHVAccount={d => d}
           isLoggedIn
-          useSSOe
           appId="rx"
           profile={{
             loading: false,

--- a/src/platform/user/authentication/utilities.js
+++ b/src/platform/user/authentication/utilities.js
@@ -19,9 +19,6 @@ function sessionTypeUrl(type = '', version = 'v0', application = null) {
   }`;
 }
 
-const MFA_URL = sessionTypeUrl('mfa');
-const VERIFY_URL = sessionTypeUrl('verify');
-
 const loginUrl = (policy, version, application) => {
   switch (policy) {
     case 'mhv':
@@ -89,12 +86,12 @@ export function login(policy, version = 'v0', application = null) {
   );
 }
 
-export function mfa() {
-  return redirect(MFA_URL, 'multifactor-link-clicked');
+export function mfa(version = 'v0') {
+  return redirect(sessionTypeUrl('mfa', version), 'multifactor-link-clicked');
 }
 
-export function verify() {
-  return redirect(VERIFY_URL, 'verify-link-clicked');
+export function verify(version = 'v0') {
+  return redirect(sessionTypeUrl('verify', version), 'verify-link-clicked');
 }
 
 export function logout(version = 'v0') {

--- a/src/platform/user/tests/authentication/utilities.unit.spec.js
+++ b/src/platform/user/tests/authentication/utilities.unit.spec.js
@@ -73,8 +73,18 @@ describe('authentication URL helpers', () => {
     expect(global.window.location).to.include('/sessions/mfa/new');
   });
 
+  it('should redirect for MFA v1', () => {
+    mfa('v1');
+    expect(global.window.location).to.include('/v1/sessions/mfa/new');
+  });
+
   it('should redirect for verify', () => {
     verify();
     expect(global.window.location).to.include('/sessions/verify/new');
+  });
+
+  it('should redirect for verify v1', () => {
+    verify('v1');
+    expect(global.window.location).to.include('/v1/sessions/verify/new');
   });
 });


### PR DESCRIPTION
Updating all the `mfa` and `verify` onclick handlers to reference the SSOe feature flag and based on that decide if the should redirect the request to version 0 or version 1 authentication.

closes department-of-veterans-affairs/va.gov-team#6914

## Testing done
- [x] locally ran tests with SSOe enabled/disabled to confirm that the "verify your identity" button redirects to either v0 or v1 of the authentication controller
- [x] locally ran tests with SSOe enabled/disabled to cofirm that the "setup 2-factor authentication" button redirects to either v0 or v1 of the authentication controller

## Definition of done
- [x] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
