### PR TITLE
Preprocess Cypress tests with Webpack.

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,6 +115,7 @@
     "@babel/preset-env": "^7.0.0",
     "@babel/preset-react": "^7.0.0",
     "@babel/register": "^7.0.0",
+    "@cypress/webpack-preprocessor": "^5.2.0",
     "@department-of-veterans-affairs/generator-vets-website": "^3.3.1",
     "@octokit/rest": "^16.43.1",
     "@sentry/browser": "^5.4.0",

--- a/src/platform/testing/e2e/cypress/plugins/index.js
+++ b/src/platform/testing/e2e/cypress/plugins/index.js
@@ -1,1 +1,20 @@
-module.exports = () => {};
+const webpackPreprocessor = require('@cypress/webpack-preprocessor');
+
+module.exports = on => {
+  const ENV = 'localhost';
+
+  const options = {
+    webpackOptions: {
+      // Import our own Webpack config.
+      ...require('../../../../../../config/webpack.config.js')(ENV),
+
+      // Expose some Node globals.
+      node: {
+        __dirname: true,
+        __filename: true,
+      },
+    },
+  };
+
+  on('file:preprocessor', webpackPreprocessor(options));
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -894,6 +894,15 @@
     tunnel-agent "^0.6.0"
     uuid "^3.3.2"
 
+"@cypress/webpack-preprocessor@^5.2.0":
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/@cypress/webpack-preprocessor/-/webpack-preprocessor-5.4.0.tgz#c13135d9533ff2a000dc87ee2f043961ed7bc398"
+  integrity sha512-ZI+OsY0QRvtCRiIH9zpuYWPKN29426RteBkNR+8hDHnmvk11XBenSXnDU9bdMRMcaMpMpej2RWLF7NkuvmEYPQ==
+  dependencies:
+    bluebird "3.7.1"
+    debug "4.1.1"
+    lodash "4.17.15"
+
 "@cypress/xvfb@1.2.4":
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/@cypress/xvfb/-/xvfb-1.2.4.tgz#2daf42e8275b39f4aa53c14214e557bd14e7748a"
@@ -2791,6 +2800,11 @@ block-stream@*:
   resolved "https://registry.yarnpkg.com/block-stream/-/block-stream-0.0.9.tgz#13ebfe778a03205cfe03751481ebb4b3300c126a"
   dependencies:
     inherits "~2.0.0"
+
+bluebird@3.7.1:
+  version "3.7.1"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.1.tgz#df70e302b471d7473489acf26a93d63b53f874de"
+  integrity sha512-DdmyoGCleJnkbp3nkbxTLJ18rjDsE4yCggEwKNXkeV123sPNfOCYeDoeuOY+F2FrSjO1YXcTU+dsy96KMy+gcg==
 
 bluebird@3.7.2, bluebird@^3.5.5:
   version "3.7.2"


### PR DESCRIPTION
## Description
Uses Webpack instead of the default Browserify as a preprocessor. Lets us write tests using our Webpack and Babel config.

## Testing done
Ran Cypress tests (not included) without issues.

## Acceptance criteria
- [ ] Cypress tests should be preprocessed with Webpack.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
