### PR TITLE
Fetch cms export

### DIFF
--- a/package.json
+++ b/package.json
@@ -296,6 +296,7 @@
     "reselect": "^2.5.4",
     "sanitize-html": "^1.20.1",
     "syswide-cas": "^5.3.0",
+    "tar-fs": "^2.0.1",
     "tinyliquid": "^0.2.33",
     "url-search-params": "^0.10.0",
     "uswds": "1.6.10",

--- a/script/test-cms-export.js
+++ b/script/test-cms-export.js
@@ -1,11 +1,10 @@
-// Dependencies
+const path = require('path');
 const assert = require('assert');
 const commandLineArgs = require('command-line-args');
 const { map } = require('lodash');
-// Relative
-const {
-  contentDir,
-} = require('../src/site/stages/build/process-cms-exports/helpers');
+
+const contentDir = path.resolve(__dirname, '../../cms-export/content');
+
 const assembleEntityTree = require('../src/site/stages/build/process-cms-exports')(
   contentDir,
 );
@@ -45,7 +44,7 @@ if (nodeName) {
     assert(printIndex >= 0, `Print index (${printIndex}) must be >= 0`);
   }
 
-  const fileNames = readAllNodeNames();
+  const fileNames = readAllNodeNames(contentDir);
   const entities = map(fileNames, entityDetails =>
     readEntity(contentDir, ...entityDetails),
   );

--- a/src/site/stages/build/drupal/api.js
+++ b/src/site/stages/build/drupal/api.js
@@ -113,9 +113,9 @@ function getDrupalClient(buildOptions) {
      *
      * @return {String} - The path to the untarred CMS export.
      */
-    async fetchExportContent({ log } = { log: true }) {
+    async fetchExportContent({ debug } = { debug: false }) {
       /* eslint-disable no-console */
-      const say = log ? console.log : () => {};
+      const say = debug ? console.log : () => {};
 
       say(
         chalk.green('Fetching content export from'),
@@ -172,7 +172,15 @@ function getDrupalClient(buildOptions) {
       });
     },
 
-    getNonNodeContent(onlyPublishedContent = true) {
+    getNonNodeContent(
+      { onlyPublishedContent, debug } = {
+        onlyPublishedContent: true,
+        debug: false,
+      },
+    ) {
+      // eslint-disable-next-line no-console
+      const say = debug ? console.log : () => {};
+      say('Querying for non-node content');
       return this.query({
         query: getQuery(queries.GET_ALL_PAGES, { useTomeSync: true }),
         variables: {
@@ -181,7 +189,10 @@ function getDrupalClient(buildOptions) {
       });
     },
 
-    getExportedPages() {
+    getExportedPages({ debug } = { debug: true }) {
+      // eslint-disable-next-line no-console
+      const say = debug ? console.log : () => {};
+      say('Transforming CMS export');
       const contentDir = buildOptions['cms-export-dir'];
       const entities = readAllNodeNames(contentDir).map(entityDetails =>
         readEntity(contentDir, ...entityDetails),

--- a/src/site/stages/build/drupal/api.js
+++ b/src/site/stages/build/drupal/api.js
@@ -137,6 +137,7 @@ function getDrupalClient(buildOptions) {
         );
         await new Promise(resolve => {
           const parentPath = path.join(buildOptions['cms-export-dir'], '..');
+          fs.ensureDirSync(parentPath);
           // This untars to parentDir/cms-export-content/ because the tarball
           // contains a single directory named cms-export-content.
           response.body.pipe(tar.extract(parentPath));

--- a/src/site/stages/build/drupal/api.js
+++ b/src/site/stages/build/drupal/api.js
@@ -9,7 +9,7 @@ const { queries, getQuery } = require('./queries');
 const syswidecas = require('syswide-cas');
 
 const {
-  contentDir,
+  getContentDir,
   readAllNodeNames,
   readEntity,
 } = require('../process-cms-exports/helpers');
@@ -125,11 +125,11 @@ function getDrupalClient(buildOptions) {
     },
 
     getExportedPages() {
-      const exportDir = buildOptions['cms-export-dir'] || contentDir;
+      const exportDir = buildOptions['cms-export-dir'];
       const entities = readAllNodeNames(exportDir).map(entityDetails =>
         readEntity(exportDir, ...entityDetails),
       );
-      const assembleEntityTree = entityTreeFactory(exportDir || contentDir);
+      const assembleEntityTree = entityTreeFactory(getContentDir(exportDir));
 
       const modifiedEntities = entities.map(entity =>
         assembleEntityTree(entity),

--- a/src/site/stages/build/drupal/metalsmith-drupal.js
+++ b/src/site/stages/build/drupal/metalsmith-drupal.js
@@ -225,12 +225,12 @@ async function getContentFromExport(buildOptions) {
   const contentApi = getApiClient(buildOptions);
 
   if (shouldPullDrupal(buildOptions)) {
-    await contentApi.fetchExportContent({ debug: true });
+    await contentApi.fetchExportContent();
   }
 
-  const drupalPages = await contentApi.getNonNodeContent({ debug: true });
+  const drupalPages = await contentApi.getNonNodeContent();
   drupalPages.data.nodeQuery = {
-    entities: contentApi.getExportedPages({ debug: true }),
+    entities: contentApi.getExportedPages(),
   };
 
   return drupalPages;

--- a/src/site/stages/build/drupal/metalsmith-drupal.js
+++ b/src/site/stages/build/drupal/metalsmith-drupal.js
@@ -303,6 +303,7 @@ function getDrupalContent(buildOptions) {
       log('Failed to pipe Drupal content into Metalsmith!');
       if (
         buildOptions.buildtype !== ENVIRONMENTS.LOCALHOST ||
+        buildOptions[USE_CMS_EXPORT_BUILD_ARG] ||
         buildOptions['drupal-fail-fast']
       ) {
         done(err);

--- a/src/site/stages/build/drupal/metalsmith-drupal.js
+++ b/src/site/stages/build/drupal/metalsmith-drupal.js
@@ -41,8 +41,7 @@ const getDrupalCachePath = buildOptions =>
 // the content is not available in the cache.
 const shouldPullDrupal = buildOptions =>
   buildOptions[PULL_DRUPAL_BUILD_ARG] ||
-  (!fs.existsSync(getDrupalCachePath(buildOptions)) &&
-    buildOptions.buildtype !== ENVIRONMENTS.LOCALHOST); // Don't require a cache to build locally.
+  !fs.existsSync(getDrupalCachePath(buildOptions));
 
 function pipeDrupalPagesIntoMetalsmith(contentData, files) {
   const {

--- a/src/site/stages/build/drupal/metalsmith-drupal.js
+++ b/src/site/stages/build/drupal/metalsmith-drupal.js
@@ -227,6 +227,9 @@ async function getContentFromExport(buildOptions) {
 
   if (shouldPullDrupal(buildOptions)) {
     // TODO: Download and untar the latest content export
+    await contentApi.fetchExportContent();
+    // TODO: Time the response time and log it
+    // May do this as by passing a { log: true } to fetchExportContents
   }
 
   const drupalPages = await contentApi.getNonNodeContent();

--- a/src/site/stages/build/drupal/metalsmith-drupal.js
+++ b/src/site/stages/build/drupal/metalsmith-drupal.js
@@ -226,15 +226,12 @@ async function getContentFromExport(buildOptions) {
   const contentApi = getApiClient(buildOptions);
 
   if (shouldPullDrupal(buildOptions)) {
-    // TODO: Download and untar the latest content export
-    await contentApi.fetchExportContent();
-    // TODO: Time the response time and log it
-    // May do this as by passing a { log: true } to fetchExportContents
+    await contentApi.fetchExportContent({ debug: true });
   }
 
-  const drupalPages = await contentApi.getNonNodeContent();
+  const drupalPages = await contentApi.getNonNodeContent({ debug: true });
   drupalPages.data.nodeQuery = {
-    entities: contentApi.getExportedPages(),
+    entities: contentApi.getExportedPages({ debug: true }),
   };
 
   return drupalPages;

--- a/src/site/stages/build/drupal/metalsmith-drupal.js
+++ b/src/site/stages/build/drupal/metalsmith-drupal.js
@@ -32,19 +32,17 @@ const PULL_DRUPAL_BUILD_ARG = 'pull-drupal';
 const USE_CMS_EXPORT_BUILD_ARG = 'use-cms-export';
 const CMS_EXPORT_DIR_BUILD_ARG = 'cms-export-dir';
 
-// We need to pull the Drupal content if we have --pull-drupal or --use-cms-export, OR if
-// the content is not available in the cache.
-const shouldPullDrupal = buildOptions => {
-  const drupalCache = buildOptions[USE_CMS_EXPORT_BUILD_ARG]
+const getDrupalCachePath = buildOptions =>
+  buildOptions[USE_CMS_EXPORT_BUILD_ARG]
     ? buildOptions[CMS_EXPORT_DIR_BUILD_ARG]
     : path.join(buildOptions.cacheDirectory, DRUPAL_CACHE_FILENAME);
-  const isDrupalAvailableInCache = fs.existsSync(drupalCache);
-  return (
-    buildOptions[PULL_DRUPAL_BUILD_ARG] ||
-    (!isDrupalAvailableInCache &&
-      buildOptions.buildtype !== ENVIRONMENTS.LOCALHOST) // Don't require a cache to build locally.
-  );
-};
+
+// We need to pull the Drupal content if we have --pull-drupal or --use-cms-export, OR if
+// the content is not available in the cache.
+const shouldPullDrupal = buildOptions =>
+  buildOptions[PULL_DRUPAL_BUILD_ARG] ||
+  (!fs.existsSync(getDrupalCachePath(buildOptions)) &&
+    buildOptions.buildtype !== ENVIRONMENTS.LOCALHOST); // Don't require a cache to build locally.
 
 function pipeDrupalPagesIntoMetalsmith(contentData, files) {
   const {
@@ -161,29 +159,24 @@ function pipeDrupalPagesIntoMetalsmith(contentData, files) {
   }
 }
 
-async function loadDrupal(buildOptions) {
+/**
+ * Uses Drupal content via a new GraphQL query or the cached result of a
+ * previous query. This is where the cache is saved.
+ *
+ * @param {Object} buildOptions
+ * @return {Object} - The result of the GraphQL query
+ */
+async function getContentViaGraphQL(buildOptions) {
   const contentApi = getApiClient(buildOptions);
-  const drupalCache = path.join(
-    buildOptions.cacheDirectory,
-    DRUPAL_CACHE_FILENAME,
-  );
+  const drupalCache = getDrupalCachePath(buildOptions);
   const drupalHubMenuNames = path.join(
     buildOptions.paramsDirectory,
     DRUPAL_HUB_NAV_FILENAME,
   );
 
-  const isDrupalAvailableInCache = fs.existsSync(drupalCache);
-
-  const shouldPull = shouldPullDrupal(buildOptions);
   let drupalPages = null;
 
-  if (!isDrupalAvailableInCache) {
-    log(`Drupal content unavailable in local cache: ${drupalCache}`);
-  } else {
-    log(`Drupal content cache found: ${drupalCache}`);
-  }
-
-  if (shouldPull) {
+  if (shouldPullDrupal(buildOptions)) {
     log(
       `Attempting to load Drupal content from API at ${contentApi.getSiteUri()}`,
     );
@@ -192,22 +185,17 @@ async function loadDrupal(buildOptions) {
 
     console.time(drupalTimer);
 
-    if (buildOptions[USE_CMS_EXPORT_BUILD_ARG]) {
-      drupalPages = await contentApi.getNonNodeContent();
-      drupalPages.data.nodeQuery = {
-        entities: contentApi.getExportedPages(),
-      };
-    } else {
-      drupalPages = await contentApi.getAllPages();
-    }
+    drupalPages = await contentApi.getAllPages();
 
     console.timeEnd(drupalTimer);
 
+    // Error handling
     if (drupalPages.errors && drupalPages.errors.length) {
       log(JSON.stringify(drupalPages.errors, null, 2));
       throw new Error('Drupal query returned with errors');
     }
 
+    // Save new cache
     fs.outputJsonSync(drupalCache, drupalPages, { spaces: 2 });
 
     if (drupalPages.data.allSideNavMachineNamesQuery) {
@@ -224,6 +212,43 @@ async function loadDrupal(buildOptions) {
     // eslint-disable-next-line import/no-dynamic-require
     drupalPages = require(drupalCache);
   }
+
+  return drupalPages;
+}
+
+/**
+ * Use Drupal content via the CMS export. Fetch and untar the CMS export as needed.
+ *
+ * @param {Object} buildOptions
+ * @return {Object} - The transformed content from the cms export
+ */
+async function getContentFromExport(buildOptions) {
+  const contentApi = getApiClient(buildOptions);
+
+  if (shouldPullDrupal(buildOptions)) {
+    // TODO: Download and untar the latest content export
+  }
+
+  const drupalPages = await contentApi.getNonNodeContent();
+  drupalPages.data.nodeQuery = {
+    entities: contentApi.getExportedPages(),
+  };
+
+  return drupalPages;
+}
+
+async function loadDrupal(buildOptions) {
+  const drupalCache = getDrupalCachePath(buildOptions);
+
+  if (!fs.existsSync(drupalCache)) {
+    log(`Drupal content unavailable in local cache: ${drupalCache}`);
+  } else {
+    log(`Drupal content cache found: ${drupalCache}`);
+  }
+
+  const drupalPages = buildOptions[USE_CMS_EXPORT_BUILD_ARG]
+    ? await getContentFromExport(buildOptions)
+    : await getContentViaGraphQL(buildOptions);
 
   log('Drupal successfully loaded!');
   return drupalPages;
@@ -258,14 +283,10 @@ function getDrupalContent(buildOptions) {
     return noop;
   }
 
-  // Declared above the middleware scope so that it's cached during the watch task.
-  let drupalData = null;
-
   return async (files, metalsmith, done) => {
+    let drupalData = null;
     try {
-      if (!drupalData) {
-        drupalData = await loadDrupal(buildOptions);
-      }
+      drupalData = await loadDrupal(buildOptions);
       drupalData = convertDrupalFilesToLocal(drupalData, files, buildOptions);
 
       await loadCachedDrupalFiles(buildOptions, files);

--- a/src/site/stages/build/drupal/metalsmith-drupal.js
+++ b/src/site/stages/build/drupal/metalsmith-drupal.js
@@ -28,20 +28,19 @@ const DRUPAL_HUB_NAV_FILENAME = 'hubNavNames.json';
 // should pull the latest Drupal data.
 const PULL_DRUPAL_BUILD_ARG = 'pull-drupal';
 // If "--use-cms-export" is passed into the build args, then the build
-// should use the files in the tome-sync export directory
+// should use the files in the cms-export directory
 const USE_CMS_EXPORT_BUILD_ARG = 'use-cms-export';
+const CMS_EXPORT_DIR_BUILD_ARG = 'cms-export-dir';
 
 // We need to pull the Drupal content if we have --pull-drupal or --use-cms-export, OR if
 // the content is not available in the cache.
 const shouldPullDrupal = buildOptions => {
-  const drupalCache = path.join(
-    buildOptions.cacheDirectory,
-    DRUPAL_CACHE_FILENAME,
-  );
+  const drupalCache = buildOptions[USE_CMS_EXPORT_BUILD_ARG]
+    ? buildOptions[CMS_EXPORT_DIR_BUILD_ARG]
+    : path.join(buildOptions.cacheDirectory, DRUPAL_CACHE_FILENAME);
   const isDrupalAvailableInCache = fs.existsSync(drupalCache);
   return (
     buildOptions[PULL_DRUPAL_BUILD_ARG] ||
-    buildOptions[USE_CMS_EXPORT_BUILD_ARG] ||
     (!isDrupalAvailableInCache &&
       buildOptions.buildtype !== ENVIRONMENTS.LOCALHOST) // Don't require a cache to build locally.
   );

--- a/src/site/stages/build/options.js
+++ b/src/site/stages/build/options.js
@@ -14,7 +14,7 @@ const defaultContentDir = '../../../../../vagov-content/pages';
 
 const getDrupalClient = require('./drupal/api');
 const { shouldPullDrupal } = require('./drupal/metalsmith-drupal');
-const { exportDir } = require('./process-cms-exports/helpers');
+const { defaultCMSExportContentDir } = require('./process-cms-exports/helpers');
 const { logDrupal } = require('./drupal/utilities-drupal');
 const { useFlags } = require('./drupal/load-saved-flags');
 
@@ -63,7 +63,7 @@ function gatherFromCommandLine() {
 
   // Set defaults which require the value of other options
   options['cms-export-dir'] =
-    options['cms-export-dir'] || exportDir(options.buildtype);
+    options['cms-export-dir'] || defaultCMSExportContentDir(options.buildtype);
 
   if (options.unexpected && options.unexpected.length !== 0) {
     throw new Error(`Unexpected arguments: '${options.unexpected}'`);

--- a/src/site/stages/build/options.js
+++ b/src/site/stages/build/options.js
@@ -69,8 +69,6 @@ function gatherFromCommandLine() {
     throw new Error(`Unexpected arguments: '${options.unexpected}'`);
   }
 
-  process.env.buildOptions = options;
-
   return options;
 }
 

--- a/src/site/stages/build/options.js
+++ b/src/site/stages/build/options.js
@@ -64,6 +64,8 @@ function gatherFromCommandLine() {
     throw new Error(`Unexpected arguments: '${options.unexpected}'`);
   }
 
+  process.env.buildOptions = options;
+
   return options;
 }
 

--- a/src/site/stages/build/options.js
+++ b/src/site/stages/build/options.js
@@ -14,6 +14,7 @@ const defaultContentDir = '../../../../../vagov-content/pages';
 
 const getDrupalClient = require('./drupal/api');
 const { shouldPullDrupal } = require('./drupal/metalsmith-drupal');
+const { exportDir } = require('./process-cms-exports/helpers');
 const { logDrupal } = require('./drupal/utilities-drupal');
 const { useFlags } = require('./drupal/load-saved-flags');
 
@@ -32,7 +33,7 @@ const COMMAND_LINE_OPTIONS_DEFINITIONS = [
   { name: 'content-directory', type: String, defaultValue: defaultContentDir },
   { name: 'pull-drupal', type: Boolean, defaultValue: false },
   { name: 'use-cms-export', type: Boolean, defaultValue: false },
-  { name: 'cms-export-dir', type: String, defaultValue: false },
+  { name: 'cms-export-dir', type: String, defaultValue: null },
   { name: 'drupal-fail-fast', type: Boolean, defaultValue: false },
   {
     name: 'drupal-address',
@@ -59,6 +60,10 @@ const COMMAND_LINE_OPTIONS_DEFINITIONS = [
 
 function gatherFromCommandLine() {
   const options = commandLineArgs(COMMAND_LINE_OPTIONS_DEFINITIONS);
+
+  // Set defaults which require the value of other options
+  options['cms-export-dir'] =
+    options['cms-export-dir'] || exportDir(options.buildtype);
 
   if (options.unexpected && options.unexpected.length !== 0) {
     throw new Error(`Unexpected arguments: '${options.unexpected}'`);

--- a/src/site/stages/build/process-cms-exports/helpers.js
+++ b/src/site/stages/build/process-cms-exports/helpers.js
@@ -4,24 +4,16 @@ const path = require('path');
 const get = require('lodash/get');
 
 /**
- * The path to the CMS export.
+ * The path to the CMS export content.
  *
  * @param {String} buildtype - The build type
- * @return {String} - The path to the saved CMS export directory
+ * @return {String} - The path to the saved CMS export content
  */
-const exportDir = buildtype =>
-  path.join(__dirname, `../../../../../.cache/${buildtype}/cms-export/`);
-
-/**
- * The path to the directory with all the JSON files from the CMS export.
- *
- * NOTE: This is just a subdirectory of the cmsExportDirectory.
- *
- * @param {String} cmsExportDirectory - The path to the extracted cms export
- * @return {String} - The path to the content/ subdirectory in the cms export directory
- */
-const getContentDir = cmsExportDirectory =>
-  path.join(cmsExportDirectory, 'content');
+const defaultCMSExportContentDir = buildtype =>
+  path.join(
+    __dirname,
+    `../../../../../.cache/${buildtype}/cms-export-content/`,
+  );
 
 /**
  * The sub-type can be found in a few different properties, depending
@@ -50,8 +42,7 @@ function getContentModelType(entity) {
 }
 
 module.exports = {
-  exportDir,
-  getContentDir,
+  defaultCMSExportContentDir,
   typeProperties,
   getContentModelType,
 

--- a/src/site/stages/build/process-cms-exports/helpers.js
+++ b/src/site/stages/build/process-cms-exports/helpers.js
@@ -116,11 +116,16 @@ module.exports = {
   },
 
   /**
-   * Get all the starting nodes
+   * Get all the starting node IDs.
+   *
+   * @param {String} dir - The path to the directory with the content JSON files
+   * @return {String[][]} - An array of tuples consisting of the entity type
+   *                        (always "node") and UUID.
+   *                        E.g. [["node", "123"], ["node", "456"]]
    */
-  readAllNodeNames(dirName = contentDir) {
+  readAllNodeNames(dir) {
     return fs
-      .readdirSync(dirName)
+      .readdirSync(dir)
       .filter(name => name.startsWith('node'))
       .map(name => name.split('.').slice(0, 2));
   },

--- a/src/site/stages/build/process-cms-exports/helpers.js
+++ b/src/site/stages/build/process-cms-exports/helpers.js
@@ -9,7 +9,7 @@ const get = require('lodash/get');
  */
 const contentDir = path.join(
   __dirname,
-  '../../../../../../tome-sync-output/content/',
+  '../../../../../../cms-export/content/',
 );
 
 /**

--- a/src/site/stages/build/process-cms-exports/helpers.js
+++ b/src/site/stages/build/process-cms-exports/helpers.js
@@ -4,13 +4,14 @@ const path = require('path');
 const get = require('lodash/get');
 
 /**
- * This assumes the tome-sync output is sibling to the vets-website
- * directory.
+ * Where to find the cms-export
  */
-const contentDir = path.join(
+const exportDir = path.join(
   __dirname,
-  '../../../../../../cms-export/content/',
+  `../../../../../.cache/${process.env.buildOptions &&
+    process.env.buildOptions.buildType}/cms-export/`,
 );
+const contentDir = path.join(exportDir, 'content');
 
 /**
  * The sub-type can be found in a few different properties, depending
@@ -39,6 +40,7 @@ function getContentModelType(entity) {
 }
 
 module.exports = {
+  exportDir,
   contentDir,
   typeProperties,
   getContentModelType,

--- a/src/site/stages/build/process-cms-exports/helpers.js
+++ b/src/site/stages/build/process-cms-exports/helpers.js
@@ -4,14 +4,24 @@ const path = require('path');
 const get = require('lodash/get');
 
 /**
- * Where to find the cms-export
+ * The path to the CMS export.
+ *
+ * @param {String} buildtype - The build type
+ * @return {String} - The path to the saved CMS export directory
  */
-const exportDir = path.join(
-  __dirname,
-  `../../../../../.cache/${process.env.buildOptions &&
-    process.env.buildOptions.buildType}/cms-export/`,
-);
-const contentDir = path.join(exportDir, 'content');
+const exportDir = buildtype =>
+  path.join(__dirname, `../../../../../.cache/${buildtype}/cms-export/`);
+
+/**
+ * The path to the directory with all the JSON files from the CMS export.
+ *
+ * NOTE: This is just a subdirectory of the cmsExportDirectory.
+ *
+ * @param {String} cmsExportDirectory - The path to the extracted cms export
+ * @return {String} - The path to the content/ subdirectory in the cms export directory
+ */
+const getContentDir = cmsExportDirectory =>
+  path.join(cmsExportDirectory, 'content');
 
 /**
  * The sub-type can be found in a few different properties, depending
@@ -41,7 +51,7 @@ function getContentModelType(entity) {
 
 module.exports = {
   exportDir,
-  contentDir,
+  getContentDir,
   typeProperties,
   getContentModelType,
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2390,6 +2390,15 @@ bl@^1.0.0:
     readable-stream "^2.3.5"
     safe-buffer "^5.1.1"
 
+bl@^4.0.1:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/bl/-/bl-4.0.2.tgz#52b71e9088515d0606d9dd9cc7aa48dc1f98e73a"
+  integrity sha512-j4OH8f6Qg2bGuWfRiltT2HYGx0e1QcBTrK9KAHNMwMZdQnDZFk0ZSYIpADjYCB3U12nicC5tVJwSIhwOWjb4RQ==
+  dependencies:
+    buffer "^5.5.0"
+    inherits "^2.0.4"
+    readable-stream "^3.4.0"
+
 blob-polyfill@^2.0.20171115:
   version "2.0.20171115"
   resolved "https://registry.yarnpkg.com/blob-polyfill/-/blob-polyfill-2.0.20171115.tgz#8e5c2659dda443365fafd6dd421517653f1d5ffd"
@@ -2827,6 +2836,14 @@ buffer@^4.3.0:
     base64-js "^1.0.2"
     ieee754 "^1.1.4"
     isarray "^1.0.0"
+
+buffer@^5.5.0:
+  version "5.6.0"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.6.0.tgz#a31749dc7d81d84db08abf937b6b8c4033f62786"
+  integrity sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==
+  dependencies:
+    base64-js "^1.0.2"
+    ieee754 "^1.1.4"
 
 builtin-modules@^1.0.0:
   version "1.1.1"
@@ -4884,7 +4901,7 @@ encoding@^0.1.11:
   dependencies:
     iconv-lite "~0.4.13"
 
-end-of-stream@^1.0.0, end-of-stream@^1.1.0:
+end-of-stream@^1.0.0, end-of-stream@^1.1.0, end-of-stream@^1.4.1:
   version "1.4.4"
   resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.4.tgz#5ae64a5f45057baf3626ec14da0ca5e4b2431eb0"
   integrity sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==
@@ -7578,7 +7595,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.0, inherits@~2.0.1, inherits@~2.0.3:
+inherits@2, inherits@^2.0.1, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.0, inherits@~2.0.1, inherits@~2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -10255,6 +10272,11 @@ mixin-object@^2.0.1:
     for-in "^0.1.3"
     is-extendable "^0.1.1"
 
+mkdirp-classic@^0.5.2:
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz#fa10c9115cc6d8865be221ba47ee9bed78601113"
+  integrity sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==
+
 mkdirp@0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.0.tgz#1d73076a6df986cd9344e15e71fcc05a4c9abf12"
@@ -12663,6 +12685,15 @@ readable-stream@^2.3.0, readable-stream@^2.3.5:
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
+readable-stream@^3.4.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
+  integrity sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==
+  dependencies:
+    inherits "^2.0.3"
+    string_decoder "^1.1.1"
+    util-deprecate "^1.0.1"
+
 readable-stream@~2.0.0:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.0.6.tgz#8f90341e68a53ccc928788dacfcd11b36eb9b78e"
@@ -14664,6 +14695,16 @@ tapable@^1.1.0, tapable@^1.1.3:
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-1.1.3.tgz#a1fccc06b58db61fd7a45da2da44f5f3a3e67ba2"
   integrity sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==
 
+tar-fs@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/tar-fs/-/tar-fs-2.0.1.tgz#e44086c1c60d31a4f0cf893b1c4e155dabfae9e2"
+  integrity sha512-6tzWDMeroL87uF/+lin46k+Q+46rAJ0SyPGz7OW7wTgblI273hsBqk2C1j0/xNadNLKDTUL9BukSjB7cwgmlPA==
+  dependencies:
+    chownr "^1.1.1"
+    mkdirp-classic "^0.5.2"
+    pump "^3.0.0"
+    tar-stream "^2.0.0"
+
 tar-stream@^1.5.2:
   version "1.6.2"
   resolved "https://registry.yarnpkg.com/tar-stream/-/tar-stream-1.6.2.tgz#8ea55dab37972253d9a9af90fdcd559ae435c555"
@@ -14675,6 +14716,17 @@ tar-stream@^1.5.2:
     readable-stream "^2.3.0"
     to-buffer "^1.1.1"
     xtend "^4.0.0"
+
+tar-stream@^2.0.0:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/tar-stream/-/tar-stream-2.1.2.tgz#6d5ef1a7e5783a95ff70b69b97455a5968dc1325"
+  integrity sha512-UaF6FoJ32WqALZGOIAApXx+OdxhekNMChu6axLJR85zMMjXKWFGjbIRe+J6P4UnRGg9rAwWvbTT0oI7hD/Un7Q==
+  dependencies:
+    bl "^4.0.1"
+    end-of-stream "^1.4.1"
+    fs-constants "^1.0.0"
+    inherits "^2.0.3"
+    readable-stream "^3.1.1"
 
 tar@^2.0.0:
   version "2.2.1"


### PR DESCRIPTION
## Description
Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/2699

With this PR, we can now run the latest CMS export through the build process with the `--use-cms-export` flag. Rather than relying on the directory to just be there (through some manual process like we had before), it'll fetch the tarball and extract it to the location specified by the `--cms-export-dir` CLI argument.

## Testing done
Made me a table of expected behavior and ran through the list.

| GraphQL or Export | Has cache? | --pull-drupal? | Expected behavior                         | Works as expected? |
|-------------------|------------|----------------|-------------------------------------------|--------------------|
| GraphQL           | No         | No             | Pull pages.json from Drupal               | Yes                |
| GraphQL           | No         | Yes            | Pull pages.json from Drupal               | Yes                |
| GraphQL           | Yes        | No             | Use GraphQL + .cache/pages.json/          | Yes                |
| GraphQL           | Yes        | Yes            | Pull pages.json from Drupal               | Yes                |
| Export            | No         | No             | Pull and untar cms-export.tar from Drupal | Yes                |
| Export            | No         | Yes            | Pull and untar cms-export.tar from Drupal | Yes                |
| Export            | Yes        | No             | Use cms-export/ directory                 | Yes                |
| Export            | Yes        | Yes            | Pull and untar cms-export.tar from Drupal | Yes                |


## Screenshots
N/A

## Acceptance criteria
- [x] All the scenarios in the table above work as expected
