### PR TITLE
Very basic front-loading of profile data

### DIFF
--- a/src/applications/personalization/profile-2/components/ProfileWrapper.jsx
+++ b/src/applications/personalization/profile-2/components/ProfileWrapper.jsx
@@ -1,28 +1,93 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
+import LoadingIndicator from '@department-of-veterans-affairs/formation-react/LoadingIndicator';
 
 import RequiredLoginView from 'platform/user/authorization/components/RequiredLoginView';
 import backendServices from 'platform/user/profile/constants/backendServices';
 
+import {
+  fetchMilitaryInformation as fetchMilitaryInformationAction,
+  fetchHero as fetchHeroAction,
+} from 'applications/personalization/profile360/actions';
+
 import ProfileHeader from './ProfileHeader';
 import ProfileSideNav from './ProfileSideNav';
 
-const ProfileWrapper = ({ children, user }) => (
-  <RequiredLoginView serviceRequired={backendServices.USER_PROFILE} user={user}>
-    <ProfileHeader />
-    <div className="usa-grid usa-grid-full">
-      <div className="usa-width-one-fourth">
-        <ProfileSideNav />
-      </div>
-      <div className="usa-width-three-fourths">{children}</div>
+const ProfileWrapper = ({
+  children,
+  fetchFullName,
+  fetchMilitaryInformation,
+  showLoader,
+  user,
+}) => {
+  useEffect(
+    () => {
+      fetchMilitaryInformation();
+      fetchFullName();
+    },
+    [fetchMilitaryInformation, fetchFullName],
+  );
+
+  // content to show if the component is waiting for data to load
+  const loadingContent = (
+    <div className="vads-u-margin-y--5">
+      <LoadingIndicator setFocus message="Loading your information..." />
     </div>
-  </RequiredLoginView>
-);
+  );
 
-const mapStateToProps = state => ({
-  user: state.user,
-});
+  // content to show after data has loaded
+  // note that `children` will be passed in via React Router.
+  const mainContent = (
+    <>
+      <ProfileHeader />
+      <div className="usa-grid usa-grid-full">
+        <div className="usa-width-one-fourth">
+          <ProfileSideNav />
+        </div>
+        <div className="usa-width-three-fourths">{children}</div>
+      </div>
+    </>
+  );
 
-export { ProfileWrapper };
+  const renderContent = () => {
+    if (showLoader) {
+      return loadingContent;
+    }
+    return mainContent;
+  };
 
-export default connect(mapStateToProps)(ProfileWrapper);
+  return (
+    <RequiredLoginView
+      serviceRequired={backendServices.USER_PROFILE}
+      user={user}
+    >
+      {renderContent()}
+    </RequiredLoginView>
+  );
+};
+
+const mapStateToProps = state => {
+  // this piece of state will be set if the call to load military info succeeds or fails
+  const hasLoadedMilitaryInformation =
+    state.vaProfile?.militaryInformation?.serviceHistory;
+  // this piece of state will be set if the call to load name info succeeds or fails
+  const hasLoadedFullName = state.vaProfile?.hero?.userFullName;
+  const isLoading = !hasLoadedMilitaryInformation || !hasLoadedFullName;
+
+  return {
+    user: state.user,
+    showLoader: isLoading,
+  };
+};
+
+const mapDispatchToProps = {
+  fetchMilitaryInformation: fetchMilitaryInformationAction,
+  fetchFullName: fetchHeroAction,
+};
+
+export { ProfileWrapper, mapStateToProps };
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(ProfileWrapper);

--- a/src/applications/personalization/profile-2/tests/components/ProfileWrapper.unit.spec.js
+++ b/src/applications/personalization/profile-2/tests/components/ProfileWrapper.unit.spec.js
@@ -1,0 +1,63 @@
+// import React from 'react';
+// import { shallow } from 'enzyme';
+import { expect } from 'chai';
+// import sinon from 'sinon';
+
+// import backendServices from 'platform/user/profile/constants/backendServices';
+// import RequiredLoginView from 'platform/user/authorization/components/RequiredLoginView';
+
+import {
+  // ProfileWrapper,
+  mapStateToProps,
+} from '../../components/ProfileWrapper';
+
+// These component tests are all throwing `Invariant Violation: Invalid hook
+// call` errors so they are disabled for now.
+
+// describe('ProfileWrapper', () => {
+//   let wrapper;
+//   const fetchMilitaryInfoSpy = sinon.spy();
+//   const fetchFullNameSpy = sinon.spy();
+
+//   beforeEach(() => {
+//     const defaultProps = {
+//       user: {},
+//       showLoader: false,
+//       fetchFullName: fetchFullNameSpy,
+//       fetchMilitaryInformation: fetchMilitaryInfoSpy,
+//     };
+
+//     wrapper = shallow(<ProfileWrapper {...defaultProps} />);
+//   });
+
+//   afterEach(() => {
+//     wrapper.unmount();
+//   });
+
+//   it('renders a RequiredLoginView component that requires the USER_PROFILE', () => {
+//     expect(wrapper.type()).to.equal(RequiredLoginView);
+//     expect(wrapper.prop('serviceRequired')).to.equal(
+//       backendServices.USER_PROFILE,
+//     );
+//   });
+//   it('should render a spinner if it is loading data', () => {
+//     wrapper.setProps({ showLoader: true });
+//     const loader = wrapper.find('LoadingIndicator');
+//     expect(loader.length).to.equal(1);
+//   });
+//   it('loads the military information data when it mounts', () => {
+//     expect(fetchMilitaryInfoSpy.called).to.be.true;
+//   });
+//   it('loads the full name data when it mounts', () => {
+//     expect(fetchFullNameSpy.called).to.be.true;
+//   });
+// });
+
+describe('mapStateToProps', () => {
+  it('returns an object with the correct keys', () => {
+    const state = {};
+    const props = mapStateToProps(state);
+    const expectedKeys = ['user', 'showLoader'];
+    expect(Object.keys(props)).to.deep.equal(expectedKeys);
+  });
+});


### PR DESCRIPTION
## Description
This PR expands the ProfileWrapper component to load military history and the Vet's full name on load. This way child components like ProfileHeader and MilitaryInformation can simply pull the data out of Redux without making API calls themselves.

There is still much to do: conditionally load direct deposit payment info, test the mapStateToProps, get the component unit tests to work, etc

## Testing done
Local. 

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs