### PR TITLE
VAVFS-change-story-sort: Changing story sort order on listing page.

### DIFF
--- a/src/site/stages/build/drupal/graphql/storyListingPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/storyListingPage.graphql.js
@@ -8,7 +8,7 @@ module.exports = `
  fragment storyListingPage on NodeStoryListing {
     ${entityElementsFromPages}
     fieldIntroText
-    reverseFieldListingNode(limit: 500, filter: {conditions: [{field: "type", value: "news_story"}, {field: "status", value: "1", operator: EQUAL}]}, sort: {field: "changed", direction: DESC}) {
+    reverseFieldListingNode(limit: 500, filter: {conditions: [{field: "type", value: "news_story"}, {field: "status", value: "1", operator: EQUAL}]}, sort: {field: "created", direction: DESC}) {
       entities {
         ... on NodeNewsStory {
           entityId


### PR DESCRIPTION
## Description
Presently, stories are sorting by last update. This pr changes to sort by creation date

## Testing done
Visual

## Screenshots
![image](https://user-images.githubusercontent.com/2404547/80635542-011a9400-8a2a-11ea-90a1-979e2f5dd473.png)

## Acceptance criteria
- [ ] Go to `pittsburgh-health-care/stories/` and visually verify first few stories listed match sequence in screenshot