### PR TITLE
Inline foresee script

### DIFF
--- a/src/site/includes/survey-tools.html
+++ b/src/site/includes/survey-tools.html
@@ -1,5 +1,11 @@
-{% if buildtype == 'vagovprod' or buildtype == 'vagovstaging' %}
+{% if buildtype == 'vagovprod' %}
   <script>
-    {% include "src/site/assets/js/foresee/{{ buildtype }}.js" %}
+    {% include "src/site/assets/js/foresee/vagovprod.js" %}
+  </script>
+{% endif %}
+
+{% if buildtype == 'vagovstaging' %}
+  <script>
+    {% include "src/site/assets/js/foresee/vagovstaging.js" %}
   </script>
 {% endif %}

--- a/src/site/includes/survey-tools.html
+++ b/src/site/includes/survey-tools.html
@@ -1,3 +1,5 @@
 {% if buildtype == 'vagovprod' or buildtype == 'vagovstaging' %}
-  <script type="text/javascript" src="/js/foresee/{{ buildtype }}.js"></script>
+  <script>
+    {% include "src/site/assets/js/foresee/{{ buildtype }}.js" %}
+  </script>
 {% endif %}


### PR DESCRIPTION
## Description

This is another fix for some CSP errors.

![image](https://user-images.githubusercontent.com/2008881/80542154-6191ce80-8961-11ea-9785-8a4c3b5254c7.png)



## Testing done

1. I built the site using a `vagovstaging` buildtype:
    - `NODE_ENV=production yarn build:content --buildtype vagovstaging`
1. Deleted the `build/localhost` directory and `mv`d the `vagovstaging` build to be `localhost`
1. Ran the site with `yarn watch`
1. Verified that the foresee script showed up


## Screenshots

![image](https://user-images.githubusercontent.com/2008881/80541962-052eaf00-8961-11ea-9d1e-5466143bb1bd.png)



## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
