### PR TITLE
[E2E Tests] Disable announcement site-wide

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends gconf-service l
   && apt-get update \
   && apt-get install -y google-chrome-unstable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst ttf-freefont \
     --no-install-recommends \
-  && npm install -g s3-cli
+  && npm install -g yarn@$YARN_VERSION \
+  && npm install -g s3-cli \
+  && chmod +x /usr/local/lib/node_modules/yarn/bin/yarn.js
 
 RUN curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > /cc-test-reporter
 RUN chmod +x /cc-test-reporter

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN groupadd -g $userid vets-website \
   && useradd -u $userid -r -m -d /application -g vets-website vets-website
 
 ENV YARN_VERSION 1.21.1
+ENV NODE_VERSION 10.15.3
 ENV NODE_ENV production
 
 RUN apt-get update && apt-get install -y --no-install-recommends gconf-service libasound2 libatk1.0-0 libc6 libcairo2 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # based on https://github.com/nodejs/docker-node/blob/master/4.7/slim/Dockerfile
 
-FROM node:10
+FROM node:10.15.3
 
 # default case is Jenkins, but we want to be able to overwrite this
 ARG userid=504

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # based on https://github.com/nodejs/docker-node/blob/master/4.7/slim/Dockerfile
 
-FROM node:10.15.3
+FROM node:10
 
 # default case is Jenkins, but we want to be able to overwrite this
 ARG userid=504
@@ -8,7 +8,6 @@ RUN groupadd -g $userid vets-website \
   && useradd -u $userid -r -m -d /application -g vets-website vets-website
 
 ENV YARN_VERSION 1.21.1
-ENV NODE_VERSION 10.15.3
 ENV NODE_ENV production
 
 RUN apt-get update && apt-get install -y --no-install-recommends gconf-service libasound2 libatk1.0-0 libc6 libcairo2 \
@@ -26,9 +25,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends gconf-service l
   && apt-get update \
   && apt-get install -y google-chrome-unstable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-kacst ttf-freefont \
     --no-install-recommends \
-  && npm install -g yarn@$YARN_VERSION \
-  && npm install -g s3-cli \
-  && chmod +x /usr/local/lib/node_modules/yarn/bin/yarn.js
+  && npm install -g s3-cli
 
 RUN curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > /cc-test-reporter
 RUN chmod +x /cc-test-reporter

--- a/src/applications/personalization/preferences/tests/e2e/emptyPreferences.e2e.spec.js
+++ b/src/applications/personalization/preferences/tests/e2e/emptyPreferences.e2e.spec.js
@@ -13,60 +13,6 @@ function emptyPreferences(browser, token) {
   initChoicesGetMock(token);
   initHealthPostMock(token);
 
-  // init announcements
-  browser.execute(() => {
-    window.localStorage.setItem(
-      'DISMISSED_ANNOUNCEMENTS',
-      '["welcome-to-new-va"]',
-    );
-  });
-
-  // verify FTUX Find VA benefits modal
-  browser
-    .url(`${E2eHelpers.baseUrl}/my-va`)
-    .waitForElementVisible('.va-modal-body', Timeouts.slow);
-  browser.assert.containsText('.va-modal-body', 'Find VA benefits');
-
-  // accept find benefits modal
-  browser
-    .click('.va-modal-body .usa-button')
-    // land on correct page
-    .waitForElementVisible('#dashboard-title', Timeouts.slow);
-  browser.assert.containsText('#dashboard-title', 'Find VA benefits');
-
-  // init announcements
-  browser.execute(() => {
-    // window.localStorage.clear();
-    window.localStorage.setItem(
-      'DISMISSED_ANNOUNCEMENTS',
-      '["welcome-to-new-va"]',
-    );
-  });
-
-  // verify modal
-  browser
-    .url(`${E2eHelpers.baseUrl}/my-va`)
-    .waitForElementVisible('.va-modal-body', Timeouts.slow);
-  browser.assert.containsText('.va-modal-body', 'Find VA benefits');
-
-  // decline find benefits modal
-  browser
-    .click('.va-modal-body .usa-button-secondary')
-    // land on correct page
-    .waitForElementVisible('#dashboard-title', Timeouts.slow);
-  browser.assert.containsText('#dashboard-title', 'My VA');
-
-  // init announcements
-  browser.execute(() => {
-    window.localStorage.setItem('DISMISSED_ANNOUNCEMENTS', '*');
-  });
-
-  // ensure that modal does not appear if it has been dismissed
-  browser
-    .url(`${E2eHelpers.baseUrl}/my-va`)
-    .waitForElementVisible('body', Timeouts.slow);
-  browser.assert.elementNotPresent('.va-modal-body');
-
   // without having selected any preferences, ensure that none appear
   browser.assert.containsText(
     '.user-profile-row div div div p',

--- a/src/applications/personalization/profile-2/tests/components/AccountSecurityContent.unit.spec.jsx
+++ b/src/applications/personalization/profile-2/tests/components/AccountSecurityContent.unit.spec.jsx
@@ -76,6 +76,7 @@ describe('AccountSecurityContent', () => {
     });
     describe('when `showMHVTermsAndConditions` is `false`', () => {
       it('should pass in two rows of data', () => {
+        props = makeDefaultProps();
         props.showMHVTermsAndConditions = false;
         wrapper = shallow(<AccountSecurityContent {...props} />);
         infoTableData = wrapper.find('ProfileInfoTable').prop('data');

--- a/src/platform/site-wide/tests/accessible-modal.e2e.spec.js
+++ b/src/platform/site-wide/tests/accessible-modal.e2e.spec.js
@@ -1,5 +1,4 @@
 const E2eHelpers = require('../../testing/e2e/helpers');
-const Timeouts = require('../../testing/e2e/timeouts.js');
 
 const overlay = '#modal-crisisline';
 const firstModalItem = 'a[href="tel:18002738255"]';
@@ -15,12 +14,6 @@ module.exports = E2eHelpers.createE2eTest(client => {
   client.openUrl(`${E2eHelpers.baseUrl}/`);
 
   E2eHelpers.overrideSmoothScrolling(client);
-
-  client
-    .waitForElementVisible('body', Timeouts.normal)
-    .waitForElementVisible(firstOpenControl, Timeouts.slow)
-    .click('.announcement-brand-consolidation button')
-    .axeCheck('.main');
 
   // --------------------- //
   // --- Modal tests --- //

--- a/src/platform/testing/e2e/helpers.js
+++ b/src/platform/testing/e2e/helpers.js
@@ -2,6 +2,12 @@ const Timeouts = require('./timeouts');
 const Path = require('path');
 const FindRoot = require('find-root');
 
+const BASE_URL = `http://${process.env.WEB_HOST || 'localhost'}:${process.env
+  .WEB_PORT || 3333}`;
+
+const API_URL = `http://${process.env.API_HOST || 'localhost'}:${process.env
+  .API_PORT || 3000}`;
+
 function overrideVetsGovApi(client) {
   client.execute(
     url => {
@@ -94,6 +100,7 @@ function uploadTestFile(client, fileData) {
 function createE2eTest(beginApplication) {
   return {
     'Begin application': client => {
+      client.openUrl(BASE_URL);
       overrideSmoothScrolling(client);
       disableAnnouncements(client);
       beginApplication(client);
@@ -147,10 +154,8 @@ function expectInputToNotBeSelected(client, field) {
 }
 
 module.exports = {
-  baseUrl: `http://${process.env.WEB_HOST || 'localhost'}:${process.env
-    .WEB_PORT || 3333}`,
-  apiUrl: `http://${process.env.API_HOST || 'localhost'}:${process.env
-    .API_PORT || 3000}`,
+  baseUrl: BASE_URL,
+  apiUrl: API_URL,
   createE2eTest,
   disableAnnouncements,
   uploadTestFile,

--- a/src/platform/testing/e2e/helpers.js
+++ b/src/platform/testing/e2e/helpers.js
@@ -95,6 +95,7 @@ function createE2eTest(beginApplication) {
   return {
     'Begin application': client => {
       overrideSmoothScrolling(client);
+      disableAnnouncements(client);
       beginApplication(client);
       client.end();
     },


### PR DESCRIPTION
## Description
This PR modifies the E2E helper function for creating E2E tests to include disabling the site-wide announcements. Particularly, the site-wide maintenance banner was popping up and disrupting the Nightwatch viewport for selecting elements, breaking E2E tests. 

## Testing done
The CI is the test 😄 

## Screenshots
N/A

## Acceptance criteria
- [ ] E2E tests execute with announcements disabled

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
