### PR TITLE
VAVFS-6206: Updating facility names with full titles.

### DIFF
--- a/src/site/facilities/health_service.drupal.liquid
+++ b/src/site/facilities/health_service.drupal.liquid
@@ -19,12 +19,12 @@
                 {% endif %}
 
                 {% if healthService.fieldLocalHealthCareService.length > 0 %}
-                    <h3>Available at these {{ regionNickname }} locations</h3>
+                    <h3>Available at these {{ regionOrOffice }} locations</h3>
                     <ul class="usa-unstyled-list">
                         {% for location in healthService.fieldLocalHealthCareService %}
                             {% assign facility = location.entity.fieldFacilityLocation.entity %}
                             {% if facility != empty %}<li class="vads-u-margin-bottom--2">
-                                <a href="{{ facility.entityUrl.path }}">{{ facility.fieldNicknameForThisFacility }}</a></li>{% endif %}
+                                <a href="{{ facility.entityUrl.path }}">{{ facility.title }}</a></li>{% endif %}
                         {% endfor %}
                     </ul>
                 {% endif %}

--- a/src/site/layouts/health_care_local_facility.drupal.liquid
+++ b/src/site/layouts/health_care_local_facility.drupal.liquid
@@ -411,7 +411,7 @@ more.\r\n",
 
           <!-- Social Links -->
           {% include "src/site/facilities/facility_social_links.drupal.liquid"
-          with regionNickname = fieldRegionPage.entity.fieldNicknameForThisFacility
+          with regionNickname = fieldRegionPage.entity.title
           fieldGovdeliveryIdEmerg = fieldRegionPage.entity.fieldGovdeliveryIdEmerg
           fieldGovdeliveryIdNews = fieldRegionPage.entity.fieldGovdeliveryIdNews
           fieldOperatingStatus = fieldRegionPage.entity.fieldOperatingStatus

--- a/src/site/layouts/health_care_region_detail_page.drupal.liquid
+++ b/src/site/layouts/health_care_region_detail_page.drupal.liquid
@@ -62,7 +62,7 @@
             <!-- Social Links -->
             {% if isContactPage %}
               {% if fieldFacebook != empty || fieldFlickr != empty || fieldInstagram != empty || fieldTwitter != empty || fieldEmailSubscription != empty || (fieldLinks != empty and fieldLinks.length)%}
-                {% include "src/site/facilities/facility_social_links.drupal.liquid" with regionNickname = fieldOffice.entity.fieldNicknameForThisFacility %}
+                {% include "src/site/facilities/facility_social_links.drupal.liquid" with regionNickname = fieldOffice.entity.title %}
               {% endif %}
             {% endif %}
           </article>
@@ -136,7 +136,7 @@
             <!-- Social Links -->
             {% if isContactPage %}
               {% if fieldFacebook != empty || fieldFlickr != empty || fieldInstagram != empty || fieldTwitter != empty || fieldEmailSubscription != empty || (fieldLinks != empty and fieldLinks.length)%}
-                {% include "src/site/facilities/facility_social_links.drupal.liquid" with regionNickname = fieldOffice.entity.fieldNicknameForThisFacility %}
+                {% include "src/site/facilities/facility_social_links.drupal.liquid" with regionNickname = fieldOffice.entity.title %}
               {% endif %}
             {% endif %}
           </article>

--- a/src/site/layouts/health_care_region_page.drupal.liquid
+++ b/src/site/layouts/health_care_region_page.drupal.liquid
@@ -306,7 +306,7 @@ Example data:
 
           <!-- Social Links -->
           {% if fieldFacebook != empty || fieldFlickr != empty || fieldInstagram != empty || fieldTwitter != empty || fieldEmailSubscription != empty %}
-          {% include "src/site/facilities/facility_social_links.drupal.liquid" with regionNickname = fieldNicknameForThisFacility %}
+          {% include "src/site/facilities/facility_social_links.drupal.liquid" with regionNickname = title %}
           {% endif %}
 
         </article>

--- a/src/site/stages/build/drupal/graphql/bioPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/bioPage.graphql.js
@@ -21,6 +21,7 @@ module.exports = `
         ...on NodeHealthCareRegionPage {
           ${entityElementsFromPages}
           fieldNicknameForThisFacility
+          title
         }
       }
     }

--- a/src/site/stages/build/drupal/graphql/facilities-fragments/healthCareRegionHealthServices.node.graphql.js
+++ b/src/site/stages/build/drupal/graphql/facilities-fragments/healthCareRegionHealthServices.node.graphql.js
@@ -29,6 +29,7 @@ const HEALTH_SERVICES_RESULTS = `
                     }
                   }
                   fieldNicknameForThisFacility
+                  title
                 }
               }
             }

--- a/src/site/stages/build/drupal/graphql/healthCareLocalFacilityPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/healthCareLocalFacilityPage.graphql.js
@@ -7,6 +7,7 @@ module.exports = `
     changed
     fieldFacilityLocatorApiId
     fieldNicknameForThisFacility
+    title
     fieldIntroText
     fieldOperatingStatusFacility
     fieldLocationServices {

--- a/src/site/stages/build/drupal/graphql/healthCareLocalFacilityPage.old.graphql.js
+++ b/src/site/stages/build/drupal/graphql/healthCareLocalFacilityPage.old.graphql.js
@@ -6,6 +6,7 @@ module.exports = `
     changed
     fieldFacilityLocatorApiId
     fieldNicknameForThisFacility
+    title
     fieldIntroText
     fieldLocationServices {
       entity {

--- a/src/site/stages/build/drupal/graphql/healthCareRegionPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/healthCareRegionPage.graphql.js
@@ -14,6 +14,7 @@ module.exports = `
   fragment healthCareRegionPage on NodeHealthCareRegionPage {
     ${entityElementsFromPages}
     fieldNicknameForThisFacility
+    title
     fieldMedia {
       entity {
         ... on MediaImage {

--- a/src/site/stages/build/drupal/graphql/healthServicesListingPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/healthServicesListingPage.graphql.js
@@ -64,6 +64,7 @@ module.exports = `
                             }
                           }
                           fieldNicknameForThisFacility
+                          title
                         }
                       }
                     }


### PR DESCRIPTION
## Description
 - Relates to https://github.com/department-of-veterans-affairs/va.gov-team/issues/6206
 - In multiple places, a legacy field is being used for facility title (fieldNicknameForThisFacility). 
 - This pr adds title field to remaining graphql queries that have fieldNicknameForThisFacility. 
 - All template instances that use fieldNicknameForThisFacility are updated / replaced with title

## Testing done
Build, and visual

## Screenshots
![image](https://user-images.githubusercontent.com/2404547/79029721-a517ca80-7b63-11ea-9704-5af8aaf22bc5.png)

## Acceptance criteria
- [ ] Will require interactive qa - multiple pages will have to be spot checked, and confirmation that no instances of facility nickname appear