### PR TITLE
Fix platform alias - pw

### DIFF
--- a/src/applications/static-pages/createApplicationStatus.js
+++ b/src/applications/static-pages/createApplicationStatus.js
@@ -8,7 +8,7 @@ export default function createApplicationStatus(store, form) {
   );
   if (root) {
     import(/* webpackChunkName: "application-status" */
-    '../../platform/forms/save-in-progress/ApplicationStatus').then(module => {
+    'platform/forms/save-in-progress/ApplicationStatus').then(module => {
       const ApplicationStatus = module.default;
       ReactDOM.render(
         <Provider store={store}>

--- a/src/applications/static-pages/createCallToActionWidget.js
+++ b/src/applications/static-pages/createCallToActionWidget.js
@@ -11,7 +11,7 @@ export default async function createCallToActionWidget(store, widgetType) {
   if (widgets.length) {
     const {
       default: CallToActionWidget,
-    } = await import(/* webpackChunkName: "cta-widget" */ '../../platform/site-wide/cta-widget');
+    } = await import(/* webpackChunkName: "cta-widget" */ 'platform/site-wide/cta-widget');
 
     connectFeatureToggle(store.dispatch);
 

--- a/src/applications/static-pages/facilities/BasicFacilityListWidget.jsx
+++ b/src/applications/static-pages/facilities/BasicFacilityListWidget.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { apiRequest } from '../../../platform/utilities/api';
+import { apiRequest } from 'platform/utilities/api';
 import LoadingIndicator from '@department-of-veterans-affairs/formation-react/LoadingIndicator';
 import FacilityTitle from './FacilityTitle';
 import FacilityAddress from './FacilityAddress';

--- a/src/applications/static-pages/facilities/FacilityAppointmentWaitTimesWidget.jsx
+++ b/src/applications/static-pages/facilities/FacilityAppointmentWaitTimesWidget.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import LoadingIndicator from '@department-of-veterans-affairs/formation-react/LoadingIndicator';
-import { formatDateLong } from '../../../platform/utilities/date';
+import { formatDateLong } from 'platform/utilities/date';
 import FacilityApiAlert from './FacilityApiAlert';
 import { connect } from 'react-redux';
 import _ from 'lodash';

--- a/src/applications/static-pages/facilities/FacilityListWidget.jsx
+++ b/src/applications/static-pages/facilities/FacilityListWidget.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { apiRequest } from '../../../platform/utilities/api';
+import { apiRequest } from 'platform/utilities/api';
 import LoadingIndicator from '@department-of-veterans-affairs/formation-react/LoadingIndicator';
 import FacilityApiAlert from './FacilityApiAlert';
 import { sortFacilitiesByName } from './facilityUtilities';

--- a/src/applications/static-pages/facilities/FacilityMapWidget.jsx
+++ b/src/applications/static-pages/facilities/FacilityMapWidget.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import LoadingIndicator from '@department-of-veterans-affairs/formation-react/LoadingIndicator';
 import { mapboxToken } from '../../facility-locator/utils/mapboxToken';
 import { buildAddressArray } from '../../facility-locator/utils/facilityAddress';
-import environment from '../../../platform/utilities/environment';
+import environment from 'platform/utilities/environment';
 import { connect } from 'react-redux';
 
 export class FacilityMapWidget extends React.Component {

--- a/src/applications/static-pages/facilities/FacilityPatientSatisfactionScoresWidget.jsx
+++ b/src/applications/static-pages/facilities/FacilityPatientSatisfactionScoresWidget.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import LoadingIndicator from '@department-of-veterans-affairs/formation-react/LoadingIndicator';
-import { formatDateLong } from '../../../platform/utilities/date';
-import { displayPercent } from '../../../platform/utilities/ui';
+import { formatDateLong } from 'platform/utilities/date';
+import { displayPercent } from 'platform/utilities/ui';
 import FacilityApiAlert from './FacilityApiAlert';
 import { connect } from 'react-redux';
 

--- a/src/applications/static-pages/facilities/OtherFacilityListWidget.jsx
+++ b/src/applications/static-pages/facilities/OtherFacilityListWidget.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { apiRequest } from '../../../platform/utilities/api';
+import { apiRequest } from 'platform/utilities/api';
 import LoadingIndicator from '@department-of-veterans-affairs/formation-react/LoadingIndicator';
 import FacilityApiAlert from './FacilityApiAlert';
 import { cleanPhoneNumber, sortFacilitiesByName } from './facilityUtilities';

--- a/src/applications/static-pages/facilities/actions/index.js
+++ b/src/applications/static-pages/facilities/actions/index.js
@@ -1,4 +1,4 @@
-import { apiRequest } from '../../../../platform/utilities/api';
+import { apiRequest } from 'platform/utilities/api';
 
 export const FETCH_FACILITY_STARTED = 'FETCH_FACILITY_STARTED';
 

--- a/src/applications/yellow-ribbon/api/index.js
+++ b/src/applications/yellow-ribbon/api/index.js
@@ -3,7 +3,7 @@
 // Dependencies.
 import appendQuery from 'append-query';
 // Relative imports.
-import { apiRequest } from '../../../platform/utilities/api';
+import { apiRequest } from 'platform/utilities/api';
 import { normalizeResponse } from '../helpers';
 
 export const fetchResultsApi = async (options = {}) => {

--- a/src/platform/site-wide/user-nav/components/SearchHelpSignIn.jsx
+++ b/src/platform/site-wide/user-nav/components/SearchHelpSignIn.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import recordEvent from '../../../../platform/monitoring/record-event';
+import recordEvent from 'platform/monitoring/record-event';
 
 import isVATeamSiteSubdomain from '../../../utilities/environment/va-subdomain';
 import { hasSession } from 'platform/user/profile/utilities';

--- a/src/platform/site-wide/user-nav/components/SearchMenu.jsx
+++ b/src/platform/site-wide/user-nav/components/SearchMenu.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
-import recordEvent from '../../../../platform/monitoring/record-event';
+import recordEvent from 'platform/monitoring/record-event';
 
 import { replaceWithStagingDomain } from '../../../utilities/environment/stagingDomains';
 import IconSearch from '@department-of-veterans-affairs/formation-react/IconSearch';


### PR DESCRIPTION
## Description

`va/use-resolved-path` rule from the `va custom plugin` has been added to the testing stage in CircleCI (`circle.esint.json`).

The purpose of this rule is to resolve the path to use the existing aliases generated in babel.

In this case we are removing all instances containing `../` from the `platform` alias.

This change should help the code to be in compliance with the rule and removes the errors from `additional-linting` CircleCI check.

## Revised Folders
### Public Websites
src/applications/proxy-rewrite/redirects/crossDomainRedirects.json => 0
src/platform/site-wide => 2
src/applications/static-pages => 10
src/applications/find-forms => 0
src/applications/yellow-ribbon => 1
Total errors fixed: 13

## Testing done
Locally

## Screenshots

<img width="698" alt="Screen Shot 2020-04-22 at 11 22 12 AM" src="https://user-images.githubusercontent.com/55560129/80001621-934ff480-848c-11ea-84dd-fe95ab80f964.png">

## Acceptance criteria
- [x] Remove all `../platform/` instances
