### PR TITLE
bradl3yC - 8480 - Modify hideOnReview to accept a callback

### DIFF
--- a/src/platform/forms-system/src/js/review/ObjectField.jsx
+++ b/src/platform/forms-system/src/js/review/ObjectField.jsx
@@ -101,8 +101,13 @@ class ObjectField extends React.Component {
       const hideOnReviewIfFalse =
         _.get([propName, 'ui:options', 'hideOnReviewIfFalse'], uiSchema) ===
         true;
-      const hideOnReview =
-        _.get([propName, 'ui:options', 'hideOnReview'], uiSchema) === true;
+      let hideOnReview = _.get(
+        [propName, 'ui:options', 'hideOnReview'],
+        uiSchema,
+      );
+      if (typeof hideOnReview === 'function') {
+        hideOnReview = hideOnReview(formData, formContext);
+      }
       return (
         (!hideOnReviewIfFalse || !!formData[propName]) &&
         !hideOnReview &&

--- a/src/platform/forms-system/test/js/review/ObjectField.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/review/ObjectField.unit.spec.jsx
@@ -208,6 +208,40 @@ describe('Schemaform review: ObjectField', () => {
 
     expect(tree.everySubTree('SchemaField')).to.be.empty;
   });
+  it('should hide fields that are hide on review using callback', () => {
+    const onChange = sinon.spy();
+    const onBlur = sinon.spy();
+    const schema = {
+      type: 'object',
+      properties: {
+        test: {
+          type: 'boolean',
+        },
+      },
+    };
+    const formData = {
+      test: true,
+    };
+    const uiSchema = {
+      test: {
+        'ui:options': {
+          hideOnReview: () => formData.test,
+        },
+      },
+    };
+    const tree = SkinDeep.shallowRender(
+      <ObjectField
+        schema={schema}
+        uiSchema={uiSchema}
+        idSchema={{}}
+        formData={formData}
+        onChange={onChange}
+        onBlur={onBlur}
+      />,
+    );
+
+    expect(tree.everySubTree('SchemaField')).to.be.empty;
+  });
   it('should hide false fields that are hide on review false', () => {
     const onChange = sinon.spy();
     const onBlur = sinon.spy();


### PR DESCRIPTION
## Description
Currently the hideOnReview key within form-system only accepts a boolean.  This will now allow it to accept either a boolean or a callback to allow more logic when determining if a component is visible in the review page.

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
