### PR TITLE
MDT - Update the 'Personal information' component on C1P1

### DIFF
--- a/src/applications/disability-benefits/2346/2346-schema.json
+++ b/src/applications/disability-benefits/2346/2346-schema.json
@@ -249,30 +249,38 @@
       "enum": ["yes", "no"]
     },
     "supplies": {
-      "type": "object",
-      "properties": {
-        "product_name": { "type": "string" },
-        "product_group": { "type": "string" },
-        "product_id": { "type": "number" },
-        "available_for_reorder": { "type": "boolean" },
-        "last_order_date": {
-          "type": "string",
-          "format": "date"
-        },
-        "productName": {
-          "type": "string"
-        },
-        "quantity": { "type": "number" }
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "deviceName": { "type": "string" },
+          "productName": { "type": "string" },
+          "productGroup": { "type": "string" },
+          "productId": { "type": "string" },
+          "availableForReorder": { "type": "boolean" },
+          "lastOrderDate": {
+            "type": "string",
+            "format": "date"
+          },
+          "nextAvailabilityDate": {
+            "type": "string",
+            "format": "date"
+          },
+          "quantity": { "type": "number" },
+          "size": {
+            "type": "string"
+          }
+        }
       }
     },
     "accessories": {
       "type": "object",
       "properties": {
-        "product_name": { "type": "string" },
-        "product_group": { "type": "string" },
-        "product_id": { "type": "number" },
-        "available_for_reorder": { "type": "boolean" },
-        "last_order_date": {
+        "productName": { "type": "string" },
+        "productGroup": { "type": "string" },
+        "productId": { "type": "number" },
+        "availableForReorder": { "type": "boolean" },
+        "lastOrderDate": {
           "type": "string",
           "format": "date"
         },
@@ -333,7 +341,6 @@
     "fullName",
     "gender",
     "email",
-    "dateOfBirth",
-    "supplies"
+    "dateOfBirth"
   ]
 }

--- a/src/applications/disability-benefits/2346/2346-schema.json
+++ b/src/applications/disability-benefits/2346/2346-schema.json
@@ -274,25 +274,26 @@
       }
     },
     "accessories": {
-      "type": "object",
-      "properties": {
-        "productName": { "type": "string" },
-        "productGroup": { "type": "string" },
-        "productId": { "type": "number" },
-        "availableForReorder": { "type": "boolean" },
-        "lastOrderDate": {
-          "type": "string",
-          "format": "date"
-        },
-        "nextAvailabilityDate": {
-          "type": "string",
-          "format": "date"
-        },
-        "quantity": {
-          "type": "number"
-        },
-        "size": {
-          "type": "string"
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "productName": { "type": "string" },
+          "productGroup": { "type": "string" },
+          "productId": { "type": "string" },
+          "availableForReorder": { "type": "boolean" },
+          "lastOrderDate": {
+            "type": "string",
+            "format": "date"
+          },
+          "nextAvailabilityDate": {
+            "type": "string",
+            "format": "date"
+          },
+          "quantity": { "type": "number" },
+          "size": {
+            "type": "string"
+          }
         }
       }
     },

--- a/src/applications/disability-benefits/2346/components/SelectArrayItemsAccessoriesWidget.jsx
+++ b/src/applications/disability-benefits/2346/components/SelectArrayItemsAccessoriesWidget.jsx
@@ -73,6 +73,7 @@ class SelectArrayItemsAccessoriesWidget extends React.Component {
                 name={supply.productId}
                 type="checkbox"
                 onChange={this.handleChecked}
+                checked={selectedItems.includes(supply.productId)}
               />
               <label htmlFor={supply.productId} className="main">
                 Order accessoires for this device

--- a/src/applications/disability-benefits/2346/components/SelectArrayItemsAccessoriesWidget.jsx
+++ b/src/applications/disability-benefits/2346/components/SelectArrayItemsAccessoriesWidget.jsx
@@ -21,7 +21,7 @@ class SelectArrayItemsAccessoriesWidget extends React.Component {
     const supplies = set(
       `[${index}].${this.props.options.selectedPropName}`,
       checked,
-      this.props.supplies,
+      this.props.value || this.props.supplies,
     );
     this.props.onChange(supplies);
   };

--- a/src/applications/disability-benefits/2346/components/SelectArrayItemsAccessoriesWidget.jsx
+++ b/src/applications/disability-benefits/2346/components/SelectArrayItemsAccessoriesWidget.jsx
@@ -33,6 +33,7 @@ class SelectArrayItemsAccessoriesWidget extends React.Component {
       if (!selected && formContext.onReviewPage) return null;
       return supply.productGroup === HEARING_AID_ACCESSORIES &&
         supply.availableForReorder === true ? (
+        // eslint-disable-next-line react/jsx-indent
         <div key={supply.productId} className="order-background">
           <p className="vads-u-font-size--md vads-u-font-weight--bold">
             {supply.productName}

--- a/src/applications/disability-benefits/2346/components/SelectArrayItemsAccessoriesWidget.jsx
+++ b/src/applications/disability-benefits/2346/components/SelectArrayItemsAccessoriesWidget.jsx
@@ -8,82 +8,71 @@ import {
   BLUE_BACKGROUND,
   WHITE_BACKGROUND,
 } from '../constants';
+import get from 'platform/utilities/data/get';
+import set from 'platform/utilities/data/set';
 // TODO: Safety checks for `selected` callback and `label` element
 
 class SelectArrayItemsAccessoriesWidget extends React.Component {
-  state = {
-    selectedItems: [],
-  };
   componentDidMount() {
     this.props.getReOrderBatteryAndAccessoriesInformationData();
   }
 
-  handleChecked = e => {
-    e.persist();
-    if (e.target.checked) {
-      this.setState(prevState => ({
-        selectedItems: prevState.selectedItems.concat(e.target.name),
-      }));
-    } else {
-      this.setState(prevState => ({
-        selectedItems: prevState.selectedItems.filter(i => i !== e.target.name),
-      }));
-    }
+  handleChecked = (index, checked) => {
+    const supplies = set(
+      `[${index}].${this.props.options.selectedPropName}`,
+      checked,
+      this.props.supplies,
+    );
+    this.props.onChange(supplies);
   };
 
   render() {
-    const { supplies } = this.props;
-    const { selectedItems } = this.state;
-
-    return supplies.map(
-      supply =>
-        supply.productGroup === HEARING_AID_ACCESSORIES &&
+    const { value, supplies, options, formContext } = this.props;
+    return (value || supplies).map((supply, index) => {
+      const selected = get(options.selectedPropName, supply);
+      if (!selected && formContext.onReviewPage) return null;
+      return supply.productGroup === HEARING_AID_ACCESSORIES &&
         supply.availableForReorder === true ? (
-          <div key={supply.productId} className="order-background">
-            <p className="vads-u-font-size--md vads-u-font-weight--bold">
-              {supply.productName}
-            </p>
-            <div className="vads-u-border-left--10px vads-u-border-color--primary-alt">
-              <div className="usa-alert-body mdot-alert-body">
-                <p className="vads-u-margin--1px">
-                  <span className="vads-u-font-weight--bold">Battery: </span>
-                  {supply.productId}
-                </p>
-                <p className="vads-u-margin--1px">
-                  <span className="vads-u-font-weight--bold">Quantity: </span>
-                  {supply.quantity} <br />
-                  Approximately {supply.quantity} months supply
-                </p>
-                <p className="vads-u-margin--1px">
-                  <span className="vads-u-font-weight--bold">
-                    Last order date:{' '}
-                  </span>{' '}
-                  {moment(supply.lastOrderDate).format('MM/DD/YYYY')}
-                </p>
-              </div>
-            </div>
-            <div
-              className={
-                selectedItems.includes(supply.productId)
-                  ? BLUE_BACKGROUND
-                  : WHITE_BACKGROUND
-              }
-            >
-              <input
-                name={supply.productId}
-                type="checkbox"
-                onChange={this.handleChecked}
-                checked={selectedItems.includes(supply.productId)}
-              />
-              <label htmlFor={supply.productId} className="main">
-                Order accessoires for this device
-              </label>
+        <div key={supply.productId} className="order-background">
+          <p className="vads-u-font-size--md vads-u-font-weight--bold">
+            {supply.productName}
+          </p>
+          <div className="vads-u-border-left--10px vads-u-border-color--primary-alt">
+            <div className="usa-alert-body mdot-alert-body">
+              <p className="vads-u-margin--1px">
+                <span className="vads-u-font-weight--bold">Battery: </span>
+                {supply.productId}
+              </p>
+              <p className="vads-u-margin--1px">
+                <span className="vads-u-font-weight--bold">Quantity: </span>
+                {supply.quantity} <br />
+                Approximately {supply.quantity} months supply
+              </p>
+              <p className="vads-u-margin--1px">
+                <span className="vads-u-font-weight--bold">
+                  Last order date:{' '}
+                </span>{' '}
+                {moment(supply.lastOrderDate).format('MM/DD/YYYY')}
+              </p>
             </div>
           </div>
-        ) : (
-          ''
-        ),
-    );
+          <div className={selected ? BLUE_BACKGROUND : WHITE_BACKGROUND}>
+            <input
+              id={supply.productId}
+              name={supply.productId}
+              type="checkbox"
+              onChange={e => this.handleChecked(index, e.target.checked)}
+              checked={selected}
+            />
+            <label htmlFor={supply.productId} className="main">
+              Order accessoires for this device
+            </label>
+          </div>
+        </div>
+      ) : (
+        ''
+      );
+    });
   }
 }
 
@@ -104,7 +93,7 @@ SelectArrayItemsAccessoriesWidget.propTypes = {
 };
 
 const mapStateToProps = state => ({
-  supplies: state.form?.loadedData?.formData?.supplies,
+  supplies: state.form?.loadedData?.formData?.supplies || [],
 });
 const mapDispatchToProps = {
   getReOrderBatteryAndAccessoriesInformationData,

--- a/src/applications/disability-benefits/2346/components/SelectArrayItemsBatteriesWidget.jsx
+++ b/src/applications/disability-benefits/2346/components/SelectArrayItemsBatteriesWidget.jsx
@@ -8,80 +8,70 @@ import {
   BLUE_BACKGROUND,
   WHITE_BACKGROUND,
 } from '../constants';
+import get from 'platform/utilities/data/get';
+import set from 'platform/utilities/data/set';
 // TODO: Safety checks for `selected` callback and `label` element
 
 class SelectArrayItemsBatteriesWidget extends React.Component {
-  state = {
-    selectedItems: [],
-  };
   componentDidMount() {
     this.props.getReOrderBatteryAndAccessoriesInformationData();
   }
 
-  handleChecked = e => {
-    e.persist();
-    if (e.target.checked) {
-      this.setState(prevState => ({
-        selectedItems: prevState.selectedItems.concat(e.target.name),
-      }));
-    } else {
-      this.setState(prevState => ({
-        selectedItems: prevState.selectedItems.filter(i => i !== e.target.name),
-      }));
-    }
+  handleChecked = (index, checked) => {
+    const supplies = set(
+      `[${index}].${this.props.options.selectedPropName}`,
+      checked,
+      this.props.supplies,
+    );
+    this.props.onChange(supplies);
   };
 
   render() {
-    const { supplies } = this.props;
-    const { selectedItems } = this.state;
-
-    return supplies.map(
-      supply =>
-        supply.productGroup === HEARING_AID_BATTERIES ? (
-          <div key={supply.productId} className="order-background">
-            <p className="vads-u-font-size--md vads-u-font-weight--bold">
-              {supply.productName}
-            </p>
-            <div className="vads-u-border-left--10px vads-u-border-color--primary-alt">
-              <div className="usa-alert-body mdot-alert-body">
-                <p className="vads-u-margin--1px">
-                  <span className="vads-u-font-weight--bold">Battery: </span>
-                  {supply.productId}
-                </p>
-                <p className="vads-u-margin--1px">
-                  <span className="vads-u-font-weight--bold">Quantity: </span>
-                  {supply.quantity} <br />
-                  Approximately {supply.quantity} months supply
-                </p>
-                <p className="vads-u-margin--1px">
-                  <span className="vads-u-font-weight--bold">
-                    Last order date:{' '}
-                  </span>{' '}
-                  {moment(supply.lastOrderDate).format('MM/DD/YYYY')}
-                </p>
-              </div>
-            </div>
-            <div
-              className={
-                selectedItems.includes(supply.productId)
-                  ? BLUE_BACKGROUND
-                  : WHITE_BACKGROUND
-              }
-            >
-              <input
-                name={supply.productId}
-                type="checkbox"
-                onChange={this.handleChecked}
-              />
-              <label htmlFor={supply.productId} className="main">
-                Order batteries for this device
-              </label>
+    const { value, supplies, options, formContext } = this.props;
+    return (value || supplies).map((supply, index) => {
+      const selected = get(options.selectedPropName, supply);
+      if (!selected && formContext.onReviewPage) return null;
+      return supply.productGroup === HEARING_AID_BATTERIES ? (
+        <div key={supply.productId} className="order-background">
+          <p className="vads-u-font-size--md vads-u-font-weight--bold">
+            {supply.productName}
+          </p>
+          <div className="vads-u-border-left--10px vads-u-border-color--primary-alt">
+            <div className="usa-alert-body mdot-alert-body">
+              <p className="vads-u-margin--1px">
+                <span className="vads-u-font-weight--bold">Battery: </span>
+                {supply.productId}
+              </p>
+              <p className="vads-u-margin--1px">
+                <span className="vads-u-font-weight--bold">Quantity: </span>
+                {supply.quantity} <br />
+                Approximately {supply.quantity} months supply
+              </p>
+              <p className="vads-u-margin--1px">
+                <span className="vads-u-font-weight--bold">
+                  Last order date:{' '}
+                </span>{' '}
+                {moment(supply.lastOrderDate).format('MM/DD/YYYY')}
+              </p>
             </div>
           </div>
-        ) : (
-          ''
-        ),
-    );
+          <div className={selected ? BLUE_BACKGROUND : WHITE_BACKGROUND}>
+            <input
+              id={supply.productId}
+              name={supply.productId}
+              type="checkbox"
+              onChange={e => this.handleChecked(index, e.target.checked)}
+              checked={selected}
+            />
+            <label htmlFor={supply.productId} className="main">
+              Order batteries for this device
+            </label>
+          </div>
+        </div>
+      ) : (
+        ''
+      );
+    });
   }
 }
 
@@ -102,7 +92,7 @@ SelectArrayItemsBatteriesWidget.propTypes = {
 };
 
 const mapStateToProps = state => ({
-  supplies: state.form?.loadedData?.formData?.supplies,
+  supplies: state.form?.loadedData?.formData?.supplies || [],
 });
 const mapDispatchToProps = {
   getReOrderBatteryAndAccessoriesInformationData,

--- a/src/applications/disability-benefits/2346/components/SelectArrayItemsBatteriesWidget.jsx
+++ b/src/applications/disability-benefits/2346/components/SelectArrayItemsBatteriesWidget.jsx
@@ -21,7 +21,7 @@ class SelectArrayItemsBatteriesWidget extends React.Component {
     const supplies = set(
       `[${index}].${this.props.options.selectedPropName}`,
       checked,
-      this.props.supplies,
+      this.props.value || this.props.supplies,
     );
     this.props.onChange(supplies);
   };

--- a/src/applications/disability-benefits/2346/components/personalInfoBox.jsx
+++ b/src/applications/disability-benefits/2346/components/personalInfoBox.jsx
@@ -15,11 +15,11 @@ class personalInfoBox extends React.Component {
       <div>
         <p>This is the personal information we have for you.</p>
         <div>
-          <div className="usa-alert schemaform-sip-alert">
+          <div className="personal-info-box">
             <div className="usa-alert-body">
-              <p className="vads-u-margin--1px">
+              <h3 className="usa-alert-heading">
                 {first} {last}
-              </p>
+              </h3>
               <p className="vads-u-margin--1px">
                 Date of Birth: {moment(dateOfBirth).format('MM/DD/YYYY')}
               </p>

--- a/src/applications/disability-benefits/2346/config/form.js
+++ b/src/applications/disability-benefits/2346/config/form.js
@@ -178,6 +178,9 @@ const formConfig = {
               'ui:options': {
                 expandUnder: 'view:addAccessories',
                 expandUnderCondition: 'yes',
+                showFieldLabel: 'label',
+                keepInPageOnReview: true,
+                selectedPropName: 'view:selected',
               },
             },
           },

--- a/src/applications/disability-benefits/2346/config/form.js
+++ b/src/applications/disability-benefits/2346/config/form.js
@@ -131,10 +131,14 @@ const formConfig = {
               'ui:title': 'Which hearing aid do you need batteries for?',
               'ui:description':
                 'You will be sent a 6 month supply of batteries for each device you select below.',
-              'ui:field': SelectArrayItemsBatteriesWidget,
+              'ui:field': 'StringField',
+              'ui:widget': SelectArrayItemsBatteriesWidget,
               'ui:options': {
                 expandUnder: 'view:addBatteries',
                 expandUnderCondition: 'yes',
+                showFieldLabel: 'label',
+                keepInPageOnReview: true,
+                selectedPropName: 'view:selected',
               },
             },
           },
@@ -169,7 +173,8 @@ const formConfig = {
               'ui:title': 'Which hearing aid do you need batteries for?',
               'ui:description':
                 'You will be sent a 6 month supply of batteries for each device you select below.',
-              'ui:field': SelectArrayItemsAccessoriesWidget,
+              'ui:field': 'StringField',
+              'ui:widget': SelectArrayItemsAccessoriesWidget,
               'ui:options': {
                 expandUnder: 'view:addAccessories',
                 expandUnderCondition: 'yes',

--- a/src/applications/disability-benefits/2346/sass/form-2346.scss
+++ b/src/applications/disability-benefits/2346/sass/form-2346.scss
@@ -7,6 +7,12 @@
 @import "~@department-of-veterans-affairs/formation/sass/modules/m-omb-info";
 @import "../../../../platform/forms/sass/m-form-confirmation";
 
+.personal-info-box {
+  margin-left: 0rem;
+  border-left: 8px solid #0071bb;
+  padding-left: 2rem;
+}
+
 .order-background {
   background-color: #f1f1f1;
   padding-left: 2em;
@@ -57,8 +63,9 @@ label {
   font-weight: normal;
 }
 
-[type=checkbox]:checked + label::before, [type=radio]:checked + label::before {
-   background-color: #fff;
+[type="checkbox"]:checked + label::before,
+[type="radio"]:checked + label::before {
+  background-color: #fff;
 }
 
 .blue-bar-block {


### PR DESCRIPTION
## Description
As a veteran placing an order for hearing batteries and accessories, I need to confirm my personal information so I can ensure my personal information is correct in my medical record.

## Testing done
Implement the 'Personal information' component styling that matches other forms on VA.gov. An example of this styling can be found on the 21-526-EZ form.

## Screenshots
![Cursor_and_Request_for_hearing_aid_batteries_and_accessories___Veterans_Affairs](https://user-images.githubusercontent.com/875558/78742287-91811f80-7929-11ea-8dd6-a6da5decd9ec.png)

## Acceptance criteria
- [ ] _The correct styling for the 'Personal information' component will be incorporated_

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
