### PR TITLE
Feature/forms sip support 403

### DIFF
--- a/src/platform/forms/save-in-progress/SaveInProgressErrorPage.jsx
+++ b/src/platform/forms/save-in-progress/SaveInProgressErrorPage.jsx
@@ -111,7 +111,8 @@ class SaveInProgressErrorPage extends React.Component {
         content = (
           <div>
             <div className="usa-alert usa-alert-error background-color-only">
-              We can't process this request. {forbidden || DEFAULT_FORBIDDEN_MESSAGE}
+              We can't process this request.
+              {forbidden || DEFAULT_FORBIDDEN_MESSAGE}
             </div>
             <div style={{ marginTop: '30px' }} />
           </div>

--- a/src/platform/forms/save-in-progress/SaveInProgressErrorPage.jsx
+++ b/src/platform/forms/save-in-progress/SaveInProgressErrorPage.jsx
@@ -111,7 +111,6 @@ class SaveInProgressErrorPage extends React.Component {
         content = (
           <div>
             <div className="usa-alert usa-alert-error background-color-only">
-              We can't process this request.
               {forbidden || DEFAULT_FORBIDDEN_MESSAGE}
             </div>
             <div style={{ marginTop: '30px' }} />

--- a/src/platform/forms/save-in-progress/SaveInProgressErrorPage.jsx
+++ b/src/platform/forms/save-in-progress/SaveInProgressErrorPage.jsx
@@ -16,6 +16,10 @@ import ProgressButton from '@department-of-veterans-affairs/formation-react/Prog
 
 import { toggleLoginModal } from '../../site-wide/user-nav/actions';
 
+const DEFAULT_FORBIDDEN_MESSAGE = `
+  We can't process this request. We're sorry. We can't give you access to this information. For help, please call the VA.gov help desk at 855-574-7286 (TTY: 711). We’re here Monday–Friday, 8:00 a.m.–8:00 p.m. ET.
+`;
+
 // For now, this only handles loading errors, but it could feasibly be reworked
 //  to handle save errors as well if we need it to.
 class SaveInProgressErrorPage extends React.Component {
@@ -107,8 +111,7 @@ class SaveInProgressErrorPage extends React.Component {
         content = (
           <div>
             <div className="usa-alert usa-alert-error background-color-only">
-              message TBD
-              {forbidden}
+              {forbidden || DEFAULT_FORBIDDEN_MESSAGE}
             </div>
             <div style={{ marginTop: '30px' }} />
           </div>

--- a/src/platform/forms/save-in-progress/SaveInProgressErrorPage.jsx
+++ b/src/platform/forms/save-in-progress/SaveInProgressErrorPage.jsx
@@ -58,7 +58,7 @@ class SaveInProgressErrorPage extends React.Component {
 
   render() {
     const { loadedStatus } = this.props;
-    const { noAuth, notFound } =
+    const { forbidden, noAuth, notFound } =
       this.props.route.formConfig.savedFormMessages || {};
     let content;
 
@@ -100,6 +100,17 @@ class SaveInProgressErrorPage extends React.Component {
                 Continue Your Application
               </button>
             </div>
+          </div>
+        );
+        break;
+      case LOAD_STATUSES.forbidden:
+        content = (
+          <div>
+            <div className="usa-alert usa-alert-error background-color-only">
+              message TBD
+              {forbidden}
+            </div>
+            <div style={{ marginTop: '30px' }} />
           </div>
         );
         break;

--- a/src/platform/forms/save-in-progress/SaveInProgressErrorPage.jsx
+++ b/src/platform/forms/save-in-progress/SaveInProgressErrorPage.jsx
@@ -17,7 +17,7 @@ import ProgressButton from '@department-of-veterans-affairs/formation-react/Prog
 import { toggleLoginModal } from '../../site-wide/user-nav/actions';
 
 const DEFAULT_FORBIDDEN_MESSAGE = `
-  We can't process this request. We're sorry. We can't give you access to this information. For help, please call the VA.gov help desk at 855-574-7286 (TTY: 711). We’re here Monday–Friday, 8:00 a.m.–8:00 p.m. ET.
+  We're sorry. We can't give you access to this information. For help, please call the VA.gov help desk at 855-574-7286 (TTY: 711). We’re here Monday–Friday, 8:00 a.m.–8:00 p.m. ET.
 `;
 
 // For now, this only handles loading errors, but it could feasibly be reworked
@@ -111,7 +111,7 @@ class SaveInProgressErrorPage extends React.Component {
         content = (
           <div>
             <div className="usa-alert usa-alert-error background-color-only">
-              {forbidden || DEFAULT_FORBIDDEN_MESSAGE}
+              We can't process this request. {forbidden || DEFAULT_FORBIDDEN_MESSAGE}
             </div>
             <div style={{ marginTop: '30px' }} />
           </div>

--- a/src/platform/forms/save-in-progress/actions.js
+++ b/src/platform/forms/save-in-progress/actions.js
@@ -241,6 +241,8 @@ export function fetchInProgressForm(
       },
     })
       .then(res => {
+        return Promise.reject(LOAD_STATUSES.forbidden);
+
         if (res.ok) {
           return res.json();
         }

--- a/src/platform/forms/save-in-progress/actions.js
+++ b/src/platform/forms/save-in-progress/actions.js
@@ -342,10 +342,6 @@ export function fetchInProgressForm(
             recordEvent({
               event: `${trackingPrefix}sip-form-load-signed-out`,
             });
-          } else if (loadedStatus === LOAD_STATUSES.forbidden) {
-            recordEvent({
-              event: `${trackingPrefix}sip-form-load-failed`,
-            });
           } else {
             Sentry.captureMessage(`vets_sip_error_load: ${loadedStatus}`);
             recordEvent({

--- a/src/platform/forms/save-in-progress/actions.js
+++ b/src/platform/forms/save-in-progress/actions.js
@@ -330,8 +330,8 @@ export function fetchInProgressForm(
         // If prefilling went wrong for a non-auth reason, it probably means that
         // they didn’t have info to use and we can continue on as usual
         if (
-          prefill && 
-          loadedStatus !== LOAD_STATUSES.noAuth && 
+          prefill &&
+          loadedStatus !== LOAD_STATUSES.noAuth &&
           loadedStatus !== LOAD_STATUSES.forbidden
         ) {
           dispatch(setPrefillComplete());

--- a/src/platform/forms/save-in-progress/actions.js
+++ b/src/platform/forms/save-in-progress/actions.js
@@ -46,6 +46,7 @@ export const LOAD_STATUSES = Object.freeze({
   pending: 'pending',
   noAuth: 'no-auth',
   failure: 'failure',
+  forbidden: 'forbidden',
   notFound: 'not-found',
   invalidData: 'invalid-data',
   success: 'success',
@@ -244,10 +245,13 @@ export function fetchInProgressForm(
           return res.json();
         }
 
+        // Make me a switch?
         let status = LOAD_STATUSES.failure;
         if (res.status === 401) {
           dispatch(logOut());
           status = LOAD_STATUSES.noAuth;
+        } else if (res.status === 403) {
+          status = LOAD_STATUSES.forbidden;
         } else if (res.status === 404) {
           status = LOAD_STATUSES.notFound;
         }
@@ -325,7 +329,7 @@ export function fetchInProgressForm(
 
         // If prefilling went wrong for a non-auth reason, it probably means that
         // they didn’t have info to use and we can continue on as usual
-        if (prefill && loadedStatus !== LOAD_STATUSES.noAuth) {
+        if (prefill && loadedStatus !== LOAD_STATUSES.noAuth && loadedStatus !== LOAD_STATUSES.forbidden) {
           dispatch(setPrefillComplete());
           recordEvent({
             event: `${trackingPrefix}sip-form-prefill-failed`,
@@ -337,6 +341,10 @@ export function fetchInProgressForm(
           if (loadedStatus === LOAD_STATUSES.noAuth) {
             recordEvent({
               event: `${trackingPrefix}sip-form-load-signed-out`,
+            });
+          } else if (loadedStatus === LOAD_STATUSES.forbidden) {
+            recordEvent({
+              event: `${trackingPrefix}sip-form-load-failed`,
             });
           } else {
             Sentry.captureMessage(`vets_sip_error_load: ${loadedStatus}`);

--- a/src/platform/forms/save-in-progress/actions.js
+++ b/src/platform/forms/save-in-progress/actions.js
@@ -241,8 +241,6 @@ export function fetchInProgressForm(
       },
     })
       .then(res => {
-        return Promise.reject(LOAD_STATUSES.forbidden);
-
         if (res.ok) {
           return res.json();
         }

--- a/src/platform/forms/save-in-progress/actions.js
+++ b/src/platform/forms/save-in-progress/actions.js
@@ -329,7 +329,11 @@ export function fetchInProgressForm(
 
         // If prefilling went wrong for a non-auth reason, it probably means that
         // they didn’t have info to use and we can continue on as usual
-        if (prefill && loadedStatus !== LOAD_STATUSES.noAuth && loadedStatus !== LOAD_STATUSES.forbidden) {
+        if (
+          prefill && 
+          loadedStatus !== LOAD_STATUSES.noAuth && 
+          loadedStatus !== LOAD_STATUSES.forbidden
+        ) {
           dispatch(setPrefillComplete());
           recordEvent({
             event: `${trackingPrefix}sip-form-prefill-failed`,

--- a/src/platform/forms/save-in-progress/helpers.js
+++ b/src/platform/forms/save-in-progress/helpers.js
@@ -54,7 +54,7 @@ export function createRoutesWithSaveInProgress(formConfig) {
 
     newRoutes.splice(newRoutes.length - 1, 0, {
       path: 'error',
-      component: SaveInProgress,
+      component: SaveInProgressErrorPage,
       pageList, // In case we need it for startOver?
       formConfig,
     });

--- a/src/platform/forms/save-in-progress/helpers.js
+++ b/src/platform/forms/save-in-progress/helpers.js
@@ -54,7 +54,7 @@ export function createRoutesWithSaveInProgress(formConfig) {
 
     newRoutes.splice(newRoutes.length - 1, 0, {
       path: 'error',
-      component: SaveInProgressErrorPage,
+      component: SaveInProgress,
       pageList, // In case we need it for startOver?
       formConfig,
     });

--- a/src/platform/forms/tests/save-in-progress/SaveInProgressErrorPage.unit.spec.jsx
+++ b/src/platform/forms/tests/save-in-progress/SaveInProgressErrorPage.unit.spec.jsx
@@ -103,6 +103,23 @@ describe('<SaveInProgressErrorPage>', () => {
       'Continue Your Application',
     );
   });
+  it('should render the forbidden failure error', () => {
+    const tree = ReactTestUtils.renderIntoDocument(
+      <SaveInProgressErrorPage
+        updateLogInUrls={f => f}
+        isLoggedIn
+        router={router}
+        loginUrls={mockLoginUrl}
+        route={route}
+        loadedStatus={LOAD_STATUSES.forbidden}
+      />,
+    );
+    const findDOM = findDOMNode(tree);
+
+    expect(findDOM.querySelector('.usa-alert').textContent).to.contain(
+      'message TBD',
+    );
+  });
   it('should go back', () => {
     const fetchFormStatusSpy = sinon.spy();
     const tree = ReactTestUtils.renderIntoDocument(

--- a/src/platform/forms/tests/save-in-progress/SaveInProgressErrorPage.unit.spec.jsx
+++ b/src/platform/forms/tests/save-in-progress/SaveInProgressErrorPage.unit.spec.jsx
@@ -117,7 +117,7 @@ describe('<SaveInProgressErrorPage>', () => {
     const findDOM = findDOMNode(tree);
 
     expect(findDOM.querySelector('.usa-alert').textContent).to.contain(
-      `We can't process this request.`,
+      `We're sorry. We can't give you access to this information.`,
     );
   });
   it('should go back', () => {

--- a/src/platform/forms/tests/save-in-progress/SaveInProgressErrorPage.unit.spec.jsx
+++ b/src/platform/forms/tests/save-in-progress/SaveInProgressErrorPage.unit.spec.jsx
@@ -117,7 +117,7 @@ describe('<SaveInProgressErrorPage>', () => {
     const findDOM = findDOMNode(tree);
 
     expect(findDOM.querySelector('.usa-alert').textContent).to.contain(
-      'message TBD',
+      `We can't process this request.`,
     );
   });
   it('should go back', () => {


### PR DESCRIPTION
## Description
The purpose of this change is to support 403 - forbidden response status codes from api's in the forms library/framework. 

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
