### PR TITLE
Fix unit test using moment constructor to initialize value

### DIFF
--- a/src/applications/disability-benefits/2346/tests/ConfirmationPage.unit.spec.jsx
+++ b/src/applications/disability-benefits/2346/tests/ConfirmationPage.unit.spec.jsx
@@ -8,6 +8,7 @@ describe('ConfirmationPage', () => {
     getState: () => ({
       form: {
         submission: {
+          submittedAt: '2020-05-08T20:32:13-05:00',
           response: {
             attributes: {
               confirmationNumber: '123456',


### PR DESCRIPTION
The tested component was using `moment()` as a fallback date value. This was breaking a test where a date wasn't mocked out.