### PR TITLE
Fix platform alias - batch3

### DIFF
--- a/circle.eslint.json
+++ b/circle.eslint.json
@@ -11,7 +11,7 @@
     "va/use-resolved-path": [
       2,
       {
-        "aliases": ["applications", "site", "vet360"]
+        "aliases": ["applications", "platform", "site", "vet360"]
       }
     ],
     "react/prefer-stateless-function": 2

--- a/src/applications/auth/auth-entry.jsx
+++ b/src/applications/auth/auth-entry.jsx
@@ -1,7 +1,7 @@
-import '../../platform/polyfills';
+import 'platform/polyfills';
 import './sass/auth.scss';
 
-import startApp from '../../platform/startup';
+import startApp from 'platform/startup';
 import routes from './routes';
 
 startApp({ routes, entryName: 'auth' });

--- a/src/applications/auth/containers/AuthApp.jsx
+++ b/src/applications/auth/containers/AuthApp.jsx
@@ -5,15 +5,15 @@ import * as Sentry from '@sentry/browser';
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 import LoadingIndicator from '@department-of-veterans-affairs/formation-react/LoadingIndicator';
 
-import recordEvent from '../../../platform/monitoring/record-event';
-import { toggleLoginModal } from '../../../platform/site-wide/user-nav/actions';
-import { authnSettings } from '../../../platform/user/authentication/utilities';
+import recordEvent from 'platform/monitoring/record-event';
+import { toggleLoginModal } from 'platform/site-wide/user-nav/actions';
+import { authnSettings } from 'platform/user/authentication/utilities';
 import {
   hasSession,
   setupProfileSession,
-} from '../../../platform/user/profile/utilities';
-import { apiRequest } from '../../../platform/utilities/api';
-import get from '../../../platform/utilities/data/get';
+} from 'platform/user/profile/utilities';
+import { apiRequest } from 'platform/utilities/api';
+import get from 'platform/utilities/data/get';
 import { ssoe } from 'platform/user/authentication/selectors';
 
 const REDIRECT_IGNORE_PATTERN = new RegExp(

--- a/src/applications/beta-enrollment/actions/index.js
+++ b/src/applications/beta-enrollment/actions/index.js
@@ -1,4 +1,4 @@
-import { apiRequest } from '../../../platform/utilities/api';
+import { apiRequest } from 'platform/utilities/api';
 
 export const REGISTERING_SERVICE = 'REGISTERING_SERVICE';
 export const REGISTER_SERVICE = 'REGISTER_SERVICE';

--- a/src/applications/beta-enrollment/beta-enrollment-entry.jsx
+++ b/src/applications/beta-enrollment/beta-enrollment-entry.jsx
@@ -1,6 +1,6 @@
-import '../../platform/polyfills';
+import 'platform/polyfills';
 
-import startApp from '../../platform/startup';
+import startApp from 'platform/startup';
 
 import routes from './routes';
 import manifest from './manifest.json';

--- a/src/applications/beta-enrollment/containers/BetaApp.jsx
+++ b/src/applications/beta-enrollment/containers/BetaApp.jsx
@@ -6,7 +6,7 @@ import { features } from '../routes';
 import {
   isProfileLoading,
   createIsServiceAvailableSelector,
-} from '../../../platform/user/selectors';
+} from 'platform/user/selectors';
 
 class BetaApp extends React.Component {
   static propTypes = {

--- a/src/applications/beta-enrollment/containers/BetaEnrollmentButton.jsx
+++ b/src/applications/beta-enrollment/containers/BetaEnrollmentButton.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { registerBeta } from '../actions';
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
-import { createIsServiceAvailableSelector } from '../../../platform/user/selectors';
+import { createIsServiceAvailableSelector } from 'platform/user/selectors';
 
 class BetaEnrollmentButton extends React.Component {
   static propTypes = {

--- a/src/applications/burials/BurialsApp.jsx
+++ b/src/applications/burials/BurialsApp.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import RoutedSavableApp from '../../platform/forms/save-in-progress/RoutedSavableApp';
+import RoutedSavableApp from 'platform/forms/save-in-progress/RoutedSavableApp';
 import formConfig from './config/form';
 
 export default function BurialsEntry({ location, children }) {

--- a/src/applications/burials/burials-entry.jsx
+++ b/src/applications/burials/burials-entry.jsx
@@ -1,7 +1,7 @@
-import '../../platform/polyfills';
+import 'platform/polyfills';
 import './sass/burials.scss';
 
-import startApp from '../../platform/startup';
+import startApp from 'platform/startup';
 
 import routes from './routes';
 import reducer from './reducer';

--- a/src/applications/burials/components/ErrorText.jsx
+++ b/src/applications/burials/components/ErrorText.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import CallVBACenter from '../../../platform/static-data/CallVBACenter';
+import CallVBACenter from 'platform/static-data/CallVBACenter';
 
 export default function ErrorText() {
   return (

--- a/src/applications/burials/components/IntroductionPage.jsx
+++ b/src/applications/burials/components/IntroductionPage.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
 
-import { focusElement } from '../../../platform/utilities/ui';
+import { focusElement } from 'platform/utilities/ui';
 import OMBInfo from '@department-of-veterans-affairs/formation-react/OMBInfo';
 import FormTitle from 'platform/forms-system/src/js/components/FormTitle';
-import SaveInProgressIntro from '../../../platform/forms/save-in-progress/SaveInProgressIntro';
+import SaveInProgressIntro from 'platform/forms/save-in-progress/SaveInProgressIntro';
 
 class IntroductionPage extends React.Component {
   componentDidMount() {

--- a/src/applications/burials/containers/ConfirmationPage.jsx
+++ b/src/applications/burials/containers/ConfirmationPage.jsx
@@ -4,7 +4,7 @@ import moment from 'moment';
 import { connect } from 'react-redux';
 import Scroll from 'react-scroll';
 
-import { focusElement } from '../../../platform/utilities/ui';
+import { focusElement } from 'platform/utilities/ui';
 import { benefitsLabels } from '../labels';
 
 const scroller = Scroll.scroller;

--- a/src/applications/burials/definitions/toursOfDuty.js
+++ b/src/applications/burials/definitions/toursOfDuty.js
@@ -1,5 +1,5 @@
 import dateRangeUI from 'platform/forms-system/src/js/definitions/dateRange';
-import ServicePeriodView from '../../../platform/forms/components/ServicePeriodView';
+import ServicePeriodView from 'platform/forms/components/ServicePeriodView';
 
 export default {
   'ui:title': 'Service periods',

--- a/src/applications/burials/helpers.jsx
+++ b/src/applications/burials/helpers.jsx
@@ -3,7 +3,7 @@ import * as Sentry from '@sentry/browser';
 import moment from 'moment';
 
 import { transformForSubmit } from 'platform/forms-system/src/js/helpers';
-import { apiRequest } from '../../platform/utilities/api';
+import { apiRequest } from 'platform/utilities/api';
 
 function checkStatus(guid) {
   const headers = { 'Content-Type': 'application/json' };

--- a/src/applications/burials/migrations.js
+++ b/src/applications/burials/migrations.js
@@ -1,4 +1,4 @@
-import { isValidCentralMailPostalCode } from '../../platform/forms/address/validations';
+import { isValidCentralMailPostalCode } from 'platform/forms/address/validations';
 
 export default [
   // 0 > 1, move user back to address page if zip code is bad

--- a/src/applications/burials/reducer.js
+++ b/src/applications/burials/reducer.js
@@ -1,5 +1,5 @@
 import formConfig from './config/form';
-import { createSaveInProgressFormReducer } from '../../platform/forms/save-in-progress/reducers';
+import { createSaveInProgressFormReducer } from 'platform/forms/save-in-progress/reducers';
 
 export default {
   form: createSaveInProgressFormReducer(formConfig),

--- a/src/applications/burials/routes.jsx
+++ b/src/applications/burials/routes.jsx
@@ -1,4 +1,4 @@
-import { createRoutesWithSaveInProgress } from '../../platform/forms/save-in-progress/helpers';
+import { createRoutesWithSaveInProgress } from 'platform/forms/save-in-progress/helpers';
 
 import formConfig from './config/form';
 import BurialsApp from './BurialsApp.jsx';

--- a/src/applications/burials/tests/config/benefitsSelection.unit.spec.jsx
+++ b/src/applications/burials/tests/config/benefitsSelection.unit.spec.jsx
@@ -7,7 +7,7 @@ import {
   DefinitionTester,
   submitForm,
   getFormDOM,
-} from '../../../../platform/testing/unit/schemaform-utils.jsx';
+} from 'platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form.js';
 
 describe('Burials benefits selection', () => {

--- a/src/applications/burials/tests/config/burialAllowance.unit.spec.jsx
+++ b/src/applications/burials/tests/config/burialAllowance.unit.spec.jsx
@@ -7,7 +7,7 @@ import {
   DefinitionTester,
   submitForm,
   getFormDOM,
-} from '../../../../platform/testing/unit/schemaform-utils.jsx';
+} from 'platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form.js';
 
 describe('Burials burial allowance', () => {

--- a/src/applications/burials/tests/config/burialInformation.unit.spec.jsx
+++ b/src/applications/burials/tests/config/burialInformation.unit.spec.jsx
@@ -6,7 +6,7 @@ import ReactTestUtils from 'react-dom/test-utils';
 import {
   DefinitionTester,
   getFormDOM,
-} from '../../../../platform/testing/unit/schemaform-utils.jsx';
+} from 'platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form.js';
 
 describe('Burials veteran burial information', () => {

--- a/src/applications/burials/tests/config/claimantContactInformation.unit.spec.jsx
+++ b/src/applications/burials/tests/config/claimantContactInformation.unit.spec.jsx
@@ -8,7 +8,7 @@ import {
   DefinitionTester,
   submitForm,
   getFormDOM,
-} from '../../../../platform/testing/unit/schemaform-utils.jsx';
+} from 'platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form.js';
 
 describe('Burials claimant contact information', () => {

--- a/src/applications/burials/tests/config/claimantInformation.unit.spec.jsx
+++ b/src/applications/burials/tests/config/claimantInformation.unit.spec.jsx
@@ -7,7 +7,7 @@ import ReactTestUtils from 'react-dom/test-utils';
 import {
   DefinitionTester,
   submitForm,
-} from '../../../../platform/testing/unit/schemaform-utils.jsx';
+} from 'platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form.js';
 
 describe('Burials claimant information', () => {

--- a/src/applications/burials/tests/config/documents.unit.spec.jsx
+++ b/src/applications/burials/tests/config/documents.unit.spec.jsx
@@ -6,7 +6,7 @@ import ReactTestUtils from 'react-dom/test-utils';
 import {
   DefinitionTester,
   getFormDOM,
-} from '../../../../platform/testing/unit/schemaform-utils.jsx';
+} from 'platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form';
 
 describe('Burials document upload', () => {

--- a/src/applications/burials/tests/config/plotAllowance.unit.spec.jsx
+++ b/src/applications/burials/tests/config/plotAllowance.unit.spec.jsx
@@ -7,7 +7,7 @@ import {
   DefinitionTester,
   submitForm,
   getFormDOM,
-} from '../../../../platform/testing/unit/schemaform-utils.jsx';
+} from 'platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form.js';
 
 describe('Burials plot allowance', () => {

--- a/src/applications/burials/tests/config/previousNames.unit.spec.jsx
+++ b/src/applications/burials/tests/config/previousNames.unit.spec.jsx
@@ -8,7 +8,7 @@ import {
   DefinitionTester,
   submitForm,
   getFormDOM,
-} from '../../../../platform/testing/unit/schemaform-utils.jsx';
+} from 'platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form.js';
 
 describe('Burial military history previous names', () => {

--- a/src/applications/burials/tests/config/servicePeriods.unit.spec.jsx
+++ b/src/applications/burials/tests/config/servicePeriods.unit.spec.jsx
@@ -7,7 +7,7 @@ import ReactTestUtils from 'react-dom/test-utils';
 import {
   DefinitionTester,
   submitForm,
-} from '../../../../platform/testing/unit/schemaform-utils.jsx';
+} from 'platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form.js';
 
 describe('Burial military history service periods', () => {

--- a/src/applications/burials/tests/config/veteranInformation.unit.spec.jsx
+++ b/src/applications/burials/tests/config/veteranInformation.unit.spec.jsx
@@ -6,7 +6,7 @@ import ReactTestUtils from 'react-dom/test-utils';
 import {
   DefinitionTester,
   getFormDOM,
-} from '../../../../platform/testing/unit/schemaform-utils.jsx';
+} from 'platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form.js';
 
 describe('Burials veteran information', () => {

--- a/src/applications/burials/validation.js
+++ b/src/applications/burials/validation.js
@@ -1,5 +1,5 @@
 import moment from 'moment';
-import { isValidCentralMailPostalCode } from '../../platform/forms/address/validations';
+import { isValidCentralMailPostalCode } from 'platform/forms/address/validations';
 
 export function validateBurialAndDeathDates(errors, page) {
   const { burialDate, deathDate, veteranDateOfBirth } = page;

--- a/src/applications/claims-status/actions/index.jsx
+++ b/src/applications/claims-status/actions/index.jsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import * as Sentry from '@sentry/browser';
-import get from '../../../platform/utilities/data/get';
-import recordEvent from '../../../platform/monitoring/record-event';
-import environment from '../../../platform/utilities/environment';
+import get from 'platform/utilities/data/get';
+import recordEvent from 'platform/monitoring/record-event';
+import environment from 'platform/utilities/environment';
 import localStorage from 'platform/utilities/storage/localStorage';
-import { apiRequest } from '../../../platform/utilities/api';
+import { apiRequest } from 'platform/utilities/api';
 import { makeAuthRequest } from '../utils/helpers';
 import {
   getErrorStatus,

--- a/src/applications/claims-status/claims-status-entry.jsx
+++ b/src/applications/claims-status/claims-status-entry.jsx
@@ -1,4 +1,4 @@
-import '../../platform/polyfills';
+import 'platform/polyfills';
 
 import './sass/claims-status.scss';
 
@@ -7,9 +7,9 @@ import { createHistory } from 'history';
 import { IndexRedirect, Route, Router, useRouterHistory } from 'react-router';
 import { Provider } from 'react-redux';
 
-import startReactApp from '../../platform/startup/react';
-import createCommonStore from '../../platform/startup/store';
-import startSitewideComponents from '../../platform/site-wide';
+import startReactApp from 'platform/startup/react';
+import createCommonStore from 'platform/startup/store';
+import startSitewideComponents from 'platform/site-wide';
 
 import ClaimsStatusApp from './containers/ClaimsStatusApp.jsx';
 import routes from './routes.jsx';

--- a/src/applications/claims-status/components/AddFilesForm.jsx
+++ b/src/applications/claims-status/components/AddFilesForm.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { Link } from 'react-router';
 import Scroll from 'react-scroll';
 
-import recordEvent from '../../../platform/monitoring/record-event';
+import recordEvent from 'platform/monitoring/record-event';
 
 import ErrorableFileInput from '@department-of-veterans-affairs/formation-react/ErrorableFileInput';
 import ErrorableSelect from '@department-of-veterans-affairs/formation-react/ErrorableSelect';
@@ -14,7 +14,7 @@ import Modal from '@department-of-veterans-affairs/formation-react/Modal';
 import UploadStatus from './UploadStatus';
 import MailOrFax from './MailOrFax';
 import { displayFileSize, DOC_TYPES, getTopPosition } from '../utils/helpers';
-import { getScrollOptions } from '../../../platform/utilities/ui';
+import { getScrollOptions } from 'platform/utilities/ui';
 import {
   validateIfDirty,
   isNotBlank,

--- a/src/applications/claims-status/components/ClaimPhase.jsx
+++ b/src/applications/claims-status/components/ClaimPhase.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { Link } from 'react-router';
 import moment from 'moment';
 import _ from 'lodash/fp';
-import recordEvent from '../../../platform/monitoring/record-event';
+import recordEvent from 'platform/monitoring/record-event';
 import { getUserPhaseDescription } from '../utils/helpers';
 
 const stepClasses = {

--- a/src/applications/claims-status/components/ClosedClaimMessage.jsx
+++ b/src/applications/claims-status/components/ClosedClaimMessage.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Link } from 'react-router';
 import moment from 'moment';
 import { orderBy } from 'lodash';
-import recordEvent from '../../../platform/monitoring/record-event';
+import recordEvent from 'platform/monitoring/record-event';
 import { APPEAL_TYPES } from '../utils/appeals-v2-helpers';
 
 import { getClaimType } from '../utils/helpers';

--- a/src/applications/claims-status/containers/AdditionalEvidencePage.jsx
+++ b/src/applications/claims-status/containers/AdditionalEvidencePage.jsx
@@ -7,7 +7,7 @@ import LoadingIndicator from '@department-of-veterans-affairs/formation-react/Lo
 import Notification from '../components/Notification';
 import EvidenceWarning from '../components/EvidenceWarning';
 import { scrollToTop, setPageFocus, setUpPage } from '../utils/page';
-import { getScrollOptions } from '../../../platform/utilities/ui';
+import { getScrollOptions } from 'platform/utilities/ui';
 
 import {
   addFile,

--- a/src/applications/claims-status/containers/AppealInfo.jsx
+++ b/src/applications/claims-status/containers/AppealInfo.jsx
@@ -22,7 +22,7 @@ import {
   AVAILABLE,
   getTypeName,
 } from '../utils/appeals-v2-helpers';
-import CallVBACenter from '../../../platform/static-data/CallVBACenter';
+import CallVBACenter from 'platform/static-data/CallVBACenter';
 
 const capitalizeWord = word => {
   const capFirstLetter = word[0].toUpperCase();

--- a/src/applications/claims-status/containers/ClaimEstimationPage.jsx
+++ b/src/applications/claims-status/containers/ClaimEstimationPage.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { Link } from 'react-router';
 import AskVAQuestions from '../components/AskVAQuestions';
-import CallVBACenter from '../../../platform/static-data/CallVBACenter';
+import CallVBACenter from 'platform/static-data/CallVBACenter';
 import ClaimsBreadcrumbs from '../components/ClaimsBreadcrumbs';
 import { setUpPage } from '../utils/page';
 

--- a/src/applications/claims-status/containers/ClaimsStatusApp.jsx
+++ b/src/applications/claims-status/containers/ClaimsStatusApp.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { connect } from 'react-redux';
 
-import backendServices from '../../../platform/user/profile/constants/backendServices';
-import RequiredLoginView from '../../../platform/user/authorization/components/RequiredLoginView';
+import backendServices from 'platform/user/profile/constants/backendServices';
+import RequiredLoginView from 'platform/user/authorization/components/RequiredLoginView';
 import ClaimsAppealsUnavailable from '../components/ClaimsAppealsUnavailable';
 
 // This needs to be a React component for RequiredLoginView to pass down

--- a/src/applications/claims-status/containers/YourClaimsPageV2.jsx
+++ b/src/applications/claims-status/containers/YourClaimsPageV2.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import backendServices from '../../../platform/user/profile/constants/backendServices';
-import recordEvent from '../../../platform/monitoring/record-event';
+import backendServices from 'platform/user/profile/constants/backendServices';
+import recordEvent from 'platform/monitoring/record-event';
 
 import Modal from '@department-of-veterans-affairs/formation-react/Modal';
 import {

--- a/src/applications/claims-status/reducers/uploads.js
+++ b/src/applications/claims-status/reducers/uploads.js
@@ -14,7 +14,7 @@ import {
   SET_UPLOADER,
 } from '../actions/index.jsx';
 
-import { makeField, dirtyAllFields } from '../../../platform/forms/fields';
+import { makeField, dirtyAllFields } from 'platform/forms/fields';
 
 const initialState = {
   files: [],

--- a/src/applications/claims-status/tests/components/ClaimsStatusApp.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/ClaimsStatusApp.unit.spec.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import SkinDeep from 'skin-deep';
 import { expect } from 'chai';
 
-import backendServices from '../../../../platform/user/profile/constants/backendServices';
+import backendServices from 'platform/user/profile/constants/backendServices';
 
 import { ClaimsStatusApp, AppContent } from '../../containers/ClaimsStatusApp';
 

--- a/src/applications/claims-status/utils/helpers.js
+++ b/src/applications/claims-status/utils/helpers.js
@@ -1,7 +1,7 @@
 import _ from 'lodash/fp';
 import * as Sentry from '@sentry/browser';
 
-import environment from '../../../platform/utilities/environment';
+import environment from 'platform/utilities/environment';
 import localStorage from 'platform/utilities/storage/localStorage';
 import { fetchAndUpdateSessionExpiration as fetch } from 'platform/utilities/api';
 import { SET_UNAUTHORIZED } from '../actions/index.jsx';

--- a/src/applications/claims-status/utils/page.js
+++ b/src/applications/claims-status/utils/page.js
@@ -2,7 +2,7 @@ import Scroll from 'react-scroll';
 
 const scroller = Scroll.animateScroll;
 
-import { getScrollOptions } from '../../../platform/utilities/ui';
+import { getScrollOptions } from 'platform/utilities/ui';
 
 export function scrollToTop() {
   scroller.scrollToTop(getScrollOptions());

--- a/src/applications/coronavirus-chatbot/createCoronavirusChatbot.js
+++ b/src/applications/coronavirus-chatbot/createCoronavirusChatbot.js
@@ -1,4 +1,4 @@
-import recordEvent from '../../platform/monitoring/record-event';
+import recordEvent from 'platform/monitoring/record-event';
 import { GA_PREFIX } from './utils';
 
 export default (_store, widgetType) => {

--- a/src/applications/coronavirus-chatbot/index.js
+++ b/src/applications/coronavirus-chatbot/index.js
@@ -1,5 +1,5 @@
-import { apiRequest } from '../../platform/utilities/api';
-import recordEvent from '../../platform/monitoring/record-event';
+import { apiRequest } from 'platform/utilities/api';
+import recordEvent from 'platform/monitoring/record-event';
 import { watchForButtonClicks, GA_PREFIX } from './utils';
 
 export const defaultLocale = 'en-US';

--- a/src/applications/discharge-wizard/components/FormQuestions.jsx
+++ b/src/applications/discharge-wizard/components/FormQuestions.jsx
@@ -4,11 +4,11 @@ import PropTypes from 'prop-types';
 import { Link } from 'react-router';
 import Scroll from 'react-scroll';
 
-import recordEvent from '../../../platform/monitoring/record-event';
+import recordEvent from 'platform/monitoring/record-event';
 import ErrorableRadioButtons from '@department-of-veterans-affairs/formation-react/ErrorableRadioButtons';
 import ErrorableSelect from '@department-of-veterans-affairs/formation-react/ErrorableSelect';
-import { months } from '../../../platform/static-data/options-for-select.js';
-import { focusElement } from '../../../platform/utilities/ui';
+import { months } from 'platform/static-data/options-for-select.js';
+import { focusElement } from 'platform/utilities/ui';
 import {
   questionLabels,
   prevApplicationYearCutoff,

--- a/src/applications/discharge-wizard/components/InstructionsPage.jsx
+++ b/src/applications/discharge-wizard/components/InstructionsPage.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router';
-import recordEvent from '../../../platform/monitoring/record-event';
+import recordEvent from 'platform/monitoring/record-event';
 
 class InstructionsPage extends React.Component {
   constructor(props) {

--- a/src/applications/discharge-wizard/config.js
+++ b/src/applications/discharge-wizard/config.js
@@ -1,4 +1,4 @@
-import * as options from '../../platform/static-data/options-for-select';
+import * as options from 'platform/static-data/options-for-select';
 
 export const labels = {
   drb: 'Discharge Review Board',

--- a/src/applications/discharge-wizard/containers/GuidancePage.jsx
+++ b/src/applications/discharge-wizard/containers/GuidancePage.jsx
@@ -1,8 +1,8 @@
 import { connect } from 'react-redux';
 import React from 'react';
 import moment from 'moment';
-import recordEvent from '../../../platform/monitoring/record-event';
-import localStorage from '../../../platform/utilities/storage/localStorage';
+import recordEvent from 'platform/monitoring/record-event';
+import localStorage from 'platform/utilities/storage/localStorage';
 
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 import CarefulConsiderationStatement from '../components/CarefulConsiderationStatement';

--- a/src/applications/discharge-wizard/containers/RequestDD214.jsx
+++ b/src/applications/discharge-wizard/containers/RequestDD214.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import localStorage from '../../../platform/utilities/storage/localStorage';
+import localStorage from 'platform/utilities/storage/localStorage';
 import { board, venueAddress, branchOfService } from '../utils';
 
 class RequestDD214 extends React.Component {

--- a/src/applications/discharge-wizard/discharge-wizard-entry.jsx
+++ b/src/applications/discharge-wizard/discharge-wizard-entry.jsx
@@ -1,7 +1,7 @@
-import '../../platform/polyfills';
+import 'platform/polyfills';
 import './sass/discharge-wizard.scss';
 
-import startApp from '../../platform/startup';
+import startApp from 'platform/startup';
 
 import routes from './routes';
 import reducer from './reducers';

--- a/src/applications/hca/HealthCareApp.jsx
+++ b/src/applications/hca/HealthCareApp.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import RoutedSavableApp from '../../platform/forms/save-in-progress/RoutedSavableApp';
+import RoutedSavableApp from 'platform/forms/save-in-progress/RoutedSavableApp';
 import formConfig from './config/form';
 
 export default function HealthCareEntry({ location, children }) {

--- a/src/applications/hca/components/ErrorText.jsx
+++ b/src/applications/hca/components/ErrorText.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import CallHRC from '../../../platform/static-data/CallHRC';
+import CallHRC from 'platform/static-data/CallHRC';
 
 export default function ErrorText() {
   return (

--- a/src/applications/hca/definitions/dependent.js
+++ b/src/applications/hca/definitions/dependent.js
@@ -1,5 +1,5 @@
 import _ from 'lodash/fp';
-import fullNameUI from '../../../platform/forms/definitions/fullName';
+import fullNameUI from 'platform/forms/definitions/fullName';
 import currentOrPastDateUI from 'platform/forms-system/src/js/definitions/currentOrPastDate';
 import ssnUI from 'platform/forms-system/src/js/definitions/ssn';
 import currencyUI from 'platform/forms-system/src/js/definitions/currency';

--- a/src/applications/hca/hca-entry.jsx
+++ b/src/applications/hca/hca-entry.jsx
@@ -1,7 +1,7 @@
-import '../../platform/polyfills';
+import 'platform/polyfills';
 import './sass/hca.scss';
 
-import startApp from '../../platform/startup';
+import startApp from 'platform/startup';
 
 import routes from './routes';
 import reducer from './reducer';

--- a/src/applications/hca/tests/config/additionalInformation.unit.spec.js
+++ b/src/applications/hca/tests/config/additionalInformation.unit.spec.js
@@ -7,7 +7,7 @@ import ReactTestUtils from 'react-dom/test-utils';
 import {
   DefinitionTester,
   submitForm,
-} from '../../../../platform/testing/unit/schemaform-utils.jsx';
+} from 'platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form';
 
 describe('Hca additionalInformation', () => {

--- a/src/applications/hca/tests/config/annualIncome.unit.spec.jsx
+++ b/src/applications/hca/tests/config/annualIncome.unit.spec.jsx
@@ -7,7 +7,7 @@ import ReactTestUtils from 'react-dom/test-utils';
 import {
   DefinitionTester,
   submitForm,
-} from '../../../../platform/testing/unit/schemaform-utils';
+} from 'platform/testing/unit/schemaform-utils';
 import formConfig from '../../config/form';
 
 describe('Hca annual income', () => {

--- a/src/applications/hca/tests/config/deductibleExpenses.unit.spec.jsx
+++ b/src/applications/hca/tests/config/deductibleExpenses.unit.spec.jsx
@@ -7,7 +7,7 @@ import ReactTestUtils from 'react-dom/test-utils';
 import {
   DefinitionTester,
   submitForm,
-} from '../../../../platform/testing/unit/schemaform-utils';
+} from 'platform/testing/unit/schemaform-utils';
 import formConfig from '../../config/form';
 
 describe('Hca deductible expenses', () => {

--- a/src/applications/hca/tests/config/dependentInformation.unit.spec.jsx
+++ b/src/applications/hca/tests/config/dependentInformation.unit.spec.jsx
@@ -7,8 +7,8 @@ import ReactTestUtils from 'react-dom/test-utils';
 import {
   DefinitionTester,
   submitForm,
-} from '../../../../platform/testing/unit/schemaform-utils';
-import { fillDate } from '../../../../platform/testing/unit/helpers';
+} from 'platform/testing/unit/schemaform-utils';
+import { fillDate } from 'platform/testing/unit/helpers';
 import formConfig from '../../config/form';
 
 describe('Hca dependent information', () => {

--- a/src/applications/hca/tests/config/financialDisclosure.unit.spec.js
+++ b/src/applications/hca/tests/config/financialDisclosure.unit.spec.js
@@ -7,7 +7,7 @@ import ReactTestUtils from 'react-dom/test-utils';
 import {
   DefinitionTester,
   submitForm,
-} from '../../../../platform/testing/unit/schemaform-utils.jsx';
+} from 'platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form';
 
 describe('Hca financial disclosure', () => {

--- a/src/applications/hca/tests/config/general.unit.spec.jsx
+++ b/src/applications/hca/tests/config/general.unit.spec.jsx
@@ -7,7 +7,7 @@ import ReactTestUtils from 'react-dom/test-utils';
 import {
   DefinitionTester,
   submitForm,
-} from '../../../../platform/testing/unit/schemaform-utils.jsx';
+} from 'platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form';
 
 describe('Hca general insurance', () => {

--- a/src/applications/hca/tests/config/medicare.unit.spec.jsx
+++ b/src/applications/hca/tests/config/medicare.unit.spec.jsx
@@ -7,7 +7,7 @@ import ReactTestUtils from 'react-dom/test-utils';
 import {
   DefinitionTester,
   submitForm,
-} from '../../../../platform/testing/unit/schemaform-utils.jsx';
+} from 'platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form';
 
 describe('Hca medicare', () => {

--- a/src/applications/hca/tests/config/serviceInformation.unit.spec.js
+++ b/src/applications/hca/tests/config/serviceInformation.unit.spec.js
@@ -8,7 +8,7 @@ import {
   DefinitionTester,
   fillData,
   fillDate,
-} from '../../../../platform/testing/unit/schemaform-utils.jsx';
+} from 'platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form';
 
 describe('Hca serviceInformation', () => {

--- a/src/applications/hca/tests/config/spouseInformation.unit.spec.jsx
+++ b/src/applications/hca/tests/config/spouseInformation.unit.spec.jsx
@@ -7,7 +7,7 @@ import ReactTestUtils from 'react-dom/test-utils';
 import {
   DefinitionTester,
   submitForm,
-} from '../../../../platform/testing/unit/schemaform-utils';
+} from 'platform/testing/unit/schemaform-utils';
 import formConfig from '../../config/form';
 
 describe('Hca spouse information', () => {

--- a/src/applications/hca/tests/config/vaBenefits.unit.spec.js
+++ b/src/applications/hca/tests/config/vaBenefits.unit.spec.js
@@ -7,7 +7,7 @@ import ReactTestUtils from 'react-dom/test-utils';
 import {
   DefinitionTester,
   submitForm,
-} from '../../../../platform/testing/unit/schemaform-utils.jsx';
+} from 'platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form';
 
 describe('Hca vaBenefits', () => {

--- a/src/applications/hca/tests/config/vaFacility.unit.spec.jsx
+++ b/src/applications/hca/tests/config/vaFacility.unit.spec.jsx
@@ -7,7 +7,7 @@ import ReactTestUtils from 'react-dom/test-utils';
 import {
   DefinitionTester,
   submitForm,
-} from '../../../../platform/testing/unit/schemaform-utils.jsx';
+} from 'platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form';
 
 describe('Hca VA facility', () => {

--- a/src/applications/hca/tests/config/veteranInformation.unit.spec.jsx
+++ b/src/applications/hca/tests/config/veteranInformation.unit.spec.jsx
@@ -7,7 +7,7 @@ import sinon from 'sinon';
 import {
   DefinitionTester,
   submitForm,
-} from '../../../../platform/testing/unit/schemaform-utils.jsx';
+} from 'platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form.js';
 
 describe('HCA veteranInformation', () => {

--- a/src/applications/hca/validation.js
+++ b/src/applications/hca/validation.js
@@ -4,7 +4,7 @@ import {
   convertToDateField,
   validateCurrentOrPastDate,
 } from 'platform/forms-system/src/js/validation';
-import { isValidDateRange } from '../../platform/forms/validations';
+import { isValidDateRange } from 'platform/forms/validations';
 
 function calculateEndDate() {
   const endDateLimit = 1;

--- a/src/applications/id-card-beta/actions/index.js
+++ b/src/applications/id-card-beta/actions/index.js
@@ -1,4 +1,4 @@
-import { apiRequest } from '../../../platform/utilities/api';
+import { apiRequest } from 'platform/utilities/api';
 
 export const BETA_REGISTERING = 'BETA_REGISTERING';
 export const BETA_REGISTER_SUCCESS = 'BETA_REGISTER_SUCCESS';

--- a/src/applications/id-card-beta/containers/IDCardBetaEnrollment.jsx
+++ b/src/applications/id-card-beta/containers/IDCardBetaEnrollment.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { connect } from 'react-redux';
 
-import backendServices from '../../../platform/user/profile/constants/backendServices';
-import RequiredLoginView from '../../../platform/user/authorization/components/RequiredLoginView';
+import backendServices from 'platform/user/profile/constants/backendServices';
+import RequiredLoginView from 'platform/user/authorization/components/RequiredLoginView';
 
 function IDCardBetaEnrollment({ user, children }) {
   return (

--- a/src/applications/id-card-beta/id-card-beta-entry.jsx
+++ b/src/applications/id-card-beta/id-card-beta-entry.jsx
@@ -1,7 +1,7 @@
-import '../../platform/polyfills';
+import 'platform/polyfills';
 import '../personalization/profile360/sass/user-profile.scss';
 
-import startApp from '../../platform/startup';
+import startApp from 'platform/startup';
 
 import routes from './routes';
 import reducer from './reducers';

--- a/src/applications/login/app-entry.jsx
+++ b/src/applications/login/app-entry.jsx
@@ -1,6 +1,6 @@
-import '../../platform/polyfills';
+import 'platform/polyfills';
 
-import startApp from '../../platform/startup';
+import startApp from 'platform/startup';
 
 import routes from './routes';
 import reducer from './reducers';

--- a/src/applications/personalization/account/actions/index.js
+++ b/src/applications/personalization/account/actions/index.js
@@ -1,1 +1,1 @@
-export * from '../../../../platform/user/profile/actions';
+export * from 'platform/user/profile/actions';

--- a/src/applications/personalization/connected-accounts/actions/index.js
+++ b/src/applications/personalization/connected-accounts/actions/index.js
@@ -1,6 +1,6 @@
 import { apiRequest } from 'platform/utilities/api';
 
-export * from '../../../../platform/user/profile/actions';
+export * from 'platform/user/profile/actions';
 
 export const LOADING_CONNECTED_ACCOUNTS = 'LOADING_CONNECTED_ACCOUNTS';
 export const FINISHED_CONNECTED_ACCOUNTS = 'FINISHED_CONNECTED_ACCOUNTS';

--- a/src/applications/post-911-gib-status/actions/post-911-gib-status.js
+++ b/src/applications/post-911-gib-status/actions/post-911-gib-status.js
@@ -1,7 +1,7 @@
 import * as Sentry from '@sentry/browser';
 
-import recordEvent from '../../../platform/monitoring/record-event';
-import { apiRequest } from '../../../platform/utilities/api';
+import recordEvent from 'platform/monitoring/record-event';
+import { apiRequest } from 'platform/utilities/api';
 
 import {
   BACKEND_AUTHENTICATION_ERROR,

--- a/src/applications/post-911-gib-status/components/EnrollmentPeriod.jsx
+++ b/src/applications/post-911-gib-status/components/EnrollmentPeriod.jsx
@@ -4,8 +4,8 @@ import Scroll from 'react-scroll';
 
 import InfoPair from './InfoPair';
 
-import { formatDateParsedZoneShort } from '../../../platform/utilities/date';
-import { getScrollOptions } from '../../../platform/utilities/ui';
+import { formatDateParsedZoneShort } from 'platform/utilities/date';
+import { getScrollOptions } from 'platform/utilities/ui';
 
 const scroller = Scroll.scroller;
 

--- a/src/applications/post-911-gib-status/components/UserInfoSection.jsx
+++ b/src/applications/post-911-gib-status/components/UserInfoSection.jsx
@@ -6,7 +6,7 @@ import InfoPair from './InfoPair';
 import {
   formatDateShort,
   formatDateParsedZoneLong,
-} from '../../../platform/utilities/date';
+} from 'platform/utilities/date';
 import {
   formatPercent,
   formatVAFileNumber,

--- a/src/applications/post-911-gib-status/containers/Post911GIBStatusApp.jsx
+++ b/src/applications/post-911-gib-status/containers/Post911GIBStatusApp.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { connect } from 'react-redux';
 
-import backendServices from '../../../platform/user/profile/constants/backendServices';
-import RequiredLoginView from '../../../platform/user/authorization/components/RequiredLoginView';
+import backendServices from 'platform/user/profile/constants/backendServices';
+import RequiredLoginView from 'platform/user/authorization/components/RequiredLoginView';
 import DowntimeNotification, {
   externalServices,
-} from '../../../platform/monitoring/DowntimeNotification';
+} from 'platform/monitoring/DowntimeNotification';
 
 import Main from './Main';
 

--- a/src/applications/post-911-gib-status/containers/PrintPage.jsx
+++ b/src/applications/post-911-gib-status/containers/PrintPage.jsx
@@ -3,8 +3,8 @@ import { connect } from 'react-redux';
 
 import UserInfoSection from '../components/UserInfoSection';
 
-import { focusElement } from '../../../platform/utilities/ui';
-import { formatDateLong } from '../../../platform/utilities/date';
+import { focusElement } from 'platform/utilities/ui';
+import { formatDateLong } from 'platform/utilities/date';
 
 export class PrintPage extends React.Component {
   componentDidMount() {

--- a/src/applications/post-911-gib-status/containers/StatusPage.jsx
+++ b/src/applications/post-911-gib-status/containers/StatusPage.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import recordEvent from '../../../platform/monitoring/record-event';
-import { focusElement } from '../../../platform/utilities/ui';
+import recordEvent from 'platform/monitoring/record-event';
+import { focusElement } from 'platform/utilities/ui';
 
 import FormTitle from 'platform/forms-system/src/js/components/FormTitle';
 

--- a/src/applications/post-911-gib-status/post-911-gib-status-entry.jsx
+++ b/src/applications/post-911-gib-status/post-911-gib-status-entry.jsx
@@ -1,7 +1,7 @@
-import '../../platform/polyfills';
+import 'platform/polyfills';
 import './sass/post-911-gib-status.scss';
 
-import startApp from '../../platform/startup';
+import startApp from 'platform/startup';
 
 import routes from './routes';
 import reducer from './reducers';

--- a/src/applications/post-911-gib-status/tests/containers/Post911GIBStatusApp.unit.spec.jsx
+++ b/src/applications/post-911-gib-status/tests/containers/Post911GIBStatusApp.unit.spec.jsx
@@ -4,7 +4,7 @@ import { expect } from 'chai';
 
 import Post911GIBStatusApp from '../../containers/Post911GIBStatusApp';
 import reducer from '../../reducers/index.js';
-import createCommonStore from '../../../../platform/startup/store';
+import createCommonStore from 'platform/startup/store';
 
 const store = createCommonStore(reducer);
 

--- a/src/applications/post-911-gib-status/tests/containers/StatusPage.unit.spec.jsx
+++ b/src/applications/post-911-gib-status/tests/containers/StatusPage.unit.spec.jsx
@@ -7,7 +7,7 @@ import ReactTestUtils from 'react-dom/test-utils';
 import StatusPage from '../../containers/StatusPage';
 
 import reducer from '../../reducers/index.js';
-import createCommonStore from '../../../../platform/startup/store';
+import createCommonStore from 'platform/startup/store';
 
 const store = createCommonStore(reducer);
 const defaultProps = store.getState();

--- a/src/applications/post-911-gib-status/utils/helpers.jsx
+++ b/src/applications/post-911-gib-status/utils/helpers.jsx
@@ -3,7 +3,7 @@ import { Link } from 'react-router';
 
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 
-import { formatDateParsedZoneLong } from '../../../platform/utilities/date';
+import { formatDateParsedZoneLong } from 'platform/utilities/date';
 import EducationWizard from '../components/EducationWizard';
 import wizardConfig from './wizardConfig';
 

--- a/src/applications/proxy-rewrite/partials/header.js
+++ b/src/applications/proxy-rewrite/partials/header.js
@@ -1,4 +1,4 @@
-import { replaceWithStagingDomain } from '../../../platform/utilities/environment/stagingDomains';
+import { replaceWithStagingDomain } from 'platform/utilities/environment/stagingDomains';
 
 export default `
 <header class="header merger">

--- a/src/applications/proxy-rewrite/proxy-rewrite-entry.jsx
+++ b/src/applications/proxy-rewrite/proxy-rewrite-entry.jsx
@@ -15,8 +15,8 @@ import addMenuListeners from 'platform/site-wide/accessible-menus';
 import startMegaMenuWidget from 'platform/site-wide/mega-menu';
 import startMobileMenuButton from 'platform/site-wide/mobile-menu-button';
 
-// import startLRNHealthCarWidget from '../../platform/site-wide/left-rail-navs/health-care';
-// import startAnnouncementWidget from '../../platform/site-wide/announcements';
+// import startLRNHealthCarWidget from 'platform/site-wide/left-rail-navs/health-care';
+// import startAnnouncementWidget from 'platform/site-wide/announcements';
 import startVAFooter, { footerElemementId } from 'platform/site-wide/va-footer';
 import redirectIfNecessary from './redirects';
 import addFocusBehaviorToCrisisLineModal from 'platform/site-wide/accessible-VCL-modal';

--- a/src/applications/proxy-rewrite/redirects/index.js
+++ b/src/applications/proxy-rewrite/redirects/index.js
@@ -1,4 +1,4 @@
-import environment from '../../../platform/utilities/environment';
+import environment from 'platform/utilities/environment';
 // Currently we only have approval for disability related ones:
 import crossDomainRedirects from './crossDomainRedirects.json';
 

--- a/src/applications/public-outreach-materials/public-outreach-materials-entry.js
+++ b/src/applications/public-outreach-materials/public-outreach-materials-entry.js
@@ -1,8 +1,8 @@
-import '../../platform/polyfills';
+import 'platform/polyfills';
 import './sass/public-outreach-materials.scss';
 
-import createCommonStore from '../../platform/startup/store';
-import startSitewideComponents from '../../platform/site-wide';
+import createCommonStore from 'platform/startup/store';
+import startSitewideComponents from 'platform/site-wide';
 
 import { libraryListeners } from './libraries/library-filters';
 

--- a/src/applications/search/actions/index.js
+++ b/src/applications/search/actions/index.js
@@ -2,7 +2,7 @@ export const FETCH_SEARCH_RESULTS = 'FETCH_SEARCH_RESULTS';
 export const FETCH_SEARCH_RESULTS_SUCCESS = 'FETCH_SEARCH_RESULTS_SUCCESS';
 export const FETCH_SEARCH_RESULTS_FAILURE = 'FETCH_SEARCH_RESULTS_FAILURE';
 
-import { apiRequest } from '../../../platform/utilities/api';
+import { apiRequest } from 'platform/utilities/api';
 
 export function fetchSearchResults(query, page) {
   return dispatch => {

--- a/src/applications/search/containers/SearchApp.jsx
+++ b/src/applications/search/containers/SearchApp.jsx
@@ -5,14 +5,14 @@ import { connect } from 'react-redux';
 
 import { fetchSearchResults } from '../actions';
 import { formatResponseString } from '../utils';
-import recordEvent from '../../../platform/monitoring/record-event';
-import { replaceWithStagingDomain } from '../../../platform/utilities/environment/stagingDomains';
+import recordEvent from 'platform/monitoring/record-event';
+import { replaceWithStagingDomain } from 'platform/utilities/environment/stagingDomains';
 
 import { focusElement } from 'platform/utilities/ui';
 
 import DowntimeNotification, {
   externalServices,
-} from '../../../platform/monitoring/DowntimeNotification';
+} from 'platform/monitoring/DowntimeNotification';
 import LoadingIndicator from '@department-of-veterans-affairs/formation-react/LoadingIndicator';
 import IconSearch from '@department-of-veterans-affairs/formation-react/IconSearch';
 import Pagination from '@department-of-veterans-affairs/formation-react/Pagination';

--- a/src/applications/search/search-entry.jsx
+++ b/src/applications/search/search-entry.jsx
@@ -1,7 +1,7 @@
-import '../../platform/polyfills';
+import 'platform/polyfills';
 import './styles.scss';
 
-import startApp from '../../platform/startup';
+import startApp from 'platform/startup';
 
 import routes from './routes';
 import reducer from './reducers';

--- a/src/applications/terms-and-conditions/actions/index.js
+++ b/src/applications/terms-and-conditions/actions/index.js
@@ -1,5 +1,5 @@
-import recordEvent from '../../../platform/monitoring/record-event';
-import { apiRequest } from '../../../platform/utilities/api';
+import recordEvent from 'platform/monitoring/record-event';
+import { apiRequest } from 'platform/utilities/api';
 
 export const FETCHING_LATEST_TERMS = 'FETCHING_LATEST_TERMS';
 export const FETCH_LATEST_TERMS_FAILURE = 'FETCH_LATEST_TERMS_FAILURE';

--- a/src/applications/terms-and-conditions/containers/MhvTermsAndConditions.jsx
+++ b/src/applications/terms-and-conditions/containers/MhvTermsAndConditions.jsx
@@ -6,9 +6,9 @@ import appendQuery from 'append-query';
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 import LoadingIndicator from '@department-of-veterans-affairs/formation-react/LoadingIndicator';
 
-import recordEvent from '../../../platform/monitoring/record-event';
-import { hasSession } from '../../../platform/user/profile/utilities';
-import { getScrollOptions } from '../../../platform/utilities/ui';
+import recordEvent from 'platform/monitoring/record-event';
+import { hasSession } from 'platform/user/profile/utilities';
+import { getScrollOptions } from 'platform/utilities/ui';
 
 import {
   acceptTerms,

--- a/src/applications/terms-and-conditions/terms-and-conditions-entry.js
+++ b/src/applications/terms-and-conditions/terms-and-conditions-entry.js
@@ -1,7 +1,7 @@
-import '../../platform/polyfills';
+import 'platform/polyfills';
 import './sass/terms-and-conditions.scss';
 
-import startApp from '../../platform/startup';
+import startApp from 'platform/startup';
 
 import routes from './routes';
 import reducer from './reducers';

--- a/src/applications/validate-mhv-account/containers/CreateMHVAccount.jsx
+++ b/src/applications/validate-mhv-account/containers/CreateMHVAccount.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { ssoe } from '../../../platform/user/authentication/selectors';
-import { logout } from '../../../platform/user/authentication/utilities';
+import { ssoe } from 'platform/user/authentication/selectors';
+import { logout } from 'platform/user/authentication/utilities';
 import MessageTemplate from './../components/MessageTemplate';
 
-import { createAndUpgradeMHVAccount } from '../../../platform/user/profile/actions';
+import { createAndUpgradeMHVAccount } from 'platform/user/profile/actions';
 
 class CreateMHVAccount extends React.Component {
   logoutHandler = () => {

--- a/src/applications/validate-mhv-account/containers/CreateMHVAccountFailed.jsx
+++ b/src/applications/validate-mhv-account/containers/CreateMHVAccountFailed.jsx
@@ -4,7 +4,7 @@ import { connect } from 'react-redux';
 import CollapsiblePanel from '@department-of-veterans-affairs/formation-react/CollapsiblePanel';
 
 import MessageTemplate from '../components/MessageTemplate';
-import { createAndUpgradeMHVAccount } from '../../../platform/user/profile/actions';
+import { createAndUpgradeMHVAccount } from 'platform/user/profile/actions';
 
 function CreateMHVAccountFailed(props) {
   const content = {

--- a/src/applications/validate-mhv-account/containers/ErrorMessage.jsx
+++ b/src/applications/validate-mhv-account/containers/ErrorMessage.jsx
@@ -9,7 +9,7 @@ import NeedsVAPatient from '../components/errors/NeedsVAPatient';
 import CreateMHVAccountFailed from './CreateMHVAccountFailed';
 import UpgradeAccountFailed from './UpgradeAccountFailed';
 import { ACCOUNT_STATES } from './../constants';
-import { MVI_ERROR_STATES } from './../../../platform/monitoring/RequiresMVI/constants';
+import { MVI_ERROR_STATES } from 'platform/monitoring/RequiresMVI/constants';
 
 export default function ErrorMessage({ params }) {
   let errorCode = params.errorCode

--- a/src/applications/validate-mhv-account/containers/Main.jsx
+++ b/src/applications/validate-mhv-account/containers/Main.jsx
@@ -3,10 +3,10 @@ import { connect } from 'react-redux';
 import { withRouter } from 'react-router';
 import LoadingIndicator from '@department-of-veterans-affairs/formation-react/LoadingIndicator';
 
-import { isLoggedIn, selectProfile } from '../../../platform/user/selectors';
-import get from '../../../platform/utilities/data/get';
-import environment from '../../../platform/utilities/environment/index';
-import { replaceWithStagingDomain } from '../../../platform/utilities/environment/stagingDomains';
+import { isLoggedIn, selectProfile } from 'platform/user/selectors';
+import get from 'platform/utilities/data/get';
+import environment from 'platform/utilities/environment/index';
+import { replaceWithStagingDomain } from 'platform/utilities/environment/stagingDomains';
 import { ACCOUNT_STATES, MHV_ACCOUNT_LEVELS, MHV_URL } from './../constants';
 
 /**

--- a/src/applications/validate-mhv-account/containers/UpgradeAccountFailed.jsx
+++ b/src/applications/validate-mhv-account/containers/UpgradeAccountFailed.jsx
@@ -4,7 +4,7 @@ import { connect } from 'react-redux';
 import CollapsiblePanel from '@department-of-veterans-affairs/formation-react/CollapsiblePanel';
 
 import MessageTemplate from '../components/MessageTemplate';
-import { upgradeMHVAccount } from '../../../platform/user/profile/actions';
+import { upgradeMHVAccount } from 'platform/user/profile/actions';
 
 function UpgradeMHVAccountFailed(props) {
   const content = {

--- a/src/applications/validate-mhv-account/containers/UpgradeMHVAccount.jsx
+++ b/src/applications/validate-mhv-account/containers/UpgradeMHVAccount.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import MessageTemplate from '../components/MessageTemplate';
 
-import { upgradeMHVAccount } from '../../../platform/user/profile/actions';
+import { upgradeMHVAccount } from 'platform/user/profile/actions';
 
 function UpgradeMHVAccount(props) {
   const content = {

--- a/src/applications/validate-mhv-account/containers/ValidateMHVAccount.jsx
+++ b/src/applications/validate-mhv-account/containers/ValidateMHVAccount.jsx
@@ -4,12 +4,12 @@ import { withRouter } from 'react-router';
 import appendQuery from 'append-query';
 import LoadingIndicator from '@department-of-veterans-affairs/formation-react/LoadingIndicator';
 
-import { fetchMHVAccount } from '../../../platform/user/profile/actions';
+import { fetchMHVAccount } from 'platform/user/profile/actions';
 
-import recordEvent from '../../../platform/monitoring/record-event';
-import { selectProfile } from '../../../platform/user/selectors';
-import environment from '../../../platform/utilities/environment/index';
-import { replaceWithStagingDomain } from '../../../platform/utilities/environment/stagingDomains';
+import recordEvent from 'platform/monitoring/record-event';
+import { selectProfile } from 'platform/user/selectors';
+import environment from 'platform/utilities/environment/index';
+import { replaceWithStagingDomain } from 'platform/utilities/environment/stagingDomains';
 import {
   ACCOUNT_STATES,
   ACCOUNT_STATES_SET,
@@ -17,7 +17,7 @@ import {
   MHV_URL,
 } from './../constants';
 
-import { MVI_ERROR_STATES } from './../../../platform/monitoring/RequiresMVI/constants';
+import { MVI_ERROR_STATES } from 'platform/monitoring/RequiresMVI/constants';
 
 class ValidateMHVAccount extends React.Component {
   componentDidMount() {

--- a/src/applications/validate-mhv-account/validate-mhv-account-entry.jsx
+++ b/src/applications/validate-mhv-account/validate-mhv-account-entry.jsx
@@ -1,6 +1,6 @@
-import '../../platform/polyfills';
+import 'platform/polyfills';
 
-import startApp from '../../platform/startup';
+import startApp from 'platform/startup';
 import routes from './routes';
 import manifest from './manifest.json';
 

--- a/src/applications/verify/verify-entry.jsx
+++ b/src/applications/verify/verify-entry.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import '../../platform/polyfills';
-import startApp from '../../platform/startup';
+import 'platform/polyfills';
+import startApp from 'platform/startup';
 import VerifyApp from './containers/VerifyApp';
 
 startApp({ component: <VerifyApp /> });

--- a/src/applications/veteran-id-card/actions/index.js
+++ b/src/applications/veteran-id-card/actions/index.js
@@ -1,5 +1,5 @@
-import recordEvent from '../../../platform/monitoring/record-event';
-import { apiRequest } from '../../../platform/utilities/api';
+import recordEvent from 'platform/monitoring/record-event';
+import { apiRequest } from 'platform/utilities/api';
 
 export const ATTRS_FETCHING = 'ATTRS_FETCHING';
 export const ATTRS_SUCCESS = 'ATTRS_SUCCESS';

--- a/src/applications/veteran-id-card/components/RequiredVeteranView.jsx
+++ b/src/applications/veteran-id-card/components/RequiredVeteranView.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 
 import SystemDownView from '@department-of-veterans-affairs/formation-react/SystemDownView';
 
-import EmailVICHelp from '../../../platform/static-data/EmailVICHelp';
+import EmailVICHelp from 'platform/static-data/EmailVICHelp';
 
 function RequiredVeteranView({ userProfile, children }) {
   let view;

--- a/src/applications/veteran-id-card/config.jsx
+++ b/src/applications/veteran-id-card/config.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import EmailVICHelp from '../../platform/static-data/EmailVICHelp';
+import EmailVICHelp from 'platform/static-data/EmailVICHelp';
 
 const config = {
   messages: {

--- a/src/applications/veteran-id-card/containers/Main.jsx
+++ b/src/applications/veteran-id-card/containers/Main.jsx
@@ -4,7 +4,7 @@ import { has, head } from 'lodash';
 import { initiateIdRequest, timeoutRedirect } from '../actions';
 import config from '../config';
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
-import EmailVICHelp from '../../../platform/static-data/EmailVICHelp';
+import EmailVICHelp from 'platform/static-data/EmailVICHelp';
 
 class Main extends React.Component {
   constructor(props) {

--- a/src/applications/veteran-id-card/containers/VeteranIDCard.jsx
+++ b/src/applications/veteran-id-card/containers/VeteranIDCard.jsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { connect } from 'react-redux';
 
-import backendServices from '../../../platform/user/profile/constants/backendServices';
-import recordEvent from '../../../platform/monitoring/record-event';
+import backendServices from 'platform/user/profile/constants/backendServices';
+import recordEvent from 'platform/monitoring/record-event';
 import DowntimeNotification, {
   externalServices,
-} from '../../../platform/monitoring/DowntimeNotification';
-import RequiredLoginView from '../../../platform/user/authorization/components/RequiredLoginView';
+} from 'platform/monitoring/DowntimeNotification';
+import RequiredLoginView from 'platform/user/authorization/components/RequiredLoginView';
 import RequiredVeteranView from '../components/RequiredVeteranView';
 import EmailCapture from './EmailCapture';
 

--- a/src/applications/veteran-id-card/veteran-id-card-entry.jsx
+++ b/src/applications/veteran-id-card/veteran-id-card-entry.jsx
@@ -1,8 +1,8 @@
-import '../../platform/polyfills';
+import 'platform/polyfills';
 import React from 'react';
 import './sass/veteran-id-card.scss';
 
-import startApp from '../../platform/startup';
+import startApp from 'platform/startup';
 import VeteranIDCard from './containers/VeteranIDCard';
 import Main from './containers/Main';
 


### PR DESCRIPTION
## Description

`va/use-resolved-path` rule from the `va custom plugin` has been added to the testing stage in CircleCI (`circle.esint.json`).

The purpose of this rule is to resolve the path to use the existing aliases generated in babel.

In this case we are removing all instances containing `../` from the `platform` alias.

This change should help the code to be in compliance with the rule and removes the errors from `additional-linting` CircleCI check.

## Testing done
Locally

## Definition of done
- [x] Added `platform` to the aliases array in the `va/use-resolved-path` rule
