### PR TITLE
Add character limit to street address field

### DIFF
--- a/src/platform/user/profile/vet360/components/AddressField/address-schemas.js
+++ b/src/platform/user/profile/vet360/components/AddressField/address-schemas.js
@@ -125,17 +125,17 @@ const uiSchema = {
     },
   },
   addressLine1: {
-    'ui:title': 'Street address (35 characters maximum)',
+    'ui:title': `Street address (${STREET_LINE_MAX_LENGTH} characters maximum)`,
     'ui:errorMessages': {
       required: 'Street address is required',
       pattern: `Street address must be under ${STREET_LINE_MAX_LENGTH} characters`,
     },
   },
   addressLine2: {
-    'ui:title': 'Street address (35 characters maximum)',
+    'ui:title': `Street address (${STREET_LINE_MAX_LENGTH} characters maximum)`,
   },
   addressLine3: {
-    'ui:title': 'Street address (35 characters maximum)',
+    'ui:title': `Street address (${STREET_LINE_MAX_LENGTH} characters maximum)`,
   },
   city: {
     'ui:errorMessages': {

--- a/src/platform/user/profile/vet360/components/AddressField/address-schemas.js
+++ b/src/platform/user/profile/vet360/components/AddressField/address-schemas.js
@@ -125,17 +125,17 @@ const uiSchema = {
     },
   },
   addressLine1: {
-    'ui:title': 'Street address',
+    'ui:title': 'Street address (35 characters maximum)',
     'ui:errorMessages': {
       required: 'Street address is required',
       pattern: `Street address must be under ${STREET_LINE_MAX_LENGTH} characters`,
     },
   },
   addressLine2: {
-    'ui:title': 'Street address',
+    'ui:title': 'Street address (35 characters maximum)',
   },
   addressLine3: {
-    'ui:title': 'Street address',
+    'ui:title': 'Street address (35 characters maximum)',
   },
   city: {
     'ui:errorMessages': {


### PR DESCRIPTION
https://github.com/department-of-veterans-affairs/va.gov-team/issues/8199

## Description
Add character limit to the 3 street address fields on the profile.

## Testing done
Unit tests still run as expected.

## Screenshots
![image](https://user-images.githubusercontent.com/14869324/80141607-088ff800-8567-11ea-8af8-ec54c002bfc0.png)


## Acceptance criteria
- [x] Add max character length to 3 street fields on the profile.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
