### PR TITLE
Update international addresses preview handling

### DIFF
--- a/src/platform/forms/address/helpers.js
+++ b/src/platform/forms/address/helpers.js
@@ -22,9 +22,9 @@ export const ADDRESS_TYPES = {
  * @typedef {object} Address
  * @property {AddressType} type
  * @property {string} countryName
- * @property {string} [addressOne]
- * @property {string} [addressTwo]
- * @property {string} [addressThree]
+ * @property {string} [addressLine1]
+ * @property {string} [addressLine2]
+ * @property {string} [addressLine3]
  * @property {string} [addressEffectiveAt]
  * @property {string} [city]
  * @property {string} [stateCode]
@@ -126,32 +126,52 @@ export function getStateName(abbreviation = '') {
 export function formatAddress(address) {
   /* eslint-disable prefer-template */
 
+  const {
+    addressLine1,
+    addressLine3,
+    addressLine2,
+    city,
+    countryName,
+    internationalPostalCode,
+    militaryPostOfficeTypeCode,
+    militaryStateCode,
+    province,
+    stateCode,
+    type,
+    zipCode,
+  } = address;
+
+  const country = type === ADDRESS_TYPES.international ? countryName : '';
+  let cityStateZip = '';
+
   const street =
-    [address.addressOne, address.addressTwo, address.addressThree]
+    [addressLine1, addressLine2, addressLine3]
       .filter(item => item)
       .join(', ') || '';
 
-  const country =
-    address.type === ADDRESS_TYPES.international ? address.countryName : '';
-  let cityStateZip = '';
-
-  switch (address.type) {
+  switch (type) {
     case ADDRESS_TYPES.domestic:
-      cityStateZip = address.city || '';
-      if (address.city && address.stateCode) cityStateZip += ', ';
-      if (address.stateCode) cityStateZip += getStateName(address.stateCode);
-      if (address.zipCode) cityStateZip += ' ' + address.zipCode;
+      cityStateZip = city || '';
+      if (city && stateCode) cityStateZip += ', ';
+      if (stateCode) cityStateZip += getStateName(stateCode);
+      if (zipCode) cityStateZip += ' ' + zipCode;
       break;
 
     case ADDRESS_TYPES.military:
-      cityStateZip = address.militaryPostOfficeTypeCode || '';
-      if (address.militaryPostOfficeTypeCode && address.militaryStateCode)
-        cityStateZip += ', ';
-      if (address.militaryStateCode) cityStateZip += address.militaryStateCode;
-      if (address.zipCode) cityStateZip += ' ' + address.zipCode;
+      cityStateZip = militaryPostOfficeTypeCode || '';
+      if (militaryPostOfficeTypeCode && militaryStateCode) cityStateZip += ', ';
+      if (militaryStateCode) cityStateZip += militaryStateCode;
+      if (zipCode) cityStateZip += ' ' + zipCode;
       break;
 
+    // For international addresses we add a comma after the province
     case ADDRESS_TYPES.international:
+      cityStateZip =
+        [city, province, internationalPostalCode]
+          .filter(item => item)
+          .join(', ') || '';
+      break;
+
     default:
       cityStateZip = address.city;
   }

--- a/src/platform/forms/tests/address.unit.spec.js
+++ b/src/platform/forms/tests/address.unit.spec.js
@@ -7,9 +7,9 @@ import { expect } from 'chai';
 const domestic = {
   type: 'DOMESTIC',
   countryName: 'USA',
-  addressOne: '140 Rock Creek Church Rd NW',
-  addressTwo: 'Apt 57',
-  addressThree: 'Area Name',
+  addressLine1: '140 Rock Creek Church Rd NW',
+  addressLine2: 'Apt 57',
+  addressLine3: 'Area Name',
   city: 'Springfield',
   stateCode: 'OR',
   zipCode: '97477',
@@ -19,18 +19,20 @@ const domestic = {
 const international = {
   type: 'INTERNATIONAL',
   countryName: 'France',
-  addressOne: '2 Avenue Gabriel',
-  addressTwo: 'Line2',
-  addressThree: 'Line3',
+  addressLine1: '2 Avenue Gabriel',
+  addressLine2: 'Line2',
+  addressLine3: 'Line3',
   city: 'Paris',
+  province: 'Ile-de-France',
+  internationalPostalCode: '75000',
 };
 
 // 'countryName' is NOT part of the Military Address model.
 const military = {
   type: 'MILITARY',
-  addressOne: '57 Columbus Strassa',
-  addressTwo: 'Line2',
-  addressThree: 'Ben Franklin Village',
+  addressLine1: '57 Columbus Strassa',
+  addressLine2: 'Line2',
+  addressLine3: 'Ben Franklin Village',
   militaryPostOfficeTypeCode: 'APO',
   militaryStateCode: 'AE',
   zipCode: '09028',
@@ -55,7 +57,7 @@ describe('formatAddress', () => {
       country: '',
     };
     const address = { ...domestic };
-    address.addressThree = '';
+    address.addressLine3 = '';
     expect(addressUtils.formatAddress(address)).to.deep.equal(expectedResult);
   });
 
@@ -66,8 +68,8 @@ describe('formatAddress', () => {
       country: '',
     };
     const address = { ...domestic };
-    address.addressTwo = '';
-    address.addressThree = '';
+    address.addressLine2 = '';
+    address.addressLine3 = '';
     expect(addressUtils.formatAddress(address)).to.deep.equal(expectedResult);
   });
 
@@ -84,7 +86,7 @@ describe('formatAddress', () => {
   it('formats international addresses', () => {
     const expectedResult = {
       street: '2 Avenue Gabriel, Line2, Line3',
-      cityStateZip: 'Paris',
+      cityStateZip: 'Paris, Ile-de-France, 75000',
       country: 'France',
     };
 
@@ -119,9 +121,9 @@ describe('consolidateAddress', () => {
     const expectedResult = {
       type: 'MILITARY',
       countryName: 'USA',
-      addressOne: military.addressOne,
-      addressTwo: military.addressTwo,
-      addressThree: military.addressThree,
+      addressLine1: military.addressLine1,
+      addressLine2: military.addressLine2,
+      addressLine3: military.addressLine3,
       city: military.militaryPostOfficeTypeCode,
       stateCode: military.militaryStateCode,
       zipCode: military.zipCode,

--- a/src/platform/user/profile/vet360/components/AddressField/AddressView.jsx
+++ b/src/platform/user/profile/vet360/components/AddressField/AddressView.jsx
@@ -3,15 +3,14 @@ import React from 'react';
 import { formatAddress } from 'platform/forms/address/helpers';
 
 export default function AddressView({ data: address }) {
+  const { addressType } = address;
+
   const { street, cityStateZip, country } = formatAddress({
-    addressOne: address.addressLine1,
-    addressTwo: address.addressLine2,
-    addressThree: address.addressLine3,
-    // force formatting of military addresses as domestic
-    type: address.addressType.match(/military/i)
-      ? 'DOMESTIC'
-      : address.addressType.toUpperCase(),
     ...address,
+    // force formatting of military addresses as domestic
+    type: addressType.match(/military/i)
+      ? 'DOMESTIC'
+      : addressType.toUpperCase(),
   });
 
   return (

--- a/src/platform/user/profile/vet360/containers/AddressValidationModal.jsx
+++ b/src/platform/user/profile/vet360/containers/AddressValidationModal.jsx
@@ -200,8 +200,7 @@ class AddressValidationModal extends React.Component {
             {city &&
               province &&
               internationalPostalCode && (
-                <span
-                >{` ${city}, ${province}, ${internationalPostalCode}`}</span>
+                <span >{` ${city}, ${province}, ${internationalPostalCode}`}</span>
               )}
             {/* State/Province/Region is not required with international addresses */}
             {city &&

--- a/src/platform/user/profile/vet360/containers/AddressValidationModal.jsx
+++ b/src/platform/user/profile/vet360/containers/AddressValidationModal.jsx
@@ -200,7 +200,9 @@ class AddressValidationModal extends React.Component {
             {city &&
               province &&
               internationalPostalCode && (
-                <span >{` ${city}, ${province}, ${internationalPostalCode}`}</span>
+                <span>
+                  {`${city}, ${province}, ${internationalPostalCode}`}
+                </span>
               )}
             {/* State/Province/Region is not required with international addresses */}
             {city &&

--- a/src/platform/user/profile/vet360/containers/AddressValidationModal.jsx
+++ b/src/platform/user/profile/vet360/containers/AddressValidationModal.jsx
@@ -17,6 +17,7 @@ import { focusElement } from 'platform/utilities/ui';
 import { getValidationMessageKey } from '../../utilities';
 import { ADDRESS_VALIDATION_MESSAGES } from '../../constants/addressValidationMessages';
 import recordEvent from 'platform/monitoring/record-event';
+import countries from 'platform/user/profile/vet360/constants/countries.json';
 
 import * as VET360 from '../constants';
 
@@ -144,7 +145,20 @@ class AddressValidationModal extends React.Component {
       city,
       stateCode,
       zipCode,
+      internationalPostalCode,
+      province,
+      countryCodeIso3,
     } = address;
+
+    // Check what's desired for military base
+    // countryCodeIso3: livesOnMilitaryBase
+    // ? USA.COUNTRY_ISO3_CODE
+    // : countryCodeIso3,
+
+    const displayCountry = countries.find(
+      country => country.countryCodeISO3 === countryCodeIso3,
+    );
+    const displayCountryName = displayCountry?.countryName;
 
     const isAddressFromUser = id === 'userEntered';
     const hasConfirmedSuggestions =
@@ -160,18 +174,17 @@ class AddressValidationModal extends React.Component {
         key={id}
         className="vads-u-margin-bottom--1p5 address-validation-container"
       >
-        {isFirstOptionOrEnabled &&
-          hasConfirmedSuggestions && (
-            <input
-              className="address-validation-input"
-              type="radio"
-              id={id}
-              onChange={
-                isFirstOptionOrEnabled && this.onChangeHandler(address, id)
-              }
-              checked={selectedAddressId === id}
-            />
-          )}
+        {isFirstOptionOrEnabled && hasConfirmedSuggestions && (
+          <input
+            className="address-validation-input"
+            type="radio"
+            id={id}
+            onChange={
+              isFirstOptionOrEnabled && this.onChangeHandler(address, id)
+            }
+            checked={selectedAddressId === id}
+          />
+        )}
         <label
           htmlFor={id}
           className="vads-u-margin-top--2 vads-u-display--flex vads-u-align-items--center"
@@ -180,15 +193,25 @@ class AddressValidationModal extends React.Component {
             {addressLine1 && <span>{addressLine1}</span>}
             {addressLine2 && <span>{` ${addressLine2}`}</span>}
             {addressLine3 && <span>{` ${addressLine3}`}</span>}
-            {city &&
-              stateCode &&
-              zipCode && <span>{` ${city}, ${stateCode} ${zipCode}`}</span>}
-            {isAddressFromUser &&
-              showEditLink && (
-                <button className="va-button-link" onClick={this.onEditClick}>
-                  Edit Address
-                </button>
-              )}
+
+            {city && stateCode && zipCode && (
+              <span>{` ${city}, ${stateCode} ${zipCode}`}</span>
+            )}
+            {city && province && internationalPostalCode && (
+              <span>{` ${city}, ${province}, ${internationalPostalCode}`}</span>
+            )}
+            {/* State/Province/Region is not required with international addresses */}
+            {city && !province && internationalPostalCode && (
+              <span>{` ${city}, ${internationalPostalCode}`}</span>
+            )}
+
+            {displayCountryName && <span>{displayCountryName}</span>}
+
+            {isAddressFromUser && showEditLink && (
+              <button className="va-button-link" onClick={this.onEditClick}>
+                Edit Address
+              </button>
+            )}
           </div>
         </label>
       </div>

--- a/src/platform/user/profile/vet360/containers/AddressValidationModal.jsx
+++ b/src/platform/user/profile/vet360/containers/AddressValidationModal.jsx
@@ -150,14 +150,13 @@ class AddressValidationModal extends React.Component {
       countryCodeIso3,
     } = address;
 
-    // Check what's desired for military base
-    // countryCodeIso3: livesOnMilitaryBase
-    // ? USA.COUNTRY_ISO3_CODE
-    // : countryCodeIso3,
-
+    // We display the country except for US addresses (including military bases)
     const displayCountry = countries.find(
-      country => country.countryCodeISO3 === countryCodeIso3,
+      country =>
+        country.countryCodeISO3 === countryCodeIso3 &&
+        countryCodeIso3 !== 'USA',
     );
+
     const displayCountryName = displayCountry?.countryName;
 
     const isAddressFromUser = id === 'userEntered';
@@ -174,17 +173,18 @@ class AddressValidationModal extends React.Component {
         key={id}
         className="vads-u-margin-bottom--1p5 address-validation-container"
       >
-        {isFirstOptionOrEnabled && hasConfirmedSuggestions && (
-          <input
-            className="address-validation-input"
-            type="radio"
-            id={id}
-            onChange={
-              isFirstOptionOrEnabled && this.onChangeHandler(address, id)
-            }
-            checked={selectedAddressId === id}
-          />
-        )}
+        {isFirstOptionOrEnabled &&
+          hasConfirmedSuggestions && (
+            <input
+              className="address-validation-input"
+              type="radio"
+              id={id}
+              onChange={
+                isFirstOptionOrEnabled && this.onChangeHandler(address, id)
+              }
+              checked={selectedAddressId === id}
+            />
+          )}
         <label
           htmlFor={id}
           className="vads-u-margin-top--2 vads-u-display--flex vads-u-align-items--center"
@@ -194,24 +194,30 @@ class AddressValidationModal extends React.Component {
             {addressLine2 && <span>{` ${addressLine2}`}</span>}
             {addressLine3 && <span>{` ${addressLine3}`}</span>}
 
-            {city && stateCode && zipCode && (
-              <span>{` ${city}, ${stateCode} ${zipCode}`}</span>
-            )}
-            {city && province && internationalPostalCode && (
-              <span>{` ${city}, ${province}, ${internationalPostalCode}`}</span>
-            )}
+            {city &&
+              stateCode &&
+              zipCode && <span>{` ${city}, ${stateCode} ${zipCode}`}</span>}
+            {city &&
+              province &&
+              internationalPostalCode && (
+                <span
+                >{` ${city}, ${province}, ${internationalPostalCode}`}</span>
+              )}
             {/* State/Province/Region is not required with international addresses */}
-            {city && !province && internationalPostalCode && (
-              <span>{` ${city}, ${internationalPostalCode}`}</span>
-            )}
+            {city &&
+              !province &&
+              internationalPostalCode && (
+                <span>{` ${city}, ${internationalPostalCode}`}</span>
+              )}
 
             {displayCountryName && <span>{displayCountryName}</span>}
 
-            {isAddressFromUser && showEditLink && (
-              <button className="va-button-link" onClick={this.onEditClick}>
-                Edit Address
-              </button>
-            )}
+            {isAddressFromUser &&
+              showEditLink && (
+                <button className="va-button-link" onClick={this.onEditClick}>
+                  Edit Address
+                </button>
+              )}
           </div>
         </label>
       </div>


### PR DESCRIPTION
This PR addresses both
(1) https://github.com/department-of-veterans-affairs/va.gov-team/issues/7525
(2) https://github.com/department-of-veterans-affairs/va.gov-team/issues/7493 (bullet point 1)

## Description
- We want to display the city, province, and country for international addresses both on the Address Validation Modal as well as in the profile.

- Unlike US addresses, we add a comma after the province (or city if province is not available)

- We do not display the country when the address is US-based or military (unchanged requirements)

## Testing done
Tested locally and updated the unit test for international addresses.

## Screenshots
![image](https://user-images.githubusercontent.com/14869324/80532382-4a4ee300-8959-11ea-9b24-b409e6fe7a2f.png)

![image](https://user-images.githubusercontent.com/14869324/80532612-a6196c00-8959-11ea-83a2-f11eee304f67.png)


## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
