### PR TITLE
Remove cookie block from nutrition

### DIFF
--- a/src/applications/proxy-rewrite/proxy-rewrite-whitelist.json
+++ b/src/applications/proxy-rewrite/proxy-rewrite-whitelist.json
@@ -84,7 +84,7 @@
     {
       "hostname": "www.nutrition.va.gov",
       "pathnameBeginning": "/",
-      "cookieOnly": true
+      "cookieOnly": false
     },
     {
       "hostname": "www.oedca.va.gov",


### PR DESCRIPTION
## Description
- launches VA.gov header and footer in production for www.nutrition.va.gov

## Testing done
On Chrome and IE 11

## Screenshots

### Chrome

![nutrition](https://user-images.githubusercontent.com/55560129/81340898-95b27100-907e-11ea-9288-353c1b522ce5.png)

### IE 11

![nutrition IE](https://user-images.githubusercontent.com/55560129/81340910-9a772500-907e-11ea-8adf-6ebe8e2f494f.png)

## Acceptance criteria
- [x] Verify header and footer are added
- [x] Check that most css (specially drop-downs) are still functional

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
