### PR TITLE
Updating axe-check-required documentation link

### DIFF
--- a/script/eslint-plugin-va/rules/axe-e2e-tests.js
+++ b/script/eslint-plugin-va/rules/axe-e2e-tests.js
@@ -1,5 +1,5 @@
 const MESSAGE =
-  'e2e Tests must include at least one axeCheck call. Source code can be found here: ./src/platform/testing/e2e/nightwatch-commands/axeCheck.js';
+  'e2e tests must include at least one axeCheck call. Documentation for adding checks and understanding errors can be found here: https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/engineering/frontend/eslint/axe-check-required.md';
 
 const rule = {
   meta: {


### PR DESCRIPTION
## Description
Updating the link in our `const MESSAGE` to point to recently added documentation instead of the source code for `axeCheck`.

## Testing done
* Confirmed the documentation file exists and URL resolves properly
* Reviewed file and had it approved by front-end engineer and VSP content/IA specialist

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
