### PR TITLE
Facility Locator does not load in IE11

### DIFF
--- a/src/applications/facility-locator/constants/index.js
+++ b/src/applications/facility-locator/constants/index.js
@@ -60,6 +60,4 @@ export const BOUNDING_RADIUS = 0.75;
 /**
  *Defines the marker letter list
  */
-export const MARKER_LETTERS = new Set([
-  ...'abcdefghijklmnopqrstuvwxyz'.toUpperCase(),
-]);
+export const MARKER_LETTERS = new Set('ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split(''));


### PR DESCRIPTION
fix replace spread operator with split
issue: https://github.com/department-of-veterans-affairs/va.gov-team/issues/8077

## Testing done
Locally

## Screenshots
e11
<img width="1343" alt="Screen Shot 2020-04-16 at 10 49 02 AM" src="https://user-images.githubusercontent.com/100468/79478127-a1a39980-7fd0-11ea-8245-7ed8acd3f5d1.png">


## Acceptance criteria
- [x] Facility Locator page should load as expected without errors

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
