### PR TITLE
Turn on prefer-stateless-function in circle linter

### DIFF
--- a/circle.eslint.json
+++ b/circle.eslint.json
@@ -13,6 +13,7 @@
       {
         "aliases": ["applications", "site", "vet360"]
       }
-    ]
+    ],
+    "react/prefer-stateless-function": 2
   }
 }


### PR DESCRIPTION
## Description

Part of https://github.com/department-of-veterans-affairs/va.gov-team/issues/8286

This turns on the `prefer-stateless-function` linting rule in the `additional-linting` step that Circle runs.  All existing errors for this linting rule have been resolved.

In order to _fully_ turn this rule on we would just have to remove this line:

```diff
diff --git a/.eslintrc b/.eslintrc
index 450e007cb..7f7b9aa7c 100644
--- a/.eslintrc
+++ b/.eslintrc
@@ -64,7 +64,6 @@
 
     /* || react plugin || */
     "react/no-multi-comp": 0, // Leave organization to code reviewer discretion.
-    "react/prefer-stateless-function": 0, // Leave statelessness to code reviewer discretion.
     "react/jsx-key": 2,
     "react/jsx-pascal-case": 2,
     "react/jsx-no-duplicate-props": 2,
```


## Testing done

Linting

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
