### PR TITLE
JavaScript-only focus on chatbot button containers

### DIFF
--- a/src/applications/coronavirus-chatbot/index.js
+++ b/src/applications/coronavirus-chatbot/index.js
@@ -1,6 +1,6 @@
 import { apiRequest } from 'platform/utilities/api';
 import recordEvent from 'platform/monitoring/record-event';
-import { GA_PREFIX, addEventListenerToButtons } from './utils';
+import { GA_PREFIX, handleButtonsPostRender } from './utils';
 import * as Sentry from '@sentry/browser';
 
 export const defaultLocale = 'en-US';
@@ -154,6 +154,6 @@ const chatRequested = scenario => {
 };
 
 export default function initializeChatbot() {
-  addEventListenerToButtons();
+  handleButtonsPostRender();
   return chatRequested('va_coronavirus_chatbot');
 }

--- a/src/applications/coronavirus-chatbot/utils.js
+++ b/src/applications/coronavirus-chatbot/utils.js
@@ -33,12 +33,31 @@ const handleDisableAndScroll = event => {
   scrollToNewMessage();
 };
 
-export const addEventListenerToButtons = () => {
-  setInterval(() => {
-    const buttons = document.getElementsByClassName('ac-pushButton');
-    for (let i = 0; i < buttons.length; i++) {
-      buttons[i].addEventListener('click', handleDisableAndScroll);
+/*
+https://github.com/department-of-veterans-affairs/covid19-chatbot/issues/98
+Bot framework renders button containers with tab index 0. This method sets
+tab index to -1 so button containers have javascript-only focus.
+*/
+const removeKeyboardFocusFromContainer = () => {
+  const buttonContainers = document.getElementsByClassName('ac-adaptiveCard');
+  for (let i = 0; i < buttonContainers.length; i++) {
+    if (buttonContainers[i].hasAttribute('tabIndex')) {
+      buttonContainers[i].setAttribute('tabIndex', '-1');
     }
+  }
+};
+
+const addEventListenerToButtons = () => {
+  const buttons = document.getElementsByClassName('ac-pushButton');
+  for (let i = 0; i < buttons.length; i++) {
+    buttons[i].addEventListener('click', handleDisableAndScroll);
+  }
+};
+
+export const handleButtonsPostRender = () => {
+  setInterval(() => {
+    removeKeyboardFocusFromContainer();
+    addEventListenerToButtons();
   }, 10);
 };
 


### PR DESCRIPTION
## Description
Related to this issue [department-of-veterans-affairs/covid19-chatbot#98]

The bot framework initially renders the button containers with tabIndex=0, so we are setting tabIndex=-1 for accessibility.

## Testing done


## Screenshots


## Acceptance criteria
- [ ] Prompt container no longer receives keyboard focus when navigating by pressing `TAB`

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
