### PR TITLE
Add support for title-less ProfileInfoTable

### DIFF
--- a/src/applications/personalization/profile-2/components/ProfileInfoTable.jsx
+++ b/src/applications/personalization/profile-2/components/ProfileInfoTable.jsx
@@ -52,9 +52,11 @@ const ProfileInfoTable = ({
 
   return (
     <div className={tableClasses.join(' ')} data-field-name={fieldName}>
-      <h3 className={[...titleClasses, ...titleClassesMedium].join(' ')}>
-        {title}
-      </h3>
+      {title && (
+        <h3 className={[...titleClasses, ...titleClassesMedium].join(' ')}>
+          {title}
+        </h3>
+      )}
       {data
         .map(element => (dataTransformer ? dataTransformer(element) : element))
         .map((row, index) => (
@@ -82,7 +84,7 @@ const ProfileInfoTable = ({
 };
 
 ProfileInfoTable.propTypes = {
-  title: PropTypes.string.isRequired,
+  title: PropTypes.string,
   fieldName: PropTypes.string.isRequired,
   data: PropTypes.array.isRequired,
   dataTransformer: PropTypes.func,

--- a/src/applications/personalization/profile-2/sass/profile-info-table.scss
+++ b/src/applications/personalization/profile-2/sass/profile-info-table.scss
@@ -22,7 +22,13 @@ $corner-size: 4px;
     }
   }
 
-  div.table-row:last-of-type {
+  div.table-row:first-child {
+    border: 1px solid;
+    border-top-left-radius: $corner-size;
+    border-top-right-radius: $corner-size;
+  }
+
+  div.table-row:last-child {
     border-bottom-left-radius: $corner-size;
     border-bottom-right-radius: $corner-size;
   }

--- a/src/applications/personalization/profile-2/tests/components/ProfileInfoTable.unit.spec.js
+++ b/src/applications/personalization/profile-2/tests/components/ProfileInfoTable.unit.spec.js
@@ -7,18 +7,19 @@ import ProfileInfoTable from '../../components/ProfileInfoTable';
 
 describe('ProfileInfoTable', () => {
   let dataTransformerSpy;
-  const props = {
-    title: 'Table Title',
-    fieldName: 'profileField',
-    data: [
-      { title: 'row 1', value: 'value 1' },
-      { title: 'row 2', value: 'value 2' },
-    ],
-  };
+  let props;
   let wrapper;
   beforeEach(() => {
     dataTransformerSpy = sinon.spy(arg => arg);
-    props.dataTransformer = dataTransformerSpy;
+    props = {
+      title: 'Table Title',
+      fieldName: 'profileField',
+      data: [
+        { title: 'row 1', value: 'value 1' },
+        { title: 'row 2', value: 'value 2' },
+      ],
+      dataTransformer: dataTransformerSpy,
+    };
     wrapper = shallow(<ProfileInfoTable {...props} />);
   });
   afterEach(() => {
@@ -34,6 +35,9 @@ describe('ProfileInfoTable', () => {
     const h3 = wrapper.find('h3');
     expect(h3.text()).to.equal(props.title);
   });
+  it('should render an h3 tag as the first child element', () => {
+    expect(wrapper.childAt(0).type()).to.equal('h3');
+  });
   it('renders a table row div for each entry in the data prop', () => {
     const tableRows = wrapper.find('div > div.table-row');
     expect(tableRows.length).to.equal(props.data.length);
@@ -47,6 +51,30 @@ describe('ProfileInfoTable', () => {
       const { title, value } = props.data[index];
       expect(row.text().includes(title)).to.be.true;
       expect(row.text().includes(value)).to.be.true;
+    });
+  });
+  describe('when no title is set', () => {
+    beforeEach(() => {
+      props = {
+        fieldName: 'profileField',
+        data: [
+          { title: 'row 1', value: 'value 1' },
+          { title: 'row 2', value: 'value 2' },
+        ],
+      };
+      wrapper = shallow(<ProfileInfoTable {...props} />);
+    });
+    afterEach(() => {
+      wrapper.unmount();
+    });
+    it('should not render an h3 tag', () => {
+      const h3 = wrapper.find('h3');
+      expect(h3.length).to.equal(0);
+    });
+    it('should render a table-row div as its first child', () => {
+      const firstChild = wrapper.childAt(0);
+      expect(firstChild.type()).to.equal('div');
+      expect(firstChild.hasClass('table-row')).to.be.true;
     });
   });
 });


### PR DESCRIPTION
## Description
I just realized that Profile 2.0 will require showing info tables that do not have a title (see these [build specs](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/identity-personalization/profile/Combine%20Profile%20and%20Account/Design/design-specs/account-security.md) for an example of that). This PR adds support for that to the `ProfileInfoTable`

## Testing done
Local + new unit tests

## Screenshots
<details>
  <summary>Table with title</summary>
  
![image](https://user-images.githubusercontent.com/20728956/79378642-84a89100-7f12-11ea-9bba-d58298664b17.png)

</details>

<details>
  <summary>Table without title</summary>
  
![image](https://user-images.githubusercontent.com/20728956/79378631-7fe3dd00-7f12-11ea-856b-f061c9c58e3c.png)

</details>

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs