### PR TITLE
Add chatbot link to Facility Locator

### DIFF
--- a/src/applications/facility-locator/containers/VAMap.jsx
+++ b/src/applications/facility-locator/containers/VAMap.jsx
@@ -29,11 +29,14 @@ import {
 } from '../constants';
 import { areGeocodeEqual, setFocus } from '../utils/helpers';
 import { facilityLocatorShowCommunityCares } from '../utils/selectors';
-import { isProduction } from 'platform/site-wide/feature-toggles/selectors';
+import {
+  isProduction,
+  toggleValues,
+} from 'platform/site-wide/feature-toggles/selectors';
 import Pagination from '@department-of-veterans-affairs/formation-react/Pagination';
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 import mbxGeo from '@mapbox/mapbox-sdk/services/geocoding';
-import recordEvent from '../../../platform/monitoring/record-event';
+import recordEvent from 'platform/monitoring/record-event';
 
 const mbxClient = mbxGeo(mapboxClient);
 
@@ -717,6 +720,13 @@ class VAMap extends Component {
   };
 
   render() {
+    const chatbotLink = this.props.showCovidChatbotLink && (
+      <>
+        For answers to questions about how COVID-19 may affect your VA health
+        appointments, benefits, and services, use our VA{' '}
+        <a href="/coronavirus-chatbot/">coronavirus chatbot</a>.
+      </>
+    );
     return (
       <div>
         <div className="title-section">
@@ -730,10 +740,10 @@ class VAMap extends Component {
             health care providers.
           </p>
           <p>
-            <strong>Coronavirus update:</strong> Many VA and community provider
-            locations have changing hours and services due to COVID-19. For your
-            safety, please call before visiting any location to ask about
-            getting help by phone or video.
+            <strong>Coronavirus update:</strong> {chatbotLink} Many VA and
+            community provider locations have changing hours and services due to
+            COVID-19. For your safety, please call before visiting any location
+            to ask about getting help by phone or video.
           </p>
           <p>
             <strong>Need same-day care for a minor illness or injury?</strong>{' '}
@@ -759,6 +769,8 @@ function mapStateToProps(state) {
     results: state.searchResult.results,
     pagination: state.searchResult.pagination,
     selectedResult: state.searchResult.selectedResult,
+    showCovidChatbotLink: toggleValues(state)
+      .facilityLocatorShowCovid19ChatbotLink,
   };
 }
 

--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -1,4 +1,6 @@
 export default Object.freeze({
+  facilityLocatorShowCovid19ChatbotLink:
+    'facilityLocatorShowCovid19ChatbotLink',
   dashboardShowCovid19Alert: 'dashboardShowCovid19Alert',
   facilityLocatorShowCommunityCares: 'facilityLocatorShowCommunityCares',
   profileShowProfile2: 'profile_show_profile_2.0',


### PR DESCRIPTION
## Description
Like it says on the tin, this PR adds the chatbot link to the facility locator page behind a feature toggle.

Originating ticket: https://github.com/department-of-veterans-affairs/covid19-chatbot/issues/121

Depends on https://github.com/department-of-veterans-affairs/vets-api/pull/4165
**Note:** That vets-api PR has to go in first and the feature flag set to `false` before this can be merged in, otherwise the link will show to everybody.

## Testing done
Turned the feature toggle off and on while looking at the content on the facility locator page. (See screenshots.)

## Screenshots
**Without the feature toggle enabled**
![image](https://user-images.githubusercontent.com/12970166/79807360-819d0e80-831f-11ea-8638-b5b7aef3fd68.png)

**With the feature toggle enabled**
![image](https://user-images.githubusercontent.com/12970166/79807389-97123880-831f-11ea-946d-890566e725b5.png)

## Acceptance criteria
- [x] When the feature toggle is disabled, the link to the chatbot is NOT rendered
- [x] When the feature toggle is enabled, the link to the chatbot IS rendered