### PR TITLE
Sanlouise 8586 breadcrumbs current section

### DIFF
--- a/src/applications/personalization/profile-2/components/ProfileWrapper.jsx
+++ b/src/applications/personalization/profile-2/components/ProfileWrapper.jsx
@@ -1,16 +1,16 @@
 import React, { Component } from 'react';
-import { connect } from 'react-redux';
 import Breadcrumbs from '@department-of-veterans-affairs/formation-react/Breadcrumbs';
 import LoadingIndicator from '@department-of-veterans-affairs/formation-react/LoadingIndicator';
-
 import RequiredLoginView from 'platform/user/authorization/components/RequiredLoginView';
 import backendServices from 'platform/user/profile/constants/backendServices';
+import { isWideScreen } from 'platform/utilities/accessibility/index';
+import { connect } from 'react-redux';
+
 import {
   createIsServiceAvailableSelector,
   isMultifactorEnabled,
   selectProfile,
 } from 'platform/user/selectors';
-
 import { fetchMHVAccount as fetchMHVAccountAction } from 'platform/user/profile/actions';
 import {
   fetchMilitaryInformation as fetchMilitaryInformationAction,
@@ -82,15 +82,17 @@ class ProfileWrapper extends Component {
       activeRouteName,
     } = this.createBreadCrumbAttributes();
 
-    const onPersonalInformationPage =
-      this.props?.location?.pathname === '/personal-information';
+    // We do not want to display 'Profile' on the mobile personal-information route
+    const onPersonalInformationMobile =
+      this.props?.location?.pathname === '/personal-information' &&
+      !isWideScreen();
 
     return (
       <>
         {/* Breadcrumbs */}
         <Breadcrumbs className="vads-u-padding-x--1 vads-u-padding-y--1p5 medium-screen:vads-u-padding-y--0">
           <a href="/">Home</a>
-          {!onPersonalInformationPage && <a href="/profile-2/">Profile</a>}
+          {!onPersonalInformationMobile && <a href="/profile-2/">Profile</a>}
           <a href={activeLocation}>{activeRouteName}</a>
         </Breadcrumbs>
 

--- a/src/applications/personalization/profile-2/components/ProfileWrapper.jsx
+++ b/src/applications/personalization/profile-2/components/ProfileWrapper.jsx
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
+import Breadcrumbs from '@department-of-veterans-affairs/formation-react/Breadcrumbs';
 import LoadingIndicator from '@department-of-veterans-affairs/formation-react/LoadingIndicator';
 
 import RequiredLoginView from 'platform/user/authorization/components/RequiredLoginView';
@@ -60,23 +61,60 @@ class ProfileWrapper extends Component {
     </div>
   );
 
+  createBreadCrumbAttributes = () => {
+    const { location, route } = this.props;
+    const activeLocation = location?.pathname.replace('/', '');
+    const childRoutes = route?.childRoutes;
+    const activeRoute = childRoutes.find(
+      childRoute => childRoute.path === activeLocation,
+    );
+
+    const activeRouteName = activeRoute?.name;
+    const activeRouteAriaLabel = `View your ${activeRouteName} details`;
+
+    return { activeLocation, activeRouteAriaLabel, activeRouteName };
+  };
+
   // content to show after data has loaded
   // note that `children` will be passed in via React Router.
-  mainContent = () => (
-    <>
-      <MobileMenuTrigger />
-      <div className="mobile-fixed-spacer" />
-      <ProfileHeader />
-      <div className="usa-grid usa-grid-full">
-        <div className="usa-width-one-fourth">
-          <ProfileSideNav />
+  mainContent = () => {
+    const {
+      activeLocation,
+      activeRouteAriaLabel,
+      activeRouteName,
+    } = this.createBreadCrumbAttributes();
+
+    return (
+      <>
+        <MobileMenuTrigger />
+
+        {/* Breadcrumbs */}
+        <Breadcrumbs className="vads-u-padding-x--0 vads-u-padding-y--1p5 medium-screen:vads-u-padding-y--0">
+          <a href="/" aria-label="back to VA Home page">
+            Home
+          </a>
+          <a href="/profile-2/" aria-label="back to the Profile page">
+            Profile
+          </a>
+          <a href={activeLocation} aria-label={activeRouteAriaLabel}>
+            {activeRouteName}
+          </a>
+        </Breadcrumbs>
+
+        <div className="mobile-fixed-spacer" />
+        <ProfileHeader />
+
+        <div className="usa-grid usa-grid-full">
+          <div className="usa-width-one-fourth">
+            <ProfileSideNav />
+          </div>
+          <div className="usa-width-two-thirds vads-u-padding-bottom--4 vads-u-padding-x--1 medium-screen:vads-u-padding--0 medium-screen:vads-u-padding-bottom--6">
+            {this.props.children}
+          </div>
         </div>
-        <div className="usa-width-two-thirds vads-u-padding-bottom--4 vads-u-padding-x--1 medium-screen:vads-u-padding--0 medium-screen:vads-u-padding-bottom--6">
-          {this.props.children}
-        </div>
-      </div>
-    </>
-  );
+      </>
+    );
+  };
 
   renderContent = () => {
     if (this.props.showLoader) {

--- a/src/applications/personalization/profile-2/components/ProfileWrapper.jsx
+++ b/src/applications/personalization/profile-2/components/ProfileWrapper.jsx
@@ -86,10 +86,8 @@ class ProfileWrapper extends Component {
 
     return (
       <>
-        <MobileMenuTrigger />
-
         {/* Breadcrumbs */}
-        <Breadcrumbs className="vads-u-padding-x--0 vads-u-padding-y--1p5 medium-screen:vads-u-padding-y--0">
+        <Breadcrumbs className="vads-u-padding-x--1 vads-u-padding-y--1p5 medium-screen:vads-u-padding-y--0">
           <a href="/" aria-label="back to VA Home page">
             Home
           </a>
@@ -100,6 +98,8 @@ class ProfileWrapper extends Component {
             {activeRouteName}
           </a>
         </Breadcrumbs>
+
+        <MobileMenuTrigger />
 
         <div className="mobile-fixed-spacer" />
         <ProfileHeader />

--- a/src/applications/personalization/profile-2/components/ProfileWrapper.jsx
+++ b/src/applications/personalization/profile-2/components/ProfileWrapper.jsx
@@ -70,9 +70,8 @@ class ProfileWrapper extends Component {
     );
 
     const activeRouteName = activeRoute?.name;
-    const activeRouteAriaLabel = `View your ${activeRouteName} details`;
 
-    return { activeLocation, activeRouteAriaLabel, activeRouteName };
+    return { activeLocation, activeRouteName };
   };
 
   // content to show after data has loaded
@@ -80,7 +79,6 @@ class ProfileWrapper extends Component {
   mainContent = () => {
     const {
       activeLocation,
-      activeRouteAriaLabel,
       activeRouteName,
     } = this.createBreadCrumbAttributes();
 
@@ -88,15 +86,9 @@ class ProfileWrapper extends Component {
       <>
         {/* Breadcrumbs */}
         <Breadcrumbs className="vads-u-padding-x--1 vads-u-padding-y--1p5 medium-screen:vads-u-padding-y--0">
-          <a href="/" aria-label="back to VA Home page">
-            Home
-          </a>
-          <a href="/profile-2/" aria-label="back to the Profile page">
-            Profile
-          </a>
-          <a href={activeLocation} aria-label={activeRouteAriaLabel}>
-            {activeRouteName}
-          </a>
+          <a href="/">Home</a>
+          <a href="/profile-2/">Profile</a>
+          <a href={activeLocation}>{activeRouteName}</a>
         </Breadcrumbs>
 
         <MobileMenuTrigger />

--- a/src/applications/personalization/profile-2/components/ProfileWrapper.jsx
+++ b/src/applications/personalization/profile-2/components/ProfileWrapper.jsx
@@ -82,12 +82,15 @@ class ProfileWrapper extends Component {
       activeRouteName,
     } = this.createBreadCrumbAttributes();
 
+    const onPersonalInformationPage =
+      this.props?.location?.pathname === '/personal-information';
+
     return (
       <>
         {/* Breadcrumbs */}
         <Breadcrumbs className="vads-u-padding-x--1 vads-u-padding-y--1p5 medium-screen:vads-u-padding-y--0">
           <a href="/">Home</a>
-          <a href="/profile-2/">Profile</a>
+          {!onPersonalInformationPage && <a href="/profile-2/">Profile</a>}
           <a href={activeLocation}>{activeRouteName}</a>
         </Breadcrumbs>
 

--- a/src/applications/personalization/profile-2/manifest.json
+++ b/src/applications/personalization/profile-2/manifest.json
@@ -7,13 +7,6 @@
   "template": {
     "vagovprod": false,
     "title": "Your Profile",
-    "layout": "page-react.html",
-    "includeBreadcrumbs": true,
-    "breadcrumbs_override": [
-      {
-        "path": "profile-2/",
-        "name": "Your profile"
-      }
-    ]
+    "layout": "page-react.html"
   }
 }

--- a/src/applications/personalization/profile-2/tests/components/ProfileWrapper.unit.spec.js
+++ b/src/applications/personalization/profile-2/tests/components/ProfileWrapper.unit.spec.js
@@ -45,26 +45,6 @@ describe('ProfileWrapper', () => {
             key: 'personal-information',
             name: 'Personal and contact Information',
           },
-          {
-            path: 'military-information',
-            key: 'military-information',
-            name: 'Military information',
-          },
-          {
-            path: 'direct-deposit',
-            key: 'direct-deposit',
-            name: 'Direct deposit information',
-          },
-          {
-            path: 'account-security',
-            key: 'account-security',
-            name: 'Account security',
-          },
-          {
-            path: 'connected-applications',
-            key: 'connected-applications',
-            name: 'Connected applications',
-          },
         ],
       },
     };

--- a/src/applications/personalization/profile-2/tests/components/ProfileWrapper.unit.spec.js
+++ b/src/applications/personalization/profile-2/tests/components/ProfileWrapper.unit.spec.js
@@ -35,6 +35,38 @@ describe('ProfileWrapper', () => {
       shouldFetchDirectDepositInformation: true,
       showLoader: false,
       user: {},
+      location: {
+        pathname: '/personal-information',
+      },
+      route: {
+        childRoutes: [
+          {
+            path: 'personal-information',
+            key: 'personal-information',
+            name: 'Personal and contact Information',
+          },
+          {
+            path: 'military-information',
+            key: 'military-information',
+            name: 'Military information',
+          },
+          {
+            path: 'direct-deposit',
+            key: 'direct-deposit',
+            name: 'Direct deposit information',
+          },
+          {
+            path: 'account-security',
+            key: 'account-security',
+            name: 'Account security',
+          },
+          {
+            path: 'connected-applications',
+            key: 'connected-applications',
+            name: 'Connected applications',
+          },
+        ],
+      },
     };
   });
 
@@ -78,6 +110,25 @@ describe('ProfileWrapper', () => {
     it('should fetch the My HealtheVet data', () => {
       const wrapper = shallow(<ProfileWrapper {...defaultProps} />);
       expect(fetchMHVAccountSpy.called).to.be.true;
+      wrapper.unmount();
+    });
+
+    it('should render BreadCrumbs', () => {
+      const wrapper = shallow(<ProfileWrapper {...defaultProps} />);
+      expect(wrapper.find('Breadcrumbs')).to.have.lengthOf(1);
+      wrapper.unmount();
+    });
+
+    it('should render the correct breadcrumb (Personal and contact Information)', () => {
+      const wrapper = shallow(<ProfileWrapper {...defaultProps} />);
+      const BreadCrumbs = wrapper.find('Breadcrumbs');
+      const activeRouteText = BreadCrumbs.find('a')
+        .last()
+        .text();
+
+      expect(activeRouteText).to.include(
+        defaultProps.route.childRoutes[0].name,
+      );
       wrapper.unmount();
     });
 

--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -124,14 +124,7 @@
     "template": {
       "vagovprod": false,
       "title": "Your Profile",
-      "layout": "page-react.html",
-      "includeBreadcrumbs": true,
-      "breadcrumbs_override": [
-        {
-          "path": "profile-2/",
-          "name": "Your profile"
-        }
-      ]
+      "layout": "page-react.html"
     }
   },
   {


### PR DESCRIPTION
[TICKET](https://github.com/department-of-veterans-affairs/va.gov-team/issues/8586)

Breadcrumbs displaying logic:
- On Desktop we always have 3 breadcrumbs
- On mobile, we show 'Profile' only. Exception is the Profile Information page where we only show 'Home'.

## Description
Add Breadcrumbs to Profile 2.0.

## Testing done
Works locally, added a unit test to ensure the correct route name renders within the last bread crumb.

## Screenshots
![image](https://user-images.githubusercontent.com/14869324/80810319-d1ca6b00-8b80-11ea-96e2-e33724a5f230.png)

![image](https://user-images.githubusercontent.com/14869324/80976353-962ddc00-8de0-11ea-8181-21c9783b1c91.png)

![image](https://user-images.githubusercontent.com/14869324/80976372-9f1ead80-8de0-11ea-9385-e92fec18b799.png)


## Acceptance criteria
- [x] Add breadcrumbs on Desktop and Mobile. Mobile only shows a single 'profile' bread crumb, just like we do it in other places of the app like Yellow Ribbon.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
