### PR TITLE
7994 ga events view dependents

### DIFF
--- a/src/applications/personalization/view-dependents/actions/index.js
+++ b/src/applications/personalization/view-dependents/actions/index.js
@@ -1,3 +1,4 @@
+import recordEvent from 'platform/monitoring/record-event';
 import { getData } from '../util';
 
 export const FETCH_ALL_DEPENDENTS_SUCCESS = 'FETCH_ALL_DEPENDENTS_SUCCESS';
@@ -8,11 +9,16 @@ export function fetchAllDependents() {
     const response = await getData('/dependents_applications/show');
 
     if (response.errors) {
+      recordEvent({
+        event: `disability-view-dependents-load-failed`,
+        'error-key': `${response.errors[0].status}_internal_error`,
+      });
       dispatch({
         type: FETCH_ALL_DEPENDENTS_FAILED,
         response,
       });
     } else {
+      recordEvent({ event: `disability-view-dependents-load-success` });
       dispatch({
         type: FETCH_ALL_DEPENDENTS_SUCCESS,
         response,

--- a/src/applications/personalization/view-dependents/components/ViewDependentsHeader/ViewDependentsHeader.jsx
+++ b/src/applications/personalization/view-dependents/components/ViewDependentsHeader/ViewDependentsHeader.jsx
@@ -1,22 +1,34 @@
-import React from 'react';
+import recordEvent from 'platform/monitoring/record-event';
+import React, { Component } from 'react';
 
-const ViewDependentsHeader = () => (
-  <div className="vads-l-row">
-    <div className="vads-l-col--12">
-      <h1>Your VA Dependents</h1>
-      <p className="vads-u-font-size--md vads-u-font-family--serif">
-        Below is a list of dependents we have on file for you. You can file a
-        claim for additional disability compensation whenever you add a new
-        dependent.
-      </p>
-      <a
-        href="https://www.ebenefits.va.gov/ebenefits/about/feature?feature=dependent-compensation"
-        className="usa-button-primary va-button-primary"
-      >
-        Add or remove a dependent
-      </a>
-    </div>
-  </div>
-);
+class ViewDependentsHeader extends Component {
+  handleClick = () => {
+    recordEvent({
+      event: 'cta-default-button-click',
+    });
+  };
+
+  render() {
+    return (
+      <div className="vads-l-row">
+        <div className="vads-l-col--12">
+          <h1>Your VA Dependents</h1>
+          <p className="vads-u-font-size--md vads-u-font-family--serif">
+            Below is a list of dependents we have on file for you. You can file
+            a claim for additional disability compensation whenever you add a
+            new dependent.
+          </p>
+          <a
+            href="https://www.ebenefits.va.gov/ebenefits/about/feature?feature=dependent-compensation"
+            className="usa-button-primary va-button-primary"
+            onClick={this.handleClick}
+          >
+            Add or remove a dependent
+          </a>
+        </div>
+      </div>
+    );
+  }
+}
 
 export default ViewDependentsHeader;

--- a/src/applications/personalization/view-dependents/layouts/ViewDependentsLayout.jsx
+++ b/src/applications/personalization/view-dependents/layouts/ViewDependentsLayout.jsx
@@ -12,15 +12,8 @@ import {
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 import { isServerError, isClientError } from '../util';
 import { errorFragment, infoFragment, breadcrumbLinks } from './helpers';
-import recordEvent from 'platform/monitoring/record-event';
 
 class ViewDependentsLayout extends Component {
-  fireAnalyticsEvent = () => {
-    recordEvent({
-      event: 'cta-primary-button-click',
-    });
-  };
-
   render() {
     let mainContent;
 
@@ -47,9 +40,7 @@ class ViewDependentsLayout extends Component {
       <div className="vads-l-grid-container vads-u-padding--2">
         <div className="vads-l-row">
           <div className="vads-l-col--12 medium-screen:vads-l-col--8">
-            <ViewDependentsHeader
-              fireAnalyticsEvent={this.fireAnalyticsEvent}
-            />
+            <ViewDependentsHeader />
             {mainContent}
           </div>
           <div className="vads-l-col--12 medium-screen:vads-l-col--4">

--- a/src/applications/personalization/view-dependents/layouts/ViewDependentsLayout.jsx
+++ b/src/applications/personalization/view-dependents/layouts/ViewDependentsLayout.jsx
@@ -12,8 +12,15 @@ import {
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 import { isServerError, isClientError } from '../util';
 import { errorFragment, infoFragment, breadcrumbLinks } from './helpers';
+import recordEvent from 'platform/monitoring/record-event';
 
 class ViewDependentsLayout extends Component {
+  fireAnalyticsEvent = () => {
+    recordEvent({
+      event: 'cta-primary-button-click',
+    });
+  };
+
   render() {
     let mainContent;
 
@@ -40,7 +47,9 @@ class ViewDependentsLayout extends Component {
       <div className="vads-l-grid-container vads-u-padding--2">
         <div className="vads-l-row">
           <div className="vads-l-col--12 medium-screen:vads-l-col--8">
-            <ViewDependentsHeader />
+            <ViewDependentsHeader
+              fireAnalyticsEvent={this.fireAnalyticsEvent}
+            />
             {mainContent}
           </div>
           <div className="vads-l-col--12 medium-screen:vads-l-col--4">


### PR DESCRIPTION
## Description
[Original Ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/7994)

This ticket is to add the analytics events for the View Dependents page. The events needed are

1. The event for when the page loads and is successful
2. The event for when the page loads an fails
3. The event for when someone clicks the primary button on the View Dependents page

## Testing done
Tested that all events fire using dataslayer in Firefox

## Acceptance criteria
- [x] Events fire with the appropriate names

