### PR TITLE
Added userToken to DocumentUpload

### DIFF
--- a/src/applications/disability-benefits/all-claims/tests/automated-tests.puppeteer.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/automated-tests.puppeteer.spec.js
@@ -16,7 +16,7 @@ const testData = getTestDataSets(join(__dirname, 'data'), {
 const testConfig = {
   debug: true,
   setup: userToken => {
-    PageHelpers.initDocumentUploadMock();
+    PageHelpers.initDocumentUploadMock(userToken);
     PageHelpers.initApplicationSubmitMock(userToken);
     PageHelpers.initItfMock(userToken);
     PageHelpers.initPaymentInformationMock(userToken);

--- a/src/applications/disability-benefits/all-claims/tests/disability-benefits-helpers.js
+++ b/src/applications/disability-benefits/all-claims/tests/disability-benefits-helpers.js
@@ -2,8 +2,8 @@ import moment from 'moment';
 
 const mock = require('platform/testing/e2e/mock-helpers');
 
-function initDocumentUploadMock() {
-  mock(null, {
+function initDocumentUploadMock(token) {
+  mock(token, {
     path: '/v0/upload_supporting_evidence',
     verb: 'post',
     value: {


### PR DESCRIPTION
## Description
In this [PR](https://github.com/department-of-veterans-affairs/vets-website/pull/12304), we are adding a CSRF token to prevent possible attacks when uploading files. This change caused some e2e tests to fail. This PR will fix that.

When the e2e test (`automated-tests.puppeteer.spec.js`) calls `/v0/upload_supporting_evidence`, it's returning a `500 Internal Server Error` and based on the `mockapi.js` it needs a userToken to obtain a response. This PR will address that issue.

## Testing done
Locally

## Screenshots

### Before
<img width="1177" alt="Screen Shot 2020-04-27 at 11 41 48 AM" src="https://user-images.githubusercontent.com/55560129/80404089-a862c400-888e-11ea-8191-13d421705557.png">

### After
<img width="783" alt="Screen Shot 2020-04-27 at 1 56 21 PM" src="https://user-images.githubusercontent.com/55560129/80404246-e95ad880-888e-11ea-9957-fcd0c14505ac.png">



## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
