### PR TITLE
fix reason for appt to disallow all spaces in form

### DIFF
--- a/src/applications/vaos/containers/ReasonForAppointmentPage.jsx
+++ b/src/applications/vaos/containers/ReasonForAppointmentPage.jsx
@@ -13,6 +13,7 @@ import { getFormPageInfo } from '../utils/selectors';
 import { scrollAndFocus } from '../utils/scrollAndFocus';
 import { PURPOSE_TEXT } from '../utils/constants';
 import TextareaWidget from '../components/TextareaWidget';
+import { validateWhiteSpace } from 'platform/forms/validations';
 
 const initialSchema = {
   type: 'object',
@@ -41,6 +42,7 @@ const uiSchema = {
       expandUnder: 'reasonForAppointment',
       expandUnderCondition: reasonForAppointment => !!reasonForAppointment,
     },
+    'ui:validations': [validateWhiteSpace],
   },
 };
 

--- a/src/applications/vaos/tests/containers/ReasonForAppointmentPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/containers/ReasonForAppointmentPage.unit.spec.jsx
@@ -109,6 +109,7 @@ describe('VAOS <ReasonForAppointmentPage>', () => {
 
     form.unmount();
   });
+
   it('document title should match h1 text', () => {
     const openReasonForAppointment = sinon.spy();
     const updateReasonForAppointmentData = sinon.spy();
@@ -124,6 +125,27 @@ describe('VAOS <ReasonForAppointmentPage>', () => {
 
     expect(form.find('h1').text()).to.equal(pageTitle);
     expect(document.title).contain(pageTitle);
+
+    form.unmount();
+  });
+
+  it('should show error msg when enter all spaces', () => {
+    const openReasonForAppointment = sinon.spy();
+    const routeToNextAppointmentPage = sinon.spy();
+
+    const form = mount(
+      <ReasonForAppointmentPage
+        openReasonForAppointment={openReasonForAppointment}
+        routeToNextAppointmentPage={routeToNextAppointmentPage}
+        data={{
+          reasonForAppointment: 'routine-follow-up',
+          reasonAdditionalInfo: '   ',
+        }}
+      />,
+    );
+    form.find('form').simulate('submit');
+
+    expect(form.find('.usa-input-error-message').length).to.equal(1);
 
     form.unmount();
   });


### PR DESCRIPTION
## Description
fix the reason for appointment form to entry of all spaces 

## Testing done
unit test

## Screenshots
![image](https://user-images.githubusercontent.com/54327023/81295730-df7b6700-903e-11ea-94a2-71c9a4b897ae.png)


## Acceptance criteria
- [ ] error message will display when using solely spaces to submit form

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
