### PR TITLE
MDOT Accessories Page - No Accessories UI

### DIFF
--- a/src/applications/disability-benefits/2346/components/SelectArrayItemsAccessoriesWidget.jsx
+++ b/src/applications/disability-benefits/2346/components/SelectArrayItemsAccessoriesWidget.jsx
@@ -41,6 +41,20 @@ class SelectArrayItemsAccessoriesWidget extends Component {
       accessorySupply => accessorySupply.availableForReorder === false,
     );
 
+    const noAccessoriesContent = (
+      <>
+        <p>
+          You can only order accessories online that you have received in the
+          past two years.
+        </p>
+        <p>
+          If you need accessories like domes, wax guards, cleaning supplies, or
+          desiccant, call the DLC Customer Service Station at{' '}
+          <a href="tel:303-273-6200">303-273-6200</a> or email{' '}
+          <a href="mailto:dalc.css@va.gov">dalc.css@va.gov</a>.
+        </p>
+      </>
+    );
     return (
       <>
         {!areAccessorySuppliesIneligible && (
@@ -127,14 +141,24 @@ class SelectArrayItemsAccessoriesWidget extends Component {
             )}
           </div>
         ))}
-        <AdditionalInfo triggerText="What if I don't see the accessories I need?">
-          <p>
-            If you need a different accessory or an adjustment to an available
-            item, call the DLC Customer Service Station at{' '}
-            <a href="tel:303-273-6200">303-273-6200</a> or email{' '}
-            <a href="mailto:dalc.css@va.gov">dalc.css@va.gov</a>.
-          </p>
-        </AdditionalInfo>
+        {accessorySupplies.length > 0 && (
+          <AdditionalInfo triggerText="What if I don't see the accessories I need?">
+            <p>
+              If you need a different accessory or an adjustment to an available
+              item, call the DLC Customer Service Station at{' '}
+              <a href="tel:303-273-6200">303-273-6200</a> or email{' '}
+              <a href="mailto:dalc.css@va.gov">dalc.css@va.gov</a>.
+            </p>
+          </AdditionalInfo>
+        )}
+        {accessorySupplies.length <= 0 && (
+          <AlertBox
+            headline="You're hearing accessories aren't available for online ordering"
+            content={noAccessoriesContent}
+            status="info"
+            isVisible
+          />
+        )}
       </>
     );
   }


### PR DESCRIPTION
## Description
This PR focuses on adding the UI screen for if the Veteran's accessories are not able to be ordered online.

## Testing done


## Screenshots
![screenshot-localhost_3001-2020 05 05-15_46_41](https://user-images.githubusercontent.com/12755283/81109134-a4b2eb00-8ee7-11ea-94d7-311e5279e0ec.png)

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
