### PR TITLE
Refactor instructions logic on VAOS appt list

### DIFF
--- a/src/applications/vaos/components/AppointmentInstructions.jsx
+++ b/src/applications/vaos/components/AppointmentInstructions.jsx
@@ -1,14 +1,21 @@
 import React from 'react';
+import { PURPOSE_TEXT } from '../utils/constants';
 
 export default function AppointmentInstructions({ instructions }) {
-  if (!instructions) {
+  if (
+    !instructions ||
+    !PURPOSE_TEXT.some(purpose => instructions.startsWith(purpose.short))
+  ) {
     return null;
   }
+
+  const [header, body] = instructions.split(': ', 2);
+
   return (
     <div className="vads-u-flex--1 vads-u-margin-bottom--2 vaos-u-word-break--break-word">
       <dl className="vads-u-margin--0">
-        <dt className="vads-u-font-weight--bold">{instructions.header}</dt>
-        <dd>{instructions.body}</dd>
+        <dt className="vads-u-font-weight--bold">{header}</dt>
+        <dd>{body}</dd>
       </dl>
     </div>
   );

--- a/src/applications/vaos/components/CommunityCareInstructions.jsx
+++ b/src/applications/vaos/components/CommunityCareInstructions.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+export default function AppointmentInstructions({ instructions }) {
+  if (!instructions) {
+    return null;
+  }
+  return (
+    <div className="vads-u-flex--1 vads-u-margin-bottom--2 vaos-u-word-break--break-word">
+      <dl className="vads-u-margin--0">
+        <dt className="vads-u-font-weight--bold">Special instructions</dt>
+        <dd>{instructions}</dd>
+      </dl>
+    </div>
+  );
+}

--- a/src/applications/vaos/components/ConfirmedAppointmentListItem.jsx
+++ b/src/applications/vaos/components/ConfirmedAppointmentListItem.jsx
@@ -7,6 +7,7 @@ import AddToCalendar from './AddToCalendar';
 import VAFacilityLocation from './VAFacilityLocation';
 import AppointmentDateTime from './AppointmentDateTime';
 import AppointmentInstructions from './AppointmentInstructions';
+import CommunityCareInstructions from './CommunityCareInstructions';
 import AppointmentStatus from './AppointmentStatus';
 import ConfirmedCommunityCareLocation from './ConfirmedCommunityCareLocation';
 
@@ -27,6 +28,9 @@ export default function ConfirmedAppointmentListItem({
 }) {
   const cancelled = appointment.status === APPOINTMENT_STATUS.cancelled;
   const isPastAppointment = appointment.isPastAppointment;
+  const isInPersonVAAppointment =
+    !appointment.videoType && !appointment.isCommunityCare;
+  const isVideoAppointment = !!appointment.videoType;
 
   const itemClasses = classNames(
     'vads-u-background-color--gray-lightest vads-u-padding--2p5 vads-u-margin-bottom--3',
@@ -39,7 +43,7 @@ export default function ConfirmedAppointmentListItem({
 
   let header;
   let location;
-  if (appointment.videoType) {
+  if (isVideoAppointment) {
     header = 'VA Video Connect';
     location = 'Video conference';
   } else if (appointment.isCommunityCare) {
@@ -80,18 +84,22 @@ export default function ConfirmedAppointmentListItem({
           {appointment.isCommunityCare && (
             <ConfirmedCommunityCareLocation appointment={appointment} />
           )}
-          {!!appointment.videoType && (
+          {isVideoAppointment && (
             <VideoVisitSection appointment={appointment} />
           )}
-          {!appointment.isCommunityCare &&
-            !appointment.videoType && (
-              <VAFacilityLocation
-                facility={facility}
-                clinicName={appointment.clinicName}
-              />
-            )}
+          {isInPersonVAAppointment && (
+            <VAFacilityLocation
+              facility={facility}
+              clinicName={appointment.clinicName}
+            />
+          )}
         </div>
-        <AppointmentInstructions instructions={appointment.instructions} />
+        {appointment.isCommunityCare && (
+          <CommunityCareInstructions instructions={appointment.instructions} />
+        )}
+        {isInPersonVAAppointment && (
+          <AppointmentInstructions instructions={appointment.instructions} />
+        )}
       </div>
 
       {!cancelled &&

--- a/src/applications/vaos/tests/components/AppointmentInstructions.unit.spec.jsx
+++ b/src/applications/vaos/tests/components/AppointmentInstructions.unit.spec.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+
+import AppointmentInstructions from '../../components/AppointmentInstructions';
+
+describe('VAOS <AppointmentInstructions>', () => {
+  it('should return instructions', () => {
+    const tree = shallow(
+      <AppointmentInstructions instructions="Follow-up/Routine: Testing" />,
+    );
+    expect(tree.text()).to.contain('Follow-up/Routine');
+    expect(tree.text()).to.contain('Testing');
+
+    tree.unmount();
+  });
+
+  it('should not return instructions without matching prefix', () => {
+    const tree = shallow(<AppointmentInstructions instructions="test" />);
+    expect(tree.text()).to.be.empty;
+    tree.unmount();
+  });
+
+  it('should not return instructions if empty', () => {
+    const tree = shallow(<AppointmentInstructions instructions="" />);
+    expect(tree.text()).to.be.empty;
+    tree.unmount();
+  });
+});

--- a/src/applications/vaos/tests/components/CommunityCareInstructions.unit.spec.jsx
+++ b/src/applications/vaos/tests/components/CommunityCareInstructions.unit.spec.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+
+import CommunityCareInstructions from '../../components/CommunityCareInstructions';
+
+describe('VAOS <CommunityCareInstructions>', () => {
+  it('should return instructions', () => {
+    const tree = shallow(<CommunityCareInstructions instructions="Testing" />);
+    expect(tree.text()).to.contain('Special instructions');
+    expect(tree.text()).to.contain('Testing');
+
+    tree.unmount();
+  });
+
+  it('should not return instructions if empty', () => {
+    const tree = shallow(<CommunityCareInstructions instructions="" />);
+    expect(tree.text()).to.be.empty;
+    tree.unmount();
+  });
+});

--- a/src/applications/vaos/tests/components/ConfirmedAppointmentListItem.unit.spec.jsx
+++ b/src/applications/vaos/tests/components/ConfirmedAppointmentListItem.unit.spec.jsx
@@ -19,6 +19,7 @@ describe('VAOS <ConfirmedAppointmentListItem> Regular Appointment', () => {
     clinicId: '123',
     duration: 60,
     clinicName: 'C&P BEV AUDIO FTC1',
+    instructions: 'Follow-up/Routine: Instructions',
   };
   const facility = {
     address: {
@@ -81,8 +82,9 @@ describe('VAOS <ConfirmedAppointmentListItem> Regular Appointment', () => {
     expect(tree.find('FacilityAddress').exists()).to.be.true;
   });
 
-  it('should not show booking note', () => {
-    expect(tree.text()).not.to.contain('Booking note');
+  it('should show instructions', () => {
+    expect(tree.text()).to.contain('Follow-up/Routine');
+    expect(tree.text()).to.contain('Instructions');
   });
 
   it('should show cancel link', () => {
@@ -107,6 +109,7 @@ describe('VAOS <ConfirmedAppointmentListItem> Community Care Appointment', () =>
     appointmentDate: moment('05/22/2019 10:00:00', 'MM/DD/YYYY HH:mm:ss'),
     providerPractice: 'My Clinic',
     timeZone: 'UTC',
+    instructions: 'Instruction text',
     address: {
       street: '123 second st',
       city: 'Northampton',
@@ -144,6 +147,10 @@ describe('VAOS <ConfirmedAppointmentListItem> Community Care Appointment', () =>
   it('should display clinic address', () => {
     expect(tree.text()).to.contain('123 second stNorthampton, MA 22222');
   });
+
+  it('should display instructions', () => {
+    expect(tree.text()).to.contain('Instruction text');
+  });
 });
 
 describe('VAOS <ConfirmedAppointmentListItem> Video Appointment', () => {
@@ -159,10 +166,7 @@ describe('VAOS <ConfirmedAppointmentListItem> Video Appointment', () => {
     clinicId: '456',
     videoLink: url,
     status: APPOINTMENT_STATUS.booked,
-    instructions: {
-      header: 'My reason isn’t listed',
-      body: 'Booking note',
-    },
+    instructions: 'My reason isn’t listed: Booking note',
   };
 
   const tree = mount(
@@ -173,9 +177,9 @@ describe('VAOS <ConfirmedAppointmentListItem> Video Appointment', () => {
     expect(tree.find('VideoVisitSection').length).to.equal(1);
   });
 
-  it('should show booking note', () => {
-    expect(tree.text()).to.contain('Booking note');
-    expect(tree.text()).to.contain('My reason isn’t listed');
+  it('should not show booking note', () => {
+    expect(tree.text()).not.to.contain('Booking note');
+    expect(tree.text()).not.to.contain('My reason isn’t listed');
   });
 });
 
@@ -249,10 +253,6 @@ describe('VAOS <ConfirmedAppointmentListItem> Canceled Appointment', () => {
 
   it('should show facility address', () => {
     expect(tree.find('FacilityAddress').exists()).to.be.true;
-  });
-
-  it('should not show booking note', () => {
-    expect(tree.text()).not.to.contain('Booking note');
   });
 
   it('contain class that breaks long comments', () => {

--- a/src/applications/vaos/tests/utils/appointment.unit.spec.jsx
+++ b/src/applications/vaos/tests/utils/appointment.unit.spec.jsx
@@ -245,58 +245,6 @@ describe('VAOS appointment helpers', () => {
       });
     });
 
-    describe('instructions', () => {
-      it('should return community care appointment instructions', () => {
-        const appt = transformAppointment({
-          ...ccData,
-          instructionsToVeteran: 'Instruction to veteran',
-        });
-        expect(appt.instructions.header).to.equal('Special instructions');
-        expect(appt.instructions.body).to.equal('Instruction to veteran');
-      });
-
-      it('should return VA instructions', () => {
-        const appt = transformAppointment({
-          ...vaData,
-          vdsAppointments: [
-            {
-              bookingNote: 'Follow-up/Routine: Testing',
-            },
-          ],
-        });
-        expect(appt.instructions.header).to.equal('Follow-up/Routine');
-        expect(appt.instructions.body).to.equal('Testing');
-      });
-      it('should return VA video instructions', () => {
-        const appt = transformAppointment({
-          ...vaData,
-          vdsAppointments: [
-            {
-              bookingNote: '',
-            },
-          ],
-          vvsAppointments: [
-            {
-              bookingNotes: 'Follow-up/Routine: Testing',
-            },
-          ],
-        });
-        expect(appt.instructions.header).to.equal('Follow-up/Routine');
-        expect(appt.instructions.body).to.equal('Testing');
-      });
-      it('should not return VA instructions without matching prefix', () => {
-        const appt = transformAppointment({
-          ...vaData,
-          vvsAppointments: [
-            {
-              bookingNotes: 'Testing',
-            },
-          ],
-        });
-        expect(appt.instructions).to.be.null;
-      });
-    });
-
     describe('duration', () => {
       it('should return the default appointment duration for CC', () => {
         const appt = transformAppointment(ccData);

--- a/src/applications/vaos/utils/appointment.js
+++ b/src/applications/vaos/utils/appointment.js
@@ -403,7 +403,7 @@ export function transformAppointment(appointment) {
     isPastAppointment: false,
     instructions:
       appointment.instructionsToVeteran ||
-      appointment.vdsAppointments?.[0].bookingNote,
+      appointment.vdsAppointments?.[0]?.bookingNote,
     duration: getAppointmentDuration(appointment),
     appointmentDate: getMomentConfirmedDate(appointment),
     status: getAppointmentStatus(appointment),

--- a/src/applications/vaos/utils/appointment.js
+++ b/src/applications/vaos/utils/appointment.js
@@ -354,59 +354,6 @@ function getVideoType(appt) {
   return null;
 }
 
-function hasInstructions(appt) {
-  const bookingNotes =
-    appt.vdsAppointments?.[0]?.bookingNote ||
-    appt.vvsAppointments?.[0]?.bookingNotes;
-
-  return (
-    !!bookingNotes &&
-    PURPOSE_TEXT.some(purpose => bookingNotes.startsWith(purpose.short))
-  );
-}
-
-function getAppointmentInstructions(appt) {
-  const bookingNotes =
-    appt.vdsAppointments?.[0]?.bookingNote ||
-    appt.vvsAppointments?.[0]?.bookingNotes;
-
-  const instructions = bookingNotes?.split(': ', 2);
-
-  if (instructions && instructions.length > 1) {
-    return instructions[1];
-  }
-
-  return null;
-}
-
-function getAppointmentInstructionsHeader(appt) {
-  const bookingNotes =
-    appt.vdsAppointments?.[0]?.bookingNote ||
-    appt.vvsAppointments?.[0]?.bookingNotes;
-
-  const instructions = bookingNotes?.split(': ', 2);
-
-  return instructions ? instructions[0] : '';
-}
-
-function getInstructions(appointment) {
-  if (appointment.instructionsToVeteran) {
-    return {
-      header: 'Special instructions',
-      body: appointment.instructionsToVeteran,
-    };
-  }
-
-  if (hasInstructions(appointment)) {
-    return {
-      header: getAppointmentInstructionsHeader(appointment),
-      body: getAppointmentInstructions(appointment),
-    };
-  }
-
-  return null;
-}
-
 function getAppointmentStatus(appointment, isPastAppointment) {
   switch (getAppointmentType(appointment)) {
     case APPOINTMENT_TYPES.ccAppointment:
@@ -454,7 +401,9 @@ export function transformAppointment(appointment) {
     ...appointmentTypes,
     apiData: appointment,
     isPastAppointment: false,
-    instructions: getInstructions(appointment),
+    instructions:
+      appointment.instructionsToVeteran ||
+      appointment.vdsAppointments?.[0].bookingNote,
     duration: getAppointmentDuration(appointment),
     appointmentDate: getMomentConfirmedDate(appointment),
     status: getAppointmentStatus(appointment),


### PR DESCRIPTION
## Description
This refactors some of the instructions logic for the appointment list page. Instead of doing the parsing in a utilities function, this puts that logic in a React component, since it's really related to how we present instructions to users. I've also removed the logic related to video appointments, since we were never showing those anyway (there's future work to show instructions for those appointments).

## Testing done
Unit testing

## Acceptance criteria
- [ ] Instructions still show up

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
