### PR TITLE
[Development] Remove circular form config dependency

### DIFF
--- a/src/applications/disability-benefits/all-claims/config/form.js
+++ b/src/applications/disability-benefits/all-claims/config/form.js
@@ -33,12 +33,10 @@ import {
   isNotUploadingPrivateMedical,
   hasNewPtsdDisability,
   hasNewDisabilities,
-  newConditionsOnly,
   increaseOnly,
-  newAndIncrease,
-  noClaimTypeSelected,
   isDisabilityPtsd,
   directToCorrectForm,
+  DISABILITY_SHARED_CONFIG,
 } from '../utils';
 
 import captureEvents from '../analytics-functions';
@@ -262,18 +260,15 @@ const formConfig = {
       pages: {
         disabilitiesOrientation: {
           title: '',
-          path: 'disabilities/orientation',
-          // Only show the page if both (or potentially neither) options are chosen on the claim-type page
-          depends: formData =>
-            newAndIncrease(formData) || noClaimTypeSelected(formData),
+          path: DISABILITY_SHARED_CONFIG.orientation.path,
+          depends: DISABILITY_SHARED_CONFIG.orientation.depends,
           uiSchema: { 'ui:description': disabilitiesOrientation },
           schema: { type: 'object', properties: {} },
         },
         ratedDisabilities: {
           title: 'Existing conditions (rated disabilities)',
-          path: 'disabilities/rated-disabilities',
-          depends: formData =>
-            hasRatedDisabilities(formData) && !newConditionsOnly(formData),
+          path: DISABILITY_SHARED_CONFIG.ratedDisabilities.path,
+          depends: DISABILITY_SHARED_CONFIG.ratedDisabilities.depends,
           uiSchema: ratedDisabilities.uiSchema,
           schema: ratedDisabilities.schema,
         },
@@ -286,8 +281,8 @@ const formConfig = {
         },
         addDisabilities: {
           title: 'Add a new disability',
-          path: 'new-disabilities/add',
-          depends: hasNewDisabilities,
+          path: DISABILITY_SHARED_CONFIG.addDisabilities.path,
+          depends: DISABILITY_SHARED_CONFIG.addDisabilities.depends,
           uiSchema: addDisabilities.uiSchema,
           schema: addDisabilities.schema,
           updateFormData: addDisabilities.updateFormData,

--- a/src/applications/disability-benefits/all-claims/content/summaryOfDisabilities.jsx
+++ b/src/applications/disability-benefits/all-claims/content/summaryOfDisabilities.jsx
@@ -1,10 +1,13 @@
 import React from 'react';
 import { Link } from 'react-router';
-
 import environment from 'platform/utilities/environment';
-import { capitalizeEachWord, isDisabilityPtsd } from '../utils';
+
+import {
+  capitalizeEachWord,
+  isDisabilityPtsd,
+  DISABILITY_SHARED_CONFIG,
+} from '../utils';
 import { ptsdTypeEnum } from './ptsdTypeInfo';
-import formConfig from '../config/form';
 import { NULL_CONDITION_STRING } from '../constants';
 
 const mapDisabilityName = (disabilityName, formData, index) => {
@@ -30,19 +33,18 @@ const mapDisabilityName = (disabilityName, formData, index) => {
 };
 
 const getRedirectLink = formData => {
-  if (environment.isProduction() || !formConfig) {
+  if (environment.isProduction()) {
     return 'go back to the beginning of this step and add it';
   }
-  const pages = formConfig.chapters.disabilities.pages;
   // Start from orientation page; assuming user has both existing & new
   // disabilities selected
-  let destinationPath = pages.disabilitiesOrientation.path;
+  let destinationPath = DISABILITY_SHARED_CONFIG.orientation.path;
 
-  if (pages.ratedDisabilities.depends(formData)) {
+  if (DISABILITY_SHARED_CONFIG.ratedDisabilities.depends(formData)) {
     // start from rated disabilities page
-    destinationPath = pages.ratedDisabilities.path;
-  } else if (pages.addDisabilities.depends(formData)) {
-    destinationPath = pages.addDisabilities.path;
+    destinationPath = DISABILITY_SHARED_CONFIG.ratedDisabilities.path;
+  } else if (DISABILITY_SHARED_CONFIG.addDisabilities.depends(formData)) {
+    destinationPath = DISABILITY_SHARED_CONFIG.addDisabilities.path;
   }
   return (
     <Link

--- a/src/applications/disability-benefits/all-claims/utils.jsx
+++ b/src/applications/disability-benefits/all-claims/utils.jsx
@@ -791,3 +791,21 @@ export const activeServicePeriods = formData =>
   _.get('serviceInformation.servicePeriods', formData, []).filter(
     sp => !sp.dateRange.to || moment(sp.dateRange.to).isAfter(moment()),
   );
+
+export const DISABILITY_SHARED_CONFIG = {
+  orientation: {
+    path: 'disabilities/orientation',
+    // Only show the page if both (or potentially neither) options are chosen on the claim-type page
+    depends: formData =>
+      newAndIncrease(formData) || noClaimTypeSelected(formData),
+  },
+  ratedDisabilities: {
+    path: 'disabilities/rated-disabilities',
+    depends: formData =>
+      hasRatedDisabilities(formData) && !newConditionsOnly(formData),
+  },
+  addDisabilities: {
+    path: 'new-disabilities/add',
+    depends: hasNewDisabilities,
+  },
+};


### PR DESCRIPTION
## Description

This PR removes a circular dependency that pulls in `form/config` to determine the path of a redirect link. The `path` string and `depends` function were moved into the `utils` file.

This fix prevents issues with BDD integration.

## Testing done

Local unit tests

## Screenshots

N/A

## Acceptance criteria
- [x] Circular dependency removed

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
