### PR TITLE
[ZOOM]: Section 103 - Modal windows MUST be usable at 200% to 400% zoom fix

### DIFF
--- a/src/applications/gi/containers/Modals.jsx
+++ b/src/applications/gi/containers/Modals.jsx
@@ -620,51 +620,47 @@ export class Modals extends React.Component {
         onClose={this.props.hideModal}
         visible={this.shouldDisplayModal('section103')}
       >
-        <div>
-          <div className="vads-u-padding--1p5 vads-u-margin-top--neg2">
-            <h3>Protection against late VA payments</h3>
-            <p>
-              If VA payments to institutions are delayed, schools receiving GI
-              Bill benefits must allow beneficiaries to continue attending their
-              classes if they have sufficient proof of eligibility on file.
-            </p>
-            <p>
-              Schools may require proof of GI Bill eligibility in the form of:
-            </p>
-            <ul>
-              <li>
-                Certificate of Eligibility (COE) <strong>or</strong>
-              </li>
-              <li>
-                Certificate of Eligibility (COE) and additional criteria such as
-                an award letter or other documents the school specifies
-              </li>
-            </ul>
-            <p>
-              <strong>
-                Schools can't impose late fees, deny access to facilities or
-                classes, or otherwise penalize beneficiaries if VA is late with
-                tuition and/or fees payments.
-              </strong>{' '}
-              The restriction on penalties doesn't apply if the beneficiary owes
-              additional fees to the school beyond the tuition and fees that VA
-              pays. Students are protected from these penalties up to 90 days
-              from the beginning of the term.
-            </p>
-            <p>
-              Contact the School Certifying Official (SCO) to learn more about
-              the school’s policy.{' '}
-              <a
-                href="https://benefits.va.gov/gibill/fgib/transition_act.asp"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                Read our FAQs on the Veterans Benefits and Transition Act
-              </a>{' '}
-              to learn more about protections against late VA payments.
-            </p>
-          </div>
+        <div className="align-left">
+          <h3>Protection against late VA payments</h3>
         </div>
+        <p>
+          If VA payments to institutions are delayed, schools receiving GI Bill
+          benefits must allow beneficiaries to continue attending their classes
+          if they have sufficient proof of eligibility on file.
+        </p>
+        <p>Schools may require proof of GI Bill eligibility in the form of:</p>
+        <ul>
+          <li>
+            Certificate of Eligibility (COE) <strong>or</strong>
+          </li>
+          <li>
+            Certificate of Eligibility (COE) and additional criteria such as an
+            award letter or other documents the school specifies
+          </li>
+        </ul>
+        <p>
+          <strong>
+            Schools can't impose late fees, deny access to facilities or
+            classes, or otherwise penalize beneficiaries if VA is late with
+            tuition and/or fees payments.
+          </strong>{' '}
+          The restriction on penalties doesn't apply if the beneficiary owes
+          additional fees to the school beyond the tuition and fees that VA
+          pays. Students are protected from these penalties up to 90 days from
+          the beginning of the term.
+        </p>
+        <p>
+          Contact the School Certifying Official (SCO) to learn more about the
+          school’s policy.{' '}
+          <a
+            href="https://benefits.va.gov/gibill/fgib/transition_act.asp"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Read our FAQs on the Veterans Benefits and Transition Act
+          </a>{' '}
+          to learn more about protections against late VA payments.
+        </p>
       </Modal>
     </span>
   );
@@ -1093,29 +1089,27 @@ export class Modals extends React.Component {
         onClose={this.props.hideModal}
         visible={this.shouldDisplayModal('giBillChapter')}
       >
-        <div>
-          <div className="vads-u-padding-top--1p5 vads-u-margin-top--neg0p25">
-            <h3>Which GI Bill benefit do you want to use?</h3>
-            <p>
-              You may be eligible for multiple types of education and training
-              programs. Different programs offer different benefits, so it’s
-              important to choose the program that will best meet your needs.
-              Use this tool to compare programs and schools.
-            </p>
-            <p>
-              For detailed information on eligibility requirements and general
-              program benefits, visit{' '}
-              <a
-                href="/education/eligibility/"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                this page
-              </a>
-              .
-            </p>
-          </div>
+        <div className="align-left">
+          <h3>Which GI Bill benefit do you want to use?</h3>
         </div>
+        <p>
+          You may be eligible for multiple types of education and training
+          programs. Different programs offer different benefits, so it’s
+          important to choose the program that will best meet your needs. Use
+          this tool to compare programs and schools.
+        </p>
+        <p>
+          For detailed information on eligibility requirements and general
+          program benefits, visit{' '}
+          <a
+            href="/education/eligibility/"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            this page
+          </a>
+          .
+        </p>
       </Modal>
 
       <Modal

--- a/src/applications/gi/containers/Modals.jsx
+++ b/src/applications/gi/containers/Modals.jsx
@@ -620,45 +620,51 @@ export class Modals extends React.Component {
         onClose={this.props.hideModal}
         visible={this.shouldDisplayModal('section103')}
       >
-        <h3>Protection against late VA payments</h3>
-        <p>
-          If VA payments to institutions are delayed, schools receiving GI Bill
-          benefits must allow beneficiaries to continue attending their classes
-          if they have sufficient proof of eligibility on file.
-        </p>
-        <p>Schools may require proof of GI Bill eligibility in the form of:</p>
-        <ul>
-          <li>
-            Certificate of Eligibility (COE) <strong>or</strong>
-          </li>
-          <li>
-            Certificate of Eligibility (COE) and additional criteria such as an
-            award letter or other documents the school specifies
-          </li>
-        </ul>
-        <p>
-          <strong>
-            Schools can't impose late fees, deny access to facilities or
-            classes, or otherwise penalize beneficiaries if VA is late with
-            tuition and/or fees payments.
-          </strong>{' '}
-          The restriction on penalties doesn't apply if the beneficiary owes
-          additional fees to the school beyond the tuition and fees that VA
-          pays. Students are protected from these penalties up to 90 days from
-          the beginning of the term.
-        </p>
-        <p>
-          Contact the School Certifying Official (SCO) to learn more about the
-          school’s policy.{' '}
-          <a
-            href="https://benefits.va.gov/gibill/fgib/transition_act.asp"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Read our FAQs on the Veterans Benefits and Transition Act
-          </a>{' '}
-          to learn more about protections against late VA payments.
-        </p>
+        <div>
+          <div className="vads-u-padding--1p5 vads-u-margin-top--neg2">
+            <h3>Protection against late VA payments</h3>
+            <p>
+              If VA payments to institutions are delayed, schools receiving GI
+              Bill benefits must allow beneficiaries to continue attending their
+              classes if they have sufficient proof of eligibility on file.
+            </p>
+            <p>
+              Schools may require proof of GI Bill eligibility in the form of:
+            </p>
+            <ul>
+              <li>
+                Certificate of Eligibility (COE) <strong>or</strong>
+              </li>
+              <li>
+                Certificate of Eligibility (COE) and additional criteria such as
+                an award letter or other documents the school specifies
+              </li>
+            </ul>
+            <p>
+              <strong>
+                Schools can't impose late fees, deny access to facilities or
+                classes, or otherwise penalize beneficiaries if VA is late with
+                tuition and/or fees payments.
+              </strong>{' '}
+              The restriction on penalties doesn't apply if the beneficiary owes
+              additional fees to the school beyond the tuition and fees that VA
+              pays. Students are protected from these penalties up to 90 days
+              from the beginning of the term.
+            </p>
+            <p>
+              Contact the School Certifying Official (SCO) to learn more about
+              the school’s policy.{' '}
+              <a
+                href="https://benefits.va.gov/gibill/fgib/transition_act.asp"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Read our FAQs on the Veterans Benefits and Transition Act
+              </a>{' '}
+              to learn more about protections against late VA payments.
+            </p>
+          </div>
+        </div>
       </Modal>
     </span>
   );
@@ -1087,25 +1093,29 @@ export class Modals extends React.Component {
         onClose={this.props.hideModal}
         visible={this.shouldDisplayModal('giBillChapter')}
       >
-        <h3>Which GI Bill benefit do you want to use?</h3>
-        <p>
-          You may be eligible for multiple types of education and training
-          programs. Different programs offer different benefits, so it’s
-          important to choose the program that will best meet your needs. Use
-          this tool to compare programs and schools.
-        </p>
-        <p>
-          For detailed information on eligibility requirements and general
-          program benefits, visit{' '}
-          <a
-            href="/education/eligibility/"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            this page
-          </a>
-          .
-        </p>
+        <div>
+          <div className="vads-u-padding-top--1p5 vads-u-margin-top--neg0p25">
+            <h3>Which GI Bill benefit do you want to use?</h3>
+            <p>
+              You may be eligible for multiple types of education and training
+              programs. Different programs offer different benefits, so it’s
+              important to choose the program that will best meet your needs.
+              Use this tool to compare programs and schools.
+            </p>
+            <p>
+              For detailed information on eligibility requirements and general
+              program benefits, visit{' '}
+              <a
+                href="/education/eligibility/"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                this page
+              </a>
+              .
+            </p>
+          </div>
+        </div>
       </Modal>
 
       <Modal

--- a/src/applications/gi/sass/partials/_gi-modal.scss
+++ b/src/applications/gi/sass/partials/_gi-modal.scss
@@ -7,7 +7,7 @@
       z-index: 100;
     }
     .align-left {
-      margin-right: 1em;
+      margin-right: 1.5em;
     }
     ul {
       margin-left: 1em;

--- a/src/applications/gi/sass/partials/_gi-modal.scss
+++ b/src/applications/gi/sass/partials/_gi-modal.scss
@@ -6,6 +6,9 @@
       overflow: scroll;
       z-index: 100;
     }
+    .align-left {
+      margin-right: 1em;
+    }
     ul {
       margin-left: 1em;
     }

--- a/src/applications/gi/sass/partials/_gi-modal.scss
+++ b/src/applications/gi/sass/partials/_gi-modal.scss
@@ -1,9 +1,11 @@
 .gi-app {
   .va-modal {
     .va-modal-inner {
+      max-height: 100vh;
       max-width: 600px;
+      overflow: scroll;
+      z-index: 100;
     }
-
     ul {
       margin-left: 1em;
     }


### PR DESCRIPTION
## Description
Several of the modal windows are expanding out of the viewport at 200-250% zoom. I saw this on a few of the longer modals like Yellow Ribbon and the college housing. Screenshot of Yellow Ribbon attached below.

https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/9240

text button overlap bug 

https://github.com/department-of-veterans-affairs/va.gov-team/issues/9262

## Testing done
local testing

## Screenshots
![Screen Shot 2020-05-19 at 1 30 15 PM](https://user-images.githubusercontent.com/50601724/82358743-f2921d80-99d4-11ea-93fb-939e52eeb25f.png)
![Screen Shot 2020-05-19 at 1 29 51 PM](https://user-images.githubusercontent.com/50601724/82358751-f45be100-99d4-11ea-8fe4-a09f43d68287.png)
300%
![Screen Shot 2020-05-20 at 11 59 03 AM](https://user-images.githubusercontent.com/50601724/82468903-59750c80-9a91-11ea-89c1-40db88d587eb.png)


400%
![Screen Shot 2020-05-20 at 11 59 49 AM](https://user-images.githubusercontent.com/50601724/82469007-77db0800-9a91-11ea-8fc3-c8279e097039.png)


500%
![Screen Shot 2020-05-20 at 11 51 07 AM](https://user-images.githubusercontent.com/50601724/82468063-63e2d680-9a90-11ea-879f-ee237fb07ae9.png)




## Acceptance criteria
- [x] The modals do not break out of the viewport at any zoom between 200% and 400%
- [x] No other zoom levels break or change their layout

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
