### PR TITLE
[CODEOWNERS] Break up vsa-frontend into vsa teams

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -43,5 +43,6 @@ src/platform/user/profile/vet360 @department-of-veterans-affairs/vsa-caregiver-f
 src/applications/vaos @department-of-veterans-affairs/vfs-vaos
 
 # Booz Allen Team
+src/applications/static-pages/school-resources @department-of-veterans-affairs/bah-code-reviewers
 src/applications/gi @department-of-veterans-affairs/bah-code-reviewers
 src/applications/edu-benefits/1995 @department-of-veterans-affairs/bah-code-reviewers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -27,6 +27,7 @@ src/applications/personalization/view-dependents @department-of-veterans-affairs
 # Public Websites
 src/applications/proxy-rewrite/redirects/crossDomainRedirects.json @department-of-veterans-affairs/vsa-public-websites-frontend @department-of-veterans-affairs/frontend-review-group
 src/platform/site-wide @department-of-veterans-affairs/vsa-public-websites-frontend @department-of-veterans-affairs/frontend-review-group
+src/applications/static-pages @department-of-veterans-affairs/vsa-public-websites-frontend @department-of-veterans-affairs/frontend-review-group
 src/applications/find-forms @department-of-veterans-affairs/vsa-public-websites-frontend @department-of-veterans-affairs/vsa-facilities-frontend @department-of-veterans-affairs/vsa-caregiver-frontend
 src/applications/yellow-ribbon @department-of-veterans-affairs/vsa-public-websites-frontend @department-of-veterans-affairs/vsa-facilities-frontend @department-of-veterans-affairs/vsa-caregiver-frontend
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,20 +5,40 @@
 
 *       @department-of-veterans-affairs/frontend-review-group
 
-# VSA
-src/applications/proxy-rewrite/redirects/crossDomainRedirects.json @department-of-veterans-affairs/vsa-frontend
-src/applications/find-forms @department-of-veterans-affairs/vsa-frontend
-src/platform/site-wide @department-of-veterans-affairs/vsa-frontend
-src/applications/yellow-ribbon @department-of-veterans-affairs/vsa-frontend
-src/applications/personalization @department-of-veterans-affairs/vsa-frontend
-src/applications/letters @department-of-veterans-affairs/vsa-frontend
-src/applications/disability-benefits @department-of-veterans-affairs/vsa-frontend
-src/platform/user/profile/vet360 @department-of-veterans-affairs/vsa-frontend
+# VSA ----
+
+# Authenticated Experience
+src/applications/personalization @department-of-veterans-affairs/vsa-authd-exp-frontend @department-of-veterans-affairs/vsa-ebenefits-frontend
+src/platform/user/profile/vet360 @department-of-veterans-affairs/vsa-authd-exp-frontend @department-of-veterans-affairs/frontend-review-group
+
+# Benefits and Memorials
+src/applications/letters @department-of-veterans-affairs/vsa-bam-1-frontend @department-of-veterans-affairs/vsa-authd-exp-frontend
+src/applications/disability-benefits @department-of-veterans-affairs/vsa-bam-1-frontend @department-of-veterans-affairs/vsa-ebenefits-frontend
+
+# Benefits and Memorials 2
+src/applications/disability-benefits/2346 @department-of-veterans-affairs/vsa-bam-2-frontend @department-of-veterans-affairs/vsa-bam-1-frontend @department-of-veterans-affairs/vsa-caregiver-frontend @department-of-veterans-affairs/vsa-ebenefits-frontend
+
+# eBenefits
+src/applications/disability-benefits/686 @department-of-veterans-affairs/vsa-ebenefits-frontend @department-of-veterans-affairs/vsa-bam-1-frontend
+src/applications/disability-benefits/686c-674 @department-of-veterans-affairs/vsa-ebenefits-frontend @department-of-veterans-affairs/vsa-bam-1-frontend
+
+# Public Websites
+src/applications/proxy-rewrite/redirects/crossDomainRedirects.json @department-of-veterans-affairs/vsa-public-websites-frontend
+src/platform/site-wide @department-of-veterans-affairs/vsa-public-websites-frontend @department-of-veterans-affairs/frontend-review-group
+src/applications/find-forms @department-of-veterans-affairs/vsa-public-websites-frontend @department-of-veterans-affairs/vsa-facilities-frontend @department-of-veterans-affairs/vsa-caregiver-frontend
+src/applications/yellow-ribbon @department-of-veterans-affairs/vsa-public-websites-frontend @department-of-veterans-affairs/vsa-facilities-frontend @department-of-veterans-affairs/vsa-caregiver-frontend
+
+# Facility Locator
+src/applications/facility-locator @department-of-veterans-affairs/vsa-facilities-frontend @department-of-veterans-affairs/vsa-public-websites-frontend
+
+# Caregiver
+src/platform/user/profile/vet360 @department-of-veterans-affairs/vsa-caregiver-frontend @department-of-veterans-affairs/vsa-bam-1-frontend
+
+# ---/VSA
 
 # Other
 src/applications/vaos @department-of-veterans-affairs/vfs-vaos
-# Facilities team
-src/applications/facility-locator @department-of-veterans-affairs/facility-locator-frontend
+
 # Booz Allen Team
 src/applications/gi @department-of-veterans-affairs/bah-code-reviewers
 src/applications/edu-benefits/1995 @department-of-veterans-affairs/bah-code-reviewers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -37,7 +37,7 @@ src/applications/facility-locator @department-of-veterans-affairs/vsa-facilities
 # Caregiver
 src/platform/user/profile/vet360 @department-of-veterans-affairs/vsa-caregiver-frontend @department-of-veterans-affairs/vsa-bam-1-frontend
 
-# ---/VSA
+# /--- VSA
 
 # Other
 src/applications/vaos @department-of-veterans-affairs/vfs-vaos

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -35,7 +35,7 @@ src/applications/yellow-ribbon @department-of-veterans-affairs/vsa-public-websit
 src/applications/facility-locator @department-of-veterans-affairs/vsa-facilities-frontend @department-of-veterans-affairs/vsa-public-websites-frontend
 
 # Caregiver
-src/platform/user/profile/vet360 @department-of-veterans-affairs/vsa-caregiver-frontend @department-of-veterans-affairs/vsa-bam-1-frontend
+src/applications/caregivers @department-of-veterans-affairs/vsa-caregiver-frontend @department-of-veterans-affairs/vsa-bam-1-frontend
 
 # /--- VSA
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -21,6 +21,8 @@ src/applications/disability-benefits/2346 @department-of-veterans-affairs/vsa-ba
 # eBenefits
 src/applications/disability-benefits/686 @department-of-veterans-affairs/vsa-ebenefits-frontend @department-of-veterans-affairs/vsa-bam-1-frontend
 src/applications/disability-benefits/686c-674 @department-of-veterans-affairs/vsa-ebenefits-frontend @department-of-veterans-affairs/vsa-bam-1-frontend
+src/applications/personalization/rated-disabilities @department-of-veterans-affairs/vsa-ebenefits-frontend @department-of-veterans-affairs/vsa-authd-exp-frontend
+src/applications/personalization/view-dependents @department-of-veterans-affairs/vsa-ebenefits-frontend @department-of-veterans-affairs/vsa-authd-exp-frontend
 
 # Public Websites
 src/applications/proxy-rewrite/redirects/crossDomainRedirects.json @department-of-veterans-affairs/vsa-public-websites-frontend @department-of-veterans-affairs/frontend-review-group

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -23,7 +23,7 @@ src/applications/disability-benefits/686 @department-of-veterans-affairs/vsa-ebe
 src/applications/disability-benefits/686c-674 @department-of-veterans-affairs/vsa-ebenefits-frontend @department-of-veterans-affairs/vsa-bam-1-frontend
 
 # Public Websites
-src/applications/proxy-rewrite/redirects/crossDomainRedirects.json @department-of-veterans-affairs/vsa-public-websites-frontend
+src/applications/proxy-rewrite/redirects/crossDomainRedirects.json @department-of-veterans-affairs/vsa-public-websites-frontend @department-of-veterans-affairs/frontend-review-group
 src/platform/site-wide @department-of-veterans-affairs/vsa-public-websites-frontend @department-of-veterans-affairs/frontend-review-group
 src/applications/find-forms @department-of-veterans-affairs/vsa-public-websites-frontend @department-of-veterans-affairs/vsa-facilities-frontend @department-of-veterans-affairs/vsa-caregiver-frontend
 src/applications/yellow-ribbon @department-of-veterans-affairs/vsa-public-websites-frontend @department-of-veterans-affairs/vsa-facilities-frontend @department-of-veterans-affairs/vsa-caregiver-frontend


### PR DESCRIPTION
## Description
This PR breaks apart the single `vsa-frontend` group used in the `codeowners` file into the individual VSA teams that own each tool/directory. It also attempts to designate backup reviewers for each directory.

## Testing done
N/A

## Screenshots
N/A

## Acceptance criteria
- [ ] Pull requests merge permissions are more granular

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
