### PR TITLE
[Chatbot] Add CDN source into header

### DIFF
--- a/src/site/includes/header.html
+++ b/src/site/includes/header.html
@@ -59,6 +59,10 @@
 <link rel='stylesheet' href='/assets/css/ie.css'>
 <![endif]-->
 
+  {% if botframework_cdn %}
+    <script src="{{ botframework_cdn }}"></script>
+  {% endif %}
+
   <script defer nomodule data-entry-name="polyfills.js"></script>
   <script defer data-entry-name="vendor.js"></script>
   <script defer data-entry-name="{{ entryname | default: 'static-pages' }}.js"></script>


### PR DESCRIPTION
## Description
Sibling PR - https://github.com/department-of-veterans-affairs/vagov-content/pull/674

We believe that the chatbot may sometimes be experiencing a runtime error if all scripts are cached and the app entry point is loading before `window.WebChat` is defined by the CDN script. This is because the CDN is in the DOM at a later point than the entry point. This PR moves the CDN into the header before the app code.

## Testing done
Made sure CDN was in the DOM still

## Screenshots
![image](https://user-images.githubusercontent.com/1915775/80826426-3224d100-8bb0-11ea-99a8-4250643df329.png)


## Acceptance criteria
- [ ] CDN script is in DOM before app code (static-pages)

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
