### PR TITLE
Hide cancel modal close button while loading

### DIFF
--- a/src/applications/vaos/components/cancel/CancelAppointmentConfirmationModal.jsx
+++ b/src/applications/vaos/components/cancel/CancelAppointmentConfirmationModal.jsx
@@ -14,6 +14,7 @@ export default function CancelAppointmentConfirmationModal({
       status="warning"
       visible
       onClose={onClose}
+      hideCloseButton={status === FETCH_STATUS.loading}
       title="Do you want to cancel your appointment?"
     >
       If you want to reschedule this appointment, you’ll need to first cancel

--- a/src/applications/vaos/tests/components/cancel/CancelAppointmentConfirmationModal.unit.spec.jsx
+++ b/src/applications/vaos/tests/components/cancel/CancelAppointmentConfirmationModal.unit.spec.jsx
@@ -14,6 +14,7 @@ describe('VAOS <CancelAppointmentConfirmationModal>', () => {
     );
 
     expect(tree.find('Modal').props().status).to.equal('warning');
+    expect(tree.find('Modal').find('button').length).to.equal(3);
     expect(
       tree
         .find('Modal')
@@ -36,6 +37,7 @@ describe('VAOS <CancelAppointmentConfirmationModal>', () => {
       <CancelAppointmentConfirmationModal status={FETCH_STATUS.loading} />,
     );
 
+    expect(tree.find('Modal').find('button').length).to.equal(2);
     expect(
       tree
         .find('Modal')
@@ -46,7 +48,7 @@ describe('VAOS <CancelAppointmentConfirmationModal>', () => {
       tree
         .find('Modal')
         .find('button')
-        .at(2)
+        .at(1)
         .props().disabled,
     ).to.be.true;
 


### PR DESCRIPTION
## Description
This fixes an error that happens when you click the modal close button while in the process of cancelling an appointment. We disable the other buttons, so we should hide the close button and prevent users from closing the modal.

## Testing done
Local and unit testing

## Screenshots
![Screen Shot 2020-05-07 at 1 10 55 PM](https://user-images.githubusercontent.com/634932/81323947-36dffe00-9064-11ea-97bd-1ab45a57bf8a.png)


## Acceptance criteria
- [ ] Can't close the modal while in the process of cancelling an appointment

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
