### PR TITLE
Separate error event and info for VAOS 400 cancel

### DIFF
--- a/src/applications/vaos/actions/appointments.js
+++ b/src/applications/vaos/actions/appointments.js
@@ -335,9 +335,10 @@ export function confirmCancelAppointment() {
         if (
           cancelReasons.some(reason => reason.number === UNABLE_TO_KEEP_APPT)
         ) {
+          cancelReason = UNABLE_TO_KEEP_APPT;
           await updateAppointment({
             ...cancelData,
-            cancelReason: UNABLE_TO_KEEP_APPT,
+            cancelReason,
           });
         } else if (
           cancelReasons.some(reason => VALID_CANCEL_CODES.has(reason.number))

--- a/src/applications/vaos/actions/appointments.js
+++ b/src/applications/vaos/actions/appointments.js
@@ -365,7 +365,7 @@ export function confirmCancelAppointment() {
       });
       resetDataLayer();
     } catch (e) {
-      if (e.errors?.[0]?.code === 'VAOS_400') {
+      if (e?.errors?.[0]?.code === 'VAOS_400') {
         Sentry.withScope(scope => {
           scope.setExtra('error', e);
           scope.setExtra('cancelReasons', cancelReasons);

--- a/src/applications/vaos/actions/appointments.js
+++ b/src/applications/vaos/actions/appointments.js
@@ -299,6 +299,8 @@ export function confirmCancelAppointment() {
       appointmentType: isPendingRequest ? 'pending' : 'confirmed',
       facilityType: isCommunityCare(appointment) ? 'cc' : 'va',
     };
+    let cancelReasons = null;
+    let cancelReason = null;
 
     try {
       recordEvent({
@@ -328,7 +330,7 @@ export function confirmCancelAppointment() {
           cancelCode: 'PC',
         };
 
-        const cancelReasons = await getCancelReasons(appointment.facilityId);
+        cancelReasons = await getCancelReasons(appointment.facilityId);
 
         if (
           cancelReasons.some(reason => reason.number === UNABLE_TO_KEEP_APPT)
@@ -340,7 +342,7 @@ export function confirmCancelAppointment() {
         } else if (
           cancelReasons.some(reason => VALID_CANCEL_CODES.has(reason.number))
         ) {
-          const cancelReason = cancelReasons.find(reason =>
+          cancelReason = cancelReasons.find(reason =>
             VALID_CANCEL_CODES.has(reason.number),
           );
           await updateAppointment({
@@ -362,7 +364,16 @@ export function confirmCancelAppointment() {
       });
       resetDataLayer();
     } catch (e) {
-      captureError(e, true);
+      if (e.errors?.[0]?.code === 'VAOS_400') {
+        Sentry.withScope(scope => {
+          scope.setExtra('error', e);
+          scope.setExtra('cancelReasons', cancelReasons);
+          scope.setExtra('cancelReason', cancelReason);
+          Sentry.captureMessage('Cancel failed due to bad request');
+        });
+      } else {
+        captureError(e, true);
+      }
       dispatch({
         type: CANCEL_APPOINTMENT_CONFIRMED_FAILED,
       });


### PR DESCRIPTION
## Description
This separates out cancel errors from other bad requests, so that we don't lose real bad request issues that we need to research. It also adds some additional info around cancel reasons.

## Testing done
Local testing


## Acceptance criteria
- [ ] Cancellation logs reasons in separate event

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
