### PR TITLE
Feature/8134 vaos upcoming appointments tab goes to two lines at 400 percent

### DIFF
--- a/src/applications/vaos/components/TabItem.jsx
+++ b/src/applications/vaos/components/TabItem.jsx
@@ -23,7 +23,6 @@ export default function TabItem({
 
   const tabClasses = classNames(
     'vaos-appts__tab',
-    'vads-u-display--inline-block',
     'vads-u-text-align--center',
     'vads-u-color--gray-dark',
   );
@@ -31,7 +30,7 @@ export default function TabItem({
   return (
     <li
       role="presentation"
-      className="vads-u-display--inline-block vads-u-margin--0"
+      className="vads-u-margin--0"
     >
       <IndexLink
         id={`tab${id}`}

--- a/src/applications/vaos/components/TabItem.jsx
+++ b/src/applications/vaos/components/TabItem.jsx
@@ -28,10 +28,7 @@ export default function TabItem({
   );
 
   return (
-    <li
-      role="presentation"
-      className="vads-u-margin--0"
-    >
+    <li role="presentation" className="vads-u-margin--0">
       <IndexLink
         id={`tab${id}`}
         aria-controls={isActive ? `tabpanel${id}` : null}

--- a/src/applications/vaos/sass/vaos.scss
+++ b/src/applications/vaos/sass/vaos.scss
@@ -4,12 +4,14 @@
 .vaos-appts__tabs {
   padding: 0;
   border-bottom: 1px solid $color-gray-light;
+  display: flex;
 }
 
 .vaos-appts__tabs li {
   width: 50%;
+  display: flex;
 
-  @include media($medium-screen) {
+  @include media($medium-screen) { 
     width: 200px;
   }
 }
@@ -17,16 +19,18 @@
 .vaos-appts__tab {
   width: 100%;
   font-size: 14px;
-  border-color: $color-gray-light;
   border: solid 1px $color-gray-light;
   border-radius: 0 !important;
   position: relative;
   list-style: none;
-  padding: 6px 9px;
+  padding: 6px 0px;
   cursor: pointer;
   bottom: -1px;
   text-decoration: none;
-  background: $color-gray-light-alt;
+  background-color: $color-gray-light-alt;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 
   &:hover, &:focus, &:active {
     color: $color-gray-dark;
@@ -42,7 +46,6 @@
   }
 
   @include media($medium-screen) {
-    padding: 6px 12px;  
     font-size: 16px;
   }
 }

--- a/src/applications/vaos/tests/components/TabItem.unit.spec.jsx
+++ b/src/applications/vaos/tests/components/TabItem.unit.spec.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 import { expect } from 'chai';
 import sinon from 'sinon';
 
@@ -90,4 +90,14 @@ describe('<TabItem>', () => {
     expect(document.activeElement.id).to.equal('tabpaneltitle');
     tree.unmount();
   });
+
+  it('should render flex css for tab', () => {
+    const tree = mount(
+      <TabItem id="title" title="Title Here" tabpath="upcoming" />,
+    );
+    expect(tree.find('IndexLink').props().className).to.contain('vaos-appts__tab');
+
+    tree.unmount();
+  });
+
 });

--- a/src/applications/vaos/tests/components/TabItem.unit.spec.jsx
+++ b/src/applications/vaos/tests/components/TabItem.unit.spec.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shallow, mount } from 'enzyme';
+import { shallow } from 'enzyme';
 import { expect } from 'chai';
 import sinon from 'sinon';
 
@@ -92,12 +92,13 @@ describe('<TabItem>', () => {
   });
 
   it('should render flex css for tab', () => {
-    const tree = mount(
+    const tree = shallow(
       <TabItem id="title" title="Title Here" tabpath="upcoming" />,
     );
-    expect(tree.find('IndexLink').props().className).to.contain('vaos-appts__tab');
+    expect(tree.find('IndexLink').props().className).to.contain(
+      'vaos-appts__tab',
+    );
 
     tree.unmount();
   });
-
 });


### PR DESCRIPTION
## Description
The "Upcoming Appointments" tab in the view appointment page break into two lines when display is enlarged to 400% causing the "Past Appointment" tab height to be shorter

## Testing done
visual and unit test

## Screenshots
![image](https://user-images.githubusercontent.com/54327023/80832571-e75c8680-8bba-11ea-9076-75a4ab42cd4a.png)


## Acceptance criteria
- [ ] Both tabs have matching height
- [ ] Text inside the tabs are vertically aligned

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
