### PR TITLE
Add extra data for request failures

### DIFF
--- a/src/applications/vaos/actions/newAppointment.js
+++ b/src/applications/vaos/actions/newAppointment.js
@@ -764,7 +764,7 @@ export function submitAppointmentOrRequest(router) {
         } catch (error) {
           // These are ancillary updates, the request went through if the first submit
           // succeeded
-          captureError(error, false, null, {
+          captureError(error, false, 'Request message failure', {
             messageLength: newAppointment?.data?.reasonAdditionalInfo?.length,
           });
         }
@@ -792,7 +792,7 @@ export function submitAppointmentOrRequest(router) {
             cityState: requestBody.cityState,
           };
         }
-        captureError(error, true, null, extraData);
+        captureError(error, true, 'Request submission failure', extraData);
         dispatch({
           type: FORM_SUBMIT_FAILED,
         });

--- a/src/applications/vaos/actions/newAppointment.js
+++ b/src/applications/vaos/actions/newAppointment.js
@@ -737,6 +737,7 @@ export function submitAppointmentOrRequest(router) {
         newAppointment.data.facilityType === FACILITY_TYPES.COMMUNITY_CARE;
       const eventType = isCommunityCare ? 'community-care' : 'request';
       const flow = isCommunityCare ? GA_FLOWS.CC_REQUEST : GA_FLOWS.VA_REQUEST;
+      let requestBody;
 
       recordEvent({
         event: `${GA_PREFIX}-${eventType}-submission`,
@@ -745,9 +746,7 @@ export function submitAppointmentOrRequest(router) {
       });
 
       try {
-        let requestBody;
         let requestData;
-
         if (isCommunityCare) {
           requestBody = transformFormToCCRequest(getState());
           requestData = await submitRequest('cc', requestBody);
@@ -780,7 +779,18 @@ export function submitAppointmentOrRequest(router) {
         resetDataLayer();
         router.push('/new-appointment/confirmation');
       } catch (error) {
-        captureError(error, true);
+        let extraData = null;
+        if (requestBody) {
+          extraData = {
+            vaParent: data?.vaParent,
+            vaFacility: data?.vaFacility,
+            chosenTypeOfCare: data?.typeOfCareId,
+            facility: requestBody.facility,
+            typeOfCareId: requestBody.typeOfCareId,
+            cityState: requestBody.cityState,
+          };
+        }
+        captureError(error, true, null, extraData);
         dispatch({
           type: FORM_SUBMIT_FAILED,
         });

--- a/src/applications/vaos/actions/newAppointment.js
+++ b/src/applications/vaos/actions/newAppointment.js
@@ -764,7 +764,9 @@ export function submitAppointmentOrRequest(router) {
         } catch (error) {
           // These are ancillary updates, the request went through if the first submit
           // succeeded
-          captureError(error);
+          captureError(error, false, null, {
+            messageLength: newAppointment?.data?.reasonAdditionalInfo?.length,
+          });
         }
 
         dispatch({

--- a/src/applications/vaos/utils/error.js
+++ b/src/applications/vaos/utils/error.js
@@ -2,7 +2,12 @@ import * as Sentry from '@sentry/browser';
 import { recordVaosError } from './events';
 import environment from 'platform/utilities/environment';
 
-export function captureError(err, skipRecordEvent = false, customTitle) {
+export function captureError(
+  err,
+  skipRecordEvent = false,
+  customTitle,
+  extraData,
+) {
   let eventErrorKey;
 
   if (err instanceof Error) {
@@ -11,6 +16,9 @@ export function captureError(err, skipRecordEvent = false, customTitle) {
   } else {
     Sentry.withScope(scope => {
       scope.setExtra('error', err);
+      if (extraData) {
+        scope.setExtra('extraData', extraData);
+      }
       const errorTitle =
         customTitle || err?.errors?.[0]?.title || err?.issue?.[0]?.code || err;
       const message = `vaos_server_error${errorTitle ? `: ${errorTitle}` : ''}`;


### PR DESCRIPTION
## Description
This adds some extra data to the Sentry log for request failures

## Testing done
Local testing

## Acceptance criteria
- [ ] Extra data is captured

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
