### PR TITLE
686-fix-property-name

### DIFF
--- a/src/applications/disability-benefits/686c-674/config/chapters/report-child-stopped-attending-school/child-information/childInformation.js
+++ b/src/applications/disability-benefits/686c-674/config/chapters/report-child-stopped-attending-school/child-information/childInformation.js
@@ -1,5 +1,5 @@
 import currentOrPastDateUI from 'platform/forms-system/src/js/definitions/currentOrPastDate';
-
+import { TASK_KEYS } from '../../../constants';
 import { isChapterFieldRequired } from '../../../helpers';
 import { genericSchemas } from '../../../generic-schema';
 import { validateName } from '../../../utilities';
@@ -21,7 +21,7 @@ export const uiSchema = {
       'ui:required': formData =>
         isChapterFieldRequired(
           formData,
-          'reportChild18OrOlderIsNotAttendingSchool',
+          TASK_KEYS.reportChild18OrOlderIsNotAttendingSchool,
         ),
       'ui:title': 'Child’s first name',
       'ui:errorMessages': { required: 'Please enter a first name' },
@@ -31,7 +31,7 @@ export const uiSchema = {
       'ui:required': formData =>
         isChapterFieldRequired(
           formData,
-          'reportChild18OrOlderIsNotAttendingSchool',
+          TASK_KEYS.reportChild18OrOlderIsNotAttendingSchool,
         ),
       'ui:title': 'Child’s last name',
       'ui:errorMessages': { required: 'Please enter a last name' },
@@ -47,7 +47,7 @@ export const uiSchema = {
       'ui:required': formData =>
         isChapterFieldRequired(
           formData,
-          'reportChild18OrOlderIsNotAttendingSchool',
+          TASK_KEYS.reportChild18OrOlderIsNotAttendingSchool,
         ),
     },
   },

--- a/src/applications/disability-benefits/686c-674/config/constants.js
+++ b/src/applications/disability-benefits/686c-674/config/constants.js
@@ -13,8 +13,8 @@ export const TASK_KEYS = {
   reportDeath: 'reportDeath',
   reportStepchildNotInHousehold: 'reportStepchildNotInHousehold',
   reportMarriageOfChildUnder18: 'reportMarriageOfChildUnder18',
-  reportChild18orOlderIsNotAttendingSchool:
-    'reportChild18orOlderIsNotAttendingSchool',
+  reportChild18OrOlderIsNotAttendingSchool:
+    'reportChild18OrOlderIsNotAttendingSchool',
   report674: 'report674',
 };
 

--- a/src/applications/disability-benefits/686c-674/config/form.js
+++ b/src/applications/disability-benefits/686c-674/config/form.js
@@ -272,7 +272,7 @@ const formConfig = {
           depends: formData =>
             isChapterFieldRequired(
               formData,
-              TASK_KEYS.reportChild18orOlderIsNotAttendingSchool,
+              TASK_KEYS.reportChild18OrOlderIsNotAttendingSchool,
             ),
           title:
             'Information needed to report a child 18-23 years old stopped attending school',


### PR DESCRIPTION
## Description
There was a discrepancy in naming conventions in the 686 that prevented one of the workflows from displaying when its corresponding checkbox was selected on the task wizard. This pull request fixes that issue. 

## Testing done
- local

## Screenshots
<img width="999" alt="Screen Shot 2020-04-10 at 2 53 55 PM" src="https://user-images.githubusercontent.com/15097156/79025778-99181280-7b3b-11ea-9dfc-064d912be776.png">
<img width="736" alt="Screen Shot 2020-04-10 at 2 54 06 PM" src="https://user-images.githubusercontent.com/15097156/79025783-9b7a6c80-7b3b-11ea-99b7-c86eadf8ed1a.png">
<img width="858" alt="Screen Shot 2020-04-10 at 2 54 19 PM" src="https://user-images.githubusercontent.com/15097156/79025785-9c130300-7b3b-11ea-8906-ab34acb4efb2.png">


## Acceptance criteria
- [x] Workflow is accessible.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
