### PR TITLE
Rough version of proper side nav

### DIFF
--- a/src/applications/personalization/profile-2/components/AccountSecurity.jsx
+++ b/src/applications/personalization/profile-2/components/AccountSecurity.jsx
@@ -7,7 +7,10 @@ import AccountSecurityContent from './AccountSecurityContent';
 
 const AccountSecurity = () => (
   <>
-    <h2 tabIndex="-1" className="vads-u-margin-y--4">
+    <h2
+      tabIndex="-1"
+      className="vads-u-margin-y--2 medium-screen:vads-u-margin-y--4"
+    >
       Account security
     </h2>
     <DowntimeNotification

--- a/src/applications/personalization/profile-2/components/ConnectedApplications.jsx
+++ b/src/applications/personalization/profile-2/components/ConnectedApplications.jsx
@@ -1,5 +1,12 @@
 import React from 'react';
 
-const ConnectedApplications = () => <h1>Connected Applications</h1>;
+const ConnectedApplications = () => (
+  <h2
+    tabIndex="-1"
+    className="vads-u-margin-y--2 medium-screen:vads-u-margin-y--4"
+  >
+    Connected Applications
+  </h2>
+);
 
 export default ConnectedApplications;

--- a/src/applications/personalization/profile-2/components/DirectDeposit.jsx
+++ b/src/applications/personalization/profile-2/components/DirectDeposit.jsx
@@ -1,5 +1,12 @@
 import React from 'react';
 
-const DirectDeposit = () => <h1>Direct Deposit</h1>;
+const DirectDeposit = () => (
+  <h2
+    tabIndex="-1"
+    className="vads-u-margin-y--2 medium-screen:vads-u-margin-y--4"
+  >
+    Direct Deposit
+  </h2>
+);
 
 export default DirectDeposit;

--- a/src/applications/personalization/profile-2/components/PersonalInformation.jsx
+++ b/src/applications/personalization/profile-2/components/PersonalInformation.jsx
@@ -1,5 +1,12 @@
 import React from 'react';
 
-const PersonalInformation = () => <h2>Personal Information</h2>;
+const PersonalInformation = () => (
+  <h2
+    tabIndex="-1"
+    className="vads-u-margin-y--2 medium-screen:vads-u-margin-y--4"
+  >
+    Personal Information
+  </h2>
+);
 
 export default PersonalInformation;

--- a/src/applications/personalization/profile-2/components/ProfileHeader.jsx
+++ b/src/applications/personalization/profile-2/components/ProfileHeader.jsx
@@ -18,10 +18,13 @@ const ProfileHeader = ({
   // the outer full-width background of the header banner
   const wrapperClasses = prefixUtilityClasses([
     'background-color--gray-dark',
-    'margin-bottom--2',
+    'margin-bottom--0',
     'padding-y--2',
   ]);
-  const wrapperClassesMedium = prefixUtilityClasses(['padding-y--3'], 'medium');
+  const wrapperClassesMedium = prefixUtilityClasses(
+    ['padding-y--3', 'margin-bottom--2'],
+    'medium',
+  );
 
   // the inner content of the header banner
   const innerWrapperClasses = prefixUtilityClasses([
@@ -58,11 +61,11 @@ const ProfileHeader = ({
   const fullNameClasses = prefixUtilityClasses([
     'font-size--h3',
     'margin-top--0',
-    'margin-bottom--1p5',
+    'margin-bottom--0p5',
     'text-align--center',
   ]);
   const fullNameClassesMedium = prefixUtilityClasses(
-    ['text-align--left'],
+    ['text-align--left', 'margin-bottom--1p5'],
     'medium',
   );
 

--- a/src/applications/personalization/profile-2/components/ProfileInfoTable.jsx
+++ b/src/applications/personalization/profile-2/components/ProfileInfoTable.jsx
@@ -76,7 +76,7 @@ const ProfileInfoTable = ({
             >
               {row.title}
             </h4>
-            <p className={tableRowDataClasses.join(' ')}>{row.value}</p>
+            <div className={tableRowDataClasses.join(' ')}>{row.value}</div>
           </div>
         ))}
     </div>

--- a/src/applications/personalization/profile-2/components/ProfileSideNav.jsx
+++ b/src/applications/personalization/profile-2/components/ProfileSideNav.jsx
@@ -4,43 +4,54 @@ import { Link } from 'react-router';
 import { childRoutes } from '../routes';
 
 const ProfileSideNav = () => (
-  <nav className="profile-side-nav">
-    <ul>
-      <li>
-        <Link
-          activeClassName="is-active"
-          to={childRoutes.personalInformation.path}
-        >
-          {childRoutes.personalInformation.name}
-        </Link>
-      </li>
-      <li>
-        <Link
-          activeClassName="is-active"
-          to={childRoutes.militaryInformation.path}
-        >
-          {childRoutes.militaryInformation.name}
-        </Link>
-      </li>
-      <li>
-        <Link activeClassName="is-active" to={childRoutes.directDeposit.path}>
-          {childRoutes.directDeposit.name}
-        </Link>
-      </li>
-      <li>
-        <Link activeClassName="is-active" to={childRoutes.accountSecurity.path}>
-          {childRoutes.accountSecurity.name}
-        </Link>
-      </li>
-      <li>
-        <Link
-          activeClassName="is-active"
-          to={childRoutes.connectedApplications.path}
-        >
-          {childRoutes.connectedApplications.name}
-        </Link>
-      </li>
-    </ul>
+  <nav className="va-sidebarnav" id="va-detailpage-sidebar">
+    <div>
+      <button
+        type="button"
+        aria-label="Close this menu"
+        className="va-btn-close-icon va-sidebarnav-close"
+      />
+      <h4>Profile</h4>
+      <ul>
+        <li>
+          <Link
+            activeClassName="is-active"
+            to={childRoutes.personalInformation.path}
+          >
+            {childRoutes.personalInformation.name}
+          </Link>
+        </li>
+        <li>
+          <Link
+            activeClassName="is-active"
+            to={childRoutes.militaryInformation.path}
+          >
+            {childRoutes.militaryInformation.name}
+          </Link>
+        </li>
+        <li>
+          <Link activeClassName="is-active" to={childRoutes.directDeposit.path}>
+            {childRoutes.directDeposit.name}
+          </Link>
+        </li>
+        <li>
+          <Link
+            activeClassName="is-active"
+            to={childRoutes.accountSecurity.path}
+          >
+            {childRoutes.accountSecurity.name}
+          </Link>
+        </li>
+        <li>
+          <Link
+            activeClassName="is-active"
+            to={childRoutes.connectedApplications.path}
+          >
+            {childRoutes.connectedApplications.name}
+          </Link>
+        </li>
+      </ul>
+    </div>
   </nav>
 );
 

--- a/src/applications/personalization/profile-2/components/ProfileWrapper.jsx
+++ b/src/applications/personalization/profile-2/components/ProfileWrapper.jsx
@@ -63,12 +63,34 @@ class ProfileWrapper extends Component {
   // note that `children` will be passed in via React Router.
   mainContent = () => (
     <>
+      {/* the mobile sidenav trigger button */}
+      <button
+        type="button"
+        className="va-btn-sidebarnav-trigger"
+        aria-controls="va-detailpage-sidebar"
+      >
+        <span>
+          <b>Profile Menu</b>
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="444.819"
+            height="444.819"
+            viewBox="0 0 444.819 444.819"
+          >
+            <path
+              fill="#ffffff"
+              d="M352.025 196.712L165.885 10.848C159.028 3.615 150.468 0 140.185 0s-18.84 3.62-25.696 10.848l-21.7 21.416c-7.045 7.043-10.567 15.604-10.567 25.692 0 9.897 3.52 18.56 10.566 25.98L231.544 222.41 92.785 361.168c-7.04 7.043-10.563 15.604-10.563 25.693 0 9.9 3.52 18.566 10.564 25.98l21.7 21.417c7.043 7.043 15.612 10.564 25.697 10.564 10.09 0 18.656-3.52 25.697-10.564L352.025 248.39c7.046-7.423 10.57-16.084 10.57-25.98.002-10.09-3.524-18.655-10.57-25.698z"
+            />
+          </svg>
+        </span>
+      </button>
+      <div className="mobile-fixed-spacer" />
       <ProfileHeader />
       <div className="usa-grid usa-grid-full">
         <div className="usa-width-one-fourth">
           <ProfileSideNav />
         </div>
-        <div className="usa-width-two-thirds vads-u-padding-x--1 vads-u-padding-bottom--4 medium-screen:vads-u-padding--0 medium-screen:vads-u-padding-bottom--6">
+        <div className="usa-width-two-thirds vads-u-padding-bottom--4 vads-u-padding-x--1 medium-screen:vads-u-padding--0 medium-screen:vads-u-padding-bottom--6">
           {this.props.children}
         </div>
       </div>

--- a/src/applications/personalization/profile-2/sass/profile-2.scss
+++ b/src/applications/personalization/profile-2/sass/profile-2.scss
@@ -1,22 +1,7 @@
 @import "~@department-of-veterans-affairs/formation/sass/shared-variables";
 @import "../../../../platform/forms/sass/m-schemaform";
 @import "./profile-info-table";
-
-nav.profile-side-nav {
-  ul {
-    padding: 0;
-  }
-  li {
-    list-style: none;
-  }
-  a {
-    text-decoration: none;
-  }
-  a.is-active {
-    font-weight: bold;
-    color: $color-black;
-  }
-}
+@import "./profile-sidenav";
 
 .profile-service-badge {
   max-height: 108px;

--- a/src/applications/personalization/profile-2/sass/profile-sidenav.scss
+++ b/src/applications/personalization/profile-2/sass/profile-sidenav.scss
@@ -1,0 +1,149 @@
+$nav-item-padding: units-px(1) units-px(2) units-px(1) units-px(1.5);
+
+.va-sidebarnav {
+  border-bottom: 1px solid $color-gray-lighter;
+  display: block;
+
+  // We would normally include all of the mobile style declarations the default
+  // values since we learn towards doing mobile-first. But that would require
+  // doing a lot of resetting/unsetting values to something "normal" at >=
+  // medium screens, which seems like more trouble than it's worth in this case.
+  @include media-maxwidth($medium-screen - 1) {
+    display: none;
+    height: 100%;
+    left: 0;
+    overflow: scroll;
+    padding: 1.6rem;
+    position: absolute;
+    top: 0;
+    visibility: hidden;
+    width: 100%;
+
+    // The overlay that covers the entire page behind the open menu
+    &::before {
+      background: $color-link-default-hover;
+      content: '\00A0';
+      display: block;
+      height: 100%;
+      left: 0;
+      position: fixed;
+      top: 0;
+      width: 100%;
+      z-index: 1;
+    }
+
+    // The actual background behind the side nav menu on mobile
+    > div {
+      -webkit-transition: 100ms transform linear;
+      background: $color-white;
+      border-left: 1px solid $color-gray-light;
+      height: 100%;
+      max-width: 30rem;
+      overflow: auto;
+      padding: units-px(4) units-px(2) units-px(2);
+      position: absolute;
+      right: 0;
+      top: 0;
+      transform: translateX(100%);
+      transition: 100ms transform linear;
+      visibility: visible;
+      width: 80%;
+      z-index: 2;
+    }
+
+    &--opened {
+      display: block;
+      position: fixed;
+      visibility: visible;
+      z-index: $top-layer;
+
+      & > div {
+        transform: translateX(0);
+      }
+    }
+  }
+
+  button.va-sidebarnav-close {
+    position: absolute;
+    right: 2px;
+    top: 2px;
+
+    &:hover,
+    &:focus {
+      background-color: $color-gray-lightest;
+    }
+
+    @include media($medium-screen) {
+      display: none;
+    }
+  }
+
+  h4 {
+    border: 1px solid $color-gray-lighter;
+    border-left: none;
+    border-right: none;
+    color: $color-black;
+    margin-bottom: units-px(2);
+    margin-top: units-px(4);
+    padding: $nav-item-padding;
+  }
+
+  ul {
+    padding: 0;
+  }
+  li {
+    list-style: none;
+    margin-bottom: 0;
+
+    a {
+      border-left: 4px solid transparent;
+      display: inline-block;
+      padding: $nav-item-padding;
+      text-decoration: none;
+      width: 100%;
+
+      &:hover,
+      &:focus {
+        background-color: $color-primary-alt-lightest;
+        border-color: $color-link-default;
+        padding-left: 14px;
+        transition: background-color 0.1s ease-in-out,
+          border-color 0.1s ease-in-out, padding 0.1s ease-in-out;
+      }
+      &.is-active {
+        background-color: $color-gray-lightest;
+        border-left: 4px solid $color-base;
+        color: $color-black;
+        font-weight: bold;
+        padding-left: units-px(1.5);
+      }
+    }
+  }
+}
+
+// This is the trigger-button on mobile
+.va-btn-sidebarnav-trigger {
+  background-color: $color-primary;
+  color: $color-white;
+  margin: units-px(1) 0;
+  width: 100%;
+
+  &:hover {
+    background-color: $color-primary-darker;
+  }
+
+  &:focus,
+  &:hover {
+    svg {
+      fill: $color-white;
+    }
+  }
+
+  &.fixed-trigger {
+    margin: 0;
+    position: fixed;
+    top: 0;
+    width: 100%;
+    z-index: $top-layer;
+  }
+}


### PR DESCRIPTION
## Description
This adds the DOM/styling for the Profile 2.0 sidenav for both mobile and desktop. It does not include the JS to actually toggle the sidenav visibility on mobile or pin the mobile sidenav trigger button to the top of the window. That will work will come in the next PR

## Testing done
Local

## Screenshots
<details>
  <summary>Desktop</summary>
  
![image](https://user-images.githubusercontent.com/20728956/80041305-f784af80-84b0-11ea-909a-fa944b274035.png)

</details>

<details>
  <summary>Mobile</summary>
  
![image](https://user-images.githubusercontent.com/20728956/80041336-0ec39d00-84b1-11ea-9046-abe6cb646e1f.png)

</details>

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs