### PR TITLE
put need help footer on all form 2346 pages

### DIFF
--- a/src/applications/disability-benefits/2346/components/FooterInfo.jsx
+++ b/src/applications/disability-benefits/2346/components/FooterInfo.jsx
@@ -1,0 +1,32 @@
+import React from 'react';
+
+const FooterInfo = () => {
+  const sectionClassNames =
+    'vads-u-margin-y--2p5 vads-u-display--flex vads-u-flex-direction--column';
+  return (
+    <section className="need-help-footer row vads-u-padding-x--1p5">
+      <h5>Need Help?</h5>
+      <hr />
+      <span>
+        For help filling out this form, you can contact your local coordinator,
+        or call our main VA information line at :{' '}
+      </span>
+
+      <section className={sectionClassNames}>
+        <a href="tel:18008271000">1-800-827-1000</a>
+      </section>
+
+      <section className={sectionClassNames}>
+        <span>
+          To report a problem with this form, please call the Technical Help
+          Help Desk:
+        </span>
+        <a href="tel:18555747286">1-855-574-7286</a>
+        <a href="tel:18008778339">TTY: 1-800-877-8339</a>
+        <span>Monday through Friday, 8:00a.m. — 7:00p.m. ET.</span>
+      </section>
+    </section>
+  );
+};
+
+export default FooterInfo;

--- a/src/applications/disability-benefits/2346/components/IntroductionPage.jsx
+++ b/src/applications/disability-benefits/2346/components/IntroductionPage.jsx
@@ -2,15 +2,15 @@ import FormTitle from 'platform/forms-system/src/js/components/FormTitle';
 import SaveInProgressIntro from 'platform/forms/save-in-progress/SaveInProgressIntro';
 import React from 'react';
 
-const IntroductionPage = () => (
+const IntroductionPage = props => (
   <div className="schemaform-intro">
     <FormTitle title="Order hearing aid batteries and accessories" />
     <p>Equal to VA Form 2346 (Request for Batteries and Accessories).</p>
     <SaveInProgressIntro
       hideUnauthedStartLink
-      prefillEnabled={this.props.route.formConfig.prefillEnabled}
-      messages={this.props.route.formConfig.savedFormMessages}
-      pageList={this.props.route.pageList}
+      prefillEnabled={props.route.formConfig.prefillEnabled}
+      messages={props.route.formConfig.savedFormMessages}
+      pageList={props.route.pageList}
       startText="Order hearing aid batteries and accessories"
     >
       Please complete the 2346 form to apply for ordering hearing aid batteries
@@ -92,8 +92,8 @@ const IntroductionPage = () => (
     <SaveInProgressIntro
       buttonOnly
       hideUnauthedStartLink
-      messages={this.props.route.formConfig.savedFormMessages}
-      pageList={this.props.route.pageList}
+      messages={props.route.formConfig.savedFormMessages}
+      pageList={props.route.pageList}
       startText="Order hearing aid batteries and accessories"
     />
   </div>

--- a/src/applications/disability-benefits/2346/components/IntroductionPage.jsx
+++ b/src/applications/disability-benefits/2346/components/IntroductionPage.jsx
@@ -1,114 +1,102 @@
 import FormTitle from 'platform/forms-system/src/js/components/FormTitle';
 import SaveInProgressIntro from 'platform/forms/save-in-progress/SaveInProgressIntro';
-import { focusElement } from 'platform/utilities/ui';
 import React from 'react';
 
-class IntroductionPage extends React.Component {
-  componentDidMount() {
-    focusElement('.va-nav-breadcrumbs-list');
-  }
-
-  render() {
-    return (
-      <div className="schemaform-intro">
-        <FormTitle title="Order hearing aid batteries and accessories" />
-        <p>Equal to VA Form 2346 (Request for Batteries and Accessories).</p>
-        <SaveInProgressIntro
-          hideUnauthedStartLink
-          prefillEnabled={this.props.route.formConfig.prefillEnabled}
-          messages={this.props.route.formConfig.savedFormMessages}
-          pageList={this.props.route.pageList}
-          startText="Order hearing aid batteries and accessories"
-        >
-          Please complete the 2346 form to apply for ordering hearing aid
-          batteries and accessories.
-        </SaveInProgressIntro>
-        <h2
-          className="vads-u-font-size--h4"
-          itemProp="name"
-          id="am-i-eligible-to-order-prosthe"
-        >
-          Follow the steps below to order hearing aid batteries and accessories.
-        </h2>
-        <div className="process schemaform-process">
-          <ol>
-            <li className="process-step list-one">
-              <h3 className="vads-u-font-size--h5">Prepare</h3>
-              <p>To place an order, you’ll need your:</p>
-              <ul>
-                <li>Shipping address</li>
-                <li>Email address</li>
-                <li>Hearing aid information</li>
-              </ul>
-              <h4>What if I need help with my order?</h4>
-              <p>
-                If you need help ordering hearing aid batteries and accessories,
-                you can call the Denver Logistics Center Customer Service
-                Section at{' '}
-                <a
-                  title="Dial the telephone number 303-273-6200"
-                  href="tel:303-273-6200"
-                >
-                  303-273-6200
-                </a>
-              </p>
-            </li>
-            <li className="process-step list-two">
-              <h3 className="vads-u-font-size--h5">Place your order</h3>
-              <p>
-                Complete this hearing aid batteries and accessories order form.
-              </p>
-              <p>These are the steps you can expect when placing an order:</p>
-              <ul>
-                <li>Confirm your personal information</li>
-                <li>Confirm or edit your shipping address and email address</li>
-                <li>Select any hearing aids that need batteries</li>
-                <li>Select any hearing aid accessories you need</li>
-                <li>Review and submit order</li>
-              </ul>
-              <p>
-                After submitting the order form, you’ll get a confirmation
-                message. You can print this for your records.
-              </p>
-            </li>
-            <li className="process-step list-three">
-              <h3>Track your order </h3>
-              <p>
-                You will receive an email with an order tracking number 1-2 days
-                after your order is submitted.
-              </p>
-            </li>
-            <li className="process-step list-four">
-              <h3 className="vads-u-font-size--h5">Receive your order</h3>
-              <p>
-                You should receive your order within the timeframe indicated by
-                the order tracking number.
-              </p>
-              <h4>What if I have questions about my order?</h4>
-              <p>
-                If you have questions about your order, you can call the DLC
-                Customer Service Section at{' '}
-                <a
-                  title="Dial the telephone number 303-273-6200"
-                  href="tel:303-273-6200"
-                >
-                  303-273-6200
-                </a>
-                .{' '}
-              </p>
-            </li>
-          </ol>
-        </div>
-        <SaveInProgressIntro
-          buttonOnly
-          hideUnauthedStartLink
-          messages={this.props.route.formConfig.savedFormMessages}
-          pageList={this.props.route.pageList}
-          startText="Order hearing aid batteries and accessories"
-        />
-      </div>
-    );
-  }
-}
+const IntroductionPage = () => (
+  <div className="schemaform-intro">
+    <FormTitle title="Order hearing aid batteries and accessories" />
+    <p>Equal to VA Form 2346 (Request for Batteries and Accessories).</p>
+    <SaveInProgressIntro
+      hideUnauthedStartLink
+      prefillEnabled={this.props.route.formConfig.prefillEnabled}
+      messages={this.props.route.formConfig.savedFormMessages}
+      pageList={this.props.route.pageList}
+      startText="Order hearing aid batteries and accessories"
+    >
+      Please complete the 2346 form to apply for ordering hearing aid batteries
+      and accessories.
+    </SaveInProgressIntro>
+    <h2
+      className="vads-u-font-size--h4"
+      itemProp="name"
+      id="am-i-eligible-to-order-prosthe"
+    >
+      Follow the steps below to order hearing aid batteries and accessories.
+    </h2>
+    <div className="process schemaform-process">
+      <ol>
+        <li className="process-step list-one">
+          <h3 className="vads-u-font-size--h5">Prepare</h3>
+          <p>To place an order, you’ll need your:</p>
+          <ul>
+            <li>Shipping address</li>
+            <li>Email address</li>
+            <li>Hearing aid information</li>
+          </ul>
+          <h4>What if I need help with my order?</h4>
+          <p>
+            If you need help ordering hearing aid batteries and accessories, you
+            can call the Denver Logistics Center Customer Service Section at{' '}
+            <a
+              title="Dial the telephone number 303-273-6200"
+              href="tel:303-273-6200"
+            >
+              303-273-6200
+            </a>
+          </p>
+        </li>
+        <li className="process-step list-two">
+          <h3 className="vads-u-font-size--h5">Place your order</h3>
+          <p>Complete this hearing aid batteries and accessories order form.</p>
+          <p>These are the steps you can expect when placing an order:</p>
+          <ul>
+            <li>Confirm your personal information</li>
+            <li>Confirm or edit your shipping address and email address</li>
+            <li>Select any hearing aids that need batteries</li>
+            <li>Select any hearing aid accessories you need</li>
+            <li>Review and submit order</li>
+          </ul>
+          <p>
+            After submitting the order form, you’ll get a confirmation message.
+            You can print this for your records.
+          </p>
+        </li>
+        <li className="process-step list-three">
+          <h3>Track your order </h3>
+          <p>
+            You will receive an email with an order tracking number 1-2 days
+            after your order is submitted.
+          </p>
+        </li>
+        <li className="process-step list-four">
+          <h3 className="vads-u-font-size--h5">Receive your order</h3>
+          <p>
+            You should receive your order within the timeframe indicated by the
+            order tracking number.
+          </p>
+          <h4>What if I have questions about my order?</h4>
+          <p>
+            If you have questions about your order, you can call the DLC
+            Customer Service Section at{' '}
+            <a
+              title="Dial the telephone number 303-273-6200"
+              href="tel:303-273-6200"
+            >
+              303-273-6200
+            </a>
+            .{' '}
+          </p>
+        </li>
+      </ol>
+    </div>
+    <SaveInProgressIntro
+      buttonOnly
+      hideUnauthedStartLink
+      messages={this.props.route.formConfig.savedFormMessages}
+      pageList={this.props.route.pageList}
+      startText="Order hearing aid batteries and accessories"
+    />
+  </div>
+);
 
 export default IntroductionPage;

--- a/src/applications/disability-benefits/2346/config/form.js
+++ b/src/applications/disability-benefits/2346/config/form.js
@@ -3,6 +3,7 @@ import PersonalInfoBox from '../components/PersonalInfoBox';
 import { schemaFields } from '../constants';
 import ConfirmationPage from '../containers/ConfirmationPage';
 import IntroductionPage from '../components/IntroductionPage';
+import FooterInfo from '../components/FooterInfo';
 import fullSchemaMDOT from '../schemas/2346-schema.json';
 import { buildAddressSchema } from '../schemas/address-schema';
 import UIDefinitions from '../schemas/definitions/2346UI';
@@ -55,6 +56,7 @@ const formConfig = {
   trackingPrefix: 'va-2346a-',
   introduction: IntroductionPage,
   confirmation: ConfirmationPage,
+  footerContent: FooterInfo,
   formId: VA_FORM_IDS.FORM_VA_2346A,
   version: 0,
   prefillEnabled: true,


### PR DESCRIPTION
## Description
Problem description. How might we include contact information in case veterans experience difficulties with the form?

## Testing done
_Add the 'Need help' component that's on the [bottom of the relevant form screens](https://vsateams.invisionapp.com/share/6MVTG94WNH5)_

## Screenshots
![Cursor_and_Request_for_hearing_aid_batteries_and_accessories___Veterans_Affairs](https://user-images.githubusercontent.com/875558/78739308-f89ad600-7921-11ea-8dc8-6af67b47a113.png)


## Acceptance criteria
- [ ] _The 'Need help' component is displayed on every relevant form page_
- [ ] _The content in each 'Need help' component matches the Invision prototype/the copy provided in the GH documentation (both are linked in the Tasks section)_

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
