### PR TITLE
Fix linting warnings in burials app

### DIFF
--- a/src/applications/burials/tests/00-all-fields.e2e.spec.js
+++ b/src/applications/burials/tests/00-all-fields.e2e.spec.js
@@ -1,8 +1,8 @@
-const E2eHelpers = require('../../../platform/testing/e2e/helpers');
-const Timeouts = require('../../../platform/testing/e2e/timeouts');
+const E2eHelpers = require('platform/testing/e2e/helpers');
+const Timeouts = require('platform/testing/e2e/timeouts');
 const PageHelpers = require('./burial-helpers');
 const testData = require('./schema/maximal-test.json');
-const FormsTestHelpers = require('../../../platform/testing/e2e/form-helpers');
+const FormsTestHelpers = require('platform/testing/e2e/form-helpers');
 
 const runTest = E2eHelpers.createE2eTest(client => {
   PageHelpers.initApplicationSubmitMock();

--- a/src/applications/burials/tests/burial-helpers.js
+++ b/src/applications/burials/tests/burial-helpers.js
@@ -1,5 +1,5 @@
-const mock = require('../../../platform/testing/e2e/mock-helpers');
-const Timeouts = require('../../../platform/testing/e2e/timeouts.js');
+const mock = require('platform/testing/e2e/mock-helpers');
+const Timeouts = require('platform/testing/e2e/timeouts.js');
 
 function completeClaimantInformation(client, data) {
   client


### PR DESCRIPTION
## Description

There are a lot of warnings in the `lint:circle` script during the `additional-linting` check, and it's creating a lot of noise. This PR fixes the linting warnings in the `burials` app to help reduce some of the noise. 

For example: https://circleci.com/gh/department-of-veterans-affairs/vets-website/25586?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-checks-link

## Testing done

CI

## Acceptance criteria
- [x] CI passes

## Definition of done
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
