### PR TITLE
Remove vaProfileAddressValidation feature flag from FE

### DIFF
--- a/src/platform/user/profile/vet360/actions/transactions.js
+++ b/src/platform/user/profile/vet360/actions/transactions.js
@@ -11,7 +11,6 @@ import {
   isSuccessfulTransaction,
   isFailedTransaction,
 } from '../util/transactions';
-import { vaProfileUseAddressValidation } from '../selectors';
 import { FIELD_NAMES, ADDRESS_POU } from 'vet360/constants';
 
 export const VET360_TRANSACTIONS_FETCH_SUCCESS =
@@ -145,7 +144,7 @@ export function createTransaction(
   payload,
   analyticsSectionName,
 ) {
-  return async (dispatch, getState) => {
+  return async dispatch => {
     const options = {
       body: JSON.stringify(payload),
       method,
@@ -153,7 +152,6 @@ export function createTransaction(
         'Content-Type': 'application/json',
       },
     };
-    const state = getState();
     try {
       dispatch({
         type: VET360_TRANSACTION_REQUESTED,
@@ -165,16 +163,8 @@ export function createTransaction(
         ? await apiRequest(route, options)
         : await localVet360.createTransaction();
 
-      // We want the validateAddreses method handling dataLayer events for saving / updating addresses.
-      if (vaProfileUseAddressValidation(state)) {
-        if (!fieldName.toLowerCase().includes('address')) {
-          recordEvent({
-            event:
-              method === 'DELETE' ? 'profile-deleted' : 'profile-transaction',
-            'profile-section': analyticsSectionName,
-          });
-        }
-      } else {
+      // We want the validateAddresses method handling dataLayer events for saving / updating addresses.
+      if (!fieldName.toLowerCase().includes('address')) {
         recordEvent({
           event:
             method === 'DELETE' ? 'profile-deleted' : 'profile-transaction',

--- a/src/platform/user/profile/vet360/containers/Vet360ProfileField.jsx
+++ b/src/platform/user/profile/vet360/containers/Vet360ProfileField.jsx
@@ -23,7 +23,6 @@ import {
   selectVet360Transaction,
   selectCurrentlyOpenEditModal,
   selectEditedFormField,
-  vaProfileUseAddressValidation,
 } from '../selectors';
 
 import Vet360ProfileFieldHeading from '../components/base/Vet360ProfileFieldHeading';
@@ -113,12 +112,7 @@ class Vet360ProfileField extends React.Component {
   };
 
   onSubmit = () => {
-    // The validateAddress thunk will handle its own dataLayer additions
-    if (this.props.useAddressValidation) {
-      if (!this.props.fieldName.toLowerCase().includes('address')) {
-        this.captureEvent('update-button');
-      }
-    } else {
+    if (!this.props.fieldName.toLowerCase().includes('address')) {
       this.captureEvent('update-button');
     }
 
@@ -132,10 +126,7 @@ class Vet360ProfileField extends React.Component {
 
     const method = payload.id ? 'PUT' : 'POST';
 
-    if (
-      this.props.fieldName.toLowerCase().includes('address') &&
-      this.props.useAddressValidation
-    ) {
+    if (this.props.fieldName.toLowerCase().includes('address')) {
       this.props.validateAddress(
         this.props.apiRoute,
         method,
@@ -281,11 +272,9 @@ export const mapStateToProps = (state, ownProps) => {
   );
   const data = selectVet360Field(state, fieldName);
   const isEmpty = !data;
-  const useAddressValidation = vaProfileUseAddressValidation(state);
   const addressValidationType =
     state.vet360.addressValidation.addressValidationType;
   const showValidationModal =
-    useAddressValidation &&
     ownProps.ValidationModal &&
     addressValidationType === fieldName &&
     selectCurrentlyOpenEditModal(state) === 'addressValidation';
@@ -300,7 +289,6 @@ export const mapStateToProps = (state, ownProps) => {
     isEmpty,
     transaction,
     transactionRequest,
-    useAddressValidation,
   };
 };
 

--- a/src/platform/user/profile/vet360/selectors.js
+++ b/src/platform/user/profile/vet360/selectors.js
@@ -1,6 +1,4 @@
 import backendServices from 'platform/user/profile/constants/backendServices';
-import FEATURE_FLAG_NAMES from 'platform/utilities/feature-toggles/featureFlagNames';
-import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
 
 import { VET360_INITIALIZATION_STATUS, INIT_VET360_ID } from './constants';
 
@@ -131,8 +129,4 @@ export function selectVet360InitializationStatus(state) {
     transaction,
     transactionRequest,
   };
-}
-
-export function vaProfileUseAddressValidation(state) {
-  return toggleValues(state)[FEATURE_FLAG_NAMES.vaProfileAddressValidation];
 }

--- a/src/platform/user/profile/vet360/tests/containers/Vet360ProfileField.unit.spec.jsx
+++ b/src/platform/user/profile/vet360/tests/containers/Vet360ProfileField.unit.spec.jsx
@@ -189,17 +189,6 @@ describe('mapStateToProps', () => {
         expect(mappedProps.showValidationModal).to.be.true;
       });
     });
-    describe('when the feature flag is not set', () => {
-      it('sets `showValidationModal` to `false`', () => {
-        const state = showValidationModalState();
-        state.featureToggles = {};
-        const mappedProps = mapStateToProps(state, {
-          fieldName: 'mailingAddress',
-          ValidationModal: () => {},
-        });
-        expect(mappedProps.showValidationModal).to.be.false;
-      });
-    });
     describe('when the address validation modal is not open', () => {
       it('sets `showValidationModal` to `false`', () => {
         const state = showValidationModalState();

--- a/src/platform/user/profile/vet360/tests/selectors.unit.spec.js
+++ b/src/platform/user/profile/vet360/tests/selectors.unit.spec.js
@@ -340,24 +340,3 @@ describe('selectVet360InitializationStatus', () => {
     );
   });
 });
-
-describe('vaProfileUseAddressValidation', () => {
-  it('returns `true` if the feature flag is set', () => {
-    expect(
-      selectors.vaProfileUseAddressValidation({
-        featureToggles: {
-          vaProfileAddressValidation: true,
-        },
-      }),
-    ).to.be.true;
-  });
-  it('returns `undefined` if the feature flag is not set', () => {
-    expect(
-      selectors.vaProfileUseAddressValidation({
-        featureToggles: {
-          anotherFeatureFlag: true,
-        },
-      }),
-    ).to.be.undefined;
-  });
-});

--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -9,7 +9,6 @@ export default Object.freeze({
   vaOnlineSchedulingDirect: 'vaOnlineSchedulingDirect',
   vaOnlineSchedulingPast: 'vaOnlineSchedulingPast',
   vaGlobalDowntimeNotification: 'vaGlobalDowntimeNotification',
-  vaProfileAddressValidation: 'vaProfileAddressValidation',
   ssoe: 'ssoe',
   eduBenefitsStemScholarship: 'eduBenefitsStemScholarship',
 });


### PR DESCRIPTION
## Description
Just like it says on the tin: stop using the `vaProfileAddressValidation` feature flag in the front end code. This feature has been rolled out to 100% of users for about two weeks now and we do not anticipate needing to roll it back.

## Testing done
Local

## Screenshots
N/A

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs