### PR TITLE
Remove cookie block from oefoif

### DIFF
--- a/src/applications/proxy-rewrite/proxy-rewrite-whitelist.json
+++ b/src/applications/proxy-rewrite/proxy-rewrite-whitelist.json
@@ -94,7 +94,7 @@
     {
       "hostname": "www.oefoif.va.gov",
       "pathnameBeginning": "/",
-      "cookieOnly": true
+      "cookieOnly": false
     },
     {
       "hostname": "www.oprm.va.gov",


### PR DESCRIPTION
## Description
- launches VA.gov header and footer in production for www.oefoif.va.gov

## Testing done
On Chrome and IE 11

## Screenshots

### Chrome

![oefoif](https://user-images.githubusercontent.com/55560129/81342449-46217480-9081-11ea-92db-f05249a8a4b9.png)

### IE 11

![oefoif IE](https://user-images.githubusercontent.com/55560129/81342464-4ae62880-9081-11ea-951a-6ad43c537991.png)

## Acceptance criteria
- [x] Verify header and footer are added
- [x] Check that most css (specially drop-downs) are still functional

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
