### PR TITLE
changed primary green button to accurate copy

### DIFF
--- a/src/applications/disability-benefits/2346/components/IntroductionPage.jsx
+++ b/src/applications/disability-benefits/2346/components/IntroductionPage.jsx
@@ -18,7 +18,7 @@ class IntroductionPage extends React.Component {
           prefillEnabled={this.props.route.formConfig.prefillEnabled}
           messages={this.props.route.formConfig.savedFormMessages}
           pageList={this.props.route.pageList}
-          startText="Start the Application"
+          startText="Order hearing aid batteries and accessories"
         >
           Please complete the 2346 form to apply for ordering hearing aid
           batteries and accessories.
@@ -104,7 +104,7 @@ class IntroductionPage extends React.Component {
           hideUnauthedStartLink
           messages={this.props.route.formConfig.savedFormMessages}
           pageList={this.props.route.pageList}
-          startText="Start the Application"
+          startText="Order hearing aid batteries and accessories"
         />
       </div>
     );


### PR DESCRIPTION
## Description
As a veteran that is logged in, I need to be able to progress from the form's Introduction page into the ordering flow so I can place an order.

## Testing done
_Update the design in staging so it aligns with the [prototype](https://vsateams.invisionapp.com/share/6CVSW1NTJB4)_

## Screenshots
![Cursor_and_Request_for_hearing_aid_batteries_and_accessories___Veterans_Affairs](https://user-images.githubusercontent.com/875558/78740380-95f70980-7924-11ea-8b1c-83c01e9c1007.png)

## Acceptance criteria
- [ ] _Update both of the primary green buttons on the MDT's introduction page (auth) with [the content provided in the prototype](https://vsateams.invisionapp.com/share/6CVSW1NTJB4)_
- [ ] _Update the padding surrounding both of the buttons so it aligns with other forms on VA.gov_

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
