### PR TITLE
Replace moment with date-fns in hca

### DIFF
--- a/package.json
+++ b/package.json
@@ -245,6 +245,7 @@
     "cookie": "^0.3.1",
     "cookie-parser": "^1.4.3",
     "core-js": "^2.5.7",
+    "date-fns": "^2.11.1",
     "downshift": "^1.22.5",
     "express": "^4.14.0",
     "express-http-proxy": "^1.5.1",

--- a/src/applications/hca/containers/ConfirmationPage.jsx
+++ b/src/applications/hca/containers/ConfirmationPage.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import moment from 'moment';
+import { format, parseISO } from 'date-fns';
 import { connect } from 'react-redux';
 import Scroll from 'react-scroll';
 
@@ -65,7 +65,9 @@ export class ConfirmationPage extends React.Component {
               <li>
                 <strong>{dateTitle}</strong>
                 <br />
-                <span>{moment(response.timestamp).format('MMM D, YYYY')}</span>
+                <span>
+                  {format(parseISO(response.timestamp), 'MMM d, yyyy')}
+                </span>
               </li>
             </ul>
           )}

--- a/src/applications/hca/enrollment-status-helpers.jsx
+++ b/src/applications/hca/enrollment-status-helpers.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import moment from 'moment';
+import { format } from 'date-fns';
 
 import { isValidDateString } from 'platform/utilities/date';
 import { HCA_ENROLLMENT_STATUSES } from './constants';
@@ -89,7 +89,7 @@ export function getEnrollmentDetails(
     blocks.push(
       <>
         <strong>You applied on: </strong>
-        {moment(applicationDate).format('MMMM D, YYYY')}
+        {format(Date.parse(applicationDate), 'MMMM d, yyyy')}
       </>,
     );
   }
@@ -98,7 +98,7 @@ export function getEnrollmentDetails(
     blocks.push(
       <>
         <strong>We enrolled you on: </strong>
-        {moment(enrollmentDate).format('MMMM D, YYYY')}
+        {format(Date.parse(enrollmentDate), 'MMMM d, yyyy')}
       </>,
     );
   }
@@ -971,7 +971,7 @@ export function getAlertContent(
     blocks.push(
       <p key="you-applied-on">
         <strong>You applied on:</strong>{' '}
-        {moment(applicationDate).format('MMMM D, YYYY')}
+        {format(Date.parse(applicationDate), 'MMMM d, yyyy')}
       </p>,
     );
   }

--- a/src/applications/hca/helpers.jsx
+++ b/src/applications/hca/helpers.jsx
@@ -590,12 +590,6 @@ export function getCSTDate() {
   return new Date(centralTime);
 }
 
-export function isBeforeCentralTimeDate(date) {
-  const lastDischargeDate = moment(date, 'YYYY-MM-DD');
-  const centralTimeDate = moment(getCSTDate());
-  return lastDischargeDate.isBefore(centralTimeDate.startOf('day'));
-}
-
 export function validateDate(date) {
   const newDate = moment(date, 'YYYY-MM-DD');
   const day = newDate.date();

--- a/src/applications/hca/helpers.jsx
+++ b/src/applications/hca/helpers.jsx
@@ -596,10 +596,6 @@ export function isBeforeCentralTimeDate(date) {
   return lastDischargeDate.isBefore(centralTimeDate.startOf('day'));
 }
 
-export function isAfterCentralTimeDate(date) {
-  return !isBeforeCentralTimeDate(date);
-}
-
 export function validateDate(date) {
   const newDate = moment(date, 'YYYY-MM-DD');
   const day = newDate.date();

--- a/src/applications/hca/helpers.jsx
+++ b/src/applications/hca/helpers.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import _ from 'lodash/fp';
-import moment from 'moment';
 import AdditionalInfo from '@department-of-veterans-affairs/formation-react/AdditionalInfo';
 import vaMedicalFacilities from 'vets-json-schema/dist/vaMedicalFacilities.json';
 
@@ -15,7 +14,6 @@ import {
   createFormPageList,
 } from 'platform/forms-system/src/js/helpers';
 import { getInactivePages } from 'platform/forms/helpers';
-import { isValidDate } from 'platform/forms/validations';
 import { isInMVI } from 'platform/user/selectors';
 
 import facilityLocator from '../facility-locator/manifest.json';
@@ -535,14 +533,6 @@ export const idFormUiSchema = {
     },
   },
 };
-
-export function validateDate(date) {
-  const newDate = moment(date, 'YYYY-MM-DD');
-  const day = newDate.date();
-  const month = newDate.month() + 1; // Note: Months are zero indexed, so January is month 0.
-  const year = newDate.year();
-  return isValidDate(day, month, year);
-}
 
 /**
  * Helper that takes two sets of props and returns true if any of its relevant

--- a/src/applications/hca/helpers.jsx
+++ b/src/applications/hca/helpers.jsx
@@ -536,60 +536,6 @@ export const idFormUiSchema = {
   },
 };
 
-/**
- *
- * Provides the current Central Time CT offset according to whether or not daylight savings is in effect
- * @export
- * @param {boolean} isDST
- * @returns {number} offset in minutes
- */
-export function getCSTOffset(isDST) {
-  const offsetHours = isDST ? -5 : -6;
-  return offsetHours * 60;
-}
-
-/**
- *
- * Converts a timezone offset into milliseconds
- * @export
- * @param {number} offset (in minutes)
- */
-export function getOffsetTime(offset) {
-  return 60000 * offset;
-}
-
-/**
- *
- * Adjusts a given time using an offset
- * @export
- * @param {number} time (in milliseconds)
- * @param {number} offset (in milliseconds)
- */
-export function getAdjustedTime(time, offset) {
-  return time + offset;
-}
-
-/**
- * Provides a current date object in Central Time CT
- * Adapted from https://stackoverflow.com/a/46355483 and https://stackoverflow.com/a/17085556
- */
-export function getCSTDate() {
-  const today = new Date();
-  const isDST = moment().isDST();
-  const cstOffset = getCSTOffset(isDST);
-
-  // The UTC and Central Time times are defined in milliseconds
-  // UTC time is determined by adding the local offset to the local time
-  const utcTime = getAdjustedTime(
-    today.getTime(),
-    getOffsetTime(today.getTimezoneOffset()),
-  );
-
-  // Central Time is determined by adjusting the UTC time (derived above) using the CST offset
-  const centralTime = getAdjustedTime(utcTime, getOffsetTime(cstOffset));
-  return new Date(centralTime);
-}
-
 export function validateDate(date) {
   const newDate = moment(date, 'YYYY-MM-DD');
   const day = newDate.date();

--- a/src/applications/hca/tests/config/serviceInformation.unit.spec.js
+++ b/src/applications/hca/tests/config/serviceInformation.unit.spec.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { mount } from 'enzyme';
-import moment from 'moment';
+import { format, addDays } from 'date-fns';
 
 import {
   DefinitionTester,
@@ -70,9 +70,7 @@ describe('Hca serviceInformation', () => {
     fillDate(
       form,
       'root_lastDischargeDate',
-      moment()
-        .add(130, 'days')
-        .format('YYYY-MM-DD'),
+      format(addDays(Date.now(), 130), 'yyyy-MM-dd'),
     );
     fillData(form, 'select#root_dischargeType', 'general');
 

--- a/src/applications/hca/tests/containers/ConfirmationPage.unit.spec.jsx
+++ b/src/applications/hca/tests/containers/ConfirmationPage.unit.spec.jsx
@@ -26,7 +26,7 @@ describe('hca <ConfirmationPage>', () => {
     const tree = SkinDeep.shallowRender(<ConfirmationPage form={form} />);
 
     expect(tree.subTree('.claim-list')).to.exist;
-    expect(tree.everySubTree('span')[2].text()).to.contain('Jan. 1, 2010');
+    expect(tree.everySubTree('span')[2].text()).to.contain('Jan 1, 2010');
     expect(tree.everySubTree('.how-long')[0].text()).to.contain(
       'We usually decide on applications within 1 week.',
     );

--- a/src/applications/hca/tests/hca-helpers.js
+++ b/src/applications/hca/tests/hca-helpers.js
@@ -1,7 +1,7 @@
 const mock = require('platform/testing/e2e/mock-helpers');
 const Timeouts = require('platform/testing/e2e/timeouts.js');
 const Auth = require('platform/testing/e2e/auth.js');
-const moment = require('moment');
+const { addDays, getUnixTime } = require('date-fns');
 const VA_FORM_IDS = require('platform/forms/constants').VA_FORM_IDS;
 
 function completeIDForm(client, data) {
@@ -484,9 +484,7 @@ function initSaveInProgressMock(url, client) {
               last_updated: 1501608808,
               metadata: {
                 last_updated: 1506792808,
-                expires_at: moment()
-                  .add(1, 'day')
-                  .unix(),
+                expires_at: getUnixTime(addDays(Date.now(), 1)),
               },
             },
           ],
@@ -537,9 +535,7 @@ function initSaveInProgressMock(url, client) {
         version: 0,
         returnUrl: '/veteran-information/birth-information',
         savedAt: 1498588443698,
-        expires_at: moment()
-          .add(1, 'day')
-          .unix(),
+        expires_at: getUnixTime(addDays(Date.now(), 1)),
         last_updated: 1498588443,
       },
     },
@@ -555,9 +551,7 @@ function initSaveInProgressMock(url, client) {
             version: 0,
             returnUrl: '/veteran-information/birth-information',
             savedAt: 1498588443698,
-            expires_at: moment()
-              .add(1, 'day')
-              .unix(),
+            expires_at: getUnixTime(addDays(Date.now(), 1)),
             last_updated: 1498588443,
           },
         },

--- a/src/applications/hca/tests/helpers.unit.spec.jsx
+++ b/src/applications/hca/tests/helpers.unit.spec.jsx
@@ -7,7 +7,6 @@ import {
   getMedicalCenterNameByID,
   getOffsetTime,
   getAdjustedTime,
-  isBeforeCentralTimeDate,
   transformAttachments,
 } from '../helpers.jsx';
 
@@ -110,14 +109,6 @@ describe('HCA helpers', () => {
   describe('getAdjustedTime', () => {
     it('should determine utc time', () => {
       expect(getAdjustedTime(1, 1)).to.equal(2);
-    });
-  });
-  describe('isBeforeCentralTimeDate', () => {
-    it('should return true if the discharge date is after the Central Time reference date', () => {
-      expect(isBeforeCentralTimeDate('9999-12-24')).to.be.false;
-    });
-    it('should return false if the discharge date is not after the Central Time reference date', () => {
-      expect(isBeforeCentralTimeDate('2000-12-12')).to.be.true;
     });
   });
   describe('transformAttachments', () => {

--- a/src/applications/hca/tests/helpers.unit.spec.jsx
+++ b/src/applications/hca/tests/helpers.unit.spec.jsx
@@ -7,7 +7,6 @@ import {
   getMedicalCenterNameByID,
   getOffsetTime,
   getAdjustedTime,
-  isAfterCentralTimeDate,
   isBeforeCentralTimeDate,
   transformAttachments,
 } from '../helpers.jsx';
@@ -111,14 +110,6 @@ describe('HCA helpers', () => {
   describe('getAdjustedTime', () => {
     it('should determine utc time', () => {
       expect(getAdjustedTime(1, 1)).to.equal(2);
-    });
-  });
-  describe('isAfterCentralTimeDate', () => {
-    it('should return true if the discharge date is after the Central Time reference date', () => {
-      expect(isAfterCentralTimeDate('9999-12-24')).to.be.true;
-    });
-    it('should return false if the discharge date is not after the Central Time reference date', () => {
-      expect(isAfterCentralTimeDate('2000-12-12')).to.be.false;
     });
   });
   describe('isBeforeCentralTimeDate', () => {

--- a/src/applications/hca/tests/helpers.unit.spec.jsx
+++ b/src/applications/hca/tests/helpers.unit.spec.jsx
@@ -3,10 +3,7 @@ import { expect } from 'chai';
 import {
   didEnrollmentStatusChange,
   expensesLessThanIncome,
-  getCSTOffset,
   getMedicalCenterNameByID,
-  getOffsetTime,
-  getAdjustedTime,
   transformAttachments,
 } from '../helpers.jsx';
 
@@ -93,24 +90,7 @@ describe('HCA helpers', () => {
         .be.true;
     });
   });
-  describe('getCSTOffset', () => {
-    it('should return -300 if is daylight savings time', () => {
-      expect(getCSTOffset(true)).to.equal(-300);
-    });
-    it('should return -360 if is not daylight savings time', () => {
-      expect(getCSTOffset(false)).to.equal(-360);
-    });
-  });
-  describe('getOffsetTime', () => {
-    it('should convert an offset number of minutes into milliseconds', () => {
-      expect(getOffsetTime(1)).to.equal(60000);
-    });
-  });
-  describe('getAdjustedTime', () => {
-    it('should determine utc time', () => {
-      expect(getAdjustedTime(1, 1)).to.equal(2);
-    });
-  });
+
   describe('transformAttachments', () => {
     it('should do nothing if there are no attachments to transform', () => {
       const inputData = { firstName: 'Pat' };

--- a/src/applications/hca/tests/validation.unit.spec.js
+++ b/src/applications/hca/tests/validation.unit.spec.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
-import moment from 'moment';
+import { addDays, addYears, format } from 'date-fns';
 
 import {
   validateServiceDates,
@@ -39,9 +39,7 @@ describe('hca validation', () => {
       validateServiceDates(
         errors,
         {
-          lastDischargeDate: moment()
-            .add(367, 'days')
-            .format('YYYY-MM-DD'),
+          lastDischargeDate: format(addDays(Date.now(), 367), 'yyyy-MM-dd'),
           lastEntryDate: '2011-01-01',
         },
         {},
@@ -57,9 +55,7 @@ describe('hca validation', () => {
       validateServiceDates(
         errors,
         {
-          lastDischargeDate: moment()
-            .add(1, 'year')
-            .format('YYYY-MM-DD'),
+          lastDischargeDate: format(addYears(Date.now(), 1), 'yyyy-MM-dd'),
           lastEntryDate: '2011-01-01',
         },
         {},

--- a/src/applications/hca/validation.js
+++ b/src/applications/hca/validation.js
@@ -1,4 +1,5 @@
 import moment from 'moment';
+import { addYears, endOfDay, format, isAfter } from 'date-fns';
 import _ from 'lodash/fp';
 import {
   convertToDateField,
@@ -13,9 +14,7 @@ function calculateEndDate() {
   return {
     endDateLimit,
     description,
-    endDate: moment()
-      .endOf('day')
-      .add(endDateLimit, 'years'),
+    endDate: addYears(endOfDay(Date.now()), endDateLimit),
   };
 }
 
@@ -31,19 +30,20 @@ export function validateServiceDates(
   // TODO: Use a constant instead of a magic string
   if (
     !isValidDateRange(fromDate, toDate) ||
-    moment(lastDischargeDate, 'YYYY-MM-DD').isAfter(endDateInfo.endDate)
+    isAfter(Date.parse(lastDischargeDate), endDateInfo.endDate)
   ) {
     errors.lastDischargeDate.addError(
-      `Discharge date must be after the service period start date and before ${endDateInfo.endDate.format(
-        'MMMM D, YYYY',
+      `Discharge date must be after the service period start date and before ${format(
+        endDateInfo.endDate,
+        'MMMM d, yyyy',
       )} (${endDateInfo.description} from today)`,
     );
   }
 
   if (veteranDateOfBirth) {
-    const dateOfBirth = moment(veteranDateOfBirth);
+    const dateOfBirth = Date.parse(veteranDateOfBirth);
 
-    if (dateOfBirth.add(15, 'years').isAfter(moment(lastEntryDate))) {
+    if (isAfter(addYears(dateOfBirth, 15), Date.parse(lastEntryDate))) {
       errors.lastEntryDate.addError(
         'You must have been at least 15 years old when you entered the service',
       );

--- a/src/applications/hca/validation.js
+++ b/src/applications/hca/validation.js
@@ -1,4 +1,3 @@
-import moment from 'moment';
 import _ from 'lodash/fp';
 import { addYears, endOfDay, format, isAfter } from 'date-fns';
 import {
@@ -80,12 +79,11 @@ export function validateDependentDate(
   index,
 ) {
   const dependent = Date.parse(dependentDate);
-  const dob = moment(_.get(`dependents[${index}].dateOfBirth`, formData));
+  const dob =
+    Date.parse(_.get(`dependents[${index}].dateOfBirth`, formData)) ||
+    Date.now();
 
-  if (
-    formData.discloseFinancialInformation &&
-    isAfter(dob.toDate(), dependent)
-  ) {
+  if (formData.discloseFinancialInformation && isAfter(dob, dependent)) {
     errors.addError('This date must come after the dependent’s birth date');
   }
   validateCurrentOrPastDate(errors, dependentDate);

--- a/src/applications/hca/validation.js
+++ b/src/applications/hca/validation.js
@@ -1,6 +1,4 @@
-import moment from 'moment';
 import { addYears, endOfDay, format, isAfter } from 'date-fns';
-import _ from 'lodash/fp';
 import {
   convertToDateField,
   validateCurrentOrPastDate,
@@ -71,18 +69,10 @@ export function validateMarriageDate(
   validateCurrentOrPastDate(errors, marriageDate);
 }
 
-export function validateDependentDate(
-  errors,
-  dependentDate,
-  formData,
-  schema,
-  messages,
-  index,
-) {
-  const dependent = moment(dependentDate);
-  const dob = moment(_.get(`dependents[${index}].dateOfBirth`, formData));
+export function validateDependentDate(errors, dependentDate, formData) {
+  const dependent = Date.parse(dependentDate);
 
-  if (formData.discloseFinancialInformation && dob.isAfter(dependent)) {
+  if (formData.discloseFinancialInformation && isAfter(Date.now(), dependent)) {
     errors.addError('This date must come after the dependent’s birth date');
   }
   validateCurrentOrPastDate(errors, dependentDate);

--- a/src/applications/hca/validation.js
+++ b/src/applications/hca/validation.js
@@ -1,3 +1,5 @@
+import moment from 'moment';
+import _ from 'lodash/fp';
 import { addYears, endOfDay, format, isAfter } from 'date-fns';
 import {
   convertToDateField,
@@ -69,10 +71,21 @@ export function validateMarriageDate(
   validateCurrentOrPastDate(errors, marriageDate);
 }
 
-export function validateDependentDate(errors, dependentDate, formData) {
+export function validateDependentDate(
+  errors,
+  dependentDate,
+  formData,
+  schema,
+  messages,
+  index,
+) {
   const dependent = Date.parse(dependentDate);
+  const dob = moment(_.get(`dependents[${index}].dateOfBirth`, formData));
 
-  if (formData.discloseFinancialInformation && isAfter(Date.now(), dependent)) {
+  if (
+    formData.discloseFinancialInformation &&
+    isAfter(dob.toDate(), dependent)
+  ) {
     errors.addError('This date must come after the dependent’s birth date');
   }
   validateCurrentOrPastDate(errors, dependentDate);

--- a/src/applications/hca/validation.js
+++ b/src/applications/hca/validation.js
@@ -1,4 +1,3 @@
-import _ from 'lodash/fp';
 import { addYears, endOfDay, format, isAfter } from 'date-fns';
 import {
   convertToDateField,
@@ -80,8 +79,7 @@ export function validateDependentDate(
 ) {
   const dependent = Date.parse(dependentDate);
   const dob =
-    Date.parse(_.get(`dependents[${index}].dateOfBirth`, formData)) ||
-    Date.now();
+    Date.parse(formData?.dependents?.[index]?.dateOfBirth) || Date.now();
 
   if (formData.discloseFinancialInformation && isAfter(dob, dependent)) {
     errors.addError('This date must come after the dependent’s birth date');

--- a/src/applications/hca/validation.js
+++ b/src/applications/hca/validation.js
@@ -56,13 +56,13 @@ export function validateMarriageDate(
   marriageDate,
   { spouseDateOfBirth, veteranDateOfBirth, discloseFinancialInformation },
 ) {
-  const vetDOB = moment(veteranDateOfBirth);
-  const spouseDOB = moment(spouseDateOfBirth);
-  const marriage = moment(marriageDate);
+  const vetDOB = Date.parse(veteranDateOfBirth);
+  const spouseDOB = Date.parse(spouseDateOfBirth);
+  const marriage = Date.parse(marriageDate);
 
   if (
     discloseFinancialInformation &&
-    (vetDOB.isAfter(marriage) || spouseDOB.isAfter(marriage))
+    (isAfter(vetDOB, marriage) || isAfter(spouseDOB, marriage))
   ) {
     errors.addError(
       'Date of marriage cannot be before the Veteran’s or the spouse’s date of birth',

--- a/yarn.lock
+++ b/yarn.lock
@@ -4075,6 +4075,11 @@ data-urls@^1.0.0:
     whatwg-mimetype "^2.1.0"
     whatwg-url "^7.0.0"
 
+date-fns@^2.11.1:
+  version "2.11.1"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.11.1.tgz#197b8be1bbf5c5e6fe8bea817f0fe111820e7a12"
+  integrity sha512-3RdUoinZ43URd2MJcquzBbDQo+J87cSzB8NkXdZiN5ia1UNyep0oCyitfiL88+R7clGTeq/RniXAc16gWyAu1w==
+
 dateformat@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-3.0.3.tgz#a6e37499a4d9a9cf85ef5872044d62901c9889ae"


### PR DESCRIPTION
## Description

This is part of https://github.com/department-of-veterans-affairs/va.gov-team/issues/6763

This removes all _explicit_ usage of `moment` from the `hca` app.  The forms system still uses moment, so it will still get used implicitly in the app.


## Testing done

Local unit testing


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
