### PR TITLE
[COGNITION]: GIBCT - Caution flags' bulleted lists SHOULD have valid HTML for screen reader usability #7987

### DIFF
--- a/src/applications/gi/components/profile/CautionFlagHeading.jsx
+++ b/src/applications/gi/components/profile/CautionFlagHeading.jsx
@@ -28,7 +28,7 @@ const CautionFlagHeading = ({ cautionFlags, onViewWarnings }) => {
                       className="headingFlag vads-u-margin-left--1p5"
                       key={flag.id}
                     >
-                      <div>{flag.title}</div>
+                      {flag.title}
                     </li>
                   ))}
               </ul>


### PR DESCRIPTION
## Description

https://github.com/department-of-veterans-affairs/va.gov-team/issues/7987

## Testing done


## Screenshots


## Acceptance criteria
- [ ] Screen readers read the bullet point and text in one group, not forcing users to press `DOWN_ARROW` or `i` twice.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
