### PR TITLE
Add event tracking for nav item clicks

### DIFF
--- a/src/platform/site-wide/side-nav/components/NavItemRow.js
+++ b/src/platform/site-wide/side-nav/components/NavItemRow.js
@@ -54,9 +54,9 @@ const NavItemRow = ({ depth, item, toggleItemExpanded }) => {
           expanded: !moreThanLevel2SelectedExpanded && isExpanded,
           open: moreThanLevel2SelectedExpanded,
         })}
+        href={href}
         onClick={toggleItemExpanded(id)}
         rel="noopener noreferrer"
-        href={href}
         style={{ paddingLeft: indentation }}
       >
         {/* Label text */}
@@ -78,8 +78,9 @@ const NavItemRow = ({ depth, item, toggleItemExpanded }) => {
       className={classNames('va-sidenav-item-label', {
         open: !!(depth >= 2 && isSelected),
       })}
-      rel="noopener noreferrer"
       href={href}
+      onClick={toggleItemExpanded(id)}
+      rel="noopener noreferrer"
       style={{ paddingLeft: indentation }}
     >
       {/* Label text */}

--- a/src/platform/site-wide/side-nav/components/SideNav.js
+++ b/src/platform/site-wide/side-nav/components/SideNav.js
@@ -2,6 +2,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import recordEvent from 'platform/monitoring/record-event';
 import { find, filter, get, map, orderBy } from 'lodash';
 // Relative
 import NavItem from './NavItem';
@@ -13,10 +14,9 @@ class SideNav extends Component {
 
   constructor(props) {
     super(props);
-    this.toggleUlClass = this.toggleUlClass.bind(this);
     this.state = {
-      navItemsLookup: props.navItemsLookup,
       active: false,
+      navItemsLookup: props.navItemsLookup,
     };
   }
 
@@ -28,30 +28,57 @@ class SideNav extends Component {
     const hasChildren = get(navItem, 'hasChildren');
     const expanded = get(navItem, 'expanded');
     const depth = get(navItem, 'depth');
+    const label = get(navItem, 'label');
+    const parentID = get(navItem, 'parentID');
+
+    // Derive the parent item and its properties.
+    const parentItem = get(navItemsLookup, `[${parentID}]`);
+    const parentLabel = get(parentItem, 'label');
 
     // Determine if the nav item is top-level.
-    const isTopNavItem = depth < 2;
+    const isTopNavItem = depth <= 1;
 
-    // Escape early if the item has no children or is not collapsible.
-    if (!hasChildren || isTopNavItem) {
+    // Escape early if the item is a top nav item.
+    if (isTopNavItem) {
       return;
     }
 
-    // Flip the item's expanded property.
-    this.setState({
-      navItemsLookup: {
-        ...navItemsLookup,
-        [id]: {
-          ...navItemsLookup[id],
-          expanded: !expanded,
+    // Escape early if the item has children.
+    if (hasChildren) {
+      // Track expand/collapse.
+      recordEvent({
+        event: `nav-sidenav-dropdown-${expanded ? 'collapse' : 'expand'}`,
+        'sidenav-dropdown-header': label,
+      });
+
+      // Flip the item's expanded property.
+      this.setState({
+        navItemsLookup: {
+          ...navItemsLookup,
+          [id]: {
+            ...navItemsLookup[id],
+            expanded: !expanded,
+          },
         },
-      },
+      });
+      return;
+    }
+
+    // Track non-nested sidenav item click: https://github.com/department-of-veterans-affairs/va.gov-team/issues/7643
+    if (depth === 2) {
+      recordEvent({ event: 'nav-sidenav' });
+      return;
+    }
+
+    // Track item with no children click.
+    recordEvent({
+      event: 'nav-sidenav-child',
+      'sidenav-dropdown-header': parentLabel,
     });
   };
 
   toggleUlClass = () => {
-    const currentState = this.state.active;
-    this.setState({ active: !currentState });
+    this.setState({ active: !this.state.active });
   };
 
   renderChildItems = (parentID, depth) => {
@@ -74,6 +101,7 @@ class SideNav extends Component {
         key={get(item, 'id')}
         renderChildItems={this.renderChildItems}
         sortedNavItems={sortedNavItems}
+        toggleItemExpanded={this.toggleItemExpanded}
       />
     ));
   };
@@ -94,8 +122,8 @@ class SideNav extends Component {
     return (
       <div
         className={classNames(
-          `va-sidenav-wrapper usa-width-one-fourth va-sidenav vads-u-margin--1 medium-screen:vads-u-height--auto medium-screen:vads-u-margin-y--0 medium-screen:vads-u-margin-left--0 medium-screen:vads-u-margin-right--2p5 ${
-            this.state.active ? `va-sidenav-height` : null
+          `va-sidenav-wrapper usa-width-one-fourth va-sidenav vads-u-margin--1 medium-screen:vads-u-height--auto medium-screen  :vads-u-margin-y--0 medium-screen:vads-u-margin-left--0 m  edium-screen:vads-u-mar  gin-right--2p5   ${
+          this.state.active ? `va-side  n  av-height` : null
           }`,
         )}
       >

--- a/src/platform/site-wide/side-nav/components/SideNav.js
+++ b/src/platform/site-wide/side-nav/components/SideNav.js
@@ -122,16 +122,26 @@ class SideNav extends Component {
     return (
       <div
         className={classNames(
-          `va-sidenav-wrapper usa-width-one-fourth va-sidenav vads-u-margin--1 medium-screen:vads-u-height--auto medium-screen  :vads-u-margin-y--0 medium-screen:vads-u-margin-left--0 m  edium-screen:vads-u-mar  gin-right--2p5   ${
-          this.state.active ? `va-side  n  av-height` : null
-          }`,
+          'medium-screen:vads-u-height--auto',
+          'medium-screen:vads-u-margin-left--0',
+          'medium-screen:vads-u-margin-right--2p5',
+          'medium-screen:vads-u-margin-y--0',
+          'usa-width-one-fourth',
+          'va-sidenav',
+          'va-sidenav-wrapper',
+          'vads-u-margin--1',
+          {
+            'va-sidenav-height': !!this.state.active,
+          },
         )}
       >
         <button
           type="button"
           aria-describedby="va-sidenav-ul-container"
           className={classNames(
-            `vads-u-color--primary medium-screen:vads-u-display--none va-sidenav-default-trigger`,
+            'medium-screen:vads-u-display--none',
+            'va-sidenav-default-trigger',
+            'vads-u-color--primary',
           )}
           onClick={this.toggleUlClass}
         >
@@ -140,12 +150,16 @@ class SideNav extends Component {
         <ul
           id="va-sidenav-ul-container"
           className={classNames(
-            `va-sidenav vads-u-margin-top--0 vads-u-padding--0`,
+            'va-sidenav',
+            'vads-u-margin-top--0',
+            'vads-u-padding--0',
           )}
         >
           <div
             className={classNames(
-              `va-sidenav-display-onclick-line medium-screen:vads-u-display--none line`,
+              'line',
+              'medium-screen:vads-u-display--none',
+              'va-sidenav-display-onclick-line',
             )}
           />
           {/* Render all the items recursively. */}


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/7643

This PR adds GA event tracking for nav item clicks:

Interaction | Screenshot | Datalayer Requirements
------------ | -------------  | -------------
Clicks on Left Nav Dropdowns - Expands | ![image](https://user-images.githubusercontent.com/48527022/78256205-37fe9800-74c6-11ea-8373-300a0cc5b237.png) | ```dataLayer.push({```<br>```'event':'nav-sidenav-dropdown-expand',```<br>```'sidenav-dropdown-header': 'About us'});```
Clicks on Left Nav Dropdowns - Collapses | ![image](https://user-images.githubusercontent.com/48527022/78256916-29fd4700-74c7-11ea-9f80-b8667574001b.png) | ```dataLayer.push({```<br>```'event':'nav-sidenav-dropdown-collapse',```<br>```'sidenav-dropdown-header': 'About us'});```
Clicks on Left Nav - Child | ![image](https://user-images.githubusercontent.com/48527022/78258934-f8d24600-74c9-11ea-9695-94224b21f703.png)) | ```dataLayer.push({```<br>```'event':'nav-sidenav-child,```<br>```'sidenav-dropdown-header': 'Locations'});```
Clicks on Left Nav - Content Only | ![image](https://user-images.githubusercontent.com/48527022/78259925-5024e600-74cb-11ea-8274-5b1eda85548a.png) | ```dataLayer.push({```<br>```'event':'nav-sidenav'});```

One caveat is that it looks like the updated UI doesn't support collapsing the SideNav, so that event will likely never fire.

## Testing done


## Screenshots


## Acceptance criteria
- [x] Add GA events for nav item clicks.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
