### PR TITLE
Chatbot checkboxes disabled on submit

### DIFF
--- a/src/applications/coronavirus-chatbot/createCoronavirusChatbot.js
+++ b/src/applications/coronavirus-chatbot/createCoronavirusChatbot.js
@@ -10,36 +10,30 @@ export default (_store, widgetType) => {
     return;
   }
 
-  import(/* webpackChunkName: "chatbot" */ './index')
-    .then(module => {
-      const initializeChatbot = module.default;
-      initializeChatbot()
-        .then(webchatOptions => {
-          window.WebChat.renderWebChat(webchatOptions, root);
-        })
-        .then(
-          recordEvent({
-            event: `${GA_PREFIX}-connection-successful`,
-            'error-key': undefined,
-          }),
-        )
-        .catch(() => {
-          recordEvent({
-            event: `${GA_PREFIX}-connection-failure`,
-            'error-key': 'XX_failed_to_start_chat',
-          });
+  import(/* webpackChunkName: "chatbot" */ './index').then(module => {
+    const initializeChatbot = module.default;
+    initializeChatbot()
+      .then(webchatOptions => {
+        recordEvent({
+          event: `${GA_PREFIX}-connection-successful`,
+          'error-key': undefined,
         });
-    })
-    .then(() => {
-      recordEvent({
-        event: `${GA_PREFIX}-load-successful`,
-        'error-key': undefined,
+        recordEvent({
+          event: `${GA_PREFIX}-load-successful`,
+          'error-key': undefined,
+        });
+
+        window.WebChat.renderWebChat(webchatOptions, root);
+      })
+      .catch(() => {
+        recordEvent({
+          event: `${GA_PREFIX}-connection-failure`,
+          'error-key': 'XX_failed_to_start_chat',
+        });
+        recordEvent({
+          event: `${GA_PREFIX}-load-failure`,
+          'error-key': undefined,
+        });
       });
-    })
-    .catch(() => {
-      recordEvent({
-        event: `${GA_PREFIX}-load-failure`,
-        'error-key': undefined,
-      });
-    });
+  });
 };

--- a/src/applications/coronavirus-chatbot/createCoronavirusChatbot.js
+++ b/src/applications/coronavirus-chatbot/createCoronavirusChatbot.js
@@ -13,17 +13,30 @@ export default (_store, widgetType) => {
   import(/* webpackChunkName: "chatbot" */ './index')
     .then(module => {
       const initializeChatbot = module.default;
-      initializeChatbot(root);
+      initializeChatbot()
+        .then(webchatOptions => {
+          window.WebChat.renderWebChat(webchatOptions, root);
+        })
+        .then(
+          recordEvent({
+            event: `${GA_PREFIX}-connection-successful`,
+            'error-key': undefined,
+          }),
+        )
+        .catch(() => {
+          recordEvent({
+            event: `${GA_PREFIX}-connection-failure`,
+            'error-key': 'XX_failed_to_start_chat',
+          });
+        });
     })
-    // eslint-disable-next-line no-unused-vars
-    .then(res => {
+    .then(() => {
       recordEvent({
         event: `${GA_PREFIX}-load-successful`,
         'error-key': undefined,
       });
     })
-    // eslint-disable-next-line no-unused-vars
-    .catch(error => {
+    .catch(() => {
       recordEvent({
         event: `${GA_PREFIX}-load-failure`,
         'error-key': undefined,

--- a/src/applications/coronavirus-chatbot/createCoronavirusChatbot.js
+++ b/src/applications/coronavirus-chatbot/createCoronavirusChatbot.js
@@ -10,10 +10,10 @@ export default (_store, widgetType) => {
     return;
   }
 
-  import(/* webpackChunkName: "chatbot" */ './index').then(module => {
+  import(/* webpackChunkName: "chatbot" */ './index').then(async module => {
     const initializeChatbot = module.default;
-    initializeChatbot()
-      .then(webchatOptions => {
+    try {
+        const webchatOptions = await initializeChatbot();
         recordEvent({
           event: `${GA_PREFIX}-connection-successful`,
           'error-key': undefined,
@@ -22,11 +22,9 @@ export default (_store, widgetType) => {
           event: `${GA_PREFIX}-load-successful`,
           'error-key': undefined,
         });
-
         window.WebChat.renderWebChat(webchatOptions, root);
-      })
-      .catch(() => {
-        recordEvent({
+    } catch(err) {
+      recordEvent({
           event: `${GA_PREFIX}-connection-failure`,
           'error-key': 'XX_failed_to_start_chat',
         });
@@ -34,6 +32,7 @@ export default (_store, widgetType) => {
           event: `${GA_PREFIX}-load-failure`,
           'error-key': undefined,
         });
+    }
       });
   });
 };

--- a/src/applications/coronavirus-chatbot/createCoronavirusChatbot.js
+++ b/src/applications/coronavirus-chatbot/createCoronavirusChatbot.js
@@ -13,26 +13,25 @@ export default (_store, widgetType) => {
   import(/* webpackChunkName: "chatbot" */ './index').then(async module => {
     const initializeChatbot = module.default;
     try {
-        const webchatOptions = await initializeChatbot();
-        recordEvent({
-          event: `${GA_PREFIX}-connection-successful`,
-          'error-key': undefined,
-        });
-        recordEvent({
-          event: `${GA_PREFIX}-load-successful`,
-          'error-key': undefined,
-        });
-        window.WebChat.renderWebChat(webchatOptions, root);
-    } catch(err) {
+      const webchatOptions = await initializeChatbot();
       recordEvent({
-          event: `${GA_PREFIX}-connection-failure`,
-          'error-key': 'XX_failed_to_start_chat',
-        });
-        recordEvent({
-          event: `${GA_PREFIX}-load-failure`,
-          'error-key': undefined,
-        });
-    }
+        event: `${GA_PREFIX}-connection-successful`,
+        'error-key': undefined,
       });
+      recordEvent({
+        event: `${GA_PREFIX}-load-successful`,
+        'error-key': undefined,
+      });
+      window.WebChat.renderWebChat(webchatOptions, root);
+    } catch (err) {
+      recordEvent({
+        event: `${GA_PREFIX}-connection-failure`,
+        'error-key': 'XX_failed_to_start_chat',
+      });
+      recordEvent({
+        event: `${GA_PREFIX}-load-failure`,
+        'error-key': undefined,
+      });
+    }
   });
 };

--- a/src/applications/coronavirus-chatbot/index.js
+++ b/src/applications/coronavirus-chatbot/index.js
@@ -1,6 +1,6 @@
 import { apiRequest } from '../../platform/utilities/api';
 import recordEvent from '../../platform/monitoring/record-event';
-import { GA_PREFIX, watchForButtonClicks } from './utils';
+import { GA_PREFIX, addEventListenerToButtons } from './utils';
 
 export const defaultLocale = 'en-US';
 const localeRegExPattern = /^[a-z]{2}(-[A-Z]{2})?$/;
@@ -149,6 +149,6 @@ const chatRequested = scenario => {
 };
 
 export default function initializeChatbot() {
-  watchForButtonClicks();
+  addEventListenerToButtons();
   return chatRequested('va_coronavirus_chatbot');
 }

--- a/src/applications/coronavirus-chatbot/index.js
+++ b/src/applications/coronavirus-chatbot/index.js
@@ -1,11 +1,10 @@
-import { apiRequest } from 'platform/utilities/api';
-import recordEvent from 'platform/monitoring/record-event';
-import { watchForButtonClicks, GA_PREFIX } from './utils';
+import { apiRequest } from '../../platform/utilities/api';
+import recordEvent from '../../platform/monitoring/record-event';
+import { GA_PREFIX, watchForButtonClicks } from './utils';
 
 export const defaultLocale = 'en-US';
 const localeRegExPattern = /^[a-z]{2}(-[A-Z]{2})?$/;
 let chatBotScenario = 'unknown';
-let root = null;
 
 export const extractLocale = localeParam => {
   if (localeParam === 'autodetect') {
@@ -35,10 +34,6 @@ export const getUserLocation = callback => {
       callback();
     },
   );
-};
-
-const startChat = (user, webchatOptions) => {
-  window.WebChat.renderWebChat(webchatOptions, root);
 };
 
 const initBotConversation = jsonWebToken => {
@@ -108,7 +103,7 @@ const initBotConversation = jsonWebToken => {
       return next(action);
     },
   );
-  const webchatOptions = {
+  return {
     directLine: botConnection,
     styleOptions,
     store: webchatStore,
@@ -116,18 +111,6 @@ const initBotConversation = jsonWebToken => {
     username: user.name,
     locale: user.locale,
   };
-  try {
-    startChat(user, webchatOptions);
-    recordEvent({
-      event: `${GA_PREFIX}-connection-successful`,
-      'error-key': undefined,
-    });
-  } catch (error) {
-    recordEvent({
-      event: `${GA_PREFIX}-connection-failure`,
-      'error-key': 'XX_failed_to_start_chat',
-    });
-  }
 };
 
 export const requestChatBot = loc => {
@@ -157,18 +140,17 @@ export const requestChatBot = loc => {
       });
     });
 };
+
 const chatRequested = scenario => {
   chatBotScenario = scenario;
   const params = new URLSearchParams(location.search);
   if (params.has('shareLocation')) {
     getUserLocation(requestChatBot);
-  } else {
-    requestChatBot();
   }
+  return requestChatBot();
 };
 
-export default function initializeChatbot(_root) {
-  root = _root;
+export default function initializeChatbot() {
   watchForButtonClicks();
-  chatRequested('va_coronavirus_chatbot');
+  return chatRequested('va_coronavirus_chatbot');
 }

--- a/src/applications/coronavirus-chatbot/index.js
+++ b/src/applications/coronavirus-chatbot/index.js
@@ -131,9 +131,7 @@ export const requestChatBot = loc => {
   }
   return apiRequest(path, { method: 'POST' })
     .then(({ token }) => initBotConversation(token))
-    .catch(error => {
-      // eslint-disable-next-line no-console
-      console.log(error);
+    .catch(() => {
       recordEvent({
         event: `${GA_PREFIX}-connection-failure`,
         'error-key': 'XX_failed_to_init_bot_convo',

--- a/src/applications/coronavirus-chatbot/utils.js
+++ b/src/applications/coronavirus-chatbot/utils.js
@@ -10,15 +10,8 @@ const disableButtons = event => {
 };
 
 const disableCheckboxes = () => {
-  const inputs = document
-    .getElementById('webchat')
-    .getElementsByTagName('input');
-
-  for (let i = 0; i < inputs.length; i++) {
-    if (inputs[i].type === 'checkbox') {
-      inputs[i].disabled = true;
-    }
-  }
+[...document.querySelectorAll('#webchat input[type="checkbox"]')]
+    .forEach(input => input.disabled = true);
 };
 
 const scrollToNewMessage = () => {

--- a/src/applications/coronavirus-chatbot/utils.js
+++ b/src/applications/coronavirus-chatbot/utils.js
@@ -12,6 +12,16 @@ const disableButtons = event => {
     event.target.tagName === 'BUTTON' ? event.target : event.target.parentNode;
   const siblingButtons = targetButton.parentNode.childNodes;
 
+  const inputs = document
+    .getElementById('webchat')
+    .getElementsByTagName('input');
+
+  for (let i = 0; i < inputs.length; i++) {
+    if (inputs[i].type === 'checkbox') {
+      inputs[i].disabled = true;
+    }
+  }
+
   for (let i = 0; i < siblingButtons.length; i++) {
     siblingButtons[i].disabled = true;
   }

--- a/src/applications/coronavirus-chatbot/utils.js
+++ b/src/applications/coronavirus-chatbot/utils.js
@@ -10,8 +10,13 @@ const disableButtons = event => {
 };
 
 const disableCheckboxes = () => {
-[...document.querySelectorAll('#webchat input[type="checkbox"]')]
-    .forEach(input => input.disabled = true);
+  [...document.querySelectorAll('#webchat input[type="checkbox"]')].forEach(
+    input => {
+      const currentInput = input;
+      currentInput.disabled = true;
+      return currentInput;
+    },
+  );
 };
 
 const scrollToNewMessage = () => {

--- a/src/applications/coronavirus-chatbot/utils.js
+++ b/src/applications/coronavirus-chatbot/utils.js
@@ -1,17 +1,15 @@
-const scrollToNewMessage = () => {
-  const messages = document.getElementsByClassName(
-    'webchat__stackedLayout--fromUser',
-  );
-  const lastMessageFromUser = messages[messages.length - 1];
-  lastMessageFromUser.scrollIntoView({ behavior: 'smooth' });
-};
-
 const disableButtons = event => {
   // if user clicked the div, bubble up to parent to disable the button
   const targetButton =
     event.target.tagName === 'BUTTON' ? event.target : event.target.parentNode;
   const siblingButtons = targetButton.parentNode.childNodes;
 
+  for (let i = 0; i < siblingButtons.length; i++) {
+    siblingButtons[i].disabled = true;
+  }
+};
+
+const disableCheckboxes = () => {
   const inputs = document
     .getElementById('webchat')
     .getElementsByTagName('input');
@@ -21,18 +19,27 @@ const disableButtons = event => {
       inputs[i].disabled = true;
     }
   }
-
-  for (let i = 0; i < siblingButtons.length; i++) {
-    siblingButtons[i].disabled = true;
-  }
 };
 
-export const watchForButtonClicks = () => {
+const scrollToNewMessage = () => {
+  const messages = document.getElementsByClassName(
+    'webchat__stackedLayout--fromUser',
+  );
+  const lastMessageFromUser = messages[messages.length - 1];
+  lastMessageFromUser.scrollIntoView({ behavior: 'smooth' });
+};
+
+const handleDisableAndScroll = event => {
+  disableButtons(event);
+  disableCheckboxes();
+  scrollToNewMessage();
+};
+
+export const addEventListenerToButtons = () => {
   setInterval(() => {
     const buttons = document.getElementsByClassName('ac-pushButton');
     for (let i = 0; i < buttons.length; i++) {
-      buttons[i].addEventListener('click', disableButtons);
-      buttons[i].addEventListener('click', scrollToNewMessage);
+      buttons[i].addEventListener('click', handleDisableAndScroll);
     }
   }, 10);
 };

--- a/src/platform/site-wide/tests/sitemap/sitemap-helpers.js
+++ b/src/platform/site-wide/tests/sitemap/sitemap-helpers.js
@@ -17,6 +17,7 @@ function sitemapURLs() {
         .map(n => n.text().replace(DOMAIN_REGEX, `${E2eHelpers.baseUrl}/`))
         .filter(url => !url.endsWith('auth/login/callback/'))
         .filter(url => !url.includes('playbook/'))
+        .filter(url => !url.includes('coronavirus-chatbot/'))
         .filter(url => !url.includes('pittsburgh-health-care/'))
         .filter(url => !/.*opt-out-information-sharing.*/.test(url)),
     )


### PR DESCRIPTION
## Description
- Refactors event listener logic around disabling buttons, disabling checkboxes (new!), and scrolling to the newest user message
- Moved GA events around, refactors order @batemapf 
- Fixes this bug for chatbot checkboxes [department-of-veterans-affairs/covid19-chatbot#138](https://github.com/department-of-veterans-affairs/covid19-chatbot/issues/138) @pjhill 
- Extracts `window.WebChat.renderWebChat(webchatOptions, root)` call from within `index.js/startChat` method

## Testing done
Just manual testing for now. Works in Chrome, Safari, Firefox, IE11.

**Next steps: an automated UI test to validate this functionality.**

## Screenshots
<img width="550" alt="Screen Shot 2020-04-23 at 4 59 22 PM" src="https://user-images.githubusercontent.com/60353062/80149412-9cbc8800-8584-11ea-9e59-f982f4c514a5.png">

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
