### PR TITLE
Kelsonic 8039 make homepage banner site wide

### DIFF
--- a/src/site/stages/build/drupal/home.js
+++ b/src/site/stages/build/drupal/home.js
@@ -39,6 +39,10 @@ function addHomeContent(contentData, files, metalsmith, buildOptions) {
     const bannerFile = fs.readFileSync(bannerLocation);
     const banner = yaml.safeLoad(bannerFile);
 
+    // Add the homepage_banner to metalsmith metadata.
+    // eslint-disable-next-line camelcase
+    metalsmith.metadata({ homepage_banner: banner, ...metalsmith.metadata() });
+
     homeEntityObj = {
       ...homeEntityObj,
       // Since homepage is not an independent node, we don't have a source for metatags. So we need to hard-code these for now.

--- a/src/site/stages/build/drupal/home.js
+++ b/src/site/stages/build/drupal/home.js
@@ -39,10 +39,6 @@ function addHomeContent(contentData, files, metalsmith, buildOptions) {
     const bannerFile = fs.readFileSync(bannerLocation);
     const banner = yaml.safeLoad(bannerFile);
 
-    // Add the homepage_banner to metalsmith metadata.
-    // eslint-disable-next-line camelcase
-    metalsmith.metadata({ homepage_banner: banner, ...metalsmith.metadata() });
-
     homeEntityObj = {
       ...homeEntityObj,
       // Since homepage is not an independent node, we don't have a source for metatags. So we need to hard-code these for now.

--- a/src/site/stages/build/drupal/metalsmith-drupal.js
+++ b/src/site/stages/build/drupal/metalsmith-drupal.js
@@ -47,7 +47,12 @@ const shouldPullDrupal = buildOptions => {
   );
 };
 
-function pipeDrupalPagesIntoMetalsmith(contentData, files) {
+function pipeDrupalPagesIntoMetalsmith(
+  contentData,
+  files,
+  metalsmith,
+  buildOptions,
+) {
   const {
     data: {
       nodeQuery: { entities: pages },
@@ -78,7 +83,12 @@ function pipeDrupalPagesIntoMetalsmith(contentData, files) {
       entityBundle,
     } = page;
 
-    const pageCompiled = compilePage(page, contentData);
+    const pageCompiled = compilePage(
+      page,
+      contentData,
+      metalsmith,
+      buildOptions,
+    );
     const drupalPageDir = path.join('.', drupalUrl);
     const drupalFileName = path.join(drupalPageDir, 'index.html');
 
@@ -270,7 +280,12 @@ function getDrupalContent(buildOptions) {
       drupalData = convertDrupalFilesToLocal(drupalData, files, buildOptions);
 
       await loadCachedDrupalFiles(buildOptions, files);
-      pipeDrupalPagesIntoMetalsmith(drupalData, files);
+      pipeDrupalPagesIntoMetalsmith(
+        drupalData,
+        files,
+        metalsmith,
+        buildOptions,
+      );
       addHomeContent(drupalData, files, metalsmith, buildOptions);
       log('Successfully piped Drupal content into Metalsmith!');
       buildOptions.drupalData = drupalData;

--- a/src/site/stages/build/drupal/page.js
+++ b/src/site/stages/build/drupal/page.js
@@ -316,6 +316,7 @@ function compilePage(page, contentData, metalsmith, buildOptions) {
 
   // Add the homepage banner.
   if (banner) {
+    // eslint-disable-next-line camelcase
     page.homepage_banner = banner;
   }
 

--- a/src/site/stages/build/drupal/page.js
+++ b/src/site/stages/build/drupal/page.js
@@ -1,5 +1,7 @@
 /* eslint-disable no-param-reassign, no-continue */
+const fs = require('fs-extra');
 const path = require('path');
+const yaml = require('js-yaml');
 const _ = require('lodash');
 const set = require('lodash/fp/set');
 
@@ -247,7 +249,7 @@ function getFacilitySidebar(page, contentData) {
   return { links: [] };
 }
 
-function compilePage(page, contentData) {
+function compilePage(page, contentData, metalsmith, buildOptions) {
   const {
     data: {
       burialsAndMemorialsBenefQuery: burialsHubSidebarNav = {},
@@ -305,6 +307,17 @@ function compilePage(page, contentData) {
   }
 
   let pageCompiled;
+
+  // Derive the homepage banner.
+  const fragmentsRoot = metalsmith.path(buildOptions.contentFragments);
+  const bannerLocation = path.join(fragmentsRoot, 'home/banner.yml');
+  const bannerFile = fs.readFileSync(bannerLocation);
+  const banner = yaml.safeLoad(bannerFile);
+
+  // Add the homepage banner.
+  if (banner) {
+    page.homepage_banner = banner;
+  }
 
   switch (entityBundle) {
     case 'office':


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/8039

This PR adds the `homepage_banner` (which is more of a `site-wide banner` at this point) to all page types, including:

```
'event'
'event_listing'
'health_care_local_facility'
'health_care_region_detail_page'
'health_care_region_page'
'health_services_listing'
'leadership_listing'
'locations_listing'
'news_story'
'office'
'person_profile'
'press_release'
'press_releases_listing'
'publication_listing'
'story_listing'
'vamc_operating_status_and_alerts'
```

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
