### PR TITLE
Change Profile route based on feature flag

### DIFF
--- a/src/applications/personalization/profile-2/selectors.js
+++ b/src/applications/personalization/profile-2/selectors.js
@@ -1,0 +1,5 @@
+import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
+import FEATURE_FLAG_NAMES from 'platform/utilities/feature-toggles/featureFlagNames';
+
+export const showProfile2 = state =>
+  toggleValues(state)[FEATURE_FLAG_NAMES.profileShowProfile2];

--- a/src/platform/site-wide/user-nav/components/PersonalizationDropdown.jsx
+++ b/src/platform/site-wide/user-nav/components/PersonalizationDropdown.jsx
@@ -5,6 +5,8 @@ import { ssoe } from 'platform/user/authentication/selectors';
 import { logout } from 'platform/user/authentication/utilities';
 import recordEvent from 'platform/monitoring/record-event';
 
+import { showProfile2 } from 'applications/personalization/profile-2/selectors';
+
 const recordNavUserEvent = section => () => {
   recordEvent({ event: 'nav-user', 'nav-user-section': section });
 };
@@ -15,6 +17,8 @@ const recordProfileEvent = recordNavUserEvent('profile');
 const recordAccountEvent = recordNavUserEvent('account');
 
 export class PersonalizationDropdown extends React.Component {
+  profileUrl = () => (this.props.useProfile2 ? '/profile-2' : '/profile');
+
   signOut = () => {
     // Prevent double clicking of "Sign Out"
     if (!this.signOutDisabled) {
@@ -40,7 +44,7 @@ export class PersonalizationDropdown extends React.Component {
           </a>
         </li>
         <li>
-          <a href="/profile" onClick={recordProfileEvent}>
+          <a href={this.profileUrl()} onClick={recordProfileEvent}>
             Profile
           </a>
         </li>
@@ -62,6 +66,7 @@ export class PersonalizationDropdown extends React.Component {
 function mapStateToProps(state) {
   return {
     useSSOe: ssoe(state),
+    useProfile2: showProfile2(state),
   };
 }
 

--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -1,6 +1,7 @@
 export default Object.freeze({
   dashboardShowCovid19Alert: 'dashboardShowCovid19Alert',
   facilityLocatorShowCommunityCares: 'facilityLocatorShowCommunityCares',
+  profileShowProfile2: 'profile_show_profile_2.0',
   profileShowReceiveTextNotifications: 'profileShowReceiveTextNotifications',
   vaOnlineScheduling: 'vaOnlineScheduling',
   vaOnlineSchedulingCancel: 'vaOnlineSchedulingCancel',


### PR DESCRIPTION
## Description
This changes where the Profile link in the main nav's dropdown menu directs based on the `profile_show_profile_2.0` feature flag.

## Testing done
Local

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs