### PR TITLE
Fix platform alias - fl

### DIFF
--- a/src/applications/facility-locator/actions/index.js
+++ b/src/applications/facility-locator/actions/index.js
@@ -16,7 +16,7 @@ import { LocationType, BOUNDING_RADIUS } from '../constants';
 import { ccLocatorEnabled } from '../config';
 
 import mbxGeo from '@mapbox/mapbox-sdk/services/geocoding';
-import recordEvent from '../../../platform/monitoring/record-event';
+import recordEvent from 'platform/monitoring/record-event';
 
 const mbxClient = mbxGeo(mapboxClient);
 /**

--- a/src/applications/facility-locator/api/index.js
+++ b/src/applications/facility-locator/api/index.js
@@ -1,5 +1,5 @@
 import MockApi from './MockLocatorApi';
 import LiveApi from './LocatorApi';
-import environment from '../../../platform/utilities/environment';
+import environment from 'platform/utilities/environment';
 
 export default (environment.isLocalhost() ? MockApi : LiveApi);

--- a/src/applications/facility-locator/components/AppointmentInfo.jsx
+++ b/src/applications/facility-locator/components/AppointmentInfo.jsx
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import { get, some, pull, startCase } from 'lodash';
 import classNames from 'classnames';
 import moment from 'moment';
-import recordEvent from '../../../platform/monitoring/record-event';
+import recordEvent from 'platform/monitoring/record-event';
 
 /**
  * VA Facility Appointments

--- a/src/applications/facility-locator/components/LocationMap.jsx
+++ b/src/applications/facility-locator/components/LocationMap.jsx
@@ -1,5 +1,5 @@
 import { mapboxToken } from '../utils/mapboxToken';
-import environment from '../../../platform/utilities/environment';
+import environment from 'platform/utilities/environment';
 import React, { Component } from 'react';
 import { LocationType, PinNames } from '../constants';
 

--- a/src/applications/facility-locator/components/SearchControls.jsx
+++ b/src/applications/facility-locator/components/SearchControls.jsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import FacilityTypeDropdown from './FacilityTypeDropdown';
 import ServiceTypeAhead from './ServiceTypeAhead';
-import recordEvent from '../../../platform/monitoring/record-event';
+import recordEvent from 'platform/monitoring/record-event';
 import { LocationType } from '../constants';
 import {
   healthServices,

--- a/src/applications/facility-locator/config.js
+++ b/src/applications/facility-locator/config.js
@@ -1,4 +1,4 @@
-import environment from '../../platform/utilities/environment';
+import environment from 'platform/utilities/environment';
 import compact from 'lodash/compact';
 import { LocationType, FacilityType } from './constants';
 import manifest from './manifest.json';

--- a/src/applications/facility-locator/containers/FacilityDetail.jsx
+++ b/src/applications/facility-locator/containers/FacilityDetail.jsx
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { fetchVAFacility } from '../actions';
-import { focusElement } from '../../../platform/utilities/ui';
+import { focusElement } from 'platform/utilities/ui';
 import AccessToCare from '../components/AccessToCare';
 import LocationAddress from '../components/search-results/LocationAddress';
 import LocationDirectionsLink from '../components/search-results/LocationDirectionsLink';

--- a/src/applications/facility-locator/containers/FacilityLocatorApp.jsx
+++ b/src/applications/facility-locator/containers/FacilityLocatorApp.jsx
@@ -4,7 +4,7 @@ import React from 'react';
 import appendQuery from 'append-query';
 import DowntimeNotification, {
   externalServices,
-} from '../../../platform/monitoring/DowntimeNotification';
+} from 'platform/monitoring/DowntimeNotification';
 import { validateIdString } from '../utils/helpers';
 import Breadcrumbs from '@department-of-veterans-affairs/formation-react/Breadcrumbs';
 import { ccLocatorEnabled } from '../config';

--- a/src/applications/facility-locator/containers/ProviderDetail.jsx
+++ b/src/applications/facility-locator/containers/ProviderDetail.jsx
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { object, func } from 'prop-types';
 import { fetchProviderDetail } from '../actions';
-import { focusElement } from '../../../platform/utilities/ui';
+import { focusElement } from 'platform/utilities/ui';
 import LoadingIndicator from '@department-of-veterans-affairs/formation-react/LoadingIndicator';
 import LocationMap from '../components/LocationMap';
 import LocationAddress from '../components/search-results/LocationAddress';

--- a/src/applications/facility-locator/containers/VAMap.jsx
+++ b/src/applications/facility-locator/containers/VAMap.jsx
@@ -33,7 +33,7 @@ import { isProduction } from 'platform/site-wide/feature-toggles/selectors';
 import Pagination from '@department-of-veterans-affairs/formation-react/Pagination';
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 import mbxGeo from '@mapbox/mapbox-sdk/services/geocoding';
-import recordEvent from '../../../platform/monitoring/record-event';
+import recordEvent from 'platform/monitoring/record-event';
 
 const mbxClient = mbxGeo(mapboxClient);
 

--- a/src/applications/facility-locator/facility-locator-entry.jsx
+++ b/src/applications/facility-locator/facility-locator-entry.jsx
@@ -1,7 +1,7 @@
-import '../../platform/polyfills';
+import 'platform/polyfills';
 import './sass/facility-locator.scss';
 
-import startApp from '../../platform/startup';
+import startApp from 'platform/startup';
 
 import routes from './routes';
 import reducer from './reducers';


### PR DESCRIPTION
## Description

`va/use-resolved-path` rule from the `va custom plugin` has been added to the testing stage in CircleCI (`circle.esint.json`).

The purpose of this rule is to resolve the path to use the existing aliases generated in babel.

In this case we are removing all instances containing `../` from the `platform` alias.

This change should help the code to be in compliance with the rule and removes the errors from `additional-linting` CircleCI check.

## Revised Folders
### Facility Locator
src/applications/facility-locator => 12
Total errors fixed: 12

## Testing done
Locally

## Screenshots

<img width="679" alt="Screen Shot 2020-04-22 at 12 27 44 PM" src="https://user-images.githubusercontent.com/55560129/80007732-b1215780-8494-11ea-9ee5-f6336b564c8c.png">

## Acceptance criteria
- [x] Remove all `../platform/` instances
