### PR TITLE
VAOS list refactor 2: appointments and cancelling

### DIFF
--- a/src/applications/vaos/actions/appointments.js
+++ b/src/applications/vaos/actions/appointments.js
@@ -1,7 +1,6 @@
 import moment from 'moment';
 import * as Sentry from '@sentry/browser';
-import { FETCH_STATUS, GA_PREFIX } from '../utils/constants';
-import { getMomentConfirmedDate, isCommunityCare } from '../utils/appointment';
+import { FETCH_STATUS, GA_PREFIX, APPOINTMENT_TYPES } from '../utils/constants';
 import recordEvent from 'platform/monitoring/record-event';
 import { resetDataLayer } from '../utils/events';
 
@@ -289,17 +288,18 @@ export function cancelAppointment(appointment) {
   };
 }
 
-const SUBMITTED_REQUEST = 'Submitted';
 const CANCELLED_REQUEST = 'Cancelled';
 export function confirmCancelAppointment() {
   return async (dispatch, getState) => {
     const appointment = getState().appointments.appointmentToCancel;
-    const isPendingRequest = appointment.status === SUBMITTED_REQUEST;
+    const isConfirmedAppointment =
+      appointment.appointmentType === APPOINTMENT_TYPES.vaAppointment;
     const eventPrefix = `${GA_PREFIX}-cancel-appointment-submission`;
     const additionalEventdata = {
-      appointmentType: isPendingRequest ? 'pending' : 'confirmed',
-      facilityType: isCommunityCare(appointment) ? 'cc' : 'va',
+      appointmentType: !isConfirmedAppointment ? 'pending' : 'confirmed',
+      facilityType: appointment.isCommunityCare ? 'cc' : 'va',
     };
+    let apiData = appointment.apiData;
     let cancelReasons = null;
     let cancelReason = null;
 
@@ -313,21 +313,23 @@ export function confirmCancelAppointment() {
         type: CANCEL_APPOINTMENT_CONFIRMED,
       });
 
-      if (isPendingRequest) {
-        await updateRequest({
-          ...appointment,
+      if (!isConfirmedAppointment) {
+        apiData = await updateRequest({
+          ...appointment.apiData,
           status: CANCELLED_REQUEST,
           appointmentRequestDetailCode: ['DETCODE8'],
         });
       } else {
         const cancelData = {
-          appointmentTime: getMomentConfirmedDate(appointment).format(
+          appointmentTime: appointment.appointmentDate.format(
             'MM/DD/YYYY HH:mm:ss',
           ),
           clinicId: appointment.clinicId,
           facilityId: appointment.facilityId,
           remarks: '',
-          clinicName: appointment.vdsAppointments[0].clinic.name,
+          // Grabbing this from the api data because it's not clear if
+          // we have to send the real name or if the friendly name is ok
+          clinicName: appointment.apiData.vdsAppointments[0].clinic.name,
           cancelCode: 'PC',
         };
 
@@ -358,6 +360,7 @@ export function confirmCancelAppointment() {
 
       dispatch({
         type: CANCEL_APPOINTMENT_CONFIRMED_SUCCEEDED,
+        apiData,
       });
 
       recordEvent({

--- a/src/applications/vaos/api/index.js
+++ b/src/applications/vaos/api/index.js
@@ -434,7 +434,17 @@ export function updateAppointment(appt) {
 export function updateRequest(req) {
   let promise;
   if (USE_MOCK_DATA) {
-    promise = Promise.resolve();
+    promise = import('./requests.json')
+      .then(module => (module.default ? module.default : module))
+      .then(data => ({
+        data: {
+          id: req.id,
+          attributes: {
+            ...data.data.find(item => item.id === req.id).attributes,
+            status: 'Cancelled',
+          },
+        },
+      }));
   } else {
     promise = apiRequest(`/vaos/appointment_requests/${req.id}`, {
       method: 'PUT',
@@ -443,7 +453,10 @@ export function updateRequest(req) {
     });
   }
 
-  return promise;
+  return promise.then(resp => ({
+    ...resp.data.attributes,
+    id: resp.data.id,
+  }));
 }
 
 export function submitRequest(type, request) {

--- a/src/applications/vaos/components/AppointmentDateTime.jsx
+++ b/src/applications/vaos/components/AppointmentDateTime.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import {
+  getAppointmentTimezoneAbbreviation,
+  getAppointmentTimezoneDescription,
+} from '../utils/appointment';
+
+export default function AppointmentDateTime({
+  appointmentDate,
+  timezone,
+  facilityId,
+}) {
+  if (!appointmentDate.isValid()) {
+    return null;
+  }
+
+  return (
+    <>
+      {appointmentDate.format('dddd, MMMM D, YYYY')} at{' '}
+      {appointmentDate.format('h:mm')}
+      <span aria-hidden="true">
+        {' '}
+        {appointmentDate.format('a')}{' '}
+        {getAppointmentTimezoneAbbreviation(timezone, facilityId)}
+      </span>
+      <span className="sr-only">
+        {appointmentDate.format('a')}{' '}
+        {getAppointmentTimezoneDescription(timezone, facilityId)}
+      </span>
+    </>
+  );
+}

--- a/src/applications/vaos/components/AppointmentDateTime.jsx
+++ b/src/applications/vaos/components/AppointmentDateTime.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import {
   getAppointmentTimezoneAbbreviation,
   getAppointmentTimezoneDescription,
-} from '../utils/appointment';
+} from '../utils/appointment-new';
 
 export default function AppointmentDateTime({
   appointmentDate,

--- a/src/applications/vaos/components/AppointmentInstructions.jsx
+++ b/src/applications/vaos/components/AppointmentInstructions.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+export default function AppointmentInstructions({ instructions }) {
+  if (!instructions) {
+    return null;
+  }
+  return (
+    <div className="vads-u-flex--1 vads-u-margin-bottom--2 vaos-u-word-break--break-word">
+      <dl className="vads-u-margin--0">
+        <dt className="vads-u-font-weight--bold">{instructions.header}</dt>
+        <dd>{instructions.body}</dd>
+      </dl>
+    </div>
+  );
+}

--- a/src/applications/vaos/components/ConfirmationDirectScheduleInfo.jsx
+++ b/src/applications/vaos/components/ConfirmationDirectScheduleInfo.jsx
@@ -3,7 +3,7 @@ import moment from '../utils/moment-tz.js';
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 import FacilityAddress from './FacilityAddress';
 import AddToCalendar from './AddToCalendar';
-import { getFacilityAddress } from '../utils/appointment';
+import { formatFacilityAddress } from '../utils/formatters';
 import {
   getTimezoneAbbrBySystemId,
   getTimezoneBySystemId,
@@ -84,7 +84,7 @@ export default function ConfirmationDirectScheduleInfo({
             <AddToCalendar
               summary="VA Appointment"
               description=""
-              location={getFacilityAddress(facilityDetails)}
+              location={formatFacilityAddress(facilityDetails)}
               startDateTime={momentDate.toDate()}
               duation={appointmentLength}
             />

--- a/src/applications/vaos/components/ConfirmedAppointmentListItem.jsx
+++ b/src/applications/vaos/components/ConfirmedAppointmentListItem.jsx
@@ -65,7 +65,7 @@ export default function ConfirmedAppointmentListItem({
           facilityId={appointment.facilityId}
         />
       </h3>
-      {!isPastAppointment && (
+      {(!isPastAppointment || cancelled) && (
         <AppointmentStatus status={appointment.status} index={index} />
       )}
       <div className="vads-u-display--flex vads-u-flex-direction--column small-screen:vads-u-flex-direction--row">

--- a/src/applications/vaos/components/ConfirmedAppointmentListItem.jsx
+++ b/src/applications/vaos/components/ConfirmedAppointmentListItem.jsx
@@ -1,50 +1,51 @@
 import React from 'react';
 import classNames from 'classnames';
 import {
-  getAppointmentAddress,
-  getAppointmentDate,
-  getAppointmentDateTime,
-  getAppointmentDuration,
-  getAppointmentInstructions,
-  getAppointmentInstructionsHeader,
-  getAppointmentLocation,
-  getAppointmentTypeHeader,
-  getLocationHeader,
-  getMomentConfirmedDate,
-  hasInstructions,
-  isVideoVisit,
-} from '../utils/appointment';
-import {
-  CANCELLED_APPOINTMENT_SET,
-  APPOINTMENT_TYPES,
-} from '../utils/constants';
+  formatAppointmentDate,
+  formatFacilityAddress,
+} from '../utils/formatters';
+import { APPOINTMENT_STATUS } from '../utils/constants';
 import VideoVisitSection from './VideoVisitSection';
 import AddToCalendar from './AddToCalendar';
+import VAFacilityLocation from './VAFacilityLocation';
+import AppointmentDateTime from './AppointmentDateTime';
+import AppointmentInstructions from './AppointmentInstructions';
+import AppointmentStatus from './AppointmentStatus';
+import ConfirmedCommunityCareLocation from './ConfirmedCommunityCareLocation';
 
 export default function ConfirmedAppointmentListItem({
   appointment,
-  type,
   index,
   cancelAppointment,
   showCancelButton,
   facility,
-  isPastAppointment,
 }) {
-  let canceled = false;
-  if (type === APPOINTMENT_TYPES.vaAppointment) {
-    canceled = CANCELLED_APPOINTMENT_SET.has(
-      appointment.vdsAppointments?.[0]?.currentStatus,
-    );
-  }
+  const cancelled = appointment.status === APPOINTMENT_STATUS.cancelled;
+  const isPastAppointment = appointment.isPastAppointment;
 
   const itemClasses = classNames(
     'vads-u-background-color--gray-lightest vads-u-padding--2p5 vads-u-margin-bottom--3',
     {
       'vads-u-border-top--4px': !isPastAppointment,
-      'vads-u-border-color--green': !canceled && !isPastAppointment,
-      'vads-u-border-color--secondary-dark': canceled && !isPastAppointment,
+      'vads-u-border-color--green': !cancelled && !isPastAppointment,
+      'vads-u-border-color--secondary-dark': cancelled && !isPastAppointment,
     },
   );
+
+  let header;
+  let location;
+  if (appointment.videoType) {
+    header = 'VA Video Connect';
+    location = 'Video conference';
+  } else if (appointment.isCommunityCare) {
+    header = 'Community Care';
+    location = `${appointment.address.street} ${appointment.address.city}, ${
+      appointment.address.state
+    } ${appointment.address.zipCode}`;
+  } else {
+    header = 'VA Appointment';
+    location = facility ? formatFacilityAddress(facility) : null;
+  }
 
   return (
     <li
@@ -55,69 +56,53 @@ export default function ConfirmedAppointmentListItem({
         id={`card-${index}-type`}
         className="vaos-form__title vads-u-font-size--sm vads-u-font-weight--normal vads-u-font-family--sans"
       >
-        {getAppointmentTypeHeader(appointment)}
+        {header}
       </div>
       <h3 className="vaos-appts__date-time vads-u-font-size--h3 vads-u-margin-x--0">
-        {getAppointmentDateTime(appointment)}
+        <AppointmentDateTime
+          appointmentDate={appointment.appointmentDate}
+          timezone={appointment.timeZone}
+          facilityId={appointment.facilityId}
+        />
       </h3>
-      {(!isPastAppointment || canceled) && (
-        <div className="vads-u-margin-top--2 vads-u-margin-bottom--2">
-          {canceled ? (
-            <i aria-hidden="true" className="fas fa-exclamation-circle" />
-          ) : (
-            <i aria-hidden="true" className="fas fa-check-circle" />
-          )}
-          <span
-            id={`card-${index}-state`}
-            className="vads-u-font-weight--bold vads-u-margin-left--1 vads-u-display--inline-block"
-          >
-            {canceled ? 'Canceled' : 'Confirmed'}
-          </span>
-        </div>
+      {!isPastAppointment && (
+        <AppointmentStatus status={appointment.status} index={index} />
       )}
-
       <div className="vads-u-display--flex vads-u-flex-direction--column small-screen:vads-u-flex-direction--row">
         <div className="vads-u-flex--1 vads-u-margin-bottom--2 vads-u-margin-right--1 vaos-u-word-break--break-word">
-          {isVideoVisit(appointment) && !isPastAppointment ? (
+          {appointment.isCommunityCare && (
+            <ConfirmedCommunityCareLocation appointment={appointment} />
+          )}
+          {!!appointment.videoType && (
             <VideoVisitSection appointment={appointment} />
-          ) : (
-            <dl className="vads-u-margin--0">
-              <dt className="vads-u-font-weight--bold">
-                {getLocationHeader(appointment)}
-              </dt>
-              <dd>{getAppointmentLocation(appointment, facility)}</dd>
-            </dl>
           )}
+          {!appointment.isCommunityCare &&
+            !appointment.videoType && (
+              <VAFacilityLocation
+                facility={facility}
+                clinicName={appointment.clinicName}
+              />
+            )}
         </div>
-        {hasInstructions(appointment) &&
-          !isPastAppointment && (
-            <div className="vads-u-flex--1 vads-u-margin-bottom--2 vaos-u-word-break--break-word">
-              <dl className="vads-u-margin--0">
-                <dt className="vads-u-font-weight--bold">
-                  {getAppointmentInstructionsHeader(appointment)}
-                </dt>
-                <dd>{getAppointmentInstructions(appointment)}</dd>
-              </dl>
-            </div>
-          )}
+        <AppointmentInstructions instructions={appointment.instructions} />
       </div>
 
-      {!canceled &&
+      {!cancelled &&
         !isPastAppointment && (
           <div className="vads-u-margin-top--2">
             <AddToCalendar
-              summary={getAppointmentTypeHeader(appointment)}
+              summary={header}
               description={
-                hasInstructions(appointment)
-                  ? `${getAppointmentInstructionsHeader(
-                      appointment,
-                    )}. ${getAppointmentInstructions(appointment)}`
+                appointment.instructions
+                  ? `${appointment.instructions.header}. ${
+                      appointment.instructions.body
+                    }`
                   : ''
               }
-              location={getAppointmentAddress(appointment, facility)}
-              duration={getAppointmentDuration(appointment)}
-              startDateTime={getMomentConfirmedDate(appointment).toDate()}
-              endDateTime={getMomentConfirmedDate(appointment)}
+              location={location}
+              duration={appointment.duration}
+              startDateTime={appointment.appointmentDate.toDate()}
+              endDateTime={appointment.appointmentDate}
             />
             {showCancelButton && (
               <button
@@ -128,7 +113,7 @@ export default function ConfirmedAppointmentListItem({
                 Cancel appointment
                 <span className="sr-only">
                   {' '}
-                  on {getAppointmentDate(appointment)}
+                  on {formatAppointmentDate(appointment.appointmentDate)}
                 </span>
               </button>
             )}

--- a/src/applications/vaos/components/ConfirmedCommunityCareLocation.jsx
+++ b/src/applications/vaos/components/ConfirmedCommunityCareLocation.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import FacilityDirectionsLink from './FacilityDirectionsLink';
+
+export default function ConfirmedCommunityCareLocation({ appointment }) {
+  return (
+    <dl className="vads-u-margin--0">
+      <dt className="vads-u-font-weight--bold">
+        {appointment.providerPractice}
+      </dt>
+      <dd>
+        {appointment.address.street}
+        <br />
+        {appointment.address.city}, {appointment.address.state}{' '}
+        {appointment.address.zipCode}
+        <br />
+        <FacilityDirectionsLink location={appointment} />
+      </dd>
+    </dl>
+  );
+}

--- a/src/applications/vaos/components/NoValidVAFacilities.jsx
+++ b/src/applications/vaos/components/NoValidVAFacilities.jsx
@@ -4,7 +4,7 @@ import FacilityDirectionsLink from './FacilityDirectionsLink';
 import FacilityHours from './FacilityHours';
 import { FETCH_STATUS } from '../utils/constants';
 import LoadingIndicator from '@department-of-veterans-affairs/formation-react/LoadingIndicator';
-import { lowerCase } from '../utils/appointment';
+import { lowerCase } from '../utils/formatters';
 
 export default function NoValidVAFacilities({ formContext }) {
   const {

--- a/src/applications/vaos/components/PastAppointmentsList.jsx
+++ b/src/applications/vaos/components/PastAppointmentsList.jsx
@@ -6,10 +6,7 @@ import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 import { fetchPastAppointments } from '../actions/appointments';
 import { FETCH_STATUS, APPOINTMENT_TYPES } from '../utils/constants';
 import { vaosPastAppts } from '../utils/selectors';
-import {
-  getAppointmentType,
-  getPastAppointmentDateRangeOptions,
-} from '../utils/appointment';
+import { getPastAppointmentDateRangeOptions } from '../utils/appointment';
 import ConfirmedAppointmentListItem from './ConfirmedAppointmentListItem';
 import PastAppointmentsDateDropdown from './PastAppointmentsDateDropdown';
 import TabNav from './TabNav';
@@ -71,9 +68,7 @@ export class PastAppointmentsList extends React.Component {
         <>
           <ul className="usa-unstyled-list" id="appointments-list">
             {past.map((appt, index) => {
-              const type = getAppointmentType(appt);
-
-              switch (type) {
+              switch (appt.appointmentType) {
                 case APPOINTMENT_TYPES.ccAppointment:
                 case APPOINTMENT_TYPES.vaAppointment:
                   return (
@@ -81,13 +76,11 @@ export class PastAppointmentsList extends React.Component {
                       key={index}
                       index={index}
                       appointment={appt}
-                      type={type}
                       facility={
                         systemClinicToFacilityMap[
                           `${appt.facilityId}_${appt.clinicId}`
                         ]
                       }
-                      isPastAppointment
                     />
                   );
                 default:

--- a/src/applications/vaos/components/VideoVisitSection.jsx
+++ b/src/applications/vaos/components/VideoVisitSection.jsx
@@ -2,62 +2,55 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import moment from 'moment';
-import {
-  getVideoVisitLink,
-  isGFEVideoVisit,
-  getMomentConfirmedDate,
-} from '../utils/appointment';
+import { VIDEO_TYPES } from '../utils/constants';
 
 export default function VideoVisitSection({ appointment }) {
   let linkContent = <span>Video visit link unavailable</span>;
 
-  if (isGFEVideoVisit(appointment)) {
+  if (appointment.isPastAppointment) {
+    linkContent = <span>Video conference</span>;
+  } else if (appointment.videoType === VIDEO_TYPES.gfe) {
     linkContent = (
       <span>Join the video session from the device provided by the VA.</span>
     );
-  } else {
-    const videoLink = getVideoVisitLink(appointment);
+  } else if (appointment.videoLink) {
+    const diff = appointment.appointmentDate.diff(moment(), 'minutes');
 
-    if (videoLink) {
-      const apptTime = getMomentConfirmedDate(appointment);
-      const diff = apptTime.diff(moment(), 'minutes');
+    // Button is enabled 30 minutes prior to start time, until 4 hours after start time
+    const disableVideoLink = diff < -30 || diff > 240;
+    const linkClasses = classNames(
+      'usa-button',
+      'vads-u-margin-left--0',
+      'vads-u-margin-right--1p5',
+      { 'usa-button-disabled': disableVideoLink },
+    );
 
-      // Button is enabled 30 minutes prior to start time, until 4 hours after start time
-      const disableVideoLink = diff < -30 || diff > 240;
-      const linkClasses = classNames(
-        'usa-button',
-        'vads-u-margin-left--0',
-        'vads-u-margin-right--1p5',
-        { 'usa-button-disabled': disableVideoLink },
-      );
-
-      linkContent = (
-        <div className="vaos-appts__video-visit">
-          <a
-            aria-describedby={
-              disableVideoLink
-                ? `description-join-link-${appointment.id}`
-                : undefined
-            }
-            href={videoLink}
-            target="_blank"
-            rel="noopener noreferrer"
-            className={linkClasses}
-            onClick={disableVideoLink ? e => e.preventDefault() : undefined}
+    linkContent = (
+      <div className="vaos-appts__video-visit">
+        <a
+          aria-describedby={
+            disableVideoLink
+              ? `description-join-link-${appointment.id}`
+              : undefined
+          }
+          href={appointment.videoLink}
+          target="_blank"
+          rel="noopener noreferrer"
+          className={linkClasses}
+          onClick={disableVideoLink ? e => e.preventDefault() : undefined}
+        >
+          Join session
+        </a>
+        {disableVideoLink && (
+          <span
+            id={`description-join-link-${appointment.id}`}
+            className="vads-u-display--block vads-u-font-style--italic"
           >
-            Join session
-          </a>
-          {disableVideoLink && (
-            <span
-              id={`description-join-link-${appointment.id}`}
-              className="vads-u-display--block vads-u-font-style--italic"
-            >
-              You can join VA Video Connect 30 minutes prior to the start time
-            </span>
-          )}
-        </div>
-      );
-    }
+            You can join VA Video Connect 30 minutes prior to the start time
+          </span>
+        )}
+      </div>
+    );
   }
 
   return (

--- a/src/applications/vaos/components/VideoVisitSection.jsx
+++ b/src/applications/vaos/components/VideoVisitSection.jsx
@@ -8,8 +8,10 @@ export default function VideoVisitSection({ appointment }) {
   let linkContent = <span>Video visit link unavailable</span>;
 
   if (appointment.isPastAppointment) {
-    linkContent = <span>Video conference</span>;
-  } else if (appointment.videoType === VIDEO_TYPES.gfe) {
+    return <span>Video conference</span>;
+  }
+
+  if (appointment.videoType === VIDEO_TYPES.gfe) {
     linkContent = (
       <span>Join the video session from the device provided by the VA.</span>
     );

--- a/src/applications/vaos/components/cancel/CancelAppointmentFailedModal.jsx
+++ b/src/applications/vaos/components/cancel/CancelAppointmentFailedModal.jsx
@@ -8,10 +8,6 @@ export default function CancelAppointmentFailedModal({
   facility,
   onClose,
 }) {
-  const clinicName =
-    appointment.clinicFriendlyName ||
-    appointment.vdsAppointments?.[0]?.clinic.name;
-
   return (
     <Modal
       id="cancelAppt"
@@ -25,9 +21,9 @@ export default function CancelAppointmentFailedModal({
         contact your medical center to cancel:
       </p>
       <p>
-        {clinicName ? (
+        {appointment.clinicName ? (
           <>
-            {clinicName}
+            {appointment.clinicName}
             <br />
           </>
         ) : null}

--- a/src/applications/vaos/components/cancel/CancelAppointmentModal.jsx
+++ b/src/applications/vaos/components/cancel/CancelAppointmentModal.jsx
@@ -8,7 +8,6 @@ import CancelAppointmentConfirmationModal from './CancelAppointmentConfirmationM
 import CancelCernerAppointmentModal from './CancelCernerAppointmentModal';
 
 import { FETCH_STATUS, APPOINTMENT_TYPES } from '../../utils/constants';
-import { isVideoVisit, getAppointmentType } from '../../utils/appointment';
 
 export default class CancelAppointmentModal extends React.Component {
   render() {
@@ -26,15 +25,14 @@ export default class CancelAppointmentModal extends React.Component {
       return null;
     }
 
-    if (isVideoVisit(appointmentToCancel)) {
+    if (appointmentToCancel.videoType) {
       return (
         <CancelVideoAppointmentModal onClose={onClose} facility={facility} />
       );
     }
 
     if (
-      getAppointmentType(appointmentToCancel) ===
-      APPOINTMENT_TYPES.ccAppointment
+      appointmentToCancel.appointmentType === APPOINTMENT_TYPES.ccAppointment
     ) {
       return (
         <CancelCommunityCareAppointmentModal

--- a/src/applications/vaos/components/cancel/CancelCommunityCareAppointmentModal.jsx
+++ b/src/applications/vaos/components/cancel/CancelCommunityCareAppointmentModal.jsx
@@ -5,7 +5,9 @@ export default function CancelCommunityCareAppointmentModal({
   onClose,
   appointment,
 }) {
-  const hasName = !!appointment.name?.firstName && !!appointment.name?.lastName;
+  const hasName =
+    !!appointment.providerName?.firstName &&
+    !!appointment.providerName?.lastName;
   return (
     <Modal
       id="cancelAppt"
@@ -19,7 +21,8 @@ export default function CancelCommunityCareAppointmentModal({
       <div className="vads-u-margin-y--2">
         {hasName && (
           <>
-            {appointment.name.firstName} {appointment.name.lastName}
+            {appointment.providerName.firstName}{' '}
+            {appointment.providerName.lastName}
             <br />
           </>
         )}

--- a/src/applications/vaos/components/review/Description.jsx
+++ b/src/applications/vaos/components/review/Description.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { getTypeOfCare } from '../../utils/selectors';
 import { FLOW_TYPES, FACILITY_TYPES } from '../../utils/constants';
-import { lowerCase } from '../../utils/appointment';
+import { lowerCase } from '../../utils/formatters';
 
 export default function Description({ data, flowType }) {
   const typeOfCare = lowerCase(getTypeOfCare(data)?.name);

--- a/src/applications/vaos/reducers/appointments.js
+++ b/src/applications/vaos/reducers/appointments.js
@@ -28,10 +28,16 @@ import {
   getRealFacilityId,
   sortPastAppointments,
 } from '../utils/appointment';
-
-import { transformRequest } from '../utils/appointment-new';
-
-import { FETCH_STATUS } from '../utils/constants';
+import {
+  transformRequest,
+  transformAppointment,
+  transformPastAppointment,
+} from '../utils/appointment-new';
+import {
+  FETCH_STATUS,
+  APPOINTMENT_TYPES,
+  APPOINTMENT_STATUS,
+} from '../utils/constants';
 
 const initialState = {
   future: null,
@@ -59,6 +65,7 @@ export default function appointmentsReducer(state = initialState, action) {
 
       const confirmedFilteredAndSorted = [...vaAppointments, ...ccAppointments]
         .filter(appt => filterFutureConfirmedAppointments(appt, action.today))
+        .map(transformAppointment)
         .sort(sortFutureConfirmedAppointments);
 
       const requestsFilteredAndSorted = [
@@ -91,6 +98,7 @@ export default function appointmentsReducer(state = initialState, action) {
 
       const confirmedFilteredAndSorted = [...vaAppointments, ...ccAppointments]
         .filter(appt => filterPastAppointments(appt, startDate, endDate))
+        .map(transformPastAppointment)
         .sort(sortPastAppointments);
 
       return {
@@ -160,17 +168,25 @@ export default function appointmentsReducer(state = initialState, action) {
           return appt;
         }
 
-        // confirmed VA appt
-        if (state.appointmentToCancel.clinicId) {
-          return set(
-            'vdsAppointments[0].currentStatus',
+        let newAppt = appt;
+
+        if (
+          state.appointmentToCancel.appointmentType ===
+          APPOINTMENT_TYPES.vaAppointment
+        ) {
+          newAppt = set(
+            'apiData.vdsAppointments[0].currentStatus',
             'CANCELLED BY PATIENT',
-            appt,
+            newAppt,
           );
+        } else {
+          newAppt = {
+            ...newAppt,
+            apiData: action.apiData,
+          };
         }
 
-        // Appt request
-        return { ...appt, status: 'Cancelled' };
+        return { ...newAppt, status: APPOINTMENT_STATUS.cancelled };
       });
       return {
         ...state,

--- a/src/applications/vaos/tests/actions/appointments.unit.spec.js
+++ b/src/applications/vaos/tests/actions/appointments.unit.spec.js
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
+import moment from 'moment';
 
 import {
   resetFetch,
@@ -33,6 +34,7 @@ import {
   CANCEL_APPOINTMENT_CLOSED,
 } from './../../actions/appointments';
 
+import { APPOINTMENT_TYPES, APPOINTMENT_STATUS } from '../../utils/constants';
 import { STARTED_NEW_APPOINTMENT_FLOW } from '../../actions/sitewide';
 
 import facilityData from '../../api/facility_data.json';
@@ -291,12 +293,20 @@ describe('VAOS actions: appointments', () => {
       const state = {
         appointments: {
           appointmentToCancel: {
+            apiData: {
+              vdsAppointments: [
+                {
+                  clinic: {
+                    name: 'Clinic name',
+                  },
+                },
+              ],
+            },
+            appointmentType: APPOINTMENT_TYPES.vaAppointment,
+            appointmentDate: moment('2019-01-02'),
+            status: APPOINTMENT_STATUS.booked,
             facilityId: '983',
-            vdsAppointments: [
-              {
-                clinic: {},
-              },
-            ],
+            clinicId: '1234',
           },
         },
       };
@@ -310,6 +320,7 @@ describe('VAOS actions: appointments', () => {
       );
       expect(dispatch.secondCall.args[0]).to.deep.equal({
         type: CANCEL_APPOINTMENT_CONFIRMED_SUCCEEDED,
+        apiData: state.appointments.appointmentToCancel.apiData,
       });
 
       expect(global.window.dataLayer[0]).to.deep.equal({
@@ -334,11 +345,17 @@ describe('VAOS actions: appointments', () => {
         appointments: {
           appointmentToCancel: {
             facilityId: '983',
-            vdsAppointments: [
-              {
-                clinic: {},
-              },
-            ],
+            clinicId: '455',
+            status: APPOINTMENT_STATUS.booked,
+            appointmentDate: moment('2020-01-01'),
+            appointmentType: APPOINTMENT_TYPES.vaAppointment,
+            apiData: {
+              vdsAppointments: [
+                {
+                  clinic: {},
+                },
+              ],
+            },
           },
         },
       };
@@ -352,6 +369,7 @@ describe('VAOS actions: appointments', () => {
       );
       expect(dispatch.secondCall.args[0]).to.deep.equal({
         type: CANCEL_APPOINTMENT_CONFIRMED_SUCCEEDED,
+        apiData: state.appointments.appointmentToCancel.apiData,
       });
 
       expect(
@@ -360,11 +378,16 @@ describe('VAOS actions: appointments', () => {
     });
 
     it('should cancel request', async () => {
-      setFetchJSONResponse(global.fetch, {});
+      setFetchJSONResponse(global.fetch, {
+        data: { id: 'test', attributes: {} },
+      });
       const state = {
         appointments: {
           appointmentToCancel: {
-            status: 'Submitted',
+            facilityId: '983',
+            status: APPOINTMENT_STATUS.booked,
+            appointmentType: APPOINTMENT_TYPES.request,
+            apiData: {},
           },
         },
       };
@@ -378,20 +401,29 @@ describe('VAOS actions: appointments', () => {
       );
       expect(dispatch.secondCall.args[0]).to.deep.equal({
         type: CANCEL_APPOINTMENT_CONFIRMED_SUCCEEDED,
+        apiData: {
+          id: 'test',
+        },
       });
     });
 
     it('should send fail action if cancel fails', async () => {
-      setFetchJSONResponse(global.fetch, { data: [] });
+      setFetchJSONFailure(global.fetch, { errors: [] });
       const state = {
         appointments: {
           appointmentToCancel: {
+            apiData: {
+              vdsAppointments: [
+                {
+                  clinic: {
+                    name: 'Testing',
+                  },
+                },
+              ],
+            },
             facilityId: '983',
-            vdsAppointments: [
-              {
-                clinic: {},
-              },
-            ],
+            appointmentDate: moment('2019-01-01'),
+            appointmentType: APPOINTMENT_TYPES.vaAppointment,
           },
         },
       };

--- a/src/applications/vaos/tests/components/AddToCalendar.unit.spec.jsx
+++ b/src/applications/vaos/tests/components/AddToCalendar.unit.spec.jsx
@@ -2,107 +2,19 @@ import React from 'react';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { shallow } from 'enzyme';
-import { getTimezoneBySystemId } from '../../utils/timezone';
 import moment from '../../utils/moment-tz.js';
 
 import AddToCalendar from '../../components/AddToCalendar';
-import {
-  getAppointmentAddress,
-  getAppointmentDuration,
-  getAppointmentInstructions,
-  getAppointmentInstructionsHeader,
-  getAppointmentTypeHeader,
-  getFacilityAddress,
-  getMomentConfirmedDate,
-} from '../../utils/appointment';
 
 describe('VAOS <AddToCalendar>', () => {
-  const facility = {
-    address: {
-      physical: {
-        address1: '',
-        city: '',
-        state: '',
-        zip: '',
-      },
-    },
-  };
-
-  const communityCareAppointment = {
-    appointmentTime: '01/02/2020 13:45:00',
-    timeZone: '-04:00 EDT',
-    address: {
-      street: '',
-      city: '',
-      state: '',
-      zipCode: '',
-    },
-  };
-
-  const vaAppointment = {
-    clinicId: ' ',
-    startDate: '2020-01-02T16:00:00Z',
-    vdsAppointments: [
-      {
-        appointmentLength: '',
-      },
-    ],
-  };
-
-  describe('Add community care appointment to calendar', () => {
-    const tree = shallow(
-      <AddToCalendar
-        summary={getAppointmentTypeHeader(communityCareAppointment)}
-        description={`${getAppointmentInstructionsHeader(
-          communityCareAppointment,
-        )}. ${getAppointmentInstructions(communityCareAppointment)}`}
-        location={getAppointmentAddress(communityCareAppointment)}
-        duration={getAppointmentDuration(communityCareAppointment)}
-        startDateTime={getMomentConfirmedDate(
-          communityCareAppointment,
-        ).toDate()}
-      />,
-    );
-
-    const link = tree.find('a');
-
-    it('should render', () => {
-      expect(tree.exists()).to.be.true;
-    });
-
-    it('should contain valid ICS begin command', () => {
-      expect(link.props().href).to.contain(
-        encodeURIComponent('BEGIN:VCALENDAR'),
-      );
-    });
-
-    it('should contain valid ICS end command', () => {
-      expect(link.props().href).to.contain(encodeURIComponent('END:VCALENDAR'));
-    });
-
-    it('should download ICS commands to a file named "Community_Care.ics"', () => {
-      expect(link.props().download).to.equal('Community_Care.ics');
-    });
-
-    it('should have an aria label', () => {
-      expect(link.props()['aria-label']).to.equal(
-        `Add January 2, 2020 appointment to your calendar`,
-      );
-    });
-
-    tree.unmount();
-  });
-
   describe('Add VA appointment to calendar', () => {
     const tree = shallow(
       <AddToCalendar
-        summary={getAppointmentTypeHeader(vaAppointment)}
-        description={`${getAppointmentInstructionsHeader(
-          vaAppointment,
-        )}. ${getAppointmentInstructions(vaAppointment)}`}
-        location={getAppointmentAddress(vaAppointment, facility)}
-        duration={getAppointmentDuration(vaAppointment)}
-        startDateTime={getMomentConfirmedDate(vaAppointment).toDate()}
+        summary="VA Appointment"
+        description="Some description"
+        location="A location"
+        duration={60}
+        startDateTime={moment('2020-01-02').toDate()}
       />,
     );
 
@@ -127,72 +39,6 @@ describe('VAOS <AddToCalendar>', () => {
     });
 
     tree.unmount();
-  });
-
-  describe('Add to calendar direct schedule confirmation page', () => {
-    const props = {
-      appointmentLength: 20,
-      facilityDetails: {
-        id: 'vha_983',
-        name: 'Cheyenne VA Medical Center',
-        address: {
-          physical: {
-            zip: '82001-5356',
-            city: 'Cheyenne',
-            state: 'WY',
-            address1: '2360 East Pershing Boulevard',
-            address2: null,
-            address3: null,
-          },
-        },
-      },
-      data: {
-        calendarData: {
-          selectedDates: [
-            {
-              dateTime: '2020-03-12T16:40:00',
-            },
-          ],
-        },
-      },
-      systemId: '983',
-    };
-
-    const dateTime = props.data.calendarData.selectedDates[0].dateTime;
-    const timezone = getTimezoneBySystemId(props.systemId);
-    const momentDate = timezone
-      ? moment(dateTime).tz(timezone.timezone, true)
-      : moment(dateTime);
-
-    const tree = shallow(
-      <AddToCalendar
-        summary="VA Appointment"
-        description=""
-        location={getFacilityAddress(props.facilityDetails)}
-        startDateTime={momentDate.toDate()}
-        duration={props.appointmentLength}
-      />,
-    );
-
-    const link = tree.find('a');
-
-    it('should render', () => {
-      expect(tree.exists()).to.be.true;
-    });
-
-    it('should contain valid ICS end command', () => {
-      expect(link.props().href).to.contain(encodeURIComponent('END:VCALENDAR'));
-    });
-
-    it('should download ICS commands to a file named "VA_Appointment.ics"', () => {
-      expect(link.props().download).to.equal('VA_Appointment.ics');
-    });
-
-    it('should have an aria label', () => {
-      expect(link.props()['aria-label']).to.equal(
-        `Add March 12, 2020 appointment to your calendar`,
-      );
-    });
   });
 
   describe('Add appointment request to calendar in IE', () => {
@@ -203,13 +49,11 @@ describe('VAOS <AddToCalendar>', () => {
     });
     const tree = shallow(
       <AddToCalendar
-        summary={getAppointmentTypeHeader(vaAppointment)}
-        description={`${getAppointmentInstructionsHeader(
-          vaAppointment,
-        )}. ${getAppointmentInstructions(vaAppointment)}`}
-        location={getAppointmentAddress(vaAppointment, facility)}
-        duration={getAppointmentDuration(vaAppointment)}
-        startDateTime={getMomentConfirmedDate(vaAppointment).toDate()}
+        summary="VA Appointment"
+        description="Some description"
+        location="A location"
+        duration={60}
+        startDateTime={moment('2020-01-02').toDate()}
       />,
     );
 

--- a/src/applications/vaos/tests/components/ConfirmedAppointmentListItem.unit.spec.jsx
+++ b/src/applications/vaos/tests/components/ConfirmedAppointmentListItem.unit.spec.jsx
@@ -1,34 +1,24 @@
 import React from 'react';
 import { expect } from 'chai';
-import { shallow } from 'enzyme';
+import { mount } from 'enzyme';
 import sinon from 'sinon';
 import moment from 'moment';
 
-import { APPOINTMENT_TYPES } from '../../utils/constants';
+import {
+  APPOINTMENT_TYPES,
+  APPOINTMENT_STATUS,
+  VIDEO_TYPES,
+} from '../../utils/constants';
 import ConfirmedAppointmentListItem from '../../components/ConfirmedAppointmentListItem';
 
 describe('VAOS <ConfirmedAppointmentListItem> Regular Appointment', () => {
   const appointment = {
-    appointmentType: 'Testing',
-    startDate: '2019-12-11T16:00:00Z',
+    status: APPOINTMENT_STATUS.booked,
+    appointmentDate: moment('2019-12-11T16:00:00Z'),
     facilityId: '983',
     clinicId: '123',
-    vvsAppointments: [],
-    vdsAppointments: [
-      {
-        appointmentLength: '60',
-        appointmentTime: '2019-12-11T16:00:00Z',
-        clinic: {
-          name: 'C&P BEV AUDIO FTC1',
-          askForCheckIn: false,
-          facilityCode: '983',
-        },
-        patientId: '7216691',
-        type: 'REGULAR',
-        currentStatus: 'NO ACTION TAKEN/TODAY',
-        bookingNote: 'Booking note',
-      },
-    ],
+    duration: 60,
+    clinicName: 'C&P BEV AUDIO FTC1',
   };
   const facility = {
     address: {
@@ -51,7 +41,7 @@ describe('VAOS <ConfirmedAppointmentListItem> Regular Appointment', () => {
   let tree;
 
   beforeEach(() => {
-    tree = shallow(
+    tree = mount(
       <ConfirmedAppointmentListItem
         showCancelButton
         cancelAppointment={cancelAppointment}
@@ -84,12 +74,7 @@ describe('VAOS <ConfirmedAppointmentListItem> Regular Appointment', () => {
   });
 
   it('should display clinic name', () => {
-    expect(
-      tree
-        .find('dt')
-        .first()
-        .text(),
-    ).to.contain('C&P BEV AUDIO FTC1');
+    expect(tree.text()).to.contain('C&P BEV AUDIO FTC1');
   });
 
   it('should show facility address', () => {
@@ -115,8 +100,11 @@ describe('VAOS <ConfirmedAppointmentListItem> Regular Appointment', () => {
 
 describe('VAOS <ConfirmedAppointmentListItem> Community Care Appointment', () => {
   const appointment = {
-    appointmentRequestId: 'guid',
-    appointmentTime: '05/22/2019 10:00:00',
+    id: 'guid',
+    appointmentType: APPOINTMENT_TYPES.ccAppointment,
+    isCommunityCare: true,
+    status: APPOINTMENT_STATUS.booked,
+    appointmentDate: moment('05/22/2019 10:00:00', 'MM/DD/YYYY HH:mm:ss'),
     providerPractice: 'My Clinic',
     timeZone: 'UTC',
     address: {
@@ -127,7 +115,7 @@ describe('VAOS <ConfirmedAppointmentListItem> Community Care Appointment', () =>
     },
   };
 
-  const tree = shallow(
+  const tree = mount(
     <ConfirmedAppointmentListItem appointment={appointment} />,
   );
 
@@ -150,45 +138,34 @@ describe('VAOS <ConfirmedAppointmentListItem> Community Care Appointment', () =>
   });
 
   it('should display clinic name', () => {
-    expect(tree.find('dt').text()).to.contain('My Clinic');
+    expect(tree.text()).to.contain('My Clinic');
   });
 
   it('should display clinic address', () => {
-    expect(tree.find('dd').text()).to.contain(
-      '123 second stNorthampton, MA 22222',
-    );
+    expect(tree.text()).to.contain('123 second stNorthampton, MA 22222');
   });
 });
 
 describe('VAOS <ConfirmedAppointmentListItem> Video Appointment', () => {
-  const apptTime = moment()
-    .add(20, 'minutes')
-    .format();
+  const apptTime = moment().add(20, 'minutes');
 
   const url =
     'https://care2.evn.va.gov/vvc-app/?join=1&media=1&escalate=1&conference=VVC1012210@care2.evn.va.gov&pin=4790493668#';
   const appointment = {
-    startDate: apptTime,
+    appointmentType: APPOINTMENT_TYPES.vaAppointment,
+    videoType: VIDEO_TYPES.videoConnect,
+    appointmentDate: apptTime,
     facilityId: '984',
     clinicId: '456',
-    vvsAppointments: [
-      {
-        bookingNotes: 'My reason isn’t listed: Booking note',
-        patients: {
-          patient: [
-            {
-              virtualMeetingRoom: {
-                url,
-              },
-            },
-          ],
-        },
-      },
-    ],
-    vdsAppointments: [],
+    videoLink: url,
+    status: APPOINTMENT_STATUS.booked,
+    instructions: {
+      header: 'My reason isn’t listed',
+      body: 'Booking note',
+    },
   };
 
-  const tree = shallow(
+  const tree = mount(
     <ConfirmedAppointmentListItem appointment={appointment} />,
   );
 
@@ -204,26 +181,11 @@ describe('VAOS <ConfirmedAppointmentListItem> Video Appointment', () => {
 
 describe('VAOS <ConfirmedAppointmentListItem> Canceled Appointment', () => {
   const appointment = {
-    appointmentType: 'Testing',
-    startDate: '2019-12-11T16:00:00Z',
+    appointmentDate: moment('2019-12-11T16:00:00Z'),
+    status: APPOINTMENT_STATUS.cancelled,
     facilityId: '983',
     clinicId: '123',
-    vvsAppointments: [],
-    vdsAppointments: [
-      {
-        appointmentLength: '60',
-        appointmentTime: '2019-12-11T16:00:00Z',
-        clinic: {
-          name: 'C&P BEV AUDIO FTC1',
-          askForCheckIn: false,
-          facilityCode: '983',
-        },
-        patientId: '7216691',
-        type: 'REGULAR',
-        currentStatus: 'NO-SHOW',
-        bookingNote: 'Booking note',
-      },
-    ],
+    clinicName: 'C&P BEV AUDIO FTC1',
   };
   const facility = {
     address: {
@@ -245,7 +207,7 @@ describe('VAOS <ConfirmedAppointmentListItem> Canceled Appointment', () => {
   let tree;
 
   beforeEach(() => {
-    tree = shallow(
+    tree = mount(
       <ConfirmedAppointmentListItem
         appointment={appointment}
         type={APPOINTMENT_TYPES.vaAppointment}

--- a/src/applications/vaos/tests/components/FutureAppointmentsList.unit.spec.jsx
+++ b/src/applications/vaos/tests/components/FutureAppointmentsList.unit.spec.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { shallow, mount } from 'enzyme';
-import { FETCH_STATUS } from '../../utils/constants';
+import { FETCH_STATUS, APPOINTMENT_TYPES } from '../../utils/constants';
 
 import { FutureAppointmentsList } from '../../components/FutureAppointmentsList';
 
@@ -55,139 +55,24 @@ describe('VAOS <FutureAppointmentsList>', () => {
     tree.unmount();
   });
 
-  xit('should render 3 appointments', () => {
+  it('should render 4 appointments', () => {
     const appointments = {
       facilityData: {},
       futureStatus: FETCH_STATUS.succeeded,
       future: [
         {
-          startDate: '2019-12-11T15:00:00Z',
-          clinicId: '455',
+          appointmentType: APPOINTMENT_TYPES.request,
+        },
+        {
+          appointmentType: APPOINTMENT_TYPES.ccRequest,
+        },
+        {
+          appointmentType: APPOINTMENT_TYPES.vaAppointment,
           facilityId: '983',
-          patientIcn: '1012845331V153043',
-          vdsAppointments: [
-            {
-              appointmentLength: '60',
-              appointmentTime: '2019-12-11T15:00:00Z',
-              clinic: {
-                name: 'CASSIDY PC',
-                askForCheckIn: false,
-                facilityCode: '983',
-              },
-              patientId: '7216691',
-              type: 'REGULAR',
-              currentStatus: 'NO ACTION TAKEN/TODAY',
-            },
-          ],
+          clinicId: '455',
         },
         {
-          appointmentRequestId: '8a4885896a22f88f016a2c8834b1005d',
-          patientIdentifier: {
-            uniqueId: '1012845331V153043',
-            assigningAuthority: 'ICN',
-          },
-          distanceEligibleConfirmed: true,
-          name: {
-            firstName: '',
-            lastName: '',
-          },
-          providerPractice: 'Atlantic Medical Care',
-          providerPhone: '(407) 555-1212',
-          address: {
-            street: '123 Main Street',
-            city: 'Orlando',
-            state: 'FL',
-            zipCode: '32826',
-          },
-          instructionsToVeteran:
-            'Please arrive 15 minutes ahead of appointment.',
-          appointmentTime: '11/25/2019 13:30:00',
-          timeZone: '-04:00 EDT',
-        },
-        {
-          dataIdentifier: {
-            uniqueId: '8a48912a6c2409b9016c9a9afff101ee',
-            systemId: 'var',
-          },
-          patientIdentifier: {
-            uniqueId: '1012845331V153043',
-            assigningAuthority: 'ICN',
-          },
-          surrogateIdentifier: {},
-          lastUpdatedDate: '12/16/2019 13:14:16',
-          optionDate1: '11/01/2019',
-          optionTime1: 'AM',
-          optionDate2: 'No Date Selected',
-          optionTime2: 'No Time Selected',
-          optionDate3: 'No Date Selected',
-          optionTime3: 'No Time Selected',
-          status: 'Cancelled',
-          appointmentType: 'Outpatient Mental Health',
-          visitType: 'Office Visit',
-          facility: {
-            name: 'CHYSHR-Cheyenne VA Medical Center',
-            facilityCode: '983',
-            state: 'WY',
-            city: 'Cheyenne',
-            parentSiteCode: '983',
-            objectType: 'Facility',
-            link: [],
-          },
-          email: 'samatha.girla@va.gov',
-          textMessagingAllowed: false,
-          phoneNumber: '(703) 652-0000',
-          purposeOfVisit: 'New Issue',
-          providerId: '0',
-          secondRequest: false,
-          secondRequestSubmitted: false,
-          patient: {
-            displayName: 'MORRISON, JUDY',
-            firstName: 'JUDY',
-            lastName: 'MORRISON',
-            dateOfBirth: 'Apr 01, 1953',
-            patientIdentifier: {
-              uniqueId: '1259897978',
-            },
-            ssn: '796061976',
-            inpatient: false,
-            textMessagingAllowed: false,
-            id: '1259897978',
-            objectType: 'Patient',
-            link: [],
-          },
-          bestTimetoCall: ['Morning'],
-          appointmentRequestDetailCode: [
-            {
-              appointmentRequestDetailCodeId:
-                '8a48e78f6c8bfe02016c9bda173c005c',
-              createdDate: '12/16/2019 13:14:16',
-              detailCode: {
-                code: 'DETCODE22',
-                providerMessage: 'Cancelled - Cancelled at Veteran Request',
-                veteranMessage:
-                  'Your appointment request has been cancelled at your request.',
-                objectType: 'VARDetailCode',
-                link: [],
-              },
-              userId: '1013004612',
-              objectType: 'VARAppointmentRequestDetailCode',
-              link: [],
-            },
-          ],
-          hasVeteranNewMessage: true,
-          hasProviderNewMessage: false,
-          providerSeenAppointmentRequest: true,
-          requestedPhoneCall: false,
-          typeOfCareId: '502',
-          friendlyLocationName: 'CHYSHR-Cheyenne VA Medical Center',
-          patientId: '1259897978',
-          appointmentRequestId: '8a48912a6c2409b9016c9a9afff101ee',
-          date: '2019-08-16T07:25:44.000+0000',
-          assigningAuthority: 'ICN',
-          uniqueId: '8a48912a6c2409b9016c9a9afff101ee',
-          systemId: 'var',
-          objectType: 'VARAppointmentRequest',
-          createdDate: '12/16/2019 07:25:44',
+          appointmentType: APPOINTMENT_TYPES.ccAppointment,
         },
       ],
       systemClinicToFacilityMap: {
@@ -206,7 +91,7 @@ describe('VAOS <FutureAppointmentsList>', () => {
         .first()
         .props().facility,
     ).to.equal(appointments.systemClinicToFacilityMap['983_455']);
-    expect(tree.find('AppointmentRequestListItem').length).to.equal(1);
+    expect(tree.find('AppointmentRequestListItem').length).to.equal(2);
 
     tree.unmount();
   });

--- a/src/applications/vaos/tests/components/PastAppointmentsList.unit.spec.jsx
+++ b/src/applications/vaos/tests/components/PastAppointmentsList.unit.spec.jsx
@@ -3,8 +3,12 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import { shallow } from 'enzyme';
 import moment from 'moment';
-import { FETCH_STATUS } from '../../utils/constants';
 import { PastAppointmentsList } from '../../components/PastAppointmentsList';
+import {
+  FETCH_STATUS,
+  APPOINTMENT_TYPES,
+  APPOINTMENT_STATUS,
+} from '../../utils/constants';
 import { getPastAppointmentDateRangeOptions } from '../../utils/appointment';
 
 describe('VAOS <PastAppointmentsList>', () => {
@@ -17,131 +21,21 @@ describe('VAOS <PastAppointmentsList>', () => {
     pastSelectedIndex: 0,
     past: [
       {
-        startDate: '2019-12-11T15:00:00Z',
+        appointmentType: APPOINTMENT_TYPES.vaAppointment,
+        appointmentDate: moment('2019-12-11T15:00:00Z'),
         clinicId: '455',
         facilityId: '983',
-        patientIcn: '1012845331V153043',
-        vdsAppointments: [
-          {
-            appointmentLength: '60',
-            appointmentTime: '2019-12-11T15:00:00Z',
-            clinic: {
-              name: 'CASSIDY PC',
-              askForCheckIn: false,
-              facilityCode: '983',
-            },
-            patientId: '7216691',
-            type: 'REGULAR',
-            currentStatus: 'NO ACTION TAKEN/TODAY',
-          },
-        ],
+        status: APPOINTMENT_STATUS.booked,
       },
       {
-        appointmentRequestId: '8a4885896a22f88f016a2c8834b1005d',
-        patientIdentifier: {
-          uniqueId: '1012845331V153043',
-          assigningAuthority: 'ICN',
-        },
-        distanceEligibleConfirmed: true,
-        name: {
-          firstName: '',
-          lastName: '',
-        },
-        providerPractice: 'Atlantic Medical Care',
-        providerPhone: '(407) 555-1212',
-        address: {
-          street: '123 Main Street',
-          city: 'Orlando',
-          state: 'FL',
-          zipCode: '32826',
-        },
-        instructionsToVeteran: 'Please arrive 15 minutes ahead of appointment.',
-        appointmentTime: '11/25/2019 13:30:00',
+        appointmentType: APPOINTMENT_TYPES.ccAppointment,
+        appointmentDate: moment('2019-11-25T13:30:00Z'),
         timeZone: '-04:00 EDT',
+        status: APPOINTMENT_STATUS.booked,
       },
       {
-        dataIdentifier: {
-          uniqueId: '8a48912a6c2409b9016c9a9afff101ee',
-          systemId: 'var',
-        },
-        patientIdentifier: {
-          uniqueId: '1012845331V153043',
-          assigningAuthority: 'ICN',
-        },
-        surrogateIdentifier: {},
-        lastUpdatedDate: '12/16/2019 13:14:16',
-        optionDate1: '11/01/2019',
-        optionTime1: 'AM',
-        optionDate2: 'No Date Selected',
-        optionTime2: 'No Time Selected',
-        optionDate3: 'No Date Selected',
-        optionTime3: 'No Time Selected',
-        status: 'Cancelled',
-        appointmentType: 'Outpatient Mental Health',
-        visitType: 'Office Visit',
-        facility: {
-          name: 'CHYSHR-Cheyenne VA Medical Center',
-          facilityCode: '983',
-          state: 'WY',
-          city: 'Cheyenne',
-          parentSiteCode: '983',
-          objectType: 'Facility',
-          link: [],
-        },
-        email: 'samatha.girla@va.gov',
-        textMessagingAllowed: false,
-        phoneNumber: '(703) 652-0000',
-        purposeOfVisit: 'New Issue',
-        providerId: '0',
-        secondRequest: false,
-        secondRequestSubmitted: false,
-        patient: {
-          displayName: 'MORRISON, JUDY',
-          firstName: 'JUDY',
-          lastName: 'MORRISON',
-          dateOfBirth: 'Apr 01, 1953',
-          patientIdentifier: {
-            uniqueId: '1259897978',
-          },
-          ssn: '796061976',
-          inpatient: false,
-          textMessagingAllowed: false,
-          id: '1259897978',
-          objectType: 'Patient',
-          link: [],
-        },
-        bestTimetoCall: ['Morning'],
-        appointmentRequestDetailCode: [
-          {
-            appointmentRequestDetailCodeId: '8a48e78f6c8bfe02016c9bda173c005c',
-            createdDate: '12/16/2019 13:14:16',
-            detailCode: {
-              code: 'DETCODE22',
-              providerMessage: 'Cancelled - Cancelled at Veteran Request',
-              veteranMessage:
-                'Your appointment request has been cancelled at your request.',
-              objectType: 'VARDetailCode',
-              link: [],
-            },
-            userId: '1013004612',
-            objectType: 'VARAppointmentRequestDetailCode',
-            link: [],
-          },
-        ],
-        hasVeteranNewMessage: true,
-        hasProviderNewMessage: false,
-        providerSeenAppointmentRequest: true,
-        requestedPhoneCall: false,
-        typeOfCareId: '502',
-        friendlyLocationName: 'CHYSHR-Cheyenne VA Medical Center',
-        patientId: '1259897978',
-        appointmentRequestId: '8a48912a6c2409b9016c9a9afff101ee',
-        date: '2019-08-16T07:25:44.000+0000',
-        assigningAuthority: 'ICN',
-        uniqueId: '8a48912a6c2409b9016c9a9afff101ee',
-        systemId: 'var',
-        objectType: 'VARAppointmentRequest',
-        createdDate: '12/16/2019 07:25:44',
+        appointmentType: APPOINTMENT_TYPES.request,
+        status: APPOINTMENT_STATUS.cancelled,
       },
     ],
     systemClinicToFacilityMap: {

--- a/src/applications/vaos/tests/components/VideoVisitSection.unit.spec.jsx
+++ b/src/applications/vaos/tests/components/VideoVisitSection.unit.spec.jsx
@@ -2,32 +2,23 @@ import React from 'react';
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
 import moment from 'moment';
+import { VIDEO_TYPES, APPOINTMENT_TYPES } from '../../utils/constants';
 
 import VideoVisitSection from '../../components/VideoVisitSection';
 
 describe('Video visit', () => {
-  const dateTime = moment()
-    .add(20, 'minutes')
-    .format();
+  const dateTime = moment().add(20, 'minutes');
 
   const url =
     'https://care2.evn.va.gov/vvc-app/?join=1&media=1&escalate=1&conference=VVC1012210@care2.evn.va.gov&pin=4790493668#';
   const appointment = {
+    appointmentType: APPOINTMENT_TYPES.vaAppointment,
+    videoType: VIDEO_TYPES.videoConnect,
     facilityId: '984',
     clinicId: '456',
     id: '123',
-    vvsAppointments: [
-      {
-        patients: [
-          {
-            virtualMeetingRoom: {
-              url,
-            },
-          },
-        ],
-        dateTime,
-      },
-    ],
+    videoLink: url,
+    appointmentDate: dateTime,
   };
 
   // console.log(tree.debug());
@@ -47,20 +38,7 @@ describe('Video visit', () => {
   it('should enable video link if appointment is less than 30 minutes away', () => {
     const pastAppointment = {
       ...appointment,
-      vvsAppointments: [
-        {
-          patients: [
-            {
-              virtualMeetingRoom: {
-                url,
-              },
-            },
-          ],
-          dateTime: moment()
-            .add(-20, 'minutes')
-            .format(),
-        },
-      ],
+      appointmentDate: moment().add(-20, 'minutes'),
     };
 
     const tree = shallow(<VideoVisitSection appointment={pastAppointment} />);
@@ -75,20 +53,7 @@ describe('Video visit', () => {
   it('should disable video link if appointment is over 4 hours away', () => {
     const futureAppointment = {
       ...appointment,
-      vvsAppointments: [
-        {
-          patients: [
-            {
-              virtualMeetingRoom: {
-                url,
-              },
-            },
-          ],
-          dateTime: moment()
-            .add(245, 'minutes')
-            .format(),
-        },
-      ],
+      appointmentDate: moment().add(245, 'minutes'),
     };
 
     const tree = shallow(<VideoVisitSection appointment={futureAppointment} />);
@@ -105,11 +70,7 @@ describe('Video visit', () => {
   it('should only display a message if it is a MOBILE_GFE appointment', () => {
     const gfeAppt = {
       ...appointment,
-      vvsAppointments: [
-        {
-          appointmentKind: 'MOBILE_GFE',
-        },
-      ],
+      videoType: VIDEO_TYPES.gfe,
     };
     const tree = shallow(<VideoVisitSection appointment={gfeAppt} />);
     expect(tree.exists('.usa-button')).to.equal(false);

--- a/src/applications/vaos/tests/components/cancel/CancelAppointmentModal.unit.spec.jsx
+++ b/src/applications/vaos/tests/components/cancel/CancelAppointmentModal.unit.spec.jsx
@@ -3,7 +3,11 @@ import { expect } from 'chai';
 import { shallow } from 'enzyme';
 
 import CancelAppointmentModal from '../../../components/cancel/CancelAppointmentModal';
-import { FETCH_STATUS } from '../../../utils/constants';
+import {
+  FETCH_STATUS,
+  APPOINTMENT_TYPES,
+  VIDEO_TYPES,
+} from '../../../utils/constants';
 
 describe('VAOS <CancelAppointmentModal>', () => {
   it('should not render modal if showCancelModal is false', () => {
@@ -33,7 +37,7 @@ describe('VAOS <CancelAppointmentModal>', () => {
       <CancelAppointmentModal
         showCancelModal
         appointmentToCancel={{
-          appointmentTime: '01/22/2020',
+          appointmentType: APPOINTMENT_TYPES.ccAppointment,
         }}
         cancelAppointmentStatus={FETCH_STATUS.succeeded}
       />,
@@ -50,7 +54,8 @@ describe('VAOS <CancelAppointmentModal>', () => {
       <CancelAppointmentModal
         showCancelModal
         appointmentToCancel={{
-          vvsAppointments: [{}],
+          appointmentType: APPOINTMENT_TYPES.vaAppointment,
+          videoType: VIDEO_TYPES.videoConnect,
         }}
         cancelAppointmentStatus={FETCH_STATUS.succeeded}
       />,
@@ -66,9 +71,9 @@ describe('VAOS <CancelAppointmentModal>', () => {
       <CancelAppointmentModal
         showCancelModal
         appointmentToCancel={{
+          appointmentType: APPOINTMENT_TYPES.vaAppointment,
           clinicId: '123',
-          startDate: '11/20/2018',
-          clinicFriendlyName: 'Testing',
+          clinicName: 'Testing',
           facilityId: '123',
         }}
         cernerFacilities={['123']}
@@ -100,10 +105,7 @@ describe('VAOS <CancelAppointmentModal>', () => {
         showCancelModal
         cancelAppointmentStatus={FETCH_STATUS.failed}
         appointmentToCancel={{
-          clinicId: '123',
-          startDate: '11/20/2018',
-          clinicFriendlyName: 'Testing',
-          facilityId: '983',
+          appointmentType: APPOINTMENT_TYPES.vaAppointment,
         }}
       />,
     );

--- a/src/applications/vaos/tests/reducers/appointments.unit.spec.js
+++ b/src/applications/vaos/tests/reducers/appointments.unit.spec.js
@@ -19,7 +19,11 @@ import {
 
 import { FORM_SUBMIT_SUCCEEDED } from '../../actions/sitewide';
 
-import { FETCH_STATUS } from '../../utils/constants';
+import {
+  FETCH_STATUS,
+  APPOINTMENT_STATUS,
+  APPOINTMENT_TYPES,
+} from '../../utils/constants';
 
 const initialState = {};
 
@@ -278,12 +282,10 @@ describe('VAOS reducer: appointments', () => {
         type: CANCEL_APPOINTMENT_CONFIRMED_SUCCEEDED,
       };
       const appt = {
+        appointmentType: APPOINTMENT_TYPES.vaAppointment,
         clinicId: '123',
-        vdsAppointments: [
-          {
-            currentStatus: 'FUTURE',
-          },
-        ],
+        status: APPOINTMENT_STATUS.booked,
+        apiData: {},
       };
       const state = {
         ...initialState,
@@ -294,17 +296,20 @@ describe('VAOS reducer: appointments', () => {
 
       expect(newState.showCancelModal).to.be.true;
       expect(newState.cancelAppointmentStatus).to.equal(FETCH_STATUS.succeeded);
-      expect(newState.future[0].vdsAppointments[0].currentStatus).to.equal(
-        'CANCELLED BY PATIENT',
-      );
+      expect(newState.future[0].status).to.equal(APPOINTMENT_STATUS.cancelled);
+      expect(
+        newState.future[0].apiData.vdsAppointments[0].currentStatus,
+      ).to.equal('CANCELLED BY PATIENT');
     });
 
     it('should set status to succeeded and set request to cancelled', () => {
       const action = {
         type: CANCEL_APPOINTMENT_CONFIRMED_SUCCEEDED,
+        apiData: {},
       };
       const appt = {
-        status: 'Submitted',
+        appointmentType: APPOINTMENT_TYPES.request,
+        status: APPOINTMENT_STATUS.booked,
       };
       const state = {
         ...initialState,
@@ -315,7 +320,8 @@ describe('VAOS reducer: appointments', () => {
 
       expect(newState.showCancelModal).to.be.true;
       expect(newState.cancelAppointmentStatus).to.equal(FETCH_STATUS.succeeded);
-      expect(newState.future[0].status).to.equal('Cancelled');
+      expect(newState.future[0].apiData).to.equal(action.apiData);
+      expect(newState.future[0].status).to.equal(APPOINTMENT_STATUS.cancelled);
     });
 
     it('should set status to failed', () => {

--- a/src/applications/vaos/utils/appointment-new.jsx
+++ b/src/applications/vaos/utils/appointment-new.jsx
@@ -1,4 +1,5 @@
 import moment from './moment-tz';
+import guid from 'simple-guid';
 import environment from 'platform/utilities/environment';
 import {
   APPOINTMENT_TYPES,
@@ -9,6 +10,7 @@ import {
 } from './constants';
 
 import {
+  getTimezoneBySystemId,
   getTimezoneAbbrBySystemId,
   getTimezoneDescFromAbbr,
   stripDST,
@@ -48,8 +50,37 @@ function isGFEVideoVisit(appt) {
   return appt.vvsAppointments?.[0]?.appointmentKind === 'MOBILE_GFE';
 }
 
+function isVideoVisit(appt) {
+  return !!appt.vvsAppointments?.length || isGFEVideoVisit(appt);
+}
+
 export function getVideoVisitLink(appt) {
   return appt.vvsAppointments?.[0]?.patients?.[0]?.virtualMeetingRoom?.url;
+}
+
+/**
+ * Date and time
+ */
+
+export function getMomentConfirmedDate(appt) {
+  if (isCommunityCare(appt)) {
+    const zoneSplit = appt.timeZone.split(' ');
+    const offset = zoneSplit.length > 1 ? zoneSplit[0] : '+0:00';
+    return moment
+      .utc(appt.appointmentTime, 'MM/DD/YYYY HH:mm:ss')
+      .utcOffset(offset);
+  }
+
+  const timezone = getTimezoneBySystemId(appt.facilityId)?.timezone;
+  const date = isVideoVisit(appt)
+    ? appt.vvsAppointments[0].dateTime
+    : appt.startDate;
+
+  if (timezone) {
+    return moment(date).tz(timezone);
+  }
+
+  return moment(date);
 }
 
 export function getMomentRequestOptionDate(optionDate) {
@@ -98,6 +129,137 @@ function getRequestDateOptions(appt) {
   return options;
 }
 
+export function getPastAppointmentDateRangeOptions(today = moment()) {
+  // Past 3 months
+  const options = [
+    {
+      value: 0,
+      label: 'Past 3 months',
+      startDate: today
+        .clone()
+        .subtract(3, 'months')
+        .format(),
+      endDate: today.format(),
+    },
+  ];
+
+  // 3 month ranges going back ~1 year
+  let index = 1;
+  let monthsToSubtract = 3;
+
+  while (index < 4) {
+    const start = today
+      .clone()
+      .subtract(index === 1 ? 5 : monthsToSubtract + 2, 'months')
+      .startOf('month');
+    const end = today
+      .clone()
+      .subtract(index === 1 ? 3 : monthsToSubtract, 'months')
+      .endOf('month');
+
+    options.push({
+      value: index,
+      label: `${start.format('MMM YYYY')} – ${end.format('MMM YYYY')}`,
+      startDate: start.format(),
+      endDate: end.format(),
+    });
+
+    monthsToSubtract += 3;
+    index += 1;
+  }
+
+  // All of current year
+  options.push({
+    value: 4,
+    label: `Show all of ${today.format('YYYY')}`,
+    startDate: today
+      .clone()
+      .startOf('year')
+      .format(),
+    endDate: today.format(),
+  });
+
+  // All of last year
+  const lastYear = today.clone().subtract(1, 'years');
+
+  options.push({
+    value: 5,
+    label: `Show all of ${lastYear.format('YYYY')}`,
+    startDate: lastYear.startOf('year').format(),
+    endDate: lastYear
+      .clone()
+      .endOf('year')
+      .format(),
+  });
+
+  return options;
+}
+
+/**
+ * Filter and sort methods
+ */
+
+export function filterFutureConfirmedAppointments(appt, today) {
+  // return appointments where current time is less than appointment time
+  // +60 min or +240 min in the case of video
+  const threshold = isVideoVisit(appt) ? 240 : 60;
+  const apptDateTime = getMomentConfirmedDate(appt);
+  return (
+    apptDateTime.isValid() &&
+    apptDateTime.add(threshold, 'minutes').isAfter(today)
+  );
+}
+
+export function sortFutureConfirmedAppointments(a, b) {
+  return getMomentConfirmedDate(a).isBefore(getMomentConfirmedDate(b)) ? -1 : 1;
+}
+
+export function filterPastAppointments(appt, startDate, endDate) {
+  const apptDateTime = getMomentConfirmedDate(appt);
+  return (
+    apptDateTime.isValid() &&
+    apptDateTime.isAfter(startDate) &&
+    apptDateTime.isBefore(endDate)
+  );
+}
+
+export function sortPastAppointments(a, b) {
+  return getMomentConfirmedDate(a).isAfter(getMomentConfirmedDate(b)) ? -1 : 1;
+}
+
+export function filterRequests(request, today) {
+  const status = request?.status;
+  const optionDate1 = moment(request.optionDate1, 'MM/DD/YYYY');
+  const optionDate2 = moment(request.optionDate2, 'MM/DD/YYYY');
+  const optionDate3 = moment(request.optionDate3, 'MM/DD/YYYY');
+
+  const hasValidDateAfterToday =
+    (optionDate1.isValid() && optionDate1.isAfter(today)) ||
+    (optionDate2.isValid() && optionDate2.isAfter(today)) ||
+    (optionDate3.isValid() && optionDate3.isAfter(today));
+
+  return (
+    status === 'Submitted' || (status === 'Cancelled' && hasValidDateAfterToday)
+  );
+}
+
+export function sortFutureRequests(a, b) {
+  const aDate = getMomentRequestOptionDate(a.optionDate1);
+  const bDate = getMomentRequestOptionDate(b.optionDate1);
+
+  // If appointmentType is the same, return the one with the sooner date
+  if (a.appointmentType === b.appointmentType) {
+    return aDate.isBefore(bDate) ? -1 : 1;
+  }
+
+  // Otherwise, return sorted alphabetically by appointmentType
+  return a.appointmentType < b.appointmentType ? -1 : 1;
+}
+
+export function sortMessages(a, b) {
+  return moment(a.attributes.date).isBefore(b.attributes.date) ? -1 : 1;
+}
+
 function getPurposeOfVisit(appt) {
   switch (getAppointmentType(appt)) {
     case APPOINTMENT_TYPES.ccRequest:
@@ -112,6 +274,63 @@ function getPurposeOfVisit(appt) {
   }
 }
 
+/**
+ * Function to get the appointment duration in minutes. The default is 60 minutes.
+ *
+ * @param {*} appt
+ * @returns
+ */
+function getAppointmentDuration(appt) {
+  const appointmentLength = parseInt(
+    appt.vdsAppointments?.[0]?.appointmentLength ||
+      appt.vvsAppointments?.[0]?.duration,
+    10,
+  );
+  return isNaN(appointmentLength) ? 60 : appointmentLength;
+}
+
+/**
+ * Function to generate ICS.
+ *
+ * @param {*} summary - summary or subject of invite
+ * @param {*} description - additional detials
+ * @param {*} location - address / location
+ * @param {*} startDateTime - start datetime in js date format
+ * @param {*} endDateTime - end datetime in js date format
+ */
+
+export function generateICS(
+  summary,
+  description,
+  location,
+  startDateTime,
+  endDateTime,
+) {
+  const startDate = moment(startDateTime).format('YYYYMMDDTHHmmss');
+  const endDate = moment(endDateTime).format('YYYYMMDDTHHmmss');
+  return `BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:VA
+BEGIN:VEVENT
+UID:${guid()}
+SUMMARY:${summary}
+DESCRIPTION:${description}
+LOCATION:${location}
+DTSTAMP:${startDate}
+DTSTART:${startDate}
+DTEND:${endDate}
+END:VEVENT
+END:VCALENDAR`;
+}
+
+export function getCernerPortalLink() {
+  if (environment.isProduction()) {
+    return 'http://patientportal.myhealth.va.gov/';
+  }
+
+  return 'http://ehrm-va-test.patientportal.us.healtheintent.com/';
+}
+
 function getVideoType(appt) {
   if (isGFEVideoVisit(appt)) {
     return VIDEO_TYPES.gfe;
@@ -120,6 +339,59 @@ function getVideoType(appt) {
     appt.visitType === 'Video Conference'
   ) {
     return VIDEO_TYPES.videoConnect;
+  }
+
+  return null;
+}
+
+function hasInstructions(appt) {
+  const bookingNotes =
+    appt.vdsAppointments?.[0]?.bookingNote ||
+    appt.vvsAppointments?.[0]?.bookingNotes;
+
+  return (
+    !!bookingNotes &&
+    PURPOSE_TEXT.some(purpose => bookingNotes.startsWith(purpose.short))
+  );
+}
+
+function getAppointmentInstructions(appt) {
+  const bookingNotes =
+    appt.vdsAppointments?.[0]?.bookingNote ||
+    appt.vvsAppointments?.[0]?.bookingNotes;
+
+  const instructions = bookingNotes?.split(': ', 2);
+
+  if (instructions && instructions.length > 1) {
+    return instructions[1];
+  }
+
+  return null;
+}
+
+function getAppointmentInstructionsHeader(appt) {
+  const bookingNotes =
+    appt.vdsAppointments?.[0]?.bookingNote ||
+    appt.vvsAppointments?.[0]?.bookingNotes;
+
+  const instructions = bookingNotes?.split(': ', 2);
+
+  return instructions ? instructions[0] : '';
+}
+
+function getInstructions(appointment) {
+  if (appointment.instructionsToVeteran) {
+    return {
+      header: 'Special instructions',
+      body: appointment.instructionsToVeteran,
+    };
+  }
+
+  if (hasInstructions(appointment)) {
+    return {
+      header: getAppointmentInstructionsHeader(appointment),
+      body: getAppointmentInstructions(appointment),
+    };
   }
 
   return null;
@@ -154,6 +426,47 @@ export function getAppointmentTypes(appointment) {
     appointmentType: getAppointmentType(appointment),
     videoType: getVideoType(appointment),
     isCommunityCare: isCommunityCare(appointment),
+  };
+}
+
+export function transformAppointment(appointment) {
+  const appointmentTypes = getAppointmentTypes(appointment);
+
+  const appointmentData = {
+    ...appointmentTypes,
+    apiData: appointment,
+    isPastAppointment: false,
+    instructions: getInstructions(appointment),
+    duration: getAppointmentDuration(appointment),
+    appointmentDate: getMomentConfirmedDate(appointment),
+    status: getAppointmentStatus(appointment),
+    clinicId: appointment.clinicId,
+    facilityId: appointment.facilityId,
+    videoLink: getVideoVisitLink(appointment),
+    id: appointment.id,
+    clinicName:
+      appointment.clinicFriendlyName ||
+      appointment.vdsAppointments?.[0]?.clinic?.name,
+  };
+
+  if (appointmentTypes.appointmentType === APPOINTMENT_TYPES.ccAppointment) {
+    return {
+      ...appointmentData,
+      timeZone: appointment.timeZone,
+      address: appointment.address,
+      providerPractice: appointment.providerPractice,
+      providerName: appointment.name,
+      providerPhone: appointment.providerPhone,
+    };
+  }
+
+  return appointmentData;
+}
+
+export function transformPastAppointment(appointment) {
+  return {
+    ...transformAppointment(appointment),
+    isPastAppointment: true,
   };
 }
 


### PR DESCRIPTION
## Description
This is the second in a series of PRs refactoring the appointment list page. The primary goal is to push rendering logic out of `utils/appointment.jsx` and into the React component layer. This also lays some groundwork for our expected FHIR migration approach, which is to transform all data into a common format (FHIR) before most of the UI sees it.

In order to break this PR up, I'm not changing `utils/appointment.jsx` until the very last PR. For now, there's `utils/appointment-new.jsx` which contains ported and updated logic from that file, as well as some functions in `utils/formatters` that have been moved over.

The way to look at these changes:

1. See the reducer update to add a map call for booked appointments
2. Look at the logic for that transform in appointment-new.jsx
3. All the UI changes are adapting to that and trying to improve the consistency and organization of the cards
4. View the action and reducer updates for cancelling appointments

I don't expect this PR to fully work locally, and I am not going to merge this one, I will just merge the final one. I think it makes sense and is reviewable on its own.

## Testing done
Local testing

## Acceptance criteria
- [ ] Refactor looks like an improvement

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
