### PR TITLE
8520 accessibility fixes view dependents

### DIFF
--- a/src/applications/personalization/view-dependents/components/ViewDependentsList/ViewDependentsListItem.jsx
+++ b/src/applications/personalization/view-dependents/components/ViewDependentsList/ViewDependentsListItem.jsx
@@ -1,28 +1,29 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import moment from 'moment';
 
 function ViewDependentsListItem(props) {
   return (
     <dl className="vads-l-row vads-u-background-color--gray-lightest vads-u-margin-top--0 vads-u-margin-bottom--2 vads-u-padding-top--1 vads-u-padding-bottom--2 vads-u-padding-x--2">
-      <dd className="vads-l-col--12 vads-u-margin--0 vads-u-font-size--lg vads-u-font-weight--bold">
+      <dt className="vads-l-col--12 vads-u-margin--0 vads-u-font-size--lg vads-u-font-weight--bold">
         {props.firstName} {props.lastName}
-      </dd>
+      </dt>
 
       <dd className="vads-l-col--12 vads-u-margin--0">
-        <span className="vads-u-font-weight--bold">Relationship:</span>{' '}
+        <dfn className="vads-u-font-weight--bold">Relationship:</dfn>{' '}
         {props.relationship}
       </dd>
 
       {props.ssn ? (
         <dd className="vads-l-col--12 vads-u-margin--0">
-          <span className="vads-u-font-weight--bold">SSN:</span> {props.ssn}
+          <dfn className="vads-u-font-weight--bold">SSN:</dfn> {props.ssn}
         </dd>
       ) : null}
 
       {props.dateOfBirth ? (
         <dd className="vads-l-col--12 vads-u-margin--0">
-          <span className="vads-u-font-weight--bold">Date of birth: </span>
-          {props.dateOfBirth}
+          <dfn className="vads-u-font-weight--bold">Date of birth: </dfn>
+          {moment(props.dateOfBirth).format('MMMM D, YYYY')}
         </dd>
       ) : null}
     </dl>

--- a/src/applications/personalization/view-dependents/tests/components/ViewDependentsListItem.unit.spec.jsx
+++ b/src/applications/personalization/view-dependents/tests/components/ViewDependentsListItem.unit.spec.jsx
@@ -28,6 +28,6 @@ describe('<ViewDependentsListItem />', () => {
     expect(wrapper.text()).to.contain('Cindy');
     expect(wrapper.text()).to.contain('See');
     expect(wrapper.text()).to.contain('312-243-5634');
-    expect(wrapper.text()).to.contain('05-05-1953');
+    expect(wrapper.text()).to.contain('May 5, 1953');
   });
 });


### PR DESCRIPTION
## Description
[Ticket for definition list update](https://github.com/department-of-veterans-affairs/va.gov-team/issues/8515)
[Ticket for date format](https://github.com/department-of-veterans-affairs/va.gov-team/issues/8520)

This pull request addresses two accessibility issues in view-dependents:
1. Updates the definition list used for dependent list items to more semantic markup. Adds a `dt` tag and switches out `<span>` tags for `<dfn>` tags.
1. Formats dates to long form so months are represented by word instead of number.

## Testing done
- local.

## Screenshots
<img width="704" alt="Screen Shot 2020-05-07 at 2 27 33 PM" src="https://user-images.githubusercontent.com/15097156/81346731-a3142f00-906f-11ea-9db4-98e0d00c865c.png">
<img width="652" alt="Screen Shot 2020-05-07 at 2 28 02 PM" src="https://user-images.githubusercontent.com/15097156/81346743-aad3d380-906f-11ea-864d-bfa6ef923c9a.png">


## Acceptance criteria
- [x] definition list has been updated
- [x] dates have been formatted

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
