### PR TITLE
Added space between About this tool and Download Data links

### DIFF
--- a/src/applications/gi/components/content/AboutThisTool.jsx
+++ b/src/applications/gi/components/content/AboutThisTool.jsx
@@ -10,8 +10,7 @@ function AboutThisTool() {
           rel="noopener noreferrer"
         >
           About this Tool
-        </a>
-        {'  '}
+        </a>{' '}
         <a href="https://www.benefits.va.gov/GIBILL/docs/job_aids/ComparisonToolData.xlsx">
           Download Data on All Schools (Excel)
         </a>

--- a/src/applications/gi/components/content/AboutThisTool.jsx
+++ b/src/applications/gi/components/content/AboutThisTool.jsx
@@ -10,8 +10,12 @@ function AboutThisTool() {
           rel="noopener noreferrer"
         >
           About this Tool
-        </a>{' '}
-        <a href="https://www.benefits.va.gov/GIBILL/docs/job_aids/ComparisonToolData.xlsx">
+        </a>
+
+        <a
+          className="about-this-tool-mobile"
+          href="https://www.benefits.va.gov/GIBILL/docs/job_aids/ComparisonToolData.xlsx"
+        >
           Download Data on All Schools (Excel)
         </a>
       </div>

--- a/src/applications/gi/components/content/AboutThisTool.jsx
+++ b/src/applications/gi/components/content/AboutThisTool.jsx
@@ -11,6 +11,7 @@ function AboutThisTool() {
         >
           About this Tool
         </a>
+        {'  '}
         <a href="https://www.benefits.va.gov/GIBILL/docs/job_aids/ComparisonToolData.xlsx">
           Download Data on All Schools (Excel)
         </a>

--- a/src/applications/gi/sass/gi.scss
+++ b/src/applications/gi/sass/gi.scss
@@ -87,6 +87,11 @@
     outline: none;
   }
 }
+@media (max-width: 481px) {
+  .about-this-tool-mobile {
+    padding-left: 20px;
+  }
+}
 
 .gibct-legend {
   margin-top: 1rem;


### PR DESCRIPTION
## Description
At the bottom of the page for all Comparison Tool pages, there is an "About this tool" link. Next to the "About this tool" link, there is a "Download Data on All Schools" link. The padding between these links is missing in mobile view. The problem persists on all pages within the Comparison Tool.

https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/8504

## Testing done
Local Testing

## Screenshots
![Screen Shot 2020-05-04 at 8 43 47 AM](https://user-images.githubusercontent.com/50601724/80966895-6a602580-8de3-11ea-81d8-ed5dedcddf56.png)
![Screen Shot 2020-05-04 at 10 30 43 AM](https://user-images.githubusercontent.com/50601724/80977305-8e773300-8df2-11ea-8fe9-d5bdb3cb0b62.png)



## Acceptance criteria
- [x] There is spacing between About this tool and Download Data on All Schools (Excel) links

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
