### PR TITLE
VAVFS-7288: Fixing accessibility issue for search.

### DIFF
--- a/src/applications/facility-locator/containers/VAMap.jsx
+++ b/src/applications/facility-locator/containers/VAMap.jsx
@@ -552,11 +552,7 @@ class VAMap extends Component {
               <Tab className="small-6 tab">View Map</Tab>
             </TabList>
             <TabPanel>
-              <div
-                aria-live="polite"
-                aria-relevant="additions text"
-                className="facility-search-results"
-              >
+              <div className="facility-search-results">
                 <ResultsList
                   isMobile
                   updateUrlParams={this.updateUrlParams}
@@ -663,11 +659,7 @@ class VAMap extends Component {
             style={{ maxHeight: '78vh', overflowY: 'auto' }}
             id="searchResultsContainer"
           >
-            <div
-              aria-live="polite"
-              aria-relevant="additions text"
-              className="facility-search-results"
-            >
+            <div className="facility-search-results">
               <div>
                 <ResultsList
                   updateUrlParams={this.updateUrlParams}


### PR DESCRIPTION
## Description
Removes aria-live="polite" from /find-locations for screenreader accessibility.

## Testing done
Visual / build

## Screenshots
N/A

## Acceptance criteria
 - [ ] Enter https://staging.va.gov/find-locations in browser
 - [ ] Start screenreading device listed in Environment
 - [ ] Navigate to the search results while JAWS is reading content
 - [ ] Using keyboard only attempt to get out of the search results
 - [ ] Verify it's possible