### PR TITLE
Kelsonic 7807 yr a11y tweaks

### DIFF
--- a/src/applications/yellow-ribbon/components/SearchResult/index.jsx
+++ b/src/applications/yellow-ribbon/components/SearchResult/index.jsx
@@ -130,12 +130,7 @@ export const SearchResult = ({ school }) => (
             <br />
             (per student, per year)
           </p>
-          <p className="vads-u-margin--0">
-            <span className="sr-only">
-              Maximum Yellow Ribbon funding amount (per student, per year)
-            </span>
-            {deriveMaxAmountLabel(school)}
-          </p>
+          <p className="vads-u-margin--0">{deriveMaxAmountLabel(school)}</p>
         </div>
 
         {/* Student Count */}
@@ -143,7 +138,6 @@ export const SearchResult = ({ school }) => (
           Funding available for
         </p>
         <p className="vads-u-margin-top--0 vads-u-margin-bottom--0">
-          <span className="sr-only">Eligible students</span>
           {deriveEligibleStudentsLabel(school)}
         </p>
 
@@ -152,7 +146,6 @@ export const SearchResult = ({ school }) => (
           School website
         </p>
         <p className="vads-u-margin-top--0 vads-u-margin-bottom--0">
-          <span className="sr-only">School website</span>
           {deriveInstURLLabel(school)}
         </p>
       </div>
@@ -163,7 +156,6 @@ export const SearchResult = ({ school }) => (
           Degree type
         </p>
         <p className="vads-u-margin-top--0 vads-u-margin-bottom--0 medium-screen:vads-u-margin--0">
-          <span className="sr-only">Degree level</span>
           {deriveDegreeLevel(school)}
         </p>
 
@@ -172,7 +164,6 @@ export const SearchResult = ({ school }) => (
           School or program
         </p>
         <p className="vads-u-margin-top--0 vads-u-margin-bottom--0 medium-screen:vads-u-margin--0">
-          <span className="sr-only">School or program</span>
           {deriveDivisionProfessionalSchool(school)}
         </p>
       </div>

--- a/src/applications/yellow-ribbon/containers/SearchResults/index.jsx
+++ b/src/applications/yellow-ribbon/containers/SearchResults/index.jsx
@@ -138,7 +138,7 @@ export class SearchResults extends Component {
     if (!results.length) {
       return (
         <h2
-          className="va-introtext vads-u-font-size--lg vads-u-margin-top--1p5 vads-u-font-weight--normal"
+          className="va-introtext va-u-outline--none vads-u-font-size--lg vads-u-margin-top--1p5 vads-u-font-weight--normal"
           data-display-results-header
         >
           No results found.


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/7807

This PR removes the focus outline for `No results found.`
This PR removes unnecessary `sr-only` nodes for each `SearchResult`.

## Testing done


## Screenshots
![image](https://user-images.githubusercontent.com/12773166/79008107-e1bed400-7b19-11ea-8a0f-71db66b24ebd.png)

![image](https://user-images.githubusercontent.com/12773166/79008175-087d0a80-7b1a-11ea-9ce0-6f179598822d.png)

## Acceptance criteria
- [x] Remove focus outline on `No results found.`
- [x] Remove unnecessary `sr-only` nodes for each `SearchResult`.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
