### PR TITLE
VACMS-1381: Restoring past events pages.

### DIFF
--- a/src/site/layouts/event_listing.drupal.liquid
+++ b/src/site/layouts/event_listing.drupal.liquid
@@ -26,6 +26,10 @@
                 {% endif %}
               </div>
 
+              {% if entityUrl.breadcrumb.1.text != "Outreach and events" %}
+                {% include "src/site/facilities/facilities_events_toggle.drupal.liquid" with url = entityUrl.path %}
+              {% endif %}
+
               {% assign featuredUrl = null %}
               {% assign featuredItemSet = false %}
 

--- a/src/site/stages/build/drupal/graphql/eventListingPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/eventListingPage.graphql.js
@@ -11,6 +11,42 @@ module.exports = `
     title
     fieldIntroText
     entityId
+    secondSetOfEvents: reverseFieldListingNode(limit: 500, filter: {conditions: [{field: "status", value: "1", operator: EQUAL}, {field: "type", value: "event"}]}, sort: {field: "changed", direction: DESC}) {
+          entities {
+            ... on NodeEvent {
+              title
+              entityUrl {
+                path
+              }
+              uid {
+                targetId
+                ... on FieldNodeUid {
+                  entity {
+                    name
+                    timezone
+                  }
+                }
+              }
+              fieldFeatured
+              fieldDate {
+                startDate
+                value
+                endDate
+                endValue
+              }
+              fieldDescription
+              fieldLocationHumanreadable
+              fieldFacilityLocation {
+                entity {
+                  title
+                  entityUrl {
+                    path
+                  }
+                }
+              }
+            }
+          }
+        }
     reverseFieldListingNode(limit: 500, filter: {conditions: [{field: "status", value: "1", operator: EQUAL}, {field: "type", value: "event"}]}, sort: {field: "changed", direction: DESC}) {
         entities {
           ... on NodeEvent {

--- a/src/site/stages/build/drupal/graphql/eventListingPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/eventListingPage.graphql.js
@@ -11,7 +11,7 @@ module.exports = `
     title
     fieldIntroText
     entityId
-    secondSetOfEvents: reverseFieldListingNode(limit: 500, filter: {conditions: [{field: "status", value: "1", operator: EQUAL}, {field: "type", value: "event"}]}, sort: {field: "changed", direction: DESC}) {
+    pastEvents: reverseFieldListingNode(limit: 500, filter: {conditions: [{field: "status", value: "1", operator: EQUAL}, {field: "type", value: "event"}]}, sort: {field: "changed", direction: DESC}) {
           entities {
             ... on NodeEvent {
               title

--- a/src/site/stages/build/drupal/health-care-region.js
+++ b/src/site/stages/build/drupal/health-care-region.js
@@ -24,6 +24,64 @@ function sortServices(sortItem) {
     .value();
 }
 
+// Creates the past-events listing pages
+function createPastEventListPages(page, drupalPagePath, files) {
+  const sidebar = page.facilitySidebar;
+  // Events listing page
+  const allEvents = page.secondSetOfEvents;
+
+  // store past & current events
+  const pastEventTeasers = {
+    entities: [],
+  };
+
+  // separate current events from past events;
+  _.forEach(allEvents.entities, value => {
+    const eventTeaser = value;
+    const startDate = eventTeaser.fieldDate.startDate;
+    const isPast = moment().diff(startDate, 'days');
+    if (isPast >= 1) {
+      pastEventTeasers.entities.push(eventTeaser);
+    }
+  });
+
+  // sort past events into reverse chronological order by start date
+  pastEventTeasers.entities = _.orderBy(
+    pastEventTeasers.entities,
+    ['fieldDate.startDate'],
+    ['desc'],
+  );
+
+  // Past Events listing page
+  const pastEventsEntityUrl = createEntityUrlObj(`${drupalPagePath}`);
+
+  const pastEventsObj = Object.assign(
+    { allEventTeasers: pastEventTeasers },
+    { eventTeasers: pastEventTeasers },
+    { fieldIntroText: page.fieldIntroText },
+    { facilitySidebar: sidebar },
+    { entityUrl: pastEventsEntityUrl },
+    { title: page.title },
+    { alert: page.alert },
+  );
+  const pastEventsPage = updateEntityUrlObj(
+    pastEventsObj,
+    `${drupalPagePath}`,
+    'Past events',
+  );
+  const pastEventsPagePath = pastEventsPage.entityUrl.path;
+  pastEventsPage.regionOrOffice = page.title;
+  pastEventsPage.entityUrl = generateBreadCrumbs(pastEventsPagePath);
+
+  paginatePages(
+    pastEventsPage,
+    files,
+    'allEventTeasers',
+    'event_listing.drupal.liquid',
+    'past-events',
+  );
+}
+
 // Creates the facility pages
 function createHealthCareRegionListPages(page, drupalPagePath, files) {
   const sidebar = page.facilitySidebar;
@@ -161,60 +219,6 @@ function createHealthCareRegionListPages(page, drupalPagePath, files) {
     'news stories',
   );
 
-  // Events listing page
-  const allEvents = page.allEventTeasers;
-
-  // store past & current events
-  const pastEventTeasers = {
-    entities: [],
-  };
-
-  // separate current events from past events;
-  _.forEach(allEvents.entities, value => {
-    const eventTeaser = value;
-    const startDate = eventTeaser.fieldDate.startDate;
-    const isPast = moment().diff(startDate, 'days');
-    if (isPast >= 1) {
-      pastEventTeasers.entities.push(eventTeaser);
-    }
-  });
-
-  // sort past events into reverse chronological order by start date
-  pastEventTeasers.entities = _.orderBy(
-    pastEventTeasers.entities,
-    ['fieldDate.startDate'],
-    ['asc'],
-  );
-
-  // Past Events listing page
-  const pastEventsEntityUrl = createEntityUrlObj(`${drupalPagePath}/events`);
-
-  const pastEventsObj = Object.assign(
-    { allEventTeasers: pastEventTeasers },
-    { eventTeasers: page.eventTeasers },
-    { fieldIntroTextEventsPage: page.fieldIntroTextEventsPage },
-    { facilitySidebar: sidebar },
-    { entityUrl: pastEventsEntityUrl },
-    { title: page.title },
-    { alert: page.alert },
-  );
-  const pastEventsPage = updateEntityUrlObj(
-    pastEventsObj,
-    `${drupalPagePath}/events`,
-    'Past events',
-  );
-  const pastEventsPagePath = pastEventsPage.entityUrl.path;
-  pastEventsPage.regionOrOffice = page.title;
-  pastEventsPage.entityUrl = generateBreadCrumbs(pastEventsPagePath);
-
-  paginatePages(
-    pastEventsPage,
-    files,
-    'allEventTeasers',
-    'event_listing.drupal.liquid',
-    'past-events',
-  );
-
   // Staff bio listing page
   const bioEntityUrl = createEntityUrlObj(drupalPagePath);
   page.allStaffProfiles = {
@@ -329,6 +333,7 @@ function addPager(page, files, field, template, aria) {
 
 module.exports = {
   createHealthCareRegionListPages,
+  createPastEventListPages,
   addGetUpdatesFields,
   addPager,
   sortServices,

--- a/src/site/stages/build/drupal/health-care-region.js
+++ b/src/site/stages/build/drupal/health-care-region.js
@@ -28,7 +28,7 @@ function sortServices(sortItem) {
 function createPastEventListPages(page, drupalPagePath, files) {
   const sidebar = page.facilitySidebar;
   // Events listing page
-  const allEvents = page.secondSetOfEvents;
+  const allEvents = page.pastEvents;
 
   // store past & current events
   const pastEventTeasers = {

--- a/src/site/stages/build/drupal/health-care-region.js
+++ b/src/site/stages/build/drupal/health-care-region.js
@@ -36,8 +36,7 @@ function createPastEventListPages(page, drupalPagePath, files) {
   };
 
   // separate current events from past events;
-  _.forEach(allEvents.entities, value => {
-    const eventTeaser = value;
+  allEvents.entities.forEach(eventTeaser => {
     const startDate = eventTeaser.fieldDate.startDate;
     const isPast = moment().diff(startDate, 'days');
     if (isPast >= 1) {
@@ -53,20 +52,20 @@ function createPastEventListPages(page, drupalPagePath, files) {
   );
 
   // Past Events listing page
-  const pastEventsEntityUrl = createEntityUrlObj(`${drupalPagePath}`);
+  const pastEventsEntityUrl = createEntityUrlObj(drupalPagePath);
 
-  const pastEventsObj = Object.assign(
-    { allEventTeasers: pastEventTeasers },
-    { eventTeasers: pastEventTeasers },
-    { fieldIntroText: page.fieldIntroText },
-    { facilitySidebar: sidebar },
-    { entityUrl: pastEventsEntityUrl },
-    { title: page.title },
-    { alert: page.alert },
-  );
+  const pastEventsObj = {
+    allEventTeasers: pastEventTeasers,
+    eventTeasers: pastEventTeasers,
+    fieldIntroText: page.fieldIntroText,
+    facilitySidebar: sidebar,
+    entityUrl: pastEventsEntityUrl,
+    title: page.title,
+    alert: page.alert,
+  };
   const pastEventsPage = updateEntityUrlObj(
     pastEventsObj,
-    `${drupalPagePath}`,
+    drupalPagePath,
     'Past events',
   );
   const pastEventsPagePath = pastEventsPage.entityUrl.path;

--- a/src/site/stages/build/drupal/metalsmith-drupal.js
+++ b/src/site/stages/build/drupal/metalsmith-drupal.js
@@ -12,6 +12,7 @@ const convertDrupalFilesToLocal = require('./assets');
 const { compilePage, createFileObj } = require('./page');
 const {
   createHealthCareRegionListPages,
+  createPastEventListPages,
   addGetUpdatesFields,
   addPager,
   sortServices,
@@ -89,6 +90,7 @@ function pipeDrupalPagesIntoMetalsmith(contentData, files) {
         addGetUpdatesFields(pageCompiled, pages);
         break;
       case 'event_listing':
+        pageCompiled.pastEventTeasers = pageCompiled.secondSetOfEvents;
         pageCompiled.allEventTeasers = pageCompiled.reverseFieldListingNode;
         addPager(
           pageCompiled,
@@ -146,6 +148,9 @@ function pipeDrupalPagesIntoMetalsmith(contentData, files) {
 
     if (page.entityBundle === 'health_care_region_page') {
       createHealthCareRegionListPages(pageCompiled, drupalPageDir, files);
+    }
+    if (page.entityBundle === 'event_listing') {
+      createPastEventListPages(pageCompiled, drupalPageDir, files);
     }
   }
 

--- a/src/site/stages/build/drupal/metalsmith-drupal.js
+++ b/src/site/stages/build/drupal/metalsmith-drupal.js
@@ -90,7 +90,7 @@ function pipeDrupalPagesIntoMetalsmith(contentData, files) {
         addGetUpdatesFields(pageCompiled, pages);
         break;
       case 'event_listing':
-        pageCompiled.pastEventTeasers = pageCompiled.secondSetOfEvents;
+        pageCompiled.pastEventTeasers = pageCompiled.pastEvents;
         pageCompiled.allEventTeasers = pageCompiled.reverseFieldListingNode;
         addPager(
           pageCompiled,


### PR DESCRIPTION
## Description
Past events pages aren't visible / outputting. This pr restores them. E.g.: `/pittsburgh-health-care/events/past-events` is now visible

## Testing done
Visual

## Screenshots
![image](https://user-images.githubusercontent.com/2404547/78312761-d3bdf180-7522-11ea-972c-bc45cc6e7b7d.png)

## Acceptance criteria
- [x] Go to /pittsburgh-health-care/events/past-events` and visually verify that page is visible, and pager appears at bottom of listing.