### PR TITLE
VAVFT-7758: Fixing ie10+ flex display.

### DIFF
--- a/src/applications/static-pages/sass/modules/_m-facilities.scss
+++ b/src/applications/static-pages/sass/modules/_m-facilities.scss
@@ -45,7 +45,6 @@ $duo-tone-lighten: #000;
   .vads-l-row {
     min-width: 94%;
     max-width: 94%;
-    flex-wrap: nowrap;
   }
 }
 


### PR DESCRIPTION
## Description
Flex display is broken in IE11/Edge on Operating status page

## Testing done
Visual

## Screenshots
![image](https://user-images.githubusercontent.com/2404547/78812489-7ea63380-7999-11ea-924c-e7f7e6d16755.png)

## Acceptance criteria
- [ ] Visit `pittsburgh-health-care/operating-status/` in ie 11 / edge.
- [ ] Visually verify operating status grid is stacked, and not all on one row.