### PR TITLE
Fix appointment list sorting

### DIFF
--- a/src/applications/vaos/tests/reducers/appointments.unit.spec.js
+++ b/src/applications/vaos/tests/reducers/appointments.unit.spec.js
@@ -100,6 +100,11 @@ describe('VAOS reducer: appointments', () => {
     const newState = appointmentsReducer(initialState, action);
     expect(newState.futureStatus).to.equal(FETCH_STATUS.succeeded);
     expect(newState.future.length).to.equal(5);
+    expect(
+      newState.future[0].appointmentDate.isBefore(
+        newState.future[1].appointmentDate,
+      ),
+    ).to.be.true;
   });
 
   it('should update futureStatus to be failed when calling FETCH_FUTURE_APPOINTMENTS_FAILED', () => {
@@ -132,25 +137,37 @@ describe('VAOS reducer: appointments', () => {
       selectedIndex: 1,
       data: [
         [
-          { startDate: '2019-04-30T05:35:00', facilityId: '984' },
+          {
+            startDate: '2019-04-30T05:35:00',
+            facilityId: '984',
+            clinicId: '123',
+          },
           // appointment before start date should not show
-          { startDate: '2017-04-30T05:35:00', facilityId: '984' },
+          {
+            startDate: '2017-04-30T05:35:00',
+            facilityId: '984',
+            clinicId: '123',
+          },
           // appointment 1 hour in the future should not show
           {
             startDate: moment()
               .add(650, 'minutes')
               .format(),
+            clinicId: '123',
           },
           // appointment 30 min ago should show
           {
             startDate: moment()
               .subtract(30, 'minutes')
               .format(),
+            clinicId: '123',
           },
           // Cancelled should show
           {
-            appointmentTime: '05/29/2019 05:30:00',
-            timeZone: '+08:00 WITA',
+            startDate: moment()
+              .subtract(20, 'minutes')
+              .format(),
+            clinicId: '123',
             vdsAppointments: [
               {
                 currentStatus: 'CANCELLED BY CLINIC',
@@ -185,6 +202,11 @@ describe('VAOS reducer: appointments', () => {
     const newState = appointmentsReducer(initialState, action);
     expect(newState.pastStatus).to.equal(FETCH_STATUS.succeeded);
     expect(newState.past.length).to.equal(4);
+    expect(
+      newState.past[0].appointmentDate.isAfter(
+        newState.past[1].appointmentDate,
+      ),
+    ).to.be.true;
   });
 
   it('should update pastStatus to be failed when calling FETCH_PAST_APPOINTMENTS_FAILED', () => {

--- a/src/applications/vaos/tests/utils/appointment.unit.spec.jsx
+++ b/src/applications/vaos/tests/utils/appointment.unit.spec.jsx
@@ -512,12 +512,12 @@ describe('VAOS appointment helpers', () => {
   describe('sortFutureConfirmedAppointments', () => {
     it('should sort future confirmed appointments', () => {
       const confirmed = [
-        { startDate: '2099-04-30T05:35:00', facilityId: '984' },
-        { startDate: '2099-04-27T05:35:00', facilityId: '984' },
+        { appointmentDate: moment('2099-04-30T05:35:00'), facilityId: '984' },
+        { appointmentDate: moment('2099-04-27T05:35:00'), facilityId: '983' },
       ];
 
       const sorted = confirmed.sort(sortFutureConfirmedAppointments);
-      expect(sorted[0].startDate).to.equal('2099-04-27T05:35:00');
+      expect(sorted[0].facilityId).to.equal('983');
     });
   });
 
@@ -569,27 +569,26 @@ describe('VAOS appointment helpers', () => {
     it('should sort future requests', () => {
       const requests = [
         {
-          appointmentType: 'Primary Care',
-          optionDate1: '12/13/2019',
+          id: 'third',
+          typeOfCare: 'Primary Care',
+          dateOptions: [{ date: moment('12/13/2019', 'MM/DD/YYYY') }],
         },
         {
-          appointmentType: 'Primary Care',
-          optionDate1: '12/12/2019',
+          id: 'first',
+          typeOfCare: 'Audiology (hearing aid support)',
+          dateOptions: [{ date: moment('12/12/2019', 'MM/DD/YYYY') }],
         },
         {
-          appointmentType: 'Audiology (hearing aid support)',
-          optionDate1: '12/12/2019',
+          id: 'second',
+          typeOfCare: 'Primary Care',
+          dateOptions: [{ date: moment('12/12/2019', 'MM/DD/YYYY') }],
         },
       ];
 
       const sortedRequests = requests.sort(sortFutureRequests);
-      expect(sortedRequests[0].appointmentType).to.equal(
-        'Audiology (hearing aid support)',
-      );
-      expect(sortedRequests[1].appointmentType).to.equal('Primary Care');
-      expect(sortedRequests[1].optionDate1).to.equal('12/12/2019');
-      expect(sortedRequests[2].appointmentType).to.equal('Primary Care');
-      expect(sortedRequests[2].optionDate1).to.equal('12/13/2019');
+      expect(sortedRequests[0].id).to.equal('first');
+      expect(sortedRequests[1].id).to.equal('second');
+      expect(sortedRequests[2].id).to.equal('third');
     });
   });
 

--- a/src/applications/vaos/utils/appointment.js
+++ b/src/applications/vaos/utils/appointment.js
@@ -215,10 +215,6 @@ export function filterFutureConfirmedAppointments(appt, today) {
   );
 }
 
-export function sortFutureConfirmedAppointments(a, b) {
-  return getMomentConfirmedDate(a).isBefore(getMomentConfirmedDate(b)) ? -1 : 1;
-}
-
 export function filterPastAppointments(appt, startDate, endDate) {
   const apptDateTime = getMomentConfirmedDate(appt);
   return (
@@ -229,10 +225,6 @@ export function filterPastAppointments(appt, startDate, endDate) {
     apptDateTime.isAfter(startDate) &&
     apptDateTime.isBefore(endDate)
   );
-}
-
-export function sortPastAppointments(a, b) {
-  return getMomentConfirmedDate(a).isAfter(getMomentConfirmedDate(b)) ? -1 : 1;
 }
 
 export function filterRequests(request, today) {
@@ -251,17 +243,22 @@ export function filterRequests(request, today) {
   );
 }
 
-export function sortFutureRequests(a, b) {
-  const aDate = getMomentRequestOptionDate(a.optionDate1);
-  const bDate = getMomentRequestOptionDate(b.optionDate1);
+export function sortFutureConfirmedAppointments(a, b) {
+  return a.appointmentDate.isBefore(b.appointmentDate) ? -1 : 1;
+}
 
+export function sortPastAppointments(a, b) {
+  return a.appointmentDate.isAfter(b.appointmentDate) ? -1 : 1;
+}
+
+export function sortFutureRequests(a, b) {
   // If appointmentType is the same, return the one with the sooner date
-  if (a.appointmentType === b.appointmentType) {
-    return aDate.isBefore(bDate) ? -1 : 1;
+  if (a.typeOfCare === b.typeOfCare) {
+    return a.dateOptions[0].date.isBefore(b.dateOptions[0].date) ? -1 : 1;
   }
 
   // Otherwise, return sorted alphabetically by appointmentType
-  return a.appointmentType < b.appointmentType ? -1 : 1;
+  return a.typeOfCare.toLowerCase() < b.typeOfCare.toLowerCase() ? -1 : 1;
 }
 
 export function sortMessages(a, b) {


### PR DESCRIPTION
## Description
This fixes the appointment list sorting, which was broken in a refactor I did a couple weeks ago. I've also added some extra expectations to our tests to try to catch this in the future.

## Testing done
Local and unit testing

## Screenshots
![Screen Shot 2020-05-05 at 4 13 11 PM](https://user-images.githubusercontent.com/634932/81111680-720af180-8eeb-11ea-8491-f60ece3a8391.png)
![Screen Shot 2020-05-05 at 4 13 05 PM](https://user-images.githubusercontent.com/634932/81111683-733c1e80-8eeb-11ea-8816-6e98a9db4f4f.png)

## Acceptance criteria
- [ ] List is sorting correctly on future and past tabs

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
