### PR TITLE
fix for rendering the SingleSignOnInfoModal

### DIFF
--- a/src/platform/site-wide/announcements/containers/Announcement.jsx
+++ b/src/platform/site-wide/announcements/containers/Announcement.jsx
@@ -66,6 +66,7 @@ export class Announcement extends Component {
         announcement={announcement}
         dismiss={dismiss}
         isLoggedIn={this.props.isLoggedIn}
+        useSSOe={this.props.useSSOe}
         profile={profile}
       />
     );

--- a/src/platform/site-wide/announcements/tests/containers/Announcement.unit.spec.jsx
+++ b/src/platform/site-wide/announcements/tests/containers/Announcement.unit.spec.jsx
@@ -13,6 +13,7 @@ describe('<Announcement/>', () => {
       isInitialized: true,
       announcement: null,
       isLoggedIn: true,
+      useSSOe: true,
       profile: {},
       dismissed: [],
       initDismissedAnnouncements() {},


### PR DESCRIPTION
we need to explicitly pass the useSSOe property down to the announcement component

## Testing done
- [x] ran through tests locally to confirm info modal pops up when a user first logs in

