### PR TITLE
Split require in use-resolved-path as a warning rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -45,6 +45,12 @@
         "aliases": ["applications", "platform", "site", "vet360"]
       }
     ],
+    "va/resolved-path-on-required": [
+      1,
+      {
+        "aliases": ["applications", "platform", "site", "vet360"]
+      }
+    ],
 
     /* || fp plugin || */
     "fp/no-proxy": 2, // IE 11 has no polyfill for Proxy

--- a/script/eslint-plugin-va/index.js
+++ b/script/eslint-plugin-va/index.js
@@ -3,12 +3,19 @@ module.exports = {
     'proptypes-camel-cased': require('./rules/proptypes-camel-cased'),
     'enzyme-unmount': require('./rules/enzyme-unmount.js'),
     'use-resolved-path': require('./rules/use-resolved-path.js'),
+    'resolved-path-on-required': require('./rules/resolved-path-on-required.js'),
   },
   rulesConfig: {
     'proptypes-camel-cased': 2,
     'enzyme-unmount': 2,
     'use-resolved-path': [
       2,
+      {
+        aliases: ['applications', 'platform', 'site'],
+      },
+    ],
+    'resolved-path-on-required': [
+      1,
       {
         aliases: ['applications', 'platform', 'site'],
       },

--- a/script/eslint-plugin-va/package.json
+++ b/script/eslint-plugin-va/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-va",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "main": "index.js",
   "peerDependency": {
     "eslint": "^4.18.2"

--- a/script/eslint-plugin-va/rules/resolved-path-on-required.js
+++ b/script/eslint-plugin-va/rules/resolved-path-on-required.js
@@ -1,4 +1,4 @@
-const MESSAGE = 'Use resolved path and remove unnecessary parent path';
+const MESSAGE = 'Use resolved path if it is a babel alias';
 const DEFAULTS = ['applications'];
 
 function isIncluded(val, aliases) {
@@ -41,18 +41,9 @@ module.exports = {
     const aliases = configuration.aliases || DEFAULTS;
 
     return {
-      ImportDeclaration(node) {
-        const value = node.source.value;
-        if (isIncluded(value, aliases)) {
-          context.report({
-            node,
-            message: MESSAGE,
-          });
-        }
-      },
       CallExpression(node) {
         const callee = node.callee.name || node.callee.type;
-        if (callee === 'Import') {
+        if (callee === 'require') {
           const value = node.arguments[0].value;
           if (isIncluded(value, aliases)) {
             context.report({


### PR DESCRIPTION
## Description
`va/use-resolved-path` rule from the `va custom plugin` was evaluating the constant declaration using `require`. At this point is we don’t have an easy way to differentiate between a `require` from node and babel. Therefore, this ticket refactors this implementation by creating a new custom rule `resolved-path-on-required` to warns the use of `require` in aliases

## Testing done
Locally

## Screenshots

<img width="562" alt="Screen Shot 2020-04-21 at 1 48 23 PM" src="https://user-images.githubusercontent.com/55560129/79897181-51b14200-83d7-11ea-8573-9167f285a713.png">
