### PR TITLE
Copy vendor entry to shared-modules

### DIFF
--- a/script/build.sh
+++ b/script/build.sh
@@ -53,6 +53,7 @@ fi
 if [ "${assetSource}" = "local" ]; then
     echo "Building application assets"
     yarn build:webpack $webpackArgs
+    cp -v "${buildDir}generated/vendor.entry.js" "${buildDir}generated/shared-modules.entry.js"
 else
     echo "Will fetch application assets from the content build script"
 fi

--- a/src/site/includes/header.html
+++ b/src/site/includes/header.html
@@ -60,7 +60,7 @@
 <![endif]-->
 
   <script defer nomodule src="/generated/polyfills.entry.js"></script>
-  <script defer src="/generated/vendor.entry.js"></script>
+  <script defer src="/generated/shared-modules.entry.js"></script>
   <script defer src="/generated/{{ entryname | default: 'static-pages' }}.entry.js"></script>
 
   <!--


### PR DESCRIPTION
## Description

Part of https://github.com/department-of-veterans-affairs/va.gov-team/issues/8560

I initially tried to accomplish this using our existing webpack config but had no luck.  There are some additional plugins discussed [here](https://github.com/webpack-contrib/copy-webpack-plugin/issues/15) that might work, but it seemed simpler to just use `cp`

## Testing done

Successful local website build


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
