### PR TITLE
Fix breadcrumb routing

### DIFF
--- a/src/applications/personalization/profile-2/components/ProfileWrapper.jsx
+++ b/src/applications/personalization/profile-2/components/ProfileWrapper.jsx
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import { Link } from 'react-router';
 import Breadcrumbs from '@department-of-veterans-affairs/formation-react/Breadcrumbs';
 import LoadingIndicator from '@department-of-veterans-affairs/formation-react/LoadingIndicator';
 import RequiredLoginView from 'platform/user/authorization/components/RequiredLoginView';
@@ -92,7 +93,7 @@ class ProfileWrapper extends Component {
         {/* Breadcrumbs */}
         <Breadcrumbs className="vads-u-padding-x--1 vads-u-padding-y--1p5 medium-screen:vads-u-padding-y--0">
           <a href="/">Home</a>
-          {!onPersonalInformationMobile && <a href="/profile-2/">Profile</a>}
+          {!onPersonalInformationMobile && <Link to="/">Profile</Link>}
           <a href={activeLocation}>{activeRouteName}</a>
         </Breadcrumbs>
 


### PR DESCRIPTION
## Description

When you click the Profile crumb, it does a hard reload of the page rather than the nice instant client-side router change you get when clicking through the sidenav. I think we can get around this because the My VA Dashboard also uses the React Breadcrumb component and deals with this nicely


Solution: using Link from react-router

## Testing done
Works locally

## Acceptance criteria
- [x] update profile breadcrumb click result

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
