### PR TITLE
Clear facility id when type of care changes

### DIFF
--- a/src/applications/vaos/reducers/newAppointment.js
+++ b/src/applications/vaos/reducers/newAppointment.js
@@ -170,17 +170,19 @@ export default function formReducer(state = initialState, action) {
     }
     case FORM_DATA_UPDATED: {
       let newPages = state.pages;
+      let actionData = action.data;
       if (
-        action.data.typeOfCareId !== state.data.typeOfCareId &&
-        state.pages.vaFacility
+        actionData.typeOfCareId !== state.data.typeOfCareId &&
+        (state.pages.vaFacility || state.data.vaFacility)
       ) {
         newPages = unset('vaFacility', newPages);
+        actionData = unset('vaFacility', actionData);
       }
 
       const { data, schema } = updateSchemaAndData(
         state.pages[action.page],
         action.uiSchema,
-        action.data,
+        actionData,
       );
 
       return {

--- a/src/applications/vaos/tests/reducers/newAppointment.unit.spec.js
+++ b/src/applications/vaos/tests/reducers/newAppointment.unit.spec.js
@@ -111,6 +111,40 @@ describe('VAOS reducer: newAppointment', () => {
     expect(newState.data.prop).to.equal('testing');
   });
 
+  it('should reset facility info when type of care changes', () => {
+    const currentState = {
+      data: {
+        typeOfCareId: '323',
+        vaFacility: '123',
+      },
+      pages: {
+        test: {
+          type: 'object',
+          properties: {},
+        },
+        vaFacility: {
+          type: 'object',
+          properties: {},
+        },
+      },
+    };
+    const action = {
+      type: FORM_DATA_UPDATED,
+      page: 'test',
+      data: {
+        typeOfCareId: '504',
+        vaFacility: '123',
+      },
+      uiSchema: {},
+    };
+
+    const newState = newAppointmentReducer(currentState, action);
+
+    expect(newState.data.typeOfCareId).to.equal('504');
+    expect(newState.data.vaFacility).to.be.undefined;
+    expect(newState.pages.vaFacility).to.be.undefined;
+  });
+
   it('should mark page change as in progress', () => {
     const currentState = {
       data: {},


### PR DESCRIPTION
## Description
If you choose a facility, then go back and change your type of care, you'll get an error on the facility page if the facility you chose before isn't in the new list of facilities.

There's some complicated logic in the facility page that checks if there's a facility id and fetches different info depending on that, and it assumes any facility id chosen is still valid. I think clearing that data when type of care changes is easier to understand and keeps the code from getting even messier.

## Testing done
Local testing

## Acceptance criteria
- [ ] No error when changing type of care after choosing a facility

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
