### PR TITLE
VAVFS-5993: Adding href to cal link for focus.

### DIFF
--- a/src/site/includes/social-share.drupal.liquid
+++ b/src/site/includes/social-share.drupal.liquid
@@ -6,7 +6,7 @@
 <div data-template="includes/social-share" id="va-c-social-share">
   <ul class="usa-unstyled-list">
     <li class="vads-u-margin-bottom--2p5">
-      <a id="add-to-calendar-link" data-start="{{fieldDate.value }}" data-end="{{fieldDate.endValue}}" data-location="{{fieldAddress.addressLine1}} {{fieldAddress.locality}}, {{fieldAddress.administrativeArea}}" data-subject="{{ title }}" data-description="{{fieldDescription}}">
+      <a href="{{ entityUrl.path }}" id="add-to-calendar-link" data-start="{{fieldDate.value }}" data-end="{{fieldDate.endValue}}" data-location="{{fieldAddress.addressLine1}} {{fieldAddress.locality}}, {{fieldAddress.administrativeArea}}" data-subject="{{ title }}" data-description="{{fieldDescription}}">
         <i class="va-c-social-icon fas fa-calendar-check vads-u-margin-right--0p5"></i>Add to Calendar</a>
     </li>
 


### PR DESCRIPTION
## Description
Adds an href to cal links so screenreader can grab focus.

## Testing done
Visual

## Screenshots
N/A

## Acceptance criteria
- [ ] Go to `/pittsburgh-health-care/events/veterans-town-hall-0/` and hover over `Add to Calendar` visually verifying that href for current page appears