### PR TITLE
Internment language for NCA operating status alert

### DIFF
--- a/src/applications/facility-locator/containers/FacilityDetail.jsx
+++ b/src/applications/facility-locator/containers/FacilityDetail.jsx
@@ -14,7 +14,7 @@ import LoadingIndicator from '@department-of-veterans-affairs/formation-react/Lo
 import ServicesAtFacility from '../components/ServicesAtFacility';
 import AppointmentInfo from '../components/AppointmentInfo';
 import FacilityTypeDescription from '../components/FacilityTypeDescription';
-import { OperatingStatus } from '../constants';
+import { OperatingStatus, FacilityType } from '../constants';
 
 class FacilityDetail extends Component {
   // eslint-disable-next-line camelcase
@@ -43,7 +43,24 @@ class FacilityDetail extends Component {
     document.title = this.__previousDocTitle;
   }
 
-  showOperationStatus(operatingStatus, website) {
+  visitText(facilityType, website) {
+    if (facilityType === FacilityType.VA_CEMETARY) {
+      return (
+        <p>
+          For more information about the cemetery including interment, visit our{' '}
+          <a href={website}>cemetery website</a>.
+        </p>
+      );
+    }
+    return (
+      <p>
+        Visit the <a href={website}>website</a> to learn more about hours and
+        services.
+      </p>
+    );
+  }
+
+  showOperationStatus(operatingStatus, website, facilityType) {
     if (!operatingStatus || operatingStatus.code === 'NORMAL') {
       return null;
     }
@@ -71,12 +88,8 @@ class FacilityDetail extends Component {
               <p>{operatingStatus.additionalInfo} </p>
             )}
             {website &&
-              website !== 'NULL' && (
-                <p>
-                  Visit the <a href={website}>website</a> to learn more about
-                  hours and services.
-                </p>
-              )}
+              website !== 'NULL' &&
+              this.visitText(facilityType, website)}
           </div>
         }
         status={`${alertClass}`}
@@ -86,12 +99,18 @@ class FacilityDetail extends Component {
 
   renderFacilityInfo() {
     const { facility } = this.props;
-    const { name, website, phone, operatingStatus } = facility.attributes;
+    const {
+      name,
+      website,
+      phone,
+      operatingStatus,
+      facilityType,
+    } = facility.attributes;
 
     return (
       <div>
         <h1>{name}</h1>
-        {this.showOperationStatus(operatingStatus, website)}
+        {this.showOperationStatus(operatingStatus, website, facilityType)}
         <div className="p1">
           <FacilityTypeDescription location={facility} />
           <LocationAddress location={facility} />


### PR DESCRIPTION
## Description
issue: https://github.com/department-of-veterans-affairs/va.gov-team/issues/8530

## Testing done
Locally

## Screenshots
<img width="1113" alt="Screen Shot 2020-05-13 at 2 55 52 PM" src="https://user-images.githubusercontent.com/100468/81858811-ea943280-9529-11ea-820d-0db736fd7001.png">



## Acceptance criteria
- [x]  Add specific language to NCA facility operating status alerts to FL detail pages when facility type = cemetery and operating status = "Closed", "Notice" and "Limited Services and Hours"
TBD

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
