### PR TITLE
CT: Search results breadcrumb missing #7528

### DIFF
--- a/src/applications/gi/components/search/SearchResult.jsx
+++ b/src/applications/gi/components/search/SearchResult.jsx
@@ -59,12 +59,12 @@ export class SearchResult extends React.Component {
             <div className="row">
               <div className="small-12 usa-width-seven-twelfths medium-7 columns">
                 <h2>
-                  <a
-                    href={linkTo.pathname}
+                  <Link
+                    to={linkTo}
                     aria-label={`${name} ${locationInfo(city, state, country)}`}
                   >
                     {name}
-                  </a>
+                  </Link>
                 </h2>
               </div>
             </div>

--- a/src/applications/gi/components/vet-tec/VetTecProgramSearchResult.jsx
+++ b/src/applications/gi/components/vet-tec/VetTecProgramSearchResult.jsx
@@ -45,8 +45,8 @@ class VetTecProgramSearchResult extends React.Component {
             <div className="row vads-u-padding-top--1p5">
               <div className="small-12 medium-7 columns">
                 <h2>
-                  <a
-                    href={linkTo.pathname}
+                  <Link
+                    to={linkTo}
                     aria-label={`${description} ${locationInfo(
                       city,
                       state,
@@ -54,7 +54,7 @@ class VetTecProgramSearchResult extends React.Component {
                     )}`}
                   >
                     {description}
-                  </a>
+                  </Link>
                 </h2>
               </div>
               <div className="small-12 medium-3 columns">


### PR DESCRIPTION
## Description

https://github.com/department-of-veterans-affairs/va.gov-team/issues/7528

The institution or program name  was using an `<a>` tag instead of a `<Link>` component preventing the state from being passed to profile when clicking on the institution's or program's name in either search results

## Testing done


## Screenshots
![Screen Shot 2020-04-02 at 2 35 49 PM](https://user-images.githubusercontent.com/1094999/78287658-401efd80-74ef-11ea-8101-13a5f9988921.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
