### PR TITLE
Remove keepalive call from setupProfileSession

### DIFF
--- a/src/applications/auth/containers/AuthApp.jsx
+++ b/src/applications/auth/containers/AuthApp.jsx
@@ -14,7 +14,6 @@ import {
 } from 'platform/user/profile/utilities';
 import { apiRequest } from 'platform/utilities/api';
 import get from 'platform/utilities/data/get';
-import { ssoe } from 'platform/user/authentication/selectors';
 
 const REDIRECT_IGNORE_PATTERN = new RegExp(
   ['/auth/login/callback', '/session-expired'].join('|'),
@@ -119,7 +118,7 @@ export class AuthApp extends React.Component {
     const { type } = this.props.location.query;
     const authMetrics = new AuthMetrics(type, payload);
     authMetrics.run();
-    setupProfileSession(authMetrics.userProfile, this.props.useSSOe);
+    setupProfileSession(authMetrics.userProfile);
     this.redirect();
   };
 
@@ -375,15 +374,11 @@ export class AuthApp extends React.Component {
   }
 }
 
-const mapStateToProps = state => ({
-  useSSOe: ssoe(state),
-});
-
 const mapDispatchToProps = dispatch => ({
   openLoginModal: () => dispatch(toggleLoginModal(true)),
 });
 
 export default connect(
-  mapStateToProps,
+  null,
   mapDispatchToProps,
 )(AuthApp);

--- a/src/platform/user/profile/utilities/index.js
+++ b/src/platform/user/profile/utilities/index.js
@@ -6,8 +6,6 @@ import {
 } from '../../authentication/utilities';
 import localStorage from 'platform/utilities/storage/localStorage';
 
-import { ssoKeepAliveSession } from 'platform/utilities/sso';
-
 import {
   ADDRESS_VALIDATION_TYPES,
   BAD_UNIT_NUMBER,
@@ -136,13 +134,10 @@ export const hasSession = () => localStorage.getItem('hasSession');
 export const hasSessionSSO = () =>
   JSON.parse(localStorage.getItem('hasSessionSSO'));
 
-export function setupProfileSession(userProfile, useSSOe) {
+export function setupProfileSession(userProfile) {
   const { firstName, signIn } = userProfile;
   const loginType = (signIn && signIn.serviceName) || null;
   localStorage.setItem('hasSession', true);
-  if (useSSOe) {
-    ssoKeepAliveSession();
-  }
 
   // Since localStorage coerces everything into String,
   // this avoids setting the first name to the string 'null'.


### PR DESCRIPTION
Now that we have the keepalive call contained in the `AutoSSO` component, this call is ultimately redundant. Removing in favor of DRY-ness