### PR TITLE
Update downtime timestamps

### DIFF
--- a/src/platform/site-wide/announcements/components/Downtime.jsx
+++ b/src/platform/site-wide/announcements/components/Downtime.jsx
@@ -21,8 +21,8 @@ class Downtime extends Component {
     } = this.props;
 
     // Derive the message.
-    const formattedExpiresAt = moment(expiresAt).format('MMM D [at] h:mm a');
-    const message = `We're doing work on VA.gov. If you have trouble using online tools, check back after ${formattedExpiresAt}`;
+    const formattedExpiresAt = moment(expiresAt).format('dddd M/D [at] h:mm a');
+    const message = `DS Logon is down for maintenance. Please use ID.me or MyHealtheVet to sign in or use online tools. We hope to finish our DS Logon work by ${formattedExpiresAt}`;
 
     return (
       <PromoBanner

--- a/src/platform/site-wide/announcements/components/PreDowntime.jsx
+++ b/src/platform/site-wide/announcements/components/PreDowntime.jsx
@@ -60,7 +60,7 @@ class PreDowntime extends Component {
     const { dismiss } = this.props;
 
     // Derive the message.
-    const message = `Scheduled maintenance starts in ${minutesRemaining} minutes. If you’re filling out a form, sign in or create an account to save your work.`;
+    const message = `Scheduled maintenance on DS Logon will start in ${minutesRemaining} minutes. You can still use ID.me or MyHealtheVet to sign in or use online tools.`;
 
     return (
       <PromoBanner

--- a/src/platform/site-wide/announcements/components/PrePreDowntime.jsx
+++ b/src/platform/site-wide/announcements/components/PrePreDowntime.jsx
@@ -23,10 +23,12 @@ class PrePreDowntime extends Component {
 
     // Derive the message.
     const formattedStartsAt = moment(downtimeStartsAt).format(
-      'MMM D [at] h:mm a',
+      'ddd. M/D, h:mm a',
     );
-    const formattedExpiresAt = moment(downtimeExpiresAt).format('h:mm a');
-    const message = `We'll be doing site maintenance on ${formattedStartsAt} until ${formattedExpiresAt} You won’t be able to sign in or use some tools during this time.`;
+    const formattedExpiresAt = moment(downtimeExpiresAt).format(
+      'ddd. M/D, h:mm a',
+    );
+    const message = `DS Logon will be unavailable from ${formattedStartsAt} to ${formattedExpiresAt} Please use ID.me or MyHealtheVet to sign in or use online tools during this time.`;
 
     return (
       <PromoBanner

--- a/src/platform/site-wide/announcements/config/index.js
+++ b/src/platform/site-wide/announcements/config/index.js
@@ -15,8 +15,8 @@ import WelcomeToNewVAModal from '../components/WelcomeToNewVAModal';
 import WelcomeVAOSModal from '../components/WelcomeVAOSModal';
 
 // Derive when downtime will start and expire.
-const downtimeStartAtDate = moment.utc('2020-03-01T02:00:00.000Z').local();
-const downtimeExpiresAtDate = moment.utc('2020-03-01T02:30:00.000Z').local();
+const downtimeStartAtDate = moment.utc('2020-04-25T13:00:00.000Z').local();
+const downtimeExpiresAtDate = moment.utc('2020-04-26T13:00:00.000Z').local();
 
 const config = {
   announcements: [

--- a/src/platform/site-wide/announcements/config/index.js
+++ b/src/platform/site-wide/announcements/config/index.js
@@ -21,17 +21,17 @@ const downtimeExpiresAtDate = moment.utc('2020-04-26T13:00:00.000Z').local();
 const config = {
   announcements: [
     {
-      name: 'pre-pre-downtime',
+      name: `pre-pre-downtime-${downtimeStartAtDate.toISOString()}`,
       paths: /(.)/,
       component: PrePreDowntime,
-      startsAt: downtimeStartAtDate.clone().subtract(12, 'hours'),
+      startsAt: downtimeStartAtDate.clone().subtract(5, 'days'),
       expiresAt: downtimeStartAtDate.clone().subtract(1, 'hours'),
       // The following key-value pairs are just used as props, not in selectors.js.
       downtimeStartsAt: downtimeStartAtDate.toISOString(),
       downtimeExpiresAt: downtimeExpiresAtDate.toISOString(),
     },
     {
-      name: 'pre-downtime',
+      name: `pre-downtime-${downtimeStartAtDate.toISOString()}`,
       paths: /(.)/,
       component: PreDowntime,
       startsAt: downtimeStartAtDate.clone().subtract(1, 'hours'),
@@ -40,7 +40,7 @@ const config = {
       downtimeStartsAt: downtimeStartAtDate.toISOString(),
     },
     {
-      name: 'downtime',
+      name: `downtime-${downtimeStartAtDate.toISOString()}`,
       paths: /(.)/,
       component: Downtime,
       startsAt: downtimeStartAtDate.toISOString(),


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/8100

This PR updates the downtime timestamps.

This PR also updates the content [visible here](https://github.com/department-of-veterans-affairs/va.gov-team/issues/7876#issuecomment-615329625).

## Testing done
Tested locally.

## Screenshots

### I am in MST, so that is why the screenshots below show 2 hours before EST.

#### Before April 20 9am EST

![image](https://user-images.githubusercontent.com/12773166/79591075-41c2f680-8095-11ea-9142-e07d014aac11.png)

#### April 20 9am EST - April 25 7:59:99am EST

![image](https://user-images.githubusercontent.com/12773166/79593575-e5fa6c80-8098-11ea-8f8b-198dba6f1061.png)

#### April 25 8am EST to April 25 8:59:99am EST

![image](https://user-images.githubusercontent.com/12773166/79591846-53f16480-8096-11ea-8ca1-236bd2153356.png)

#### April 25 9am EST - April 26 8:59:99am EST

![image](https://user-images.githubusercontent.com/12773166/79593771-2fe35280-8099-11ea-83e9-f7df1714681b.png)

#### After April 26 9am EST

![image](https://user-images.githubusercontent.com/12773166/79591934-771c1400-8096-11ea-9730-02338fdb7d6f.png)

## Acceptance criteria
- [x] Update downtime timestamps
- [x] Update downtime messaging

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
