### PR TITLE
Remove cookie block from hepatitis

### DIFF
--- a/src/applications/proxy-rewrite/proxy-rewrite-whitelist.json
+++ b/src/applications/proxy-rewrite/proxy-rewrite-whitelist.json
@@ -64,7 +64,7 @@
     {
       "hostname": "www.hepatitis.va.gov",
       "pathnameBeginning": "/",
-      "cookieOnly": true
+      "cookieOnly": false
     },
     {
       "hostname": "www.hiv.va.gov",


### PR DESCRIPTION
## Description
- launches VA.gov header and footer in production for www.hepatitis.va.gov

## Testing done
On Chrome and IE 11

## Screenshots

### Chrome

![hepatitis](https://user-images.githubusercontent.com/55560129/81189764-f493bf80-8f84-11ea-8c02-ad83da64dec1.png)

### IE 11

![hepatitis IE](https://user-images.githubusercontent.com/55560129/81189776-f8bfdd00-8f84-11ea-9bc7-e7dc0ff0e790.png)

## Acceptance criteria
- [x] Verify header and footer are added
- [x] Check that most css (specially drop-downs) are still functional

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
