### PR TITLE
add poll option in webpack config to get watch working on wsl2

### DIFF
--- a/config/webpack.dev.config.js
+++ b/config/webpack.dev.config.js
@@ -27,7 +27,7 @@ function generateWebpackDevConfig(buildOptions) {
     hot: false,
     liveReload: false,
     watchOptions: {
-      poll: 1000
+      poll: 1000,
     },
     port: buildOptions.port,
     publicPath: '/generated/',

--- a/config/webpack.dev.config.js
+++ b/config/webpack.dev.config.js
@@ -26,6 +26,9 @@ function generateWebpackDevConfig(buildOptions) {
     },
     hot: false,
     liveReload: false,
+    watchOptions: {
+      poll: 1000
+    },
     port: buildOptions.port,
     publicPath: '/generated/',
     host: buildOptions.host,


### PR DESCRIPTION
## Description
Add poll option in webpack dev config to get watch working in windows wsl2 environments. 

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
