### PR TITLE
Move DD form into its own component

### DIFF
--- a/src/applications/personalization/profile360/components/BankInfoForm.jsx
+++ b/src/applications/personalization/profile360/components/BankInfoForm.jsx
@@ -1,0 +1,104 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import SchemaForm from 'platform/forms-system/src/js/components/SchemaForm';
+import LoadingButton from 'platform/site-wide/loading-button/LoadingButton';
+
+import { ACCOUNT_TYPES_OPTIONS } from '../constants';
+
+export const schema = {
+  type: 'object',
+  properties: {
+    routingNumber: {
+      type: 'string',
+      pattern: '^\\d{9}$',
+    },
+    accountNumber: {
+      type: 'string',
+      pattern: '^\\d{1,17}$',
+    },
+    accountType: {
+      type: 'string',
+      enum: Object.values(ACCOUNT_TYPES_OPTIONS),
+    },
+  },
+  required: ['accountNumber', 'routingNumber', 'accountType'],
+};
+
+export const uiSchema = {
+  routingNumber: {
+    'ui:title':
+      'Routing number (Your 9-digit routing number will update your bank’s name)',
+    'ui:errorMessages': {
+      pattern: 'Please enter the bank’s 9-digit routing number.',
+      required: 'Please enter the bank’s 9-digit routing number.',
+    },
+  },
+  accountNumber: {
+    'ui:title': 'Account number (No more than 17 digits)',
+    'ui:errorMessages': {
+      pattern: 'Please enter your account number.',
+      required: 'Please enter your account number.',
+    },
+  },
+  accountType: {
+    'ui:title': 'Account type',
+    'ui:errorMessages': {
+      required: 'Please select the type that best describes the account.',
+    },
+  },
+};
+
+const BankInfoForm = ({
+  cancelButtonClasses,
+  formChange,
+  formData,
+  formSubmit,
+  isSaving,
+  onClose,
+}) => (
+  <SchemaForm
+    // name and title are used internally by the SchemaForm
+    name="Direct Deposit Information"
+    title="Direct Deposit Information"
+    schema={schema}
+    uiSchema={uiSchema}
+    data={formData}
+    onChange={formChange}
+    onSubmit={formSubmit}
+  >
+    <LoadingButton
+      type="submit"
+      className="usa-button-primary vads-u-margin-top--0 vads-u-width--full small-screen:vads-u-width--auto"
+      isLoading={isSaving}
+    >
+      Update
+    </LoadingButton>
+
+    <button
+      type="button"
+      disabled={isSaving}
+      className={cancelButtonClasses.join(' ')}
+      onClick={onClose}
+      data-qa="cancel-button"
+    >
+      Cancel
+    </button>
+  </SchemaForm>
+);
+
+BankInfoForm.propTypes = {
+  // Classes to apply to the form's "cancel" button. Defaults to ['usa-button-secondary']
+  cancelButtonClasses: PropTypes.arrayOf(PropTypes.string).isRequired,
+  formChange: PropTypes.func.isRequired,
+  formData: PropTypes.object.isRequired,
+  formSubmit: PropTypes.func.isRequired,
+  isSaving: PropTypes.bool.isRequired,
+  onClose: PropTypes.func.isRequired,
+};
+
+BankInfoForm.defaultProps = {
+  cancelButtonClasses: ['usa-button-secondary'],
+};
+
+export default BankInfoForm;

--- a/src/applications/personalization/profile360/components/PaymentInformationEditModal.jsx
+++ b/src/applications/personalization/profile360/components/PaymentInformationEditModal.jsx
@@ -2,56 +2,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import Modal from '@department-of-veterans-affairs/formation-react/Modal';
-import LoadingButton from 'platform/site-wide/loading-button/LoadingButton';
-
-import SchemaForm from 'platform/forms-system/src/js/components/SchemaForm';
-
-import { ACCOUNT_TYPES_OPTIONS } from '../constants';
 
 import PaymentInformationEditModalError from './PaymentInformationEditModalError';
-
-const schema = {
-  type: 'object',
-  properties: {
-    routingNumber: {
-      type: 'string',
-      pattern: '^\\d{9}$',
-    },
-    accountNumber: {
-      type: 'string',
-      pattern: '^\\d{1,17}$',
-    },
-    accountType: {
-      type: 'string',
-      enum: Object.values(ACCOUNT_TYPES_OPTIONS),
-    },
-  },
-  required: ['accountNumber', 'routingNumber', 'accountType'],
-};
-
-const uiSchema = {
-  routingNumber: {
-    'ui:title':
-      'Routing number (Your 9-digit routing number will update your bank’s name)',
-    'ui:errorMessages': {
-      pattern: 'Please enter the bank’s 9-digit routing number.',
-      required: 'Please enter the bank’s 9-digit routing number.',
-    },
-  },
-  accountNumber: {
-    'ui:title': 'Account number (No more than 17 digits)',
-    'ui:errorMessages': {
-      pattern: 'Please enter your account number.',
-      required: 'Please enter your account number.',
-    },
-  },
-  accountType: {
-    'ui:title': 'Account type',
-    'ui:errorMessages': {
-      required: 'Please select the type that best describes the account.',
-    },
-  },
-};
+import BankInfoForm from './BankInfoForm';
 
 class PaymentInformationEditModal extends React.Component {
   static propTypes = {
@@ -106,32 +59,13 @@ class PaymentInformationEditModal extends React.Component {
           alt="On a personal check, find your bank's 9-digit routing number listed along the bottom-left edge, and your account number listed beside that."
         />
 
-        <SchemaForm
-          name="Direct Deposit Information"
-          title="Direct Deposit Information"
-          schema={schema}
-          uiSchema={uiSchema}
-          onSubmit={this.formSubmit}
-          onChange={formData => this.setState({ formData })}
-          data={this.state.formData}
-        >
-          <LoadingButton
-            type="submit"
-            className="usa-button-primary vads-u-margin-top--0 vads-u-width--full small-screen:vads-u-width--auto"
-            isLoading={this.props.isSaving}
-          >
-            Update
-          </LoadingButton>
-
-          <button
-            type="button"
-            disabled={this.props.isSaving}
-            className="usa-button-secondary"
-            onClick={this.props.onClose}
-          >
-            Cancel
-          </button>
-        </SchemaForm>
+        <BankInfoForm
+          formData={this.state.formData}
+          formSubmit={this.formSubmit}
+          formChange={formData => this.setState({ formData })}
+          isSaving={this.props.isSaving}
+          onClose={this.props.onClose}
+        />
       </Modal>
     );
   }

--- a/src/applications/personalization/profile360/tests/components/BankInfoForm.unit.spec.jsx
+++ b/src/applications/personalization/profile360/tests/components/BankInfoForm.unit.spec.jsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import sinon from 'sinon';
+import { mount } from 'enzyme';
+import { expect } from 'chai';
+
+import BankInfoForm, { schema, uiSchema } from '../../components/BankInfoForm';
+
+describe('<BankInfoForm/>', () => {
+  let wrapper;
+  let schemaForm;
+
+  const formSubmitSpy = sinon.spy();
+  const formChangeSpy = sinon.spy();
+  const onCloseSpy = sinon.spy();
+  const defaultProps = {
+    cancelButtonClasses: ['button-class-1', 'button-class-2'],
+    formChange: formChangeSpy,
+    formData: { name: 'Pat' },
+    formSubmit: formSubmitSpy,
+    isSaving: false,
+    onClose: onCloseSpy,
+  };
+
+  beforeEach(() => {
+    wrapper = mount(<BankInfoForm {...defaultProps} />);
+    schemaForm = wrapper.find('SchemaForm');
+  });
+
+  afterEach(() => {
+    wrapper.unmount();
+  });
+
+  it('should render a SchemaForm', () => {
+    expect(schemaForm.exists()).to.be.true;
+  });
+  it("should set the SchemaForm's schema  and uiSchema correctly", () => {
+    expect(schemaForm.props().schema).to.deep.equal(schema);
+    expect(schemaForm.props().uiSchema).to.deep.equal(uiSchema);
+  });
+  it('should pass the formData prop to the SchemaForm', () => {
+    expect(schemaForm.props().data).to.equal(defaultProps.formData);
+  });
+  it('should pass the formSubmit prop to the SchemaForm', () => {
+    expect(schemaForm.props().onSubmit).to.equal(defaultProps.formSubmit);
+  });
+  it('should pass the formChange prop to the SchemaForm', () => {
+    expect(schemaForm.props().onChange).to.equal(defaultProps.formChange);
+  });
+  it("should pass the onClose prop to the SchemaForm's cancel button", () => {
+    const cancelButton = schemaForm.find('button[data-qa="cancel-button"]');
+    expect(cancelButton.props().onClick).to.equal(defaultProps.onClose);
+  });
+  it("should pass the cancelButtonClasses prop to the SchemaForm's cancel button", () => {
+    const cancelButton = schemaForm.find('button[data-qa="cancel-button"]');
+    expect(cancelButton.props().className).to.equal(
+      defaultProps.cancelButtonClasses.join(' '),
+    );
+  });
+  it("should pass the isSaving prop to the SchemaForm's save button", () => {
+    const saveButton = schemaForm.find('LoadingButton');
+    expect(saveButton.props().isLoading).to.equal(defaultProps.isSaving);
+  });
+});


### PR DESCRIPTION
## Description
As part of my work to implement Direct Deposit in Profile 2.0 I pulled out the SchemaForm part of the PaymentInformationEditModal into its own component so I could reuse it. I don't want to muck up that PR with this somewhat unrelated work so I present to you this PR that simply refactors the existing DD edit modal.

## Testing done
Local

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs