### PR TITLE
Remove cookie block from mentalhealth

### DIFF
--- a/src/applications/proxy-rewrite/proxy-rewrite-whitelist.json
+++ b/src/applications/proxy-rewrite/proxy-rewrite-whitelist.json
@@ -74,7 +74,7 @@
     {
       "hostname": "www.mentalhealth.va.gov",
       "pathnameBeginning": "/",
-      "cookieOnly": true
+      "cookieOnly": false
     },
     {
       "hostname": "www.move.va.gov",


### PR DESCRIPTION
## Description
- launches VA.gov header and footer in production for www.mentalhealth.va.gov

## Testing done
On Chrome and IE 11

## Screenshots

### Chrome

![mentalhealth](https://user-images.githubusercontent.com/55560129/81329438-8de9d100-906c-11ea-82c9-f05714e3ddf2.png)

### IE 11

![mentalhealth IE](https://user-images.githubusercontent.com/55560129/81329446-9215ee80-906c-11ea-9061-aecb86984e30.png)

## Acceptance criteria
- [x] Verify header and footer are added
- [x] Check that most css (specially drop-downs) are still functional

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
