### PR TITLE
Group facility page errors together in Sentry and GA

### DIFF
--- a/src/applications/vaos/actions/newAppointment.js
+++ b/src/applications/vaos/actions/newAppointment.js
@@ -342,7 +342,7 @@ export function openFacilityPage(page, uiSchema, schema) {
         }
       }
     } catch (e) {
-      captureError(e);
+      captureError(e, false, 'facility page');
       dispatch({
         type: FORM_PAGE_FACILITY_OPEN_FAILED,
       });
@@ -389,7 +389,7 @@ export function updateFacilityPageData(page, uiSchema, data) {
           typeOfCareId,
         });
       } catch (e) {
-        captureError(e);
+        captureError(e, false, 'facility page');
         dispatch({
           type: FORM_FETCH_CHILD_FACILITIES_FAILED,
         });
@@ -441,7 +441,7 @@ export function updateFacilityPageData(page, uiSchema, data) {
           captureError(e);
         }
       } catch (e) {
-        captureError(e);
+        captureError(e, false, 'facility page');
         dispatch({
           type: FORM_ELIGIBILITY_CHECKS_FAILED,
         });

--- a/src/applications/vaos/utils/error.js
+++ b/src/applications/vaos/utils/error.js
@@ -2,7 +2,7 @@ import * as Sentry from '@sentry/browser';
 import { recordVaosError } from './events';
 import environment from 'platform/utilities/environment';
 
-export function captureError(err, skipRecordEvent) {
+export function captureError(err, skipRecordEvent = false, customTitle) {
   let eventErrorKey;
 
   if (err instanceof Error) {
@@ -11,7 +11,7 @@ export function captureError(err, skipRecordEvent) {
   } else {
     Sentry.withScope(scope => {
       scope.setExtra('error', err);
-      const errorTitle = err?.errors?.[0]?.title;
+      const errorTitle = customTitle || err?.errors?.[0]?.title;
       const message = `vaos_server_error${errorTitle ? `: ${errorTitle}` : ''}`;
       eventErrorKey = message;
       // the apiRequest helper returns the errors array, instead of an exception


### PR DESCRIPTION
## Description
This will group errors fetching data for the facility page into one bucket in Sentry.

## Testing done
Local

## Acceptance criteria
- [ ] Sentry errors are grouped into facility page bucket

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
