### PR TITLE
[Development] Add centralized Telephone component

### DIFF
--- a/src/platform/forms-system/src/js/components/Telephone.jsx
+++ b/src/platform/forms-system/src/js/components/Telephone.jsx
@@ -1,0 +1,145 @@
+import React from 'react';
+
+// import recordEvent from 'platform/monitoring/record-event.js';
+
+const knownNumbers = {
+  '911': ['911'],
+  '8002738255': ['crisisline', 'crisis'],
+  '8003331795': ['usdirect', 'direct', 'express'],
+  '8005351117': ['ncacenter', 'nca'],
+  '8005389552': ['dslogon', 'dmdc'],
+  '8007994889': ['vetcrisistty', 'crisistty'],
+  '8008271000': ['hotline', 'vabenefits', 'benefits', '1000'],
+  '8008778339': ['helptty'],
+  '8446982311': ['va311', '311'],
+  '8552603274': ['caregiver'],
+  '8555747286': ['hrc', 'reportline'],
+  '8663632883': ['dslogontty', 'dmdctty'],
+  '8772228387': ['helpline', 'help', '222vets'],
+  '8773270022': ['mhv', 'health', 'evet'],
+  '8774243838': ['4aidvet', '4aid', 'homeless'],
+  '8884424551': ['gibill', 'edu'],
+};
+
+const patterns = {
+  '911': '###',
+  default: '###-###-####',
+};
+
+const recordClick = () => {
+  // TO-DO: pass event name & location URL
+  // recordEvent({ event: `telephone-click` });
+};
+
+// Allow labels "gi-bill", "GI_Bill" or "GI BILL"
+const formatLabel = label => label?.replace(/[-_\s]/g, '').toLowerCase();
+
+// Strip out leading "1" and any non-digits
+const cleanHref = number =>
+  number
+    .replace(/^1/, '') // strip leading "1" from telephone number
+    .replace(/[^\d]/g, '');
+
+// Create link text from pattern
+const formatTelText = (num, pattern) => {
+  let i = 0;
+  return pattern.replace(/#/g, () => num[i++] || '');
+};
+
+const formatBlock = number => {
+  const len = number.length - 1;
+  // return rounded number as a grouped value, e.g. `800` or `1000`
+  // but split non-round numbers, e.g. `827` => `8 2 7`
+  const roundNumber = parseInt(number.slice(-len), 10) === 0;
+  return roundNumber ? number : number.split('').join(' ');
+};
+
+// Combine phone number blocks within the label separated by periods
+// "800-555-1212" => "800. 5 5 5. 1 2 1 2"
+const formatTelLabel = number =>
+  number
+    .split(/[^\d]+/)
+    .filter(n => n)
+    .map(formatBlock)
+    .join('. ');
+
+/**
+ * Produce a standardized accessible telephone link
+ * @param {string} tel - Telephone number (with or without leading "1")
+ * @param {string} use - Known phone number label, e.g. "gibill"
+ * @param {string} className - Additional class name to add
+ * @param {string} pattern - Formatted pattern using "#" as placeholders
+ * @param {string|function} label - Custom aria-label string/function
+ * @param {string|function} text - Custom link text string/function
+ * @param {function} onClick - Custom onClick function
+ */
+export default function Telephone({
+  // phone number (length _must_ match the pattern; leading "1" is removed)
+  tel = '',
+  use = '', // quick labels for known numbers
+  className = '', // additional css class to add
+  pattern = '', // output format; defaults to patterns.default value
+  label = '', // custom aria-label
+  text = '', // custom text formatting
+  onClick = recordClick,
+}) {
+  // "use" is for known numbers
+  const useString = formatLabel(use.toString());
+  const knownNumber = useString
+    ? Object.keys(knownNumbers).find(number =>
+        knownNumbers[number].find(lbl =>
+          useString.startsWith(lbl.substring(0, 4)),
+        ),
+      )
+    : tel.toString();
+
+  if (useString && !knownNumber) {
+    const known = Object.entries(knownNumbers).map(
+      ([number, labels]) =>
+        ` ${formatTelText(
+          number,
+          patterns[useString] || patterns.default,
+        )}: ${labels.join(', ')}`,
+    );
+    throw new Error(
+      `Telephone: "${useString}" label is not recognized; Predefined list:\n` +
+        `${known.join('\n')}`,
+    );
+  }
+
+  // format href: "###-### ####" => "##########"
+  const number = cleanHref(knownNumber);
+
+  const usePattern = pattern || patterns[useString] || patterns.default;
+  const patternLength = usePattern.match(/#/g).length;
+  const formattedTel = formatTelText(number, usePattern);
+
+  if (!useString && (!number || number.length !== patternLength)) {
+    throw new Error(
+      `Telephone: "${number}" does not match the pattern (${usePattern})`,
+    );
+  }
+
+  const href = number.length === 10 ? `+1${number}` : number;
+
+  const ariaLabel =
+    typeof label === 'function'
+      ? label(formattedTel)
+      : label || formatTelLabel(formattedTel);
+
+  const numberText =
+    typeof text === 'function'
+      ? text(number, usePattern)
+      : text || formattedTel;
+
+  return (
+    <a
+      className={`no-wrap ${className}`}
+      href={`tel:${href}`}
+      aria-label={ariaLabel}
+      onClick={onClick}
+    >
+      {numberText}
+    </a>
+  );
+}

--- a/src/platform/forms-system/src/js/components/Telephone.jsx
+++ b/src/platform/forms-system/src/js/components/Telephone.jsx
@@ -2,24 +2,25 @@ import React from 'react';
 
 // import recordEvent from 'platform/monitoring/record-event.js';
 
-const knownNumbers = {
-  '911': ['911'],
-  '8002738255': ['crisisline', 'crisis'],
-  '8003331795': ['usdirect', 'direct', 'express'],
-  '8005351117': ['ncacenter', 'nca'],
-  '8005389552': ['dslogon', 'dmdc'],
-  '8007994889': ['vetcrisistty', 'crisistty'],
-  '8008271000': ['hotline', 'vabenefits', 'benefits', '1000'],
-  '8008778339': ['helptty'],
-  '8446982311': ['va311', '311'],
-  '8552603274': ['caregiver'],
-  '8555747286': ['hrc', 'reportline'],
-  '8663632883': ['dslogontty', 'dmdctty'],
-  '8772228387': ['helpline', 'help', '222vets'],
-  '8773270022': ['mhv', 'health', 'evet'],
-  '8774243838': ['4aidvet', '4aid', 'homeless'],
-  '8884424551': ['gibill', 'edu'],
-};
+export const CONTACTS = Object.freeze({
+  '222_VETS': '8772228387', // VA Help Line
+  '4AID_VET': '8774243838', // National Call Center for Homeless Veterans
+  911: '911',
+  CAREGIVER: '8552603274', // VA National Caregiver Support Line
+  CRISIS_LINE: '8002738255', // Veterans Crisis hotline
+  CRISIS_TTY: '8007994889', // Veterans Crisis hotline TTY
+  DS_LOGON: '8005389552', // Defense Manpower Data Center
+  DS_LOGON_TTY: '8663632883', // Defense Manpower Data Center TTY
+  GI_BILL: '8884424551', // Education Call Center (1-888-GI-BILL-1)
+  GO_DIRECT: '8003331795', // Go Direct/Direct Express (Treasury)
+  HELP_DESK: '8555747286', // VA Help desk
+  HELP_TTY: '8008778339', // VA Help Desk TTY
+  MY_HEALTHEVET: '8773270022', // My HealtheVet help desk
+  NCA: '8005351117', // National Cemetery Scheduling Office
+  TESC: '8882242950', // U.S. Treasury Electronic Payment Solution Center
+  VA_311: '8446982311', // VA Help desk (VA311)
+  VA_BENEFITS: '8008271000', // Veterans Benefits Assistance
+});
 
 const patterns = {
   '911': '###',
@@ -65,81 +66,48 @@ const formatTelLabel = number =>
 
 /**
  * Produce a standardized accessible telephone link
- * @param {string} tel - Telephone number (with or without leading "1")
- * @param {string} use - Known phone number label, e.g. "gibill"
+ * @param {string} contact - Known phone number label; from CONTACTS, or pass a
+ *  telephone number with or without leading "1" (it gets stripped off)
  * @param {string} className - Additional class name to add
  * @param {string} pattern - Formatted pattern using "#" as placeholders
- * @param {string|function} label - Custom aria-label string/function
- * @param {string|function} text - Custom link text string/function
+ * @param {string|function} ariaLabel - Custom aria-label string
  * @param {function} onClick - Custom onClick function
  */
 export default function Telephone({
   // phone number (length _must_ match the pattern; leading "1" is removed)
-  tel = '',
-  use = '', // quick labels for known numbers
+  contact = '', // telephone number
   className = '', // additional css class to add
   pattern = '', // output format; defaults to patterns.default value
-  label = '', // custom aria-label
-  text = '', // custom text formatting
+  ariaLabel = '', // custom aria-label
   onClick = recordClick,
+  children,
 }) {
-  // "use" is for known numbers
-  const useString = formatLabel(use.toString());
-  const knownNumber = useString
-    ? Object.keys(knownNumbers).find(number =>
-        knownNumbers[number].find(lbl =>
-          useString.startsWith(lbl.substring(0, 4)),
-        ),
-      )
-    : tel.toString();
+  const contactString = formatLabel(contact.toString());
+  const rawNumber = CONTACTS[contactString] || contactString;
 
-  if (useString && !knownNumber) {
-    const known = Object.entries(knownNumbers).map(
-      ([number, labels]) =>
-        ` ${formatTelText(
-          number,
-          patterns[useString] || patterns.default,
-        )}: ${labels.join(', ')}`,
-    );
+  // strip out non-digits for use in href: "###-### ####" => "##########"
+  const cleanNumber = cleanHref(rawNumber);
+
+  const contactPattern = pattern || patterns[contactString] || patterns.default;
+  const patternLength = contactPattern.match(/#/g).length;
+  const formattedTel = formatTelText(cleanNumber, contactPattern);
+
+  if (!cleanNumber || cleanNumber.length !== patternLength) {
     throw new Error(
-      `Telephone: "${useString}" label is not recognized; Predefined list:\n` +
-        `${known.join('\n')}`,
+      `Telephone: "${cleanNumber}" does not match the pattern (${contactPattern})`,
     );
   }
 
-  // format href: "###-### ####" => "##########"
-  const number = cleanHref(knownNumber);
-
-  const usePattern = pattern || patterns[useString] || patterns.default;
-  const patternLength = usePattern.match(/#/g).length;
-  const formattedTel = formatTelText(number, usePattern);
-
-  if (!useString && (!number || number.length !== patternLength)) {
-    throw new Error(
-      `Telephone: "${number}" does not match the pattern (${usePattern})`,
-    );
-  }
-
-  const href = number.length === 10 ? `+1${number}` : number;
-
-  const ariaLabel =
-    typeof label === 'function'
-      ? label(formattedTel)
-      : label || formatTelLabel(formattedTel);
-
-  const numberText =
-    typeof text === 'function'
-      ? text(number, usePattern)
-      : text || formattedTel;
+  const href = cleanNumber.length === 10 ? `+1${cleanNumber}` : cleanNumber;
 
   return (
     <a
       className={`no-wrap ${className}`}
       href={`tel:${href}`}
-      aria-label={ariaLabel}
+      aria-label={ariaLabel || formatTelLabel(formattedTel)}
       onClick={onClick}
     >
-      {numberText}
+      {children || formattedTel}
     </a>
   );
 }

--- a/src/platform/forms-system/src/js/components/Telephone.jsx
+++ b/src/platform/forms-system/src/js/components/Telephone.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 // import recordEvent from 'platform/monitoring/record-event.js';
 
@@ -70,10 +71,10 @@ const formatTelLabel = number =>
  *  telephone number with or without leading "1" (it gets stripped off)
  * @param {string} className - Additional class name to add
  * @param {string} pattern - Formatted pattern using "#" as placeholders
- * @param {string|function} ariaLabel - Custom aria-label string
+ * @param {string} ariaLabel - Custom aria-label string
  * @param {function} onClick - Custom onClick function
  */
-export default function Telephone({
+function Telephone({
   // phone number (length _must_ match the pattern; leading "1" is removed)
   contact = '', // telephone number
   className = '', // additional css class to add
@@ -111,3 +112,13 @@ export default function Telephone({
     </a>
   );
 }
+
+Telephone.propTypes = {
+  contact: PropTypes.string,
+  className: PropTypes.string,
+  pattern: PropTypes.string,
+  ariaLabel: PropTypes.string,
+  onClick: PropTypes.func,
+};
+
+export default Telephone;

--- a/src/platform/forms-system/test/js/components/Telephone.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/components/Telephone.unit.spec.jsx
@@ -1,0 +1,168 @@
+import React from 'react';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+import sinon from 'sinon';
+
+import Telephone from '../../../src/js/components/Telephone';
+
+describe('Widget <Telephone />', () => {
+  // tel
+  it('should render a number', () => {
+    const wrapper = shallow(<Telephone tel="8005551212" />);
+    const props = wrapper.props();
+    expect(props.href).to.equal('tel:+18005551212');
+    expect(props['aria-label']).to.equal('800. 5 5 5. 1 2 1 2');
+    expect(wrapper.text()).to.equal('800-555-1212');
+    wrapper.unmount();
+  });
+  it('should render a number with a leading "1"', () => {
+    const wrapper = shallow(<Telephone tel="18005551000" />);
+    const props = wrapper.props();
+    expect(props.href).to.equal('tel:+18005551000');
+    expect(props['aria-label']).to.equal('800. 5 5 5. 1000');
+    expect(wrapper.text()).to.equal('800-555-1000');
+    wrapper.unmount();
+  });
+  it('should throw an error when not passed a number', () => {
+    expect(() => {
+      const wrapper = shallow(<Telephone />);
+      wrapper.unmount();
+    }).to.throw('Telephone: "" does not match the pattern (###-###-####)');
+  });
+  it('should throw an error when number is less than 10-digits', () => {
+    expect(() => {
+      const wrapper = shallow(<Telephone tel="4321" />);
+      wrapper.unmount();
+    }).to.throw(`Telephone: "4321" does not match the pattern (###-###-####)`);
+  });
+  it('should throw an error when number is more than 10-digits', () => {
+    expect(() => {
+      const wrapper = shallow(<Telephone tel="01234567891" />);
+      wrapper.unmount();
+    }).to.throw(
+      'Telephone: "01234567891" does not match the pattern (###-###-####)',
+    );
+  });
+
+  // use
+  it('should render a known number', () => {
+    const wrapper = shallow(<Telephone use="gi bill" />);
+    const props = wrapper.props();
+    expect(props.href).to.equal('tel:+18884424551');
+    expect(props['aria-label']).to.equal('8 8 8. 4 4 2. 4 5 5 1');
+    expect(wrapper.text()).to.equal('888-442-4551');
+    wrapper.unmount();
+  });
+  it('should render a known number using the first 4 letters', () => {
+    const wrapper = shallow(<Telephone use="dslo" />);
+    const props = wrapper.props();
+    expect(props.href).to.equal('tel:+18005389552');
+    expect(props['aria-label']).to.equal('800. 5 3 8. 9 5 5 2');
+    expect(wrapper.text()).to.equal('800-538-9552');
+    wrapper.unmount();
+  });
+  it('should render 311 (a known number)', () => {
+    const wrapper = shallow(<Telephone use={311} />);
+    const props = wrapper.props();
+    expect(props.href).to.equal('tel:+18446982311');
+    expect(props['aria-label']).to.equal('8 4 4. 6 9 8. 2 3 1 1');
+    expect(wrapper.text()).to.equal('844-698-2311');
+    wrapper.unmount();
+  });
+  it('should render 911 (a known number)', () => {
+    const wrapper = shallow(<Telephone use="911" />);
+    const props = wrapper.props();
+    expect(props.href).to.equal('tel:911');
+    expect(props['aria-label']).to.equal('9 1 1');
+    expect(wrapper.text()).to.equal('911');
+    wrapper.unmount();
+  });
+
+  // className
+  it('should render additional class name', () => {
+    const wrapper = shallow(<Telephone use="gibi" className="foo" />);
+    const props = wrapper.props();
+    expect(props.href).to.equal('tel:+18884424551');
+    expect(props['aria-label']).to.equal('8 8 8. 4 4 2. 4 5 5 1');
+    expect(props.className).to.equal('no-wrap foo');
+    expect(wrapper.text()).to.equal('888-442-4551');
+    wrapper.unmount();
+  });
+
+  // pattern
+  it('should render a custom pattern', () => {
+    const wrapper = shallow(<Telephone use="gibi" pattern="(###) ###-####" />);
+    const props = wrapper.props();
+    expect(props.href).to.equal('tel:+18884424551');
+    expect(props['aria-label']).to.equal('8 8 8. 4 4 2. 4 5 5 1');
+    expect(wrapper.text()).to.equal('(888) 442-4551');
+    wrapper.unmount();
+  });
+  it('should render a 7-digit custom pattern', () => {
+    const wrapper = shallow(<Telephone tel="5551212" pattern="###_####" />);
+    const props = wrapper.props();
+    expect(props.href).to.equal('tel:5551212');
+    expect(props['aria-label']).to.equal('5 5 5. 1 2 1 2');
+    expect(wrapper.text()).to.equal('555_1212');
+    wrapper.unmount();
+  });
+  it('should render a 3-digit custom pattern', () => {
+    const wrapper = shallow(<Telephone tel="711" pattern="# # #" />);
+    const props = wrapper.props();
+    expect(props.href).to.equal('tel:711');
+    // not sure if including a period and a space is a big deal; probably
+    // an edge case either way
+    expect(props['aria-label']).to.equal('7. 1. 1');
+    expect(wrapper.text()).to.equal('7 1 1');
+    wrapper.unmount();
+  });
+
+  // label
+  it('should render a custom label string', () => {
+    const label = '800. 5 5 5. 12 12';
+    const wrapper = shallow(<Telephone use="gibi" label={label} />);
+    const props = wrapper.props();
+    expect(props.href).to.equal('tel:+18884424551');
+    expect(props['aria-label']).to.equal('800. 5 5 5. 12 12');
+    expect(wrapper.text()).to.equal('888-442-4551');
+    wrapper.unmount();
+  });
+  it('should render a custom label function', () => {
+    const label = () => '800. 5 5 5. 12 12';
+    const wrapper = shallow(<Telephone use="gibi" label={label} />);
+    const props = wrapper.props();
+    expect(props.href).to.equal('tel:+18884424551');
+    expect(props['aria-label']).to.equal('800. 5 5 5. 12 12');
+    expect(wrapper.text()).to.equal('888-442-4551');
+    wrapper.unmount();
+  });
+
+  // text
+  it('should render a custom text string', () => {
+    const text = '1-888-GI-BILL-1';
+    const wrapper = shallow(<Telephone use="gibi" text={text} />);
+    const props = wrapper.props();
+    expect(props.href).to.equal('tel:+18884424551');
+    expect(props['aria-label']).to.equal('8 8 8. 4 4 2. 4 5 5 1');
+    expect(wrapper.text()).to.equal('1-888-GI-BILL-1');
+    wrapper.unmount();
+  });
+  it('should render a custom text function', () => {
+    const text = () => '1-888-GI-BILL-1';
+    const wrapper = shallow(<Telephone use="gibi" text={text} />);
+    const props = wrapper.props();
+    expect(props.href).to.equal('tel:+18884424551');
+    expect(props['aria-label']).to.equal('8 8 8. 4 4 2. 4 5 5 1');
+    expect(wrapper.text()).to.equal('1-888-GI-BILL-1');
+    wrapper.unmount();
+  });
+
+  // tracking
+  it('should track on click', () => {
+    const onClick = sinon.spy();
+    const wrapper = shallow(<Telephone use="gibi" onClick={onClick} />);
+    wrapper.simulate('click');
+    expect(onClick.calledOnce).to.be.true;
+    wrapper.unmount();
+  });
+});

--- a/src/platform/forms-system/test/js/components/Telephone.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/components/Telephone.unit.spec.jsx
@@ -3,13 +3,17 @@ import { expect } from 'chai';
 import { shallow } from 'enzyme';
 import sinon from 'sinon';
 
-import Telephone, { CONTACTS } from '../../../src/js/components/Telephone';
+import Telephone, {
+  CONTACTS,
+  PATTERNS,
+} from '../../../src/js/components/Telephone';
 
 describe('Widget <Telephone />', () => {
   // custom numbers
   it('should render a number', () => {
     const wrapper = shallow(<Telephone contact="8005551212" />);
     const props = wrapper.props();
+    expect(wrapper.type()).to.equal('a');
     expect(props.href).to.equal('tel:+18005551212');
     expect(props['aria-label']).to.equal('800. 5 5 5. 1 2 1 2');
     expect(wrapper.text()).to.equal('800-555-1212');
@@ -23,24 +27,26 @@ describe('Widget <Telephone />', () => {
     expect(wrapper.text()).to.equal('800-555-1000');
     wrapper.unmount();
   });
-  it('should throw an error when not passed a number', () => {
+  it('should throw an error when number does not match pattern', () => {
     expect(() => {
       const wrapper = shallow(<Telephone />);
       wrapper.unmount();
-    }).to.throw('Telephone: "" does not match the pattern (###-###-####)');
+    }).to.throw('Contact number "" does not match the pattern (###-###-####)');
   });
   it('should throw an error when number is less than 10-digits', () => {
     expect(() => {
-      const wrapper = shallow(<Telephone contact="4321" />);
+      const wrapper = shallow(<Telephone contact={4321} />);
       wrapper.unmount();
-    }).to.throw(`Telephone: "4321" does not match the pattern (###-###-####)`);
+    }).to.throw(
+      `Contact number "4321" does not match the pattern (###-###-####)`,
+    );
   });
   it('should throw an error when number is more than 10-digits', () => {
     expect(() => {
       const wrapper = shallow(<Telephone contact="01234567891" />);
       wrapper.unmount();
     }).to.throw(
-      'Telephone: "01234567891" does not match the pattern (###-###-####)',
+      'Contact number "01234567891" does not match the pattern (###-###-####)',
     );
   });
 
@@ -86,7 +92,7 @@ describe('Widget <Telephone />', () => {
   // pattern
   it('should render a custom pattern', () => {
     const wrapper = shallow(
-      <Telephone contact={CONTACTS.GI_BILL} pattern="(###) ###-####" />,
+      <Telephone contact={CONTACTS.GI_BILL} pattern={PATTERNS.WRAP_AREACODE} />,
     );
     const props = wrapper.props();
     expect(props.href).to.equal('tel:+18884424551');

--- a/src/platform/forms-system/test/js/components/Telephone.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/components/Telephone.unit.spec.jsx
@@ -3,12 +3,12 @@ import { expect } from 'chai';
 import { shallow } from 'enzyme';
 import sinon from 'sinon';
 
-import Telephone from '../../../src/js/components/Telephone';
+import Telephone, { CONTACTS } from '../../../src/js/components/Telephone';
 
 describe('Widget <Telephone />', () => {
-  // tel
+  // custom numbers
   it('should render a number', () => {
-    const wrapper = shallow(<Telephone tel="8005551212" />);
+    const wrapper = shallow(<Telephone contact="8005551212" />);
     const props = wrapper.props();
     expect(props.href).to.equal('tel:+18005551212');
     expect(props['aria-label']).to.equal('800. 5 5 5. 1 2 1 2');
@@ -16,7 +16,7 @@ describe('Widget <Telephone />', () => {
     wrapper.unmount();
   });
   it('should render a number with a leading "1"', () => {
-    const wrapper = shallow(<Telephone tel="18005551000" />);
+    const wrapper = shallow(<Telephone contact="1-800-555-1000" />);
     const props = wrapper.props();
     expect(props.href).to.equal('tel:+18005551000');
     expect(props['aria-label']).to.equal('800. 5 5 5. 1000');
@@ -31,38 +31,30 @@ describe('Widget <Telephone />', () => {
   });
   it('should throw an error when number is less than 10-digits', () => {
     expect(() => {
-      const wrapper = shallow(<Telephone tel="4321" />);
+      const wrapper = shallow(<Telephone contact="4321" />);
       wrapper.unmount();
     }).to.throw(`Telephone: "4321" does not match the pattern (###-###-####)`);
   });
   it('should throw an error when number is more than 10-digits', () => {
     expect(() => {
-      const wrapper = shallow(<Telephone tel="01234567891" />);
+      const wrapper = shallow(<Telephone contact="01234567891" />);
       wrapper.unmount();
     }).to.throw(
       'Telephone: "01234567891" does not match the pattern (###-###-####)',
     );
   });
 
-  // use
+  // known numbers
   it('should render a known number', () => {
-    const wrapper = shallow(<Telephone use="gi bill" />);
-    const props = wrapper.props();
-    expect(props.href).to.equal('tel:+18884424551');
-    expect(props['aria-label']).to.equal('8 8 8. 4 4 2. 4 5 5 1');
-    expect(wrapper.text()).to.equal('888-442-4551');
-    wrapper.unmount();
-  });
-  it('should render a known number using the first 4 letters', () => {
-    const wrapper = shallow(<Telephone use="dslo" />);
+    const wrapper = shallow(<Telephone contact={CONTACTS.DS_LOGON} />);
     const props = wrapper.props();
     expect(props.href).to.equal('tel:+18005389552');
     expect(props['aria-label']).to.equal('800. 5 3 8. 9 5 5 2');
     expect(wrapper.text()).to.equal('800-538-9552');
     wrapper.unmount();
   });
-  it('should render 311 (a known number)', () => {
-    const wrapper = shallow(<Telephone use={311} />);
+  it('should render VA311 (a known number)', () => {
+    const wrapper = shallow(<Telephone contact={CONTACTS.VA_311} />);
     const props = wrapper.props();
     expect(props.href).to.equal('tel:+18446982311');
     expect(props['aria-label']).to.equal('8 4 4. 6 9 8. 2 3 1 1');
@@ -70,7 +62,7 @@ describe('Widget <Telephone />', () => {
     wrapper.unmount();
   });
   it('should render 911 (a known number)', () => {
-    const wrapper = shallow(<Telephone use="911" />);
+    const wrapper = shallow(<Telephone contact={CONTACTS['911']} />);
     const props = wrapper.props();
     expect(props.href).to.equal('tel:911');
     expect(props['aria-label']).to.equal('9 1 1');
@@ -80,7 +72,9 @@ describe('Widget <Telephone />', () => {
 
   // className
   it('should render additional class name', () => {
-    const wrapper = shallow(<Telephone use="gibi" className="foo" />);
+    const wrapper = shallow(
+      <Telephone contact={CONTACTS.GI_BILL} className="foo" />,
+    );
     const props = wrapper.props();
     expect(props.href).to.equal('tel:+18884424551');
     expect(props['aria-label']).to.equal('8 8 8. 4 4 2. 4 5 5 1');
@@ -91,7 +85,9 @@ describe('Widget <Telephone />', () => {
 
   // pattern
   it('should render a custom pattern', () => {
-    const wrapper = shallow(<Telephone use="gibi" pattern="(###) ###-####" />);
+    const wrapper = shallow(
+      <Telephone contact={CONTACTS.GI_BILL} pattern="(###) ###-####" />,
+    );
     const props = wrapper.props();
     expect(props.href).to.equal('tel:+18884424551');
     expect(props['aria-label']).to.equal('8 8 8. 4 4 2. 4 5 5 1');
@@ -99,7 +95,7 @@ describe('Widget <Telephone />', () => {
     wrapper.unmount();
   });
   it('should render a 7-digit custom pattern', () => {
-    const wrapper = shallow(<Telephone tel="5551212" pattern="###_####" />);
+    const wrapper = shallow(<Telephone contact="5551212" pattern="###_####" />);
     const props = wrapper.props();
     expect(props.href).to.equal('tel:5551212');
     expect(props['aria-label']).to.equal('5 5 5. 1 2 1 2');
@@ -107,7 +103,7 @@ describe('Widget <Telephone />', () => {
     wrapper.unmount();
   });
   it('should render a 3-digit custom pattern', () => {
-    const wrapper = shallow(<Telephone tel="711" pattern="# # #" />);
+    const wrapper = shallow(<Telephone contact="711" pattern="# # #" />);
     const props = wrapper.props();
     expect(props.href).to.equal('tel:711');
     // not sure if including a period and a space is a big deal; probably
@@ -119,37 +115,22 @@ describe('Widget <Telephone />', () => {
 
   // label
   it('should render a custom label string', () => {
-    const label = '800. 5 5 5. 12 12';
-    const wrapper = shallow(<Telephone use="gibi" label={label} />);
+    const ariaLabel = '800. 5 5 5. 12 12';
+    const wrapper = shallow(
+      <Telephone contact={CONTACTS.GI_BILL} ariaLabel={ariaLabel} />,
+    );
     const props = wrapper.props();
     expect(props.href).to.equal('tel:+18884424551');
-    expect(props['aria-label']).to.equal('800. 5 5 5. 12 12');
-    expect(wrapper.text()).to.equal('888-442-4551');
-    wrapper.unmount();
-  });
-  it('should render a custom label function', () => {
-    const label = () => '800. 5 5 5. 12 12';
-    const wrapper = shallow(<Telephone use="gibi" label={label} />);
-    const props = wrapper.props();
-    expect(props.href).to.equal('tel:+18884424551');
-    expect(props['aria-label']).to.equal('800. 5 5 5. 12 12');
+    expect(props['aria-label']).to.equal(ariaLabel);
     expect(wrapper.text()).to.equal('888-442-4551');
     wrapper.unmount();
   });
 
   // text
   it('should render a custom text string', () => {
-    const text = '1-888-GI-BILL-1';
-    const wrapper = shallow(<Telephone use="gibi" text={text} />);
-    const props = wrapper.props();
-    expect(props.href).to.equal('tel:+18884424551');
-    expect(props['aria-label']).to.equal('8 8 8. 4 4 2. 4 5 5 1');
-    expect(wrapper.text()).to.equal('1-888-GI-BILL-1');
-    wrapper.unmount();
-  });
-  it('should render a custom text function', () => {
-    const text = () => '1-888-GI-BILL-1';
-    const wrapper = shallow(<Telephone use="gibi" text={text} />);
+    const wrapper = shallow(
+      <Telephone contact={CONTACTS.GI_BILL}>1-888-GI-BILL-1</Telephone>,
+    );
     const props = wrapper.props();
     expect(props.href).to.equal('tel:+18884424551');
     expect(props['aria-label']).to.equal('8 8 8. 4 4 2. 4 5 5 1');
@@ -160,7 +141,9 @@ describe('Widget <Telephone />', () => {
   // tracking
   it('should track on click', () => {
     const onClick = sinon.spy();
-    const wrapper = shallow(<Telephone use="gibi" onClick={onClick} />);
+    const wrapper = shallow(
+      <Telephone contact={CONTACTS.GI_BILL} onClick={onClick} />,
+    );
     wrapper.simulate('click');
     expect(onClick.calledOnce).to.be.true;
     wrapper.unmount();


### PR DESCRIPTION
## Description

This PR adds a `<Telephone />` component that builds an accessible telephone link.

To use it, import the component, then pass either a 10 (or 11) digit number in the `tel` property, or pass a "known" number tag in the `use` property.

```jsx
import Telephone, { CONTACTS } from 'platform/forms-system/src/js/components/Telephone';

export default HotLineLink = () => (
  <Telephone contact={CONTACTS.VA_BENEFITS} />
);
```

renders:

```html
<a href="tel:+18008271000" aria-label="800. 8 2 7. 1000" class="no-wrap">
  800-827-1000
</a>
```

<details><summary>Another example</summary>

<!-- leave a blank line above -->
```jsx
<Telephone contact={CONTACTS.GI_BILL}>
  1-888-GI-BILL-1
</Telephone>
```

renders:

```html
<a href="tel:+18884424551" aria-label="8 8 8. 4 4 2. 4 5 5 1">
  1-888-GI-BILL-1
</a>
```
</details>

<details><summary>One more example!</summary>

<!-- leave a blank line above -->
```jsx
<Telephone
  contact="8446982311"
  pattern="(###) ###-####"
  className="foo"
/>
```

renders:

```html
<a href="tel:+18446982311" aria-label="8 4 4. 6 9 8. 2 3 1 1" class="no-wrap foo">
  (844) 698-2311
</a>
```
</details>


Full list of properties:

```js
/**
 * Produce a standardized accessible telephone link
 * @param {string} contact - Known phone number label; from CONTACTS, or pass a
 *  telephone number with or without leading "1" (it gets stripped off)
 * @param {string} className - Additional class name to add
 * @param {string} pattern - Formatted pattern using "#" as placeholders
 * @param {string} ariaLabel - Custom aria-label string
 * @param {function} onClick - Custom onClick function
 */
```

<details><summary>Detailed Docs</summary>

<!-- leave a blank line above -->
### `contact`

- Pass in a number:
  - Any leading `1` is stripped out; if it _must_ start with a `1` then add a space in front
  - Can be any length, but _must_ match the number of `#` characters within the `pattern`, or an error is thrown
  - Property can include any non-digit characters; they will be stripped out during processing
- Known number label passed to the component
  - case-sensitive
  - current list:

    | Key | Number | Description |
    |:------|:-----|:-----|
    | `222_VETS` | `8772228387` | VA Help Line |
    | `4AID_VET` | `8774243838` | National Call Center for Homeless Veterans |
    | `911` | `911` | Emergency! |
    | `CAREGIVER` | `8552603274` | VA National Caregiver Support Line |
    | `CRISIS_LINE` | `8002738255` | Veterans Crisis hotline |
    | `CRISIS_TTY` | `8007994889` | Veterans Crisis hotline TTY |
    | `DS_LOGON` | `8005389552` | Defense Manpower Data Center |
    | `DS_LOGON_TTY` | `8663632883` | Defense Manpower Data Center TTY |
    | `GI_BILL` | `8884424551` | Education Call Center (1-888-GI-BILL-1) |
    | `GO_DIRECT` | `8003331795` | Go Direct/Direct Express (Treasury) |
    | `HELP_DESK` | `8555747286` | VA Help desk |
    | `HELP_TTY` | `8008778339` | VA Help Desk TTY |
    | `MY_HEALTHEVET` | `8773270022` | My HealtheVet help desk |
    | `NCA` | `8005351117` | National Cemetery Scheduling Office |
    | `TESC` | `8882242950` | U.S. Treasury Electronic Payment Solution Center |
    | `VA_311` | `8446982311` | VA Help desk (VA311) |
    | `VA_BENEFITS` | `8008271000` | Veterans Benefits Assistance |

### `className`

- Added as space separated class names in a string

### `pattern`

- Use `#` to represent the number
- Use any characters in and around the `#`, e.g. `(###) ###-####` or `###_###_####`
- The number of `#` characters _must_ be the same length as the number

### `ariaLabel`

- Defines a custom `aria-label`
- Pass in a string
- The built-in function will group rounded numbers together, e.g. `800` and `1000` will not be separated within the label, where as `888` will be converted into `8 8 8`; and each group is combined, but separated by a period and a space `. `. This results in something like this `8 8 8. 5 5 5. 1000`

### Custom text

- Add any custom text as a child of the `<Telephone>` component; See the included example

### `onClick`

- Defines any action to be done after the link is clicked
- The default action was going to be recording an analytics event, but is disabled in this PR until a event label can be determined.
- Only the `event` parameter is passed to this function.
</details>

Related issue: https://github.com/department-of-veterans-affairs/va.gov-team/issues/8793

## Testing done

Local unit tests added

## Screenshots

N/A

## Acceptance criteria
- [x] Accept a telephone number with or without dashes or spaces, e.g. `800 827 1000` or `8008271000`
- [x] Accept named "standard" phone numbers, e.g. `VA_311`
- [x] Allow altering the `aria-label`; not separate out `800` or `1000`, but should separate out `8 2 7` for screen-readers to improve output.
- [x] Prevent phone number wrap.
- [x] Allow changing the visual format (if required): `800-827-1000` vs `(800) 827-1000`

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable (TO DO!)
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
