### PR TITLE
fix failing unit test

### DIFF
--- a/src/applications/personalization/profile-2/tests/components/AccountSecurityContent.unit.spec.jsx
+++ b/src/applications/personalization/profile-2/tests/components/AccountSecurityContent.unit.spec.jsx
@@ -76,6 +76,7 @@ describe('AccountSecurityContent', () => {
     });
     describe('when `showMHVTermsAndConditions` is `false`', () => {
       it('should pass in two rows of data', () => {
+        props = makeDefaultProps();
         props.showMHVTermsAndConditions = false;
         wrapper = shallow(<AccountSecurityContent {...props} />);
         infoTableData = wrapper.find('ProfileInfoTable').prop('data');


### PR DESCRIPTION
## Description
Unit tests were failing with `CHOMA_SEED=HWC99ghhYz`. This fixes it.

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs