### PR TITLE
[Development/CI/CD] Fix a11y issues on 526 confirmation page

### DIFF
--- a/src/applications/disability-benefits/all-claims/content/confirmation-page.jsx
+++ b/src/applications/disability-benefits/all-claims/content/confirmation-page.jsx
@@ -118,8 +118,11 @@ const template = (props, title, content, submissionMessage, messageType) => {
           You can check the status of your claim online. Please allow 24 hours
           for your disability claim to show up there. If you don’t see your
           disability claim online after 24 hours, please call Veterans Benefits
-          Assistance at <a href="tel:+18008271000">800-827-1000</a>, Monday
-          through Friday, 8:30 a.m. to 4:30 p.m. ET.
+          Assistance at{' '}
+          <a href="tel:+18008271000" aria-label="800. 8 2 7. 1000">
+            800-827-1000
+          </a>
+          , Monday through Friday, 8:30 a.m. to 4:30 p.m. ET.
         </p>
         <p>
           <a href="/track-claims">Check the status of your claim</a>
@@ -158,8 +161,11 @@ export const retryableErrorContent = props =>
           If you don’t see your disability claim online after 24 hours,
         </strong>{' '}
         please call Veterans Benefits Assistance at{' '}
-        <a href="tel:+18008271000">800-827-1000</a>, Monday through Friday, 8:30
-        a.m. to 4:30 p.m. ET and provide this reference number {props.jobId}.
+        <a href="tel:+18008271000" aria-label="800. 8 2 7. 1000">
+          800-827-1000
+        </a>
+        , Monday through Friday, 8:30 a.m. to 4:30 p.m. ET and provide this
+        reference number {props.jobId}.
       </p>
     </div>,
     checkLaterMessage(props.jobId),
@@ -184,8 +190,11 @@ export const submitErrorContent = props =>
       <ul>
         <li>
           Please call Veterans Benefits Assistance at{' '}
-          <a href="tel:+18008271000">800-827-1000</a>, Monday through Friday,
-          8:30 a.m. to 4:30 p.m. ET, <strong>or</strong>
+          <a href="tel:+18008271000" aria-label="800. 8 2 7. 1000">
+            800-827-1000
+          </a>
+          , Monday through Friday, 8:30 a.m. to 4:30 p.m. ET,{' '}
+          <strong>or</strong>
         </li>
         <li>
           Get in touch with your nearest Veterans Service Officer (VSO).{' '}

--- a/src/applications/disability-benefits/all-claims/content/confirmation-page.jsx
+++ b/src/applications/disability-benefits/all-claims/content/confirmation-page.jsx
@@ -48,7 +48,9 @@ const template = (props, title, content, submissionMessage, messageType) => {
 
   return (
     <div>
-      <h5>Please print this page for your records.</h5>
+      <h2 className="vads-u-font-size--h5">
+        Please print this page for your records.
+      </h2>
 
       <AlertBox
         isVisible
@@ -58,10 +60,10 @@ const template = (props, title, content, submissionMessage, messageType) => {
       />
 
       <div className="inset">
-        <h4>
+        <h3 className="vads-u-font-size--h4">
           Disability Compensation Claim{' '}
           <span className="additional">(Form 21-526EZ)</span>
-        </h4>
+        </h3>
         <span>
           For {first} {middle} {last} {suffix}
         </span>
@@ -71,25 +73,27 @@ const template = (props, title, content, submissionMessage, messageType) => {
             <br />
             <span>{moment(submittedAt).format('MMM D, YYYY')}</span>
           </li>
-          <strong>Conditions claimed</strong>
-          <br />
-          <ul className="disability-list">
-            {disabilities.map((disability, i) => (
-              <li key={i}>
-                {typeof disability === 'string'
-                  ? capitalizeEachWord(disability)
-                  : NULL_CONDITION_STRING}
-              </li>
-            ))}
-          </ul>
-          {submissionMessage}
+          <li>
+            <strong>Conditions claimed</strong>
+            <br />
+            <ul className="disability-list">
+              {disabilities.map((disability, i) => (
+                <li key={i}>
+                  {typeof disability === 'string'
+                    ? capitalizeEachWord(disability)
+                    : NULL_CONDITION_STRING}
+                </li>
+              ))}
+            </ul>
+            {submissionMessage}
+          </li>
         </ul>
       </div>
 
       <div className="confirmation-guidance-container">
-        <h4 className="confirmation-guidance-heading">
+        <h3 className="confirmation-guidance-heading vads-u-font-size--h4">
           How long will it take VA to make a decision on my claim?
-        </h4>
+        </h3>
         <p className="confirmation-guidance-message">
           We process applications in the order we receive them. The amount of
           time it takes us to review you claim depends on:
@@ -107,23 +111,23 @@ const template = (props, title, content, submissionMessage, messageType) => {
           </li>
         </ul>
 
-        <h4 className="confirmation-guidance-heading">
+        <h3 className="confirmation-guidance-heading vads-u-font-size--h4">
           How can I check the status of my claim?
-        </h4>
+        </h3>
         <p className="confirmation-guidance-message">
           You can check the status of your claim online. Please allow 24 hours
           for your disability claim to show up there. If you don’t see your
           disability claim online after 24 hours, please call Veterans Benefits
-          Assistance at <a href="tel:+18008271000">800-827-1000</a>, Monday –
-          Friday, 8:30 a.m. – 4:30 p.m. ET.
+          Assistance at <a href="tel:+18008271000">800-827-1000</a>, Monday
+          through Friday, 8:30 a.m. to 4:30 p.m. ET.
         </p>
         <p>
           <a href="/track-claims">Check the status of your claim</a>
         </p>
 
-        <h4 className="confirmation-guidance-heading">
+        <h3 className="confirmation-guidance-heading vads-u-font-size--h4">
           What happens after I file a claim for disability compensation?
-        </h4>
+        </h3>
         <p className="confirmation-guidance-message">
           <a href="/disability/after-you-file-claim/">
             Learn more about what happens after you file a disability claim
@@ -153,9 +157,9 @@ export const retryableErrorContent = props =>
         <strong>
           If you don’t see your disability claim online after 24 hours,
         </strong>{' '}
-        please call Veterans Benefits Assistance at 800-827-1000, Monday –
-        Friday, 8:30 a.m. – 4:30 p.m. ET and provide this reference number{' '}
-        {props.jobId}.
+        please call Veterans Benefits Assistance at{' '}
+        <a href="tel:+18008271000">800-827-1000</a>, Monday through Friday, 8:30
+        a.m. to 4:30 p.m. ET and provide this reference number {props.jobId}.
       </p>
     </div>,
     checkLaterMessage(props.jobId),
@@ -180,8 +184,8 @@ export const submitErrorContent = props =>
       <ul>
         <li>
           Please call Veterans Benefits Assistance at{' '}
-          <a href="tel:+18008271000">800-827-1000</a>, Monday – Friday, 8:30
-          a.m. – 4:30 p.m. ET, <strong>or</strong>
+          <a href="tel:+18008271000">800-827-1000</a>, Monday through Friday,
+          8:30 a.m. to 4:30 p.m. ET, <strong>or</strong>
         </li>
         <li>
           Get in touch with your nearest Veterans Service Officer (VSO).{' '}


### PR DESCRIPTION
## Description

Form 526 has several accessibility issues that needed fixing:

- Heading levels were not increasing by one
- List (UL) did not have valid children (LI)
- Dashes within ranges needed to be modified (`Monday through Friday` and `8:30 a.m to 4:30 p.m.`)

## Testing done

Axe coconut on confirmation page

## Screenshots

<details><summary>Axe coconut result</summary>

<!-- leave a blank line above -->
![Screen Shot 2020-05-01 at 9 47 06 AM](https://user-images.githubusercontent.com/136959/80814107-e7479100-8b90-11ea-8ca8-3b6bb4b59c28.png)</details>

## Acceptance criteria
- [ ] Axe coconut issues resolved

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
