### PR TITLE
Remove cookie block from oedca

### DIFF
--- a/src/applications/proxy-rewrite/proxy-rewrite-whitelist.json
+++ b/src/applications/proxy-rewrite/proxy-rewrite-whitelist.json
@@ -89,7 +89,7 @@
     {
       "hostname": "www.oedca.va.gov",
       "pathnameBeginning": "/",
-      "cookieOnly": true
+      "cookieOnly": false
     },
     {
       "hostname": "www.oefoif.va.gov",


### PR DESCRIPTION
## Description
- launches VA.gov header and footer in production for www.oedca.va.gov

## Testing done
On Chrome and IE 11

## Screenshots

### Chrome

![oedca](https://user-images.githubusercontent.com/55560129/81342277-f80c7100-9080-11ea-9ef0-a5cdc6dde2b6.png)

### IE 11

![oedca IE](https://user-images.githubusercontent.com/55560129/81342282-fc388e80-9080-11ea-8e06-9ec53a20262a.png)

## Acceptance criteria
- [x] Verify header and footer are added
- [x] Check that most css (specially drop-downs) are still functional

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
