### PR TITLE
Refactor for readability and conditionally track event on user search

### DIFF
--- a/src/applications/yellow-ribbon/actions/index.js
+++ b/src/applications/yellow-ribbon/actions/index.js
@@ -1,8 +1,8 @@
 // Dependencies.
-import URLSearchParams from 'url-search-params';
 import recordEvent from 'platform/monitoring/record-event';
 // Relative imports.
 import { fetchResultsApi } from '../api';
+import { updateQueryParams } from '../helpers';
 import {
   FETCH_RESULTS,
   FETCH_RESULTS_FAILURE,
@@ -43,13 +43,14 @@ export const fetchResultsThunk = (options = {}) => async dispatch => {
   const city = options?.city || null;
   const contributionAmount = options?.contributionAmount || null;
   const hideFetchingState = options?.hideFetchingState;
-  const history = options?.history || window.history;
-  const location = options?.location || window.location;
+  const history = options?.history;
+  const location = options?.location;
   const name = options?.name || null;
   const numberOfStudents = options?.numberOfStudents || null;
   const page = options?.page || 1;
   const perPage = options?.perPage || 10;
   const state = options?.state || null;
+  const trackSearch = options?.trackSearch || false;
 
   const queryParamsLookup = {
     city,
@@ -68,26 +69,8 @@ export const fetchResultsThunk = (options = {}) => async dispatch => {
     }),
   );
 
-  // Derive the current query params.
-  const queryParams = new URLSearchParams(location.search);
-
-  // Set/Delete query params.
-  Object.keys(queryParamsLookup).forEach(key => {
-    // Derive the value.
-    const value = queryParamsLookup[key];
-
-    // Set the query param.
-    if (value) {
-      queryParams.set(key, value);
-      return;
-    }
-
-    // Remove the query param.
-    queryParams.delete(key);
-  });
-
-  // Update the URL with the new query params.
-  history.replaceState({}, '', `${location.pathname}?${queryParams}`);
+  // Update query params.
+  updateQueryParams(history, location, queryParamsLookup);
 
   try {
     // Attempt to make the API request to retreive results.
@@ -102,15 +85,18 @@ export const fetchResultsThunk = (options = {}) => async dispatch => {
     });
 
     // Track the API request.
-    recordEvent({
-      event: 'edu-yellow-ribbon-search',
-      'edu-yellow-ribbon-name': name || undefined,
-      'edu-yellow-ribbon-state': state || undefined,
-      'edu-yellow-ribbon-city': city || undefined,
-      'edu-yellow-ribbon-contribution-amount': contributionAmount || undefined,
-      'edu-yellow-ribbon-number-of-students': numberOfStudents || undefined,
-      'edu-yellow-ribbon-number-of-search-results': response?.totalResults,
-    });
+    if (trackSearch) {
+      recordEvent({
+        event: 'edu-yellow-ribbon-search',
+        'edu-yellow-ribbon-name': name || undefined,
+        'edu-yellow-ribbon-state': state || undefined,
+        'edu-yellow-ribbon-city': city || undefined,
+        'edu-yellow-ribbon-contribution-amount':
+          contributionAmount || undefined,
+        'edu-yellow-ribbon-number-of-students': numberOfStudents || undefined,
+        'edu-yellow-ribbon-number-of-search-results': response?.totalResults,
+      });
+    }
 
     // If we are here, the API request succeeded.
     dispatch(fetchResultsSuccess(response));

--- a/src/applications/yellow-ribbon/containers/SearchForm/index.jsx
+++ b/src/applications/yellow-ribbon/containers/SearchForm/index.jsx
@@ -230,4 +230,7 @@ const mapDispatchToProps = {
   fetchResultsThunk,
 };
 
-export default connect(mapStateToProps, mapDispatchToProps)(SearchForm);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(SearchForm);

--- a/src/applications/yellow-ribbon/containers/SearchForm/index.jsx
+++ b/src/applications/yellow-ribbon/containers/SearchForm/index.jsx
@@ -98,6 +98,7 @@ export class SearchForm extends Component {
       numberOfStudents,
       page: 1,
       state,
+      trackSearch: true,
     });
 
     // Scroll to top.
@@ -229,7 +230,4 @@ const mapDispatchToProps = {
   fetchResultsThunk,
 };
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps,
-)(SearchForm);
+export default connect(mapStateToProps, mapDispatchToProps)(SearchForm);

--- a/src/applications/yellow-ribbon/helpers/index.js
+++ b/src/applications/yellow-ribbon/helpers/index.js
@@ -1,4 +1,5 @@
 // Node modules.
+import URLSearchParams from 'url-search-params';
 import map from 'lodash/map';
 import startCase from 'lodash/startCase';
 import toLower from 'lodash/toLower';
@@ -13,3 +14,30 @@ export const normalizeResponse = response => ({
   })),
   totalResults: response?.meta?.count,
 });
+
+export const updateQueryParams = (
+  history = window.history,
+  location = window.location,
+  queryParamsLookup = {},
+) => {
+  // Derive the current query params.
+  const queryParams = new URLSearchParams(location.search);
+
+  // Set/Delete query params.
+  Object.keys(queryParamsLookup).forEach(key => {
+    // Derive the value.
+    const value = queryParamsLookup[key];
+
+    // Set the query param.
+    if (value) {
+      queryParams.set(key, value);
+      return;
+    }
+
+    // Remove the query param.
+    queryParams.delete(key);
+  });
+
+  // Update the URL with the new query params.
+  history.replaceState({}, '', `${location.pathname}?${queryParams}`);
+};

--- a/src/applications/yellow-ribbon/helpers/index.js
+++ b/src/applications/yellow-ribbon/helpers/index.js
@@ -24,10 +24,7 @@ export const updateQueryParams = (
   const queryParams = new URLSearchParams(location.search);
 
   // Set/Delete query params.
-  Object.keys(queryParamsLookup).forEach(key => {
-    // Derive the value.
-    const value = queryParamsLookup[key];
-
+  Object.entries(queryParamsLookup).forEach(([key, value]) => {
     // Set the query param.
     if (value) {
       queryParams.set(key, value);


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/7199

**Related comment:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/7199#issuecomment-622179409

This PR refactors the main `fetchResultsThunk` action for readability. It also ensures the following:

```
When a user lands on the page, do NOT track api request event.
When a user paginates on the page, do NOT track api request event.
```

## Testing done
Tests pass 🎉 

## Screenshots
N/A

## Acceptance criteria
- [x] When a user lands on the page, do NOT track api request event.
- [x] When a user paginates on the page, do NOT track api request event.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
