### PR TITLE
Remove `editModalForm` from Redux

### DIFF
--- a/src/applications/personalization/profile360/reducers/index.js
+++ b/src/applications/personalization/profile360/reducers/index.js
@@ -17,30 +17,6 @@ import {
   PAYMENT_INFORMATION_EDIT_MODAL_TOGGLED,
 } from '../actions/paymentInformation';
 
-const editModalFormsInitialState = {
-  financialInstitutionRoutingNumber: {
-    errorMessage: undefined,
-    field: {
-      value: '',
-      dirty: false,
-    },
-  },
-  accountNumber: {
-    errorMessage: undefined,
-    field: {
-      value: '',
-      dirty: false,
-    },
-  },
-  accountType: {
-    errorMessage: undefined,
-    value: {
-      value: '',
-      dirty: false,
-    },
-  },
-};
-
 const initialState = {
   hero: null,
   personalInformation: null,
@@ -50,7 +26,6 @@ const initialState = {
     isEditing: false,
     isSaving: false,
     responseError: null,
-    editModalForm: editModalFormsInitialState,
   },
 };
 
@@ -73,19 +48,13 @@ function vaProfile(state = initialState, action) {
     }
 
     case PAYMENT_INFORMATION_EDIT_MODAL_TOGGLED: {
-      let newState = set(
+      const newState = set(
         'paymentInformationUiState.isEditing',
         !state.paymentInformationUiState.isEditing,
         state,
       );
 
-      newState = set('paymentInformationUiState.responseError', null, newState);
-
-      return set(
-        'paymentInformationUiState.editModalForm',
-        editModalFormsInitialState,
-        newState,
-      );
+      return set('paymentInformationUiState.responseError', null, newState);
     }
 
     case PAYMENT_INFORMATION_SAVE_STARTED:


### PR DESCRIPTION
## Description
We stopped using this part of the Redux state after we converted the Payment Info form to use a SchemaForm with commit 6f0399587ee2050761bb226413cf4807245f7c86

## Testing done
Local + existing tests

## Screenshots
N/A

## Acceptance criteria
- [ ] Everything still works

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs