### PR TITLE
BDD: Update claim wizard gating to support navigation to the BDD form

### DIFF
--- a/src/applications/disability-benefits/bdd/constants.js
+++ b/src/applications/disability-benefits/bdd/constants.js
@@ -1,0 +1,2 @@
+export const BDD_FORM_ROOT_URL =
+  '/disability/file-benefits-delivery-at-discharge-form-21-526ez';

--- a/src/applications/disability-benefits/wizard/pages/bdd.jsx
+++ b/src/applications/disability-benefits/wizard/pages/bdd.jsx
@@ -1,66 +1,64 @@
 import React from 'react';
-import { connect } from 'react-redux';
 import moment from 'moment';
-import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
-import { isLoggedIn as isLoggedInSelector } from 'platform/user/selectors';
-import recordEvent from 'platform/monitoring/record-event';
+import ErrorableDate from '@department-of-veterans-affairs/formation-react/ErrorableDate';
 import { pageNames } from './pageList';
-import { EBEN_526_URL, BDD_INFO_URL } from '../../constants';
 
-// TODO: Add in the dates for 180 and 90 days in the future
-const dateFormat = 'MMMM DD, YYYY';
-const ninetyDays = moment()
-  .add(90, 'd')
-  .format(dateFormat);
-const oneHundredEightyDays = moment()
-  .add(180, 'd')
-  .format(dateFormat);
+// Figure out which page to go to based on the date entered
+const findNextPage = state => {
+  const dateDischarge = moment({
+    day: state.day.value,
+    // moment takes 0-indexed months, but the date picker provides 1-indexed months
+    month: parseInt(state.month.value, 10) - 1,
+    year: state.year.value,
+  });
+  const dateToday = moment();
+  const differenceBetweenDatesInDays =
+    dateDischarge.diff(dateToday, 'days') + 1;
 
-function alertContent(isLoggedIn) {
+  if (
+    differenceBetweenDatesInDays >= 90 &&
+    differenceBetweenDatesInDays <= 180
+  ) {
+    return pageNames.fileBDD;
+  }
+  return pageNames.unableToFileBDD;
+};
+
+const defaultState = {
+  day: {
+    value: '',
+    dirty: false,
+  },
+  month: {
+    value: '',
+    dirty: false,
+  },
+  year: {
+    value: '',
+    dirty: false,
+  },
+};
+
+const isDateComplete = date =>
+  date.day.value && date.month.value && date.year.value.length === 4;
+
+const BDDPage = ({ setPageState, state = defaultState }) => {
+  const onChange = pageState =>
+    setPageState(
+      pageState,
+      isDateComplete(pageState) ? findNextPage(pageState) : undefined,
+    );
   return (
-    <>
-      <p>
-        <strong>
-          If your separation date is between {ninetyDays} and{' '}
-          {oneHundredEightyDays}
-        </strong>{' '}
-        (90 and 180 days from today), you can file a disability claim through
-        the Benefits Delivery at Discharge (BDD) program.
-      </p>
-      <p>
-        <strong>If your separation date is before {ninetyDays},</strong> you
-        can’t file a BDD claim, but you can still begin the process of filing
-        your claim on eBenefits.
-      </p>
-      <a
-        href={EBEN_526_URL}
-        className="usa-button-primary va-button-primary"
-        onClick={() =>
-          isLoggedIn && recordEvent({ event: 'nav-ebenefits-click' })
-        }
-      >
-        Go to eBenefits
-      </a>
-      <p>
-        <a href={BDD_INFO_URL}>Learn more about the BDD program</a>
-      </p>
-    </>
+    <ErrorableDate
+      label="Date or anticipated date of release from active duty"
+      onValueChange={onChange}
+      name="discharge-date"
+      date={state}
+    />
   );
-}
-
-const BDDPage = ({ isLoggedIn }) => (
-  <AlertBox
-    status="error"
-    headline="You’ll need to file a claim on eBenefits"
-    content={alertContent(isLoggedIn)}
-  />
-);
-
-const mapStateToProps = state => ({
-  isLoggedIn: isLoggedInSelector(state),
-});
+};
 
 export default {
   name: pageNames.bdd,
-  component: connect(mapStateToProps)(BDDPage),
+  component: BDDPage,
 };

--- a/src/applications/disability-benefits/wizard/pages/file-bdd.jsx
+++ b/src/applications/disability-benefits/wizard/pages/file-bdd.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { pageNames } from './pageList';
+import { BDD_INFO_URL } from '../../constants';
+import { BDD_FORM_ROOT_URL } from 'applications/disability-benefits/bdd/constants';
+
+const FileBDDClaim = () => (
+  <div>
+    <p>
+      Based on your information, you may be eligible for the Benefits Delivery
+      at Discharge program that allows service members to apply for VA
+      disability benefits prior to separation.
+    </p>
+    <p>
+      <a href={BDD_INFO_URL}>
+        Learn more about Benefits Delivery at Discharge (BDD)
+      </a>
+    </p>
+    <a
+      href={`${BDD_FORM_ROOT_URL}/introduction`}
+      className="usa-button-primary va-button-primary"
+    >
+      File a Benefits Delivery at Discharge claim
+    </a>
+  </div>
+);
+
+export default {
+  name: pageNames.fileBDD,
+  component: FileBDDClaim,
+};

--- a/src/applications/disability-benefits/wizard/pages/index.js
+++ b/src/applications/disability-benefits/wizard/pages/index.js
@@ -3,6 +3,8 @@ import originalClaim from './original-claim';
 import fileOriginalClaim from './file-original-claim';
 import appeals from './appeals';
 import bdd from './bdd';
+import fileBDD from './file-bdd';
+import unableToFileBDD from './unable-to-file-bdd';
 import fileClaim from './file-claim';
 import disagreeing from './disagreeing';
 import decisionReview from './decision-review';
@@ -14,6 +16,8 @@ export default [
   fileOriginalClaim,
   appeals,
   bdd,
+  fileBDD,
+  unableToFileBDD,
   fileClaim,
   disagreeing,
   decisionReview,

--- a/src/applications/disability-benefits/wizard/pages/pageList.js
+++ b/src/applications/disability-benefits/wizard/pages/pageList.js
@@ -4,6 +4,8 @@ export const pageNames = {
   fileOriginalClaim: 'file-original-claim',
   appeals: 'appeals',
   bdd: 'bdd',
+  fileBDD: 'file-bdd',
+  unableToFileBDD: 'unable-to-file-bdd',
   fileClaim: 'file-claim',
   disagreeing: 'disagreeing',
   decisionReview: 'decision-review',

--- a/src/applications/disability-benefits/wizard/pages/unable-to-file-bdd.jsx
+++ b/src/applications/disability-benefits/wizard/pages/unable-to-file-bdd.jsx
@@ -23,8 +23,11 @@ function alertContent(isLoggedIn) {
           If your separation date is before {ninetyDays} or after{' '}
           {oneHundredEightyDays},
         </strong>{' '}
-        you can’t file a BDD claim, but you can still begin the process of
-        filing your claim on eBenefits.
+        you can’t file a BDD claim.
+      </p>
+      <p>
+        <strong>If your separation date is before {ninetyDays},</strong> you can
+        still begin the process of filing your claim on eBenefits.
       </p>
       <a
         href={EBEN_526_URL}

--- a/src/applications/disability-benefits/wizard/pages/unable-to-file-bdd.jsx
+++ b/src/applications/disability-benefits/wizard/pages/unable-to-file-bdd.jsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import moment from 'moment';
+import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
+import { pageNames } from './pageList';
+import { isLoggedIn as isLoggedInSelector } from 'platform/user/selectors';
+import recordEvent from 'platform/monitoring/record-event';
+import { EBEN_526_URL, BDD_INFO_URL } from '../../constants';
+
+const dateFormat = 'MMMM DD, YYYY';
+const ninetyDays = moment()
+  .add(90, 'days')
+  .format(dateFormat);
+const oneHundredEightyDays = moment()
+  .add(180, 'days')
+  .format(dateFormat);
+
+function alertContent(isLoggedIn) {
+  return (
+    <>
+      <p>
+        <strong>
+          If your separation date is before {ninetyDays} or after{' '}
+          {oneHundredEightyDays},
+        </strong>{' '}
+        you can’t file a BDD claim, but you can still begin the process of
+        filing your claim on eBenefits.
+      </p>
+      <a
+        href={EBEN_526_URL}
+        className="usa-button-primary va-button-primary"
+        onClick={() =>
+          isLoggedIn && recordEvent({ event: 'nav-ebenefits-click' })
+        }
+      >
+        Go to eBenefits
+      </a>
+      <p>
+        <a href={BDD_INFO_URL}>Learn more about the BDD program</a>
+      </p>
+    </>
+  );
+}
+
+const UnableToFileBDDPage = ({ isLoggedIn }) => (
+  <AlertBox
+    status="error"
+    headline="You’ll need to file a claim on eBenefits"
+    content={alertContent(isLoggedIn)}
+  />
+);
+
+const mapStateToProps = state => ({
+  isLoggedIn: isLoggedInSelector(state),
+});
+
+export default {
+  name: pageNames.unableToFileBDD,
+  component: connect(mapStateToProps)(UnableToFileBDDPage),
+};


### PR DESCRIPTION
## Description
This pull request updates the claim wizard gating to support navigation to the BDD form. 

## Screenshots
![image](https://user-images.githubusercontent.com/53942725/79596344-6a0b1f00-80ae-11ea-88f5-b0ac6ee3c7d9.png)
New structure prompts a date field after the user indicates they have not separated from service.

![image](https://user-images.githubusercontent.com/53942725/79597034-8f4c5d00-80af-11ea-9761-c44e2c9531e3.png)
Providing an invalid date indicates this to the user.

![image](https://user-images.githubusercontent.com/53942725/79597089-adb25880-80af-11ea-841f-a7f4e015b648.png)
Entering a valid date the is outside of the 90 to 180 day discharge range displays appropriate messaging explaining that the user cannot file a BDD claim.

![image](https://user-images.githubusercontent.com/53942725/79597175-ce7aae00-80af-11ea-8140-c86af1dfa39a.png)
Supplying a valid date in the range for BDD provides a link for the user to begin their BDD claim.

## Acceptance criteria
- [ ] Claim wizard gating is updated to support navigation to the BDD form