### PR TITLE
[Development/CI/CD] Add axe (accessibility) checks to puppeteer e2e tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,6 +123,7 @@
     "ascii-table": "^0.0.9",
     "autoprefixer": "^9.5.1",
     "axe-core": "^2.6.0",
+    "axe-puppeteer": "^1.1.0",
     "babel-core": "^7.0.0-bridge.0",
     "babel-eslint": "^9.0.0",
     "babel-jest": "^23.4.2",

--- a/src/platform/testing/e2e/form-tester/form-filler.js
+++ b/src/platform/testing/e2e/form-tester/form-filler.js
@@ -402,7 +402,7 @@ const fillForm = async (page, testData, testConfig, log) => {
 
   await page.click('button.usa-button-primary');
 
-  // Clicking the button a second time; because it seems to fail the first?
+  // Clicking the button a second time; because it seems to fail the first time?
   await page.click('button.usa-button-primary');
 
   // We should be on the confirmation page if all goes well

--- a/src/platform/testing/e2e/form-tester/form-filler.js
+++ b/src/platform/testing/e2e/form-tester/form-filler.js
@@ -340,9 +340,6 @@ const fillForm = async (page, testData, testConfig, log) => {
   while (!page.url().endsWith('review-and-submit')) {
     log(page.url());
 
-    // check before filling in the page
-    await axe.check(page, log);
-
     // If there's a page hook, run that
     const url = page.url();
     const hook = _.get(`pageHooks.${parseUrl(url).path}`, testConfig);

--- a/src/platform/testing/e2e/form-tester/form-filler.js
+++ b/src/platform/testing/e2e/form-tester/form-filler.js
@@ -402,9 +402,6 @@ const fillForm = async (page, testData, testConfig, log) => {
 
   await page.click('button.usa-button-primary');
 
-  // Clicking the button a second time; because it seems to fail the first time?
-  await page.click('button.usa-button-primary');
-
   // We should be on the confirmation page if all goes well
   if (!(await nextUrl(page)).endsWith('confirmation')) {
     // If we can tell what the problem probably is, provide a more helpful error message

--- a/src/platform/testing/e2e/form-tester/util.js
+++ b/src/platform/testing/e2e/form-tester/util.js
@@ -1,5 +1,6 @@
 const fs = require('fs');
 const join = require('path').join;
+const { AxePuppeteer } = require('axe-puppeteer');
 
 /**
  * Grabs the all the data for a form.
@@ -34,4 +35,101 @@ function getTestDataSets(path, rules = { extension: 'json' }) {
     }));
 }
 
-module.exports = { getTestDataSets };
+/**
+ * Axe Puppeteer testing. Get full details here:
+ * https://www.deque.com/axe/axe-for-web/documentation/api-documentation/#result-arrays
+ * @typedef {Object} Axe rules
+ * @property {String} id - Axe rule id
+ * @property {String} impact - 'moderate', 'serious', null, etc
+ * @property {Array<String>} tags - Rule tags, e.g. 'best-practoce', 'wcag2a', etc
+ * @property {String} description - Rule description; starts with "Ensures"
+ * @property {String} help - Short rule description
+ * @property {String} helpUrl - Url to deque university rule
+ * @property {Array<NodeData>} nodes - Array of elements tested
+ * ---
+ * @typedef {Object} NodeData - We're only interested in the `target` value in
+ *  this situation; see the full list at the axe url above
+ * @property {Array<String>} target - css selectors pointing to the elements
+ */
+const axe = {
+  // axe core config
+  CONFIG: {
+    checks: ['section508', 'wcag2a', 'wcag2aa'],
+  },
+
+  // ignore best practice violations, for now
+  IGNORE: 'best-practice',
+
+  // stores array of violations per page
+  violations: new Map(),
+
+  // stores AxePuppeteer instance
+  pages: new Map(),
+
+  /**
+   * Checks the page for axe violations
+   * @param {object} - Puppeteer page object
+   * @param {log} - test log
+   */
+  check: async (page, log) => {
+    const url = page.url();
+    const previousCheck = axe.violations.get(url) || [];
+    const axeChecker =
+      axe.pages.get(url) || new AxePuppeteer(page).configure(axe.CONFIG);
+
+    const results = await axeChecker.analyze();
+    const violations = results.violations?.filter(
+      v => !v.tags.includes(axe.IGNORE),
+    );
+
+    if (violations?.length) {
+      axe.violations.set(url, [...violations, ...previousCheck]);
+      violations.forEach(violation =>
+        log(`>>>> axe error: ${violation.help} <<<<`),
+      );
+    }
+    axe.pages.set(url, axeChecker);
+  },
+
+  expandAndCheck: async (page, log) => {
+    const hasAccord = await axe.expand(page, log, '.accordion-header button');
+    const hasInfo = await axe.expand(page, log, '.additional-info-button');
+    if (hasAccord || hasInfo) {
+      await axe.check(page, log);
+    }
+  },
+
+  expand: (page, log, selector) =>
+    page.$$eval(selector, els => {
+      els.forEach(button => {
+        if (button.getAttribute('aria-expanded') === 'false') {
+          button.click();
+        }
+      });
+    }),
+
+  getViolations: () => axe.violations,
+
+  clear: () => {
+    axe.violations.clear();
+    axe.pages.clear();
+  },
+
+  formatViolations: () => {
+    const message = [];
+    axe.violations.forEach((violations, key) => {
+      let violation = `\n  page: ${key}`;
+      violations.forEach(({ id, impact, tags, help, nodes }) => {
+        const tagList = tags?.join(', ') || '';
+        const nodeList = nodes.map(node => node.target).join(', ');
+        violation += `\n  id: ${id}\n  impact: ${impact}\n  tags: ${tagList}`;
+        violation += `\n  help: ${help}\n  nodes: ${nodeList}\n`;
+      });
+      message.push(violation);
+    });
+    axe.clear();
+    return message.join('  ==========');
+  },
+};
+
+module.exports = { axe, getTestDataSets };

--- a/src/platform/testing/e2e/form-tester/util.js
+++ b/src/platform/testing/e2e/form-tester/util.js
@@ -65,9 +65,6 @@ const axe = {
   // stores array of violations per page
   violations: new Map(),
 
-  // stores AxePuppeteer instance
-  pages: new Map(),
-
   hasException: error =>
     axe.CONFIG.exceptions.some(exception => error.includes(exception)),
 
@@ -79,8 +76,7 @@ const axe = {
   check: async (page, log) => {
     const url = page.url();
     const previousCheck = axe.violations.get(url) || [];
-    const axeChecker =
-      axe.pages.get(url) || new AxePuppeteer(page).configure(axe.CONFIG);
+    const axeChecker = new AxePuppeteer(page).configure(axe.CONFIG);
 
     const results = await axeChecker.analyze();
     const violations = results.violations?.filter(
@@ -97,7 +93,6 @@ const axe = {
       });
       axe.violations.set(url, [...validViolations, ...previousCheck]);
     }
-    axe.pages.set(url, axeChecker);
   },
 
   expandAndCheck: async (page, log) => {
@@ -113,7 +108,6 @@ const axe = {
 
   clear: () => {
     axe.violations.clear();
-    axe.pages.clear();
   },
 
   formatViolations: () => {

--- a/src/platform/testing/e2e/form-tester/util.js
+++ b/src/platform/testing/e2e/form-tester/util.js
@@ -92,21 +92,13 @@ const axe = {
   },
 
   expandAndCheck: async (page, log) => {
-    const hasAccord = await axe.expand(page, log, '.accordion-header button');
-    const hasInfo = await axe.expand(page, log, '.additional-info-button');
-    if (hasAccord || hasInfo) {
-      await axe.check(page, log);
-    }
+    await page.evaluate(() => {
+      document
+        .querySelectorAll('main button[aria-expanded=false]')
+        .forEach(btn => btn.click());
+    });
+    await axe.check(page, log);
   },
-
-  expand: (page, log, selector) =>
-    page.$$eval(selector, els => {
-      els.forEach(button => {
-        if (button.getAttribute('aria-expanded') === 'false') {
-          button.click();
-        }
-      });
-    }),
 
   getViolations: () => axe.violations,
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2128,6 +2128,18 @@ axe-core@^2.6.0:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-2.6.1.tgz#28772c4f76966d373acda35b9a409299dc00d1b5"
 
+axe-core@^3.5.3:
+  version "3.5.3"
+  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-3.5.3.tgz#5b7c0ee7c5197d546bd3a07c3ef701896f5773e9"
+  integrity sha512-HZpLE7xu05+8AbpqXITGdxp1Xwk8ysAXrg7MiKRY27py3DAyEJpoJQo1727pWF3F+O79V3r+cTWhOzfB49P89w==
+
+axe-puppeteer@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/axe-puppeteer/-/axe-puppeteer-1.1.0.tgz#efcf0666a7d8fefec6930b4b6ec3476c403d1b91"
+  integrity sha512-VS17Y1rDQe6A0PdeTPxwOSBfmOdj6efgxyre9cN1du1snnVilczSDtQsgifBKBlzoL/3DKfGpgIi+N+zrzODOg==
+  dependencies:
+    axe-core "^3.5.3"
+
 axobject-query@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-0.1.0.tgz#62f59dbc59c9f9242759ca349960e7a2fe3c36c0"


### PR DESCRIPTION
## Description

This PR applies to form 526 all-claims end-to-end (e2e) tests, but the form testing code is located in the platform folder.

It appears that currently only form 526 is using this specific code for testing.

Axe checks are performed on:

* Each form page, before filling in any content
* Each form page after specific page hooks are run, or after form data has been entered; and after any accordions or additional info blocks are expanded
* Review and submit page after accordions have been expanded
* Confirmation page

**NOTE** There were errors found by this update, so PRs will need to be made to address the errors before this PR can be merged.

## Testing done

Puppeteer e2e tests

## Screenshots

![Screen Shot 2020-04-15 at 5 11 37 PM](https://user-images.githubusercontent.com/136959/79394064-39a37380-7f3c-11ea-88c1-01a3e5d54669.png)

## Acceptance criteria
- [ ] Puppeteer e2e test all pass
- [ ] On hold until after reported axe errors have been fixed in a separate PR.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
