### PR TITLE
[Templates] Hide mobile button when there are no links to show

### DIFF
--- a/src/site/layouts/page.drupal.liquid
+++ b/src/site/layouts/page.drupal.liquid
@@ -9,7 +9,11 @@
     {% include 'src/site/navigation/sidebar_nav.drupal.liquid' with sidebar %}
 
     <div class="usa-width-three-fourths">
-        {% include "src/site/components/navigation-sidebar-trigger.html" with menuId = "va-detailpage-sidebar" %}
+
+        {% if sidebar.links != empty %}
+          {% include "src/site/components/navigation-sidebar-trigger.html" with menuId = "va-detailpage-sidebar" %}
+        {% endif %}
+
         {% if !entityPublished %}
         <div class="usa-alert usa-alert-info" >
           <div class="usa-alert-body">


### PR DESCRIPTION
## Description
The button shown on mobile devices for triggering the sidebar to appear is rendering on pages without a sidebar.


https://github.com/department-of-veterans-affairs/va.gov-team/issues/7744

## Testing done
- Locally, looked at `/change-direct-deposit` to confirm button was removed
- Confirmed I didn't break the sidebar on other pages

## Screenshots

### Problem 
https://www.va.gov/change-direct-deposit/
![image](https://user-images.githubusercontent.com/1915775/78832971-25023100-79ba-11ea-89fc-f8f76183b28a.png)

![image](https://user-images.githubusercontent.com/1915775/78832993-2b90a880-79ba-11ea-877b-663ec61a69e2.png)

### Fixed
![image](https://user-images.githubusercontent.com/1915775/78833136-5ed33780-79ba-11ea-84f1-79bea165de9a.png)


## Acceptance criteria
- [ ] Sidebar-trigger button does not show on mobile devices of pages without sidebars

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
