### PR TITLE
Add aria-disabled attribute to link to avoid contrast issue

### DIFF
--- a/src/applications/vaos/components/VideoVisitSection.jsx
+++ b/src/applications/vaos/components/VideoVisitSection.jsx
@@ -35,6 +35,7 @@ export default function VideoVisitSection({ appointment }) {
               ? `description-join-link-${appointment.id}`
               : undefined
           }
+          aria-disabled={disableVideoLink ? 'true' : 'false'}
           href={appointment.videoLink}
           target="_blank"
           rel="noopener noreferrer"

--- a/src/applications/vaos/tests/components/VideoVisitSection.unit.spec.jsx
+++ b/src/applications/vaos/tests/components/VideoVisitSection.unit.spec.jsx
@@ -45,6 +45,7 @@ describe('Video visit', () => {
     const link = tree.find('.usa-button');
     expect(link.length).to.equal(1);
     expect(link.props()['aria-describedby']).to.equal(undefined);
+    expect(link.props()['aria-disabled']).to.equal('false');
     expect(tree.exists('span')).to.equal(false);
     expect(tree.exists('.usa-button-disabled')).to.equal(false);
     tree.unmount();
@@ -63,6 +64,7 @@ describe('Video visit', () => {
     const describedById = 'description-join-link-123';
     const link = tree.find('.usa-button');
     expect(link.props()['aria-describedby']).to.equal(describedById);
+    expect(link.props()['aria-disabled']).to.equal('true');
     expect(tree.exists(`span#${describedById}`)).to.be.true;
     tree.unmount();
   });


### PR DESCRIPTION
## Description
This adds an aria-disabled attribute to a link to avoid a contrast issue from aXe.

## Testing done
Local testing

## Acceptance criteria
- [ ] No aXe errors

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
