### PR TITLE
Fix platform alias - bm

### DIFF
--- a/src/applications/disability-benefits/2346/routes.jsx
+++ b/src/applications/disability-benefits/2346/routes.jsx
@@ -1,4 +1,4 @@
-import { createRoutesWithSaveInProgress } from '../../../platform/forms/save-in-progress/helpers';
+import { createRoutesWithSaveInProgress } from 'platform/forms/save-in-progress/helpers';
 import formConfig from './config/form';
 import App from './containers/App.jsx';
 

--- a/src/applications/disability-benefits/526EZ/Form526EZApp.jsx
+++ b/src/applications/disability-benefits/526EZ/Form526EZApp.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import RoutedSavableApp from '../../../platform/forms/save-in-progress/RoutedSavableApp';
+import RoutedSavableApp from 'platform/forms/save-in-progress/RoutedSavableApp';
 import formConfig from './config/form';
 
 import ITFWrapper from '../all-claims/containers/ITFWrapper';

--- a/src/applications/disability-benefits/526EZ/actions/index.js
+++ b/src/applications/disability-benefits/526EZ/actions/index.js
@@ -1,6 +1,6 @@
 import * as Sentry from '@sentry/browser';
 
-import { apiRequest } from '../../../../platform/utilities/api';
+import { apiRequest } from 'platform/utilities/api';
 
 export const ITF_FETCH_INITIATED = 'ITF_FETCH_INITIATED';
 export const ITF_FETCH_SUCCEEDED = 'ITF_FETCH_SUCCEEDED';

--- a/src/applications/disability-benefits/526EZ/components/ConfirmationPoll.jsx
+++ b/src/applications/disability-benefits/526EZ/components/ConfirmationPoll.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { connect } from 'react-redux';
 
-import get from '../../../../platform/utilities/data/get';
-import { apiRequest } from '../../../../platform/utilities/api';
+import get from 'platform/utilities/data/get';
+import { apiRequest } from 'platform/utilities/api';
 
 import ConfirmationPage from '../containers/ConfirmationPage';
 import { pendingMessage } from '../content/confirmation-poll';

--- a/src/applications/disability-benefits/526EZ/components/DisabilityWizard.jsx
+++ b/src/applications/disability-benefits/526EZ/components/DisabilityWizard.jsx
@@ -7,12 +7,12 @@ import classNames from 'classnames';
 import ErrorableCheckboxGroup from '@department-of-veterans-affairs/formation-react/ErrorableCheckboxGroup';
 import ErrorableRadioButtons from '@department-of-veterans-affairs/formation-react/ErrorableRadioButtons';
 
-import { toggleLoginModal } from '../../../../platform/site-wide/user-nav/actions';
+import { toggleLoginModal } from 'platform/site-wide/user-nav/actions';
 
 import {
   isLoggedIn as isLoggedInSelector,
   isLOA3,
-} from '../../../../platform/user/selectors';
+} from 'platform/user/selectors';
 
 import ButtonContainer from './ButtonContainer';
 import {

--- a/src/applications/disability-benefits/526EZ/components/FormStartControls.jsx
+++ b/src/applications/disability-benefits/526EZ/components/FormStartControls.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import SaveInProgressIntro from '../../../../platform/forms/save-in-progress/SaveInProgressIntro';
+import SaveInProgressIntro from 'platform/forms/save-in-progress/SaveInProgressIntro';
 
 import {
   VerifiedAlert,

--- a/src/applications/disability-benefits/526EZ/components/IntroductionPage.jsx
+++ b/src/applications/disability-benefits/526EZ/components/IntroductionPage.jsx
@@ -5,10 +5,10 @@ import moment from 'moment';
 import OMBInfo from '@department-of-veterans-affairs/formation-react/OMBInfo';
 import FormTitle from 'platform/forms-system/src/js/components/FormTitle';
 
-import SaveInProgressIntro from '../../../../platform/forms/save-in-progress/SaveInProgressIntro';
-import CallToActionWidget from '../../../../platform/site-wide/cta-widget';
-import { toggleLoginModal } from '../../../../platform/site-wide/user-nav/actions';
-import { focusElement } from '../../../../platform/utilities/ui';
+import SaveInProgressIntro from 'platform/forms/save-in-progress/SaveInProgressIntro';
+import CallToActionWidget from 'platform/site-wide/cta-widget';
+import { toggleLoginModal } from 'platform/site-wide/user-nav/actions';
+import { focusElement } from 'platform/utilities/ui';
 import { urls } from '../../all-claims/utils';
 
 import { VerifiedAlert } from '../helpers';

--- a/src/applications/disability-benefits/526EZ/components/create526EmailForm.jsx
+++ b/src/applications/disability-benefits/526EZ/components/create526EmailForm.jsx
@@ -4,9 +4,9 @@ import { connect } from 'react-redux';
 
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 
-import { apiRequest } from '../../../../platform/utilities/api';
-import { requestStates } from '../../../../platform/utilities/constants';
-import backendServices from '../../../../platform/user/profile/constants/backendServices';
+import { apiRequest } from 'platform/utilities/api';
+import { requestStates } from 'platform/utilities/constants';
+import backendServices from 'platform/user/profile/constants/backendServices';
 
 class EmailForm extends React.Component {
   constructor(props) {

--- a/src/applications/disability-benefits/526EZ/containers/ConfirmationPage.jsx
+++ b/src/applications/disability-benefits/526EZ/containers/ConfirmationPage.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Scroll from 'react-scroll';
 
-import { focusElement } from '../../../../platform/utilities/ui';
+import { focusElement } from 'platform/utilities/ui';
 
 import { submissionStatuses } from '../constants';
 import {

--- a/src/applications/disability-benefits/526EZ/containers/DisabilityGate.jsx
+++ b/src/applications/disability-benefits/526EZ/containers/DisabilityGate.jsx
@@ -3,8 +3,8 @@ import { connect } from 'react-redux';
 
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 
-import { PREFILL_STATUSES } from '../../../../platform/forms/save-in-progress/actions';
-import get from '../../../../platform/utilities/data/get';
+import { PREFILL_STATUSES } from 'platform/forms/save-in-progress/actions';
+import get from 'platform/utilities/data/get';
 
 /**
  * Gates rendering the form based on whether there are any eligible disabilities.

--- a/src/applications/disability-benefits/526EZ/content/confirmation-poll.jsx
+++ b/src/applications/disability-benefits/526EZ/content/confirmation-poll.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import LoadingIndicator from '@department-of-veterans-affairs/formation-react/LoadingIndicator';
-import CallVBACenter from '../../../../platform/static-data/CallVBACenter';
+import CallVBACenter from 'platform/static-data/CallVBACenter';
 
 export const successMessage = claimId => (
   <div>

--- a/src/applications/disability-benefits/526EZ/disabilityIncreaseEntry.js
+++ b/src/applications/disability-benefits/526EZ/disabilityIncreaseEntry.js
@@ -1,5 +1,5 @@
 import DisabilityWizard from './components/DisabilityWizard';
-import ApplicationStatus from '../../../platform/forms/save-in-progress/ApplicationStatus';
+import ApplicationStatus from 'platform/forms/save-in-progress/ApplicationStatus';
 import './sass/disability-benefits.scss';
 
 // helper module so that we can code split with both of these components

--- a/src/applications/disability-benefits/526EZ/form-entry.jsx
+++ b/src/applications/disability-benefits/526EZ/form-entry.jsx
@@ -1,7 +1,7 @@
-import '../../../platform/polyfills';
+import 'platform/polyfills';
 import './sass/disability-benefits.scss';
 
-import startApp from '../../../platform/startup';
+import startApp from 'platform/startup';
 
 import routes from './routes';
 import reducer from './reducers';

--- a/src/applications/disability-benefits/526EZ/helpers.jsx
+++ b/src/applications/disability-benefits/526EZ/helpers.jsx
@@ -6,18 +6,15 @@ import { Validator } from 'jsonschema';
 import fullSchemaIncrease from 'vets-json-schema/dist/21-526EZ-schema.json';
 import moment from 'moment';
 
-import { apiRequest } from '../../../platform/utilities/api';
-import {
-  isValidUSZipCode,
-  isValidCanPostalCode,
-} from '../../../platform/forms/address';
-import { stateRequiredCountries } from '../../../platform/forms/definitions/address';
+import { apiRequest } from 'platform/utilities/api';
+import { isValidUSZipCode, isValidCanPostalCode } from 'platform/forms/address';
+import { stateRequiredCountries } from 'platform/forms/definitions/address';
 import { filterViewFields } from 'platform/forms-system/src/js/helpers';
-import cloneDeep from '../../../platform/utilities/data/cloneDeep';
-import set from '../../../platform/utilities/data/set';
-import get from '../../../platform/utilities/data/get';
+import cloneDeep from 'platform/utilities/data/cloneDeep';
+import set from 'platform/utilities/data/set';
+import get from 'platform/utilities/data/get';
 import { pick } from 'lodash';
-import { genderLabels } from '../../../platform/static-data/labels';
+import { genderLabels } from 'platform/static-data/labels';
 
 import { DateWidget } from 'platform/forms-system/src/js/review/widgets';
 import AddressViewField from 'platform/forms-system/src/js/components/AddressViewField';

--- a/src/applications/disability-benefits/526EZ/pages/privateMedicalRecordRelease.js
+++ b/src/applications/disability-benefits/526EZ/pages/privateMedicalRecordRelease.js
@@ -1,8 +1,8 @@
-import _ from '../../../../platform/utilities/data';
+import _ from 'platform/utilities/data';
 import { merge } from 'lodash';
 import fullSchema526EZ from 'vets-json-schema/dist/21-526EZ-schema.json';
 import dateRangeUI from 'platform/forms-system/src/js/definitions/dateRange';
-import { uiSchema as addressUI } from '../../../../platform/forms/definitions/address';
+import { uiSchema as addressUI } from 'platform/forms/definitions/address';
 import {
   disabilityNameTitle,
   recordReleaseDescription,

--- a/src/applications/disability-benefits/526EZ/reducers/index.js
+++ b/src/applications/disability-benefits/526EZ/reducers/index.js
@@ -1,7 +1,7 @@
 import itf from '../../all-claims/reducers/itf';
 import formConfig from '../config/form';
 
-import { createSaveInProgressFormReducer } from '../../../../platform/forms/save-in-progress/reducers';
+import { createSaveInProgressFormReducer } from 'platform/forms/save-in-progress/reducers';
 
 export default {
   form: createSaveInProgressFormReducer(formConfig),

--- a/src/applications/disability-benefits/526EZ/routes.jsx
+++ b/src/applications/disability-benefits/526EZ/routes.jsx
@@ -1,4 +1,4 @@
-import { createRoutesWithSaveInProgress } from '../../../platform/forms/save-in-progress/helpers';
+import { createRoutesWithSaveInProgress } from 'platform/forms/save-in-progress/helpers';
 
 import Form526EZApp from './Form526EZApp';
 import formConfig from './config/form';

--- a/src/applications/disability-benefits/526EZ/tests/actions/actions.unit.spec.js
+++ b/src/applications/disability-benefits/526EZ/tests/actions/actions.unit.spec.js
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
 
-import { mockApiRequest } from '../../../../../platform/testing/unit/helpers.js';
+import { mockApiRequest } from 'platform/testing/unit/helpers.js';
 
 import {
   fetchITF,

--- a/src/applications/disability-benefits/526EZ/tests/components/ConfirmationPoll.unit.spec.jsx
+++ b/src/applications/disability-benefits/526EZ/tests/components/ConfirmationPoll.unit.spec.jsx
@@ -5,7 +5,7 @@ import { expect } from 'chai';
 import {
   mockApiRequest,
   mockMultipleApiRequests,
-} from '../../../../../platform/testing/unit/helpers';
+} from 'platform/testing/unit/helpers';
 
 import { ConfirmationPoll } from '../../components/ConfirmationPoll';
 import { submissionStatuses } from '../../constants';

--- a/src/applications/disability-benefits/526EZ/tests/components/SelectArrayItemsWidget.unit.spec.jsx
+++ b/src/applications/disability-benefits/526EZ/tests/components/SelectArrayItemsWidget.unit.spec.jsx
@@ -5,7 +5,7 @@ import sinon from 'sinon';
 
 import SelectArrayItemsWidget from '../../../all-claims/components/SelectArrayItemsWidget';
 
-import get from '../../../../../platform/utilities/data/get';
+import get from 'platform/utilities/data/get';
 
 describe('<SelectArrayItemsWidget>', () => {
   let defaultProps = {};

--- a/src/applications/disability-benefits/526EZ/tests/config/documentUpload.unit.spec.jsx
+++ b/src/applications/disability-benefits/526EZ/tests/config/documentUpload.unit.spec.jsx
@@ -5,7 +5,7 @@ import { mount } from 'enzyme';
 
 import {
   DefinitionTester, // selectCheckbox
-} from '../../../../../platform/testing/unit/schemaform-utils.jsx';
+} from 'platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form.js';
 import initialData from '../schema/initialData.js';
 

--- a/src/applications/disability-benefits/526EZ/tests/config/evidenceType.unit.spec.jsx
+++ b/src/applications/disability-benefits/526EZ/tests/config/evidenceType.unit.spec.jsx
@@ -6,7 +6,7 @@ import { mount } from 'enzyme';
 import {
   DefinitionTester,
   selectCheckbox,
-} from '../../../../../platform/testing/unit/schemaform-utils.jsx';
+} from 'platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form.js';
 import initialData from '../schema/initialData.js';
 

--- a/src/applications/disability-benefits/526EZ/tests/config/primaryAddress.unit.spec.jsx
+++ b/src/applications/disability-benefits/526EZ/tests/config/primaryAddress.unit.spec.jsx
@@ -5,7 +5,7 @@ import { mount } from 'enzyme';
 
 import {
   DefinitionTester, // selectCheckbox
-} from '../../../../../platform/testing/unit/schemaform-utils.jsx';
+} from 'platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form.js';
 import {
   STATE_VALUES,

--- a/src/applications/disability-benefits/526EZ/tests/config/privateRecordChoice.unit.spec.jsx
+++ b/src/applications/disability-benefits/526EZ/tests/config/privateRecordChoice.unit.spec.jsx
@@ -6,7 +6,7 @@ import { mount } from 'enzyme';
 import {
   DefinitionTester,
   selectRadio,
-} from '../../../../../platform/testing/unit/schemaform-utils.jsx';
+} from 'platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form.js';
 import initialData from '../schema/initialData.js';
 

--- a/src/applications/disability-benefits/526EZ/tests/config/ratedDisabilities.unit.spec.jsx
+++ b/src/applications/disability-benefits/526EZ/tests/config/ratedDisabilities.unit.spec.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { expect } from 'chai';
 import { mount } from 'enzyme';
 
-import { DefinitionTester } from '../../../../../platform/testing/unit/schemaform-utils.jsx';
+import { DefinitionTester } from 'platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form.js';
 import initialData from '../schema/initialData.js';
 

--- a/src/applications/disability-benefits/526EZ/tests/config/recordUpload.unit.spec.jsx
+++ b/src/applications/disability-benefits/526EZ/tests/config/recordUpload.unit.spec.jsx
@@ -5,7 +5,7 @@ import { mount } from 'enzyme';
 
 import {
   DefinitionTester, // selectCheckbox
-} from '../../../../../platform/testing/unit/schemaform-utils.jsx';
+} from 'platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form.js';
 import initialData from '../schema/initialData.js';
 

--- a/src/applications/disability-benefits/526EZ/tests/config/reservesNationalGuardService.unit.spec.jsx
+++ b/src/applications/disability-benefits/526EZ/tests/config/reservesNationalGuardService.unit.spec.jsx
@@ -4,7 +4,7 @@ import sinon from 'sinon';
 import { mount } from 'enzyme';
 import _ from 'lodash/fp';
 
-import { DefinitionTester } from '../../../../../platform/testing/unit/schemaform-utils.jsx';
+import { DefinitionTester } from 'platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form.js';
 
 describe('Disability benefits 526EZ reservesNationalGuardService', () => {

--- a/src/applications/disability-benefits/526EZ/tests/config/specialCircumstances.unit.spec.jsx
+++ b/src/applications/disability-benefits/526EZ/tests/config/specialCircumstances.unit.spec.jsx
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import { mount } from 'enzyme';
 
-import { DefinitionTester } from '../../../../../platform/testing/unit/schemaform-utils.jsx';
+import { DefinitionTester } from 'platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form.js';
 
 describe('Disability benefits 526EZ special circumstances', () => {

--- a/src/applications/disability-benefits/526EZ/tests/config/vaFacilities.unit.spec.jsx
+++ b/src/applications/disability-benefits/526EZ/tests/config/vaFacilities.unit.spec.jsx
@@ -7,8 +7,8 @@ import {
   DefinitionTester,
   fillData,
   fillDate,
-} from '../../../../../platform/testing/unit/schemaform-utils';
-import { mockApiRequest } from '../../../../../platform/testing/unit/helpers';
+} from 'platform/testing/unit/schemaform-utils';
+import { mockApiRequest } from 'platform/testing/unit/helpers';
 import formConfig from '../../config/form.js';
 import initialData from '../schema/initialData.js';
 

--- a/src/applications/disability-benefits/526EZ/tests/config/veteranInformation.unit.spec.jsx
+++ b/src/applications/disability-benefits/526EZ/tests/config/veteranInformation.unit.spec.jsx
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import { mount } from 'enzyme';
 
-import { DefinitionTester } from '../../../../../platform/testing/unit/schemaform-utils.jsx';
+import { DefinitionTester } from 'platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form.js';
 
 describe.skip('526EZ veteran information', () => {

--- a/src/applications/disability-benefits/526EZ/tests/containers/DisabilityGate.unit.spec.jsx
+++ b/src/applications/disability-benefits/526EZ/tests/containers/DisabilityGate.unit.spec.jsx
@@ -4,7 +4,7 @@ import { shallow } from 'enzyme';
 import { merge } from 'lodash/fp';
 
 import { DisabilityGate } from '../../containers/DisabilityGate';
-import { PREFILL_STATUSES } from '../../../../../platform/forms/save-in-progress/actions';
+import { PREFILL_STATUSES } from 'platform/forms/save-in-progress/actions';
 
 describe('DisabilityGate', () => {
   it("should render the children if pre-fill hasn't returned yet", () => {

--- a/src/applications/disability-benefits/526EZ/tests/helpers.unit.spec.jsx
+++ b/src/applications/disability-benefits/526EZ/tests/helpers.unit.spec.jsx
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import _ from '../../../../platform/utilities/data';
+import _ from 'platform/utilities/data';
 
 import {
   validateDisability,

--- a/src/applications/disability-benefits/526EZ/validations.js
+++ b/src/applications/disability-benefits/526EZ/validations.js
@@ -1,4 +1,4 @@
-import get from '../../../platform/utilities/data/get';
+import get from 'platform/utilities/data/get';
 
 export function requireOneSelected(
   errors,

--- a/src/applications/disability-benefits/686/components/AuthorizationMessage.jsx
+++ b/src/applications/disability-benefits/686/components/AuthorizationMessage.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import appendQuery from 'append-query';
 import PropTypes from 'prop-types';
 
-import CallVBACenter from '../../../../platform/static-data/CallVBACenter';
+import CallVBACenter from 'platform/static-data/CallVBACenter';
 import disabilityIncreaseManifest from '../../526EZ/manifest.json';
 
 const { rootUrl: increaseRootUrl } = disabilityIncreaseManifest;

--- a/src/applications/disability-benefits/686/helpers.jsx
+++ b/src/applications/disability-benefits/686/helpers.jsx
@@ -2,7 +2,7 @@ import AdditionalInfo from '@department-of-veterans-affairs/formation-react/Addi
 import React from 'react';
 import moment from 'moment';
 import { transformForSubmit } from 'platform/forms-system/src/js/helpers';
-// import { apiRequest } from '../../../platform/utilities/api';
+// import { apiRequest } from 'platform/utilities/api';
 import numberToWords from 'platform/forms-system/src/js/utilities/data/numberToWords';
 import titleCase from 'platform/utilities/data/titleCase';
 

--- a/src/applications/disability-benefits/686c-674/app-entry.jsx
+++ b/src/applications/disability-benefits/686c-674/app-entry.jsx
@@ -1,7 +1,7 @@
-import '../../../platform/polyfills';
+import 'platform/polyfills';
 import './sass/new-686.scss';
 
-import startApp from '../../../platform/startup';
+import startApp from 'platform/startup';
 
 import routes from './routes';
 import reducer from './reducers';

--- a/src/applications/disability-benefits/686c-674/containers/App.jsx
+++ b/src/applications/disability-benefits/686c-674/containers/App.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import RoutedSavableApp from '../../../../platform/forms/save-in-progress/RoutedSavableApp';
+import RoutedSavableApp from 'platform/forms/save-in-progress/RoutedSavableApp';
 import formConfig from '../config/form';
 
 export default function App({ location, children }) {

--- a/src/applications/disability-benefits/686c-674/containers/ConfirmationPage.jsx
+++ b/src/applications/disability-benefits/686c-674/containers/ConfirmationPage.jsx
@@ -3,7 +3,7 @@ import moment from 'moment';
 import { connect } from 'react-redux';
 import Scroll from 'react-scroll';
 
-import { focusElement } from '../../../../platform/utilities/ui';
+import { focusElement } from 'platform/utilities/ui';
 
 const scroller = Scroll.scroller;
 const scrollToTop = () => {

--- a/src/applications/disability-benefits/686c-674/containers/IntroductionPage.jsx
+++ b/src/applications/disability-benefits/686c-674/containers/IntroductionPage.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
 
-import { focusElement } from '../../../../platform/utilities/ui';
+import { focusElement } from 'platform/utilities/ui';
 import OMBInfo from '@department-of-veterans-affairs/formation-react/OMBInfo';
 import FormTitle from 'platform/forms-system/src/js/components/FormTitle';
-import SaveInProgressIntro from '../../../../platform/forms/save-in-progress/SaveInProgressIntro';
+import SaveInProgressIntro from 'platform/forms/save-in-progress/SaveInProgressIntro';
 
 class IntroductionPage extends React.Component {
   componentDidMount() {

--- a/src/applications/disability-benefits/686c-674/reducers/index.js
+++ b/src/applications/disability-benefits/686c-674/reducers/index.js
@@ -1,5 +1,5 @@
 import formConfig from '../config/form';
-import { createSaveInProgressFormReducer } from '../../../../platform/forms/save-in-progress/reducers';
+import { createSaveInProgressFormReducer } from 'platform/forms/save-in-progress/reducers';
 
 export default {
   form: createSaveInProgressFormReducer(formConfig),

--- a/src/applications/disability-benefits/686c-674/routes.jsx
+++ b/src/applications/disability-benefits/686c-674/routes.jsx
@@ -1,4 +1,4 @@
-import { createRoutesWithSaveInProgress } from '../../../platform/forms/save-in-progress/helpers';
+import { createRoutesWithSaveInProgress } from 'platform/forms/save-in-progress/helpers';
 import formConfig from './config/form';
 import App from './containers/App.jsx';
 

--- a/src/applications/disability-benefits/all-claims/Form526EZApp.jsx
+++ b/src/applications/disability-benefits/all-claims/Form526EZApp.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import RoutedSavableApp from '../../../platform/forms/save-in-progress/RoutedSavableApp';
+import RoutedSavableApp from 'platform/forms/save-in-progress/RoutedSavableApp';
 import formConfig from './config/form';
 
 import ITFWrapper from './containers/ITFWrapper';

--- a/src/applications/disability-benefits/all-claims/actions/index.js
+++ b/src/applications/disability-benefits/all-claims/actions/index.js
@@ -1,6 +1,6 @@
 import * as Sentry from '@sentry/browser';
 
-import { apiRequest } from '../../../../platform/utilities/api';
+import { apiRequest } from 'platform/utilities/api';
 
 export const ITF_FETCH_INITIATED = 'ITF_FETCH_INITIATED';
 export const ITF_FETCH_SUCCEEDED = 'ITF_FETCH_SUCCEEDED';

--- a/src/applications/disability-benefits/all-claims/components/ConfirmationPoll.jsx
+++ b/src/applications/disability-benefits/all-claims/components/ConfirmationPoll.jsx
@@ -2,8 +2,8 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { createSelector } from 'reselect';
 
-import get from '../../../../platform/utilities/data/get';
-import { apiRequest } from '../../../../platform/utilities/api';
+import get from 'platform/utilities/data/get';
+import { apiRequest } from 'platform/utilities/api';
 
 import ConfirmationPage from '../containers/ConfirmationPage';
 import { pendingMessage } from '../content/confirmation-poll';

--- a/src/applications/disability-benefits/all-claims/components/IntroductionPage.jsx
+++ b/src/applications/disability-benefits/all-claims/components/IntroductionPage.jsx
@@ -2,10 +2,10 @@ import React from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 
-import { focusElement } from '../../../../platform/utilities/ui';
+import { focusElement } from 'platform/utilities/ui';
 import OMBInfo from '@department-of-veterans-affairs/formation-react/OMBInfo';
 import FormTitle from 'platform/forms-system/src/js/components/FormTitle';
-import SaveInProgressIntro from '../../../../platform/forms/save-in-progress/SaveInProgressIntro';
+import SaveInProgressIntro from 'platform/forms/save-in-progress/SaveInProgressIntro';
 import { itfNotice } from '../content/introductionPage';
 
 class IntroductionPage extends React.Component {

--- a/src/applications/disability-benefits/all-claims/components/SelectArrayItemsWidget.jsx
+++ b/src/applications/disability-benefits/all-claims/components/SelectArrayItemsWidget.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import classNames from 'classnames';
 
-import get from '../../../../platform/utilities/data/get';
-import set from '../../../../platform/utilities/data/set';
+import get from 'platform/utilities/data/get';
+import set from 'platform/utilities/data/set';
 
 // TODO: Safety checks for `selected` callback and `label` element
 

--- a/src/applications/disability-benefits/all-claims/config/4192/index.js
+++ b/src/applications/disability-benefits/all-claims/config/4192/index.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import environment from '../../../../../platform/utilities/environment';
+import environment from 'platform/utilities/environment';
 
 import {
   instructionalPart1,

--- a/src/applications/disability-benefits/all-claims/config/8940/index.js
+++ b/src/applications/disability-benefits/all-claims/config/8940/index.js
@@ -19,7 +19,7 @@ import {
   medicalCare,
   hospitalizationHistory,
 } from '../../pages';
-import environment from '../../../../../platform/utilities/environment';
+import environment from 'platform/utilities/environment';
 
 import {
   needsToEnterUnemployability,

--- a/src/applications/disability-benefits/all-claims/containers/FormSavedPage.jsx
+++ b/src/applications/disability-benefits/all-claims/containers/FormSavedPage.jsx
@@ -1,7 +1,7 @@
 import React, { Fragment } from 'react';
 import { connect } from 'react-redux';
 import moment from 'moment';
-import FormSaved from '../../../../platform/forms/save-in-progress/FormSaved';
+import FormSaved from 'platform/forms/save-in-progress/FormSaved';
 
 import AdditionalInfo from '@department-of-veterans-affairs/formation-react/AdditionalInfo';
 

--- a/src/applications/disability-benefits/all-claims/containers/RequiredServicesGate.jsx
+++ b/src/applications/disability-benefits/all-claims/containers/RequiredServicesGate.jsx
@@ -3,8 +3,8 @@ import { connect } from 'react-redux';
 
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 
-import RequiredLoginView from '../../../../platform/user/authorization/components/RequiredLoginView';
-import backendServices from '../../../../platform/user/profile/constants/backendServices';
+import RequiredLoginView from 'platform/user/authorization/components/RequiredLoginView';
+import backendServices from 'platform/user/profile/constants/backendServices';
 
 import environment from 'platform/utilities/environment';
 

--- a/src/applications/disability-benefits/all-claims/content/ptsdClassification.jsx
+++ b/src/applications/disability-benefits/all-claims/content/ptsdClassification.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import _ from '../../../../platform/utilities/data';
+import _ from 'platform/utilities/data';
 
 export const getPtsdClassification = (formData, formType) => {
   const isCombat = _.get(

--- a/src/applications/disability-benefits/all-claims/content/summaryOfEvidence.jsx
+++ b/src/applications/disability-benefits/all-claims/content/summaryOfEvidence.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import _ from '../../../../platform/utilities/data';
+import _ from 'platform/utilities/data';
 import { DATA_PATHS } from '../constants';
 
 export const summaryOfEvidenceDescription = ({ formData }) => {

--- a/src/applications/disability-benefits/all-claims/content/veteranDetails.jsx
+++ b/src/applications/disability-benefits/all-claims/content/veteranDetails.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { DateWidget } from 'platform/forms-system/src/js/review/widgets';
-import { genderLabels } from '../../../../platform/static-data/labels';
+import { genderLabels } from 'platform/static-data/labels';
 import { srSubstitute } from '../utils';
 import { editNote } from './common';
 

--- a/src/applications/disability-benefits/all-claims/form-entry.jsx
+++ b/src/applications/disability-benefits/all-claims/form-entry.jsx
@@ -1,7 +1,7 @@
-import '../../../platform/polyfills';
+import 'platform/polyfills';
 import './sass/disability-benefits.scss';
 
-import startApp from '../../../platform/startup';
+import startApp from 'platform/startup';
 
 import routes from './routes';
 import reducer from './reducers';

--- a/src/applications/disability-benefits/all-claims/migrations/02-convert-country-code.js
+++ b/src/applications/disability-benefits/all-claims/migrations/02-convert-country-code.js
@@ -1,5 +1,5 @@
-import { countries } from '../../../../platform/forms/address/index.js';
-import _ from '../../../../platform/utilities/data';
+import { countries } from 'platform/forms/address/index.js';
+import _ from 'platform/utilities/data';
 
 /**
  * Changes the form 781 and 781a addresses to use the full country name instead of the

--- a/src/applications/disability-benefits/all-claims/pages/adaptiveBenefits.js
+++ b/src/applications/disability-benefits/all-claims/pages/adaptiveBenefits.js
@@ -1,4 +1,4 @@
-import get from '../../../../platform/utilities/data/get';
+import get from 'platform/utilities/data/get';
 import {
   benefitDescription,
   doubleAllowanceAlert,

--- a/src/applications/disability-benefits/all-claims/pages/addDisabilities.js
+++ b/src/applications/disability-benefits/all-claims/pages/addDisabilities.js
@@ -1,7 +1,7 @@
 import * as autosuggest from 'platform/forms-system/src/js/definitions/autosuggest';
-import set from '../../../../platform/utilities/data/set';
-import get from '../../../../platform/utilities/data/get';
-import omit from '../../../../platform/utilities/data/omit';
+import set from 'platform/utilities/data/set';
+import get from 'platform/utilities/data/get';
+import omit from 'platform/utilities/data/omit';
 import disabilityLabels from '../content/disabilityLabels';
 import {
   descriptionInfo,

--- a/src/applications/disability-benefits/all-claims/pages/alternateNames.js
+++ b/src/applications/disability-benefits/all-claims/pages/alternateNames.js
@@ -1,6 +1,6 @@
 import FullNameField from 'platform/forms-system/src/js/fields/FullNameField';
 import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json';
-import get from '../../../../platform/utilities/data/get';
+import get from 'platform/utilities/data/get';
 
 const { alternateNames: alternateNamesSchema } = fullSchema.properties;
 

--- a/src/applications/disability-benefits/all-claims/pages/bddGoBack.jsx
+++ b/src/applications/disability-benefits/all-claims/pages/bddGoBack.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router';
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
-import environment from '../../../../platform/utilities/environment';
+import environment from 'platform/utilities/environment';
 
 import { activeServicePeriods } from '../utils';
 

--- a/src/applications/disability-benefits/all-claims/pages/bddRedirect.js
+++ b/src/applications/disability-benefits/all-claims/pages/bddRedirect.js
@@ -1,6 +1,6 @@
 import content from '../content/bddRedirect';
 import { activeServicePeriods } from '../utils';
-import environment from '../../../../platform/utilities/environment';
+import environment from 'platform/utilities/environment';
 
 export const depends = formData =>
   !environment.isProduction() && !!activeServicePeriods(formData).length;

--- a/src/applications/disability-benefits/all-claims/pages/contactInformation.js
+++ b/src/applications/disability-benefits/all-claims/pages/contactInformation.js
@@ -1,7 +1,7 @@
 import React from 'react';
-// import _ from '../../../../platform/utilities/data';
+// import _ from 'platform/utilities/data';
 import merge from 'lodash/merge';
-import omit from '../../../../platform/utilities/data/omit';
+import omit from 'platform/utilities/data/omit';
 import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json';
 // import dateUI from 'platform/forms-system/src/js/definitions/date';
 // import dateRangeUI from 'platform/forms-system/src/js/definitions/dateRange';

--- a/src/applications/disability-benefits/all-claims/pages/evidenceTypes.js
+++ b/src/applications/disability-benefits/all-claims/pages/evidenceTypes.js
@@ -1,6 +1,6 @@
 import { validateBooleanGroup } from 'platform/forms-system/src/js/validation';
 import { validateIfHasEvidence } from '../validations';
-import get from '../../../../platform/utilities/data/get';
+import get from 'platform/utilities/data/get';
 
 import { evidenceTypeHelp } from '../content/evidenceTypes';
 

--- a/src/applications/disability-benefits/all-claims/pages/fullyDevelopedClaim.js
+++ b/src/applications/disability-benefits/all-claims/pages/fullyDevelopedClaim.js
@@ -1,5 +1,5 @@
 import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json';
-import get from '../../../../platform/utilities/data/get';
+import get from 'platform/utilities/data/get';
 import {
   FDCDescription,
   FDCWarning,

--- a/src/applications/disability-benefits/all-claims/pages/homelessOrAtRisk.js
+++ b/src/applications/disability-benefits/all-claims/pages/homelessOrAtRisk.js
@@ -1,4 +1,4 @@
-import _ from '../../../../platform/utilities/data';
+import _ from 'platform/utilities/data';
 import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json';
 import merge from 'lodash/fp/merge';
 import phoneUI from 'platform/forms-system/src/js/definitions/phone';

--- a/src/applications/disability-benefits/all-claims/pages/individualsInvolvedFollowUp.js
+++ b/src/applications/disability-benefits/all-claims/pages/individualsInvolvedFollowUp.js
@@ -5,7 +5,7 @@ import {
   personDescriptionText,
 } from '../content/individualsInvolved';
 import IndividualsInvolvedCard from '../components/IndividualsInvolvedCard';
-import fullNameUI from '../../../../platform/forms/definitions/fullName';
+import fullNameUI from 'platform/forms/definitions/fullName';
 
 import currentOrPastDateUI from 'platform/forms-system/src/js/definitions/currentOrPastDate';
 

--- a/src/applications/disability-benefits/all-claims/pages/newDisabilityFollowUp.js
+++ b/src/applications/disability-benefits/all-claims/pages/newDisabilityFollowUp.js
@@ -10,7 +10,7 @@ import {
   disabilityNameTitle,
 } from '../content/newDisabilityFollowUp';
 
-import { validateLength } from '../../../../platform/forms/validations';
+import { validateLength } from 'platform/forms/validations';
 
 import { NULL_CONDITION_STRING } from '../constants';
 

--- a/src/applications/disability-benefits/all-claims/pages/privateMedicalRecords.js
+++ b/src/applications/disability-benefits/all-claims/pages/privateMedicalRecords.js
@@ -3,7 +3,7 @@ import {
   patientAcknowledgmentText,
 } from '../content/privateMedicalRecords';
 import { UploadDescription } from '../content/fileUploadDescriptions';
-import _ from '../../../../platform/utilities/data';
+import _ from 'platform/utilities/data';
 import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json';
 import { ancillaryFormUploadUi } from '../utils';
 import { DATA_PATHS } from '../constants';

--- a/src/applications/disability-benefits/all-claims/pages/privateMedicalRecordsRelease.js
+++ b/src/applications/disability-benefits/all-claims/pages/privateMedicalRecordsRelease.js
@@ -1,4 +1,4 @@
-import _ from '../../../../platform/utilities/data';
+import _ from 'platform/utilities/data';
 import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json';
 import dateRangeUI from 'platform/forms-system/src/js/definitions/dateRange';
 import {

--- a/src/applications/disability-benefits/all-claims/pages/vaMedicalRecords.js
+++ b/src/applications/disability-benefits/all-claims/pages/vaMedicalRecords.js
@@ -1,4 +1,4 @@
-import set from '../../../../platform/utilities/data/set';
+import set from 'platform/utilities/data/set';
 import merge from 'lodash/merge';
 import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json';
 import { uiSchema as autoSuggestUiSchema } from 'platform/forms-system/src/js/definitions/autosuggest';

--- a/src/applications/disability-benefits/all-claims/pages/verifyBdd.jsx
+++ b/src/applications/disability-benefits/all-claims/pages/verifyBdd.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { activeServicePeriods } from '../utils';
-import ServicePeriodView from '../../../../platform/forms/components/ServicePeriodView';
-import environment from '../../../../platform/utilities/environment';
+import ServicePeriodView from 'platform/forms/components/ServicePeriodView';
+import environment from 'platform/utilities/environment';
 
 export const depends = formData =>
   !environment.isProduction() && !!activeServicePeriods(formData).length;

--- a/src/applications/disability-benefits/all-claims/prefill-transformer.js
+++ b/src/applications/disability-benefits/all-claims/prefill-transformer.js
@@ -1,4 +1,4 @@
-import _ from '../../../platform/utilities/data';
+import _ from 'platform/utilities/data';
 import { SERVICE_CONNECTION_TYPES, disabilityActionTypes } from './constants';
 import { viewifyFields } from './utils';
 

--- a/src/applications/disability-benefits/all-claims/reducers/index.js
+++ b/src/applications/disability-benefits/all-claims/reducers/index.js
@@ -1,7 +1,7 @@
 import itf from './itf';
 import formConfig from '../config/form';
 
-import { createSaveInProgressFormReducer } from '../../../../platform/forms/save-in-progress/reducers';
+import { createSaveInProgressFormReducer } from 'platform/forms/save-in-progress/reducers';
 
 export default {
   form: createSaveInProgressFormReducer(formConfig),

--- a/src/applications/disability-benefits/all-claims/routes.jsx
+++ b/src/applications/disability-benefits/all-claims/routes.jsx
@@ -1,4 +1,4 @@
-import { createRoutesWithSaveInProgress } from '../../../platform/forms/save-in-progress/helpers';
+import { createRoutesWithSaveInProgress } from 'platform/forms/save-in-progress/helpers';
 
 import Form526EZApp from './Form526EZApp';
 import formConfig from './config/form';

--- a/src/applications/disability-benefits/all-claims/submit-transformer.js
+++ b/src/applications/disability-benefits/all-claims/submit-transformer.js
@@ -1,10 +1,10 @@
-import _ from '../../../platform/utilities/data';
+import _ from 'platform/utilities/data';
 
 import {
   transformForSubmit,
   filterViewFields,
 } from 'platform/forms-system/src/js/helpers';
-import removeDeeplyEmptyObjects from '../../../platform/utilities/data/removeDeeplyEmptyObjects';
+import removeDeeplyEmptyObjects from 'platform/utilities/data/removeDeeplyEmptyObjects';
 
 import {
   causeTypes,

--- a/src/applications/disability-benefits/all-claims/tests/actions/actions.unit.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/actions/actions.unit.spec.js
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
 
-import { mockApiRequest } from '../../../../../platform/testing/unit/helpers.js';
+import { mockApiRequest } from 'platform/testing/unit/helpers.js';
 
 import {
   fetchITF,

--- a/src/applications/disability-benefits/all-claims/tests/components/ConfirmationPoll.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/components/ConfirmationPoll.unit.spec.jsx
@@ -5,7 +5,7 @@ import { expect } from 'chai';
 import {
   mockApiRequest,
   mockMultipleApiRequests,
-} from '../../../../../platform/testing/unit/helpers';
+} from 'platform/testing/unit/helpers';
 
 import {
   ConfirmationPoll,

--- a/src/applications/disability-benefits/all-claims/tests/containers/ITFWrapper.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/containers/ITFWrapper.unit.spec.jsx
@@ -7,7 +7,7 @@ import moment from 'moment';
 
 import { ITFWrapper } from '../../containers/ITFWrapper';
 import { itfStatuses } from '../../constants';
-import { requestStates } from '../../../../../platform/utilities/constants';
+import { requestStates } from 'platform/utilities/constants';
 
 const fetchITF = sinon.spy();
 const createITF = sinon.spy();

--- a/src/applications/disability-benefits/all-claims/tests/containers/RequiredServicesGate.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/containers/RequiredServicesGate.unit.spec.jsx
@@ -4,7 +4,7 @@ import { shallow, mount } from 'enzyme';
 
 import { RequiredServicesGate } from '../../containers/RequiredServicesGate';
 
-import backendServices from '../../../../../platform/user/profile/constants/backendServices';
+import backendServices from 'platform/user/profile/constants/backendServices';
 
 describe('RequiredServicesGate', () => {
   const disallowedUser = {

--- a/src/applications/disability-benefits/all-claims/tests/pages/adaptiveBenefits.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/adaptiveBenefits.unit.spec.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { expect } from 'chai';
-import { DefinitionTester } from '../../../../../platform/testing/unit/schemaform-utils.jsx';
+import { DefinitionTester } from 'platform/testing/unit/schemaform-utils.jsx';
 import { mount } from 'enzyme';
 import formConfig from '../../config/form';
 

--- a/src/applications/disability-benefits/all-claims/tests/pages/addDisabilities.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/addDisabilities.unit.spec.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { expect } from 'chai';
 import sinon from 'sinon';
-import { DefinitionTester } from '../../../../../platform/testing/unit/schemaform-utils.jsx';
-import set from '../../../../../platform/utilities/data/set';
+import { DefinitionTester } from 'platform/testing/unit/schemaform-utils.jsx';
+import set from 'platform/utilities/data/set';
 import { mount } from 'enzyme';
 import formConfig from '../../config/form';
 

--- a/src/applications/disability-benefits/all-claims/tests/pages/additionalBehaviorChanges.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/additionalBehaviorChanges.unit.spec.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { expect } from 'chai';
 import sinon from 'sinon';
-import { DefinitionTester } from '../../../../../platform/testing/unit/schemaform-utils.jsx';
+import { DefinitionTester } from 'platform/testing/unit/schemaform-utils.jsx';
 import { mount } from 'enzyme';
 import formConfig from '../../config/form';
 

--- a/src/applications/disability-benefits/all-claims/tests/pages/additionalDocuments.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/additionalDocuments.unit.spec.jsx
@@ -5,7 +5,7 @@ import { mount } from 'enzyme';
 
 import {
   DefinitionTester, // selectCheckbox
-} from '../../../../../platform/testing/unit/schemaform-utils.jsx';
+} from 'platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form.js';
 
 const invalidDocumentData = {

--- a/src/applications/disability-benefits/all-claims/tests/pages/additionalRemarks781.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/additionalRemarks781.unit.spec.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { expect } from 'chai';
 import sinon from 'sinon';
-import { DefinitionTester } from '../../../../../platform/testing/unit/schemaform-utils.jsx';
+import { DefinitionTester } from 'platform/testing/unit/schemaform-utils.jsx';
 import { mount } from 'enzyme';
 import formConfig from '../../config/form';
 

--- a/src/applications/disability-benefits/all-claims/tests/pages/aidAndAttendance.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/aidAndAttendance.unit.spec.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { expect } from 'chai';
-import { DefinitionTester } from '../../../../../platform/testing/unit/schemaform-utils.jsx';
+import { DefinitionTester } from 'platform/testing/unit/schemaform-utils.jsx';
 import { mount } from 'enzyme';
 import formConfig from '../../config/form';
 

--- a/src/applications/disability-benefits/all-claims/tests/pages/bddRedirect.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/bddRedirect.unit.spec.jsx
@@ -3,7 +3,7 @@ import { mount } from 'enzyme';
 import moment from 'moment';
 import { expect } from 'chai';
 
-import { DefinitionTester } from '../../../../../platform/testing/unit/schemaform-utils';
+import { DefinitionTester } from 'platform/testing/unit/schemaform-utils';
 import formConfig from '../../config/form';
 
 const dateFormat = 'YYYY-MM-DD';

--- a/src/applications/disability-benefits/all-claims/tests/pages/choosePtsdType.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/choosePtsdType.unit.spec.jsx
@@ -6,7 +6,7 @@ import { mount } from 'enzyme';
 import {
   DefinitionTester,
   selectCheckbox,
-} from '../../../../../platform/testing/unit/schemaform-utils.jsx';
+} from 'platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form.js';
 import { ERR_MSG_CSS_CLASS } from '../../constants';
 

--- a/src/applications/disability-benefits/all-claims/tests/pages/contactInformation.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/contactInformation.unit.spec.jsx
@@ -6,7 +6,7 @@ import { mount } from 'enzyme';
 
 import {
   DefinitionTester, // selectCheckbox
-} from '../../../../../platform/testing/unit/schemaform-utils.jsx';
+} from 'platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form.js';
 import {
   STATE_VALUES,

--- a/src/applications/disability-benefits/all-claims/tests/pages/evidenceTypes.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/evidenceTypes.unit.spec.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { expect } from 'chai';
 import sinon from 'sinon';
-import { DefinitionTester } from '../../../../../platform/testing/unit/schemaform-utils.jsx';
+import { DefinitionTester } from 'platform/testing/unit/schemaform-utils.jsx';
 import { mount } from 'enzyme';
 import formConfig from '../../config/form';
 

--- a/src/applications/disability-benefits/all-claims/tests/pages/federalOrders.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/federalOrders.unit.spec.jsx
@@ -6,7 +6,7 @@ import {
   DefinitionTester,
   fillDate,
   selectRadio,
-} from '../../../../../platform/testing/unit/schemaform-utils.jsx';
+} from 'platform/testing/unit/schemaform-utils.jsx';
 import { mount } from 'enzyme';
 import formConfig from '../../config/form';
 

--- a/src/applications/disability-benefits/all-claims/tests/pages/finalIncident.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/finalIncident.unit.spec.jsx
@@ -7,7 +7,7 @@ import { ERR_MSG_CSS_CLASS } from '../../constants';
 import {
   DefinitionTester,
   fillData,
-} from '../../../../../platform/testing/unit/schemaform-utils';
+} from 'platform/testing/unit/schemaform-utils';
 import formConfig from '../../config/form';
 
 describe('781 last incident details', () => {

--- a/src/applications/disability-benefits/all-claims/tests/pages/fullyDevelopedClaim.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/fullyDevelopedClaim.unit.spec.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { expect } from 'chai';
 import sinon from 'sinon';
-import { DefinitionTester } from '../../../../../platform/testing/unit/schemaform-utils.jsx';
+import { DefinitionTester } from 'platform/testing/unit/schemaform-utils.jsx';
 import { mount } from 'enzyme';
 import formConfig from '../../config/form';
 import { ERR_MSG_CSS_CLASS } from '../../constants';

--- a/src/applications/disability-benefits/all-claims/tests/pages/homelessOrAtRisk.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/homelessOrAtRisk.unit.spec.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { expect } from 'chai';
 import sinon from 'sinon';
-import { DefinitionTester } from '../../../../../platform/testing/unit/schemaform-utils.jsx';
+import { DefinitionTester } from 'platform/testing/unit/schemaform-utils.jsx';
 import { mount } from 'enzyme';
 import formConfig from '../../config/form';
 

--- a/src/applications/disability-benefits/all-claims/tests/pages/hospitalizationHistory.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/hospitalizationHistory.unit.spec.jsx
@@ -6,7 +6,7 @@ import { mount } from 'enzyme';
 import {
   DefinitionTester,
   fillData,
-} from '../../../../../platform/testing/unit/schemaform-utils.jsx';
+} from 'platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form.js';
 import initialData from '../initialData.js';
 

--- a/src/applications/disability-benefits/all-claims/tests/pages/incidentDate.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/incidentDate.unit.spec.jsx
@@ -6,7 +6,7 @@ import { mount } from 'enzyme';
 import {
   DefinitionTester,
   fillDate,
-} from '../../../../../platform/testing/unit/schemaform-utils';
+} from 'platform/testing/unit/schemaform-utils';
 import formConfig from '../../config/form';
 
 describe('781 Incident Date', () => {

--- a/src/applications/disability-benefits/all-claims/tests/pages/incidentLocation.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/incidentLocation.unit.spec.jsx
@@ -8,7 +8,7 @@ import { ERR_MSG_CSS_CLASS } from '../../constants';
 import {
   DefinitionTester,
   fillData,
-} from '../../../../../platform/testing/unit/schemaform-utils.jsx';
+} from 'platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form';
 
 describe('PTSD Incident location', () => {

--- a/src/applications/disability-benefits/all-claims/tests/pages/incidentSupport.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/incidentSupport.unit.spec.jsx
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import { mount } from 'enzyme';
 
-import { DefinitionTester } from '../../../../../platform/testing/unit/schemaform-utils';
+import { DefinitionTester } from 'platform/testing/unit/schemaform-utils';
 import formConfig from '../../config/form';
 import { ERR_MSG_CSS_CLASS } from '../../constants';
 

--- a/src/applications/disability-benefits/all-claims/tests/pages/incidentUnitAssignment.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/incidentUnitAssignment.unit.spec.jsx
@@ -9,7 +9,7 @@ import {
   DefinitionTester,
   fillDate,
   fillData,
-} from '../../../../../platform/testing/unit/schemaform-utils';
+} from 'platform/testing/unit/schemaform-utils';
 import formConfig from '../../config/form';
 
 describe('781 Unit Assignment Details', () => {

--- a/src/applications/disability-benefits/all-claims/tests/pages/incomeDetails.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/incomeDetails.unit.spec.jsx
@@ -6,7 +6,7 @@ import { mount } from 'enzyme';
 import {
   DefinitionTester,
   fillData,
-} from '../../../../../platform/testing/unit/schemaform-utils.jsx';
+} from 'platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form.js';
 import initialData from '../initialData.js';
 

--- a/src/applications/disability-benefits/all-claims/tests/pages/individualUnemployability.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/individualUnemployability.unit.spec.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { expect } from 'chai';
-import { DefinitionTester } from '../../../../../platform/testing/unit/schemaform-utils.jsx';
+import { DefinitionTester } from 'platform/testing/unit/schemaform-utils.jsx';
 import { mount } from 'enzyme';
 import formConfig from '../../config/form';
 

--- a/src/applications/disability-benefits/all-claims/tests/pages/individualsInvolved.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/individualsInvolved.unit.spec.jsx
@@ -7,7 +7,7 @@ import { ERR_MSG_CSS_CLASS } from '../../constants';
 import {
   DefinitionTester,
   selectRadio,
-} from '../../../../../platform/testing/unit/schemaform-utils';
+} from 'platform/testing/unit/schemaform-utils';
 import formConfig from '../../config/form';
 
 describe('781 individuals involved yes/no', () => {

--- a/src/applications/disability-benefits/all-claims/tests/pages/individualsInvolvedFollowUp.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/individualsInvolvedFollowUp.unit.spec.jsx
@@ -9,7 +9,7 @@ import {
   fillData,
   fillDate,
   selectRadio,
-} from '../../../../../platform/testing/unit/schemaform-utils';
+} from 'platform/testing/unit/schemaform-utils';
 import formConfig from '../../config/form';
 
 describe('781 individuals involved', () => {

--- a/src/applications/disability-benefits/all-claims/tests/pages/medals.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/medals.unit.spec.jsx
@@ -6,7 +6,7 @@ import { mount } from 'enzyme';
 import {
   DefinitionTester,
   fillData,
-} from '../../../../../platform/testing/unit/schemaform-utils';
+} from 'platform/testing/unit/schemaform-utils';
 import formConfig from '../../config/form';
 
 describe('781 medals', () => {

--- a/src/applications/disability-benefits/all-claims/tests/pages/mentalHealthChanges.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/mentalHealthChanges.unit.spec.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { expect } from 'chai';
 import sinon from 'sinon';
-import { DefinitionTester } from '../../../../../platform/testing/unit/schemaform-utils.jsx';
+import { DefinitionTester } from 'platform/testing/unit/schemaform-utils.jsx';
 import { mount } from 'enzyme';
 import formConfig from '../../config/form';
 

--- a/src/applications/disability-benefits/all-claims/tests/pages/militaryDutyImpact.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/militaryDutyImpact.unit.spec.jsx
@@ -6,7 +6,7 @@ import { mount } from 'enzyme';
 import {
   DefinitionTester,
   selectRadio,
-} from '../../../../../platform/testing/unit/schemaform-utils';
+} from 'platform/testing/unit/schemaform-utils';
 import formConfig from '../../config/form';
 import { ERR_MSG_CSS_CLASS } from '../../constants';
 

--- a/src/applications/disability-benefits/all-claims/tests/pages/militaryHistory.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/militaryHistory.unit.spec.jsx
@@ -5,7 +5,7 @@ import {
   DefinitionTester,
   fillData,
   fillDate,
-} from '../../../../../platform/testing/unit/schemaform-utils.jsx';
+} from 'platform/testing/unit/schemaform-utils.jsx';
 import { mount } from 'enzyme';
 import formConfig from '../../config/form';
 

--- a/src/applications/disability-benefits/all-claims/tests/pages/newDisabilitiesFollowUp.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/newDisabilitiesFollowUp.unit.spec.jsx
@@ -5,7 +5,7 @@ import {
   DefinitionTester,
   selectRadio,
   fillData,
-} from '../../../../../platform/testing/unit/schemaform-utils.jsx';
+} from 'platform/testing/unit/schemaform-utils.jsx';
 import { mount } from 'enzyme';
 import formConfig from '../../config/form';
 

--- a/src/applications/disability-benefits/all-claims/tests/pages/pastEducationTraining.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/pastEducationTraining.unit.spec.jsx
@@ -8,7 +8,7 @@ import {
   fillData,
   fillDate,
   selectRadio,
-} from '../../../../../platform/testing/unit/schemaform-utils';
+} from 'platform/testing/unit/schemaform-utils';
 import formConfig from '../../config/form';
 import { ERR_MSG_CSS_CLASS } from '../../constants';
 

--- a/src/applications/disability-benefits/all-claims/tests/pages/pastEmploymentFormDownload.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/pastEmploymentFormDownload.unit.spec.jsx
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import { mount } from 'enzyme';
 
-import { DefinitionTester } from '../../../../../platform/testing/unit/schemaform-utils.jsx';
+import { DefinitionTester } from 'platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form.js';
 
 describe('Disability benefits 4192 Download', () => {

--- a/src/applications/disability-benefits/all-claims/tests/pages/pastEmploymentFormIntro.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/pastEmploymentFormIntro.unit.spec.jsx
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import { mount } from 'enzyme';
 
-import { DefinitionTester } from '../../../../../platform/testing/unit/schemaform-utils.jsx';
+import { DefinitionTester } from 'platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form.js';
 import { ERR_MSG_CSS_CLASS } from '../../constants';
 

--- a/src/applications/disability-benefits/all-claims/tests/pages/pastEmploymentFormUpload.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/pastEmploymentFormUpload.unit.spec.jsx
@@ -5,7 +5,7 @@ import { mount } from 'enzyme';
 
 import {
   DefinitionTester, // selectCheckbox
-} from '../../../../../platform/testing/unit/schemaform-utils.jsx';
+} from 'platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form.js';
 import { ERR_MSG_CSS_CLASS } from '../../constants';
 

--- a/src/applications/disability-benefits/all-claims/tests/pages/paymentInformation.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/paymentInformation.unit.spec.jsx
@@ -4,7 +4,7 @@ import { expect } from 'chai';
 import { mount } from 'enzyme';
 import sinon from 'sinon';
 
-import { DefinitionTester } from '../../../../../platform/testing/unit/schemaform-utils';
+import { DefinitionTester } from 'platform/testing/unit/schemaform-utils';
 
 import formConfig from '../../config/form.js';
 

--- a/src/applications/disability-benefits/all-claims/tests/pages/physicalHealthChanges.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/physicalHealthChanges.unit.spec.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { expect } from 'chai';
 import sinon from 'sinon';
-import { DefinitionTester } from '../../../../../platform/testing/unit/schemaform-utils.jsx';
+import { DefinitionTester } from 'platform/testing/unit/schemaform-utils.jsx';
 import { mount } from 'enzyme';
 import formConfig from '../../config/form';
 

--- a/src/applications/disability-benefits/all-claims/tests/pages/prisonerOfWar.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/prisonerOfWar.unit.spec.jsx
@@ -5,7 +5,7 @@ import {
   DefinitionTester,
   fillDate,
   selectRadio,
-} from '../../../../../platform/testing/unit/schemaform-utils.jsx';
+} from 'platform/testing/unit/schemaform-utils.jsx';
 import { mount } from 'enzyme';
 import formConfig from '../../config/form';
 import { ERR_MSG_CSS_CLASS } from '../../constants';

--- a/src/applications/disability-benefits/all-claims/tests/pages/privateMedicalRecords.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/privateMedicalRecords.unit.spec.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { mount } from 'enzyme';
-import { DefinitionTester } from '../../../../../platform/testing/unit/schemaform-utils.jsx';
+import { DefinitionTester } from 'platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form.js';
 
 describe('526 All Claims Private medical records', () => {

--- a/src/applications/disability-benefits/all-claims/tests/pages/privateMedicalRecordsRelease.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/privateMedicalRecordsRelease.unit.spec.jsx
@@ -7,7 +7,7 @@ import {
   DefinitionTester,
   fillData,
   fillDate,
-} from '../../../../../platform/testing/unit/schemaform-utils.jsx';
+} from 'platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form.js';
 import initialData from '../initialData.js';
 

--- a/src/applications/disability-benefits/all-claims/tests/pages/ptsdAdditionalEvents.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/ptsdAdditionalEvents.unit.spec.jsx
@@ -7,7 +7,7 @@ import { ERR_MSG_CSS_CLASS } from '../../constants';
 import {
   DefinitionTester,
   selectRadio,
-} from '../../../../../platform/testing/unit/schemaform-utils';
+} from 'platform/testing/unit/schemaform-utils';
 import formConfig from '../../config/form';
 
 describe('781 additonal events yes/no', () => {

--- a/src/applications/disability-benefits/all-claims/tests/pages/ptsdSecondaryAdditionalEvents.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/ptsdSecondaryAdditionalEvents.unit.spec.jsx
@@ -7,7 +7,7 @@ import { ERR_MSG_CSS_CLASS } from '../../constants';
 import {
   DefinitionTester,
   selectRadio,
-} from '../../../../../platform/testing/unit/schemaform-utils';
+} from 'platform/testing/unit/schemaform-utils';
 import formConfig from '../../config/form';
 
 describe('781a additonal events yes/no', () => {

--- a/src/applications/disability-benefits/all-claims/tests/pages/ptsdWalkthroughChoice781.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/ptsdWalkthroughChoice781.unit.spec.jsx
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import { mount } from 'enzyme';
 
-import { DefinitionTester } from '../../../../../platform/testing/unit/schemaform-utils.jsx';
+import { DefinitionTester } from 'platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form.js';
 import initialData from '../../../526EZ/tests/schema/initialData.js';
 

--- a/src/applications/disability-benefits/all-claims/tests/pages/ptsdWalkthroughChoice781a.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/ptsdWalkthroughChoice781a.unit.spec.jsx
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import { mount } from 'enzyme';
 
-import { DefinitionTester } from '../../../../../platform/testing/unit/schemaform-utils.jsx';
+import { DefinitionTester } from 'platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form.js';
 import initialData from '../../../526EZ/tests/schema/initialData.js';
 

--- a/src/applications/disability-benefits/all-claims/tests/pages/ratedDisabilities.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/ratedDisabilities.unit.spec.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { expect } from 'chai';
 import { mount } from 'enzyme';
 
-import { DefinitionTester } from '../../../../../platform/testing/unit/schemaform-utils.jsx';
+import { DefinitionTester } from 'platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form.js';
 import initialData from '../initialData.js';
 

--- a/src/applications/disability-benefits/all-claims/tests/pages/recentEarnedIncome.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/recentEarnedIncome.unit.spec.jsx
@@ -7,7 +7,7 @@ import {
   DefinitionTester,
   fillData,
   selectRadio,
-} from '../../../../../platform/testing/unit/schemaform-utils';
+} from 'platform/testing/unit/schemaform-utils';
 import formConfig from '../../config/form';
 import { ERR_MSG_CSS_CLASS } from '../../constants';
 

--- a/src/applications/disability-benefits/all-claims/tests/pages/recentEducationTraining.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/recentEducationTraining.unit.spec.jsx
@@ -8,7 +8,7 @@ import {
   fillData,
   fillDate,
   selectRadio,
-} from '../../../../../platform/testing/unit/schemaform-utils';
+} from 'platform/testing/unit/schemaform-utils';
 import formConfig from '../../config/form';
 import { ERR_MSG_CSS_CLASS } from '../../constants';
 

--- a/src/applications/disability-benefits/all-claims/tests/pages/recentJobApplications.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/recentJobApplications.unit.spec.jsx
@@ -8,7 +8,7 @@ import {
   fillData,
   fillDate,
   selectRadio,
-} from '../../../../../platform/testing/unit/schemaform-utils';
+} from 'platform/testing/unit/schemaform-utils';
 import formConfig from '../../config/form';
 import { ERR_MSG_CSS_CLASS } from '../../constants';
 

--- a/src/applications/disability-benefits/all-claims/tests/pages/reservesNationalGuardService.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/reservesNationalGuardService.unit.spec.jsx
@@ -5,7 +5,7 @@ import {
   DefinitionTester,
   fillData,
   fillDate,
-} from '../../../../../platform/testing/unit/schemaform-utils.jsx';
+} from 'platform/testing/unit/schemaform-utils.jsx';
 import { mount } from 'enzyme';
 import formConfig from '../../config/form';
 

--- a/src/applications/disability-benefits/all-claims/tests/pages/retirementPay.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/retirementPay.unit.spec.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { expect } from 'chai';
 import sinon from 'sinon';
-import { DefinitionTester } from '../../../../../platform/testing/unit/schemaform-utils.jsx';
+import { DefinitionTester } from 'platform/testing/unit/schemaform-utils.jsx';
 import { mount } from 'enzyme';
 import formConfig from '../../config/form';
 

--- a/src/applications/disability-benefits/all-claims/tests/pages/retirementPayWaiver.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/retirementPayWaiver.unit.spec.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { expect } from 'chai';
 import sinon from 'sinon';
-import { DefinitionTester } from '../../../../../platform/testing/unit/schemaform-utils.jsx';
+import { DefinitionTester } from 'platform/testing/unit/schemaform-utils.jsx';
 import { mount } from 'enzyme';
 import formConfig from '../../config/form';
 

--- a/src/applications/disability-benefits/all-claims/tests/pages/secondaryFinalncident.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/secondaryFinalncident.unit.spec.jsx
@@ -7,7 +7,7 @@ import { ERR_MSG_CSS_CLASS } from '../../constants';
 import {
   DefinitionTester,
   fillData,
-} from '../../../../../platform/testing/unit/schemaform-utils';
+} from 'platform/testing/unit/schemaform-utils';
 import formConfig from '../../config/form';
 
 describe('781a last incident details', () => {

--- a/src/applications/disability-benefits/all-claims/tests/pages/secondaryIncidentAuthorities.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/secondaryIncidentAuthorities.unit.spec.jsx
@@ -6,7 +6,7 @@ import { mount } from 'enzyme';
 import {
   DefinitionTester,
   fillData,
-} from '../../../../../platform/testing/unit/schemaform-utils';
+} from 'platform/testing/unit/schemaform-utils';
 import formConfig from '../../config/form';
 import { ERR_MSG_CSS_CLASS } from '../../constants';
 

--- a/src/applications/disability-benefits/all-claims/tests/pages/secondaryIncidentDate.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/secondaryIncidentDate.unit.spec.jsx
@@ -6,7 +6,7 @@ import { mount } from 'enzyme';
 import {
   DefinitionTester,
   fillDate,
-} from '../../../../../platform/testing/unit/schemaform-utils';
+} from 'platform/testing/unit/schemaform-utils';
 import formConfig from '../../config/form';
 import { ERR_MSG_CSS_CLASS } from '../../constants';
 

--- a/src/applications/disability-benefits/all-claims/tests/pages/secondaryIncidentLocation.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/secondaryIncidentLocation.unit.spec.jsx
@@ -8,7 +8,7 @@ import { ERR_MSG_CSS_CLASS } from '../../constants';
 import {
   DefinitionTester,
   fillData,
-} from '../../../../../platform/testing/unit/schemaform-utils.jsx';
+} from 'platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form';
 
 describe('PTSD Secondary Incident location', () => {

--- a/src/applications/disability-benefits/all-claims/tests/pages/secondaryIncidentUnitAssignment.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/secondaryIncidentUnitAssignment.unit.spec.jsx
@@ -9,7 +9,7 @@ import {
   DefinitionTester,
   fillDate,
   fillData,
-} from '../../../../../platform/testing/unit/schemaform-utils';
+} from 'platform/testing/unit/schemaform-utils';
 import formConfig from '../../config/form';
 
 describe('781 Unit Assignment Details', () => {

--- a/src/applications/disability-benefits/all-claims/tests/pages/secondaryOtherSources.unit.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/pages/secondaryOtherSources.unit.spec.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { expect } from 'chai';
 import sinon from 'sinon';
-import { DefinitionTester } from '../../../../../platform/testing/unit/schemaform-utils.jsx';
+import { DefinitionTester } from 'platform/testing/unit/schemaform-utils.jsx';
 import { mount } from 'enzyme';
 import formConfig from '../../config/form';
 

--- a/src/applications/disability-benefits/all-claims/tests/pages/secondaryOtherSourcesHelp.unit.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/pages/secondaryOtherSourcesHelp.unit.spec.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { expect } from 'chai';
 import sinon from 'sinon';
-import { DefinitionTester } from '../../../../../platform/testing/unit/schemaform-utils.jsx';
+import { DefinitionTester } from 'platform/testing/unit/schemaform-utils.jsx';
 import { mount } from 'enzyme';
 import formConfig from '../../config/form';
 

--- a/src/applications/disability-benefits/all-claims/tests/pages/separationPay.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/separationPay.unit.spec.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { mount } from 'enzyme';
-import { DefinitionTester } from '../../../../../platform/testing/unit/schemaform-utils';
+import { DefinitionTester } from 'platform/testing/unit/schemaform-utils';
 import formConfig from '../../config/form';
 
 describe('Separation Pay', () => {

--- a/src/applications/disability-benefits/all-claims/tests/pages/servedInCombatZone.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/servedInCombatZone.unit.spec.jsx
@@ -5,7 +5,7 @@ import sinon from 'sinon';
 import {
   DefinitionTester,
   selectRadio,
-} from '../../../../../platform/testing/unit/schemaform-utils';
+} from 'platform/testing/unit/schemaform-utils';
 import formConfig from '../../config/form';
 import { ERR_MSG_CSS_CLASS } from '../../constants';
 

--- a/src/applications/disability-benefits/all-claims/tests/pages/socialBehaviorChanges.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/socialBehaviorChanges.unit.spec.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { expect } from 'chai';
 import sinon from 'sinon';
-import { DefinitionTester } from '../../../../../platform/testing/unit/schemaform-utils.jsx';
+import { DefinitionTester } from 'platform/testing/unit/schemaform-utils.jsx';
 import { mount } from 'enzyme';
 import formConfig from '../../config/form';
 

--- a/src/applications/disability-benefits/all-claims/tests/pages/summaryOfEvidence.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/summaryOfEvidence.unit.spec.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { expect } from 'chai';
-import { DefinitionTester } from '../../../../../platform/testing/unit/schemaform-utils';
+import { DefinitionTester } from 'platform/testing/unit/schemaform-utils';
 import { mount } from 'enzyme';
 import formConfig from '../../config/form';
 

--- a/src/applications/disability-benefits/all-claims/tests/pages/supplementalBenefits.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/supplementalBenefits.unit.spec.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { expect } from 'chai';
 import sinon from 'sinon';
-import { DefinitionTester } from '../../../../../platform/testing/unit/schemaform-utils.jsx';
+import { DefinitionTester } from 'platform/testing/unit/schemaform-utils.jsx';
 import { mount } from 'enzyme';
 import formConfig from '../../config/form';
 

--- a/src/applications/disability-benefits/all-claims/tests/pages/terminallyIll.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/terminallyIll.unit.spec.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { mount } from 'enzyme';
-import { DefinitionTester } from '../../../../../platform/testing/unit/schemaform-utils';
+import { DefinitionTester } from 'platform/testing/unit/schemaform-utils';
 import formConfig from '../../config/form';
 
 describe('Terminally Ill', () => {

--- a/src/applications/disability-benefits/all-claims/tests/pages/trainingPay.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/trainingPay.unit.spec.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { mount } from 'enzyme';
-import { DefinitionTester } from '../../../../../platform/testing/unit/schemaform-utils';
+import { DefinitionTester } from 'platform/testing/unit/schemaform-utils';
 import formConfig from '../../config/form';
 
 describe('Training Pay', () => {

--- a/src/applications/disability-benefits/all-claims/tests/pages/trainingPayWaiver.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/trainingPayWaiver.unit.spec.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { mount } from 'enzyme';
-import { DefinitionTester } from '../../../../../platform/testing/unit/schemaform-utils';
+import { DefinitionTester } from 'platform/testing/unit/schemaform-utils';
 import formConfig from '../../config/form';
 import { ERR_MSG_CSS_CLASS } from '../../constants';
 

--- a/src/applications/disability-benefits/all-claims/tests/pages/unemployabilityAdditionalInformation.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/unemployabilityAdditionalInformation.unit.spec.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { expect } from 'chai';
 import sinon from 'sinon';
-import { DefinitionTester } from '../../../../../platform/testing/unit/schemaform-utils.jsx';
+import { DefinitionTester } from 'platform/testing/unit/schemaform-utils.jsx';
 import { mount } from 'enzyme';
 import formConfig from '../../config/form';
 

--- a/src/applications/disability-benefits/all-claims/tests/pages/unemployabilityCertification.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/unemployabilityCertification.unit.spec.jsx
@@ -6,7 +6,7 @@ import { mount } from 'enzyme';
 import {
   DefinitionTester,
   selectCheckbox,
-} from '../../../../../platform/testing/unit/schemaform-utils';
+} from 'platform/testing/unit/schemaform-utils';
 import formConfig from '../../config/form';
 import { ERR_MSG_CSS_CLASS } from '../../constants';
 

--- a/src/applications/disability-benefits/all-claims/tests/pages/unemployabilityDates.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/unemployabilityDates.unit.spec.jsx
@@ -4,7 +4,7 @@ import sinon from 'sinon';
 import {
   DefinitionTester,
   fillDate,
-} from '../../../../../platform/testing/unit/schemaform-utils.jsx';
+} from 'platform/testing/unit/schemaform-utils.jsx';
 import { mount } from 'enzyme';
 import formConfig from '../../config/form';
 

--- a/src/applications/disability-benefits/all-claims/tests/pages/unemployabilityDisabilities.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/unemployabilityDisabilities.spec.jsx
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import { mount } from 'enzyme';
 import sinon from 'sinon';
 
-import { DefinitionTester } from '../../../../../platform/testing/unit/schemaform-utils.jsx';
+import { DefinitionTester } from 'platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form.js';
 import initialData from '../initialData.js';
 

--- a/src/applications/disability-benefits/all-claims/tests/pages/unemployabilityDoctorCare.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/unemployabilityDoctorCare.unit.spec.jsx
@@ -6,7 +6,7 @@ import sinon from 'sinon';
 import {
   DefinitionTester,
   fillData,
-} from '../../../../../platform/testing/unit/schemaform-utils.jsx';
+} from 'platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form.js';
 import initialData from '../initialData.js';
 

--- a/src/applications/disability-benefits/all-claims/tests/pages/unemployabilityFormIntro.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/unemployabilityFormIntro.unit.spec.jsx
@@ -4,7 +4,7 @@ import sinon from 'sinon';
 import {
   DefinitionTester,
   selectRadio,
-} from '../../../../../platform/testing/unit/schemaform-utils.jsx';
+} from 'platform/testing/unit/schemaform-utils.jsx';
 import { mount } from 'enzyme';
 import formConfig from '../../config/form';
 

--- a/src/applications/disability-benefits/all-claims/tests/pages/unemployabilityFormUpload.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/unemployabilityFormUpload.unit.spec.jsx
@@ -5,7 +5,7 @@ import { mount } from 'enzyme';
 
 import {
   DefinitionTester, // selectCheckbox
-} from '../../../../../platform/testing/unit/schemaform-utils.jsx';
+} from 'platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form.js';
 import { ERR_MSG_CSS_CLASS } from '../../constants';
 

--- a/src/applications/disability-benefits/all-claims/tests/pages/uploadPtsdDocuments781.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/uploadPtsdDocuments781.unit.spec.jsx
@@ -5,7 +5,7 @@ import { mount } from 'enzyme';
 
 import {
   DefinitionTester, // selectCheckbox
-} from '../../../../../platform/testing/unit/schemaform-utils.jsx';
+} from 'platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form.js';
 import { ERR_MSG_CSS_CLASS } from '../../constants';
 

--- a/src/applications/disability-benefits/all-claims/tests/pages/uploadPtsdDocuments781a.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/uploadPtsdDocuments781a.unit.spec.jsx
@@ -5,7 +5,7 @@ import { mount } from 'enzyme';
 
 import {
   DefinitionTester, // selectCheckbox
-} from '../../../../../platform/testing/unit/schemaform-utils.jsx';
+} from 'platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form.js';
 import { ERR_MSG_CSS_CLASS } from '../../constants';
 

--- a/src/applications/disability-benefits/all-claims/tests/pages/uploadUnemployabilitySupportingDocuments.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/uploadUnemployabilitySupportingDocuments.unit.spec.jsx
@@ -5,7 +5,7 @@ import { mount } from 'enzyme';
 
 import {
   DefinitionTester, // selectCheckbox
-} from '../../../../../platform/testing/unit/schemaform-utils.jsx';
+} from 'platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form.js';
 import { ERR_MSG_CSS_CLASS } from '../../constants';
 

--- a/src/applications/disability-benefits/all-claims/tests/pages/vaEmployee.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/vaEmployee.unit.spec.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { DefinitionTester } from '../../../../../platform/testing/unit/schemaform-utils';
+import { DefinitionTester } from 'platform/testing/unit/schemaform-utils';
 import { mount } from 'enzyme';
 import { expect } from 'chai';
 import formConfig from '../../config/form';

--- a/src/applications/disability-benefits/all-claims/tests/pages/vaMedicalRecords.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/vaMedicalRecords.unit.spec.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { expect } from 'chai';
 import sinon from 'sinon';
-import { DefinitionTester } from '../../../../../platform/testing/unit/schemaform-utils.jsx';
+import { DefinitionTester } from 'platform/testing/unit/schemaform-utils.jsx';
 import { mount } from 'enzyme';
 import formConfig from '../../config/form';
 

--- a/src/applications/disability-benefits/all-claims/tests/pages/verifyBdd.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/verifyBdd.unit.spec.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { expect } from 'chai';
-import { DefinitionTester } from '../../../../../platform/testing/unit/schemaform-utils.jsx';
+import { DefinitionTester } from 'platform/testing/unit/schemaform-utils.jsx';
 import { mount } from 'enzyme';
 import moment from 'moment';
 import sinon from 'sinon';

--- a/src/applications/disability-benefits/all-claims/tests/pages/workBehaviorChanges.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/workBehaviorChanges.unit.spec.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { expect } from 'chai';
 import sinon from 'sinon';
-import { DefinitionTester } from '../../../../../platform/testing/unit/schemaform-utils.jsx';
+import { DefinitionTester } from 'platform/testing/unit/schemaform-utils.jsx';
 import { mount } from 'enzyme';
 import formConfig from '../../config/form';
 

--- a/src/applications/disability-benefits/all-claims/tests/property-names.unit.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/property-names.unit.spec.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 
-import get from '../../../../platform/utilities/data/get';
+import get from 'platform/utilities/data/get';
 import * as pages from '../pages';
 
 // Some pages have duplicate properties on purpose. These pages add new information to existing

--- a/src/applications/disability-benefits/all-claims/tests/submit-transformer.unit.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/submit-transformer.unit.spec.js
@@ -3,7 +3,7 @@ import path from 'path';
 
 import { expect } from 'chai';
 
-import _ from '../../../../platform/utilities/data';
+import _ from 'platform/utilities/data';
 
 import formConfig from '../config/form';
 

--- a/src/applications/disability-benefits/all-claims/validations.js
+++ b/src/applications/disability-benefits/all-claims/validations.js
@@ -1,4 +1,4 @@
-import _ from '../../../platform/utilities/data';
+import _ from 'platform/utilities/data';
 import some from 'lodash/some';
 import moment from 'moment';
 

--- a/src/applications/disability-benefits/components/ErrorText.jsx
+++ b/src/applications/disability-benefits/components/ErrorText.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import CallVBACenter from '../../../platform/static-data/CallVBACenter';
+import CallVBACenter from 'platform/static-data/CallVBACenter';
 
 export default function ErrorText() {
   return (

--- a/src/applications/disability-benefits/components/GetFormHelp.jsx
+++ b/src/applications/disability-benefits/components/GetFormHelp.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import CallVBACenter from '../../../platform/static-data/CallVBACenter';
+import CallVBACenter from 'platform/static-data/CallVBACenter';
 
 function GetFormHelp() {
   return (

--- a/src/applications/disability-benefits/wizard/wizard-entry.js
+++ b/src/applications/disability-benefits/wizard/wizard-entry.js
@@ -1,5 +1,5 @@
 import Wizard from '../../static-pages/wizard';
-import ApplicationStatus from '../../../platform/forms/save-in-progress/ApplicationStatus';
+import ApplicationStatus from 'platform/forms/save-in-progress/ApplicationStatus';
 import pages from './pages';
 
 export default {

--- a/src/applications/letters/actions/letters.js
+++ b/src/applications/letters/actions/letters.js
@@ -1,6 +1,6 @@
 import * as Sentry from '@sentry/browser';
 
-import recordEvent from '../../../platform/monitoring/record-event';
+import recordEvent from 'platform/monitoring/record-event';
 import { apiRequest, getStatus } from '../utils/helpers.jsx';
 import {
   BACKEND_AUTHENTICATION_ERROR,

--- a/src/applications/letters/components/DownloadLetterLink.jsx
+++ b/src/applications/letters/components/DownloadLetterLink.jsx
@@ -3,10 +3,10 @@ import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import ReactCSSTransitionGroup from 'react-transition-group/CSSTransitionGroup';
 
-import recordEvent from '../../../platform/monitoring/record-event';
+import recordEvent from 'platform/monitoring/record-event';
 import { getLetterPdf } from '../actions/letters';
 import { DOWNLOAD_STATUSES } from '../utils/constants';
-import CallVBACenter from '../../../platform/static-data/CallVBACenter';
+import CallVBACenter from 'platform/static-data/CallVBACenter';
 
 export class DownloadLetterLink extends React.Component {
   // Either download the pdf or open it in a new window, depending on the

--- a/src/applications/letters/containers/AddressSection.jsx
+++ b/src/applications/letters/containers/AddressSection.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 
-import { focusElement } from '../../../platform/utilities/ui';
+import { focusElement } from 'platform/utilities/ui';
 
 import { isAddressEmpty } from '../utils/helpers';
 import noAddressBanner from '../components/NoAddressBanner';

--- a/src/applications/letters/containers/LetterList.jsx
+++ b/src/applications/letters/containers/LetterList.jsx
@@ -6,7 +6,7 @@ import CollapsiblePanel from '@department-of-veterans-affairs/formation-react/Co
 import DownloadLetterLink from '../components/DownloadLetterLink';
 import VeteranBenefitSummaryLetter from './VeteranBenefitSummaryLetter';
 
-import { focusElement } from '../../../platform/utilities/ui';
+import { focusElement } from 'platform/utilities/ui';
 import { letterContent, bslHelpInstructions } from '../utils/helpers';
 import { AVAILABILITY_STATUSES, LETTER_TYPES } from '../utils/constants';
 

--- a/src/applications/letters/containers/LettersApp.jsx
+++ b/src/applications/letters/containers/LettersApp.jsx
@@ -2,11 +2,11 @@ import React from 'react';
 import * as Sentry from '@sentry/browser';
 import { connect } from 'react-redux';
 
-import backendServices from '../../../platform/user/profile/constants/backendServices';
-import RequiredLoginView from '../../../platform/user/authorization/components/RequiredLoginView';
-import { externalServices } from '../../../platform/monitoring/DowntimeNotification';
-import DowntimeBanner from '../../../platform/monitoring/DowntimeNotification/components/Banner';
-import CallVBACenter from '../../../platform/static-data/CallVBACenter';
+import backendServices from 'platform/user/profile/constants/backendServices';
+import RequiredLoginView from 'platform/user/authorization/components/RequiredLoginView';
+import { externalServices } from 'platform/monitoring/DowntimeNotification';
+import DowntimeBanner from 'platform/monitoring/DowntimeNotification/components/Banner';
+import CallVBACenter from 'platform/static-data/CallVBACenter';
 
 const UNREGISTERED_ERROR = 'vets_letters_user_unregistered';
 

--- a/src/applications/letters/containers/Main.jsx
+++ b/src/applications/letters/containers/Main.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 
 import LoadingIndicator from '@department-of-veterans-affairs/formation-react/LoadingIndicator';
-import { systemDownMessage } from '../../../platform/static-data/error-messages';
+import { systemDownMessage } from 'platform/static-data/error-messages';
 import { AVAILABILITY_STATUSES } from '../utils/constants';
 import { recordsNotFound, isAddressEmpty } from '../utils/helpers';
 

--- a/src/applications/letters/containers/VeteranBenefitSummaryLetter.jsx
+++ b/src/applications/letters/containers/VeteranBenefitSummaryLetter.jsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 
-import recordEvent from '../../../platform/monitoring/record-event';
+import recordEvent from 'platform/monitoring/record-event';
 import { updateBenefitSummaryRequestOption } from '../actions/letters';
 import {
   benefitOptionsMap,
@@ -10,8 +10,8 @@ import {
   optionsToAlwaysDisplay,
   getBenefitOptionText,
 } from '../utils/helpers.jsx';
-import { formatDateShort } from '../../../platform/utilities/date';
-import CallVBACenter from '../../../platform/static-data/CallVBACenter';
+import { formatDateShort } from 'platform/utilities/date';
+import CallVBACenter from 'platform/static-data/CallVBACenter';
 
 export class VeteranBenefitSummaryLetter extends React.Component {
   constructor() {

--- a/src/applications/letters/letters-entry.jsx
+++ b/src/applications/letters/letters-entry.jsx
@@ -1,7 +1,7 @@
-import '../../platform/polyfills';
+import 'platform/polyfills';
 import './sass/letters.scss';
 
-import startApp from '../../platform/startup';
+import startApp from 'platform/startup';
 
 import routes from './routes';
 import reducer from './reducers';

--- a/src/applications/letters/tests/components/DownloadLetterLink.unit.spec.jsx
+++ b/src/applications/letters/tests/components/DownloadLetterLink.unit.spec.jsx
@@ -4,7 +4,7 @@ import sinon from 'sinon';
 import { expect } from 'chai';
 import _ from 'lodash/fp';
 
-import { getFormDOM } from '../../../../platform/testing/unit/schemaform-utils';
+import { getFormDOM } from 'platform/testing/unit/schemaform-utils';
 import { DownloadLetterLink } from '../../components/DownloadLetterLink.jsx';
 import { DOWNLOAD_STATUSES } from '../../utils/constants';
 

--- a/src/applications/letters/tests/containers/LettersApp.unit.spec.jsx
+++ b/src/applications/letters/tests/containers/LettersApp.unit.spec.jsx
@@ -5,7 +5,7 @@ import { expect } from 'chai';
 import { LettersApp, AppContent } from '../../containers/LettersApp';
 
 import reducer from '../../reducers';
-import createCommonStore from '../../../../platform/startup/store';
+import createCommonStore from 'platform/startup/store';
 
 const store = createCommonStore(reducer);
 

--- a/src/applications/letters/utils/constants.js
+++ b/src/applications/letters/utils/constants.js
@@ -85,7 +85,7 @@ export const REQUEST_OPTIONS = Object.freeze({
   hasSpecialMonthlyCompensation: 'hasSpecialMonthlyCompensation',
 });
 
-import ADDRESS_DATA from '../../../platform/forms/address/data';
+import ADDRESS_DATA from 'platform/forms/address/data';
 
 export const STATE_CODE_TO_NAME = ADDRESS_DATA.states;
 

--- a/src/applications/letters/utils/helpers.jsx
+++ b/src/applications/letters/utils/helpers.jsx
@@ -1,9 +1,9 @@
 /* eslint-disable camelcase */
 import React from 'react';
 
-import { apiRequest as commonApiClient } from '../../../platform/utilities/api';
-import environment from '../../../platform/utilities/environment';
-import { formatDateShort } from '../../../platform/utilities/date';
+import { apiRequest as commonApiClient } from 'platform/utilities/api';
+import environment from 'platform/utilities/environment';
+import { formatDateShort } from 'platform/utilities/date';
 import { BENEFIT_OPTIONS, ADDRESS_TYPES, MILITARY_STATES } from './constants';
 
 import recordEvent from 'platform/monitoring/record-event';


### PR DESCRIPTION
## Description

`va/use-resolved-path` rule from the `va custom plugin` has been added to the testing stage in CircleCI (`circle.esint.json`).

The purpose of this rule is to resolve the path to use the existing aliases generated in babel.

In this case we are removing all instances containing `../` from the `platform` alias.

This change should help the code to be in compliance with the rule and removes the errors from `additional-linting` CircleCI check.

## Revised Folders
### Benefits and Memorials
src/applications/letters => 22
src/applications/disability-benefits => 190
Total errors fixed: 212

## Testing done
Locally

## Screenshots

<img width="576" alt="Screen Shot 2020-04-22 at 9 30 32 AM" src="https://user-images.githubusercontent.com/55560129/79990912-a27c7580-847f-11ea-95bb-869615326b9e.png">

## Acceptance criteria
- [x] Remove all `../platform/` instances
