### PR TITLE
Reset additional info in dataLayer on successful and failed submissions

### DIFF
--- a/src/applications/vaos/actions/appointments.js
+++ b/src/applications/vaos/actions/appointments.js
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 import { FETCH_STATUS, GA_PREFIX } from '../utils/constants';
 import { getMomentConfirmedDate, isCommunityCare } from '../utils/appointment';
 import recordEvent from 'platform/monitoring/record-event';
+import { resetDataLayer } from '../utils/events';
 
 import {
   getConfirmedAppointments,
@@ -359,6 +360,7 @@ export function confirmCancelAppointment() {
         event: `${eventPrefix}-successful`,
         ...additionalEventdata,
       });
+      resetDataLayer();
     } catch (e) {
       captureError(e, true);
       dispatch({
@@ -369,6 +371,7 @@ export function confirmCancelAppointment() {
         event: `${eventPrefix}-failed`,
         ...additionalEventdata,
       });
+      resetDataLayer();
     }
   };
 }

--- a/src/applications/vaos/actions/newAppointment.js
+++ b/src/applications/vaos/actions/newAppointment.js
@@ -48,7 +48,7 @@ import {
   recordEligibilityGAEvents,
 } from '../utils/eligibility';
 
-import { recordEligibilityFailure } from '../utils/events';
+import { recordEligibilityFailure, resetDataLayer } from '../utils/events';
 
 import { captureError } from '../utils/error';
 
@@ -655,6 +655,7 @@ export function submitAppointmentOrRequest(router) {
           flow,
           ...additionalEventData,
         });
+        resetDataLayer();
         router.push('/new-appointment/confirmation');
       } catch (error) {
         captureError(error, true);
@@ -669,6 +670,7 @@ export function submitAppointmentOrRequest(router) {
           flow,
           ...additionalEventData,
         });
+        resetDataLayer();
       }
     } else {
       const isCommunityCare =
@@ -715,6 +717,7 @@ export function submitAppointmentOrRequest(router) {
           flow,
           ...additionalEventData,
         });
+        resetDataLayer();
         router.push('/new-appointment/confirmation');
       } catch (error) {
         captureError(error, true);
@@ -735,6 +738,7 @@ export function submitAppointmentOrRequest(router) {
           flow,
           ...additionalEventData,
         });
+        resetDataLayer();
       }
     }
   };

--- a/src/applications/vaos/tests/actions/appointments.unit.spec.js
+++ b/src/applications/vaos/tests/actions/appointments.unit.spec.js
@@ -405,11 +405,20 @@ describe('VAOS actions: appointments', () => {
       expect(dispatch.secondCall.args[0]).to.deep.equal({
         type: CANCEL_APPOINTMENT_CONFIRMED_FAILED,
       });
+      const dataLayer = global.window.dataLayer;
 
-      expect(global.window.dataLayer[1]).to.deep.equal({
+      expect(dataLayer[1]).to.deep.equal({
         event: 'vaos-cancel-appointment-submission-failed',
         appointmentType: 'confirmed',
         facilityType: 'va',
+      });
+      expect(dataLayer[2]).to.deep.equal({
+        flow: undefined,
+        'health-TypeOfCare': undefined,
+        'health-ReasonForAppointment': undefined,
+        'error-key': undefined,
+        appointmentType: undefined,
+        facilityType: undefined,
       });
     });
 

--- a/src/applications/vaos/tests/actions/newAppointment.unit.spec.js
+++ b/src/applications/vaos/tests/actions/newAppointment.unit.spec.js
@@ -1044,19 +1044,28 @@ describe('VAOS newAppointment actions', () => {
       });
       await thunk(dispatch, getState);
 
+      const dataLayer = global.window.dataLayer;
       expect(dispatch.firstCall.args[0].type).to.equal(FORM_SUBMIT);
       expect(dispatch.secondCall.args[0].type).to.equal(FORM_SUBMIT_SUCCEEDED);
-      expect(global.window.dataLayer[0]).to.deep.equal({
+      expect(dataLayer[0]).to.deep.equal({
         event: 'vaos-request-submission',
         'health-TypeOfCare': 'Primary care',
         'health-ReasonForAppointment': 'routine-follow-up',
         flow: 'va-request',
       });
-      expect(global.window.dataLayer[1]).to.deep.equal({
+      expect(dataLayer[1]).to.deep.equal({
         event: 'vaos-request-submission-successful',
         'health-TypeOfCare': 'Primary care',
         'health-ReasonForAppointment': 'routine-follow-up',
         flow: 'va-request',
+      });
+      expect(dataLayer[2]).to.deep.equal({
+        flow: undefined,
+        'health-TypeOfCare': undefined,
+        'health-ReasonForAppointment': undefined,
+        'error-key': undefined,
+        appointmentType: undefined,
+        facilityType: undefined,
       });
       expect(router.push.called).to.be.true;
     });
@@ -1198,6 +1207,14 @@ describe('VAOS newAppointment actions', () => {
         flow: 'va-request',
         'health-TypeOfCare': 'Primary care',
         'health-ReasonForAppointment': 'routine-follow-up',
+      });
+      expect(global.window.dataLayer[2]).to.deep.equal({
+        flow: undefined,
+        'health-TypeOfCare': undefined,
+        'health-ReasonForAppointment': undefined,
+        'error-key': undefined,
+        appointmentType: undefined,
+        facilityType: undefined,
       });
       expect(router.push.called).to.be.false;
     });

--- a/src/applications/vaos/utils/events.js
+++ b/src/applications/vaos/utils/events.js
@@ -12,3 +12,14 @@ export function recordEligibilityFailure(errorKey) {
     event: `vaos-eligibility${errorKey ? `-${errorKey}` : ''}-failed`,
   });
 }
+
+export function resetDataLayer() {
+  recordEvent({
+    flow: undefined,
+    'health-TypeOfCare': undefined,
+    'health-ReasonForAppointment': undefined,
+    'error-key': undefined,
+    appointmentType: undefined,
+    facilityType: undefined,
+  });
+}


### PR DESCRIPTION
## Description
Fixes an issue where GA is inheriting the previous custom dimensions for unrelated events.  Resets these dimensions to `undefined` after successful submission or error.

## Testing done
Local and unit

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
