### PR TITLE
Fixed 8366 - Collect facility id and care type on Facilities Page for…

### DIFF
--- a/src/applications/vaos/actions/newAppointment.js
+++ b/src/applications/vaos/actions/newAppointment.js
@@ -266,6 +266,7 @@ export function openFacilityPage(page, uiSchema, schema) {
     const initialState = getState();
     const directSchedulingEnabled = vaosDirectScheduling(initialState);
     const newAppointment = initialState.newAppointment;
+    const typeOfCare = getTypeOfCare(newAppointment.data)?.name;
     const typeOfCareId = getTypeOfCare(newAppointment.data)?.id;
     const userSystemIds = selectSystemIds(initialState);
     let parentFacilities = newAppointment.parentFacilities;
@@ -316,7 +317,7 @@ export function openFacilityPage(page, uiSchema, schema) {
       if (parentId && !eligibleFacilities?.length) {
         recordEligibilityFailure(
           'supported-facilities',
-          typeOfCareId,
+          typeOfCare,
           parseFakeFHIRId(parentId),
         );
       }
@@ -377,6 +378,7 @@ export function updateFacilityPageData(page, uiSchema, data) {
   return async (dispatch, getState) => {
     const directSchedulingEnabled = vaosDirectScheduling(getState());
     const previousNewAppointmentState = getState().newAppointment;
+    const typeOfCare = getTypeOfCare(data)?.name;
     const typeOfCareId = getTypeOfCare(data)?.id;
     const rootOrg = getRootOrganizationFromChosenParent(
       getState(),
@@ -410,7 +412,7 @@ export function updateFacilityPageData(page, uiSchema, data) {
           dispatch(fetchFacilityDetails(parseFakeFHIRId(data.vaParent)));
           recordEligibilityFailure(
             'supported-facilities',
-            typeOfCareId,
+            typeOfCare,
             parseFakeFHIRId(data.vaParent),
           );
         }

--- a/src/applications/vaos/actions/newAppointment.js
+++ b/src/applications/vaos/actions/newAppointment.js
@@ -317,7 +317,7 @@ export function openFacilityPage(page, uiSchema, schema) {
         recordEligibilityFailure(
           'supported-facilities',
           typeOfCareId,
-          parentId,
+          parseFakeFHIRId(parentId),
         );
       }
 

--- a/src/applications/vaos/actions/newAppointment.js
+++ b/src/applications/vaos/actions/newAppointment.js
@@ -408,7 +408,11 @@ export function updateFacilityPageData(page, uiSchema, data) {
         if (!availableFacilities?.length) {
           // Remove parse function when converting this call to FHIR service
           dispatch(fetchFacilityDetails(parseFakeFHIRId(data.vaParent)));
-          recordEligibilityFailure('supported-facilities');
+          recordEligibilityFailure(
+            'supported-facilities',
+            typeOfCareId,
+            parseFakeFHIRId(data.vaParent),
+          );
         }
 
         dispatch({

--- a/src/applications/vaos/actions/newAppointment.js
+++ b/src/applications/vaos/actions/newAppointment.js
@@ -314,7 +314,11 @@ export function openFacilityPage(page, uiSchema, schema) {
       }
 
       if (parentId && !eligibleFacilities?.length) {
-        recordEligibilityFailure('supported-facilities');
+        recordEligibilityFailure(
+          'supported-facilities',
+          typeOfCareId,
+          parentId,
+        );
       }
 
       const eligibilityChecks =

--- a/src/applications/vaos/utils/events.js
+++ b/src/applications/vaos/utils/events.js
@@ -7,9 +7,15 @@ export function recordVaosError(errorKey) {
   });
 }
 
-export function recordEligibilityFailure(errorKey) {
+export function recordEligibilityFailure(
+  errorKey,
+  typeOfCare = null,
+  facilityId = null,
+) {
   recordEvent({
     event: `vaos-eligibility${errorKey ? `-${errorKey}` : ''}-failed`,
+    'health-TypeOfCare': typeOfCare,
+    'health-FacilityID': facilityId,
   });
 }
 


### PR DESCRIPTION
## Description
Collect facility id and care type on 'Facilities' Page for eligibility event #8366

## Testing done
Unit testing

## Screenshots
N/A

## Acceptance criteria
- [ ] Verify that facility id and care type are captured in Google Analytics event.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
