### PR TITLE
Check for expired session before showing alert

### DIFF
--- a/src/applications/vaos/containers/NewAppointmentLayout.jsx
+++ b/src/applications/vaos/containers/NewAppointmentLayout.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { Link } from 'react-router';
+import localStorage from 'platform/utilities/storage/localStorage';
 import Breadcrumbs from '../components/Breadcrumbs';
 import NeedHelp from '../components/NeedHelp';
 import { selectIsCernerOnlyPatient } from 'platform/user/selectors';
@@ -39,9 +40,15 @@ export class NewAppointmentLayout extends React.Component {
   }
 
   onBeforeUnload = e => {
-    e.preventDefault();
-    e.returnValue =
-      'Are you sure you wish to leave this application? All progress will be lost.';
+    const expirationDate = localStorage.getItem('sessionExpiration');
+
+    // If there's no expiration date, then the session has already expired
+    // and keeping a person on the form won't save their data
+    if (expirationDate) {
+      e.preventDefault();
+      e.returnValue =
+        'Are you sure you wish to leave this application? All progress will be lost.';
+    }
   };
 
   removeBeforeUnloadHook = () => {


### PR DESCRIPTION
## Description
This updates our unload event to only show if the session hasn't expired. Because if it has, then the user is going to lose their data no matter what.

## Testing done
Local testing

## Acceptance criteria
- [ ] Unload alert doesn't show when no session expiration

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
