### PR TITLE
Fix platform alias - bm2

### DIFF
--- a/src/applications/disability-benefits/2346/routes.jsx
+++ b/src/applications/disability-benefits/2346/routes.jsx
@@ -1,4 +1,4 @@
-import { createRoutesWithSaveInProgress } from '../../../platform/forms/save-in-progress/helpers';
+import { createRoutesWithSaveInProgress } from 'platform/forms/save-in-progress/helpers';
 import formConfig from './config/form';
 import App from './containers/App.jsx';
 


### PR DESCRIPTION
## Description

`va/use-resolved-path` rule from the `va custom plugin` has been added to the testing stage in CircleCI (`circle.esint.json`).

The purpose of this rule is to resolve the path to use the existing aliases generated in babel.

In this case we are removing all instances containing `../` from the `platform` alias.

This change should help the code to be in compliance with the rule and removes the errors from `additional-linting` CircleCI check.

## Revised Folders
### Benefits and Memorials 2
src/applications/disability-benefits/2346 => 1

## Testing done
Locally

## Screenshots

<img width="690" alt="Screen Shot 2020-04-22 at 10 51 26 AM" src="https://user-images.githubusercontent.com/55560129/79997285-66e5a980-8487-11ea-88d0-2433d46ba26d.png">

## Acceptance criteria
- [x] Remove all `../platform/` instances
