### PR TITLE
VACMS-1380: Fixing broken publication listing output.

### DIFF
--- a/src/applications/public-outreach-materials/libraries/library-filters.js
+++ b/src/applications/public-outreach-materials/libraries/library-filters.js
@@ -152,7 +152,7 @@ export function libraryReset() {
 
 export function libraryFilters(el) {
   // Grab our current page from the active pager button.
-  if (el.srcElement.className === 'pager-numbers') {
+  if (el.srcElement.classList.contains('pager-numbers')) {
     activePage = parseInt(el.srcElement.text, 10);
     sessionStorage.setItem('pageNum', parseInt(el.srcElement.text, 10));
   }

--- a/src/site/layouts/publication_listing.drupal.liquid
+++ b/src/site/layouts/publication_listing.drupal.liquid
@@ -108,8 +108,7 @@
               </div>
               {% assign even = true %}
               {% for entity in outreachAssetsDataArray.entities %}
-              {% if entity.fieldOffice.targetId == fieldOffice.targetId %}
-
+              {% if entity.fieldListing.targetId == entityId %}
 
               <div data-topic="{{entity.fieldBenefits}}"
                 {{entity.fieldBenefits | breakIntoSingles}}

--- a/src/site/stages/build/drupal/graphql/file-fragments/outreachAssets.graphql.js
+++ b/src/site/stages/build/drupal/graphql/file-fragments/outreachAssets.graphql.js
@@ -9,6 +9,9 @@ module.exports = `
         fieldFormat
         fieldBenefits
         fieldDescription
+        fieldListing {
+          targetId
+        }
         fieldMedia {
           entity {
             ... on MediaImage {


### PR DESCRIPTION
## Description
Outreach materials page is empty (Defect ticket: https://github.com/department-of-veterans-affairs/va.gov-cms/issues/1380)

## Testing done
Visual

## Screenshots
![image](https://user-images.githubusercontent.com/2404547/78284465-79ef0480-74ed-11ea-9d9d-dc1e13583d7a.png)

## Acceptance criteria
- [x] Go to `/outreach-and-events/outreach-materials/` and visually verify that assets appear on page
