### PR TITLE
[COGNITION]: GIBCT - Caution flag headings SHOULD be nested properly #7983

### DIFF
--- a/src/applications/gi/components/profile/CautionFlagDetails.jsx
+++ b/src/applications/gi/components/profile/CautionFlagDetails.jsx
@@ -14,7 +14,11 @@ const CautionFlagDetails = ({ cautionFlags }) => {
           )
           .map(flag => (
             <AlertBox
-              headline={flag.title}
+              headline={
+                <h4 className="vads-u-font-size--h3 usa-alert-heading">
+                  {flag.title}
+                </h4>
+              }
               key={flag.id}
               status="warning"
               content={


### PR DESCRIPTION
## Description
https://github.com/department-of-veterans-affairs/va.gov-team/issues/7983

## Testing done


## Screenshots


## Acceptance criteria
- [ ] All full alerts have an <h4> heading
- [ ] Screen reader headings menu shows the headings nesting properly
- [ ] Current visual design is maintained

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
