### PR TITLE
Combine profile and account links on my-va

### DIFF
--- a/src/applications/personalization/dashboard/containers/DashboardApp.jsx
+++ b/src/applications/personalization/dashboard/containers/DashboardApp.jsx
@@ -380,11 +380,7 @@ class DashboardApp extends React.Component {
           </>
         )}
 
-        {showProfile2 && (
-          <>
-            <ViewYourProfile2 />
-          </>
-        )}
+        {showProfile2 && <ViewYourProfile2 />}
       </>
     );
 

--- a/src/applications/personalization/dashboard/containers/DashboardApp.jsx
+++ b/src/applications/personalization/dashboard/containers/DashboardApp.jsx
@@ -20,6 +20,7 @@ import {
   hasServerError as hasESRServerError,
   isEnrolledInVAHealthCare,
 } from 'applications/hca/selectors';
+import { selectShowProfile2 } from 'applications/personalization/profile-2/selectors';
 
 import { recordDashboardClick } from '../helpers';
 import {
@@ -190,6 +191,26 @@ const ManageYourAccount = () => (
   </>
 );
 
+const ViewYourProfile2 = () => (
+  <>
+    <h2>View Your Profile</h2>
+    <p>
+      Go to your profile to view the information you need to manage your VA
+      benefits. You can make updates to your personal, military, and financial
+      information, as well as update your account settings to access more online
+      tools and services.
+      <br />
+      <a
+        className="usa-button-primary"
+        href={profileManifest.rootUrl}
+        onClick={recordDashboardClick('view-your-profile', 'view-button')}
+      >
+        View your profile
+      </a>
+    </p>
+  </>
+);
+
 class DashboardApp extends React.Component {
   constructor(props) {
     super(props);
@@ -305,9 +326,10 @@ class DashboardApp extends React.Component {
       canAccessMessaging,
       canAccessAppeals,
       profile,
-      showManageYourVAHealthCare,
-      showServerError,
       showCOVID19Alert,
+      showManageYourVAHealthCare,
+      showProfile2,
+      showServerError,
       vaHealthChatEligibleSystemId,
     } = this.props;
     const availableWidgetsCount = [
@@ -350,8 +372,19 @@ class DashboardApp extends React.Component {
 
         {showManageYourVAHealthCare && <ManageYourVAHealthCare />}
         <ManageBenefitsOrRequestRecords />
-        <ViewYourProfile />
-        <ManageYourAccount />
+
+        {!showProfile2 && (
+          <>
+            <ViewYourProfile />
+            <ManageYourAccount />
+          </>
+        )}
+
+        {showProfile2 && (
+          <>
+            <ViewYourProfile2 />
+          </>
+        )}
       </>
     );
 
@@ -369,6 +402,7 @@ class DashboardApp extends React.Component {
 
 export const mapStateToProps = state => {
   const profileState = selectProfile(state);
+  const showProfile2 = selectShowProfile2(state);
   const canAccessRx = profileState.services.includes(backendServices.RX);
   const canAccessMessaging = profileState.services.includes(
     backendServices.MESSAGING,
@@ -399,6 +433,7 @@ export const mapStateToProps = state => {
     canAccessAppeals,
     canAccessClaims,
     profile: profileState,
+    showProfile2,
     showManageYourVAHealthCare:
       isEnrolledInVAHealthCare(state) || canAccessRx || canAccessMessaging,
     showServerError,

--- a/src/applications/personalization/dashboard/containers/DashboardApp.jsx
+++ b/src/applications/personalization/dashboard/containers/DashboardApp.jsx
@@ -205,7 +205,7 @@ const ViewYourProfile2 = () => (
         href={profileManifest.rootUrl}
         onClick={recordDashboardClick('view-your-profile', 'view-button')}
       >
-        View your profile
+        Go to your profile
       </a>
     </p>
   </>

--- a/src/applications/personalization/dashboard/tests/containers/DashboardApp.unit.spec.jsx
+++ b/src/applications/personalization/dashboard/tests/containers/DashboardApp.unit.spec.jsx
@@ -92,6 +92,27 @@ describe('<DashboardApp>', () => {
     );
   });
 
+  it('should render the ViewYourProfile2 section when showProfile 2 is true', () => {
+    const tree = SkinDeep.shallowRender(
+      <DashboardApp {...defaultProps} showProfile2 />,
+    );
+    expect(tree.toString()).to.contain('<ViewYourProfile2 />');
+  });
+
+  it('should not render the Manage Your Account section when showProfile 2 is true', () => {
+    const tree = SkinDeep.shallowRender(
+      <DashboardApp {...defaultProps} showProfile2 />,
+    );
+    expect(tree.toString()).not.to.contain('<ManageYourAccount />');
+  });
+
+  it('should render the Manage Your Account section when showProfile 2 is false', () => {
+    const tree = SkinDeep.shallowRender(
+      <DashboardApp profile={{ loa: { current: 3 }, showProfile2: false }} />,
+    );
+    expect(tree.toString()).to.contain('<ManageYourAccount />');
+  });
+
   it('should not render warnings if information available', () => {
     const props = {
       profile: {
@@ -152,6 +173,15 @@ describe('mapStateToProps', () => {
       state.user.profile.facilities = [{ facilityId: 'abc' }];
       const props = mapStateToProps(state);
       expect(props.showCOVID19Alert).to.be.false;
+    });
+  });
+  describe('showProfile2', () => {
+    it('is set to true when the feature flag "profile_show_profile_2.0" is turned on', () => {
+      const state = defaultState();
+      const profile2 = 'profile_show_profile_2.0';
+      state.featureToggles[profile2] = true;
+      const props = mapStateToProps(state);
+      expect(props.showProfile2).to.be.true;
     });
   });
   describe('vaHealthChatEligibleFacilityId', () => {


### PR DESCRIPTION
## Description
When the feature flag for Profile 2.0 is turned on, we replace the current sections of 'View your profile' and 'Manage your account' into one paragraph with one call to action. The copy has also been updated.

This lives at the `/my-va/` route.

NOTE: the new CTA goes to `/profile` (which shows the old profile for now), there are currently tickets in the works that will consolidate this route to go to the correct profile (profile 360/Profile 2.0) depending on whether the feature flag is turned on.

## Testing done
Works locally, added unit tests.

## Screenshots
BEFORE
![image](https://user-images.githubusercontent.com/14869324/81078807-ee7de000-8eab-11ea-9973-eef8dd095e36.png)

AFTER
![image](https://user-images.githubusercontent.com/14869324/81092954-9ef4df80-8ebe-11ea-9155-86716dcbe16a.png)

## Acceptance criteria
- [x]  'Manage your profile' has been updated

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
