### PR TITLE
Avoids MHV account creation/upgrade with SSOe

### DIFF
--- a/src/applications/personalization/dashboard/containers/MessagingWidget.jsx
+++ b/src/applications/personalization/dashboard/containers/MessagingWidget.jsx
@@ -9,7 +9,8 @@ import { formattedDate } from '../utils/helpers';
 import backendServices from 'platform/user/profile/constants/backendServices';
 import { fetchFolder, fetchRecipients } from '../actions/messaging';
 import { recordDashboardClick } from '../helpers';
-import { mhvUrl } from 'platform/site-wide/cta-widget/helpers';
+import { ssoe } from 'platform/user/authentication/selectors';
+import { mhvUrl } from 'platform/site-wide/mhv/utilities';
 
 class MessagingWidget extends React.Component {
   componentDidMount() {
@@ -20,7 +21,7 @@ class MessagingWidget extends React.Component {
   }
 
   render() {
-    const { canAccessMessaging, recipients } = this.props;
+    const { canAccessMessaging, recipients, useSSOe } = this.props;
 
     if (!canAccessMessaging || (recipients && recipients.length === 0)) {
       // do not show widget if user is not a VA patient
@@ -91,7 +92,7 @@ class MessagingWidget extends React.Component {
         {content}
         <p>
           <a
-            href={mhvUrl('secure-messaging')}
+            href={mhvUrl(useSSOe, 'secure-messaging')}
             onClick={recordDashboardClick('view-all-messages')}
             rel="noopener noreferrer"
             target="_blank"
@@ -122,6 +123,7 @@ const mapStateToProps = state => {
     sort,
     pagination,
     canAccessMessaging,
+    useSSOe: ssoe(state),
   };
 };
 

--- a/src/applications/personalization/dashboard/containers/PrescriptionsWidget.jsx
+++ b/src/applications/personalization/dashboard/containers/PrescriptionsWidget.jsx
@@ -9,7 +9,8 @@ import LoadingIndicator from '@department-of-veterans-affairs/formation-react/Lo
 import { recordDashboardClick } from '../helpers';
 import PrescriptionCard from '../components/PrescriptionCard';
 import CallVBACenter from 'platform/static-data/CallVBACenter';
-import { mhvUrl } from 'platform/site-wide/cta-widget/helpers';
+import { ssoe } from 'platform/user/authentication/selectors';
+import { mhvUrl } from 'platform/site-wide/mhv/utilities';
 
 class PrescriptionsWidget extends React.Component {
   componentDidMount() {
@@ -22,7 +23,7 @@ class PrescriptionsWidget extends React.Component {
   }
 
   render() {
-    const { canAccessRx } = this.props;
+    const { canAccessRx, useSSOe } = this.props;
     if (!canAccessRx) {
       return null;
     }
@@ -66,7 +67,7 @@ class PrescriptionsWidget extends React.Component {
         <div>{content}</div>
         <p>
           <a
-            href={mhvUrl('web/myhealthevet/refill-prescriptions')}
+            href={mhvUrl(useSSOe, 'web/myhealthevet/refill-prescriptions')}
             onClick={recordDashboardClick('view-all-prescriptions')}
             rel="noopener noreferrer"
             target="_blank"
@@ -107,6 +108,7 @@ const mapStateToProps = state => {
     ...rxState.prescriptions.active,
     prescriptions,
     canAccessRx,
+    useSSOe: ssoe(state),
   };
 };
 

--- a/src/applications/personalization/dashboard/tests/containers/MessagingWidget.unit.spec.jsx
+++ b/src/applications/personalization/dashboard/tests/containers/MessagingWidget.unit.spec.jsx
@@ -6,6 +6,7 @@ import { MessagingWidget } from '../../containers/MessagingWidget';
 
 const props = {
   canAccessMessaging: true,
+  useSSOe: false,
   messages: [
     {
       messageId: 123,

--- a/src/applications/personalization/dashboard/tests/containers/PrescriptionsWidget.unit.spec.jsx
+++ b/src/applications/personalization/dashboard/tests/containers/PrescriptionsWidget.unit.spec.jsx
@@ -6,6 +6,7 @@ import { PrescriptionsWidget } from '../../containers/PrescriptionsWidget';
 
 const props = {
   canAccessRx: true,
+  useSSOe: true,
   prescriptions: [
     {
       id: '13568747',

--- a/src/applications/validate-mhv-account/constants.js
+++ b/src/applications/validate-mhv-account/constants.js
@@ -1,7 +1,3 @@
-import environment from 'platform/utilities/environment';
-import { hasSessionSSO } from 'platform/user/profile/utilities';
-import { eauthEnvironmentPrefixes } from 'platform/utilities/sso/constants';
-
 export const ACCOUNT_STATES = {
   NEEDS_VERIFICATION: 'needs_identity_verification',
   DEACTIVATED_MHV_IDS: 'has_deactivated_mhv_ids',
@@ -20,8 +16,3 @@ export const MHV_ACCOUNT_LEVELS = {
   ADVANCED: 'Advanced',
   PREMIUM: 'Premium',
 };
-
-const envPrefix = eauthEnvironmentPrefixes[environment.BUILDTYPE];
-export const MHV_URL = hasSessionSSO()
-  ? `https://${envPrefix}eauth.va.gov/mhv-portal-web/eauth`
-  : 'https://www.myhealth.va.gov/mhv-portal-web/home';

--- a/src/applications/validate-mhv-account/containers/Main.jsx
+++ b/src/applications/validate-mhv-account/containers/Main.jsx
@@ -5,9 +5,9 @@ import LoadingIndicator from '@department-of-veterans-affairs/formation-react/Lo
 
 import { isLoggedIn, selectProfile } from 'platform/user/selectors';
 import get from 'platform/utilities/data/get';
-import environment from 'platform/utilities/environment/index';
-import { replaceWithStagingDomain } from 'platform/utilities/environment/stagingDomains';
-import { ACCOUNT_STATES, MHV_ACCOUNT_LEVELS, MHV_URL } from './../constants';
+import { ssoe } from 'platform/user/authentication/selectors';
+import { mhvUrl } from 'platform/site-wide/mhv/utilities';
+import { ACCOUNT_STATES, MHV_ACCOUNT_LEVELS } from './../constants';
 
 /**
  * This is the parent component for the MyHealtheVet Account validation app.
@@ -24,6 +24,7 @@ class Main extends React.Component {
       mhvAccount,
       profile,
       router,
+      useSSOe,
     } = this.props;
 
     const pathname = location.pathname;
@@ -52,7 +53,7 @@ class Main extends React.Component {
 
       if (accountLevelChanged || accountStateChanged) {
         if (this.hasMHVAccess()) {
-          this.redirectToMHV();
+          this.redirectToMHV(useSSOe);
         } else {
           router.replace('/');
         }
@@ -72,10 +73,8 @@ class Main extends React.Component {
     );
   };
 
-  redirectToMHV = () => {
-    window.location = environment.isProduction()
-      ? MHV_URL
-      : replaceWithStagingDomain(MHV_URL);
+  redirectToMHV = useSSOe => {
+    window.location = mhvUrl(useSSOe, 'home');
   };
 
   render() {
@@ -116,6 +115,7 @@ const mapStateToProps = (state, ownProps) => {
     loadingProfile: loading,
     mhvAccount,
     profile,
+    useSSOe: ssoe(state),
   };
 };
 

--- a/src/applications/validate-mhv-account/containers/Main.jsx
+++ b/src/applications/validate-mhv-account/containers/Main.jsx
@@ -53,7 +53,7 @@ class Main extends React.Component {
 
       if (accountLevelChanged || accountStateChanged) {
         if (this.hasMHVAccess()) {
-          this.redirectToMHV(useSSOe);
+          window.location = mhvUrl(useSSOe, 'home');
         } else {
           router.replace('/');
         }
@@ -71,10 +71,6 @@ class Main extends React.Component {
       (accountLevel === MHV_ACCOUNT_LEVELS.PREMIUM ||
         accountLevel === MHV_ACCOUNT_LEVELS.ADVANCED)
     );
-  };
-
-  redirectToMHV = useSSOe => {
-    window.location = mhvUrl(useSSOe, 'home');
   };
 
   render() {

--- a/src/applications/validate-mhv-account/containers/ValidateMHVAccount.jsx
+++ b/src/applications/validate-mhv-account/containers/ValidateMHVAccount.jsx
@@ -72,7 +72,7 @@ class ValidateMHVAccount extends React.Component {
       recordEvent({ event: `${gaPrefix}-error-has-deactivated-mhv-ids` });
       router.replace(`error/has-deactivated-mhv-ids`);
       return;
-    } else if (isVaPatient !== 'true') {
+    } else if (!isVaPatient) {
       recordEvent({ event: `${gaPrefix}-error-needs-va-patient` });
       router.replace(`error/needs-va-patient`);
       return;

--- a/src/applications/validate-mhv-account/containers/ValidateMHVAccount.jsx
+++ b/src/applications/validate-mhv-account/containers/ValidateMHVAccount.jsx
@@ -8,13 +8,12 @@ import { fetchMHVAccount } from 'platform/user/profile/actions';
 
 import recordEvent from 'platform/monitoring/record-event';
 import { selectProfile } from 'platform/user/selectors';
-import environment from 'platform/utilities/environment/index';
-import { replaceWithStagingDomain } from 'platform/utilities/environment/stagingDomains';
+import { ssoe } from 'platform/user/authentication/selectors';
+import { mhvUrl } from 'platform/site-wide/mhv/utilities';
 import {
   ACCOUNT_STATES,
   ACCOUNT_STATES_SET,
   MHV_ACCOUNT_LEVELS,
-  MHV_URL,
 } from './../constants';
 
 import { MVI_ERROR_STATES } from 'platform/monitoring/RequiresMVI/constants';
@@ -25,12 +24,62 @@ class ValidateMHVAccount extends React.Component {
   }
 
   componentDidUpdate(prevProps) {
-    const { mhvAccount } = this.props;
+    const { mhvAccount, useSSOe } = this.props;
 
     if (prevProps.mhvAccount.loading && !mhvAccount.loading) {
+      if (useSSOe) {
+        this.redirectSSOe();
+      }
       this.redirect();
     }
   }
+
+  redirectSSOe = () => {
+    const {
+      profile,
+      router,
+      isVaPatient,
+      mhvAccountIdState,
+      mviStatus,
+    } = this.props;
+    const gaPrefix = 'register-mhv';
+
+    if (!profile.verified) {
+      recordEvent({ event: `${gaPrefix}-info-needs-identity-verification` });
+      router.replace('verify');
+      return;
+    }
+
+    // MVI Checks
+    const mviErrorStatesSet = new Set(Object.values(MVI_ERROR_STATES));
+
+    if (mviStatus && mviErrorStatesSet.has(mviStatus)) {
+      const hyphenatedMviStatus = mviStatus.replace(/_/g, '-').toLowerCase();
+      recordEvent({
+        event: `${gaPrefix}-error-mvi-error-${hyphenatedMviStatus}`,
+      });
+      if (mviStatus === MVI_ERROR_STATES.NOT_AUTHORIZED) {
+        router.replace('verify');
+        return;
+      }
+      router.replace(`error/mvi-error-${hyphenatedMviStatus}`);
+      return;
+    }
+
+    // TODO: If TermsAndConditions still needed, add here
+    // but add to user profile instead of getting from mhvAccount
+    if (mhvAccountIdState === 'DEACTIVATED') {
+      recordEvent({ event: `${gaPrefix}-error-has-deactivated-mhv-ids` });
+      router.replace(`error/has-deactivated-mhv-ids`);
+      return;
+    } else if (isVaPatient !== 'true') {
+      recordEvent({ event: `${gaPrefix}-error-needs-va-patient` });
+      router.replace(`error/needs-va-patient`);
+      return;
+    }
+
+    window.location = mhvUrl(true, 'home');
+  };
 
   redirect = () => {
     const { profile, mhvAccount, router, mviStatus } = this.props;
@@ -101,9 +150,7 @@ class ValidateMHVAccount extends React.Component {
       accountLevel === MHV_ACCOUNT_LEVELS.PREMIUM ||
       accountLevel === MHV_ACCOUNT_LEVELS.ADVANCED
     ) {
-      window.location = environment.isProduction()
-        ? MHV_URL
-        : replaceWithStagingDomain(MHV_URL);
+      window.location = mhvUrl(false, 'home');
     } else if (accountLevel === MHV_ACCOUNT_LEVELS.BASIC) {
       router.replace('upgrade-account');
     } else {
@@ -138,11 +185,14 @@ class ValidateMHVAccount extends React.Component {
 
 const mapStateToProps = state => {
   const profile = selectProfile(state);
-  const { mhvAccount, status } = profile;
+  const { mhvAccount, status, vaPatient, mhvAccountState } = profile;
   return {
     mhvAccount,
     mviStatus: status,
     profile,
+    isVaPatient: vaPatient,
+    mhvAccountIdState: mhvAccountState,
+    useSSOe: ssoe(state),
   };
 };
 

--- a/src/applications/validate-mhv-account/containers/ValidateMHVAccount.jsx
+++ b/src/applications/validate-mhv-account/containers/ValidateMHVAccount.jsx
@@ -67,8 +67,6 @@ class ValidateMHVAccount extends React.Component {
       return;
     }
 
-    // TODO: If TermsAndConditions still needed, add here
-    // but add to user profile instead of getting from mhvAccount
     if (mhvAccountIdState === 'DEACTIVATED') {
       recordEvent({ event: `${gaPrefix}-error-has-deactivated-mhv-ids` });
       router.replace(`error/has-deactivated-mhv-ids`);

--- a/src/applications/validate-mhv-account/containers/ValidateMHVAccount.jsx
+++ b/src/applications/validate-mhv-account/containers/ValidateMHVAccount.jsx
@@ -29,8 +29,9 @@ class ValidateMHVAccount extends React.Component {
     if (prevProps.mhvAccount.loading && !mhvAccount.loading) {
       if (useSSOe) {
         this.redirectSSOe();
+      } else {
+        this.redirect();
       }
-      this.redirect();
     }
   }
 
@@ -77,7 +78,6 @@ class ValidateMHVAccount extends React.Component {
       router.replace(`error/needs-va-patient`);
       return;
     }
-
     window.location = mhvUrl(true, 'home');
   };
 
@@ -86,7 +86,6 @@ class ValidateMHVAccount extends React.Component {
     const { accountLevel, accountState } = mhvAccount;
     const hyphenatedAccountState = accountState.replace(/_/g, '-');
     const gaPrefix = 'register-mhv';
-
     if (!profile.verified) {
       recordEvent({ event: `${gaPrefix}-info-needs-identity-verification` });
       router.replace('verify');

--- a/src/platform/site-wide/cta-widget/helpers.js
+++ b/src/platform/site-wide/cta-widget/helpers.js
@@ -1,6 +1,5 @@
 import backendServices from 'platform/user/profile/constants/backendServices';
 import { mhvUrl } from 'platform/site-wide/mhv/utilities';
-import { hasSessionSSO } from 'platform/user/profile/utilities';
 
 /**
  * These are the valid values for the Widget Type field in the Drupal CMS when
@@ -77,36 +76,36 @@ export const mhvToolName = appId => {
   return null;
 };
 
-export const toolUrl = appId => {
+export const toolUrl = (appId, useSSOe = false) => {
   switch (appId) {
     case widgetTypes.HEALTH_RECORDS:
       return {
-        url: mhvUrl(hasSessionSSO(), 'download-my-data'),
+        url: mhvUrl(useSSOe, 'download-my-data'),
         redirect: false,
       };
 
     case widgetTypes.RX:
       return {
-        url: mhvUrl(hasSessionSSO(), 'web/myhealthevet/refill-prescriptions'),
+        url: mhvUrl(useSSOe, 'web/myhealthevet/refill-prescriptions'),
         redirect: true,
       };
 
     case widgetTypes.MESSAGING:
       return {
-        url: mhvUrl(hasSessionSSO(), 'secure-messaging'),
+        url: mhvUrl(useSSOe, 'secure-messaging'),
         redirect: true,
       };
 
     case widgetTypes.VIEW_APPOINTMENTS:
     case widgetTypes.SCHEDULE_APPOINTMENTS:
       return {
-        url: mhvUrl(hasSessionSSO(), 'appointments'),
+        url: mhvUrl(useSSOe, 'appointments'),
         redirect: false,
       };
 
     case widgetTypes.LAB_AND_TEST_RESULTS:
       return {
-        url: mhvUrl(hasSessionSSO(), 'labs-tests'),
+        url: mhvUrl(useSSOe, 'labs-tests'),
         redirect: true,
       };
 

--- a/src/platform/site-wide/cta-widget/helpers.js
+++ b/src/platform/site-wide/cta-widget/helpers.js
@@ -87,13 +87,13 @@ export const toolUrl = (appId, useSSOe = false) => {
     case widgetTypes.RX:
       return {
         url: mhvUrl(useSSOe, 'web/myhealthevet/refill-prescriptions'),
-        redirect: true,
+        redirect: false,
       };
 
     case widgetTypes.MESSAGING:
       return {
         url: mhvUrl(useSSOe, 'secure-messaging'),
-        redirect: true,
+        redirect: false,
       };
 
     case widgetTypes.VIEW_APPOINTMENTS:
@@ -106,7 +106,7 @@ export const toolUrl = (appId, useSSOe = false) => {
     case widgetTypes.LAB_AND_TEST_RESULTS:
       return {
         url: mhvUrl(useSSOe, 'labs-tests'),
-        redirect: true,
+        redirect: false,
       };
 
     case widgetTypes.CLAIMS_AND_APPEALS:

--- a/src/platform/site-wide/cta-widget/helpers.js
+++ b/src/platform/site-wide/cta-widget/helpers.js
@@ -1,7 +1,6 @@
 import backendServices from 'platform/user/profile/constants/backendServices';
-import environment from 'platform/utilities/environment';
+import { mhvUrl } from 'platform/site-wide/mhv/utilities';
 import { hasSessionSSO } from 'platform/user/profile/utilities';
-import { eauthEnvironmentPrefixes } from 'platform/utilities/sso/constants';
 
 /**
  * These are the valid values for the Widget Type field in the Drupal CMS when
@@ -25,7 +24,6 @@ export const widgetTypes = {
 };
 
 const HEALTH_TOOLS = [
-  widgetTypes.DIRECT_DEPOSIT,
   widgetTypes.HEALTH_RECORDS,
   widgetTypes.LAB_AND_TEST_RESULTS,
   widgetTypes.MESSAGING,
@@ -55,31 +53,6 @@ export const hasRequiredMhvAccount = (appId, accountLevel) => {
 
 export const isHealthTool = appId => HEALTH_TOOLS.includes(appId);
 
-export const mhvBaseUrl = () => {
-  const mhvSubdomain = environment.isProduction() ? 'www' : 'mhv-syst';
-
-  return `https://${mhvSubdomain}.myhealth.va.gov`;
-};
-
-const mhvToEauthRoutes = {
-  'download-my-data': 'download_my_data',
-  'web/myhealthevet/refill-prescriptions': 'prescription_refill',
-  'secure-messaging': 'secure_messaging',
-  appointments: 'appointments',
-};
-
-const mhvUrlNonSSO = subroute => `${mhvBaseUrl()}/mhv-portal-web/${subroute}`;
-
-const mhvUrlSSO = deeplinkTarget => {
-  const envPrefix = eauthEnvironmentPrefixes[environment.BUILDTYPE];
-  const eauthDeepLink = mhvToEauthRoutes[deeplinkTarget];
-
-  return `https://${envPrefix}eauth.va.gov/mhv-portal-web/eauth?deeplinking=${eauthDeepLink}`;
-};
-
-export const mhvUrl = (subroute = '') =>
-  hasSessionSSO() ? mhvUrlSSO(subroute) : mhvUrlNonSSO(subroute);
-
 export const mhvToolName = appId => {
   switch (appId) {
     case widgetTypes.HEALTH_RECORDS:
@@ -98,9 +71,6 @@ export const mhvToolName = appId => {
     case widgetTypes.VIEW_APPOINTMENTS:
       return 'VA Appointments';
 
-    case widgetTypes.DIRECT_DEPOSIT:
-      return 'Direct Deposit';
-
     default: // Not a recognized health tool.
   }
 
@@ -111,33 +81,32 @@ export const toolUrl = appId => {
   switch (appId) {
     case widgetTypes.HEALTH_RECORDS:
       return {
-        url: mhvUrl('download-my-data'),
+        url: mhvUrl(hasSessionSSO(), 'download-my-data'),
         redirect: false,
       };
 
     case widgetTypes.RX:
       return {
-        url: mhvUrl('web/myhealthevet/refill-prescriptions'),
+        url: mhvUrl(hasSessionSSO(), 'web/myhealthevet/refill-prescriptions'),
         redirect: true,
       };
 
     case widgetTypes.MESSAGING:
       return {
-        url: mhvUrl('secure-messaging'),
+        url: mhvUrl(hasSessionSSO(), 'secure-messaging'),
         redirect: true,
       };
 
     case widgetTypes.VIEW_APPOINTMENTS:
     case widgetTypes.SCHEDULE_APPOINTMENTS:
       return {
-        url: mhvUrl('appointments'),
+        url: mhvUrl(hasSessionSSO(), 'appointments'),
         redirect: false,
       };
 
     case widgetTypes.LAB_AND_TEST_RESULTS:
       return {
-        // TODO refactor to mhvUrl once unblocked by MHV team
-        url: mhvUrlNonSSO('labs-tests'),
+        url: mhvUrl(hasSessionSSO(), 'labs-tests'),
         redirect: true,
       };
 

--- a/src/platform/site-wide/cta-widget/index.js
+++ b/src/platform/site-wide/cta-widget/index.js
@@ -54,8 +54,8 @@ import VAOnlineScheduling from './components/messages/VAOnlineScheduling';
 export class CallToActionWidget extends React.Component {
   constructor(props) {
     super(props);
-    const { appId } = props;
-    const { url, redirect } = toolUrl(appId);
+    const { appId, useSSOe } = props;
+    const { url, redirect } = toolUrl(appId, useSSOe);
 
     this._hasRedirect = redirect;
     this._popup = null;
@@ -219,7 +219,7 @@ export class CallToActionWidget extends React.Component {
   };
 
   getInaccessibleHealthToolContentSSOe = () => {
-    const { profile, isVaPatient, mhvAccountIdState } = this.props.mhvAccount;
+    const { profile, isVaPatient, mhvAccountIdState } = this.props;
 
     if (!profile.verified) {
       recordEvent({
@@ -234,7 +234,7 @@ export class CallToActionWidget extends React.Component {
     } else if (mhvAccountIdState === 'DEACTIVATED') {
       recordEvent({ event: `${this._gaPrefix}-error-has-deactivated-mhv-ids` });
       return <DeactivatedMHVIds />;
-    } else if (isVaPatient !== 'true') {
+    } else if (!isVaPatient) {
       recordEvent({ event: `${this._gaPrefix}-error-needs-va-patient` });
       return <NeedsVAPatient />;
     }

--- a/src/platform/site-wide/cta-widget/index.js
+++ b/src/platform/site-wide/cta-widget/index.js
@@ -91,7 +91,6 @@ export class CallToActionWidget extends React.Component {
       if (!accountState) {
         this.props.fetchMHVAccount();
       } else if (
-        // TODO: clean up for SSOe
         new URLSearchParams(window.location.search).get('tc_accepted')
       ) {
         // Since T&C is still required to support the existing account states,
@@ -238,8 +237,6 @@ export class CallToActionWidget extends React.Component {
       recordEvent({ event: `${this._gaPrefix}-error-needs-va-patient` });
       return <NeedsVAPatient />;
     }
-    // TODO if TermsAndConditions is still needed, add here
-    // using previous redirect logic
 
     return null;
   };

--- a/src/platform/site-wide/cta-widget/tests/helpers.unit.spec.js
+++ b/src/platform/site-wide/cta-widget/tests/helpers.unit.spec.js
@@ -1,47 +1,39 @@
 import { expect } from 'chai';
 
-import localStorage from 'platform/utilities/storage/localStorage';
 import { eauthEnvironmentPrefixes } from 'platform/utilities/sso/constants';
 import { toolUrl, widgetTypes } from '../helpers';
 import environment from '../../../utilities/environment';
 
 describe('CTA helpers', () => {
   describe('A signed-in SSO user', () => {
-    beforeEach(() => {
-      localStorage.setItem('hasSessionSSO', true);
-    });
-    afterEach(() => {
-      localStorage.removeItem('hasSessionSSO');
-    });
-
     it('Download my data', () => {
-      expect(toolUrl(widgetTypes.HEALTH_RECORDS).url).to.equal(
+      expect(toolUrl(widgetTypes.HEALTH_RECORDS, true).url).to.equal(
         `https://${
           eauthEnvironmentPrefixes[environment.BUILDTYPE]
         }eauth.va.gov/mhv-portal-web/eauth?deeplinking=download_my_data`,
       );
     });
     it('Prescription Refill', () => {
-      expect(toolUrl(widgetTypes.RX).url).to.equal(
+      expect(toolUrl(widgetTypes.RX, true).url).to.equal(
         `https://${
           eauthEnvironmentPrefixes[environment.BUILDTYPE]
         }eauth.va.gov/mhv-portal-web/eauth?deeplinking=prescription_refill`,
       );
     });
     it('Secure Messaging', () => {
-      expect(toolUrl(widgetTypes.MESSAGING).url).to.equal(
+      expect(toolUrl(widgetTypes.MESSAGING, true).url).to.equal(
         `https://${
           eauthEnvironmentPrefixes[environment.BUILDTYPE]
         }eauth.va.gov/mhv-portal-web/eauth?deeplinking=secure_messaging`,
       );
     });
     it('Appointments', () => {
-      expect(toolUrl(widgetTypes.VIEW_APPOINTMENTS).url).to.equal(
+      expect(toolUrl(widgetTypes.VIEW_APPOINTMENTS, true).url).to.equal(
         `https://${
           eauthEnvironmentPrefixes[environment.BUILDTYPE]
         }eauth.va.gov/mhv-portal-web/eauth?deeplinking=appointments`,
       );
-      expect(toolUrl(widgetTypes.SCHEDULE_APPOINTMENTS).url).to.equal(
+      expect(toolUrl(widgetTypes.SCHEDULE_APPOINTMENTS, true).url).to.equal(
         `https://${
           eauthEnvironmentPrefixes[environment.BUILDTYPE]
         }eauth.va.gov/mhv-portal-web/eauth?deeplinking=appointments`,

--- a/src/platform/site-wide/cta-widget/tests/index.unit.spec.js
+++ b/src/platform/site-wide/cta-widget/tests/index.unit.spec.js
@@ -444,7 +444,7 @@ describe('<CallToActionWidget>', () => {
       tree.unmount();
     });
     describe('account state errors', () => {
-      const defaultProps = {
+      let defaultProps = {
         fetchMHVAccount: d => d,
         isLoggedIn: true,
         appId: 'rx',
@@ -567,6 +567,63 @@ describe('<CallToActionWidget>', () => {
 
         expect(tree.find('NeedsVAPatient').exists()).to.be.true;
         tree.unmount();
+      });
+
+      describe('ssoe', () => {
+        defaultProps = { ...{ useSSOe: true }, ...defaultProps };
+
+        it('should show verify message', () => {
+          const tree = mount(
+            <CallToActionWidget
+              {...defaultProps}
+              profile={{
+                verified: false,
+              }}
+              mhvAccount={{
+                loading: false,
+                accountState: 'needs_identity_verification',
+                accountLevel: 'Basic',
+              }}
+            />,
+          );
+
+          expect(tree.find('Verify').exists()).to.be.true;
+          tree.unmount();
+        });
+
+        it('should show deactivated message', () => {
+          const tree = mount(
+            <CallToActionWidget
+              {...defaultProps}
+              mhvAccountIdState="DEACTIVATED"
+              mhvAccount={{
+                loading: false,
+                accountState: 'needs_identity_verification',
+                accountLevel: 'Basic',
+              }}
+            />,
+          );
+
+          expect(tree.find('DeactivatedMHVIds').exists()).to.be.true;
+          tree.unmount();
+        });
+
+        it('should show needs va patient message', () => {
+          const tree = mount(
+            <CallToActionWidget
+              {...defaultProps}
+              isVaPatient={false}
+              mhvAccount={{
+                loading: false,
+                accountState: 'needs_identity_verification',
+                accountLevel: 'Basic',
+              }}
+            />,
+          );
+
+          expect(tree.find('NeedsVAPatient').exists()).to.be.true;
+          tree.unmount();
+        });
       });
     });
     it('should show MHV link', () => {

--- a/src/platform/site-wide/cta-widget/tests/index.unit.spec.js
+++ b/src/platform/site-wide/cta-widget/tests/index.unit.spec.js
@@ -249,9 +249,7 @@ describe('<CallToActionWidget>', () => {
       global.dom.reconfigure({ url: 'http://localhost' });
     });
 
-    it('should open rx tool', () => {
-      const jsdomOpen = window.open;
-      window.open = sinon.spy();
+    it('should open myhealthevet popup', () => {
       const tree = mount(
         <CallToActionWidget
           appId="rx"
@@ -276,9 +274,8 @@ describe('<CallToActionWidget>', () => {
         isLoggedIn: true,
       });
 
-      expect(window.open.firstCall.args[0]).to.contain('refill-prescriptions');
+      expect(tree.find('OpenMyHealtheVet').exists()).to.be.true;
       tree.unmount();
-      window.open = jsdomOpen;
     });
 
     it('should show mvi server error', () => {
@@ -444,7 +441,7 @@ describe('<CallToActionWidget>', () => {
       tree.unmount();
     });
     describe('account state errors', () => {
-      let defaultProps = {
+      const defaultProps = {
         fetchMHVAccount: d => d,
         isLoggedIn: true,
         appId: 'rx',
@@ -570,12 +567,12 @@ describe('<CallToActionWidget>', () => {
       });
 
       describe('ssoe', () => {
-        defaultProps = { ...{ useSSOe: true }, ...defaultProps };
+        const ssoeProps = { ...{ useSSOe: true }, ...defaultProps };
 
         it('should show verify message', () => {
           const tree = mount(
             <CallToActionWidget
-              {...defaultProps}
+              {...ssoeProps}
               profile={{
                 verified: false,
               }}
@@ -594,7 +591,7 @@ describe('<CallToActionWidget>', () => {
         it('should show deactivated message', () => {
           const tree = mount(
             <CallToActionWidget
-              {...defaultProps}
+              {...ssoeProps}
               mhvAccountIdState="DEACTIVATED"
               mhvAccount={{
                 loading: false,
@@ -611,7 +608,7 @@ describe('<CallToActionWidget>', () => {
         it('should show needs va patient message', () => {
           const tree = mount(
             <CallToActionWidget
-              {...defaultProps}
+              {...ssoeProps}
               isVaPatient={false}
               mhvAccount={{
                 loading: false,

--- a/src/platform/site-wide/cta-widget/tests/index.unit.spec.js
+++ b/src/platform/site-wide/cta-widget/tests/index.unit.spec.js
@@ -567,7 +567,7 @@ describe('<CallToActionWidget>', () => {
       });
 
       describe('ssoe', () => {
-        const ssoeProps = { ...{ useSSOe: true }, ...defaultProps };
+        const ssoeProps = { ...defaultProps, useSSOe: true };
 
         it('should show verify message', () => {
           const tree = mount(

--- a/src/platform/site-wide/mhv/tests/utilities.unit.spec.js
+++ b/src/platform/site-wide/mhv/tests/utilities.unit.spec.js
@@ -1,0 +1,47 @@
+import { expect } from 'chai';
+
+import { mhvUrl } from '../utilities';
+
+describe('mhvUrl', () => {
+  it('should normalize path', () => {
+    expect(mhvUrl(false, '/home')).to.equal(
+      'https://mhv-syst.myhealth.va.gov/mhv-portal-web/home',
+    );
+  });
+
+  it('should map SSOe paths', () => {
+    expect(mhvUrl(true, 'home')).to.equal(
+      'https://int.eauth.va.gov/mhv-portal-web/eauth',
+    );
+    expect(mhvUrl(true, 'download-my-data')).to.equal(
+      'https://int.eauth.va.gov/mhv-portal-web/eauth?deeplinking=download_my_data',
+    );
+    expect(mhvUrl(true, 'web/myhealthevet/refill-prescriptions')).to.equal(
+      'https://int.eauth.va.gov/mhv-portal-web/eauth?deeplinking=prescription_refill',
+    );
+    expect(mhvUrl(true, 'secure-messaging')).to.equal(
+      'https://int.eauth.va.gov/mhv-portal-web/eauth?deeplinking=secure_messaging',
+    );
+    expect(mhvUrl(true, 'appointments')).to.equal(
+      'https://int.eauth.va.gov/mhv-portal-web/eauth?deeplinking=appointments',
+    );
+  });
+
+  it('should map non-SSOe paths', () => {
+    expect(mhvUrl(false, 'home')).to.equal(
+      'https://mhv-syst.myhealth.va.gov/mhv-portal-web/home',
+    );
+    expect(mhvUrl(false, 'download-my-data')).to.equal(
+      'https://mhv-syst.myhealth.va.gov/mhv-portal-web/download-my-data',
+    );
+    expect(mhvUrl(false, 'web/myhealthevet/refill-prescriptions')).to.equal(
+      'https://mhv-syst.myhealth.va.gov/mhv-portal-web/web/myhealthevet/refill-prescriptions',
+    );
+    expect(mhvUrl(false, 'secure-messaging')).to.equal(
+      'https://mhv-syst.myhealth.va.gov/mhv-portal-web/secure-messaging',
+    );
+    expect(mhvUrl(false, 'appointments')).to.equal(
+      'https://mhv-syst.myhealth.va.gov/mhv-portal-web/appointments',
+    );
+  });
+});

--- a/src/platform/site-wide/mhv/utilities.js
+++ b/src/platform/site-wide/mhv/utilities.js
@@ -1,0 +1,37 @@
+import environment from 'platform/utilities/environment';
+import { eauthEnvironmentPrefixes } from 'platform/utilities/sso/constants';
+
+const eauthPrefix = eauthEnvironmentPrefixes[environment.BUILDTYPE];
+const mhvPrefix = environment.isProduction() ? 'www' : 'mhv-syst';
+
+// TODO: Add labs-and-tests route
+const mhvToEauthRoutes = {
+  'download-my-data': 'eauth?deeplinking=download_my_data',
+  'web/myhealthevet/refill-prescriptions':
+    'eauth?deeplinking=prescription_refill',
+  'secure-messaging': 'eauth?deeplinking=secure_messaging',
+  appointments: 'eauth?deeplinking=appointments',
+  home: 'eauth',
+};
+
+// An MHV URL is a function of the following parameters:
+// 1. Whether this is a production or staging environment
+// 2. Whether SSOe is in use (enabled site wide, and for this particular user)
+// 3. The specific MHV path being accessed
+function mhvUrl(useSSOe, path) {
+  const normPath = path.startsWith('/') ? path.substring(1) : path;
+  if (useSSOe) {
+    const eauthDeepLink = mhvToEauthRoutes[normPath];
+    return `https://${eauthPrefix}eauth.va.gov/mhv-portal-web/${eauthDeepLink}`;
+  }
+  return `https://${mhvPrefix}.myhealth.va.gov/mhv-portal-web/${normPath}`;
+}
+
+// TODO: This function is NOT SSOe-aware and is a candidate for removal
+// after assessing its use in platform/utilities/environment/stagingDomains
+const mhvBaseUrl = () => {
+  const mhvSubdomain = environment.isProduction() ? 'www' : 'mhv-syst';
+  return `https://${mhvSubdomain}.myhealth.va.gov`;
+};
+
+export { mhvUrl, mhvBaseUrl };

--- a/src/platform/user/profile/utilities/index.js
+++ b/src/platform/user/profile/utilities/index.js
@@ -111,6 +111,8 @@ export function mapRawUserDataToState(json) {
     if (vaProfile.facilities) {
       userState.facilities = vaProfile.facilities;
     }
+    userState.vaPatient = vaProfile.vaPatient;
+    userState.mhvAccountState = vaProfile.mhvAccountState;
   }
 
   // This one is checking userState because there's no extra mapping and it's

--- a/src/platform/utilities/environment/stagingDomains.js
+++ b/src/platform/utilities/environment/stagingDomains.js
@@ -1,4 +1,4 @@
-import { mhvBaseUrl } from '../../site-wide/cta-widget/helpers';
+import { mhvBaseUrl } from '../../site-wide/mhv/utilities';
 import environment from '.';
 
 // This list also exists in script/options.js


### PR DESCRIPTION
Per agreement with MHV team, when using common SSOe sessions,
the MHV account upgrade and creation APIs are not needed, so those
interactions are removed from the validate-mhv-account and cta-widgets.

This also refactors the mhvUrl code to live in a single utility class,
and cleans up some messiness with the cta-widget and how DirectDeposit
was categorized

Fixes va.gov-team#8405

## Description
Long term, once SSOe is fully rolled out:
- The validate-mhv-account app can be significantly simplified and get rid of the conditional logic around ssoe enablement
- The CTA widget can likewise be simplified. It is probably also worthwhile to split out a health-cta-widget and a regular cta-widget since the eligibility rules are so different.
- The mhv_accounts API can probably be deprecated and not used from the frontend anymore. 

## Testing done
This was tested in localhost against mhv's staging environment using test accounts in various states.


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [x] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
