### PR TITLE
Add correlation between map pin and cards in search results and update semantic html for result items

### DIFF
--- a/src/applications/facility-locator/components/FacilityTypeDescription.jsx
+++ b/src/applications/facility-locator/components/FacilityTypeDescription.jsx
@@ -19,10 +19,12 @@ const FacilityTypeDescription = ({ location, query }) => {
   if (location.resultItem) {
     return (
       <dfn>
-        <span>
-          {facilityName(query, location) &&
-            facilityName(query, location).toUpperCase()}
-        </span>
+        <div>
+          <span>
+            {facilityName(query, location) &&
+              facilityName(query, location).toUpperCase()}
+          </span>
+        </div>
       </dfn>
     );
   }

--- a/src/applications/facility-locator/components/FacilityTypeDescription.jsx
+++ b/src/applications/facility-locator/components/FacilityTypeDescription.jsx
@@ -15,21 +15,26 @@ const facilityName = (query, location) => {
   return name;
 };
 
-const FacilityTypeDescription = ({ location, from, query }) => (
-  <p>
-    <span>
-      {from === 'SearchResult' ? (
+const FacilityTypeDescription = ({ location, query }) => {
+  if (location.resultItem) {
+    return (
+      <dfn>
         <span>
           {facilityName(query, location) &&
             facilityName(query, location).toUpperCase()}
         </span>
-      ) : (
-        <span>
-          <strong>Facility type:</strong> {facilityName(query, location)}
-        </span>
-      )}
-    </span>
-  </p>
-);
+      </dfn>
+    );
+  }
+
+  return (
+    <p>
+      <span>
+        {facilityName(query, location) &&
+          facilityName(query, location).toUpperCase()}
+      </span>
+    </p>
+  );
+};
 
 export default FacilityTypeDescription;

--- a/src/applications/facility-locator/components/ResultsList.jsx
+++ b/src/applications/facility-locator/components/ResultsList.jsx
@@ -167,21 +167,15 @@ class ResultsList extends Component {
       })
       .sort((resultA, resultB) => resultA.distance - resultB.distance);
 
-    return (
-      <div>
-        <div>
-          {sortedResults.map(
-            r =>
-              isMobile ? (
-                <div key={r.id} className="mobile-search-result">
-                  <SearchResult result={r} query={query} />
-                </div>
-              ) : (
-                <SearchResult key={r.id} result={r} query={query} />
-              ),
-          )}
-        </div>
-      </div>
+    return sortedResults.map(
+      r =>
+        isMobile ? (
+          <div key={r.id} className="mobile-search-result">
+            <SearchResult result={r} query={query} />
+          </div>
+        ) : (
+          <SearchResult key={r.id} result={r} query={query} />
+        ),
     );
   }
 }

--- a/src/applications/facility-locator/components/ResultsList.jsx
+++ b/src/applications/facility-locator/components/ResultsList.jsx
@@ -51,7 +51,7 @@ class ResultsList extends Component {
 
     if (inProgress) {
       return (
-        <div>
+        <li>
           <LoadingIndicator
             message={`Searching for ${facilityTypeName}
             in ${searchString}`}
@@ -64,7 +64,7 @@ class ResultsList extends Component {
               content="Your results should appear in less than a minute. Thank you for your patience."
             />
           </DelayedRender>
-        </div>
+        </li>
       );
     }
 
@@ -74,7 +74,7 @@ class ResultsList extends Component {
         const timedOut = error.find(err => TIMEOUTS.has(err.code));
         if (timedOut) {
           return (
-            <div
+            <li
               className="search-result-title facility-result"
               ref={this.searchResultTitle}
             >
@@ -92,13 +92,13 @@ class ResultsList extends Component {
                 If you have a medical emergency, please go to your nearest
                 emergency room or call 911.
               </p>
-            </div>
+            </li>
           );
         }
       }
 
       return (
-        <div
+        <li
           className="search-result-title facility-result"
           ref={this.searchResultTitle}
         >
@@ -112,14 +112,14 @@ class ResultsList extends Component {
             If you have a medical emergency, please go to your nearest emergency
             room or call 911.
           </p>
-        </div>
+        </li>
       );
     }
 
     if (!results || results.length < 1) {
       if (this.props.facilityTypeName === facilityTypes.cc_provider) {
         return (
-          <div
+          <li
             className="search-result-title facility-result"
             ref={this.searchResultTitle}
           >
@@ -136,18 +136,18 @@ class ResultsList extends Component {
               </li>
             </ul>
             Then click <strong>Search</strong>.
-          </div>
+          </li>
         );
       }
       return (
-        <div
+        <li
           className="search-result-title facility-result"
           ref={this.searchResultTitle}
         >
           No facilities found. Please try entering a different search term
           (Street, City, State or Postal code) and click search to find
           facilities.
-        </div>
+        </li>
       );
     }
 

--- a/src/applications/facility-locator/components/ResultsList.jsx
+++ b/src/applications/facility-locator/components/ResultsList.jsx
@@ -170,9 +170,12 @@ class ResultsList extends Component {
     return sortedResults.map(
       r =>
         isMobile ? (
-          <div key={r.id} className="mobile-search-result">
-            <SearchResult result={r} query={query} />
-          </div>
+          <SearchResult
+            key={r.id}
+            result={r}
+            query={query}
+            className="mobile-search-result"
+          />
         ) : (
           <SearchResult key={r.id} result={r} query={query} />
         ),

--- a/src/applications/facility-locator/components/ResultsList.jsx
+++ b/src/applications/facility-locator/components/ResultsList.jsx
@@ -7,6 +7,7 @@ import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 import LoadingIndicator from '@department-of-veterans-affairs/formation-react/LoadingIndicator';
 
 import { facilityTypes } from '../config';
+import { letters } from '../constants';
 
 import { distBetween } from '../utils/facilityDistance';
 import { setFocus } from '../utils/helpers';
@@ -152,7 +153,8 @@ class ResultsList extends Component {
 
     const currentLocation = position;
     const sortedResults = results
-      .map(result => {
+      .map((result, idx) => {
+        const markerText = letters[idx];
         const distance = currentLocation
           ? distBetween(
               currentLocation.latitude,
@@ -161,7 +163,7 @@ class ResultsList extends Component {
               result.attributes.long,
             )
           : null;
-        return { ...result, distance, resultItem: true };
+        return { ...result, distance, resultItem: true, markerText };
       })
       .sort((resultA, resultB) => resultA.distance - resultB.distance);
 

--- a/src/applications/facility-locator/components/SearchResult.jsx
+++ b/src/applications/facility-locator/components/SearchResult.jsx
@@ -3,26 +3,38 @@ import PropTypes from 'prop-types';
 import LocationInfoBlock from './search-results/LocationInfoBlock';
 import LocationPhoneLink from './search-results/LocationPhoneLink';
 import LocationDirectionsLink from './search-results/LocationDirectionsLink';
+import LocationAddress from './search-results/LocationAddress';
 
 // revert to stateless component given: 19fd5178f
 const SearchResult = ({ result, query }) => (
-  <div className="facility-result" id={result.id}>
-    <LocationInfoBlock location={result} from={'SearchResult'} query={query} />
-    <LocationDirectionsLink
-      location={result}
-      from={'SearchResult'}
-      query={query}
-    />
-    <LocationPhoneLink location={result} from={'SearchResult'} query={query} />
-    {query.facilityType === 'urgent_care' &&
-      query.serviceType === 'NonVAUrgentCare' && (
-        <p>
-          {' '}
-          Before going to a clinic for urgent care, please call the facility to
-          confirm that it's open and able to provide the care you need.{' '}
-        </p>
-      )}
-  </div>
+  <li className="facility-result" id={result.id}>
+    <dl>
+      <LocationInfoBlock
+        location={result}
+        from={'SearchResult'}
+        query={query}
+      />
+      <LocationAddress location={result} />
+      <LocationDirectionsLink
+        location={result}
+        from={'SearchResult'}
+        query={query}
+      />
+      <LocationPhoneLink
+        location={result}
+        from={'SearchResult'}
+        query={query}
+      />
+      {query.facilityType === 'urgent_care' &&
+        query.serviceType === 'NonVAUrgentCare' && (
+          <dd>
+            {' '}
+            Before going to a clinic for urgent care, please call the facility
+            to confirm that it's open and able to provide the care you need.{' '}
+          </dd>
+        )}
+    </dl>
+  </li>
 );
 
 SearchResult.propTypes = {

--- a/src/applications/facility-locator/components/markers/FacilityMarker.jsx
+++ b/src/applications/facility-locator/components/markers/FacilityMarker.jsx
@@ -1,0 +1,25 @@
+import DivMarker from './DivMarker';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+
+class FacilityMarker extends Component {
+  render() {
+    const { position, onClick, markerText } = this.props;
+    return (
+      <DivMarker position={position} onClick={onClick}>
+        <span className="i-pin-map"> {markerText || 'A'}</span>
+      </DivMarker>
+    );
+  }
+}
+
+FacilityMarker.defaultProps = {
+  onClick: () => {},
+};
+
+FacilityMarker.propTypes = {
+  position: PropTypes.array,
+  markerText: PropTypes.string,
+};
+
+export default FacilityMarker;

--- a/src/applications/facility-locator/components/markers/FacilityMarker.jsx
+++ b/src/applications/facility-locator/components/markers/FacilityMarker.jsx
@@ -7,7 +7,7 @@ class FacilityMarker extends Component {
     const { position, onClick, markerText } = this.props;
     return (
       <DivMarker position={position} onClick={onClick}>
-        <span className="i-pin-map"> {markerText || 'A'}</span>
+        <span className="i-pin-map"> {markerText}</span>
       </DivMarker>
     );
   }

--- a/src/applications/facility-locator/components/search-results/LocationAddress.jsx
+++ b/src/applications/facility-locator/components/search-results/LocationAddress.jsx
@@ -4,18 +4,34 @@ import { buildAddressArray } from '../../utils/facilityAddress';
 
 const LocationAddress = ({ location }) => {
   const addressArray = buildAddressArray(location);
-
-  if (addressArray.length === 0) {
+  if (location.resultItem) {
+    if (addressArray.length === 0) {
+      return (
+        <dd>
+          <strong>Address: </strong>
+          Contact for Information
+        </dd>
+      );
+    }
     return (
       <dd>
-        <strong>Address: </strong>
-        Contact for Information
+        {[].concat(...addressArray.map(e => [<br key={e} />, e])).slice(1)}
       </dd>
     );
   }
 
+  if (addressArray.length === 0) {
+    return (
+      <span>
+        <strong>Address: </strong>
+        Contact for Information
+      </span>
+    );
+  }
   return (
-    <dd>{[].concat(...addressArray.map(e => [<br key={e} />, e])).slice(1)}</dd>
+    <span>
+      {[].concat(...addressArray.map(e => [<br key={e} />, e])).slice(1)}
+    </span>
   );
 };
 

--- a/src/applications/facility-locator/components/search-results/LocationAddress.jsx
+++ b/src/applications/facility-locator/components/search-results/LocationAddress.jsx
@@ -7,17 +7,15 @@ const LocationAddress = ({ location }) => {
 
   if (addressArray.length === 0) {
     return (
-      <span>
+      <dd>
         <strong>Address: </strong>
         Contact for Information
-      </span>
+      </dd>
     );
   }
 
   return (
-    <span>
-      {[].concat(...addressArray.map(e => [<br key={e} />, e])).slice(1)}
-    </span>
+    <dd>{[].concat(...addressArray.map(e => [<br key={e} />, e])).slice(1)}</dd>
   );
 };
 

--- a/src/applications/facility-locator/components/search-results/LocationDirectionsLink.jsx
+++ b/src/applications/facility-locator/components/search-results/LocationDirectionsLink.jsx
@@ -16,7 +16,7 @@ class LocationDirectionsLink extends Component {
     }
 
     return (
-      <span>
+      <dd>
         <a
           href={`https://maps.google.com?saddr=Current+Location&daddr=${address}`}
           rel="noopener noreferrer"
@@ -26,7 +26,7 @@ class LocationDirectionsLink extends Component {
           {from === 'FacilityDetail' && <i className="fa fa-road" />}
           Directions
         </a>
-      </span>
+      </dd>
     );
   }
 }

--- a/src/applications/facility-locator/components/search-results/LocationDirectionsLink.jsx
+++ b/src/applications/facility-locator/components/search-results/LocationDirectionsLink.jsx
@@ -15,7 +15,7 @@ class LocationDirectionsLink extends Component {
       address = `${lat},${long}`;
     }
 
-    return (
+    return location.resultItem ? (
       <dd>
         <a
           href={`https://maps.google.com?saddr=Current+Location&daddr=${address}`}
@@ -27,6 +27,18 @@ class LocationDirectionsLink extends Component {
           Directions
         </a>
       </dd>
+    ) : (
+      <span>
+        <a
+          href={`https://maps.google.com?saddr=Current+Location&daddr=${address}`}
+          rel="noopener noreferrer"
+          target="_blank"
+          style={{ textDecoration: 'underline' }}
+        >
+          {from === 'FacilityDetail' && <i className="fa fa-road" />}
+          Directions
+        </a>
+      </span>
     );
   }
 }

--- a/src/applications/facility-locator/components/search-results/LocationInfoBlock.jsx
+++ b/src/applications/facility-locator/components/search-results/LocationInfoBlock.jsx
@@ -28,9 +28,11 @@ const LocationInfoBlock = ({ location, from, query }) => {
               </span>
             </p>
           ) : (
-            <h2 className="vads-u-font-size--h5 no-marg-top">
-              <Link to={`provider/${location.id}`}>{name}</Link>
-            </h2>
+            <dfn>
+              <h2 className="vads-u-font-size--h5 no-marg-top">
+                <Link to={`provider/${location.id}`}>{name}</Link>
+              </h2>
+            </dfn>
           )}
           {location.attributes.orgName && (
             <h6>{location.attributes.orgName}</h6>
@@ -48,9 +50,11 @@ const LocationInfoBlock = ({ location, from, query }) => {
               <h2 className="vads-u-font-size--h5 no-marg-top">{name}</h2>
             </a>
           ) : (
-            <h2 className="vads-u-font-size--h5 no-marg-top">
-              <Link to={`facility/${location.id}`}>{name}</Link>
-            </h2>
+            <dfn>
+              <h2 className="vads-u-font-size--h5 no-marg-top">
+                <Link to={`facility/${location.id}`}>{name}</Link>
+              </h2>
+            </dfn>
           )}
         </dfn>
       )}

--- a/src/applications/facility-locator/components/search-results/LocationInfoBlock.jsx
+++ b/src/applications/facility-locator/components/search-results/LocationInfoBlock.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router';
 import { LocationType } from '../../constants';
-import LocationAddress from './LocationAddress';
 import FacilityTypeDescription from '../FacilityTypeDescription';
 import ProviderServiceDescription from '../ProviderServiceDescription';
 import { isVADomain } from '../../utils/helpers';
@@ -12,21 +11,15 @@ const LocationInfoBlock = ({ location, from, query }) => {
   const isProvider = location.type === LocationType.CC_PROVIDER;
   const distance = location.distance;
   return (
-    <div>
-      {distance &&
-        location.resultItem && (
-          <p>
-            {!isProvider && (
-              <span className="i-pin-card">{location.markerText}</span>
-            )}
-            {!isProvider && ' '}
-            <span>
-              <strong>{distance.toFixed(1)} miles</strong>
-            </span>
-          </p>
-        )}
+    <dt>
+      {!isProvider && <span className="i-pin-card">{location.markerText}</span>}
+      {!isProvider && ' '}
+      <dfn>
+        {distance &&
+          location.resultItem && <strong>{distance.toFixed(1)} miles</strong>}
+      </dfn>
       {isProvider ? (
-        <span>
+        <dfn>
           <ProviderServiceDescription provider={location} query={query} />
           {query.facilityType === 'cc_pharmacy' ||
           query.serviceType === 'NonVAUrgentCare' ? (
@@ -43,9 +36,9 @@ const LocationInfoBlock = ({ location, from, query }) => {
           {location.attributes.orgName && (
             <h6>{location.attributes.orgName}</h6>
           )}
-        </span>
+        </dfn>
       ) : (
-        <span>
+        <dfn>
           <FacilityTypeDescription
             location={location}
             from={from}
@@ -60,12 +53,9 @@ const LocationInfoBlock = ({ location, from, query }) => {
               <Link to={`facility/${location.id}`}>{name}</Link>
             </h2>
           )}
-        </span>
+        </dfn>
       )}
-      <p>
-        <LocationAddress location={location} />
-      </p>
-    </div>
+    </dt>
   );
 };
 

--- a/src/applications/facility-locator/components/search-results/LocationInfoBlock.jsx
+++ b/src/applications/facility-locator/components/search-results/LocationInfoBlock.jsx
@@ -16,6 +16,10 @@ const LocationInfoBlock = ({ location, from, query }) => {
       {distance &&
         location.resultItem && (
           <p>
+            {!isProvider && (
+              <span className="i-pin-card">{location.markerText}</span>
+            )}
+            {!isProvider && ' '}
             <span>
               <strong>{distance.toFixed(1)} miles</strong>
             </span>

--- a/src/applications/facility-locator/components/search-results/LocationInfoBlock.jsx
+++ b/src/applications/facility-locator/components/search-results/LocationInfoBlock.jsx
@@ -12,8 +12,7 @@ const LocationInfoBlock = ({ location, from, query }) => {
   const distance = location.distance;
   return (
     <dt>
-      {!isProvider && <span className="i-pin-card">{location.markerText}</span>}
-      {!isProvider && ' '}
+      <span className="i-pin-card">{location.markerText}</span>{' '}
       <dfn>
         {distance &&
           location.resultItem && <strong>{distance.toFixed(1)} miles</strong>}

--- a/src/applications/facility-locator/components/search-results/LocationPhoneLink.jsx
+++ b/src/applications/facility-locator/components/search-results/LocationPhoneLink.jsx
@@ -14,10 +14,27 @@ const renderPhoneNumber = (
   if (!phone) {
     return null;
   }
-
   const re = /^(\d{3})[ -]?(\d{3})[ -]?(\d{4})[ ]?(x?)[ ]?(\d*)/;
-
-  return (
+  return from === 'FacilityDetail' ? (
+    <div>
+      {from === 'FacilityDetail' && <i className={`fa fa-${icon}`} />}
+      {title && <strong>{title}: </strong>}
+      {!isCCProvider && phone.replace(re, '$1-$2-$3 $4$5').replace(/x$/, '')}
+      <br />
+      {from === 'FacilityDetail' && <i className="fa fa-fw" />}
+      {subTitle}
+      {isCCProvider &&
+        ` ${phone.replace(re, '$1-$2-$3 $4$5').replace(/x$/, '')}`}
+      {from === 'FacilityDetail' ? (
+        <a
+          href={`tel:${phone.replace(/[ ]?x/, '')}`}
+          className={altPhone && 'facility-phone-alt'}
+        >
+          {phone.replace(re, '$1-$2-$3 $4$5').replace(/x$/, '')}
+        </a>
+      ) : null}
+    </div>
+  ) : (
     <dfn>
       {from === 'FacilityDetail' && <i className={`fa fa-${icon}`} />}
       {title && <strong>{title}: </strong>}
@@ -44,7 +61,7 @@ const LocationPhoneLink = ({ location, from, query }) => {
   const isCCProvider = query && query.facilityType === LocationType.CC_PROVIDER;
   if (isProvider) {
     const { caresitePhone: phone } = location.attributes;
-    return (
+    return location.resultItem ? (
       <dd>
         {renderPhoneNumber(
           isCCProvider ? 'If you have a referral' : null,
@@ -61,13 +78,30 @@ const LocationPhoneLink = ({ location, from, query }) => {
           </p>
         )}
       </dd>
+    ) : (
+      <div>
+        {renderPhoneNumber(
+          isCCProvider ? 'If you have a referral' : null,
+          isCCProvider ? 'Call this facility at' : null,
+          phone,
+          'phone',
+          true,
+          from,
+          isCCProvider,
+        )}
+        {isCCProvider && (
+          <p>
+            If you don’t have a referral, contact your local VA medical center.
+          </p>
+        )}
+      </div>
     );
   }
 
   const {
     attributes: { phone },
   } = location;
-  return (
+  return location.resultItem ? (
     <dd>
       {renderPhoneNumber('Main Number', null, phone.main, 'phone', null, from)}
       {renderPhoneNumber(
@@ -75,9 +109,22 @@ const LocationPhoneLink = ({ location, from, query }) => {
         null,
         phone.mentalHealthClinic,
         null,
+        true,
         from,
       )}
     </dd>
+  ) : (
+    <div>
+      {renderPhoneNumber('Main Number', null, phone.main, 'phone', null, from)}
+      {renderPhoneNumber(
+        'Mental Health',
+        null,
+        phone.mentalHealthClinic,
+        null,
+        true,
+        from,
+      )}
+    </div>
   );
 };
 

--- a/src/applications/facility-locator/components/search-results/LocationPhoneLink.jsx
+++ b/src/applications/facility-locator/components/search-results/LocationPhoneLink.jsx
@@ -45,7 +45,7 @@ const LocationPhoneLink = ({ location, from, query }) => {
   if (isProvider) {
     const { caresitePhone: phone } = location.attributes;
     return (
-      <div>
+      <dd>
         {renderPhoneNumber(
           isCCProvider ? 'If you have a referral' : null,
           isCCProvider ? 'Call this facility at' : null,
@@ -60,7 +60,7 @@ const LocationPhoneLink = ({ location, from, query }) => {
             If you don’t have a referral, contact your local VA medical center.
           </p>
         )}
-      </div>
+      </dd>
     );
   }
 
@@ -68,7 +68,7 @@ const LocationPhoneLink = ({ location, from, query }) => {
     attributes: { phone },
   } = location;
   return (
-    <div>
+    <dd>
       {renderPhoneNumber('Main Number', null, phone.main, 'phone', null, from)}
       {renderPhoneNumber(
         'Mental Health',
@@ -77,7 +77,7 @@ const LocationPhoneLink = ({ location, from, query }) => {
         null,
         from,
       )}
-    </div>
+    </dd>
   );
 };
 

--- a/src/applications/facility-locator/components/search-results/LocationPhoneLink.jsx
+++ b/src/applications/facility-locator/components/search-results/LocationPhoneLink.jsx
@@ -18,7 +18,7 @@ const renderPhoneNumber = (
   const re = /^(\d{3})[ -]?(\d{3})[ -]?(\d{4})[ ]?(x?)[ ]?(\d*)/;
 
   return (
-    <div>
+    <dfn>
       {from === 'FacilityDetail' && <i className={`fa fa-${icon}`} />}
       {title && <strong>{title}: </strong>}
       {!isCCProvider && phone.replace(re, '$1-$2-$3 $4$5').replace(/x$/, '')}
@@ -35,7 +35,7 @@ const renderPhoneNumber = (
           {phone.replace(re, '$1-$2-$3 $4$5').replace(/x$/, '')}
         </a>
       ) : null}
-    </div>
+    </dfn>
   );
 };
 

--- a/src/applications/facility-locator/constants/index.js
+++ b/src/applications/facility-locator/constants/index.js
@@ -56,3 +56,8 @@ export const LOCATION_OPTIONS = [
  * Defines the ± change in bounding box size for the map when changing zoom
  */
 export const BOUNDING_RADIUS = 0.75;
+
+/**
+ *Defines the marker letter list
+ */
+export const letters = [...'abcdefghijklmnopqrstuvwxyz'.toUpperCase()];

--- a/src/applications/facility-locator/containers/VAMap.jsx
+++ b/src/applications/facility-locator/containers/VAMap.jsx
@@ -19,7 +19,6 @@ import {
 import SearchControls from '../components/SearchControls';
 import ResultsList from '../components/ResultsList';
 import SearchResult from '../components/SearchResult';
-import ProviderMarker from '../components/markers/ProviderMarker';
 import FacilityMarker from '../components/markers/FacilityMarker';
 import { facilityTypes } from '../config';
 import {
@@ -490,7 +489,7 @@ class VAMap extends Component {
         case undefined:
           if (r.type === LocationType.CC_PROVIDER) {
             return (
-              <ProviderMarker {...iconProps}>{popupContent}</ProviderMarker>
+              <FacilityMarker {...iconProps}>{popupContent}</FacilityMarker>
             );
           }
           return null;

--- a/src/applications/facility-locator/containers/VAMap.jsx
+++ b/src/applications/facility-locator/containers/VAMap.jsx
@@ -19,14 +19,15 @@ import {
 import SearchControls from '../components/SearchControls';
 import ResultsList from '../components/ResultsList';
 import SearchResult from '../components/SearchResult';
-import CemeteryMarker from '../components/markers/CemeteryMarker';
-import HealthMarker from '../components/markers/HealthMarker';
-import BenefitsMarker from '../components/markers/BenefitsMarker';
-import VetCenterMarker from '../components/markers/VetCenterMarker';
 import ProviderMarker from '../components/markers/ProviderMarker';
 import FacilityMarker from '../components/markers/FacilityMarker';
 import { facilityTypes } from '../config';
-import { LocationType, FacilityType, BOUNDING_RADIUS, letters } from '../constants';
+import {
+  LocationType,
+  FacilityType,
+  BOUNDING_RADIUS,
+  letters,
+} from '../constants';
 import { areGeocodeEqual, setFocus } from '../utils/helpers';
 import { facilityLocatorShowCommunityCares } from '../utils/selectors';
 import { isProduction } from 'platform/site-wide/feature-toggles/selectors';
@@ -422,7 +423,7 @@ class VAMap extends Component {
       }
     };
 
-    return results.map((r,idx) => {
+    return results.map((r, idx) => {
       const iconProps = {
         key: r.id,
         position: [r.attributes.lat, r.attributes.long],
@@ -440,7 +441,7 @@ class VAMap extends Component {
           }
           this.props.fetchVAFacility(r.id, r);
         },
-        markerText: letters[idx]
+        markerText: letters[idx],
       };
 
       const popupContent = (
@@ -483,7 +484,9 @@ class VAMap extends Component {
         case FacilityType.VA_CEMETARY:
         case FacilityType.VA_BENEFITS_FACILITY:
         case FacilityType.VET_CENTER:
-          return <FacilityMarker{...iconProps}>{popupContent} </FacilityMarker>
+          return (
+            <FacilityMarker {...iconProps}>{popupContent} </FacilityMarker>
+          );
         case undefined:
           if (r.type === LocationType.CC_PROVIDER) {
             return (

--- a/src/applications/facility-locator/containers/VAMap.jsx
+++ b/src/applications/facility-locator/containers/VAMap.jsx
@@ -549,7 +549,7 @@ class VAMap extends Component {
               <Tab className="small-6 tab">View Map</Tab>
             </TabList>
             <TabPanel>
-              <div
+              <ol
                 aria-live="polite"
                 aria-relevant="additions text"
                 className="facility-search-results"
@@ -559,7 +559,7 @@ class VAMap extends Component {
                   updateUrlParams={this.updateUrlParams}
                   query={this.props.currentQuery}
                 />
-              </div>
+              </ol>
               {results.length > 0 && (
                 <Pagination
                   onPageSelect={this.handlePageSelect}

--- a/src/applications/facility-locator/containers/VAMap.jsx
+++ b/src/applications/facility-locator/containers/VAMap.jsx
@@ -24,8 +24,9 @@ import HealthMarker from '../components/markers/HealthMarker';
 import BenefitsMarker from '../components/markers/BenefitsMarker';
 import VetCenterMarker from '../components/markers/VetCenterMarker';
 import ProviderMarker from '../components/markers/ProviderMarker';
+import FacilityMarker from '../components/markers/FacilityMarker';
 import { facilityTypes } from '../config';
-import { LocationType, FacilityType, BOUNDING_RADIUS } from '../constants';
+import { LocationType, FacilityType, BOUNDING_RADIUS, letters } from '../constants';
 import { areGeocodeEqual, setFocus } from '../utils/helpers';
 import { facilityLocatorShowCommunityCares } from '../utils/selectors';
 import { isProduction } from 'platform/site-wide/feature-toggles/selectors';
@@ -411,7 +412,6 @@ class VAMap extends Component {
    */
   renderFacilityMarkers = () => {
     const { results } = this.props;
-
     // need to use this because Icons are rendered outside of Router context (Leaflet manipulates the DOM directly)
     const linkAction = (id, isProvider = false, e) => {
       e.preventDefault();
@@ -422,7 +422,7 @@ class VAMap extends Component {
       }
     };
 
-    return results.map(r => {
+    return results.map((r,idx) => {
       const iconProps = {
         key: r.id,
         position: [r.attributes.lat, r.attributes.long],
@@ -440,6 +440,7 @@ class VAMap extends Component {
           }
           this.props.fetchVAFacility(r.id, r);
         },
+        markerText: letters[idx]
       };
 
       const popupContent = (
@@ -479,15 +480,10 @@ class VAMap extends Component {
 
       switch (r.attributes.facilityType) {
         case FacilityType.VA_HEALTH_FACILITY:
-          return <HealthMarker {...iconProps}>{popupContent}</HealthMarker>;
         case FacilityType.VA_CEMETARY:
-          return <CemeteryMarker {...iconProps}>{popupContent}</CemeteryMarker>;
         case FacilityType.VA_BENEFITS_FACILITY:
-          return <BenefitsMarker {...iconProps}>{popupContent}</BenefitsMarker>;
         case FacilityType.VET_CENTER:
-          return (
-            <VetCenterMarker {...iconProps}>{popupContent}</VetCenterMarker>
-          );
+          return <FacilityMarker{...iconProps}>{popupContent} </FacilityMarker>
         case undefined:
           if (r.type === LocationType.CC_PROVIDER) {
             return (

--- a/src/applications/facility-locator/containers/VAMap.jsx
+++ b/src/applications/facility-locator/containers/VAMap.jsx
@@ -661,18 +661,16 @@ class VAMap extends Component {
             style={{ maxHeight: '78vh', overflowY: 'auto' }}
             id="searchResultsContainer"
           >
-            <div
+            <ol
               aria-live="polite"
               aria-relevant="additions text"
               className="facility-search-results"
             >
-              <div>
-                <ResultsList
-                  updateUrlParams={this.updateUrlParams}
-                  query={this.props.currentQuery}
-                />
-              </div>
-            </div>
+              <ResultsList
+                updateUrlParams={this.updateUrlParams}
+                query={this.props.currentQuery}
+              />
+            </ol>
           </div>
           <div
             className="columns usa-width-two-thirds medium-8 small-12"

--- a/src/applications/facility-locator/sass/facility-locator.scss
+++ b/src/applications/facility-locator/sass/facility-locator.scss
@@ -778,7 +778,7 @@ $facility-locator-color-gray: #ccc;
 .i-pin-card {
   background: $color-gray-dark;
   color: $color-white;
-  padding: 1px 7px;
+  padding: 2px 7px;
   border-radius: 50%;
   font-size: 14px;
 }

--- a/src/applications/facility-locator/sass/facility-locator.scss
+++ b/src/applications/facility-locator/sass/facility-locator.scss
@@ -88,6 +88,7 @@ $facility-locator-color-gray: #ccc;
 
   .facility-result {
     padding: 1em;
+    margin-bottom: 0em;
     background: $color-gray-light-alt;
     border-bottom: none;
 
@@ -187,9 +188,9 @@ $facility-locator-color-gray: #ccc;
   }
 
   .facility-search-results {
-    ol {
-      padding: 0;
-    }
+    margin: 0 0 0 0em ;
+    padding-left: 0em;
+    list-style-type: none;
 
     li {
       p {

--- a/src/applications/facility-locator/sass/facility-locator.scss
+++ b/src/applications/facility-locator/sass/facility-locator.scss
@@ -744,7 +744,7 @@ $facility-locator-color-gray: #ccc;
 }
 
 .no-marg-top {
-  margin-top: 0 !important;
+  margin-top: 4px !important;
 }
 
 .width-35 {

--- a/src/applications/facility-locator/sass/facility-locator.scss
+++ b/src/applications/facility-locator/sass/facility-locator.scss
@@ -773,3 +773,19 @@ $facility-locator-color-gray: #ccc;
 .va-nav-breadcrumbs:focus {
   outline: 0;
 }
+
+.i-pin-card {
+  background: $color-gray-dark;
+  color: $color-white;
+  padding: 1px 7px;
+  border-radius: 50%;
+  font-size: 14px;
+}
+
+.i-pin-map {
+  background: $color-gray-dark;
+  color: $color-white;
+  padding: 4px 9px;
+  border-radius: 50%;
+  font-size: 14px;
+}


### PR DESCRIPTION
## Description
issues:
https://github.com/department-of-veterans-affairs/va.gov-team/issues/5620
https://github.com/department-of-veterans-affairs/va.gov-team/issues/5555

## Testing done
Locally

## Screenshots
<img width="1643" alt="Screen Shot 2020-04-10 at 12 30 36 PM" src="https://user-images.githubusercontent.com/100468/79010212-1d13cf80-7b27-11ea-9df7-91ef2b99ca27.png">




## Acceptance criteria
- [x] Add semantic HTML for search results
- [x] Map pins reflect design update to Alpha & "dark gray", consistent with design spec shown above
- [x] Cards reflect Alpha & correlate to Alpha presentation/location on map
- [x] Map pin accurately references correct card in result list

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
