### PR TITLE
Fix for SCO not in line with Contact Details

### DIFF
--- a/src/applications/gi/sass/partials/_gi-profile-page.scss
+++ b/src/applications/gi/sass/partials/_gi-profile-page.scss
@@ -404,4 +404,12 @@
     color: $color-white;
     width: auto;
   }
+
+  .primary-sco-list {
+    padding-left: 0;
+  }
+
+  .secondary-sco-list {
+    padding-left: 0;
+  }
 }


### PR DESCRIPTION
## Description
https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/8078

Bug fix that addresses spacing issues around SCO primary and secondary contacts. 

## Testing done
Dev tested.

## Screenshots
![image](https://user-images.githubusercontent.com/48804654/81591400-5e97d480-938a-11ea-9608-3b51c7c32281.png)

![image](https://user-images.githubusercontent.com/48804654/81591404-6192c500-938a-11ea-97b0-58fd0b3bb020.png)


## Acceptance criteria
- [x] Primary and Secondary contact info lines up with Contact Info details. 

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
