### PR TITLE
Added sonarjs/no-redundant-boolean and no-unused-collection to testing stage

### DIFF
--- a/circle.eslint.json
+++ b/circle.eslint.json
@@ -3,6 +3,9 @@
     "sonarjs/no-extra-arguments": 2,
     "sonarjs/no-identical-expressions": 2,
     "sonarjs/max-switch-cases": [2, 40],
-    "sonarjs/no-duplicated-branches": 2
+    "sonarjs/no-duplicated-branches": 2,
+    "sonarjs/no-inverted-boolean-check": 2,
+    "sonarjs/no-redundant-boolean": 2,
+    "sonarjs/no-unused-collection": 2
   }
 }

--- a/src/applications/hca/actions.js
+++ b/src/applications/hca/actions.js
@@ -8,6 +8,7 @@ import {
 } from './selectors';
 
 // flip the `false` to `true` to fake the endpoint when testing locally
+// eslint-disable-next-line sonarjs/no-redundant-boolean
 const simulateServerLocally = environment.isLocalhost() && false;
 
 // action types related to calling /health_care_applications/enrollment_status


### PR DESCRIPTION
## Description
`no-redundant-boolean` and `no-unused-collection` rules from SonarJS have been added to the testing stage in CircleCI (`circle.esint.json`)

This rule has currently 1 error in the existing code. These errors need to be fixed or the rule needs to be disabled so they rule can be enforced moving forward. Each code owner will be responsible for fixing the issues or approving suggested PRs provided by the `frontend` team.

## Errors status by ownership

### `Frontend` team
1/1 errors were fixed/disabled

### Other teams 
1/1 errors will need to be fixed by the code owners.

## Testing done
Locally

## Acceptance criteria
- [x] `Frontend` team errors need to be fixed
