### PR TITLE
Sanlouise/refactor addressformatter

### DIFF
--- a/src/applications/personalization/profile360/sass/profile-360.scss
+++ b/src/applications/personalization/profile360/sass/profile-360.scss
@@ -85,4 +85,8 @@ input.usa-only-phone {
   .address-validation-input {
     height: 75%;
   }
+
+  [type=radio] + label::before {
+    min-width: 1.4rem;
+  }
 }

--- a/src/applications/personalization/profile360/tests/e2e/profile-360.e2e.spec.js
+++ b/src/applications/personalization/profile360/tests/e2e/profile-360.e2e.spec.js
@@ -68,7 +68,7 @@ function beginTests(browser) {
     browser,
     'mailingAddress',
     '1493 Martin Luther King Rd, Apt 1',
-    'Fulton, New York 97062',
+    'Fulton, NY 97062',
   );
   runAddressTest(
     browser,

--- a/src/platform/forms/address/helpers.js
+++ b/src/platform/forms/address/helpers.js
@@ -1,8 +1,7 @@
 import ADDRESS_DATA from './data';
+import countries from 'platform/user/profile/vet360/constants/countries.json';
 
 const STATE_NAMES = ADDRESS_DATA.states;
-const MILITARY_STATES = new Set(ADDRESS_DATA.militaryStates);
-const UNITED_STATES = 'USA';
 
 /**
  * @typedef {string} AddressType
@@ -15,7 +14,7 @@ const UNITED_STATES = 'USA';
 export const ADDRESS_TYPES = {
   domestic: 'DOMESTIC',
   international: 'INTERNATIONAL',
-  military: 'MILITARY',
+  military: 'OVERSEAS MILITARY',
 };
 
 /**
@@ -30,67 +29,7 @@ export const ADDRESS_TYPES = {
  * @property {string} [stateCode]
  * @property {string} [zipCode]
  * @property {string} [zipSuffix]
- * @property {string} [militaryPostOfficeTypeCode]
- * @property {string} [militaryStateCode]
  */
-
-/**
- * Converts an address into a standardized format so that military address follow the same interface as other address types.
- * If type is Military, then the countryName property is added and set to USA, militaryPostOfficeTypeCode is renamed to city, and militaryStateCode to stateCode.
- * Non-military addresses are unaffected.
- * @param {Address} address
- * @returns {Address} A new Address object
- */
-export function consolidateAddress(address) {
-  const consolidated = {
-    ...address,
-  };
-
-  if (consolidated.type === ADDRESS_TYPES.military) {
-    consolidated.city = consolidated.militaryPostOfficeTypeCode;
-    consolidated.stateCode = consolidated.militaryStateCode;
-    consolidated.countryName = UNITED_STATES;
-    delete consolidated.militaryPostOfficeTypeCode;
-    delete consolidated.militaryStateCode;
-  }
-
-  delete consolidated.addressEffectiveDate;
-  return consolidated;
-}
-
-/**
- * @param {Address} address
- * @returns {AddressType}
- */
-function getInferredAddressType(address) {
-  if (address.countryName !== UNITED_STATES) return ADDRESS_TYPES.international;
-  if (MILITARY_STATES.has(address.stateCode)) return ADDRESS_TYPES.military;
-  return ADDRESS_TYPES.domestic;
-}
-
-/**
- * Converts an address that may have been modified or standardized and needs its type to be inferred.
- * If type is Military, the inverse conversion of 'consolidateAddress' is performed.
- * Non-military addresses are unaffected.
- * @param {Address} address
- * @returns {Address} A new Address object
- */
-export function expandAddress(address) {
-  const expanded = {
-    ...address,
-    type: getInferredAddressType(address),
-  };
-
-  if (expanded.type === ADDRESS_TYPES.military) {
-    expanded.militaryPostOfficeTypeCode = expanded.city;
-    expanded.militaryStateCode = expanded.stateCode;
-    delete expanded.city;
-    delete expanded.stateCode;
-    delete expanded.countryName;
-  }
-
-  return expanded;
-}
 
 /**
  * Returns whether or not the address is considered empty
@@ -98,7 +37,7 @@ export function expandAddress(address) {
  * @returns {boolean}
  */
 export function isEmptyAddress(address) {
-  const ignore = ['type', 'countryName', 'addressEffectiveDate'];
+  const ignore = ['addressType', 'countryName', 'addressEffectiveDate'];
 
   if (address) {
     return Object.keys(address)
@@ -128,39 +67,48 @@ export function formatAddress(address) {
 
   const {
     addressLine1,
-    addressLine3,
     addressLine2,
+    addressLine3,
+    addressType,
     city,
+    countryCodeIso3,
     countryName,
     internationalPostalCode,
-    militaryPostOfficeTypeCode,
-    militaryStateCode,
     province,
     stateCode,
-    type,
     zipCode,
   } = address;
 
-  const country = type === ADDRESS_TYPES.international ? countryName : '';
   let cityStateZip = '';
+
+  const displayCountry = countries.find(
+    country => country.countryCodeISO3 === countryCodeIso3,
+  );
+
+  const displayCountryName = displayCountry?.countryName;
+
+  // Only show country when ADDRESS_TYPES.international
+  const country =
+    addressType === ADDRESS_TYPES.international
+      ? countryName || displayCountryName
+      : '';
 
   const street =
     [addressLine1, addressLine2, addressLine3]
       .filter(item => item)
       .join(', ') || '';
 
-  switch (type) {
+  const stateName =
+    addressType === ADDRESS_TYPES.domestic
+      ? stateCode
+      : getStateName(stateCode);
+
+  switch (addressType) {
     case ADDRESS_TYPES.domestic:
+    case ADDRESS_TYPES.military:
       cityStateZip = city || '';
       if (city && stateCode) cityStateZip += ', ';
-      if (stateCode) cityStateZip += getStateName(stateCode);
-      if (zipCode) cityStateZip += ' ' + zipCode;
-      break;
-
-    case ADDRESS_TYPES.military:
-      cityStateZip = militaryPostOfficeTypeCode || '';
-      if (militaryPostOfficeTypeCode && militaryStateCode) cityStateZip += ', ';
-      if (militaryStateCode) cityStateZip += militaryStateCode;
+      if (stateCode) cityStateZip += stateName;
       if (zipCode) cityStateZip += ' ' + zipCode;
       break;
 

--- a/src/platform/forms/tests/address.unit.spec.js
+++ b/src/platform/forms/tests/address.unit.spec.js
@@ -5,7 +5,7 @@ import { expect } from 'chai';
 // https://github.com/department-of-veterans-affairs/vets-api/blob/1efd2c206859b1a261e762a50cdb44dc8b66462d/spec/factories/pciu_address.rb#L34
 
 const domestic = {
-  type: 'DOMESTIC',
+  addressType: 'DOMESTIC',
   countryName: 'USA',
   addressLine1: '140 Rock Creek Church Rd NW',
   addressLine2: 'Apt 57',
@@ -17,7 +17,7 @@ const domestic = {
 };
 
 const international = {
-  type: 'INTERNATIONAL',
+  addressType: 'INTERNATIONAL',
   countryName: 'France',
   addressLine1: '2 Avenue Gabriel',
   addressLine2: 'Line2',
@@ -29,12 +29,12 @@ const international = {
 
 // 'countryName' is NOT part of the Military Address model.
 const military = {
-  type: 'MILITARY',
+  addressType: 'OVERSEAS MILITARY',
   addressLine1: '57 Columbus Strassa',
   addressLine2: 'Line2',
   addressLine3: 'Ben Franklin Village',
-  militaryPostOfficeTypeCode: 'APO',
-  militaryStateCode: 'AE',
+  city: 'APO',
+  stateCode: 'AE',
   zipCode: '09028',
   zipSuffix: '1234',
 };
@@ -43,7 +43,7 @@ describe('formatAddress', () => {
   it('formats domestic addresses with three street lines', () => {
     const expectedResult = {
       street: '140 Rock Creek Church Rd NW, Apt 57, Area Name',
-      cityStateZip: 'Springfield, Oregon 97477',
+      cityStateZip: 'Springfield, OR 97477',
       country: '',
     };
 
@@ -53,7 +53,7 @@ describe('formatAddress', () => {
   it('formats domestic addresses with two street lines', () => {
     const expectedResult = {
       street: '140 Rock Creek Church Rd NW, Apt 57',
-      cityStateZip: 'Springfield, Oregon 97477',
+      cityStateZip: 'Springfield, OR 97477',
       country: '',
     };
     const address = { ...domestic };
@@ -64,7 +64,7 @@ describe('formatAddress', () => {
   it('formats domestic addresses with one street line', () => {
     const expectedResult = {
       street: '140 Rock Creek Church Rd NW',
-      cityStateZip: 'Springfield, Oregon 97477',
+      cityStateZip: 'Springfield, OR 97477',
       country: '',
     };
     const address = { ...domestic };
@@ -76,7 +76,7 @@ describe('formatAddress', () => {
   it('formats military addresses', () => {
     const expectedResult = {
       street: '57 Columbus Strassa, Line2, Ben Franklin Village',
-      cityStateZip: 'APO, AE 09028',
+      cityStateZip: 'APO, Armed Forces Europe (AE) 09028',
       country: '',
     };
 
@@ -107,44 +107,14 @@ describe('isEmptyAddress', () => {
   it('detects an empty address', () => {
     expect(addressUtils.isEmptyAddress({})).to.equal(true);
     expect(
-      addressUtils.isEmptyAddress({ type: 'domestic', countryName: 'USA' }),
+      addressUtils.isEmptyAddress({
+        addressType: 'DOMESTIC',
+        countryName: 'USA',
+      }),
     ).to.equal(true);
   });
 
   it('detects a non-empty address', () => {
     expect(addressUtils.isEmptyAddress(domestic)).to.equal(false);
-  });
-});
-
-describe('consolidateAddress', () => {
-  it('converts a military address into a standard address format by adding the countryName set to USA, militaryPostOfficeTypeCode converted to city, and militaryStateCode converted to stateCode.', () => {
-    const expectedResult = {
-      type: 'MILITARY',
-      countryName: 'USA',
-      addressLine1: military.addressLine1,
-      addressLine2: military.addressLine2,
-      addressLine3: military.addressLine3,
-      city: military.militaryPostOfficeTypeCode,
-      stateCode: military.militaryStateCode,
-      zipCode: military.zipCode,
-      zipSuffix: military.zipSuffix,
-    };
-    expect(addressUtils.consolidateAddress(military)).to.deep.equal(
-      expectedResult,
-    );
-  });
-  it('does not affect non-military addresses', () => {
-    expect(addressUtils.consolidateAddress(domestic)).to.deep.equal(domestic);
-  });
-});
-
-describe('expandAddress', () => {
-  it('converts a previously-consolidated address into the proper model by inferring the address type. If it is inferred as military, the inverse conversion of consolidateAddress is performed.', () => {
-    const consolidated = addressUtils.consolidateAddress(military);
-    consolidated.type = 'Will be inferred based on address fields';
-    expect(addressUtils.expandAddress(consolidated)).to.deep.equal(military);
-  });
-  it('does not affect non-military addresses', () => {
-    expect(addressUtils.expandAddress(domestic)).to.deep.equal(domestic);
   });
 });

--- a/src/platform/user/profile/vet360/components/AddressField/AddressView.jsx
+++ b/src/platform/user/profile/vet360/components/AddressField/AddressView.jsx
@@ -3,23 +3,20 @@ import React from 'react';
 import { formatAddress } from 'platform/forms/address/helpers';
 
 export default function AddressView({ data: address }) {
-  const { addressType } = address;
-
-  const { street, cityStateZip, country } = formatAddress({
-    ...address,
-    // force formatting of military addresses as domestic
-    type: addressType.match(/military/i)
-      ? 'DOMESTIC'
-      : addressType.toUpperCase(),
-  });
+  const { street, cityStateZip, country } = formatAddress(address);
 
   return (
     <div>
       {street}
       <br />
       {cityStateZip}
-      <br />
-      {country}
+
+      {country && (
+        <>
+          <br />
+          {country}
+        </>
+      )}
     </div>
   );
 }

--- a/src/platform/user/profile/vet360/containers/AddressValidationModal.jsx
+++ b/src/platform/user/profile/vet360/containers/AddressValidationModal.jsx
@@ -173,18 +173,17 @@ class AddressValidationModal extends React.Component {
         key={id}
         className="vads-u-margin-bottom--1p5 address-validation-container"
       >
-        {isFirstOptionOrEnabled &&
-          hasConfirmedSuggestions && (
-            <input
-              className="address-validation-input"
-              type="radio"
-              id={id}
-              onChange={
-                isFirstOptionOrEnabled && this.onChangeHandler(address, id)
-              }
-              checked={selectedAddressId === id}
-            />
-          )}
+        {isFirstOptionOrEnabled && hasConfirmedSuggestions && (
+          <input
+            className="address-validation-input"
+            type="radio"
+            id={id}
+            onChange={
+              isFirstOptionOrEnabled && this.onChangeHandler(address, id)
+            }
+            checked={selectedAddressId === id}
+          />
+        )}
         <label
           htmlFor={id}
           className="vads-u-margin-top--2 vads-u-display--flex vads-u-align-items--center"
@@ -194,31 +193,24 @@ class AddressValidationModal extends React.Component {
             {addressLine2 && <span>{` ${addressLine2}`}</span>}
             {addressLine3 && <span>{` ${addressLine3}`}</span>}
 
-            {city &&
-              stateCode &&
-              zipCode && <span>{` ${city}, ${stateCode} ${zipCode}`}</span>}
-            {city &&
-              province &&
-              internationalPostalCode && (
-                <span>
-                  {`${city}, ${province}, ${internationalPostalCode}`}
-                </span>
-              )}
+            {city && stateCode && zipCode && (
+              <span>{` ${city}, ${stateCode} ${zipCode}`}</span>
+            )}
+            {city && province && internationalPostalCode && (
+              <span>{` ${city}, ${province}, ${internationalPostalCode}`}</span>
+            )}
             {/* State/Province/Region is not required with international addresses */}
-            {city &&
-              !province &&
-              internationalPostalCode && (
-                <span>{` ${city}, ${internationalPostalCode}`}</span>
-              )}
+            {city && !province && internationalPostalCode && (
+              <span>{` ${city}, ${internationalPostalCode}`}</span>
+            )}
 
             {displayCountryName && <span>{displayCountryName}</span>}
 
-            {isAddressFromUser &&
-              showEditLink && (
-                <button className="va-button-link" onClick={this.onEditClick}>
-                  Edit Address
-                </button>
-              )}
+            {isAddressFromUser && showEditLink && (
+              <button className="va-button-link" onClick={this.onEditClick}>
+                Edit Address
+              </button>
+            )}
           </div>
         </label>
       </div>

--- a/src/platform/user/profile/vet360/containers/AddressValidationModal.jsx
+++ b/src/platform/user/profile/vet360/containers/AddressValidationModal.jsx
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import Modal from '@department-of-veterans-affairs/formation-react/Modal';
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
+import { formatAddress } from 'platform/forms/address/helpers';
 import LoadingButton from 'platform/site-wide/loading-button/LoadingButton';
 import {
   openModal,
@@ -17,7 +18,6 @@ import { focusElement } from 'platform/utilities/ui';
 import { getValidationMessageKey } from '../../utilities';
 import { ADDRESS_VALIDATION_MESSAGES } from '../../constants/addressValidationMessages';
 import recordEvent from 'platform/monitoring/record-event';
-import countries from 'platform/user/profile/vet360/constants/countries.json';
 
 import * as VET360 from '../constants';
 
@@ -138,26 +138,6 @@ class AddressValidationModal extends React.Component {
       selectedAddressId,
       confirmedSuggestions,
     } = this.props;
-    const {
-      addressLine1,
-      addressLine2,
-      addressLine3,
-      city,
-      stateCode,
-      zipCode,
-      internationalPostalCode,
-      province,
-      countryCodeIso3,
-    } = address;
-
-    // We display the country except for US addresses (including military bases)
-    const displayCountry = countries.find(
-      country =>
-        country.countryCodeISO3 === countryCodeIso3 &&
-        countryCodeIso3 !== 'USA',
-    );
-
-    const displayCountryName = displayCountry?.countryName;
 
     const isAddressFromUser = id === 'userEntered';
     const hasConfirmedSuggestions =
@@ -168,49 +148,41 @@ class AddressValidationModal extends React.Component {
     const showEditLink = showEditLinkErrorState || showEditLinkNonErrorState;
     const isFirstOptionOrEnabled =
       (isAddressFromUser && validationKey) || !isAddressFromUser;
+
+    const { street, cityStateZip, country } = formatAddress(address);
+
     return (
       <div
         key={id}
         className="vads-u-margin-bottom--1p5 address-validation-container"
       >
-        {isFirstOptionOrEnabled && hasConfirmedSuggestions && (
-          <input
-            className="address-validation-input"
-            type="radio"
-            id={id}
-            onChange={
-              isFirstOptionOrEnabled && this.onChangeHandler(address, id)
-            }
-            checked={selectedAddressId === id}
-          />
-        )}
+        {isFirstOptionOrEnabled &&
+          hasConfirmedSuggestions && (
+            <input
+              className="address-validation-input"
+              type="radio"
+              id={id}
+              onChange={
+                isFirstOptionOrEnabled && this.onChangeHandler(address, id)
+              }
+              checked={selectedAddressId === id}
+            />
+          )}
         <label
           htmlFor={id}
           className="vads-u-margin-top--2 vads-u-display--flex vads-u-align-items--center"
         >
           <div className="vads-u-display--flex vads-u-flex-direction--column vads-u-padding-bottom--0p5">
-            {addressLine1 && <span>{addressLine1}</span>}
-            {addressLine2 && <span>{` ${addressLine2}`}</span>}
-            {addressLine3 && <span>{` ${addressLine3}`}</span>}
+            <span>{street}</span>
+            <span>{cityStateZip}</span>
+            <span>{country}</span>
 
-            {city && stateCode && zipCode && (
-              <span>{` ${city}, ${stateCode} ${zipCode}`}</span>
-            )}
-            {city && province && internationalPostalCode && (
-              <span>{` ${city}, ${province}, ${internationalPostalCode}`}</span>
-            )}
-            {/* State/Province/Region is not required with international addresses */}
-            {city && !province && internationalPostalCode && (
-              <span>{` ${city}, ${internationalPostalCode}`}</span>
-            )}
-
-            {displayCountryName && <span>{displayCountryName}</span>}
-
-            {isAddressFromUser && showEditLink && (
-              <button className="va-button-link" onClick={this.onEditClick}>
-                Edit Address
-              </button>
-            )}
+            {isAddressFromUser &&
+              showEditLink && (
+                <button className="va-button-link" onClick={this.onEditClick}>
+                  Edit Address
+                </button>
+              )}
           </div>
         </label>
       </div>

--- a/src/platform/user/profile/vet360/tests/containers/AddressValidationModal.unit.spec.jsx
+++ b/src/platform/user/profile/vet360/tests/containers/AddressValidationModal.unit.spec.jsx
@@ -354,6 +354,7 @@ describe('<AddressValidationModal/>', () => {
                 addressLine1: '12345 1st Ave',
                 addressLine2: 'bldg 2',
                 addressLine3: 'apt 23',
+                addressType: 'DOMESTIC',
                 city: 'Tampa',
                 stateCode: 'FL',
                 zipCode: '12346',
@@ -368,6 +369,7 @@ describe('<AddressValidationModal/>', () => {
                 addressLine1: '22222 1st Ave',
                 addressLine2: 'bldg 2',
                 addressLine3: 'apt 23',
+                addressType: 'DOMESTIC',
                 city: 'Saint Petersburg',
                 stateCode: 'FL',
                 zipCode: '55555',
@@ -397,14 +399,14 @@ describe('<AddressValidationModal/>', () => {
         .find('label')
         .at(1)
         .text(),
-    ).to.equal('12345 1st Ave bldg 2 apt 23 Tampa, FL 12346');
+    ).to.equal('12345 1st Ave, bldg 2, apt 23Tampa, FL 12346');
 
     expect(
       component
         .find('label')
         .at(2)
         .text(),
-    ).to.equal('22222 1st Ave bldg 2 apt 23 Saint Petersburg, FL 55555');
+    ).to.equal('22222 1st Ave, bldg 2, apt 23Saint Petersburg, FL 55555');
     component.unmount();
   });
 


### PR DESCRIPTION
[TICKET](https://github.com/department-of-veterans-affairs/va.gov-team/issues/8596)

### Description
While working on the international addresses preview, I noticed that we have some dead/outdated code in the `addressFormatter` helper function. We should especially clean up how we format military addresses.

We need to use the `addressFormatter` in the `AddressValidationModal` as well to ensure consistency among address formatting in our profile.

### Acceptance Criteria
- [x] Investigate if we are ever using `militaryPostOfficeTypeCode` and `militaryStateCode`
- [x] Undo passing in `type` to the `addressFormatter`
- [x] If first acceptance criteria is `false`, remove `case` statement for `military`, instead bucket military addresses with domestic ones
- [x] Use `addressFormatter` in `src/platform/user/profile/vet360/containers/AddressValidationModal.jsx`
- [x] Ensure checkbox on Address Confirmation modal is not stretched out when using long addresses
- [x] Ensure unit tests are updated

On the address validation modal we now list alle `streetLines` on the same line, and wrap to the nest line when we have long strings:

![image](https://user-images.githubusercontent.com/14869324/81246616-4d8b4400-8fd5-11ea-874d-4964cdb0b10d.png)
