### PR TITLE
Remove standalone Account page when using Profile 2.0

### DIFF
--- a/src/applications/personalization/account/containers/AccountApp.jsx
+++ b/src/applications/personalization/account/containers/AccountApp.jsx
@@ -1,17 +1,29 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
 import backendServices from 'platform/user/profile/constants/backendServices';
 import { selectUser, isLOA3 } from 'platform/user/selectors';
 
 import AccountMain from '../components/AccountMain';
 import RequiredLoginView from 'platform/user/authorization/components/RequiredLoginView';
+import localStorage from 'platform/utilities/storage/localStorage';
 import DowntimeNotification, {
   externalServices,
 } from 'platform/monitoring/DowntimeNotification';
 
 import { fetchMHVAccount } from 'platform/user/profile/actions';
 
+import { selectShowProfile2 } from 'applications/personalization/profile-2/selectors';
+
 function AccountApp(props) {
+  useEffect(
+    () => {
+      if (props.redirect) {
+        document.location.replace('/profile/account-security');
+      }
+    },
+    [props.redirect],
+  );
+
   return (
     <div>
       <RequiredLoginView
@@ -47,11 +59,15 @@ function AccountApp(props) {
 
 const mapStateToProps = state => {
   const userState = selectUser(state);
+  const showProfile2 = selectShowProfile2(state);
+  const profileVersion = localStorage.getItem('PROFILE_VERSION');
+
   return {
     isLOA3: isLOA3(state),
     login: userState.login,
     profile: userState.profile,
     user: userState,
+    redirect: showProfile2 && profileVersion !== '1',
   };
 };
 

--- a/src/applications/personalization/account/tests/containers/AccountApp.redirect.unit.spec.jsx
+++ b/src/applications/personalization/account/tests/containers/AccountApp.redirect.unit.spec.jsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import sinon from 'sinon';
+import { mount } from 'enzyme';
+import { expect } from 'chai';
+import { Provider } from 'react-redux';
+import { combineReducers, createStore } from 'redux';
+
+import { commonReducer } from 'platform/startup/store';
+import localStorage from 'platform/utilities/storage/localStorage';
+
+import AccountApp from '../../containers/AccountApp';
+
+describe('<AccountApp>', () => {
+  let wrapper;
+
+  function setUp() {
+    global.window.location.replace = sinon.spy();
+    const initialState = {
+      user: {
+        profile: {
+          loa: {
+            current: 3,
+            highest: 3,
+          },
+          multifactor: true,
+          loading: false,
+        },
+      },
+      featureToggles: {
+        'profile_show_profile_2.0': true,
+      },
+    };
+    const store = createStore(combineReducers(commonReducer), initialState);
+    wrapper = mount(
+      <Provider store={store}>
+        <AccountApp />
+      </Provider>,
+    );
+  }
+
+  it('should redirect to `profile/account-security` if the feature flag is set', () => {
+    setUp();
+
+    expect(
+      global.window.location.replace.calledWith('/profile/account-security'),
+    ).to.be.true;
+
+    wrapper.unmount();
+  });
+
+  it('should not redirect to `profile/account-security` if the feature flag is set but the "PROFILE_VERSION" localstorage key is set to "1"', () => {
+    localStorage.setItem('PROFILE_VERSION', '1');
+
+    setUp();
+
+    expect(
+      global.window.location.replace.calledWith('/profile/account-security'),
+    ).to.be.false;
+
+    wrapper.unmount();
+  });
+});

--- a/src/platform/site-wide/user-nav/components/PersonalizationDropdown.jsx
+++ b/src/platform/site-wide/user-nav/components/PersonalizationDropdown.jsx
@@ -5,6 +5,8 @@ import { ssoe } from 'platform/user/authentication/selectors';
 import { logout } from 'platform/user/authentication/utilities';
 import recordEvent from 'platform/monitoring/record-event';
 
+import { selectShowProfile2 } from 'applications/personalization/profile-2/selectors';
+
 const recordNavUserEvent = section => () => {
   recordEvent({ event: 'nav-user', 'nav-user-section': section });
 };
@@ -44,11 +46,14 @@ export class PersonalizationDropdown extends React.Component {
             Profile
           </a>
         </li>
-        <li>
-          <a href="/account" onClick={recordAccountEvent}>
-            Account
-          </a>
-        </li>
+        {this.props.showAccount && (
+          <li>
+            <a href="/account" onClick={recordAccountEvent}>
+              Account
+            </a>
+          </li>
+        )}
+
         <li>
           <a href="#" onClick={this.signOut}>
             Sign Out
@@ -62,6 +67,7 @@ export class PersonalizationDropdown extends React.Component {
 function mapStateToProps(state) {
   return {
     useSSOe: ssoe(state),
+    showAccount: !selectShowProfile2(state),
   };
 }
 

--- a/src/platform/site-wide/user-nav/tests/components/PersonalizationDropdown.unit.spec.jsx
+++ b/src/platform/site-wide/user-nav/tests/components/PersonalizationDropdown.unit.spec.jsx
@@ -60,7 +60,7 @@ describe('<PersonalizationDropdown>', () => {
   });
 
   it('should report analytics when clicking Account', () => {
-    const wrapper = shallow(<PersonalizationDropdown />);
+    const wrapper = shallow(<PersonalizationDropdown showAccount />);
     wrapper
       .find('a')
       .at(3)
@@ -68,6 +68,20 @@ describe('<PersonalizationDropdown>', () => {
     const recordedEvent = global.window.dataLayer[0];
     expect(recordedEvent.event).to.equal('nav-user');
     expect(recordedEvent['nav-user-section']).to.equal('account');
+    wrapper.unmount();
+  });
+
+  it('should show the `Account` menu item if `showAccount` prop true', () => {
+    const wrapper = shallow(<PersonalizationDropdown showAccount />);
+    const accountLink = wrapper.find('li > a[href="/account"]');
+    expect(accountLink.length).to.equal(1);
+    wrapper.unmount();
+  });
+
+  it('should not show the `Account` menu item if `showAccount` prop is not true', () => {
+    const wrapper = shallow(<PersonalizationDropdown />);
+    const accountLink = wrapper.find('li > a[href="/account"]');
+    expect(accountLink.length).to.equal(0);
     wrapper.unmount();
   });
 });


### PR DESCRIPTION
## Description
In Profile 2.0, the Account section will live at `profile/account-security` and the `account` route will eventually be removed entirely.

So:

- remove the Account item from the user dropdown if the profile 2.0 feature flag is on
- redirect if the Profile v2 feature flag is set and the browser does not have `PROFILE_VERSION === 1` set in LocalStorage.

## Testing done
Local + unit tests.
Confirmed that the LocalStorage override works

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs