### PR TITLE
Fix platform alias - batch1

### DIFF
--- a/src/applications/pensions/PensionsApp.jsx
+++ b/src/applications/pensions/PensionsApp.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import RoutedSavableApp from '../../platform/forms/save-in-progress/RoutedSavableApp';
+import RoutedSavableApp from 'platform/forms/save-in-progress/RoutedSavableApp';
 import formConfig from './config/form';
 
 export default function PensionsApp({ location, children }) {

--- a/src/applications/pensions/PensionsApp.jsx
+++ b/src/applications/pensions/PensionsApp.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import RoutedSavableApp from 'platform/forms/save-in-progress/RoutedSavableApp';
+import RoutedSavableApp from '../../platform/forms/save-in-progress/RoutedSavableApp';
 import formConfig from './config/form';
 
 export default function PensionsApp({ location, children }) {

--- a/src/applications/pensions/components/AdditionalSourcesField.jsx
+++ b/src/applications/pensions/components/AdditionalSourcesField.jsx
@@ -2,10 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import _ from 'lodash/fp';
 import Scroll from 'react-scroll';
-import {
-  scrollToFirstError,
-  focusElement,
-} from '../../../platform/utilities/ui';
+import { scrollToFirstError, focusElement } from 'platform/utilities/ui';
 import { setArrayRecordTouched } from 'platform/forms-system/src/js/helpers';
 import currencyUI from 'platform/forms-system/src/js/definitions/currency';
 

--- a/src/applications/pensions/components/AdditionalSourcesField.jsx
+++ b/src/applications/pensions/components/AdditionalSourcesField.jsx
@@ -2,7 +2,10 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import _ from 'lodash/fp';
 import Scroll from 'react-scroll';
-import { scrollToFirstError, focusElement } from 'platform/utilities/ui';
+import {
+  scrollToFirstError,
+  focusElement,
+} from '../../../platform/utilities/ui';
 import { setArrayRecordTouched } from 'platform/forms-system/src/js/helpers';
 import currencyUI from 'platform/forms-system/src/js/definitions/currency';
 

--- a/src/applications/pensions/components/ErrorText.jsx
+++ b/src/applications/pensions/components/ErrorText.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import CallVBACenter from '../../../platform/static-data/CallVBACenter';
+import CallVBACenter from 'platform/static-data/CallVBACenter';
 
 export default function ErrorText() {
   return (

--- a/src/applications/pensions/components/ErrorText.jsx
+++ b/src/applications/pensions/components/ErrorText.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import CallVBACenter from 'platform/static-data/CallVBACenter';
+import CallVBACenter from '../../../platform/static-data/CallVBACenter';
 
 export default function ErrorText() {
   return (

--- a/src/applications/pensions/components/IntroductionPage.jsx
+++ b/src/applications/pensions/components/IntroductionPage.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
 
-import { focusElement } from '../../../platform/utilities/ui';
+import { focusElement } from 'platform/utilities/ui';
 import OMBInfo from '@department-of-veterans-affairs/formation-react/OMBInfo';
 import FormTitle from 'platform/forms-system/src/js/components/FormTitle';
-import SaveInProgressIntro from '../../../platform/forms/save-in-progress/SaveInProgressIntro';
+import SaveInProgressIntro from 'platform/forms/save-in-progress/SaveInProgressIntro';
 
 class IntroductionPage extends React.Component {
   componentDidMount() {

--- a/src/applications/pensions/components/IntroductionPage.jsx
+++ b/src/applications/pensions/components/IntroductionPage.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
 
-import { focusElement } from 'platform/utilities/ui';
+import { focusElement } from '../../../platform/utilities/ui';
 import OMBInfo from '@department-of-veterans-affairs/formation-react/OMBInfo';
 import FormTitle from 'platform/forms-system/src/js/components/FormTitle';
-import SaveInProgressIntro from 'platform/forms/save-in-progress/SaveInProgressIntro';
+import SaveInProgressIntro from '../../../platform/forms/save-in-progress/SaveInProgressIntro';
 
 class IntroductionPage extends React.Component {
   componentDidMount() {

--- a/src/applications/pensions/containers/ConfirmationPage.jsx
+++ b/src/applications/pensions/containers/ConfirmationPage.jsx
@@ -3,8 +3,8 @@ import moment from 'moment';
 import { connect } from 'react-redux';
 import Scroll from 'react-scroll';
 
-import { focusElement } from '../../../platform/utilities/ui';
-import CallVBACenter from '../../../platform/static-data/CallVBACenter';
+import { focusElement } from 'platform/utilities/ui';
+import CallVBACenter from 'platform/static-data/CallVBACenter';
 
 const scroller = Scroll.scroller;
 const scrollToTop = () => {

--- a/src/applications/pensions/containers/ConfirmationPage.jsx
+++ b/src/applications/pensions/containers/ConfirmationPage.jsx
@@ -3,8 +3,8 @@ import moment from 'moment';
 import { connect } from 'react-redux';
 import Scroll from 'react-scroll';
 
-import { focusElement } from 'platform/utilities/ui';
-import CallVBACenter from 'platform/static-data/CallVBACenter';
+import { focusElement } from '../../../platform/utilities/ui';
+import CallVBACenter from '../../../platform/static-data/CallVBACenter';
 
 const scroller = Scroll.scroller;
 const scrollToTop = () => {

--- a/src/applications/pensions/migrations.js
+++ b/src/applications/pensions/migrations.js
@@ -1,7 +1,7 @@
 import _ from 'lodash/fp';
-import { isValidDateRange } from '../../platform/forms/validations';
+import { isValidDateRange } from 'platform/forms/validations';
 import { convertToDateField } from 'platform/forms-system/src/js/validation';
-import { isValidCentralMailPostalCode } from '../../platform/forms/address/validations';
+import { isValidCentralMailPostalCode } from 'platform/forms/address/validations';
 
 export default [
   // 0 -> 1, we've added some date validation and need to move users back to particular pages

--- a/src/applications/pensions/migrations.js
+++ b/src/applications/pensions/migrations.js
@@ -1,7 +1,7 @@
 import _ from 'lodash/fp';
-import { isValidDateRange } from 'platform/forms/validations';
+import { isValidDateRange } from '../../platform/forms/validations';
 import { convertToDateField } from 'platform/forms-system/src/js/validation';
-import { isValidCentralMailPostalCode } from 'platform/forms/address/validations';
+import { isValidCentralMailPostalCode } from '../../platform/forms/address/validations';
 
 export default [
   // 0 -> 1, we've added some date validation and need to move users back to particular pages

--- a/src/applications/pensions/pensions-entry.jsx
+++ b/src/applications/pensions/pensions-entry.jsx
@@ -1,7 +1,7 @@
-import '../../platform/polyfills';
+import 'platform/polyfills';
 import './sass/pensions.scss';
 
-import startApp from '../../platform/startup';
+import startApp from 'platform/startup';
 
 import routes from './routes';
 import reducer from './reducer';

--- a/src/applications/pensions/pensions-entry.jsx
+++ b/src/applications/pensions/pensions-entry.jsx
@@ -1,7 +1,7 @@
-import 'platform/polyfills';
+import '../../platform/polyfills';
 import './sass/pensions.scss';
 
-import startApp from 'platform/startup';
+import startApp from '../../platform/startup';
 
 import routes from './routes';
 import reducer from './reducer';

--- a/src/applications/pensions/reducer.js
+++ b/src/applications/pensions/reducer.js
@@ -1,5 +1,5 @@
 import formConfig from './config/form';
-import { createSaveInProgressFormReducer } from '../../platform/forms/save-in-progress/reducers';
+import { createSaveInProgressFormReducer } from 'platform/forms/save-in-progress/reducers';
 
 export default {
   form: createSaveInProgressFormReducer(formConfig),

--- a/src/applications/pensions/reducer.js
+++ b/src/applications/pensions/reducer.js
@@ -1,5 +1,5 @@
 import formConfig from './config/form';
-import { createSaveInProgressFormReducer } from 'platform/forms/save-in-progress/reducers';
+import { createSaveInProgressFormReducer } from '../../platform/forms/save-in-progress/reducers';
 
 export default {
   form: createSaveInProgressFormReducer(formConfig),

--- a/src/applications/pensions/routes.jsx
+++ b/src/applications/pensions/routes.jsx
@@ -1,4 +1,4 @@
-import { createRoutesWithSaveInProgress } from '../../platform/forms/save-in-progress/helpers';
+import { createRoutesWithSaveInProgress } from 'platform/forms/save-in-progress/helpers';
 
 import formConfig from './config/form';
 import PensionsApp from './PensionsApp.jsx';

--- a/src/applications/pensions/routes.jsx
+++ b/src/applications/pensions/routes.jsx
@@ -1,4 +1,4 @@
-import { createRoutesWithSaveInProgress } from 'platform/forms/save-in-progress/helpers';
+import { createRoutesWithSaveInProgress } from '../../platform/forms/save-in-progress/helpers';
 
 import formConfig from './config/form';
 import PensionsApp from './PensionsApp.jsx';

--- a/src/applications/pensions/tests/config/aidAttendance.unit.spec.jsx
+++ b/src/applications/pensions/tests/config/aidAttendance.unit.spec.jsx
@@ -6,7 +6,7 @@ import ReactTestUtils from 'react-dom/test-utils';
 import {
   DefinitionTester,
   getFormDOM,
-} from '../../../../platform/testing/unit/schemaform-utils.jsx';
+} from 'platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form';
 
 const definitions = formConfig.defaultDefinitions;

--- a/src/applications/pensions/tests/config/aidAttendance.unit.spec.jsx
+++ b/src/applications/pensions/tests/config/aidAttendance.unit.spec.jsx
@@ -6,7 +6,7 @@ import ReactTestUtils from 'react-dom/test-utils';
 import {
   DefinitionTester,
   getFormDOM,
-} from 'platform/testing/unit/schemaform-utils.jsx';
+} from '../../../../platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form';
 
 const definitions = formConfig.defaultDefinitions;

--- a/src/applications/pensions/tests/config/applicantInformation.unit.spec.jsx
+++ b/src/applications/pensions/tests/config/applicantInformation.unit.spec.jsx
@@ -7,7 +7,7 @@ import {
   DefinitionTester,
   submitForm,
   getFormDOM,
-} from '../../../../platform/testing/unit/schemaform-utils.jsx';
+} from 'platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form';
 
 const definitions = formConfig.defaultDefinitions;

--- a/src/applications/pensions/tests/config/applicantInformation.unit.spec.jsx
+++ b/src/applications/pensions/tests/config/applicantInformation.unit.spec.jsx
@@ -7,7 +7,7 @@ import {
   DefinitionTester,
   submitForm,
   getFormDOM,
-} from 'platform/testing/unit/schemaform-utils.jsx';
+} from '../../../../platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form';
 
 const definitions = formConfig.defaultDefinitions;

--- a/src/applications/pensions/tests/config/childrenAddress.unit.spec.jsx
+++ b/src/applications/pensions/tests/config/childrenAddress.unit.spec.jsx
@@ -6,7 +6,7 @@ import ReactTestUtils from 'react-dom/test-utils';
 import {
   DefinitionTester,
   getFormDOM,
-} from '../../../../platform/testing/unit/schemaform-utils.jsx';
+} from 'platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form.js';
 
 describe('Child address page', () => {

--- a/src/applications/pensions/tests/config/childrenAddress.unit.spec.jsx
+++ b/src/applications/pensions/tests/config/childrenAddress.unit.spec.jsx
@@ -6,7 +6,7 @@ import ReactTestUtils from 'react-dom/test-utils';
 import {
   DefinitionTester,
   getFormDOM,
-} from 'platform/testing/unit/schemaform-utils.jsx';
+} from '../../../../platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form.js';
 
 describe('Child address page', () => {

--- a/src/applications/pensions/tests/config/childrenInformation.unit.spec.jsx
+++ b/src/applications/pensions/tests/config/childrenInformation.unit.spec.jsx
@@ -7,7 +7,7 @@ import moment from 'moment';
 import {
   DefinitionTester,
   getFormDOM,
-} from '../../../../platform/testing/unit/schemaform-utils.jsx';
+} from 'platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form.js';
 
 describe('Child information page', () => {

--- a/src/applications/pensions/tests/config/childrenInformation.unit.spec.jsx
+++ b/src/applications/pensions/tests/config/childrenInformation.unit.spec.jsx
@@ -7,7 +7,7 @@ import moment from 'moment';
 import {
   DefinitionTester,
   getFormDOM,
-} from 'platform/testing/unit/schemaform-utils.jsx';
+} from '../../../../platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form.js';
 
 describe('Child information page', () => {

--- a/src/applications/pensions/tests/config/contactInformation.unit.spec.jsx
+++ b/src/applications/pensions/tests/config/contactInformation.unit.spec.jsx
@@ -6,7 +6,7 @@ import ReactTestUtils from 'react-dom/test-utils';
 import {
   DefinitionTester,
   getFormDOM,
-} from '../../../../platform/testing/unit/schemaform-utils.jsx';
+} from 'platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form';
 
 describe('Pensions contact information', () => {

--- a/src/applications/pensions/tests/config/contactInformation.unit.spec.jsx
+++ b/src/applications/pensions/tests/config/contactInformation.unit.spec.jsx
@@ -6,7 +6,7 @@ import ReactTestUtils from 'react-dom/test-utils';
 import {
   DefinitionTester,
   getFormDOM,
-} from 'platform/testing/unit/schemaform-utils.jsx';
+} from '../../../../platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form';
 
 describe('Pensions contact information', () => {

--- a/src/applications/pensions/tests/config/dependents.unit.spec.jsx
+++ b/src/applications/pensions/tests/config/dependents.unit.spec.jsx
@@ -6,7 +6,7 @@ import ReactTestUtils from 'react-dom/test-utils';
 import {
   DefinitionTester,
   getFormDOM,
-} from '../../../../platform/testing/unit/schemaform-utils.jsx';
+} from 'platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form.js';
 
 describe('Pensions dependent list', () => {

--- a/src/applications/pensions/tests/config/dependents.unit.spec.jsx
+++ b/src/applications/pensions/tests/config/dependents.unit.spec.jsx
@@ -6,7 +6,7 @@ import ReactTestUtils from 'react-dom/test-utils';
 import {
   DefinitionTester,
   getFormDOM,
-} from 'platform/testing/unit/schemaform-utils.jsx';
+} from '../../../../platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form.js';
 
 describe('Pensions dependent list', () => {

--- a/src/applications/pensions/tests/config/directDeposit.unit.spec.jsx
+++ b/src/applications/pensions/tests/config/directDeposit.unit.spec.jsx
@@ -6,7 +6,7 @@ import sinon from 'sinon';
 import {
   DefinitionTester,
   getFormDOM,
-} from '../../../../platform/testing/unit/schemaform-utils.jsx';
+} from 'platform/testing/unit/schemaform-utils.jsx';
 import fullSchemaPensions from '../../config/form';
 
 describe('Pensions directDeposit', () => {

--- a/src/applications/pensions/tests/config/directDeposit.unit.spec.jsx
+++ b/src/applications/pensions/tests/config/directDeposit.unit.spec.jsx
@@ -6,7 +6,7 @@ import sinon from 'sinon';
 import {
   DefinitionTester,
   getFormDOM,
-} from 'platform/testing/unit/schemaform-utils.jsx';
+} from '../../../../platform/testing/unit/schemaform-utils.jsx';
 import fullSchemaPensions from '../../config/form';
 
 describe('Pensions directDeposit', () => {

--- a/src/applications/pensions/tests/config/disabilityHistory.unit.spec.jsx
+++ b/src/applications/pensions/tests/config/disabilityHistory.unit.spec.jsx
@@ -7,7 +7,7 @@ import ReactTestUtils from 'react-dom/test-utils';
 import {
   DefinitionTester,
   getFormDOM,
-} from '../../../../platform/testing/unit/schemaform-utils.jsx';
+} from 'platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form.js';
 
 describe('Pensions disability history', () => {

--- a/src/applications/pensions/tests/config/disabilityHistory.unit.spec.jsx
+++ b/src/applications/pensions/tests/config/disabilityHistory.unit.spec.jsx
@@ -7,7 +7,7 @@ import ReactTestUtils from 'react-dom/test-utils';
 import {
   DefinitionTester,
   getFormDOM,
-} from 'platform/testing/unit/schemaform-utils.jsx';
+} from '../../../../platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form.js';
 
 describe('Pensions disability history', () => {

--- a/src/applications/pensions/tests/config/documents.unit.spec.jsx
+++ b/src/applications/pensions/tests/config/documents.unit.spec.jsx
@@ -6,7 +6,7 @@ import ReactTestUtils from 'react-dom/test-utils';
 import {
   DefinitionTester,
   getFormDOM,
-} from '../../../../platform/testing/unit/schemaform-utils.jsx';
+} from 'platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form';
 
 describe('Pensions document upload', () => {

--- a/src/applications/pensions/tests/config/documents.unit.spec.jsx
+++ b/src/applications/pensions/tests/config/documents.unit.spec.jsx
@@ -6,7 +6,7 @@ import ReactTestUtils from 'react-dom/test-utils';
 import {
   DefinitionTester,
   getFormDOM,
-} from 'platform/testing/unit/schemaform-utils.jsx';
+} from '../../../../platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form';
 
 describe('Pensions document upload', () => {

--- a/src/applications/pensions/tests/config/employmentHistory.unit.spec.jsx
+++ b/src/applications/pensions/tests/config/employmentHistory.unit.spec.jsx
@@ -7,7 +7,7 @@ import ReactTestUtils from 'react-dom/test-utils';
 import {
   DefinitionTester,
   getFormDOM,
-} from '../../../../platform/testing/unit/schemaform-utils.jsx';
+} from 'platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form';
 
 describe('Pensions employment history', () => {

--- a/src/applications/pensions/tests/config/employmentHistory.unit.spec.jsx
+++ b/src/applications/pensions/tests/config/employmentHistory.unit.spec.jsx
@@ -7,7 +7,7 @@ import ReactTestUtils from 'react-dom/test-utils';
 import {
   DefinitionTester,
   getFormDOM,
-} from 'platform/testing/unit/schemaform-utils.jsx';
+} from '../../../../platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form';
 
 describe('Pensions employment history', () => {

--- a/src/applications/pensions/tests/config/expedited.unit.spec.jsx
+++ b/src/applications/pensions/tests/config/expedited.unit.spec.jsx
@@ -6,7 +6,7 @@ import ReactTestUtils from 'react-dom/test-utils';
 import {
   DefinitionTester,
   getFormDOM,
-} from '../../../../platform/testing/unit/schemaform-utils.jsx';
+} from 'platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form';
 
 const definitions = formConfig.defaultDefinitions;

--- a/src/applications/pensions/tests/config/expedited.unit.spec.jsx
+++ b/src/applications/pensions/tests/config/expedited.unit.spec.jsx
@@ -6,7 +6,7 @@ import ReactTestUtils from 'react-dom/test-utils';
 import {
   DefinitionTester,
   getFormDOM,
-} from 'platform/testing/unit/schemaform-utils.jsx';
+} from '../../../../platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form';
 
 const definitions = formConfig.defaultDefinitions;

--- a/src/applications/pensions/tests/config/financialDisclosure.unit.spec.jsx
+++ b/src/applications/pensions/tests/config/financialDisclosure.unit.spec.jsx
@@ -7,7 +7,7 @@ import ReactTestUtils from 'react-dom/test-utils';
 import {
   DefinitionTester,
   submitForm,
-} from '../../../../platform/testing/unit/schemaform-utils.jsx';
+} from 'platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form.js';
 
 describe('Pensions financial disclosure', () => {

--- a/src/applications/pensions/tests/config/financialDisclosure.unit.spec.jsx
+++ b/src/applications/pensions/tests/config/financialDisclosure.unit.spec.jsx
@@ -7,7 +7,7 @@ import ReactTestUtils from 'react-dom/test-utils';
 import {
   DefinitionTester,
   submitForm,
-} from 'platform/testing/unit/schemaform-utils.jsx';
+} from '../../../../platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form.js';
 
 describe('Pensions financial disclosure', () => {

--- a/src/applications/pensions/tests/config/generalMilitaryHistory.unit.spec.jsx
+++ b/src/applications/pensions/tests/config/generalMilitaryHistory.unit.spec.jsx
@@ -6,7 +6,7 @@ import ReactTestUtils from 'react-dom/test-utils';
 import {
   DefinitionTester,
   getFormDOM,
-} from '../../../../platform/testing/unit/schemaform-utils.jsx';
+} from 'platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form';
 
 describe('Pensions general military history', () => {

--- a/src/applications/pensions/tests/config/generalMilitaryHistory.unit.spec.jsx
+++ b/src/applications/pensions/tests/config/generalMilitaryHistory.unit.spec.jsx
@@ -6,7 +6,7 @@ import ReactTestUtils from 'react-dom/test-utils';
 import {
   DefinitionTester,
   getFormDOM,
-} from 'platform/testing/unit/schemaform-utils.jsx';
+} from '../../../../platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form';
 
 describe('Pensions general military history', () => {

--- a/src/applications/pensions/tests/config/marriageHistory.unit.spec.jsx
+++ b/src/applications/pensions/tests/config/marriageHistory.unit.spec.jsx
@@ -7,7 +7,7 @@ import {
   DefinitionTester,
   submitForm,
   getFormDOM,
-} from '../../../../platform/testing/unit/schemaform-utils.jsx';
+} from 'platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form';
 
 describe('Pensions marriage history', () => {

--- a/src/applications/pensions/tests/config/marriageHistory.unit.spec.jsx
+++ b/src/applications/pensions/tests/config/marriageHistory.unit.spec.jsx
@@ -7,7 +7,7 @@ import {
   DefinitionTester,
   submitForm,
   getFormDOM,
-} from 'platform/testing/unit/schemaform-utils.jsx';
+} from '../../../../platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form';
 
 describe('Pensions marriage history', () => {

--- a/src/applications/pensions/tests/config/marriageInfo.unit.spec.jsx
+++ b/src/applications/pensions/tests/config/marriageInfo.unit.spec.jsx
@@ -7,7 +7,7 @@ import {
   DefinitionTester,
   submitForm,
   getFormDOM,
-} from '../../../../platform/testing/unit/schemaform-utils.jsx';
+} from 'platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form';
 
 describe('Pensions marriage info', () => {

--- a/src/applications/pensions/tests/config/marriageInfo.unit.spec.jsx
+++ b/src/applications/pensions/tests/config/marriageInfo.unit.spec.jsx
@@ -7,7 +7,7 @@ import {
   DefinitionTester,
   submitForm,
   getFormDOM,
-} from 'platform/testing/unit/schemaform-utils.jsx';
+} from '../../../../platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form';
 
 describe('Pensions marriage info', () => {

--- a/src/applications/pensions/tests/config/otherExpenses.unit.spec.jsx
+++ b/src/applications/pensions/tests/config/otherExpenses.unit.spec.jsx
@@ -6,7 +6,7 @@ import ReactTestUtils from 'react-dom/test-utils';
 import {
   DefinitionTester,
   getFormDOM,
-} from '../../../../platform/testing/unit/schemaform-utils.jsx';
+} from 'platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form.js';
 
 describe('Pensions', () => {

--- a/src/applications/pensions/tests/config/otherExpenses.unit.spec.jsx
+++ b/src/applications/pensions/tests/config/otherExpenses.unit.spec.jsx
@@ -6,7 +6,7 @@ import ReactTestUtils from 'react-dom/test-utils';
 import {
   DefinitionTester,
   getFormDOM,
-} from 'platform/testing/unit/schemaform-utils.jsx';
+} from '../../../../platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form.js';
 
 describe('Pensions', () => {

--- a/src/applications/pensions/tests/config/powAndSeverance.unit.spec.jsx
+++ b/src/applications/pensions/tests/config/powAndSeverance.unit.spec.jsx
@@ -7,7 +7,7 @@ import ReactTestUtils from 'react-dom/test-utils';
 import {
   DefinitionTester,
   submitForm,
-} from '../../../../platform/testing/unit/schemaform-utils.jsx';
+} from 'platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form';
 
 describe('Pensions Reserve and National Guard', () => {

--- a/src/applications/pensions/tests/config/powAndSeverance.unit.spec.jsx
+++ b/src/applications/pensions/tests/config/powAndSeverance.unit.spec.jsx
@@ -7,7 +7,7 @@ import ReactTestUtils from 'react-dom/test-utils';
 import {
   DefinitionTester,
   submitForm,
-} from 'platform/testing/unit/schemaform-utils.jsx';
+} from '../../../../platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form';
 
 describe('Pensions Reserve and National Guard', () => {

--- a/src/applications/pensions/tests/config/reserveAndNationalGuardMilitaryHistory.unit.spec.jsx
+++ b/src/applications/pensions/tests/config/reserveAndNationalGuardMilitaryHistory.unit.spec.jsx
@@ -6,7 +6,7 @@ import ReactTestUtils from 'react-dom/test-utils';
 import {
   DefinitionTester,
   getFormDOM,
-} from '../../../../platform/testing/unit/schemaform-utils.jsx';
+} from 'platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form';
 
 describe('Pensions Reserve and National Guard', () => {

--- a/src/applications/pensions/tests/config/reserveAndNationalGuardMilitaryHistory.unit.spec.jsx
+++ b/src/applications/pensions/tests/config/reserveAndNationalGuardMilitaryHistory.unit.spec.jsx
@@ -6,7 +6,7 @@ import ReactTestUtils from 'react-dom/test-utils';
 import {
   DefinitionTester,
   getFormDOM,
-} from 'platform/testing/unit/schemaform-utils.jsx';
+} from '../../../../platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form';
 
 describe('Pensions Reserve and National Guard', () => {

--- a/src/applications/pensions/tests/config/servicePeriods.unit.spec.jsx
+++ b/src/applications/pensions/tests/config/servicePeriods.unit.spec.jsx
@@ -6,7 +6,7 @@ import ReactTestUtils from 'react-dom/test-utils';
 import {
   DefinitionTester,
   getFormDOM,
-} from '../../../../platform/testing/unit/schemaform-utils.jsx';
+} from 'platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form';
 
 describe('Pensions service periods', () => {

--- a/src/applications/pensions/tests/config/servicePeriods.unit.spec.jsx
+++ b/src/applications/pensions/tests/config/servicePeriods.unit.spec.jsx
@@ -6,7 +6,7 @@ import ReactTestUtils from 'react-dom/test-utils';
 import {
   DefinitionTester,
   getFormDOM,
-} from 'platform/testing/unit/schemaform-utils.jsx';
+} from '../../../../platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form';
 
 describe('Pensions service periods', () => {

--- a/src/applications/pensions/tests/config/spouseMarriageHistory.unit.spec.jsx
+++ b/src/applications/pensions/tests/config/spouseMarriageHistory.unit.spec.jsx
@@ -7,7 +7,7 @@ import {
   DefinitionTester,
   submitForm,
   getFormDOM,
-} from '../../../../platform/testing/unit/schemaform-utils.jsx';
+} from 'platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form';
 
 describe('Pensions spouse marriage history', () => {

--- a/src/applications/pensions/tests/config/spouseMarriageHistory.unit.spec.jsx
+++ b/src/applications/pensions/tests/config/spouseMarriageHistory.unit.spec.jsx
@@ -7,7 +7,7 @@ import {
   DefinitionTester,
   submitForm,
   getFormDOM,
-} from 'platform/testing/unit/schemaform-utils.jsx';
+} from '../../../../platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form';
 
 describe('Pensions spouse marriage history', () => {

--- a/src/applications/pensions/tests/config/spouseMarriageInfo.unit.spec.jsx
+++ b/src/applications/pensions/tests/config/spouseMarriageInfo.unit.spec.jsx
@@ -7,7 +7,7 @@ import {
   DefinitionTester,
   submitForm,
   getFormDOM,
-} from '../../../../platform/testing/unit/schemaform-utils.jsx';
+} from 'platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form';
 
 describe('Pensions spouse info', () => {

--- a/src/applications/pensions/tests/config/spouseMarriageInfo.unit.spec.jsx
+++ b/src/applications/pensions/tests/config/spouseMarriageInfo.unit.spec.jsx
@@ -7,7 +7,7 @@ import {
   DefinitionTester,
   submitForm,
   getFormDOM,
-} from 'platform/testing/unit/schemaform-utils.jsx';
+} from '../../../../platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form';
 
 describe('Pensions spouse info', () => {

--- a/src/applications/pensions/validation.js
+++ b/src/applications/pensions/validation.js
@@ -1,7 +1,7 @@
 import _ from 'lodash/fp';
-import { isValidDateRange } from '../../platform/forms/validations';
+import { isValidDateRange } from 'platform/forms/validations';
 import { convertToDateField } from 'platform/forms-system/src/js/validation';
-import { isValidCentralMailPostalCode } from '../../platform/forms/address/validations';
+import { isValidCentralMailPostalCode } from 'platform/forms/address/validations';
 
 export function validateAfterMarriageDate(errors, dateOfSeparation, formData) {
   const fromDate = convertToDateField(formData.dateOfMarriage);

--- a/src/applications/pensions/validation.js
+++ b/src/applications/pensions/validation.js
@@ -1,7 +1,7 @@
 import _ from 'lodash/fp';
-import { isValidDateRange } from 'platform/forms/validations';
+import { isValidDateRange } from '../../platform/forms/validations';
 import { convertToDateField } from 'platform/forms-system/src/js/validation';
-import { isValidCentralMailPostalCode } from 'platform/forms/address/validations';
+import { isValidCentralMailPostalCode } from '../../platform/forms/address/validations';
 
 export function validateAfterMarriageDate(errors, dateOfSeparation, formData) {
   const fromDate = convertToDateField(formData.dateOfMarriage);

--- a/src/applications/pre-need/PreNeedApp.jsx
+++ b/src/applications/pre-need/PreNeedApp.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import RoutedSavableApp from '../../platform/forms/save-in-progress/RoutedSavableApp';
+import RoutedSavableApp from 'platform/forms/save-in-progress/RoutedSavableApp';
 import formConfig from './config/form';
 
 export default function PreNeedApp({ location, children }) {

--- a/src/applications/pre-need/PreNeedApp.jsx
+++ b/src/applications/pre-need/PreNeedApp.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import RoutedSavableApp from 'platform/forms/save-in-progress/RoutedSavableApp';
+import RoutedSavableApp from '../../platform/forms/save-in-progress/RoutedSavableApp';
 import formConfig from './config/form';
 
 export default function PreNeedApp({ location, children }) {

--- a/src/applications/pre-need/components/ErrorText.jsx
+++ b/src/applications/pre-need/components/ErrorText.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import CallNCACenter from '../../../platform/static-data/CallNCACenter';
+import CallNCACenter from 'platform/static-data/CallNCACenter';
 
 export default function ErrorText() {
   return (

--- a/src/applications/pre-need/components/ErrorText.jsx
+++ b/src/applications/pre-need/components/ErrorText.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import CallNCACenter from 'platform/static-data/CallNCACenter';
+import CallNCACenter from '../../../platform/static-data/CallNCACenter';
 
 export default function ErrorText() {
   return (

--- a/src/applications/pre-need/components/GetFormHelp.jsx
+++ b/src/applications/pre-need/components/GetFormHelp.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import CallNCACenter from '../../../platform/static-data/CallNCACenter';
-import CallVBACenter from '../../../platform/static-data/CallVBACenter';
+import CallNCACenter from 'platform/static-data/CallNCACenter';
+import CallVBACenter from 'platform/static-data/CallVBACenter';
 
 export default function GetFormHelp() {
   return (

--- a/src/applications/pre-need/components/GetFormHelp.jsx
+++ b/src/applications/pre-need/components/GetFormHelp.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import CallNCACenter from 'platform/static-data/CallNCACenter';
-import CallVBACenter from 'platform/static-data/CallVBACenter';
+import CallNCACenter from '../../../platform/static-data/CallNCACenter';
+import CallVBACenter from '../../../platform/static-data/CallVBACenter';
 
 export default function GetFormHelp() {
   return (

--- a/src/applications/pre-need/components/IntroductionPage.jsx
+++ b/src/applications/pre-need/components/IntroductionPage.jsx
@@ -1,10 +1,10 @@
 import React from 'react';
 
-import { focusElement } from '../../../platform/utilities/ui';
+import { focusElement } from 'platform/utilities/ui';
 import OMBInfo from '@department-of-veterans-affairs/formation-react/OMBInfo';
 import BurialModalContent from 'platform/forms/components/OMBInfoModalContent/BurialModalContent';
 import FormTitle from 'platform/forms-system/src/js/components/FormTitle';
-import SaveInProgressIntro from '../../../platform/forms/save-in-progress/SaveInProgressIntro';
+import SaveInProgressIntro from 'platform/forms/save-in-progress/SaveInProgressIntro';
 import environment from 'platform/utilities/environment';
 
 import facilityLocator from '../../facility-locator/manifest.json';

--- a/src/applications/pre-need/components/IntroductionPage.jsx
+++ b/src/applications/pre-need/components/IntroductionPage.jsx
@@ -1,10 +1,10 @@
 import React from 'react';
 
-import { focusElement } from 'platform/utilities/ui';
+import { focusElement } from '../../../platform/utilities/ui';
 import OMBInfo from '@department-of-veterans-affairs/formation-react/OMBInfo';
 import BurialModalContent from 'platform/forms/components/OMBInfoModalContent/BurialModalContent';
 import FormTitle from 'platform/forms-system/src/js/components/FormTitle';
-import SaveInProgressIntro from 'platform/forms/save-in-progress/SaveInProgressIntro';
+import SaveInProgressIntro from '../../../platform/forms/save-in-progress/SaveInProgressIntro';
 import environment from 'platform/utilities/environment';
 
 import facilityLocator from '../../facility-locator/manifest.json';

--- a/src/applications/pre-need/containers/ConfirmationPage.jsx
+++ b/src/applications/pre-need/containers/ConfirmationPage.jsx
@@ -3,7 +3,7 @@ import moment from 'moment';
 import { connect } from 'react-redux';
 import Scroll from 'react-scroll';
 
-import { focusElement } from '../../../platform/utilities/ui';
+import { focusElement } from 'platform/utilities/ui';
 
 const scroller = Scroll.scroller;
 const scrollToTop = () => {

--- a/src/applications/pre-need/containers/ConfirmationPage.jsx
+++ b/src/applications/pre-need/containers/ConfirmationPage.jsx
@@ -3,7 +3,7 @@ import moment from 'moment';
 import { connect } from 'react-redux';
 import Scroll from 'react-scroll';
 
-import { focusElement } from 'platform/utilities/ui';
+import { focusElement } from '../../../platform/utilities/ui';
 
 const scroller = Scroll.scroller;
 const scrollToTop = () => {

--- a/src/applications/pre-need/definitions/address.js
+++ b/src/applications/pre-need/definitions/address.js
@@ -6,7 +6,7 @@ import {
   states,
   isValidUSZipCode,
   isValidCanPostalCode,
-} from '../../../platform/forms/address';
+} from 'platform/forms/address';
 
 function validatePostalCodes(errors, address) {
   let isValidPostalCode = true;

--- a/src/applications/pre-need/definitions/address.js
+++ b/src/applications/pre-need/definitions/address.js
@@ -6,7 +6,7 @@ import {
   states,
   isValidUSZipCode,
   isValidCanPostalCode,
-} from 'platform/forms/address';
+} from '../../../platform/forms/address';
 
 function validatePostalCodes(errors, address) {
   let isValidPostalCode = true;

--- a/src/applications/pre-need/pre-need-entry.jsx
+++ b/src/applications/pre-need/pre-need-entry.jsx
@@ -1,7 +1,7 @@
-import '../../platform/polyfills';
+import 'platform/polyfills';
 import './sass/pre-need.scss';
 
-import startApp from '../../platform/startup';
+import startApp from 'platform/startup';
 
 import routes from './routes';
 import reducer from './reducer';

--- a/src/applications/pre-need/pre-need-entry.jsx
+++ b/src/applications/pre-need/pre-need-entry.jsx
@@ -1,7 +1,7 @@
-import 'platform/polyfills';
+import '../../platform/polyfills';
 import './sass/pre-need.scss';
 
-import startApp from 'platform/startup';
+import startApp from '../../platform/startup';
 
 import routes from './routes';
 import reducer from './reducer';

--- a/src/applications/pre-need/reducer.js
+++ b/src/applications/pre-need/reducer.js
@@ -1,5 +1,5 @@
 import formConfig from './config/form';
-import { createSaveInProgressFormReducer } from '../../platform/forms/save-in-progress/reducers';
+import { createSaveInProgressFormReducer } from 'platform/forms/save-in-progress/reducers';
 
 export default {
   form: createSaveInProgressFormReducer(formConfig),

--- a/src/applications/pre-need/reducer.js
+++ b/src/applications/pre-need/reducer.js
@@ -1,5 +1,5 @@
 import formConfig from './config/form';
-import { createSaveInProgressFormReducer } from 'platform/forms/save-in-progress/reducers';
+import { createSaveInProgressFormReducer } from '../../platform/forms/save-in-progress/reducers';
 
 export default {
   form: createSaveInProgressFormReducer(formConfig),

--- a/src/applications/pre-need/routes.jsx
+++ b/src/applications/pre-need/routes.jsx
@@ -1,4 +1,4 @@
-import { createRoutesWithSaveInProgress } from '../../platform/forms/save-in-progress/helpers';
+import { createRoutesWithSaveInProgress } from 'platform/forms/save-in-progress/helpers';
 
 import formConfig from './config/form';
 import PreNeedApp from './PreNeedApp.jsx';

--- a/src/applications/pre-need/routes.jsx
+++ b/src/applications/pre-need/routes.jsx
@@ -1,4 +1,4 @@
-import { createRoutesWithSaveInProgress } from 'platform/forms/save-in-progress/helpers';
+import { createRoutesWithSaveInProgress } from '../../platform/forms/save-in-progress/helpers';
 
 import formConfig from './config/form';
 import PreNeedApp from './PreNeedApp.jsx';

--- a/src/applications/pre-need/tests/config/applicantInfo.unit.spec.jsx
+++ b/src/applications/pre-need/tests/config/applicantInfo.unit.spec.jsx
@@ -7,7 +7,7 @@ import {
   DefinitionTester,
   fillData,
   selectRadio,
-} from '../../../../platform/testing/unit/schemaform-utils.jsx';
+} from 'platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form';
 
 describe('Pre-need applicant information', () => {

--- a/src/applications/pre-need/tests/config/applicantInfo.unit.spec.jsx
+++ b/src/applications/pre-need/tests/config/applicantInfo.unit.spec.jsx
@@ -7,7 +7,7 @@ import {
   DefinitionTester,
   fillData,
   selectRadio,
-} from 'platform/testing/unit/schemaform-utils.jsx';
+} from '../../../../platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form';
 
 describe('Pre-need applicant information', () => {

--- a/src/applications/pre-need/tests/config/burialBenefits.unit.spec.jsx
+++ b/src/applications/pre-need/tests/config/burialBenefits.unit.spec.jsx
@@ -7,7 +7,7 @@ import {
   DefinitionTester,
   fillData,
   selectRadio,
-} from '../../../../platform/testing/unit/schemaform-utils';
+} from 'platform/testing/unit/schemaform-utils';
 import formConfig from '../../config/form';
 
 let fetchMock;

--- a/src/applications/pre-need/tests/config/burialBenefits.unit.spec.jsx
+++ b/src/applications/pre-need/tests/config/burialBenefits.unit.spec.jsx
@@ -7,7 +7,7 @@ import {
   DefinitionTester,
   fillData,
   selectRadio,
-} from 'platform/testing/unit/schemaform-utils';
+} from '../../../../platform/testing/unit/schemaform-utils';
 import formConfig from '../../config/form';
 
 let fetchMock;

--- a/src/applications/pre-need/tests/config/contactInformation.unit.spec.jsx
+++ b/src/applications/pre-need/tests/config/contactInformation.unit.spec.jsx
@@ -6,7 +6,7 @@ import { mount } from 'enzyme';
 import {
   DefinitionTester,
   fillData,
-} from '../../../../platform/testing/unit/schemaform-utils.jsx';
+} from 'platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form';
 
 describe('Pre-need applicant contact information', () => {

--- a/src/applications/pre-need/tests/config/contactInformation.unit.spec.jsx
+++ b/src/applications/pre-need/tests/config/contactInformation.unit.spec.jsx
@@ -6,7 +6,7 @@ import { mount } from 'enzyme';
 import {
   DefinitionTester,
   fillData,
-} from 'platform/testing/unit/schemaform-utils.jsx';
+} from '../../../../platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form';
 
 describe('Pre-need applicant contact information', () => {

--- a/src/applications/pre-need/tests/config/documents.unit.spec.jsx
+++ b/src/applications/pre-need/tests/config/documents.unit.spec.jsx
@@ -6,7 +6,7 @@ import ReactTestUtils from 'react-dom/test-utils';
 import {
   DefinitionTester,
   getFormDOM,
-} from '../../../../platform/testing/unit/schemaform-utils.jsx';
+} from 'platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form';
 
 describe('Pre-need attachments', () => {

--- a/src/applications/pre-need/tests/config/documents.unit.spec.jsx
+++ b/src/applications/pre-need/tests/config/documents.unit.spec.jsx
@@ -6,7 +6,7 @@ import ReactTestUtils from 'react-dom/test-utils';
 import {
   DefinitionTester,
   getFormDOM,
-} from 'platform/testing/unit/schemaform-utils.jsx';
+} from '../../../../platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form';
 
 describe('Pre-need attachments', () => {

--- a/src/applications/pre-need/tests/config/preparer.unit.spec.jsx
+++ b/src/applications/pre-need/tests/config/preparer.unit.spec.jsx
@@ -7,7 +7,7 @@ import {
   DefinitionTester,
   fillData,
   selectRadio,
-} from '../../../../platform/testing/unit/schemaform-utils.jsx';
+} from 'platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form';
 
 describe('Pre-need preparer info', () => {

--- a/src/applications/pre-need/tests/config/preparer.unit.spec.jsx
+++ b/src/applications/pre-need/tests/config/preparer.unit.spec.jsx
@@ -7,7 +7,7 @@ import {
   DefinitionTester,
   fillData,
   selectRadio,
-} from 'platform/testing/unit/schemaform-utils.jsx';
+} from '../../../../platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form';
 
 describe('Pre-need preparer info', () => {

--- a/src/applications/pre-need/tests/config/servicePeriods.unit.spec.jsx
+++ b/src/applications/pre-need/tests/config/servicePeriods.unit.spec.jsx
@@ -6,7 +6,7 @@ import { mount } from 'enzyme';
 import {
   DefinitionTester,
   fillDate,
-} from '../../../../platform/testing/unit/schemaform-utils.jsx';
+} from 'platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form';
 
 describe('Pre-need service periods', () => {

--- a/src/applications/pre-need/tests/config/servicePeriods.unit.spec.jsx
+++ b/src/applications/pre-need/tests/config/servicePeriods.unit.spec.jsx
@@ -6,7 +6,7 @@ import { mount } from 'enzyme';
 import {
   DefinitionTester,
   fillDate,
-} from 'platform/testing/unit/schemaform-utils.jsx';
+} from '../../../../platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form';
 
 describe('Pre-need service periods', () => {

--- a/src/applications/pre-need/tests/config/sponsorInfo.unit.spec.jsx
+++ b/src/applications/pre-need/tests/config/sponsorInfo.unit.spec.jsx
@@ -7,7 +7,7 @@ import {
   DefinitionTester,
   fillData,
   selectRadio,
-} from '../../../../platform/testing/unit/schemaform-utils.jsx';
+} from 'platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form';
 
 describe('Pre-need sponsor information', () => {

--- a/src/applications/pre-need/tests/config/sponsorInfo.unit.spec.jsx
+++ b/src/applications/pre-need/tests/config/sponsorInfo.unit.spec.jsx
@@ -7,7 +7,7 @@ import {
   DefinitionTester,
   fillData,
   selectRadio,
-} from 'platform/testing/unit/schemaform-utils.jsx';
+} from '../../../../platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form';
 
 describe('Pre-need sponsor information', () => {

--- a/src/applications/pre-need/tests/config/sponsorMailingAddress.unit.spec.jsx
+++ b/src/applications/pre-need/tests/config/sponsorMailingAddress.unit.spec.jsx
@@ -6,7 +6,7 @@ import { mount } from 'enzyme';
 import {
   DefinitionTester,
   fillData,
-} from '../../../../platform/testing/unit/schemaform-utils.jsx';
+} from 'platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form';
 
 describe('Pre-need sponsor mailing address', () => {

--- a/src/applications/pre-need/tests/config/sponsorMailingAddress.unit.spec.jsx
+++ b/src/applications/pre-need/tests/config/sponsorMailingAddress.unit.spec.jsx
@@ -6,7 +6,7 @@ import { mount } from 'enzyme';
 import {
   DefinitionTester,
   fillData,
-} from 'platform/testing/unit/schemaform-utils.jsx';
+} from '../../../../platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form';
 
 describe('Pre-need sponsor mailing address', () => {

--- a/src/applications/pre-need/tests/config/sponsorMilitaryName.unit.spec.jsx
+++ b/src/applications/pre-need/tests/config/sponsorMilitaryName.unit.spec.jsx
@@ -7,7 +7,7 @@ import {
   DefinitionTester,
   fillData,
   selectRadio,
-} from '../../../../platform/testing/unit/schemaform-utils.jsx';
+} from 'platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form';
 
 describe('Pre-need sponsor military name', () => {

--- a/src/applications/pre-need/tests/config/sponsorMilitaryName.unit.spec.jsx
+++ b/src/applications/pre-need/tests/config/sponsorMilitaryName.unit.spec.jsx
@@ -7,7 +7,7 @@ import {
   DefinitionTester,
   fillData,
   selectRadio,
-} from 'platform/testing/unit/schemaform-utils.jsx';
+} from '../../../../platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form';
 
 describe('Pre-need sponsor military name', () => {

--- a/src/applications/pre-need/tests/config/veteranInfo.unit.spec.jsx
+++ b/src/applications/pre-need/tests/config/veteranInfo.unit.spec.jsx
@@ -7,7 +7,7 @@ import {
   DefinitionTester,
   fillData,
   selectRadio,
-} from '../../../../platform/testing/unit/schemaform-utils.jsx';
+} from 'platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form';
 
 describe('Pre-need veteran information', () => {

--- a/src/applications/pre-need/tests/config/veteranInfo.unit.spec.jsx
+++ b/src/applications/pre-need/tests/config/veteranInfo.unit.spec.jsx
@@ -7,7 +7,7 @@ import {
   DefinitionTester,
   fillData,
   selectRadio,
-} from 'platform/testing/unit/schemaform-utils.jsx';
+} from '../../../../platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form';
 
 describe('Pre-need veteran information', () => {

--- a/src/applications/pre-need/tests/definitions/address.unit.spec.jsx
+++ b/src/applications/pre-need/tests/definitions/address.unit.spec.jsx
@@ -5,7 +5,7 @@ import { mount } from 'enzyme';
 import {
   DefinitionTester,
   fillData,
-} from '../../../../platform/testing/unit/schemaform-utils.jsx';
+} from 'platform/testing/unit/schemaform-utils.jsx';
 import { schema, uiSchema } from '../../definitions/address';
 import { address } from 'vets-json-schema/dist/definitions.json';
 

--- a/src/applications/pre-need/tests/definitions/address.unit.spec.jsx
+++ b/src/applications/pre-need/tests/definitions/address.unit.spec.jsx
@@ -5,7 +5,7 @@ import { mount } from 'enzyme';
 import {
   DefinitionTester,
   fillData,
-} from 'platform/testing/unit/schemaform-utils.jsx';
+} from '../../../../platform/testing/unit/schemaform-utils.jsx';
 import { schema, uiSchema } from '../../definitions/address';
 import { address } from 'vets-json-schema/dist/definitions.json';
 

--- a/src/applications/veteran-representative/config/form.js
+++ b/src/applications/veteran-representative/config/form.js
@@ -2,15 +2,15 @@ import fullSchema from '../2122-schema.json';
 import _ from 'lodash/fp';
 import IntroductionPage from '../containers/IntroductionPage';
 import ConfirmationPage from '../containers/ConfirmationPage';
-import preSubmitInfo from '../../../platform/forms/preSubmitInfo';
+import preSubmitInfo from 'platform/forms/preSubmitInfo';
 
-import fullNameUI from '../../../platform/forms/definitions/fullName';
+import fullNameUI from 'platform/forms/definitions/fullName';
 import ssnUI from 'platform/forms-system/src/js/definitions/ssn';
-import * as addressUI from '../../../platform/forms/definitions/address.js';
+import * as addressUI from 'platform/forms/definitions/address.js';
 import currentOrPastDateUI from 'platform/forms-system/src/js/definitions/currentOrPastDate';
 import phoneUI from 'platform/forms-system/src/js/definitions/phone';
 
-import environment from '../../../platform/utilities/environment';
+import environment from 'platform/utilities/environment';
 
 const {
   veteranFullName,

--- a/src/applications/veteran-representative/config/form.js
+++ b/src/applications/veteran-representative/config/form.js
@@ -2,15 +2,15 @@ import fullSchema from '../2122-schema.json';
 import _ from 'lodash/fp';
 import IntroductionPage from '../containers/IntroductionPage';
 import ConfirmationPage from '../containers/ConfirmationPage';
-import preSubmitInfo from 'platform/forms/preSubmitInfo';
+import preSubmitInfo from '../../../platform/forms/preSubmitInfo';
 
-import fullNameUI from 'platform/forms/definitions/fullName';
+import fullNameUI from '../../../platform/forms/definitions/fullName';
 import ssnUI from 'platform/forms-system/src/js/definitions/ssn';
-import * as addressUI from 'platform/forms/definitions/address.js';
+import * as addressUI from '../../../platform/forms/definitions/address.js';
 import currentOrPastDateUI from 'platform/forms-system/src/js/definitions/currentOrPastDate';
 import phoneUI from 'platform/forms-system/src/js/definitions/phone';
 
-import environment from 'platform/utilities/environment';
+import environment from '../../../platform/utilities/environment';
 
 const {
   veteranFullName,

--- a/src/applications/veteran-representative/containers/App.jsx
+++ b/src/applications/veteran-representative/containers/App.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import RoutedSavableApp from '../../../platform/forms/save-in-progress/RoutedSavableApp';
+import RoutedSavableApp from 'platform/forms/save-in-progress/RoutedSavableApp';
 import formConfig from '../config/form';
 
 export default function App({ location, children }) {

--- a/src/applications/veteran-representative/containers/App.jsx
+++ b/src/applications/veteran-representative/containers/App.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import RoutedSavableApp from 'platform/forms/save-in-progress/RoutedSavableApp';
+import RoutedSavableApp from '../../../platform/forms/save-in-progress/RoutedSavableApp';
 import formConfig from '../config/form';
 
 export default function App({ location, children }) {

--- a/src/applications/veteran-representative/containers/ConfirmationPage.jsx
+++ b/src/applications/veteran-representative/containers/ConfirmationPage.jsx
@@ -3,7 +3,7 @@ import moment from 'moment';
 import { connect } from 'react-redux';
 import Scroll from 'react-scroll';
 
-import { focusElement } from '../../../platform/utilities/ui';
+import { focusElement } from 'platform/utilities/ui';
 
 const scroller = Scroll.scroller;
 const scrollToTop = () => {

--- a/src/applications/veteran-representative/containers/ConfirmationPage.jsx
+++ b/src/applications/veteran-representative/containers/ConfirmationPage.jsx
@@ -3,7 +3,7 @@ import moment from 'moment';
 import { connect } from 'react-redux';
 import Scroll from 'react-scroll';
 
-import { focusElement } from 'platform/utilities/ui';
+import { focusElement } from '../../../platform/utilities/ui';
 
 const scroller = Scroll.scroller;
 const scrollToTop = () => {

--- a/src/applications/veteran-representative/containers/IntroductionPage.jsx
+++ b/src/applications/veteran-representative/containers/IntroductionPage.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
 
-import { focusElement } from '../../../platform/utilities/ui';
+import { focusElement } from 'platform/utilities/ui';
 import OMBInfo from '@department-of-veterans-affairs/formation-react/OMBInfo';
 import FormTitle from 'platform/forms-system/src/js/components/FormTitle';
-import SaveInProgressIntro from '../../../platform/forms/save-in-progress/SaveInProgressIntro';
+import SaveInProgressIntro from 'platform/forms/save-in-progress/SaveInProgressIntro';
 
 class IntroductionPage extends React.Component {
   componentDidMount() {

--- a/src/applications/veteran-representative/containers/IntroductionPage.jsx
+++ b/src/applications/veteran-representative/containers/IntroductionPage.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
 
-import { focusElement } from 'platform/utilities/ui';
+import { focusElement } from '../../../platform/utilities/ui';
 import OMBInfo from '@department-of-veterans-affairs/formation-react/OMBInfo';
 import FormTitle from 'platform/forms-system/src/js/components/FormTitle';
-import SaveInProgressIntro from 'platform/forms/save-in-progress/SaveInProgressIntro';
+import SaveInProgressIntro from '../../../platform/forms/save-in-progress/SaveInProgressIntro';
 
 class IntroductionPage extends React.Component {
   componentDidMount() {

--- a/src/applications/veteran-representative/reducers/index.js
+++ b/src/applications/veteran-representative/reducers/index.js
@@ -1,5 +1,5 @@
 import formConfig from '../config/form';
-import { createSaveInProgressFormReducer } from '../../../platform/forms/save-in-progress/reducers';
+import { createSaveInProgressFormReducer } from 'platform/forms/save-in-progress/reducers';
 
 export default {
   form: createSaveInProgressFormReducer(formConfig),

--- a/src/applications/veteran-representative/reducers/index.js
+++ b/src/applications/veteran-representative/reducers/index.js
@@ -1,5 +1,5 @@
 import formConfig from '../config/form';
-import { createSaveInProgressFormReducer } from 'platform/forms/save-in-progress/reducers';
+import { createSaveInProgressFormReducer } from '../../../platform/forms/save-in-progress/reducers';
 
 export default {
   form: createSaveInProgressFormReducer(formConfig),

--- a/src/applications/veteran-representative/routes.jsx
+++ b/src/applications/veteran-representative/routes.jsx
@@ -1,4 +1,4 @@
-import { createRoutesWithSaveInProgress } from '../../platform/forms/save-in-progress/helpers';
+import { createRoutesWithSaveInProgress } from 'platform/forms/save-in-progress/helpers';
 
 import formConfig from './config/form';
 import App from './containers/App.jsx';

--- a/src/applications/veteran-representative/routes.jsx
+++ b/src/applications/veteran-representative/routes.jsx
@@ -1,4 +1,4 @@
-import { createRoutesWithSaveInProgress } from 'platform/forms/save-in-progress/helpers';
+import { createRoutesWithSaveInProgress } from '../../platform/forms/save-in-progress/helpers';
 
 import formConfig from './config/form';
 import App from './containers/App.jsx';

--- a/src/applications/veteran-representative/tests/config/authorizationForRepresentativeAccessToRecords.unit.spec.jsx
+++ b/src/applications/veteran-representative/tests/config/authorizationForRepresentativeAccessToRecords.unit.spec.jsx
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import { mount } from 'enzyme';
 
-import { DefinitionTester } from '../../../../platform/testing/unit/schemaform-utils.jsx';
+import { DefinitionTester } from 'platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form.js';
 
 describe('authorization for representative access to records', () => {

--- a/src/applications/veteran-representative/tests/config/authorizationForRepresentativeAccessToRecords.unit.spec.jsx
+++ b/src/applications/veteran-representative/tests/config/authorizationForRepresentativeAccessToRecords.unit.spec.jsx
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import { mount } from 'enzyme';
 
-import { DefinitionTester } from 'platform/testing/unit/schemaform-utils.jsx';
+import { DefinitionTester } from '../../../../platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form.js';
 
 describe('authorization for representative access to records', () => {

--- a/src/applications/veteran-representative/tests/config/authorizationToChangeClaimantAddress.unit.spec.jsx
+++ b/src/applications/veteran-representative/tests/config/authorizationToChangeClaimantAddress.unit.spec.jsx
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import { mount } from 'enzyme';
 
-import { DefinitionTester } from '../../../../platform/testing/unit/schemaform-utils.jsx';
+import { DefinitionTester } from 'platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form.js';
 
 describe('authorization to change claimant address', () => {

--- a/src/applications/veteran-representative/tests/config/authorizationToChangeClaimantAddress.unit.spec.jsx
+++ b/src/applications/veteran-representative/tests/config/authorizationToChangeClaimantAddress.unit.spec.jsx
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import { mount } from 'enzyme';
 
-import { DefinitionTester } from 'platform/testing/unit/schemaform-utils.jsx';
+import { DefinitionTester } from '../../../../platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form.js';
 
 describe('authorization to change claimant address', () => {

--- a/src/applications/veteran-representative/tests/config/claimantInformation.unit.spec.jsx
+++ b/src/applications/veteran-representative/tests/config/claimantInformation.unit.spec.jsx
@@ -6,7 +6,7 @@ import { mount } from 'enzyme';
 import {
   DefinitionTester,
   fillData,
-} from '../../../../platform/testing/unit/schemaform-utils.jsx';
+} from 'platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form.js';
 
 describe('claimant information', () => {

--- a/src/applications/veteran-representative/tests/config/claimantInformation.unit.spec.jsx
+++ b/src/applications/veteran-representative/tests/config/claimantInformation.unit.spec.jsx
@@ -6,7 +6,7 @@ import { mount } from 'enzyme';
 import {
   DefinitionTester,
   fillData,
-} from 'platform/testing/unit/schemaform-utils.jsx';
+} from '../../../../platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form.js';
 
 describe('claimant information', () => {

--- a/src/applications/veteran-representative/tests/config/limitationOfConsent.unit.spec.jsx
+++ b/src/applications/veteran-representative/tests/config/limitationOfConsent.unit.spec.jsx
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import { mount } from 'enzyme';
 
-import { DefinitionTester } from '../../../../platform/testing/unit/schemaform-utils.jsx';
+import { DefinitionTester } from 'platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form.js';
 
 describe('limitation of consent', () => {

--- a/src/applications/veteran-representative/tests/config/limitationOfConsent.unit.spec.jsx
+++ b/src/applications/veteran-representative/tests/config/limitationOfConsent.unit.spec.jsx
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import { mount } from 'enzyme';
 
-import { DefinitionTester } from 'platform/testing/unit/schemaform-utils.jsx';
+import { DefinitionTester } from '../../../../platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form.js';
 
 describe('limitation of consent', () => {

--- a/src/applications/veteran-representative/tests/config/veteranInformation.unit.spec.jsx
+++ b/src/applications/veteran-representative/tests/config/veteranInformation.unit.spec.jsx
@@ -6,7 +6,7 @@ import { mount } from 'enzyme';
 import {
   DefinitionTester,
   fillData,
-} from '../../../../platform/testing/unit/schemaform-utils.jsx';
+} from 'platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form.js';
 
 describe('claimant information', () => {

--- a/src/applications/veteran-representative/tests/config/veteranInformation.unit.spec.jsx
+++ b/src/applications/veteran-representative/tests/config/veteranInformation.unit.spec.jsx
@@ -6,7 +6,7 @@ import { mount } from 'enzyme';
 import {
   DefinitionTester,
   fillData,
-} from 'platform/testing/unit/schemaform-utils.jsx';
+} from '../../../../platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form.js';
 
 describe('claimant information', () => {

--- a/src/applications/veteran-representative/tests/config/veteranServiceOrganization.unit.spec.jsx
+++ b/src/applications/veteran-representative/tests/config/veteranServiceOrganization.unit.spec.jsx
@@ -6,7 +6,7 @@ import { mount } from 'enzyme';
 import {
   DefinitionTester,
   fillData,
-} from '../../../../platform/testing/unit/schemaform-utils.jsx';
+} from 'platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form.js';
 
 describe('veteran service organization information', () => {

--- a/src/applications/veteran-representative/tests/config/veteranServiceOrganization.unit.spec.jsx
+++ b/src/applications/veteran-representative/tests/config/veteranServiceOrganization.unit.spec.jsx
@@ -6,7 +6,7 @@ import { mount } from 'enzyme';
 import {
   DefinitionTester,
   fillData,
-} from 'platform/testing/unit/schemaform-utils.jsx';
+} from '../../../../platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form.js';
 
 describe('veteran service organization information', () => {

--- a/src/applications/veteran-representative/veteran-representative-entry.jsx
+++ b/src/applications/veteran-representative/veteran-representative-entry.jsx
@@ -1,7 +1,7 @@
-import '../../platform/polyfills';
+import 'platform/polyfills';
 import './sass/veteran-representative.scss';
 
-import startApp from '../../platform/startup';
+import startApp from 'platform/startup';
 
 import routes from './routes';
 import reducer from './reducers';

--- a/src/applications/veteran-representative/veteran-representative-entry.jsx
+++ b/src/applications/veteran-representative/veteran-representative-entry.jsx
@@ -1,7 +1,7 @@
-import 'platform/polyfills';
+import '../../platform/polyfills';
 import './sass/veteran-representative.scss';
 
-import startApp from 'platform/startup';
+import startApp from '../../platform/startup';
 
 import routes from './routes';
 import reducer from './reducers';

--- a/src/applications/vre/chapter31/Chapter31App.jsx
+++ b/src/applications/vre/chapter31/Chapter31App.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import RoutedSavableApp from '../../../platform/forms/save-in-progress/RoutedSavableApp';
+import RoutedSavableApp from 'platform/forms/save-in-progress/RoutedSavableApp';
 import formConfig from './config/form';
 
 export default function Chapter31App({ location, children }) {

--- a/src/applications/vre/chapter31/Chapter31App.jsx
+++ b/src/applications/vre/chapter31/Chapter31App.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import RoutedSavableApp from 'platform/forms/save-in-progress/RoutedSavableApp';
+import RoutedSavableApp from '../../../platform/forms/save-in-progress/RoutedSavableApp';
 import formConfig from './config/form';
 
 export default function Chapter31App({ location, children }) {

--- a/src/applications/vre/chapter31/chapter31-entry.jsx
+++ b/src/applications/vre/chapter31/chapter31-entry.jsx
@@ -1,7 +1,7 @@
-import '../../../platform/polyfills';
+import 'platform/polyfills';
 import '../sass/vre.scss';
 
-import startApp from '../../../platform/startup';
+import startApp from 'platform/startup';
 
 import routes from './routes';
 import reducer from './reducer';

--- a/src/applications/vre/chapter31/chapter31-entry.jsx
+++ b/src/applications/vre/chapter31/chapter31-entry.jsx
@@ -1,7 +1,7 @@
-import 'platform/polyfills';
+import '../../../platform/polyfills';
 import '../sass/vre.scss';
 
-import startApp from 'platform/startup';
+import startApp from '../../../platform/startup';
 
 import routes from './routes';
 import reducer from './reducer';

--- a/src/applications/vre/chapter31/components/IntroductionPage.jsx
+++ b/src/applications/vre/chapter31/components/IntroductionPage.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { focusElement } from '../../../../platform/utilities/ui';
-import SaveInProgressIntro from '../../../../platform/forms/save-in-progress/SaveInProgressIntro';
+import { focusElement } from 'platform/utilities/ui';
+import SaveInProgressIntro from 'platform/forms/save-in-progress/SaveInProgressIntro';
 import FormTitle from 'platform/forms-system/src/js/components/FormTitle';
 import OMBInfo from '@department-of-veterans-affairs/formation-react/OMBInfo';
 

--- a/src/applications/vre/chapter31/components/IntroductionPage.jsx
+++ b/src/applications/vre/chapter31/components/IntroductionPage.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { focusElement } from 'platform/utilities/ui';
-import SaveInProgressIntro from 'platform/forms/save-in-progress/SaveInProgressIntro';
+import { focusElement } from '../../../../platform/utilities/ui';
+import SaveInProgressIntro from '../../../../platform/forms/save-in-progress/SaveInProgressIntro';
 import FormTitle from 'platform/forms-system/src/js/components/FormTitle';
 import OMBInfo from '@department-of-veterans-affairs/formation-react/OMBInfo';
 

--- a/src/applications/vre/chapter31/config/form.js
+++ b/src/applications/vre/chapter31/config/form.js
@@ -2,7 +2,7 @@ import _ from 'lodash/fp';
 
 import fullSchema31 from 'vets-json-schema/dist/28-1900-schema.json';
 
-import * as address from '../../../../platform/forms/definitions/address';
+import * as address from 'platform/forms/definitions/address';
 import currencyUI from 'platform/forms-system/src/js/definitions/currency';
 import phoneUI from 'platform/forms-system/src/js/definitions/phone';
 import emailUI from 'platform/forms-system/src/js/definitions/email';
@@ -11,14 +11,14 @@ import IntroductionPage from '../components/IntroductionPage';
 import ConfirmationPage from '../containers/ConfirmationPage';
 import EducationPeriodView from '../components/EducationPeriodView';
 
-import ServicePeriodView from '../../../../platform/forms/components/ServicePeriodView';
+import ServicePeriodView from 'platform/forms/components/ServicePeriodView';
 import dateRangeUI from 'platform/forms-system/src/js/definitions/dateRange';
 import fileUploadUI from 'platform/forms-system/src/js/definitions/file';
 import yearUI from 'platform/forms-system/src/js/definitions/year';
 
-import FormFooter from '../../../../platform/forms/components/FormFooter';
-import environment from '../../../../platform/utilities/environment';
-import preSubmitInfo from '../../../../platform/forms/preSubmitInfo';
+import FormFooter from 'platform/forms/components/FormFooter';
+import environment from 'platform/utilities/environment';
+import preSubmitInfo from 'platform/forms/preSubmitInfo';
 
 import {
   disabilityRatingLabels,

--- a/src/applications/vre/chapter31/config/form.js
+++ b/src/applications/vre/chapter31/config/form.js
@@ -2,7 +2,7 @@ import _ from 'lodash/fp';
 
 import fullSchema31 from 'vets-json-schema/dist/28-1900-schema.json';
 
-import * as address from 'platform/forms/definitions/address';
+import * as address from '../../../../platform/forms/definitions/address';
 import currencyUI from 'platform/forms-system/src/js/definitions/currency';
 import phoneUI from 'platform/forms-system/src/js/definitions/phone';
 import emailUI from 'platform/forms-system/src/js/definitions/email';
@@ -11,14 +11,14 @@ import IntroductionPage from '../components/IntroductionPage';
 import ConfirmationPage from '../containers/ConfirmationPage';
 import EducationPeriodView from '../components/EducationPeriodView';
 
-import ServicePeriodView from 'platform/forms/components/ServicePeriodView';
+import ServicePeriodView from '../../../../platform/forms/components/ServicePeriodView';
 import dateRangeUI from 'platform/forms-system/src/js/definitions/dateRange';
 import fileUploadUI from 'platform/forms-system/src/js/definitions/file';
 import yearUI from 'platform/forms-system/src/js/definitions/year';
 
-import FormFooter from 'platform/forms/components/FormFooter';
-import environment from 'platform/utilities/environment';
-import preSubmitInfo from 'platform/forms/preSubmitInfo';
+import FormFooter from '../../../../platform/forms/components/FormFooter';
+import environment from '../../../../platform/utilities/environment';
+import preSubmitInfo from '../../../../platform/forms/preSubmitInfo';
 
 import {
   disabilityRatingLabels,

--- a/src/applications/vre/chapter31/containers/ConfirmationPage.jsx
+++ b/src/applications/vre/chapter31/containers/ConfirmationPage.jsx
@@ -3,8 +3,8 @@ import { connect } from 'react-redux';
 import Scroll from 'react-scroll';
 import moment from 'moment';
 
-import { focusElement } from '../../../../platform/utilities/ui';
-import FormFooter from '../../../../platform/forms/components/FormFooter';
+import { focusElement } from 'platform/utilities/ui';
+import FormFooter from 'platform/forms/components/FormFooter';
 import GetFormHelp from '../../components/GetFormHelp';
 
 const scroller = Scroll.scroller;

--- a/src/applications/vre/chapter31/containers/ConfirmationPage.jsx
+++ b/src/applications/vre/chapter31/containers/ConfirmationPage.jsx
@@ -3,8 +3,8 @@ import { connect } from 'react-redux';
 import Scroll from 'react-scroll';
 import moment from 'moment';
 
-import { focusElement } from 'platform/utilities/ui';
-import FormFooter from 'platform/forms/components/FormFooter';
+import { focusElement } from '../../../../platform/utilities/ui';
+import FormFooter from '../../../../platform/forms/components/FormFooter';
 import GetFormHelp from '../../components/GetFormHelp';
 
 const scroller = Scroll.scroller;

--- a/src/applications/vre/chapter31/reducer.js
+++ b/src/applications/vre/chapter31/reducer.js
@@ -1,5 +1,5 @@
 import formConfig from './config/form';
-import { createSaveInProgressFormReducer } from '../../../platform/forms/save-in-progress/reducers';
+import { createSaveInProgressFormReducer } from 'platform/forms/save-in-progress/reducers';
 
 export default {
   form: createSaveInProgressFormReducer(formConfig),

--- a/src/applications/vre/chapter31/reducer.js
+++ b/src/applications/vre/chapter31/reducer.js
@@ -1,5 +1,5 @@
 import formConfig from './config/form';
-import { createSaveInProgressFormReducer } from 'platform/forms/save-in-progress/reducers';
+import { createSaveInProgressFormReducer } from '../../../platform/forms/save-in-progress/reducers';
 
 export default {
   form: createSaveInProgressFormReducer(formConfig),

--- a/src/applications/vre/chapter31/routes.jsx
+++ b/src/applications/vre/chapter31/routes.jsx
@@ -1,4 +1,4 @@
-import { createRoutesWithSaveInProgress } from '../../../platform/forms/save-in-progress/helpers';
+import { createRoutesWithSaveInProgress } from 'platform/forms/save-in-progress/helpers';
 
 import formConfig from './config/form';
 import Chapter31App from './Chapter31App.jsx';

--- a/src/applications/vre/chapter31/routes.jsx
+++ b/src/applications/vre/chapter31/routes.jsx
@@ -1,4 +1,4 @@
-import { createRoutesWithSaveInProgress } from 'platform/forms/save-in-progress/helpers';
+import { createRoutesWithSaveInProgress } from '../../../platform/forms/save-in-progress/helpers';
 
 import formConfig from './config/form';
 import Chapter31App from './Chapter31App.jsx';

--- a/src/applications/vre/chapter36/Chapter36App.jsx
+++ b/src/applications/vre/chapter36/Chapter36App.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import RoutedSavableApp from '../../../platform/forms/save-in-progress/RoutedSavableApp';
+import RoutedSavableApp from 'platform/forms/save-in-progress/RoutedSavableApp';
 import formConfig from './config/form';
 
 export default function Chapter36App({ location, children }) {

--- a/src/applications/vre/chapter36/Chapter36App.jsx
+++ b/src/applications/vre/chapter36/Chapter36App.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import RoutedSavableApp from 'platform/forms/save-in-progress/RoutedSavableApp';
+import RoutedSavableApp from '../../../platform/forms/save-in-progress/RoutedSavableApp';
 import formConfig from './config/form';
 
 export default function Chapter36App({ location, children }) {

--- a/src/applications/vre/chapter36/chapter36-entry.jsx
+++ b/src/applications/vre/chapter36/chapter36-entry.jsx
@@ -1,7 +1,7 @@
-import '../../../platform/polyfills';
+import 'platform/polyfills';
 import '../sass/vre.scss';
 
-import startApp from '../../../platform/startup';
+import startApp from 'platform/startup';
 
 import routes from './routes';
 import reducer from './reducer';

--- a/src/applications/vre/chapter36/chapter36-entry.jsx
+++ b/src/applications/vre/chapter36/chapter36-entry.jsx
@@ -1,7 +1,7 @@
-import 'platform/polyfills';
+import '../../../platform/polyfills';
 import '../sass/vre.scss';
 
-import startApp from 'platform/startup';
+import startApp from '../../../platform/startup';
 
 import routes from './routes';
 import reducer from './reducer';

--- a/src/applications/vre/chapter36/components/IntroductionPage.jsx
+++ b/src/applications/vre/chapter36/components/IntroductionPage.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
 
-import { focusElement } from '../../../../platform/utilities/ui';
+import { focusElement } from 'platform/utilities/ui';
 import OMBInfo from '@department-of-veterans-affairs/formation-react/OMBInfo';
 import FormTitle from 'platform/forms-system/src/js/components/FormTitle';
-import SaveInProgressIntro from '../../../../platform/forms/save-in-progress/SaveInProgressIntro';
+import SaveInProgressIntro from 'platform/forms/save-in-progress/SaveInProgressIntro';
 
 class IntroductionPage extends React.Component {
   componentDidMount() {

--- a/src/applications/vre/chapter36/components/IntroductionPage.jsx
+++ b/src/applications/vre/chapter36/components/IntroductionPage.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
 
-import { focusElement } from 'platform/utilities/ui';
+import { focusElement } from '../../../../platform/utilities/ui';
 import OMBInfo from '@department-of-veterans-affairs/formation-react/OMBInfo';
 import FormTitle from 'platform/forms-system/src/js/components/FormTitle';
-import SaveInProgressIntro from 'platform/forms/save-in-progress/SaveInProgressIntro';
+import SaveInProgressIntro from '../../../../platform/forms/save-in-progress/SaveInProgressIntro';
 
 class IntroductionPage extends React.Component {
   componentDidMount() {

--- a/src/applications/vre/chapter36/config/form.js
+++ b/src/applications/vre/chapter36/config/form.js
@@ -2,27 +2,27 @@ import _ from 'lodash/fp';
 
 import fullSchema36 from 'vets-json-schema/dist/28-8832-schema.json';
 
-import { genderLabels } from '../../../../platform/static-data/labels.jsx';
+import { genderLabels } from 'platform/static-data/labels.jsx';
 
-import * as address from '../../../../platform/forms/definitions/address';
+import * as address from 'platform/forms/definitions/address';
 import { benefitsLabels, dischargeTypeLabels } from '../../utils/labels.jsx';
 import IntroductionPage from '../components/IntroductionPage';
 import ConfirmationPage from '../containers/ConfirmationPage';
 import { transform } from '../helpers';
 import createVeteranInfoPage from '../../pages/veteranInfo';
 
-import ServicePeriodView from '../../../../platform/forms/components/ServicePeriodView';
+import ServicePeriodView from 'platform/forms/components/ServicePeriodView';
 import dateRangeUI from 'platform/forms-system/src/js/definitions/dateRange';
 import currentOrPastDateUI from 'platform/forms-system/src/js/definitions/currentOrPastDate';
-import fullNameUI from '../../../../platform/forms/definitions/fullName';
+import fullNameUI from 'platform/forms/definitions/fullName';
 import phoneUI from 'platform/forms-system/src/js/definitions/phone';
 import emailUI from 'platform/forms-system/src/js/definitions/email';
 import ssnUI from 'platform/forms-system/src/js/definitions/ssn';
 import { validateMatch } from 'platform/forms-system/src/js/validation';
 
-import FormFooter from '../../../../platform/forms/components/FormFooter';
-import preSubmitInfo from '../../../../platform/forms/preSubmitInfo';
-// import environment from '../../../../platform/utilities/environment';
+import FormFooter from 'platform/forms/components/FormFooter';
+import preSubmitInfo from 'platform/forms/preSubmitInfo';
+// import environment from 'platform/utilities/environment';
 
 const {
   applicantEmail,

--- a/src/applications/vre/chapter36/config/form.js
+++ b/src/applications/vre/chapter36/config/form.js
@@ -2,27 +2,27 @@ import _ from 'lodash/fp';
 
 import fullSchema36 from 'vets-json-schema/dist/28-8832-schema.json';
 
-import { genderLabels } from 'platform/static-data/labels.jsx';
+import { genderLabels } from '../../../../platform/static-data/labels.jsx';
 
-import * as address from 'platform/forms/definitions/address';
+import * as address from '../../../../platform/forms/definitions/address';
 import { benefitsLabels, dischargeTypeLabels } from '../../utils/labels.jsx';
 import IntroductionPage from '../components/IntroductionPage';
 import ConfirmationPage from '../containers/ConfirmationPage';
 import { transform } from '../helpers';
 import createVeteranInfoPage from '../../pages/veteranInfo';
 
-import ServicePeriodView from 'platform/forms/components/ServicePeriodView';
+import ServicePeriodView from '../../../../platform/forms/components/ServicePeriodView';
 import dateRangeUI from 'platform/forms-system/src/js/definitions/dateRange';
 import currentOrPastDateUI from 'platform/forms-system/src/js/definitions/currentOrPastDate';
-import fullNameUI from 'platform/forms/definitions/fullName';
+import fullNameUI from '../../../../platform/forms/definitions/fullName';
 import phoneUI from 'platform/forms-system/src/js/definitions/phone';
 import emailUI from 'platform/forms-system/src/js/definitions/email';
 import ssnUI from 'platform/forms-system/src/js/definitions/ssn';
 import { validateMatch } from 'platform/forms-system/src/js/validation';
 
-import FormFooter from 'platform/forms/components/FormFooter';
-import preSubmitInfo from 'platform/forms/preSubmitInfo';
-// import environment from 'platform/utilities/environment';
+import FormFooter from '../../../../platform/forms/components/FormFooter';
+import preSubmitInfo from '../../../../platform/forms/preSubmitInfo';
+// import environment from '../../../../platform/utilities/environment';
 
 const {
   applicantEmail,

--- a/src/applications/vre/chapter36/containers/ConfirmationPage.jsx
+++ b/src/applications/vre/chapter36/containers/ConfirmationPage.jsx
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 import Scroll from 'react-scroll';
 import moment from 'moment';
 
-import { focusElement } from '../../../../platform/utilities/ui';
+import { focusElement } from 'platform/utilities/ui';
 
 const scroller = Scroll.scroller;
 const scrollToTop = () => {

--- a/src/applications/vre/chapter36/containers/ConfirmationPage.jsx
+++ b/src/applications/vre/chapter36/containers/ConfirmationPage.jsx
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 import Scroll from 'react-scroll';
 import moment from 'moment';
 
-import { focusElement } from 'platform/utilities/ui';
+import { focusElement } from '../../../../platform/utilities/ui';
 
 const scroller = Scroll.scroller;
 const scrollToTop = () => {

--- a/src/applications/vre/chapter36/reducer.js
+++ b/src/applications/vre/chapter36/reducer.js
@@ -1,5 +1,5 @@
 import formConfig from './config/form';
-import { createSaveInProgressFormReducer } from '../../../platform/forms/save-in-progress/reducers';
+import { createSaveInProgressFormReducer } from 'platform/forms/save-in-progress/reducers';
 
 export default {
   form: createSaveInProgressFormReducer(formConfig),

--- a/src/applications/vre/chapter36/reducer.js
+++ b/src/applications/vre/chapter36/reducer.js
@@ -1,5 +1,5 @@
 import formConfig from './config/form';
-import { createSaveInProgressFormReducer } from 'platform/forms/save-in-progress/reducers';
+import { createSaveInProgressFormReducer } from '../../../platform/forms/save-in-progress/reducers';
 
 export default {
   form: createSaveInProgressFormReducer(formConfig),

--- a/src/applications/vre/chapter36/routes.jsx
+++ b/src/applications/vre/chapter36/routes.jsx
@@ -1,4 +1,4 @@
-import { createRoutesWithSaveInProgress } from '../../../platform/forms/save-in-progress/helpers';
+import { createRoutesWithSaveInProgress } from 'platform/forms/save-in-progress/helpers';
 
 import formConfig from './config/form';
 import Chapter36App from './Chapter36App.jsx';

--- a/src/applications/vre/chapter36/routes.jsx
+++ b/src/applications/vre/chapter36/routes.jsx
@@ -1,4 +1,4 @@
-import { createRoutesWithSaveInProgress } from 'platform/forms/save-in-progress/helpers';
+import { createRoutesWithSaveInProgress } from '../../../platform/forms/save-in-progress/helpers';
 
 import formConfig from './config/form';
 import Chapter36App from './Chapter36App.jsx';

--- a/src/applications/vre/pages/veteranInfo.js
+++ b/src/applications/vre/pages/veteranInfo.js
@@ -1,7 +1,7 @@
 import _ from 'lodash/fp';
 
 import currentOrPastDateUI from 'platform/forms-system/src/js/definitions/currentOrPastDate';
-import fullNameUI from '../../../platform/forms/definitions/fullName';
+import fullNameUI from 'platform/forms/definitions/fullName';
 import ssnUI from 'platform/forms-system/src/js/definitions/ssn';
 
 export default function createVeteranInfoPage(formSchema, extra) {

--- a/src/applications/vre/pages/veteranInfo.js
+++ b/src/applications/vre/pages/veteranInfo.js
@@ -1,7 +1,7 @@
 import _ from 'lodash/fp';
 
 import currentOrPastDateUI from 'platform/forms-system/src/js/definitions/currentOrPastDate';
-import fullNameUI from 'platform/forms/definitions/fullName';
+import fullNameUI from '../../../platform/forms/definitions/fullName';
 import ssnUI from 'platform/forms-system/src/js/definitions/ssn';
 
 export default function createVeteranInfoPage(formSchema, extra) {

--- a/src/applications/vre/tests/chapter31/config/contactInformation.unit.spec.jsx
+++ b/src/applications/vre/tests/chapter31/config/contactInformation.unit.spec.jsx
@@ -6,7 +6,7 @@ import { mount } from 'enzyme';
 import {
   DefinitionTester,
   fillData,
-} from '../../../../../platform/testing/unit/schemaform-utils.jsx';
+} from 'platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../../chapter31/config/form.js';
 
 describe('VRE chapter 31 contact information', () => {

--- a/src/applications/vre/tests/chapter31/config/contactInformation.unit.spec.jsx
+++ b/src/applications/vre/tests/chapter31/config/contactInformation.unit.spec.jsx
@@ -6,7 +6,7 @@ import { mount } from 'enzyme';
 import {
   DefinitionTester,
   fillData,
-} from 'platform/testing/unit/schemaform-utils.jsx';
+} from '../../../../../platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../../chapter31/config/form.js';
 
 describe('VRE chapter 31 contact information', () => {

--- a/src/applications/vre/tests/chapter31/config/disabilityInformation.unit.spec.jsx
+++ b/src/applications/vre/tests/chapter31/config/disabilityInformation.unit.spec.jsx
@@ -7,7 +7,7 @@ import {
   DefinitionTester,
   fillData,
   selectRadio,
-} from '../../../../../platform/testing/unit/schemaform-utils.jsx';
+} from 'platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../../chapter31/config/form.js';
 
 describe('VRE chapter 31 disability information', () => {

--- a/src/applications/vre/tests/chapter31/config/disabilityInformation.unit.spec.jsx
+++ b/src/applications/vre/tests/chapter31/config/disabilityInformation.unit.spec.jsx
@@ -7,7 +7,7 @@ import {
   DefinitionTester,
   fillData,
   selectRadio,
-} from 'platform/testing/unit/schemaform-utils.jsx';
+} from '../../../../../platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../../chapter31/config/form.js';
 
 describe('VRE chapter 31 disability information', () => {

--- a/src/applications/vre/tests/chapter31/config/educationInformation.unit.spec.jsx
+++ b/src/applications/vre/tests/chapter31/config/educationInformation.unit.spec.jsx
@@ -6,7 +6,7 @@ import { mount } from 'enzyme';
 import {
   DefinitionTester,
   fillData,
-} from '../../../../../platform/testing/unit/schemaform-utils.jsx';
+} from 'platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../../chapter31/config/form.js';
 
 describe('VRE chapter 31 education information', () => {

--- a/src/applications/vre/tests/chapter31/config/educationInformation.unit.spec.jsx
+++ b/src/applications/vre/tests/chapter31/config/educationInformation.unit.spec.jsx
@@ -6,7 +6,7 @@ import { mount } from 'enzyme';
 import {
   DefinitionTester,
   fillData,
-} from 'platform/testing/unit/schemaform-utils.jsx';
+} from '../../../../../platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../../chapter31/config/form.js';
 
 describe('VRE chapter 31 education information', () => {

--- a/src/applications/vre/tests/chapter31/config/militaryHistory.unit.spec.jsx
+++ b/src/applications/vre/tests/chapter31/config/militaryHistory.unit.spec.jsx
@@ -6,7 +6,7 @@ import { mount } from 'enzyme';
 import {
   DefinitionTester,
   fillData,
-} from '../../../../../platform/testing/unit/schemaform-utils.jsx';
+} from 'platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../../chapter31/config/form.js';
 
 describe('VRE chapter 31 military history', () => {

--- a/src/applications/vre/tests/chapter31/config/militaryHistory.unit.spec.jsx
+++ b/src/applications/vre/tests/chapter31/config/militaryHistory.unit.spec.jsx
@@ -6,7 +6,7 @@ import { mount } from 'enzyme';
 import {
   DefinitionTester,
   fillData,
-} from 'platform/testing/unit/schemaform-utils.jsx';
+} from '../../../../../platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../../chapter31/config/form.js';
 
 describe('VRE chapter 31 military history', () => {

--- a/src/applications/vre/tests/chapter31/config/veteranAddress.unit.spec.jsx
+++ b/src/applications/vre/tests/chapter31/config/veteranAddress.unit.spec.jsx
@@ -7,7 +7,7 @@ import {
   DefinitionTester,
   fillData,
   selectRadio,
-} from '../../../../../platform/testing/unit/schemaform-utils.jsx';
+} from 'platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../../chapter31/config/form.js';
 
 describe('VRE chapter 31 applicant address', () => {

--- a/src/applications/vre/tests/chapter31/config/veteranAddress.unit.spec.jsx
+++ b/src/applications/vre/tests/chapter31/config/veteranAddress.unit.spec.jsx
@@ -7,7 +7,7 @@ import {
   DefinitionTester,
   fillData,
   selectRadio,
-} from 'platform/testing/unit/schemaform-utils.jsx';
+} from '../../../../../platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../../chapter31/config/form.js';
 
 describe('VRE chapter 31 applicant address', () => {

--- a/src/applications/vre/tests/chapter31/config/veteranInformation.unit.spec.jsx
+++ b/src/applications/vre/tests/chapter31/config/veteranInformation.unit.spec.jsx
@@ -6,7 +6,7 @@ import { mount } from 'enzyme';
 import {
   DefinitionTester,
   fillData,
-} from '../../../../../platform/testing/unit/schemaform-utils.jsx';
+} from 'platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../../chapter31/config/form.js';
 
 describe('VRE chapter 31 veteran information', () => {

--- a/src/applications/vre/tests/chapter31/config/veteranInformation.unit.spec.jsx
+++ b/src/applications/vre/tests/chapter31/config/veteranInformation.unit.spec.jsx
@@ -6,7 +6,7 @@ import { mount } from 'enzyme';
 import {
   DefinitionTester,
   fillData,
-} from 'platform/testing/unit/schemaform-utils.jsx';
+} from '../../../../../platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../../chapter31/config/form.js';
 
 describe('VRE chapter 31 veteran information', () => {

--- a/src/applications/vre/tests/chapter31/config/workInformation.unit.spec.jsx
+++ b/src/applications/vre/tests/chapter31/config/workInformation.unit.spec.jsx
@@ -7,7 +7,7 @@ import {
   DefinitionTester,
   fillData,
   selectRadio,
-} from '../../../../../platform/testing/unit/schemaform-utils.jsx';
+} from 'platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../../chapter31/config/form.js';
 
 describe('VRE chapter 31 work information', () => {

--- a/src/applications/vre/tests/chapter31/config/workInformation.unit.spec.jsx
+++ b/src/applications/vre/tests/chapter31/config/workInformation.unit.spec.jsx
@@ -7,7 +7,7 @@ import {
   DefinitionTester,
   fillData,
   selectRadio,
-} from 'platform/testing/unit/schemaform-utils.jsx';
+} from '../../../../../platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../../chapter31/config/form.js';
 
 describe('VRE chapter 31 work information', () => {

--- a/src/applications/vre/tests/chapter36/config/additionalInformation.unit.spec.jsx
+++ b/src/applications/vre/tests/chapter36/config/additionalInformation.unit.spec.jsx
@@ -7,7 +7,7 @@ import {
   DefinitionTester,
   selectCheckbox,
   selectRadio,
-} from '../../../../../platform/testing/unit/schemaform-utils.jsx';
+} from 'platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../../chapter36/config/form.js';
 
 describe('VRE chapter 36 applicant additional information', () => {

--- a/src/applications/vre/tests/chapter36/config/additionalInformation.unit.spec.jsx
+++ b/src/applications/vre/tests/chapter36/config/additionalInformation.unit.spec.jsx
@@ -7,7 +7,7 @@ import {
   DefinitionTester,
   selectCheckbox,
   selectRadio,
-} from 'platform/testing/unit/schemaform-utils.jsx';
+} from '../../../../../platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../../chapter36/config/form.js';
 
 describe('VRE chapter 36 applicant additional information', () => {

--- a/src/applications/vre/tests/chapter36/config/applicantAddress.unit.spec.jsx
+++ b/src/applications/vre/tests/chapter36/config/applicantAddress.unit.spec.jsx
@@ -6,7 +6,7 @@ import { mount } from 'enzyme';
 import {
   DefinitionTester,
   fillData,
-} from '../../../../../platform/testing/unit/schemaform-utils.jsx';
+} from 'platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../../chapter36/config/form.js';
 
 describe('VRE chapter 36 applicant address', () => {

--- a/src/applications/vre/tests/chapter36/config/applicantAddress.unit.spec.jsx
+++ b/src/applications/vre/tests/chapter36/config/applicantAddress.unit.spec.jsx
@@ -6,7 +6,7 @@ import { mount } from 'enzyme';
 import {
   DefinitionTester,
   fillData,
-} from 'platform/testing/unit/schemaform-utils.jsx';
+} from '../../../../../platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../../chapter36/config/form.js';
 
 describe('VRE chapter 36 applicant address', () => {

--- a/src/applications/vre/tests/chapter36/config/applicantInformation.unit.spec.jsx
+++ b/src/applications/vre/tests/chapter36/config/applicantInformation.unit.spec.jsx
@@ -7,7 +7,7 @@ import {
   DefinitionTester,
   selectRadio,
   fillData,
-} from '../../../../../platform/testing/unit/schemaform-utils.jsx';
+} from 'platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../../chapter36/config/form.js';
 
 describe('VRE chapter 36 applicant information', () => {

--- a/src/applications/vre/tests/chapter36/config/applicantInformation.unit.spec.jsx
+++ b/src/applications/vre/tests/chapter36/config/applicantInformation.unit.spec.jsx
@@ -7,7 +7,7 @@ import {
   DefinitionTester,
   selectRadio,
   fillData,
-} from 'platform/testing/unit/schemaform-utils.jsx';
+} from '../../../../../platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../../chapter36/config/form.js';
 
 describe('VRE chapter 36 applicant information', () => {

--- a/src/applications/vre/tests/chapter36/config/applicantMilitaryHistory.unit.spec.jsx
+++ b/src/applications/vre/tests/chapter36/config/applicantMilitaryHistory.unit.spec.jsx
@@ -6,7 +6,7 @@ import { mount } from 'enzyme';
 import {
   DefinitionTester,
   fillData,
-} from '../../../../../platform/testing/unit/schemaform-utils.jsx';
+} from 'platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../../chapter36/config/form.js';
 
 describe('VRE chapter 36 applicant military history', () => {

--- a/src/applications/vre/tests/chapter36/config/applicantMilitaryHistory.unit.spec.jsx
+++ b/src/applications/vre/tests/chapter36/config/applicantMilitaryHistory.unit.spec.jsx
@@ -6,7 +6,7 @@ import { mount } from 'enzyme';
 import {
   DefinitionTester,
   fillData,
-} from 'platform/testing/unit/schemaform-utils.jsx';
+} from '../../../../../platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../../chapter36/config/form.js';
 
 describe('VRE chapter 36 applicant military history', () => {

--- a/src/applications/vre/tests/chapter36/config/contactInformation.unit.spec.jsx
+++ b/src/applications/vre/tests/chapter36/config/contactInformation.unit.spec.jsx
@@ -6,7 +6,7 @@ import { mount } from 'enzyme';
 import {
   DefinitionTester,
   fillData,
-} from '../../../../../platform/testing/unit/schemaform-utils.jsx';
+} from 'platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../../chapter36/config/form.js';
 
 describe('VRE chapter 36 contact information', () => {

--- a/src/applications/vre/tests/chapter36/config/contactInformation.unit.spec.jsx
+++ b/src/applications/vre/tests/chapter36/config/contactInformation.unit.spec.jsx
@@ -6,7 +6,7 @@ import { mount } from 'enzyme';
 import {
   DefinitionTester,
   fillData,
-} from 'platform/testing/unit/schemaform-utils.jsx';
+} from '../../../../../platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../../chapter36/config/form.js';
 
 describe('VRE chapter 36 contact information', () => {

--- a/src/applications/vre/tests/chapter36/config/dependentInformation.unit.spec.jsx
+++ b/src/applications/vre/tests/chapter36/config/dependentInformation.unit.spec.jsx
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import { mount } from 'enzyme';
 
-import { DefinitionTester } from '../../../../../platform/testing/unit/schemaform-utils.jsx';
+import { DefinitionTester } from 'platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../../chapter36/config/form.js';
 
 describe('VRE chapter 36 dependent information', () => {

--- a/src/applications/vre/tests/chapter36/config/dependentInformation.unit.spec.jsx
+++ b/src/applications/vre/tests/chapter36/config/dependentInformation.unit.spec.jsx
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import { mount } from 'enzyme';
 
-import { DefinitionTester } from 'platform/testing/unit/schemaform-utils.jsx';
+import { DefinitionTester } from '../../../../../platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../../chapter36/config/form.js';
 
 describe('VRE chapter 36 dependent information', () => {

--- a/src/applications/vre/tests/chapter36/config/serviceHistory.unit.spec.jsx
+++ b/src/applications/vre/tests/chapter36/config/serviceHistory.unit.spec.jsx
@@ -6,7 +6,7 @@ import { mount } from 'enzyme';
 import {
   DefinitionTester,
   fillData,
-} from '../../../../../platform/testing/unit/schemaform-utils.jsx';
+} from 'platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../../chapter36/config/form.js';
 
 describe('VRE chapter 36 military history', () => {

--- a/src/applications/vre/tests/chapter36/config/serviceHistory.unit.spec.jsx
+++ b/src/applications/vre/tests/chapter36/config/serviceHistory.unit.spec.jsx
@@ -6,7 +6,7 @@ import { mount } from 'enzyme';
 import {
   DefinitionTester,
   fillData,
-} from 'platform/testing/unit/schemaform-utils.jsx';
+} from '../../../../../platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../../chapter36/config/form.js';
 
 describe('VRE chapter 36 military history', () => {

--- a/src/applications/vre/tests/chapter36/config/veteranInformation.unit.spec.jsx
+++ b/src/applications/vre/tests/chapter36/config/veteranInformation.unit.spec.jsx
@@ -6,7 +6,7 @@ import { mount } from 'enzyme';
 import {
   DefinitionTester,
   fillData,
-} from '../../../../../platform/testing/unit/schemaform-utils.jsx';
+} from 'platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../../chapter36/config/form.js';
 
 describe('VRE chapter 36 veteran information', () => {

--- a/src/applications/vre/tests/chapter36/config/veteranInformation.unit.spec.jsx
+++ b/src/applications/vre/tests/chapter36/config/veteranInformation.unit.spec.jsx
@@ -6,7 +6,7 @@ import { mount } from 'enzyme';
 import {
   DefinitionTester,
   fillData,
-} from 'platform/testing/unit/schemaform-utils.jsx';
+} from '../../../../../platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../../chapter36/config/form.js';
 
 describe('VRE chapter 36 veteran information', () => {

--- a/src/platform/user/authorization/containers/MHVApp.jsx
+++ b/src/platform/user/authorization/containers/MHVApp.jsx
@@ -15,7 +15,7 @@ import {
   createMHVAccount,
   fetchMHVAccount,
   upgradeMHVAccount,
-} from '../../../../platform/user/profile/actions';
+} from 'platform/user/profile/actions';
 
 /* eslint-disable camelcase */
 const INELIGIBLE_MESSAGES = {

--- a/src/platform/user/authorization/containers/MHVApp.jsx
+++ b/src/platform/user/authorization/containers/MHVApp.jsx
@@ -15,7 +15,7 @@ import {
   createMHVAccount,
   fetchMHVAccount,
   upgradeMHVAccount,
-} from 'platform/user/profile/actions';
+} from '../../../../platform/user/profile/actions';
 
 /* eslint-disable camelcase */
 const INELIGIBLE_MESSAGES = {

--- a/src/platform/utilities/sso/constants.js
+++ b/src/platform/utilities/sso/constants.js
@@ -1,4 +1,4 @@
-import ENVIRONMENTS from '../../../site/constants/environments';
+import ENVIRONMENTS from 'site/constants/environments';
 
 export const eauthEnvironmentPrefixes = {
   [ENVIRONMENTS.LOCALHOST]: 'pint.',


### PR DESCRIPTION
## Description

`va/use-resolved-path` rule from the `va custom plugin` has been added to the testing stage in CircleCI (`circle.esint.json`).

The purpose of this rule is to resolve the path to use the existing aliases generated in babel.

In this case we are removing all instances containing `../` from the `platform` alias.

This change should help the code to be in compliance with the rule and removes the errors from `additional-linting` CircleCI check.

## Testing done
Locally