### PR TITLE
Skip landing page creation on watch task

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -264,7 +264,7 @@ module.exports = env => {
         // Only create a new landing page if one doesn't already exist from a
         // previous build. This is useful for using the content build page for
         // testing.
-        .filter(manifest => fs.existsSync(landingPagePath(manifest.rootUrl)))
+        .filter(manifest => !fs.existsSync(landingPagePath(manifest.rootUrl)))
         .map(
           manifest =>
             new HtmlWebpackPlugin({

--- a/src/applications/personalization/profile-2/tests/components/AccountSecurityContent.unit.spec.jsx
+++ b/src/applications/personalization/profile-2/tests/components/AccountSecurityContent.unit.spec.jsx
@@ -76,6 +76,7 @@ describe('AccountSecurityContent', () => {
     });
     describe('when `showMHVTermsAndConditions` is `false`', () => {
       it('should pass in two rows of data', () => {
+        props = makeDefaultProps();
         props.showMHVTermsAndConditions = false;
         wrapper = shallow(<AccountSecurityContent {...props} />);
         infoTableData = wrapper.find('ProfileInfoTable').prop('data');


### PR DESCRIPTION
## Description
I got the logic backwards like a nincompoop. :man_facepalming: 

## Testing done
Manual testing.
1. `yarn build:content` to create the "real" landing page
1. `yarn watch`
1. Navigate to http://localhost:3001/burials-and-memorials/application/530/introduction
1. Verify that the header and footer are correct, and the page title is correct
