### PR TITLE
Add GTM event triggers to chatbot

### DIFF
--- a/src/applications/coronavirus-chatbot/createCoronavirusChatbot.js
+++ b/src/applications/coronavirus-chatbot/createCoronavirusChatbot.js
@@ -1,3 +1,6 @@
+import recordEvent from '../../platform/monitoring/record-event';
+import { GA_PREFIX } from './utils';
+
 export default (_store, widgetType) => {
   // Derive the element to render our widget.
   const root = document.querySelector(`[data-widget-type="${widgetType}"]`);
@@ -7,8 +10,22 @@ export default (_store, widgetType) => {
     return;
   }
 
-  import(/* webpackChunkName: "chatbot" */ './index').then(module => {
-    const initializeChatbot = module.default;
-    initializeChatbot(root);
-  });
+  import(/* webpackChunkName: "chatbot" */ './index')
+    .then(module => {
+      const initializeChatbot = module.default;
+      initializeChatbot(root);
+    })
+    // eslint-disable-next-line no-unused-vars
+    .then(res => {
+      recordEvent({
+        event: `${GA_PREFIX}-load-successful`,
+      });
+    })
+    // eslint-disable-next-line no-unused-vars
+    .catch(error => {
+      recordEvent({
+        event: `${GA_PREFIX}-load-failure`,
+        'error-key': undefined,
+      });
+    });
 };

--- a/src/applications/coronavirus-chatbot/createCoronavirusChatbot.js
+++ b/src/applications/coronavirus-chatbot/createCoronavirusChatbot.js
@@ -19,6 +19,7 @@ export default (_store, widgetType) => {
     .then(res => {
       recordEvent({
         event: `${GA_PREFIX}-load-successful`,
+        'error-key': undefined,
       });
     })
     // eslint-disable-next-line no-unused-vars

--- a/src/applications/coronavirus-chatbot/index.js
+++ b/src/applications/coronavirus-chatbot/index.js
@@ -119,6 +119,7 @@ const initBotConversation = jsonWebToken => {
     startChat(user, webchatOptions);
     recordEvent({
       event: `${GA_PREFIX}-connection-successful`,
+      'error-key': undefined,
     });
   } catch (error) {
     recordEvent({

--- a/src/applications/coronavirus-chatbot/index.js
+++ b/src/applications/coronavirus-chatbot/index.js
@@ -1,5 +1,6 @@
 import { apiRequest } from '../../platform/utilities/api';
-import { watchForButtonClicks } from './utils';
+import recordEvent from '../../platform/monitoring/record-event';
+import { watchForButtonClicks, GA_PREFIX } from './utils';
 
 export const defaultLocale = 'en-US';
 const localeRegExPattern = /^[a-z]{2}(-[A-Z]{2})?$/;
@@ -114,7 +115,17 @@ const initBotConversation = jsonWebToken => {
     username: user.name,
     locale: user.locale,
   };
-  startChat(user, webchatOptions);
+  try {
+    startChat(user, webchatOptions);
+    recordEvent({
+      event: `${GA_PREFIX}-connection-successful`,
+    });
+  } catch (error) {
+    recordEvent({
+      event: `${GA_PREFIX}-connection-failure`,
+      'error-key': 'XX_failed_to_start_chat',
+    });
+  }
 };
 
 export const requestChatBot = loc => {
@@ -133,12 +144,15 @@ export const requestChatBot = loc => {
   if (params.has('userName')) {
     path += `&userName=${params.get('userName')}`;
   }
-
   return apiRequest(path, { method: 'POST' })
     .then(({ token }) => initBotConversation(token))
     .catch(error => {
       // eslint-disable-next-line no-console
       console.log(error);
+      recordEvent({
+        event: `${GA_PREFIX}-connection-failure`,
+        'error-key': 'XX_failed_to_init_bot_convo',
+      });
     });
 };
 const chatRequested = scenario => {

--- a/src/applications/coronavirus-chatbot/utils.js
+++ b/src/applications/coronavirus-chatbot/utils.js
@@ -17,3 +17,5 @@ export const watchForButtonClicks = () => {
     }
   }, 10);
 };
+
+export const GA_PREFIX = 'chatbot';


### PR DESCRIPTION
## Description

Adds three sets of GTM event triggers to address [initial chatbot analytics needs](https://github.com/department-of-veterans-affairs/covid19-chatbot/issues/111) for launch and per VSP Insights & Analytics team [guidance](https://github.com/department-of-veterans-affairs/va.gov-team/issues/8104#issuecomment-616749350):
- success/failure triggers on the loading of the chatbot widget, using `chatbot-load-[successful|failure]`
- success/failure triggers on the initiation of a connection to the bot service, using `chatbot-connection [successful|failure]` with discrete `error-key`
- success/failure for the start of a conversation, , using `chatbot-connection [successful|failure]` with discrete `error-key`

## Testing done
Manually `throw`d errors at various breakpoints and verified correct events were being pushed to `dataLayer`.

## Acceptance criteria
- [ ] Two success events are logged if there are no issues loading the widget and connecting to the service
- [ ] `chatbot-load-failure` is added to `dataLayer` if error is thrown during widget import / execution
- [ ] `chatbot-connection-failure` with `XX_failed_to_init_bot_convo` as the value for `error-key` is added to `dataLayer` if error is thrown during bot connection setup and initialization
- [ ] `chatbot-connection-failure` with `XX_failed_to_start_chat` as the value for `error-key` is added to `dataLayer` if error is thrown during rendering of the chat window

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
