### PR TITLE
[COGNITION]: GIBCT - Single search result SHOULD read "1 result" instead of "1 results" #7991

### DIFF
--- a/src/applications/gi/containers/SearchPage.jsx
+++ b/src/applications/gi/containers/SearchPage.jsx
@@ -26,6 +26,7 @@ import { getScrollOptions, focusElement } from 'platform/utilities/ui';
 import SearchResult from '../components/search/SearchResult';
 import InstitutionSearchForm from '../components/search/InstitutionSearchForm';
 import ServiceError from '../components/ServiceError';
+import { renderSearchResultsHeader } from '../utils/render';
 
 const { Element: ScrollElement, scroller } = Scroll;
 
@@ -240,21 +241,10 @@ export class SearchPage extends React.Component {
     return searchResults;
   };
 
-  renderSearchResultsHeader = search => {
-    const header = search.count === 1 ? 'Search Result' : 'Search Results';
-
-    return (
-      <h1 tabIndex={-1}>
-        {!search.inProgress &&
-          `${(search.count || 0).toLocaleString()} ${header}`}
-      </h1>
-    );
-  };
-
   renderInstitutionSearchForm = (searchResults, filtersClass) => (
     <div>
       <div className="vads-l-col--10 search-results-count">
-        {this.renderSearchResultsHeader(this.props.search)}
+        {renderSearchResultsHeader(this.props.search)}
       </div>
       <InstitutionSearchForm
         filtersClass={filtersClass}

--- a/src/applications/gi/containers/SearchPage.jsx
+++ b/src/applications/gi/containers/SearchPage.jsx
@@ -240,12 +240,16 @@ export class SearchPage extends React.Component {
     return searchResults;
   };
 
-  renderSearchResultsHeader = search => (
-    <h1 tabIndex={-1}>
-      {!search.inProgress &&
-        `${(search.count || 0).toLocaleString()} Search Results`}
-    </h1>
-  );
+  renderSearchResultsHeader = search => {
+    const header = search.count === 1 ? 'Search Result' : 'Search Results';
+
+    return (
+      <h1 tabIndex={-1}>
+        {!search.inProgress &&
+          `${(search.count || 0).toLocaleString()} ${header}`}
+      </h1>
+    );
+  };
 
   renderInstitutionSearchForm = (searchResults, filtersClass) => (
     <div>

--- a/src/applications/gi/containers/VetTecSearchPage.jsx
+++ b/src/applications/gi/containers/VetTecSearchPage.jsx
@@ -22,7 +22,7 @@ import Pagination from '@department-of-veterans-affairs/formation-react/Paginati
 import { getScrollOptions, focusElement } from 'platform/utilities/ui';
 import VetTecProgramSearchResult from '../components/vet-tec/VetTecProgramSearchResult';
 import VetTecSearchForm from '../components/vet-tec/VetTecSearchForm';
-import { renderVetTecLogo } from '../utils/render';
+import { renderVetTecLogo, renderSearchResultsHeader } from '../utils/render';
 import ServiceError from '../components/ServiceError';
 
 const { Element: ScrollElement, scroller } = Scroll;
@@ -226,13 +226,6 @@ export class VetTecSearchPage extends React.Component {
     return searchResults;
   };
 
-  renderSearchResultsHeader = search => (
-    <h1 tabIndex={-1}>
-      {!search.inProgress &&
-        `${(search.count || 0).toLocaleString()} Search Results`}
-    </h1>
-  );
-
   render() {
     const { search, filters } = this.props;
 
@@ -258,7 +251,7 @@ export class VetTecSearchPage extends React.Component {
             </div>
             <div className="vads-l-row vads-u-justify-content--space-between vads-u-align-items--flex-end vads-u-margin-top--neg3">
               <div className="vads-l-col--9 search-results-count">
-                {this.renderSearchResultsHeader(this.props.search)}
+                {renderSearchResultsHeader(this.props.search)}
               </div>
               <div className="vads-l-col--3">
                 <div className="vads-u-display--none single-column-display-block vettec-logo-container">

--- a/src/applications/gi/utils/render.jsx
+++ b/src/applications/gi/utils/render.jsx
@@ -134,3 +134,14 @@ export const renderVetTecLogo = classNames => (
     alt="Vet Tec Logo"
   />
 );
+
+export const renderSearchResultsHeader = search => {
+  const header = search.count === 1 ? 'Search Result' : 'Search Results';
+
+  return (
+    <h1 tabIndex={-1}>
+      {!search.inProgress &&
+        `${(search.count || 0).toLocaleString()} ${header}`}
+    </h1>
+  );
+};


### PR DESCRIPTION
## Description
https://github.com/department-of-veterans-affairs/va.gov-team/issues/7991

## Testing done
- loaded VET TEC search results with more than 1 result
- loaded VET TEC search results with 1 result
- loaded CT search results with more than 1 result
- loaded CT search results with 1 result


## Screenshots
![Screen Shot 2020-04-15 at 12 23 30 PM](https://user-images.githubusercontent.com/1094999/79361911-ec131080-7f13-11ea-866d-0a970be0255b.png)

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
