### PR TITLE
Add correlation between map pin and cards in search results

### DIFF
--- a/src/applications/facility-locator/components/ResultsList.jsx
+++ b/src/applications/facility-locator/components/ResultsList.jsx
@@ -7,6 +7,7 @@ import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 import LoadingIndicator from '@department-of-veterans-affairs/formation-react/LoadingIndicator';
 
 import { facilityTypes } from '../config';
+import { MARKER_LETTERS } from '../constants';
 
 import { distBetween } from '../utils/facilityDistance';
 import { setFocus } from '../utils/helpers';
@@ -151,8 +152,10 @@ class ResultsList extends Component {
     }
 
     const currentLocation = position;
+    const markers = MARKER_LETTERS.values();
     const sortedResults = results
       .map(result => {
+        const markerText = markers.next().value;
         const distance = currentLocation
           ? distBetween(
               currentLocation.latitude,
@@ -161,7 +164,7 @@ class ResultsList extends Component {
               result.attributes.long,
             )
           : null;
-        return { ...result, distance, resultItem: true };
+        return { ...result, distance, resultItem: true, markerText };
       })
       .sort((resultA, resultB) => resultA.distance - resultB.distance);
 

--- a/src/applications/facility-locator/components/markers/FacilityMarker.jsx
+++ b/src/applications/facility-locator/components/markers/FacilityMarker.jsx
@@ -7,7 +7,7 @@ class FacilityMarker extends Component {
     const { position, onClick, markerText } = this.props;
     return (
       <DivMarker position={position} onClick={onClick}>
-        <span className="i-pin-map"> {markerText}</span>
+        <span className="i-pin-card-map"> {markerText}</span>
       </DivMarker>
     );
   }

--- a/src/applications/facility-locator/components/markers/FacilityMarker.jsx
+++ b/src/applications/facility-locator/components/markers/FacilityMarker.jsx
@@ -1,0 +1,21 @@
+import DivMarker from './DivMarker';
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+
+class FacilityMarker extends Component {
+  render() {
+    const { position, onClick, markerText } = this.props;
+    return (
+      <DivMarker position={position} onClick={onClick}>
+        <span className="i-pin-map"> {markerText}</span>
+      </DivMarker>
+    );
+  }
+}
+
+FacilityMarker.propTypes = {
+  position: PropTypes.array,
+  markerText: PropTypes.string,
+};
+
+export default FacilityMarker;

--- a/src/applications/facility-locator/components/search-results/LocationInfoBlock.jsx
+++ b/src/applications/facility-locator/components/search-results/LocationInfoBlock.jsx
@@ -16,7 +16,8 @@ const LocationInfoBlock = ({ location, from, query }) => {
       {distance &&
         location.resultItem && (
           <p>
-            <span>
+            <span className="i-pin-card">{location.markerText}</span>
+            <span className="vads-u-margin-left--1">
               <strong>{distance.toFixed(1)} miles</strong>
             </span>
           </p>

--- a/src/applications/facility-locator/components/search-results/LocationInfoBlock.jsx
+++ b/src/applications/facility-locator/components/search-results/LocationInfoBlock.jsx
@@ -16,7 +16,7 @@ const LocationInfoBlock = ({ location, from, query }) => {
       {distance &&
         location.resultItem && (
           <p>
-            <span className="i-pin-card">{location.markerText}</span>
+            <span className="i-pin-card-map">{location.markerText}</span>
             <span className="vads-u-margin-left--1">
               <strong>{distance.toFixed(1)} miles</strong>
             </span>

--- a/src/applications/facility-locator/constants/index.js
+++ b/src/applications/facility-locator/constants/index.js
@@ -56,3 +56,10 @@ export const LOCATION_OPTIONS = [
  * Defines the ± change in bounding box size for the map when changing zoom
  */
 export const BOUNDING_RADIUS = 0.75;
+
+/**
+ *Defines the marker letter list
+ */
+export const MARKER_LETTERS = new Set([
+  ...'abcdefghijklmnopqrstuvwxyz'.toUpperCase(),
+]);

--- a/src/applications/facility-locator/containers/VAMap.jsx
+++ b/src/applications/facility-locator/containers/VAMap.jsx
@@ -19,13 +19,14 @@ import {
 import SearchControls from '../components/SearchControls';
 import ResultsList from '../components/ResultsList';
 import SearchResult from '../components/SearchResult';
-import CemeteryMarker from '../components/markers/CemeteryMarker';
-import HealthMarker from '../components/markers/HealthMarker';
-import BenefitsMarker from '../components/markers/BenefitsMarker';
-import VetCenterMarker from '../components/markers/VetCenterMarker';
-import ProviderMarker from '../components/markers/ProviderMarker';
+import FacilityMarker from '../components/markers/FacilityMarker';
 import { facilityTypes } from '../config';
-import { LocationType, FacilityType, BOUNDING_RADIUS } from '../constants';
+import {
+  LocationType,
+  FacilityType,
+  BOUNDING_RADIUS,
+  MARKER_LETTERS,
+} from '../constants';
 import { areGeocodeEqual, setFocus } from '../utils/helpers';
 import { facilityLocatorShowCommunityCares } from '../utils/selectors';
 import { isProduction } from 'platform/site-wide/feature-toggles/selectors';
@@ -422,6 +423,7 @@ class VAMap extends Component {
       }
     };
 
+    const markers = MARKER_LETTERS.values();
     return results.map(r => {
       const iconProps = {
         key: r.id,
@@ -440,6 +442,7 @@ class VAMap extends Component {
           }
           this.props.fetchVAFacility(r.id, r);
         },
+        markerText: markers.next().value,
       };
 
       const popupContent = (
@@ -479,19 +482,14 @@ class VAMap extends Component {
 
       switch (r.attributes.facilityType) {
         case FacilityType.VA_HEALTH_FACILITY:
-          return <HealthMarker {...iconProps}>{popupContent}</HealthMarker>;
         case FacilityType.VA_CEMETARY:
-          return <CemeteryMarker {...iconProps}>{popupContent}</CemeteryMarker>;
         case FacilityType.VA_BENEFITS_FACILITY:
-          return <BenefitsMarker {...iconProps}>{popupContent}</BenefitsMarker>;
         case FacilityType.VET_CENTER:
-          return (
-            <VetCenterMarker {...iconProps}>{popupContent}</VetCenterMarker>
-          );
+          return <FacilityMarker {...iconProps}>{popupContent}</FacilityMarker>;
         case undefined:
           if (r.type === LocationType.CC_PROVIDER) {
             return (
-              <ProviderMarker {...iconProps}>{popupContent}</ProviderMarker>
+              <FacilityMarker {...iconProps}>{popupContent}</FacilityMarker>
             );
           }
           return null;

--- a/src/applications/facility-locator/sass/facility-locator.scss
+++ b/src/applications/facility-locator/sass/facility-locator.scss
@@ -773,3 +773,19 @@ $facility-locator-color-gray: #ccc;
 .va-nav-breadcrumbs:focus {
   outline: 0;
 }
+
+.i-pin-card {
+  background: $color-gray-dark;
+  color: $color-white;
+  padding: 1px 7px;
+  border-radius: 50%;
+  font-size: 14px;
+}
+
+.i-pin-map {
+  background: $color-gray-dark;
+  color: $color-white;
+  padding: 4px 9px;
+  border-radius: 50%;
+  font-size: 14px;
+}

--- a/src/applications/facility-locator/sass/facility-locator.scss
+++ b/src/applications/facility-locator/sass/facility-locator.scss
@@ -774,18 +774,11 @@ $facility-locator-color-gray: #ccc;
   outline: 0;
 }
 
-.i-pin-card {
+.i-pin-card-map {
   background: $color-gray-dark;
   color: $color-white;
-  padding: 1px 7px;
+  padding: 2px 8px;
   border-radius: 50%;
-  font-size: 14px;
-}
-
-.i-pin-map {
-  background: $color-gray-dark;
-  color: $color-white;
-  padding: 4px 9px;
-  border-radius: 50%;
-  font-size: 14px;
+  font-size: 16px;
+  font-family: 'Source Sans Pro', sans-serif !important;
 }


### PR DESCRIPTION
## Description
issues:
department-of-veterans-affairs/va.gov-team#5620

## Testing done
Locally

## Screenshots
<img width="1276" alt="Screen Shot 2020-04-13 at 3 22 34 PM" src="https://user-images.githubusercontent.com/100468/79157662-9cf5a000-7d9a-11ea-8d11-f48233f51ecd.png">


## Acceptance criteria
- [x] Add correlation between map pin and cards in search results

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
