### PR TITLE
Fix platform alias - bah

### DIFF
--- a/src/applications/edu-benefits/1995/Form1995App.jsx
+++ b/src/applications/edu-benefits/1995/Form1995App.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import RoutedSavableApp from '../../../platform/forms/save-in-progress/RoutedSavableApp';
+import RoutedSavableApp from 'platform/forms/save-in-progress/RoutedSavableApp';
 import formConfig from './config/form';
 
 export default function Form1995Entry({ location, children }) {

--- a/src/applications/edu-benefits/1995/analytics-functions.js
+++ b/src/applications/edu-benefits/1995/analytics-functions.js
@@ -1,4 +1,4 @@
-import recordEvent from '../../../platform/monitoring/record-event';
+import recordEvent from 'platform/monitoring/record-event';
 
 export default {
   ineligibilityStillApply: isStillApplying => {

--- a/src/applications/edu-benefits/1995/containers/ConfirmationPage.jsx
+++ b/src/applications/edu-benefits/1995/containers/ConfirmationPage.jsx
@@ -3,7 +3,7 @@ import moment from 'moment';
 import { connect } from 'react-redux';
 import Scroll from 'react-scroll';
 
-import { focusElement } from '../../../../platform/utilities/ui';
+import { focusElement } from 'platform/utilities/ui';
 
 import { benefitsLabels } from '../../utils/labels';
 

--- a/src/applications/edu-benefits/1995/containers/IntroductionPage.jsx
+++ b/src/applications/edu-benefits/1995/containers/IntroductionPage.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import { focusElement } from '../../../../platform/utilities/ui';
+import { focusElement } from 'platform/utilities/ui';
 import OMBInfo from '@department-of-veterans-affairs/formation-react/OMBInfo';
 import FormTitle from 'platform/forms-system/src/js/components/FormTitle';
-import SaveInProgressIntro from '../../../../platform/forms/save-in-progress/SaveInProgressIntro';
+import SaveInProgressIntro from 'platform/forms/save-in-progress/SaveInProgressIntro';
 
 export class IntroductionPage extends React.Component {
   componentDidMount() {

--- a/src/applications/edu-benefits/1995/edu-benefits-entry.jsx
+++ b/src/applications/edu-benefits/1995/edu-benefits-entry.jsx
@@ -1,7 +1,7 @@
-import '../../../platform/polyfills';
+import 'platform/polyfills';
 import '../sass/edu-benefits.scss';
 
-import startApp from '../../../platform/startup';
+import startApp from 'platform/startup';
 
 import routes from './routes';
 import reducer from './reducer';

--- a/src/applications/edu-benefits/1995/reducer.js
+++ b/src/applications/edu-benefits/1995/reducer.js
@@ -1,5 +1,5 @@
 import formConfig from './config/form';
-import { createSaveInProgressFormReducer } from '../../../platform/forms/save-in-progress/reducers';
+import { createSaveInProgressFormReducer } from 'platform/forms/save-in-progress/reducers';
 
 export default {
   form: createSaveInProgressFormReducer(formConfig),

--- a/src/applications/edu-benefits/1995/routes.jsx
+++ b/src/applications/edu-benefits/1995/routes.jsx
@@ -1,4 +1,4 @@
-import { createRoutesWithSaveInProgress } from '../../../platform/forms/save-in-progress/helpers';
+import { createRoutesWithSaveInProgress } from 'platform/forms/save-in-progress/helpers';
 
 import Form1995App from './Form1995App';
 import formConfig from './config/form';

--- a/src/applications/gi/config.js
+++ b/src/applications/gi/config.js
@@ -1,4 +1,4 @@
-import environment from '../../platform/utilities/environment';
+import environment from 'platform/utilities/environment';
 import manifest from './manifest.json';
 
 export const api = {

--- a/src/applications/gi/gi-entry.jsx
+++ b/src/applications/gi/gi-entry.jsx
@@ -1,7 +1,7 @@
-import '../../platform/polyfills';
+import 'platform/polyfills';
 import './sass/gi.scss';
 
-import startApp from '../../platform/startup';
+import startApp from 'platform/startup';
 
 import routes from './routes';
 import reducer from './reducers';

--- a/src/applications/gi/tests/components/EligibilityForm.unit.spec.jsx
+++ b/src/applications/gi/tests/components/EligibilityForm.unit.spec.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { expect } from 'chai';
 import SkinDeep from 'skin-deep';
 
-import createCommonStore from '../../../../platform/startup/store';
+import createCommonStore from 'platform/startup/store';
 import { EligibilityForm } from '../../components/search/EligibilityForm';
 import reducer from '../../reducers';
 

--- a/src/applications/gi/tests/containers/LandingPage.unit.spec.js
+++ b/src/applications/gi/tests/containers/LandingPage.unit.spec.js
@@ -4,7 +4,7 @@ import sinon from 'sinon';
 import { shallow, mount } from 'enzyme';
 import { Provider } from 'react-redux';
 
-import createCommonStore from '../../../../platform/startup/store';
+import createCommonStore from 'platform/startup/store';
 import { LandingPage } from '../../containers/LandingPage';
 import reducer from '../../reducers';
 

--- a/src/applications/gi/tests/containers/Modals.unit.spec.js
+++ b/src/applications/gi/tests/containers/Modals.unit.spec.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { expect } from 'chai';
 import SkinDeep from 'skin-deep';
 
-import createCommonStore from '../../../../platform/startup/store';
+import createCommonStore from 'platform/startup/store';
 import { Modals } from '../../containers/Modals';
 import reducer from '../../reducers';
 

--- a/src/applications/gi/tests/containers/ProfilePage.unit.spec.js
+++ b/src/applications/gi/tests/containers/ProfilePage.unit.spec.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { expect } from 'chai';
 import SkinDeep from 'skin-deep';
 
-import createCommonStore from '../../../../platform/startup/store';
+import createCommonStore from 'platform/startup/store';
 import { ProfilePage } from '../../containers/ProfilePage';
 import reducer from '../../reducers';
 

--- a/src/applications/gi/tests/containers/SearchPage.unit.spec.js
+++ b/src/applications/gi/tests/containers/SearchPage.unit.spec.js
@@ -5,7 +5,7 @@ import sinon from 'sinon';
 import { mount, shallow } from 'enzyme';
 import { Provider } from 'react-redux';
 
-import createCommonStore from '../../../../platform/startup/store';
+import createCommonStore from 'platform/startup/store';
 import { SearchPage } from '../../containers/SearchPage';
 import reducer from '../../reducers';
 

--- a/src/applications/gi/tests/selectors/calculator.unit.spec.js
+++ b/src/applications/gi/tests/selectors/calculator.unit.spec.js
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { set } from 'lodash/fp';
 
 import { calculatorConstants } from '../gibct-helpers';
-import createCommonStore from '../../../../platform/startup/store';
+import createCommonStore from 'platform/startup/store';
 import reducer from '../../reducers';
 import { getCalculatedBenefits } from '../../selectors/calculator';
 import { formatCurrency } from '../../utils/helpers';

--- a/src/applications/gi/tests/selectors/vetTecCalculator.unit.spec.js
+++ b/src/applications/gi/tests/selectors/vetTecCalculator.unit.spec.js
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { set } from 'lodash/fp';
 
 import { calculatorConstants } from '../gibct-helpers';
-import createCommonStore from '../../../../platform/startup/store';
+import createCommonStore from 'platform/startup/store';
 import reducer from '../../reducers';
 import { getCalculatedBenefits } from '../../selectors/vetTecCalculator';
 


### PR DESCRIPTION
## Description

`va/use-resolved-path` rule from the `va custom plugin` has been added to the testing stage in CircleCI (`circle.esint.json`).

The purpose of this rule is to resolve the path to use the existing aliases generated in babel.

In this case we are removing all instances containing `../` from the `platform` alias.

This change should help the code to be in compliance with the rule and removes the errors from `additional-linting` CircleCI check.

## Revised Folders
### bah
src/applications/static-pages/school-resources => 0
src/applications/gi => 10
src/applications/edu-benefits/1995 => 9
src/applications/edu-benefits/10203 => 0
Total errors fixed: 19

## Testing done
Locally

## Screenshots

<img width="634" alt="Screen Shot 2020-04-22 at 2 57 14 PM" src="https://user-images.githubusercontent.com/55560129/80022932-c5704f00-84aa-11ea-9eb2-f89a25ef30ad.png">

## Acceptance criteria
- [x] Remove all `../platform/` instances
