### PR TITLE
Fix: Caution Flags not showing on search results in production

### DIFF
--- a/src/applications/gi/components/search/InstitutionFilterForm.jsx
+++ b/src/applications/gi/components/search/InstitutionFilterForm.jsx
@@ -199,7 +199,7 @@ InstitutionFilterForm.propTypes = {
     priorityEnrollment: PropTypes.object,
     independentStudy: PropTypes.object,
     stemIndicator: PropTypes.object,
-    excludeCautionFlags: PropTypes,
+    excludeCautionFlags: PropTypes.bool,
   }),
 };
 

--- a/src/applications/gi/components/search/SearchResult.jsx
+++ b/src/applications/gi/components/search/SearchResult.jsx
@@ -32,15 +32,13 @@ export class SearchResult extends React.Component {
       state,
       country,
       studentCount,
+      cautionFlag,
+      cautionFlags,
     } = this.props;
 
     const tuition = this.estimate(estimated.tuition);
     const housing = this.estimate(estimated.housing);
     const books = this.estimate(estimated.books);
-    const cautionFlags = [...this.props.cautionFlags].filter(
-      flag => flag.title,
-    );
-
     const linkTo = {
       pathname: `profile/${facilityCode}`,
       query: version ? { version } : {},
@@ -70,13 +68,11 @@ export class SearchResult extends React.Component {
                 </h2>
               </div>
             </div>
-            {(schoolClosing || (cautionFlags && cautionFlags.length > 0)) && (
+            {(schoolClosing || cautionFlag) && (
               <div className="row alert-row">
                 <div className="small-12 columns">
                   {renderSchoolClosingAlert({ schoolClosing, schoolClosingOn })}
-                  {cautionFlags &&
-                    cautionFlags.length > 0 &&
-                    renderCautionAlert({ cautionFlags })}
+                  {renderCautionAlert({ cautionFlag, cautionFlags })}
                 </div>
               </div>
             )}

--- a/src/applications/gi/components/vet-tec/VetTecProgramSearchResult.jsx
+++ b/src/applications/gi/components/vet-tec/VetTecProgramSearchResult.jsx
@@ -23,11 +23,14 @@ class VetTecProgramSearchResult extends React.Component {
       dodBah,
       schoolClosing,
       schoolClosingOn,
+      cautionFlags,
     } = result;
 
     const tuition = isPresent(tuitionAmount)
       ? formatCurrency(tuitionAmount)
       : 'TBD';
+
+    const cautionFlag = cautionFlags && cautionFlags.length > 0;
 
     const displayHours =
       lengthInHours === '0' ? 'TBD' : `${lengthInHours} hours`;
@@ -36,10 +39,6 @@ class VetTecProgramSearchResult extends React.Component {
       pathname: `profile/${facilityCode}/${description}`,
       query: version ? { version } : {},
     };
-
-    const cautionFlags = this.props.result.cautionFlags
-      ? [...this.props.result.cautionFlags].filter(flag => flag.title)
-      : [];
 
     return (
       <div className="search-result">
@@ -64,13 +63,11 @@ class VetTecProgramSearchResult extends React.Component {
                 {renderPreferredProviderFlag(this.props.result)}
               </div>
             </div>
-            {(schoolClosing || (cautionFlags && cautionFlags.length > 0)) && (
+            {(schoolClosing || cautionFlag) && (
               <div className="row alert-row">
                 <div className="small-12 columns">
                   {renderSchoolClosingAlert({ schoolClosing, schoolClosingOn })}
-                  {cautionFlags &&
-                    cautionFlags.length > 0 &&
-                    renderCautionAlert({ cautionFlags })}
+                  {renderCautionAlert({ cautionFlag, cautionFlags })}
                 </div>
               </div>
             )}

--- a/src/applications/gi/containers/SearchPage.jsx
+++ b/src/applications/gi/containers/SearchPage.jsx
@@ -210,6 +210,7 @@ export class SearchPage extends React.Component {
                 state={result.state}
                 zip={result.zip}
                 country={result.country}
+                cautionFlag={result.cautionFlag}
                 cautionFlags={result.cautionFlags}
                 studentCount={result.studentCount}
                 bah={result.bah}

--- a/src/applications/gi/utils/render.jsx
+++ b/src/applications/gi/utils/render.jsx
@@ -47,37 +47,35 @@ export const renderSchoolClosingAlert = result => {
 };
 
 export const renderCautionAlert = result => {
-  const { cautionFlags } = result;
-  if (cautionFlags.length === 0) return null;
+  const { cautionFlag, cautionFlags } = result;
 
   // Prod flag for 6803
   if (!environment.isProduction()) {
+    const validFlags = [...cautionFlags]
+      .filter(flag => flag.title)
+      .sort((a, b) => (a.title.toLowerCase() < b.title.toLowerCase() ? -1 : 1));
+
     return (
       <AlertBox
         className="vads-u-margin-top--1"
         content={
           <ul className="vads-u-margin-top--0">
-            {[...cautionFlags]
-              .sort(
-                (a, b) =>
-                  a.title.toLowerCase() < b.title.toLowerCase() ? -1 : 1,
-              )
-              .map(flag => (
-                <li
-                  className="vads-u-margin-y--0p25 vads-u-margin-left--1p5"
-                  key={flag.id}
-                >
-                  {flag.title}
-                </li>
-              ))}
+            {validFlags.map(flag => (
+              <li
+                className="vads-u-margin-y--0p25 vads-u-margin-left--1p5"
+                key={flag.id}
+              >
+                {flag.title}
+              </li>
+            ))}
           </ul>
         }
         headline={
-          cautionFlags.length > 1
+          validFlags.length > 1
             ? 'This school has cautionary warnings'
             : 'This school has a cautionary warning'
         }
-        isVisible={cautionFlags.length > 0}
+        isVisible={validFlags.length > 0}
         status="warning"
       />
     );
@@ -87,7 +85,7 @@ export const renderCautionAlert = result => {
       className="vads-u-margin-top--1"
       content={<p>This school has cautionary warnings</p>}
       headline="Caution"
-      isVisible={cautionFlags.length > 0}
+      isVisible={cautionFlag}
       status="warning"
     />
   );


### PR DESCRIPTION
## Description
Updated search results to use existing `caution_flag` field instead of newer `caution_flags` field (which isn't available in production)

https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/7788

## Testing done
Tested locally and QA reviewed

## Screenshots
![image](https://user-images.githubusercontent.com/41960449/78915166-83cab780-7a59-11ea-97f5-70b93fdf8d47.png)

## Acceptance criteria
- [x] Caution flags are displayed correctly

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
