### PR TITLE
Flag for manual review messaging

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,7 +95,7 @@ jobs:
         # ESLint is disabled
 
         `vets-website` uses ESLint to help enforce code quality. In most
-        situations we would like for it to remain enabled
+        situations we would like for to remain enabled.
 
         ## What you can do
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,7 +95,7 @@ jobs:
         # ESLint is disabled
 
         `vets-website` uses ESLint to help enforce code quality. In most
-        situations we would like for to remain enabled.
+        situations we would like ESLint to remain enabled.
 
         ## What you can do
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,7 +91,15 @@ jobs:
       - image: circleci/node:10.18
     environment:
       CODE_PATTERN: (/* eslint-disable)|(// eslint-disable)
-      OVERALL_REVIEW_COMMENT: ESLint is disabled - _please_ wait for a VSP review.
+      OVERALL_REVIEW_COMMENT: >
+        # ESLint is disabled
+        `vets-website` uses ESLint to help enforce code quality. In most
+        situations we would like for it to remain enabled
+
+        ## What you can do
+        See if the code can be refactored to avoid disabling ESLint, or wait for
+        a VSP review.
+
       LINE_COMMENT: ESLint disabled here
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,7 +118,7 @@ jobs:
     environment:
       CODE_PATTERN: Sentry\.
       OVERALL_REVIEW_COMMENT: >
-        # Sentry is found
+        # Sentry call found
 
         Sentry captures a lot of data, and we want to make sure that we only
         keep information that will be useful for troubleshooting issues.  This

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -144,7 +144,18 @@ jobs:
       - image: circleci/node:10.18
     environment:
       CODE_PATTERN: (<i )|(<i$)
-      OVERALL_REVIEW_COMMENT: Found `<i>` tag in changes. _Please_ wait for a VSP review.
+      OVERALL_REVIEW_COMMENT: >
+        # Icon found
+
+        Icons can be decorative, but sometimes they are used to convey meaning.
+        If there are any semantics associated with an icon, those semantics
+        should also be conveyed to a screen reader.
+
+        ## What you can do
+
+        Review the markup and see if the icon provides information that isn't
+        represented textually, or wait for a VSP review.
+
       LINE_COMMENT: icon found
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,7 +117,18 @@ jobs:
       - image: circleci/node:10.18
     environment:
       CODE_PATTERN: Sentry\.
-      OVERALL_REVIEW_COMMENT: Sentry call found - Check for potential PII exposure. _Please_ wait for a VSP review.
+      OVERALL_REVIEW_COMMENT: >
+        # Sentry is found
+
+        Sentry captures a lot of data, and we want to make sure that we only
+        keep information that will be useful for troubleshooting issues.  This
+        means that PII should not be recorded.
+
+        ## What you can do
+
+        Review your call to Sentry and see if you can reasonably reduce any
+        information that is included, or wait for a VSP review.
+
       LINE_COMMENT: Sentry found
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,10 +93,12 @@ jobs:
       CODE_PATTERN: (/* eslint-disable)|(// eslint-disable)
       OVERALL_REVIEW_COMMENT: >
         # ESLint is disabled
+
         `vets-website` uses ESLint to help enforce code quality. In most
         situations we would like for it to remain enabled
 
         ## What you can do
+
         See if the code can be refactored to avoid disabling ESLint, or wait for
         a VSP review.
 

--- a/src/platform/forms-system/src/js/validation.js
+++ b/src/platform/forms-system/src/js/validation.js
@@ -15,12 +15,12 @@ import {
   isValidPartialMonthYearInPast,
 } from './utilities/validations';
 
-/* eslint-disable-next-line no-console */
-console.log('Boo');
-
 /*
  * This contains the code for supporting our own custom validations and messages
  */
+
+/* eslint-disable-next-line no-console */
+console.log('Eeek');
 
 /*
  * Override the default messages for these json schema error types

--- a/src/platform/forms-system/src/js/validation.js
+++ b/src/platform/forms-system/src/js/validation.js
@@ -15,6 +15,9 @@ import {
   isValidPartialMonthYearInPast,
 } from './utilities/validations';
 
+/* eslint-disable-next-line no-console */
+console.log('Boo');
+
 /*
  * This contains the code for supporting our own custom validations and messages
  */

--- a/src/platform/forms-system/src/js/validation.js
+++ b/src/platform/forms-system/src/js/validation.js
@@ -19,9 +19,6 @@ import {
  * This contains the code for supporting our own custom validations and messages
  */
 
-/* eslint-disable-next-line no-console */
-console.log('Eeek');
-
 /*
  * Override the default messages for these json schema error types
  */


### PR DESCRIPTION
## Description

These changes address https://github.com/department-of-veterans-affairs/va.gov-team/issues/6859

The messages don't link to any external documentation since the details are already provided as part of the message body.  The content has been modeled after the [VA error message guidelines](https://design.va.gov/patterns/messaging-error-messages#additional-guidance)

## Testing done


## Screenshots

An example:

![image](https://user-images.githubusercontent.com/2008881/78834208-11979b80-79a3-11ea-90d8-ff3fa67d6dbf.png)



## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
