### PR TITLE
Fixes ssoeEbenefitsLinks feature flag inflection

### DIFF
--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -15,7 +15,7 @@ export default Object.freeze({
   vaGlobalDowntimeNotification: 'vaGlobalDowntimeNotification',
   ssoe: 'ssoe',
   ssoeInbound: 'ssoeInbound',
-  ssoeEbenefitsLinks: 'ssoe_ebenefits_links',
+  ssoeEbenefitsLinks: 'ssoeEbenefitsLinks',
   eduBenefitsStemScholarship: 'eduBenefitsStemScholarship',
   eduSection103: 'edu_section_103',
   gibctEstimateYourBenefits: 'gibctEstimateYourBenefits',


### PR DESCRIPTION
ssoeEbenefitsLinks feature flag is not working, because this value
was snake-cased, not taking into account the auto-inflection that
happens when the feature flag API request happens

## Description


## Testing done
Tested locally and saw that the feature flag was coming through as true in developer console.


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
