### PR TITLE
add covid19 screener flag

### DIFF
--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -1,4 +1,5 @@
 export default Object.freeze({
+  preEntryCovid19Screener: 'preEntryCovid19Screener',
   dashboardShowCovid19Alert: 'dashboardShowCovid19Alert',
   facilityLocatorShowCommunityCares: 'facilityLocatorShowCommunityCares',
   profileShowProfile2: 'profile_show_profile_2.0',


### PR DESCRIPTION
_connects to https://github.com/department-of-veterans-affairs/vets-api/pull/4281_

## Description
This change set implements the frontend half of a Flipper feature toggle to support the pre-entry covid screener to be deployed on VA.gov.

The CTO health products team is rolling out a nationwide screener to be used by VHA facilities at entry points. The screener will ask all prospective entrants a series of questions designed to identify covid symptoms or exposure to the novel coronavirus. Users will enter the screener by either: (1) navigating directly to the va.gov URL; (2) texting an SMS five-digit short code and receiving the va.gov URL back; or (3) scanning a QR code that will load the va.gov URL. At the end of the screener, the user will be given a status which will be used at a human-staffed check point to determine if the user needs additional screening.

We view this simple screener as the first step towards moving parts of the outpatient or on-campus experience into digital channels. In particular, we want to ensure that veterans/patients and their caregivers who would not normally interact with VHA digitally have a delightful experience and become more interested / less hostile to digital channels.

Additional details are [here](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/health-care/COVID-screener/product-brief.md).

No dependencies introduced.

## Original issue(s)
Issue: https://github.com/department-of-veterans-affairs/va.gov-team/issues/9126
Epic: https://github.com/department-of-veterans-affairs/va.gov-team/issues/8963

## Testing done
Manual.

## Screenshots
N/A

## Acceptance criteria
- [x] Flag is available for use.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
