### PR TITLE
Front-load all data for the new Profile

### DIFF
--- a/src/applications/personalization/profile-2/components/ProfileWrapper.jsx
+++ b/src/applications/personalization/profile-2/components/ProfileWrapper.jsx
@@ -1,35 +1,43 @@
-import React, { useEffect } from 'react';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import LoadingIndicator from '@department-of-veterans-affairs/formation-react/LoadingIndicator';
 
 import RequiredLoginView from 'platform/user/authorization/components/RequiredLoginView';
 import backendServices from 'platform/user/profile/constants/backendServices';
+import {
+  createIsServiceAvailableSelector,
+  isMultifactorEnabled,
+} from 'platform/user/selectors';
 
 import {
   fetchMilitaryInformation as fetchMilitaryInformationAction,
   fetchHero as fetchHeroAction,
+  fetchPersonalInformation as fetchPersonalInformationAction,
 } from 'applications/personalization/profile360/actions';
+import { fetchPaymentInformation as fetchPaymentInformationAction } from 'applications/personalization/profile360/actions/paymentInformation';
 
 import ProfileHeader from './ProfileHeader';
 import ProfileSideNav from './ProfileSideNav';
 
-const ProfileWrapper = ({
-  children,
-  fetchFullName,
-  fetchMilitaryInformation,
-  showLoader,
-  user,
-}) => {
-  useEffect(
-    () => {
-      fetchMilitaryInformation();
-      fetchFullName();
-    },
-    [fetchMilitaryInformation, fetchFullName],
-  );
+class ProfileWrapper extends Component {
+  componentDidMount() {
+    const {
+      fetchFullName,
+      fetchMilitaryInformation,
+      fetchPersonalInformation,
+      fetchPaymentInformation,
+      shouldFetchDirectDepositInformation,
+    } = this.props;
+    fetchMilitaryInformation();
+    fetchFullName();
+    fetchPersonalInformation();
+    if (shouldFetchDirectDepositInformation) {
+      fetchPaymentInformation();
+    }
+  }
 
   // content to show if the component is waiting for data to load
-  const loadingContent = (
+  loadingContent = (
     <div className="vads-u-margin-y--5">
       <LoadingIndicator setFocus message="Loading your information..." />
     </div>
@@ -37,52 +45,79 @@ const ProfileWrapper = ({
 
   // content to show after data has loaded
   // note that `children` will be passed in via React Router.
-  const mainContent = (
+  mainContent = (
     <>
       <ProfileHeader />
       <div className="usa-grid usa-grid-full">
         <div className="usa-width-one-fourth">
           <ProfileSideNav />
         </div>
-        <div className="usa-width-three-fourths">{children}</div>
+        <div className="usa-width-three-fourths">{this.props.children}</div>
       </div>
     </>
   );
 
-  const renderContent = () => {
-    if (showLoader) {
-      return loadingContent;
+  renderContent = () => {
+    if (this.props.showLoader) {
+      return this.loadingContent;
     }
-    return mainContent;
+    return this.mainContent;
   };
 
-  return (
-    <RequiredLoginView
-      serviceRequired={backendServices.USER_PROFILE}
-      user={user}
-    >
-      {renderContent()}
-    </RequiredLoginView>
-  );
-};
+  render() {
+    return (
+      <RequiredLoginView
+        serviceRequired={backendServices.USER_PROFILE}
+        user={this.props.user}
+      >
+        {this.renderContent()}
+      </RequiredLoginView>
+    );
+  }
+}
 
 const mapStateToProps = state => {
-  // this piece of state will be set if the call to load military info succeeds or fails
-  const hasLoadedMilitaryInformation =
-    state.vaProfile?.militaryInformation?.serviceHistory;
-  // this piece of state will be set if the call to load name info succeeds or fails
-  const hasLoadedFullName = state.vaProfile?.hero?.userFullName;
-  const isLoading = !hasLoadedMilitaryInformation || !hasLoadedFullName;
+  const isEvssAvailableSelector = createIsServiceAvailableSelector(
+    backendServices.EVSS_CLAIMS,
+  );
+  const isEvssAvailable = isEvssAvailableSelector(state);
+  const is2faEnabled = isMultifactorEnabled(state);
+  const shouldFetchDirectDepositInformation = isEvssAvailable && is2faEnabled;
+
+  // this piece of state will be set if the call to load military info succeeds
+  // or fails:
+  const hasLoadedMilitaryInformation = state.vaProfile?.militaryInformation;
+
+  // this piece of state will be set if the call to load personal info succeeds
+  // or fails:
+  const hasLoadedPersonalInformation = state.vaProfile?.personalInformation;
+
+  // this piece of state will be set if the call to load name info succeeds or
+  // fails:
+  const hasLoadedFullName = state.vaProfile?.hero;
+
+  // this piece of state will be set if the call to load name info succeeds or
+  // fails:
+  const hasLoadedPaymentInformation = state.vaProfile?.paymentInformation;
+
+  const hasLoadedAllData =
+    hasLoadedMilitaryInformation &&
+    hasLoadedFullName &&
+    hasLoadedPersonalInformation &&
+    (shouldFetchDirectDepositInformation ? hasLoadedPaymentInformation : true);
 
   return {
     user: state.user,
-    showLoader: isLoading,
+    showLoader: !hasLoadedAllData,
+    shouldFetchDirectDepositInformation,
   };
 };
 
 const mapDispatchToProps = {
-  fetchMilitaryInformation: fetchMilitaryInformationAction,
   fetchFullName: fetchHeroAction,
+  fetchMilitaryInformation: fetchMilitaryInformationAction,
+  fetchPersonalInformation: fetchPersonalInformationAction,
+  fetchPaymentInformation: fetchPaymentInformationAction,
 };
 
 export { ProfileWrapper, mapStateToProps };

--- a/src/applications/personalization/profile-2/tests/components/ProfileWrapper.unit.spec.js
+++ b/src/applications/personalization/profile-2/tests/components/ProfileWrapper.unit.spec.js
@@ -12,7 +12,6 @@ import {
 } from '../../components/ProfileWrapper';
 
 describe('ProfileWrapper', () => {
-  let wrapper;
   let defaultProps;
   let fetchFullNameSpy;
   let fetchMilitaryInfoSpy;
@@ -37,7 +36,7 @@ describe('ProfileWrapper', () => {
   });
 
   it('renders a RequiredLoginView component that requires the USER_PROFILE', () => {
-    wrapper = shallow(<ProfileWrapper {...defaultProps} />);
+    const wrapper = shallow(<ProfileWrapper {...defaultProps} />);
     expect(wrapper.type()).to.equal(RequiredLoginView);
     expect(wrapper.prop('serviceRequired')).to.equal(
       backendServices.USER_PROFILE,
@@ -47,7 +46,7 @@ describe('ProfileWrapper', () => {
 
   it('should render a spinner if it is loading data', () => {
     defaultProps.showLoader = true;
-    wrapper = shallow(<ProfileWrapper {...defaultProps} />);
+    const wrapper = shallow(<ProfileWrapper {...defaultProps} />);
     wrapper.setProps({ showLoader: true });
     const loader = wrapper.find('LoadingIndicator');
     expect(loader.length).to.equal(1);
@@ -55,26 +54,26 @@ describe('ProfileWrapper', () => {
   });
 
   it('fetches the military information data when it mounts', () => {
-    wrapper = shallow(<ProfileWrapper {...defaultProps} />);
+    const wrapper = shallow(<ProfileWrapper {...defaultProps} />);
     expect(fetchMilitaryInfoSpy.called).to.be.true;
     wrapper.unmount();
   });
 
   it('fetches the full name data when it mounts', () => {
-    wrapper = shallow(<ProfileWrapper {...defaultProps} />);
+    const wrapper = shallow(<ProfileWrapper {...defaultProps} />);
     expect(fetchFullNameSpy.called).to.be.true;
     wrapper.unmount();
   });
 
   it('fetches the personal information data when it mounts', () => {
-    wrapper = shallow(<ProfileWrapper {...defaultProps} />);
+    const wrapper = shallow(<ProfileWrapper {...defaultProps} />);
     expect(fetchPersonalInfoSpy.called).to.be.true;
     wrapper.unmount();
   });
 
   describe('when `shouldFetchDirectDepositInformation` is `true`', () => {
     it('fetches the payment information data when it mounts', () => {
-      wrapper = shallow(<ProfileWrapper {...defaultProps} />);
+      const wrapper = shallow(<ProfileWrapper {...defaultProps} />);
       expect(fetchPaymentInfoSpy.called).to.be.true;
       wrapper.unmount();
     });
@@ -83,7 +82,7 @@ describe('ProfileWrapper', () => {
   describe('when `shouldFetchDirectDepositInformation` is `false`', () => {
     it('should not fetch the payment information data when it mounts', () => {
       defaultProps.shouldFetchDirectDepositInformation = false;
-      wrapper = shallow(<ProfileWrapper {...defaultProps} />);
+      const wrapper = shallow(<ProfileWrapper {...defaultProps} />);
       expect(fetchPaymentInfoSpy.called).to.be.false;
       wrapper.unmount();
     });

--- a/src/applications/personalization/profile-2/tests/components/ProfileWrapper.unit.spec.js
+++ b/src/applications/personalization/profile-2/tests/components/ProfileWrapper.unit.spec.js
@@ -1,63 +1,277 @@
-// import React from 'react';
-// import { shallow } from 'enzyme';
+import React from 'react';
+import { shallow } from 'enzyme';
 import { expect } from 'chai';
-// import sinon from 'sinon';
+import sinon from 'sinon';
 
-// import backendServices from 'platform/user/profile/constants/backendServices';
-// import RequiredLoginView from 'platform/user/authorization/components/RequiredLoginView';
+import backendServices from 'platform/user/profile/constants/backendServices';
+import RequiredLoginView from 'platform/user/authorization/components/RequiredLoginView';
 
 import {
-  // ProfileWrapper,
+  ProfileWrapper,
   mapStateToProps,
 } from '../../components/ProfileWrapper';
 
-// These component tests are all throwing `Invariant Violation: Invalid hook
-// call` errors so they are disabled for now.
+describe('ProfileWrapper', () => {
+  let wrapper;
+  let defaultProps;
+  let fetchFullNameSpy;
+  let fetchMilitaryInfoSpy;
+  let fetchPaymentInfoSpy;
+  let fetchPersonalInfoSpy;
 
-// describe('ProfileWrapper', () => {
-//   let wrapper;
-//   const fetchMilitaryInfoSpy = sinon.spy();
-//   const fetchFullNameSpy = sinon.spy();
+  beforeEach(() => {
+    fetchFullNameSpy = sinon.spy();
+    fetchMilitaryInfoSpy = sinon.spy();
+    fetchPaymentInfoSpy = sinon.spy();
+    fetchPersonalInfoSpy = sinon.spy();
 
-//   beforeEach(() => {
-//     const defaultProps = {
-//       user: {},
-//       showLoader: false,
-//       fetchFullName: fetchFullNameSpy,
-//       fetchMilitaryInformation: fetchMilitaryInfoSpy,
-//     };
+    defaultProps = {
+      fetchFullName: fetchFullNameSpy,
+      fetchMilitaryInformation: fetchMilitaryInfoSpy,
+      fetchPaymentInformation: fetchPaymentInfoSpy,
+      fetchPersonalInformation: fetchPersonalInfoSpy,
+      shouldFetchDirectDepositInformation: true,
+      showLoader: false,
+      user: {},
+    };
+  });
 
-//     wrapper = shallow(<ProfileWrapper {...defaultProps} />);
-//   });
+  it('renders a RequiredLoginView component that requires the USER_PROFILE', () => {
+    wrapper = shallow(<ProfileWrapper {...defaultProps} />);
+    expect(wrapper.type()).to.equal(RequiredLoginView);
+    expect(wrapper.prop('serviceRequired')).to.equal(
+      backendServices.USER_PROFILE,
+    );
+    wrapper.unmount();
+  });
 
-//   afterEach(() => {
-//     wrapper.unmount();
-//   });
+  it('should render a spinner if it is loading data', () => {
+    defaultProps.showLoader = true;
+    wrapper = shallow(<ProfileWrapper {...defaultProps} />);
+    wrapper.setProps({ showLoader: true });
+    const loader = wrapper.find('LoadingIndicator');
+    expect(loader.length).to.equal(1);
+    wrapper.unmount();
+  });
 
-//   it('renders a RequiredLoginView component that requires the USER_PROFILE', () => {
-//     expect(wrapper.type()).to.equal(RequiredLoginView);
-//     expect(wrapper.prop('serviceRequired')).to.equal(
-//       backendServices.USER_PROFILE,
-//     );
-//   });
-//   it('should render a spinner if it is loading data', () => {
-//     wrapper.setProps({ showLoader: true });
-//     const loader = wrapper.find('LoadingIndicator');
-//     expect(loader.length).to.equal(1);
-//   });
-//   it('loads the military information data when it mounts', () => {
-//     expect(fetchMilitaryInfoSpy.called).to.be.true;
-//   });
-//   it('loads the full name data when it mounts', () => {
-//     expect(fetchFullNameSpy.called).to.be.true;
-//   });
-// });
+  it('fetches the military information data when it mounts', () => {
+    wrapper = shallow(<ProfileWrapper {...defaultProps} />);
+    expect(fetchMilitaryInfoSpy.called).to.be.true;
+    wrapper.unmount();
+  });
+
+  it('fetches the full name data when it mounts', () => {
+    wrapper = shallow(<ProfileWrapper {...defaultProps} />);
+    expect(fetchFullNameSpy.called).to.be.true;
+    wrapper.unmount();
+  });
+
+  it('fetches the personal information data when it mounts', () => {
+    wrapper = shallow(<ProfileWrapper {...defaultProps} />);
+    expect(fetchPersonalInfoSpy.called).to.be.true;
+    wrapper.unmount();
+  });
+
+  describe('when `shouldFetchDirectDepositInformation` is `true`', () => {
+    it('fetches the payment information data when it mounts', () => {
+      wrapper = shallow(<ProfileWrapper {...defaultProps} />);
+      expect(fetchPaymentInfoSpy.called).to.be.true;
+      wrapper.unmount();
+    });
+  });
+
+  describe('when `shouldFetchDirectDepositInformation` is `false`', () => {
+    it('should not fetch the payment information data when it mounts', () => {
+      defaultProps.shouldFetchDirectDepositInformation = false;
+      wrapper = shallow(<ProfileWrapper {...defaultProps} />);
+      expect(fetchPaymentInfoSpy.called).to.be.false;
+      wrapper.unmount();
+    });
+  });
+});
 
 describe('mapStateToProps', () => {
+  const makeDefaultProfileState = () => ({
+    multifactor: true,
+    services: ['evss-claims'],
+  });
+  const makeDefaultVaProfileState = () => ({
+    hero: {
+      userFullName: {
+        first: 'Wesley',
+        middle: 'Watson',
+        last: 'Ford',
+        suffix: null,
+      },
+    },
+    personalInformation: {
+      gender: 'M',
+      birthDate: '1986-05-06',
+    },
+    militaryInformation: {
+      serviceHistory: {
+        serviceHistory: [
+          {
+            branchOfService: 'Air Force',
+            beginDate: '2009-04-12',
+            endDate: '2013-04-11',
+            personnelCategoryTypeCode: 'V',
+          },
+        ],
+      },
+    },
+    paymentInformation: {
+      responses: [
+        {
+          controlInformation: {},
+          paymentAccount: {},
+          paymentAddress: {},
+          paymentType: 'CNP',
+        },
+      ],
+    },
+  });
+  const makeDefaultState = () => ({
+    user: {
+      profile: makeDefaultProfileState(),
+    },
+    vaProfile: makeDefaultVaProfileState(),
+  });
+
   it('returns an object with the correct keys', () => {
-    const state = {};
+    const state = makeDefaultState();
     const props = mapStateToProps(state);
-    const expectedKeys = ['user', 'showLoader'];
+    const expectedKeys = [
+      'user',
+      'showLoader',
+      'shouldFetchDirectDepositInformation',
+    ];
     expect(Object.keys(props)).to.deep.equal(expectedKeys);
+  });
+
+  describe('#user', () => {
+    it('is pulled from state.user', () => {
+      const state = makeDefaultState();
+      const props = mapStateToProps(state);
+      expect(props.user).to.deep.equal(state.user);
+    });
+  });
+
+  describe('#shouldFetchDirectDepositInformation', () => {
+    it('is `true` when user has 2FA set and has access to EVSS', () => {
+      const state = makeDefaultState();
+      const props = mapStateToProps(state);
+      expect(props.shouldFetchDirectDepositInformation).to.be.true;
+    });
+
+    it('is `false` when user has 2FA set but does not have access to EVSS', () => {
+      const state = makeDefaultState();
+      state.user.profile.services = [];
+      const props = mapStateToProps(state);
+      expect(props.shouldFetchDirectDepositInformation).to.be.false;
+    });
+
+    it('is `false` when the user has access to EVSS but does not have 2FA set', () => {
+      const state = makeDefaultState();
+      state.user.profile.multifactor = false;
+      const props = mapStateToProps(state);
+      expect(props.shouldFetchDirectDepositInformation).to.be.false;
+    });
+
+    it('is `false` when the user does not have 2FA set and does not have access to EVSS', () => {
+      const state = makeDefaultState();
+      state.user.profile.multifactor = false;
+      state.user.profile.services = [];
+      const props = mapStateToProps(state);
+      expect(props.shouldFetchDirectDepositInformation).to.be.false;
+    });
+  });
+
+  describe('#showLoader', () => {
+    describe('when direct deposit info should be fetched', () => {
+      it('is `false` when all required data calls have resolved successfully', () => {
+        const state = makeDefaultState();
+        const props = mapStateToProps(state);
+        expect(props.showLoader).to.be.false;
+      });
+
+      it('is `false` when all required data calls have either resolved successfully or errored', () => {
+        const state = makeDefaultState();
+        state.vaProfile.paymentInformation.error = {};
+        const props = mapStateToProps(state);
+        expect(props.showLoader).to.be.false;
+      });
+
+      it('is `true` when the call to fetch payment info has not resolved but all others have', () => {
+        const state = makeDefaultState();
+        delete state.vaProfile.paymentInformation;
+        const props = mapStateToProps(state);
+        expect(props.showLoader).to.be.true;
+      });
+
+      it('is `true` when the call to fetch personal info has not resolved but all others have', () => {
+        const state = makeDefaultState();
+        delete state.vaProfile.personalInformation;
+        const props = mapStateToProps(state);
+        expect(props.showLoader).to.be.true;
+      });
+
+      it('is `true` when the call to fetch military info has not resolved but all others have', () => {
+        const state = makeDefaultState();
+        delete state.vaProfile.militaryInformation;
+        const props = mapStateToProps(state);
+        expect(props.showLoader).to.be.true;
+      });
+
+      it('is `true` when the call to fetch the full name has not resolved but all others have', () => {
+        const state = makeDefaultState();
+        delete state.vaProfile.hero;
+        const props = mapStateToProps(state);
+        expect(props.showLoader).to.be.true;
+      });
+    });
+
+    describe('when direct deposit info should not be fetched because the user has not set up 2FA', () => {
+      let state;
+      beforeEach(() => {
+        state = makeDefaultState();
+        state.user.profile.multifactor = false;
+        delete state.vaProfile.paymentInformation;
+      });
+
+      it('is `false` when all required data calls have resolved successfully', () => {
+        const props = mapStateToProps(state);
+        expect(props.showLoader).to.be.false;
+      });
+
+      it('is `false` when all required data calls have either resolved successfully or errored', () => {
+        state.vaProfile.personalInformation.error = {};
+        const props = mapStateToProps(state);
+        expect(props.showLoader).to.be.false;
+      });
+
+      it('is `false` when the call to fetch payment info has not resolved', () => {
+        const props = mapStateToProps(state);
+        expect(props.showLoader).to.be.false;
+      });
+
+      it('is `true` when the call to fetch personal info has not resolved', () => {
+        delete state.vaProfile.personalInformation;
+        const props = mapStateToProps(state);
+        expect(props.showLoader).to.be.true;
+      });
+
+      it('is `true` when the call to fetch military info has not resolved', () => {
+        delete state.vaProfile.militaryInformation;
+        const props = mapStateToProps(state);
+        expect(props.showLoader).to.be.true;
+      });
+
+      it('is `true` when the call to fetch the full name has not resolved', () => {
+        delete state.vaProfile.hero;
+        const props = mapStateToProps(state);
+        expect(props.showLoader).to.be.true;
+      });
+    });
   });
 });


### PR DESCRIPTION
## Description
We are now frontloading all of the data needed by the profile. We conditionally call the GET paymentInformation endpoint only when the user has 2FA set up and also has EVSS.

## Testing done
Added a lot of coverage for the `mapStateToProps` function. That function is kind of the key to this working properly. The component itself is pretty simple; it just renders content based on its props. So making sure that `mapStateToProps` sets those props correctly is the the important part.

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs