### PR TITLE
VACMS-1166: Updating introtext field query on page type.

### DIFF
--- a/src/site/layouts/page.drupal.liquid
+++ b/src/site/layouts/page.drupal.liquid
@@ -20,9 +20,11 @@
 
       <article class="usa-content">
         <h1>{{ title }}</h1>
-        <div class="va-introtext">
-          <p>{{ fieldIntroText }}</p>
-        </div>
+        {% if fieldIntroTextLimitedHtml.processed %}
+          <div class="va-introtext">
+            <p>{{ fieldIntroTextLimitedHtml.processed }}</p>
+          </div>
+        {% endif %}
         {% if fieldAlert.length %}
           {% for alert in fieldAlert %}
             {% if alert.entity != empty %}

--- a/src/site/stages/build/drupal/graphql/page.graphql.js
+++ b/src/site/stages/build/drupal/graphql/page.graphql.js
@@ -28,7 +28,9 @@ module.exports = `
 
   fragment page on NodePage {
     ${entityElementsFromPages}
-    fieldIntroText
+    fieldIntroTextLimitedHtml {
+      processed
+    }
     fieldDescription
     fieldFeaturedContent {
       entity {


### PR DESCRIPTION
## Description
Replaces old plain text drupal field with a new wysiwyg drupal field.

## Testing done
Visual

## Screenshots
fieldIntroTextLimitedHtml.processed
![image](https://user-images.githubusercontent.com/2404547/78599027-5e059e80-781e-11ea-80c4-70f5fcdc454d.png)

## Acceptance criteria
- [ ] Go to `coronavirus-veteran-frequently-asked-questions/` and visually verify that intro text beginning with "Our call centers and some VA health facilities are currently" appears at top of page.