### PR TITLE
Add nonce to webchat script

### DIFF
--- a/src/site/includes/header.html
+++ b/src/site/includes/header.html
@@ -60,7 +60,7 @@
 <![endif]-->
 
   {% if botframework_cdn %}
-    <script src="{{ botframework_cdn }}"></script>
+    <script nonce="**CSP_NONCE**" src="{{ botframework_cdn }}"></script>
   {% endif %}
 
   <script defer nomodule data-entry-name="polyfills.js"></script>


### PR DESCRIPTION
## Description

Try adding a nonce to the script that loads the webchat JS.  Our reverse proxy does a substitute anywhere it finds `**CSP_NONCE**`.


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
