### PR TITLE
[ACCESSIBILITY/CI/CD] Update letters e2e tests

### DIFF
--- a/src/applications/letters/tests/01-authed.e2e.spec.js
+++ b/src/applications/letters/tests/01-authed.e2e.spec.js
@@ -22,10 +22,25 @@ module.exports = E2eHelpers.createE2eTest(client => {
     .expect.element('.usa-accordion-bordered')
     .to.be.present.before(Timeouts.normal);
 
+  client.elements('css selector', '.usa-accordion-bordered', result => {
+    client.assert.equal(result.value.length, 5);
+  });
+
   client
-    .click('.usa-accordion-bordered')
+    .click(`.usa-accordion-bordered:nth-of-type(1)`)
     .expect.element('.va-button-primary')
     .to.be.present.before(Timeouts.normal);
+
+  client
+    .click(`.usa-accordion-bordered:nth-of-type(2)`)
+    .click(`.usa-accordion-bordered:nth-of-type(3)`)
+    .click(`.usa-accordion-bordered:nth-of-type(4)`)
+    .click(`.usa-accordion-bordered:nth-of-type(5)`)
+    .waitForElementVisible(
+      `.usa-accordion-bordered:nth-of-type(5) .usa-accordion-content`,
+      Timeouts.normal,
+    )
+    .axeCheck('.main');
 
   // -- Go to letters list -- //
 


### PR DESCRIPTION
## Description

The letters app end-to-end tests did not previously expand all content accordions and perform an accessibility check using axe. This PR does that.

## Testing done

Updated e2e test

## Screenshots

![Screen Shot 2020-04-10 at 2 27 52 PM](https://user-images.githubusercontent.com/136959/79017675-87cd0700-7b37-11ea-8a5f-8824093f3bcf.png)

## Acceptance criteria
- [x] Axe check is performed on letters app expanded accordions

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
