### PR TITLE
Added CSRF prevention to other apps

### DIFF
--- a/src/applications/claims-status/actions/index.jsx
+++ b/src/applications/claims-status/actions/index.jsx
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 import get from '../../../platform/utilities/data/get';
 import recordEvent from '../../../platform/monitoring/record-event';
 import environment from '../../../platform/utilities/environment';
+import localStorage from 'platform/utilities/storage/localStorage';
 import { apiRequest } from '../../../platform/utilities/api';
 import { makeAuthRequest } from '../utils/helpers';
 import {
@@ -366,6 +367,7 @@ export function submitFiles(claimId, trackedItem, files) {
     require.ensure(
       [],
       require => {
+        const csrfTokenStored = localStorage.getItem('csrfToken');
         const { FineUploaderBasic } = require('fine-uploader/lib/core');
         const uploader = new FineUploaderBasic({
           request: {
@@ -375,6 +377,7 @@ export function submitFiles(claimId, trackedItem, files) {
             inputName: 'file',
             customHeaders: {
               'X-Key-Inflection': 'camel',
+              'X-CSRF-Token': csrfTokenStored,
             },
           },
           cors: {

--- a/src/applications/claims-status/utils/helpers.js
+++ b/src/applications/claims-status/utils/helpers.js
@@ -2,6 +2,7 @@ import _ from 'lodash/fp';
 import * as Sentry from '@sentry/browser';
 
 import environment from '../../../platform/utilities/environment';
+import localStorage from 'platform/utilities/storage/localStorage';
 import { fetchAndUpdateSessionExpiration as fetch } from 'platform/utilities/api';
 import { SET_UNAUTHORIZED } from '../actions/index.jsx';
 
@@ -253,6 +254,7 @@ export function makeAuthRequest(
   onSuccess,
   onError,
 ) {
+  const csrfTokenStored = localStorage.getItem('csrfToken');
   const options = _.merge(
     {
       method: 'GET',
@@ -261,6 +263,7 @@ export function makeAuthRequest(
       headers: {
         'X-Key-Inflection': 'camel',
         'Source-App-Name': window.appName,
+        'X-CSRF-Token': csrfTokenStored,
       },
       responseType: 'json',
     },

--- a/src/platform/forms/save-in-progress/api.js
+++ b/src/platform/forms/save-in-progress/api.js
@@ -1,10 +1,12 @@
 import * as Sentry from '@sentry/browser';
 import recordEvent from '../../monitoring/record-event';
 import environment from '../../utilities/environment';
+import localStorage from '../../utilities/storage/localStorage';
 import { fetchAndUpdateSessionExpiration as fetch } from '../../utilities/api';
 import { sanitizeForm } from '../helpers';
 
 export function removeFormApi(formId) {
+  const csrfTokenStored = localStorage.getItem('csrfToken');
   return fetch(`${environment.API_URL}/v0/in_progress_forms/${formId}`, {
     method: 'DELETE',
     credentials: 'include',
@@ -12,6 +14,7 @@ export function removeFormApi(formId) {
       'Content-Type': 'application/json',
       'X-Key-Inflection': 'camel',
       'Source-App-Name': window.appName,
+      'X-CSRF-Token': csrfTokenStored,
     },
   })
     .then(res => {
@@ -50,6 +53,7 @@ export function saveFormApi(
     },
     formData,
   });
+  const csrfTokenStored = localStorage.getItem('csrfToken');
 
   return fetch(`${environment.API_URL}/v0/in_progress_forms/${formId}`, {
     method: 'PUT',
@@ -58,6 +62,7 @@ export function saveFormApi(
       'Content-Type': 'application/json',
       'X-Key-Inflection': 'camel',
       'Source-App-Name': window.appName,
+      'X-CSRF-Token': csrfTokenStored,
     },
     body,
   })


### PR DESCRIPTION
## Description

This is an addition to the main [PR which added the CSRF token via header](https://github.com/department-of-veterans-affairs/vets-website/pull/12005)

There are some files in the app/platform code that are making direct `fetch()` or `XMLHTTPRequest` calls without using the `apiRequest` helper. I decided to refactor them to ensure that the requests are made with a CSRF token.

## Testing done
Locally