### PR TITLE
Kelsonic 7642 a11y find yr results

### DIFF
--- a/src/applications/yellow-ribbon/actions/index.js
+++ b/src/applications/yellow-ribbon/actions/index.js
@@ -3,27 +3,11 @@ import URLSearchParams from 'url-search-params';
 // Relative imports.
 import { fetchResultsApi } from '../api';
 import {
-  ADD_SCHOOL_TO_COMPARE,
   FETCH_RESULTS,
   FETCH_RESULTS_FAILURE,
   FETCH_RESULTS_SUCCESS,
-  REMOVE_SCHOOL_FROM_COMPARE,
   TOGGLE_SHOW_MOBILE_FORM,
-  UPDATE_PAGE,
 } from '../constants';
-
-// ============
-// Add/Remove School from comparison
-// ============
-export const addSchoolToCompareAction = school => ({
-  school,
-  type: ADD_SCHOOL_TO_COMPARE,
-});
-
-export const removeSchoolFromCompareAction = school => ({
-  school,
-  type: REMOVE_SCHOOL_FROM_COMPARE,
-});
 
 // ============
 // Fetch Results (via API)
@@ -41,14 +25,6 @@ export const fetchResultsFailure = error => ({
 export const fetchResultsSuccess = response => ({
   response,
   type: FETCH_RESULTS_SUCCESS,
-});
-
-// ============
-// Update page
-// ============
-export const updatePageAction = page => ({
-  page,
-  type: UPDATE_PAGE,
 });
 
 // ============

--- a/src/applications/yellow-ribbon/actions/index.unit.spec.js
+++ b/src/applications/yellow-ribbon/actions/index.unit.spec.js
@@ -7,13 +7,11 @@ import {
   fetchResultsFailure,
   fetchResultsSuccess,
   fetchResultsThunk,
-  addSchoolToCompareAction,
 } from './index';
 import {
   FETCH_RESULTS,
   FETCH_RESULTS_FAILURE,
   FETCH_RESULTS_SUCCESS,
-  ADD_SCHOOL_TO_COMPARE,
 } from '../constants';
 
 describe('Yellow Ribbon actions', () => {
@@ -55,21 +53,6 @@ describe('Yellow Ribbon actions', () => {
       expect(action).to.be.deep.equal({
         response,
         type: FETCH_RESULTS_SUCCESS,
-      });
-    });
-  });
-
-  describe('addSchoolToCompareAction', () => {
-    it('should return an action in the shape we expect', () => {
-      const school = {
-        id: 'asdf',
-        name: 'qwer',
-      };
-      const action = addSchoolToCompareAction(school);
-
-      expect(action).to.be.deep.equal({
-        school,
-        type: ADD_SCHOOL_TO_COMPARE,
       });
     });
   });

--- a/src/applications/yellow-ribbon/actions/index.unit.spec.js
+++ b/src/applications/yellow-ribbon/actions/index.unit.spec.js
@@ -7,14 +7,12 @@ import {
   fetchResultsFailure,
   fetchResultsSuccess,
   fetchResultsThunk,
-  updatePageAction,
   addSchoolToCompareAction,
 } from './index';
 import {
   FETCH_RESULTS,
   FETCH_RESULTS_FAILURE,
   FETCH_RESULTS_SUCCESS,
-  UPDATE_PAGE,
   ADD_SCHOOL_TO_COMPARE,
 } from '../constants';
 
@@ -72,18 +70,6 @@ describe('Yellow Ribbon actions', () => {
       expect(action).to.be.deep.equal({
         school,
         type: ADD_SCHOOL_TO_COMPARE,
-      });
-    });
-  });
-
-  describe('updatePageAction', () => {
-    it('should return an action in the shape we expect', () => {
-      const page = 1;
-      const action = updatePageAction(page);
-
-      expect(action).to.be.deep.equal({
-        page,
-        type: UPDATE_PAGE,
       });
     });
   });

--- a/src/applications/yellow-ribbon/components/FindYellowRibbonPage/index.js
+++ b/src/applications/yellow-ribbon/components/FindYellowRibbonPage/index.js
@@ -1,90 +1,79 @@
 // Node modules.
 import React from 'react';
-import Breadcrumbs from '@department-of-veterans-affairs/formation-react/Breadcrumbs';
 // Relative imports.
 import SearchForm from '../../containers/SearchForm';
 import SearchResults from '../../containers/SearchResults';
-import manifest from '../../manifest.json';
 
 export const FindYellowRibbonPage = () => (
-  <>
-    {/* Breadcrumbs */}
-    <Breadcrumbs className="vads-u-padding--1p5 medium-screen:vads-u-pading--0">
-      <a href="/">Home</a>
-      <a href="/education/">Education and training</a>
-      <a href={manifest.rootUrl}>Find a Yellow Ribbon school</a>
-    </Breadcrumbs>
+  <div className="vads-l-grid-container vads-u-padding-x--2p5 vads-u-padding-bottom--4">
+    {/* Title */}
+    <h1 className="vads-u-margin-bottom--0">Find a Yellow Ribbon school</h1>
 
-    <div className="vads-l-grid-container vads-u-padding-x--2p5 vads-u-padding-bottom--4">
-      {/* Title */}
-      <h1 className="vads-u-margin-bottom--0">Find a Yellow Ribbon school</h1>
-
-      <div className="vads-l-row">
-        {/* Search Form */}
-        <div className="vads-l-col--12">
-          {/* Pre-form content */}
-          <p className="vads-l-col--12 medium-screen:vads-l-col--7">
-            Find out if your school participates in the Yellow Ribbon program.
-            If you already have Post-9/11 GI Bill benefits, the Yellow Ribbon
-            program can help pay for higher out-of-state, private school, or
-            graduate school tuition. The amount of money you get varies by
-            school, degree type, and the program you&apos;re enrolled in.
-          </p>
-
-          <a href="/education/about-gi-bill-benefits/post-9-11/yellow-ribbon-program/">
-            Find out if you qualify for the Yellow Ribbon Program.
-          </a>
-
-          <p>
-            If you don&apos;t already have Post-9/11 GI Bill benefits, you can:
-          </p>
-
-          <ul>
-            <li>
-              <a href="/education/eligibility/">
-                Find out if you&apos;re eligible for the Post-9/11 GI Bill
-              </a>
-            </li>
-
-            <li>
-              <a href="/education/how-to-apply/">
-                Apply for Post-9/11 GI Bill benefits
-              </a>
-            </li>
-          </ul>
-
-          <p>
-            Search for schools participating in the current academic year by one
-            or all of the terms below.
-          </p>
-        </div>
-
-        {/* Search Form */}
-        <div className="vads-l-col--12 medium-screen:vads-l-col--3">
-          {/* Search Form Fields */}
-          <SearchForm />
-        </div>
-
-        {/* Search Results */}
-        <div className="vads-l-col--12 vads-u-padding-left--0 medium-screen:vads-l-col--9 medium-screen:vads-u-padding-left--5">
-          <SearchResults />
-        </div>
-
-        {/* Post-Form Content */}
+    <div className="vads-l-row">
+      {/* Search Form */}
+      <div className="vads-l-col--12">
+        {/* Pre-form content */}
         <p className="vads-l-col--12 medium-screen:vads-l-col--7">
-          Participating school information is for the current academic year. To
-          view schools for the previous academic year,{' '}
-          <a
-            href="https://www.benefits.va.gov/gibill/yellow_ribbon/yellow_ribbon_info_schools.asp"
-            rel="noreferrer noopener"
-          >
-            view the historical rates
-          </a>
-          .
+          Find out if your school participates in the Yellow Ribbon program. If
+          you already have Post-9/11 GI Bill benefits, the Yellow Ribbon program
+          can help pay for higher out-of-state, private school, or graduate
+          school tuition. The amount of money you get varies by school, degree
+          type, and the program you&apos;re enrolled in.
+        </p>
+
+        <a href="/education/about-gi-bill-benefits/post-9-11/yellow-ribbon-program/">
+          Find out if you qualify for the Yellow Ribbon Program.
+        </a>
+
+        <p>
+          If you don&apos;t already have Post-9/11 GI Bill benefits, you can:
+        </p>
+
+        <ul>
+          <li>
+            <a href="/education/eligibility/">
+              Find out if you&apos;re eligible for the Post-9/11 GI Bill
+            </a>
+          </li>
+
+          <li>
+            <a href="/education/how-to-apply/">
+              Apply for Post-9/11 GI Bill benefits
+            </a>
+          </li>
+        </ul>
+
+        <p>
+          Search for schools participating in the current academic year by one
+          or all of the terms below.
         </p>
       </div>
+
+      {/* Search Form */}
+      <div className="vads-l-col--12 medium-screen:vads-l-col--3">
+        {/* Search Form Fields */}
+        <SearchForm />
+      </div>
+
+      {/* Search Results */}
+      <div className="vads-l-col--12 vads-u-padding-left--0 medium-screen:vads-l-col--9 medium-screen:vads-u-padding-left--5">
+        <SearchResults />
+      </div>
+
+      {/* Post-Form Content */}
+      <p className="vads-l-col--12 medium-screen:vads-l-col--7">
+        Participating school information is for the current academic year. To
+        view schools for the previous academic year,{' '}
+        <a
+          href="https://www.benefits.va.gov/gibill/yellow_ribbon/yellow_ribbon_info_schools.asp"
+          rel="noreferrer noopener"
+        >
+          view the historical rates
+        </a>
+        .
+      </p>
     </div>
-  </>
+  </div>
 );
 
 export default FindYellowRibbonPage;

--- a/src/applications/yellow-ribbon/components/FindYellowRibbonPage/index.unit.spec.jsx
+++ b/src/applications/yellow-ribbon/components/FindYellowRibbonPage/index.unit.spec.jsx
@@ -11,7 +11,6 @@ describe('Find Yellow Ribbon Page <FindYellowRibbonPage>', () => {
     const text = tree.text();
 
     // Expect there to be:
-    expect(tree.find('Breadcrumbs')).to.have.lengthOf(1);
     expect(text).to.include('Find a Yellow Ribbon school');
     expect(text).to.include(
       'Find out if your school participates in the Yellow Ribbon program.',

--- a/src/applications/yellow-ribbon/components/SearchResult/index.jsx
+++ b/src/applications/yellow-ribbon/components/SearchResult/index.jsx
@@ -111,11 +111,13 @@ export const SearchResult = ({ school }) => (
   <li className="usa-unstyled-list vads-l-col vads-u-margin-bottom--2 vads-u-padding-x--2 vads-u-padding-y--2 vads-u-background-color--gray-light-alt">
     {/* School Name */}
     <p className="vads-u-font-size--h3 vads-u-font-weight--bold vads-u-margin--0">
+      <span className="sr-only">School name</span>
       {deriveNameLabel(school)}
     </p>
 
     {/* School Location */}
     <p className="vads-u-margin-bottom--1 vads-u-margin-top--0">
+      <span className="sr-only">School location</span>
       {deriveLocationLabel(school)}
     </p>
 
@@ -129,6 +131,7 @@ export const SearchResult = ({ school }) => (
             (per student, per year)
           </p>
           <p className="vads-u-margin--0">
+            <span className="sr-only">Maximum contribution amount</span>
             {deriveMaxAmountLabel(school)}
           </p>
         </div>
@@ -138,6 +141,7 @@ export const SearchResult = ({ school }) => (
           Funding available for
         </p>
         <p className="vads-u-margin-top--0 vads-u-margin-bottom--0">
+          <span className="sr-only">Eligible students</span>
           {deriveEligibleStudentsLabel(school)}
         </p>
 
@@ -146,6 +150,7 @@ export const SearchResult = ({ school }) => (
           School website
         </p>
         <p className="vads-u-margin-top--0 vads-u-margin-bottom--0">
+          <span className="sr-only">School website</span>
           {deriveInstURLLabel(school)}
         </p>
       </div>
@@ -156,6 +161,7 @@ export const SearchResult = ({ school }) => (
           Degree type
         </p>
         <p className="vads-u-margin-top--0 vads-u-margin-bottom--0 medium-screen:vads-u-margin--0">
+          <span className="sr-only">Degree level</span>
           {deriveDegreeLevel(school)}
         </p>
 
@@ -164,6 +170,7 @@ export const SearchResult = ({ school }) => (
           School or program
         </p>
         <p className="vads-u-margin-top--0 vads-u-margin-bottom--0 medium-screen:vads-u-margin--0">
+          <span className="sr-only">School or program</span>
           {deriveDivisionProfessionalSchool(school)}
         </p>
       </div>

--- a/src/applications/yellow-ribbon/components/SearchResult/index.jsx
+++ b/src/applications/yellow-ribbon/components/SearchResult/index.jsx
@@ -131,7 +131,9 @@ export const SearchResult = ({ school }) => (
             (per student, per year)
           </p>
           <p className="vads-u-margin--0">
-            <span className="sr-only">Maximum contribution amount</span>
+            <span className="sr-only">
+              Maximum Yellow Ribbon funding amount (per student, per year)
+            </span>
             {deriveMaxAmountLabel(school)}
           </p>
         </div>

--- a/src/applications/yellow-ribbon/components/SearchResult/index.jsx
+++ b/src/applications/yellow-ribbon/components/SearchResult/index.jsx
@@ -108,9 +108,11 @@ const deriveDivisionProfessionalSchool = (school = {}) => {
 };
 
 export const SearchResult = ({ school }) => (
-  <div className="vads-l-col vads-u-margin-bottom--2 vads-u-padding-x--2 vads-u-padding-y--2 vads-u-background-color--gray-light-alt">
+  <li className="usa-unstyled-list vads-l-col vads-u-margin-bottom--2 vads-u-padding-x--2 vads-u-padding-y--2 vads-u-background-color--gray-light-alt">
     {/* School Name */}
-    <h3 className="vads-u-margin--0">{deriveNameLabel(school)}</h3>
+    <p className="vads-u-font-size--h3 vads-u-font-weight--bold vads-u-margin--0">
+      {deriveNameLabel(school)}
+    </p>
 
     {/* School Location */}
     <p className="vads-u-margin-bottom--1 vads-u-margin-top--0">
@@ -121,26 +123,28 @@ export const SearchResult = ({ school }) => (
       <div className="vads-l-col--12 vads-u-display--flex vads-u-flex-direction--column vads-u-justify-content--space-between medium-screen:vads-l-col--6">
         {/* Max Contribution Amount */}
         <div className="vads-u-col">
-          <h4 className="vads-u-font-family--sans vads-u-font-size--h5 vads-u-margin--0">
+          <p className="vads-u-font-weight--bold vads-u-font-family--sans vads-u-font-size--h5 vads-u-margin--0">
             Maximum Yellow Ribbon funding amount
             <br />
             (per student, per year)
-          </h4>
-          <p className="vads-u-margin--0">{deriveMaxAmountLabel(school)}</p>
+          </p>
+          <p className="vads-u-margin--0">
+            {deriveMaxAmountLabel(school)}
+          </p>
         </div>
 
         {/* Student Count */}
-        <h4 className="vads-u-font-family--sans vads-u-font-size--h5 vads-u-margin-top--2 vads-u-margin-bottom--0">
+        <p className="vads-u-font-weight--bold vads-u-font-family--sans vads-u-font-size--h5 vads-u-margin-top--2 vads-u-margin-bottom--0">
           Funding available for
-        </h4>
+        </p>
         <p className="vads-u-margin-top--0 vads-u-margin-bottom--0">
           {deriveEligibleStudentsLabel(school)}
         </p>
 
         {/* School Website */}
-        <h4 className="vads-u-font-family--sans vads-u-font-size--h5 vads-u-margin-top--2 vads-u-margin-bottom--0">
+        <p className="vads-u-font-weight--bold vads-u-font-family--sans vads-u-font-size--h5 vads-u-margin-top--2 vads-u-margin-bottom--0">
           School website
-        </h4>
+        </p>
         <p className="vads-u-margin-top--0 vads-u-margin-bottom--0">
           {deriveInstURLLabel(school)}
         </p>
@@ -148,23 +152,23 @@ export const SearchResult = ({ school }) => (
 
       <div className="vads-l-col--12 medium-screen:vads-l-col--6 medium-screen:vads-u-padding-left--2">
         {/* Degree Level */}
-        <h4 className="vads-u-margin-top--2 vads-u-margin-bottom--0 vads-u-font-family--sans vads-u-font-size--h5 medium-screen:vads-u-margin--0">
+        <p className="vads-u-font-weight--bold vads-u-margin-top--2 vads-u-margin-bottom--0 vads-u-font-family--sans vads-u-font-size--h5 medium-screen:vads-u-margin--0">
           Degree type
-        </h4>
+        </p>
         <p className="vads-u-margin-top--0 vads-u-margin-bottom--0 medium-screen:vads-u-margin--0">
           {deriveDegreeLevel(school)}
         </p>
 
         {/* Division Professional School */}
-        <h4 className="vads-u-margin-top--2 vads-u-margin-bottom--0 vads-u-font-family--sans vads-u-font-size--h5 medium-screen:vads-u-margin-top--7 medium-screen:vads-u-margin-bottom--0">
+        <p className="school-program vads-u-font-weight--bold vads-u-margin-top--2 vads-u-margin-bottom--0 vads-u-font-family--sans vads-u-font-size--h5 medium-screen:vads-u-margin-bottom--0">
           School or program
-        </h4>
+        </p>
         <p className="vads-u-margin-top--0 vads-u-margin-bottom--0 medium-screen:vads-u-margin--0">
           {deriveDivisionProfessionalSchool(school)}
         </p>
       </div>
     </div>
-  </div>
+  </li>
 );
 
 SearchResult.propTypes = {

--- a/src/applications/yellow-ribbon/components/SearchResultsPage/index.js
+++ b/src/applications/yellow-ribbon/components/SearchResultsPage/index.js
@@ -1,12 +1,10 @@
 // Node modules.
 import React from 'react';
-import Breadcrumbs from '@department-of-veterans-affairs/formation-react/Breadcrumbs';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 // Relative imports.
 import SearchForm from '../../containers/SearchForm';
 import SearchResults from '../../containers/SearchResults';
-import manifest from '../../manifest.json';
 import { toggleShowMobileFormAction } from '../../actions';
 
 export const SearchResultsPage = ({
@@ -14,93 +12,83 @@ export const SearchResultsPage = ({
   toggleShowMobileForm,
   totalResults,
 }) => (
-  <>
-    {/* Breadcrumbs */}
-    <Breadcrumbs className="vads-u-padding--1p5 medium-screen:vads-u-pading--0">
-      <a href="/">Home</a>
-      <a href="/education/">Education and training</a>
-      <a href={manifest.rootUrl}>Find a Yellow Ribbon school</a>
-      <a href={window.location.href}>Search results</a>
-    </Breadcrumbs>
+  <div className="vads-l-grid-container vads-u-padding-x--2p5 vads-u-padding-bottom--4">
+    {/* Title */}
+    <h1 className="vads-u-margin-bottom--0">
+      Yellow Ribbon school search results
+      {/* Screen reader total results */}
+      {hasFetchedOnce && (
+        <span className="vads-u-visibility--screen-reader">
+          search returned {totalResults} schools
+        </span>
+      )}
+    </h1>
 
-    <div className="vads-l-grid-container vads-u-padding-x--2p5 vads-u-padding-bottom--4">
-      {/* Title */}
-      <h1 className="vads-u-margin-bottom--0">
-        Yellow Ribbon school search results
-        {/* Screen reader total results */}
-        {hasFetchedOnce && (
-          <span className="vads-u-visibility--screen-reader">
-            search returned {totalResults} schools
-          </span>
-        )}
-      </h1>
+    <div className="vads-l-row">
+      {/* Search Form */}
+      <div className="vads-l-col--12">
+        {/* Pre-form content */}
+        <p className="vads-l-col--12 medium-screen:vads-l-col--9">
+          Participating school information on this page is valid for the current
+          academic year, from August 2019 through July 2020. To view schools for
+          the previous academic year,{' '}
+          <a
+            href="https://www.benefits.va.gov/GIBILL/yellow_ribbon/yrp_list_2018.asp"
+            rel="noreferrer noopener"
+          >
+            view 2018 - 2019 rates
+          </a>
+          .
+        </p>
+      </div>
 
-      <div className="vads-l-row">
-        {/* Search Form */}
-        <div className="vads-l-col--12">
-          {/* Pre-form content */}
-          <p className="vads-l-col--12 medium-screen:vads-l-col--9">
-            Participating school information on this page is valid for the
-            current academic year, from August 2019 through July 2020. To view
-            schools for the previous academic year,{' '}
-            <a
-              href="https://www.benefits.va.gov/GIBILL/yellow_ribbon/yrp_list_2018.asp"
-              rel="noreferrer noopener"
-            >
-              view 2018 - 2019 rates
+      {/* Search Form */}
+      <div className="vads-l-col--12 medium-screen:vads-l-col--3">
+        {/* Toggle Mobile Form */}
+        <button
+          className="usa-button-secondary usa-button-big medium-screen:vads-u-display--none vads-u-font-size--md"
+          onClick={toggleShowMobileForm}
+          type="button"
+        >
+          Change search criteria{' '}
+          <i className="fa fa-chevron-down vads-u-padding-left--0p5" />
+        </button>
+
+        {/* Search Form Header */}
+        <h2 className="vads-u-display--none vads-u-font-size--h3 vads-u-margin-top--1p5 medium-screen:vads-u-display--flex">
+          Search criteria
+        </h2>
+
+        {/* Search Form Fields */}
+        <SearchForm />
+
+        {/* Helpful Links */}
+        <div className="vads-u-display--none medium-screen:vads-u-display--flex vads-u-flex-direction--column">
+          <h3 className="vads-u-margin-top--2">Helpful links</h3>
+          <p className="vads-u-margin-bottom--1">
+            <a href="/education/eligibility/">
+              Find out if you&apos;re eligible for the Post-9/11 GI Bill
             </a>
-            .
+          </p>
+          <p className="vads-u-margin-bottom--1 vads-u-margin-top--1">
+            <a href="/education/about-gi-bill-benefits/post-9-11/yellow-ribbon-program/">
+              Find out if you qualify for the Yellow Ribbon Program
+            </a>
+          </p>
+          <p className="vads-u-margin-top--1">
+            <a href="/education/how-to-apply/">
+              Apply for Post-9/11 GI Bill benefits
+            </a>
           </p>
         </div>
+      </div>
 
-        {/* Search Form */}
-        <div className="vads-l-col--12 medium-screen:vads-l-col--3">
-          {/* Toggle Mobile Form */}
-          <button
-            className="usa-button-secondary usa-button-big medium-screen:vads-u-display--none vads-u-font-size--md"
-            onClick={toggleShowMobileForm}
-            type="button"
-          >
-            Change search criteria{' '}
-            <i className="fa fa-chevron-down vads-u-padding-left--0p5" />
-          </button>
-
-          {/* Search Form Header */}
-          <h2 className="vads-u-display--none vads-u-font-size--h3 vads-u-margin-top--1p5 medium-screen:vads-u-display--flex">
-            Search criteria
-          </h2>
-
-          {/* Search Form Fields */}
-          <SearchForm />
-
-          {/* Helpful Links */}
-          <div className="vads-u-display--none medium-screen:vads-u-display--flex vads-u-flex-direction--column">
-            <h3 className="vads-u-margin-top--2">Helpful links</h3>
-            <p className="vads-u-margin-bottom--1">
-              <a href="/education/eligibility/">
-                Find out if you&apos;re eligible for the Post-9/11 GI Bill
-              </a>
-            </p>
-            <p className="vads-u-margin-bottom--1 vads-u-margin-top--1">
-              <a href="/education/about-gi-bill-benefits/post-9-11/yellow-ribbon-program/">
-                Find out if you qualify for the Yellow Ribbon Program
-              </a>
-            </p>
-            <p className="vads-u-margin-top--1">
-              <a href="/education/how-to-apply/">
-                Apply for Post-9/11 GI Bill benefits
-              </a>
-            </p>
-          </div>
-        </div>
-
-        {/* Search Results */}
-        <div className="vads-l-col--12 vads-u-padding-left--0 medium-screen:vads-l-col--9 medium-screen:vads-u-padding-left--5">
-          <SearchResults />
-        </div>
+      {/* Search Results */}
+      <div className="vads-l-col--12 vads-u-padding-left--0 medium-screen:vads-l-col--9 medium-screen:vads-u-padding-left--5">
+        <SearchResults />
       </div>
     </div>
-  </>
+  </div>
 );
 
 SearchResultsPage.propTypes = {

--- a/src/applications/yellow-ribbon/components/SearchResultsPage/index.js
+++ b/src/applications/yellow-ribbon/components/SearchResultsPage/index.js
@@ -29,7 +29,7 @@ export const SearchResultsPage = ({
         Yellow Ribbon school search results
         {/* Screen reader total results */}
         {hasFetchedOnce && (
-          <span className="ads-u-visibility--screen-reader">
+          <span className="vads-u-visibility--screen-reader">
             search returned {totalResults} schools
           </span>
         )}
@@ -106,7 +106,7 @@ export const SearchResultsPage = ({
 SearchResultsPage.propTypes = {
   // From mapStateToProps.
   hasFetchedOnce: PropTypes.bool.isRequired,
-  totalResults: PropTypes.number.isRequired,
+  totalResults: PropTypes.number,
   // From mapDispatchToProps.
   toggleShowMobileForm: PropTypes.func.isRequired,
 };

--- a/src/applications/yellow-ribbon/components/SearchResultsPage/index.js
+++ b/src/applications/yellow-ribbon/components/SearchResultsPage/index.js
@@ -56,9 +56,9 @@ export const SearchResultsPage = ({ toggleShowMobileForm }) => (
           </button>
 
           {/* Search Form Header */}
-          <h3 className="vads-u-display--none vads-u-margin-top--1p5 medium-screen:vads-u-display--flex">
+          <h2 className="vads-u-display--none vads-u-font-size--h3 vads-u-margin-top--1p5 medium-screen:vads-u-display--flex">
             Search criteria
-          </h3>
+          </h2>
 
           {/* Search Form Fields */}
           <SearchForm />

--- a/src/applications/yellow-ribbon/components/SearchResultsPage/index.js
+++ b/src/applications/yellow-ribbon/components/SearchResultsPage/index.js
@@ -9,7 +9,11 @@ import SearchResults from '../../containers/SearchResults';
 import manifest from '../../manifest.json';
 import { toggleShowMobileFormAction } from '../../actions';
 
-export const SearchResultsPage = ({ toggleShowMobileForm }) => (
+export const SearchResultsPage = ({
+  hasFetchedOnce,
+  toggleShowMobileForm,
+  totalResults,
+}) => (
   <>
     {/* Breadcrumbs */}
     <Breadcrumbs className="vads-u-padding--1p5 medium-screen:vads-u-pading--0">
@@ -23,6 +27,12 @@ export const SearchResultsPage = ({ toggleShowMobileForm }) => (
       {/* Title */}
       <h1 className="vads-u-margin-bottom--0">
         Yellow Ribbon school search results
+        {/* Screen reader total results */}
+        {hasFetchedOnce && (
+          <span className="ads-u-visibility--screen-reader">
+            search returned {totalResults} schools
+          </span>
+        )}
       </h1>
 
       <div className="vads-l-row">
@@ -94,15 +104,23 @@ export const SearchResultsPage = ({ toggleShowMobileForm }) => (
 );
 
 SearchResultsPage.propTypes = {
+  // From mapStateToProps.
+  hasFetchedOnce: PropTypes.bool.isRequired,
+  totalResults: PropTypes.number.isRequired,
   // From mapDispatchToProps.
   toggleShowMobileForm: PropTypes.func.isRequired,
 };
+
+const mapStateToProps = state => ({
+  hasFetchedOnce: state.yellowRibbonReducer.hasFetchedOnce,
+  totalResults: state.yellowRibbonReducer.totalResults,
+});
 
 const mapDispatchToProps = dispatch => ({
   toggleShowMobileForm: () => dispatch(toggleShowMobileFormAction()),
 });
 
 export default connect(
-  null,
+  mapStateToProps,
   mapDispatchToProps,
 )(SearchResultsPage);

--- a/src/applications/yellow-ribbon/components/SearchResultsPage/index.unit.spec.jsx
+++ b/src/applications/yellow-ribbon/components/SearchResultsPage/index.unit.spec.jsx
@@ -11,7 +11,6 @@ describe('Search Results Page <SearchResultsPage>', () => {
     const text = tree.text();
 
     // Expect there to be:
-    expect(tree.find('Breadcrumbs')).to.have.lengthOf(1);
     expect(text).to.include('Yellow Ribbon school search results');
 
     // Expect there NOT to be:

--- a/src/applications/yellow-ribbon/constants/index.js
+++ b/src/applications/yellow-ribbon/constants/index.js
@@ -1,8 +1,4 @@
-export const ADD_SCHOOL_TO_COMPARE = 'yellow-ribbon/ADD_SCHOOL_TO_COMPARE';
 export const FETCH_RESULTS = 'yellow-ribbon/FETCH_RESULTS';
 export const FETCH_RESULTS_FAILURE = 'yellow-ribbon/FETCH_RESULTS_FAILURE';
 export const FETCH_RESULTS_SUCCESS = 'yellow-ribbon/FETCH_RESULTS_SUCCESS';
-export const REMOVE_SCHOOL_FROM_COMPARE =
-  'yellow-ribbon/REMOVE_SCHOOL_FROM_COMPARE';
 export const TOGGLE_SHOW_MOBILE_FORM = 'yellow-ribbon/TOGGLE_SHOW_MOBILE_FORM';
-export const UPDATE_PAGE = 'yellow-ribbon/UPDATE_PAGE';

--- a/src/applications/yellow-ribbon/constants/index.unit.spec.js
+++ b/src/applications/yellow-ribbon/constants/index.unit.spec.js
@@ -5,8 +5,7 @@ import {
   FETCH_RESULTS,
   FETCH_RESULTS_FAILURE,
   FETCH_RESULTS_SUCCESS,
-  UPDATE_PAGE,
-  ADD_SCHOOL_TO_COMPARE,
+  TOGGLE_SHOW_MOBILE_FORM,
 } from './index';
 
 describe('Yellow Ribbon constants', () => {
@@ -14,7 +13,6 @@ describe('Yellow Ribbon constants', () => {
     expect(FETCH_RESULTS).to.include('yellow-ribbon');
     expect(FETCH_RESULTS_FAILURE).to.include('yellow-ribbon');
     expect(FETCH_RESULTS_SUCCESS).to.include('yellow-ribbon');
-    expect(ADD_SCHOOL_TO_COMPARE).to.include('yellow-ribbon');
-    expect(UPDATE_PAGE).to.include('yellow-ribbon');
+    expect(TOGGLE_SHOW_MOBILE_FORM).to.include('yellow-ribbon');
   });
 });

--- a/src/applications/yellow-ribbon/containers/SearchForm/index.jsx
+++ b/src/applications/yellow-ribbon/containers/SearchForm/index.jsx
@@ -106,7 +106,7 @@ export class SearchForm extends Component {
 
   render() {
     const { onCheckboxChange, onReactStateChange, onSubmitHandler } = this;
-    const { showMobileForm } = this.props;
+    const { fetching, showMobileForm } = this.props;
     const {
       city,
       contributionAmount,
@@ -204,6 +204,7 @@ export class SearchForm extends Component {
         {/* Submit Button */}
         <button
           className="usa-button-primary va-button-primary vads-u-width--auto vads-u-padding-y--1p5 vads-u-margin-top--2"
+          disabled={fetching}
           type="submit"
         >
           Search

--- a/src/applications/yellow-ribbon/containers/SearchForm/index.jsx
+++ b/src/applications/yellow-ribbon/containers/SearchForm/index.jsx
@@ -138,6 +138,7 @@ export class SearchForm extends Component {
         </label>
         <div className="vads-u-flex--1">
           <input
+            aria-label="Name of institution"
             className="usa-input"
             name="yr-search-name"
             onChange={onReactStateChange('name')}
@@ -152,6 +153,7 @@ export class SearchForm extends Component {
         </label>
         <div className="vads-u-flex--1">
           <select
+            aria-label="State of institution"
             name="yr-search-state"
             onChange={onReactStateChange('state')}
             value={state}
@@ -174,6 +176,7 @@ export class SearchForm extends Component {
         </label>
         <div className="vads-u-flex--1">
           <input
+            aria-label="City of institution"
             className="usa-input"
             name="yr-search-city"
             onChange={onReactStateChange('city')}

--- a/src/applications/yellow-ribbon/containers/SearchResults/index.jsx
+++ b/src/applications/yellow-ribbon/containers/SearchResults/index.jsx
@@ -158,11 +158,11 @@ export class SearchResults extends Component {
         </h2>
 
         {/* Table of Results */}
-        <div className="search-results vads-u-margin-top--2">
+        <ul className="search-results vads-u-margin-top--2 vads-u-padding--0">
           {map(results, school => (
             <SearchResult key={school?.id} school={school} />
           ))}
-        </div>
+        </ul>
 
         {/* Pagination */}
         <Pagination

--- a/src/applications/yellow-ribbon/containers/SearchResults/index.jsx
+++ b/src/applications/yellow-ribbon/containers/SearchResults/index.jsx
@@ -33,8 +33,8 @@ export class SearchResults extends Component {
     totalResults: PropTypes.number,
   };
 
-  componentWillUpdate(nextProps) {
-    const justRefreshed = nextProps.fetching && !this.props.fetching;
+  componentDidUpdate(prevProps) {
+    const justRefreshed = prevProps.fetching && !this.props.fetching;
 
     if (justRefreshed) {
       focusElement('[data-forms-focus]');
@@ -153,11 +153,15 @@ export class SearchResults extends Component {
     return (
       <>
         <h2
-          className="va-introtext vads-u-font-size--lg vads-u-margin-top--1p5 vads-u-font-weight--normal"
+          className="va-introtext vads-u-outline--none vads-u-font-size--lg vads-u-margin-top--1p5 vads-u-font-weight--normal"
           data-forms-focus
         >
-          Displaying {resultsStartNumber}-{resultsEndNumber} of {totalResults}{' '}
-          results
+          Displaying {resultsStartNumber}
+          <span className="usa-sr-only">through</span>
+          <span aria-hidden="true" role="presentation">
+            &ndash;
+          </span>
+          {resultsEndNumber} of {totalResults} results
         </h2>
 
         {/* Table of Results */}

--- a/src/applications/yellow-ribbon/containers/SearchResults/index.jsx
+++ b/src/applications/yellow-ribbon/containers/SearchResults/index.jsx
@@ -9,7 +9,7 @@ import map from 'lodash/map';
 // Relative imports.
 import SearchResult from '../../components/SearchResult';
 import scrollToTop from 'platform/utilities/ui/scrollToTop';
-import { fetchResultsThunk, updatePageAction } from '../../actions';
+import { fetchResultsThunk } from '../../actions';
 import { focusElement } from 'platform/utilities/ui';
 
 export class SearchResults extends Component {
@@ -42,7 +42,7 @@ export class SearchResults extends Component {
   }
 
   onPageSelect = page => {
-    const { fetchResults, perPage, updatePage } = this.props;
+    const { fetchResults, perPage } = this.props;
 
     // Derive the current name params.
     const queryParams = new URLSearchParams(window.location.search);
@@ -53,9 +53,6 @@ export class SearchResults extends Component {
     const name = queryParams.get('name') || '';
     const numberOfStudents = queryParams.get('numberOfStudents') || '';
     const state = queryParams.get('state') || '';
-
-    // Update the page.
-    updatePage(page);
 
     // Refetch results.
     fetchResults({
@@ -192,7 +189,6 @@ const mapStateToProps = state => ({
 
 const mapDispatchToProps = dispatch => ({
   fetchResults: options => fetchResultsThunk(options)(dispatch),
-  updatePage: page => dispatch(updatePageAction(page)),
 });
 
 export default connect(

--- a/src/applications/yellow-ribbon/containers/SearchResults/index.jsx
+++ b/src/applications/yellow-ribbon/containers/SearchResults/index.jsx
@@ -143,7 +143,7 @@ export class SearchResults extends Component {
 
     return (
       <>
-        <h2 className="vads-u-font-size--lg vads-u-margin-top--1p5 vads-u-font-weight--normal">
+        <h2 className="va-introtext vads-u-font-size--lg vads-u-margin-top--1p5 vads-u-font-weight--normal">
           Displaying {resultsStartNumber}-{resultsEndNumber} of {totalResults}{' '}
           results
         </h2>

--- a/src/applications/yellow-ribbon/containers/SearchResults/index.jsx
+++ b/src/applications/yellow-ribbon/containers/SearchResults/index.jsx
@@ -115,7 +115,7 @@ export class SearchResults extends Component {
 
     // Show loading indicator if we are fetching.
     if (fetching) {
-      return <LoadingIndicator message="Loading search results..." />;
+      return <LoadingIndicator setFocus message="Loading search results..." />;
     }
 
     // Show the error alert box if there was an error.
@@ -137,7 +137,10 @@ export class SearchResults extends Component {
     // Show no results found message.
     if (!results.length) {
       return (
-        <h2 className="vads-u-font-size--lg vads-u-margin-top--1p5 vads-u-font-weight--normal">
+        <h2
+          className="va-introtext vads-u-font-size--lg vads-u-margin-top--1p5 vads-u-font-weight--normal"
+          data-forms-focus
+        >
           No results found.
         </h2>
       );

--- a/src/applications/yellow-ribbon/containers/SearchResults/index.jsx
+++ b/src/applications/yellow-ribbon/containers/SearchResults/index.jsx
@@ -10,6 +10,7 @@ import map from 'lodash/map';
 import SearchResult from '../../components/SearchResult';
 import scrollToTop from 'platform/utilities/ui/scrollToTop';
 import { fetchResultsThunk, updatePageAction } from '../../actions';
+import { focusElement } from 'platform/utilities/ui';
 
 export class SearchResults extends Component {
   static propTypes = {
@@ -31,6 +32,14 @@ export class SearchResults extends Component {
     perPage: PropTypes.number.isRequired,
     totalResults: PropTypes.number,
   };
+
+  componentWillUpdate(nextProps) {
+    const justRefreshed = nextProps.fetching && !this.props.fetching;
+
+    if (justRefreshed) {
+      focusElement('[data-forms-focus]');
+    }
+  }
 
   onPageSelect = page => {
     const { fetchResults, perPage, updatePage } = this.props;
@@ -143,7 +152,10 @@ export class SearchResults extends Component {
 
     return (
       <>
-        <h2 className="va-introtext vads-u-font-size--lg vads-u-margin-top--1p5 vads-u-font-weight--normal">
+        <h2
+          className="va-introtext vads-u-font-size--lg vads-u-margin-top--1p5 vads-u-font-weight--normal"
+          data-forms-focus
+        >
           Displaying {resultsStartNumber}-{resultsEndNumber} of {totalResults}{' '}
           results
         </h2>

--- a/src/applications/yellow-ribbon/containers/SearchResults/index.jsx
+++ b/src/applications/yellow-ribbon/containers/SearchResults/index.jsx
@@ -37,7 +37,7 @@ export class SearchResults extends Component {
     const justRefreshed = prevProps.fetching && !this.props.fetching;
 
     if (justRefreshed) {
-      focusElement('[data-forms-focus]');
+      focusElement('[data-display-results-header]');
     }
   }
 
@@ -139,7 +139,7 @@ export class SearchResults extends Component {
       return (
         <h2
           className="va-introtext vads-u-font-size--lg vads-u-margin-top--1p5 vads-u-font-weight--normal"
-          data-forms-focus
+          data-display-results-header
         >
           No results found.
         </h2>
@@ -153,11 +153,11 @@ export class SearchResults extends Component {
     return (
       <>
         <h2
-          className="va-introtext vads-u-outline--none vads-u-font-size--lg vads-u-margin-top--1p5 vads-u-font-weight--normal"
-          data-forms-focus
+          className="va-introtext va-u-outline--none vads-u-font-size--lg vads-u-margin-top--1p5 vads-u-font-weight--normal"
+          data-display-results-header
         >
           Displaying {resultsStartNumber}
-          <span className="usa-sr-only">through</span>
+          <span className="vads-u-visibility--screen-reader">through</span>
           <span aria-hidden="true" role="presentation">
             &ndash;
           </span>

--- a/src/applications/yellow-ribbon/containers/YellowRibbonApp/index.jsx
+++ b/src/applications/yellow-ribbon/containers/YellowRibbonApp/index.jsx
@@ -1,20 +1,27 @@
 // Node modules.
 import React from 'react';
+import Breadcrumbs from '@department-of-veterans-affairs/formation-react/Breadcrumbs';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 // Relative imports.
 import FindYellowRibbonPage from '../../components/FindYellowRibbonPage';
 import SearchResultsPage from '../../components/SearchResultsPage';
+import manifest from '../../manifest.json';
 
-export const YellowRibbonApp = ({ hasFetchedOnce }) => {
-  // "Yellow Ribbon school search results" page.
-  if (hasFetchedOnce) {
-    return <SearchResultsPage />;
-  }
+export const YellowRibbonApp = ({ hasFetchedOnce }) => (
+  <>
+    {/* Breadcrumbs */}
+    <Breadcrumbs className="vads-u-padding--1p5 medium-screen:vads-u-pading--0">
+      <a href="/">Home</a>
+      <a href="/education/">Education and training</a>
+      <a href={manifest.rootUrl}>Find a Yellow Ribbon school</a>
+      {hasFetchedOnce && <a href={window.location.href}>Search results</a>}
+    </Breadcrumbs>
 
-  // "Find a Yellow Ribbon school" page.
-  return <FindYellowRibbonPage />;
-};
+    {/* Derive the Page */}
+    {hasFetchedOnce ? <SearchResultsPage /> : <FindYellowRibbonPage />}
+  </>
+);
 
 YellowRibbonApp.propTypes = {
   // From mapStateToProps.

--- a/src/applications/yellow-ribbon/containers/YellowRibbonApp/index.unit.spec.jsx
+++ b/src/applications/yellow-ribbon/containers/YellowRibbonApp/index.unit.spec.jsx
@@ -12,6 +12,7 @@ describe('Yellow Ribbon container <YellowRibbonApp>', () => {
     const tree = shallow(<YellowRibbonApp />);
 
     // Expect there to be:
+    expect(tree.find('Breadcrumbs')).to.have.lengthOf(1);
     expect(tree.find(FindYellowRibbonPage)).to.have.lengthOf(1);
     expect(tree.find(SearchResultsPage)).to.have.lengthOf(0);
 
@@ -22,6 +23,7 @@ describe('Yellow Ribbon container <YellowRibbonApp>', () => {
     const tree = shallow(<YellowRibbonApp hasFetchedOnce />);
 
     // Expect there to be:
+    expect(tree.find('Breadcrumbs')).to.have.lengthOf(1);
     expect(tree.find(FindYellowRibbonPage)).to.have.lengthOf(0);
     expect(tree.find(SearchResultsPage)).to.have.lengthOf(1);
 

--- a/src/applications/yellow-ribbon/reducers/index.js
+++ b/src/applications/yellow-ribbon/reducers/index.js
@@ -1,16 +1,9 @@
-// Dependencies
-import concat from 'lodash/concat';
-import filter from 'lodash/filter';
-import pick from 'lodash/pick';
 // Relative imports.
 import {
-  ADD_SCHOOL_TO_COMPARE,
   FETCH_RESULTS,
   FETCH_RESULTS_FAILURE,
   FETCH_RESULTS_SUCCESS,
-  REMOVE_SCHOOL_FROM_COMPARE,
   TOGGLE_SHOW_MOBILE_FORM,
-  UPDATE_PAGE,
 } from '../constants';
 
 const initialState = {
@@ -29,16 +22,6 @@ const initialState = {
 
 export const yellowRibbonReducer = (state = initialState, action) => {
   switch (action.type) {
-    case ADD_SCHOOL_TO_COMPARE: {
-      return {
-        ...state,
-        schoolIDs: concat(state.schoolIDs, action?.school?.id),
-        schoolsLookup: {
-          ...state.schoolsLookup,
-          [action?.school?.id]: action?.school,
-        },
-      };
-    }
     case FETCH_RESULTS: {
       return {
         ...state,
@@ -60,24 +43,8 @@ export const yellowRibbonReducer = (state = initialState, action) => {
         totalResults: action?.response?.totalResults,
       };
     }
-    case REMOVE_SCHOOL_FROM_COMPARE: {
-      // Derive the updated list of school IDs.
-      const schoolIDs = filter(
-        state.schoolIDs,
-        id => id !== action?.school?.id,
-      );
-
-      return {
-        ...state,
-        schoolIDs,
-        schoolsLookup: pick(state.schoolsLookup, schoolIDs),
-      };
-    }
     case TOGGLE_SHOW_MOBILE_FORM: {
       return { ...state, showMobileForm: !state.showMobileForm };
-    }
-    case UPDATE_PAGE: {
-      return { ...state, page: action.page };
     }
     default: {
       return { ...state };

--- a/src/applications/yellow-ribbon/sass/yellow-ribbon.scss
+++ b/src/applications/yellow-ribbon/sass/yellow-ribbon.scss
@@ -1,0 +1,5 @@
+@media (min-width: 768px) {
+  .school-program {
+    margin-top: 36px !important;
+  }
+}

--- a/src/applications/yellow-ribbon/sass/yellow-ribbon.scss
+++ b/src/applications/yellow-ribbon/sass/yellow-ribbon.scss
@@ -3,3 +3,7 @@
     margin-top: 36px !important;
   }
 }
+
+.vads-u-outline--none:focus {
+  outline: none;
+}

--- a/src/applications/yellow-ribbon/sass/yellow-ribbon.scss
+++ b/src/applications/yellow-ribbon/sass/yellow-ribbon.scss
@@ -4,6 +4,6 @@
   }
 }
 
-.vads-u-outline--none:focus {
+.va-u-outline--none:focus {
   outline: none;
 }


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/7642

**Another related issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/7133

This PR resolves a11y issues for YR.

## Testing done
Updated unit tests.

## Screenshots
![localhost_3001_education_yellow-ribbon-participating-schools__](https://user-images.githubusercontent.com/12773166/78698543-b93b9d80-78bf-11ea-8260-4077bd240de3.png)

## Acceptance criteria
Resolve the following:
- [x] (3x) Form elements must have labels | 508-issue-semantic-markup.
- [x] Heading levels should only increase by one | axe-core, screenreader.
- [x] Zoom to 400% at 1280px — Reveals a number of cut off text areas. | zoom, 508-issue-mobile
- [x] The search results should read as a list for a screen reader. | 508-issue-cognition, screenreader
- [x] For non-sighted users, consider adding the <span class="sr-only">Label of what the info is</span> for each item. | 508-issue-cognition, screenreader
- [x] All the "heading level 4" becomes extra noisy as a screen reader user. | 508-issue-cognition, screenreader
- [x] Remove unused actions/constants/reducer logic and their respective tests.
- [x] Run Axe check and ensure 0 non-site-wide a11y errors.
- [x] Focus should be managed. | 508-issue-focus-mgmt, screenreader
As Liz mentioned, focus should move from the Search button to the H1 on the search results page. If a search is updated on the results screen, then focus should move to the results heading.
- [x] Focus outline should be evident on the pagination links. This may be a sitewide design system issue. | 508-issue-focus-mgmt
- [x] In the keyboard test, I got stuck on the Search button. When I tabbed, I went to the content below, and it took a long time to get to the search results, which was disorienting as a sighted, keyboard and screen reader user. | 508-issue-focus-mgmt

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
