### PR TITLE
Profile 2.0 navigation menu tweaks

### DIFF
--- a/src/applications/personalization/profile-2/components/AccountSecurity.jsx
+++ b/src/applications/personalization/profile-2/components/AccountSecurity.jsx
@@ -21,7 +21,7 @@ class AccountSecurity extends Component {
       <>
         <h2
           tabIndex="-1"
-          className="vads-u-margin-y--2 medium-screen:vads-u-margin-y--4"
+          className="vads-u-line-height--1  vads-u-margin-y--2 medium-screen:vads-u-margin-y--4"
           data-focus-target
         >
           Account security

--- a/src/applications/personalization/profile-2/components/ConnectedApplications.jsx
+++ b/src/applications/personalization/profile-2/components/ConnectedApplications.jsx
@@ -9,7 +9,7 @@ const ConnectedApplications = () => {
   return (
     <h2
       tabIndex="-1"
-      className="vads-u-margin-y--2 medium-screen:vads-u-margin-y--4"
+      className="vads-u-line-height--1  vads-u-margin-y--2 medium-screen:vads-u-margin-y--4"
       data-focus-target
     >
       Connected Applications

--- a/src/applications/personalization/profile-2/components/DirectDeposit.jsx
+++ b/src/applications/personalization/profile-2/components/DirectDeposit.jsx
@@ -10,7 +10,7 @@ const DirectDeposit = () => {
   return (
     <h2
       tabIndex="-1"
-      className="vads-u-margin-y--2 medium-screen:vads-u-margin-y--4"
+      className="vads-u-line-height--1  vads-u-margin-y--2 medium-screen:vads-u-margin-y--4"
       data-focus-target
     >
       Direct Deposit

--- a/src/applications/personalization/profile-2/components/MilitaryInformation.jsx
+++ b/src/applications/personalization/profile-2/components/MilitaryInformation.jsx
@@ -149,7 +149,7 @@ const MilitaryInformation = ({ militaryInformation }) => (
   <>
     <h2
       tabIndex="-1"
-      className="vads-u-margin-y--2 medium-screen:vads-u-margin-y--4"
+      className="vads-u-line-height--1  vads-u-margin-y--2 medium-screen:vads-u-margin-y--4"
       data-focus-target
     >
       Military information

--- a/src/applications/personalization/profile-2/components/MobileMenuTrigger.jsx
+++ b/src/applications/personalization/profile-2/components/MobileMenuTrigger.jsx
@@ -102,7 +102,7 @@ const MobileMenuTrigger = ({
   const buttonClasses = classnames({ fixed: isMenuTriggerPinned });
 
   return (
-    <div className="va-btn-sidebarnav-trigger">
+    <div className="va-btn-mobile-nav-trigger">
       {/*
       This invisible placeholder fills the vertical space normally taken up by the `button` when the `button`'s position is fixed and it is pulled out of the normal page flow.
       */}
@@ -114,10 +114,8 @@ const MobileMenuTrigger = ({
         onClick={openSideNav}
         ref={button}
       >
-        <span>
-          <b>Profile Menu</b>
-          <img src="/img/arrow-right-white.svg" alt="" />
-        </span>
+        <b>Profile Menu</b>
+        <img src="/img/arrow-right-white.svg" alt="" />
       </button>
     </div>
   );

--- a/src/applications/personalization/profile-2/components/PersonalInformation.jsx
+++ b/src/applications/personalization/profile-2/components/PersonalInformation.jsx
@@ -10,7 +10,7 @@ const PersonalInformation = () => {
   return (
     <h2
       tabIndex="-1"
-      className="vads-u-margin-y--2 medium-screen:vads-u-margin-y--4"
+      className="vads-u-line-height--1  vads-u-margin-y--2 medium-screen:vads-u-margin-y--4"
       data-focus-target
     >
       Personal Information

--- a/src/applications/personalization/profile-2/routes.jsx
+++ b/src/applications/personalization/profile-2/routes.jsx
@@ -9,7 +9,7 @@ const personalInformation = {
   path: 'personal-information',
   component: PersonalInformation,
   key: 'personal-information',
-  name: 'Personal and contact Information',
+  name: 'Personal and contact information',
 };
 
 const militaryInformation = {
@@ -37,7 +37,7 @@ const connectedApplications = {
   path: 'connected-applications',
   component: ConnectedApplications,
   key: 'connected-applications',
-  name: 'Connected applications',
+  name: 'Connected apps',
 };
 
 export const childRoutes = {

--- a/src/applications/personalization/profile-2/sass/mobile-sidenav-trigger.scss
+++ b/src/applications/personalization/profile-2/sass/mobile-sidenav-trigger.scss
@@ -1,4 +1,4 @@
-.va-btn-sidebarnav-trigger {
+.va-btn-mobile-nav-trigger {
   margin: units-px(1) 0;
 
   button {
@@ -7,6 +7,9 @@
     width: 100%;
     margin: 0;
     border-radius: 0;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
 
     &.fixed {
       position: fixed;
@@ -22,5 +25,8 @@
       height: 10px;
       width: auto;
     }
+  }
+  @include media($medium-screen) {
+    display: none;
   }
 }


### PR DESCRIPTION
## Description
This addresses a few small requests from our designer.

## Testing done
Local

## Screenshots
![image](https://user-images.githubusercontent.com/20728956/80996709-2118d180-8df5-11ea-8c86-6ed1dd9b2cf3.png)

## Acceptance criteria
- [x] mobile trigger button is left aligned 
- [x] menu item labels are updated
- [x] section headers align better vertically to top of sidenav menu

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs