### PR TITLE
Remove cookie block from ethics

### DIFF
--- a/src/applications/proxy-rewrite/proxy-rewrite-whitelist.json
+++ b/src/applications/proxy-rewrite/proxy-rewrite-whitelist.json
@@ -54,7 +54,7 @@
     {
       "hostname": "www.ethics.va.gov",
       "pathnameBeginning": "/",
-      "cookieOnly": true
+      "cookieOnly": false
     },
     {
       "hostname": "www.healthquality.va.gov",


### PR DESCRIPTION
## Description
- launches VA.gov header and footer in production for www.ethics.va.gov

## Testing done
On Chrome and IE 11

## Screenshots

### Chrome

![ethics](https://user-images.githubusercontent.com/55560129/81188915-f315c780-8f83-11ea-88a8-98f342d7c951.png)

### IE 11

![ethics IE](https://user-images.githubusercontent.com/55560129/81188932-fa3cd580-8f83-11ea-8e50-e7ea49c2bd99.png)

## Acceptance criteria
- [x] Verify header and footer are added
- [x] Check that most css (specially drop-downs) are still functional

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
