### PR TITLE
Update the content in the subway map on the form's introduction page

### DIFF
--- a/src/applications/disability-benefits/2346/components/IntroductionPage.jsx
+++ b/src/applications/disability-benefits/2346/components/IntroductionPage.jsx
@@ -1,4 +1,3 @@
-import OMBInfo from '@department-of-veterans-affairs/formation-react/OMBInfo';
 import FormTitle from 'platform/forms-system/src/js/components/FormTitle';
 import SaveInProgressIntro from 'platform/forms/save-in-progress/SaveInProgressIntro';
 import { focusElement } from 'platform/utilities/ui';
@@ -30,8 +29,8 @@ class IntroductionPage extends React.Component {
         <div className="process schemaform-process">
           <ol>
             <li className="process-step list-one">
-              <h3>Prepare</h3>
-              <p>To place an order, you'll need your:</p>
+              <h3 className="vads-u-font-size--h5">Prepare</h3>
+              <p>To place an order, you’ll need your:</p>
               <ul>
                 <li>Shipping address</li>
                 <li>Email address</li>
@@ -39,17 +38,24 @@ class IntroductionPage extends React.Component {
               </ul>
               <h4>What if I need help with my order?</h4>
               <p>
-                If you need help ordering hearing aid and betteries and
-                accessories, you cna contact the Devner Logistics Center (DLC)
-                at <a href="tel:303-273-6200">303-273-6200</a>
+                If you need help ordering hearing aid batteries and accessories,
+                you can call the Denver Logistics Center Customer Service
+                Section at
+                <a
+                  aria-label="3 0 3. 2 7 3. 6 2 0 0."
+                  title="Dial the telephone number 303-273-6200"
+                  href="tel:303-273-6200"
+                >
+                  303-273-6200
+                </a>
               </p>
             </li>
             <li className="process-step list-two">
-              <h3>Place your order</h3>
+              <h3 className="vads-u-font-size--h5">Place your order</h3>
               <p>
                 Complete this hearing aid batteries and accessories order form.
               </p>
-              <p>These are the steps you can expect when placing an oder:</p>
+              <p>These are the steps you can expect when placing an order:</p>
               <ul>
                 <li>Confirm your personal information</li>
                 <li>Confirm or edit your shipping address and email address</li>
@@ -58,28 +64,35 @@ class IntroductionPage extends React.Component {
                 <li>Review and submit order</li>
               </ul>
               <p>
-                After submitting the order, you'll get a confirmation message.
-                You can print this for your records.
+                After submitting the order form, you’ll get a confirmation
+                message. You can print this for your records.
               </p>
             </li>
             <li className="process-step list-three">
-              <h3>Track your order</h3>
+              <h3>Track your order </h3>
               <p>
-                You will recieve an email with an order tracking number 1-2 days
+                You will receive an email with an order tracking number 1-2 days
                 after your order is submitted.
               </p>
             </li>
             <li className="process-step list-four">
-              <h3>Review your order</h3>
+              <h5>Receive your order</h5>
               <p>
-                You should recieve your order withing the timeframe indicated by
+                You should receive your order within the timeframe indicated by
                 the order tracking number.
               </p>
               <h4>What if I have questions about my order?</h4>
               <p>
-                If you have questions about your order, you can contact the
-                Denver Logistics Center (DLC) at{' '}
-                <a href="tel:303-273-6200">303-273-6200</a>.{' '}
+                If you have questions about your order, you can call the DLC
+                Customer Service Section at{' '}
+                <a
+                  aria-label="3 0 3. 2 7 3. 6 2 0 0."
+                  title="Dial the telephone number 303-273-6200"
+                  href="tel:303-273-6200"
+                >
+                  303-273-6200
+                </a>
+                .{' '}
               </p>
             </li>
           </ol>
@@ -91,9 +104,6 @@ class IntroductionPage extends React.Component {
           pageList={this.props.route.pageList}
           startText="Start the Application"
         />
-        <div className="omb-info--container vads-u-padding-left--0">
-          <OMBInfo resBurden={30} ombNumber="2900-0862" expDate="02/28/2022" />
-        </div>
       </div>
     );
   }

--- a/src/applications/disability-benefits/2346/components/IntroductionPage.jsx
+++ b/src/applications/disability-benefits/2346/components/IntroductionPage.jsx
@@ -23,8 +23,12 @@ class IntroductionPage extends React.Component {
           Please complete the 2346 form to apply for ordering hearing aid
           batteries and accessories.
         </SaveInProgressIntro>
-        <h2 itemProp="name" id="am-i-eligible-to-order-prosthe">
-          Follow the steps below to order hearing aid batteries aid accessories.
+        <h2
+          className="vads-u-font-size--h4"
+          itemProp="name"
+          id="am-i-eligible-to-order-prosthe"
+        >
+          Follow the steps below to order hearing aid batteries and accessories.
         </h2>
         <div className="process schemaform-process">
           <ol>
@@ -40,9 +44,8 @@ class IntroductionPage extends React.Component {
               <p>
                 If you need help ordering hearing aid batteries and accessories,
                 you can call the Denver Logistics Center Customer Service
-                Section at
+                Section at{' '}
                 <a
-                  aria-label="3 0 3. 2 7 3. 6 2 0 0."
                   title="Dial the telephone number 303-273-6200"
                   href="tel:303-273-6200"
                 >
@@ -86,7 +89,6 @@ class IntroductionPage extends React.Component {
                 If you have questions about your order, you can call the DLC
                 Customer Service Section at{' '}
                 <a
-                  aria-label="3 0 3. 2 7 3. 6 2 0 0."
                   title="Dial the telephone number 303-273-6200"
                   href="tel:303-273-6200"
                 >

--- a/src/applications/disability-benefits/2346/components/IntroductionPage.jsx
+++ b/src/applications/disability-benefits/2346/components/IntroductionPage.jsx
@@ -76,7 +76,7 @@ class IntroductionPage extends React.Component {
               </p>
             </li>
             <li className="process-step list-four">
-              <h5>Receive your order</h5>
+              <h3 className="vads-u-font-size--h5">Receive your order</h3>
               <p>
                 You should receive your order within the timeframe indicated by
                 the order tracking number.

--- a/src/applications/disability-benefits/2346/components/IntroductionPage.jsx
+++ b/src/applications/disability-benefits/2346/components/IntroductionPage.jsx
@@ -11,7 +11,7 @@ class IntroductionPage extends React.Component {
   render() {
     return (
       <div className="schemaform-intro">
-        <FormTitle title="VA Form 2346" />
+        <FormTitle title="Order hearing aid batteries and accessories" />
         <p>Equal to VA Form 2346 (Request for Batteries and Accessories).</p>
         <SaveInProgressIntro
           hideUnauthedStartLink

--- a/src/applications/disability-benefits/2346/config/form.js
+++ b/src/applications/disability-benefits/2346/config/form.js
@@ -7,7 +7,7 @@ import SelectArrayItemsBatteriesWidget from '../components/SelectArrayItemsBatte
 import SelectArrayItemsAccessoriesWidget from '../components/SelectArrayItemsAccessoriesWidget';
 import { schemaFields } from '../constants';
 import ConfirmationPage from '../containers/ConfirmationPage';
-import IntroductionPage from '../containers/IntroductionPage';
+import IntroductionPage from '../components/IntroductionPage';
 import UIDefinitions from '../definitions/2346UI';
 
 const {


### PR DESCRIPTION
## Description
As a veteran placing an order for hearing aid batteries and accessories, I need to review all of the steps in the ordering process so I can make sure I have all of the required information to place an order and am confident in the next steps after submitting my order form.

## Testing done
Typos in the subway map's content are rectified.

## Screenshots
![Cursor_and_Request_for_hearing_aid_batteries_and_accessories___Veterans_Affairs](https://user-images.githubusercontent.com/875558/78743405-88de1880-792c-11ea-9203-3a77d02867f7.png)

## Acceptance criteria
- [ ] _The introduction screen's subway map will have the correct content_

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
