### PR TITLE
Inline the record-event asset script

### DIFF
--- a/src/platform/landing-pages/dev-template.ejs
+++ b/src/platform/landing-pages/dev-template.ejs
@@ -6,7 +6,9 @@
     <meta name="MobileOptimized" content="320">
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
-    <script src="/js/record-event.js"></script>
+    <script>
+      {% include "src/site/assets/js/record-event.js" %}
+    </script>
 
 
     <!-- Icons -->

--- a/src/site/includes/header.html
+++ b/src/site/includes/header.html
@@ -26,7 +26,9 @@
   {% include "src/site/includes/metatags.liquid" %}
   {% endif %}
 
-  <script src="/js/record-event.js"></script>
+  <script>
+    {% include "src/site/assets/js/record-event.js" %}
+  </script>
 
   {% include 'src/site/includes/google-analytics' %}
 


### PR DESCRIPTION
## Description

This should help us remove a CSP error:

![image](https://user-images.githubusercontent.com/2008881/80531569-b3c9f400-894f-11ea-83c6-0640f6c7c862.png)

Also, this will be one less file in `assets/js` that we need to be concerned about with the webpack build. Once the templates have been built the `record-event.js` asset won't matter.

## Testing done

Local.  Built the site and clicked a button that would record the `nav-crisis-header` event to make sure the `recordEvent` function was still defined.


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
