### PR TITLE
[Development/Discovery] Add 526 v1 comments

### DIFF
--- a/src/applications/disability-benefits/all-claims/prefill-transformer.js
+++ b/src/applications/disability-benefits/all-claims/prefill-transformer.js
@@ -2,6 +2,10 @@ import _ from 'platform/utilities/data';
 import { SERVICE_CONNECTION_TYPES, disabilityActionTypes } from './constants';
 import { viewifyFields } from './utils';
 
+// ****************************************
+// This entire file _may_ be obsolete once
+// form 526EZ v1 is no longer supported
+// ****************************************
 export const filterServiceConnected = (disabilities = []) =>
   disabilities.filter(
     d => d.decisionCode === SERVICE_CONNECTION_TYPES.serviceConnected,
@@ -46,6 +50,9 @@ export default function prefillTransformer(pages, formData, metadata) {
     const { veteran } = data;
 
     if (veteran) {
+      // Form 526 v1 data; transform into v2 format
+      // This transform already includes the attachments data (list of uploaded
+      // documents)
       const { emailAddress, primaryPhone, mailingAddress } = veteran;
       newData.phoneAndEmail = {};
       if (emailAddress) {


### PR DESCRIPTION
## Description

Added inline comments as a reminder for when we ultimately remove form 526 v1 code.

The associated ticket (https://github.com/department-of-veterans-affairs/va.gov-team/issues/7810) was meant to be a discovery to ensure that form 526 v1 save-in-progress (SIP) calls transformed & saved all attachments into the v2 form. It does.

## Testing done

Unit tests, but really no code changes

## Screenshots

N/A

## Acceptance criteria
- [x] Verified 526 v1 SIP saves all attachments when transformed into a v2 data.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
