### PR TITLE
[Development] Change review card cancel button style

### DIFF
--- a/src/platform/forms-system/src/js/components/ReviewCardField.jsx
+++ b/src/platform/forms-system/src/js/components/ReviewCardField.jsx
@@ -167,9 +167,23 @@ export default class ReviewCardField extends React.Component {
       'vads-u-margin-x--0',
     ].join(' ');
 
-    const buttonClasses = ['vads-u-margin-top--1', 'vads-u-width--auto'].join(
-      ' ',
-    );
+    const updateButtonClasses = [
+      'update-button',
+      'usa-button-primary',
+      'vads-u-margin-top--1',
+      'vads-u-margin-right--1p5',
+      'vads-u-width--auto',
+    ].join(' ');
+
+    const cancelButtonClasses = [
+      'cancel-button',
+      // keeping secondary style, but it has a shadow box outline; removed by
+      // inline styling. And we can't use `va-button-link` because when hovered,
+      // it removes all padding & add a background color (using !important)
+      'usa-button-secondary',
+      'vads-u-text-decoration--underline',
+      'vads-u-width--auto',
+    ].join(' ');
 
     return (
       <div className="review-card">
@@ -191,17 +205,13 @@ export default class ReviewCardField extends React.Component {
             readonly={readonly}
           />
           <div className="vads-u-display--flex vads-u-flex-direction--row vads-u-margin-top--2p5">
-            <button
-              className={`update-button usa-button-primary ${buttonClasses} vads-u-margin-right--2p5`}
-              style={{ minWidth: '12rem' }}
-              onClick={this.update}
-            >
-              {volatileData ? 'Save' : 'Done'}
+            <button className={updateButtonClasses} onClick={this.update}>
+              Save
             </button>
             {((volatileData && this.state.canCancel) || !volatileData) && (
               <button
-                className={`cancel-button usa-button-secondary ${buttonClasses}`}
-                style={{ minWidth: '12rem' }}
+                className={cancelButtonClasses}
+                style={{ boxShadow: 'none' }}
                 onClick={this.cancelUpdate}
               >
                 Cancel


### PR DESCRIPTION
## Description

The review card cancel button was previously styled as a secondary button

![](https://user-images.githubusercontent.com/136959/79499496-abd59000-7ff0-11ea-9403-abf9147ece2e.png)

The styling caused some users to accidentally click the cancel button instead of the "Done" button.

Our design team recommended changing the "Done" text to "Save" and changing the style of the cancel button to appear as a link.

Associated links:
- Slack: https://dsva.slack.com/archives/C0NGDDXME/p1587739670202100
- Ticket: https://github.com/department-of-veterans-affairs/va.gov-team/issues/8096

## Testing done

Local unit tests

## Screenshots

![link](https://user-images.githubusercontent.com/136959/80249459-7c99d100-8637-11ea-891a-03fc8206aa74.png)

<details><summary>Focus outline</summary>

<!-- leave a blank line above -->
![Screen Shot 2020-04-24 at 2 28 18 PM](https://user-images.githubusercontent.com/136959/80249690-e87c3980-8637-11ea-9119-9e3c2d79a289.png)
</details>

<details><summary>Full screenshot</summary>

<!-- leave a blank line above -->
![](https://user-images.githubusercontent.com/136959/80249501-90ddce00-8637-11ea-9562-3034e6728f9e.png)
</details>

<details><summary>Mobile (iPhone 5) view</summary>

<!-- leave a blank line above -->
![Screen Shot 2020-04-24 at 2 33 27 PM](https://user-images.githubusercontent.com/136959/80250060-a56e9600-8638-11ea-93c9-707cd11dbb58.png)
</details>

## Acceptance criteria
- [x] "Done" text changed to "Save"
- [x] "Cancel" button made to look like a link

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
