### PR TITLE
add AccountSecurity component

### DIFF
--- a/src/applications/personalization/profile-2/components/AccountSecurity.jsx
+++ b/src/applications/personalization/profile-2/components/AccountSecurity.jsx
@@ -1,5 +1,22 @@
 import React from 'react';
+import DowntimeNotification, {
+  externalServices,
+} from 'platform/monitoring/DowntimeNotification';
 
-const AccountSecurity = () => <h1>Account Security</h1>;
+import AccountSecurityContent from './AccountSecurityContent';
+
+const AccountSecurity = () => (
+  <>
+    <h2 tabIndex="-1" className="vads-u-margin-y--4">
+      Account security
+    </h2>
+    <DowntimeNotification
+      appTitle="Account Security"
+      dependencies={[externalServices.emis, externalServices.mvi]}
+    >
+      <AccountSecurityContent />
+    </DowntimeNotification>
+  </>
+);
 
 export default AccountSecurity;

--- a/src/applications/personalization/profile-2/components/AccountSecurityContent.jsx
+++ b/src/applications/personalization/profile-2/components/AccountSecurityContent.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
@@ -49,7 +50,7 @@ export const AccountSecurityContent = ({
   }
 
   return (
-    <div>
+    <>
       <ProfileInfoTable data={data} fieldName="accountSecurity" />
       <AlertBox
         status="info"
@@ -75,8 +76,16 @@ export const AccountSecurityContent = ({
           Go to VA.gov FAQs
         </a>
       </AlertBox>
-    </div>
+    </>
   );
+};
+
+AccountSecurityContent.propTypes = {
+  isIdentityVerified: PropTypes.bool.isRequired,
+  isMultifactorEnabled: PropTypes.bool.isRequired,
+  mhvAccount: PropTypes.object,
+  showMHVTermsAndConditions: PropTypes.bool.isRequired,
+  useSSOe: PropTypes.bool.isRequired,
 };
 
 export const mapStateToProps = state => {

--- a/src/applications/personalization/profile-2/components/AccountSecurityContent.jsx
+++ b/src/applications/personalization/profile-2/components/AccountSecurityContent.jsx
@@ -1,0 +1,97 @@
+import React from 'react';
+import { connect } from 'react-redux';
+
+import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
+
+import recordEvent from 'platform/monitoring/record-event';
+import {
+  isLOA3 as isLOA3Selector,
+  isMultifactorEnabled as isMultifactorEnabledSelector,
+  selectProfile,
+} from 'platform/user/selectors';
+import { ssoe as ssoeSelector } from 'platform/user/authentication/selectors';
+
+import ProfileInfoTable from './ProfileInfoTable';
+import TwoFactorAuthorizationStatus from './TwoFactorAuthorizationStatus';
+import IdentityVerificationStatus from './IdentityVerificationStatus';
+import MHVTermsAndConditionsStatus from './MHVTermsAndConditionsStatus';
+
+export const AccountSecurityContent = ({
+  isIdentityVerified,
+  isMultifactorEnabled,
+  mhvAccount,
+  showMHVTermsAndConditions,
+  useSSOe,
+}) => {
+  const data = [
+    {
+      title: 'Identity verification',
+      value: (
+        <IdentityVerificationStatus isIdentityVerified={isIdentityVerified} />
+      ),
+    },
+    {
+      title: '2-factor authentication',
+      value: (
+        <TwoFactorAuthorizationStatus
+          isMultifactorEnabled={isMultifactorEnabled}
+          useSSOe={useSSOe}
+        />
+      ),
+    },
+  ];
+
+  if (showMHVTermsAndConditions) {
+    data.push({
+      title: 'Terms and conditions',
+      value: <MHVTermsAndConditionsStatus mhvAccount={mhvAccount} />,
+    });
+  }
+
+  return (
+    <div>
+      <ProfileInfoTable data={data} fieldName="accountSecurity" />
+      <AlertBox
+        status="info"
+        headline="Have questions about signing in to VA.gov?"
+        className="medium-screen:vads-u-margin-top--4"
+        backgroundOnly
+      >
+        <p>
+          Get answers to frequently asked questions about how to sign in, common
+          issues with verifying your identity, and your privacy and security on
+          VA.gov.
+        </p>
+        <a
+          href="/sign-in-faq/"
+          onClick={() =>
+            recordEvent({
+              event: 'account-navigation',
+              'account-action': 'view-link',
+              'account-section': 'vets-faqs',
+            })
+          }
+        >
+          Go to VA.gov FAQs
+        </a>
+      </AlertBox>
+    </div>
+  );
+};
+
+export const mapStateToProps = state => {
+  const profile = selectProfile(state);
+  const { verified, mhvAccount } = profile;
+  const showMHVTermsAndConditions =
+    verified && MHVTermsAndConditionsStatus.willRenderContent(mhvAccount);
+
+  return {
+    isIdentityVerified: isLOA3Selector(state),
+    isMultifactorEnabled: isMultifactorEnabledSelector(state),
+    mhvAccount,
+    showMHVTermsAndConditions,
+    useSSOe: ssoeSelector(state),
+  };
+};
+
+export default connect(mapStateToProps)(AccountSecurityContent);

--- a/src/applications/personalization/profile-2/components/IdentityVerificationStatus.jsx
+++ b/src/applications/personalization/profile-2/components/IdentityVerificationStatus.jsx
@@ -1,0 +1,33 @@
+import React from 'react';
+
+import recordEvent from 'platform/monitoring/record-event';
+
+import Verified from './Verified';
+
+const IdentityVerificationStatus = ({ isIdentityVerified }) => {
+  if (isIdentityVerified) {
+    return <Verified>We’ve verified your identity.</Verified>;
+  }
+  return (
+    <>
+      <p className="vads-u-margin--0">
+        We need to make sure you’re you — and not someone pretending to be you —
+        before we can give you access to your personal and health-related
+        information. This helps to keep your information safe, and to prevent
+        fraud and identity theft.
+      </p>
+      <p className="vads-u-margin-bottom--0">
+        <a
+          href="/verify?next=/profile"
+          onClick={() => {
+            recordEvent({ event: 'verify-link-clicked' });
+          }}
+        >
+          Verify your identity
+        </a>
+      </p>
+    </>
+  );
+};
+
+export default IdentityVerificationStatus;

--- a/src/applications/personalization/profile-2/components/MHVTermsAndConditionsStatus.jsx
+++ b/src/applications/personalization/profile-2/components/MHVTermsAndConditionsStatus.jsx
@@ -1,0 +1,73 @@
+import React from 'react';
+
+import recordEvent from 'platform/monitoring/record-event';
+
+import Verified from './Verified';
+
+const MHVTermsAndConditionsStatus = ({ mhvAccount }) => {
+  const termsAndConditionsUrl =
+    '/health-care/medical-information-terms-conditions';
+
+  if (mhvAccount.termsAndConditionsAccepted) {
+    return (
+      <Verified>
+        <>
+          You’ve accepted the latest Terms and Conditions for Medical
+          Information.
+          <p className="vads-u-margin-bottom--0">
+            <a
+              href={termsAndConditionsUrl}
+              onClick={() =>
+                recordEvent({
+                  event: 'account-navigation',
+                  'account-action': 'view-link',
+                  'account-section': 'terms',
+                })
+              }
+            >
+              View terms and conditions for medical information
+            </a>
+          </p>
+        </>
+      </Verified>
+    );
+  } else if (mhvAccount.accountState === 'needs_terms_acceptance') {
+    return (
+      <>
+        <p className="vads-u-margin--0">
+          To get started using our health tools, you’ll need to read and agree
+          to the Terms and Conditions for Medical Information. This will give us
+          your permission to show you your VA medical information on this site.
+        </p>
+        <p className="vads-u-margin-bottom--0">
+          <a
+            href={termsAndConditionsUrl}
+            onClick={() =>
+              recordEvent({
+                event: 'account-navigation',
+                'account-action': 'view-link',
+                'account-section': 'terms',
+              })
+            }
+          >
+            Go to the Terms and Conditions for Health Tools
+          </a>
+        </p>
+      </>
+    );
+  }
+  return null;
+};
+
+/**
+ * A static helper so that potential parent components will know if this
+ * component will render content at all and potentially adjust their own
+ * rendering logic to account for that. For example, if the parent component
+ * will wrap this component in other markup and it wants to avoid making that
+ * additional wrapper markup if this component will not render anything.
+ */
+MHVTermsAndConditionsStatus.willRenderContent = mhvAccount =>
+  mhvAccount.termsAndConditionsAccepted ||
+  mhvAccount.accountState === 'needs_terms_acceptance';
+
+export default MHVTermsAndConditionsStatus;

--- a/src/applications/personalization/profile-2/components/TwoFactorAuthorizationStatus.jsx
+++ b/src/applications/personalization/profile-2/components/TwoFactorAuthorizationStatus.jsx
@@ -1,0 +1,39 @@
+import React from 'react';
+
+import recordEvent from 'platform/monitoring/record-event';
+import { mfa } from 'platform/user/authentication/utilities';
+
+import Verified from './Verified';
+
+const TwoFactorAuthorizationStatus = ({ isMultifactorEnabled, useSSOe }) => {
+  if (isMultifactorEnabled) {
+    return (
+      <Verified>
+        You’ve added an extra layer of security to your account with 2-factor
+        authentication.
+      </Verified>
+    );
+  }
+
+  const mfaHandler = useSSO => {
+    recordEvent({ event: 'multifactor-link-clicked' });
+    mfa(useSSO ? 'v1' : 'v0');
+  };
+
+  return (
+    <>
+      <p className="vads-u-margin--0">
+        Add an extra layer of security (called 2-factor authentication). This
+        helps to make sure only you can access your account - even if someone
+        gets your password.
+      </p>
+      <p className="vads-u-margin-bottom--0">
+        <button className="va-button-link" onClick={() => mfaHandler(useSSOe)}>
+          Set up 2-factor authentication
+        </button>
+      </p>
+    </>
+  );
+};
+
+export default TwoFactorAuthorizationStatus;

--- a/src/applications/personalization/profile-2/components/Verified.jsx
+++ b/src/applications/personalization/profile-2/components/Verified.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const Verified = ({ children }) => (
+  <p className="vads-u-margin--0 vads-u-padding-left--3">
+    <i className="fa fa-check vads-u-color--green vads-u-margin-right--0p5 vads-u-margin-left--neg3" />{' '}
+    {children}
+  </p>
+);
+
+Verified.propTypes = {
+  children: PropTypes.node.isRequired,
+};
+
+export default Verified;

--- a/src/applications/personalization/profile-2/tests/components/AccountSecurity.unit.spec.jsx
+++ b/src/applications/personalization/profile-2/tests/components/AccountSecurity.unit.spec.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { expect } from 'chai';
+
+import DowntimeNotification, {
+  externalServices,
+} from 'platform/monitoring/DowntimeNotification';
+
+import AccountSecurity from '../../components/AccountSecurity';
+import AccountSecurityContent from '../../components/AccountSecurityContent';
+
+describe('AccountSecurity', () => {
+  let wrapper;
+  beforeEach(() => {
+    wrapper = shallow(<AccountSecurity />);
+  });
+  afterEach(() => {
+    wrapper.unmount();
+  });
+  it('renders an h2 tag as its first child', () => {
+    const firstChild = wrapper.childAt(0);
+    expect(firstChild.type()).to.equal('h2');
+  });
+
+  it('renders a properly configured DowntimeNotification component as its second child', () => {
+    const secondChild = wrapper.childAt(1);
+    expect(secondChild.type()).to.equal(DowntimeNotification);
+    expect(secondChild.prop('dependencies')).to.deep.equal([
+      externalServices.emis,
+      externalServices.mvi,
+    ]);
+    expect(secondChild.children().type()).to.equal(AccountSecurityContent);
+  });
+});

--- a/src/applications/personalization/profile-2/tests/components/AccountSecurityContent.unit.spec.jsx
+++ b/src/applications/personalization/profile-2/tests/components/AccountSecurityContent.unit.spec.jsx
@@ -1,0 +1,255 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { expect } from 'chai';
+
+import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
+
+import {
+  AccountSecurityContent,
+  mapStateToProps,
+} from '../../components/AccountSecurityContent';
+import ProfileInfoTable from '../../components/ProfileInfoTable';
+import IdentityVerificationStatus from '../../components/IdentityVerificationStatus';
+import TwoFactorAuthorizationStatus from '../../components/TwoFactorAuthorizationStatus';
+import MHVTermsAndConditionsStatus from '../../components/MHVTermsAndConditionsStatus';
+
+describe('AccountSecurityContent', () => {
+  let wrapper;
+  const makeDefaultProps = () => ({
+    isIdentityVerified: true,
+    isMultifactorEnabled: true,
+    mhvAccount: { termsAndConditionsAccepted: true },
+    showMHVTermsAndConditions: true,
+    useSSOe: true,
+  });
+
+  it('should render a ProfileInfoTable as its first child', () => {
+    wrapper = shallow(<AccountSecurityContent {...makeDefaultProps()} />);
+    expect(wrapper.childAt(0).type()).to.equal(ProfileInfoTable);
+    wrapper.unmount();
+  });
+
+  describe('child ProfileInfoTable', () => {
+    let infoTableData;
+    let props;
+    describe('when `showMHVTermsAndConditions` is `true`', () => {
+      beforeEach(() => {
+        props = makeDefaultProps();
+        wrapper = shallow(<AccountSecurityContent {...props} />);
+        infoTableData = wrapper.find('ProfileInfoTable').prop('data');
+      });
+      afterEach(() => {
+        wrapper.unmount();
+      });
+      it('should pass in three rows of data', () => {
+        expect(infoTableData.length).to.equal(3);
+      });
+      it('should have the correct row titles', () => {
+        const expectedTitles = [
+          'Identity verification',
+          '2-factor authentication',
+          'Terms and conditions',
+        ];
+        infoTableData.forEach((row, rowIndex) => {
+          expect(row.title).to.equal(expectedTitles[rowIndex]);
+        });
+      });
+      it('should pass the `isIdentityVerified` prop to the `IdentityVerificationStatus` component in the first row', () => {
+        const firstRowComponent = infoTableData[0].value;
+        expect(firstRowComponent.type).to.equal(IdentityVerificationStatus);
+        expect(firstRowComponent.props.isIdentityVerified).to.equal(
+          props.isIdentityVerified,
+        );
+      });
+      it('should pass the `isMultifactorEnabled` prop to the `TwoFactorAuthorizationStatus` component in the second row', () => {
+        const secondRowComponent = infoTableData[1].value;
+        expect(secondRowComponent.type).to.equal(TwoFactorAuthorizationStatus);
+        expect(secondRowComponent.props.isMultifactorEnabled).to.equal(
+          props.isMultifactorEnabled,
+        );
+      });
+      it('should pass the `mhvAccount` prop to the `MHVTermsAndConditionsStatus` component in the second row', () => {
+        const thirdRowComponent = infoTableData[2].value;
+        expect(thirdRowComponent.type).to.equal(MHVTermsAndConditionsStatus);
+        expect(thirdRowComponent.props.mhvAccount).to.equal(props.mhvAccount);
+      });
+    });
+    describe('when `showMHVTermsAndConditions` is `false`', () => {
+      it('should pass in two rows of data', () => {
+        props.showMHVTermsAndConditions = false;
+        wrapper = shallow(<AccountSecurityContent {...props} />);
+        infoTableData = wrapper.find('ProfileInfoTable').prop('data');
+        expect(infoTableData.length).to.equal(2);
+        wrapper.unmount();
+      });
+    });
+  });
+
+  it('should render a properly configured AlertBox as its second child', () => {
+    wrapper = shallow(<AccountSecurityContent {...makeDefaultProps()} />);
+    const alertBox = wrapper.childAt(1);
+    const alertBoxText = alertBox.find('p');
+    const alertBoxLink = alertBox.find('a');
+    expect(alertBox.type()).to.equal(AlertBox);
+    expect(alertBox.prop('status')).to.equal('info');
+    expect(alertBox.prop('headline')).to.equal(
+      'Have questions about signing in to VA.gov?',
+    );
+    expect(alertBox.prop('backgroundOnly')).to.be.true;
+    expect(alertBoxText.text()).to.contain('Get answers');
+    expect(alertBoxLink.prop('href')).to.equal('/sign-in-faq/');
+    expect(alertBoxLink.text()).to.equal('Go to VA.gov FAQs');
+    wrapper.unmount();
+  });
+});
+
+describe('mapStateToProps', () => {
+  describe('isIdentityVerified', () => {
+    it('should be `true` if the user is LOA3', () => {
+      const mappedProps = mapStateToProps({
+        user: {
+          profile: {
+            loa: {
+              current: 3,
+            },
+          },
+        },
+      });
+      expect(mappedProps.isIdentityVerified).to.be.true;
+    });
+    it('should be `false` if the user is not LOA3', () => {
+      const mappedProps = mapStateToProps({
+        user: {
+          profile: {
+            loa: {
+              current: 1,
+            },
+          },
+        },
+      });
+      expect(mappedProps.isIdentityVerified).to.be.false;
+    });
+  });
+
+  describe('isMultifactorEnabled', () => {
+    it('should be `true` if the user has multifactor enabled', () => {
+      const mappedProps = mapStateToProps({
+        user: {
+          profile: {
+            multifactor: true,
+            loa: {
+              current: 1,
+            },
+          },
+        },
+      });
+      expect(mappedProps.isMultifactorEnabled).to.be.true;
+    });
+    it('should be `false` if the user does not have multifactor enabled', () => {
+      const mappedProps = mapStateToProps({
+        user: {
+          profile: {
+            multifactor: false,
+            loa: {
+              current: 1,
+            },
+          },
+        },
+      });
+      expect(mappedProps.isMultifactorEnabled).to.be.false;
+    });
+  });
+
+  describe('mhvAccount', () => {
+    it('should be pulled from the profile', () => {
+      const mhvAccount = {
+        termsAndConditionsAccepted: false,
+        accountState: 'needs_terms_acceptance',
+      };
+      const mappedProps = mapStateToProps({
+        user: {
+          profile: {
+            loa: {
+              current: 1,
+            },
+            mhvAccount,
+          },
+        },
+      });
+      expect(mappedProps.mhvAccount).to.deep.equal(mhvAccount);
+    });
+  });
+
+  describe('showMHVTermsAndConditions', () => {
+    it('should be `true` if the user is verified and the user has accepted terms and conditions', () => {
+      const mhvAccount = {
+        termsAndConditionsAccepted: true,
+      };
+      const mappedProps = mapStateToProps({
+        user: {
+          profile: {
+            loa: {
+              current: 1,
+            },
+            verified: true,
+            mhvAccount,
+          },
+        },
+      });
+      expect(mappedProps.showMHVTermsAndConditions).to.be.true;
+    });
+    it('should be `true` if the user is verified and the user needs to accept terms and conditions', () => {
+      const mhvAccount = {
+        termsAndConditionsAccepted: false,
+        accountState: 'needs_terms_acceptance',
+      };
+      const mappedProps = mapStateToProps({
+        user: {
+          profile: {
+            loa: {
+              current: 1,
+            },
+            verified: true,
+            mhvAccount,
+          },
+        },
+      });
+      expect(mappedProps.showMHVTermsAndConditions).to.be.true;
+    });
+    it('should be `false` if the user is verified but has neither accepted or needs to accept the terms and conditions', () => {
+      const mhvAccount = {
+        termsAndConditionsAccepted: false,
+        accountState: 'another_state',
+      };
+      const mappedProps = mapStateToProps({
+        user: {
+          profile: {
+            loa: {
+              current: 1,
+            },
+            verified: true,
+            mhvAccount,
+          },
+        },
+      });
+      expect(mappedProps.showMHVTermsAndConditions).to.be.false;
+    });
+    it('should be `false` if the user is not verified', () => {
+      const mhvAccount = {
+        termsAndConditionsAccepted: true,
+      };
+      const mappedProps = mapStateToProps({
+        user: {
+          profile: {
+            loa: {
+              current: 1,
+            },
+            verified: false,
+            mhvAccount,
+          },
+        },
+      });
+      expect(mappedProps.showMHVTermsAndConditions).to.be.false;
+    });
+  });
+});

--- a/src/applications/personalization/profile-2/tests/components/IdentityVerificationStatus.unit.spec.jsx
+++ b/src/applications/personalization/profile-2/tests/components/IdentityVerificationStatus.unit.spec.jsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { expect } from 'chai';
+
+import IdentityVerificationStatus from '../../components/IdentityVerificationStatus';
+import Verified from '../../components/Verified';
+
+describe('IdentityVerificationStatus', () => {
+  describe('when `isIdentityVerified` is `true`', () => {
+    it('should render a <Verified> component', () => {
+      const wrapper = shallow(
+        <IdentityVerificationStatus isIdentityVerified />,
+      );
+      expect(wrapper.type()).to.equal(Verified);
+      expect(
+        wrapper
+          .at(0)
+          .dive()
+          .text()
+          .includes('We’ve verified your identity.'),
+      ).to.be.true;
+      wrapper.unmount();
+    });
+  });
+  describe('when `isIdentityVerified` is `false`', () => {
+    it('should render info about verifying your identity', () => {
+      const wrapper = shallow(
+        <IdentityVerificationStatus isIdentityVerified={false} />,
+      );
+      const p = wrapper.find('p').at(0);
+      expect(
+        p
+          .text()
+          .includes(
+            'We need to make sure you’re you — and not someone pretending to be you — before we can give you access to your personal and health-related information. This helps to keep your information safe, and to prevent fraud and identity theft.',
+          ),
+      ).to.be.true;
+      wrapper.unmount();
+    });
+    it('should render a link to verify your identity', () => {
+      const wrapper = shallow(
+        <IdentityVerificationStatus isMultifactorEnabled={false} />,
+      );
+      const link = wrapper.find('a');
+      expect(link.prop('href')).to.equal('/verify?next=/profile');
+      expect(link.text().includes('Verify your identity')).to.be.true;
+      wrapper.unmount();
+    });
+  });
+});

--- a/src/applications/personalization/profile-2/tests/components/MHVTermsAndConditionsStatus.unit.spec.jsx
+++ b/src/applications/personalization/profile-2/tests/components/MHVTermsAndConditionsStatus.unit.spec.jsx
@@ -1,0 +1,133 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { expect } from 'chai';
+
+import MHVTermsAndConditionsStatus from '../../components/MHVTermsAndConditionsStatus';
+import Verified from '../../components/Verified';
+
+describe('MHVTermsAndConditionsStatus', () => {
+  describe('render output', () => {
+    let wrapper;
+    let mhvAccount;
+    describe('when user has accepted terms and conditions', () => {
+      beforeEach(() => {
+        mhvAccount = {
+          termsAndConditionsAccepted: true,
+        };
+        wrapper = shallow(
+          <MHVTermsAndConditionsStatus mhvAccount={mhvAccount} />,
+        );
+      });
+      afterEach(() => {
+        wrapper.unmount();
+      });
+
+      it('should render a <Verified> component', () => {
+        expect(wrapper.type()).to.equal(Verified);
+        expect(
+          wrapper
+            .at(0)
+            .dive()
+            .text()
+            .includes(
+              'You’ve accepted the latest Terms and Conditions for Medical Information',
+            ),
+        ).to.be.true;
+      });
+
+      it('should render a link to view the terms and conditions', () => {
+        const link = wrapper.find('a');
+        expect(link.prop('href')).to.equal(
+          '/health-care/medical-information-terms-conditions',
+        );
+        expect(
+          link
+            .text()
+            .includes('View terms and conditions for medical information'),
+        ).to.be.true;
+      });
+    });
+    describe('when user still needs to accept terms and conditions', () => {
+      beforeEach(() => {
+        mhvAccount = {
+          termsAndConditionsAccepted: false,
+          accountState: 'needs_terms_acceptance',
+        };
+        wrapper = shallow(
+          <MHVTermsAndConditionsStatus mhvAccount={mhvAccount} />,
+        );
+      });
+      afterEach(() => {
+        wrapper.unmount();
+      });
+
+      it('should render info about needing to accept terms and conditions', () => {
+        const p = wrapper.find('p').at(0);
+        expect(
+          p
+            .text()
+            .includes(
+              'To get started using our health tools, you’ll need to read and agree to the Terms and Conditions for Medical Information. This will give us your permission to show you your VA medical information on this site.',
+            ),
+        ).to.be.true;
+      });
+
+      it('should render a link to verify your identity', () => {
+        const link = wrapper.find('a');
+        expect(link.prop('href')).to.equal(
+          '/health-care/medical-information-terms-conditions',
+        );
+        expect(
+          link
+            .text()
+            .includes('Go to the Terms and Conditions for Health Tools'),
+        ).to.be.true;
+      });
+    });
+    describe('in all other cases', () => {
+      it('should render nothing', () => {
+        mhvAccount = {
+          accountState: 'some_other_state',
+          termsAndConditionsAccepted: false,
+        };
+        wrapper = shallow(
+          <MHVTermsAndConditionsStatus mhvAccount={mhvAccount} />,
+        );
+        expect(wrapper.isEmptyRender()).to.be.true;
+        wrapper.unmount();
+      });
+    });
+  });
+
+  describe('willRenderContent static method', () => {
+    describe('when user has accepted terms and conditions', () => {
+      it('should return `true`', () => {
+        const mhvAccount = {
+          termsAndConditionsAccepted: true,
+        };
+        expect(MHVTermsAndConditionsStatus.willRenderContent(mhvAccount)).to.be
+          .true;
+      });
+    });
+    describe('when user still needs to accept terms and conditions', () => {
+      it('should return `true`', () => {
+        const mhvAccount = {
+          termsAndConditionsAccepted: false,
+          accountState: 'needs_terms_acceptance',
+        };
+        expect(MHVTermsAndConditionsStatus.willRenderContent(mhvAccount)).to.be
+          .true;
+      });
+    });
+    describe('in all other cases', () => {
+      it('should return `false`', () => {
+        const mhvAccount = {
+          termsAndConditionsAccepted: false,
+          accountState: 'some_other_state',
+        };
+        expect(MHVTermsAndConditionsStatus.willRenderContent(mhvAccount)).to.be
+          .false;
+      });
+    });
+  });
+});

--- a/src/applications/personalization/profile-2/tests/components/TwoFactorAuthorizationStatus.unit.spec.jsx
+++ b/src/applications/personalization/profile-2/tests/components/TwoFactorAuthorizationStatus.unit.spec.jsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { expect } from 'chai';
+
+import TwoFactorAuthorizationStatus from '../../components/TwoFactorAuthorizationStatus';
+import Verified from '../../components/Verified';
+
+describe('TwoFactorAuthorizationStatus', () => {
+  describe('when `isMultifactorEnabled` is `true`', () => {
+    it('should render a <Verified> component', () => {
+      const wrapper = shallow(
+        <TwoFactorAuthorizationStatus isMultifactorEnabled />,
+      );
+      expect(wrapper.type()).to.equal(Verified);
+      expect(
+        wrapper
+          .at(0)
+          .dive()
+          .text()
+          .includes(
+            'You’ve added an extra layer of security to your account with 2-factor authentication.',
+          ),
+      ).to.be.true;
+      wrapper.unmount();
+    });
+  });
+  describe('when `isMultifactorEnabled` is `false`', () => {
+    it('should render info about setting up 2FA', () => {
+      const wrapper = shallow(
+        <TwoFactorAuthorizationStatus isMultifactorEnabled={false} />,
+      );
+      const p = wrapper.find('p').at(0);
+      expect(
+        p
+          .text()
+          .includes(
+            'Add an extra layer of security (called 2-factor authentication). This helps to make sure only you can access your account - even if someone gets your password.',
+          ),
+      ).to.be.true;
+      wrapper.unmount();
+    });
+    it('should render a link to set up 2FA', () => {
+      const wrapper = shallow(
+        <TwoFactorAuthorizationStatus isMultifactorEnabled={false} />,
+      );
+      const link = wrapper.find('button.va-button-link');
+      expect(link.text().includes('Set up 2-factor authentication')).to.be.true;
+      wrapper.unmount();
+    });
+  });
+});

--- a/src/applications/personalization/profile-2/tests/components/Verified.unit.spec.jsx
+++ b/src/applications/personalization/profile-2/tests/components/Verified.unit.spec.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { expect } from 'chai';
+
+import Verified from '../../components/Verified';
+
+describe('Verified component', () => {
+  let wrapper;
+  const text = 'This is verified';
+  beforeEach(() => {
+    wrapper = shallow(<Verified>{text}</Verified>);
+  });
+  afterEach(() => {
+    wrapper.unmount();
+  });
+  it('should render a `p` tag', () => {
+    expect(wrapper.type()).to.equal('p');
+  });
+
+  it('should render a Font Awesome check mark as its first child', () => {
+    const firstChild = wrapper.childAt(0);
+    expect(firstChild.type()).to.equal('i');
+    expect(firstChild.hasClass('fa-check')).to.be.true;
+  });
+
+  it('should render its `children` after the check mark', () => {
+    expect(wrapper.text().includes(text)).to.be.true;
+  });
+});


### PR DESCRIPTION
## Description
This PR fleshes out the Account Security section of Profile 2.0

**TODO:**
- [ ] add tests for the AccountSecurityContent component (these are mostly done locally, but I wanted to get this PR open)

## Testing done
Local + pretty solid unit tests for the new components

## Screenshots
<details>
  <summary>All green</summary>
  
![image](https://user-images.githubusercontent.com/20728956/79588266-83997000-8088-11ea-9f78-4d7317b9a82f.png)

</details>

<details>
  <summary>Action needed</summary>
  
![image](https://user-images.githubusercontent.com/20728956/79588284-8bf1ab00-8088-11ea-8156-194d8ee28a28.png)

</details>

<details>
  <summary>Case where MHV section is not shown at all</summary>
  
![image](https://user-images.githubusercontent.com/20728956/79588292-914ef580-8088-11ea-8d5e-2863441787c2.png)

</details>

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs