### PR TITLE
MDOT: Personal Info Component- Make Middle Name Not Required

### DIFF
--- a/src/applications/disability-benefits/2346/components/PersonalInfoBox.jsx
+++ b/src/applications/disability-benefits/2346/components/PersonalInfoBox.jsx
@@ -51,7 +51,7 @@ PersonalInfoBox.propTypes = {
     fullName: PropTypes.shape({
       first: PropTypes.string.isRequired,
       last: PropTypes.string.isRequired,
-      middle: PropTypes.string.isRequired,
+      middle: PropTypes.string,
     }).isRequired,
     gender: PropTypes.string.isRequired,
     dateOfBirth: PropTypes.string.isRequired,


### PR DESCRIPTION
## Description
This PR removes the middle name required prop type, which removes the warning shown when a Veteran does not have a middle name on file.

## Testing done
Console tab on Chrome DevTools

## Screenshots
<img width="1440" alt="Screen Shot 2020-05-01 at 2 54 54 PM" src="https://user-images.githubusercontent.com/12755283/80833053-cc3e4680-8bbb-11ea-831a-0cd634774d8f.png">


## Acceptance criteria
- [ ] The warning for not having a middle name should be gone

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
