### PR TITLE
Remove unused date validations related to moment

### DIFF
--- a/src/platform/forms/tests/validations.unit.spec.js
+++ b/src/platform/forms/tests/validations.unit.spec.js
@@ -14,7 +14,6 @@ import {
   isValidPartialDate,
   isValidPartialMonthYear,
   isValidPartialMonthYearInPast,
-  isValidPartialMonthYearRange,
   isValidSSN,
   validateCustomFormComponent,
   validateLength,
@@ -192,93 +191,6 @@ describe('Validations unit tests', () => {
         },
       };
       expect(isValidDateRange(fromDate, toDate)).to.be.true;
-    });
-  });
-
-  describe('isValidPartialMonthYearRange', () => {
-    it('should validate partial range', () => {
-      const fromDate = {
-        month: {
-          value: '2',
-        },
-        year: {
-          value: '2001',
-        },
-      };
-
-      const toDate = {
-        month: {
-          value: '3',
-        },
-        year: {
-          value: '',
-        },
-      };
-
-      expect(isValidPartialMonthYearRange(fromDate, toDate)).to.be.true;
-    });
-    it('should not validate invalid range', () => {
-      const fromDate = {
-        month: {
-          value: '2',
-        },
-        year: {
-          value: '2002',
-        },
-      };
-
-      const toDate = {
-        month: {
-          value: '3',
-        },
-        year: {
-          value: '2001',
-        },
-      };
-
-      expect(isValidPartialMonthYearRange(fromDate, toDate)).to.be.false;
-    });
-    it('should validate same date range', () => {
-      const fromDate = {
-        month: {
-          value: '2',
-        },
-        year: {
-          value: '2001',
-        },
-      };
-
-      const toDate = {
-        month: {
-          value: '2',
-        },
-        year: {
-          value: '2001',
-        },
-      };
-
-      expect(isValidPartialMonthYearRange(fromDate, toDate)).to.be.true;
-    });
-    it('should validate year only range', () => {
-      const fromDate = {
-        month: {
-          value: '',
-        },
-        year: {
-          value: '2001',
-        },
-      };
-
-      const toDate = {
-        month: {
-          value: '',
-        },
-        year: {
-          value: '2002',
-        },
-      };
-
-      expect(isValidPartialMonthYearRange(fromDate, toDate)).to.be.true;
     });
   });
 

--- a/src/platform/forms/tests/validations.unit.spec.js
+++ b/src/platform/forms/tests/validations.unit.spec.js
@@ -6,7 +6,6 @@ import {
   isBlank,
   isNotBlank,
   isValidDate,
-  isValidDateOver17,
   isValidDateRange,
   isValidMonetaryValue,
   isValidName,
@@ -240,34 +239,6 @@ describe('Validations unit tests', () => {
     });
   });
 
-  describe('isValidDateOver17', () => {
-    it('validates turning 17 today', () => {
-      const date = moment()
-        .startOf('day')
-        .subtract(17, 'years');
-      expect(
-        isValidDateOver17(
-          date.date().toString(),
-          (date.month() + 1).toString(),
-          date.year().toString(),
-        ),
-      ).to.be.true;
-    });
-
-    it('does not validate turning 17 tomorrow', () => {
-      const date = moment()
-        .startOf('day')
-        .subtract(17, 'years')
-        .add(1, 'days');
-      expect(
-        isValidDateOver17(
-          date.date().toString(),
-          (date.month() + 1).toString(),
-          date.year().toString(),
-        ),
-      ).to.be.false;
-    });
-  });
   describe('isValidPartialDate', () => {
     it('should validate complete date', () => {
       expect(isValidPartialDate('5', '10', '2010')).to.be.true;

--- a/src/platform/forms/tests/validations.unit.spec.js
+++ b/src/platform/forms/tests/validations.unit.spec.js
@@ -5,7 +5,6 @@ import moment from 'moment';
 import {
   isBlank,
   isNotBlank,
-  isValidCurrentOrPastDate,
   isValidDate,
   isValidDateOver17,
   isValidDateRange,
@@ -190,36 +189,6 @@ describe('Validations unit tests', () => {
         },
       };
       expect(isValidDateRange(fromDate, toDate)).to.be.true;
-    });
-  });
-
-  describe('isValidCurrentOrPastDate', () => {
-    it('should validate past date', () => {
-      expect(isValidCurrentOrPastDate('2', '2', '2000')).to.be.true;
-    });
-    it('should validate current date', () => {
-      expect(
-        isValidCurrentOrPastDate(
-          moment()
-            .date()
-            .toString(),
-          (moment().month() + 1).toString(),
-          moment()
-            .year()
-            .toString(),
-        ),
-      ).to.be.true;
-    });
-    it('should not validate date in future', () => {
-      expect(
-        isValidCurrentOrPastDate(
-          (moment().date() + 1).toString(),
-          (moment().month() + 1).toString(),
-          moment()
-            .year()
-            .toString(),
-        ),
-      ).to.be.false;
     });
   });
 

--- a/src/platform/forms/tests/validations.unit.spec.js
+++ b/src/platform/forms/tests/validations.unit.spec.js
@@ -1,6 +1,5 @@
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import moment from 'moment';
 
 import {
   isBlank,
@@ -9,7 +8,6 @@ import {
   isValidDateRange,
   isValidMonetaryValue,
   isValidName,
-  isValidPartialDate,
   isValidSSN,
   validateCustomFormComponent,
   validateLength,
@@ -238,43 +236,6 @@ describe('Validations unit tests', () => {
     });
   });
 
-  describe('isValidPartialDate', () => {
-    it('should validate complete date', () => {
-      expect(isValidPartialDate('5', '10', '2010')).to.be.true;
-    });
-    it('should validate empty date', () => {
-      expect(isValidPartialDate('', '', '')).to.be.true;
-    });
-    it('should validate month year date', () => {
-      expect(isValidPartialDate('', '10', '2050')).to.be.true;
-    });
-    it('should validate month day date', () => {
-      expect(isValidPartialDate('10', '10', '')).to.be.true;
-    });
-    it('should validate day year date', () => {
-      expect(isValidPartialDate('20', '', '2010')).to.be.true;
-    });
-    it('should validate day date', () => {
-      expect(isValidPartialDate('20', '', '')).to.be.true;
-    });
-    it('should validate year date', () => {
-      expect(isValidPartialDate('', '', '2010')).to.be.true;
-    });
-    it('should not validate year before 1900', () => {
-      expect(isValidPartialDate('', '', '1899')).to.be.false;
-    });
-    it('should not validate year more than 100 years in future', () => {
-      expect(
-        isValidPartialDate(
-          '',
-          '',
-          moment()
-            .add(101, 'year')
-            .year(),
-        ),
-      ).to.be.false;
-    });
-  });
   describe('validateCustomFormComponent', () => {
     it('should return object validation results', () => {
       const validation = {

--- a/src/platform/forms/tests/validations.unit.spec.js
+++ b/src/platform/forms/tests/validations.unit.spec.js
@@ -10,7 +10,6 @@ import {
   isValidMonetaryValue,
   isValidName,
   isValidPartialDate,
-  isValidPartialMonthYear,
   isValidSSN,
   validateCustomFormComponent,
   validateLength,
@@ -307,25 +306,6 @@ describe('Validations unit tests', () => {
       ];
 
       expect(validateCustomFormComponent(validation)).to.equal(validation[1]);
-    });
-  });
-  describe('isValidPartialMonthYear', () => {
-    it('should validate month and year', () => {
-      expect(
-        isValidPartialMonthYear(
-          '2',
-          moment()
-            .add(5, 'year')
-            .year()
-            .toString(),
-        ),
-      ).to.be.true;
-    });
-    it('should not validate bad year', () => {
-      expect(isValidPartialMonthYear('2', '2500')).to.be.false;
-    });
-    it('should not validate bad month', () => {
-      expect(isValidPartialMonthYear('20', '2001')).to.be.false;
     });
   });
 

--- a/src/platform/forms/tests/validations.unit.spec.js
+++ b/src/platform/forms/tests/validations.unit.spec.js
@@ -13,7 +13,6 @@ import {
   isValidName,
   isValidPartialDate,
   isValidPartialMonthYear,
-  isValidPartialMonthYearInPast,
   isValidSSN,
   validateCustomFormComponent,
   validateLength,
@@ -387,34 +386,6 @@ describe('Validations unit tests', () => {
     });
     it('should not validate bad month', () => {
       expect(isValidPartialMonthYear('20', '2001')).to.be.false;
-    });
-  });
-  describe('isValidPartialMonthYearInPast', () => {
-    it('should validate month and year in past', () => {
-      expect(isValidPartialMonthYearInPast('2', '2001')).to.be.true;
-    });
-    it('should validate month and year that is current', () => {
-      const currentMonthIndexedAtOne = moment().month() + 1;
-
-      expect(
-        isValidPartialMonthYearInPast(
-          currentMonthIndexedAtOne.toString(),
-          moment()
-            .year()
-            .toString(),
-        ),
-      ).to.be.true;
-    });
-    it('should not validate month and year that is in the future', () => {
-      expect(
-        isValidPartialMonthYearInPast(
-          '2',
-          moment()
-            .add(2, 'year')
-            .year()
-            .toString(),
-        ),
-      ).to.be.false;
     });
   });
 

--- a/src/platform/forms/validations.js
+++ b/src/platform/forms/validations.js
@@ -167,23 +167,6 @@ function isBlankMonthYear(field) {
   return isBlank(field.month.value) && isBlank(field.year.value);
 }
 
-function isValidDateOver17(day, month, year) {
-  if (!isValidYear(year)) {
-    return false;
-  }
-
-  const momentDate = moment({
-    day,
-    month: parseInt(month, 10) - 1,
-    year,
-  });
-  return momentDate.isBefore(
-    moment()
-      .endOf('day')
-      .subtract(17, 'years'),
-  );
-}
-
 /**
  * Field Validations *
  */
@@ -310,7 +293,6 @@ export {
   isNotBlankDateField,
   isValidDate,
   isValidDateField,
-  isValidDateOver17,
   isValidDateRange,
   isValidEmail,
   isValidFullNameField,

--- a/src/platform/forms/validations.js
+++ b/src/platform/forms/validations.js
@@ -64,10 +64,6 @@ function isValidYearOrBlank(value) {
   return isValidYear(value) || value === '';
 }
 
-function isValidCurrentOrPastYear(value) {
-  return Number(value) >= 1900 && Number(value) < moment().year() + 1;
-}
-
 function isValidMonths(value) {
   return Number(value) >= 0;
 }
@@ -366,7 +362,6 @@ export {
   isNotBlank,
   isNotBlankDateField,
   isValidAnyDate,
-  isValidCurrentOrPastYear,
   isValidCurrentOrPastDate,
   isValidCurrentOrFutureMonthYear,
   isValidFutureDate,

--- a/src/platform/forms/validations.js
+++ b/src/platform/forms/validations.js
@@ -163,16 +163,6 @@ function isValidPartialMonthYear(month, year) {
   return isValidPartialDate(null, null, year);
 }
 
-function isValidPartialMonthYearRange(fromDate, toDate) {
-  if (!fromDate.year.value || !toDate.year.value) {
-    return true;
-  }
-  const momentStart = dateToMoment(fromDate);
-  const momentEnd = dateToMoment(toDate);
-
-  return momentStart.isSameOrBefore(momentEnd);
-}
-
 function isValidPartialMonthYearInPast(month, year) {
   if (typeof month === 'object') {
     throw new Error('Pass a month and a year to function');
@@ -367,7 +357,6 @@ export {
   isValidPartialDateField,
   isValidPartialMonthYear,
   isValidPartialMonthYearInPast,
-  isValidPartialMonthYearRange,
   isValidRequiredField,
   isValidSSN,
   isValidValue,

--- a/src/platform/forms/validations.js
+++ b/src/platform/forms/validations.js
@@ -163,22 +163,6 @@ function isValidPartialMonthYear(month, year) {
   return isValidPartialDate(null, null, year);
 }
 
-function isValidPartialMonthYearInPast(month, year) {
-  if (typeof month === 'object') {
-    throw new Error('Pass a month and a year to function');
-  }
-  const momentDate = moment({
-    year,
-    month: month ? parseInt(month, 10) - 1 : null,
-  });
-  return (
-    !year ||
-    (isValidPartialMonthYear(month, year) &&
-      momentDate.isValid() &&
-      momentDate.isSameOrBefore(moment().startOf('month')))
-  );
-}
-
 function isValidCurrentOrPastDate(day, month, year) {
   const momentDate = moment({ day, month: parseInt(month, 10) - 1, year });
   return momentDate.isSameOrBefore(moment().endOf('day'), 'day');
@@ -356,7 +340,6 @@ export {
   isValidPartialDate,
   isValidPartialDateField,
   isValidPartialMonthYear,
-  isValidPartialMonthYearInPast,
   isValidRequiredField,
   isValidSSN,
   isValidValue,

--- a/src/platform/forms/validations.js
+++ b/src/platform/forms/validations.js
@@ -163,11 +163,6 @@ function isValidPartialMonthYear(month, year) {
   return isValidPartialDate(null, null, year);
 }
 
-function isValidCurrentOrFutureMonthYear(month, year) {
-  const momentDate = moment({ month: parseInt(month, 10) - 1, year });
-  return momentDate.isSameOrAfter(moment(), 'month');
-}
-
 function isBlankMonthYear(field) {
   return isBlank(field.month.value) && isBlank(field.year.value);
 }
@@ -313,7 +308,6 @@ export {
   isFullDate,
   isNotBlank,
   isNotBlankDateField,
-  isValidCurrentOrFutureMonthYear,
   isValidDate,
   isValidDateField,
   isValidDateOver17,

--- a/src/platform/forms/validations.js
+++ b/src/platform/forms/validations.js
@@ -140,17 +140,6 @@ function isValidDateRange(fromDate, toDate) {
   return momentStart.isBefore(momentEnd);
 }
 
-function isValidPartialMonthYear(month, year) {
-  if (typeof month === 'object') {
-    throw new Error('Pass a month and a year to function');
-  }
-  if (month && (Number(month) > 12 || Number(month) < 1)) {
-    return false;
-  }
-
-  return isValidPartialDate(null, null, year);
-}
-
 function isBlankMonthYear(field) {
   return isBlank(field.month.value) && isBlank(field.year.value);
 }
@@ -290,7 +279,6 @@ export {
   isValidMonetaryValue,
   isValidPhone,
   isValidPartialDate,
-  isValidPartialMonthYear,
   isValidRequiredField,
   isValidSSN,
   isValidValue,

--- a/src/platform/forms/validations.js
+++ b/src/platform/forms/validations.js
@@ -60,10 +60,6 @@ function isValidYear(value) {
   );
 }
 
-function isValidYearOrBlank(value) {
-  return isValidYear(value) || value === '';
-}
-
 function isValidMonths(value) {
   return Number(value) >= 0;
 }
@@ -308,7 +304,6 @@ export {
   isValidSSN,
   isValidValue,
   isValidYear,
-  isValidYearOrBlank,
   validateCustomFormComponent,
   validateIfDirty,
   validateIfDirtyDate,

--- a/src/platform/forms/validations.js
+++ b/src/platform/forms/validations.js
@@ -163,11 +163,6 @@ function isValidPartialMonthYear(month, year) {
   return isValidPartialDate(null, null, year);
 }
 
-function isValidCurrentOrPastDate(day, month, year) {
-  const momentDate = moment({ day, month: parseInt(month, 10) - 1, year });
-  return momentDate.isSameOrBefore(moment().endOf('day'), 'day');
-}
-
 function isValidFutureDate(day, month, year) {
   const momentDate = moment({ day, month: parseInt(month, 10) - 1, year });
   return momentDate.isAfter(moment().endOf('day'), 'day');
@@ -323,7 +318,6 @@ export {
   isFullDate,
   isNotBlank,
   isNotBlankDateField,
-  isValidCurrentOrPastDate,
   isValidCurrentOrFutureMonthYear,
   isValidFutureDate,
   isValidDate,

--- a/src/platform/forms/validations.js
+++ b/src/platform/forms/validations.js
@@ -268,7 +268,6 @@ export {
   isValidRequiredField,
   isValidSSN,
   isValidValue,
-  isValidYear,
   validateCustomFormComponent,
   validateIfDirty,
   validateIfDirtyDate,

--- a/src/platform/forms/validations.js
+++ b/src/platform/forms/validations.js
@@ -118,14 +118,6 @@ function validateIfDirtyDate(dayField, monthField, yearField, validator) {
   return true;
 }
 
-function isValidPartialDate(day, month, year) {
-  if (year && !isValidYear(year)) {
-    return false;
-  }
-
-  return true;
-}
-
 function isValidDateField(field) {
   return isValidDate(field.day.value, field.month.value, field.year.value);
 }
@@ -278,7 +270,6 @@ export {
   isValidName,
   isValidMonetaryValue,
   isValidPhone,
-  isValidPartialDate,
   isValidRequiredField,
   isValidSSN,
   isValidValue,

--- a/src/platform/forms/validations.js
+++ b/src/platform/forms/validations.js
@@ -122,18 +122,6 @@ function validateIfDirtyDate(dayField, monthField, yearField, validator) {
   return true;
 }
 
-function isValidAnyDate(day, month, year) {
-  if (!isValidYear(year)) {
-    return false;
-  }
-
-  return moment({
-    day,
-    month: month ? parseInt(month, 10) - 1 : month,
-    year,
-  }).isValid();
-}
-
 function isValidPartialDate(day, month, year) {
   if (year && !isValidYear(year)) {
     return false;
@@ -361,7 +349,6 @@ export {
   isFullDate,
   isNotBlank,
   isNotBlankDateField,
-  isValidAnyDate,
   isValidCurrentOrPastDate,
   isValidCurrentOrFutureMonthYear,
   isValidFutureDate,

--- a/src/platform/forms/validations.js
+++ b/src/platform/forms/validations.js
@@ -163,11 +163,6 @@ function isValidPartialMonthYear(month, year) {
   return isValidPartialDate(null, null, year);
 }
 
-function isValidFutureDate(day, month, year) {
-  const momentDate = moment({ day, month: parseInt(month, 10) - 1, year });
-  return momentDate.isAfter(moment().endOf('day'), 'day');
-}
-
 function isValidCurrentOrFutureMonthYear(month, year) {
   const momentDate = moment({ month: parseInt(month, 10) - 1, year });
   return momentDate.isSameOrAfter(moment(), 'month');
@@ -319,7 +314,6 @@ export {
   isNotBlank,
   isNotBlankDateField,
   isValidCurrentOrFutureMonthYear,
-  isValidFutureDate,
   isValidDate,
   isValidDateField,
   isValidDateOver17,

--- a/src/platform/forms/validations.js
+++ b/src/platform/forms/validations.js
@@ -118,10 +118,6 @@ function validateIfDirtyDate(dayField, monthField, yearField, validator) {
   return true;
 }
 
-function isValidDateField(field) {
-  return isValidDate(field.day.value, field.month.value, field.year.value);
-}
-
 function isValidDateRange(fromDate, toDate) {
   if (isBlankDateField(toDate) || isBlankDateField(fromDate)) {
     return true;
@@ -261,7 +257,6 @@ export {
   isNotBlank,
   isNotBlankDateField,
   isValidDate,
-  isValidDateField,
   isValidDateRange,
   isValidEmail,
   isValidFullNameField,

--- a/src/platform/forms/validations.js
+++ b/src/platform/forms/validations.js
@@ -130,14 +130,6 @@ function isValidDateField(field) {
   return isValidDate(field.day.value, field.month.value, field.year.value);
 }
 
-function isValidPartialDateField(field) {
-  return isValidPartialDate(
-    field.day.value,
-    field.month.value,
-    field.year.value,
-  );
-}
-
 function isValidDateRange(fromDate, toDate) {
   if (isBlankDateField(toDate) || isBlankDateField(fromDate)) {
     return true;
@@ -298,7 +290,6 @@ export {
   isValidMonetaryValue,
   isValidPhone,
   isValidPartialDate,
-  isValidPartialDateField,
   isValidPartialMonthYear,
   isValidRequiredField,
   isValidSSN,


### PR DESCRIPTION
## Description

Related to:

- https://github.com/department-of-veterans-affairs/va.gov-team/issues/599
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/6763

I'm investigating removing `moment` from the platform code, but a decent chunk of that platform code that uses moment isn't used anywhere else.  This is an effort to remove that unused code so that the moment transition won't have to worry about it.

In `src/platform/forms/validations.js`, the remaining functions that _directly_ use `moment` are:

- `isValidYear()`
- `isValidDateRange()`
  - Used in:
    - `src/applications/pensions/validation.js`
    - `src/applications/pensions/migrations.js`
    - `src/applications/hca/validation.js`
    - `src/applications/disability-benefits/686/validation.js`

`isValidYear()` is used in `isValidDate()` in the same file, and _that_ function is only used in `src/applications/hca/helpers.jsx`.

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
