### PR TITLE
[Development] Remove unused 526 submitted fields

### DIFF
--- a/src/applications/disability-benefits/all-claims/submit-transformer.js
+++ b/src/applications/disability-benefits/all-claims/submit-transformer.js
@@ -174,7 +174,12 @@ export function transformRelatedDisabilities(
 
 export const removeExtraData = formData => {
   // EVSS no longer accepts some keys
-  const ratingKeysToRemove = ['ratingDecisionId'];
+  const ratingKeysToRemove = [
+    'ratingDecisionId',
+    'decisionCode',
+    'decisionText',
+    'ratingPercentage',
+  ];
   const clonedData = _.cloneDeep(formData);
   const disabilities = clonedData.ratedDisabilities;
   if (disabilities?.length) {

--- a/src/applications/disability-benefits/all-claims/tests/data/transformed-data/full-781-781a-8940-test.json
+++ b/src/applications/disability-benefits/all-claims/tests/data/transformed-data/full-781-781a-8940-test.json
@@ -5,18 +5,12 @@
         "name": "Diabetes mellitus0",
         "ratedDisabilityId": "0",
         "diagnosticCode": 5238,
-        "decisionCode": "SVCCONNCTED",
-        "decisionText": "Service Connected",
-        "ratingPercentage": 100,
         "disabilityActionType": "NONE"
       },
       {
         "name": "Diabetes mellitus1",
         "ratedDisabilityId": "1",
         "diagnosticCode": 5238,
-        "decisionCode": "SVCCONNCTED",
-        "decisionText": "Service Connected",
-        "ratingPercentage": 100,
         "disabilityActionType": "NONE",
         "unemployabilityDisability": true
       }

--- a/src/applications/disability-benefits/all-claims/tests/data/transformed-data/maximal-test.json
+++ b/src/applications/disability-benefits/all-claims/tests/data/transformed-data/maximal-test.json
@@ -67,36 +67,24 @@
         "name": "Diabetes mellitus0",
         "ratedDisabilityId": "0",
         "diagnosticCode": 5238,
-        "decisionCode": "SVCCONNCTED",
-        "decisionText": "Service Connected",
-        "ratingPercentage": 100,
         "disabilityActionType": "INCREASE"
       },
       {
         "name": "Diabetes mellitus1",
         "ratedDisabilityId": "1",
         "diagnosticCode": 5238,
-        "decisionCode": "SVCCONNCTED",
-        "decisionText": "Service Connected",
-        "ratingPercentage": 100,
         "disabilityActionType": "INCREASE"
       },
       {
         "name": "De-selected",
         "ratedDisabilityId": "1",
         "diagnosticCode": 5238,
-        "decisionCode": "SVCCONNCTED",
-        "decisionText": "Service Connected",
-        "ratingPercentage": 100,
         "disabilityActionType": "NONE"
       },
       {
         "name": "Not selected",
         "ratedDisabilityId": "1",
         "diagnosticCode": 5238,
-        "decisionCode": "SVCCONNCTED",
-        "decisionText": "Service Connected",
-        "ratingPercentage": 100,
         "disabilityActionType": "NONE"
       }
     ],

--- a/src/applications/disability-benefits/all-claims/tests/data/transformed-data/minimal-test.json
+++ b/src/applications/disability-benefits/all-claims/tests/data/transformed-data/minimal-test.json
@@ -18,18 +18,12 @@
         "name": "Diabetes mellitus0",
         "ratedDisabilityId": "0",
         "diagnosticCode": 5238,
-        "decisionCode": "SVCCONNCTED",
-        "decisionText": "Service Connected",
-        "ratingPercentage": 100,
         "disabilityActionType": "INCREASE"
       },
       {
         "name": "Diabetes mellitus1",
         "ratedDisabilityId": "1",
         "diagnosticCode": 5238,
-        "decisionCode": "SVCCONNCTED",
-        "decisionText": "Service Connected",
-        "ratingPercentage": 100,
         "disabilityActionType": "NONE"
       }
     ],

--- a/src/applications/disability-benefits/all-claims/tests/data/transformed-data/secondary-new-test.json
+++ b/src/applications/disability-benefits/all-claims/tests/data/transformed-data/secondary-new-test.json
@@ -47,36 +47,24 @@
         "name": "Diabetes mellitus0",
         "ratedDisabilityId": "0",
         "diagnosticCode": 5238,
-        "decisionCode": "SVCCONNCTED",
-        "decisionText": "Service Connected",
-        "ratingPercentage": 100,
         "disabilityActionType": "NONE"
       },
       {
         "name": "Diabetes mellitus1",
         "ratedDisabilityId": "1",
         "diagnosticCode": 5238,
-        "decisionCode": "SVCCONNCTED",
-        "decisionText": "Service Connected",
-        "ratingPercentage": 100,
         "disabilityActionType": "NONE"
       },
       {
         "name": "De-selected",
         "ratedDisabilityId": "1",
         "diagnosticCode": 5238,
-        "decisionCode": "SVCCONNCTED",
-        "decisionText": "Service Connected",
-        "ratingPercentage": 100,
         "disabilityActionType": "NONE"
       },
       {
         "name": "Not selected",
         "ratedDisabilityId": "1",
         "diagnosticCode": 5238,
-        "decisionCode": "SVCCONNCTED",
-        "decisionText": "Service Connected",
-        "ratingPercentage": 100,
         "disabilityActionType": "NONE"
       }
     ],

--- a/src/applications/disability-benefits/all-claims/tests/data/transformed-data/upload-781-781a-8940-test.json
+++ b/src/applications/disability-benefits/all-claims/tests/data/transformed-data/upload-781-781a-8940-test.json
@@ -5,18 +5,12 @@
         "name": "Diabetes mellitus0",
         "ratedDisabilityId": "0",
         "diagnosticCode": 5238,
-        "decisionCode": "SVCCONNCTED",
-        "decisionText": "Service Connected",
-        "ratingPercentage": 100,
         "disabilityActionType": "NONE"
       },
       {
         "name": "Diabetes mellitus1",
         "ratedDisabilityId": "1",
         "diagnosticCode": 5238,
-        "decisionCode": "SVCCONNCTED",
-        "decisionText": "Service Connected",
-        "ratingPercentage": 100,
         "disabilityActionType": "NONE"
       }
     ],


### PR DESCRIPTION
## Description

Form 526 data submitted to EVSS has become much more strict. Extra data provided by the [rated disabilities api](https://department-of-veterans-affairs.github.io/va-digital-services-platform-docs/api-reference/#/form_526/getRatedDisabilities) was previously allowed to pass through, but does not need to be submitted. 

`ratingDecisionId` was initially removed in ticket https://github.com/department-of-veterans-affairs/va.gov-team/issues/8350, but additional fields need to be removed. This PR removes:

- `decisionCode`
- `decisionText`
- `ratingPercentage`

Associated ticket: https://github.com/department-of-veterans-affairs/va.gov-team/issues/8486

## Testing done

Local unit tests
Puppeteer e2e tests

## Screenshots

N/A

## Acceptance criteria
- [x] unnecessary rated disability fields have been removed from submitted data

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
