### PR TITLE
Add path started events and tests

### DIFF
--- a/src/applications/vaos/actions/newAppointment.js
+++ b/src/applications/vaos/actions/newAppointment.js
@@ -186,12 +186,10 @@ export function startDirectScheduleFlow(appointments) {
 }
 
 export function startRequestAppointmentFlow(isCommunityCare) {
-  const event = `vaos-${
-    isCommunityCare ? 'community-care' : 'request'
-  }-path-started`;
-
   recordEvent({
-    event,
+    event: `vaos-${
+      isCommunityCare ? 'community-care' : 'request'
+    }-path-started`,
   });
 
   return {

--- a/src/applications/vaos/actions/newAppointment.js
+++ b/src/applications/vaos/actions/newAppointment.js
@@ -177,13 +177,23 @@ export function updateFacilityType(facilityType) {
 }
 
 export function startDirectScheduleFlow(appointments) {
+  recordEvent({ event: 'vaos-direct-path-started' });
+
   return {
     type: START_DIRECT_SCHEDULE_FLOW,
     appointments,
   };
 }
 
-export function startRequestAppointmentFlow() {
+export function startRequestAppointmentFlow(isCommunityCare) {
+  const event = `vaos-${
+    isCommunityCare ? 'community-care' : 'request'
+  }-path-started`;
+
+  recordEvent({
+    event,
+  });
+
   return {
     type: START_REQUEST_APPOINTMENT_FLOW,
   };

--- a/src/applications/vaos/newAppointmentFlow.js
+++ b/src/applications/vaos/newAppointmentFlow.js
@@ -108,6 +108,7 @@ export default {
                 // If CC enabled systems and toc is podiatry, skip typeOfFacility
                 if (isPodiatry(state)) {
                   dispatch(updateFacilityType(FACILITY_TYPES.COMMUNITY_CARE));
+                  dispatch(startRequestAppointmentFlow(true));
                   return 'requestDateTime';
                 }
                 return 'typeOfFacility';
@@ -135,12 +136,13 @@ export default {
   },
   typeOfFacility: {
     url: '/new-appointment/choose-facility-type',
-    next(state) {
+    next(state, dispatch) {
       if (isCCAudiology(state)) {
         return 'audiologyCareType';
       }
 
       if (isCCFacility(state)) {
+        dispatch(startRequestAppointmentFlow(true));
         return 'requestDateTime';
       }
 
@@ -204,7 +206,10 @@ export default {
   },
   audiologyCareType: {
     url: '/new-appointment/audiology',
-    next: 'requestDateTime',
+    next(state, dispatch) {
+      dispatch(startRequestAppointmentFlow(true));
+      return 'requestDateTime';
+    },
     previous: 'typeOfFacility',
   },
   ccPreferences: {
@@ -244,7 +249,7 @@ export default {
       }
 
       if (eligibilityStatus.request) {
-        dispatch(startRequestAppointmentFlow());
+        dispatch(startRequestAppointmentFlow(isCCFacility(state)));
         return 'requestDateTime';
       }
 
@@ -274,7 +279,7 @@ export default {
     previous: 'vaFacility',
     next(state, dispatch) {
       if (getFormData(state).clinicId === 'NONE') {
-        dispatch(startRequestAppointmentFlow());
+        dispatch(startRequestAppointmentFlow(isCCFacility(state)));
         return 'requestDateTime';
       }
 
@@ -328,7 +333,7 @@ export default {
 
       return 'visitType';
     },
-    previous(state) {
+    previous(state, dispatch) {
       if (isCCFacility(state)) {
         return 'ccPreferences';
       }
@@ -337,6 +342,7 @@ export default {
         return 'selectDateTime';
       }
 
+      dispatch(startRequestAppointmentFlow());
       return 'requestDateTime';
     },
   },

--- a/src/applications/vaos/newAppointmentFlow.js
+++ b/src/applications/vaos/newAppointmentFlow.js
@@ -249,7 +249,7 @@ export default {
       }
 
       if (eligibilityStatus.request) {
-        dispatch(startRequestAppointmentFlow(isCCFacility(state)));
+        dispatch(startRequestAppointmentFlow());
         return 'requestDateTime';
       }
 
@@ -279,7 +279,7 @@ export default {
     previous: 'vaFacility',
     next(state, dispatch) {
       if (getFormData(state).clinicId === 'NONE') {
-        dispatch(startRequestAppointmentFlow(isCCFacility(state)));
+        dispatch(startRequestAppointmentFlow());
         return 'requestDateTime';
       }
 
@@ -333,7 +333,7 @@ export default {
 
       return 'visitType';
     },
-    previous(state, dispatch) {
+    previous(state) {
       if (isCCFacility(state)) {
         return 'ccPreferences';
       }
@@ -342,7 +342,6 @@ export default {
         return 'selectDateTime';
       }
 
-      dispatch(startRequestAppointmentFlow());
       return 'requestDateTime';
     },
   },

--- a/src/applications/vaos/tests/actions/newAppointment.unit.spec.js
+++ b/src/applications/vaos/tests/actions/newAppointment.unit.spec.js
@@ -24,6 +24,8 @@ import {
   onCalendarChange,
   hideTypeOfCareUnavailableModal,
   startNewAppointmentFlow,
+  startDirectScheduleFlow,
+  startRequestAppointmentFlow,
   requestAppointmentDateChoice,
   FORM_PAGE_OPENED,
   FORM_DATA_UPDATED,
@@ -55,6 +57,7 @@ import {
   FORM_CALENDAR_DATA_CHANGED,
   FORM_HIDE_TYPE_OF_CARE_UNAVAILABLE_MODAL,
   START_REQUEST_APPOINTMENT_FLOW,
+  START_DIRECT_SCHEDULE_FLOW,
 } from '../../actions/newAppointment';
 import {
   FORM_SUBMIT_SUCCEEDED,
@@ -812,6 +815,31 @@ describe('VAOS newAppointment actions', () => {
       );
 
       expect(action.type).to.equal(FORM_REASON_FOR_APPOINTMENT_CHANGED);
+    });
+  });
+
+  describe('startDirectScheduleFlow', () => {
+    it('should return START_DIRECT_SCHEDULE_FLOW action and record direct schedule event', () => {
+      const action = startDirectScheduleFlow();
+      expect(action.type).to.equal(START_DIRECT_SCHEDULE_FLOW);
+      const dataLayer = global.window.dataLayer;
+      expect(dataLayer[0].event).to.equal('vaos-direct-path-started');
+    });
+  });
+
+  describe('startRequsetAppointmentFlow', () => {
+    it('should return START_REQUEST_APPOINTMENT_FLOW action and expected record request event if isCommunityCare === true', () => {
+      const action = startRequestAppointmentFlow(true);
+      expect(action.type).to.equal(START_REQUEST_APPOINTMENT_FLOW);
+      const dataLayer = global.window.dataLayer;
+      expect(dataLayer[0].event).to.equal('vaos-community-care-path-started');
+    });
+
+    it('should return START_REQUEST_APPOINTMENT_FLOW action and record expected request event if isCommunityCare === false', () => {
+      const action = startRequestAppointmentFlow();
+      expect(action.type).to.equal(START_REQUEST_APPOINTMENT_FLOW);
+      const dataLayer = global.window.dataLayer;
+      expect(dataLayer[0].event).to.equal('vaos-request-path-started');
     });
   });
 

--- a/src/applications/vaos/tests/actions/newAppointment.unit.spec.js
+++ b/src/applications/vaos/tests/actions/newAppointment.unit.spec.js
@@ -827,7 +827,7 @@ describe('VAOS newAppointment actions', () => {
     });
   });
 
-  describe('startRequsetAppointmentFlow', () => {
+  describe('startRequestAppointmentFlow', () => {
     it('should return START_REQUEST_APPOINTMENT_FLOW action and expected record request event if isCommunityCare === true', () => {
       const action = startRequestAppointmentFlow(true);
       expect(action.type).to.equal(START_REQUEST_APPOINTMENT_FLOW);

--- a/src/applications/vaos/tests/newAppointmentFlow.unit.spec.js
+++ b/src/applications/vaos/tests/newAppointmentFlow.unit.spec.js
@@ -256,8 +256,16 @@ describe('VAOS newAppointmentFlow', () => {
           },
         };
 
-        const nextState = newAppointmentFlow.typeOfFacility.next(state);
+        const dispatch = sinon.spy();
+
+        const nextState = newAppointmentFlow.typeOfFacility.next(
+          state,
+          dispatch,
+        );
         expect(nextState).to.equal('requestDateTime');
+        expect(dispatch.firstCall.args[0].type).to.equal(
+          'newAppointment/START_REQUEST_APPOINTMENT_FLOW',
+        );
       });
 
       it('should be vaFacility page if they chose VA', () => {
@@ -760,11 +768,17 @@ describe('VAOS newAppointmentFlow', () => {
           },
         };
 
+        const dispatch = sinon.spy();
+
         const nextState = newAppointmentFlow.reasonForAppointment.previous(
           state,
+          dispatch,
         );
 
         expect(nextState).to.equal('requestDateTime');
+        expect(dispatch.firstCall.args[0].type).to.equal(
+          'newAppointment/START_REQUEST_APPOINTMENT_FLOW',
+        );
       });
     });
   });

--- a/src/applications/vaos/tests/newAppointmentFlow.unit.spec.js
+++ b/src/applications/vaos/tests/newAppointmentFlow.unit.spec.js
@@ -768,17 +768,11 @@ describe('VAOS newAppointmentFlow', () => {
           },
         };
 
-        const dispatch = sinon.spy();
-
-        const nextState = newAppointmentFlow.reasonForAppointment.previous(
+        const prevState = newAppointmentFlow.reasonForAppointment.previous(
           state,
-          dispatch,
         );
 
-        expect(nextState).to.equal('requestDateTime');
-        expect(dispatch.firstCall.args[0].type).to.equal(
-          'newAppointment/START_REQUEST_APPOINTMENT_FLOW',
-        );
+        expect(prevState).to.equal('requestDateTime');
       });
     });
   });

--- a/src/applications/vaos/tests/newAppointmentFlow.unit.spec.js
+++ b/src/applications/vaos/tests/newAppointmentFlow.unit.spec.js
@@ -768,11 +768,11 @@ describe('VAOS newAppointmentFlow', () => {
           },
         };
 
-        const prevState = newAppointmentFlow.reasonForAppointment.previous(
+        const nextState = newAppointmentFlow.reasonForAppointment.previous(
           state,
         );
 
-        expect(prevState).to.equal('requestDateTime');
+        expect(nextState).to.equal('requestDateTime');
       });
     });
   });


### PR DESCRIPTION
## Description
Add events to "flow started" actions so we can calculate conversion rates more easily for GA Dashboard

## Testing done
Local and unit

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
