### PR TITLE
VAVFS-5961: Adding aria-labeledby to banner.

### DIFF
--- a/src/site/components/fullwidth_banner_alerts.drupal.liquid
+++ b/src/site/components/fullwidth_banner_alerts.drupal.liquid
@@ -29,7 +29,7 @@
 
   {% if outputStatus == true %}
     <div data-template="components/fullwidth_banner_alerts" data-entity-id="{{ entity.entityId }}"
-      aria-labelledby="usa-alert-heading-{{ entity.entityId }}"
+      aria-labelledby="usa-alert-header-text-{{ entity.entityId }}"
       class="usa-alert-full-width dismissable-option-header usa-alert-full-width-{{ alertType }}"
       id="usa-alert-full-width-{{ entity.entityId }}" role="region">
       <div class="usa-alert usa-alert-{{ alertType }}" role="alert">
@@ -42,7 +42,7 @@
           </button>
         {% endif %}
         <div class="usa-alert-body">
-          <h3 class="usa-alert-heading">
+          <h3 class="usa-alert-heading" id="usa-alert-header-text-{{ entity.entityId }}">
             {{ entity.title }}
           </h3>
           <div class="additional-info-content usa-alert-text">


### PR DESCRIPTION
## Description
Fullwidth banner had an aria-labeledby attribute that doesn't have a corresponding id. This pr adds said id to the banner text

## Testing done
Visual

## Screenshots
![image](https://user-images.githubusercontent.com/2404547/80037294-50f4da80-84c1-11ea-954f-8e37d9755e37.png)

## Acceptance criteria
- [ ] Visit `pittsburgh-health-care/university-drive-campus-map/` and open up inspector (per screenshot). Confirm banner aria-labeledby matches id of banner body div.