### PR TITLE
[Development/CI/CD] Fix ReviewCardField accessibility

### DIFF
--- a/src/applications/disability-benefits/all-claims/components/PaymentView.jsx
+++ b/src/applications/disability-benefits/all-claims/components/PaymentView.jsx
@@ -59,7 +59,7 @@ export const PaymentView = ({ formData = {}, originalData = {} }) => {
   );
 
   return (
-    <div>
+    <>
       {!dataChanged && (
         <p>We’re currently paying your compensation to this account</p>
       )}
@@ -76,7 +76,7 @@ export const PaymentView = ({ formData = {}, originalData = {} }) => {
       {dataChanged && (
         <AlertBox isVisible status="warning" content={accountsDifferContent} />
       )}
-    </div>
+    </>
   );
 };
 

--- a/src/platform/forms-system/src/js/components/ReviewCardField.jsx
+++ b/src/platform/forms-system/src/js/components/ReviewCardField.jsx
@@ -219,17 +219,21 @@ export default class ReviewCardField extends React.Component {
           {subtitle && <div className="review-card--subtitle">{subtitle}</div>}
           {needsDlWrapper ? <dl className="review">{Field}</dl> : Field}
           <div className="vads-u-display--flex vads-u-flex-direction--row vads-u-margin-top--2p5">
-            <button className={updateButtonClasses} onClick={this.update}>
-              Save
-            </button>
-            {((volatileData && this.state.canCancel) || !volatileData) && (
-              <button
-                className={cancelButtonClasses}
-                style={{ boxShadow: 'none' }}
-                onClick={this.cancelUpdate}
-              >
-                Cancel
-              </button>
+            {!formContext.reviewMode && (
+              <>
+                <button className={updateButtonClasses} onClick={this.update}>
+                  Save
+                </button>
+                {((volatileData && this.state.canCancel) || !volatileData) && (
+                  <button
+                    className={cancelButtonClasses}
+                    style={{ boxShadow: 'none' }}
+                    onClick={this.cancelUpdate}
+                  >
+                    Cancel
+                  </button>
+                )}
+              </>
             )}
           </div>
         </div>

--- a/src/platform/forms-system/src/js/components/ReviewCardField.jsx
+++ b/src/platform/forms-system/src/js/components/ReviewCardField.jsx
@@ -149,6 +149,7 @@ export default class ReviewCardField extends React.Component {
       registry,
       required,
       schema,
+      formContext,
     } = this.props;
     const { SchemaField } = registry.fields;
     // We've already used the ui:field and ui:title
@@ -185,25 +186,38 @@ export default class ReviewCardField extends React.Component {
       'vads-u-width--auto',
     ].join(' ');
 
+    const Field = (
+      <SchemaField
+        name={idSchema.$id}
+        required={required}
+        schema={schema}
+        uiSchema={uiSchema}
+        errorSchema={errorSchema}
+        idSchema={idSchema}
+        formData={formData}
+        onChange={onChange}
+        onBlur={onBlur}
+        registry={registry}
+        disabled={disabled}
+        readonly={readonly}
+      />
+    );
+
+    // ObjectField is set to be wrapped in a div instead of a dl, so we move
+    // that dl wrap to here; this change fixes an accessibility issue
+    const needsDlWrapper =
+      // Wrap in DL only if on review page & in review mode
+      formContext.onReviewPage &&
+      formContext.reviewMode &&
+      // volatileData is for arrays, which displays separate blocks
+      uiSchema['ui:options']?.volatileData;
+
     return (
       <div className="review-card">
         <div className="review-card--body input-section va-growable-background">
           <h4 className={titleClasses}>{title}</h4>
           {subtitle && <div className="review-card--subtitle">{subtitle}</div>}
-          <SchemaField
-            name={idSchema.$id}
-            required={required}
-            schema={schema}
-            uiSchema={uiSchema}
-            errorSchema={errorSchema}
-            idSchema={idSchema}
-            formData={formData}
-            onChange={onChange}
-            onBlur={onBlur}
-            registry={registry}
-            disabled={disabled}
-            readonly={readonly}
-          />
+          {needsDlWrapper ? <dl className="review">{Field}</dl> : Field}
           <div className="vads-u-display--flex vads-u-flex-direction--row vads-u-margin-top--2p5">
             <button className={updateButtonClasses} onClick={this.update}>
               Save
@@ -318,7 +332,7 @@ export default class ReviewCardField extends React.Component {
 
     // If the data is volatile, cache the original data before clearing it out so we
     //  have the option to cancel later
-    if (this.props.uiSchema['ui:options'].volatileData) {
+    if (this.props.uiSchema['ui:options']?.volatileData) {
       newState.oldData = this.props.formData;
       this.resetFormData();
     }

--- a/src/platform/forms-system/src/js/review/ObjectField.jsx
+++ b/src/platform/forms-system/src/js/review/ObjectField.jsx
@@ -115,6 +115,7 @@ class ObjectField extends React.Component {
         !collapsedOnSchema
       );
     };
+    let divWrapper = false;
 
     const renderedProperties = this.orderAndFilterProperties(properties).map(
       (objectFields, index) => {
@@ -123,6 +124,11 @@ class ObjectField extends React.Component {
         // we can check if its expanded by seeing if there are any visible "children"
         const visible = rest.filter(
           prop => !_.get(['properties', prop, 'ui:collapsed'], schema),
+        );
+        // Use div or dl to wrap content for array type schemas (e.g. bank info)
+        // fixes axe issue on review-and-submit
+        divWrapper = objectFields.some(
+          name => uiSchema?.[name]?.['ui:options']?.volatileData,
         );
         if (objectFields.length > 1 && visible.length > 0) {
           return objectFields.filter(showField).map(renderField);
@@ -140,6 +146,8 @@ class ObjectField extends React.Component {
       const editLabel =
         _.get('ui:options.ariaLabelForEditButtonOnReview', uiSchema) ||
         `Edit ${title}`;
+
+      const Tag = divWrapper ? 'div' : 'dl';
 
       return (
         <>
@@ -159,7 +167,7 @@ class ObjectField extends React.Component {
               </button>
             </div>
           )}
-          <dl className="review">{renderedProperties}</dl>
+          <Tag className="review">{renderedProperties}</Tag>
         </>
       );
     }

--- a/src/platform/forms-system/test/js/components/ReviewCardField.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/components/ReviewCardField.unit.spec.jsx
@@ -236,6 +236,44 @@ describe('Schemaform: ReviewCardField', () => {
       tree.unmount();
     });
 
+    it('should remove the save button in review mode', () => {
+      const tree = shallow(<ReviewCardField {...defaultVDProps} />);
+      expect(tree.find('.update-button').length).to.equal(0);
+      tree.unmount();
+    });
+
+    it('should render a dl wrapper in review mode', () => {
+      const props = set(
+        'uiSchema.ui:options.startInEdit',
+        true,
+        defaultVDProps,
+      );
+      const tree = mount(
+        <ReviewCardField
+          {...props}
+          formContext={{ onReviewPage: true, reviewMode: true }}
+        />,
+      );
+      expect(tree.find('dl.review').length).to.equal(1);
+      tree.unmount();
+    });
+
+    it('should not render a dl wrapper in edit mode', () => {
+      const props = set(
+        'uiSchema.ui:options.startInEdit',
+        true,
+        defaultVDProps,
+      );
+      const tree = mount(
+        <ReviewCardField
+          {...props}
+          formContext={{ onReviewPage: true, reviewMode: false }}
+        />,
+      );
+      expect(tree.find('.review').length).to.equal(0);
+      tree.unmount();
+    });
+
     it('should add a "New X" button in review mode', () => {
       const tree = shallow(<ReviewCardField {...defaultVDProps} />);
       const editButtons = tree.find('.edit-button');
@@ -266,10 +304,11 @@ describe('Schemaform: ReviewCardField', () => {
       tree.unmount();
     });
 
-    it('should add a cancel button in edit mode', () => {
+    it('should add a save & cancel button in edit mode', () => {
       const tree = shallow(<ReviewCardField {...defaultVDProps} />);
       // Start editing
       tree.find('.usa-button-primary').simulate('click');
+      expect(tree.find('.update-button').length).to.equal(1);
       expect(tree.find('.cancel-button').length).to.equal(1);
       tree.unmount();
     });

--- a/src/platform/forms-system/test/js/review/ObjectField.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/review/ObjectField.unit.spec.jsx
@@ -337,6 +337,9 @@ describe('Schemaform review: ObjectField', () => {
       tree.subTree('.form-review-panel-page-header-row').subTree('.edit-btn')
         .props['aria-label'],
     ).to.equal('Edit Page Title');
+    const review = tree.props.children[1];
+    expect(review.type).to.equal('dl');
+    expect(review.props.className).to.equal('review');
   });
   it('should render aria-label on edit button using value from config', () => {
     const onChange = sinon.spy();
@@ -369,5 +372,43 @@ describe('Schemaform review: ObjectField', () => {
       tree.subTree('.form-review-panel-page-header-row').subTree('.edit-btn')
         .props['aria-label'],
     ).to.equal('Custom label');
+  });
+
+  it('should render a div when rendering a ReviewCardField content with volatileData', () => {
+    const onChange = sinon.spy();
+    const onBlur = sinon.spy();
+    const schema = {
+      type: 'object',
+      properties: {
+        test: {
+          type: 'string',
+        },
+      },
+    };
+    const uiSchema = {
+      test: {
+        'ui:options': {
+          volatileData: true,
+        },
+      },
+    };
+    const formData = {
+      test: { foo: 'test' },
+    };
+    const tree = SkinDeep.shallowRender(
+      <ObjectField
+        schema={schema}
+        uiSchema={uiSchema}
+        formContext={{ pageTitle: 'Blah' }}
+        idSchema={{ $id: 'root' }}
+        formData={formData}
+        onChange={onChange}
+        onBlur={onBlur}
+      />,
+    );
+    // expecting a "div.review" instead of a "dl.review"
+    const review = tree.props.children[1];
+    expect(review.type).to.equal('div');
+    expect(review.props.className).to.equal('review');
   });
 });


### PR DESCRIPTION
## Description

This PR fixes an accessibility issue within the `ReviewCardField` and `ObjectField` components.

It's related to:

- issue https://github.com/department-of-veterans-affairs/va.gov-team/issues/7319
- PR https://github.com/department-of-veterans-affairs/vets-website/pull/12241

the errors fixed by this PR are preventing completion of the PR above.

### Before

When the `ObjectField` renders a `ReviewCardField` that contains `volatileData` (e.g. bank account info) it wraps the content in a `DL` tag. This tag only allows `DT` and `DD` as children, and a `DIV` wrapping those children (in modern browsers); That's `DL` > `DIV` > `DT/DD`. But because the ReviewCardField includes other elements, such as headers & buttons. This causes a "serious" impact accessibility issue

<details><summary>Axe Coconut DL content accessibility issue</summary>

<!-- leave a blank line above -->
![Screen Shot 2020-04-28 at 3 47 47 PM](https://user-images.githubusercontent.com/136959/80539386-0bc32380-896d-11ea-85de-4c71866ca3b2.png)</details>

<details><summary>DOM structure (before)</summary>

<!-- leave a blank line above -->
![Screen Shot 2020-04-28 at 3 55 52 PM](https://user-images.githubusercontent.com/136959/80539670-8a1fc580-896d-11ea-923d-336e9efb30fa.png)</details>

Since this issue only occurs when a `ReviewCardField` with `volatileData` set as `true` and both of the effected components are called separately, they both need to check this option and alter their behavior.

### After

<details><summary>Axe Coconut result</summary>

<!-- leave a blank line above -->
Please ignore the first two accessibility issues (missing document title & html language attribute). I only seems to appear locally, and not in the staging environment.

![Screen Shot 2020-04-28 at 3 50 34 PM](https://user-images.githubusercontent.com/136959/80540126-55f8d480-896e-11ea-8e52-86a71e2e2d2d.png)</details>

<details><summary>DOM structure (after)</summary>

<!-- leave a blank line above -->
![Screen Shot 2020-04-28 at 3 57 20 PM](https://user-images.githubusercontent.com/136959/80540306-aff99a00-896e-11ea-8a0f-c01cdee0ba60.png)</details>

## Testing done

Local unit tests; additional tests added & passing

## Screenshots

See above

## Acceptance criteria

Axe Coconut (extension) testing passes on:

- [x] (user 228) 526 banking account info page: https://staging.va.gov/disability/file-disability-claim-form-21-526ez/payment-information
- [x] (user 228) 526 review & submit page: https://staging.va.gov/disability/file-disability-claim-form-21-526ez/review-and-submit
- [x] (user 0) 0994 edu banking info: https://staging.va.gov/education/about-gi-bill-benefits/how-to-use-benefits/vettec-high-tech-program/apply-for-vettec-form-22-0994/direct-deposit-information
- [x] (user 0) 0994 edu benefits review & submit: https://staging.va.gov/education/about-gi-bill-benefits/how-to-use-benefits/vettec-high-tech-program/apply-for-vettec-form-22-0994/review-and-submit

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
