### PR TITLE
Added localhost to va-subdomains

### DIFF
--- a/src/platform/utilities/environment/va-subdomain.js
+++ b/src/platform/utilities/environment/va-subdomain.js
@@ -4,5 +4,8 @@
  * @module platform/brand-consolidation/va-subdomain
  */
 export default function isVATeamSiteSubdomain() {
-  return !window.location.hostname.match(/(www|staging|dev).va.gov/gi);
+  return (
+    !window.location.hostname.match(/(www|staging|dev).va.gov/gi) &&
+    !window.location.hostname.match(/(localhost|127.0.0.1)/gi)
+  );
 }


### PR DESCRIPTION
## Description
The missing `localhost` is redirecting to the `va.gov` when testing locally

## Testing done
Locally

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
