### PR TITLE
Add noindex meta tag on non-prod envs

### DIFF
--- a/src/site/includes/header.html
+++ b/src/site/includes/header.html
@@ -20,6 +20,10 @@
   <meta name="MobileOptimized" content="320">
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
+  {% if buildtype != 'vagovprod' %}
+    <meta name="robots" content="noindex">
+  {% endif %}
+
   {% if drupalTags %}
   {% include "src/site/includes/metatags.drupal.liquid" %}
   {% else %}


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/7588

This PR adds a no-index meta tag on every page in non-prod envs.

## Testing done
N/A

## Screenshots
![image](https://user-images.githubusercontent.com/12773166/81439458-a66cf080-912b-11ea-9b34-93294aec5c4a.png)


## Acceptance criteria
- [x] Add a no-index meta tag on every page in non-prod envs.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
