### PR TITLE
VAVFS-8299: Updating in page alerts to follow 508 compliant h levels.

### DIFF
--- a/src/applications/facility-locator/containers/FacilityDetail.jsx
+++ b/src/applications/facility-locator/containers/FacilityDetail.jsx
@@ -63,6 +63,7 @@ class FacilityDetail extends Component {
     }
     return (
       <AlertBox
+        level={2}
         headline={`${operationStatusTitle}`}
         content={
           <div>


### PR DESCRIPTION
## Description
Prevents facility alert headers from throwing 508 error when h2 is skipped. These alerts appear after title, and need to be h2's.

## Testing done
Visual

## Screenshots
![image](https://user-images.githubusercontent.com/2404547/80753440-45c23000-8afb-11ea-84d6-21f0eaf75e61.png)

## Acceptance criteria
- [ ] Using test data, go to `/find-locations/facility/nca_s1130` and visually verify that alert header is wrapped in an H2