### PR TITLE
Add back sr-only tags

### DIFF
--- a/src/applications/yellow-ribbon/components/SearchResult/index.jsx
+++ b/src/applications/yellow-ribbon/components/SearchResult/index.jsx
@@ -111,13 +111,13 @@ export const SearchResult = ({ school }) => (
   <li className="usa-unstyled-list vads-l-col vads-u-margin-bottom--2 vads-u-padding-x--2 vads-u-padding-y--2 vads-u-background-color--gray-light-alt">
     {/* School Name */}
     <p className="vads-u-font-size--h3 vads-u-font-weight--bold vads-u-margin--0">
-      <span className="sr-only">School name</span>
+      <span className="sr-only">School name:</span>
       {deriveNameLabel(school)}
     </p>
 
     {/* School Location */}
     <p className="vads-u-margin-bottom--1 vads-u-margin-top--0">
-      <span className="sr-only">School location</span>
+      <span className="sr-only">School location:</span>
       {deriveLocationLabel(school)}
     </p>
 
@@ -129,6 +129,7 @@ export const SearchResult = ({ school }) => (
             Maximum Yellow Ribbon funding amount
             <br />
             (per student, per year)
+            <span className="sr-only">:</span>
           </p>
           <p className="vads-u-margin--0">{deriveMaxAmountLabel(school)}</p>
         </div>
@@ -136,6 +137,7 @@ export const SearchResult = ({ school }) => (
         {/* Student Count */}
         <p className="vads-u-font-weight--bold vads-u-font-family--sans vads-u-font-size--h5 vads-u-margin-top--2 vads-u-margin-bottom--0">
           Funding available for
+          <span className="sr-only">:</span>
         </p>
         <p className="vads-u-margin-top--0 vads-u-margin-bottom--0">
           {deriveEligibleStudentsLabel(school)}
@@ -144,6 +146,7 @@ export const SearchResult = ({ school }) => (
         {/* School Website */}
         <p className="vads-u-font-weight--bold vads-u-font-family--sans vads-u-font-size--h5 vads-u-margin-top--2 vads-u-margin-bottom--0">
           School website
+          <span className="sr-only">:</span>
         </p>
         <p className="vads-u-margin-top--0 vads-u-margin-bottom--0">
           {deriveInstURLLabel(school)}
@@ -154,6 +157,7 @@ export const SearchResult = ({ school }) => (
         {/* Degree Level */}
         <p className="vads-u-font-weight--bold vads-u-margin-top--2 vads-u-margin-bottom--0 vads-u-font-family--sans vads-u-font-size--h5 medium-screen:vads-u-margin--0">
           Degree type
+          <span className="sr-only">:</span>
         </p>
         <p className="vads-u-margin-top--0 vads-u-margin-bottom--0 medium-screen:vads-u-margin--0">
           {deriveDegreeLevel(school)}
@@ -162,6 +166,7 @@ export const SearchResult = ({ school }) => (
         {/* Division Professional School */}
         <p className="school-program vads-u-font-weight--bold vads-u-margin-top--2 vads-u-margin-bottom--0 vads-u-font-family--sans vads-u-font-size--h5 medium-screen:vads-u-margin-bottom--0">
           School or program
+          <span className="sr-only">:</span>
         </p>
         <p className="vads-u-margin-top--0 vads-u-margin-bottom--0 medium-screen:vads-u-margin--0">
           {deriveDivisionProfessionalSchool(school)}

--- a/src/applications/yellow-ribbon/components/SearchResult/index.jsx
+++ b/src/applications/yellow-ribbon/components/SearchResult/index.jsx
@@ -111,13 +111,13 @@ export const SearchResult = ({ school }) => (
   <li className="usa-unstyled-list vads-l-col vads-u-margin-bottom--2 vads-u-padding-x--2 vads-u-padding-y--2 vads-u-background-color--gray-light-alt">
     {/* School Name */}
     <p className="vads-u-font-size--h3 vads-u-font-weight--bold vads-u-margin--0">
-      <span className="sr-only">School name:</span>
+      <span className="sr-only">School name</span>
       {deriveNameLabel(school)}
     </p>
 
     {/* School Location */}
     <p className="vads-u-margin-bottom--1 vads-u-margin-top--0">
-      <span className="sr-only">School location:</span>
+      <span className="sr-only">School location</span>
       {deriveLocationLabel(school)}
     </p>
 


### PR DESCRIPTION
## Description
This PR adds `:` to the end of the labels for screen readers.

## Testing done
N/A

## Screenshots
N/A

## Acceptance criteria
- [x] Add colons at the end of the search result labels for screen readers.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
