### PR TITLE
adding downtime banner for SSOe problems

### DIFF
--- a/src/platform/monitoring/external-services/config.js
+++ b/src/platform/monitoring/external-services/config.js
@@ -21,6 +21,8 @@ export const EXTERNAL_SERVICES = {
   mvi: 'mvi',
   // Search.gov API
   search: 'search',
+  // SSOe authentication
+  ssoe: 'ssoe',
   // The Image Management System (education forms)
   tims: 'tims',
   // Vet360 - data source for centralized veteran contact information

--- a/src/platform/user/authentication/components/SignInModal.jsx
+++ b/src/platform/user/authentication/components/SignInModal.jsx
@@ -90,7 +90,7 @@ export class SignInModal extends React.Component {
     return (
       <>
         {this.downtimeBanner(
-          [EXTERNAL_SERVICES.idme],
+          [EXTERNAL_SERVICES.idme, EXTERNAL_SERVICES.ssoe],
           'Our sign in process isn’t working right now',
           'error',
           'We’re sorry. We’re working to fix some problems with our sign in process. If you’d like to sign in to VA.gov, please check back later.',


### PR DESCRIPTION
## Description

Adding `ssoe` to the list of services that can trigger the sign in downtime error.  If either this or `idme` is down, the sign in modal will display the following message.

<img width="1038" alt="Screen Shot 2020-05-18 at 22 38 28" src="https://user-images.githubusercontent.com/170002/82288947-7ce86c00-9958-11ea-8d83-2d7864a54d9a.png">

closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/9228
