### PR TITLE
Directions should reflect the user's search address query

### DIFF
--- a/src/applications/facility-locator/components/ResultsList.jsx
+++ b/src/applications/facility-locator/components/ResultsList.jsx
@@ -164,7 +164,13 @@ class ResultsList extends Component {
               result.attributes.long,
             )
           : null;
-        return { ...result, distance, resultItem: true, markerText };
+        return {
+          ...result,
+          distance,
+          resultItem: true,
+          markerText,
+          searchString,
+        };
       })
       .sort((resultA, resultB) => resultA.distance - resultB.distance);
 

--- a/src/applications/facility-locator/components/search-results/LocationDirectionsLink.jsx
+++ b/src/applications/facility-locator/components/search-results/LocationDirectionsLink.jsx
@@ -16,7 +16,9 @@ function LocationDirectionsLink({ location, from }) {
   return (
     <span>
       <a
-        href={`https://maps.google.com?saddr=Current+Location&daddr=${address}`}
+        href={`https://maps.google.com?saddr=${
+          location.searchString
+        }&daddr=${address}`}
         rel="noopener noreferrer"
         target="_blank"
         style={{ textDecoration: 'underline' }}


### PR DESCRIPTION
## Description
issue: https://github.com/department-of-veterans-affairs/va.gov-team/issues/5840

## Testing done
Locally

## Screenshots
<img width="1483" alt="Screen Shot 2020-05-05 at 12 48 43 PM" src="https://user-images.githubusercontent.com/100468/81098978-c6a07380-8ecf-11ea-8b7f-376770568c81.png">


## Acceptance criteria
- [x] Directions should reflect the user's search address query



## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
