### PR TITLE
Update Status Filtering

### DIFF
--- a/src/applications/vaos/utils/appointment.js
+++ b/src/applications/vaos/utils/appointment.js
@@ -206,12 +206,15 @@ export function getPastAppointmentDateRangeOptions(today = moment()) {
 export function filterFutureConfirmedAppointments(appt, today) {
   // return appointments where current time is less than appointment time
   // +60 min or +240 min in the case of video
-  const threshold = isVideoVisit(appt) ? 240 : 60;
+  const isVideo = isVideoVisit(appt);
+  const threshold = isVideo ? 240 : 60;
   const apptDateTime = getMomentConfirmedDate(appt);
+  const status = isVideo
+    ? appt.vvsAppointments?.[0]?.status?.code
+    : appt.vdsAppointments?.[0]?.currentStatus;
+
   return (
-    !FUTURE_APPOINTMENTS_HIDDEN_SET.has(
-      appt.vdsAppointments?.[0]?.currentStatus,
-    ) &&
+    !FUTURE_APPOINTMENTS_HIDDEN_SET.has(status) &&
     apptDateTime.isValid() &&
     apptDateTime.add(threshold, 'minutes').isAfter(today)
   );
@@ -223,10 +226,11 @@ export function sortFutureConfirmedAppointments(a, b) {
 
 export function filterPastAppointments(appt, startDate, endDate) {
   const apptDateTime = getMomentConfirmedDate(appt);
+  const status = isVideoVisit(appt)
+    ? appt.vvsAppointments?.[0]?.status?.code
+    : appt.vdsAppointments?.[0]?.currentStatus;
   return (
-    !PAST_APPOINTMENTS_HIDDEN_SET.has(
-      appt.vdsAppointments?.[0]?.currentStatus,
-    ) &&
+    !PAST_APPOINTMENTS_HIDDEN_SET.has(status) &&
     apptDateTime.isValid() &&
     apptDateTime.isAfter(startDate) &&
     apptDateTime.isBefore(endDate)
@@ -365,7 +369,10 @@ function getAppointmentStatus(appointment, isPastAppointment) {
         : APPOINTMENT_STATUS.pending;
     }
     case APPOINTMENT_TYPES.vaAppointment: {
-      const currentStatus = appointment.vdsAppointments?.[0]?.currentStatus;
+      const currentStatus = isVideoVisit(appointment)
+        ? appointment.vvsAppointments?.[0]?.status?.code
+        : appointment.vdsAppointments?.[0]?.currentStatus;
+
       if (
         (isPastAppointment &&
           PAST_APPOINTMENTS_HIDE_STATUS_SET.has(currentStatus)) ||

--- a/src/applications/vaos/utils/constants.js
+++ b/src/applications/vaos/utils/constants.js
@@ -13,11 +13,13 @@ export const APPOINTMENT_TYPES = {
 };
 
 export const APPOINTMENT_STATUS = {
-  pending: 'pending',
+  arrived: 'arrived',
   booked: 'booked',
   cancelled: 'cancelled',
   fulfilled: 'fulfilled',
   noshow: 'noshow',
+  pending: 'pending',
+  proposed: 'proposed',
 };
 
 export const VIDEO_TYPES = {
@@ -246,23 +248,33 @@ export const CANCELLED_APPOINTMENT_SET = new Set([
 
 // Appointments in these "HIDE_STATUS_SET"s should show in list, but their status should be hidden
 export const FUTURE_APPOINTMENTS_HIDE_STATUS_SET = new Set([
-  'CHECKED IN',
-  'CHECKED OUT',
-  'NO ACTION TAKEN',
-  'NO-SHOW & AUTO RE-BOOK',
-  'ACTION REQUIRED',
+  'ACT REQ/CHECKED IN',
+  'ACT REQ/CHECKED OUT',
 ]);
 
 export const PAST_APPOINTMENTS_HIDE_STATUS_SET = new Set([
-  ...FUTURE_APPOINTMENTS_HIDE_STATUS_SET,
-  'NO-SHOW',
+  'ACTION REQUIRED',
   'INPATIENT APPOINTMENT',
+  'INPATIENT/ACT REQ',
+  'INPATIENT/CHECKED IN',
+  'INPATIENT/CHECKED OUT',
+  'INPATIENT/FUTURE',
+  'INPATIENT/NO ACT TAKN',
+  'NO ACTION TAKEN',
+  'NO-SHOW & AUTO RE-BOOK',
+  'NO-SHOW',
   'NON-COUNT',
 ]);
 
 // Appointments in these "HIDDEN_SET"s should not be shown in appointment lists at all
 export const FUTURE_APPOINTMENTS_HIDDEN_SET = new Set(['NO-SHOW', 'DELETED']);
-export const PAST_APPOINTMENTS_HIDDEN_SET = new Set(['FUTURE', 'DELETED']);
+export const PAST_APPOINTMENTS_HIDDEN_SET = new Set([
+  'FUTURE',
+  'DELETED',
+  null,
+  '<null>',
+  'Deleted',
+]);
 
 export const FLOW_TYPES = {
   DIRECT: 'direct',


### PR DESCRIPTION
## Description
Update status filtering and hiding based on final spreadsheet below.  Also fixed `getAppointmentStatus()` util to handle video appointment statuses.

![image](https://user-images.githubusercontent.com/786704/81259976-efb72600-8fed-11ea-8ec5-ec004bda65bd.png)


## Testing done
Local and unit

## Acceptance criteria
- [ ] Statuses are shown as Completed, have a hidden status, or are hidden completely based on table above

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
