### PR TITLE
VACMS-1296: Refactorting graphql for listing pages.

### DIFF
--- a/src/site/components/events_list.drupal.liquid
+++ b/src/site/components/events_list.drupal.liquid
@@ -1,10 +1,7 @@
 {% assign timezone = "America/New_York" %}
 <div class="events-listing events-show">
   {% assign count = 0 %}
-  {% assign eventsArray = fieldOffice.entity.reverseFieldOfficeNode.entities %}
-  {% if outreachSidebar.name == 'Outreach and events' %}
-    {% assign eventsArray = reverseFieldOfficeNode.entities %}
-  {% endif %}
+  {% assign eventsArray = reverseFieldListingNode.entities %}
   {% assign sortedEventsArray = eventsArray | eventSorter %}
   {% for event in sortedEventsArray %}
     {% if event.title.length %}

--- a/src/site/layouts/event_listing.drupal.liquid
+++ b/src/site/layouts/event_listing.drupal.liquid
@@ -25,9 +25,7 @@
                   </p>
                 {% endif %}
               </div>
-              {% if entityUrl.breadcrumb.1.text != "Outreach and events" %}
-                {% include "src/site/facilities/facilities_events_toggle.drupal.liquid" with url = entityUrl.path %}
-              {% endif %}
+
               {% assign featuredUrl = null %}
               {% assign featuredItemSet = false %}
 

--- a/src/site/stages/build/drupal/graphql/eventListingPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/eventListingPage.graphql.js
@@ -11,7 +11,7 @@ module.exports = `
     title
     fieldIntroText
     entityId
-    reverseFieldOfficeNode(limit: 500, filter: {conditions: [{field: "status", value: "1", operator: EQUAL}, {field: "type", value: "event"}]}, sort: {field: "changed", direction: DESC}) {
+    reverseFieldListingNode(limit: 500, filter: {conditions: [{field: "status", value: "1", operator: EQUAL}, {field: "type", value: "event"}]}, sort: {field: "changed", direction: DESC}) {
         entities {
           ... on NodeEvent {
             title
@@ -54,42 +54,6 @@ module.exports = `
           entityLabel
           title
           fieldNicknameForThisFacility
-        }
-        reverseFieldOfficeNode(limit: 500, filter: {conditions: [{field: "type", value: "event"}, {field: "status", value: "1", operator: EQUAL}]}, sort: {field: "changed", direction: DESC}) {
-            entities {
-              ... on NodeEvent {
-                title
-                fieldFeatured
-                entityUrl {
-                  path
-                }
-                uid {
-                  targetId
-                  ... on FieldNodeUid {
-                    entity {
-                      name
-                      timezone
-                    }
-                  }
-                }
-                fieldDate {
-                  startDate
-                  value
-                  endDate
-                  endValue
-                }
-                fieldDescription
-                fieldLocationHumanreadable
-                fieldFacilityLocation {
-                  entity {
-                    title
-                    entityUrl {
-                      path
-                    }
-                  }
-                }
-            }
-          }
         }
       }
     }

--- a/src/site/stages/build/drupal/graphql/pressReleasesListingPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/pressReleasesListingPage.graphql.js
@@ -8,34 +8,29 @@ module.exports = `
  fragment pressReleasesListingPage on NodePressReleasesListing {
     ${entityElementsFromPages}
     fieldIntroText
-    fieldOffice {
-      entity {
-        title
-        reverseFieldOfficeNode(limit: 500, filter: {conditions: [{field: "type", value: "press_release"}, {field: "status", value: "1", operator: EQUAL}]}) {
-          entities {
-            ... on NodePressRelease {
-              entityId
-              title
-              fieldReleaseDate {
-                value
+    reverseFieldListingNode(limit: 500, filter: {conditions: [{field: "type", value: "press_release"}, {field: "status", value: "1", operator: EQUAL}]}) {
+      entities {
+        ... on NodePressRelease {
+          entityId
+          title
+          fieldReleaseDate {
+            value
+          }
+          entityUrl {
+            path
+          }
+          uid {
+            targetId
+            ... on FieldNodeUid {
+              entity {
+                name
+                timezone
               }
-              entityUrl {
-                path
-              }
-              uid {
-                targetId
-                ... on FieldNodeUid {
-                  entity {
-                    name
-                    timezone
-                  }
-                }
-              }
-              promote
-              created
-              fieldIntroText
             }
           }
+          promote
+          created
+          fieldIntroText
         }
       }
     }

--- a/src/site/stages/build/drupal/graphql/storyListingPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/storyListingPage.graphql.js
@@ -8,58 +8,53 @@ module.exports = `
  fragment storyListingPage on NodeStoryListing {
     ${entityElementsFromPages}
     fieldIntroText
-    fieldOffice {
-      entity {
-        title
-        reverseFieldOfficeNode(limit: 500, filter: {conditions: [{field: "type", value: "news_story"}, {field: "status", value: "1", operator: EQUAL}]}) {
-          entities {
-            ... on NodeNewsStory {
-              entityId
-              title
-              fieldFeatured
-              entityUrl {
-                path
-              }
-              uid {
-                targetId
-                ... on FieldNodeUid {
-                  entity {
-                    name
-                    timezone
-                  }
-                }
-              }
-              promote
-              created
-              fieldAuthor {
-                entity {
-                  ...on NodePersonProfile {
-                    title
-                    fieldDescription
-                  }
-                }
-              }
-              fieldImageCaption
-              fieldIntroText
-              fieldMedia {
-                entity {
-                  ... on MediaImage {
-                    image {
-                      alt
-                      title
-                      derivative(style: _21MEDIUMTHUMBNAIL) {
-                        url
-                        width
-                        height
-                      }
-                    }
-                  }
-                }
-              }
-              fieldFullStory {
-                processed
+    reverseFieldListingNode(limit: 500, filter: {conditions: [{field: "type", value: "news_story"}, {field: "status", value: "1", operator: EQUAL}]}) {
+      entities {
+        ... on NodeNewsStory {
+          entityId
+          title
+          fieldFeatured
+          entityUrl {
+            path
+          }
+          uid {
+            targetId
+            ... on FieldNodeUid {
+              entity {
+                name
+                timezone
               }
             }
+          }
+          promote
+          created
+          fieldAuthor {
+            entity {
+              ...on NodePersonProfile {
+                title
+                fieldDescription
+              }
+            }
+          }
+          fieldImageCaption
+          fieldIntroText
+          fieldMedia {
+            entity {
+              ... on MediaImage {
+                image {
+                  alt
+                  title
+                  derivative(style: _21MEDIUMTHUMBNAIL) {
+                    url
+                    width
+                    height
+                  }
+                }
+              }
+            }
+          }
+          fieldFullStory {
+            processed
           }
         }
       }
@@ -67,6 +62,7 @@ module.exports = `
     fieldOffice {
       targetId
       entity {
+        title
         ... on NodeHealthCareRegionPage {
           entityLabel
           title

--- a/src/site/stages/build/drupal/metalsmith-drupal.js
+++ b/src/site/stages/build/drupal/metalsmith-drupal.js
@@ -89,10 +89,7 @@ function pipeDrupalPagesIntoMetalsmith(contentData, files) {
         addGetUpdatesFields(pageCompiled, pages);
         break;
       case 'event_listing':
-        pageCompiled.allEventTeasers = pageCompiled.fieldOffice.entity
-          .reverseFieldOfficeNode.entities.length
-          ? pageCompiled.fieldOffice.entity.reverseFieldOfficeNode
-          : pageCompiled.reverseFieldOfficeNode;
+        pageCompiled.allEventTeasers = pageCompiled.reverseFieldListingNode;
         addPager(
           pageCompiled,
           files,
@@ -102,8 +99,7 @@ function pipeDrupalPagesIntoMetalsmith(contentData, files) {
         );
         break;
       case 'story_listing':
-        pageCompiled.allNewsStoryTeasers =
-          page.fieldOffice.entity.reverseFieldOfficeNode;
+        pageCompiled.allNewsStoryTeasers = page.reverseFieldListingNode;
         addPager(
           pageCompiled,
           files,
@@ -113,8 +109,7 @@ function pipeDrupalPagesIntoMetalsmith(contentData, files) {
         );
         break;
       case 'press_releases_listing':
-        pageCompiled.allPressReleaseTeasers =
-          page.fieldOffice.entity.reverseFieldOfficeNode;
+        pageCompiled.allPressReleaseTeasers = page.reverseFieldListingNode;
         addPager(
           pageCompiled,
           files,
@@ -128,7 +123,7 @@ function pipeDrupalPagesIntoMetalsmith(contentData, files) {
           pageCompiled.fieldOffice.entity.reverseFieldRegionPageNode.entities,
         );
         break;
-      case 'leaderships_listing':
+      case 'leadership_listing':
         pageCompiled.allStaffProfiles = page.fieldLeadership;
         addPager(
           pageCompiled,


### PR DESCRIPTION
## Description
Brings previously approved code for listings refactorings back into codebase - was reverted and was missed when replacement commits were merged. See https://github.com/department-of-veterans-affairs/vets-website/pull/11997/files

## Testing done
Visual

## Acceptance criteria
- [ ] Event listing pages, e.g: `pittsburgh-health-care/events` outputs list of events.