### PR TITLE
Vendor fix

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -21,21 +21,25 @@ const headerFooterData = require('../src/platform/landing-pages/header-footer-da
 const getAbsolutePath = relativePath =>
   path.join(__dirname, '../', relativePath);
 
+const sharedModules = [
+  getAbsolutePath('src/platform/polyfills'),
+  'react',
+  'react-dom',
+  'react-redux',
+  'redux',
+  'redux-thunk',
+  '@sentry/browser',
+];
+
 const globalEntryFiles = {
   polyfills: getAbsolutePath('src/platform/polyfills/preESModulesPolyfills.js'),
   style: getAbsolutePath('src/platform/site-wide/sass/style.scss'),
   styleConsolidated: getAbsolutePath(
     'src/applications/proxy-rewrite/sass/style-consolidated.scss',
   ),
-  vendor: [
-    getAbsolutePath('src/platform/polyfills'),
-    'react',
-    'react-dom',
-    'react-redux',
-    'redux',
-    'redux-thunk',
-    '@sentry/browser',
-  ],
+  vendor: sharedModules,
+  // This is to solve the issue of the vendor file being cached
+  'shared-modules': sharedModules,
 };
 
 /**

--- a/script/build.sh
+++ b/script/build.sh
@@ -53,6 +53,7 @@ fi
 if [ "${assetSource}" = "local" ]; then
     echo "Building application assets"
     yarn build:webpack $webpackArgs
+    cp -v "${buildDir}generated/vendor.entry.js" "${buildDir}generated/shared-modules.entry.js"
 else
     echo "Will fetch application assets from the content build script"
 fi

--- a/script/build.sh
+++ b/script/build.sh
@@ -53,7 +53,6 @@ fi
 if [ "${assetSource}" = "local" ]; then
     echo "Building application assets"
     yarn build:webpack $webpackArgs
-    cp -v "${buildDir}generated/vendor.entry.js" "${buildDir}generated/shared-modules.entry.js"
 else
     echo "Will fetch application assets from the content build script"
 fi


### PR DESCRIPTION
## Description

This is a patch for https://github.com/department-of-veterans-affairs/vets-website/pull/12427 so that local development will still work without necessarily running `yarn build` (i.e., instead running `yarn build:content`)

## Testing done

- `yarn build:content` followed by `yarn watch` works
- `yarn build` followed by `yarn watch` also works

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
