### PR TITLE
[CI/CD] Fix form 526 a11y

### DIFF
--- a/src/applications/disability-benefits/526EZ/tests/components/SelectArrayItemsWidget.unit.spec.jsx
+++ b/src/applications/disability-benefits/526EZ/tests/components/SelectArrayItemsWidget.unit.spec.jsx
@@ -25,12 +25,27 @@ describe('<SelectArrayItemsWidget>', () => {
     // Reset default props before each test
     onChangeSpy.reset();
     defaultProps = {
-      value: [{ name: 'item one', propTwo: 'asdf' }, { name: 'item two' }],
+      value: [
+        {
+          name: 'item one',
+          propTwo: 'asdf',
+          className: 'vads-u-display--inline',
+        },
+        {
+          name: 'item two',
+          className: 'vads-u-display--inline',
+        },
+      ],
       id: 'id',
       onChange: onChangeSpy,
       options: {
         label: labelElement,
         selectedPropName,
+        customTitle: 'Title',
+      },
+      formContext: {
+        onReviewPage: true,
+        reviewMode: false,
       },
     };
   });

--- a/src/applications/disability-benefits/526EZ/tests/config/ratedDisabilities.unit.spec.jsx
+++ b/src/applications/disability-benefits/526EZ/tests/config/ratedDisabilities.unit.spec.jsx
@@ -77,7 +77,7 @@ describe('Disability benefits 526EZ -- Rated disabilities selection', () => {
     expect(
       labels
         .at(0)
-        .find('h5')
+        .find('h3')
         .text(),
     ).to.equal('Post Traumatic Stress Disorder');
     expect(
@@ -91,7 +91,7 @@ describe('Disability benefits 526EZ -- Rated disabilities selection', () => {
     expect(
       labels
         .at(1)
-        .find('h5')
+        .find('h3')
         .text(),
     ).to.equal('Intervertebral Disc Syndrome');
     expect(

--- a/src/applications/disability-benefits/526EZ/tests/config/ratedDisabilities.unit.spec.jsx
+++ b/src/applications/disability-benefits/526EZ/tests/config/ratedDisabilities.unit.spec.jsx
@@ -77,7 +77,7 @@ describe('Disability benefits 526EZ -- Rated disabilities selection', () => {
     expect(
       labels
         .at(0)
-        .find('h4')
+        .find('h5')
         .text(),
     ).to.equal('Post Traumatic Stress Disorder');
     expect(
@@ -91,7 +91,7 @@ describe('Disability benefits 526EZ -- Rated disabilities selection', () => {
     expect(
       labels
         .at(1)
-        .find('h4')
+        .find('h5')
         .text(),
     ).to.equal('Intervertebral Disc Syndrome');
     expect(

--- a/src/applications/disability-benefits/all-claims/components/SelectArrayItemsWidget.jsx
+++ b/src/applications/disability-benefits/all-claims/components/SelectArrayItemsWidget.jsx
@@ -20,7 +20,7 @@ export default class SelectArrayItemsWidget extends React.Component {
   defaultSelectedPropName = 'view:selected';
 
   render() {
-    const { value: items, id, options, required } = this.props;
+    const { value: items, id, options, required, formContext } = this.props;
     // Need customTitle to set error message above title.
     const { label: Label, selectedPropName, disabled, customTitle } = options;
 
@@ -48,8 +48,19 @@ export default class SelectArrayItemsWidget extends React.Component {
               { selected: itemIsSelected },
             );
 
+            // ObjectField is set to be wrapped in a div instead of a dl, so we move
+            // that dl wrap to here; this change fixes an accessibility issue
+            const Tag =
+              // Wrap in DL only if on review page & in review mode
+              formContext.onReviewPage &&
+              formContext.reviewMode &&
+              // volatileData is for arrays, which displays separate blocks
+              customTitle
+                ? 'dl'
+                : 'div';
+
             return (
-              <div key={index}>
+              <Tag key={index}>
                 <dt className={widgetClasses}>
                   <input
                     type="checkbox"
@@ -71,7 +82,7 @@ export default class SelectArrayItemsWidget extends React.Component {
                   </label>
                 </dt>
                 <dd />
-              </div>
+              </Tag>
             );
           })}
       </>

--- a/src/applications/disability-benefits/all-claims/components/SelectArrayItemsWidget.jsx
+++ b/src/applications/disability-benefits/all-claims/components/SelectArrayItemsWidget.jsx
@@ -35,10 +35,13 @@ export default class SelectArrayItemsWidget extends React.Component {
       false,
     );
 
+    const Tag = formContext.onReviewPage ? 'h4' : 'h3';
+
     // Note: Much of this was stolen from CheckboxWidget
     return (
       <>
-        {customTitle?.trim() && items && <h5>{customTitle}</h5>}
+        {customTitle?.trim() &&
+          items && <Tag className="vads-u-font-size--h5">{customTitle}</Tag>}
         {items && (!inReviewMode || (inReviewMode && hasSelections)) ? (
           items.map((item, index) => {
             const itemIsSelected = !!get(

--- a/src/applications/disability-benefits/all-claims/components/SelectArrayItemsWidget.jsx
+++ b/src/applications/disability-benefits/all-claims/components/SelectArrayItemsWidget.jsx
@@ -39,7 +39,7 @@ export default class SelectArrayItemsWidget extends React.Component {
     return (
       <>
         {customTitle?.trim() && items && <h5>{customTitle}</h5>}
-        {!inReviewMode || (inReviewMode && hasSelections) ? (
+        {items && (!inReviewMode || (inReviewMode && hasSelections)) ? (
           items.map((item, index) => {
             const itemIsSelected = !!get(
               selectedPropName || this.defaultSelectedPropName,

--- a/src/applications/disability-benefits/all-claims/components/SelectArrayItemsWidget.jsx
+++ b/src/applications/disability-benefits/all-claims/components/SelectArrayItemsWidget.jsx
@@ -68,7 +68,13 @@ export default class SelectArrayItemsWidget extends React.Component {
                 }
               />
             );
-            const elementId = `${id}_${index}`;
+            // On the review & submit page, there may be more than one
+            // of these components in edit mode with the same content, e.g. 526
+            // ratedDisabilities & unemployabilityDisabilities causing
+            // duplicate input ids/names... an `appendId` value is added to the
+            // ui:options
+            const appendId = options.appendId ? `_${options.appendId}` : '';
+            const elementId = `${id}_${index}${appendId}`;
 
             const widgetClasses = classNames(
               'form-checkbox',

--- a/src/applications/disability-benefits/all-claims/content/ratedDisabilities.jsx
+++ b/src/applications/disability-benefits/all-claims/content/ratedDisabilities.jsx
@@ -10,24 +10,24 @@ import { NULL_CONDITION_STRING } from '../constants';
  * @property {String} ratingPercentage
  * @param {Disability} disability
  */
-export const disabilityOption = ({ name, ratingPercentage }) => {
+export const disabilityOption = ({ name, ratingPercentage, className }) => {
   // May need to throw an error to Sentry if any of these doesn't exist
   // A valid rated disability *can* have a rating percentage of 0%
   const showRatingPercentage = Number.isInteger(ratingPercentage);
 
   return (
-    <div>
-      <h4>
+    <>
+      <h5 className={`vads-u-font-size--h4 ${className}`}>
         {typeof name === 'string'
           ? capitalizeEachWord(name)
           : NULL_CONDITION_STRING}
-      </h4>
+      </h5>
       {showRatingPercentage && (
         <p>
           Current rating: <strong>{ratingPercentage}%</strong>
         </p>
       )}
-    </div>
+    </>
   );
 };
 

--- a/src/applications/disability-benefits/all-claims/content/ratedDisabilities.jsx
+++ b/src/applications/disability-benefits/all-claims/content/ratedDisabilities.jsx
@@ -17,11 +17,11 @@ export const disabilityOption = ({ name, ratingPercentage, className }) => {
 
   return (
     <>
-      <h5 className={`vads-u-font-size--h4 ${className}`}>
+      <h3 className={`vads-u-font-size--h4 ${className}`}>
         {typeof name === 'string'
           ? capitalizeEachWord(name)
           : NULL_CONDITION_STRING}
-      </h5>
+      </h3>
       {showRatingPercentage && (
         <p>
           Current rating: <strong>{ratingPercentage}%</strong>

--- a/src/applications/disability-benefits/all-claims/content/unemployabilityDisabilities.jsx
+++ b/src/applications/disability-benefits/all-claims/content/unemployabilityDisabilities.jsx
@@ -44,11 +44,17 @@ export const disabilitiesDescription = (
 );
 
 export const helpDescription = (
-  <div>
-    <p>
-      <strong>Please note:</strong> If you expect to see something that isn’t
-      included in this list or if you have other questions about your claim,
-      contact: 877-222-8387, Monday – Friday, 8:00 a.m. – 8:00 p.m. ET.
-    </p>
-  </div>
+  <p>
+    <strong>Please note:</strong> If you expect to see something that isn’t
+    included in this list or if you have other questions about your claim,
+    contact:{' '}
+    <a
+      className="no-wrap"
+      href="tel:18772228387"
+      aria-label="8 7 7. 2 2 2. 8 3 8 7"
+    >
+      877-222-8387
+    </a>
+    , Monday through Friday, 8:00 a.m. to 8:00 p.m. ET.
+  </p>
 );

--- a/src/applications/disability-benefits/all-claims/content/unemployabilityDisabilities.jsx
+++ b/src/applications/disability-benefits/all-claims/content/unemployabilityDisabilities.jsx
@@ -10,38 +10,44 @@ const helpClicked = () =>
       'Disability - Form 526EZ - What is substantially gainful employment',
   });
 
-export const disabilitiesDescription = (
-  <div>
-    <h5>Rated, service-connected, and new disabilities</h5>
-    <p>
-      Individual unemployability is awarded based on service-connected
-      disabilities.
-    </p>
-    <p>
-      Below are the rated, service-connected disabilities, and new disabilities
-      you’re claiming. Please choose the disability or disabilities that prevent
-      you from getting and keeping a steady job (substantially gainful
-      employment).
-    </p>
-    <AdditionalInfo
-      triggerText="What’s substantially gainful employment?"
-      onClick={helpClicked}
-    >
-      <p>Substantially gainful employment means:</p>
-      <ul>
-        <li>
-          You’re employed in a competitive marketplace or job that isn’t in a
-          protected environment, such as a family business or sheltered
-          workshop.
-        </li>
-        <li>
-          Your annual earnings are higher than the poverty threshold for one
-          person.
-        </li>
-      </ul>
-    </AdditionalInfo>
-  </div>
-);
+export const disabilitiesDescription = ({ formContext }) => {
+  // Fix header accessibility
+  const Tag = formContext.onReviewPage ? 'h4' : 'h3';
+  return (
+    <div>
+      <Tag className="vads-u-font-size--h5">
+        Rated, service-connected, and new disabilities
+      </Tag>
+      <p>
+        Individual unemployability is awarded based on service-connected
+        disabilities.
+      </p>
+      <p>
+        Below are the rated, service-connected disabilities, and new
+        disabilities you’re claiming. Please choose the disability or
+        disabilities that prevent you from getting and keeping a steady job
+        (substantially gainful employment).
+      </p>
+      <AdditionalInfo
+        triggerText="What’s substantially gainful employment?"
+        onClick={helpClicked}
+      >
+        <p>Substantially gainful employment means:</p>
+        <ul>
+          <li>
+            You’re employed in a competitive marketplace or job that isn’t in a
+            protected environment, such as a family business or sheltered
+            workshop.
+          </li>
+          <li>
+            Your annual earnings are higher than the poverty threshold for one
+            person.
+          </li>
+        </ul>
+      </AdditionalInfo>
+    </div>
+  );
+};
 
 export const helpDescription = (
   <p>

--- a/src/applications/disability-benefits/all-claims/pages/ratedDisabilities.js
+++ b/src/applications/disability-benefits/all-claims/pages/ratedDisabilities.js
@@ -24,6 +24,9 @@ export const uiSchema = {
       label: disabilityOption,
       widgetClassNames: 'widget-outline',
       keepInPageOnReview: true,
+      // making the customTitle truthy but an empty string (trimmable), so the
+      // ObjectField doesn't wrap this content in a <DL> and break accessibility
+      customTitle: ' ',
     },
     'ui:validations': [requireRatedDisability],
   },

--- a/src/applications/disability-benefits/all-claims/pages/unemployabilityDisabilities.js
+++ b/src/applications/disability-benefits/all-claims/pages/unemployabilityDisabilities.js
@@ -27,6 +27,11 @@ export const uiSchema = {
       widgetClassNames: 'widget-outline widget-outline-group',
       keepInPageOnReview: true,
       customTitle: 'Rated disabilities',
+      // On the review & submit page, both this SelectArrayItemsWidget and the
+      // main ratedDisabilities widget could be in edit mode causing duplicate
+      // input ids/names... this appends a value on the ID to make it unique
+      // so axe-coconut doesn't complain
+      appendId: '2',
     },
   },
   newDisabilities: {
@@ -41,6 +46,7 @@ export const uiSchema = {
       widgetClassNames: 'widget-outline',
       keepInPageOnReview: true,
       customTitle: 'New unrated disabilities',
+      appendId: '2',
     },
   },
   'view:unemployabilityHelp': {

--- a/src/applications/disability-benefits/all-claims/sass/disability-benefits.scss
+++ b/src/applications/disability-benefits/all-claims/sass/disability-benefits.scss
@@ -88,10 +88,6 @@ ul.original-disability-list {
     margin-bottom: 0;
   }
 }
-.all-disabilities-title {
-  margin-top: 0.2em;
-  margin-bottom: 1.4em;
-}
 
 // Mimics usa-form-group-year minus the float and sets the max width so the
 //  error formatting doesn't increase the size

--- a/src/applications/disability-benefits/all-claims/tests/data/maximal-test.json
+++ b/src/applications/disability-benefits/all-claims/tests/data/maximal-test.json
@@ -212,7 +212,7 @@
       },
       {
         "name": "De-selected",
-        "ratedDisabilityId": "1",
+        "ratedDisabilityId": "2",
         "ratingDecisionId": "63655",
         "diagnosticCode": 5238,
         "decisionCode": "SVCCONNCTED",
@@ -223,7 +223,7 @@
       },
       {
         "name": "Not selected",
-        "ratedDisabilityId": "1",
+        "ratedDisabilityId": "3",
         "ratingDecisionId": "63655",
         "diagnosticCode": 5238,
         "decisionCode": "SVCCONNCTED",

--- a/src/applications/disability-benefits/all-claims/tests/data/secondary-new-test.json
+++ b/src/applications/disability-benefits/all-claims/tests/data/secondary-new-test.json
@@ -163,7 +163,7 @@
       },
       {
         "name": "De-selected",
-        "ratedDisabilityId": "1",
+        "ratedDisabilityId": "2",
         "ratingDecisionId": "63655",
         "diagnosticCode": 5238,
         "decisionCode": "SVCCONNCTED",
@@ -173,7 +173,7 @@
       },
       {
         "name": "Not selected",
-        "ratedDisabilityId": "1",
+        "ratedDisabilityId": "3",
         "ratingDecisionId": "63655",
         "diagnosticCode": 5238,
         "decisionCode": "SVCCONNCTED",

--- a/src/applications/disability-benefits/all-claims/tests/data/transformed-data/maximal-test.json
+++ b/src/applications/disability-benefits/all-claims/tests/data/transformed-data/maximal-test.json
@@ -77,13 +77,13 @@
       },
       {
         "name": "De-selected",
-        "ratedDisabilityId": "1",
+        "ratedDisabilityId": "2",
         "diagnosticCode": 5238,
         "disabilityActionType": "NONE"
       },
       {
         "name": "Not selected",
-        "ratedDisabilityId": "1",
+        "ratedDisabilityId": "3",
         "diagnosticCode": 5238,
         "disabilityActionType": "NONE"
       }

--- a/src/applications/disability-benefits/all-claims/tests/data/transformed-data/secondary-new-test.json
+++ b/src/applications/disability-benefits/all-claims/tests/data/transformed-data/secondary-new-test.json
@@ -57,13 +57,13 @@
       },
       {
         "name": "De-selected",
-        "ratedDisabilityId": "1",
+        "ratedDisabilityId": "2",
         "diagnosticCode": 5238,
         "disabilityActionType": "NONE"
       },
       {
         "name": "Not selected",
-        "ratedDisabilityId": "1",
+        "ratedDisabilityId": "3",
         "diagnosticCode": 5238,
         "disabilityActionType": "NONE"
       }

--- a/src/applications/disability-benefits/all-claims/tests/pages/ratedDisabilities.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/ratedDisabilities.unit.spec.jsx
@@ -77,7 +77,7 @@ describe('Disability benefits 526EZ -- Rated disabilities selection', () => {
     expect(
       labels
         .at(0)
-        .find('h5')
+        .find('h3')
         .text(),
     ).to.equal('Post Traumatic Stress Disorder');
     expect(
@@ -91,7 +91,7 @@ describe('Disability benefits 526EZ -- Rated disabilities selection', () => {
     expect(
       labels
         .at(1)
-        .find('h5')
+        .find('h3')
         .text(),
     ).to.equal('Intervertebral Disc Syndrome');
     expect(

--- a/src/applications/disability-benefits/all-claims/tests/pages/ratedDisabilities.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/ratedDisabilities.unit.spec.jsx
@@ -77,7 +77,7 @@ describe('Disability benefits 526EZ -- Rated disabilities selection', () => {
     expect(
       labels
         .at(0)
-        .find('h4')
+        .find('h5')
         .text(),
     ).to.equal('Post Traumatic Stress Disorder');
     expect(
@@ -91,7 +91,7 @@ describe('Disability benefits 526EZ -- Rated disabilities selection', () => {
     expect(
       labels
         .at(1)
-        .find('h4')
+        .find('h5')
         .text(),
     ).to.equal('Intervertebral Disc Syndrome');
     expect(

--- a/src/applications/disability-benefits/all-claims/tests/pages/unemployabilityDisabilities.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/unemployabilityDisabilities.spec.jsx
@@ -46,7 +46,7 @@ describe('Select related disabilities for unemployability', () => {
     );
 
     form
-      .find('input#root_ratedDisabilities_0')
+      .find('input#root_ratedDisabilities_0_2')
       .props()
       .onChange({ target: { checked: true } });
     form.find('form').simulate('submit');
@@ -87,7 +87,7 @@ describe('Select related disabilities for unemployability', () => {
     expect(
       labels
         .at(0)
-        .find('h4')
+        .find('h3')
         .text(),
     ).to.equal('Post Traumatic Stress Disorder');
     expect(
@@ -101,7 +101,7 @@ describe('Select related disabilities for unemployability', () => {
     expect(
       labels
         .at(1)
-        .find('h4')
+        .find('h3')
         .text(),
     ).to.equal('Intervertebral Disc Syndrome');
     expect(
@@ -115,14 +115,14 @@ describe('Select related disabilities for unemployability', () => {
     expect(
       labels
         .at(2)
-        .find('h4')
+        .find('h3')
         .text(),
     ).to.equal('CAD');
 
     expect(
       labels
         .at(3)
-        .find('h4')
+        .find('h3')
         .text(),
     ).to.equal('Cancer');
 

--- a/src/platform/forms-system/src/js/components/FieldTemplate.jsx
+++ b/src/platform/forms-system/src/js/components/FieldTemplate.jsx
@@ -27,7 +27,7 @@ export default function FieldTemplate(props) {
   const requiredSpan = required ? (
     <span className="schemaform-required-span">(*Required)</span>
   ) : null;
-  const label = uiSchema['ui:title'] || props.label;
+  const label = uiSchema['ui:title'] || props.label || '';
   const isDateField = uiSchema['ui:widget'] === 'date';
   const showFieldLabel =
     uiSchema['ui:options'] && uiSchema['ui:options'].showFieldLabel;
@@ -98,7 +98,7 @@ export default function FieldTemplate(props) {
 
   // Don't render empty labels - prevents duplicate IDs on review & submit page
   const renderLabel =
-    typeof label === 'string' && (requiredSpan || label.trim());
+    typeof label !== 'string' || (requiredSpan || label.trim());
 
   const content = (
     <>

--- a/src/platform/forms-system/src/js/components/FieldTemplate.jsx
+++ b/src/platform/forms-system/src/js/components/FieldTemplate.jsx
@@ -31,8 +31,6 @@ export default function FieldTemplate(props) {
   const isDateField = uiSchema['ui:widget'] === 'date';
   const showFieldLabel =
     uiSchema['ui:options'] && uiSchema['ui:options'].showFieldLabel;
-  const hideLabelText =
-    uiSchema['ui:options'] && uiSchema['ui:options'].hideLabelText;
   const useLabelElement = showFieldLabel === 'label';
 
   const description = uiSchema['ui:description'];
@@ -96,13 +94,15 @@ export default function FieldTemplate(props) {
     </label>
   );
 
-  // Don't render empty labels - prevents duplicate IDs on review & submit page
-  const renderLabel =
-    typeof label !== 'string' || (requiredSpan || label.trim());
+  // Don't render hidden or empty labels - prevents duplicate IDs on review &
+  // submit page
+  const showLabel =
+    !uiSchema['ui:options']?.hideLabelText &&
+    (typeof label !== 'string' || (requiredSpan || label.trim()));
 
   const content = (
     <>
-      {!hideLabelText && renderLabel && labelElement}
+      {showLabel && labelElement}
       {textDescription && <p>{textDescription}</p>}
       {DescriptionField && (
         <DescriptionField options={uiSchema['ui:options']} />

--- a/src/platform/forms-system/src/js/components/FieldTemplate.jsx
+++ b/src/platform/forms-system/src/js/components/FieldTemplate.jsx
@@ -96,9 +96,13 @@ export default function FieldTemplate(props) {
     </label>
   );
 
+  // Don't render empty labels - prevents duplicate IDs on review & submit page
+  const renderLabel =
+    typeof label === 'string' && (requiredSpan || label.trim());
+
   const content = (
     <>
-      {!hideLabelText && labelElement}
+      {!hideLabelText && renderLabel && labelElement}
       {textDescription && <p>{textDescription}</p>}
       {DescriptionField && (
         <DescriptionField options={uiSchema['ui:options']} />

--- a/src/platform/forms-system/src/js/fields/ArrayField.jsx
+++ b/src/platform/forms-system/src/js/fields/ArrayField.jsx
@@ -283,7 +283,9 @@ export default class ArrayField extends React.Component {
                       {isLast &&
                       items.length > 1 &&
                       uiSchema['ui:options'].itemName ? (
-                        <h5>New {uiSchema['ui:options'].itemName}</h5>
+                        <h3 className="vads-u-font-size--h5">
+                          New {uiSchema['ui:options'].itemName}
+                        </h3>
                       ) : null}
                       <div className="input-section">
                         <SchemaField

--- a/src/platform/forms-system/src/js/fields/FileField.jsx
+++ b/src/platform/forms-system/src/js/fields/FileField.jsx
@@ -260,7 +260,8 @@ export default class FileField extends React.Component {
                     }
                   }}
                   tabIndex="0"
-                  aria-label={uiSchema['ui:title'] || schema.title}
+                  aria-label={`${buttonText} ${uiSchema['ui:title'] ||
+                    schema.title}`}
                 >
                   {buttonText}
                 </span>

--- a/src/platform/forms-system/src/js/fields/FileField.jsx
+++ b/src/platform/forms-system/src/js/fields/FileField.jsx
@@ -243,6 +243,8 @@ export default class FileField extends React.Component {
           </ul>
         )}
         {(maxItems === null || files.length < maxItems) &&
+          // Don't render an upload button on review & submit page while in
+          // review mode
           !formContext.reviewMode &&
           !isUploading && (
             <>

--- a/src/platform/forms-system/src/js/fields/FileField.jsx
+++ b/src/platform/forms-system/src/js/fields/FileField.jsx
@@ -117,6 +117,8 @@ export default class FileField extends React.Component {
     let { buttonText = 'Upload' } = uiOptions;
     if (files.length > 0) buttonText = uiOptions.addAnotherLabel;
 
+    const Tag = formContext.onReviewPage ? 'dl' : 'div';
+
     return (
       <div
         className={
@@ -176,7 +178,7 @@ export default class FileField extends React.Component {
                   )}
                   {!hasErrors &&
                     _.get('properties.attachmentId', itemSchema) && (
-                      <div className="schemaform-file-attachment">
+                      <Tag className="schemaform-file-attachment review">
                         <SchemaField
                           name="attachmentId"
                           required={attachmentIdRequired}
@@ -193,11 +195,11 @@ export default class FileField extends React.Component {
                           disabled={this.props.disabled}
                           readonly={this.props.readonly}
                         />
-                      </div>
+                      </Tag>
                     )}
                   {!hasErrors &&
                     uiOptions.attachmentName && (
-                      <div className="schemaform-file-attachment">
+                      <Tag className="schemaform-file-attachment review">
                         <SchemaField
                           name="attachmentName"
                           required
@@ -214,7 +216,7 @@ export default class FileField extends React.Component {
                           disabled={this.props.disabled}
                           readonly={this.props.readonly}
                         />
-                      </div>
+                      </Tag>
                     )}
                   {!file.uploading &&
                     hasErrors && (
@@ -241,8 +243,9 @@ export default class FileField extends React.Component {
           </ul>
         )}
         {(maxItems === null || files.length < maxItems) &&
+          !formContext.reviewMode &&
           !isUploading && (
-            <div>
+            <>
               <label
                 id={`${idSchema.$id}_add_label`}
                 htmlFor={idSchema.$id}
@@ -270,7 +273,7 @@ export default class FileField extends React.Component {
                 name={idSchema.$id}
                 onChange={this.onAddFile}
               />
-            </div>
+            </>
           )}
       </div>
     );

--- a/src/platform/forms-system/src/js/fields/ObjectField.jsx
+++ b/src/platform/forms-system/src/js/fields/ObjectField.jsx
@@ -212,13 +212,24 @@ class ObjectField extends React.Component {
       </div>
     );
 
+    // Id's are not always unique on the review and submit page
+    const id =
+      isRoot && formContext.onReviewPage
+        ? Object.keys(idSchema)
+            .reduce((ids, key) => {
+              ids.push(idSchema[key].$id || '');
+              return ids;
+            }, [])
+            .join('_')
+        : idSchema.$id;
+
     const fieldContent = (
       <div className={containerClassNames}>
         {hasTitleOrDescription && (
           <div className="schemaform-block-header">
             {CustomTitleField && !showFieldLabel ? (
               <CustomTitleField
-                id={`${idSchema.$id}__title`}
+                id={`${id}__title`}
                 formData={formData}
                 formContext={formContext}
                 required={required}
@@ -226,7 +237,7 @@ class ObjectField extends React.Component {
             ) : null}
             {!CustomTitleField && title && !showFieldLabel ? (
               <TitleField
-                id={`${idSchema.$id}__title`}
+                id={`${id}__title`}
                 title={title}
                 required={required}
                 formContext={formContext}

--- a/src/platform/forms-system/src/js/fields/ObjectField.jsx
+++ b/src/platform/forms-system/src/js/fields/ObjectField.jsx
@@ -163,8 +163,9 @@ class ObjectField extends React.Component {
       disabled,
       readonly,
       onBlur,
+      formContext,
     } = this.props;
-    const { definitions, fields, formContext } = this.props.registry;
+    const { definitions, fields } = this.props.registry;
     const { TitleField } = fields;
     const SchemaField = this.SchemaField;
     const formData = Object.keys(this.props.formData || {}).length
@@ -220,6 +221,7 @@ class ObjectField extends React.Component {
               ids.push(idSchema[key].$id || '');
               return ids;
             }, [])
+            .filter(k => k)
             .join('_')
         : idSchema.$id;
 

--- a/src/platform/forms-system/src/js/fields/TitleField.jsx
+++ b/src/platform/forms-system/src/js/fields/TitleField.jsx
@@ -8,7 +8,7 @@ export default function TitleField({ id, title }) {
     'schemaform-block-subtitle': !isRoot,
   });
 
-  return (
+  return typeof title === 'string' && title.trim() === '' ? null : (
     <legend className={classes} id={id}>
       {title}
     </legend>

--- a/src/platform/forms-system/src/js/fields/TitleField.jsx
+++ b/src/platform/forms-system/src/js/fields/TitleField.jsx
@@ -8,7 +8,9 @@ export default function TitleField({ id, title }) {
     'schemaform-block-subtitle': !isRoot,
   });
 
-  return typeof title === 'string' && title.trim() === '' ? null : (
+  const isEmptyTitle = typeof title === 'string' && title.trim() === '';
+
+  return isEmptyTitle ? null : (
     <legend className={classes} id={id}>
       {title}
     </legend>

--- a/src/platform/forms-system/src/js/review/ArrayField.jsx
+++ b/src/platform/forms-system/src/js/review/ArrayField.jsx
@@ -207,7 +207,7 @@ class ArrayField extends React.Component {
       <div className={itemsNeeded ? 'schemaform-review-array-warning' : null}>
         {title && (
           <div className="form-review-panel-page-header-row">
-            <h5 className="form-review-panel-page-header">{title}</h5>
+            <h3 className="form-review-panel-page-header">{title}</h3>
             {itemsNeeded && (
               <span className="schemaform-review-array-warning-icon" />
             )}

--- a/src/platform/forms-system/src/js/review/ObjectField.jsx
+++ b/src/platform/forms-system/src/js/review/ObjectField.jsx
@@ -127,9 +127,14 @@ class ObjectField extends React.Component {
         );
         // Use div or dl to wrap content for array type schemas (e.g. bank info)
         // fixes axe issue on review-and-submit
-        divWrapper = objectFields.some(
-          name => uiSchema?.[name]?.['ui:options']?.volatileData,
-        );
+        divWrapper = objectFields.some(name => {
+          const options = uiSchema?.[name]?.['ui:options'] || {};
+          return (
+            options.volatileData || // ReviewCardField
+            options.customTitle || // SelectArrayItemsWidget
+            options.addAnotherLabel // fileUiSchema
+          );
+        });
         if (objectFields.length > 1 && visible.length > 0) {
           return objectFields.filter(showField).map(renderField);
         }

--- a/src/platform/forms-system/src/js/review/ObjectField.jsx
+++ b/src/platform/forms-system/src/js/review/ObjectField.jsx
@@ -160,7 +160,9 @@ class ObjectField extends React.Component {
             <div className="form-review-panel-page-header-row">
               {title?.trim() &&
                 !formContext.hideTitle && (
-                  <h5 className="form-review-panel-page-header">{title}</h5>
+                  <h3 className="form-review-panel-page-header vads-u-font-size--h5">
+                    {title}
+                  </h3>
                 )}
               <button
                 type="button"

--- a/src/platform/forms-system/test/js/components/FieldTemplate.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/components/FieldTemplate.unit.spec.jsx
@@ -269,4 +269,57 @@ describe('Schemaform <FieldTemplate>', () => {
     expect(tree.subTree('label').text()).to.equal('Title');
     expect(tree.subTree('fieldset')).to.be.false;
   });
+
+  it('should not render a label if empty or whitespace only title provided', () => {
+    const schema = {
+      type: 'string',
+    };
+    const uiSchema = {
+      'ui:title': '  ',
+    };
+    const formContext = {
+      touched: {},
+    };
+    const errors = ['Some error'];
+    const tree = SkinDeep.shallowRender(
+      <FieldTemplate
+        id="test"
+        schema={schema}
+        uiSchema={uiSchema}
+        rawErrors={errors}
+        formContext={formContext}
+      >
+        <div className="field-child" />
+      </FieldTemplate>,
+    );
+
+    expect(tree.subTree('label')).to.be.false;
+    expect(tree.everySubTree('.field-child')).not.to.be.empty;
+    expect(tree.everySubTree('.usa-input-error-message')).to.be.empty;
+  });
+  it('should render required even with a whitespace only title', () => {
+    const schema = {
+      type: 'string',
+    };
+    const uiSchema = {
+      'ui:title': '  ',
+    };
+    const formContext = {
+      touched: {},
+    };
+    const tree = SkinDeep.shallowRender(
+      <FieldTemplate
+        id="test"
+        schema={schema}
+        uiSchema={uiSchema}
+        required
+        formContext={formContext}
+      >
+        <div className="field-child" />
+      </FieldTemplate>,
+    );
+
+    expect(tree.subTree('label')).not.to.be.empty;
+    expect(tree.everySubTree('.schemaform-required-span')).not.to.be.empty;
+  });
 });

--- a/src/platform/forms-system/test/js/components/FieldTemplate.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/components/FieldTemplate.unit.spec.jsx
@@ -32,6 +32,33 @@ describe('Schemaform <FieldTemplate>', () => {
     expect(tree.everySubTree('.field-child')).not.to.be.empty;
     expect(tree.everySubTree('.usa-input-error-message')).to.be.empty;
   });
+  it('should render a label if JSX is provided', () => {
+    const schema = {
+      type: 'string',
+    };
+    const uiSchema = {
+      'ui:title': <span>Title</span>,
+    };
+    const formContext = {
+      touched: {},
+    };
+    const errors = ['Some error'];
+    const tree = SkinDeep.shallowRender(
+      <FieldTemplate
+        id="test"
+        schema={schema}
+        uiSchema={uiSchema}
+        rawErrors={errors}
+        formContext={formContext}
+      >
+        <div className="field-child" />
+      </FieldTemplate>,
+    );
+
+    expect(tree.subTree('label').text()).to.equal('Title');
+    expect(tree.everySubTree('.field-child')).not.to.be.empty;
+    expect(tree.everySubTree('.usa-input-error-message')).to.be.empty;
+  });
   it('should render object', () => {
     const schema = {
       type: 'object',
@@ -269,7 +296,28 @@ describe('Schemaform <FieldTemplate>', () => {
     expect(tree.subTree('label').text()).to.equal('Title');
     expect(tree.subTree('fieldset')).to.be.false;
   });
+  it('should not render a label if no title provided', () => {
+    const schema = {
+      type: 'string',
+    };
+    const uiSchema = {};
+    const formContext = {
+      touched: {},
+    };
+    const errors = ['Some error'];
+    const tree = SkinDeep.shallowRender(
+      <FieldTemplate
+        id="test"
+        schema={schema}
+        uiSchema={uiSchema}
+        rawErrors={errors}
+        formContext={formContext}
+      />,
+    );
 
+    expect(tree.subTree('label')).to.be.false;
+    expect(tree.everySubTree('.usa-input-error-message')).to.be.empty;
+  });
   it('should not render a label if empty or whitespace only title provided', () => {
     const schema = {
       type: 'string',

--- a/src/platform/forms-system/test/js/fields/FileField.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/fields/FileField.unit.spec.jsx
@@ -315,6 +315,46 @@ describe('Schemaform <FileField>', () => {
     expect(tree.find('label').exists()).to.be.false;
     tree.unmount();
   });
+  it('should not render upload button on review & submit page while in review mode', () => {
+    const idSchema = {
+      $id: 'field',
+    };
+    const schema = {
+      additionalItems: {},
+      items: [
+        {
+          properties: {},
+        },
+      ],
+    };
+    const uiSchema = fileUploadUI('Files');
+    const formData = [
+      {
+        confirmationCode: 'asdfds',
+        name: 'Test file name',
+      },
+    ];
+    const registry = {
+      fields: {
+        SchemaField: f => f,
+      },
+    };
+    const tree = shallow(
+      <FileField
+        registry={registry}
+        schema={schema}
+        uiSchema={uiSchema}
+        idSchema={idSchema}
+        formData={formData}
+        formContext={{ reviewMode: true }}
+        onChange={f => f}
+        requiredSchema={requiredSchema}
+      />,
+    );
+
+    expect(tree.find('label').exists()).to.be.false;
+    tree.unmount();
+  });
 
   it('should delete file', () => {
     const uiSchema = fileUploadUI('Files');

--- a/src/platform/forms-system/test/js/fields/FileField.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/fields/FileField.unit.spec.jsx
@@ -493,4 +493,120 @@ describe('Schemaform <FileField>', () => {
     );
     tree.unmount();
   });
+
+  // Accessibility checks
+  it('should render a div wrapper when not on the review page', () => {
+    const idSchema = {
+      $id: 'field',
+    };
+    const schema = {
+      additionalItems: {
+        type: 'object',
+        properties: {
+          attachmentId: {
+            type: 'string',
+          },
+        },
+      },
+      items: [
+        {
+          type: 'object',
+          properties: {
+            name: {
+              type: 'string',
+            },
+          },
+        },
+      ],
+    };
+    const uiSchema = fileUploadUI('Files', {
+      attachmentName: {
+        'ui:title': 'Document name',
+      },
+    });
+    const formData = [
+      {
+        confirmationCode: 'asdfds',
+        name: 'Test file name',
+      },
+    ];
+    const registry = {
+      fields: {
+        SchemaField: f => f,
+      },
+    };
+    const tree = shallow(
+      <FileField
+        registry={registry}
+        schema={schema}
+        uiSchema={uiSchema}
+        idSchema={idSchema}
+        formData={formData}
+        formContext={{ onReviewPage: false }}
+        onChange={f => f}
+        requiredSchema={requiredSchema}
+      />,
+    );
+
+    // expect dl wrapper on review page
+    expect(tree.find('div.review').exists()).to.be.true;
+    tree.unmount();
+  });
+  it('should render a dl wrapper when on the review page', () => {
+    const idSchema = {
+      $id: 'field',
+    };
+    const schema = {
+      additionalItems: {
+        type: 'object',
+        properties: {
+          attachmentId: {
+            type: 'string',
+          },
+        },
+      },
+      items: [
+        {
+          type: 'object',
+          properties: {
+            name: {
+              type: 'string',
+            },
+          },
+        },
+      ],
+    };
+    const uiSchema = fileUploadUI('Files', {
+      attachmentName: {
+        'ui:title': 'Document name',
+      },
+    });
+    const formData = [
+      {
+        confirmationCode: 'asdfds',
+        name: 'Test file name',
+      },
+    ];
+    const registry = {
+      fields: {
+        SchemaField: f => f,
+      },
+    };
+    const tree = shallow(
+      <FileField
+        registry={registry}
+        schema={schema}
+        uiSchema={uiSchema}
+        idSchema={idSchema}
+        formData={formData}
+        formContext={{ onReviewPage: true }}
+        onChange={f => f}
+        requiredSchema={requiredSchema}
+      />,
+    );
+
+    // expect dl wrapper on review page
+    expect(tree.find('dl.review').exists()).to.be.true;
+    tree.unmount();
+  });
 });

--- a/src/platform/forms-system/test/js/fields/TitleField.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/fields/TitleField.unit.spec.jsx
@@ -6,13 +6,20 @@ import TitleField from '../../../src/js/fields/TitleField';
 
 describe('Schemaform <TitleField>', () => {
   it('should render legend for root', () => {
-    const tree = SkinDeep.shallowRender(<TitleField id="root__title" />);
-
+    const tree = SkinDeep.shallowRender(
+      <TitleField id="root__title" title="foo" />,
+    );
     expect(tree.subTree('legend')).not.to.be.false;
   });
   it('should render subtitle for non-root', () => {
-    const tree = SkinDeep.shallowRender(<TitleField id="root_someField" />);
-
+    const Foo = <div>Foo</div>;
+    const tree = SkinDeep.shallowRender(
+      <TitleField id="root_someField" title={<Foo />} />,
+    );
     expect(tree.subTree('.schemaform-block-subtitle')).not.to.be.false;
+  });
+  it('should not render anything if no title is provided', () => {
+    const tree = SkinDeep.shallowRender(<TitleField id="root__title" />);
+    expect(tree.subTree('TitleField')).to.be.false;
   });
 });

--- a/src/platform/forms-system/test/js/review/ArrayField.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/review/ArrayField.unit.spec.jsx
@@ -152,8 +152,7 @@ describe('Schemaform review <ArrayField>', () => {
     );
 
     tree.getMountedInstance().handleAdd();
-
-    expect(tree.everySubTree('h5')[1].text()).to.equal('New Item name');
+    expect(tree.everySubTree('h5')[0].text()).to.equal('New Item name');
     expect(tree.everySubTree('button')[2].text()).to.equal(
       'Add Another Item name',
     );

--- a/src/platform/forms-system/test/js/review/ObjectField.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/review/ObjectField.unit.spec.jsx
@@ -411,4 +411,78 @@ describe('Schemaform review: ObjectField', () => {
     expect(review.type).to.equal('div');
     expect(review.props.className).to.equal('review');
   });
+  it('should render a div when rendering a custom title, like in the SelectArrayItemsWidget', () => {
+    const onChange = sinon.spy();
+    const onBlur = sinon.spy();
+    const schema = {
+      type: 'object',
+      properties: {
+        test: {
+          type: 'string',
+        },
+      },
+    };
+    const uiSchema = {
+      test: {
+        'ui:options': {
+          addAnotherLabel: 'test',
+        },
+      },
+    };
+    const formData = {
+      test: { foo: 'test' },
+    };
+    const tree = SkinDeep.shallowRender(
+      <ObjectField
+        schema={schema}
+        uiSchema={uiSchema}
+        formContext={{ pageTitle: 'Blah' }}
+        idSchema={{ $id: 'root' }}
+        formData={formData}
+        onChange={onChange}
+        onBlur={onBlur}
+      />,
+    );
+    // expecting a "div.review" instead of a "dl.review"
+    const review = tree.props.children[1];
+    expect(review.type).to.equal('div');
+    expect(review.props.className).to.equal('review');
+  });
+  it('should render a div when rendering the file UI', () => {
+    const onChange = sinon.spy();
+    const onBlur = sinon.spy();
+    const schema = {
+      type: 'object',
+      properties: {
+        test: {
+          type: 'string',
+        },
+      },
+    };
+    const uiSchema = {
+      test: {
+        'ui:options': {
+          addAnotherLabel: 'test',
+        },
+      },
+    };
+    const formData = {
+      test: { foo: 'test' },
+    };
+    const tree = SkinDeep.shallowRender(
+      <ObjectField
+        schema={schema}
+        uiSchema={uiSchema}
+        formContext={{ pageTitle: 'Blah' }}
+        idSchema={{ $id: 'root' }}
+        formData={formData}
+        onChange={onChange}
+        onBlur={onBlur}
+      />,
+    );
+    // expecting a "div.review" instead of a "dl.review"
+    const review = tree.props.children[1];
+    expect(review.type).to.equal('div');
+    expect(review.props.className).to.equal('review');
+  });
 });


### PR DESCRIPTION
## Description

This PR modifies the output of the listed widget & field components to wrap their rendered output in an accessible HTML tag on the form review page.

- `SelectArrayItemsWidget` - wrap with either `dl` (on review page) or `div`
- `FileField`
  - wrap with `dl` (on review page) or `div`
  - Fixed upload/add button `aria-label` text
- `ObjectField` - wrap with either `div` (on review page) or `dl` for the following:
  - `ReviewCardField`
  - `SelectArrayItemsWidget`
  - Any component using `fileUISchema`

Related issues/PR:

- e2e test issue: https://github.com/department-of-veterans-affairs/va.gov-team/issues/7319
- ticket for part 2 of fixes: https://github.com/department-of-veterans-affairs/va.gov-team/issues/8595
- part 1 of a11y fixes: https://github.com/department-of-veterans-affairs/vets-website/pull/12408
- e2e test PR: https://github.com/department-of-veterans-affairs/vets-website/pull/12241

With the merging of this PR, accessibility issues on form 526 review page _should_ all be resolved.

## Testing done

Local unit tests

## Screenshots

<details><summary>`SelectArrayItemsWidget` output</summary>

<!-- leave a blank line above -->
![](https://user-images.githubusercontent.com/934879/80719635-6077b300-8ac1-11ea-8195-24f004689409.png)
</details>

<details><summary>`FileField` display </summary>

<!-- leave a blank line above -->
![](https://user-images.githubusercontent.com/934879/80719617-59e93b80-8ac1-11ea-8fd3-4d88c33f2e91.png)
</details>

<details><summary>`FileField` button</summary>

<!-- leave a blank line above -->
![Screen Shot 2020-04-30 at 3 15 10 PM](https://user-images.githubusercontent.com/136959/80765016-98a1e480-8b07-11ea-8595-ec38131f4701.png)
</details>

## Acceptance criteria

Axe Coconut (extension) testing passes on (user 228):

- [ ] Individual unemployability: https://staging.va.gov/disability/file-disability-claim-form-21-526ez/unemployability-disabilities
- [ ] Supporting evidence upload: https://staging.va.gov/disability/file-disability-claim-form-21-526ez/supporting-evidence/additional-evidence
- [ ] Review & submit page: https://staging.va.gov/disability/file-disability-claim-form-21-526ez/review-and-submit

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
