### PR TITLE
Try adding a nonce to script

### DIFF
--- a/src/site/includes/header.html
+++ b/src/site/includes/header.html
@@ -67,7 +67,7 @@
   We participate in the US government’s analytics program. See the data at analytics.usa.gov.
   https://github.com/digital-analytics-program/gov-wide-code
 -->
-  <script async type="text/javascript" src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=VA"
+  <script async type="text/javascript" nonce="**CSP_NONCE**" src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=VA"
     id="_fed_an_ua_tag"></script>
 
   <script type="text/javascript">


### PR DESCRIPTION
## Description

An attempt to fix another CSP issue.  With `strict-dynamic` we get an error on the script for the digitalgov analytics:

![image](https://user-images.githubusercontent.com/2008881/80545849-26939900-8969-11ea-8c07-c7f3e444f149.png)




In the [docs for `strict-dynamic`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#strict-dynamic_2), it says:

>  For example, a policy such as `script-src 'strict-dynamic' 'nonce-R4nd0m' https://whitelisted.com/` would allow loading of a root script with `<script nonce="R4nd0m" src="https://example.com/loader.js">`

So, even `script` tags that have a `src` attribute should respect the nonce, apparently.


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
