### PR TITLE
MDOT: Batteries Page- Add Prescribed Date

### DIFF
--- a/src/applications/disability-benefits/2346/components/SelectArrayItemsBatteriesWidget.jsx
+++ b/src/applications/disability-benefits/2346/components/SelectArrayItemsBatteriesWidget.jsx
@@ -77,7 +77,7 @@ class SelectArrayItemsBatteriesWidget extends Component {
             <h4 className="vads-u-font-size--md vads-u-font-weight--bold">
               {batterySupply.deviceName}
             </h4>
-            <p>Prescribed 1/18/2018</p>
+            <p>Prescribed {moment(batterySupply.prescribedDate).calendar()}</p>
             <div className="vads-u-border-left--10px vads-u-border-color--primary-alt">
               <div className="usa-alert-body vads-u-padding-left--1">
                 <p className="vads-u-margin--1px vads-u-margin-y--1">
@@ -192,6 +192,7 @@ SelectArrayItemsBatteriesWidget.propTypes = {
       nextAvailabilityDate: PropTypes.string.isRequired,
       quantity: PropTypes.number.isRequired,
       size: PropTypes.string,
+      prescribedDate: PropTypes.string,
     }),
   ),
   selectedProducts: PropTypes.arrayOf(

--- a/src/applications/disability-benefits/2346/components/SelectArrayItemsBatteriesWidget.jsx
+++ b/src/applications/disability-benefits/2346/components/SelectArrayItemsBatteriesWidget.jsx
@@ -77,7 +77,10 @@ class SelectArrayItemsBatteriesWidget extends Component {
             <h4 className="vads-u-font-size--md vads-u-font-weight--bold">
               {batterySupply.deviceName}
             </h4>
-            <p>Prescribed {moment(batterySupply.prescribedDate).calendar()}</p>
+            <p>
+              Prescribed{' '}
+              {moment(batterySupply.prescribedDate).format('MMMM DD, YYYY')}
+            </p>
             <div className="vads-u-border-left--10px vads-u-border-color--primary-alt">
               <div className="usa-alert-body vads-u-padding-left--1">
                 <p className="vads-u-margin--1px vads-u-margin-y--1">


### PR DESCRIPTION
## Description
This PR focused on adding the prescribed date of the battery.

## Testing done


## Screenshots
![screenshot-localhost_3001-2020 05 14-10_55_33](https://user-images.githubusercontent.com/12755283/81950049-790fbf00-95d1-11ea-8d31-df16fd8f1343.png)



## Acceptance criteria
- [ ] Each battery display should show a prescribed date

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
