### PR TITLE
Clear .babelcache when resetting environment.

### DIFF
--- a/script/reset-environment.sh
+++ b/script/reset-environment.sh
@@ -26,7 +26,9 @@ fi
 echo "Removing Babel cache..."
 rm -rf ./.babelcache
 if [ $? -eq 0 ]; then
-    echo "Successfully cleaned out the .babelcache folder."
+    echo "Successfully cleaned out .babelcache."
+else
+    echo "Please manually remove your .babelcache folder."
 fi
 
 echo "Removing the node modules folder..."
@@ -40,5 +42,5 @@ if [ $? -eq 0 ]; then
         echo "Please manually re-run yarn install from the command line."
     fi
 else
-    echo "Please manually try check your ./node_modules folder for issues."
+    echo "Please manually check your ./node_modules folder for issues."
 fi

--- a/script/reset-environment.sh
+++ b/script/reset-environment.sh
@@ -24,6 +24,8 @@ else
 fi
 echo "Removing the node modules folder..."
 rm -rf ./node_modules
+echo "Removing Babel cache..."
+rm -rf ./.babelcache
 if [ $? -eq 0 ]; then
     echo "Successfully cleaned out the node modules folder."
     yarn install

--- a/script/reset-environment.sh
+++ b/script/reset-environment.sh
@@ -22,10 +22,15 @@ else
         esac
     fi
 fi
-echo "Removing the node modules folder..."
-rm -rf ./node_modules
+
 echo "Removing Babel cache..."
 rm -rf ./.babelcache
+if [ $? -eq 0 ]; then
+    echo "Successfully cleaned out the .babelcache folder."
+fi
+
+echo "Removing the node modules folder..."
+rm -rf ./node_modules
 if [ $? -eq 0 ]; then
     echo "Successfully cleaned out the node modules folder."
     yarn install


### PR DESCRIPTION
## Description
Path resolution can be break sometimes. The reset environment script should involve nuking `.babelcache` to resolve that.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
