### PR TITLE
fix phone number validation for CC providers

### DIFF
--- a/src/applications/vaos/containers/CommunityCarePreferencesPage.jsx
+++ b/src/applications/vaos/containers/CommunityCarePreferencesPage.jsx
@@ -49,6 +49,7 @@ const initialSchema = {
         phone: {
           type: 'string',
           minLength: 10,
+          pattern: '^[0-9]{10}$',
         },
       },
     },

--- a/src/applications/vaos/tests/containers/CommunityCarePreferencesPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/containers/CommunityCarePreferencesPage.unit.spec.jsx
@@ -108,4 +108,37 @@ describe('VAOS <CommunityCarePreferencesPage>', () => {
 
     form.unmount();
   });
+
+  it('should display error msg when phone number exceeds 10 char', () => {
+    const routeToNextAppointmentPage = sinon.spy();
+
+    const form = mount(
+      <CommunityCarePreferencesPageTester
+        data={{
+          hasCommunityCareProvider: true,
+          preferredLanguage: 'english',
+          communityCareProvider: {
+            practiceName: 'Practice name',
+            firstName: 'Jane',
+            lastName: 'Doe',
+            phone: '5555555555555555555555555',
+            address: {
+              street: '123 Test',
+              street2: 'line 2',
+              city: 'Northampton',
+              state: 'MA',
+              postalCode: '01060',
+            },
+          },
+        }}
+        routeToNextAppointmentPage={routeToNextAppointmentPage}
+      />,
+    );
+
+    form.find('form').simulate('submit');
+
+    expect(form.find('.usa-input-error').length).to.equal(1);
+    expect(routeToNextAppointmentPage.called).to.be.false;
+    form.unmount();
+  });
 });


### PR DESCRIPTION
## Description
limit phone number to 10 digits in the CC provider form

## Testing done
local and unit

## Screenshots
![image](https://user-images.githubusercontent.com/54327023/81447856-6158b680-914b-11ea-9127-572f98788e31.png)


## Acceptance criteria
- [ ] accepts only 10 digits for CC provider phone number

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
