### PR TITLE
Bradl3yC - Fix a11y issue with form system proper heading nesting

### DIFF
--- a/src/platform/forms-system/src/js/components/FormNav.jsx
+++ b/src/platform/forms-system/src/js/components/FormNav.jsx
@@ -67,11 +67,11 @@ export default class FormNav extends React.Component {
             aria-valuemax={chapters.length}
             className="nav-header nav-header-schemaform"
           >
-            <h4>
+            <h2 className="vads-u-font-size--h4">
               <span className="form-process-step current">{current}</span>{' '}
               <span className="form-process-total">of {chapters.length}</span>{' '}
               {chapterName}
-            </h4>
+            </h2>
           </div>
         </div>
       </div>

--- a/src/platform/forms-system/src/js/components/FormNav.jsx
+++ b/src/platform/forms-system/src/js/components/FormNav.jsx
@@ -67,11 +67,11 @@ export default class FormNav extends React.Component {
             aria-valuemax={chapters.length}
             className="nav-header nav-header-schemaform"
           >
-            <h4 className="vads-u-font-size--h4">
+            <h2 className="vads-u-font-size--h4">
               <span className="form-process-step current">{current}</span>{' '}
               <span className="form-process-total">of {chapters.length}</span>{' '}
               {chapterName}
-            </h4>
+            </h2>
           </div>
         </div>
       </div>

--- a/src/platform/forms-system/src/js/components/FormNav.jsx
+++ b/src/platform/forms-system/src/js/components/FormNav.jsx
@@ -67,11 +67,11 @@ export default class FormNav extends React.Component {
             aria-valuemax={chapters.length}
             className="nav-header nav-header-schemaform"
           >
-            <h2 className="vads-u-font-size--h4">
+            <h4 className="vads-u-font-size--h4">
               <span className="form-process-step current">{current}</span>{' '}
               <span className="form-process-total">of {chapters.length}</span>{' '}
               {chapterName}
-            </h2>
+            </h4>
           </div>
         </div>
       </div>

--- a/src/platform/forms-system/src/js/review/ReviewPage.jsx
+++ b/src/platform/forms-system/src/js/review/ReviewPage.jsx
@@ -24,7 +24,7 @@ const scrollToTop = () => {
 class ReviewPage extends React.Component {
   componentDidMount() {
     scrollToTop();
-    focusElement('h4');
+    focusElement('h2');
   }
 
   render() {

--- a/src/platform/forms-system/src/js/review/ReviewPage.jsx
+++ b/src/platform/forms-system/src/js/review/ReviewPage.jsx
@@ -24,7 +24,7 @@ const scrollToTop = () => {
 class ReviewPage extends React.Component {
   componentDidMount() {
     scrollToTop();
-    focusElement('h2');
+    focusElement('nav-header-schemaform');
   }
 
   render() {

--- a/src/platform/forms-system/src/js/review/ReviewPage.jsx
+++ b/src/platform/forms-system/src/js/review/ReviewPage.jsx
@@ -24,7 +24,7 @@ const scrollToTop = () => {
 class ReviewPage extends React.Component {
   componentDidMount() {
     scrollToTop();
-    focusElement('nav-header-schemaform');
+    focusElement('h2');
   }
 
   render() {

--- a/src/platform/forms/save-in-progress/RoutedSavableReviewPage.jsx
+++ b/src/platform/forms/save-in-progress/RoutedSavableReviewPage.jsx
@@ -46,7 +46,7 @@ class RoutedSavableReviewPage extends React.Component {
 
   componentDidMount() {
     scrollToTop();
-    focusElement('h4');
+    focusElement('h2');
   }
 
   autoSave = () => {


### PR DESCRIPTION
## Description
This resolves an a11y issue within the form system for heading levels - Currently the title is an h1 while the next heading level is an h4.  This swaps it to an h2 and uses utility classes to style to h4 keeping inline with the design spec

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
