### PR TITLE
Remove cookie block from move

### DIFF
--- a/src/applications/proxy-rewrite/proxy-rewrite-whitelist.json
+++ b/src/applications/proxy-rewrite/proxy-rewrite-whitelist.json
@@ -79,7 +79,7 @@
     {
       "hostname": "www.move.va.gov",
       "pathnameBeginning": "/",
-      "cookieOnly": true
+      "cookieOnly": false
     },
     {
       "hostname": "www.nutrition.va.gov",


### PR DESCRIPTION
## Description
- launches VA.gov header and footer in production for www.move.va.gov

## Testing done
On Chrome and IE 11

## Screenshots

### Chrome

![move](https://user-images.githubusercontent.com/55560129/81329642-da351100-906c-11ea-86a2-fe7b5adae66d.png)

### IE 11

![move IE](https://user-images.githubusercontent.com/55560129/81329661-de612e80-906c-11ea-996e-64dad3e1e90b.png)

## Acceptance criteria
- [x] Verify header and footer are added
- [x] Check that most css (specially drop-downs) are still functional

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
