### PR TITLE
Update yarn.lock due to formation-react version bump

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -844,9 +844,9 @@
     to-fast-properties "^2.0.0"
 
 "@department-of-veterans-affairs/formation-react@^5.2.0":
-  version "5.2.4"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/formation-react/-/formation-react-5.2.4.tgz#65ca940bf0e7866cb7315602ede3a0cb8eb7d65d"
-  integrity sha512-1aNbSK9/9TNFi7XMkkh8IYDKmWzln7wGiPHu6/KGGejeBkZcLJfHyP+elvTXyHjSgZnA71D09UEuzhJtEqDFoA==
+  version "5.2.5"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/formation-react/-/formation-react-5.2.5.tgz#1542035f9e3629c59c11fb676848654c6488fd94"
+  integrity sha512-ob70xEKNdWOMm4YYFBlaW8MXhTlf5UNX4qjKa6RtR9urq8TxrIum5WfwjlzOBCQkWWVf6OxZjNOttzp29Q+48g==
   dependencies:
     classnames "^2.2.6"
     lodash "^4.17.15"

--- a/yarn.lock
+++ b/yarn.lock
@@ -844,9 +844,9 @@
     to-fast-properties "^2.0.0"
 
 "@department-of-veterans-affairs/formation-react@^5.2.0":
-  version "5.2.3"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/formation-react/-/formation-react-5.2.3.tgz#ed66897924be577abc6f4b1a653035740980a2ad"
-  integrity sha512-AvDLyOuZIV6Ppcey7D40qFdi+UYGpXaBZmdrfBX/C1aqAbihlA60JV1Mr3ir4Z91nkC7260nmkUGm51HmGsNrw==
+  version "5.2.4"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/formation-react/-/formation-react-5.2.4.tgz#65ca940bf0e7866cb7315602ede3a0cb8eb7d65d"
+  integrity sha512-1aNbSK9/9TNFi7XMkkh8IYDKmWzln7wGiPHu6/KGGejeBkZcLJfHyP+elvTXyHjSgZnA71D09UEuzhJtEqDFoA==
   dependencies:
     classnames "^2.2.6"
     lodash "^4.17.15"


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/7199

This PR bumps the version of `formation-react`.

## Testing done


## Screenshots


## Acceptance criteria
- [x] Bump `formation-react` version.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
