### PR TITLE
Prefer stateless function in veteran-id-card

### DIFF
--- a/src/applications/veteran-id-card/components/RequiredVeteranView.jsx
+++ b/src/applications/veteran-id-card/components/RequiredVeteranView.jsx
@@ -5,28 +5,26 @@ import SystemDownView from '@department-of-veterans-affairs/formation-react/Syst
 
 import EmailVICHelp from '../../../platform/static-data/EmailVICHelp';
 
-class RequiredVeteranView extends React.Component {
-  render() {
-    let view;
+function RequiredVeteranView({ userProfile, children }) {
+  let view;
 
-    if (this.props.userProfile.veteranStatus === 'SERVER_ERROR') {
-      // If eMIS status is null, show a system down message.
-      view = (
-        <SystemDownView
-          messageLine1="We’re sorry. We can’t process your request for a Veteran ID Card right now because we can't access your records at the moment. Please try again in a few minutes."
-          messageLine2={
-            <span>
-              Please <EmailVICHelp />
-            </span>
-          }
-        />
-      );
-    } else {
-      view = this.props.children;
-    }
-
-    return <div>{view}</div>;
+  if (userProfile.veteranStatus === 'SERVER_ERROR') {
+    // If eMIS status is null, show a system down message.
+    view = (
+      <SystemDownView
+        messageLine1="We’re sorry. We can’t process your request for a Veteran ID Card right now because we can't access your records at the moment. Please try again in a few minutes."
+        messageLine2={
+          <span>
+            Please <EmailVICHelp />
+          </span>
+        }
+      />
+    );
+  } else {
+    view = children;
   }
+
+  return <div>{view}</div>;
 }
 
 RequiredVeteranView.propTypes = {


### PR DESCRIPTION
## Description

Part of https://github.com/department-of-veterans-affairs/va.gov-team/issues/8286

The `veteran-id-card` app only has 1 bit of code that breaks `prefer-stateless-function`


## Testing done

Linting

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
