### PR TITLE
[Find forms] Add download attribute

### DIFF
--- a/src/applications/find-forms/components/SearchResult.jsx
+++ b/src/applications/find-forms/components/SearchResult.jsx
@@ -29,7 +29,12 @@ export default function SearchResult({ form }) {
       </dd>
 
       <dd className="vads-u-padding-bottom--3">
-        <a href={form.attributes.url} rel="noopener noreferrer" target="_blank">
+        <a
+          href={form.attributes.url}
+          rel="noopener noreferrer"
+          target="_blank"
+          download
+        >
           Download VA form {form.id} {pdf}
         </a>
       </dd>


### PR DESCRIPTION
## Description
Makes a form PDF download to the tray instead of in a new tab.

https://github.com/department-of-veterans-affairs/va.gov-team/issues/7474

## Testing done
According to https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a - 

> download only works for same-origin URLs, or the blob: and data: schemes.

So I couldn't really test this locally because localhost != va.gov form locations. But I used dev tools to add the `download` attribute to links on va.gov/find-forms, so I verified this will work.

## Screenshots
![image](https://user-images.githubusercontent.com/1915775/78282493-62624c80-74ea-11ea-8b3c-36cdee312197.png)


## Acceptance criteria
- [ ] PDFs download instead of opening in new tab

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
