### PR TITLE
Add missing icons to institutions profile pages Bug #8503

### DIFF
--- a/src/applications/gi/components/profile/HeadingSummary.jsx
+++ b/src/applications/gi/components/profile/HeadingSummary.jsx
@@ -68,17 +68,20 @@ class HeadingSummary extends React.Component {
           <div>
             <div className="usa-width-one-half medium-6 small-12 column">
               <IconWithInfo icon="map-marker" present={addressPresent}>
+                {'  '}
                 {formattedAddress}
               </IconWithInfo>
               <IconWithInfo icon="globe" present={it.website}>
                 <a href={it.website} target="_blank" rel="noopener noreferrer">
+                  {'  '}
                   {it.website}
                 </a>
               </IconWithInfo>
               <IconWithInfo
-                icon="calendar-o"
+                icon="calendar"
                 present={it.type !== 'ojt' && it.highestDegree}
               >
+                {'  '}
                 {_.isFinite(it.highestDegree)
                   ? `${it.highestDegree} year`
                   : it.highestDegree}{' '}
@@ -91,18 +94,21 @@ class HeadingSummary extends React.Component {
                 On-the-job training
               </IconWithInfo>
               <IconWithInfo
-                icon="institution"
+                icon="university"
                 present={it.type && it.type !== 'ojt'}
               >
+                {'  '}
                 {_.capitalize(it.type)} school
               </IconWithInfo>
               <IconWithInfo
                 icon="map"
                 present={it.localeType && it.type && it.type !== 'ojt'}
               >
+                {'  '}
                 {_.capitalize(it.localeType)} locale
               </IconWithInfo>
-              <IconWithInfo icon="group" present={it.type && it.type !== 'ojt'}>
+              <IconWithInfo icon="users" present={it.type && it.type !== 'ojt'}>
+                {' '}
                 {schoolSize(it.undergradEnrollment)} size
               </IconWithInfo>
             </div>

--- a/src/applications/gi/components/profile/HeadingSummary.jsx
+++ b/src/applications/gi/components/profile/HeadingSummary.jsx
@@ -91,24 +91,25 @@ class HeadingSummary extends React.Component {
 
             <div className="usa-width-one-half medium-6 small-12 column">
               <IconWithInfo icon="briefcase" present={it.type === 'ojt'}>
+                {'   '}
                 On-the-job training
               </IconWithInfo>
               <IconWithInfo
                 icon="university"
                 present={it.type && it.type !== 'ojt'}
               >
-                {'  '}
+                {'   '}
                 {_.capitalize(it.type)} school
               </IconWithInfo>
               <IconWithInfo
                 icon="map"
                 present={it.localeType && it.type && it.type !== 'ojt'}
               >
-                {'  '}
+                {'   '}
                 {_.capitalize(it.localeType)} locale
               </IconWithInfo>
               <IconWithInfo icon="users" present={it.type && it.type !== 'ojt'}>
-                {' '}
+                {'   '}
                 {schoolSize(it.undergradEnrollment)} size
               </IconWithInfo>
             </div>


### PR DESCRIPTION
## Description
Under the school name on the profile page, several brief descriptions of the school are listed. Each of these descriptions has an associated icon. The icons for length, type, and size are no longer displaying

https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/8503

## Testing done
Local testing completed

## Screenshots
![Screen Shot 2020-05-04 at 8 17 48 AM](https://user-images.githubusercontent.com/50601724/80964971-c45eec00-8ddf-11ea-9d04-ef550a6153d7.png)

## Acceptance criteria
- [x] Icons appear for length, type and size. 

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
