### PR TITLE
 Removes chatbot feature flags from FAQ and Facility Locator pages

### DIFF
--- a/src/applications/facility-locator/containers/VAMap.jsx
+++ b/src/applications/facility-locator/containers/VAMap.jsx
@@ -2,19 +2,19 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { browserHistory } from 'react-router';
 import { connect } from 'react-redux';
-import { Tabs, TabList, TabPanel, Tab } from 'react-tabs';
-import { Map, TileLayer, FeatureGroup } from 'react-leaflet';
+import { Tab, TabList, TabPanel, Tabs } from 'react-tabs';
+import { FeatureGroup, Map, TileLayer } from 'react-leaflet';
 import mapboxClient from '../components/MapboxClient';
 import { mapboxToken } from '../utils/mapboxToken';
 import isMobile from 'ismobilejs';
-import { isEmpty, debounce } from 'lodash';
+import { debounce, isEmpty } from 'lodash';
 import appendQuery from 'append-query';
 import {
-  updateSearchQuery,
+  clearSearchResults,
+  fetchVAFacility,
   genBBoxFromAddress,
   searchWithBounds,
-  fetchVAFacility,
-  clearSearchResults,
+  updateSearchQuery,
 } from '../actions';
 import SearchControls from '../components/SearchControls';
 import ResultsList from '../components/ResultsList';
@@ -23,17 +23,14 @@ import FacilityMarker from '../components/markers/FacilityMarker';
 import CurrentPositionMarker from '../components/markers/CurrentPositionMarker';
 import { facilityTypes } from '../config';
 import {
-  LocationType,
-  FacilityType,
   BOUNDING_RADIUS,
+  FacilityType,
+  LocationType,
   MARKER_LETTERS,
 } from '../constants';
 import { areGeocodeEqual, setFocus } from '../utils/helpers';
 import { facilityLocatorShowCommunityCares } from '../utils/selectors';
-import {
-  isProduction,
-  toggleValues,
-} from 'platform/site-wide/feature-toggles/selectors';
+import { isProduction } from 'platform/site-wide/feature-toggles/selectors';
 import Pagination from '@department-of-veterans-affairs/formation-react/Pagination';
 import mbxGeo from '@mapbox/mapbox-sdk/services/geocoding';
 import recordEvent from 'platform/monitoring/record-event';
@@ -741,7 +738,7 @@ class VAMap extends Component {
   };
 
   render() {
-    const chatbotLink = this.props.showCovidChatbotLink && (
+    const chatbotLink = (
       <>
         For answers to questions about how COVID-19 may affect your VA health
         appointments, benefits, and services, use our VA{' '}
@@ -790,8 +787,6 @@ function mapStateToProps(state) {
     results: state.searchResult.results,
     pagination: state.searchResult.pagination,
     selectedResult: state.searchResult.selectedResult,
-    showCovidChatbotLink: toggleValues(state)
-      .facilityLocatorShowCovid19ChatbotLink,
   };
 }
 

--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -1,8 +1,5 @@
 export default Object.freeze({
-  facilityLocatorShowCovid19ChatbotLink:
-    'facilityLocatorShowCovid19ChatbotLink',
   dashboardShowCovid19Alert: 'dashboardShowCovid19Alert',
-  covid19FaqChatbotLink: 'covid19FaqChatbotLink',
   facilityLocatorShowCommunityCares: 'facilityLocatorShowCommunityCares',
   profileShowProfile2: 'profile_show_profile_2.0',
   profileShowReceiveTextNotifications: 'profileShowReceiveTextNotifications',


### PR DESCRIPTION
## Description
Tracked in this issue [department-of-veterans-affairs/covid19-chatbot#142]

Since the COVID-19 chatbot is now live in production, we no longer need these feature flags. **These code changes remove them from the FAQ and Facility Locator pages.**

Previous PRs related to adding the feature flags:
- [Tracking Issue](https://github.com/department-of-veterans-affairs/covid19-chatbot/issues/121)
- [Add to FAQ page](https://github.com/department-of-veterans-affairs/vets-website/pull/12299/files#diff-b5e61a0c86dd4a14bf595b6c3377416a)
- [Add to Facility Locator](https://github.com/department-of-veterans-affairs/vets-website/pull/12287/files)

Need to remove the flags in vets-api as well: [PR](https://github.com/department-of-veterans-affairs/vets-api/pull/4246)

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
