### PR TITLE
VAVFS-8494: Fixing menu height in safari.

### DIFF
--- a/src/platform/site-wide/sass/modules/_m-vet-nav.scss
+++ b/src/platform/site-wide/sass/modules/_m-vet-nav.scss
@@ -537,3 +537,14 @@ body.va-pos-fixed {
   }
 
 }
+
+// Safari needs this to correctly display megamenu
+#mega-menu {
+  .login-container {
+    .row {
+      &.va-flex {
+        display:  grid;
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Description
In safari, menu height takes over entire page.

## Testing done
Visual

## Screenshots
N/A

## Acceptance criteria
- [ ] In safari, go to `pittsburgh-health-care/operating-status/`
- [ ] Visually verify that megamenu (blue background) does not take over screen - page should display like others

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
