### PR TITLE
[Redirect] Remove VET TECH Training Providers redirect

### DIFF
--- a/src/applications/proxy-rewrite/redirects/crossDomainRedirects.json
+++ b/src/applications/proxy-rewrite/redirects/crossDomainRedirects.json
@@ -723,10 +723,5 @@
     "domain": "www.benefits.va.gov",
     "src": "/gibill/fgib/vettec_veteran.asp",
     "dest": "/education/about-gi-bill-benefits/how-to-use-benefits/vettec-high-tech-program/"
-  },
-  {
-    "domain": "www.benefits.va.gov",
-    "src": "/gibill/fgib/vettectrainingproviders.asp",
-    "dest": "/education/about-gi-bill-benefits/how-to-use-benefits/vettec-high-tech-program/"
   }
 ]


### PR DESCRIPTION
## Description
This PR removes a redirect that should have gone out - https://dsva.slack.com/archives/C52CL1PKQ/p1586527307312100

https://github.com/department-of-veterans-affairs/va.gov-team/issues/7853

## Acceptance criteria
- [ ] Redirect is gone

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
