### PR TITLE
Move past appointment history/matching clinic check into eligibility checks

### DIFF
--- a/src/applications/vaos/actions/newAppointment.js
+++ b/src/applications/vaos/actions/newAppointment.js
@@ -176,12 +176,11 @@ export function updateFacilityType(facilityType) {
   };
 }
 
-export function startDirectScheduleFlow(appointments) {
+export function startDirectScheduleFlow() {
   recordEvent({ event: 'vaos-direct-path-started' });
 
   return {
     type: START_DIRECT_SCHEDULE_FLOW,
-    appointments,
   };
 }
 

--- a/src/applications/vaos/newAppointmentFlow.js
+++ b/src/applications/vaos/newAppointmentFlow.js
@@ -7,16 +7,11 @@ import {
   getEligibilityStatus,
   vaosCommunityCare,
   getCCEType,
-  getClinicsForChosenFacility,
   getTypeOfCare,
   selectSystemIds,
 } from './utils/selectors';
 import { FACILITY_TYPES, FLOW_TYPES, TYPES_OF_CARE } from './utils/constants';
-import {
-  getCommunityCare,
-  getLongTermAppointmentHistory,
-  getSitesSupportingVAR,
-} from './api';
+import { getCommunityCare, getSitesSupportingVAR } from './api';
 import {
   showTypeOfCareUnavailableModal,
   startDirectScheduleFlow,
@@ -25,7 +20,6 @@ import {
   updateCCEnabledSystems,
   updateCCEligibility,
 } from './actions/newAppointment';
-import { recordVaosError, recordEligibilityFailure } from './utils/events';
 
 const AUDIOLOGY = '203';
 const SLEEP_CARE = 'SLEEP';
@@ -223,29 +217,8 @@ export default {
       const eligibilityStatus = getEligibilityStatus(state);
 
       if (eligibilityStatus.direct) {
-        let appointments = null;
-
-        try {
-          appointments = await getLongTermAppointmentHistory();
-          const clinics = getClinicsForChosenFacility(state);
-          const hasMatchingClinics = clinics.some(
-            clinic =>
-              !!appointments.find(
-                appt =>
-                  clinic.siteCode === appt.facilityId &&
-                  clinic.clinicId === appt.clinicId,
-              ),
-          );
-
-          if (hasMatchingClinics) {
-            dispatch(startDirectScheduleFlow(appointments));
-            return 'clinicChoice';
-          }
-          recordEligibilityFailure('direct-no-matching-past-clinics');
-        } catch (error) {
-          recordVaosError('eligbility-direct-no-matching-past-clinics-error');
-          captureError(error);
-        }
+        dispatch(startDirectScheduleFlow());
+        return 'clinicChoice';
       }
 
       if (eligibilityStatus.request) {

--- a/src/applications/vaos/reducers/newAppointment.js
+++ b/src/applications/vaos/reducers/newAppointment.js
@@ -324,6 +324,8 @@ export default function formReducer(state = initialState, action) {
 
       let eligibility = state.eligibility;
       let clinics = state.clinics;
+      let pastAppointments;
+
       if (action.eligibilityData) {
         const facilityEligibility = getEligibilityChecks(
           getSystemFromFacility(facilities, newData.vaFacility),
@@ -342,6 +344,8 @@ export default function formReducer(state = initialState, action) {
             [`${data.vaFacility}_${action.typeOfCareId}`]: action
               .eligibilityData.clinics,
           };
+
+          pastAppointments = action.eligibilityData.pastAppointments;
         }
       }
 
@@ -360,6 +364,7 @@ export default function formReducer(state = initialState, action) {
         },
         eligibility,
         clinics,
+        pastAppointments,
       };
     }
     case FORM_PAGE_FACILITY_OPEN_FAILED:
@@ -488,6 +493,7 @@ export default function formReducer(state = initialState, action) {
           [`${state.data.vaFacility}_${action.typeOfCareId}`]: eligibility,
         },
         eligibilityStatus: FETCH_STATUS.succeeded,
+        pastAppointments: action.eligibilityData.pastAppointments,
       };
     }
     case FORM_ELIGIBILITY_CHECKS_FAILED: {
@@ -499,7 +505,6 @@ export default function formReducer(state = initialState, action) {
     case START_DIRECT_SCHEDULE_FLOW:
       return {
         ...state,
-        pastAppointments: action.appointments,
         data: {
           ...state.data,
           calendarData: {},

--- a/src/applications/vaos/tests/actions/newAppointment.unit.spec.js
+++ b/src/applications/vaos/tests/actions/newAppointment.unit.spec.js
@@ -216,7 +216,6 @@ describe('VAOS newAppointment actions', () => {
       expect(dispatch.secondCall.args[0].type).to.equal(
         FORM_FETCH_FACILITY_DETAILS_SUCCEEDED,
       );
-      global.fetch.reset();
     });
   });
 
@@ -312,7 +311,6 @@ describe('VAOS newAppointment actions', () => {
         typeOfCareId: defaultState.newAppointment.data.typeOfCareId,
       });
       expect(global.fetch.secondCall.args[0]).to.contain('/systems/983/');
-      global.fetch.reset();
     });
 
     it('should send fail action if a fetch fails', async () => {
@@ -652,8 +650,6 @@ describe('VAOS newAppointment actions', () => {
     });
 
     it('should fetch eligibility info if facility is selected', async () => {
-      resetFetch();
-      mockFetch();
       setFetchJSONResponse(global.fetch.onCall(0), {
         data: {
           attributes: {

--- a/src/applications/vaos/tests/actions/newAppointment.unit.spec.js
+++ b/src/applications/vaos/tests/actions/newAppointment.unit.spec.js
@@ -68,6 +68,7 @@ import parentFacilities from '../../api/facilities.json';
 import facilities983 from '../../api/facilities_983.json';
 import clinics from '../../api/clinicList983.json';
 import facilityDetails from '../../api/facility_details_983.json';
+import pastAppointments from '../../api/confirmed_va.json';
 import {
   FACILITY_TYPES,
   FETCH_STATUS,
@@ -215,6 +216,7 @@ describe('VAOS newAppointment actions', () => {
       expect(dispatch.secondCall.args[0].type).to.equal(
         FORM_FETCH_FACILITY_DETAILS_SUCCEEDED,
       );
+      global.fetch.reset();
     });
   });
 
@@ -310,6 +312,7 @@ describe('VAOS newAppointment actions', () => {
         typeOfCareId: defaultState.newAppointment.data.typeOfCareId,
       });
       expect(global.fetch.secondCall.args[0]).to.contain('/systems/983/');
+      global.fetch.reset();
     });
 
     it('should send fail action if a fetch fails', async () => {
@@ -649,7 +652,9 @@ describe('VAOS newAppointment actions', () => {
     });
 
     it('should fetch eligibility info if facility is selected', async () => {
-      setFetchJSONResponse(global.fetch, {
+      resetFetch();
+      mockFetch();
+      setFetchJSONResponse(global.fetch.onCall(0), {
         data: {
           attributes: {
             durationInMonths: 0,
@@ -674,7 +679,11 @@ describe('VAOS newAppointment actions', () => {
         },
       });
       setFetchJSONResponse(global.fetch.onCall(3), clinics);
-      setFetchJSONResponse(global.fetch.onCall(4), facilityDetails);
+      setFetchJSONResponse(global.fetch.onCall(4), pastAppointments);
+      setFetchJSONResponse(global.fetch.onCall(5), pastAppointments);
+      setFetchJSONResponse(global.fetch.onCall(6), pastAppointments);
+      setFetchJSONResponse(global.fetch.onCall(7), pastAppointments);
+      setFetchJSONResponse(global.fetch.onCall(8), facilityDetails);
       const dispatch = sinon.spy();
       const previousState = {
         ...defaultState,
@@ -706,6 +715,7 @@ describe('VAOS newAppointment actions', () => {
       expect(dispatch.secondCall.args[0].type).to.equal(
         FORM_ELIGIBILITY_CHECKS,
       );
+
       expect(dispatch.thirdCall.args[0].type).to.equal(
         FORM_ELIGIBILITY_CHECKS_SUCCEEDED,
       );

--- a/src/applications/vaos/tests/newAppointmentFlow.unit.spec.js
+++ b/src/applications/vaos/tests/newAppointmentFlow.unit.spec.js
@@ -342,39 +342,6 @@ describe('VAOS newAppointmentFlow', () => {
 
         resetFetch();
       });
-      it('should be requestDateTime page if past appointments request errors', async () => {
-        mockFetch();
-        setFetchJSONFailure(global.fetch, {});
-        const state = {
-          ...defaultState,
-          newAppointment: {
-            ...defaultState.newAppointment,
-            eligibility: {
-              '983_323': {
-                directSupported: true,
-                directPastVisit: true,
-                directPACT: true,
-                directClinics: true,
-                requestSupported: true,
-                requestPastVisit: true,
-                requestLimit: true,
-              },
-            },
-          },
-        };
-        const dispatch = sinon.spy();
-
-        const nextState = await newAppointmentFlow.vaFacility.next(
-          state,
-          dispatch,
-        );
-        expect(dispatch.firstCall.args[0].type).to.equal(
-          'newAppointment/START_REQUEST_APPOINTMENT_FLOW',
-        );
-        expect(nextState).to.equal('requestDateTime');
-
-        resetFetch();
-      });
       it('should throw error if not eligible for requests or direct', async () => {
         const state = {
           ...defaultState,

--- a/src/applications/vaos/tests/reducers/newAppointment.unit.spec.js
+++ b/src/applications/vaos/tests/reducers/newAppointment.unit.spec.js
@@ -17,7 +17,6 @@ import {
   FORM_ELIGIBILITY_CHECKS_SUCCEEDED,
   FORM_ELIGIBILITY_CHECKS_FAILED,
   FORM_CLINIC_PAGE_OPENED_SUCCEEDED,
-  START_DIRECT_SCHEDULE_FLOW,
   FORM_CALENDAR_FETCH_SLOTS,
   FORM_CALENDAR_FETCH_SLOTS_SUCCEEDED,
   FORM_CALENDAR_FETCH_SLOTS_FAILED,
@@ -558,71 +557,6 @@ describe('VAOS reducer: newAppointment', () => {
   });
 
   describe('open clinic page reducers', () => {
-    it('should save past appointments to state', () => {
-      const appointments = [
-        {
-          id: 'ade93d5b68dc06fb47bddfab6548fc64',
-          type: 'va_appointments',
-          attributes: {
-            startDate: '2019-10-07T14:00:00Z',
-            clinicId: '455',
-            clinicFriendlyName: null,
-            facilityId: '983',
-            communityCare: false,
-            vdsAppointments: [
-              {
-                bookingNote: null,
-                appointmentLength: '60',
-                appointmentTime: '2019-10-07T14:00:00Z',
-                clinic: {
-                  name: 'CHY PC CASSIDY',
-                  askForCheckIn: false,
-                  facilityCode: '983',
-                },
-                type: 'SERVICE CONNECTED',
-                currentStatus: 'FUTURE',
-              },
-            ],
-            vvsAppointments: [],
-          },
-        },
-        {
-          id: '8f9792ed196a9112fb17ed2f5fa2996b',
-          type: 'va_appointments',
-          attributes: {
-            startDate: '2019-10-07T16:00:00Z',
-            clinicId: '308',
-            clinicFriendlyName: null,
-            facilityId: '983',
-            communityCare: false,
-            vdsAppointments: [
-              {
-                bookingNote: null,
-                appointmentLength: null,
-                appointmentTime: '2019-10-07T16:00:00Z',
-                clinic: {
-                  name: 'CHY OPT VAR1',
-                  askForCheckIn: false,
-                  facilityCode: '983',
-                },
-                type: 'REGULAR',
-                currentStatus: 'FUTURE',
-              },
-            ],
-            vvsAppointments: [],
-          },
-        },
-      ];
-
-      const action = {
-        type: START_DIRECT_SCHEDULE_FLOW,
-        appointments,
-      };
-
-      const newState = newAppointmentReducer(defaultState, action);
-
-      expect(newState.pastAppointments).to.deep.equal(action.appointments);
-    });
     it('should set single clinic list in schema', () => {
       const state = {
         ...defaultState,

--- a/src/applications/vaos/tests/utils/eligibility.unit.spec.js
+++ b/src/applications/vaos/tests/utils/eligibility.unit.spec.js
@@ -8,6 +8,7 @@ import {
 } from 'platform/testing/unit/helpers';
 
 import clinics from '../../api/clinicList983.json';
+import confirmed from '../../api/confirmed_va.json';
 
 import {
   isEligible,
@@ -24,6 +25,7 @@ describe('VAOS scheduling eligibility logic', () => {
 
     beforeEach(() => {
       setFetchJSONResponse(global.fetch, clinics);
+      setFetchJSONResponse(global.fetch.onCall(1), confirmed);
     });
 
     afterEach(() => {
@@ -50,6 +52,8 @@ describe('VAOS scheduling eligibility logic', () => {
         'requestSupported',
         'directPastVisit',
         'clinics',
+        'hasMatchingClinics',
+        'pastAppointments',
       ]);
     });
     it('should skip pact if not primary care', async () => {
@@ -72,6 +76,8 @@ describe('VAOS scheduling eligibility logic', () => {
         'requestSupported',
         'directPastVisit',
         'clinics',
+        'hasMatchingClinics',
+        'pastAppointments',
       ]);
     });
     it('should finish all calls even if one fails', async () => {
@@ -95,6 +101,8 @@ describe('VAOS scheduling eligibility logic', () => {
         'requestSupported',
         'directPastVisit',
         'clinics',
+        'hasMatchingClinics',
+        'pastAppointments',
       ]);
     });
   });
@@ -135,6 +143,8 @@ describe('VAOS scheduling eligibility logic', () => {
 
     it('should calculate successful statuses', () => {
       const eligibilityChecks = getEligibilityChecks('983', '323', {
+        hasMatchingClinics: true,
+        pastAppointments: [{}],
         clinics: [{}],
         directSupported: true,
         requestSupported: true,
@@ -245,11 +255,7 @@ describe('VAOS scheduling eligibility logic', () => {
   describe('GA Events', () => {
     it('should record error events with fetch failures', async () => {
       mockFetch();
-      setFetchJSONFailure(global.fetch.onCall(0), { errors: [{}] });
-      setFetchJSONFailure(global.fetch.onCall(1), { errors: [{}] });
-      setFetchJSONFailure(global.fetch.onCall(2), { errors: [{}] });
-      setFetchJSONFailure(global.fetch.onCall(3), { errors: [{}] });
-      setFetchJSONFailure(global.fetch.onCall(4), { errors: [{}] });
+      setFetchJSONFailure(global.fetch, { errors: [{}] });
       await getEligibilityData(
         {
           institutionCode: '983',
@@ -266,7 +272,7 @@ describe('VAOS scheduling eligibility logic', () => {
             e.event === 'vaos-error' &&
             e['error-key'].startsWith('eligibility-'),
         ).length,
-      ).to.equal(4);
+      ).to.equal(5);
       resetFetch();
     });
 


### PR DESCRIPTION
## Description
This PR moves the long term appointment history and matching clinics check into the eligibility check promise chain, and toggles the `directClinics` flag to false if user does not have any past appointment clinics that match.

## Testing done
Local and unit

## Screenshots
![image](https://user-images.githubusercontent.com/786704/79489694-8c2e6f80-7fd0-11ea-8e73-c06e3ed402b0.png)


## Acceptance criteria
- [ ] Error is displayed instead of user getting stuck on past appointment history check

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
