### PR TITLE
[Development] Add an internal form 526 redirect link

### DIFF
--- a/src/applications/disability-benefits/all-claims/content/separationTrainingPay.jsx
+++ b/src/applications/disability-benefits/all-claims/content/separationTrainingPay.jsx
@@ -1,10 +1,7 @@
 import React from 'react';
 
-export const hasSeparationPayTitle = (
-  <p className="vads-u-margin-top--0">
-    Did you receive separation pay or disability severance pay?
-  </p>
-);
+export const hasSeparationPayTitle =
+  'Did you receive separation pay or disability severance pay?';
 
 export const separationPayDetailsDescription = (
   <p>

--- a/src/applications/disability-benefits/all-claims/content/summaryOfDisabilities.jsx
+++ b/src/applications/disability-benefits/all-claims/content/summaryOfDisabilities.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router';
 
+import environment from 'platform/utilities/environment';
 import { capitalizeEachWord, isDisabilityPtsd } from '../utils';
 import { ptsdTypeEnum } from './ptsdTypeInfo';
 import formConfig from '../config/form';
@@ -55,15 +56,19 @@ export const SummaryOfDisabilitiesDescription = ({ formData }) => {
   const orientationPath =
     formConfig?.chapters.disabilities.pages.disabilitiesOrientation.path || '/';
 
+  const showLink = environment.isProduction() ? (
+    'go back to the beginning of this step and add it'
+  ) : (
+    <Link aria-label="Add missing disabilities" to={orientationPath}>
+      go back and add it
+    </Link>
+  );
+
   return (
     <>
       <p>
         Below is the list of disabilities you’re claiming in this application.
-        If a disability is missing from the list, please{' '}
-        <Link aria-label="Add missing disabilities" to={orientationPath}>
-          go back and add it
-        </Link>
-        .
+        If a disability is missing from the list, please {showLink}.
       </p>
       <ul>{selectedDisabilitiesList}</ul>
     </>

--- a/src/applications/disability-benefits/all-claims/content/summaryOfDisabilities.jsx
+++ b/src/applications/disability-benefits/all-claims/content/summaryOfDisabilities.jsx
@@ -59,7 +59,10 @@ export const SummaryOfDisabilitiesDescription = ({ formData }) => {
   const showLink = environment.isProduction() ? (
     'go back to the beginning of this step and add it'
   ) : (
-    <Link aria-label="Add missing disabilities" to={orientationPath}>
+    <Link
+      aria-label="Add missing disabilities"
+      to={`${orientationPath}?redirect`}
+    >
       go back and add it
     </Link>
   );

--- a/src/applications/disability-benefits/all-claims/content/summaryOfDisabilities.jsx
+++ b/src/applications/disability-benefits/all-claims/content/summaryOfDisabilities.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
-// import { Link } from 'react-router';
+import { Link } from 'react-router';
 
 import { capitalizeEachWord, isDisabilityPtsd } from '../utils';
 import { ptsdTypeEnum } from './ptsdTypeInfo';
-// import formConfig from '../config/form';
+import formConfig from '../config/form';
 import { NULL_CONDITION_STRING } from '../constants';
 
 const mapDisabilityName = (disabilityName, formData, index) => {
@@ -52,18 +52,17 @@ export const SummaryOfDisabilitiesDescription = ({ formData }) => {
   const selectedDisabilitiesList = ratedDisabilityNames
     .concat(newDisabilityNames)
     .map((name, i) => mapDisabilityName(name, formData, i));
-  // const orientationPath =
-  //   formConfig?.chapters.disabilities.pages.disabilitiesOrientation.path || '/';
+  const orientationPath =
+    formConfig?.chapters.disabilities.pages.disabilitiesOrientation.path || '/';
 
   return (
     <>
       <p>
         Below is the list of disabilities you’re claiming in this application.
-        If a disability is missing from the list, please go back to the
-        beginning of this step and add it
-        {/* <Link aria-label="Add missing disabilities" to={orientationPath}>
+        If a disability is missing from the list, please{' '}
+        <Link aria-label="Add missing disabilities" to={orientationPath}>
           go back and add it
-        </Link> */}
+        </Link>
         .
       </p>
       <ul>{selectedDisabilitiesList}</ul>


### PR DESCRIPTION
## Description

On form 526 summary of disabilities page (https://staging.va.gov/disability/file-disability-claim-form-21-526ez/disabilities/summary), we instruct the user to restart the step; but it is not an easy process to go back in the form a variable number of times (at least 8) to get to the start of step 2 (https://staging.va.gov/disability/file-disability-claim-form-21-526ez/disabilities/orientation).

This PR adds a link to jump to the beginning of the step 2 (orientation page), allowing the user to add either existing or new disabilities instead of telling them to "go back".

This was previously originally added in #11391, but was found to cause routing issues (see this discussion in Slack: https://dsva.slack.com/archives/C5AGLBNRK/p1582209001297700). The link was then removed in #11744. This PR adds it back, but additionally includes a `?redirect` search parameter - which _should_ fix the routing issue based on [this code](https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/platform/forms/save-in-progress/RoutedSavableApp.jsx#L63)

Associated ticket: https://github.com/department-of-veterans-affairs/va.gov-team/issues/6068

## Testing done

Local unit tests

## Screenshots

![](https://user-images.githubusercontent.com/136959/80425110-a279dc80-88a8-11ea-8f64-9ec139aaea30.png)

## Acceptance criteria
- [ ] Link shows in a non-production environment, until it has been tested in staging.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
