### PR TITLE
Workaround for supporting Fetch with Cypress stubs.

### DIFF
--- a/src/platform/testing/e2e/cypress/support/index.js
+++ b/src/platform/testing/e2e/cypress/support/index.js
@@ -1,0 +1,7 @@
+// Workaround to allow Cypress to intercept requests made with the Fetch API.
+// This forces fetch to fall back to the polyfill, which can get intercepted.
+// https://github.com/cypress-io/cypress/issues/95
+Cypress.on('window:before:load', window => {
+  // eslint-disable-next-line no-param-reassign
+  delete window.fetch;
+});


### PR DESCRIPTION
## Description
Cypress can't stub our `fetch` calls unless we force them to fall back to the polyfill. The root issue is linked and described in the comment.

## Testing done
Stubbed out API requests in tests (not included).

## Acceptance criteria
- [ ] Cypress should be able to stub API requests made with `fetch`.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
