### PR TITLE
MDOT- Address Page: Copy Update For the Edit Address Views

### DIFF
--- a/src/applications/disability-benefits/2346/schemas/definitions/2346UI.js
+++ b/src/applications/disability-benefits/2346/schemas/definitions/2346UI.js
@@ -2,8 +2,8 @@ import { isValidEmail } from 'platform/forms/validations';
 import React from 'react';
 import AddressViewField from '../../components/AddressViewField';
 import ReviewCardField from '../../components/ReviewCardField';
-import ReviewPageBatteries from '../../components/ReviewPageBatteries';
 import ReviewPageAccessories from '../../components/ReviewPageAccessories';
+import ReviewPageBatteries from '../../components/ReviewPageBatteries';
 import SelectArrayItemsAccessoriesWidget from '../../components/SelectArrayItemsAccessoriesWidget';
 import SelectArrayItemsBatteriesWidget from '../../components/SelectArrayItemsBatteriesWidget';
 import { schemaFields } from '../../constants';
@@ -39,6 +39,22 @@ const addAccessoriesUITitle = (
   </h4>
 );
 
+const addressDescription = (
+  <>
+    <p>
+      Any updates you make here to your address will apply only to this
+      application.
+    </p>
+    <p>
+      To update your address for all of your VA accounts, you’ll need to go to
+      your profile page.{' '}
+      <a href="va.gov/profile">
+        View the address that's on file in your profile.
+      </a>
+    </p>
+  </>
+);
+
 export default {
   'ui:title': fullSchema.title,
   'ui:options': {
@@ -52,6 +68,7 @@ export default {
         formData => formData.permanentAddress,
       ),
       'ui:title': 'Permanent address',
+      'ui:subtitle': addressDescription,
       'ui:field': ReviewCardField,
       'ui:options': {
         viewComponent: AddressViewField,
@@ -83,6 +100,7 @@ export default {
         return true;
       }),
       'ui:title': 'Temporary address',
+      'ui:subtitle': addressDescription,
       'ui:field': ReviewCardField,
       'ui:options': {
         viewComponent: AddressViewField,


### PR DESCRIPTION
## Description
This PR focuses on updating the copy for the edit address views.

## Testing done


## Screenshots
![screenshot-localhost_3001-2020 05 04-14_52_36](https://user-images.githubusercontent.com/12755283/81002263-f0499400-8e16-11ea-9af0-cb1ea88ea120.png)

## Acceptance criteria
- [ ] If I click edit my address, I should see copy explaining that my address will only be updating on this application.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
