### PR TITLE
[Site-wide] Remove "My" from MyVA311

### DIFF
--- a/src/applications/validate-mhv-account/components/errors/NeedsVAPatient.jsx
+++ b/src/applications/validate-mhv-account/components/errors/NeedsVAPatient.jsx
@@ -19,7 +19,7 @@ const NeedsVAPatient = () => {
           </strong>
         </p>
         <p>
-          Call MyVA311 (<a href="tel:844-698-2311">844-698-2311</a>
+          Call VA311 (<a href="tel:844-698-2311">844-698-2311</a>
           ), and select 3 to reach your nearest VA medical center. If you have
           hearing loss, call TTY: 711.
         </p>

--- a/src/platform/landing-pages/header-footer-data.json
+++ b/src/platform/landing-pages/header-footer-data.json
@@ -197,7 +197,7 @@
     },
     {
       "column": 4,
-      "label": "Call MyVA311:",
+      "label": "Call VA311:",
       "href": "tel:18446982311",
       "order": 3,
       "target": null,

--- a/src/platform/site-wide/cta-widget/components/messages/NeedsVAPatient.jsx
+++ b/src/platform/site-wide/cta-widget/components/messages/NeedsVAPatient.jsx
@@ -17,7 +17,7 @@ const NeedsVAPatient = () => {
           </strong>
         </p>
         <p>
-          Call MyVA311 (<a href="tel:844-698-2311">844-698-2311</a>
+          Call VA311 (<a href="tel:844-698-2311">844-698-2311</a>
           ), and select 3 to reach your nearest VA medical center. If you have
           hearing loss, call TTY: 711.
         </p>

--- a/src/platform/site-wide/user-nav/components/HelpMenu.jsx
+++ b/src/platform/site-wide/user-nav/components/HelpMenu.jsx
@@ -25,7 +25,7 @@ function HelpMenu({ clickHandler, cssClass, isOpen }) {
         <a href="https://iris.custhelp.va.gov/app/ask">Ask a Question</a>
       </p>
       <p>
-        <a href="tel:18446982311">Call MyVA311: 844-698-2311</a>
+        <a href="tel:18446982311">Call VA311: 844-698-2311</a>
       </p>
       <p>TTY: 711</p>
     </div>

--- a/src/platform/static-data/footer-links.json
+++ b/src/platform/static-data/footer-links.json
@@ -196,7 +196,7 @@
   },
   {
     "column": 4,
-    "label": "Call MyVA311:",
+    "label": "Call VA311:",
     "href": "tel:18446982311",
     "order": 3,
     "target": null,

--- a/src/site/includes/homepage-warning.html
+++ b/src/site/includes/homepage-warning.html
@@ -2,7 +2,7 @@
   <div id="top-of-page-alert" class="usa-alert usa-alert-warning">
       <div class="usa-alert-body">
           <h4 class="usa-alert-heading">Some VA.gov tools and features may not be working as expected</h4>
-          <p class="usa-alert-text">We’re sorry. We’re working to fix some problems with DS Logon right now. Please check back later or call MyVA311 for help: <a href="tel:18446982311">844-698-2311</a>. If you have hearing loss,
+          <p class="usa-alert-text">We’re sorry. We’re working to fix some problems with DS Logon right now. Please check back later or call VA311 for help: <a href="tel:18446982311">844-698-2311</a>. If you have hearing loss,
       call TTY: 711.</p>
       </div>
   </div>


### PR DESCRIPTION
## Description
We're just using VA311 instead of MyVA311 now.

https://github.com/department-of-veterans-affairs/va.gov-team/issues/8267

## Testing done
I just did a search for "MyVA311" throughout the vets-website source and replaces instances. I didn't touch the Tome-Sync stuff.

## Screenshots
![image](https://user-images.githubusercontent.com/1915775/80516611-b7f71100-8951-11ea-805c-81145566c964.png)


## Acceptance criteria
- [ ] "My" is removed from VA311 links.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
