### PR TITLE
[CMS] Configure sidenav for Decision Reviews into GraphQL build

### DIFF
--- a/src/site/stages/build/drupal/graphql/navigation-fragments/sidebar.nav.graphql.js
+++ b/src/site/stages/build/drupal/graphql/navigation-fragments/sidebar.nav.graphql.js
@@ -121,5 +121,8 @@ if (cmsFeatureFlags.FEATURE_ALL_HUB_SIDE_NAVS && hubNavNames !== null) {
     recordsBenefitsHubQuery: ${queryFilter('records-benefits-hub')} {
       ${SIDEBAR_QUERY}
     }
+    decisionReviewsHubQuery: ${queryFilter('decision-reviews-benefits-h')} {
+      ${SIDEBAR_QUERY}
+    }
 `;
 }

--- a/src/site/stages/build/drupal/page.js
+++ b/src/site/stages/build/drupal/page.js
@@ -260,6 +260,7 @@ function compilePage(page, contentData) {
       lifeInsuranceBenefitsHubQuery: lifeInsuranceHubSidebarNav = {},
       pensionBenefitsHubQuery: pensionHubSidebarNav = {},
       recordsBenefitsHubQuery: recordsHubSidebarNav = {},
+      decisionReviewsHubQuery: decisionReviewsSidebarNav = {},
       alerts: alertsItem = {},
       bannerAlerts: bannerAlertsItem = {},
       outreachSidebarQuery: outreachSidebarNav = {},
@@ -283,6 +284,7 @@ function compilePage(page, contentData) {
     lifeInsuranceHubSidebarNav,
     pensionHubSidebarNav,
     recordsHubSidebarNav,
+    decisionReviewsSidebarNav,
   ];
   let sidebarNavItems;
 


### PR DESCRIPTION
## Description
This PR configured a sidenav for the `/decision-reviews` hub. I have little idea how this part of the build works. I'm just following the pattern.

Ticket - https://github.com/department-of-veterans-affairs/va.gov-team/issues/7494

## Testing done
I don't think I can test, because I don't think that sidenav data lives in Drupal in any environment yet.

## Screenshots
N/A

## Acceptance criteria
- [ ] Config for sidenav is added

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
