### PR TITLE
Runs only 508 ruleset on chatbot page

### DIFF
--- a/src/platform/site-wide/tests/sitemap/sitemap-helpers.js
+++ b/src/platform/site-wide/tests/sitemap/sitemap-helpers.js
@@ -17,7 +17,6 @@ function sitemapURLs() {
         .map(n => n.text().replace(DOMAIN_REGEX, `${E2eHelpers.baseUrl}/`))
         .filter(url => !url.endsWith('auth/login/callback/'))
         .filter(url => !url.includes('playbook/'))
-        .filter(url => !url.includes('coronavirus-chatbot/'))
         .filter(url => !url.includes('pittsburgh-health-care/'))
         .filter(url => !/.*opt-out-information-sharing.*/.test(url)),
     )
@@ -32,6 +31,11 @@ function sitemapURLs() {
         '/find-locations/',
         // This is here because an aXe bug flags the autosuggest component on this page
         '/gi-bill-comparison-tool/',
+        /* Using the Microsoft Healthbot framework, the chatbot currently violates
+        two rules in the WCAG 2.0(A) ruleset: aria-valid-attr-value and aria-required-children.
+        There are open Github issues with Microsoft to address these.
+        The 508 ruleset is slightly less strict to test on chatbot for now. */
+        '/coronavirus-chatbot/',
       ];
       // Whitelist of URLs to only test against the 'section508' rule set and not
       // the stricter 'wcag2a' rule set. For each URL added to this list, please


### PR DESCRIPTION
The chatbot page was originally excluded from all rulesets, but now runs only the 508 ruleset in order to avoid the stricter WCAG ruleset that checks aria labels.

## Description
[department-of-veterans-affairs/covid19-chatbot#184] 

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
