### PR TITLE
MDOT Batteries Page & Review Page: No Batteries UI/ No Supplies Review Page

### DIFF
--- a/src/applications/disability-benefits/2346/components/ReviewPageAccessories.jsx
+++ b/src/applications/disability-benefits/2346/components/ReviewPageAccessories.jsx
@@ -8,8 +8,8 @@ const ReviewPageAccessories = ({ selectedProductInfo, accessorySupplies }) => (
         You have requested to receive the following accessories:
       </span>
       <span>
-        ({selectedProductInfo.length} out of {accessorySupplies.length}{' '}
-        selected)
+        ({selectedProductInfo?.length || 0} out of{' '}
+        {accessorySupplies?.length || 0} selected)
       </span>
     </div>
     <div className="vads-u-margin-bottom--3">
@@ -31,7 +31,7 @@ const ReviewPageAccessories = ({ selectedProductInfo, accessorySupplies }) => (
 
 const mapStateToProps = state => {
   const supplies = state.form?.loadedData?.formData?.supplies;
-  const accessorySupplies = supplies.filter(supply =>
+  const accessorySupplies = supplies?.filter(supply =>
     supply.productGroup?.includes('accessories'),
   );
   const selectedProducts = state.form?.data?.selectedProducts;

--- a/src/applications/disability-benefits/2346/components/ReviewPageBatteries.jsx
+++ b/src/applications/disability-benefits/2346/components/ReviewPageBatteries.jsx
@@ -8,7 +8,8 @@ const ReviewPageBatteries = ({ selectedProductInfo, batterySupplies }) => (
         You have requested to receive batteries for the following hearing aids:
       </span>
       <span>
-        ({selectedProductInfo.length} out of {batterySupplies.length} selected)
+        ({selectedProductInfo?.length || 0} out of{' '}
+        {batterySupplies?.length || 0} selected)
       </span>
     </div>
     <div className="vads-u-margin-bottom--3">

--- a/src/applications/disability-benefits/2346/components/SelectArrayItemsBatteriesWidget.jsx
+++ b/src/applications/disability-benefits/2346/components/SelectArrayItemsBatteriesWidget.jsx
@@ -12,17 +12,18 @@ import {
 } from '../constants';
 
 class SelectArrayItemsBatteriesWidget extends Component {
-  handleChecked = (checked, supply) => {
+  handleChecked = (checked, batterySupply) => {
     const { selectedProducts, formData } = this.props;
     let updatedSelectedProducts;
     if (checked) {
       updatedSelectedProducts = [
         ...selectedProducts,
-        { productId: supply.productId },
+        { productId: batterySupply.productId },
       ];
     } else {
       updatedSelectedProducts = selectedProducts.filter(
-        selectedProduct => selectedProduct.productId !== supply.productId,
+        selectedProduct =>
+          selectedProduct.productId !== batterySupply.productId,
       );
     }
     const updatedFormData = {
@@ -36,10 +37,24 @@ class SelectArrayItemsBatteriesWidget extends Component {
     const { supplies, selectedProducts } = this.props;
     const currentDate = moment();
     const batterySupplies = supplies.filter(
-      supply => supply.productGroup === HEARING_AID_BATTERIES,
+      batterySupply => batterySupply.productGroup === HEARING_AID_BATTERIES,
     );
     const areBatterySuppliesIneligible = batterySupplies.every(
       batterySupply => batterySupply.availableForReorder === false,
+    );
+
+    const noBatteriesContent = (
+      <>
+        <p>
+          You can only order batteries online that you have received in the past
+          two years.
+        </p>
+        <p>
+          If you need batteries, call the DLC Customer Service Station at{' '}
+          <a href="tel:303-273-6200">303-273-6200</a> or email{' '}
+          <a href="mailto:dalc.css@va.gov">dalc.css@va.gov</a>.
+        </p>
+      </>
     );
 
     return (
@@ -54,105 +69,106 @@ class SelectArrayItemsBatteriesWidget extends Component {
             </p>
           </>
         )}
-        {batterySupplies.map(
-          supply =>
-            supply.productGroup === HEARING_AID_BATTERIES ? (
-              <div
-                key={supply.productId}
-                className="vads-u-background-color--gray-lightest vads-u-padding-left--4 vads-u-padding-top--1 vads-u-padding-bottom--4 battery-page vads-u-margin-y--3"
-              >
-                <h4 className="vads-u-font-size--md vads-u-font-weight--bold">
-                  {supply.deviceName}
-                </h4>
-                <p>Prescribed 1/18/2018</p>
-                <div className="vads-u-border-left--10px vads-u-border-color--primary-alt">
-                  <div className="usa-alert-body vads-u-padding-left--1">
-                    <p className="vads-u-margin--1px vads-u-margin-y--1">
-                      <span className="vads-u-font-weight--bold">
-                        Battery:{' '}
-                      </span>
-                      {supply.productId}
-                    </p>
-                    <p className="vads-u-margin--1px vads-u-margin-y--1">
-                      <span className="vads-u-font-weight--bold">
-                        Quantity:{' '}
-                      </span>
-                      {supply.quantity}
-                    </p>
-                    <p className="vads-u-margin--1px vads-u-margin-y--1">
-                      <span className="vads-u-font-weight--bold">
-                        Last order date:{' '}
-                      </span>{' '}
-                      {moment(supply.lastOrderDate).format('MM/DD/YYYY')}
-                    </p>
-                  </div>
-                </div>
-                {currentDate.diff(supply.nextAvailabilityDate, 'days') < 0 ? (
-                  <AlertBox
-                    className="vads-u-color--black vads-u-background-color--white"
-                    headline={`You can't reorder batteries for this device until ${moment(
-                      supply.nextAvailabilityDate,
-                    ).format('MMMM D, YYYY')}`}
-                    content={
-                      <>
-                        <p>
-                          You can only order batteries for each device once
-                          every 5 months. Each battery order comes with a
-                          6-month supply.
-                        </p>
-                        <p>
-                          If you need batteries sooner, call the DLC Customer
-                          Service Station at{' '}
-                          <a href="tel:303-273-6200">303-273-6200</a> or email{' '}
-                          <a href="mailto:dalc.css@va.gov">dalc.css@va.gov</a>.
-                        </p>
-                      </>
-                    }
-                    status="warning"
-                  />
-                ) : (
-                  <div
-                    className={
-                      selectedProducts.find(
-                        selectedProduct =>
-                          selectedProduct.productId === supply.productId,
-                      )
-                        ? BLUE_BACKGROUND
-                        : WHITE_BACKGROUND
-                    }
-                  >
-                    <input
-                      name={supply.productId}
-                      type="checkbox"
-                      onChange={e =>
-                        this.handleChecked(e.target.checked, supply)
-                      }
-                      checked={
-                        !!selectedProducts.find(
-                          selectedProduct =>
-                            selectedProduct.productId === supply.productId,
-                        )
-                      }
-                    />
-                    <label htmlFor={supply.productId} className="main">
-                      Order batteries for this device
-                    </label>
-                  </div>
-                )}
+        {batterySupplies.map(batterySupply => (
+          <div
+            key={batterySupply.productId}
+            className="vads-u-background-color--gray-lightest vads-u-padding-left--4 vads-u-padding-top--1 vads-u-padding-bottom--4 battery-page vads-u-margin-y--3"
+          >
+            <h4 className="vads-u-font-size--md vads-u-font-weight--bold">
+              {batterySupply.deviceName}
+            </h4>
+            <p>Prescribed 1/18/2018</p>
+            <div className="vads-u-border-left--10px vads-u-border-color--primary-alt">
+              <div className="usa-alert-body vads-u-padding-left--1">
+                <p className="vads-u-margin--1px vads-u-margin-y--1">
+                  <span className="vads-u-font-weight--bold">Battery: </span>
+                  {batterySupply.productId}
+                </p>
+                <p className="vads-u-margin--1px vads-u-margin-y--1">
+                  <span className="vads-u-font-weight--bold">Quantity: </span>
+                  {batterySupply.quantity}
+                </p>
+                <p className="vads-u-margin--1px vads-u-margin-y--1">
+                  <span className="vads-u-font-weight--bold">
+                    Last order date:{' '}
+                  </span>{' '}
+                  {moment(batterySupply.lastOrderDate).format('MM/DD/YYYY')}
+                </p>
               </div>
+            </div>
+            {currentDate.diff(batterySupply.nextAvailabilityDate, 'days') <
+            0 ? (
+              <AlertBox
+                className="vads-u-color--black vads-u-background-color--white"
+                headline={`You can't reorder batteries for this device until ${moment(
+                  batterySupply.nextAvailabilityDate,
+                ).format('MMMM D, YYYY')}`}
+                content={
+                  <>
+                    <p>
+                      You can only order batteries for each device once every 5
+                      months. Each battery order comes with a 6-month supply.
+                    </p>
+                    <p>
+                      If you need batteries sooner, call the DLC Customer
+                      Service Station at{' '}
+                      <a href="tel:303-273-6200">303-273-6200</a> or email{' '}
+                      <a href="mailto:dalc.css@va.gov">dalc.css@va.gov</a>.
+                    </p>
+                  </>
+                }
+                status="warning"
+              />
             ) : (
-              ''
-            ),
+              <div
+                className={
+                  selectedProducts.find(
+                    selectedProduct =>
+                      selectedProduct.productId === batterySupply.productId,
+                  )
+                    ? BLUE_BACKGROUND
+                    : WHITE_BACKGROUND
+                }
+              >
+                <input
+                  name={batterySupply.productId}
+                  type="checkbox"
+                  onChange={e =>
+                    this.handleChecked(e.target.checked, batterySupply)
+                  }
+                  checked={
+                    !!selectedProducts.find(
+                      selectedProduct =>
+                        selectedProduct.productId === batterySupply.productId,
+                    )
+                  }
+                />
+                <label htmlFor={batterySupply.productId} className="main">
+                  Order batteries for this device
+                </label>
+              </div>
+            )}
+          </div>
+        ))}
+        {batterySupplies.length > 0 && (
+          <AdditionalInfo triggerText="What if I don't see my hearing aid?">
+            <p>
+              You'll need to call your audiologist to update your record with
+              all your hearing devices.
+            </p>
+            <a href="https://www.va.gov/find-locations/">
+              Find contact information for your local VA medical center
+            </a>
+          </AdditionalInfo>
         )}
-        <AdditionalInfo triggerText="What if I don't see my hearing aid?">
-          <p>
-            You'll need to call your audiologist to update your record with all
-            your hearing devices.
-          </p>
-          <a href="https://www.va.gov/find-locations/">
-            Find contact information for your local VA medical center
-          </a>
-        </AdditionalInfo>
+        {batterySupplies.length <= 0 && (
+          <AlertBox
+            headline="Your batteries aren't available for online ordering"
+            content={noBatteriesContent}
+            status="info"
+            isVisible
+          />
+        )}
       </>
     );
   }


### PR DESCRIPTION
## Description
This PR focuses on adding UI for if the Veteran is not able to reorder their batteries online and handling no supplies on the review page.

## Testing done


## Screenshots
![screenshot-localhost_3001-2020 05 05-16_54_00 (1)](https://user-images.githubusercontent.com/12755283/81115093-2ce9be00-8ef1-11ea-901c-3d4634d6720b.png)

![screenshot-localhost_3001-2020 05 05-16_54_00](https://user-images.githubusercontent.com/12755283/81115069-252a1980-8ef1-11ea-9343-453be8ab8577.png)


## Acceptance criteria
- [ ] The veteran should see UI telling them that they cannot order batteries online
- [ ] The veteran should see 0 out of 0 selected if they cannot order batteries or accessories online

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
