### PR TITLE
Prefer stateless function vaos

### DIFF
--- a/src/applications/vaos/components/TabNav.jsx
+++ b/src/applications/vaos/components/TabNav.jsx
@@ -3,25 +3,23 @@ import React from 'react';
 
 import TabItem from './TabItem';
 
-class TabNav extends React.Component {
-  render() {
-    return (
-      <ul className="va-tabs vaos-appts__tabs" role="tablist">
-        <TabItem
-          id="upcoming"
-          shortcut={1}
-          tabpath="/"
-          title="Upcoming appointments"
-        />
-        <TabItem
-          id="past"
-          shortcut={2}
-          tabpath="/past"
-          title="Past appointments"
-        />
-      </ul>
-    );
-  }
+function TabNav() {
+  return (
+    <ul className="va-tabs vaos-appts__tabs" role="tablist">
+      <TabItem
+        id="upcoming"
+        shortcut={1}
+        tabpath="/"
+        title="Upcoming appointments"
+      />
+      <TabItem
+        id="past"
+        shortcut={2}
+        tabpath="/past"
+        title="Past appointments"
+      />
+    </ul>
+  );
 }
 
 TabNav.propTypes = {

--- a/src/applications/vaos/components/cancel/CancelAppointmentModal.jsx
+++ b/src/applications/vaos/components/cancel/CancelAppointmentModal.jsx
@@ -9,79 +9,75 @@ import CancelCernerAppointmentModal from './CancelCernerAppointmentModal';
 
 import { FETCH_STATUS, APPOINTMENT_TYPES } from '../../utils/constants';
 
-export default class CancelAppointmentModal extends React.Component {
-  render() {
-    const {
-      showCancelModal,
-      appointmentToCancel,
-      cancelAppointmentStatus,
-      onClose,
-      onConfirm,
-      facility,
-      cernerFacilities,
-    } = this.props;
+export default function CancelAppointmentModal(props) {
+  const {
+    showCancelModal,
+    appointmentToCancel,
+    cancelAppointmentStatus,
+    onClose,
+    onConfirm,
+    facility,
+    cernerFacilities,
+  } = props;
 
-    if (!showCancelModal) {
-      return null;
-    }
-
-    if (appointmentToCancel.videoType) {
-      return (
-        <CancelVideoAppointmentModal onClose={onClose} facility={facility} />
-      );
-    }
-
-    if (
-      appointmentToCancel.appointmentType === APPOINTMENT_TYPES.ccAppointment
-    ) {
-      return (
-        <CancelCommunityCareAppointmentModal
-          onClose={onClose}
-          appointment={appointmentToCancel}
-        />
-      );
-    }
-
-    const isCerner = cernerFacilities?.some(facilityId =>
-      this.props.appointmentToCancel.facilityId?.startsWith(facilityId),
-    );
-
-    if (isCerner) {
-      return (
-        <CancelCernerAppointmentModal
-          onClose={onClose}
-          status={cancelAppointmentStatus}
-        />
-      );
-    }
-
-    if (cancelAppointmentStatus === FETCH_STATUS.failed) {
-      return (
-        <CancelAppointmentFailedModal
-          appointment={appointmentToCancel}
-          facility={facility}
-          onClose={onClose}
-        />
-      );
-    }
-
-    if (cancelAppointmentStatus === FETCH_STATUS.succeeded) {
-      return <CancelAppointmentSucceededModal onClose={onClose} />;
-    }
-
-    if (
-      cancelAppointmentStatus === FETCH_STATUS.notStarted ||
-      cancelAppointmentStatus === FETCH_STATUS.loading
-    ) {
-      return (
-        <CancelAppointmentConfirmationModal
-          onClose={onClose}
-          onConfirm={onConfirm}
-          status={cancelAppointmentStatus}
-        />
-      );
-    }
-
+  if (!showCancelModal) {
     return null;
   }
+
+  if (appointmentToCancel.videoType) {
+    return (
+      <CancelVideoAppointmentModal onClose={onClose} facility={facility} />
+    );
+  }
+
+  if (appointmentToCancel.appointmentType === APPOINTMENT_TYPES.ccAppointment) {
+    return (
+      <CancelCommunityCareAppointmentModal
+        onClose={onClose}
+        appointment={appointmentToCancel}
+      />
+    );
+  }
+
+  const isCerner = cernerFacilities?.some(facilityId =>
+    props.appointmentToCancel.facilityId?.startsWith(facilityId),
+  );
+
+  if (isCerner) {
+    return (
+      <CancelCernerAppointmentModal
+        onClose={onClose}
+        status={cancelAppointmentStatus}
+      />
+    );
+  }
+
+  if (cancelAppointmentStatus === FETCH_STATUS.failed) {
+    return (
+      <CancelAppointmentFailedModal
+        appointment={appointmentToCancel}
+        facility={facility}
+        onClose={onClose}
+      />
+    );
+  }
+
+  if (cancelAppointmentStatus === FETCH_STATUS.succeeded) {
+    return <CancelAppointmentSucceededModal onClose={onClose} />;
+  }
+
+  if (
+    cancelAppointmentStatus === FETCH_STATUS.notStarted ||
+    cancelAppointmentStatus === FETCH_STATUS.loading
+  ) {
+    return (
+      <CancelAppointmentConfirmationModal
+        onClose={onClose}
+        onConfirm={onConfirm}
+        status={cancelAppointmentStatus}
+      />
+    );
+  }
+
+  return null;
 }


### PR DESCRIPTION
## Description

Part of https://github.com/department-of-veterans-affairs/va.gov-team/issues/8286

This fixes the 2 `prefer-stateless-function` linting errors in vaos.  `<TabNav>` doesn't have any props, but I left the `propTypes` in because I don't know if there are plans on adding props back in.

## Testing done

Linting


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
