### PR TITLE
ProfileWrapper loads MHV data on mount

### DIFF
--- a/src/applications/personalization/profile-2/components/MilitaryInformation.jsx
+++ b/src/applications/personalization/profile-2/components/MilitaryInformation.jsx
@@ -33,9 +33,18 @@ const MilitaryInformationContent = ({ militaryInformation }) => {
               <p>
                 We’re sorry. We can’t find your Department of Defense (DoD) ID.
                 We need this to access your military service records. Please
-                call us at 800-827-1000, or visit your nearest VA regional
-                office and request to be added to the Defense Enrollment
-                Eligibility Reporting System (DEERS).
+                call us at{' '}
+                <a
+                  href="tel:1-800-827-1000"
+                  aria-label="800. 8 2 7. 1000."
+                  title="Dial the telephone number 800-827-1000"
+                  className="no-wrap"
+                >
+                  800-827-1000
+                </a>
+                , or visit your nearest VA regional office and request to be
+                added to the Defense Enrollment Eligibility Reporting System
+                (DEERS).
               </p>
               <a href={facilityLocator.rootUrl}>
                 Find your nearest VA regional office
@@ -111,14 +120,18 @@ const MilitaryInformationContent = ({ militaryInformation }) => {
             To reach the DMDC, call{' '}
             <a
               href="tel:1-800-538-9552"
-              aria-label="8 0 0. 5 3 8. 9 5 5 2."
+              aria-label="800. 5 3 8. 9 5 5 2."
               title="Dial the telephone number 800-538-9552"
               className="no-wrap"
             >
               1-800-538-9552
             </a>
             , Monday through Friday (except federal holidays), 8:00 a.m. to 8:00
-            p.m. ET. If you have hearing loss, call TTY: 1-866-363-2883.
+            p.m. ET. If you have hearing loss, call TTY:{' '}
+            <a href="tel:1-866-363-2883" className="no-wrap">
+              1-866-363-2883
+            </a>
+            .
           </p>
         </AdditionalInfo>
       </div>

--- a/src/applications/personalization/profile-2/components/MilitaryInformation.jsx
+++ b/src/applications/personalization/profile-2/components/MilitaryInformation.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React from 'react';
 import { some } from 'lodash';
 import { connect } from 'react-redux';
 
@@ -16,138 +16,130 @@ import facilityLocator from 'applications/facility-locator/manifest.json';
 import ProfileInfoTable from './ProfileInfoTable';
 import { transformServiceHistoryEntryIntoTableRow } from '../helpers';
 
-class MilitaryInformationContent extends React.Component {
-  render() {
-    const {
-      serviceHistory: { serviceHistory, error },
-    } = this.props.militaryInformation;
+const MilitaryInformationContent = ({ militaryInformation }) => {
+  const {
+    serviceHistory: { serviceHistory, error },
+  } = militaryInformation;
 
-    if (error) {
-      if (some(error.errors, ['code', '403'])) {
-        return (
-          <AlertBox
-            isVisible
-            status="warning"
-            headline="We can’t access your military information"
-            content={
-              <div>
-                <p>
-                  We’re sorry. We can’t find your Department of Defense (DoD)
-                  ID. We need this to access your military service records.
-                  Please call us at 800-827-1000, or visit your nearest VA
-                  regional office and request to be added to the Defense
-                  Enrollment Eligibility Reporting System (DEERS).
-                </p>
-                <a href={facilityLocator.rootUrl}>
-                  Find your nearest VA regional office
-                </a>
-                .
-                <p>
-                  You can also request to be added to DEERS through our online
-                  customer help center.
-                </p>
-                <a href="https://iris.custhelp.va.gov/app/answers/detail/a_id/3036/~/not-registered-in-deers%2C-or-received-and-error-message-while-trying-to">
-                  Get instructions from our help center
-                </a>
-                .
-              </div>
-            }
-          />
-        );
-      } else if (some(error.errors, e => ['500', '503'].includes(e.code))) {
-        return <LoadFail information="military" />;
-      }
-    }
-
-    if (serviceHistory.length === 0) {
+  if (error) {
+    if (some(error.errors, ['code', '403'])) {
       return (
         <AlertBox
           isVisible
           status="warning"
           headline="We can’t access your military information"
           content={
-            <p>
-              We’re sorry. We can’t access your military service records. If you
-              think you should be able to view your service information here,
-              please file a request to change or correct your DD214 or other
-              military records.
-            </p>
+            <div>
+              <p>
+                We’re sorry. We can’t find your Department of Defense (DoD) ID.
+                We need this to access your military service records. Please
+                call us at 800-827-1000, or visit your nearest VA regional
+                office and request to be added to the Defense Enrollment
+                Eligibility Reporting System (DEERS).
+              </p>
+              <a href={facilityLocator.rootUrl}>
+                Find your nearest VA regional office
+              </a>
+              .
+              <p>
+                You can also request to be added to DEERS through our online
+                customer help center.
+              </p>
+              <a href="https://iris.custhelp.va.gov/app/answers/detail/a_id/3036/~/not-registered-in-deers%2C-or-received-and-error-message-while-trying-to">
+                Get instructions from our help center
+              </a>
+              .
+            </div>
           }
         />
       );
+    } else if (some(error.errors, e => ['500', '503'].includes(e.code))) {
+      return <LoadFail information="military" />;
     }
+  }
 
+  if (serviceHistory.length === 0) {
     return (
-      <>
-        <ProfileInfoTable
-          data={serviceHistory}
-          dataTransformer={transformServiceHistoryEntryIntoTableRow}
-          title="Period of service"
-          fieldName="serviceHistory"
-        />
-        <div className="vads-u-margin-top--4 vads-u-margin-bottom--6">
-          <AdditionalInfo
-            triggerText="What if my military service information doesn’t look right?"
-            onClick={() => {
-              recordEvent({
-                event: 'profile-navigation',
-                'profile-action': 'view-link',
-                'profile-section': 'update-military-information',
-              });
-            }}
-          >
-            <p>
-              Some Veterans have reported seeing military service information in
-              their VA.gov profiles that doesn’t seem right. When this happens,
-              it’s because there’s an error in the information we’re pulling
-              into VA.gov from the Defense Enrollment Eligibility Reporting
-              System (DEERS).
-            </p>
-            <p>
-              If the military service information in your profile doesn’t look
-              right, please call the Defense Manpower Data Center (DMDC).
-              They’ll work with you to update your information in DEERS.
-            </p>
-            <p>
-              To reach the DMDC, call{' '}
-              <a
-                href="tel:1-800-538-9552"
-                aria-label="8 0 0. 5 3 8. 9 5 5 2."
-                title="Dial the telephone number 800-538-9552"
-                className="no-wrap"
-              >
-                1-800-538-9552
-              </a>
-              , Monday through Friday (except federal holidays), 8:00 a.m. to
-              8:00 p.m. ET. If you have hearing loss, call TTY: 1-866-363-2883.
-            </p>
-          </AdditionalInfo>
-        </div>
-      </>
+      <AlertBox
+        isVisible
+        status="warning"
+        headline="We can’t access your military information"
+        content={
+          <p>
+            We’re sorry. We can’t access your military service records. If you
+            think you should be able to view your service information here,
+            please file a request to change or correct your DD214 or other
+            military records.
+          </p>
+        }
+      />
     );
   }
-}
 
-class MilitaryInformation extends Component {
-  render() {
-    return (
-      <>
-        <h2 tabIndex="-1" className="vads-u-margin-y--4">
-          Military information
-        </h2>
-        <DowntimeNotification
-          appTitle="Military Information"
-          render={handleDowntimeForSection('military service')}
-          dependencies={[externalServices.emis]}
+  return (
+    <>
+      <ProfileInfoTable
+        data={serviceHistory}
+        dataTransformer={transformServiceHistoryEntryIntoTableRow}
+        title="Period of service"
+        fieldName="serviceHistory"
+      />
+      <div className="vads-u-margin-top--4 vads-u-margin-bottom--6">
+        <AdditionalInfo
+          triggerText="What if my military service information doesn’t look right?"
+          onClick={() => {
+            recordEvent({
+              event: 'profile-navigation',
+              'profile-action': 'view-link',
+              'profile-section': 'update-military-information',
+            });
+          }}
         >
-          <MilitaryInformationContent
-            militaryInformation={this.props.militaryInformation}
-          />
-        </DowntimeNotification>
-      </>
-    );
-  }
-}
+          <p>
+            Some Veterans have reported seeing military service information in
+            their VA.gov profiles that doesn’t seem right. When this happens,
+            it’s because there’s an error in the information we’re pulling into
+            VA.gov from the Defense Enrollment Eligibility Reporting System
+            (DEERS).
+          </p>
+          <p>
+            If the military service information in your profile doesn’t look
+            right, please call the Defense Manpower Data Center (DMDC). They’ll
+            work with you to update your information in DEERS.
+          </p>
+          <p>
+            To reach the DMDC, call{' '}
+            <a
+              href="tel:1-800-538-9552"
+              aria-label="8 0 0. 5 3 8. 9 5 5 2."
+              title="Dial the telephone number 800-538-9552"
+              className="no-wrap"
+            >
+              1-800-538-9552
+            </a>
+            , Monday through Friday (except federal holidays), 8:00 a.m. to 8:00
+            p.m. ET. If you have hearing loss, call TTY: 1-866-363-2883.
+          </p>
+        </AdditionalInfo>
+      </div>
+    </>
+  );
+};
+
+const MilitaryInformation = ({ militaryInformation }) => (
+  <>
+    <h2 tabIndex="-1" className="vads-u-margin-y--4">
+      Military information
+    </h2>
+    <DowntimeNotification
+      appTitle="Military Information"
+      render={handleDowntimeForSection('military service')}
+      dependencies={[externalServices.emis]}
+    >
+      <MilitaryInformationContent militaryInformation={militaryInformation} />
+    </DowntimeNotification>
+  </>
+);
 
 const mapStateToProps = state => ({
   militaryInformation: state.vaProfile?.militaryInformation,

--- a/src/applications/personalization/profile-2/components/ProfileWrapper.jsx
+++ b/src/applications/personalization/profile-2/components/ProfileWrapper.jsx
@@ -7,8 +7,10 @@ import backendServices from 'platform/user/profile/constants/backendServices';
 import {
   createIsServiceAvailableSelector,
   isMultifactorEnabled,
+  selectProfile,
 } from 'platform/user/selectors';
 
+import { fetchMHVAccount as fetchMHVAccountAction } from 'platform/user/profile/actions';
 import {
   fetchMilitaryInformation as fetchMilitaryInformationAction,
   fetchHero as fetchHeroAction,
@@ -23,11 +25,13 @@ class ProfileWrapper extends Component {
   componentDidMount() {
     const {
       fetchFullName,
+      fetchMHVAccount,
       fetchMilitaryInformation,
       fetchPersonalInformation,
       fetchPaymentInformation,
       shouldFetchDirectDepositInformation,
     } = this.props;
+    fetchMHVAccount();
     fetchMilitaryInformation();
     fetchFullName();
     fetchPersonalInformation();
@@ -102,6 +106,12 @@ const mapStateToProps = state => {
   // or fails:
   const hasLoadedMilitaryInformation = state.vaProfile?.militaryInformation;
 
+  // when the call to load MHV fails, `errors` will be set to a non-null value
+  // when the call succeeds, the `accountState` will be set to a non-null value
+  const hasLoadedMHVInformation =
+    selectProfile(state)?.mhvAccount?.errors ||
+    selectProfile(state)?.mhvAccount?.accountState;
+
   // this piece of state will be set if the call to load personal info succeeds
   // or fails:
   const hasLoadedPersonalInformation = state.vaProfile?.personalInformation;
@@ -115,8 +125,9 @@ const mapStateToProps = state => {
   const hasLoadedPaymentInformation = state.vaProfile?.paymentInformation;
 
   const hasLoadedAllData =
-    hasLoadedMilitaryInformation &&
     hasLoadedFullName &&
+    hasLoadedMHVInformation &&
+    hasLoadedMilitaryInformation &&
     hasLoadedPersonalInformation &&
     (shouldFetchDirectDepositInformation ? hasLoadedPaymentInformation : true);
 
@@ -129,6 +140,7 @@ const mapStateToProps = state => {
 
 const mapDispatchToProps = {
   fetchFullName: fetchHeroAction,
+  fetchMHVAccount: fetchMHVAccountAction,
   fetchMilitaryInformation: fetchMilitaryInformationAction,
   fetchPersonalInformation: fetchPersonalInformationAction,
   fetchPaymentInformation: fetchPaymentInformationAction,

--- a/src/applications/personalization/profile-2/tests/components/ProfileWrapper.unit.spec.js
+++ b/src/applications/personalization/profile-2/tests/components/ProfileWrapper.unit.spec.js
@@ -15,17 +15,20 @@ describe('ProfileWrapper', () => {
   let defaultProps;
   let fetchFullNameSpy;
   let fetchMilitaryInfoSpy;
+  let fetchMHVAccountSpy;
   let fetchPaymentInfoSpy;
   let fetchPersonalInfoSpy;
 
   beforeEach(() => {
     fetchFullNameSpy = sinon.spy();
     fetchMilitaryInfoSpy = sinon.spy();
+    fetchMHVAccountSpy = sinon.spy();
     fetchPaymentInfoSpy = sinon.spy();
     fetchPersonalInfoSpy = sinon.spy();
 
     defaultProps = {
       fetchFullName: fetchFullNameSpy,
+      fetchMHVAccount: fetchMHVAccountSpy,
       fetchMilitaryInformation: fetchMilitaryInfoSpy,
       fetchPaymentInformation: fetchPaymentInfoSpy,
       fetchPersonalInformation: fetchPersonalInfoSpy,
@@ -72,6 +75,12 @@ describe('ProfileWrapper', () => {
       wrapper.unmount();
     });
 
+    it('should fetch the My HealtheVet data', () => {
+      const wrapper = shallow(<ProfileWrapper {...defaultProps} />);
+      expect(fetchMHVAccountSpy.called).to.be.true;
+      wrapper.unmount();
+    });
+
     describe('when `shouldFetchDirectDepositInformation` is `true`', () => {
       it('should fetch the payment information data', () => {
         const wrapper = shallow(<ProfileWrapper {...defaultProps} />);
@@ -108,6 +117,11 @@ describe('mapStateToProps', () => {
   const makeDefaultProfileState = () => ({
     multifactor: true,
     services: ['evss-claims'],
+    mhvAccount: {
+      accountState: 'needs_terms_acceptance',
+      errors: null,
+      loading: false,
+    },
   });
   const makeDefaultVaProfileState = () => ({
     hero: {
@@ -209,9 +223,13 @@ describe('mapStateToProps', () => {
         expect(props.showLoader).to.be.false;
       });
 
-      it('is `false` when all required data calls have either resolved successfully or errored', () => {
+      it('is `false` when all required data calls have errored', () => {
         const state = makeDefaultState();
-        state.vaProfile.paymentInformation.error = {};
+        state.vaProfile.paymentInformation = { error: {} };
+        state.vaProfile.userFullName = { error: {} };
+        state.vaProfile.personalInformation = { error: {} };
+        state.vaProfile.militaryInformation = { error: {} };
+        state.user.profile.mhvAccount = { errors: [] };
         const props = mapStateToProps(state);
         expect(props.showLoader).to.be.false;
       });
@@ -240,6 +258,17 @@ describe('mapStateToProps', () => {
       it('is `true` when the call to fetch the full name has not resolved but all others have', () => {
         const state = makeDefaultState();
         delete state.vaProfile.hero;
+        const props = mapStateToProps(state);
+        expect(props.showLoader).to.be.true;
+      });
+
+      it('is `true` when the call to fetch MHV info has not resolved but all others have', () => {
+        const state = makeDefaultState();
+        state.user.profile.mhvAccount = {
+          accountState: null,
+          errors: null,
+          loading: false,
+        };
         const props = mapStateToProps(state);
         expect(props.showLoader).to.be.true;
       });
@@ -283,6 +312,16 @@ describe('mapStateToProps', () => {
 
       it('is `true` when the call to fetch the full name has not resolved', () => {
         delete state.vaProfile.hero;
+        const props = mapStateToProps(state);
+        expect(props.showLoader).to.be.true;
+      });
+
+      it('is `true` when the call to fetch MHV info has not resolved', () => {
+        state.user.profile.mhvAccount = {
+          accountState: null,
+          errors: null,
+          loading: false,
+        };
         const props = mapStateToProps(state);
         expect(props.showLoader).to.be.true;
       });


### PR DESCRIPTION
## Description
This PR does two things:
- adds a call to load MHV data when the ProfileWrapper mounts
- refactors the existing MilitaryInfo components to be functional components.

## Testing done
Local + new unit tests

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs