### PR TITLE
Uses imported stylesheet for chatbot page

### DIFF
--- a/src/applications/coronavirus-chatbot/createCoronavirusChatbot.js
+++ b/src/applications/coronavirus-chatbot/createCoronavirusChatbot.js
@@ -4,6 +4,7 @@ import * as Sentry from '@sentry/browser';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import ChatbotLoadError from './components/ChatbotLoadError';
+import './sass/coronavirus-chatbot.scss';
 
 export default (_store, widgetType) => {
   // Derive the element to render our widget.

--- a/src/applications/coronavirus-chatbot/sass/coronavirus-chatbot.scss
+++ b/src/applications/coronavirus-chatbot/sass/coronavirus-chatbot.scss
@@ -1,0 +1,170 @@
+#webchat {
+  margin-top: 20px;
+}
+
+#webchat button div {
+  overflow: visible !important;
+  white-space: pre-wrap !important;
+  text-overflow: unset !important;
+}
+
+/* divs between buttons in button container */
+.ac-actionSet > div {
+  display: none;
+}
+
+/* ancestor container of buttons */
+div.ac-container.ac-adaptiveCard > div > div {
+  overflow: unset !important;
+}
+
+/* button style in answers before being selected */
+button.ac-pushButton {
+  justify-content: left !important;
+  text-align: left !important;
+  overflow: visible !important;
+  margin: 4px 0 !important;
+  font-weight: 700 !important;
+  /* $color-primary from design.va.gov */
+  color: #0071bb;
+  border: 2px solid #0071bb !important;
+}
+
+button.ac-pushButton:hover {
+  /* $color-primary-darker from design.va.gov */
+  color: #003e73;
+  border: 2px solid #003e73 !important;
+  background: white;
+}
+
+#webchat button:disabled {
+  padding: 10px !important;
+  min-height: 38px !important;
+  background: #d6d7d9 !important;
+  color: #ffffff !important;
+  border: 0 !important;
+}
+
+#webchat[watermark="true"] [role="complementary"] ul[role="list"]::after {
+  content: "Powered By ...";
+  background: linear-gradient(rgba(248, 248, 248, 0), rgba(248, 248, 248, .63), #F8F8F8 40%);
+  bottom: 0;
+  right: 0;
+  color: #707070;
+  display: block;
+  font-family: 'Segoe Semibold', Calibri, 'Helvetica Neue', Arial, sans-serif;
+  font-size: 12px;
+  padding: 15px 10px 10px;
+  position: sticky;
+  text-align: right;
+}
+
+#webchat input[type=checkbox] {
+  -webkit-appearance: checkbox;
+  -moz-appearance: checkbox;
+  opacity: 1.0;
+  width: auto;
+  height: 1.6rem;
+  margin-top: 5px !important;
+}
+
+/* labels for checkboxes */
+#webchat label.ac-textBlock {
+  font-size: 16px !important;
+  margin-top: 0 !important;
+  margin-left: 16px !important;
+  text-overflow: unset !important;
+  white-space: unset !important;
+}
+
+#webchat div.ac-input.ac-choiceSetInput-multiSelect {
+  margin-bottom: 15px;
+}
+
+#webchat div.ac-input.ac-choiceSetInput-multiSelect > div {
+  align-items: flex-start !important;
+}
+
+#webchat .ac-input.ac-multichoiceInput.ac-choiceSetInput-compact {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  padding-right: 2.5rem;
+}
+
+.webchat__bubble__content {
+  border: 0 !important;
+  border-radius: 5px !important;
+  /* $color-base from design.va.gov */
+  color: #212121 !important;
+}
+
+/* side vertical container with avatar in it */
+.webchat__stackedLayout__avatar {
+  margin: 7px 8px 0 !important;
+}
+
+/* horizontal container with chat bubbles */
+.webchat__stacked_indented_content {
+  margin: 0 8px !important;
+}
+
+/* padding around question chat bubbles */
+.css-18q9i6z {
+  padding: 16px 8px !important;
+}
+
+/* gap between end of scroll area and bg */
+.css-1qyo5rb:first-child {
+  margin-top: 4px !important;
+}
+
+/* padding between question chat bubbles */
+.css-1qyo5rb:not(:first-child) {
+  padding-bottom: 8px !important;
+  margin-bottom: 0 !important;
+}
+
+/* padding around answer chat bubbles */
+div.ac-container.ac-adaptiveCard {
+  padding: 16px 8px !important;
+}
+
+/* additional padding around answer chat bubbles
+(3px + webchat__row 5px + css-1qyo5rb 8px = 16px from design specs) */
+.webchat__stackedLayout--fromUser {
+  padding: 3px 0 !important;
+}
+
+/* "just now/5 mins ago" time indicator for each message */
+.css-1kceze8 {
+  visibility: hidden !important;
+  height: 0;
+}
+
+/* unnecessary div above answer options in chat bubble */
+.ac-horizontal-separator {
+  height: 0 !important;
+}
+
+/* container around dropdown element */
+.ac-input-container {
+  flex-wrap: wrap !important;
+}
+
+/* dropdown element (ex: states list) */
+.ac-input.ac-multichoiceInput.ac-choiceSetInput-compact {
+  margin-bottom: 8px !important;
+  min-width: 100% !important;
+}
+
+.css-yb0hx9.webchat__initialsAvatar.css-10h6e9z {
+  font-weight: 700 !important;
+  font-size: 18px !important;
+  /* $color-primary-darkest from design.va.gov */
+  background: #112e51 !important;
+}
+
+.css-1t62idy {
+  flex-direction: row;
+}

--- a/src/applications/coronavirus-chatbot/sass/coronavirus-chatbot.scss
+++ b/src/applications/coronavirus-chatbot/sass/coronavirus-chatbot.scss
@@ -1,3 +1,5 @@
+@import "~@department-of-veterans-affairs/formation/sass/shared-variables";
+
 #webchat {
   margin-top: 20px;
 }
@@ -25,38 +27,22 @@ button.ac-pushButton {
   overflow: visible !important;
   margin: 4px 0 !important;
   font-weight: 700 !important;
-  /* $color-primary from design.va.gov */
-  color: #0071bb;
-  border: 2px solid #0071bb !important;
+  color: $color-primary;
+  border: 2px solid $color-primary !important;
 }
 
 button.ac-pushButton:hover {
-  /* $color-primary-darker from design.va.gov */
-  color: #003e73;
-  border: 2px solid #003e73 !important;
-  background: white;
+  color: $color-primary-darker;
+  border: 2px solid $color-primary-darker !important;
+  background: $color-white;
 }
 
 #webchat button:disabled {
   padding: 10px !important;
   min-height: 38px !important;
-  background: #d6d7d9 !important;
-  color: #ffffff !important;
+  background: $color-gray-lighter !important;
+  color: $color-white !important;
   border: 0 !important;
-}
-
-#webchat[watermark="true"] [role="complementary"] ul[role="list"]::after {
-  content: "Powered By ...";
-  background: linear-gradient(rgba(248, 248, 248, 0), rgba(248, 248, 248, .63), #F8F8F8 40%);
-  bottom: 0;
-  right: 0;
-  color: #707070;
-  display: block;
-  font-family: 'Segoe Semibold', Calibri, 'Helvetica Neue', Arial, sans-serif;
-  font-size: 12px;
-  padding: 15px 10px 10px;
-  position: sticky;
-  text-align: right;
 }
 
 #webchat input[type=checkbox] {
@@ -95,8 +81,7 @@ button.ac-pushButton:hover {
 .webchat__bubble__content {
   border: 0 !important;
   border-radius: 5px !important;
-  /* $color-base from design.va.gov */
-  color: #212121 !important;
+  color: $color-base;
 }
 
 /* side vertical container with avatar in it */
@@ -161,8 +146,7 @@ div.ac-container.ac-adaptiveCard {
 .css-yb0hx9.webchat__initialsAvatar.css-10h6e9z {
   font-weight: 700 !important;
   font-size: 18px !important;
-  /* $color-primary-darkest from design.va.gov */
-  background: #112e51 !important;
+  background: $color-primary-darkest !important;
 }
 
 .css-1t62idy {


### PR DESCRIPTION
## Description
The chatbot page currently uses inline styles, which are added and updated in `coronavirus-chatbot.md` in the `vagov-content` repo.

It is better practice to have stylesheets live closer to the components themselves, in the `vets-website` repo. Per this [Slack thread](https://dsva.slack.com/archives/CBU0KDSB1/p1589299880433400?thread_ts=1589224721.377400&cid=CBU0KDSB1), this change has been implemented. The chatbot page now imports its own stylesheet that lives in `vets-website`.

_Another [PR](https://github.com/department-of-veterans-affairs/vagov-content/pull/680) will follow to remove the inline styles from `vagov-content`._

Tracked in this issue: [department-of-veterans-affairs/covid19-chatbot#130]

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
