### PR TITLE
bradl3yC - 7126 - update form intro page (unauth) messaging

### DIFF
--- a/src/applications/disability-benefits/2346/components/IntroductionPage.jsx
+++ b/src/applications/disability-benefits/2346/components/IntroductionPage.jsx
@@ -1,5 +1,6 @@
 import FormTitle from 'platform/forms-system/src/js/components/FormTitle';
 import SaveInProgressIntro from 'platform/forms/save-in-progress/SaveInProgressIntro';
+import UnverifiedPrefillAlert from './UnverifiedPrefillAlert';
 import React from 'react';
 
 const IntroductionPage = props => (
@@ -11,6 +12,8 @@ const IntroductionPage = props => (
       prefillEnabled={props.route.formConfig.prefillEnabled}
       messages={props.route.formConfig.savedFormMessages}
       pageList={props.route.pageList}
+      verifyRequiredPrefill={props.route.formConfig.verifyRequiredPrefill}
+      unverifiedPrefillAlert={<UnverifiedPrefillAlert />}
       startText="Order hearing aid batteries and accessories"
     >
       Please complete the 2346 form to apply for ordering hearing aid batteries

--- a/src/applications/disability-benefits/2346/components/IntroductionPage.jsx
+++ b/src/applications/disability-benefits/2346/components/IntroductionPage.jsx
@@ -1,7 +1,7 @@
+import React from 'react';
 import FormTitle from 'platform/forms-system/src/js/components/FormTitle';
 import SaveInProgressIntro from 'platform/forms/save-in-progress/SaveInProgressIntro';
 import UnverifiedPrefillAlert from './UnverifiedPrefillAlert';
-import React from 'react';
 
 const IntroductionPage = props => (
   <div className="schemaform-intro">

--- a/src/applications/disability-benefits/2346/components/UnverifiedPrefillAlert.jsx
+++ b/src/applications/disability-benefits/2346/components/UnverifiedPrefillAlert.jsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import { toggleLoginModal } from 'platform/site-wide/user-nav/actions';
+
+const UnverifiedPrefillAlert = props => (
+  <div className="usa-alert usa-alert-info schemaform-sip-alert">
+    <div className="usa-alert-body">
+      <h3 className="usa-alert-heading">
+        Save time—and save your work in progress—by signing in before starting
+        your order
+      </h3>
+      <div className="usa-alert-text">
+        <p className="vads-u-font-size--h4">
+          When you’re signed in to your VA.gov account:
+        </p>
+        <ul>
+          <li>
+            We can prefill part of your order based on your account details.
+          </li>
+          <li>
+            You can save your order in progress, and come back later to finish
+            filling it out. You’ll have 60 days from the date you start or
+            update your order to submit it. After 60 days, we’ll delete the
+            order form and you’ll need to start over.
+          </li>
+        </ul>
+        <p>
+          <strong>Note:</strong> If you sign in after you’ve started your
+          application, you won’t be able to save the information you’ve already
+          filled in.
+        </p>
+        <button
+          className="usa-button-primary"
+          onClick={() => props.toggleLoginModal(true, 'cta-form')}
+        >
+          Sign in to start your order
+        </button>
+      </div>
+    </div>
+  </div>
+);
+
+const mapDispatchToProps = {
+  toggleLoginModal,
+};
+
+export default connect(
+  null,
+  mapDispatchToProps,
+)(UnverifiedPrefillAlert);

--- a/src/applications/disability-benefits/2346/components/UnverifiedPrefillAlert.jsx
+++ b/src/applications/disability-benefits/2346/components/UnverifiedPrefillAlert.jsx
@@ -29,6 +29,7 @@ const UnverifiedPrefillAlert = props => (
         </p>
         <button
           className="usa-button-primary"
+          type="button"
           onClick={() => props.toggleLoginModal(true, 'cta-form')}
         >
           Sign in to start your order

--- a/src/applications/disability-benefits/2346/components/UnverifiedPrefillAlert.jsx
+++ b/src/applications/disability-benefits/2346/components/UnverifiedPrefillAlert.jsx
@@ -10,9 +10,7 @@ const UnverifiedPrefillAlert = props => (
         your order
       </h3>
       <div className="usa-alert-text">
-        <p className="vads-u-font-size--h4">
-          When you’re signed in to your VA.gov account:
-        </p>
+        <p>When you’re signed in to your VA.gov account:</p>
         <ul>
           <li>
             We can prefill part of your order based on your account details.

--- a/src/applications/disability-benefits/2346/config/form.js
+++ b/src/applications/disability-benefits/2346/config/form.js
@@ -54,6 +54,7 @@ const formConfig = {
   submit: () =>
     Promise.resolve({ attributes: { confirmationNumber: '123123123' } }),
   trackingPrefix: 'va-2346a-',
+  verifyRequiredPrefill: true,
   introduction: IntroductionPage,
   confirmation: ConfirmationPage,
   footerContent: FooterInfo,


### PR DESCRIPTION
## Description
Add custom component for the form intro page (unauth) messaging

## Testing done


## Screenshots
![Screen Shot 2020-04-13 at 11 41 07 AM](https://user-images.githubusercontent.com/6165421/79135572-8db42980-7d7d-11ea-9a12-0a6f13b43e43.png)


## Acceptance criteria
- [X] Copy update to mach mocks provided by design

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
