### PR TITLE
lint rule for warning when e2e test does not contain axeCheck

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -179,6 +179,14 @@
         "no-unused-expressions": 0,
         "react/no-find-dom-node": 0
       }
+    },
+    {
+      "files": [
+        "**/*.e2e.spec.js"
+      ],
+      "rules": {
+        "va/axe-check-required": 1
+      }
     }
   ]
 }

--- a/script/eslint-plugin-va/index.js
+++ b/script/eslint-plugin-va/index.js
@@ -4,6 +4,7 @@ module.exports = {
     'enzyme-unmount': require('./rules/enzyme-unmount.js'),
     'use-resolved-path': require('./rules/use-resolved-path.js'),
     'resolved-path-on-required': require('./rules/resolved-path-on-required.js'),
+    'axe-check-required': require('./rules/axe-e2e-tests'),
   },
   rulesConfig: {
     'proptypes-camel-cased': 2,
@@ -20,5 +21,6 @@ module.exports = {
         aliases: ['applications', 'platform', 'site'],
       },
     ],
+    'axe-check-required': 1,
   },
 };

--- a/script/eslint-plugin-va/rules/axe-e2e-tests.js
+++ b/script/eslint-plugin-va/rules/axe-e2e-tests.js
@@ -12,21 +12,24 @@ const rule = {
   },
   create: context => {
     let axeCheckCount = 0;
+
+    const checkAxeCountForReport = node => {
+      if (axeCheckCount === 0) {
+        const message = `${MESSAGE}`;
+        context.report({
+          node,
+          message,
+        });
+      }
+    };
+
     return {
       MemberExpression: node => {
         if (node.property.name === 'axeCheck') {
           axeCheckCount++;
         }
       },
-      'Program:exit': function(node) {
-        if (axeCheckCount === 0) {
-          const message = `${MESSAGE}`;
-          context.report({
-            node,
-            message,
-          });
-        }
-      },
+      'Program:exit': checkAxeCountForReport,
     };
   },
 };

--- a/script/eslint-plugin-va/rules/axe-e2e-tests.js
+++ b/script/eslint-plugin-va/rules/axe-e2e-tests.js
@@ -1,5 +1,5 @@
 const MESSAGE =
-  'THIS IS A SUPER AWESOME ERROR MESSAGE ABOUT AXE CHECKS IN E2E TESTS';
+  'e2e Tests must include at least one axeCheck call. Source code can be found here: ./src/platform/testing/e2e/nightwatch-commands/axeCheck.js';
 
 const rule = {
   meta: {

--- a/script/eslint-plugin-va/rules/axe-e2e-tests.js
+++ b/script/eslint-plugin-va/rules/axe-e2e-tests.js
@@ -1,0 +1,34 @@
+const MESSAGE =
+  'THIS IS A SUPER AWESOME ERROR MESSAGE ABOUT AXE CHECKS IN E2E TESTS';
+
+const rule = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description: MESSAGE,
+      category: 'best practices',
+      recommended: false,
+    },
+  },
+  create: context => {
+    let axeCheckCount = 0;
+    return {
+      MemberExpression: node => {
+        if (node.property.name === 'axeCheck') {
+          axeCheckCount++;
+        }
+      },
+      'Program:exit': function(node) {
+        if (axeCheckCount === 0) {
+          const message = `${MESSAGE}`;
+          context.report({
+            node,
+            message,
+          });
+        }
+      },
+    };
+  },
+};
+
+module.exports = rule;


### PR DESCRIPTION
## Description
When an e2e test does not contain at least 1 instance of axeCheck, we will throw a warning to alert the user to the helper method. Run rule in circle ci.

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
