### PR TITLE
Add feature flag for inbound sso, update keep-alive call

### DIFF
--- a/src/platform/site-wide/user-nav/containers/Main.jsx
+++ b/src/platform/site-wide/user-nav/containers/Main.jsx
@@ -12,7 +12,7 @@ import environment from 'platform/utilities/environment';
 import { hasSession, hasSessionSSO } from 'platform/user/profile/utilities';
 import { autoLogin, autoLogout } from 'platform/user/authentication/utilities';
 import { ssoKeepAliveSession } from 'platform/utilities/sso';
-import { ssoe } from 'platform/user/authentication/selectors';
+import { ssoe, ssoeInbound } from 'platform/user/authentication/selectors';
 import { isLoggedIn, isProfileLoading, isLOA3 } from 'platform/user/selectors';
 
 import { getBackendStatuses } from 'platform/monitoring/external-services/actions';
@@ -80,11 +80,11 @@ export class Main extends React.Component {
     }
 
     if (hasSession()) {
-      if (canCallSSO && !hasSessionSSO()) {
+      if (canCallSSO && this.props.useAutoLoginLogout && !hasSessionSSO()) {
         autoLogout();
       }
       this.props.initializeProfile();
-    } else if (canCallSSO && hasSessionSSO()) {
+    } else if (canCallSSO && this.props.useAutoLoginLogout && hasSessionSSO()) {
       autoLogin();
     } else {
       this.props.updateLoggedInStatus(false);
@@ -212,6 +212,7 @@ export const mapStateToProps = state => {
     shouldConfirmLeavingForm,
     userGreeting: selectUserGreeting(state),
     useSSOe: ssoe(state),
+    useAutoLoginLogout: ssoeInbound(state),
     ...state.navigation,
   };
 };

--- a/src/platform/site-wide/user-nav/tests/containers/Main.unit.spec.jsx
+++ b/src/platform/site-wide/user-nav/tests/containers/Main.unit.spec.jsx
@@ -30,6 +30,7 @@ describe('<Main>', () => {
     updateLoggedInStatus: sinon.spy(),
     initializeProfile: sinon.spy(),
     useSSOe: false,
+    useAutoLoginLogout: false,
   };
 
   const oldWindow = global.window;
@@ -91,7 +92,7 @@ describe('<Main>', () => {
     it('should automatically initiate a session log in if a SSOe-flagged user has an active SSOe session but no vets-website session', () => {
       localStorage.setItem('hasSessionSSO', true);
       authUtils.autoLogin = sinon.spy();
-      const wrapper = shallow(<Main {...props} useSSOe />);
+      const wrapper = shallow(<Main {...props} useSSOe useAutoLoginLogout />);
       global.window.simulate('load');
       expect(authUtils.autoLogin.called).to.be.true;
       wrapper.unmount();
@@ -100,7 +101,7 @@ describe('<Main>', () => {
     it('should automatically log out if a SSOe-flagged user has an active vets-website session but no SSOe session', () => {
       localStorage.setItem('hasSession', true);
       authUtils.autoLogout = sinon.spy();
-      const wrapper = shallow(<Main {...props} useSSOe />);
+      const wrapper = shallow(<Main {...props} useSSOe useAutoLoginLogout />);
       global.window.simulate('load');
       expect(authUtils.autoLogout.called).to.be.true;
       wrapper.unmount();

--- a/src/platform/user/authentication/selectors.js
+++ b/src/platform/user/authentication/selectors.js
@@ -2,3 +2,5 @@ import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
 import FEATURE_FLAG_NAMES from 'platform/utilities/feature-toggles/featureFlagNames';
 
 export const ssoe = state => toggleValues(state)[FEATURE_FLAG_NAMES.ssoe];
+export const ssoeInbound = state =>
+  toggleValues(state)[FEATURE_FLAG_NAMES.ssoeInbound];

--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -14,6 +14,7 @@ export default Object.freeze({
   vaOnlineSchedulingPast: 'vaOnlineSchedulingPast',
   vaGlobalDowntimeNotification: 'vaGlobalDowntimeNotification',
   ssoe: 'ssoe',
+  ssoeInbound: 'ssoeInbound',
   eduBenefitsStemScholarship: 'eduBenefitsStemScholarship',
   eduSection103: 'edu_section_103',
   gibctEstimateYourBenefits: 'gibctEstimateYourBenefits',

--- a/src/platform/utilities/sso/index.js
+++ b/src/platform/utilities/sso/index.js
@@ -10,9 +10,8 @@ const keepAlive = environment.isLocalhost() ? mockKeepAlive : liveKeepAlive;
 let ssoSessionLength = 9000; // milliseconds
 
 export async function ssoKeepAliveSession() {
-  const res = await keepAlive();
-
   try {
+    const res = await keepAlive();
     const hasSSOsession = res.headers.get('session-alive');
     if (hasSSOsession === 'true') {
       // 'session-timeout' is in seconds, convert to milliseconds

--- a/src/platform/utilities/sso/keepAliveSSO.js
+++ b/src/platform/utilities/sso/keepAliveSSO.js
@@ -5,5 +5,8 @@ export default function keepAlive() {
     method: 'GET',
     credentials: 'include',
     cache: 'no-store',
+    headers: {
+      'Content-Type': 'application/json',
+    },
   });
 }


### PR DESCRIPTION
## Description

This wires in a feature for inbound SSO (i.e., automatic login or logout of a `vets-api` session depending on the existence of an SSOe session), so we can toggle that independently of general SSOe session establishment via normal login interactions.

