### PR TITLE
Fix `resolved-path-on-required` warnings in claims-status e2e tests

### DIFF
--- a/src/applications/claims-status/tests/e2e/00.claims-list-breadcrumb.e2e.spec.js
+++ b/src/applications/claims-status/tests/e2e/00.claims-list-breadcrumb.e2e.spec.js
@@ -1,7 +1,7 @@
-const E2eHelpers = require('../../../../platform/testing/e2e/helpers');
-const Timeouts = require('../../../../platform/testing/e2e/timeouts.js');
+const E2eHelpers = require('platform/testing/e2e/helpers');
+const Timeouts = require('platform/testing/e2e/timeouts.js');
 const DisabilityHelpers = require('./claims-status-helpers');
-const Auth = require('../../../../platform/testing/e2e/auth');
+const Auth = require('platform/testing/e2e/auth');
 
 module.exports = E2eHelpers.createE2eTest(client => {
   const token = Auth.getUserToken();

--- a/src/applications/claims-status/tests/e2e/00.claims-list.e2e.spec.js
+++ b/src/applications/claims-status/tests/e2e/00.claims-list.e2e.spec.js
@@ -1,7 +1,7 @@
-const E2eHelpers = require('../../../../platform/testing/e2e/helpers');
-const Timeouts = require('../../../../platform/testing/e2e/timeouts.js');
+const E2eHelpers = require('platform/testing/e2e/helpers');
+const Timeouts = require('platform/testing/e2e/timeouts.js');
 const DisabilityHelpers = require('./claims-status-helpers');
-const Auth = require('../../../../platform/testing/e2e/auth');
+const Auth = require('platform/testing/e2e/auth');
 
 module.exports = E2eHelpers.createE2eTest(client => {
   const token = Auth.getUserToken();

--- a/src/applications/claims-status/tests/e2e/01.claim-status-decision.e2e.spec.js
+++ b/src/applications/claims-status/tests/e2e/01.claim-status-decision.e2e.spec.js
@@ -1,7 +1,7 @@
-const E2eHelpers = require('../../../../platform/testing/e2e/helpers');
-const Timeouts = require('../../../../platform/testing/e2e/timeouts.js');
+const E2eHelpers = require('platform/testing/e2e/helpers');
+const Timeouts = require('platform/testing/e2e/timeouts.js');
 const DisabilityHelpers = require('./claims-status-helpers');
-const Auth = require('../../../../platform/testing/e2e/auth');
+const Auth = require('platform/testing/e2e/auth');
 
 module.exports = E2eHelpers.createE2eTest(client => {
   const token = Auth.getUserToken();

--- a/src/applications/claims-status/tests/e2e/01.claim-status-est-current.e2e.spec.js
+++ b/src/applications/claims-status/tests/e2e/01.claim-status-est-current.e2e.spec.js
@@ -1,7 +1,7 @@
-const E2eHelpers = require('../../../../platform/testing/e2e/helpers');
-const Timeouts = require('../../../../platform/testing/e2e/timeouts.js');
+const E2eHelpers = require('platform/testing/e2e/helpers');
+const Timeouts = require('platform/testing/e2e/timeouts.js');
 const DisabilityHelpers = require('./claims-status-helpers');
-const Auth = require('../../../../platform/testing/e2e/auth');
+const Auth = require('platform/testing/e2e/auth');
 const moment = require('moment');
 
 module.exports = E2eHelpers.createE2eTest(client => {

--- a/src/applications/claims-status/tests/e2e/01.claim-status-est-past.e2e.spec.js
+++ b/src/applications/claims-status/tests/e2e/01.claim-status-est-past.e2e.spec.js
@@ -1,7 +1,7 @@
-const E2eHelpers = require('../../../../platform/testing/e2e/helpers');
-const Timeouts = require('../../../../platform/testing/e2e/timeouts.js');
+const E2eHelpers = require('platform/testing/e2e/helpers');
+const Timeouts = require('platform/testing/e2e/timeouts.js');
 const DisabilityHelpers = require('./claims-status-helpers');
-const Auth = require('../../../../platform/testing/e2e/auth');
+const Auth = require('platform/testing/e2e/auth');
 const moment = require('moment');
 
 module.exports = E2eHelpers.createE2eTest(client => {

--- a/src/applications/claims-status/tests/e2e/01.claim-status-est.e2e.spec.js
+++ b/src/applications/claims-status/tests/e2e/01.claim-status-est.e2e.spec.js
@@ -1,7 +1,7 @@
-const E2eHelpers = require('../../../../platform/testing/e2e/helpers');
-const Timeouts = require('../../../../platform/testing/e2e/timeouts.js');
+const E2eHelpers = require('platform/testing/e2e/helpers');
+const Timeouts = require('platform/testing/e2e/timeouts.js');
 const DisabilityHelpers = require('./claims-status-helpers');
-const Auth = require('../../../../platform/testing/e2e/auth');
+const Auth = require('platform/testing/e2e/auth');
 const moment = require('moment');
 
 module.exports = E2eHelpers.createE2eTest(client => {

--- a/src/applications/claims-status/tests/e2e/01.claim-status.e2e.spec.js
+++ b/src/applications/claims-status/tests/e2e/01.claim-status.e2e.spec.js
@@ -1,7 +1,7 @@
-const E2eHelpers = require('../../../../platform/testing/e2e/helpers');
-const Timeouts = require('../../../../platform/testing/e2e/timeouts.js');
+const E2eHelpers = require('platform/testing/e2e/helpers');
+const Timeouts = require('platform/testing/e2e/timeouts.js');
 const DisabilityHelpers = require('./claims-status-helpers');
-const Auth = require('../../../../platform/testing/e2e/auth');
+const Auth = require('platform/testing/e2e/auth');
 
 module.exports = E2eHelpers.createE2eTest(client => {
   const token = Auth.getUserToken();

--- a/src/applications/claims-status/tests/e2e/02.claim-files.e2e.spec.js
+++ b/src/applications/claims-status/tests/e2e/02.claim-files.e2e.spec.js
@@ -1,7 +1,7 @@
-const E2eHelpers = require('../../../../platform/testing/e2e/helpers');
-const Timeouts = require('../../../../platform/testing/e2e/timeouts.js');
+const E2eHelpers = require('platform/testing/e2e/helpers');
+const Timeouts = require('platform/testing/e2e/timeouts.js');
 const DisabilityHelpers = require('./claims-status-helpers');
-const Auth = require('../../../../platform/testing/e2e/auth');
+const Auth = require('platform/testing/e2e/auth');
 
 module.exports = E2eHelpers.createE2eTest(client => {
   const token = Auth.getUserToken();

--- a/src/applications/claims-status/tests/e2e/03.claim-details.e2e.spec.js
+++ b/src/applications/claims-status/tests/e2e/03.claim-details.e2e.spec.js
@@ -1,7 +1,7 @@
-const E2eHelpers = require('../../../../platform/testing/e2e/helpers');
-const Timeouts = require('../../../../platform/testing/e2e/timeouts.js');
+const E2eHelpers = require('platform/testing/e2e/helpers');
+const Timeouts = require('platform/testing/e2e/timeouts.js');
 const DisabilityHelpers = require('./claims-status-helpers');
-const Auth = require('../../../../platform/testing/e2e/auth');
+const Auth = require('platform/testing/e2e/auth');
 
 module.exports = E2eHelpers.createE2eTest(client => {
   const token = Auth.getUserToken();

--- a/src/applications/claims-status/tests/e2e/04.claim-ask-va.e2e.spec.js
+++ b/src/applications/claims-status/tests/e2e/04.claim-ask-va.e2e.spec.js
@@ -1,7 +1,7 @@
-const E2eHelpers = require('../../../../platform/testing/e2e/helpers');
-const Timeouts = require('../../../../platform/testing/e2e/timeouts.js');
+const E2eHelpers = require('platform/testing/e2e/helpers');
+const Timeouts = require('platform/testing/e2e/timeouts.js');
 const DisabilityHelpers = require('./claims-status-helpers');
-const Auth = require('../../../../platform/testing/e2e/auth');
+const Auth = require('platform/testing/e2e/auth');
 
 module.exports = E2eHelpers.createE2eTest(client => {
   const token = Auth.getUserToken();

--- a/src/applications/claims-status/tests/e2e/05.claim-additional-evidence.e2e.spec.js
+++ b/src/applications/claims-status/tests/e2e/05.claim-additional-evidence.e2e.spec.js
@@ -1,7 +1,7 @@
-const E2eHelpers = require('../../../../platform/testing/e2e/helpers');
-const Timeouts = require('../../../../platform/testing/e2e/timeouts.js');
+const E2eHelpers = require('platform/testing/e2e/helpers');
+const Timeouts = require('platform/testing/e2e/timeouts.js');
 const DisabilityHelpers = require('./claims-status-helpers');
-const Auth = require('../../../../platform/testing/e2e/auth');
+const Auth = require('platform/testing/e2e/auth');
 
 module.exports = E2eHelpers.createE2eTest(client => {
   const token = Auth.getUserToken();

--- a/src/applications/claims-status/tests/e2e/05.claim-document-request.e2e.spec.js
+++ b/src/applications/claims-status/tests/e2e/05.claim-document-request.e2e.spec.js
@@ -1,7 +1,7 @@
-const E2eHelpers = require('../../../../platform/testing/e2e/helpers');
-const Timeouts = require('../../../../platform/testing/e2e/timeouts.js');
+const E2eHelpers = require('platform/testing/e2e/helpers');
+const Timeouts = require('platform/testing/e2e/timeouts.js');
 const DisabilityHelpers = require('./claims-status-helpers');
-const Auth = require('../../../../platform/testing/e2e/auth');
+const Auth = require('platform/testing/e2e/auth');
 
 module.exports = E2eHelpers.createE2eTest(client => {
   const token = Auth.getUserToken();

--- a/src/applications/claims-status/tests/e2e/06-claim-estimation-breadcrumb.e2e.spec.js
+++ b/src/applications/claims-status/tests/e2e/06-claim-estimation-breadcrumb.e2e.spec.js
@@ -1,7 +1,7 @@
-const E2eHelpers = require('../../../../platform/testing/e2e/helpers');
-const Timeouts = require('../../../../platform/testing/e2e/timeouts.js');
+const E2eHelpers = require('platform/testing/e2e/helpers');
+const Timeouts = require('platform/testing/e2e/timeouts.js');
 const DisabilityHelpers = require('./claims-status-helpers');
-const Auth = require('../../../../platform/testing/e2e/auth');
+const Auth = require('platform/testing/e2e/auth');
 
 module.exports = E2eHelpers.createE2eTest(client => {
   const token = Auth.getUserToken();

--- a/src/applications/claims-status/tests/e2e/06.claim-estimation.e2e.spec.js
+++ b/src/applications/claims-status/tests/e2e/06.claim-estimation.e2e.spec.js
@@ -1,7 +1,7 @@
-const E2eHelpers = require('../../../../platform/testing/e2e/helpers');
-const Timeouts = require('../../../../platform/testing/e2e/timeouts.js');
+const E2eHelpers = require('platform/testing/e2e/helpers');
+const Timeouts = require('platform/testing/e2e/timeouts.js');
 const DisabilityHelpers = require('./claims-status-helpers');
-const Auth = require('../../../../platform/testing/e2e/auth');
+const Auth = require('platform/testing/e2e/auth');
 
 module.exports = E2eHelpers.createE2eTest(client => {
   const token = Auth.getUserToken();

--- a/src/applications/claims-status/tests/e2e/claims-status-helpers.js
+++ b/src/applications/claims-status/tests/e2e/claims-status-helpers.js
@@ -1,4 +1,4 @@
-const mock = require('../../../../platform/testing/e2e/mock-helpers');
+const mock = require('platform/testing/e2e/mock-helpers');
 
 function initAskVAMock(token) {
   mock(token, {


### PR DESCRIPTION
## Description

There are a lot of warnings in the `lint:circle` script during the `additional-linting` check, and it's creating a lot of noise. This PR fixes the linting warnings in the `burials` app to help reduce some of the noise. 

For example: https://circleci.com/gh/department-of-veterans-affairs/vets-website/25586?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-checks-link

## Testing done

CI

## Acceptance criteria
- [x] CI passes

## Definition of done
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
