### PR TITLE
Make the ProfileInfoTable responsive

### DIFF
--- a/src/applications/personalization/profile-2/components/ProfileInfoTable.jsx
+++ b/src/applications/personalization/profile-2/components/ProfileInfoTable.jsx
@@ -89,7 +89,7 @@ const ProfileInfoTable = ({
             >
               {row.title}
             </h4>
-            <p className={[...tableRowDataClasses].join(' ')}>{row.value}</p>
+            <p className={tableRowDataClasses.join(' ')}>{row.value}</p>
           </div>
         ))}
     </div>

--- a/src/applications/personalization/profile-2/components/ProfileInfoTable.jsx
+++ b/src/applications/personalization/profile-2/components/ProfileInfoTable.jsx
@@ -1,37 +1,109 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const ProfileInfoTable = ({ data, dataTransformer, fieldName, title }) => (
-  <table className="profile-info-table" data-field-name={fieldName}>
-    <thead>
-      <tr>
-        <th>
-          <h3>{title}</h3>
-        </th>
-      </tr>
-    </thead>
-    <tbody>
+/**
+ * Helper that prefixes class names with an optional responsive prefix and the
+ * `vads-u-` utility class prefix.
+ *
+ * @param {string[]} classes - Array of classes to prefix with `vads-u-`
+ * @param {string} screenSize - Optional screen size
+ * @returns {string[]} The input `classes` array with the correct prefixes
+ * applied
+ *
+ * Example: `prefixUtilityClasses(['my-class'], 'medium')` returns
+ * ['medium-screen:vads-u-my-class']
+ */
+const prefixUtilityClasses = (classes, screenSize = '') => {
+  const colonizedScreenSize = screenSize ? `${screenSize}-screen:` : '';
+  return classes.map(className => `${colonizedScreenSize}vads-u-${className}`);
+};
+
+const ProfileInfoTable = ({
+  data,
+  dataTransformer,
+  fieldName,
+  title,
+  className,
+}) => {
+  const tableClasses = ['profile-info-table', className];
+  const titleClasses = prefixUtilityClasses([
+    'background-color--gray-lightest',
+    'border--1px',
+    'border-color--gray-lighter',
+    'color--gray-darkest',
+    'margin--0',
+    'padding-x--2',
+    'padding-y--1p5',
+  ]);
+  const titleClassesMedium = prefixUtilityClasses(
+    ['padding-x--3', 'padding-y--2'],
+    'medium',
+  );
+  const tableRowClasses = prefixUtilityClasses([
+    'border-color--gray-lighter',
+    'color-gray-dark',
+    'display--flex',
+    'flex-direction--column',
+    'padding-x--2',
+    'padding-y--1p5',
+  ]);
+  const tableRowClassesMedium = prefixUtilityClasses(
+    ['flex-direction--row', 'padding--3'],
+    'medium',
+  );
+  const tableRowTitleClasses = prefixUtilityClasses([
+    'font-family--sans',
+    'font-size--base',
+    'font-weight--bold',
+    'line-height--4',
+    'margin--0',
+    'margin-bottom--1',
+  ]);
+  const tableRowTitleMediumClasses = prefixUtilityClasses(
+    ['margin-bottom--0', 'margin-right--2'],
+    'medium',
+  );
+  const tableRowDataClasses = ['vads-u-margin--0'];
+
+  return (
+    <div className={[...tableClasses].join(' ')} data-field-name={fieldName}>
+      <h3 className={[...titleClasses, ...titleClassesMedium].join(' ')}>
+        {title}
+      </h3>
       {data
         .map(element => (dataTransformer ? dataTransformer(element) : element))
         .map((row, index) => (
-          <tr key={index}>
-            <td>
-              <h4 className="vads-u-font-family--sans vads-u-font-size--base vads-u-font-weight--bold">
-                {row.title}
-              </h4>
-            </td>
-            <td>{row.value}</td>
-          </tr>
+          <div
+            key={index}
+            className={`'table-row' ${[
+              'table-row',
+              ...tableRowClasses,
+              ...tableRowClassesMedium,
+            ].join(' ')}`}
+          >
+            <h4
+              className={[
+                ...tableRowTitleClasses,
+                ...tableRowTitleMediumClasses,
+              ].join(' ')}
+            >
+              {row.title}
+            </h4>
+            <p className={[...tableRowDataClasses].join(' ')}>{row.value}</p>
+          </div>
         ))}
-    </tbody>
-  </table>
-);
+    </div>
+  );
+};
 
 ProfileInfoTable.propTypes = {
   title: PropTypes.string.isRequired,
   fieldName: PropTypes.string.isRequired,
   data: PropTypes.array.isRequired,
   dataTransformer: PropTypes.func,
+  className: PropTypes.string,
 };
+
+export { prefixUtilityClasses };
 
 export default ProfileInfoTable;

--- a/src/applications/personalization/profile-2/components/ProfileWrapper.jsx
+++ b/src/applications/personalization/profile-2/components/ProfileWrapper.jsx
@@ -64,7 +64,9 @@ class ProfileWrapper extends Component {
         <div className="usa-width-one-fourth">
           <ProfileSideNav />
         </div>
-        <div className="usa-width-three-fourths">{this.props.children}</div>
+        <div className="usa-width-three-fourths columns">
+          {this.props.children}
+        </div>
       </div>
     </>
   );

--- a/src/applications/personalization/profile-2/sass/profile-info-table.scss
+++ b/src/applications/personalization/profile-2/sass/profile-info-table.scss
@@ -1,65 +1,29 @@
+$corner-size: 4px;
+
 .profile-info-table {
-  border-collapse: collapse;
-  border-spacing: 0;
-
-  th:first-child {
-    border-top-left-radius: 4px;
-    border-top-right-radius: 4px;
-    border-bottom: none;
-    width: 100%;
-  }
-
-  tr:not(:last-child) {
-    td {
-      border-bottom: none;
-    }
-  }
-
-  tr:last-child {
-    td:last-child {
-      border-bottom-right-radius: 4px;
-      border-bottom-left-radius: 4px;
-    }
-  }
-
-  th,
-  td {
-    border: 1px solid $color-gray-lighter;
-    text-align: left;
-    display: flex;
-    padding: units(1.5) units(4);
-  }
-
-  tr {
-    display: flex;
-    flex-direction: row;
-    border: none;
-  }
-
-  td {
-    padding: 10px 30px;
-    width: 100%;
-  }
-
-  tr,
-  td:first-child {
-    border-right: none;
-    width: 75%;
-  }
-
-  tr,
-  td:last-child {
-    border-left: none;
-    width: 100%
-  }
-
   h3 {
-    color: $color-primary-darkest;
-    margin: unset;
+    border-top-left-radius: $corner-size;
+    border-top-right-radius: $corner-size;
   }
 
-  h4 {
-    color: $color-gray-dark;
-    margin: unset;
+  // there is a bug that prevents setting an overall 1px border with a 0px
+  // top-border override using the utility classes. And applying three utility
+  // classes - one each for left, right, and bottom - felt like the wrong kind
+  // of hack.
+  div.table-row {
+    border: 1px solid;
+    border-top: 0;
+
+    h4 {
+      @include media($medium-screen) {
+        width: 216px;
+        flex-shrink: 0;
+      }
+    }
+  }
+
+  div.table-row:last-of-type {
+    border-bottom-left-radius: $corner-size;
+    border-bottom-right-radius: $corner-size;
   }
 }

--- a/src/applications/personalization/profile-2/tests/components/ProfileInfoTable.unit.spec.js
+++ b/src/applications/personalization/profile-2/tests/components/ProfileInfoTable.unit.spec.js
@@ -3,7 +3,28 @@ import sinon from 'sinon';
 import { shallow } from 'enzyme';
 import { expect } from 'chai';
 
-import ProfileInfoTable from '../../components/ProfileInfoTable';
+import ProfileInfoTable, {
+  prefixUtilityClasses,
+} from '../../components/ProfileInfoTable';
+
+describe('prefixUtilityClasses', () => {
+  const classes = ['class-1', 'class-2'];
+  it('should prefix an array of classes with `vads-u-`', () => {
+    const expectedResult = ['vads-u-class-1', 'vads-u-class-2'];
+    const result = prefixUtilityClasses(classes);
+    expect(result).to.deep.equal(expectedResult);
+  });
+  describe('when passed a screenSize', () => {
+    it('should prefix an array of classes with the responsive prefix and `vads-u-`', () => {
+      const expectedResult = [
+        'medium-screen:vads-u-class-1',
+        'medium-screen:vads-u-class-2',
+      ];
+      const result = prefixUtilityClasses(classes, 'medium');
+      expect(result).to.deep.equal(expectedResult);
+    });
+  });
+});
 
 describe('ProfileInfoTable', () => {
   let dataTransformerSpy;
@@ -24,18 +45,18 @@ describe('ProfileInfoTable', () => {
   afterEach(() => {
     wrapper.unmount();
   });
-  it('renders a `table`', () => {
-    expect(wrapper.type()).to.equal('table');
+  it('renders a `div`', () => {
+    expect(wrapper.type()).to.equal('div');
   });
-  it("sets the table's data-field-name to the fieldName prop", () => {
+  it("sets the div's data-field-name to the fieldName prop", () => {
     expect(wrapper.prop('data-field-name')).to.equal(props.fieldName);
   });
   it('renders the title prop in an h3 tag', () => {
     const h3 = wrapper.find('h3');
     expect(h3.text()).to.equal(props.title);
   });
-  it('renders a table row for each entry in the data prop', () => {
-    const tableRows = wrapper.find('tbody > tr');
+  it('renders a table row div for each entry in the data prop', () => {
+    const tableRows = wrapper.find('div > div.table-row');
     expect(tableRows.length).to.equal(props.data.length);
   });
   it('calls the dataTransformer once for each row of data', () => {


### PR DESCRIPTION
## Description
This make the ProfileInfoTable component responsive, switching from a single column on small screens to two columns on medium+ screens. This change required moving from using an HTML `table` to rendering the table with `div`s and using flexbox.

## Testing done
Local + unit tests

## Screenshots
<details>
  <summary>Mobile</summary>
  
<img width="499" alt="Screen Shot 2020-04-13 at 9 06 19 AM" src="https://user-images.githubusercontent.com/20728956/79137018-cdbbe200-7d66-11ea-9434-fe2cef4d59cf.png">

</details>
<details>
  <summary>Medium Screens</summary>
  
<img width="728" alt="Screen Shot 2020-04-13 at 9 06 33 AM" src="https://user-images.githubusercontent.com/20728956/79137044-d6acb380-7d66-11ea-8ac3-ecd8de5bc185.png">


</details>


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs