### PR TITLE
Displays specific error messages for auth errors

### DIFF
--- a/src/applications/auth/containers/AuthApp.jsx
+++ b/src/applications/auth/containers/AuthApp.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { connect } from 'react-redux';
 
 import * as Sentry from '@sentry/browser';
+import AdditionalInfo from '@department-of-veterans-affairs/formation-react/AdditionalInfo';
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 import LoadingIndicator from '@department-of-veterans-affairs/formation-react/LoadingIndicator';
 
@@ -274,6 +275,138 @@ export class AuthApp extends React.Component {
           <>
             <p>Please sign in again.</p>
             <button onClick={this.props.openLoginModal}>Sign in</button>
+          </>
+        );
+        break;
+
+      // Multiple MHV ID error
+      case '101':
+        alertContent = (
+          <p>
+            We're sorry. We found more than one My HealtheVet account identifier
+            for you.
+          </p>
+        );
+        troubleshootingContent = (
+          <>
+            <p>You can fix this issue in one of these ways:</p>
+            <AdditionalInfo triggerText="Call the My HealtheVet help desk">
+              <p>
+                Call us at <a href="tel:877-327-0022">877-327-0022</a>. We’re
+                here Monday through Friday, 8:00 a.m. to 8:00 p.m. ET. If you
+                have hearing loss, call TTY: 800-877-3399.
+              </p>
+              <p>
+                Tell the representative that you tried to sign in to use VA.gov,
+                but received an error message telling you that you have more
+                than one My HealtheVet account.
+              </p>
+            </AdditionalInfo>
+            <AdditionalInfo triggerText="Or submit an online help request to My HealtheVet">
+              <p>
+                Use the My HealtheVet contact form to submit an online request
+                for help online.
+              </p>
+              <p>
+                <strong>Fill in the form fields as below:</strong>
+              </p>
+              <ul>
+                <li>
+                  <strong>Topic: </strong>
+                  Select <strong>Account Login</strong>.
+                </li>
+                <li>
+                  <strong>Category: </strong>
+                  Select <strong>Request for Assistance</strong>.
+                </li>
+                <li>
+                  <strong>Comments: </strong> Type, or copy and paste, the
+                  message below:
+                  <p>
+                    “When I tried to sign in to use VA.gov, I received an error
+                    message telling me I have more than one MyHealtheVet
+                    account.”
+                  </p>
+                </li>
+              </ul>
+              <p>
+                Then, complete the rest of the form and click{' '}
+                <strong>Submit</strong>.
+              </p>
+              <p>
+                <a
+                  href="https://www.myhealth.va.gov/mhv-portal-web/contact-us"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Go to the My HealtheVet contact form
+                </a>
+              </p>
+            </AdditionalInfo>
+          </>
+        );
+        break;
+
+      // Multiple EDIPI error
+      case '102':
+        alertContent = (
+          <p>
+            We're sorry. We found more than one DoD ID number (EDIPI) for you.
+          </p>
+        );
+        troubleshootingContent = (
+          <>
+            <p>
+              <strong>
+                Please use our online form to submit a request for help.
+              </strong>
+            </p>
+            <p>Type, or copy and paste, the message below:</p>
+            <p>
+              “When I tried to sign in to use VA.gov, I received an error
+              message telling me I have more than one DoD ID number (EDIPI) on
+              my account.”
+            </p>
+            <p>
+              <a
+                href="https://www.accesstocare.va.gov/sign-in-help?_ga=2.9898741.1324318578.1552319576-1143343955.1509985973"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Submit a request to get help signing in
+              </a>
+            </p>
+          </>
+        );
+        break;
+
+      // ICN mismatch error
+      case '103':
+        alertContent = (
+          <p>We're sorry. We found a mis-match in your account records.</p>
+        );
+        troubleshootingContent = (
+          <>
+            <p>
+              <strong>
+                Please use our online form to submit a request for help.
+              </strong>
+            </p>
+            <p>Type, or copy and paste, the message below:</p>
+            <p>
+              “When I tried to sign in to use VA.gov, I received an error
+              message telling me the ICN number on my My HealtheVet account does
+              not match the one on my VA.gov account."
+            </p>
+            <p>
+              <a
+                href="https://www.accesstocare.va.gov/sign-in-help?_ga=2.9898741.1324318578.1552319576-1143343955.1509985973"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Submit a request to get help signing in
+              </a>
+            </p>
           </>
         );
         break;

--- a/src/applications/auth/containers/AuthApp.jsx
+++ b/src/applications/auth/containers/AuthApp.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { connect } from 'react-redux';
 
 import * as Sentry from '@sentry/browser';
-import AdditionalInfo from '@department-of-veterans-affairs/formation-react/AdditionalInfo';
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 import LoadingIndicator from '@department-of-veterans-affairs/formation-react/LoadingIndicator';
 
@@ -290,59 +289,65 @@ export class AuthApp extends React.Component {
         troubleshootingContent = (
           <>
             <p>You can fix this issue in one of these ways:</p>
-            <AdditionalInfo triggerText="Call the My HealtheVet help desk">
-              <p>
-                Call us at <a href="tel:877-327-0022">877-327-0022</a>. We’re
-                here Monday through Friday, 8:00 a.m. to 8:00 p.m. ET. If you
-                have hearing loss, call TTY: 800-877-3399.
-              </p>
-              <p>
-                Tell the representative that you tried to sign in to use VA.gov,
-                but received an error message telling you that you have more
-                than one My HealtheVet account.
-              </p>
-            </AdditionalInfo>
-            <AdditionalInfo triggerText="Or submit an online help request to My HealtheVet">
-              <p>
-                Use the My HealtheVet contact form to submit an online request
-                for help online.
-              </p>
-              <p>
-                <strong>Fill in the form fields as below:</strong>
-              </p>
-              <ul>
-                <li>
-                  <strong>Topic: </strong>
-                  Select <strong>Account Login</strong>.
-                </li>
-                <li>
-                  <strong>Category: </strong>
-                  Select <strong>Request for Assistance</strong>.
-                </li>
-                <li>
-                  <strong>Comments: </strong> Type, or copy and paste, the
-                  message below:
-                  <p>
-                    “When I tried to sign in to use VA.gov, I received an error
-                    message telling me I have more than one MyHealtheVet
-                    account.”
-                  </p>
-                </li>
-              </ul>
-              <p>
-                Then, complete the rest of the form and click{' '}
-                <strong>Submit</strong>.
-              </p>
-              <p>
-                <a
-                  href="https://www.myhealth.va.gov/mhv-portal-web/contact-us"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  Go to the My HealtheVet contact form
-                </a>
-              </p>
-            </AdditionalInfo>
+            <ul>
+              <li>
+                <strong>Call the My HealtheVet help desk</strong>
+                <p>
+                  Call us at <a href="tel:877-327-0022">877-327-0022</a>. We’re
+                  here Monday through Friday, 8:00 a.m. to 8:00 p.m. ET. If you
+                  have hearing loss, call TTY: 800-877-3399.
+                </p>
+                <p>
+                  Tell the representative that you tried to sign in to use
+                  VA.gov, but received an error message telling you that you
+                  have more than one My HealtheVet account.
+                </p>
+              </li>
+              <li>
+                <strong>
+                  Or submit an online help request to My HealtheVet
+                </strong>
+                <p>
+                  Use the My HealtheVet contact form to submit an online request
+                  for help online.
+                </p>
+                <p>
+                  <strong>Fill in the form fields as below:</strong>
+                </p>
+                <ul>
+                  <li>
+                    <strong>Topic: </strong>
+                    Select <strong>Account Login</strong>.
+                  </li>
+                  <li>
+                    <strong>Category: </strong>
+                    Select <strong>Request for Assistance</strong>.
+                  </li>
+                  <li>
+                    <strong>Comments: </strong> Type, or copy and paste, the
+                    message below:
+                    <p>
+                      “When I tried to sign in to use VA.gov, I received an
+                      error message telling me I have more than one MyHealtheVet
+                      account.”
+                    </p>
+                  </li>
+                </ul>
+                <p>
+                  Then, complete the rest of the form and click{' '}
+                  <strong>Submit</strong>.
+                </p>
+                <p>
+                  <a
+                    href="https://www.myhealth.va.gov/mhv-portal-web/contact-us"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    Go to the My HealtheVet contact form
+                  </a>
+                </p>
+              </li>
+            </ul>
           </>
         );
         break;

--- a/src/applications/auth/containers/AuthApp.jsx
+++ b/src/applications/auth/containers/AuthApp.jsx
@@ -166,6 +166,7 @@ export class AuthApp extends React.Component {
         );
         troubleshootingContent = (
           <>
+            <h3>What you can do:</h3>
             <p>
               Please try again, and this time, select “Accept” on the final page
               of the identity verification process. Or, if you don’t want to
@@ -191,6 +192,7 @@ export class AuthApp extends React.Component {
         );
         troubleshootingContent = (
           <>
+            <h3>What you can do:</h3>
             <p>
               Please update your computer’s settings to the current date and
               time, and then try again.
@@ -209,6 +211,7 @@ export class AuthApp extends React.Component {
         );
         troubleshootingContent = (
           <>
+            <h3>What you can do:</h3>
             <p>
               <strong>Please try signing in again.</strong> If you still can’t
               sign in, please use our online form to submit a request for help.
@@ -240,6 +243,7 @@ export class AuthApp extends React.Component {
         );
         troubleshootingContent = (
           <>
+            <h3>What you can do:</h3>
             <p>
               <strong>Please try signing in again.</strong> If you still can’t
               sign in, please use our online form to submit a request for help.
@@ -272,6 +276,7 @@ export class AuthApp extends React.Component {
         );
         troubleshootingContent = (
           <>
+            <h3>What you can do:</h3>
             <p>Please sign in again.</p>
             <button onClick={this.props.openLoginModal}>Sign in</button>
           </>
@@ -280,15 +285,16 @@ export class AuthApp extends React.Component {
 
       // Multiple MHV ID error
       case '101':
+        header = 'We can’t sign you in';
         alertContent = (
           <p>
-            We're sorry. We found more than one My HealtheVet account identifier
-            for you.
+            We’re having trouble signing you in to VA.gov right now because we
+            found more than one MyHealtheVet account for you.
           </p>
         );
         troubleshootingContent = (
           <>
-            <p>You can fix this issue in one of these ways:</p>
+            <h3>How can I fix this issue?</h3>
             <ul>
               <li>
                 <strong>Call the My HealtheVet help desk</strong>
@@ -298,54 +304,39 @@ export class AuthApp extends React.Component {
                   have hearing loss, call TTY: 800-877-3399.
                 </p>
                 <p>
-                  Tell the representative that you tried to sign in to use
-                  VA.gov, but received an error message telling you that you
-                  have more than one My HealtheVet account.
+                  Tell the representative that you tried to sign in to VA.gov,
+                  but got an error message that you have more than one My
+                  HealtheVet account.
                 </p>
               </li>
               <li>
-                <strong>
-                  Or submit an online help request to My HealtheVet
-                </strong>
+                <strong>Submit a request for online help</strong>
                 <p>
-                  Use the My HealtheVet contact form to submit an online request
-                  for help online.
-                </p>
-                <p>
-                  <strong>Fill in the form fields as below:</strong>
-                </p>
-                <ul>
-                  <li>
-                    <strong>Topic: </strong>
-                    Select <strong>Account Login</strong>.
-                  </li>
-                  <li>
-                    <strong>Category: </strong>
-                    Select <strong>Request for Assistance</strong>.
-                  </li>
-                  <li>
-                    <strong>Comments: </strong> Type, or copy and paste, the
-                    message below:
-                    <p>
-                      “When I tried to sign in to use VA.gov, I received an
-                      error message telling me I have more than one MyHealtheVet
-                      account.”
-                    </p>
-                  </li>
-                </ul>
-                <p>
-                  Then, complete the rest of the form and click{' '}
-                  <strong>Submit</strong>.
-                </p>
-                <p>
+                  Fill out a
                   <a
                     href="https://www.myhealth.va.gov/mhv-portal-web/contact-us"
                     target="_blank"
                     rel="noopener noreferrer"
                   >
-                    Go to the My HealtheVet contact form
-                  </a>
+                    MyHealtheVet online help form
+                  </a>{' '}
+                  to get help signing in. Enter the following information in the
+                  form fields.
                 </p>
+                <p>
+                  <strong>Fill in the form fields as below:</strong>
+                </p>
+                <ul>
+                  <li>Topic: Select "Account Login"</li>
+                  <li>Category: Select "Request for Assistance"</li>
+                  <li>
+                    Comments: Type, or copy and paste, the below message:
+                    <br />
+                    “When I tried to sign in to VA.gov, I got an error message
+                    saying that I have more than one MyHealtheVet account.”
+                  </li>
+                </ul>
+                <p>Complete the rest of the form and then click Submit.</p>
               </li>
             </ul>
           </>
@@ -354,66 +345,41 @@ export class AuthApp extends React.Component {
 
       // Multiple EDIPI error
       case '102':
+        header = 'We can’t sign you in';
         alertContent = (
           <p>
-            We're sorry. We found more than one DoD ID number (EDIPI) for you.
+            We’re having trouble signing you in to VA.gov right now because we
+            found more than one DoD ID number for you. To fix this issue, please{' '}
+            <a
+              href="https://www.accesstocare.va.gov/sign-in-help?_ga=2.9898741.1324318578.1552319576-1143343955.1509985973"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              submit a request to get help signing in.
+            </a>
           </p>
         );
-        troubleshootingContent = (
-          <>
-            <p>
-              <strong>
-                Please use our online form to submit a request for help.
-              </strong>
-            </p>
-            <p>Type, or copy and paste, the message below:</p>
-            <p>
-              “When I tried to sign in to use VA.gov, I received an error
-              message telling me I have more than one DoD ID number (EDIPI) on
-              my account.”
-            </p>
-            <p>
-              <a
-                href="https://www.accesstocare.va.gov/sign-in-help?_ga=2.9898741.1324318578.1552319576-1143343955.1509985973"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                Submit a request to get help signing in
-              </a>
-            </p>
-          </>
-        );
+        troubleshootingContent = null;
         break;
 
       // ICN mismatch error
       case '103':
+        header = 'We can’t sign you in';
         alertContent = (
-          <p>We're sorry. We found a mis-match in your account records.</p>
+          <p>
+            We’re having trouble signing you in right now because your My
+            HealtheVet account number doesn’t match the account number on your
+            VA.gov account. To fix this issue, please{' '}
+            <a
+              href="https://www.accesstocare.va.gov/sign-in-help?_ga=2.9898741.1324318578.1552319576-1143343955.1509985973"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              submit a request to get help signing in.
+            </a>
+          </p>
         );
-        troubleshootingContent = (
-          <>
-            <p>
-              <strong>
-                Please use our online form to submit a request for help.
-              </strong>
-            </p>
-            <p>Type, or copy and paste, the message below:</p>
-            <p>
-              “When I tried to sign in to use VA.gov, I received an error
-              message telling me the ICN number on my My HealtheVet account does
-              not match the one on my VA.gov account."
-            </p>
-            <p>
-              <a
-                href="https://www.accesstocare.va.gov/sign-in-help?_ga=2.9898741.1324318578.1552319576-1143343955.1509985973"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                Submit a request to get help signing in
-              </a>
-            </p>
-          </>
-        );
+        troubleshootingContent = null;
         break;
 
       // Catch all generic error
@@ -426,6 +392,7 @@ export class AuthApp extends React.Component {
         );
         troubleshootingContent = (
           <>
+            <h3>What you can do:</h3>
             <p>
               <strong>Try taking these steps to fix the problem:</strong>
             </p>
@@ -496,7 +463,6 @@ export class AuthApp extends React.Component {
       <div className="usa-content columns small-12">
         <h1>{header}</h1>
         <AlertBox content={alertContent} isVisible status="error" />
-        <h3>What you can do:</h3>
         {troubleshootingContent}
       </div>
     );


### PR DESCRIPTION
Displays user-friendly error messages for the additional
validation checks added in vets-api PR 4235, for several corner cases
around a user having multiple MHV Account ID, EDIPI, or ICN values.

## Description
Goes with https://github.com/department-of-veterans-affairs/vets-api/pull/4235
Fixes https://github.com/department-of-veterans-affairs/va.gov-team/issues/8820 and
partially fixes https://github.com/department-of-veterans-affairs/va.gov-team-sensitive/issues/88

The Multiple MHV ID error message is lifted from the MHV health tools validation checks, and will obviate that check (since the user can't log in, they can't get to the MHV health tools.

The other two errors (duplicate EDIPI and ICN mis-match) direct users to the same general-purpose accesstocare.va.gov "get help signing in" form as other login errors.

## Testing done
Tested locally by navigating to `/auth/login/callback?auth=fail&code=101`, `...102`, `...103`

## Screenshots
### Duplicate MHV IDs (collapsed)
![Screenshot_2020-05-06 Auth](https://user-images.githubusercontent.com/20694532/81238415-e6f72d80-8fb6-11ea-8622-6f2265197165.png)
### Duplicate MHV IDs (expanded)
![Screenshot_2020-05-06 Auth(1)](https://user-images.githubusercontent.com/20694532/81238422-e9598780-8fb6-11ea-9b6f-a23a6d25b0f3.png)
### Duplicate EDIPIs
![Screenshot_2020-05-06 Auth(2)](https://user-images.githubusercontent.com/20694532/81238425-e9f21e00-8fb6-11ea-8e07-049a35174c1c.png)
### ICN mis-match
![Screenshot_2020-05-06 Auth(3)](https://user-images.githubusercontent.com/20694532/81238427-ea8ab480-8fb6-11ea-9d95-27ce4b1e8c3f.png)

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
