### PR TITLE
VET TEC caution flag fix

### DIFF
--- a/src/applications/gi/components/vet-tec/VetTecProgramSearchResult.jsx
+++ b/src/applications/gi/components/vet-tec/VetTecProgramSearchResult.jsx
@@ -37,9 +37,9 @@ class VetTecProgramSearchResult extends React.Component {
       query: version ? { version } : {},
     };
 
-    const cautionFlags = [...this.props.result.cautionFlags].filter(
-      flag => flag.title,
-    );
+    const cautionFlags = this.props.result.cautionFlags
+      ? [...this.props.result.cautionFlags].filter(flag => flag.title)
+      : [];
 
     return (
       <div className="search-result">


### PR DESCRIPTION
## Description
Fix for caution flags not appearing in prod.

https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/7356

## Testing done
Tested locally and QA review

## Screenshots
![image](https://user-images.githubusercontent.com/41960449/78790781-ffa30200-797c-11ea-9d0f-2569b0e3fed3.png)

## Acceptance criteria
- [x] VET TEC programs display correctly

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
