### PR TITLE
VAVFS-7641: Add tracking for three click event types.

### DIFF
--- a/src/platform/site-wide/side-nav/components/SideNav.js
+++ b/src/platform/site-wide/side-nav/components/SideNav.js
@@ -28,7 +28,6 @@ class SideNav extends Component {
     const hasChildren = get(navItem, 'hasChildren');
     const expanded = get(navItem, 'expanded');
     const depth = get(navItem, 'depth');
-    const label = get(navItem, 'label');
     const parentID = get(navItem, 'parentID');
 
     // Derive the parent item and its properties.
@@ -45,12 +44,6 @@ class SideNav extends Component {
 
     // Escape early if the item has children.
     if (hasChildren) {
-      // Track expand/collapse.
-      recordEvent({
-        event: `nav-sidenav-dropdown-${expanded ? 'collapse' : 'expand'}`,
-        'sidenav-dropdown-header': label,
-      });
-
       // Flip the item's expanded property.
       this.setState({
         navItemsLookup: {

--- a/src/site/components/banner_alerts.drupal.liquid
+++ b/src/site/components/banner_alerts.drupal.liquid
@@ -52,7 +52,10 @@
 
             {% if entity.fieldAlertOperatingStatusCta == true %}
               <p>
-                <a href="{{ statusUrl }}">Get
+                <a href="{{ statusUrl }}" onclick="recordEvent({
+                  'event':'nav-warning-alert-box-content-link-click',
+                  'alertBoxHeading': '{{entity.title}}'
+                  });">Get
                   updates on affected services and facilities</a>
               </p>
             {% endif %}

--- a/src/site/components/fullwidth_banner_alerts.drupal.liquid
+++ b/src/site/components/fullwidth_banner_alerts.drupal.liquid
@@ -50,7 +50,10 @@
 
             {% if entity.fieldAlertOperatingStatusCta == true and statusUrl.length %}
               <p>
-                <a href="{{ statusUrl }}">Get
+                <a href="{{ statusUrl }}" onclick="recordEvent({
+                  'event':'nav-warning-alert-box-content-link-click',
+                  'alertBoxHeading': '{{entity.title}}'
+                  });">Get
                   updates on affected services and facilities</a>
               </p>
             {% endif %}

--- a/src/site/includes/operatingStatusFlags.drupal.liquid
+++ b/src/site/includes/operatingStatusFlags.drupal.liquid
@@ -37,6 +37,9 @@
   }
 </style>
 {% if fieldOperatingStatusFacility == 'notice' %}<a
+  onclick="recordEvent({
+  'event': 'nav-info-box-click',
+  'infoBoxText': 'Facility Notice'});"
   class="operating-status-link"
   href="{{facilitySidebar.links.0.url.path}}/operating-status">
   <span
@@ -48,6 +51,9 @@
 </a>
 {% elsif fieldOperatingStatusFacility == 'limited' %}
 <a class="operating-status-link"
+  onclick="recordEvent({
+  'event': 'nav-info-box-click',
+  'infoBoxText': 'Facility Notice'});"
   href="{{facilitySidebar.links.0.url.path}}/operating-status"><span
     class="operating-status-flag operating-status-flag-warning operating-status usa-alert usa-alert-warning background-color-only vads-u-margin-top--1 vads-u-padding-y--1 vads-u-padding-x--1p5">
     <i class="fa fa-exclamation-triangle" aria-hidden="true"></i> Limited
@@ -57,6 +63,9 @@
 </a>
 {% elsif fieldOperatingStatusFacility == 'closed' %}
 <a class="operating-status-link"
+  onclick="recordEvent({
+  'event': 'nav-info-box-click',
+  'infoBoxText': 'Facility Notice'});"
   href="{{facilitySidebar.links.0.url.path}}/operating-status"><span
     class="operating-status-flag operating-status-flag-error operating-status usa-alert usa-alert-error background-color-only vads-u-margin-top--1 vads-u-padding-y--1 vads-u-padding-x--1p5">
     <i class="fa fa-exclamation-circle" aria-hidden="true"></i> Facility

--- a/src/site/includes/operatingStatusFlags.drupal.liquid
+++ b/src/site/includes/operatingStatusFlags.drupal.liquid
@@ -39,7 +39,7 @@
 {% if fieldOperatingStatusFacility == 'notice' %}<a
   onclick="recordEvent({
   'event': 'nav-info-box-click',
-  'infoBoxText': 'Facility Notice'});"
+  'infoBoxText': 'Facility notice'});"
   class="operating-status-link"
   href="{{facilitySidebar.links.0.url.path}}/operating-status">
   <span
@@ -53,7 +53,7 @@
 <a class="operating-status-link"
   onclick="recordEvent({
   'event': 'nav-info-box-click',
-  'infoBoxText': 'Facility Notice'});"
+  'infoBoxText': 'Facility limited'});"
   href="{{facilitySidebar.links.0.url.path}}/operating-status"><span
     class="operating-status-flag operating-status-flag-warning operating-status usa-alert usa-alert-warning background-color-only vads-u-margin-top--1 vads-u-padding-y--1 vads-u-padding-x--1p5">
     <i class="fa fa-exclamation-triangle" aria-hidden="true"></i> Limited
@@ -65,7 +65,7 @@
 <a class="operating-status-link"
   onclick="recordEvent({
   'event': 'nav-info-box-click',
-  'infoBoxText': 'Facility Notice'});"
+  'infoBoxText': 'Facility closed'});"
   href="{{facilitySidebar.links.0.url.path}}/operating-status"><span
     class="operating-status-flag operating-status-flag-error operating-status usa-alert usa-alert-error background-color-only vads-u-margin-top--1 vads-u-padding-y--1 vads-u-padding-x--1p5">
     <i class="fa fa-exclamation-circle" aria-hidden="true"></i> Facility

--- a/src/site/layouts/vamc_operating_status_and_alerts.drupal.liquid
+++ b/src/site/layouts/vamc_operating_status_and_alerts.drupal.liquid
@@ -86,6 +86,8 @@
                                 <dt
                                     class="vads-l-col--6 vads-u-margin-y--3 vads-u-display--flex operating-status-title">
                                     <a class="facility-title-width vads-u-font-weight--bold"
+                                        onclick="recordEvent({
+                                        'event':'nav-health-care-facility-status-click'});"
                                         href="{{status.entity.entityUrl.path}}">{{ status.entity.title }}</a>
                                 </dt>
                                 <dd class="vads-l-col--6">


### PR DESCRIPTION
## Description
See https://github.com/department-of-veterans-affairs/va.gov-team/issues/7641
Adds tracking for click events on  
 - links within the banner
 - Facilities in 'Facility operating statuses' list
 - Facility Notice Info Box on facility pages

## Testing done
Console

## Screenshots
N/A

## Acceptance criteria
- [x] To be QA'd by @jonwehausen on this instance http://vfsanalytics.web.ci.cms.va.gov/