### PR TITLE
fix bug with sticky nav trigger

### DIFF
--- a/src/applications/personalization/profile-2/components/MobileMenuTrigger.jsx
+++ b/src/applications/personalization/profile-2/components/MobileMenuTrigger.jsx
@@ -53,6 +53,7 @@ const MobileMenuTrigger = ({
 
       if (justSwitchedToMobile) {
         setIsMobile(true);
+        setTriggerHeight(window.getComputedStyle(button.current).height);
       }
 
       if (justSwitchedToDesktop) {


### PR DESCRIPTION
## Description
This fixes a bug where the page content jumps up when the menu trigger "sticks" to the top of the window.

## Testing done
Local

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs