### PR TITLE
BDD: Make inaccessible from production

### DIFF
--- a/src/applications/disability-benefits/wizard/pages/bdd.jsx
+++ b/src/applications/disability-benefits/wizard/pages/bdd.jsx
@@ -3,6 +3,9 @@ import moment from 'moment';
 import ErrorableDate from '@department-of-veterans-affairs/formation-react/ErrorableDate';
 import { pageNames } from './pageList';
 
+import environment from 'platform/utilities/environment';
+import unableToFileBDD from './unable-to-file-bdd';
+
 // Figure out which page to go to based on the date entered
 const findNextPage = state => {
   const dateDischarge = moment({
@@ -48,6 +51,11 @@ const BDDPage = ({ setPageState, state = defaultState }) => {
       pageState,
       isDateComplete(pageState) ? findNextPage(pageState) : undefined,
     );
+
+  if (environment.isProduction()) {
+    return <unableToFileBDD.component />;
+  }
+
   return (
     <ErrorableDate
       label="Date or anticipated date of release from active duty"

--- a/src/applications/disability-benefits/wizard/pages/unable-to-file-bdd.jsx
+++ b/src/applications/disability-benefits/wizard/pages/unable-to-file-bdd.jsx
@@ -7,6 +7,8 @@ import { isLoggedIn as isLoggedInSelector } from 'platform/user/selectors';
 import recordEvent from 'platform/monitoring/record-event';
 import { EBEN_526_URL, BDD_INFO_URL } from '../../constants';
 
+import environment from 'platform/utilities/environment';
+
 const dateFormat = 'MMMM DD, YYYY';
 const ninetyDays = moment()
   .add(90, 'days')
@@ -16,6 +18,37 @@ const oneHundredEightyDays = moment()
   .format(dateFormat);
 
 function alertContent(isLoggedIn) {
+  if (environment.isProduction()) {
+    return (
+      <>
+        <p>
+          <strong>
+            If your separation date is between {ninetyDays} and{' '}
+            {oneHundredEightyDays}
+          </strong>{' '}
+          (90 and 180 days from today), you can file a disability claim through
+          the Benefits Delivery at Discharge (BDD) program.
+        </p>
+        <p>
+          <strong>If your separation date is before {ninetyDays},</strong> you
+          can't file a BDD claim, but you can still begin the process of filing
+          your claim on eBenefits.
+        </p>
+        <a
+          href={EBEN_526_URL}
+          className="usa-button-primary va-button-primary"
+          onClick={() =>
+            isLoggedIn && recordEvent({ event: 'nav-ebenefits-click' })
+          }
+        >
+          Go to eBenefits
+        </a>
+        <p>
+          <a href={BDD_INFO_URL}>Learn more about the BDD program</a>
+        </p>
+      </>
+    );
+  }
   return (
     <>
       <p>
@@ -47,7 +80,7 @@ function alertContent(isLoggedIn) {
 
 const UnableToFileBDDPage = ({ isLoggedIn }) => (
   <AlertBox
-    status="error"
+    status="warning"
     headline="You’ll need to file a claim on eBenefits"
     content={alertContent(isLoggedIn)}
   />

--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -350,7 +350,8 @@
           "name": "File for Benefits Delivery at Discharge",
           "path": "disability/file-benefits-delivery-at-discharge-form-21-526ez"
         }
-      ]
+      ],
+      "vagovprod": false
     }
   },
   {


### PR DESCRIPTION
## Description
This pull request makes changes to the BDD form and gating to only show the form in staging and only allow users into the form via gating in staging. All access to the form is hidden in production. This means that the BDD branch can be merged into master. This pull request also changes the BDD gating message to be a warning instead of an error.

## Acceptance criteria
- [ ] BDD form is flagged to not appear in production
- [ ] BDD gating will direct users to eBenefits in production
- [ ] BDD alert messaging on gating screen is changed to a "warning"