### PR TITLE
safer handling of PPIU error responses

### DIFF
--- a/src/applications/personalization/profile360/tests/util/index.unit.spec.js
+++ b/src/applications/personalization/profile360/tests/util/index.unit.spec.js
@@ -47,6 +47,20 @@ describe('profile utils', () => {
       const eventDataObject = createDirectDepositAnalyticsDataObject([]);
       expect(eventDataObject).to.deep.equal(defaultDataObject);
     });
+    // Wednesday, April 22, 2020 We saw errors in Sentry due to unsafe prop
+    // drilling in our hasErrorMessage helper. This test was added to replicate
+    // the error.
+    // http://sentry.vfs.va.gov/vets-gov/website-production/issues/115880/
+    it('returns the correct data when passed an error object that is missing a messages array', () => {
+      let eventDataObject = createDirectDepositAnalyticsDataObject([{}]);
+      expect(eventDataObject).to.deep.equal(defaultDataObject);
+      eventDataObject = createDirectDepositAnalyticsDataObject([
+        {
+          meta: {},
+        },
+      ]);
+      expect(eventDataObject).to.deep.equal(defaultDataObject);
+    });
     it('returns the correct data when a bad address error is passed', () => {
       const eventDataObject = createDirectDepositAnalyticsDataObject([
         {

--- a/src/applications/personalization/profile360/util/index.js
+++ b/src/applications/personalization/profile360/util/index.js
@@ -34,15 +34,15 @@ export async function getData(apiRoute, options) {
 const hasErrorMessage = (errors, errorKey, errorText) => {
   if (errorText) {
     return errors.some(err =>
-      err.meta.messages.some(
+      err?.meta?.messages?.some(
         message =>
           message.key === errorKey &&
-          message.text.toLowerCase().includes(errorText.toLowerCase()),
+          message.text?.toLowerCase().includes(errorText.toLowerCase()),
       ),
     );
   }
   return errors.some(err =>
-    err.meta.messages.some(message => message.key === errorKey),
+    err?.meta?.messages?.some(message => message.key === errorKey),
   );
 };
 

--- a/src/applications/personalization/profile360/util/index.js
+++ b/src/applications/personalization/profile360/util/index.js
@@ -34,7 +34,7 @@ export async function getData(apiRoute, options) {
 const hasErrorMessage = (errors, errorKey, errorText) => {
   if (errorText) {
     return errors.some(err =>
-      err?.meta?.messages?.some(
+      err.meta?.messages?.some(
         message =>
           message.key === errorKey &&
           message.text?.toLowerCase().includes(errorText.toLowerCase()),
@@ -42,7 +42,7 @@ const hasErrorMessage = (errors, errorKey, errorText) => {
     );
   }
   return errors.some(err =>
-    err?.meta?.messages?.some(message => message.key === errorKey),
+    err.meta?.messages?.some(message => message.key === errorKey),
   );
 };
 


### PR DESCRIPTION
## Description
To deal with Sentry errors we started seeing today. http://sentry.vfs.va.gov/vets-gov/website-production/issues/115880/

## Testing done
Added unit tests that try to replicate the response we were getting from `PUT ppiu/payment_information`

## Screenshots
N/A

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs