### PR TITLE
[Development] Add save-in-progress dev modal

### DIFF
--- a/src/platform/forms/sass/_m-schemaform.scss
+++ b/src/platform/forms/sass/_m-schemaform.scss
@@ -672,3 +672,15 @@ textarea:focus {
     right: 1em;
   }
 }
+
+textarea.resize-none {
+  resize: none;
+}
+
+textarea.resize-y {
+  resize: vertical;
+}
+
+textarea.resize-x {
+  resize: horizontal;
+}

--- a/src/platform/forms/save-in-progress/RoutedSavablePage.jsx
+++ b/src/platform/forms/save-in-progress/RoutedSavablePage.jsx
@@ -42,7 +42,7 @@ class RoutedSavablePage extends React.Component {
   }
 
   render() {
-    const { user, form, formConfig } = this.props;
+    const { user, form, formConfig, route } = this.props;
     const contentAfterButtons = (
       <div>
         <SaveStatus
@@ -56,6 +56,7 @@ class RoutedSavablePage extends React.Component {
           locationPathname={this.props.location.pathname}
           form={form}
           formConfig={formConfig}
+          route={route}
           user={user}
           showLoginModal={this.props.showLoginModal}
           saveAndRedirectToReturnUrl={this.props.saveAndRedirectToReturnUrl}

--- a/src/platform/forms/save-in-progress/RoutedSavablePage.jsx
+++ b/src/platform/forms/save-in-progress/RoutedSavablePage.jsx
@@ -57,6 +57,7 @@ class RoutedSavablePage extends React.Component {
           form={form}
           formConfig={formConfig}
           route={route}
+          pageList={route.pageList}
           user={user}
           showLoginModal={this.props.showLoginModal}
           saveAndRedirectToReturnUrl={this.props.saveAndRedirectToReturnUrl}

--- a/src/platform/forms/save-in-progress/RoutedSavableReviewPage.jsx
+++ b/src/platform/forms/save-in-progress/RoutedSavableReviewPage.jsx
@@ -75,6 +75,7 @@ class RoutedSavableReviewPage extends React.Component {
         locationPathname={location.pathname}
         form={form}
         formConfig={route?.formConfig}
+        pageList={route.pageList}
         user={user}
         showLoginModal={showLoginModal}
         saveAndRedirectToReturnUrl={this.props.saveAndRedirectToReturnUrl}
@@ -190,6 +191,7 @@ class RoutedSavableReviewPage extends React.Component {
           form={form}
           formConfig={formConfig}
           user={user}
+          pageList={pageList}
           showLoginModal={this.props.showLoginModal}
           saveAndRedirectToReturnUrl={this.props.saveAndRedirectToReturnUrl}
           toggleLoginModal={this.props.toggleLoginModal}

--- a/src/platform/forms/save-in-progress/SaveFormLink.jsx
+++ b/src/platform/forms/save-in-progress/SaveFormLink.jsx
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types';
 import { SAVE_STATUSES, saveErrors } from './actions';
 import { focusElement } from '../../utilities/ui';
 import { APP_TYPE_DEFAULT } from '../../forms-system/src/js/constants';
+import SipsDevModal from './SaveInProgressDevModal';
 
 const Element = Scroll.Element;
 const scroller = Scroll.scroller;
@@ -80,6 +81,7 @@ class SaveFormLink extends React.Component {
               {this.props.children || `Finish this ${appType} later`}
             </button>
             {!this.props.children && '.'}
+            <SipsDevModal {...this.props} />
           </span>
         )}
       </div>

--- a/src/platform/forms/save-in-progress/SaveFormLink.jsx
+++ b/src/platform/forms/save-in-progress/SaveFormLink.jsx
@@ -40,13 +40,12 @@ class SaveFormLink extends React.Component {
 
   render() {
     if (!this.props.user.login.currentlyLoggedIn) return null;
-
     const { savedStatus } = this.props.form;
     const { formConfig } = this.props;
     const appType = formConfig?.customText?.appType || APP_TYPE_DEFAULT;
 
     return (
-      <div style={{ display: this.props.children ? 'inline' : null }}>
+      <div className={this.props.children ? 'vads-u-display--inline' : ''}>
         <Element name="saveFormLinkTop" />
         {saveErrors.has(savedStatus) && (
           <div

--- a/src/platform/forms/save-in-progress/SaveInProgressDevModal.jsx
+++ b/src/platform/forms/save-in-progress/SaveInProgressDevModal.jsx
@@ -12,7 +12,7 @@ const SipsDevModal = props => {
   const [sipsUrl, setSipsUrl] = useState(null);
   const [errorMessage, setError] = useState('');
 
-  const availablePaths = props.route.pageList.map(page => page.path);
+  const availablePaths = props?.route?.pageList.map(page => page.path) || [];
 
   const openSipsModal = () => {
     setSipsData(JSON.stringify(props.form.data, null, 2));

--- a/src/platform/forms/save-in-progress/SaveInProgressDevModal.jsx
+++ b/src/platform/forms/save-in-progress/SaveInProgressDevModal.jsx
@@ -93,11 +93,12 @@ const SipsDevModal = props => {
           </div>
         </>
       </Modal>{' '}
-      <button
-        type="button"
-        className="va-button-link vads-u-color--gray-medium"
-        onClick={openSipsModal}
-      >
+      <button type="button" className="va-button-link" onClick={openSipsModal}>
+        <i
+          aria-hidden="true"
+          className="fas fa-cog vads-upadding-right--1"
+          role="img"
+        />
         Open save-in-progress menu
       </button>
     </>

--- a/src/platform/forms/save-in-progress/SaveInProgressDevModal.jsx
+++ b/src/platform/forms/save-in-progress/SaveInProgressDevModal.jsx
@@ -94,12 +94,8 @@ const SipsDevModal = props => {
         </>
       </Modal>{' '}
       <button type="button" className="va-button-link" onClick={openSipsModal}>
-        <i
-          aria-hidden="true"
-          className="fas fa-cog vads-upadding-right--1"
-          role="img"
-        />
-        Open save-in-progress menu
+        <i aria-hidden="true" className="fas fa-cog" role="img" /> Open
+        save-in-progress menu
       </button>
     </>
   );

--- a/src/platform/forms/save-in-progress/SaveInProgressDevModal.jsx
+++ b/src/platform/forms/save-in-progress/SaveInProgressDevModal.jsx
@@ -1,0 +1,117 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import Modal from '@department-of-veterans-affairs/formation-react/Modal';
+import ErrorableTextArea from '@department-of-veterans-affairs/formation-react/ErrorableTextArea';
+import ErrorableSelect from '@department-of-veterans-affairs/formation-react/ErrorableSelect';
+
+import environment from 'platform/utilities/environment';
+
+const SipsDevModal = props => {
+  const [isModalVisible, toggleModal] = useState(false);
+  const [sipsData, setSipsData] = useState(null);
+  const [sipsUrl, setSipsUrl] = useState(null);
+  const [errorMessage, setError] = useState('');
+
+  const availablePaths = props.route.pageList.map(page => page.path);
+
+  const openSipsModal = () => {
+    setSipsData(JSON.stringify(props.form.data, null, 2));
+    setSipsUrl(props.locationPathname);
+    toggleModal(true);
+  };
+
+  const saveData = (event, type) => {
+    event.preventDefault();
+    const { formId, version, data } = props.form;
+    const parsedData = JSON.parse(sipsData);
+    const newData =
+      type === 'merge' ? Object.assign({}, data, parsedData) : sipsData;
+    setError('');
+    props.saveAndRedirectToReturnUrl(formId, newData, version, sipsUrl);
+    toggleModal(false);
+  };
+
+  const handleChange = value => {
+    try {
+      JSON.parse(value);
+      setError('');
+    } catch (err) {
+      setError(err?.message || err?.name);
+    }
+    setSipsData(value);
+  };
+
+  return environment.isProduction() ? null : (
+    <>
+      <Modal
+        title="Save in progress data"
+        id="sip-menu"
+        cssClass=""
+        visible={isModalVisible}
+        onClose={() => toggleModal(false)}
+      >
+        <>
+          <ErrorableTextArea
+            errorMessage={errorMessage}
+            label="Form data"
+            name="sips_data"
+            additionalClass="resize-y"
+            field={{ value: sipsData }}
+            onValueChange={field => handleChange(field.value)}
+          />
+          <ErrorableSelect
+            label="Return url"
+            name="sips_url"
+            options={availablePaths}
+            value={{ value: sipsUrl }}
+            includeBlankOption={false}
+            onValueChange={value => setSipsUrl(value.value)}
+            additionalClass="additional-class"
+          />
+          <p />
+          <div className="row">
+            <div className="small-6 columns">
+              <button
+                disabled={!!errorMessage}
+                className="usa-button-primary"
+                title="Replace all save-in-progress data"
+                onClick={e => saveData(e, 'replace')}
+              >
+                Replace
+              </button>
+            </div>
+            <div className="small-6 columns end">
+              <button
+                disabled={!!errorMessage}
+                className="usa-button-secondary"
+                title="Merge new data into existing save-in-progress data"
+                onClick={e => saveData(e, 'merge')}
+              >
+                Merge
+              </button>
+            </div>
+          </div>
+        </>
+      </Modal>{' '}
+      <button
+        type="button"
+        className="va-button-link vads-u-color--gray-medium"
+        onClick={openSipsModal}
+      >
+        Open save-in-progress menu
+      </button>
+    </>
+  );
+};
+
+SipsDevModal.propTypes = {
+  form: PropTypes.shape({
+    formId: PropTypes.string.isRequired,
+    version: PropTypes.number.isRequired,
+    data: PropTypes.object.isRequired,
+  }),
+  locationPathname: PropTypes.string.isRequired,
+  saveAndRedirectToReturnUrl: PropTypes.func.isRequired,
+};
+
+export default SipsDevModal;

--- a/src/platform/forms/save-in-progress/SaveInProgressDevModal.jsx
+++ b/src/platform/forms/save-in-progress/SaveInProgressDevModal.jsx
@@ -41,7 +41,7 @@ const SipsDevModal = props => {
     setSipsData(value);
   };
 
-  return environment.isProduction() ? null : (
+  return (
     <>
       <Modal
         title="Save in progress data"
@@ -114,4 +114,4 @@ SipsDevModal.propTypes = {
   saveAndRedirectToReturnUrl: PropTypes.func.isRequired,
 };
 
-export default SipsDevModal;
+export default (environment.isProduction() ? null : SipsDevModal);

--- a/src/platform/forms/save-in-progress/SaveInProgressDevModal.jsx
+++ b/src/platform/forms/save-in-progress/SaveInProgressDevModal.jsx
@@ -12,7 +12,7 @@ const SipsDevModal = props => {
   const [sipsUrl, setSipsUrl] = useState(null);
   const [errorMessage, setError] = useState('');
 
-  const availablePaths = props?.route?.pageList.map(page => page.path) || [];
+  const availablePaths = props?.pageList.map(page => page.path) || [];
 
   const openSipsModal = () => {
     setSipsData(JSON.stringify(props.form.data, null, 2));
@@ -106,6 +106,11 @@ SipsDevModal.propTypes = {
     formId: PropTypes.string.isRequired,
     version: PropTypes.number.isRequired,
     data: PropTypes.object.isRequired,
+    pageList: PropTypes.arrayOf(
+      PropTypes.shape({
+        path: PropTypes.string.isRequired,
+      }),
+    ),
   }),
   locationPathname: PropTypes.string.isRequired,
   saveAndRedirectToReturnUrl: PropTypes.func.isRequired,

--- a/src/platform/forms/save-in-progress/SaveInProgressDevModal.jsx
+++ b/src/platform/forms/save-in-progress/SaveInProgressDevModal.jsx
@@ -5,6 +5,7 @@ import ErrorableTextArea from '@department-of-veterans-affairs/formation-react/E
 import ErrorableSelect from '@department-of-veterans-affairs/formation-react/ErrorableSelect';
 
 import environment from 'platform/utilities/environment';
+import { getActivePages } from 'platform/forms-system/src/js/helpers';
 
 const SipsDevModal = props => {
   const [isModalVisible, toggleModal] = useState(false);
@@ -12,7 +13,10 @@ const SipsDevModal = props => {
   const [sipsUrl, setSipsUrl] = useState(null);
   const [errorMessage, setError] = useState('');
 
-  const availablePaths = props?.pageList.map(page => page.path) || [];
+  const availablePaths = getActivePages(
+    props?.pageList || [],
+    props.form.data,
+  ).map(page => page.path);
 
   const openSipsModal = () => {
     setSipsData(JSON.stringify(props.form.data, null, 2));

--- a/src/platform/forms/save-in-progress/SaveInProgressDevModal.jsx
+++ b/src/platform/forms/save-in-progress/SaveInProgressDevModal.jsx
@@ -6,12 +6,27 @@ import ErrorableSelect from '@department-of-veterans-affairs/formation-react/Err
 
 import environment from 'platform/utilities/environment';
 import { getActivePages } from 'platform/forms-system/src/js/helpers';
+import localStorage from 'platform/utilities/storage/localStorage';
+
+const checkHash = () => {
+  const hash = (window?.location?.hash || '').toLowerCase();
+  if (hash.includes('#dev-')) {
+    localStorage.setItem('DEV_MODE', hash.includes('#dev-on'));
+  }
+};
 
 const SipsDevModal = props => {
   const [isModalVisible, toggleModal] = useState(false);
   const [sipsData, setSipsData] = useState(null);
   const [sipsUrl, setSipsUrl] = useState(null);
   const [errorMessage, setError] = useState('');
+
+  // Only show SipsDevModal when url hash includes "#dev-(on|off)"
+  checkHash();
+  const showLink = localStorage.getItem('DEV_MODE');
+  if (showLink !== 'true') {
+    return null;
+  }
 
   const availablePaths = getActivePages(
     props?.pageList || [],
@@ -97,7 +112,12 @@ const SipsDevModal = props => {
           </div>
         </>
       </Modal>{' '}
-      <button type="button" className="va-button-link" onClick={openSipsModal}>
+      <button
+        key={showLink}
+        type="button"
+        className="va-button-link"
+        onClick={openSipsModal}
+      >
         <i aria-hidden="true" className="fas fa-cog" role="img" /> Open
         save-in-progress menu
       </button>

--- a/src/platform/forms/save-in-progress/SaveInProgressDevModal.jsx
+++ b/src/platform/forms/save-in-progress/SaveInProgressDevModal.jsx
@@ -43,8 +43,15 @@ const SipsDevModal = props => {
     event.preventDefault();
     const { formId, version, data } = props.form;
     const parsedData = JSON.parse(sipsData);
+
+    // maximal-data.json is wrapped in `{ "data": {...} }
+    // lets extract that out to make it easier for users
+    const keys = Object.keys(parsedData);
+    const resultingData =
+      keys.length === 1 && keys[0] === 'data' ? parsedData.data : parsedData;
+
     const newData =
-      type === 'merge' ? Object.assign({}, data, parsedData) : sipsData;
+      type === 'merge' ? Object.assign({}, data, resultingData) : resultingData;
     setError('');
     props.saveAndRedirectToReturnUrl(formId, newData, version, sipsUrl);
     toggleModal(false);

--- a/src/platform/forms/save-in-progress/SaveInProgressDevModal.jsx
+++ b/src/platform/forms/save-in-progress/SaveInProgressDevModal.jsx
@@ -8,6 +8,9 @@ import environment from 'platform/utilities/environment';
 import { getActivePages } from 'platform/forms-system/src/js/helpers';
 import localStorage from 'platform/utilities/storage/localStorage';
 
+const docsPage =
+  'https://department-of-veterans-affairs.github.io/veteran-facing-services-tools/forms/save-in-progress-menu';
+
 const checkHash = () => {
   const hash = (window?.location?.hash || '').toLowerCase();
   if (hash.includes('#dev-')) {
@@ -94,6 +97,11 @@ const SipsDevModal = props => {
             onValueChange={value => setSipsUrl(value.value)}
             additionalClass="additional-class"
           />
+          <p />
+          <a href={docsPage}>
+            <i aria-hidden="true" className="fas fa-info-circle" role="img" />{' '}
+            How to use this menu
+          </a>
           <p />
           <div className="row">
             <div className="small-6 columns">

--- a/src/platform/forms/save-in-progress/SaveInProgressDevModal.jsx
+++ b/src/platform/forms/save-in-progress/SaveInProgressDevModal.jsx
@@ -120,4 +120,4 @@ SipsDevModal.propTypes = {
   saveAndRedirectToReturnUrl: PropTypes.func.isRequired,
 };
 
-export default (environment.isProduction() ? null : SipsDevModal);
+export default (environment.isProduction() ? () => null : SipsDevModal);

--- a/src/platform/forms/tests/save-in-progress/SaveInProgressDevModal.unit.spec.jsx
+++ b/src/platform/forms/tests/save-in-progress/SaveInProgressDevModal.unit.spec.jsx
@@ -1,0 +1,237 @@
+import React from 'react';
+import _ from 'lodash/fp';
+import ReactDOM /* , { act } */ from 'react-dom';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import ReactTestUtils from 'react-dom/test-utils';
+
+import {
+  getFormDOM,
+  fillData,
+} from 'platform/testing/unit/schemaform-utils.jsx';
+import localStorage from 'platform/utilities/storage/localStorage';
+import SipsDevModal from '../../save-in-progress/SaveInProgressDevModal';
+import { SAVE_STATUSES } from '../../save-in-progress/actions';
+
+describe('Schemaform <SipsDevModal>', () => {
+  let oldLocation;
+
+  const props = {
+    loggedInUser: {
+      profile: {
+        userFullName: 'something',
+      },
+      login: {
+        currentlyLoggedIn: true,
+      },
+    },
+    form: {
+      formId: 'test',
+      version: 1,
+      data: {},
+      trackingPrefix: 'test-',
+      savedStatus: SAVE_STATUSES.notAttempted,
+    },
+    locationPathname: '/page-1',
+    pageList: [
+      { path: '/introduction' },
+      { path: '/page-1' },
+      { path: '/page-2' },
+      { path: 'review-and-submit' },
+    ],
+  };
+
+  const resetAfter = () => {
+    window.location = oldLocation;
+    localStorage.getItem.restore();
+  };
+
+  afterEach(resetAfter);
+
+  function setLoc(storage = 'true', dev = 'on') {
+    oldLocation = window.location;
+    delete window.location;
+    sinon.stub(localStorage, 'getItem').returns(storage);
+    window.location = {
+      hash: `#dev-${dev}`,
+    };
+  }
+
+  it('should not render sips-modal link when disabled', () => {
+    setLoc('false', 'off');
+    const dom = document.createElement('div');
+    ReactDOM.render(<SipsDevModal {...props} />, dom);
+    expect(dom.querySelector('.va-button-link')).to.be.null;
+    expect(dom.querySelector('.va-modal')).to.be.null;
+
+    // link should render immediately after updating the hash (not working)
+    // act(() => { // TypeError: (0 , _reactDom.act) is not a function
+    //   resetAfter();
+    //   setLoc();
+    // });
+    // expect(dom.querySelector('.va-button-link')).to.be.ok;
+  });
+
+  it('should render sips-modal link on page 1', () => {
+    setLoc();
+    const modal = ReactTestUtils.renderIntoDocument(
+      <div>
+        <SipsDevModal {...props} />
+      </div>,
+    );
+    const dom = getFormDOM(modal);
+    expect(dom.querySelector('.va-button-link').textContent).to.be.contain(
+      'save-in-progress menu',
+    );
+    expect(dom.querySelector('.va-modal')).to.be.null;
+  });
+  it('should render the modal on click', () => {
+    setLoc();
+    const modal = ReactTestUtils.renderIntoDocument(
+      <div>
+        <SipsDevModal {...props} />
+      </div>,
+    );
+    const dom = getFormDOM(modal);
+    // open the sips modal
+    dom.click('.va-button-link');
+    expect(dom.querySelector('.va-modal')).to.not.be.false;
+  });
+
+  it('should replace the form data & include return url', () => {
+    setLoc();
+    const data = _.cloneDeep(props);
+    const newData = {
+      page1: { foo: true },
+      page2: { bar: 'ok' },
+    };
+    let result = {};
+    const updateResult = (formId, modData, version, sipsUrl) => {
+      result = { formId, data: modData, version, sipsUrl };
+    };
+
+    const modal = ReactTestUtils.renderIntoDocument(
+      <div>
+        <SipsDevModal {...data} saveAndRedirectToReturnUrl={updateResult} />
+      </div>,
+    );
+    const dom = getFormDOM(modal);
+    // open the sips modal
+    dom.click('.va-button-link');
+    dom.fillData('textarea', JSON.stringify(newData));
+    dom.fillData('select', '/page-2');
+    dom.click('.usa-button-primary'); // replace button
+    expect(result).to.deep.equal({
+      formId: 'test',
+      version: 1,
+      data: newData,
+      sipsUrl: '/page-2',
+    });
+    // Modal closed
+    expect(dom.querySelector('.va-modal')).to.be.null;
+  });
+  it('should replace the form data from maximal-test.json & include return url', () => {
+    setLoc();
+    const data = _.cloneDeep(props);
+    const newData = {
+      data: {
+        page1: { foo: true },
+        page2: { bar: 'ok' },
+      },
+    };
+    let result = {};
+    const updateResult = (formId, modData, version, sipsUrl) => {
+      result = { formId, data: modData, version, sipsUrl };
+    };
+    const modal = ReactTestUtils.renderIntoDocument(
+      <div>
+        <SipsDevModal {...data} saveAndRedirectToReturnUrl={updateResult} />
+      </div>,
+    );
+    const dom = getFormDOM(modal);
+    // open the sips modal
+    dom.click('.va-button-link');
+    dom.fillData('textarea', JSON.stringify(newData));
+    dom.fillData('select', '/page-2');
+    // replace button
+    dom.click('.usa-button-primary');
+    expect(result).to.deep.equal({
+      formId: 'test',
+      version: 1,
+      data: newData.data,
+      sipsUrl: '/page-2',
+    });
+    // Modal closed
+    expect(dom.querySelector('.va-modal')).to.be.null;
+  });
+
+  it('should merge partial data into the form data & include return url', () => {
+    setLoc();
+    const data = _.cloneDeep(props);
+    data.form.data = {
+      page1: { foo: true },
+      page2: { bar: 'ok' },
+    };
+    const newData = { page3: { test: '100' } };
+    let result = {};
+    const updateResult = (formId, modData, version, sipsUrl) => {
+      result = { formId, data: modData, version, sipsUrl };
+    };
+
+    const modal = ReactTestUtils.renderIntoDocument(
+      <div>
+        <SipsDevModal {...data} saveAndRedirectToReturnUrl={updateResult} />
+      </div>,
+    );
+    const dom = getFormDOM(modal);
+    // open the sips modal
+    dom.click('.va-button-link');
+    dom.fillData('textarea', JSON.stringify(newData));
+    dom.fillData('select', '/page-1');
+    // merge button
+    dom.click('.usa-button-secondary');
+    expect(result).to.deep.equal({
+      formId: 'test',
+      version: 1,
+      data: { ...data.form.data, ...newData },
+      sipsUrl: '/page-1',
+    });
+    // Modal closed
+    expect(dom.querySelector('.va-modal')).to.be.null;
+  });
+  it('should unwrap "data" & merge partial data into the form data & include return url', () => {
+    setLoc();
+    const data = _.cloneDeep(props);
+    data.form.data = {
+      page1: { foo: true },
+      page2: { bar: 'ok' },
+    };
+    // Wrapped in "data"
+    const newData = { data: { page3: { test: '100' } } };
+    let result = {};
+    const updateResult = (formId, modData, version, sipsUrl) => {
+      result = { formId, data: modData, version, sipsUrl };
+    };
+
+    const modal = ReactTestUtils.renderIntoDocument(
+      <div>
+        <SipsDevModal {...data} saveAndRedirectToReturnUrl={updateResult} />
+      </div>,
+    );
+    const dom = getFormDOM(modal);
+    // open the sips modal
+    dom.click('.va-button-link');
+    dom.fillData('textarea', JSON.stringify(newData));
+    dom.fillData('select', '/page-1');
+    // merge button
+    dom.click('.usa-button-secondary');
+    expect(result).to.deep.equal({
+      formId: 'test',
+      version: 1,
+      data: { ...data.form.data, ...newData.data },
+      sipsUrl: '/page-1',
+    });
+    // Modal closed
+    expect(dom.querySelector('.va-modal')).to.be.null;
+  });
+});


### PR DESCRIPTION
## Description

Filling out forms takes a long time. This addition will hopefully save both developers and non-developers many hours of valuable time.

This tool adds an additional link ("Open save-in-progress menu") next to the save form progress link  in a **non-production environment**.

![Screen Shot 2020-05-14 at 8 38 00 AM](https://user-images.githubusercontent.com/136959/81942571-e581c280-95bf-11ea-9f87-8e4da4318a18.png)

Once used, it opens a modal

![Screen Shot 2020-05-14 at 8 38 41 AM](https://user-images.githubusercontent.com/136959/81942694-106c1680-95c0-11ea-8f05-ef5ded14986e.png)

### Form data

This textarea contains a JSON format of the save-in-progress data. It can be shared in an issue ticket, in chat or edited in place. Invalid JSON will show an error message and disable the buttons that allow updating

### Return url

Select from a list of form destinations. This is where the form will return to once you use one of the update buttons. The form will reload, but it will return to the page of the form you selected

### Replace button

This button will replace _all_ form data with whatever is included in the textarea. If the textarea contains invalid data, it may break the form; but it can be recovered from by restarting, instead of continuing, the form progress

### Merge button

This button merges, or replaces a portion of the form data, contained within the textarea. This allows you to only share a part of the complete form data instead of all of it.

### Scenarios

A designer wants to get a developer to fix an interaction on a particular page of a form. They could jump on a call, share their screen and explain the problem. Great! Now the developer needs to fill out the form, and make their way to that same page. Filling out forms takes a lot of time!

A developer may need a QA or accessibility review on a particular page within a form. 

## Testing done

This is a proof of concept. Testing will be added once it has been reviewed

## Screenshots

See the description

## Acceptance criteria

- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
