### PR TITLE
Add SECURITY.md file to vets-website

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -19,11 +19,6 @@ A responsible disclosure policy helps protect users of the project from publicly
 without a fix by employing a process where vulnerabilities are first triaged in a private manner, and only publicly 
 disclosed after a reasonable time period that allows patching the vulnerability and provides an upgrade path for users.
 
-When contacting us directly via email, we will do our best efforts to respond in a reasonable time to resolve the issue. 
-
-We kindly ask you to refrain from malicious acts that put our users, the project, or any of the project’s team members 
-at risk.
-
 ## Reporting a Vulnerability
 
 If you discover a suspected security vulnerability, please report it to 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -26,9 +26,6 @@ at risk.
 
 ## Reporting a Vulnerability
 
-We consider the security of our systems a top priority. But no matter how much effort we put into system security, 
-there can still be vulnerabilities present.
-
 If you discover a security vulnerability, please report (suspected) security vulnerabilities to 
 **[security@va.gov](mailto:security@va.gov)** and include the word "SECURITY" in the subject line. 
 You will receive a response from us within 48 hours. If the issue is confirmed, we will release a 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,35 @@
+# Security Policy
+
+The VA.gov team takes security issues in VA.gov seriously. We appreciate your efforts to responsibly 
+disclosure your findings, and will make every effort to acknowledge your contributions.
+
+## Supported Versions
+
+We release patches for security vulnerabilities. Which versions are eligible receiving such patches depend on the 
+[CVSS v3.0](https://www.first.org/cvss/calculator/3.0) Rating:
+
+| Version | Supported          |
+| ------- | ------------------ |
+| >4.0.x  | :white_check_mark: |
+| < 4.0   | :x:                |
+
+## Responsible disclosure security policy
+
+A responsible disclosure policy helps protect users of the project from publicly disclosed security vulnerabilities 
+without a fix by employing a process where vulnerabilities are first triaged in a private manner, and only publicly 
+disclosed after a reasonable time period that allows patching the vulnerability and provides an upgrade path for users.
+
+When contacting us directly via email, we will do our best efforts to respond in a reasonable time to resolve the issue. 
+
+We kindly ask you to refrain from malicious acts that put our users, the project, or any of the project’s team members 
+at risk.
+
+## Reporting a Vulnerability
+
+We consider the security of our systems a top priority. But no matter how much effort we put into system security, 
+there can still be vulnerabilities present.
+
+If you discover a security vulnerability, please report (suspected) security vulnerabilities to 
+**[security@va.gov](mailto:security@va.gov)** and include the word "SECURITY" in the subject line. 
+You will receive a response from us within 48 hours. If the issue is confirmed, we will release a 
+patch as soon as possible depending on complexity but historically within a few days.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,7 +8,7 @@ disclosure your findings, and will make every effort to acknowledge your contrib
 We release patches for security vulnerabilities. Which versions are eligible receiving such patches depend on the 
 [CVSS v3.0](https://www.first.org/cvss/calculator/3.0) Rating:
 
-| Version | Supported          |
+| Score | Elegible          |
 | ------- | ------------------ |
 | >4.0.x  | :white_check_mark: |
 | < 4.0   | :x:                |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,7 +8,7 @@ disclosure your findings, and will make every effort to acknowledge your contrib
 We release patches for security vulnerabilities. Which versions are eligible receiving such patches depend on the 
 [CVSS v3.0](https://www.first.org/cvss/calculator/3.0) Rating:
 
-| Score | Elegible          |
+| Score   | Eligible           |
 | ------- | ------------------ |
 | >4.0.x  | :white_check_mark: |
 | < 4.0   | :x:                |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -23,5 +23,5 @@ disclosed after a reasonable time period that allows patching the vulnerability 
 
 If you discover a suspected security vulnerability, please report it to 
 **[security@va.gov](mailto:security@va.gov)** and include the word "SECURITY" in the subject line. 
-You will receive a response from us within 48 hours. If the issue is confirmed, we will release a 
+You will receive a response from us within 2 business days. If the issue is confirmed, we will release a 
 patch as soon as possible depending on complexity but historically within a few days.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -26,7 +26,7 @@ at risk.
 
 ## Reporting a Vulnerability
 
-If you discover a security vulnerability, please report (suspected) security vulnerabilities to 
+If you discover a suspected security vulnerability, please report it to 
 **[security@va.gov](mailto:security@va.gov)** and include the word "SECURITY" in the subject line. 
 You will receive a response from us within 48 hours. If the issue is confirmed, we will release a 
 patch as soon as possible depending on complexity but historically within a few days.


### PR DESCRIPTION
## Description

Repositories may now specify a security policy by creating a file named `SECURITY.md`. This file should be used to instruct users about how and when to report security vulnerabilities to the repository maintainers. When included, this file will be shown in the repository’s “Security” tab, and in the new issue workflow.

This PR is a draft for the `SECURITY.md` file
