### PR TITLE
7689-hide-unauthed-start-link

### DIFF
--- a/src/applications/disability-benefits/686c-674/containers/IntroductionPage.jsx
+++ b/src/applications/disability-benefits/686c-674/containers/IntroductionPage.jsx
@@ -16,6 +16,7 @@ class IntroductionPage extends React.Component {
         <FormTitle title="New 686" />
         <p>qual to VA Form 21-686 (New 686).</p>
         <SaveInProgressIntro
+          hideUnauthedStartLink
           prefillEnabled={this.props.route.formConfig.prefillEnabled}
           messages={this.props.route.formConfig.savedFormMessages}
           pageList={this.props.route.pageList}


### PR DESCRIPTION
## Description
[Original Ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/7689)

This pull request hides the unauthenticated start link for the 686c-674 by passing the `hideUnauthedStartLink` prop to `<SaveInProgressIntro />`

## Testing done
- local

## Screenshots
<img width="685" alt="Screen Shot 2020-04-06 at 3 00 55 PM" src="https://user-images.githubusercontent.com/15097156/78609538-b7b69a80-7817-11ea-800f-0bb402c7e4f7.png">


## Acceptance criteria
- [x] the link has been hidden.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
