### PR TITLE
Remove comparison search result test update

### DIFF
--- a/src/applications/gi/components/search/SearchResult.jsx
+++ b/src/applications/gi/components/search/SearchResult.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { Link } from 'react-router';
-import environment from 'platform/utilities/environment';
 import { estimatedBenefits } from '../../selectors/estimator';
 import { formatCurrency, locationInfo } from '../../utils/helpers';
 import {
@@ -50,30 +49,12 @@ export class SearchResult extends React.Component {
             <div className="row">
               <div className="small-12 usa-width-seven-twelfths medium-7 columns">
                 <h2>
-                  {!environment.isProduction() && (
-                    <a
-                      onClick={() => this.props.handleLinkClick(facilityCode)}
-                      aria-label={`${name} ${locationInfo(
-                        city,
-                        state,
-                        country,
-                      )}`}
-                    >
-                      {name}
-                    </a>
-                  )}
-                  {environment.isProduction() && (
-                    <Link
-                      to={linkTo}
-                      aria-label={`${name} ${locationInfo(
-                        city,
-                        state,
-                        country,
-                      )}`}
-                    >
-                      {name}
-                    </Link>
-                  )}
+                  <Link
+                    to={linkTo}
+                    aria-label={`${name} ${locationInfo(city, state, country)}`}
+                  >
+                    {name}
+                  </Link>
                 </h2>
               </div>
             </div>

--- a/src/applications/gi/containers/SearchPage.jsx
+++ b/src/applications/gi/containers/SearchPage.jsx
@@ -121,12 +121,6 @@ export class SearchPage extends React.Component {
     }
   };
 
-  handleSearchLinkClick = facilityCode => {
-    const version = this.props.location.query.version;
-    const query = version ? { version } : {};
-    this.props.router.push({ pathname: `profile/${facilityCode}`, query });
-  };
-
   handlePageSelect = page => {
     this.props.router.push({
       ...this.props.location,
@@ -229,7 +223,6 @@ export class SearchPage extends React.Component {
                 yr={result.yr}
                 poe={result.poe}
                 eightKeys={result.eightKeys}
-                handleLinkClick={this.handleSearchLinkClick}
               />
             ))}
           </div>


### PR DESCRIPTION
## Description
Removed comparison tool search result link test that was behind a prod flag.

## Testing done
Tested locally and QA reviewed

## Screenshots
N/A

## Acceptance criteria
- [x] Search result links still work

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
