### PR TITLE
[Tech debt] Fix axe error

### DIFF
--- a/src/platform/forms-system/src/js/components/FieldTemplate.jsx
+++ b/src/platform/forms-system/src/js/components/FieldTemplate.jsx
@@ -59,6 +59,7 @@ export default function FieldTemplate(props) {
 
   const containerClassNames = classNames(
     'schemaform-field-template',
+    errorClass,
     _.get(['ui:options', 'classNames'], uiSchema),
   );
   const labelClassNames = classNames({
@@ -96,7 +97,7 @@ export default function FieldTemplate(props) {
   );
 
   const content = (
-    <div className={errorClass}>
+    <>
       {!hideLabelText && labelElement}
       {textDescription && <p>{textDescription}</p>}
       {DescriptionField && (
@@ -106,7 +107,7 @@ export default function FieldTemplate(props) {
       {errorSpan}
       {<div className={inputWrapperClassNames}>{children}</div>}
       {help}
-    </div>
+    </>
   );
 
   if (useFieldsetLegend) {


### PR DESCRIPTION
## Description
 The `FieldTemplate` component will output a `<fieldset>` if the uiSchema is set to use certain widgets. And when it does, it also creates a matching `<legend>`; but the legend is a child of a wrapping div.

This is the axe error

![Screen Shot 2020-04-01 at 10 49 20 AM](https://user-images.githubusercontent.com/136959/78158260-9ebc7c80-7406-11ea-8e5d-732ac61da4bc.png)

The fix (shown in the right column of the screenshot) is to make sure the legend is the first child of the fieldset. This PR does that.

## Testing done

Local unit tests

## Screenshots

Shown above

## Acceptance criteria
- [ ] axe issue is resolved

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
