### PR TITLE
Add link for fiduciary claim

### DIFF
--- a/src/applications/disability-benefits/wizard/pages/decision-review.jsx
+++ b/src/applications/disability-benefits/wizard/pages/decision-review.jsx
@@ -8,8 +8,8 @@ const alertContent = (
       If you disagree with a VA decision on your claim, you can request a
       decision review on all or some of the decision. In most situations, you
       have one year from the date on your decision letter to request a decision
-      review. The deadline to file may be different if you have a fiduciary
-      claim, a{' '}
+      review. The deadline to file may be different if you have a{' '}
+      <a href="/decision-reviews/fiduciary-claims">fiduciary claim</a>, a{' '}
       <a href="/decision-reviews/multiple-party-claims/">contested claim</a>, or
       if you’re filing a{' '}
       <a href="/decision-reviews/#supplemental-claim">Supplemental Claim</a>.


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/7737

This PR adds a missing a tag.

## Testing done
Locally, no updates to tests.

## Screenshots
![image](https://user-images.githubusercontent.com/12773166/79007012-84298800-7b17-11ea-9a51-fb5469fa6f97.png)

## Acceptance criteria
- [x] Add a tag with link for `fiduciary claim` text.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
