### PR TITLE
Added CSRF to feature toggles

### DIFF
--- a/src/platform/utilities/feature-toggles/flipper-client.js
+++ b/src/platform/utilities/feature-toggles/flipper-client.js
@@ -19,16 +19,27 @@ function FlipperClient({
   let _timeoutId;
   let _pollingActive;
   const _subscriberCallbacks = [];
+  const csrfTokenStored = localStorage.getItem('csrfToken');
 
   const _fetchToggleValues = async () => {
     const response = await fetch(`${host}${toggleValuesPath}`, {
       credentials: 'include',
+      headers: {
+        'X-CSRF-Token': csrfTokenStored,
+      },
     });
     if (!response.ok) {
       const errorMessage = `Failed to fetch toggle values with status ${
         response.status
       } ${response.statusText}`;
       throw new Error(errorMessage);
+    }
+
+    // Get CSRF Token from API header
+    const csrfToken = response.headers.get('X-CSRF-Token');
+
+    if (csrfToken && csrfToken !== csrfTokenStored) {
+      localStorage.setItem('csrfToken', csrfToken);
     }
 
     return response.json();


### PR DESCRIPTION
## Description

This is an addition to the main [PR which added the CSRF token via header](https://github.com/department-of-veterans-affairs/vets-website/pull/12005)

There are some files in the app/platform code that are making direct `fetch()` or `XMLHTTPRequest` calls without using the `apiRequest` helper. I decided to refactor them to ensure that the requests are made with a CSRF token.

## Testing done
Locally