### PR TITLE
Adds scrolling to webchat

### DIFF
--- a/src/applications/coronavirus-chatbot/index.js
+++ b/src/applications/coronavirus-chatbot/index.js
@@ -153,6 +153,6 @@ const chatRequested = scenario => {
 
 export default function initializeChatbot(_root) {
   root = _root;
-  watchForButtonClicks();
+  watchForButtonClicks(root);
   chatRequested('va_coronavirus_chatbot');
 }

--- a/src/applications/coronavirus-chatbot/index.js
+++ b/src/applications/coronavirus-chatbot/index.js
@@ -153,6 +153,6 @@ const chatRequested = scenario => {
 
 export default function initializeChatbot(_root) {
   root = _root;
-  watchForButtonClicks(root);
+  watchForButtonClicks();
   chatRequested('va_coronavirus_chatbot');
 }

--- a/src/applications/coronavirus-chatbot/utils.js
+++ b/src/applications/coronavirus-chatbot/utils.js
@@ -15,8 +15,6 @@ const disableButtons = event => {
   for (let i = 0; i < siblingButtons.length; i++) {
     siblingButtons[i].disabled = true;
   }
-
-  scrollToNewMessage();
 };
 
 export const watchForButtonClicks = () => {
@@ -24,6 +22,7 @@ export const watchForButtonClicks = () => {
     const buttons = document.getElementsByClassName('ac-pushButton');
     for (let i = 0; i < buttons.length; i++) {
       buttons[i].addEventListener('click', disableButtons);
+      buttons[i].addEventListener('click', scrollToNewMessage);
     }
   }, 10);
 };

--- a/src/applications/coronavirus-chatbot/utils.js
+++ b/src/applications/coronavirus-chatbot/utils.js
@@ -1,3 +1,9 @@
+const scrollToNewMessage = () => {
+  const messages = document.getElementsByClassName('webchat__stackedLayout--fromUser');
+  const lastMessageFromUser = messages[messages.length - 1];
+  lastMessageFromUser.scrollIntoView({behavior: 'smooth'});
+}
+
 const disableButtons = event => {
   // if user clicked the div, bubble up to parent to disable the button
   const targetButton =
@@ -7,6 +13,8 @@ const disableButtons = event => {
   for (let i = 0; i < siblingButtons.length; i++) {
     siblingButtons[i].disabled = true;
   }
+
+  scrollToNewMessage();
 };
 
 export const watchForButtonClicks = () => {

--- a/src/applications/coronavirus-chatbot/utils.js
+++ b/src/applications/coronavirus-chatbot/utils.js
@@ -1,8 +1,10 @@
 const scrollToNewMessage = () => {
-  const messages = document.getElementsByClassName('webchat__stackedLayout--fromUser');
+  const messages = document.getElementsByClassName(
+    'webchat__stackedLayout--fromUser',
+  );
   const lastMessageFromUser = messages[messages.length - 1];
-  lastMessageFromUser.scrollIntoView({behavior: 'smooth'});
-}
+  lastMessageFromUser.scrollIntoView({ behavior: 'smooth' });
+};
 
 const disableButtons = event => {
   // if user clicked the div, bubble up to parent to disable the button


### PR DESCRIPTION
## Page to edit
url: https://dev.va.gov/coronavirus-chatbot/

## Origin of request (internal/stakeholder/user feedback)
Related to this [issue](https://github.com/department-of-veterans-affairs/covid19-chatbot/issues/128)

## Description of what's needed (edits/link changes/additions)

- When the user clicks on a button, the page scrolls to the last message from the user (which is the first message of the new content)
- Scrolling is smooth (vs jumping to new location)