### PR TITLE
Add comma to address formatter

### DIFF
--- a/src/platform/forms/address/helpers.js
+++ b/src/platform/forms/address/helpers.js
@@ -126,11 +126,10 @@ export function getStateName(abbreviation = '') {
 export function formatAddress(address) {
   /* eslint-disable prefer-template */
 
-  let street = address.addressOne || '';
-  if (address.addressOne && address.addressTwo) street += ', ';
-  if (address.addressTwo) street += address.addressTwo;
-  if (address.addressTwo && address.addressThree) street += ',';
-  if (address.addressThree) street += ' ' + address.addressThree;
+  const street =
+    [address.addressOne, address.addressTwo, address.addressThree]
+      .filter(item => item)
+      .join(', ') || '';
 
   const country =
     address.type === ADDRESS_TYPES.international ? address.countryName : '';

--- a/src/platform/forms/address/helpers.js
+++ b/src/platform/forms/address/helpers.js
@@ -129,6 +129,7 @@ export function formatAddress(address) {
   let street = address.addressOne || '';
   if (address.addressOne && address.addressTwo) street += ', ';
   if (address.addressTwo) street += address.addressTwo;
+  if (address.addressTwo && address.addressThree) street += ',';
   if (address.addressThree) street += ' ' + address.addressThree;
 
   const country =

--- a/src/platform/forms/tests/address.unit.spec.js
+++ b/src/platform/forms/tests/address.unit.spec.js
@@ -40,7 +40,7 @@ const military = {
 describe('formatAddress', () => {
   it('formats domestic addresses with three street lines', () => {
     const expectedResult = {
-      street: '140 Rock Creek Church Rd NW, Apt 57 Area Name',
+      street: '140 Rock Creek Church Rd NW, Apt 57, Area Name',
       cityStateZip: 'Springfield, Oregon 97477',
       country: '',
     };
@@ -73,7 +73,7 @@ describe('formatAddress', () => {
 
   it('formats military addresses', () => {
     const expectedResult = {
-      street: '57 Columbus Strassa, Line2 Ben Franklin Village',
+      street: '57 Columbus Strassa, Line2, Ben Franklin Village',
       cityStateZip: 'APO, AE 09028',
       country: '',
     };
@@ -83,7 +83,7 @@ describe('formatAddress', () => {
 
   it('formats international addresses', () => {
     const expectedResult = {
-      street: '2 Avenue Gabriel, Line2 Line3',
+      street: '2 Avenue Gabriel, Line2, Line3',
       cityStateZip: 'Paris',
       country: 'France',
     };


### PR DESCRIPTION
## Description
https://github.com/department-of-veterans-affairs/va.gov-team/issues/7498

Originally, there was no comma between addressLine2 and addressLine3. Now, there is :) 

## Testing done
Updated unit tests.

## Screenshots
![image](https://user-images.githubusercontent.com/14869324/79925996-0740bd00-83f9-11ea-9197-0d7bbd01a691.png)

## Acceptance criteria
- [x] There should a comma between addressLine2 and addressLine3.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
