### PR TITLE
Upgrade eslint-plugin-react - AE

### DIFF
--- a/src/applications/personalization/profile360/components/PaymentInformationEditModal.jsx
+++ b/src/applications/personalization/profile360/components/PaymentInformationEditModal.jsx
@@ -21,6 +21,9 @@ class PaymentInformationEditModal extends React.Component {
 
   componentDidUpdate = prevProps => {
     if (this.props.isEditing && !prevProps.isEditing) {
+      /* This line was diasbled because the `if` statement above should */
+      /* prevent the infinite loop from happening. */
+      // eslint-disable-next-line react/no-did-update-set-state
       this.setState({ formData: {} });
     }
   };


### PR DESCRIPTION
## Description

`eslint-plugin-react` plugin has been upgraded to the latest version.

This change should help the code to be in compliance with the rule and removes the errors from `additional-linting` CircleCI check.

You can use `setState` inside `componentDidUpdate`. The problem is that somehow you are creating an infinite loop because there's no break condition.

Based on the [react documentation for `componentDidUpdate`](https://reactjs.org/docs/react-component.html#componentdidupdate), this file is following these recommendations to avoid the infinite loop by having an `if` statement prior setting the state, therefore, I'm going to disable this ESLint rule.

```
componentDidUpdate(prevProps) {
  // Typical usage (don't forget to compare props):
  if (this.props.userID !== prevProps.userID) {
    this.fetchData(this.props.userID);
  }
}
```

> You may call setState() immediately in componentDidUpdate() but note that it must be wrapped in a condition like in the example above

## Testing done
Locally

## Screenshots

<img width="993" alt="Screen Shot 2020-05-13 at 5 30 49 PM" src="https://user-images.githubusercontent.com/55560129/82066636-ab86ee00-969d-11ea-8f90-b5804eb0ab34.png">
