### PR TITLE
[Development] Remove `ratingDecisionId` from 526 submit

### DIFF
--- a/src/applications/disability-benefits/all-claims/config/schema.js
+++ b/src/applications/disability-benefits/all-claims/config/schema.js
@@ -523,9 +523,6 @@ const schema = {
           ratedDisabilityId: {
             type: 'string',
           },
-          ratingDecisionId: {
-            type: 'string',
-          },
           diagnosticCode: {
             type: 'number',
           },
@@ -550,9 +547,6 @@ const schema = {
                   $ref: '#/definitions/specialIssues',
                 },
                 ratedDisabilityId: {
-                  type: 'string',
-                },
-                ratingDecisionId: {
                   type: 'string',
                 },
                 diagnosticCode: {

--- a/src/applications/disability-benefits/all-claims/submit-transformer.js
+++ b/src/applications/disability-benefits/all-claims/submit-transformer.js
@@ -172,6 +172,24 @@ export function transformRelatedDisabilities(
   );
 }
 
+export const removeExtraData = formData => {
+  // EVSS no longer accepts some keys
+  const ratingKeysToRemove = ['ratingDecisionId'];
+  const clonedData = _.cloneDeep(formData);
+  const disabilities = clonedData.ratedDisabilities;
+  if (disabilities?.length) {
+    clonedData.ratedDisabilities = disabilities.map(disability =>
+      Object.keys(disability).reduce((acc, key) => {
+        if (!ratingKeysToRemove.includes(key)) {
+          acc[key] = disability[key];
+        }
+        return acc;
+      }, {}),
+    );
+  }
+  return clonedData;
+};
+
 /**
  * Returns an array of the maximum set of PTSD incident form data field names
  */
@@ -551,6 +569,7 @@ export function transform(formConfig, form) {
     setActionTypes, // Must run after addBackRatedDisabilities
     filterRatedViewFields, // Must be run after setActionTypes
     filterServicePeriods,
+    removeExtraData, // Removed data EVSS does't want
     addPOWSpecialIssues,
     addPTSDCause,
     addClassificationCodeToNewDisabilities,

--- a/src/applications/disability-benefits/all-claims/tests/data/transformed-data/full-781-781a-8940-test.json
+++ b/src/applications/disability-benefits/all-claims/tests/data/transformed-data/full-781-781a-8940-test.json
@@ -4,7 +4,6 @@
       {
         "name": "Diabetes mellitus0",
         "ratedDisabilityId": "0",
-        "ratingDecisionId": "63655",
         "diagnosticCode": 5238,
         "decisionCode": "SVCCONNCTED",
         "decisionText": "Service Connected",
@@ -14,7 +13,6 @@
       {
         "name": "Diabetes mellitus1",
         "ratedDisabilityId": "1",
-        "ratingDecisionId": "63655",
         "diagnosticCode": 5238,
         "decisionCode": "SVCCONNCTED",
         "decisionText": "Service Connected",

--- a/src/applications/disability-benefits/all-claims/tests/data/transformed-data/maximal-test.json
+++ b/src/applications/disability-benefits/all-claims/tests/data/transformed-data/maximal-test.json
@@ -66,7 +66,6 @@
       {
         "name": "Diabetes mellitus0",
         "ratedDisabilityId": "0",
-        "ratingDecisionId": "63655",
         "diagnosticCode": 5238,
         "decisionCode": "SVCCONNCTED",
         "decisionText": "Service Connected",
@@ -76,7 +75,6 @@
       {
         "name": "Diabetes mellitus1",
         "ratedDisabilityId": "1",
-        "ratingDecisionId": "63655",
         "diagnosticCode": 5238,
         "decisionCode": "SVCCONNCTED",
         "decisionText": "Service Connected",
@@ -86,7 +84,6 @@
       {
         "name": "De-selected",
         "ratedDisabilityId": "1",
-        "ratingDecisionId": "63655",
         "diagnosticCode": 5238,
         "decisionCode": "SVCCONNCTED",
         "decisionText": "Service Connected",
@@ -96,7 +93,6 @@
       {
         "name": "Not selected",
         "ratedDisabilityId": "1",
-        "ratingDecisionId": "63655",
         "diagnosticCode": 5238,
         "decisionCode": "SVCCONNCTED",
         "decisionText": "Service Connected",

--- a/src/applications/disability-benefits/all-claims/tests/data/transformed-data/minimal-test.json
+++ b/src/applications/disability-benefits/all-claims/tests/data/transformed-data/minimal-test.json
@@ -17,7 +17,6 @@
       {
         "name": "Diabetes mellitus0",
         "ratedDisabilityId": "0",
-        "ratingDecisionId": "63655",
         "diagnosticCode": 5238,
         "decisionCode": "SVCCONNCTED",
         "decisionText": "Service Connected",
@@ -27,7 +26,6 @@
       {
         "name": "Diabetes mellitus1",
         "ratedDisabilityId": "1",
-        "ratingDecisionId": "63655",
         "diagnosticCode": 5238,
         "decisionCode": "SVCCONNCTED",
         "decisionText": "Service Connected",

--- a/src/applications/disability-benefits/all-claims/tests/data/transformed-data/secondary-new-test.json
+++ b/src/applications/disability-benefits/all-claims/tests/data/transformed-data/secondary-new-test.json
@@ -46,7 +46,6 @@
       {
         "name": "Diabetes mellitus0",
         "ratedDisabilityId": "0",
-        "ratingDecisionId": "63655",
         "diagnosticCode": 5238,
         "decisionCode": "SVCCONNCTED",
         "decisionText": "Service Connected",
@@ -56,7 +55,6 @@
       {
         "name": "Diabetes mellitus1",
         "ratedDisabilityId": "1",
-        "ratingDecisionId": "63655",
         "diagnosticCode": 5238,
         "decisionCode": "SVCCONNCTED",
         "decisionText": "Service Connected",
@@ -66,7 +64,6 @@
       {
         "name": "De-selected",
         "ratedDisabilityId": "1",
-        "ratingDecisionId": "63655",
         "diagnosticCode": 5238,
         "decisionCode": "SVCCONNCTED",
         "decisionText": "Service Connected",
@@ -76,7 +73,6 @@
       {
         "name": "Not selected",
         "ratedDisabilityId": "1",
-        "ratingDecisionId": "63655",
         "diagnosticCode": 5238,
         "decisionCode": "SVCCONNCTED",
         "decisionText": "Service Connected",

--- a/src/applications/disability-benefits/all-claims/tests/data/transformed-data/upload-781-781a-8940-test.json
+++ b/src/applications/disability-benefits/all-claims/tests/data/transformed-data/upload-781-781a-8940-test.json
@@ -4,7 +4,6 @@
       {
         "name": "Diabetes mellitus0",
         "ratedDisabilityId": "0",
-        "ratingDecisionId": "63655",
         "diagnosticCode": 5238,
         "decisionCode": "SVCCONNCTED",
         "decisionText": "Service Connected",
@@ -14,7 +13,6 @@
       {
         "name": "Diabetes mellitus1",
         "ratedDisabilityId": "1",
-        "ratingDecisionId": "63655",
         "diagnosticCode": 5238,
         "decisionCode": "SVCCONNCTED",
         "decisionText": "Service Connected",


### PR DESCRIPTION
## Description

Due to increased restrictions, form 526 submissions need to remove `ratingDecisionId` from the submitted data.

See https://github.com/department-of-veterans-affairs/va.gov-team/issues/8350 for more details

## Testing done

Updated unit tests

## Screenshots

N/A

## Acceptance criteria
- [x] `ratingDecisionid` removed from submission;
- [x] updated unit tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
