### PR TITLE
Add re-certification announcement

### DIFF
--- a/src/applications/static-pages/school-resources/constants/announcements.json
+++ b/src/applications/static-pages/school-resources/constants/announcements.json
@@ -1,5 +1,12 @@
 [
-  {    
+  {
+    "name": "107 Re-certification Information for School Certifying Officials Webinar Page",
+    "url": "https://www.benefits.va.gov/gibill/resources/education_resources/school_certifying_officials/presentations.asp",
+    "date": "2020-04-20",
+    "displayStartDate": "2020-04-20",
+    "displayEndDate": "2020-05-20"
+  },
+  {
     "name": "Temporary relief from your GI Bill benefit debt",
     "url": "https://www.facebook.com/gibillEducation/posts/10156986880046615?__tn__=-R",
     "date": "2020-04-15",


### PR DESCRIPTION
## Description
Add re-certification announcement

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [X] Events are logged appropriately
- [X] Documentation has been updated, if applicable
- [X] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
