### PR TITLE
VAVFS-7244: Fixing pop-up accessibility.

### DIFF
--- a/src/applications/facility-locator/containers/VAMap.jsx
+++ b/src/applications/facility-locator/containers/VAMap.jsx
@@ -34,7 +34,6 @@ import {
   toggleValues,
 } from 'platform/site-wide/feature-toggles/selectors';
 import Pagination from '@department-of-veterans-affairs/formation-react/Pagination';
-import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 import mbxGeo from '@mapbox/mapbox-sdk/services/geocoding';
 import recordEvent from 'platform/monitoring/record-event';
 
@@ -49,30 +48,46 @@ const otherToolsLink = (
   </p>
 );
 
+const headingStyle = {
+  fontWeight: '700',
+  fontFamily: 'Bitter, Georgia, Cambria, Times New Roman, Times, serif',
+  lineHeight: '1.3',
+  clear: 'both',
+};
+
+const ddStyle = {
+  margin: '2rem 0 .5rem 0',
+  lineHeight: '1.5',
+};
+
 // Link to urgent care benefit web page
 const urgentCareDialogLink = (
-  <AlertBox status="warning">
-    <h3 className="usa-alert-heading" tabIndex="-1">
-      Important information about your Community Care appointment
-    </h3>
-    <p>
-      Click below to learn how to prepare for your urgent care appointment with
-      a Community Care provider.
-    </p>
-    <button
-      className="usa-button-primary vads-u-margin-y--0"
-      onClick={() => {
-        // Record event
-        recordEvent({ event: 'cta-primary-button-click' });
-        window.open(
-          'https://www.va.gov/COMMUNITYCARE/programs/veterans/Urgent_Care.asp',
-          '_blank',
-        );
-      }}
-    >
-      Learn about VA urgent care benefit
-    </button>
-  </AlertBox>
+  <div className="usa-alert usa-alert-warning">
+    <div className="usa-alert-body">
+      <dl className="usa-alert-text">
+        <dt className="usa-alert-heading" style={headingStyle} tabIndex="-1">
+          Important information about your Community Care appointment
+        </dt>
+        <dd style={ddStyle}>
+          Click below to learn how to prepare for your urgent care appointment
+          with a Community Care provider.
+        </dd>
+        <button
+          className="usa-button-primary vads-u-margin-y--0"
+          onClick={() => {
+            // Record event
+            recordEvent({ event: 'cta-primary-button-click' });
+            window.open(
+              'https://www.va.gov/COMMUNITYCARE/programs/veterans/Urgent_Care.asp',
+              '_blank',
+            );
+          }}
+        >
+          Learn about VA urgent care benefit
+        </button>
+      </dl>
+    </div>
+  </div>
 );
 
 class VAMap extends Component {


### PR DESCRIPTION
## Description
Replaces H3 in on page alert with dl to prevent accessibility error when h2 doesn't exist.

## Testing done
Build / code inspector

## Screenshots
https://user-images.githubusercontent.com/57469/77672628-801a3980-6f5f-11ea-9dc0-57617a37bcdb.png 

## Acceptance criteria
- [ ] Go to `find-locations/?address=04101&context=Portland%2C Maine 04101%2C United States&facilityType=urgent_care&location=43.66%2C-70.25&page=1&serviceType=NonVAUrgentCare&zoomLevel=4` and use code inspector to verify that alert banner header is not an h3, but is instead a dt.