### PR TITLE
Add VS Code workspace extension recommendations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,9 +28,14 @@ src/applications/proxy-rewrite/tests/__image_snapshots__/__diff_output__/
 temp
 
 # Ignore user's editor/IDE prefs
+.vscode/
 .idea/
 .swp
 .swo
 all-links.csv
 .tern-port
 *.iml
+
+# Track recommended extensions
+!.vscode/settings.default.json
+

--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,6 @@ src/applications/proxy-rewrite/tests/__image_snapshots__/__diff_output__/
 temp
 
 # Ignore user's editor/IDE prefs
-.vscode/
 .idea/
 .swp
 .swo

--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,7 @@ src/applications/proxy-rewrite/tests/__image_snapshots__/__diff_output__/
 temp
 
 # Ignore user's editor/IDE prefs
-.vscode/*
+.vscode/
 .idea/
 .swp
 .swo
@@ -37,5 +37,5 @@ all-links.csv
 *.iml
 
 # Track recommended extensions
-!.vscode/settings.default.json
+!.vscode/extensions.json
 

--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,7 @@ src/applications/proxy-rewrite/tests/__image_snapshots__/__diff_output__/
 temp
 
 # Ignore user's editor/IDE prefs
-.vscode/
+.vscode/*
 .idea/
 .swp
 .swo

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,3 @@
 {
-  "recommendations": ["dbaeumer.vscode-eslint"]
+  "recommendations": ["dbaeumer.vscode-eslint", "esbenp.prettier-vscode"]
 }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,7 @@
 {
-  "recommendations": ["dbaeumer.vscode-eslint", "esbenp.prettier-vscode"]
+  "recommendations": [
+    "dbaeumer.vscode-eslint",
+    "esbenp.prettier-vscode",
+    "glen-84.sass-lint"
+  ]
 }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,9 @@
+{
+  "recommendations": [
+    "dbaeumer.vscode-eslint",
+    "esbenp.prettier-vscode",
+    "ms-vsliveshare.vsliveshare",
+    "visualstudioexptteam.vscodeintellicode",
+    "wayou.vscode-todo-highlight"
+  ]
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,9 +1,3 @@
 {
-  "recommendations": [
-    "dbaeumer.vscode-eslint",
-    "esbenp.prettier-vscode",
-    "ms-vsliveshare.vsliveshare",
-    "visualstudioexptteam.vscodeintellicode",
-    "wayou.vscode-todo-highlight"
-  ]
+  "recommendations": ["dbaeumer.vscode-eslint"]
 }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,7 +1,6 @@
 {
   "recommendations": [
     "dbaeumer.vscode-eslint",
-    "esbenp.prettier-vscode",
     "glen-84.sass-lint"
   ]
 }


### PR DESCRIPTION
## Description
VS Code allows projects to recommend extensions: https://code.visualstudio.com/docs/editor/extension-gallery#_workspace-recommended-extensions

Note: the `.vscode` directory is still gitignored, only `extensions.json` is tracked because it is optional for user.

Update: split off shared `settings.json` issue to https://github.com/department-of-veterans-affairs/vets-website/issues/12845

## Testing done
Workspace recommendations appear in `@recommended` search

## Screenshots
![Screenshot from 2020-05-15 09-56-54-cropped](https://user-images.githubusercontent.com/63597655/82058431-be47f580-9692-11ea-8a22-65faf7ad8a14.png)


## Acceptance criteria
- [x] Workspace recommendations appear in `@recommended` search

## Definition of done
- [ ] Documentation has been updated, if applicable
- [X] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
