### PR TITLE
[COGNITION]: GIBCT - caution flags SHOULD NOT announce themselves dynamically to screen readers #7982

### DIFF
--- a/src/applications/gi/components/AlertBox.jsx
+++ b/src/applications/gi/components/AlertBox.jsx
@@ -33,7 +33,7 @@ class AlertBox extends React.Component {
   }
 
   render() {
-    if (!this.props.isVisible) return <div aria-live="polite" />;
+    if (!this.props.isVisible) return null;
 
     const alertClass = classNames(
       'usa-alert',
@@ -66,7 +66,6 @@ class AlertBox extends React.Component {
 
     return (
       <div
-        aria-live="polite"
         className={alertClass}
         ref={ref => {
           this._ref = ref;


### PR DESCRIPTION
## Description
https://github.com/department-of-veterans-affairs/va.gov-team/issues/7982

## Testing done

- Start VO
- Navigate to the search results page in question ( http://localhost:3001/gi-bill-comparison-tool/search?category=school&name=Dodge+City or https://staging.va.gov/gi-bill-comparison-tool/search?category=school&name=Dodge+City)
- Verify the alert box is not read aloud
- Go back to the previous page using breadcrumbs
- Initiate a new search for “Dodge City”

## Screenshots


## Acceptance criteria
- [ ]  VoiceOver does not announce the alerts until I cursor to them


## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
