### PR TITLE
Remove cookie block from health quality

### DIFF
--- a/src/applications/proxy-rewrite/proxy-rewrite-whitelist.json
+++ b/src/applications/proxy-rewrite/proxy-rewrite-whitelist.json
@@ -59,7 +59,7 @@
     {
       "hostname": "www.healthquality.va.gov",
       "pathnameBeginning": "/",
-      "cookieOnly": true
+      "cookieOnly": false
     },
     {
       "hostname": "www.hepatitis.va.gov",


### PR DESCRIPTION
## Description
- launches VA.gov header and footer in production for www.healthquality.va.gov

## Testing done
On Chrome and IE 11

## Screenshots

### Chrome

![healthquality](https://user-images.githubusercontent.com/55560129/81189395-80591c00-8f84-11ea-8daf-0b07250350ff.png)

### IE 11

![healthquality IE](https://user-images.githubusercontent.com/55560129/81189410-84853980-8f84-11ea-9b41-7770e71072aa.png)

## Acceptance criteria
- [x] Verify header and footer are added
- [x] Check that most css (specially drop-downs) are still functional

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
