### PR TITLE
Mojaray2k Review Page reorder supplies 6157

### DIFF
--- a/src/applications/disability-benefits/2346/components/SelectArrayItemsAccessoriesWidget.jsx
+++ b/src/applications/disability-benefits/2346/components/SelectArrayItemsAccessoriesWidget.jsx
@@ -68,6 +68,7 @@ class SelectArrayItemsAccessoriesWidget extends Component {
                 name={supply.productId}
                 type="checkbox"
                 onChange={this.handleChecked}
+                checked={selectedItems.includes(supply.productId)}
               />
               <label htmlFor={supply.productId} className="main">
                 Order accessoires for this device


### PR DESCRIPTION
## Description
As a veteran , I need the ability to see what I have ordered so I can be sure I ordered what I need before placing order. the eligibility, item number, and reorder date is data provided by Reorder API

## Testing done
The Review page will have all the items the Veteran ordered in previous pages allowing the Veteran to see what they are ordering before placing order.

## Screenshots
![Cursor_and_Request_for_hearing_aid_batteries_and_accessories___Veterans_Affairs_and_Comparing_master___mojaray2k-review-page-reorder-supplies-6157_·_department-of-veterans-affairs_vets-website](https://user-images.githubusercontent.com/875558/78602547-a45dfc00-7824-11ea-9ec4-47bd30100f0b.png)


## Acceptance criteria
- [ ] User should see selected Items from either the supplies or accessories pages
- [ ] User should be able to update either the supplies or accessories pages

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
