### PR TITLE
VAVFS-8242: Adding href wrapping to naked numbers.

### DIFF
--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -119,16 +119,12 @@ module.exports = function registerFilters() {
 
   liquid.filters.outputLinks = data => {
     // Change phone to tap to dial.
-    const replacePattern = /(?:(?:\+?([1-9]|[0-9][0-9]|[0-9][0-9][0-9])\s*(?:[.-]\s*)?)?(?:\(\s*([2-9]1[02-9]|[2-9][02-8]1|[2-9][02-8][02-9])\s*\)|([0-9][1-9]|[0-9]1[02-9]|[2-9][02-8]1|[2-9][02-8][02-9]))\s*(?:[.-]\s*)?)?([2-9]1[02-9]|[2-9][02-9]1|[2-9][02-9]{2})\s*(?:[.-]\s*)?([0-9]{4})(?:\s*(?:#|x\.?|ext\.?|extension)\s*(\d+))?/;
-
-    if (data.match(replacePattern)) {
-      const number = data.match(replacePattern)[0];
-      const replacedText = data.replace(
+    const replacePattern = /((\d{3}-))?\d{3}-\d{3}-\d{4}(?!([^<]*>)|(((?!<a).)*<\/a>))/g;
+    if (data) {
+      return data.replace(
         replacePattern,
-        `<a target="_blank" href="tel:${number}">Phone: ${number}</a>`,
+        '<a target="_blank" href="tel:$&">$&</a>',
       );
-
-      return replacedText;
     }
 
     return data;

--- a/src/site/paragraphs/wysiwyg.drupal.liquid
+++ b/src/site/paragraphs/wysiwyg.drupal.liquid
@@ -10,6 +10,6 @@
 {% endcomment %}
 
 <div data-template="paragraphs/wysiwyg" data-entity-id="{{ entity.entityId }}" class="processed-content">
-    {{ entity.fieldWysiwyg.processed | drupalToVaPath }}
+    {{ entity.fieldWysiwyg.processed | drupalToVaPath | outputLinks }}
 </div>
 


### PR DESCRIPTION
## Description
Content entry people sometimes forget to wrap phone numbers in wysiwyg in href. This task adds a filter to template to handle this.

## Testing done
Visual

## Screenshots
![image](https://user-images.githubusercontent.com/2404547/80151485-2588f300-8588-11ea-854a-ca01bb4fccc3.png)

## Acceptance criteria
- [ ] Go to `pittsburgh-health-care/contact-us/` open a fieldset, and visually verify that phone numbers are click to dial.