### PR TITLE
Add usePrevious React hook to Platform

### DIFF
--- a/src/applications/personalization/profile-2/components/direct-deposit/DirectDepositContent.jsx
+++ b/src/applications/personalization/profile-2/components/direct-deposit/DirectDepositContent.jsx
@@ -9,6 +9,7 @@ import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 
 import EbenefitsLink from 'platform/site-wide/ebenefits/containers/EbenefitsLink';
 import { isLOA3, isMultifactorEnabled } from 'platform/user/selectors';
+import { usePrevious } from 'platform/utilities/react-hooks';
 
 import {
   editModalToggled,
@@ -29,33 +30,6 @@ import FraudVictimAlert from './FraudVictimAlert';
 import AdditionalInformation from './DirectDepositInformation';
 
 import { prefixUtilityClasses } from '../../helpers';
-
-// TODO: move this to a common location (in platform?) for easy sharing
-/**
- * While not included with React, this hook is described in the React Hooks
- * documentation:
- * https://reactjs.org/docs/hooks-faq.html#how-to-get-the-previous-props-or-state
- *
- * as well as on usehooks.com:
- * https://usehooks.com/usePrevious/
- *
- * This post does a deeper dive for those who are new to hooks:
- * https://blog.logrocket.com/how-to-get-previous-props-state-with-react-hooks/
- */
-const usePrevious = value => {
-  const valueRef = useRef();
-  useEffect(
-    () => {
-      valueRef.current = value;
-    },
-    // only run this useEffect hook if `value` changes
-    [value],
-  );
-  // this returns _before_ the `useEffect` call completes, so this will return
-  // whatever was stored in `ref.current` _before_ this function's `useEffect`
-  // callback runs
-  return valueRef.current;
-};
 
 export const DirectDepositContent = ({
   isAuthorized,

--- a/src/platform/utilities/react-hooks.js
+++ b/src/platform/utilities/react-hooks.js
@@ -1,0 +1,27 @@
+import { useEffect, useRef } from 'react';
+
+/**
+ * While not included with React, this hook is described in the React Hooks
+ * documentation:
+ * https://reactjs.org/docs/hooks-faq.html#how-to-get-the-previous-props-or-state
+ *
+ * as well as on usehooks.com:
+ * https://usehooks.com/usePrevious/
+ *
+ * This post does a deeper dive for those who are new to hooks:
+ * https://blog.logrocket.com/how-to-get-previous-props-state-with-react-hooks/
+ */
+export const usePrevious = value => {
+  const valueRef = useRef();
+  useEffect(
+    () => {
+      valueRef.current = value;
+    },
+    // only run this useEffect hook if `value` changes
+    [value],
+  );
+  // this returns _before_ the `useEffect` call completes, so this will return
+  // whatever was stored in `ref.current` _before_ this function's `useEffect`
+  // callback runs
+  return valueRef.current;
+};

--- a/src/platform/utilities/react-hooks.js
+++ b/src/platform/utilities/react-hooks.js
@@ -10,18 +10,22 @@ import { useEffect, useRef } from 'react';
  *
  * This post does a deeper dive for those who are new to hooks:
  * https://blog.logrocket.com/how-to-get-previous-props-state-with-react-hooks/
+ *
+ * @param {*} nextValue - The value to return the next time this hook is run
+ * @returns {*} - The value that was passed to this hook the previous time that
+ * it was run. Or `undefined` if the hook is being run for the first time.
  */
-export const usePrevious = value => {
-  const valueRef = useRef();
+export const usePrevious = nextValue => {
+  const previousValue = useRef();
   useEffect(
     () => {
-      valueRef.current = value;
+      previousValue.current = nextValue;
     },
-    // only run this useEffect hook if `value` changes
-    [value],
+    // only run this useEffect hook if `nextValue` changes
+    [nextValue],
   );
-  // this returns _before_ the `useEffect` call completes, so this will return
-  // whatever was stored in `ref.current` _before_ this function's `useEffect`
-  // callback runs
-  return valueRef.current;
+  // This returns _before_ the `useEffect` call completes, so this will return
+  // whatever was stored in `previousValue.current` _before_ this function's
+  // `useEffect` callback runs
+  return previousValue.current;
 };

--- a/src/platform/utilities/react-hooks.unit.spec.js
+++ b/src/platform/utilities/react-hooks.unit.spec.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { expect } from 'chai';
+
+import { usePrevious } from './react-hooks';
+
+describe('usePrevious', () => {
+  let container;
+  let previousValue;
+
+  const TestComponent = ({ aValue }) => {
+    previousValue = usePrevious(aValue);
+    return null;
+  };
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    document.body.removeChild(container);
+    container = null;
+  });
+
+  it('should return undefined on first use', () => {
+    ReactDOM.render(<TestComponent aValue={0} />, container);
+    expect(previousValue).to.be.undefined;
+  });
+
+  it('should return the previous value it was given', () => {
+    ReactDOM.render(<TestComponent aValue={0} />, container);
+    ReactDOM.render(<TestComponent aValue={1} />, container);
+    expect(previousValue).to.equal(0);
+
+    ReactDOM.render(<TestComponent aValue={2} />, container);
+    expect(previousValue).to.equal(1);
+  });
+});


### PR DESCRIPTION
## Description
I propose we have a place for React Hooks in Platform

## Testing done
- [x] Unit tests

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs