### PR TITLE
Fire supported failure event only when we have a parent id

### DIFF
--- a/src/applications/vaos/actions/newAppointment.js
+++ b/src/applications/vaos/actions/newAppointment.js
@@ -292,7 +292,7 @@ export function openFacilityPage(page, uiSchema, schema) {
         facilityId = eligibleFacilities[0].institutionCode;
       }
 
-      if (!eligibleFacilities?.length) {
+      if (parentId && !eligibleFacilities?.length) {
         recordEligibilityFailure('supported-facilities');
       }
 


### PR DESCRIPTION
## Description
We're firing the supported-facilities-failure event too often, because we're not checking to make sure the user has a chose parent facility before checking to see if any child facilities are supported.

## Testing done
Local testing

## Acceptance criteria
- [ ] Event fires at correct times

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
