### PR TITLE
Added babel nullish-coalescing plugin

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,25 +1,35 @@
 {
   // Javascript settings.
   "presets": [
-    ["@babel/env", {
-      "forceAllTransforms": true,
-      "targets": {
-        /* This is the full list of browsers we support, but we are not using it because we want babel-polyfill
+    [
+      "@babel/env",
+      {
+        "forceAllTransforms": true,
+        "targets": {
+          /* This is the full list of browsers we support, but we are not using it because we want babel-polyfill
          * to include only polyfills for more modern browsers.
          * Older browser polyfills are in preESModulesPolyfills.js
          */
-        /* "browsers": ["Chrome 60", "Firefox 57", "iOS 9", "Edge 14", "ChromeAndroid 64", "Safari 10", "ie 11"] */
-        /*
+          /* "browsers": ["Chrome 60", "Firefox 57", "iOS 9", "Edge 14", "ChromeAndroid 64", "Safari 10", "ie 11"] */
+          /*
          * This is the list of browers we support that all also have support for the nomodule script
          * attribute, meaning we can make them ignore a file that includes polyfills for older browsers
          */
-        "browsers": ["Chrome 61", "Firefox 60", "iOS 11", "Edge 16", "ChromeAndroid 67", "Safari 11"]
-      },
-      "useBuiltIns": "entry",
-      "modules": false,
-      "debug": false
-    }],
-    "@babel/react",
+          "browsers": [
+            "Chrome 61",
+            "Firefox 60",
+            "iOS 11",
+            "Edge 16",
+            "ChromeAndroid 67",
+            "Safari 11"
+          ]
+        },
+        "useBuiltIns": "entry",
+        "modules": false,
+        "debug": false
+      }
+    ],
+    "@babel/react"
   ],
   "plugins": [
     "lodash",
@@ -29,17 +39,21 @@
     "@babel/plugin-proposal-numeric-separator",
     "@babel/plugin-proposal-throw-expressions",
     // Stage 3
+    "@babel/plugin-proposal-nullish-coalescing-operator",
     "@babel/plugin-proposal-optional-chaining",
     "@babel/plugin-syntax-dynamic-import",
     "@babel/plugin-syntax-import-meta",
     ["@babel/plugin-proposal-class-properties", { "loose": false }],
     "@babel/plugin-proposal-json-strings",
-    ["module-resolver", {
-      "root": "./src",
-      "alias": {
-        "vet360": "./src/platform/user/profile/vet360"
+    [
+      "module-resolver",
+      {
+        "root": "./src",
+        "alias": {
+          "vet360": "./src/platform/user/profile/vet360"
+        }
       }
-    }]
+    ]
   ],
   // Share polyfills between files.
   "env": {
@@ -63,10 +77,13 @@
     },
     "production": {
       "plugins": [
-        ["transform-react-remove-prop-types", {
-          "removeImport": true
-        }]
+        [
+          "transform-react-remove-prop-types",
+          {
+            "removeImport": true
+          }
+        ]
       ]
-    },
-  },
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
     "@babel/plugin-proposal-export-namespace-from": "^7.0.0",
     "@babel/plugin-proposal-function-sent": "^7.0.0",
     "@babel/plugin-proposal-json-strings": "^7.0.0",
+    "@babel/plugin-proposal-nullish-coalescing-operator": "^7.8.3",
     "@babel/plugin-proposal-numeric-separator": "^7.0.0",
     "@babel/plugin-proposal-optional-chaining": "^7.2.0",
     "@babel/plugin-proposal-throw-expressions": "^7.0.0",
@@ -299,7 +300,6 @@
     "uswds": "1.6.10",
     "vanilla-lazyload": "^8.17.0",
     "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#08d3607b312334cb734466a09d058fc1e1143f35",
-
     "whatwg-fetch": "^2.0.3"
   },
   "resolutions": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -197,6 +197,11 @@
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0.tgz#bbb3fbee98661c569034237cc03967ba99b4f250"
 
+"@babel/helper-plugin-utils@^7.8.0", "@babel/helper-plugin-utils@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.3.tgz#9ea293be19babc0f52ff8ca88b34c3611b208670"
+  integrity sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ==
+
 "@babel/helper-regex@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-regex/-/helper-regex-7.0.0.tgz#2c1718923b57f9bbe64705ffe5640ac64d9bdb27"
@@ -331,6 +336,14 @@
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/plugin-syntax-json-strings" "^7.2.0"
 
+"@babel/plugin-proposal-nullish-coalescing-operator@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.8.3.tgz#e4572253fdeed65cddeecfdab3f928afeb2fd5d2"
+  integrity sha512-TS9MlfzXpXKt6YYomudb/KU7nQI6/xnapG6in1uZxoxDghuSMZsPb6D2fyUwNYSAp4l1iR7QtFOjkqcRYcUsfw==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.8.3"
+    "@babel/plugin-syntax-nullish-coalescing-operator" "^7.8.0"
+
 "@babel/plugin-proposal-numeric-separator@^7.0.0":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.2.0.tgz#646854daf4cd22fd6733f6076013a936310443ac"
@@ -416,6 +429,13 @@
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.2.0.tgz#0b85a3b4bc7cdf4cc4b8bf236335b907ca22e7c7"
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-syntax-nullish-coalescing-operator@^7.8.0":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz#167ed70368886081f74b5c36c65a88c03b66d1a9"
+  integrity sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.8.0"
 
 "@babel/plugin-syntax-numeric-separator@^7.2.0":
   version "7.2.0"


### PR DESCRIPTION
## Description
In preparation for `nullish coalescing` to be part of the upcoming ECMA 2020 standard, ([Currently on stage 4](https://github.com/tc39/proposal-nullish-coalescing)). We will be adding this [babel plugin](https://babeljs.io/docs/en/babel-plugin-proposal-nullish-coalescing-operator).

In a near future, we will also look into an ESLint plugin that will help with the implementation

## Acceptance criteria
- [x] `@babel/plugin-proposal-nullish-coalescing-operator` added into the `.babelrc` file

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
