### PR TITLE
adjust CSS of military history section

### DIFF
--- a/src/applications/personalization/profile-2/components/MilitaryInformation.jsx
+++ b/src/applications/personalization/profile-2/components/MilitaryInformation.jsx
@@ -85,7 +85,7 @@ class MilitaryInformationContent extends React.Component {
           title="Period of service"
           fieldName="serviceHistory"
         />
-        <div className="vads-u-margin-y--4">
+        <div className="vads-u-margin-top--4 vads-u-margin-bottom--6">
           <AdditionalInfo
             triggerText="What if my military service information doesn’t look right?"
             onClick={() => {
@@ -131,8 +131,10 @@ class MilitaryInformationContent extends React.Component {
 class MilitaryInformation extends Component {
   render() {
     return (
-      <div>
-        <h2 tabIndex="-1">Military information</h2>
+      <>
+        <h2 tabIndex="-1" className="vads-u-margin-y--4">
+          Military information
+        </h2>
         <DowntimeNotification
           appTitle="Military Information"
           render={handleDowntimeForSection('military service')}
@@ -142,7 +144,7 @@ class MilitaryInformation extends Component {
             militaryInformation={this.props.militaryInformation}
           />
         </DowntimeNotification>
-      </div>
+      </>
     );
   }
 }

--- a/src/applications/personalization/profile-2/components/ProfileHeader.jsx
+++ b/src/applications/personalization/profile-2/components/ProfileHeader.jsx
@@ -82,8 +82,6 @@ const ProfileHeader = ({
     <div className={[...wrapperClasses, ...wrapperClassesMedium].join(' ')}>
       <div
         className={[
-          // ...wrapperClasses,
-          // ...wrapperClassesMedium,
           ...innerWrapperClasses,
           ...innerWrapperClassesMedium,
           'usa-grid',

--- a/src/applications/personalization/profile-2/components/ProfileHeader.jsx
+++ b/src/applications/personalization/profile-2/components/ProfileHeader.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import orderBy from 'lodash/orderBy';
 
 import { SERVICE_BADGE_IMAGE_PATHS } from '../constants';
-import { getServiceBranchDisplayName } from '../helpers';
+import { getServiceBranchDisplayName, prefixUtilityClasses } from '../helpers';
 
 const ProfileHeader = ({
   userFullName: { first, middle, last, suffix },
@@ -15,25 +15,106 @@ const ProfileHeader = ({
     .filter(name => !!name)
     .join(' ');
 
+  const wrapperClasses = prefixUtilityClasses([
+    'align-items--center',
+    'background-color--gray-dark',
+    'color--white',
+    'display--flex',
+    'justify-content--center',
+    'margin-bottom--2',
+    'padding-y--2',
+  ]);
+  const wrapperClassesMedium = prefixUtilityClasses(['padding-y--3'], 'medium');
+  const innerWrapperClasses = prefixUtilityClasses([
+    'align-items--center',
+    'display--flex',
+    'flex-direction--column',
+    'width--full',
+  ]);
+  const innerWrapperClassesMedium = prefixUtilityClasses(
+    ['flex-direction--row'],
+    'medium',
+  );
+  const serviceBadgeClasses = prefixUtilityClasses([
+    'text-align--center',
+    'margin-bottom--2',
+  ]);
+  const serviceBadgeClassesMedium = prefixUtilityClasses(
+    ['text-align--right', 'margin-bottom--0', 'padding-right--2'],
+    'medium',
+  );
+  const titleClasses = prefixUtilityClasses([
+    'display--none',
+    'font-family--sans',
+    'font-size--base',
+    'font-weight--normal',
+    'margin-bottom--2',
+    'margin-top--0',
+  ]);
+  const titleClassesMedium = prefixUtilityClasses(['display--flex'], 'medium');
+  const fullNameClasses = prefixUtilityClasses([
+    'font-size--h3',
+    'margin-top--0',
+    'margin-bottom--1p5',
+    'text-align--center',
+  ]);
+  const fullNameClassesMedium = prefixUtilityClasses(
+    ['text-align--left'],
+    'medium',
+  );
+  const latestBranchClasses = prefixUtilityClasses([
+    'font-family--sans',
+    'font-size--base',
+    'font-weight--normal',
+    'margin--0',
+    'text-align--center',
+  ]);
+  const latestBranchClassesMedium = prefixUtilityClasses(
+    ['text-align--left'],
+    'medium',
+  );
+
   return (
-    <div className="vads-u-background-color--gray-dark vads-u-color--white vads-u-margin-bottom--2 vads-u-padding-y--3 vads-u-display--flex vads-u-align-items--center vads-u-justify-content--center">
-      <div className="medium-screen:vads-u-flex-direction--row usa-grid usa-grid-full vads-u-display--flex vads-u-flex-direction--column vads-u-align-items--center vads-u-width--full">
-        <div className="medium-screen:vads-u-padding-left--8 usa-width-one-fourth">
+    <div className={[...wrapperClasses, ...wrapperClassesMedium].join(' ')}>
+      <div
+        className={[
+          ...innerWrapperClasses,
+          ...innerWrapperClassesMedium,
+          'usa-grid',
+          'usa-grid-full',
+        ].join(' ')}
+      >
+        <div
+          className={[
+            ...serviceBadgeClasses,
+            ...serviceBadgeClassesMedium,
+            'usa-width-one-fourth',
+          ].join(' ')}
+        >
           {showBadgeImage && (
             <img
-              className="profileServiceBadge"
+              className="profile-service-badge"
               src={SERVICE_BADGE_IMAGE_PATHS.get(latestBranchOfService)}
               alt="service badge"
             />
           )}
         </div>
-        <div className="headerNameWrapper vads-u-flex-direction--column">
-          <h1 className="medium-screen:vads-u-display--flex vads-u-display--none vads-u-font-family--sans vads-u-font-size--base vads-u-font-weight--normal">
+        <div className="name-and-title-wrapper">
+          <h1 className={[...titleClasses, ...titleClassesMedium].join(' ')}>
             Your Profile
           </h1>
-          <h2 className="vads-u-font-size--h3">{fullName}</h2>
+          <h2
+            className={[...fullNameClasses, ...fullNameClassesMedium].join(' ')}
+          >
+            {fullName}
+          </h2>
           {latestBranchOfService && (
-            <h3 className="vads-u-font-family--sans vads-u-font-size--base vads-u-font-weight--normal">
+            <h3
+              className={[
+                ...latestBranchClasses,
+                ...latestBranchClassesMedium,
+              ].join(' ')}
+            >
               {getServiceBranchDisplayName(latestBranchOfService)}
             </h3>
           )}

--- a/src/applications/personalization/profile-2/components/ProfileHeader.jsx
+++ b/src/applications/personalization/profile-2/components/ProfileHeader.jsx
@@ -16,17 +16,14 @@ const ProfileHeader = ({
     .join(' ');
 
   const wrapperClasses = prefixUtilityClasses([
-    'align-items--center',
     'background-color--gray-dark',
-    'color--white',
-    'display--flex',
-    'justify-content--center',
     'margin-bottom--2',
     'padding-y--2',
   ]);
   const wrapperClassesMedium = prefixUtilityClasses(['padding-y--3'], 'medium');
   const innerWrapperClasses = prefixUtilityClasses([
     'align-items--center',
+    'color--white',
     'display--flex',
     'flex-direction--column',
     'width--full',
@@ -78,6 +75,8 @@ const ProfileHeader = ({
     <div className={[...wrapperClasses, ...wrapperClassesMedium].join(' ')}>
       <div
         className={[
+          // ...wrapperClasses,
+          // ...wrapperClassesMedium,
           ...innerWrapperClasses,
           ...innerWrapperClassesMedium,
           'usa-grid',

--- a/src/applications/personalization/profile-2/components/ProfileHeader.jsx
+++ b/src/applications/personalization/profile-2/components/ProfileHeader.jsx
@@ -15,12 +15,15 @@ const ProfileHeader = ({
     .filter(name => !!name)
     .join(' ');
 
+  // the outer full-width background of the header banner
   const wrapperClasses = prefixUtilityClasses([
     'background-color--gray-dark',
     'margin-bottom--2',
     'padding-y--2',
   ]);
   const wrapperClassesMedium = prefixUtilityClasses(['padding-y--3'], 'medium');
+
+  // the inner content of the header banner
   const innerWrapperClasses = prefixUtilityClasses([
     'align-items--center',
     'color--white',
@@ -32,6 +35,7 @@ const ProfileHeader = ({
     ['flex-direction--row'],
     'medium',
   );
+
   const serviceBadgeClasses = prefixUtilityClasses([
     'text-align--center',
     'margin-bottom--2',
@@ -40,6 +44,7 @@ const ProfileHeader = ({
     ['text-align--right', 'margin-bottom--0', 'padding-right--2'],
     'medium',
   );
+
   const titleClasses = prefixUtilityClasses([
     'display--none',
     'font-family--sans',
@@ -49,6 +54,7 @@ const ProfileHeader = ({
     'margin-top--0',
   ]);
   const titleClassesMedium = prefixUtilityClasses(['display--flex'], 'medium');
+
   const fullNameClasses = prefixUtilityClasses([
     'font-size--h3',
     'margin-top--0',
@@ -59,6 +65,7 @@ const ProfileHeader = ({
     ['text-align--left'],
     'medium',
   );
+
   const latestBranchClasses = prefixUtilityClasses([
     'font-family--sans',
     'font-size--base',

--- a/src/applications/personalization/profile-2/components/ProfileInfoTable.jsx
+++ b/src/applications/personalization/profile-2/components/ProfileInfoTable.jsx
@@ -1,22 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-/**
- * Helper that prefixes class names with an optional responsive prefix and the
- * `vads-u-` utility class prefix.
- *
- * @param {string[]} classes - Array of classes to prefix with `vads-u-`
- * @param {string} screenSize - Optional screen size
- * @returns {string[]} The input `classes` array with the correct prefixes
- * applied
- *
- * Example: `prefixUtilityClasses(['my-class'], 'medium')` returns
- * ['medium-screen:vads-u-my-class']
- */
-const prefixUtilityClasses = (classes, screenSize = '') => {
-  const colonizedScreenSize = screenSize ? `${screenSize}-screen:` : '';
-  return classes.map(className => `${colonizedScreenSize}vads-u-${className}`);
-};
+import { prefixUtilityClasses } from '../helpers';
 
 const ProfileInfoTable = ({
   data,
@@ -48,7 +33,7 @@ const ProfileInfoTable = ({
     'padding-y--1p5',
   ]);
   const tableRowClassesMedium = prefixUtilityClasses(
-    ['flex-direction--row', 'padding--3'],
+    ['flex-direction--row', 'padding-x--3', 'padding-y--4'],
     'medium',
   );
   const tableRowTitleClasses = prefixUtilityClasses([
@@ -66,7 +51,7 @@ const ProfileInfoTable = ({
   const tableRowDataClasses = ['vads-u-margin--0'];
 
   return (
-    <div className={[...tableClasses].join(' ')} data-field-name={fieldName}>
+    <div className={tableClasses.join(' ')} data-field-name={fieldName}>
       <h3 className={[...titleClasses, ...titleClassesMedium].join(' ')}>
         {title}
       </h3>

--- a/src/applications/personalization/profile-2/components/ProfileWrapper.jsx
+++ b/src/applications/personalization/profile-2/components/ProfileWrapper.jsx
@@ -64,7 +64,7 @@ class ProfileWrapper extends Component {
         <div className="usa-width-one-fourth">
           <ProfileSideNav />
         </div>
-        <div className="usa-width-three-fourths columns">
+        <div className="usa-width-two-thirds vads-u-padding-x--1 medium-screen:vads-u-padding--0">
           {this.props.children}
         </div>
       </div>

--- a/src/applications/personalization/profile-2/helpers.js
+++ b/src/applications/personalization/profile-2/helpers.js
@@ -66,3 +66,20 @@ export const transformServiceHistoryEntryIntoTableRow = entry => ({
     entry.endDate,
   ).format('ll')}`,
 });
+
+/**
+ * Helper that prefixes class names with an optional responsive prefix and the
+ * `vads-u-` utility class prefix.
+ *
+ * @param {string[]} classes - Array of classes to prefix with `vads-u-`
+ * @param {string} screenSize - Optional screen size
+ * @returns {string[]} The input `classes` array with the correct prefixes
+ * applied
+ *
+ * Example: `prefixUtilityClasses(['my-class'], 'medium')` returns
+ * ['medium-screen:vads-u-my-class']
+ */
+export const prefixUtilityClasses = (classes, screenSize = '') => {
+  const colonizedScreenSize = screenSize ? `${screenSize}-screen:` : '';
+  return classes.map(className => `${colonizedScreenSize}vads-u-${className}`);
+};

--- a/src/applications/personalization/profile-2/sass/profile-2.scss
+++ b/src/applications/personalization/profile-2/sass/profile-2.scss
@@ -18,18 +18,6 @@ nav.profile-side-nav {
   }
 }
 
-.headerNameWrapper {
-  width: 100%;
-  text-align: center;
-  h3 {
-    margin-top: 0;
-  }
-  @media (min-width: $medium-screen) {
-    width: 60%;
-    text-align: left;
-  }
-}
-
-.profileServiceBadge {
+.profile-service-badge {
   max-height: 108px;
 }

--- a/src/applications/personalization/profile-2/tests/components/ProfileInfoTable.unit.spec.js
+++ b/src/applications/personalization/profile-2/tests/components/ProfileInfoTable.unit.spec.js
@@ -3,28 +3,7 @@ import sinon from 'sinon';
 import { shallow } from 'enzyme';
 import { expect } from 'chai';
 
-import ProfileInfoTable, {
-  prefixUtilityClasses,
-} from '../../components/ProfileInfoTable';
-
-describe('prefixUtilityClasses', () => {
-  const classes = ['class-1', 'class-2'];
-  it('should prefix an array of classes with `vads-u-`', () => {
-    const expectedResult = ['vads-u-class-1', 'vads-u-class-2'];
-    const result = prefixUtilityClasses(classes);
-    expect(result).to.deep.equal(expectedResult);
-  });
-  describe('when passed a screenSize', () => {
-    it('should prefix an array of classes with the responsive prefix and `vads-u-`', () => {
-      const expectedResult = [
-        'medium-screen:vads-u-class-1',
-        'medium-screen:vads-u-class-2',
-      ];
-      const result = prefixUtilityClasses(classes, 'medium');
-      expect(result).to.deep.equal(expectedResult);
-    });
-  });
-});
+import ProfileInfoTable from '../../components/ProfileInfoTable';
 
 describe('ProfileInfoTable', () => {
   let dataTransformerSpy;

--- a/src/applications/personalization/profile-2/tests/helpers.unit.spec.js
+++ b/src/applications/personalization/profile-2/tests/helpers.unit.spec.js
@@ -2,6 +2,7 @@ import { expect } from 'chai';
 
 import {
   getServiceBranchDisplayName,
+  prefixUtilityClasses,
   transformServiceHistoryEntryIntoTableRow,
 } from '../helpers';
 
@@ -21,6 +22,25 @@ describe('getServiceBranchDisplayName', () => {
   describe('when not passed one of the five USA military branches', () => {
     it('should simply return what it was passed', () => {
       expect(getServiceBranchDisplayName('Other')).to.equal('Other');
+    });
+  });
+});
+
+describe('prefixUtilityClasses', () => {
+  const classes = ['class-1', 'class-2'];
+  it('should prefix an array of classes with `vads-u-`', () => {
+    const expectedResult = ['vads-u-class-1', 'vads-u-class-2'];
+    const result = prefixUtilityClasses(classes);
+    expect(result).to.deep.equal(expectedResult);
+  });
+  describe('when passed a screenSize', () => {
+    it('should prefix an array of classes with the responsive prefix and `vads-u-`', () => {
+      const expectedResult = [
+        'medium-screen:vads-u-class-1',
+        'medium-screen:vads-u-class-2',
+      ];
+      const result = prefixUtilityClasses(classes, 'medium');
+      expect(result).to.deep.equal(expectedResult);
     });
   });
 });


### PR DESCRIPTION
## Description
- Addresses some feedback @tressaellen had here https://github.com/department-of-veterans-affairs/va.gov-team/issues/5354#issuecomment-613216679
- Addresses some other issues I found
- Cleans up markup

## Testing done
Local

## Screenshots
<details>
  <summary>Mobile</summary>
  
<img width="507" alt="Screen Shot 2020-04-14 at 1 36 00 PM" src="https://user-images.githubusercontent.com/20728956/79272095-c58ea000-7e55-11ea-991b-dd24807ef6be.png">

</details>

<details>
  <summary>Larger screens</summary>
  
<img width="1097" alt="Screen Shot 2020-04-14 at 12 02 54 PM" src="https://user-images.githubusercontent.com/20728956/79272131-d808d980-7e55-11ea-8435-59932136c7c3.png">

</details>

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs