### PR TITLE
Improve use-resolved-path message

### DIFF
--- a/script/eslint-plugin-va/package.json
+++ b/script/eslint-plugin-va/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-va",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "main": "index.js",
   "peerDependency": {
     "eslint": "^4.18.2"

--- a/script/eslint-plugin-va/rules/use-resolved-path.js
+++ b/script/eslint-plugin-va/rules/use-resolved-path.js
@@ -1,5 +1,6 @@
-const MESSAGE = 'Use resolved path and remove unnecessary parent path';
+const MESSAGE = 'Do not use relative path. ';
 const DEFAULTS = ['applications'];
+let ALIASPATH = 'Instead, use absolute path for ';
 
 function isIncluded(val, aliases) {
   const isString = str => typeof str === 'string';
@@ -11,7 +12,10 @@ function isIncluded(val, aliases) {
 
   for (alias of aliases) {
     const path = `../${alias}/`;
-    if (val.includes(path)) return true;
+    if (val.includes(path)) {
+      ALIASPATH += alias;
+      return true;
+    }
   }
   return false;
 }
@@ -46,7 +50,7 @@ module.exports = {
         if (isIncluded(value, aliases)) {
           context.report({
             node,
-            message: MESSAGE,
+            message: MESSAGE + ALIASPATH,
           });
         }
       },
@@ -57,7 +61,7 @@ module.exports = {
           if (isIncluded(value, aliases)) {
             context.report({
               node,
-              message: MESSAGE,
+              message: MESSAGE + ALIASPATH,
             });
           }
         }

--- a/script/eslint-plugin-va/rules/use-resolved-path.js
+++ b/script/eslint-plugin-va/rules/use-resolved-path.js
@@ -1,6 +1,7 @@
-const MESSAGE = 'Do not use relative path. ';
+const MESSAGE =
+  'Import from ALIASES directly, relative to "src" instead of relative to current working directory.';
 const DEFAULTS = ['applications'];
-let ALIASPATH = 'Instead, use absolute path for ';
+let ALIASPATH = '';
 
 function isIncluded(val, aliases) {
   const isString = str => typeof str === 'string';
@@ -13,7 +14,7 @@ function isIncluded(val, aliases) {
   for (alias of aliases) {
     const path = `../${alias}/`;
     if (val.includes(path)) {
-      ALIASPATH += alias;
+      ALIASPATH = alias;
       return true;
     }
   }
@@ -48,9 +49,10 @@ module.exports = {
       ImportDeclaration(node) {
         const value = node.source.value;
         if (isIncluded(value, aliases)) {
+          const message = `Import from '${ALIASPATH}' directly, relative to 'src' instead of relative to current working directory.`;
           context.report({
             node,
-            message: MESSAGE + ALIASPATH,
+            message,
           });
         }
       },
@@ -59,9 +61,10 @@ module.exports = {
         if (callee === 'Import') {
           const value = node.arguments[0].value;
           if (isIncluded(value, aliases)) {
+            const message = `Import from '${ALIASPATH}' directly, relative to 'src' instead of relative to current working directory.`;
             context.report({
               node,
-              message: MESSAGE + ALIASPATH,
+              message,
             });
           }
         }


### PR DESCRIPTION
## Description
This PR improves the message generated by ESLint. The message has been change to describe better the issue. The folder that provides the issue is now dynamically displayed.

## Testing done
Locally

## Screenshots
<img width="998" alt="Screen Shot 2020-05-19 at 3 04 08 PM" src="https://user-images.githubusercontent.com/55560129/82367753-4eaf6e80-99e2-11ea-9e62-b0f2b53a9f93.png">

<img width="823" alt="Screen Shot 2020-05-19 at 3 04 46 PM" src="https://user-images.githubusercontent.com/55560129/82367770-53742280-99e2-11ea-9c9d-cff4ff47b8dc.png">

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
