### PR TITLE
Add facility info to request limit message

### DIFF
--- a/src/applications/vaos/actions/newAppointment.js
+++ b/src/applications/vaos/actions/newAppointment.js
@@ -327,7 +327,8 @@ export function openFacilityPage(page, uiSchema, schema) {
         try {
           const eligibility = getEligibilityStatus(getState());
           if (!eligibility.direct && !eligibility.request) {
-            dispatch(fetchFacilityDetails(facilityId));
+            const thunk = fetchFacilityDetails(facilityId);
+            await thunk(dispatch, getState);
           }
         } catch (e) {
           captureError(e);
@@ -426,7 +427,8 @@ export function updateFacilityPageData(page, uiSchema, data) {
         try {
           const eligibility = getEligibilityStatus(getState());
           if (!eligibility.direct && !eligibility.request) {
-            dispatch(fetchFacilityDetails(data.vaFacility));
+            const thunk = fetchFacilityDetails(data.vaFacility);
+            await thunk(dispatch, getState);
           }
         } catch (e) {
           captureError(e);

--- a/src/applications/vaos/actions/newAppointment.js
+++ b/src/applications/vaos/actions/newAppointment.js
@@ -17,6 +17,7 @@ import {
   getSystemFromChosenFacility,
   vaosCommunityCare,
   selectSystemIds,
+  getEligibilityStatus,
 } from '../utils/selectors';
 import {
   getParentFacilities,
@@ -315,6 +316,17 @@ export function openFacilityPage(page, uiSchema, schema) {
         typeOfCareId,
         eligibilityData,
       });
+
+      if (facilityId) {
+        try {
+          const eligibility = getEligibilityStatus(getState());
+          if (!eligibility.direct && !eligibility.request) {
+            dispatch(fetchFacilityDetails(facilityId));
+          }
+        } catch (e) {
+          captureError(e);
+        }
+      }
     } catch (e) {
       captureError(e);
       dispatch({
@@ -403,6 +415,15 @@ export function updateFacilityPageData(page, uiSchema, data) {
           typeOfCareId,
           eligibilityData,
         });
+
+        try {
+          const eligibility = getEligibilityStatus(getState());
+          if (!eligibility.direct && !eligibility.request) {
+            dispatch(fetchFacilityDetails(data.vaFacility));
+          }
+        } catch (e) {
+          captureError(e);
+        }
       } catch (e) {
         captureError(e);
         dispatch({

--- a/src/applications/vaos/components/EligibilityCheckMessage.jsx
+++ b/src/applications/vaos/components/EligibilityCheckMessage.jsx
@@ -1,8 +1,13 @@
 import React from 'react';
+import { Link } from 'react-router';
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 import ErrorMessage from './ErrorMessage';
+import FacilityAddress from './FacilityAddress';
 
-export default function EligibilityCheckMessage({ eligibility }) {
+export default function EligibilityCheckMessage({
+  eligibility,
+  facilityDetails,
+}) {
   if (eligibility.requestFailed) {
     return <ErrorMessage />;
   }
@@ -47,12 +52,35 @@ export default function EligibilityCheckMessage({ eligibility }) {
       <div aria-atomic="true" aria-live="assertive">
         <AlertBox
           status="warning"
-          headline="You already have an appointment request at this location"
-        >
-          Our records show that you have an open appointment request at this
-          location. We can’t schedule any more appointments at this facility
-          until the open appointment requests are scheduled or canceled.
-        </AlertBox>
+          headline="You’ve reached the limit for appointment requests at this location"
+          content={
+            <>
+              <p>
+                Our records show that you have an open appointment request at
+                this location. We can’t schedule any more appointments at this
+                facility until your open requests are scheduled or canceled. To
+                schedule or cancel your open appointments:
+              </p>
+              <ul>
+                <li>
+                  Go to <Link to="/">your appointment list</Link> and cancel
+                  open requests, or
+                </li>
+                {facilityDetails && (
+                  <li>
+                    Call your medical facility:
+                    <br />
+                    <FacilityAddress
+                      name={facilityDetails.name}
+                      facility={facilityDetails}
+                    />
+                  </li>
+                )}
+                {!facilityDetails && <li>Call your medical facility</li>}
+              </ul>
+            </>
+          }
+        />
       </div>
     );
   }

--- a/src/applications/vaos/containers/VAFacilityPage.jsx
+++ b/src/applications/vaos/containers/VAFacilityPage.jsx
@@ -116,6 +116,7 @@ export class VAFacilityPage extends React.Component {
       typeOfCare,
       facilityDetailsStatus,
       parentDetails,
+      facilityDetails,
       hasDataFetchingError,
       hasEligibilityError,
       parentOfChosenFacility,
@@ -227,7 +228,10 @@ export class VAFacilityPage extends React.Component {
         >
           {notEligibleAtChosenFacility && (
             <div className="vads-u-margin-top--2">
-              <EligibilityCheckMessage eligibility={eligibility} />
+              <EligibilityCheckMessage
+                facilityDetails={facilityDetails}
+                eligibility={eligibility}
+              />
             </div>
           )}
           {hasEligibilityError && <ErrorMessage />}
@@ -256,6 +260,7 @@ VAFacilityPage.propTypes = {
   schema: PropTypes.object,
   data: PropTypes.object.isRequired,
   facility: PropTypes.object,
+  facilityDetails: PropTypes.object,
   loadingParentFacilities: PropTypes.bool,
   loadingFacilities: PropTypes.bool,
   singleValidVALocation: PropTypes.bool,

--- a/src/applications/vaos/tests/actions/newAppointment.unit.spec.js
+++ b/src/applications/vaos/tests/actions/newAppointment.unit.spec.js
@@ -64,6 +64,7 @@ import {
 import parentFacilities from '../../api/facilities.json';
 import facilities983 from '../../api/facilities_983.json';
 import clinics from '../../api/clinicList983.json';
+import facilityDetails from '../../api/facility_details_983.json';
 import {
   FACILITY_TYPES,
   FETCH_STATUS,
@@ -393,6 +394,13 @@ describe('VAOS newAppointment actions', () => {
       const firstAction = dispatch.firstCall.args[0];
       expect(firstAction.type).to.equal(FORM_PAGE_FACILITY_OPEN_SUCCEEDED);
 
+      expect(dispatch.secondCall.args[0].type).to.equal(
+        FORM_FETCH_FACILITY_DETAILS,
+      );
+      expect(dispatch.thirdCall.args[0].type).to.equal(
+        FORM_FETCH_FACILITY_DETAILS_SUCCEEDED,
+      );
+
       expect(firstAction.eligibilityData).to.not.be.null;
     });
 
@@ -663,6 +671,7 @@ describe('VAOS newAppointment actions', () => {
         },
       });
       setFetchJSONResponse(global.fetch.onCall(3), clinics);
+      setFetchJSONResponse(global.fetch.onCall(4), facilityDetails);
       const dispatch = sinon.spy();
       const previousState = {
         ...defaultState,
@@ -694,11 +703,17 @@ describe('VAOS newAppointment actions', () => {
       expect(dispatch.secondCall.args[0].type).to.equal(
         FORM_ELIGIBILITY_CHECKS,
       );
-      expect(dispatch.lastCall.args[0].type).to.equal(
+      expect(dispatch.thirdCall.args[0].type).to.equal(
         FORM_ELIGIBILITY_CHECKS_SUCCEEDED,
       );
+      expect(dispatch.getCall(3).args[0].type).to.equal(
+        FORM_FETCH_FACILITY_DETAILS,
+      );
+      expect(dispatch.getCall(4).args[0].type).to.equal(
+        FORM_FETCH_FACILITY_DETAILS_SUCCEEDED,
+      );
 
-      const succeededAction = dispatch.lastCall.args[0];
+      const succeededAction = dispatch.thirdCall.args[0];
       const eligibilityData = succeededAction.eligibilityData;
       expect(succeededAction.typeOfCareId).to.equal(
         defaultState.newAppointment.data.typeOfCareId,

--- a/src/applications/vaos/tests/components/EligibilityCheckMessage.unit.spec.jsx
+++ b/src/applications/vaos/tests/components/EligibilityCheckMessage.unit.spec.jsx
@@ -28,7 +28,37 @@ describe('VAOS <EligibilityCheckMessage>', () => {
 
     const tree = mount(<EligibilityCheckMessage eligibility={eligibility} />);
 
-    expect(tree.text()).to.contain('already have an appointment request');
+    expect(tree.text()).to.contain(
+      'You’ve reached the limit for appointment requests at this location',
+    );
+    expect(tree.find('[aria-atomic="true"]').exists()).to.be.true;
+    tree.unmount();
+  });
+
+  it('should render limit message with facility', () => {
+    const eligibility = {
+      requestSupported: true,
+      requestPastVisit: true,
+      requestLimit: false,
+    };
+    const facilityDetails = {
+      name: 'Test name',
+      address: {
+        physical: {},
+      },
+      phone: {
+        main: '213131231',
+      },
+    };
+
+    const tree = mount(
+      <EligibilityCheckMessage
+        facilityDetails={facilityDetails}
+        eligibility={eligibility}
+      />,
+    );
+
+    expect(tree.text()).to.contain('Test name');
     expect(tree.find('[aria-atomic="true"]').exists()).to.be.true;
     tree.unmount();
   });

--- a/src/applications/vaos/utils/selectors.js
+++ b/src/applications/vaos/utils/selectors.js
@@ -218,6 +218,7 @@ export function getFacilityPageInfo(state) {
       newAppointment.eligibilityStatus === FETCH_STATUS.failed,
     typeOfCare: getTypeOfCare(data)?.name,
     parentDetails: newAppointment?.facilityDetails[data.vaParent],
+    facilityDetails: newAppointment?.facilityDetails[data.vaFacility],
     parentOfChosenFacility: getParentOfChosenFacility(state),
     cernerFacilities:
       selectFacilities(state)


### PR DESCRIPTION
## Description
This adds the facility info to the request limit message

## Testing done
Local and unit testing

## Screenshots
![Screen Shot 2020-03-30 at 11 19 20 AM](https://user-images.githubusercontent.com/634932/78077339-358d2880-7376-11ea-896e-1f6bd238d752.png)


## Acceptance criteria
- [ ] Facility info shown

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
