### PR TITLE
Create reusable ProfileInfoTable

### DIFF
--- a/src/applications/personalization/profile-2/components/MilitaryInformation.jsx
+++ b/src/applications/personalization/profile-2/components/MilitaryInformation.jsx
@@ -2,21 +2,22 @@ import React, { Component } from 'react';
 import { some } from 'lodash';
 import { connect } from 'react-redux';
 
-import DowntimeNotification, {
-  externalServices,
-} from 'platform/monitoring/DowntimeNotification';
-import moment from 'moment';
-import LoadFail from 'applications/personalization/profile360/components/LoadFail';
-import LoadingSection from 'applications/personalization/profile360/components/LoadingSection';
-import { handleDowntimeForSection } from 'applications/personalization/profile360/components/DowntimeBanner';
 import AdditionalInfo from '@department-of-veterans-affairs/formation-react/AdditionalInfo';
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 
 import recordEvent from 'platform/monitoring/record-event';
+import DowntimeNotification, {
+  externalServices,
+} from 'platform/monitoring/DowntimeNotification';
+import LoadFail from 'applications/personalization/profile360/components/LoadFail';
+import { handleDowntimeForSection } from 'applications/personalization/profile360/components/DowntimeBanner';
 import facilityLocator from 'applications/facility-locator/manifest.json';
 
+import ProfileInfoTable from './ProfileInfoTable';
+import { transformServiceHistoryEntryIntoTableRow } from '../helpers';
+
 class MilitaryInformationContent extends React.Component {
-  renderContent = () => {
+  render() {
     const {
       serviceHistory: { serviceHistory, error },
     } = this.props.militaryInformation;
@@ -77,78 +78,52 @@ class MilitaryInformationContent extends React.Component {
     }
 
     return (
-      <table className="militaryInformation" data-field-name="serviceHistory">
-        <thead>
-          <tr>
-            <th>
-              <h3>Period of service</h3>
-            </th>
-          </tr>
-        </thead>
-        <tbody>
-          {serviceHistory.map((service, index) => (
-            <tr key={index}>
-              <td>
-                <h4 className="vads-u-font-family--sans vads-u-font-size--base vads-u-font-weight--bold">
-                  {service.branchOfService}
-                </h4>
-              </td>
-              <td>
-                {moment(service.beginDate).format('MMM D, YYYY')} &ndash;{' '}
-                {moment(service.endDate).format('MMM D, YYYY')}
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
-    );
-  };
-
-  render() {
-    return (
-      <div className="vads-u-margin-bottom--2">
-        <LoadingSection
-          isLoading={!this.props.militaryInformation}
-          message="Loading military information..."
-          render={this.renderContent}
+      <>
+        <ProfileInfoTable
+          data={serviceHistory}
+          dataTransformer={transformServiceHistoryEntryIntoTableRow}
+          title="Period of service"
+          fieldName="serviceHistory"
         />
-        <AdditionalInfo
-          triggerText="What if my military service information doesn’t look right?"
-          onClick={() => {
-            recordEvent({
-              event: 'profile-navigation',
-              'profile-action': 'view-link',
-              'profile-section': 'update-military-information',
-            });
-          }}
-        >
-          <p>
-            Some Veterans have reported seeing military service information in
-            their VA.gov profiles that doesn’t seem right. When this happens,
-            it’s because there’s an error in the information we’re pulling into
-            VA.gov from the Defense Enrollment Eligibility Reporting System
-            (DEERS).
-          </p>
-          <p>
-            If the military service information in your profile doesn’t look
-            right, please call the Defense Manpower Data Center (DMDC). They’ll
-            work with you to update your information in DEERS.
-          </p>
-          <p>
-            To reach the DMDC, call{' '}
-            <a
-              href="tel:1-800-538-9552"
-              aria-label="8 0 0. 5 3 8. 9 5 5 2."
-              title="Dial the telephone number 800-538-9552"
-              className="no-wrap"
-            >
-              1-800-538-9552
-            </a>
-            , Monday through Friday (except federal holidays), 8:00 a.m. to 8:00
-            p.m. ET. If you have hearing loss, call TTY: 1-866-363-2883.
-          </p>
-        </AdditionalInfo>
-      </div>
+        <div className="vads-u-margin-y--4">
+          <AdditionalInfo
+            triggerText="What if my military service information doesn’t look right?"
+            onClick={() => {
+              recordEvent({
+                event: 'profile-navigation',
+                'profile-action': 'view-link',
+                'profile-section': 'update-military-information',
+              });
+            }}
+          >
+            <p>
+              Some Veterans have reported seeing military service information in
+              their VA.gov profiles that doesn’t seem right. When this happens,
+              it’s because there’s an error in the information we’re pulling
+              into VA.gov from the Defense Enrollment Eligibility Reporting
+              System (DEERS).
+            </p>
+            <p>
+              If the military service information in your profile doesn’t look
+              right, please call the Defense Manpower Data Center (DMDC).
+              They’ll work with you to update your information in DEERS.
+            </p>
+            <p>
+              To reach the DMDC, call{' '}
+              <a
+                href="tel:1-800-538-9552"
+                aria-label="8 0 0. 5 3 8. 9 5 5 2."
+                title="Dial the telephone number 800-538-9552"
+                className="no-wrap"
+              >
+                1-800-538-9552
+              </a>
+              , Monday through Friday (except federal holidays), 8:00 a.m. to
+              8:00 p.m. ET. If you have hearing loss, call TTY: 1-866-363-2883.
+            </p>
+          </AdditionalInfo>
+        </div>
+      </>
     );
   }
 }
@@ -157,14 +132,15 @@ class MilitaryInformation extends Component {
   render() {
     return (
       <div>
-        <h2 className="va-profile-heading" tabIndex="-1">
-          Military information
-        </h2>
+        <h2 tabIndex="-1">Military information</h2>
         <DowntimeNotification
+          appTitle="Military Information"
           render={handleDowntimeForSection('military service')}
           dependencies={[externalServices.emis]}
         >
-          <MilitaryInformationContent {...this.props} />
+          <MilitaryInformationContent
+            militaryInformation={this.props.militaryInformation}
+          />
         </DowntimeNotification>
       </div>
     );
@@ -172,7 +148,7 @@ class MilitaryInformation extends Component {
 }
 
 const mapStateToProps = state => ({
-  militaryInformation: state.vaProfile.militaryInformation,
+  militaryInformation: state.vaProfile?.militaryInformation,
 });
 
 export default connect(mapStateToProps)(MilitaryInformation);

--- a/src/applications/personalization/profile-2/components/ProfileHeader.jsx
+++ b/src/applications/personalization/profile-2/components/ProfileHeader.jsx
@@ -1,8 +1,10 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
-import { imagePaths } from '../constants';
 import orderBy from 'lodash/orderBy';
+
+import { SERVICE_BADGE_IMAGE_PATHS } from '../constants';
+import { getServiceBranchDisplayName } from '../helpers';
 
 const ProfileHeader = ({
   userFullName: { first, middle, last, suffix },
@@ -20,7 +22,7 @@ const ProfileHeader = ({
           {showBadgeImage && (
             <img
               className="profileServiceBadge"
-              src={imagePaths[latestBranchOfService]}
+              src={SERVICE_BADGE_IMAGE_PATHS.get(latestBranchOfService)}
               alt="service badge"
             />
           )}
@@ -32,7 +34,7 @@ const ProfileHeader = ({
           <h2 className="vads-u-font-size--h3">{fullName}</h2>
           {latestBranchOfService && (
             <h3 className="vads-u-font-family--sans vads-u-font-size--base vads-u-font-weight--normal">
-              United States {latestBranchOfService}
+              {getServiceBranchDisplayName(latestBranchOfService)}
             </h3>
           )}
         </div>
@@ -51,7 +53,7 @@ const mapStateToProps = state => {
   return {
     userFullName: state.vaProfile?.hero?.userFullName,
     latestBranchOfService,
-    showBadgeImage: Boolean(imagePaths[latestBranchOfService]),
+    showBadgeImage: SERVICE_BADGE_IMAGE_PATHS.has(latestBranchOfService),
   };
 };
 
@@ -67,11 +69,11 @@ ProfileHeader.defaultProps = {
 
 ProfileHeader.propTypes = {
   userFullName: PropTypes.shape({
-    first: PropTypes.string.isRequired,
-    middle: PropTypes.string.isRequired,
-    last: PropTypes.string.isRequired,
+    first: PropTypes.string,
+    middle: PropTypes.string,
+    last: PropTypes.string,
+    suffix: PropTypes.string,
   }).isRequired,
-  // defaulting to Army for now as placeholder
   latestBranchOfService: PropTypes.string.isRequired,
 };
 

--- a/src/applications/personalization/profile-2/components/ProfileInfoTable.jsx
+++ b/src/applications/personalization/profile-2/components/ProfileInfoTable.jsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const ProfileInfoTable = ({ data, dataTransformer, fieldName, title }) => (
+  <table className="profile-info-table" data-field-name={fieldName}>
+    <thead>
+      <tr>
+        <th>
+          <h3>{title}</h3>
+        </th>
+      </tr>
+    </thead>
+    <tbody>
+      {data
+        .map(element => (dataTransformer ? dataTransformer(element) : element))
+        .map((row, index) => (
+          <tr key={index}>
+            <td>
+              <h4 className="vads-u-font-family--sans vads-u-font-size--base vads-u-font-weight--bold">
+                {row.title}
+              </h4>
+            </td>
+            <td>{row.value}</td>
+          </tr>
+        ))}
+    </tbody>
+  </table>
+);
+
+ProfileInfoTable.propTypes = {
+  title: PropTypes.string.isRequired,
+  fieldName: PropTypes.string.isRequired,
+  data: PropTypes.array.isRequired,
+  dataTransformer: PropTypes.func,
+};
+
+export default ProfileInfoTable;

--- a/src/applications/personalization/profile-2/components/ProfileWrapper.jsx
+++ b/src/applications/personalization/profile-2/components/ProfileWrapper.jsx
@@ -45,7 +45,10 @@ class ProfileWrapper extends Component {
     }
   }
 
-  // content to show if the component is waiting for data to load
+  // content to show if the component is waiting for data to load. This loader
+  // matches the loader shown by the RequiredLoginView component, so when the
+  // RequiredLoginView is done with its loading and this function takes over, it
+  // appears seamless to the user.
   loadingContent = () => (
     <div className="vads-u-margin-y--5">
       <LoadingIndicator setFocus message="Loading your information..." />

--- a/src/applications/personalization/profile-2/constants.js
+++ b/src/applications/personalization/profile-2/constants.js
@@ -1,7 +1,17 @@
-export const imagePaths = {
-  Army: '/img/vic-army-symbol.png',
-  'Coast Guard': '/img/vic-cg-emblem.png',
-  'Air Force': '/img/vic-air-force-coat-of-arms.png',
-  Navy: '/img/vic-navy-emblem.png',
-  'Marine Corps': '/img/vic-usmc-emblem.png',
-};
+// The values of these constants map to the possible values that come back from
+// the GET profile/service_history API.
+export const USA_MILITARY_BRANCHES = Object.freeze({
+  army: 'Army',
+  coastGuard: 'Coast Guard',
+  airForce: 'Air Force',
+  navy: 'Navy',
+  marineCorps: 'Marine Corps',
+});
+
+export const SERVICE_BADGE_IMAGE_PATHS = new Map([
+  [USA_MILITARY_BRANCHES.army, '/img/vic-army-symbol.png'],
+  [USA_MILITARY_BRANCHES.coastGuard, '/img/vic-cg-emblem.png'],
+  [USA_MILITARY_BRANCHES.airForce, '/img/vic-air-force-coat-of-arms.png'],
+  [USA_MILITARY_BRANCHES.navy, '/img/vic-navy-emblem.png'],
+  [USA_MILITARY_BRANCHES.marineCorps, '/img/vic-usmc-emblem.png'],
+]);

--- a/src/applications/personalization/profile-2/helpers.js
+++ b/src/applications/personalization/profile-2/helpers.js
@@ -1,4 +1,5 @@
 import moment from 'moment';
+import { USA_MILITARY_BRANCHES } from './constants';
 
 const asyncReturn = (returnValue, delay = 300) =>
   new Promise(resolve => {
@@ -10,21 +11,58 @@ const asyncReturn = (returnValue, delay = 300) =>
 export const asyncFetchMilitaryInformation = () =>
   asyncReturn({
     serviceHistory: [
-      { branchOfService: 'Army', beginDate: moment(), endDate: moment() },
+      {
+        branchOfService: 'Army',
+        beginDate: '2010-05-10',
+        endDate: '2010-08-15',
+      },
       {
         branchOfService: 'Air Force',
-        beginDate: moment(),
-        endDate: moment(),
+        beginDate: '2010-01-31',
+        endDate: '2010-03-01',
+      },
+      {
+        branchOfService: 'Other',
+        beginDate: '2011-02-28',
+        endDate: '2011-12-25',
       },
       {
         branchOfService: 'Marine Corps',
-        beginDate: moment(),
-        endDate: moment(),
-      },
-      {
-        branchOfService: 'Air Force',
-        beginDate: moment(),
-        endDate: moment(),
+        beginDate: '2012-04-01',
+        endDate: '2012-05-01',
       },
     ],
   });
+
+/**
+ * Prefixes the serviceBranch with 'United States' if it's a valid US military
+ * branch. Otherwise it returns the original serviceBranch without changing it
+ *
+ * @param {string} serviceBranch - the branch to potentially prefix with 'United
+ * States'
+ * @returns {string} the service branch with or without 'United States'
+ * prepended to it
+ *
+ */
+export const getServiceBranchDisplayName = serviceBranch => {
+  if (Object.values(USA_MILITARY_BRANCHES).includes(serviceBranch)) {
+    return `United States ${serviceBranch}`;
+  }
+  return serviceBranch;
+};
+
+/**
+ *
+ * Transforms a service history object into an object with `title` and `value`
+ * keys, which the format required by a single row in a `ProfileInfoTable`
+ *
+ * @param {Object} entry - a service history object with `branchOfService`,
+ * `beginDate`, and `endDate` keys
+ * @returns {Object} An object with `title` and `value` keys
+ */
+export const transformServiceHistoryEntryIntoTableRow = entry => ({
+  title: getServiceBranchDisplayName(entry.branchOfService),
+  value: `${moment(entry.beginDate).format('ll')} – ${moment(
+    entry.endDate,
+  ).format('ll')}`,
+});

--- a/src/applications/personalization/profile-2/sass/profile-2.scss
+++ b/src/applications/personalization/profile-2/sass/profile-2.scss
@@ -1,5 +1,6 @@
 @import "~@department-of-veterans-affairs/formation/sass/shared-variables";
 @import "../../../../platform/forms/sass/m-schemaform";
+@import "./profile-info-table";
 
 nav.profile-side-nav {
   ul {
@@ -16,73 +17,6 @@ nav.profile-side-nav {
     color: $color-black;
   }
 }
-
-.militaryInformation {
-  border-collapse: collapse;
-  border-spacing: 0;
-
-  th:first-child {
-    border-top-left-radius: 4px;
-    border-top-right-radius: 4px;
-    border-bottom: none;
-    width: 100%;
-  }
-
-  tr:not(:last-child) {
-    td {
-      border-bottom: none;
-    }
-  }
-
-  tr:last-child {
-    td:last-child {
-      border-bottom-right-radius: 4px;
-      border-bottom-left-radius: 4px;
-    }
-  }
-
-  th,
-  td {
-    border: 1px solid $color-gray-lighter;
-    text-align: left;
-    display: flex;
-    padding: units(1.5) units(4);
-  }
-
-  tr {
-    display: flex;
-    flex-direction: row;
-    border: none;
-  }
-
-  td {
-    padding: 10px 30px;
-    width: 100%;
-  }
-
-  tr,
-  td:first-child {
-    border-right: none;
-    width: 75%;
-  }
-
-  tr,
-  td:last-child {
-    border-left: none;
-    width: 100%
-  }
-
-  h3 {
-    color: $color-primary-darkest;
-    margin: unset;
-  }
-
-  h4 {
-    color: $color-gray-dark;
-    margin: unset;
-  }
-}
-
 
 .headerNameWrapper {
   width: 100%;

--- a/src/applications/personalization/profile-2/sass/profile-info-table.scss
+++ b/src/applications/personalization/profile-2/sass/profile-info-table.scss
@@ -1,0 +1,65 @@
+.profile-info-table {
+  border-collapse: collapse;
+  border-spacing: 0;
+
+  th:first-child {
+    border-top-left-radius: 4px;
+    border-top-right-radius: 4px;
+    border-bottom: none;
+    width: 100%;
+  }
+
+  tr:not(:last-child) {
+    td {
+      border-bottom: none;
+    }
+  }
+
+  tr:last-child {
+    td:last-child {
+      border-bottom-right-radius: 4px;
+      border-bottom-left-radius: 4px;
+    }
+  }
+
+  th,
+  td {
+    border: 1px solid $color-gray-lighter;
+    text-align: left;
+    display: flex;
+    padding: units(1.5) units(4);
+  }
+
+  tr {
+    display: flex;
+    flex-direction: row;
+    border: none;
+  }
+
+  td {
+    padding: 10px 30px;
+    width: 100%;
+  }
+
+  tr,
+  td:first-child {
+    border-right: none;
+    width: 75%;
+  }
+
+  tr,
+  td:last-child {
+    border-left: none;
+    width: 100%
+  }
+
+  h3 {
+    color: $color-primary-darkest;
+    margin: unset;
+  }
+
+  h4 {
+    color: $color-gray-dark;
+    margin: unset;
+  }
+}

--- a/src/applications/personalization/profile-2/tests/components/ProfileHeader.unit.spec.jsx
+++ b/src/applications/personalization/profile-2/tests/components/ProfileHeader.unit.spec.jsx
@@ -19,18 +19,18 @@ const fakeStore = {
           serviceHistory: [
             {
               branchOfService: 'Army',
-              beginDate: '2004-2-1',
-              endDate: '2007-2-1',
+              beginDate: '2004-02-01',
+              endDate: '2007-02-01',
             },
             {
               branchOfService: 'Navy',
-              beginDate: '2007-2-1',
-              endDate: '2009-2-1',
+              beginDate: '2007-02-01',
+              endDate: '2009-02-01',
             },
             {
               branchOfService: 'Coast Guard',
-              beginDate: '2009-2-1',
-              endDate: '2019-2-1',
+              beginDate: '2009-02-01',
+              endDate: '2019-02-01',
             },
           ],
         },

--- a/src/applications/personalization/profile-2/tests/components/ProfileInfoTable.unit.spec.js
+++ b/src/applications/personalization/profile-2/tests/components/ProfileInfoTable.unit.spec.js
@@ -1,0 +1,52 @@
+import React from 'react';
+import sinon from 'sinon';
+import { shallow } from 'enzyme';
+import { expect } from 'chai';
+
+import ProfileInfoTable from '../../components/ProfileInfoTable';
+
+describe('ProfileInfoTable', () => {
+  let dataTransformerSpy;
+  const props = {
+    title: 'Table Title',
+    fieldName: 'profileField',
+    data: [
+      { title: 'row 1', value: 'value 1' },
+      { title: 'row 2', value: 'value 2' },
+    ],
+  };
+  let wrapper;
+  beforeEach(() => {
+    dataTransformerSpy = sinon.spy(arg => arg);
+    props.dataTransformer = dataTransformerSpy;
+    wrapper = shallow(<ProfileInfoTable {...props} />);
+  });
+  afterEach(() => {
+    wrapper.unmount();
+  });
+  it('renders a `table`', () => {
+    expect(wrapper.type()).to.equal('table');
+  });
+  it("sets the table's data-field-name to the fieldName prop", () => {
+    expect(wrapper.prop('data-field-name')).to.equal(props.fieldName);
+  });
+  it('renders the title prop in an h3 tag', () => {
+    const h3 = wrapper.find('h3');
+    expect(h3.text()).to.equal(props.title);
+  });
+  it('renders a table row for each entry in the data prop', () => {
+    const tableRows = wrapper.find('tbody > tr');
+    expect(tableRows.length).to.equal(props.data.length);
+  });
+  it('calls the dataTransformer once for each row of data', () => {
+    expect(dataTransformerSpy.callCount).to.equal(props.data.length);
+  });
+  it("renders each data object's title and value in a table row", () => {
+    const tableRows = wrapper.find('tbody > tr');
+    tableRows.forEach((row, index) => {
+      const { title, value } = props.data[index];
+      expect(row.text().includes(title)).to.be.true;
+      expect(row.text().includes(value)).to.be.true;
+    });
+  });
+});

--- a/src/applications/personalization/profile-2/tests/helpers.unit.spec.js
+++ b/src/applications/personalization/profile-2/tests/helpers.unit.spec.js
@@ -1,0 +1,43 @@
+import { expect } from 'chai';
+
+import {
+  getServiceBranchDisplayName,
+  transformServiceHistoryEntryIntoTableRow,
+} from '../helpers';
+
+import { USA_MILITARY_BRANCHES } from '../constants';
+
+describe('getServiceBranchDisplayName', () => {
+  describe('when passed a valid USA military branches', () => {
+    Object.values(USA_MILITARY_BRANCHES).forEach(branch => {
+      it('should prefix the branch name with `United States`', () => {
+        expect(getServiceBranchDisplayName(branch)).to.equal(
+          `United States ${branch}`,
+        );
+      });
+    });
+  });
+
+  describe('when not passed one of the five USA military branches', () => {
+    it('should simply return what it was passed', () => {
+      expect(getServiceBranchDisplayName('Other')).to.equal('Other');
+    });
+  });
+});
+
+describe('transformServiceHistoryEntryIntoTableRow', () => {
+  it('should convert military service history into the format the ProfileInfoTable expects', () => {
+    const serviceHistory = {
+      branchOfService: 'Army',
+      beginDate: '2000-01-31',
+      endDate: '2010-12-25',
+    };
+    const transformedData = transformServiceHistoryEntryIntoTableRow(
+      serviceHistory,
+    );
+    expect(transformedData.title).to.equal(
+      `United States ${serviceHistory.branchOfService}`,
+    );
+    expect(transformedData.value).to.equal('Jan. 31, 2000 – Dec. 25, 2010');
+  });
+});


### PR DESCRIPTION
## Description
The primary purpose of this PR is to create a new `ProfileInfoTable`, based on the military information's table, that can be reused through the different pages of the new Profile app.

## Testing done
Local + lots of unit tests

## Screenshots
the new component in place looks identical to the non-component version of service history
![image](https://user-images.githubusercontent.com/20728956/78937959-3274f500-7a66-11ea-8358-f5785727061a.png)

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs