### PR TITLE
fix console warnings for disability benefits wizard

### DIFF
--- a/src/applications/disability-benefits/wizard/pages/unable-to-file-bdd.jsx
+++ b/src/applications/disability-benefits/wizard/pages/unable-to-file-bdd.jsx
@@ -5,7 +5,7 @@ import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 import { pageNames } from './pageList';
 import { isLoggedIn as isLoggedInSelector } from 'platform/user/selectors';
 import recordEvent from 'platform/monitoring/record-event';
-import { EBEN_526_URL, BDD_INFO_URL } from '../../constants';
+import { EBEN_526_PATH, BDD_INFO_URL } from '../../constants';
 
 import environment from 'platform/utilities/environment';
 
@@ -35,7 +35,7 @@ function alertContent(isLoggedIn) {
           your claim on eBenefits.
         </p>
         <a
-          href={EBEN_526_URL}
+          href={EBEN_526_PATH}
           className="usa-button-primary va-button-primary"
           onClick={() =>
             isLoggedIn && recordEvent({ event: 'nav-ebenefits-click' })
@@ -63,7 +63,7 @@ function alertContent(isLoggedIn) {
         still begin the process of filing your claim on eBenefits.
       </p>
       <a
-        href={EBEN_526_URL}
+        href={EBEN_526_PATH}
         className="usa-button-primary va-button-primary"
         onClick={() =>
           isLoggedIn && recordEvent({ event: 'nav-ebenefits-click' })


### PR DESCRIPTION
## Description
An import was creating console warnings on `yarn watch` due to being improperly named. This pull request fixes the import to re-align it with the constant it is importing. 

Updates `EBEN_526_URL` to `EBEN_526_PATH`

## Testing done


## Screenshots
![Screen Shot 2020-05-07 at 4 00 45 PM](https://user-images.githubusercontent.com/15097156/81352850-6ef33b00-907c-11ea-9bfc-e07ada04cb99.png)
![Screen Shot 2020-05-07 at 4 04 21 PM](https://user-images.githubusercontent.com/15097156/81352852-71559500-907c-11ea-9ae8-999882e3bdc2.png)


## Acceptance criteria
- [x] Import has been updated, no console warnings.

## Definition of done
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
