### PR TITLE
SonarJs enforcing rules batch 2

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -86,6 +86,14 @@
     "sonarjs/prefer-object-literal": 2,
     "sonarjs/prefer-single-boolean-return": 2,
     "sonarjs/prefer-while": 2,
+    "sonarjs/no-extra-arguments": 2,
+    "sonarjs/no-identical-expressions": 2,
+    "sonarjs/max-switch-cases": [2, 40],
+    "sonarjs/no-duplicated-branches": 2,
+    "sonarjs/no-inverted-boolean-check": 2,
+    "sonarjs/no-redundant-boolean": 2,
+    "sonarjs/no-unused-collection": 2,
+    "sonarjs/no-small-switch": 2,
 
     /* || airbnb plugin || */
     // this is the airbnb default, minus for..of

--- a/circle.eslint.json
+++ b/circle.eslint.json
@@ -1,13 +1,5 @@
 {
   "rules": {
-    "sonarjs/no-extra-arguments": 2,
-    "sonarjs/no-identical-expressions": 2,
-    "sonarjs/max-switch-cases": [2, 40],
-    "sonarjs/no-duplicated-branches": 2,
-    "sonarjs/no-inverted-boolean-check": 2,
-    "sonarjs/no-redundant-boolean": 2,
-    "sonarjs/no-unused-collection": 2,
-    "sonarjs/no-small-switch": 2,
     "va/use-resolved-path": [
       2,
       {


### PR DESCRIPTION
## Description
After placing these SonarJS rules in the testing stage during the Sprint Sprint 23 & 24. We are moving them to be forced into the `.eslintrc` file.

## Testing done
Locally

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs