### PR TITLE
Fix platform alias - vaos

### DIFF
--- a/src/applications/vaos/tests/utils/selectors.unit.spec.js
+++ b/src/applications/vaos/tests/utils/selectors.unit.spec.js
@@ -20,7 +20,7 @@ import {
   selectCernerFacilities,
 } from '../../utils/selectors';
 
-import { selectIsCernerOnlyPatient } from '../../../../platform/user/selectors';
+import { selectIsCernerOnlyPatient } from 'platform/user/selectors';
 
 describe('VAOS selectors', () => {
   describe('getNewAppointment', () => {


### PR DESCRIPTION
## Description

`va/use-resolved-path` rule from the `va custom plugin` has been added to the testing stage in CircleCI (`circle.esint.json`).

The purpose of this rule is to resolve the path to use the existing aliases generated in babel.

In this case we are removing all instances containing `../` from the `platform` alias.

This change should help the code to be in compliance with the rule and removes the errors from `additional-linting` CircleCI check.

## Revised Folders
### Vaos
src/applications/vaos => 1
Total errors fixed: 1

## Testing done
Locally

## Screenshots

<img width="623" alt="Screen Shot 2020-04-22 at 2 45 12 PM" src="https://user-images.githubusercontent.com/55560129/80021254-3b26eb80-84a8-11ea-9ae7-da8ed72d4bae.png">

## Acceptance criteria
- [x] Remove all `../platform/` instances
