### PR TITLE
[Development] Add original claim feature flipper

### DIFF
--- a/src/applications/disability-benefits/all-claims/components/IntroductionPage.jsx
+++ b/src/applications/disability-benefits/all-claims/components/IntroductionPage.jsx
@@ -204,7 +204,7 @@ IntroductionPage.propTypes = {
     pageList: PropTypes.array.isRequired,
   }).isRequired,
   user: PropTypes.shape({}),
-  allowOriginalClaim: PropTypes.func,
+  allowOriginalClaim: PropTypes.bool,
 };
 
 export default connect(mapStateToProps)(IntroductionPage);

--- a/src/applications/disability-benefits/all-claims/components/IntroductionPage.jsx
+++ b/src/applications/disability-benefits/all-claims/components/IntroductionPage.jsx
@@ -19,9 +19,13 @@ class IntroductionPage extends React.Component {
 
   render() {
     const services = selectAvailableServices(this.props) || [];
+    const allowOriginalClaim =
+      this.props.allowOriginalClaim || this.props.testOriginalClaim;
     const allowContinue = services.includes('original-claim')
-      ? this.props.allowOriginalClaim // original claim feature flag
-      : services.includes('form526'); // "form526" service required to proceed
+      ? allowOriginalClaim // original claim feature flag
+      : true; // services.includes('form526'); // <- "form526" service should
+    // be required to proceed; not changing this now in case it breaks something
+
     // Remove this once we original claims feature toggle is set to 100%
     if (!allowContinue) {
       return (

--- a/src/applications/disability-benefits/all-claims/config/selectors.js
+++ b/src/applications/disability-benefits/all-claims/config/selectors.js
@@ -1,0 +1,6 @@
+// import the toggleValues helper
+import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
+import FEATURE_FLAG_NAMES from 'platform/utilities/feature-toggles/featureFlagNames';
+
+export const originalClaimsFeature = state =>
+  toggleValues(state)[FEATURE_FLAG_NAMES.form526OriginalClaims];

--- a/src/applications/disability-benefits/all-claims/tests/containers/IntroductionPage.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/containers/IntroductionPage.unit.spec.jsx
@@ -14,7 +14,23 @@ describe('<IntroductionPage/>', () => {
       },
       pageList: [],
     },
+    // 'form526' service _should_ be required to proceed
+    user: {
+      profile: {
+        services: ['form526'],
+      },
+    },
   };
+
+  const originalClaimsProps = allow => ({
+    ...defaultProps,
+    testOriginalClaim: allow,
+    user: {
+      profile: {
+        services: ['original-claim'],
+      },
+    },
+  });
 
   it('should render', () => {
     const wrapper = shallow(<IntroductionPage {...defaultProps} />);
@@ -34,6 +50,29 @@ describe('<IntroductionPage/>', () => {
     expect(
       wrapper.find('withRouter(Connect(SaveInProgressIntro))').length,
     ).to.equal(2);
+    wrapper.unmount();
+  });
+
+  it('should render as usual (allow original claim)', () => {
+    const wrapper = shallow(
+      <IntroductionPage {...originalClaimsProps(true)} />,
+    );
+    expect(
+      wrapper.find('withRouter(Connect(SaveInProgressIntro))').length,
+    ).to.equal(2);
+    expect(wrapper.find('FormTitle').length).to.equal(1);
+    expect(wrapper.find('Connect(FileOriginalClaimPage)').length).to.equal(0);
+    wrapper.unmount();
+  });
+  it('should block original claim & show alert', () => {
+    const wrapper = shallow(
+      <IntroductionPage {...originalClaimsProps(false)} />,
+    );
+    expect(
+      wrapper.find('withRouter(Connect(SaveInProgressIntro))').length,
+    ).to.equal(0);
+    expect(wrapper.find('FormTitle').length).to.equal(1);
+    expect(wrapper.find('Connect(FileOriginalClaimPage)').length).to.equal(1);
     wrapper.unmount();
   });
 });

--- a/src/applications/disability-benefits/wizard/pages/bdd.jsx
+++ b/src/applications/disability-benefits/wizard/pages/bdd.jsx
@@ -50,7 +50,7 @@ function alertContent(isLoggedIn) {
 
 const BDDPage = ({ isLoggedIn }) => (
   <AlertBox
-    status="error"
+    status="warning"
     headline="You’ll need to file a claim on eBenefits"
     content={alertContent(isLoggedIn)}
   />

--- a/src/applications/disability-benefits/wizard/pages/file-original-claim.jsx
+++ b/src/applications/disability-benefits/wizard/pages/file-original-claim.jsx
@@ -8,7 +8,7 @@ import recordEvent from 'platform/monitoring/record-event';
 function FileOriginalClaimPage({ isLoggedIn }) {
   return (
     <AlertBox
-      status="error"
+      status="warning"
       headline="You’ll need to file a claim on eBenefits"
       content={
         <>

--- a/src/platform/user/selectors.js
+++ b/src/platform/user/selectors.js
@@ -3,13 +3,13 @@
 
 export const selectUser = state => state.user;
 export const isLoggedIn = state => selectUser(state).login.currentlyLoggedIn;
-export const selectProfile = state => selectUser(state).profile;
+export const selectProfile = state => selectUser(state)?.profile;
 export const isInMVI = state => selectProfile(state).status === 'OK';
 export const isProfileLoading = state => selectProfile(state).loading;
 export const isLOA3 = state => selectProfile(state).loa.current === 3;
 export const isLOA1 = state => selectProfile(state).loa.current === 1;
 export const isMultifactorEnabled = state => selectProfile(state).multifactor;
-export const selectAvailableServices = state => selectProfile(state).services;
+export const selectAvailableServices = state => selectProfile(state)?.services;
 export const selectPatientFacilities = state =>
   selectProfile(state)?.facilities?.filter(
     f => !f.facilityId.startsWith('742'),

--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -17,4 +17,5 @@ export default Object.freeze({
   eduBenefitsStemScholarship: 'eduBenefitsStemScholarship',
   eduSection103: 'edu_section_103',
   gibctEstimateYourBenefits: 'gibctEstimateYourBenefits',
+  form526OriginalClaims: 'form526OriginalClaims',
 });


### PR DESCRIPTION
## Description

Original claims (for form 526EZ) has been unblocked on the backend.

- Add flipper feature (https://github.com/department-of-veterans-affairs/vets-api/pull/4140 - DONE) 
- We need to remove the gating question (see PR #12146)
- Complete back-end integrations (PR #12147)

Once this PR and the above are merged, we can ramp up users who can file an original claim

### **NOTE** this PR needs a design & content review before merging!

Associated ticket: https://github.com/department-of-veterans-affairs/va.gov-team/issues/7921

### Update (4/27/2020)

Changed BDD wizard choice to display a "warning" alert vs an "error" alert (see screenshot)

## Testing done

Unit tests added & passing

## Screenshots

When a user already has a claim or claim in progress, they will see one of these screens

<details><summary>Has previous claim</summary>

<!-- leave a blank line above -->
<img width="742" alt="Screen Shot 2020-04-22 at 4 36 02 PM" src="https://user-images.githubusercontent.com/136959/80039989-b4c9d400-84be-11ea-863a-7dd5fde31738.png">
</details>
<details><summary>Claim in progress</summary>

<!-- leave a blank line above -->
![Screen Shot 2020-04-22 at 5 26 23 PM](https://user-images.githubusercontent.com/136959/80039950-9e237d00-84be-11ea-9931-1d46f4c6d7bd.png)
</details>

In this PR, when a user has never started an original claim, they will see one of these screens:

<details><summary>Original claim (feature flag allows them to continue)</summary>

<!-- leave a blank line above -->
(same as "Has previous claim")
<img width="742" alt="Screen Shot 2020-04-22 at 4 36 02 PM" src="https://user-images.githubusercontent.com/136959/80039989-b4c9d400-84be-11ea-863a-7dd5fde31738.png">
</details>
<details>
<summary>Original claim (feature flag prevents continuing)</summary>

<!-- leave a blank line above -->
Update: Changed to a "warning" type alert

![Screen Shot 2020-04-27 at 2 40 14 PM](https://user-images.githubusercontent.com/136959/80413686-76089500-8895-11ea-8a7a-7a682c025810.png)

Note: currently this is the same alert shown when the user selects "Yes" as a first time filer in the gating wizard

<img width="755" alt="Screen Shot 2020-04-22 at 4 35 24 PM" src="https://user-images.githubusercontent.com/136959/80040313-6bc64f80-84bf-11ea-8973-629efae37022.png">
</details>

<details>
<summary>Not separated from military (BDD) wizard choice</summary>

<!-- leave a blank line above -->
Modified alert type to be a "warning" instead of an "error"

![Screen Shot 2020-04-27 at 2 34 43 PM](https://user-images.githubusercontent.com/136959/80413849-b700a980-8895-11ea-8e8b-c093d9ebbfb3.png)
</details>


## Acceptance criteria
- [ ] Original claim allowed when feature flag allows; user will see a normal claims flow
- [ ] Original claim prevented when feature flag disallows; user will see a message directing them to start the form on the eBenefits website. 
- [ ] Wizard update to BDD: Not separated from military shows a warning

## Definition of done
- [x] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
