### PR TITLE
Dynamically add the Covid19 chatbot link to FAQ page

### DIFF
--- a/src/applications/static-pages/covidFaqLink.js
+++ b/src/applications/static-pages/covidFaqLink.js
@@ -1,0 +1,19 @@
+import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
+
+const insertLink = () => {
+  const linkParagraph = document.createElement('p');
+  linkParagraph.innerHTML =
+    'You can also use our <a href="/coronavirus-chatbot/">VA coronavirus chatbot</a> to get answers to your questions.';
+  const introText = document.querySelector('.va-introtext');
+  introText.parentNode.insertBefore(linkParagraph, introText.nextSibling);
+};
+
+export default function addLinkToCovidFAQ(store) {
+  let linkAdded = false;
+  store.subscribe(() => {
+    if (!linkAdded && toggleValues(store.getState()).covid19FaqChatbotLink) {
+      insertLink();
+      linkAdded = true;
+    }
+  });
+}

--- a/src/applications/static-pages/covidFaqLink.js
+++ b/src/applications/static-pages/covidFaqLink.js
@@ -5,11 +5,15 @@ const insertLink = () => {
   linkParagraph.innerHTML =
     'You can also use our <a href="/coronavirus-chatbot/">VA coronavirus chatbot</a> to get answers to your questions.';
   const introText = document.querySelector('.va-introtext');
+
+  // Insert the link after the intro text
   introText.parentNode.insertBefore(linkParagraph, introText.nextSibling);
 };
 
 export default function addLinkToCovidFAQ(store) {
+  // Only add the link once
   let linkAdded = false;
+
   store.subscribe(() => {
     if (!linkAdded && toggleValues(store.getState()).covid19FaqChatbotLink) {
       insertLink();

--- a/src/applications/static-pages/static-pages-entry.js
+++ b/src/applications/static-pages/static-pages-entry.js
@@ -29,6 +29,7 @@ import createHigherLevelReviewApplicationStatus from 'applications/disability-be
 import createPost911GiBillStatusWidget, {
   post911GIBillStatusReducer,
 } from '../post-911-gib-status/createPost911GiBillStatusWidget';
+import addLinkToCovidFAQ from './covidFaqLink';
 
 // No-react styles.
 import './sass/static-pages.scss';
@@ -134,6 +135,10 @@ createHomepageBanner(store, widgetTypes.HOMEPAGE_BANNER);
 // homepage widgets
 if (location.pathname === '/') {
   createMyVALoginWidget(store);
+}
+
+if (location.pathname === '/coronavirus-veteran-frequently-asked-questions/') {
+  addLinkToCovidFAQ(store);
 }
 
 /* eslint-disable no-unused-vars,camelcase */

--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -1,5 +1,6 @@
 export default Object.freeze({
   dashboardShowCovid19Alert: 'dashboardShowCovid19Alert',
+  covid19FaqChatbotLink: 'covid19FaqChatbotLink',
   facilityLocatorShowCommunityCares: 'facilityLocatorShowCommunityCares',
   profileShowProfile2: 'profile_show_profile_2.0',
   profileShowReceiveTextNotifications: 'profileShowReceiveTextNotifications',


### PR DESCRIPTION
## Description
Adds the link to the chatbot on the `/coronavirus-veteran-frequently-asked-questions/` page.

Good news! This didn't require any changes to the content! :tada: 

Originating ticket: https://github.com/department-of-veterans-affairs/covid19-chatbot/issues/121#issue-603391159

## Testing done
Toggled the feature on and off and tested the result. See the screenshots below.

## Screenshots
**With the feature toggle off**
![image](https://user-images.githubusercontent.com/12970166/79925894-63ebaa00-83f0-11ea-9660-059aeb1cee58.png)

**With the feature toggle on**
![image](https://user-images.githubusercontent.com/12970166/79925869-533b3400-83f0-11ea-8613-fdf41e4b01b1.png)


## Acceptance criteria
- [ ] When the feature toggle is turned off, the link doesn't get added to the page
- [ ] When the feature toggle is turned on, the link DOES get added to the page
