### PR TITLE
Fix linting errors in coronavirus-chatbot/index.js

### DIFF
--- a/src/applications/coronavirus-chatbot/index.js
+++ b/src/applications/coronavirus-chatbot/index.js
@@ -1,5 +1,5 @@
-import { apiRequest } from '../../platform/utilities/api';
-import recordEvent from '../../platform/monitoring/record-event';
+import { apiRequest } from 'platform/utilities/api';
+import recordEvent from 'platform/monitoring/record-event';
 import { GA_PREFIX, addEventListenerToButtons } from './utils';
 
 export const defaultLocale = 'en-US';


### PR DESCRIPTION
## Description

The [`additional-linting` check is failing](https://github.com/department-of-veterans-affairs/vets-website/runs/637126865) in `master`. This PR fixes the linting errors that were causing the check to fail. 

## Testing done

CI

## Acceptance criteria
- [x] CI passes

## Definition of done
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
