### PR TITLE
Removed resolved-path-on-required

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -45,12 +45,6 @@
         "aliases": ["applications", "platform", "site", "vet360"]
       }
     ],
-    "va/resolved-path-on-required": [
-      1,
-      {
-        "aliases": ["applications", "platform", "site", "vet360"]
-      }
-    ],
 
     /* || fp plugin || */
     "fp/no-proxy": 2, // IE 11 has no polyfill for Proxy


### PR DESCRIPTION
## Description
We are turning off `va/resolved-path-on-required` linting rule since it's generating too many warnings

## Testing done
Locally

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
