### PR TITLE
[CI/CD] Fix form 526 headers

### DIFF
--- a/src/applications/disability-benefits/all-claims/components/ArrayField.jsx
+++ b/src/applications/disability-benefits/all-claims/components/ArrayField.jsx
@@ -302,6 +302,8 @@ export default class ArrayField extends React.Component {
             const isLast = items.length === index + 1;
             const isEditing = this.state.editing[index];
 
+            const Tag = formContext.onReviewPage ? 'h5' : 'h3';
+
             if (isEditing) {
               return (
                 <div key={index} className="va-growable-background">
@@ -311,7 +313,9 @@ export default class ArrayField extends React.Component {
                       {isLast &&
                       items.length > 1 &&
                       uiSchema['ui:options'].itemName ? (
-                        <h5>New {uiSchema['ui:options'].itemName}</h5>
+                        <Tag className="vads-u-font-size--h5">
+                          New {uiSchema['ui:options'].itemName}
+                        </Tag>
                       ) : null}
                       <div className="input-section">
                         <SchemaField

--- a/src/applications/disability-benefits/all-claims/components/IntroductionPage.jsx
+++ b/src/applications/disability-benefits/all-claims/components/IntroductionPage.jsx
@@ -52,22 +52,22 @@ class IntroductionPage extends React.Component {
           downtime={this.props.route.formConfig.downtime}
         />
         {itfNotice}
-        <h4>
+        <h2 className="vads-u-font-size--h4">
           Follow the steps below to file a claim for a new or secondary
           condition or for increased disability compensation.
-        </h4>
+        </h2>
         <div className="process schemaform-process">
           <ol>
             <li className="process-step list-one">
               <div>
-                <h5>Prepare</h5>
+                <h3 className="vads-u-font-size--h5">Prepare</h3>
               </div>
               <div>
-                <h6>
+                <h4 className="vads-u-font-size--h6">
                   When you file a disability claim, you’ll have a chance to
                   provide evidence to support your claim. Evidence could
                   include:
-                </h6>
+                </h4>
               </div>
               <ul>
                 <li>
@@ -141,7 +141,7 @@ class IntroductionPage extends React.Component {
             </li>
             <li className="process-step list-two">
               <div>
-                <h5>Apply</h5>
+                <h3 className="vads-u-font-size--h5">Apply</h3>
               </div>
               <p>
                 Complete this disability compensation benefits form. After
@@ -151,7 +151,7 @@ class IntroductionPage extends React.Component {
             </li>
             <li className="process-step list-three">
               <div>
-                <h5>VA Review</h5>
+                <h3 className="vads-u-font-size--h5">VA Review</h3>
               </div>
               <p>
                 We process applications in the order we receive them. The amount
@@ -162,7 +162,7 @@ class IntroductionPage extends React.Component {
             </li>
             <li className="process-step list-four">
               <div>
-                <h5>Decision</h5>
+                <h3 className="vads-u-font-size--h5">Decision</h3>
               </div>
               <p>
                 Once we’ve processed your claim, you’ll get a notice in the mail

--- a/src/applications/disability-benefits/all-claims/content/employmentHistory.jsx
+++ b/src/applications/disability-benefits/all-claims/content/employmentHistory.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 export const employmentDescription = (
   <div>
-    <h4>Employment history</h4>
+    <h3 className="vads-u-font-size--h4">Employment history</h3>
     <p>
       Now we’re going to ask you about your employment history. Please enter
       your most recent employer first and work back through the past 5 years. Be

--- a/src/applications/disability-benefits/all-claims/content/fileUploadDescriptions.jsx
+++ b/src/applications/disability-benefits/all-claims/content/fileUploadDescriptions.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 export const UploadDescription = ({ uploadTitle }) => (
   <div>
-    {uploadTitle && <h5>{uploadTitle}</h5>}
+    {uploadTitle && <h3 className="vads-u-font-size--h5">{uploadTitle}</h3>}
     <p>
       You can upload your document in a .pdf, .jpeg, or .png file format. You’ll
       first need to scan a copy of your document onto your computer or mobile

--- a/src/applications/disability-benefits/all-claims/content/fullyDevelopedClaim.jsx
+++ b/src/applications/disability-benefits/all-claims/content/fullyDevelopedClaim.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 export const FDCDescription = (
   <div>
-    <h5>Fully developed claim program</h5>
+    <h3 className="vads-u-font-size--h5">Fully developed claim program</h3>
     <p>
       You can apply using the Fully Developed Claim (FDC) program if you’ve
       uploaded all the supporting documents or additional forms needed to

--- a/src/applications/disability-benefits/all-claims/content/incomeDetails.jsx
+++ b/src/applications/disability-benefits/all-claims/content/incomeDetails.jsx
@@ -12,7 +12,7 @@ const helpClicked = () =>
 
 export const incomeDescription = (
   <div>
-    <h4>Income details</h4>
+    <h3 className="vads-u-font-size--h4">Income details</h3>
     <p>
       Now we’re going to ask you about your income history. Please provide your
       gross income, which is all the money you earned through employment for the

--- a/src/applications/disability-benefits/all-claims/content/instructionalPart2.jsx
+++ b/src/applications/disability-benefits/all-claims/content/instructionalPart2.jsx
@@ -2,11 +2,11 @@ import React from 'react';
 
 const instructionalPart2Description = (
   <div>
-    <h4>Fill in employer details</h4>
+    <h3 className="vads-u-font-size--h4">Fill in employer details</h3>
     <p>
       Put the employer’s name and address in <strong>Box 1.</strong>
     </p>
-    <img src="/img/part2-image.png" alt="Box 2" />
+    <img src="/img/part2-image.png" alt="Box 1" />
   </div>
 );
 

--- a/src/applications/disability-benefits/all-claims/content/instructionalPart3.jsx
+++ b/src/applications/disability-benefits/all-claims/content/instructionalPart3.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 export const instructionalPart3Description = (
   <div>
-    <h4>Fill in return address</h4>
+    <h3 className="vads-u-font-size--h4">Fill in return address</h3>
     <p>
       Put the VA Claims Intake Center address listed below in{' '}
       <strong>Box 2.</strong> This is where your employer will return the form
@@ -10,9 +10,9 @@ export const instructionalPart3Description = (
     </p>
     <div className="blue-bar-block">
       Department of Veterans Affairs Claims Intake Center PO Box 4444
-      Janesville, WI 53547-4444 Or fax them toll-free: 844-531-7818
+      Janesville, WI 53547-4444, Or fax them toll-free: 844-531-7818
     </div>
 
-    <img src="/img/part3-image.png" alt="Box 1" />
+    <img src="/img/part3-image.png" alt="Box 2" />
   </div>
 );

--- a/src/applications/disability-benefits/all-claims/content/instructionalPart3.jsx
+++ b/src/applications/disability-benefits/all-claims/content/instructionalPart3.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { claimsIntakeAddress } from './itfWrapper';
 
 export const instructionalPart3Description = (
   <div>
@@ -8,11 +9,8 @@ export const instructionalPart3Description = (
       <strong>Box 2.</strong> This is where your employer will return the form
       after they’ve completed their sections.
     </p>
-    <div className="blue-bar-block">
-      Department of Veterans Affairs Claims Intake Center PO Box 4444
-      Janesville, WI 53547-4444, Or fax them toll-free: 844-531-7818
-    </div>
-
+    {claimsIntakeAddress}
+    <p>Or fax them toll-free: 844-531-7818</p>
     <img src="/img/part3-image.png" alt="Box 2" />
   </div>
 );

--- a/src/applications/disability-benefits/all-claims/content/summaryOfDisabilities.jsx
+++ b/src/applications/disability-benefits/all-claims/content/summaryOfDisabilities.jsx
@@ -48,7 +48,7 @@ const getRedirectLink = formData => {
   }
   return (
     <Link
-      aria-label="Add missing disabilities"
+      aria-label="go back and add it, any missing disabilities"
       to={{
         pathname: destinationPath || '/',
         search: '?redirect',

--- a/src/applications/disability-benefits/all-claims/content/summaryOfDisabilities.jsx
+++ b/src/applications/disability-benefits/all-claims/content/summaryOfDisabilities.jsx
@@ -47,15 +47,18 @@ const getRedirectLink = formData => {
     destinationPath = DISABILITY_SHARED_CONFIG.addDisabilities.path;
   }
   return (
-    <Link
-      aria-label="go back and add it, any missing disabilities"
-      to={{
-        pathname: destinationPath || '/',
-        search: '?redirect',
-      }}
-    >
-      go back and add it
-    </Link>
+    <>
+      <Link
+        aria-label="go back and add any missing disabilities"
+        to={{
+          pathname: destinationPath || '/',
+          search: '?redirect',
+        }}
+      >
+        go back and add
+      </Link>{' '}
+      it
+    </>
   );
 };
 

--- a/src/applications/disability-benefits/all-claims/content/unemployabilityDates.jsx
+++ b/src/applications/disability-benefits/all-claims/content/unemployabilityDates.jsx
@@ -12,7 +12,7 @@ const helpClicked = () =>
 
 export const dateDescription = (
   <div>
-    <h5>Disability dates</h5>
+    <h3 className="vads-u-font-size--h5">Disability dates</h3>
     <p>
       Now we’ll ask you to tell us when your disability prevented you from
       working.
@@ -26,17 +26,21 @@ export const dateFieldsDescription = (
       triggerText="How are these dates different?"
       onClick={helpClicked}
     >
-      <h5>Date you became too disabled to work</h5>
+      <h3 className="vads-u-font-size--h5">
+        Date you became too disabled to work
+      </h3>
       <p>
         This is the date you could no longer work full time or part time due to
         your service-connected disability.
       </p>
-      <h5>Date you last worked full-time</h5>
+      <h3 className="vads-u-font-size--h5">Date you last worked full-time</h3>
       <p>
         This is the date you could no longer work full time due to your
         service-connected disability.
       </p>
-      <h5>Date your disability began to affect your full-time employment</h5>
+      <h3 className="vads-u-font-size--h5">
+        Date your disability began to affect your full-time employment
+      </h3>
       <p>
         This is the date when started to reduce your work hours or to take time
         off from work due to your service-connected disability.

--- a/src/applications/disability-benefits/all-claims/content/unemployabilityFormIntro.jsx
+++ b/src/applications/disability-benefits/all-claims/content/unemployabilityFormIntro.jsx
@@ -6,7 +6,9 @@ export const unemployabilityTitle = (
   </legend>
 );
 
-export const unemployabilityPageTitle = title => <h4>{title}</h4>;
+export const unemployabilityPageTitle = title => (
+  <h3 className="vads-u-font-size--h4">{title}</h3>
+);
 
 export const introDescription = (
   <div>
@@ -20,7 +22,7 @@ export const introDescription = (
       <ol>
         <li className="process-step list-one">
           <div>
-            <h5>Answer questions</h5>
+            <h3>Answer questions</h3>
             <p>
               First, we’ll ask you questions about your situation and how your
               service-connected disability prevents you from holding down a
@@ -34,7 +36,7 @@ export const introDescription = (
         </li>
         <li className="process-step list-two">
           <div>
-            <h5>Send former employers a request for information form</h5>
+            <h3>Send former employers a request for information form</h3>
             <p>
               Then, we’ll ask you to send each of your former employers a form
               to fill out verifying your past work. You’ll be able to download

--- a/src/applications/disability-benefits/all-claims/content/uploadUnemployabilitySupportingDocuments.jsx
+++ b/src/applications/disability-benefits/all-claims/content/uploadUnemployabilitySupportingDocuments.jsx
@@ -2,13 +2,12 @@ import React from 'react';
 
 export const uploadDescription = () => (
   <div>
-    <h4>Supporting Documents</h4>
+    <h3 className="vads-u-font-size--h4">Supporting Documents</h3>
     <p>
       When you file a claim for Individual Unemployability, you'll have a chance
       to provide supporting documents that show your disability prevents you
       from holding down a steady job.
     </p>
-    <br />
     <p>Some examples of supporting documents include:</p>
     <ul>
       <li>Medical records</li>

--- a/src/applications/disability-benefits/all-claims/pages/additionalDocuments.js
+++ b/src/applications/disability-benefits/all-claims/pages/additionalDocuments.js
@@ -8,9 +8,11 @@ const { attachments } = full526EZSchema.properties;
 export const uiSchema = {
   additionalDocuments: {
     ...ancillaryFormUploadUi(
-      'Lay statements or other evidence',
+      'to lay statements or other evidence',
       'Adding additional evidence:',
-      {},
+      {
+        addAnotherLabel: 'Add another document',
+      },
     ),
     'ui:description': UploadDescription,
   },

--- a/src/applications/disability-benefits/all-claims/pages/medicalCare.jsx
+++ b/src/applications/disability-benefits/all-claims/pages/medicalCare.jsx
@@ -3,7 +3,7 @@ import { unemployabilityTitle } from '../content/unemployabilityFormIntro';
 
 const medicalDescription = (
   <div>
-    <h4>Medical Care</h4>
+    <h3 className="vads-u-font-size--h4">Medical Care</h3>
     <p>
       Did you spend time in a hospital or under a doctor's care for your
       service-connected disabilities in the past 12 months?

--- a/src/applications/disability-benefits/all-claims/pages/privateMedicalRecords.js
+++ b/src/applications/disability-benefits/all-claims/pages/privateMedicalRecords.js
@@ -11,11 +11,11 @@ import { DATA_PATHS } from '../constants';
 const { privateMedicalRecordAttachments } = fullSchema.properties;
 
 const fileUploadUi = ancillaryFormUploadUi(
-  'Upload your private medical records',
+  'to your private medical records',
   ' ',
   {
     attachmentId: '',
-    addAnotherLabel: 'Add Another Document',
+    addAnotherLabel: 'Add another document',
   },
 );
 
@@ -24,8 +24,8 @@ export const uiSchema = {
     'Now we’ll ask you about your private medical records for your claimed disability.',
   'view:aboutPrivateMedicalRecords': {
     'ui:title': 'About private medical records',
-    'ui:description': `If you have your private medical records, you can upload them to your 
-      application. If you want us to get them for you, you’ll need to 
+    'ui:description': `If you have your private medical records, you can upload them to your
+      application. If you want us to get them for you, you’ll need to
       authorize their release.`,
   },
   'view:uploadPrivateRecordsQualifier': {

--- a/src/applications/disability-benefits/all-claims/pages/privateMedicalRecords.js
+++ b/src/applications/disability-benefits/all-claims/pages/privateMedicalRecords.js
@@ -37,6 +37,8 @@ export const uiSchema = {
           Y: 'Yes',
           N: 'No, please get my records from my doctor.',
         },
+        // Force ReviewFieldTemplate to wrap this component in a <dl>
+        useDlWrap: true,
       },
     },
     'view:privateRecordsChoiceHelp': {

--- a/src/applications/disability-benefits/all-claims/pages/unemployabilityAdditionalInformation.jsx
+++ b/src/applications/disability-benefits/all-claims/pages/unemployabilityAdditionalInformation.jsx
@@ -7,7 +7,7 @@ const {
 } = fullSchema.properties.form8940.properties.unemployability.properties;
 
 const additionalInformationDescription = (
-  <div>
+  <>
     <h4>Additional Information</h4>
     <p>
       If there’s any other information you’d like to give us as part of your
@@ -18,11 +18,14 @@ const additionalInformationDescription = (
       reason you’re no longer able to work. Providing specific examples will
       help us understand your claim.
     </p>
-    <p>
-      If you’ve left one or more jobs because of your service-connected
-      disabilities, please note that.
-    </p>
-  </div>
+  </>
+);
+
+const textareaLabel = (
+  <p>
+    If you’ve left one or more jobs because of your service-connected
+    disabilities, please note that.
+  </p>
 );
 
 export const uiSchema = {
@@ -30,7 +33,7 @@ export const uiSchema = {
   'ui:description': additionalInformationDescription,
   unemployability: {
     remarks: {
-      'ui:title': ' ',
+      'ui:title': textareaLabel,
       'ui:widget': 'textarea',
       'ui:options': {
         rows: 5,

--- a/src/applications/disability-benefits/all-claims/pages/unemployabilityAdditionalInformation.jsx
+++ b/src/applications/disability-benefits/all-claims/pages/unemployabilityAdditionalInformation.jsx
@@ -7,8 +7,8 @@ const {
 } = fullSchema.properties.form8940.properties.unemployability.properties;
 
 const additionalInformationDescription = (
-  <>
-    <h4>Additional Information</h4>
+  <div>
+    <h3 className="vads-u-font-size--h4">Additional Information</h3>
     <p>
       If there’s any other information you’d like to give us as part of your
       claim, please add it here.
@@ -18,7 +18,7 @@ const additionalInformationDescription = (
       reason you’re no longer able to work. Providing specific examples will
       help us understand your claim.
     </p>
-  </>
+  </div>
 );
 
 const textareaLabel = (

--- a/src/applications/disability-benefits/all-claims/pages/unemployabilityDoctorCare.js
+++ b/src/applications/disability-benefits/all-claims/pages/unemployabilityDoctorCare.js
@@ -37,8 +37,7 @@ export const uiSchema = {
           false,
         ),
         dates: {
-          'ui:title': ' ',
-          'ui:description': doctorDatesDecription,
+          'ui:title': doctorDatesDecription,
           'ui:widget': 'textarea',
           'ui:options': {
             rows: 5,

--- a/src/applications/disability-benefits/all-claims/sass/disability-benefits.scss
+++ b/src/applications/disability-benefits/all-claims/sass/disability-benefits.scss
@@ -107,3 +107,40 @@ ul.original-disability-list {
   height: auto;
   white-space: pre-wrap;
 }
+
+// Style fix for "Private medical records"
+div.review {
+  border-bottom: 1px solid $color-gray-light;
+  .review-row {
+    display: flex;
+    justify-content: space-between;
+    flex-direction: column;
+    border-top: 1px solid $color-gray-light;
+    padding: 1.5rem;
+    padding-left: 0;
+  }
+  .review-row > dd {
+    font-weight: bold;
+    text-align: right;
+  }
+  .review-row > dt > p {
+    margin-top: 0;
+    margin-bottom: 0;
+  }
+}
+
+@media (min-width: 481px) {
+  div.review {
+    .review-row {
+      flex-direction: row;
+    }
+    .review-row > dd {
+      padding-left: 5px;
+      min-width: 100px;
+    }
+    .review-row > dt {
+      max-width: 60%;
+      min-width: 40%;
+    }
+  }
+}

--- a/src/applications/disability-benefits/all-claims/sass/disability-benefits.scss
+++ b/src/applications/disability-benefits/all-claims/sass/disability-benefits.scss
@@ -103,7 +103,6 @@ ul.original-disability-list {
   background: none;
   border: none;
   font-weight: bold;
-  padding-left: 0;
   white-space: pre-wrap;
   height: auto;
   white-space: pre-wrap;

--- a/src/platform/forms-system/src/js/components/ReviewCardField.jsx
+++ b/src/platform/forms-system/src/js/components/ReviewCardField.jsx
@@ -166,6 +166,7 @@ export default class ReviewCardField extends React.Component {
       'vads-u-margin-top--1',
       'vads-u-margin-bottom--2p5',
       'vads-u-margin-x--0',
+      'vads-u-font-size--h4',
     ].join(' ');
 
     const updateButtonClasses = [
@@ -212,10 +213,12 @@ export default class ReviewCardField extends React.Component {
       // volatileData is for arrays, which displays separate blocks
       uiSchema['ui:options']?.volatileData;
 
+    const Tag = formContext.onReviewPage ? 'h4' : 'h3';
+
     return (
       <div className="review-card">
         <div className="review-card--body input-section va-growable-background">
-          <h4 className={titleClasses}>{title}</h4>
+          <Tag className={titleClasses}>{title}</Tag>
           {subtitle && <div className="review-card--subtitle">{subtitle}</div>}
           {needsDlWrapper ? <dl className="review">{Field}</dl> : Field}
           <div className="vads-u-display--flex vads-u-flex-direction--row vads-u-margin-top--2p5">
@@ -283,6 +286,7 @@ export default class ReviewCardField extends React.Component {
       'review-card--title',
       'vads-u-display--inline',
       'vads-u-margin--0',
+      'vads-u-font-size--h4',
     ].join(' ');
     const bodyClasses = [
       'review-card--body',
@@ -299,10 +303,12 @@ export default class ReviewCardField extends React.Component {
       'vads-u-width--auto',
     ].join(' ');
 
+    const Tag = this.props.formContext.onReviewPage ? 'h4' : 'h3';
+
     return (
       <div className="review-card">
         <div className={headerClasses} style={{ minHeight: '5rem' }}>
-          <h4 className={titleClasses}>{title}</h4>
+          <Tag className={titleClasses}>{title}</Tag>
           {!volatileData && (
             <button
               className={`usa-button-secondary ${editButton}`}

--- a/src/platform/forms-system/src/js/fields/FileField.jsx
+++ b/src/platform/forms-system/src/js/fields/FileField.jsx
@@ -117,7 +117,8 @@ export default class FileField extends React.Component {
     let { buttonText = 'Upload' } = uiOptions;
     if (files.length > 0) buttonText = uiOptions.addAnotherLabel;
 
-    const Tag = formContext.onReviewPage ? 'dl' : 'div';
+    const Tag =
+      formContext.onReviewPage && formContext.reviewMode ? 'dl' : 'div';
 
     return (
       <div

--- a/src/platform/forms-system/src/js/review/ObjectField.jsx
+++ b/src/platform/forms-system/src/js/review/ObjectField.jsx
@@ -132,7 +132,7 @@ class ObjectField extends React.Component {
           return (
             options.volatileData || // ReviewCardField
             options.customTitle || // SelectArrayItemsWidget
-            options.addAnotherLabel // fileUiSchema
+            (options.addAnotherLabel && formContext.reviewMode) // fileUiSchema
           );
         });
         if (objectFields.length > 1 && visible.length > 0) {

--- a/src/platform/forms-system/src/js/review/ReviewFieldTemplate.jsx
+++ b/src/platform/forms-system/src/js/review/ReviewFieldTemplate.jsx
@@ -34,9 +34,10 @@ export default function ReviewFieldTemplate(props) {
       return null;
     }
   }
+  const Tag = uiSchema?.['ui:options']?.useDlWrap ? 'dl' : 'div';
 
   return (
-    <div className="review-row">
+    <Tag className="review-row">
       <dt>
         {label}
         {textDescription && <p>{textDescription}</p>}
@@ -46,6 +47,6 @@ export default function ReviewFieldTemplate(props) {
         {!textDescription && !DescriptionField && description}
       </dt>
       <dd>{children}</dd>
-    </div>
+    </Tag>
   );
 }

--- a/src/platform/forms-system/test/js/fields/FileField.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/fields/FileField.unit.spec.jsx
@@ -639,7 +639,7 @@ describe('Schemaform <FileField>', () => {
         uiSchema={uiSchema}
         idSchema={idSchema}
         formData={formData}
-        formContext={{ onReviewPage: true }}
+        formContext={{ onReviewPage: true, reviewMode: true }}
         onChange={f => f}
         requiredSchema={requiredSchema}
       />,

--- a/src/platform/forms-system/test/js/review/ObjectField.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/review/ObjectField.unit.spec.jsx
@@ -425,7 +425,7 @@ describe('Schemaform review: ObjectField', () => {
     const uiSchema = {
       test: {
         'ui:options': {
-          addAnotherLabel: 'test',
+          customTitle: 'test',
         },
       },
     };
@@ -436,7 +436,7 @@ describe('Schemaform review: ObjectField', () => {
       <ObjectField
         schema={schema}
         uiSchema={uiSchema}
-        formContext={{ pageTitle: 'Blah' }}
+        formContext={{ pageTitle: 'Blah', reviewMode: false }}
         idSchema={{ $id: 'root' }}
         formData={formData}
         onChange={onChange}
@@ -448,7 +448,7 @@ describe('Schemaform review: ObjectField', () => {
     expect(review.type).to.equal('div');
     expect(review.props.className).to.equal('review');
   });
-  it('should render a div when rendering the file UI', () => {
+  it('should render a div when the file UI is in review mode', () => {
     const onChange = sinon.spy();
     const onBlur = sinon.spy();
     const schema = {
@@ -473,7 +473,7 @@ describe('Schemaform review: ObjectField', () => {
       <ObjectField
         schema={schema}
         uiSchema={uiSchema}
-        formContext={{ pageTitle: 'Blah' }}
+        formContext={{ pageTitle: 'Blah', reviewMode: true }}
         idSchema={{ $id: 'root' }}
         formData={formData}
         onChange={onChange}
@@ -483,6 +483,43 @@ describe('Schemaform review: ObjectField', () => {
     // expecting a "div.review" instead of a "dl.review"
     const review = tree.props.children[1];
     expect(review.type).to.equal('div');
+    expect(review.props.className).to.equal('review');
+  });
+  it('should render a dl when the file UI is in edit mode', () => {
+    const onChange = sinon.spy();
+    const onBlur = sinon.spy();
+    const schema = {
+      type: 'object',
+      properties: {
+        test: {
+          type: 'string',
+        },
+      },
+    };
+    const uiSchema = {
+      test: {
+        'ui:options': {
+          addAnotherLabel: 'test',
+        },
+      },
+    };
+    const formData = {
+      test: { foo: 'test' },
+    };
+    const tree = SkinDeep.shallowRender(
+      <ObjectField
+        schema={schema}
+        uiSchema={uiSchema}
+        formContext={{ pageTitle: 'Blah', reviewMode: false }}
+        idSchema={{ $id: 'root' }}
+        formData={formData}
+        onChange={onChange}
+        onBlur={onBlur}
+      />,
+    );
+    // expecting a "dl.review" instead of a "div.review"
+    const review = tree.props.children[1];
+    expect(review.type).to.equal('dl');
     expect(review.props.className).to.equal('review');
   });
 });


### PR DESCRIPTION
## Description

A few form 526 page headers do not meet the accessibility criteria of heading levels only increasing by one.

This PR was meant to fix all headers, but also includes some other fixes:

- Fix wrong `alt` tag content
- Fix `aria-label` content that doesn't include the link or button text
- Switch to use an existing claims intake address component
- Add missing label to `textarea`
- Remove unnecessary CSS
- Fix file field wrapper in edit mode (I missed fixing this in #12449)

Related: https://github.com/department-of-veterans-affairs/va.gov-team/issues/8595

## Testing done

Local unit test (updated)

## Screenshots

N/A - the adjusted headers included CSS to maintain the font size 

## Acceptance criteria

- [ ] Axe coconut (extension) testing passes on all form 526 form content (user 228); The header within the footer will still show as an error, but that is outside the scope of this PR.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
