### PR TITLE
526: Original claims back end integration for production

### DIFF
--- a/src/applications/disability-benefits/all-claims/containers/RequiredServicesGate.jsx
+++ b/src/applications/disability-benefits/all-claims/containers/RequiredServicesGate.jsx
@@ -6,26 +6,17 @@ import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 import RequiredLoginView from '../../../../platform/user/authorization/components/RequiredLoginView';
 import backendServices from '../../../../platform/user/profile/constants/backendServices';
 
-import environment from 'platform/utilities/environment';
-
 export function RequiredServicesGate({ user, location, children }) {
   // Short-circuit the check on the intro page
   if (location.pathname === '/introduction') {
     return children;
   }
 
-  const currentlyLoggedIn = user.login.currentlyLoggedIn;
-  const userProfileServices = user.profile.services;
-  let missingInformation = !userProfileServices.includes(
-    backendServices.FORM526,
-  );
-  if (missingInformation && !environment.isProduction()) {
-    missingInformation = !userProfileServices.includes(
-      backendServices.ORIGINAL_CLAIMS,
-    );
-  }
-
-  if (currentlyLoggedIn && missingInformation) {
+  if (
+    user.login.currentlyLoggedIn &&
+    !user.profile.services.includes(backendServices.FORM526) &&
+    !user.profile.services.includes(backendServices.ORIGINAL_CLAIMS)
+  ) {
     return (
       <div className="usa-grid full-page-alert">
         <AlertBox
@@ -38,16 +29,15 @@ export function RequiredServicesGate({ user, location, children }) {
     );
   }
 
-  let serviceRequired = backendServices.FORM526;
-  if (!environment.isProduction()) {
-    serviceRequired = [
-      backendServices.FORM526,
-      backendServices.ORIGINAL_CLAIMS,
-    ];
-  }
-
   return (
-    <RequiredLoginView serviceRequired={serviceRequired} user={user} verify>
+    <RequiredLoginView
+      serviceRequired={[
+        backendServices.FORM526,
+        backendServices.ORIGINAL_CLAIMS,
+      ]}
+      user={user}
+      verify
+    >
       {children}
     </RequiredLoginView>
   );


### PR DESCRIPTION
## Description
This PR adds back end user services integration for original claims for the 526 form in production. Currently, this functionality is only supported in staging. This PR removes the staging restriction and will allow users to start a claim using the original claims service in all environments. The PR will not be merged until proper testing has been done with the B&M 1 back end team.

## Acceptance criteria
- [ ] Users with the original claims user service can begin the 526 form in production
- [ ] Testing has been done with B&M 1 back end