### PR TITLE
replace language in request appt page to say afternoon instead of eve…

### DIFF
--- a/src/applications/vaos/components/review/PreferredDates.jsx
+++ b/src/applications/vaos/components/review/PreferredDates.jsx
@@ -7,8 +7,7 @@ function PreferredDates(props) {
       {formatDateLong(selected.date)}
       {selected.optionTime?.toLowerCase() === 'am'
         ? ' in the morning'
-        : ' in the evening'}
-      <br />
+        : ' in the afternoon'}
     </li>
   ));
 

--- a/src/applications/vaos/tests/components/ReviewRequestInfo.unit.spec.jsx
+++ b/src/applications/vaos/tests/components/ReviewRequestInfo.unit.spec.jsx
@@ -19,7 +19,7 @@ const defaultData = {
     selectedDates: [
       {
         date: '2019-11-25',
-        optionTime: 'AM',
+        optionTime: 'PM',
       },
       {
         date: '2019-11-26',
@@ -81,7 +81,7 @@ describe('VAOS <ReviewRequestInfo>', () => {
     });
 
     it('should render preferred date and time section', () => {
-      expect(text).to.contain('November 25, 2019 in the morning');
+      expect(text).to.contain('November 25, 2019 in the afternoon');
     });
 
     it('should render contact details section', () => {
@@ -156,7 +156,7 @@ describe('VAOS <ReviewRequestInfo>', () => {
     });
 
     it('should render preferred date section', () => {
-      expect(text).to.contain('November 25, 2019 in the morning');
+      expect(text).to.contain('November 25, 2019 in the afternoon');
     });
 
     it('should render multiple preferred dates', () => {


### PR DESCRIPTION
## Description
replace language in request appointment page to say "afternoon" instead of "evening"

## Testing done
unit test

## Screenshots
![image](https://user-images.githubusercontent.com/54327023/78378845-8c297b00-759f-11ea-808d-af418807fbe6.png)


## Acceptance criteria
- [ ] the request page will say "afternoon" in the preferred date and time section

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
