### PR TITLE
updating the SSO Info Modal to toggle on the ssoe feature flag

### DIFF
--- a/src/platform/site-wide/announcements/components/SingleSignOnInfoModal.jsx
+++ b/src/platform/site-wide/announcements/components/SingleSignOnInfoModal.jsx
@@ -1,9 +1,12 @@
 import React from 'react';
 import Modal from '@department-of-veterans-affairs/formation-react/Modal';
-import { hasSessionSSO } from 'platform/user/profile/utilities';
 
-export default function SingleSignOnInfoModal({ dismiss, isLoggedIn }) {
-  if (!isLoggedIn || !hasSessionSSO()) return null;
+export default function SingleSignOnInfoModal({
+  dismiss,
+  isLoggedIn,
+  useSSOe,
+}) {
+  if (!isLoggedIn || !useSSOe) return null;
 
   return (
     <Modal visible onClose={dismiss} id="modal-announcment">

--- a/src/platform/site-wide/announcements/containers/Announcement.jsx
+++ b/src/platform/site-wide/announcements/containers/Announcement.jsx
@@ -2,6 +2,8 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
+
+import { ssoe } from 'platform/user/authentication/selectors';
 // Relative imports.
 import { isLoggedIn, selectProfile } from '../../../user/selectors';
 import { selectAnnouncement } from '../selectors';
@@ -74,6 +76,7 @@ const mapStateToProps = state => ({
   announcement: selectAnnouncement(state),
   isLoggedIn: isLoggedIn(state),
   profile: selectProfile(state),
+  useSSOe: ssoe(state),
   ...state.announcements,
 });
 

--- a/src/platform/site-wide/announcements/tests/components/SingleSignOnInfoModal.unit.spec.jsx
+++ b/src/platform/site-wide/announcements/tests/components/SingleSignOnInfoModal.unit.spec.jsx
@@ -3,14 +3,9 @@ import { expect } from 'chai';
 import { mount } from 'enzyme';
 import sinon from 'sinon';
 
-import localStorage from 'platform/utilities/storage/localStorage';
 import SingleSignOnInfoModal from '../../components/SingleSignOnInfoModal';
 
 describe('Announcements <SingleSignOnInfoModal>', () => {
-  afterEach(() => {
-    localStorage.clear();
-  });
-
   it('does not render for users that are logged in but without SSO', () => {
     const tree = mount(<SingleSignOnInfoModal isLoggedIn />);
 
@@ -20,10 +15,11 @@ describe('Announcements <SingleSignOnInfoModal>', () => {
   });
 
   it('renders for logged in SSO users', () => {
-    localStorage.setItem('hasSessionSSO', true);
     const dismiss = sinon.spy();
 
-    const tree = mount(<SingleSignOnInfoModal isLoggedIn dismiss={dismiss} />);
+    const tree = mount(
+      <SingleSignOnInfoModal isLoggedIn dismiss={dismiss} useSSOe />,
+    );
 
     expect(tree.text()).to.contain(
       'Sign in once to access the VA sites you use most',
@@ -33,10 +29,11 @@ describe('Announcements <SingleSignOnInfoModal>', () => {
   });
 
   it('closes when the dismiss handler is fired', () => {
-    localStorage.setItem('hasSessionSSO', true);
     const dismiss = sinon.spy();
 
-    const tree = mount(<SingleSignOnInfoModal isLoggedIn dismiss={dismiss} />);
+    const tree = mount(
+      <SingleSignOnInfoModal isLoggedIn dismiss={dismiss} useSSOe />,
+    );
 
     tree
       .find('button')


### PR DESCRIPTION
Right now its checking to see if the user has a sso session in their local storage.  Because the call to set this only happens if both the `ssoe` and `ssoeInbound` feature flags are set, the info modal won't show for users with `ssoeInbound` disabled.
