### PR TITLE
Ensure checkbox works for military addresses

### DIFF
--- a/src/platform/user/profile/vet360/components/AddressField/AddressEditModal.jsx
+++ b/src/platform/user/profile/vet360/components/AddressField/AddressEditModal.jsx
@@ -3,13 +3,13 @@ import { connect } from 'react-redux';
 import pickBy from 'lodash/pickBy';
 import { focusElement } from 'platform/utilities/ui';
 
-import { ADDRESS_POU, ADDRESS_TYPES, FIELD_NAMES, USA } from 'vet360/constants';
-
+import { ADDRESS_POU, FIELD_NAMES, USA } from 'vet360/constants';
 import Vet360EditModal from '../base/Vet360EditModal';
-
 import CopyMailingAddress from 'vet360/containers/CopyMailingAddress';
-
 import ContactInfoForm from '../ContactInfoForm';
+
+const MILITARY_CITY_VALUES = ['APO', 'DPO', 'FPO'];
+const MILITARY_STATE_VALUES = ['AA', 'AE', 'AP'];
 
 class AddressEditModal extends React.Component {
   componentWillUnmount() {
@@ -64,7 +64,8 @@ class AddressEditModal extends React.Component {
   selectLivesOnMilitaryBaseCheckbox = data => {
     if (
       data?.addressPou === ADDRESS_POU.CORRESPONDENCE &&
-      data?.addressType === ADDRESS_TYPES.OVERSEAS_MILITARY
+      MILITARY_STATE_VALUES.includes(data?.stateCode) &&
+      MILITARY_CITY_VALUES.includes(data?.city)
     ) {
       return { ...data, 'view:livesOnMilitaryBase': true };
     }

--- a/src/platform/user/profile/vet360/components/AddressField/AddressEditModal.jsx
+++ b/src/platform/user/profile/vet360/components/AddressField/AddressEditModal.jsx
@@ -1,15 +1,13 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import pickBy from 'lodash/pickBy';
+import ADDRESS_DATA from 'platform/forms/address/data';
 import { focusElement } from 'platform/utilities/ui';
 
 import { ADDRESS_POU, FIELD_NAMES, USA } from 'vet360/constants';
 import Vet360EditModal from '../base/Vet360EditModal';
 import CopyMailingAddress from 'vet360/containers/CopyMailingAddress';
 import ContactInfoForm from '../ContactInfoForm';
-
-const MILITARY_CITY_VALUES = ['APO', 'DPO', 'FPO'];
-const MILITARY_STATE_VALUES = ['AA', 'AE', 'AP'];
 
 class AddressEditModal extends React.Component {
   componentWillUnmount() {
@@ -64,8 +62,8 @@ class AddressEditModal extends React.Component {
   selectLivesOnMilitaryBaseCheckbox = data => {
     if (
       data?.addressPou === ADDRESS_POU.CORRESPONDENCE &&
-      MILITARY_STATE_VALUES.includes(data?.stateCode) &&
-      MILITARY_CITY_VALUES.includes(data?.city)
+      ADDRESS_DATA.militaryStates.includes(data?.stateCode) &&
+      ADDRESS_DATA.militaryCities.includes(data?.city)
     ) {
       return { ...data, 'view:livesOnMilitaryBase': true };
     }


### PR DESCRIPTION
## Description
Ensure the checkbox is marked when editing a military address.

When an overseas military address is saved to VA Profile, it comes back as a domestic address.
The FE does flag it as an overseas military address when we make the call our API, but after the save succeeds it comes back from VA Profile as domestic. A side effect of this is that the "I live on a military base" checkbox is un-checked when you go to edit your address.

Note: I did not need to merge https://github.com/department-of-veterans-affairs/va.gov-team/issues/8596, the issue was unrelated.

## Testing done
Works locally.

## Screenshots
![image](https://user-images.githubusercontent.com/14869324/81214281-dcc43780-8f94-11ea-8c8d-dc3ef87000d1.png)


## Acceptance criteria
- [x] Change how the FE determines if an address we get from VA Profile is an overseas military or not so we can pre-check that box.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
