### PR TITLE
[Homepage] Generate banner as static HTML

### DIFF
--- a/src/site/includes/header.html
+++ b/src/site/includes/header.html
@@ -80,8 +80,8 @@
 
   {% include "src/site/components/fullwidth_banner_alerts.drupal.liquid" %}
 
-  {% if path == '' or path == '/' %}
-  <div data-widget-type="homepage-banner"></div>
+  {% if homepage_banner %}
+    {% include "src/site/includes/homepage-banner.liquid" with banner = homepage_banner %}
   {% endif %}
 
   <script async src="/js/incompatible-browser.js"></script>

--- a/src/site/includes/homepage-banner.liquid
+++ b/src/site/includes/homepage-banner.liquid
@@ -1,0 +1,10 @@
+<div class="usa-alert-full-width usa-alert-full-width-{{ banner.type }}">
+  <div class="usa-alert usa-alert-{{ banner.type }}">
+    <div class="usa-alert-body">
+      <h3 class="usa-alert-heading">{{ banner.title }}</h3>
+      <div class="usa-alert-text">
+        {{ banner.content }}
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/site/stages/build/drupal/home.js
+++ b/src/site/stages/build/drupal/home.js
@@ -1,8 +1,11 @@
 /* eslint-disable no-param-reassign, no-continue */
+const fs = require('fs-extra');
+const path = require('path');
+const yaml = require('js-yaml');
 const { createEntityUrlObj, createFileObj } = require('./page');
 
 // Processes the data received from the home page query.
-function addHomeContent(contentData, files) {
+function addHomeContent(contentData, files, metalsmith, buildOptions) {
   // We cannot limit menu items in Drupal, so we must do it here.
   const menuLength = 4;
 
@@ -31,6 +34,11 @@ function addHomeContent(contentData, files) {
       },
     );
 
+    const fragmentsRoot = metalsmith.path(buildOptions.contentFragments);
+    const bannerLocation = path.join(fragmentsRoot, 'home/banner.yml');
+    const bannerFile = fs.readFileSync(bannerLocation);
+    const banner = yaml.safeLoad(bannerFile);
+
     homeEntityObj = {
       ...homeEntityObj,
       // Since homepage is not an independent node, we don't have a source for metatags. So we need to hard-code these for now.
@@ -40,6 +48,8 @@ function addHomeContent(contentData, files) {
       cards: homePageMenuQuery.links.slice(0, menuLength), // Top Tasks menu. We have a hard limit.
       hubs, // Full hub list.
       promos: homePagePromoBlockQuery.itemsOfEntitySubqueueHomePagePromos, // Promo blocks.
+      // eslint-disable-next-line camelcase
+      homepage_banner: banner,
     };
 
     // Let Metalsmith know we're here.

--- a/src/site/stages/build/drupal/metalsmith-drupal.js
+++ b/src/site/stages/build/drupal/metalsmith-drupal.js
@@ -160,8 +160,6 @@ function pipeDrupalPagesIntoMetalsmith(contentData, files) {
   if (skippedContent.emptyEntities) {
     log(`Skipped ${skippedContent.emptyEntities} empty entities`);
   }
-
-  addHomeContent(contentData, files);
 }
 
 async function loadDrupal(buildOptions) {
@@ -273,6 +271,7 @@ function getDrupalContent(buildOptions) {
 
       await loadCachedDrupalFiles(buildOptions, files);
       pipeDrupalPagesIntoMetalsmith(drupalData, files);
+      addHomeContent(drupalData, files, metalsmith, buildOptions);
       log('Successfully piped Drupal content into Metalsmith!');
       buildOptions.drupalData = drupalData;
       done();


### PR DESCRIPTION
## Description
This PR removes the React widget for the homepage banner in return for generating static HTML from the YML file in vagov-content. This has some drawbacks (deployment speed, risk of blocked deployments), but the request to `githubusercontent.com` fails sometimes in IE, and we have received a couple notices about this, so we need to get this patched. It seems to be contained to only GFE laptops but since I can't recreate it myself, it's better to just patch it completely.

## Testing done
Observed the banner locally and page source

## Screenshots

![image](https://user-images.githubusercontent.com/1915775/78909862-18c9b280-7a52-11ea-9c3b-9b4bf0716a0f.png)

![image](https://user-images.githubusercontent.com/1915775/78912939-3e58bb00-7a56-11ea-871e-5f9b5ab04627.png)


## Acceptance criteria
- [x] Banner is rendered statically

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
