### PR TITLE
Search result link click changes

### DIFF
--- a/src/applications/gi/components/search/SearchResult.jsx
+++ b/src/applications/gi/components/search/SearchResult.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { Link } from 'react-router';
+import environment from 'platform/utilities/environment';
 import { estimatedBenefits } from '../../selectors/estimator';
 import { formatCurrency, locationInfo } from '../../utils/helpers';
 import {
@@ -49,12 +50,23 @@ export class SearchResult extends React.Component {
             <div className="row">
               <div className="small-12 usa-width-seven-twelfths medium-7 columns">
                 <h2>
-                  <Link
-                    to={linkTo}
-                    aria-label={`${name} ${locationInfo(city, state, country)}`}
-                  >
-                    {name}
-                  </Link>
+                  {!environment.isProduction() && (
+                    <a onClick={() => this.props.handleLinkClick(facilityCode)}>
+                      {name}
+                    </a>
+                  )}
+                  {environment.isProduction() && (
+                    <Link
+                      to={linkTo}
+                      aria-label={`${name} ${locationInfo(
+                        city,
+                        state,
+                        country,
+                      )}`}
+                    >
+                      {name}
+                    </Link>
+                  )}
                 </h2>
               </div>
             </div>

--- a/src/applications/gi/components/search/SearchResult.jsx
+++ b/src/applications/gi/components/search/SearchResult.jsx
@@ -51,7 +51,14 @@ export class SearchResult extends React.Component {
               <div className="small-12 usa-width-seven-twelfths medium-7 columns">
                 <h2>
                   {!environment.isProduction() && (
-                    <a onClick={() => this.props.handleLinkClick(facilityCode)}>
+                    <a
+                      onClick={() => this.props.handleLinkClick(facilityCode)}
+                      aria-label={`${name} ${locationInfo(
+                        city,
+                        state,
+                        country,
+                      )}`}
+                    >
                       {name}
                     </a>
                   )}

--- a/src/applications/gi/containers/SearchPage.jsx
+++ b/src/applications/gi/containers/SearchPage.jsx
@@ -121,6 +121,12 @@ export class SearchPage extends React.Component {
     }
   };
 
+  handleSearchLinkClick = facilityCode => {
+    const version = this.props.location.query.version;
+    const query = version ? { version } : {};
+    this.props.router.push({ pathname: `profile/${facilityCode}`, query });
+  };
+
   handlePageSelect = page => {
     this.props.router.push({
       ...this.props.location,
@@ -223,6 +229,7 @@ export class SearchPage extends React.Component {
                 yr={result.yr}
                 poe={result.poe}
                 eightKeys={result.eightKeys}
+                handleLinkClick={this.handleSearchLinkClick}
               />
             ))}
           </div>


### PR DESCRIPTION
## Description
Update search result link to directly push institution profile to router instead of using Link.

[ZenHub Issue](https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/8228)

## Testing done
Tested locally and QA reviewed

## Screenshots
![image](https://user-images.githubusercontent.com/41960449/81585996-ee398500-9382-11ea-8390-96969e73b706.png)

## Acceptance criteria
- [x] State is not lost on link click in Staging

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
