### PR TITLE
Add new VAOS toggles

### DIFF
--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -14,7 +14,7 @@ export default Object.freeze({
   vaOnlineSchedulingVSPAppointmentNew: 'vaOnlineSchedulingVspAppointmentNew',
   vaOnlineSchedulingCCSPAppointmentList:
     'vaOnlineSchedulingCcspAppointmentList',
-  vaOnlineSchedulingCCSPAppointmentNew: 'vaOnlineSchedulingCcspRequestNew',
+  vaOnlineSchedulingCCSPRequestNew: 'vaOnlineSchedulingCcspRequestNew',
   vaOnlineSchedulingVSPRequestList: 'vaOnlineSchedulingVspRequestList',
   vaOnlineSchedulingVSPRequestNew: 'vaOnlineSchedulingVspRequestNew',
   vaGlobalDowntimeNotification: 'vaGlobalDowntimeNotification',

--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -10,6 +10,13 @@ export default Object.freeze({
   vaOnlineSchedulingCommunityCare: 'vaOnlineSchedulingCommunityCare',
   vaOnlineSchedulingDirect: 'vaOnlineSchedulingDirect',
   vaOnlineSchedulingPast: 'vaOnlineSchedulingPast',
+  vaOnlineSchedulingVSPAppointmentList: 'vaOnlineSchedulingVspAppointmentList',
+  vaOnlineSchedulingVSPAppointmentNew: 'vaOnlineSchedulingVspAppointmentNew',
+  vaOnlineSchedulingCCSPAppointmentList:
+    'vaOnlineSchedulingCcspAppointmentList',
+  vaOnlineSchedulingCCSPAppointmentNew: 'vaOnlineSchedulingCcspRequestNew',
+  vaOnlineSchedulingVSPRequestList: 'vaOnlineSchedulingVspRequestList',
+  vaOnlineSchedulingVSPRequestNew: 'vaOnlineSchedulingVspRequestNew',
   vaGlobalDowntimeNotification: 'vaGlobalDowntimeNotification',
   ssoe: 'ssoe',
   ssoeInbound: 'ssoeInbound',


### PR DESCRIPTION
## Description
This adds new VAOS toggles to the names object to match the ones added on the backend (https://github.com/department-of-veterans-affairs/vets-api/pull/4289)

## Acceptance criteria
- [ ] Toggles show up

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
