### PR TITLE
[Development] Redirect 526 to correct starting point

### DIFF
--- a/src/applications/disability-benefits/all-claims/content/summaryOfDisabilities.jsx
+++ b/src/applications/disability-benefits/all-claims/content/summaryOfDisabilities.jsx
@@ -41,8 +41,8 @@ const getRedirectLink = formData => {
   if (pages.ratedDisabilities.depends(formData)) {
     // start from rated disabilities page
     destinationPath = pages.ratedDisabilities.path;
-  } else if (pages.newDisabilities.depends(formData)) {
-    destinationPath = pages.newDisabilities.path;
+  } else if (pages.addDisabilities.depends(formData)) {
+    destinationPath = pages.addDisabilities.path;
   }
   return (
     <Link

--- a/src/applications/disability-benefits/all-claims/content/summaryOfDisabilities.jsx
+++ b/src/applications/disability-benefits/all-claims/content/summaryOfDisabilities.jsx
@@ -29,6 +29,34 @@ const mapDisabilityName = (disabilityName, formData, index) => {
   return <li key={`"${disabilityName}-${index}"`}>{disabilityName}</li>;
 };
 
+const getRedirectLink = formData => {
+  if (environment.isProduction() || !formConfig) {
+    return 'go back to the beginning of this step and add it';
+  }
+  const pages = formConfig.chapters.disabilities.pages;
+  // Start from orientation page; assuming user has both existing & new
+  // disabilities selected
+  let destinationPath = pages.disabilitiesOrientation.path;
+
+  if (pages.ratedDisabilities.depends(formData)) {
+    // start from rated disabilities page
+    destinationPath = pages.ratedDisabilities.path;
+  } else if (pages.newDisabilities.depends(formData)) {
+    destinationPath = pages.newDisabilities.path;
+  }
+  return (
+    <Link
+      aria-label="Add missing disabilities"
+      to={{
+        pathname: destinationPath || '/',
+        search: '?redirect',
+      }}
+    >
+      go back and add it
+    </Link>
+  );
+};
+
 export const SummaryOfDisabilitiesDescription = ({ formData }) => {
   const { ratedDisabilities, newDisabilities } = formData;
   const ratedDisabilityNames = ratedDisabilities
@@ -53,19 +81,8 @@ export const SummaryOfDisabilitiesDescription = ({ formData }) => {
   const selectedDisabilitiesList = ratedDisabilityNames
     .concat(newDisabilityNames)
     .map((name, i) => mapDisabilityName(name, formData, i));
-  const orientationPath =
-    formConfig?.chapters.disabilities.pages.disabilitiesOrientation.path || '/';
 
-  const showLink = environment.isProduction() ? (
-    'go back to the beginning of this step and add it'
-  ) : (
-    <Link
-      aria-label="Add missing disabilities"
-      to={`${orientationPath}?redirect`}
-    >
-      go back and add it
-    </Link>
-  );
+  const showLink = getRedirectLink(formData);
 
   return (
     <>


### PR DESCRIPTION
## Description

While testing the merged code from https://github.com/department-of-veterans-affairs/vets-website/pull/12384, I discovered that I was redirecting the user to a page that did not always exist within the form path. The orientation page is only visible when the user chooses to include _both_ existing and new disabilities.

<details><summary>Orientation page</summary>

<!-- leave a blank line above -->
https://staging.va.gov/disability/file-disability-claim-form-21-526ez/disabilities/orientation

![Screen Shot 2020-04-29 at 1 18 21 PM](https://user-images.githubusercontent.com/136959/80631859-feb13d80-8a1b-11ea-887f-db5e5ddab8a0.png)</details>

This PR determines the correct path to redirect the user back to using the form config `depends` function. This destination changes based on the selection made on the claim type page

<details><summary>Claim type page</summary>

<!-- leave a blank line above -->
https://staging.va.gov/disability/file-disability-claim-form-21-526ez/claim-type

![Screen Shot 2020-04-29 at 1 15 45 PM](https://user-images.githubusercontent.com/136959/80631604-97938900-8a1b-11ea-94ac-494879131668.png)</details>

This change still won't show in production until it has been throughly tested.

## Testing done

Local unit tests

## Screenshots

![](https://user-images.githubusercontent.com/136959/80425110-a279dc80-88a8-11ea-8f64-9ec139aaea30.png)

## Acceptance criteria

- [ ] Link shows in a non-production environment
- Link redirects to proper destination:
  - [ ] Orientation page when both existing & new disabilities are selected - https://staging.va.gov/disability/file-disability-claim-form-21-526ez/disabilities/orientation
  - [ ] Existing (rated) disability selection page when only existing disabilities are selected - https://staging.va.gov/disability/file-disability-claim-form-21-526ez/disabilities/rated-disabilities
  - [ ] Add disability page shown when only new disabilities are selected - https://staging.va.gov/disability/file-disability-claim-form-21-526ez/new-disabilities/add

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
