### PR TITLE
updating ebenefits link selector to use isLoggedIn selector

### DIFF
--- a/src/platform/site-wide/ebenefits/selectors.js
+++ b/src/platform/site-wide/ebenefits/selectors.js
@@ -2,11 +2,11 @@ import {
   ssoe,
   ssoeEbenefitsLinks,
 } from 'platform/user/authentication/selectors';
-import { hasSessionSSO } from 'platform/user/profile/utilities';
+import { isLoggedIn } from 'platform/user/selectors';
 
 // the following criteria must be true for the proxied/eauth function
 // a) user is authenticated
 // b) the SSOe feature flag enabled
 // c) the SSOe eBenefits links feature flag enabled
 export const shouldUseProxyUrl = state =>
-  hasSessionSSO() && ssoe(state) && ssoeEbenefitsLinks(state);
+  isLoggedIn(state) && ssoe(state) && ssoeEbenefitsLinks(state);

--- a/src/platform/site-wide/ebenefits/tests/selectors.unit.spec.js
+++ b/src/platform/site-wide/ebenefits/tests/selectors.unit.spec.js
@@ -1,0 +1,45 @@
+import { expect } from 'chai';
+import * as selectors from '../selectors';
+
+describe('ebenefits selectors', () => {
+  describe('shouldUseProxyUrl', () => {
+    let state = {};
+    beforeEach(() => {
+      state = {
+        featureToggles: {
+          ssoe: false,
+          ssoeEbenefitsLinks: false,
+        },
+        user: {
+          login: {
+            currentlyLoggedIn: false,
+          },
+        },
+      };
+    });
+
+    it('renders false when user is logged out', () => {
+      state.featureToggles.ssoe = true;
+      expect(selectors.shouldUseProxyUrl(state)).to.equal(false);
+      state.featureToggles.ssoeEbenefitsLinks = true;
+      expect(selectors.shouldUseProxyUrl(state)).to.equal(false);
+    });
+    it('renders false when feature flags are off', () => {
+      state.user.login.currentlyLoggedIn = true;
+      expect(selectors.shouldUseProxyUrl(state)).to.equal(false);
+      state.featureToggles.ssoe = true;
+      state.featureToggles.ssoeEbenefitsLinks = false;
+      expect(selectors.shouldUseProxyUrl(state)).to.equal(false);
+      state.featureToggles.ssoe = false;
+      state.featureToggles.ssoeEbenefitsLinks = true;
+      expect(selectors.shouldUseProxyUrl(state)).to.equal(false);
+    });
+    it('renders true when user is logged in and feature flags are on', () => {
+      expect(selectors.shouldUseProxyUrl(state)).to.equal(false);
+      state.user.login.currentlyLoggedIn = true;
+      state.featureToggles.ssoe = true;
+      state.featureToggles.ssoeEbenefitsLinks = true;
+      expect(selectors.shouldUseProxyUrl(state)).to.equal(true);
+    });
+  });
+});


### PR DESCRIPTION
The `hasSessionSSO()` function only returns true if the user is a) logged in and b) the /keepalive endpoint successfully returns a response.  When determining when to render eBenefits links via the proxy, we only need to know if the user is logged in, as if the SSOe feature flag is enabled it can be assumed the user has an SSOe session.