### PR TITLE
Fix eslint-plugin-react-hooks for non-hooks

### DIFF
--- a/src/applications/claims-status/claims-status-entry.jsx
+++ b/src/applications/claims-status/claims-status-entry.jsx
@@ -22,6 +22,7 @@ window.appName = manifest.entryName;
 
 const store = createCommonStore(reducer);
 
+/* eslint-disable react-hooks/rules-of-hooks */
 const history = useRouterHistory(createHistory)({
   basename: manifest.rootUrl,
 });

--- a/src/site/stages/build/process-cms-exports/schemas/transformed/node-vamc_operating_status_and_alerts.js
+++ b/src/site/stages/build/process-cms-exports/schemas/transformed/node-vamc_operating_status_and_alerts.js
@@ -20,6 +20,7 @@ module.exports = {
       type: 'array',
       items: {
         // Yes, it's wrapped in entity here, but not in the originating schema
+        /* eslint-disable react-hooks/rules-of-hooks */
         entity: usePartialSchema(localFacilitySchema, [
           'title',
           'entityUrl',


### PR DESCRIPTION
## Description

`eslint-plugin-react-hooks` plugin has been upgraded to the latest version.

This change should help the code to be in compliance with the rule and removes the errors from `additional-linting` CircleCI check.

The `react-hooks/rules-of-hooks` only checks if the function starts with the word "use"! This lint rule is not really looking if it's an actual hook.

[react/packages/eslint-plugin-react-hooks/src/RulesOfHooks.js](https://github.com/facebook/react/blob/36a6e29bb3eead85e3500ba7269cbcd55516a8fb/packages/eslint-plugin-react-hooks/src/RulesOfHooks.js#L11-L20)

This rule can be triggered if a function starts with `use` like in this case, therefore, we are disabling this rule for these 2 files.

## Testing done
Locally

## Screenshots

<img width="1111" alt="Screen Shot 2020-05-15 at 1 35 49 PM" src="https://user-images.githubusercontent.com/55560129/82081894-1132a480-96b5-11ea-9cab-ce8d856f11cd.png">

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
