### PR TITLE
[Homepage] Account for visible property

### DIFF
--- a/src/site/includes/homepage-banner.liquid
+++ b/src/site/includes/homepage-banner.liquid
@@ -1,3 +1,4 @@
+{% if banner.visible %}
 <div class="usa-alert-full-width usa-alert-full-width-{{ banner.type }}">
   <div class="usa-alert usa-alert-{{ banner.type }}">
     <div class="usa-alert-body">
@@ -8,3 +9,4 @@
     </div>
   </div>
 </div>
+{% endif %}


### PR DESCRIPTION
## Description
I forgot to account for the `visible` property in the template for the homepage banner (now a static template as opposed to a React component), although the current banner will be published indefinitely.

## Testing done
Flipped boolean value in local vagov-content

## Screenshots
N/A

## Acceptance criteria
- [ ] `visible` property is supported

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
