### PR TITLE
add analytics to covid-19 banner

### DIFF
--- a/src/applications/personalization/dashboard/covid-19.jsx
+++ b/src/applications/personalization/dashboard/covid-19.jsx
@@ -3,6 +3,7 @@ import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 
 import FEATURE_FLAG_NAMES from 'platform/utilities/feature-toggles/featureFlagNames';
 import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
+import recordEvent from 'platform/monitoring/record-event';
 
 /*
 These lists were created by taking the list of supported facilities from
@@ -178,6 +179,13 @@ export const COVID19Alert = ({ facilityId }) => (
       className="usa-button-primary"
       href="https://mobile.va.gov/app/va-health-chat"
       rel="noopener noreferrer"
+      onClick={() => {
+        recordEvent({
+          event: 'dashboard-navigation',
+          'dashboard-action': 'view-link',
+          'dashboard-product': 'learn-more-chat',
+        });
+      }}
     >
       Learn more about VA health chat
     </a>


### PR DESCRIPTION
## Description
Record analytics when user clicks on covid-19 banner's CTA button

## Testing done
Local

## Screenshots
N/A

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs