### PR TITLE
MDOT Order Batteries Page: "Can't Reorder Batteries Until" Next Availability Date UI Screen

### DIFF
--- a/src/applications/disability-benefits/2346/components/SelectArrayItemsBatteriesWidget.jsx
+++ b/src/applications/disability-benefits/2346/components/SelectArrayItemsBatteriesWidget.jsx
@@ -1,5 +1,5 @@
-import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 import moment from 'moment';
+import { setData } from 'platform/forms-system/src/js/actions';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
@@ -8,107 +8,117 @@ import {
   HEARING_AID_BATTERIES,
   WHITE_BACKGROUND,
 } from '../constants';
-// TODO: Safety checks for `selected` callback and `label` element
 
 class SelectArrayItemsBatteriesWidget extends Component {
-  state = {
-    selectedItems: [],
-  };
-
-  handleChecked = e => {
-    e.persist();
-    if (e.target.checked) {
-      this.setState(prevState => ({
-        selectedItems: prevState.selectedItems.concat(e.target.name),
-      }));
+  handleChecked = (productId, checked, supply) => {
+    const { selectedProducts, formData } = this.props;
+    let updatedSelectedProducts;
+    if (checked) {
+      updatedSelectedProducts = [
+        ...selectedProducts,
+        { productId: supply.productId },
+      ];
     } else {
-      this.setState(prevState => ({
-        selectedItems: prevState.selectedItems.filter(i => i !== e.target.name),
-      }));
+      updatedSelectedProducts = selectedProducts.filter(
+        selectedProduct => selectedProduct.productId !== supply.productId,
+      );
     }
+    const updatedFormData = {
+      ...formData,
+      selectedProducts: updatedSelectedProducts,
+    };
+    return this.props.setData(updatedFormData);
   };
 
   render() {
-    const { supplies } = this.props;
-    const { selectedItems } = this.state;
-    const currentDate = moment();
+    const { supplies, selectedProducts } = this.props;
 
-    return supplies.map(
-      supply =>
-        supply.productGroup === HEARING_AID_BATTERIES ? (
-          <div key={supply.productId} className="vads-u-color--gray-lightest">
-            <p className="vads-u-font-size--md vads-u-font-weight--bold">
-              {supply.productName}
-            </p>
-            <div className="vads-u-border-left--10px vads-u-border-color--primary-alt">
-              <div className="usa-alert-body vads-u-padding-left--1">
-                <p className="vads-u-margin--1px">
-                  <span className="vads-u-font-weight--bold">Battery: </span>
-                  {supply.productId}
-                </p>
-                <p className="vads-u-margin--1px">
-                  <span className="vads-u-font-weight--bold">Quantity: </span>
-                  {supply.quantity} <br />
-                  Approximately {supply.quantity} months supply
-                </p>
-                <p className="vads-u-margin--1px">
-                  <span className="vads-u-font-weight--bold">
-                    Last order date:{' '}
-                  </span>{' '}
-                  {moment(supply.lastOrderDate).format('MM/DD/YYYY')}
-                </p>
-              </div>
-            </div>
-            {currentDate.diff(supply.nextAvailabilityDate, 'days') < 0 ? (
-              <AlertBox
-                className="vads-u-color--black"
-                headline={
-                  <p>
-                    You can't reorder batteries for this device until{' '}
-                    {moment(supply.nextAvailabilityDate).format('MMMM/D/YYYY')}
-                  </p>
-                }
-                content={
-                  <>
-                    <p>
-                      You can only order batteries for each device once every 5
-                      months. Each battery order comes with a 6-month supply.
-                    </p>{' '}
-                    <p>
-                      If you need batteries sooner, please call the DLC Customer
-                      Service Station at{' '}
-                      <a href="tel:303-273-6200">303-273-6200</a> or email{' '}
-                      <a href="mailto:dalc.css@va.gov">dalc.css@va.gov</a>.
-                    </p>
-                  </>
-                }
-                status="warning"
-              />
-            ) : (
+    return (
+      <>
+        <h4>Select the hearing aids that need batteries</h4>
+        <p>
+          You'll be sent a 6-month supply of batteries for each device you
+          choose below.
+        </p>
+        {supplies.map(
+          supply =>
+            supply.productGroup === HEARING_AID_BATTERIES ? (
               <div
-                className={
-                  selectedItems.includes(supply.productId)
-                    ? BLUE_BACKGROUND
-                    : WHITE_BACKGROUND
-                }
+                key={supply.productId}
+                className="vads-u-background-color--gray-lightest vads-u-padding-left--4 vads-u-padding-top--1 vads-u-padding-bottom--4"
               >
-                <input
-                  name={supply.productId}
-                  type="checkbox"
-                  onChange={this.handleChecked}
-                />
-                <label htmlFor={supply.productId} className="main">
-                  Order batteries for this device
-                </label>
+                <h4 className="vads-u-font-size--md vads-u-font-weight--bold">
+                  {supply.productName}
+                </h4>
+                <p>Prescribed 1/18/2018</p>
+                <div className="vads-u-border-left--10px vads-u-border-color--primary-alt">
+                  <div className="usa-alert-body vads-u-padding-left--1">
+                    <p className="vads-u-margin--1px vads-u-margin-y--1">
+                      <span className="vads-u-font-weight--bold">
+                        Battery:{' '}
+                      </span>
+                      {supply.productId}
+                    </p>
+                    <p className="vads-u-margin--1px vads-u-margin-y--1">
+                      <span className="vads-u-font-weight--bold">
+                        Quantity:{' '}
+                      </span>
+                      {supply.quantity}
+                    </p>
+                    <p className="vads-u-margin--1px vads-u-margin-y--1">
+                      <span className="vads-u-font-weight--bold">
+                        Last order date:{' '}
+                      </span>{' '}
+                      {moment(supply.lastOrderDate).format('MM/DD/YYYY')}
+                    </p>
+                  </div>
+                </div>
+                <div
+                  className={
+                    selectedProducts.find(
+                      selectedProduct =>
+                        selectedProduct.productId === supply.productId,
+                    )
+                      ? BLUE_BACKGROUND
+                      : WHITE_BACKGROUND
+                  }
+                >
+                  <input
+                    id={supply.productId}
+                    type="checkbox"
+                    onChange={e => {
+                      this.handleChecked(
+                        supply.productId,
+                        e.target.checked,
+                        supply,
+                      );
+                    }}
+                    checked={
+                      !!selectedProducts.find(
+                        selectedProduct =>
+                          selectedProduct.productId === supply.productId,
+                      )
+                    }
+                  />
+                  <label htmlFor={supply.productId} className="main">
+                    Order batteries for this device
+                  </label>
+                </div>
               </div>
-            )}
-          </div>
-        ) : (
-          ''
-        ),
+            ) : (
+              ''
+            ),
+        )}
+      </>
     );
   }
 }
+
+SelectArrayItemsBatteriesWidget.defaultProps = {
+  formData: {},
+  supplies: [],
+  selectedProducts: [],
+};
 
 SelectArrayItemsBatteriesWidget.propTypes = {
   supplies: PropTypes.arrayOf(
@@ -124,10 +134,24 @@ SelectArrayItemsBatteriesWidget.propTypes = {
       size: PropTypes.string,
     }),
   ),
+  selectedProducts: PropTypes.arrayOf(
+    PropTypes.shape({
+      productId: PropTypes.string,
+    }),
+  ),
 };
 
 const mapStateToProps = state => ({
   supplies: state.form?.loadedData?.formData?.supplies,
+  formData: state.form?.data,
+  selectedProducts: state.form?.data?.selectedProducts,
 });
 
-export default connect(mapStateToProps)(SelectArrayItemsBatteriesWidget);
+const mapDispatchToProps = {
+  setData,
+};
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(SelectArrayItemsBatteriesWidget);

--- a/src/applications/disability-benefits/2346/components/SelectArrayItemsBatteriesWidget.jsx
+++ b/src/applications/disability-benefits/2346/components/SelectArrayItemsBatteriesWidget.jsx
@@ -1,3 +1,4 @@
+import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 import moment from 'moment';
 import { setData } from 'platform/forms-system/src/js/actions';
 import PropTypes from 'prop-types';
@@ -32,6 +33,7 @@ class SelectArrayItemsBatteriesWidget extends Component {
 
   render() {
     const { supplies, selectedProducts } = this.props;
+    const currentDate = moment();
 
     return (
       <>
@@ -48,7 +50,7 @@ class SelectArrayItemsBatteriesWidget extends Component {
                 className="vads-u-background-color--gray-lightest vads-u-padding-left--4 vads-u-padding-top--1 vads-u-padding-bottom--4"
               >
                 <h4 className="vads-u-font-size--md vads-u-font-weight--bold">
-                  {supply.productName}
+                  {supply.deviceName}
                 </h4>
                 <p>Prescribed 1/18/2018</p>
                 <div className="vads-u-border-left--10px vads-u-border-color--primary-alt">
@@ -73,37 +75,47 @@ class SelectArrayItemsBatteriesWidget extends Component {
                     </p>
                   </div>
                 </div>
-                <div
-                  className={
-                    selectedProducts.find(
-                      selectedProduct =>
-                        selectedProduct.productId === supply.productId,
-                    )
-                      ? BLUE_BACKGROUND
-                      : WHITE_BACKGROUND
-                  }
-                >
-                  <input
-                    id={supply.productId}
-                    type="checkbox"
-                    onChange={e => {
-                      this.handleChecked(
-                        supply.productId,
-                        e.target.checked,
-                        supply,
-                      );
-                    }}
-                    checked={
-                      !!selectedProducts.find(
-                        selectedProduct =>
-                          selectedProduct.productId === supply.productId,
-                      )
+                {currentDate.diff(supply.nextAvailabilityDate, 'days') < 0 ? (
+                  <AlertBox
+                    className="vads-u-color--black vads-u-background-color--white"
+                    headline={`You can't reorder batteries for this device until ${moment(
+                      supply.nextAvailabilityDate,
+                    ).format('MMMM D, YYYY')}`}
+                    content={
+                      <>
+                        <p>
+                          You can only order batteries for each device once
+                          every 5 months. Each battery order comes with a
+                          6-month supply.
+                        </p>
+                        <p>
+                          If you need batteries sooner, please call the DLC
+                          Customer Service Station at{' '}
+                          <a href="tel:303-273-6200">303-273-6200</a> or email{' '}
+                          <a href="mailto:dalc.css@va.gov">dalc.css@va.gov</a>.
+                        </p>
+                      </>
                     }
+                    status="warning"
                   />
-                  <label htmlFor={supply.productId} className="main">
-                    Order batteries for this device
-                  </label>
-                </div>
+                ) : (
+                  <div
+                    className={
+                      selectedProducts.includes(supply.productId)
+                        ? BLUE_BACKGROUND
+                        : WHITE_BACKGROUND
+                    }
+                  >
+                    <input
+                      name={supply.productId}
+                      type="checkbox"
+                      onChange={this.handleChecked}
+                    />
+                    <label htmlFor={supply.productId} className="main">
+                      Order batteries for this device
+                    </label>
+                  </div>
+                )}
               </div>
             ) : (
               ''

--- a/src/applications/disability-benefits/2346/components/SelectArrayItemsBatteriesWidget.jsx
+++ b/src/applications/disability-benefits/2346/components/SelectArrayItemsBatteriesWidget.jsx
@@ -1,5 +1,5 @@
+import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 import moment from 'moment';
-import { setData } from 'platform/forms-system/src/js/actions';
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
@@ -8,117 +8,107 @@ import {
   HEARING_AID_BATTERIES,
   WHITE_BACKGROUND,
 } from '../constants';
+// TODO: Safety checks for `selected` callback and `label` element
 
 class SelectArrayItemsBatteriesWidget extends Component {
-  handleChecked = (productId, checked, supply) => {
-    const { selectedProducts, formData } = this.props;
-    let updatedSelectedProducts;
-    if (checked) {
-      updatedSelectedProducts = [
-        ...selectedProducts,
-        { productId: supply.productId },
-      ];
+  state = {
+    selectedItems: [],
+  };
+
+  handleChecked = e => {
+    e.persist();
+    if (e.target.checked) {
+      this.setState(prevState => ({
+        selectedItems: prevState.selectedItems.concat(e.target.name),
+      }));
     } else {
-      updatedSelectedProducts = selectedProducts.filter(
-        selectedProduct => selectedProduct.productId !== supply.productId,
-      );
+      this.setState(prevState => ({
+        selectedItems: prevState.selectedItems.filter(i => i !== e.target.name),
+      }));
     }
-    const updatedFormData = {
-      ...formData,
-      selectedProducts: updatedSelectedProducts,
-    };
-    return this.props.setData(updatedFormData);
   };
 
   render() {
-    const { supplies, selectedProducts } = this.props;
+    const { supplies } = this.props;
+    const { selectedItems } = this.state;
+    const currentDate = moment();
 
-    return (
-      <>
-        <h4>Select the hearing aids that need batteries</h4>
-        <p>
-          You'll be sent a 6-month supply of batteries for each device you
-          choose below.
-        </p>
-        {supplies.map(
-          supply =>
-            supply.productGroup === HEARING_AID_BATTERIES ? (
-              <div
-                key={supply.productId}
-                className="vads-u-background-color--gray-lightest vads-u-padding-left--4 vads-u-padding-top--1 vads-u-padding-bottom--4"
-              >
-                <h4 className="vads-u-font-size--md vads-u-font-weight--bold">
-                  {supply.productName}
-                </h4>
-                <p>Prescribed 1/18/2018</p>
-                <div className="vads-u-border-left--10px vads-u-border-color--primary-alt">
-                  <div className="usa-alert-body vads-u-padding-left--1">
-                    <p className="vads-u-margin--1px vads-u-margin-y--1">
-                      <span className="vads-u-font-weight--bold">
-                        Battery:{' '}
-                      </span>
-                      {supply.productId}
-                    </p>
-                    <p className="vads-u-margin--1px vads-u-margin-y--1">
-                      <span className="vads-u-font-weight--bold">
-                        Quantity:{' '}
-                      </span>
-                      {supply.quantity}
-                    </p>
-                    <p className="vads-u-margin--1px vads-u-margin-y--1">
-                      <span className="vads-u-font-weight--bold">
-                        Last order date:{' '}
-                      </span>{' '}
-                      {moment(supply.lastOrderDate).format('MM/DD/YYYY')}
-                    </p>
-                  </div>
-                </div>
-                <div
-                  className={
-                    selectedProducts.find(
-                      selectedProduct =>
-                        selectedProduct.productId === supply.productId,
-                    )
-                      ? BLUE_BACKGROUND
-                      : WHITE_BACKGROUND
-                  }
-                >
-                  <input
-                    id={supply.productId}
-                    type="checkbox"
-                    onChange={e => {
-                      this.handleChecked(
-                        supply.productId,
-                        e.target.checked,
-                        supply,
-                      );
-                    }}
-                    checked={
-                      !!selectedProducts.find(
-                        selectedProduct =>
-                          selectedProduct.productId === supply.productId,
-                      )
-                    }
-                  />
-                  <label htmlFor={supply.productId} className="main">
-                    Order batteries for this device
-                  </label>
-                </div>
+    return supplies.map(
+      supply =>
+        supply.productGroup === HEARING_AID_BATTERIES ? (
+          <div key={supply.productId} className="vads-u-color--gray-lightest">
+            <p className="vads-u-font-size--md vads-u-font-weight--bold">
+              {supply.productName}
+            </p>
+            <div className="vads-u-border-left--10px vads-u-border-color--primary-alt">
+              <div className="usa-alert-body vads-u-padding-left--1">
+                <p className="vads-u-margin--1px">
+                  <span className="vads-u-font-weight--bold">Battery: </span>
+                  {supply.productId}
+                </p>
+                <p className="vads-u-margin--1px">
+                  <span className="vads-u-font-weight--bold">Quantity: </span>
+                  {supply.quantity} <br />
+                  Approximately {supply.quantity} months supply
+                </p>
+                <p className="vads-u-margin--1px">
+                  <span className="vads-u-font-weight--bold">
+                    Last order date:{' '}
+                  </span>{' '}
+                  {moment(supply.lastOrderDate).format('MM/DD/YYYY')}
+                </p>
               </div>
+            </div>
+            {currentDate.diff(supply.nextAvailabilityDate, 'days') < 0 ? (
+              <AlertBox
+                className="vads-u-color--black"
+                headline={
+                  <p>
+                    You can't reorder batteries for this device until{' '}
+                    {moment(supply.nextAvailabilityDate).format('MMMM/D/YYYY')}
+                  </p>
+                }
+                content={
+                  <>
+                    <p>
+                      You can only order batteries for each device once every 5
+                      months. Each battery order comes with a 6-month supply.
+                    </p>{' '}
+                    <p>
+                      If you need batteries sooner, please call the DLC Customer
+                      Service Station at{' '}
+                      <a href="tel:303-273-6200">303-273-6200</a> or email{' '}
+                      <a href="mailto:dalc.css@va.gov">dalc.css@va.gov</a>.
+                    </p>
+                  </>
+                }
+                status="warning"
+              />
             ) : (
-              ''
-            ),
-        )}
-      </>
+              <div
+                className={
+                  selectedItems.includes(supply.productId)
+                    ? BLUE_BACKGROUND
+                    : WHITE_BACKGROUND
+                }
+              >
+                <input
+                  name={supply.productId}
+                  type="checkbox"
+                  onChange={this.handleChecked}
+                />
+                <label htmlFor={supply.productId} className="main">
+                  Order batteries for this device
+                </label>
+              </div>
+            )}
+          </div>
+        ) : (
+          ''
+        ),
     );
   }
 }
-
-SelectArrayItemsBatteriesWidget.defaultProps = {
-  formData: {},
-  supplies: [],
-  selectedProducts: [],
-};
 
 SelectArrayItemsBatteriesWidget.propTypes = {
   supplies: PropTypes.arrayOf(
@@ -134,24 +124,10 @@ SelectArrayItemsBatteriesWidget.propTypes = {
       size: PropTypes.string,
     }),
   ),
-  selectedProducts: PropTypes.arrayOf(
-    PropTypes.shape({
-      productId: PropTypes.string,
-    }),
-  ),
 };
 
 const mapStateToProps = state => ({
   supplies: state.form?.loadedData?.formData?.supplies,
-  formData: state.form?.data,
-  selectedProducts: state.form?.data?.selectedProducts,
 });
 
-const mapDispatchToProps = {
-  setData,
-};
-
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps,
-)(SelectArrayItemsBatteriesWidget);
+export default connect(mapStateToProps)(SelectArrayItemsBatteriesWidget);

--- a/src/applications/disability-benefits/2346/sass/form-2346.scss
+++ b/src/applications/disability-benefits/2346/sass/form-2346.scss
@@ -110,3 +110,10 @@ label {
     margin-right: 0;
   }
 }
+
+.usa-alert {
+  width: 90%;
+  .usa-alert-heading {
+    font-size: 16px;
+  }
+}


### PR DESCRIPTION
## Description
Creating the "you can't reorder hearing aid batteries for this device until" the next availability date ui screen for the battery page.

Work is based on [this design](https://vsateams.invisionapp.com/share/6MVTG94WNH5#/screens/405269597) and discussion with designers to put the additional info inside of the alert box due to feedback received on current design.

UI screen should only show if the next availability date is the current day or a past day.

## Testing done


## Screenshots
![screenshot-localhost_3001-2020 04 27-15_03_08](https://user-images.githubusercontent.com/12755283/80411673-9a1aa500-889a-11ea-959c-48d1ea8e081c.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
