### PR TITLE
Handle both http and https schemes in drupal assets build script.

### DIFF
--- a/src/site/stages/build/drupal/assets.js
+++ b/src/site/stages/build/drupal/assets.js
@@ -2,11 +2,13 @@ const getDrupalClient = require('./api');
 const cheerio = require('cheerio');
 const { PUBLIC_URLS } = require('../../../constants/drupals');
 
-const PUBLIC_URLS_NO_SCHEME = {};
-Object.entries(PUBLIC_URLS).map(item => {
-  PUBLIC_URLS_NO_SCHEME[item[0]] = item[1].replace('http:', ':');
-  return PUBLIC_URLS_NO_SCHEME;
-});
+const PUBLIC_URLS_NO_SCHEME = Object.entries(PUBLIC_URLS).reduce(
+  (returnValue, item) => ({
+    ...returnValue,
+    [item[0]]: item[1].replace('http:', ':'),
+  }),
+  {},
+);
 
 function replacePathInData(data, replacer) {
   let current = data;

--- a/src/site/stages/build/drupal/assets.js
+++ b/src/site/stages/build/drupal/assets.js
@@ -2,6 +2,12 @@ const getDrupalClient = require('./api');
 const cheerio = require('cheerio');
 const { PUBLIC_URLS } = require('../../../constants/drupals');
 
+const PUBLIC_URLS_NO_SCHEME = {};
+Object.entries(PUBLIC_URLS).map(item => {
+  PUBLIC_URLS_NO_SCHEME[item[0]] = item[1].replace('http:', ':');
+  return PUBLIC_URLS_NO_SCHEME;
+});
+
 function replacePathInData(data, replacer) {
   let current = data;
   if (Array.isArray(data)) {
@@ -62,7 +68,9 @@ function updateAttr(attr, doc, client) {
     // *.ci.cms.va.gov ENVs don't have AWS URLs.
     const newAssetPath = convertAssetPath(srcAttr);
     const awsURI = usingAWS
-      ? Object.entries(PUBLIC_URLS).find(entry => entry[1] === siteURI)[0]
+      ? Object.entries(PUBLIC_URLS_NO_SCHEME).find(entry =>
+          siteURI.match(entry[1]),
+        )[0]
       : null;
 
     assetsToDownload.push({

--- a/src/site/stages/build/drupal/assets.js
+++ b/src/site/stages/build/drupal/assets.js
@@ -87,7 +87,7 @@ function updateAttr(attr, doc, client) {
     )[0];
     // *.ci.cms.va.gov ENVs don't have AWS URLs.
     const newAssetPath = convertAssetPath(srcAttr);
-    const awsURI = getAwsURI(usingAWS, siteURI);
+    const awsURI = getAwsURI(siteURI, usingAWS);
 
     assetsToDownload.push({
       // URLs in WYSIWYG content won't be the AWS URLs, they'll be CMS URLs.

--- a/src/site/stages/build/drupal/assets.js
+++ b/src/site/stages/build/drupal/assets.js
@@ -1,5 +1,6 @@
 const getDrupalClient = require('./api');
 const cheerio = require('cheerio');
+const chalk = require('chalk');
 const { PUBLIC_URLS } = require('../../../constants/drupals');
 
 const PUBLIC_URLS_NO_SCHEME = Object.entries(PUBLIC_URLS).reduce(
@@ -55,6 +56,23 @@ function convertAssetPath(url) {
   return `/files/${path}`;
 }
 
+function getAwsURI(siteURI, usingAWS) {
+  if (!usingAWS) return null;
+
+  const matchingEntries = Object.entries(PUBLIC_URLS_NO_SCHEME).find(entry =>
+    siteURI.match(entry[1]),
+  );
+
+  if (!matchingEntries) {
+    // eslint-disable-next-line no-console
+    console.warn(chalk.red(`Could not find AWS bucket for: ${siteURI}`));
+
+    return null;
+  }
+
+  return matchingEntries[0];
+}
+
 // @todo Explain _why_ this function is needed.
 function updateAttr(attr, doc, client) {
   const assetsToDownload = [];
@@ -69,11 +87,7 @@ function updateAttr(attr, doc, client) {
     )[0];
     // *.ci.cms.va.gov ENVs don't have AWS URLs.
     const newAssetPath = convertAssetPath(srcAttr);
-    const awsURI = usingAWS
-      ? Object.entries(PUBLIC_URLS_NO_SCHEME).find(entry =>
-          siteURI.match(entry[1]),
-        )[0]
-      : null;
+    const awsURI = getAwsURI(usingAWS, siteURI);
 
     assetsToDownload.push({
       // URLs in WYSIWYG content won't be the AWS URLs, they'll be CMS URLs.

--- a/src/site/stages/build/drupal/assets.js
+++ b/src/site/stages/build/drupal/assets.js
@@ -87,7 +87,11 @@ function updateAttr(attr, doc, client) {
     )[0];
     // *.ci.cms.va.gov ENVs don't have AWS URLs.
     const newAssetPath = convertAssetPath(srcAttr);
+    // eslint-disable-next-line no-console
+    console.log(`${siteURI} | ${usingAWS}`);
     const awsURI = getAwsURI(siteURI, usingAWS);
+    // eslint-disable-next-line no-console
+    console.log(`awsURI: ${awsURI}`);
 
     assetsToDownload.push({
       // URLs in WYSIWYG content won't be the AWS URLs, they'll be CMS URLs.

--- a/src/site/stages/build/drupal/assets.js
+++ b/src/site/stages/build/drupal/assets.js
@@ -87,11 +87,7 @@ function updateAttr(attr, doc, client) {
     )[0];
     // *.ci.cms.va.gov ENVs don't have AWS URLs.
     const newAssetPath = convertAssetPath(srcAttr);
-    // eslint-disable-next-line no-console
-    console.log(`${siteURI} | ${usingAWS}`);
     const awsURI = getAwsURI(siteURI, usingAWS);
-    // eslint-disable-next-line no-console
-    console.log(`awsURI: ${awsURI}`);
 
     assetsToDownload.push({
       // URLs in WYSIWYG content won't be the AWS URLs, they'll be CMS URLs.


### PR DESCRIPTION
## Description
Currently, the content deployment does not handle both http and https schemes. This PR is to update the script to handle both casaes. 

## Testing done
Tested locally with variations of http & https.

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
