### PR TITLE
cap street address lines to 35 char

### DIFF
--- a/src/platform/user/profile/vet360/components/AddressField/address-schemas.js
+++ b/src/platform/user/profile/vet360/components/AddressField/address-schemas.js
@@ -20,6 +20,8 @@ const MILITARY_STATES = Object.entries(ADDRESS_DATA.states).reduce(
   {},
 );
 
+const STREET_LINE_MAX_LENGTH = 35;
+
 const formSchema = {
   type: 'object',
   properties: {
@@ -38,19 +40,19 @@ const formSchema = {
     addressLine1: {
       type: 'string',
       minLength: 1,
-      maxLength: 100,
+      maxLength: STREET_LINE_MAX_LENGTH,
       pattern: '^.*\\S.*',
     },
     addressLine2: {
       type: 'string',
       minLength: 1,
-      maxLength: 100,
+      maxLength: STREET_LINE_MAX_LENGTH,
       pattern: '^.*\\S.*',
     },
     addressLine3: {
       type: 'string',
       minLength: 1,
-      maxLength: 100,
+      maxLength: STREET_LINE_MAX_LENGTH,
       pattern: '^.*\\S.*',
     },
     city: {
@@ -126,7 +128,7 @@ const uiSchema = {
     'ui:title': 'Street address',
     'ui:errorMessages': {
       required: 'Street address is required',
-      pattern: 'Street address must be under 100 characters',
+      pattern: `Street address must be under ${STREET_LINE_MAX_LENGTH} characters`,
     },
   },
   addressLine2: {


### PR DESCRIPTION
## Description
prevent users from entering more than 35 characters per street address line to account for a limitation in VA Profile

## Testing done
Local. Can neither type more than 35 characters. and pasting long lines results in the text getting truncated to 35 characters.

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs