### PR TITLE
Kelsonic 7474 download pdf forms tweak ie

### DIFF
--- a/package.json
+++ b/package.json
@@ -249,6 +249,7 @@
     "cookie": "^0.3.1",
     "cookie-parser": "^1.4.3",
     "core-js": "^2.5.7",
+    "downloadjs": "^1.4.7",
     "downshift": "^1.22.5",
     "express": "^4.14.0",
     "express-http-proxy": "^1.5.1",

--- a/src/applications/find-forms/components/SearchResult.jsx
+++ b/src/applications/find-forms/components/SearchResult.jsx
@@ -1,9 +1,31 @@
+// Node modules.
 import React from 'react';
 import moment from 'moment';
-
+import download from 'downloadjs';
+// Relative imports.
 import * as customPropTypes from '../prop-types';
 
-export default function SearchResult({ form }) {
+const onDownloadClick = url => event => {
+  // Escape early if we're not on IE.
+  if (!navigator.msSaveBlob) {
+    return;
+  }
+
+  // Prevent browser default behavior.
+  event.preventDefault();
+
+  try {
+    // Attempt to download the file.
+    const request = download(url);
+
+    // If we aren't able to, resort to opening the download link in a new tab.
+    request.onerror = window.open(url, '_blank');
+  } catch (error) {
+    window.open(url, '_blank');
+  }
+};
+
+const SearchResult = ({ form }) => {
   if (!form?.attributes) {
     return null;
   }
@@ -39,18 +61,20 @@ export default function SearchResult({ form }) {
 
       <dd className="vads-u-padding-bottom--3">
         <a
+          download={form.attributes.url}
           href={form.attributes.url}
-          rel="noopener noreferrer"
-          target="_blank"
-          download
+          onClick={onDownloadClick(form.attributes.url)}
+          rel="noreferrer noopener"
         >
           Download VA form {form.id} {pdf}
         </a>
       </dd>
     </>
   );
-}
+};
 
 SearchResult.propTypes = {
   form: customPropTypes.Form.isRequired,
 };
+
+export default SearchResult;

--- a/yarn.lock
+++ b/yarn.lock
@@ -5915,6 +5915,11 @@ downgrade-root@^1.0.0:
     default-uid "^1.0.0"
     is-root "^1.0.0"
 
+downloadjs@^1.4.7:
+  version "1.4.7"
+  resolved "https://registry.yarnpkg.com/downloadjs/-/downloadjs-1.4.7.tgz#f69f96f940e0d0553dac291139865a3cd0101e3c"
+  integrity sha1-9p+W+UDg0FU9rCkROYZaPNAQHjw=
+
 downshift@^1.22.5:
   version "1.22.5"
   resolved "https://registry.yarnpkg.com/downshift/-/downshift-1.22.5.tgz#48103b2f80259157b01b96d6bdc344c51ce0743e"


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/7474

This PR adds the following functionality:

When clicking on a download link, rely on the `download` attribute EXCEPT on IE, where we prevent browser default behavior and download the file via JS. If that fails due to CORS issues (or 404, etc.), resort to browser default behavior and open the link in a new tab.

## Testing done
Locally, though very difficult since we get CORS or 404 issues.

## Screenshots
#### Before click
![image](https://user-images.githubusercontent.com/12773166/79883815-9629e700-83b1-11ea-8942-e5a6a6764eb1.png)

#### After click (CORS issue)
![image](https://user-images.githubusercontent.com/12773166/79883857-a346d600-83b1-11ea-9cd8-7a741a4b3713.png)

#### After click (404 issue, notice the 404 download is in the tray)
![image](https://user-images.githubusercontent.com/12773166/79884273-2d8f3a00-83b2-11ea-9b99-8b3ce3fab4d3.png)

## Acceptance criteria
- [x] Remove `target="_blank"`
- [x] Ensure link is downloaded when clicked.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
