### PR TITLE
Add chunkname to import

### DIFF
--- a/src/applications/covid19-chatbot/createCoronavirusChatbot.js
+++ b/src/applications/covid19-chatbot/createCoronavirusChatbot.js
@@ -7,8 +7,7 @@ export default (_store, widgetType) => {
     return;
   }
 
-  // webpackChunkName: "chatbot"
-  import('./index').then(module => {
+  import(/* webpackChunkName: "chatbot" */ './index').then(module => {
     const initializeChatbot = module.default;
     initializeChatbot(root);
   });


### PR DESCRIPTION
## Description
Looks like the comment needs to be [inside the `import()` statement](https://webpack.js.org/guides/code-splitting/#dynamic-imports) for Webpack to name it properly.

## Testing done
Watched the name change in the dev tools network tab. (See screenshots.)

## Screenshots
**Before**
![image](https://user-images.githubusercontent.com/12970166/79594569-18549b80-8092-11ea-8045-717d5220b2db.png)

**After**
![image](https://user-images.githubusercontent.com/12970166/79594451-e17e8580-8091-11ea-96ec-97780fb8257d.png)


## Acceptance criteria
- [x] The bundle is named appropriately