### PR TITLE
Added CSRF prevention to forms-system

### DIFF
--- a/src/platform/forms-system/src/js/actions.js
+++ b/src/platform/forms-system/src/js/actions.js
@@ -3,6 +3,7 @@ import moment from 'moment';
 import { transformForSubmit } from './helpers';
 import recordEvent from 'platform/monitoring/record-event';
 import { timeFromNow } from './utilities/date';
+import localStorage from 'platform/utilities/storage/localStorage';
 
 export const SET_EDIT_MODE = 'SET_EDIT_MODE';
 export const SET_DATA = 'SET_DATA';
@@ -78,6 +79,8 @@ export function setViewedPages(pageKeys) {
 }
 
 export function submitToUrl(body, submitUrl, trackingPrefix, eventData) {
+  // This item should have been set in any previous API calls
+  const csrfTokenStored = localStorage.getItem('csrfToken');
   return new Promise((resolve, reject) => {
     const req = new XMLHttpRequest();
     req.open('POST', submitUrl);
@@ -128,6 +131,7 @@ export function submitToUrl(body, submitUrl, trackingPrefix, eventData) {
 
     req.setRequestHeader('X-Key-Inflection', 'camel');
     req.setRequestHeader('Content-Type', 'application/json');
+    req.setRequestHeader('X-CSRF-Token', csrfTokenStored);
     req.withCredentials = true;
 
     req.send(body);

--- a/src/platform/forms-system/test/js/actions.unit.spec.js
+++ b/src/platform/forms-system/test/js/actions.unit.spec.js
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
 
+import localStorage from 'platform/utilities/storage/localStorage';
 import {
   setData,
   SET_DATA,
@@ -17,6 +18,14 @@ import {
 } from '../../src/js/actions';
 
 describe('Schemaform actions:', () => {
+  before(() => {
+    sinon.stub(localStorage, 'getItem');
+  });
+
+  after(() => {
+    localStorage.getItem.restore();
+  });
+
   describe('setData', () => {
     it('should return action', () => {
       const data = {};


### PR DESCRIPTION
## Description

This is an addition to the main [PR which added the CSRF token via header](https://github.com/department-of-veterans-affairs/vets-website/pull/12005)

There is a file the `forms-system` that is making direct `XMLHTTPRequest` calls without using the `apiRequest` helper. I decided to refactor them to ensure that the requests are made with a CSRF token.

## Testing done
Locally
