### PR TITLE
Fix platform alias - eBenefits

### DIFF
--- a/src/applications/disability-benefits/686/components/AuthorizationMessage.jsx
+++ b/src/applications/disability-benefits/686/components/AuthorizationMessage.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import appendQuery from 'append-query';
 import PropTypes from 'prop-types';
 
-import CallVBACenter from '../../../../platform/static-data/CallVBACenter';
+import CallVBACenter from 'platform/static-data/CallVBACenter';
 import disabilityIncreaseManifest from '../../526EZ/manifest.json';
 
 const { rootUrl: increaseRootUrl } = disabilityIncreaseManifest;

--- a/src/applications/disability-benefits/686c-674/app-entry.jsx
+++ b/src/applications/disability-benefits/686c-674/app-entry.jsx
@@ -1,7 +1,7 @@
-import '../../../platform/polyfills';
+import 'platform/polyfills';
 import './sass/new-686.scss';
 
-import startApp from '../../../platform/startup';
+import startApp from 'platform/startup';
 
 import routes from './routes';
 import reducer from './reducers';

--- a/src/applications/disability-benefits/686c-674/containers/App.jsx
+++ b/src/applications/disability-benefits/686c-674/containers/App.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import RoutedSavableApp from '../../../../platform/forms/save-in-progress/RoutedSavableApp';
+import RoutedSavableApp from 'platform/forms/save-in-progress/RoutedSavableApp';
 import formConfig from '../config/form';
 
 export default function App({ location, children }) {

--- a/src/applications/disability-benefits/686c-674/containers/ConfirmationPage.jsx
+++ b/src/applications/disability-benefits/686c-674/containers/ConfirmationPage.jsx
@@ -3,7 +3,7 @@ import moment from 'moment';
 import { connect } from 'react-redux';
 import Scroll from 'react-scroll';
 
-import { focusElement } from '../../../../platform/utilities/ui';
+import { focusElement } from 'platform/utilities/ui';
 
 const scroller = Scroll.scroller;
 const scrollToTop = () => {

--- a/src/applications/disability-benefits/686c-674/containers/IntroductionPage.jsx
+++ b/src/applications/disability-benefits/686c-674/containers/IntroductionPage.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
 
-import { focusElement } from '../../../../platform/utilities/ui';
+import { focusElement } from 'platform/utilities/ui';
 import OMBInfo from '@department-of-veterans-affairs/formation-react/OMBInfo';
 import FormTitle from 'platform/forms-system/src/js/components/FormTitle';
-import SaveInProgressIntro from '../../../../platform/forms/save-in-progress/SaveInProgressIntro';
+import SaveInProgressIntro from 'platform/forms/save-in-progress/SaveInProgressIntro';
 
 class IntroductionPage extends React.Component {
   componentDidMount() {

--- a/src/applications/disability-benefits/686c-674/reducers/index.js
+++ b/src/applications/disability-benefits/686c-674/reducers/index.js
@@ -1,5 +1,5 @@
 import formConfig from '../config/form';
-import { createSaveInProgressFormReducer } from '../../../../platform/forms/save-in-progress/reducers';
+import { createSaveInProgressFormReducer } from 'platform/forms/save-in-progress/reducers';
 
 export default {
   form: createSaveInProgressFormReducer(formConfig),

--- a/src/applications/disability-benefits/686c-674/routes.jsx
+++ b/src/applications/disability-benefits/686c-674/routes.jsx
@@ -1,4 +1,4 @@
-import { createRoutesWithSaveInProgress } from '../../../platform/forms/save-in-progress/helpers';
+import { createRoutesWithSaveInProgress } from 'platform/forms/save-in-progress/helpers';
 import formConfig from './config/form';
 import App from './containers/App.jsx';
 


### PR DESCRIPTION
## Description

`va/use-resolved-path` rule from the `va custom plugin` has been added to the testing stage in CircleCI (`circle.esint.json`).

The purpose of this rule is to resolve the path to use the existing aliases generated in babel.

In this case we are removing all instances containing `../` from the `platform` alias.

This change should help the code to be in compliance with the rule and removes the errors from `additional-linting` CircleCI check.

## Revised Folders
### eBenefits
src/applications/disability-benefits/686 => 1
src/applications/disability-benefits/686c-674 => 8
src/applications/personalization/rated-disabilities => 0
src/applications/personalization/view-dependents => 0
Total errors fixed: 9

## Testing done
Locally

## Screenshots

<img width="704" alt="Screen Shot 2020-04-22 at 10 59 42 AM" src="https://user-images.githubusercontent.com/55560129/79999210-a7462700-8489-11ea-9bdc-6287deffe385.png">

## Acceptance criteria
- [x] Remove all `../platform/` instances
