### PR TITLE
Add help output to the build:content task

### DIFF
--- a/script/build-content.js
+++ b/script/build-content.js
@@ -2,8 +2,15 @@ const chokidar = require('chokidar');
 const chalk = require('chalk');
 const debounce = require('lodash/debounce');
 
+const printBuildHelp = require('./content-build-help');
 const getOptions = require('../src/site/stages/build/options');
 const build = require('../src/site/stages/build');
+
+// If help, echo the options
+if (process.argv[2] === 'help') {
+  printBuildHelp();
+  process.exit(0);
+}
 
 async function buildContent() {
   const buildOptions = await getOptions();

--- a/script/content-build-help.js
+++ b/script/content-build-help.js
@@ -1,0 +1,103 @@
+/* eslint-disable no-console */
+const path = require('path');
+const commandLineUsage = require('command-line-usage');
+
+const parentDir = path.resolve(__dirname, '../../');
+const defaultContentDir = path.join(parentDir, 'vagov-content');
+const defaultCmsExportDir = path.join(parentDir, 'cms-export/content');
+
+const helpSections = [
+  {
+    header: 'Main Options',
+    optionList: [
+      {
+        name: 'buildtype',
+        type: String,
+        description:
+          'Use a specific buildtype.\nOptions include {bold localhost} (default), {bold vagovdev}, {bold vagovstaging}, {bold vagovprod}.',
+      },
+      {
+        name: 'watch',
+        type: Boolean,
+        description: 'Rebuild content when a template change is detected.',
+      },
+      {
+        name: 'destination',
+        type: String,
+        description: 'Specify a directory to write the build output.',
+      },
+      {
+        name: 'asset-source',
+        type: String,
+        description:
+          'Tell the build where to pull the application assets from.\nOptions include {bold local} (default), {bold deployed}, or a {bold vets-website commit hash}.',
+      },
+      {
+        name: 'content-directory',
+        type: String,
+        description: `Tell the build where to find the vagov-content repo.\nDefaults to {underline ${defaultContentDir}}`,
+      },
+      {
+        name: 'pull-drupal',
+        type: Boolean,
+        description:
+          'Pull the latest content from Drupal. If false, the build will try to use the local cache found in .cache/',
+      },
+      {
+        name: 'use-cms-export',
+        type: Boolean,
+        description:
+          'Use the CMS export instead of GraphQL to fetch the content nodes.',
+      },
+      {
+        name: 'cms-export-dir',
+        type: String,
+        description: `Specify where to find the CMS export.\nDefaults to {underline ${defaultCmsExportDir}}`,
+      },
+      {
+        name: 'drupal-fail-fast',
+        type: Boolean,
+        description: 'Fail the build quickly if an error is encountered.',
+      },
+      {
+        name: 'drupal-address',
+        type: String,
+        description:
+          'Specify the address of the Drupal server to pull the content from.',
+      },
+      {
+        name: 'drupal-user',
+        type: String,
+        description:
+          'Specify the user to authenticate as when querying the Drupal server.',
+      },
+      {
+        name: 'drupal-password',
+        type: String,
+        description: 'Specify the password for the --drupal-user.',
+      },
+      {
+        name: 'no-drupal-proxy',
+        type: Boolean,
+        description:
+          "Don't use the SOCKS proxy when connecting to the Drupal server.",
+      },
+      {
+        name: 'accessibility',
+        type: Boolean,
+        description: 'Inject the aXe checker into all HTML files.',
+      },
+      {
+        name: 'lint-plain-language',
+        type: Boolean,
+        description: 'Lint HTML files for plain language.',
+      },
+    ],
+  },
+];
+
+const printBuildHelp = () => {
+  console.log(commandLineUsage(helpSections));
+};
+
+module.exports = printBuildHelp;

--- a/script/content-build-help.js
+++ b/script/content-build-help.js
@@ -8,7 +8,7 @@ const defaultCmsExportDir = path.join(parentDir, 'cms-export/content');
 
 const helpSections = [
   {
-    header: 'Main Options',
+    header: 'Options',
     optionList: [
       {
         name: 'buildtype',


### PR DESCRIPTION
## Description
Adds a help command to the `build:content` task.

## Screenshots
![image](https://user-images.githubusercontent.com/12970166/80736934-a9cb0100-8ac7-11ea-9809-66f1f7d50b2b.png)