### PR TITLE
Sets chatbot bubble min-width to avoid text cutoff

### DIFF
--- a/src/applications/coronavirus-chatbot/index.js
+++ b/src/applications/coronavirus-chatbot/index.js
@@ -63,6 +63,7 @@ const initBotConversation = jsonWebToken => {
     userAvatarInitials: 'You',
     backgroundColor: '#F8F8F8',
     primaryFont: 'Source Sans Pro, sans-serif',
+    bubbleMinWidth: 100,
   };
 
   const webchatStore = window.WebChat.createStore(


### PR DESCRIPTION
## Description
Related to [this issue](https://github.com/department-of-veterans-affairs/covid19-chatbot/issues/135)

Chat bubbles now have a min width of 100px instead of the default 250px, so text can wrap on small screens without getting cut off.

## Screenshots
![buttons min100](https://user-images.githubusercontent.com/19177102/80024281-ce622000-84ac-11ea-95ce-c1d7d3ef8b1a.png)

## Acceptance criteria
- [ ] Given I am on mobile, when my font size is enlarged, then I should see the Chatbot buttons resize or wrap
