### PR TITLE
[Static pages] Exit early if there isn't a homepage banner

### DIFF
--- a/src/applications/static-pages/analytics/addHomepageBannerListeners.js
+++ b/src/applications/static-pages/analytics/addHomepageBannerListeners.js
@@ -8,6 +8,8 @@ export default function addHomepageBannerListeners() {
 
   const container = document.querySelector(selectors.template);
 
+  if (!container) return;
+
   container.addEventListener('click', event => {
     if (!isAnchor(event.target)) {
       return;

--- a/src/applications/static-pages/analytics/index.js
+++ b/src/applications/static-pages/analytics/index.js
@@ -8,26 +8,30 @@ import addHomepageBannerListeners from './addHomepageBannerListeners';
  * listeners onto certain pages. If global, just execute the listener directly.
  */
 
-const pageListenersMap = new Map();
+const PAGE_EVENT_LISTENERS = new Map();
 
-pageListenersMap.set('/coronavirus-veteran-frequently-asked-questions/', [
+PAGE_EVENT_LISTENERS.set('/coronavirus-veteran-frequently-asked-questions/', [
   addJumplinkListeners,
   addQaSectionListeners,
 ]);
 
-pageListenersMap.set('/', [addHomepageBannerListeners]);
+PAGE_EVENT_LISTENERS.set('/', [addHomepageBannerListeners]);
 
-const specialListeners = pageListenersMap.get(document.location.pathname);
+function attachAnalytics() {
+  const specialListeners = PAGE_EVENT_LISTENERS.get(document.location.pathname);
 
-if (specialListeners) {
-  specialListeners.forEach(f => f());
+  if (specialListeners) {
+    specialListeners.forEach(f => f());
+  }
+
+  // Global listeners
+  addTeaserListeners();
 }
-
-// Global listeners
-addTeaserListeners();
 
 // Prevent the window from navigating away.
 // Useful to verify analytics when links are clicked.
 // window.onbeforeunload = function() {
 //   return ''
 // }
+
+document.addEventListener('DOMContentLoaded', attachAnalytics);

--- a/src/site/includes/header.html
+++ b/src/site/includes/header.html
@@ -86,7 +86,7 @@
 
   {% include "src/site/components/fullwidth_banner_alerts.drupal.liquid" %}
 
-  {% if homepage_banner %}
+  {% if homepage_banner and homepage_banner.visible %}
     {% include "src/site/includes/homepage-banner.liquid" with banner = homepage_banner %}
   {% endif %}
 


### PR DESCRIPTION
## Description
If there isn't a homepage banner, we shouldn't try to add analytics. This is a fix for a potential runtime bug. Also adds support for `visibility: false` in the banner config.

## Testing done


## Screenshots
N/A

## Acceptance criteria
- [ ] No potential runtime error

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
