### PR TITLE
Updated yellow ribbon modal content

### DIFF
--- a/src/applications/gi/components/content/YellowRibbonModalContent.jsx
+++ b/src/applications/gi/components/content/YellowRibbonModalContent.jsx
@@ -1,0 +1,44 @@
+import React from 'react';
+
+export const YellowRibbonModalContent = () => (
+  <div>
+    {' '}
+    <h3>Yellow Ribbon Program</h3>
+    <p>
+      The Yellow Ribbon Program can help you pay for higher out-of-state,
+      private school, or graduate school tuition that the{' '}
+      <a
+        href="https://www.va.gov/education/about-gi-bill-benefits/post-9-11/"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        Post-9/11 GI Bill
+      </a>{' '}
+      doesn’t cover.
+    </p>
+    <p>
+      Schools that choose to participate in the Yellow Ribbon program will
+      contribute a certain amount toward the extra tuition. VA will match the
+      participating school’s contribution, up to the total cost of the tuition
+      and fees. To learn more about the Yellow Ribbon program, please{' '}
+      <a
+        href="https://benefits.va.gov/BENEFITS/factsheets/education/Post-911_Yellow_Ribbon.pdf"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        download our fact sheet
+      </a>
+      .
+    </p>
+    <p>
+      Veterans and Fry Scholarship and Purple Heart recipients, or their
+      dependents using transferred benefits, are eligible for the maximum
+      benefit rate. Active-duty service members and their spouses aren’t
+      eligible for this program. (An active-duty service member’s dependent
+      child using transferred benefits may be eligible if the service member is
+      qualified at the 100% rate.) This information will be updated quarterly.
+    </p>
+  </div>
+);
+
+export default YellowRibbonModalContent;

--- a/src/applications/gi/components/profile/Programs.jsx
+++ b/src/applications/gi/components/profile/Programs.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import environment from 'platform/utilities/environment';
 
 export class Programs extends React.Component {
   constructor(props) {
@@ -9,7 +10,8 @@ export class Programs extends React.Component {
     const { institution } = props;
     this.programs = {
       yr: {
-        modal: 'yribbon',
+        // prod flag for 8524
+        modal: environment.isProduction() ? 'yribbon' : 'calcYr',
         text: 'Yellow Ribbon',
         link: false,
       },

--- a/src/applications/gi/components/profile/Programs.jsx
+++ b/src/applications/gi/components/profile/Programs.jsx
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import environment from 'platform/utilities/environment';
 
 export class Programs extends React.Component {
   constructor(props) {
@@ -10,8 +9,7 @@ export class Programs extends React.Component {
     const { institution } = props;
     this.programs = {
       yr: {
-        // prod flag for 8524
-        modal: environment.isProduction() ? 'yribbon' : 'calcYr',
+        modal: 'yribbon',
         text: 'Yellow Ribbon',
         link: false,
       },

--- a/src/applications/gi/containers/Modals.jsx
+++ b/src/applications/gi/containers/Modals.jsx
@@ -3,6 +3,7 @@ import { connect } from 'react-redux';
 import * as actions from '../actions';
 import Modal from '../components/Modal';
 import environment from 'platform/utilities/environment';
+import YellowRibbonModalContent from '../components/content/YellowRibbonModalContent';
 
 export class Modals extends React.Component {
   calcBeneficiaryLocationQuestionContent = () => (
@@ -238,46 +239,60 @@ export class Modals extends React.Component {
         </p>
       </Modal>
 
-      <Modal
-        onClose={this.props.hideModal}
-        visible={this.shouldDisplayModal('yribbon')}
-      >
-        <h3>Yellow Ribbon</h3>
-        <p>
-          The{' '}
-          <a
-            title="Post-9/11 GI Bill"
-            href="http://www.benefits.va.gov/gibill/post911_gibill.asp"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Post-9/11 GI Bill
-          </a>{' '}
-          can cover all in-state tuition and fees at public degree granting
-          schools, but may not cover all private degree granting schools and
-          out-of-state tuition. The Yellow Ribbon Program provides additional
-          support in those situations. Institutions voluntarily enter into an
-          agreement with VA to fund uncovered charges. VA matches each dollar of
-          unmet charges the institution agrees to contribute, up to the total
-          cost of the tuition and fees.{' '}
-          <a
-            title="Click here for FAQs about the Yellow Ribbon Program"
-            href="http://www.benefits.va.gov/gibill/docs/factsheets/2012_Yellow_Ribbon_Student_FAQs.pdf"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Click here for FAQs about the Yellow Ribbon Program
-          </a>
-        </p>
-        <p>
-          Veterans and Fry Scholarship and Purple Heart recipients are entitled
-          to the maximum benefit rate or their designated transferees can
-          receive this funding. Active-duty service members and their spouses
-          aren’t eligible for this program (child transferees of active-duty
-          service members may be eligible if the service member is qualified at
-          the 100% rate). This information will be updated quarterly.
-        </p>
-      </Modal>
+      {/* prod flag for 8524 */}
+      {environment.isProduction() && (
+        <Modal
+          onClose={this.props.hideModal}
+          visible={this.shouldDisplayModal('yribbon')}
+        >
+          <h3>Yellow Ribbon</h3>
+          <p>
+            The{' '}
+            <a
+              title="Post-9/11 GI Bill"
+              href="http://www.benefits.va.gov/gibill/post911_gibill.asp"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Post-9/11 GI Bill
+            </a>{' '}
+            can cover all in-state tuition and fees at public degree granting
+            schools, but may not cover all private degree granting schools and
+            out-of-state tuition. The Yellow Ribbon Program provides additional
+            support in those situations. Institutions voluntarily enter into an
+            agreement with VA to fund uncovered charges. VA matches each dollar
+            of unmet charges the institution agrees to contribute, up to the
+            total cost of the tuition and fees.{' '}
+            <a
+              title="Click here for FAQs about the Yellow Ribbon Program"
+              href="http://www.benefits.va.gov/gibill/docs/factsheets/2012_Yellow_Ribbon_Student_FAQs.pdf"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Click here for FAQs about the Yellow Ribbon Program
+            </a>
+          </p>
+          <p>
+            Veterans and Fry Scholarship and Purple Heart recipients are
+            entitled to the maximum benefit rate or their designated transferees
+            can receive this funding. Active-duty service members and their
+            spouses aren’t eligible for this program (child transferees of
+            active-duty service members may be eligible if the service member is
+            qualified at the 100% rate). This information will be updated
+            quarterly.
+          </p>
+        </Modal>
+      )}
+
+      {/* prod flag for 8524 */}
+      {!environment.isProduction() && (
+        <Modal
+          onClose={this.props.hideModal}
+          visible={this.shouldDisplayModal('yribbon')}
+        >
+          <YellowRibbonModalContent />
+        </Modal>
+      )}
 
       <Modal
         onClose={this.props.hideModal}
@@ -947,43 +962,7 @@ export class Modals extends React.Component {
             onClose={this.props.hideModal}
             visible={this.shouldDisplayModal('calcYr')}
           >
-            <h3>Yellow Ribbon Program</h3>
-            <p>
-              The Yellow Ribbon Program can help you pay for higher
-              out-of-state, private school, or graduate school tuition that the{' '}
-              <a
-                href="https://www.va.gov/education/about-gi-bill-benefits/post-9-11/"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                Post-9/11 GI Bill
-              </a>{' '}
-              doesn’t cover.
-            </p>
-            <p>
-              Schools that choose to participate in the Yellow Ribbon program
-              will contribute a certain amount toward the extra tuition. VA will
-              match the participating school’s contribution, up to the total
-              cost of the tuition and fees. To learn more about the Yellow
-              Ribbon program, please{' '}
-              <a
-                href="https://benefits.va.gov/BENEFITS/factsheets/education/Post-911_Yellow_Ribbon.pdf"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                download our fact sheet
-              </a>
-              .
-            </p>
-            <p>
-              Veterans and Fry Scholarship and Purple Heart recipients, or their
-              dependents using transferred benefits, are eligible for the
-              maximum benefit rate. Active-duty service members and their
-              spouses aren’t eligible for this program. (An active-duty service
-              member’s dependent child using transferred benefits may be
-              eligible if the service member is qualified at the 100% rate.)
-              This information will be updated quarterly.
-            </p>
+            <YellowRibbonModalContent />
           </Modal>
         )}
 

--- a/src/applications/gi/containers/Modals.jsx
+++ b/src/applications/gi/containers/Modals.jsx
@@ -903,40 +903,89 @@ export class Modals extends React.Component {
           </p>
         </Modal>
 
-        <Modal
-          onClose={this.props.hideModal}
-          visible={this.shouldDisplayModal('calcYr')}
-        >
-          <h3>Yellow Ribbon</h3>
-          <p>
-            The Post-9/11 GI Bill can cover all in-state tuition and fees at
-            public degree granting schools, but may not cover all private degree
-            granting schools and out-of-state tuition. The Yellow Ribbon Program
-            provides additional support in those situations. Institutions
-            voluntarily enter into an agreement with VA to fund uncovered
-            charges. VA matches each dollar of unmet charges that the
-            institution agrees to contribute, up to the total cost of the
-            tuition and fees. For Frequently Asked Questions about the Yellow
-            Ribbon Program, visit{' '}
-            <a
-              title="Click here for FAQs about the Yellow Ribbon Program"
-              href="http://www.benefits.va.gov/gibill/docs/factsheets/2012_Yellow_Ribbon_Student_FAQs.pdf"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              this page.
-            </a>
-          </p>
-          <p>
-            Veterans and Fry Scholarship and Purple Heart recipients are
-            entitled to the maximum benefit rate or their designated transferees
-            can receive this funding. Active-duty service members and their
-            spouses are not eligible for this program (child transferees of
-            active-duty service members may be eligible if the service member is
-            qualified at the 100% rate). This information will be updated
-            quarterly.
-          </p>
-        </Modal>
+        {/* prod flag for 8524 */}
+        {environment.isProduction() && (
+          <Modal
+            onClose={this.props.hideModal}
+            visible={this.shouldDisplayModal('calcYr')}
+          >
+            <h3>Yellow Ribbon</h3>
+            <p>
+              The Post-9/11 GI Bill can cover all in-state tuition and fees at
+              public degree granting schools, but may not cover all private
+              degree granting schools and out-of-state tuition. The Yellow
+              Ribbon Program provides additional support in those situations.
+              Institutions voluntarily enter into an agreement with VA to fund
+              uncovered charges. VA matches each dollar of unmet charges that
+              the institution agrees to contribute, up to the total cost of the
+              tuition and fees. For Frequently Asked Questions about the Yellow
+              Ribbon Program, visit{' '}
+              <a
+                title="Click here for FAQs about the Yellow Ribbon Program"
+                href="http://www.benefits.va.gov/gibill/docs/factsheets/2012_Yellow_Ribbon_Student_FAQs.pdf"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                this page.
+              </a>
+            </p>
+            <p>
+              Veterans and Fry Scholarship and Purple Heart recipients are
+              entitled to the maximum benefit rate or their designated
+              transferees can receive this funding. Active-duty service members
+              and their spouses are not eligible for this program (child
+              transferees of active-duty service members may be eligible if the
+              service member is qualified at the 100% rate). This information
+              will be updated quarterly.
+            </p>
+          </Modal>
+        )}
+
+        {/* prod flag for 8524 */}
+        {!environment.isProduction() && (
+          <Modal
+            onClose={this.props.hideModal}
+            visible={this.shouldDisplayModal('calcYr')}
+          >
+            <h3>Yellow Ribbon Program</h3>
+            <p>
+              The Yellow Ribbon Program can help you pay for higher
+              out-of-state, private school, or graduate school tuition that the{' '}
+              <a
+                href="https://www.va.gov/education/about-gi-bill-benefits/post-9-11/"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Post-9/11 GI Bill
+              </a>{' '}
+              doesn’t cover.
+            </p>
+            <p>
+              Schools that choose to participate in the Yellow Ribbon program
+              will contribute a certain amount toward the extra tuition. VA will
+              match the participating school’s contribution, up to the total
+              cost of the tuition and fees. To learn more about the Yellow
+              Ribbon program, please{' '}
+              <a
+                href="https://benefits.va.gov/BENEFITS/factsheets/education/Post-911_Yellow_Ribbon.pdf"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                download our fact sheet
+              </a>
+              .
+            </p>
+            <p>
+              Veterans and Fry Scholarship and Purple Heart recipients, or their
+              dependents using transferred benefits, are eligible for the
+              maximum benefit rate. Active-duty service members and their
+              spouses aren’t eligible for this program. (An active-duty service
+              member’s dependent child using transferred benefits may be
+              eligible if the service member is qualified at the 100% rate.)
+              This information will be updated quarterly.
+            </p>
+          </Modal>
+        )}
 
         <Modal
           onClose={this.props.hideModal}


### PR DESCRIPTION
## Description
Updated yellow ribbon "learn more" modal content

[ZenHub Issue](https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/8524)

## Testing done
Tested locally and QA reviewed

## Screenshots
![image](https://user-images.githubusercontent.com/41960449/81836673-cc223d00-9511-11ea-93de-711b882d62d9.png)

## Acceptance criteria
- [x] Modal content matches ZenHub issue

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
