### PR TITLE
fixed failed Axe test

### DIFF
--- a/src/applications/gi/components/AccordionItem.jsx
+++ b/src/applications/gi/components/AccordionItem.jsx
@@ -10,6 +10,7 @@ class AccordionItem extends React.Component {
     this.toggle = this.toggle.bind(this);
     this.state = {
       expanded: props.expanded,
+      button: props.button,
     };
     this.id = _.uniqueId('accordion-item-');
   }
@@ -26,33 +27,32 @@ class AccordionItem extends React.Component {
 
   render() {
     const expanded = this.state.expanded;
+    const label = this.state.button;
     const headerClasses = classNames('accordion-button-wrapper', {
       [this.props.headerClass]: this.props.headerClass,
     });
     return (
-      <div>
-        <li>
-          <h2 aria-live="off" className={headerClasses}>
-            <button
-              onClick={this.toggle}
-              className="usa-accordion-button"
-              aria-expanded={expanded}
-              aria-controls={this.id}
-            >
-              <span className="vads-u-font-family--serif accordion-button-text">
-                {this.props.button}
-              </span>
-            </button>
-          </h2>
-          <div
-            id={this.id}
-            className="usa-accordion-content"
-            aria-hidden={!expanded}
+      <li aria-label={label}>
+        <h2 aria-live="off" className={headerClasses}>
+          <button
+            onClick={this.toggle}
+            className="usa-accordion-button"
+            aria-expanded={expanded}
+            aria-controls={this.id}
           >
-            {this.props.children}
-          </div>
-        </li>
-      </div>
+            <span className="vads-u-font-family--serif accordion-button-text">
+              {this.props.button}
+            </span>
+          </button>
+        </h2>
+        <div
+          id={this.id}
+          className="usa-accordion-content"
+          aria-hidden={!expanded}
+        >
+          {this.props.children}
+        </div>
+      </li>
     );
   }
 }
@@ -61,6 +61,7 @@ AccordionItem.propTypes = {
   expanded: PropTypes.bool.isRequired,
   children: PropTypes.node.isRequired,
   button: PropTypes.string.isRequired,
+  label: PropTypes.string.isRequired,
 };
 
 AccordionItem.defaultProps = {


### PR DESCRIPTION
## Description
The GIBCT provider detail view has several accordion menus that are coded as `<div> + <li>` inside an `<ul>`. This is causing an axe error, and should be refactored as soon as possible. This current implementation breaks the relationship between the UL and its list items for screen readers. 

https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/7727

## Testing done
Local testing with axe

## Screenshots


## Acceptance criteria
- [x] Axe error no longer appears on future runs
- [x] The expand/collapse accordions maintain current functionality (no regression)

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
