### PR TITLE
Calculate benefits scroll on click 

### DIFF
--- a/src/applications/gi/containers/EstimateYourBenefits.jsx
+++ b/src/applications/gi/containers/EstimateYourBenefits.jsx
@@ -11,7 +11,8 @@ import {
   eligibilityChange,
   updateEstimatedBenefits,
 } from '../actions';
-import { focusElement } from 'platform/utilities/ui';
+import { scroller } from 'react-scroll';
+import { focusElement, getScrollOptions } from 'platform/utilities/ui';
 import { getCalculatedBenefits } from '../selectors/calculator';
 import EstimateYourBenefitsForm from '../components/profile/EstimateYourBenefitsForm';
 import EstimatedBenefits from '../components/profile/EstimatedBenefits';
@@ -24,6 +25,7 @@ export class EstimateYourBenefits extends React.Component {
 
   updateEstimatedBenefits = () => {
     this.props.updateEstimatedBenefits(this.props.calculated.outputs);
+    scroller.scrollTo('estimated-benefits', getScrollOptions());
     focusElement('#estimated-benefits');
   };
 


### PR DESCRIPTION
## Description
Update click behavior of "Calculate benefits" button to add scrolling to the "Your estimated benefits" header.

https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/8771

[ZenHub Issue](https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/8771)

## Testing done
Tested locally and QA reviewed

## Screenshots
![image](https://user-images.githubusercontent.com/41960449/81196415-024d4300-8f8d-11ea-9635-440c1b0644f5.png)

## Acceptance criteria
- [x] Clicking the "Calculates benefits" button scrolls to the "Your estimated benefits" header

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
