### PR TITLE
Adjusts chatbot scrolling wrt to footer

### DIFF
--- a/src/applications/coronavirus-chatbot/utils.js
+++ b/src/applications/coronavirus-chatbot/utils.js
@@ -30,7 +30,9 @@ const scrollToNewMessage = () => {
 const handleDisableAndScroll = event => {
   disableButtons(event);
   disableCheckboxes();
-  scrollToNewMessage();
+  setTimeout(() => {
+    scrollToNewMessage();
+  }, 700);
 };
 
 export const addEventListenerToButtons = () => {


### PR DESCRIPTION
## Description
[department-of-veterans-affairs/covid19-chatbot#156]

When a user clicks on a button (answers a question), we want the content for the next question to have loaded before the auto-scroll moves the page down. 

Previously, the scroll would happen too quickly and VA footer would seem to jump up on the page before the content was properly loaded. **A short wait time has been added to improve the user experience.**

**Note:** Scrolling speed and view of the footer will depend on internet speed and browser, but with this additional wait, UX is improved at least slightly. The wait gives time for the content to load before the auto-scroll to the last user message @toddstanich 

## Testing done

**BEFORE**
![ezgif com-optimize (1)](https://user-images.githubusercontent.com/60353062/81699367-3dd88900-9435-11ea-8aff-d2f6650e93ee.gif)



**AFTER**
![ezgif com-video-to-gif (1)](https://user-images.githubusercontent.com/60353062/81614143-98c69d80-93ad-11ea-8614-27f004dd0ed1.gif)


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
