### PR TITLE
Add covid codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -44,7 +44,7 @@ src/applications/caregivers @department-of-veterans-affairs/vsa-caregiver-fronte
 
 # Other
 src/applications/vaos @department-of-veterans-affairs/vfs-vaos
-src/applications/coronovirus-screener @department-of-veterans-affairs/va-cto-health-products
+src/applications/coronavirus-screener @department-of-veterans-affairs/va-cto-health-products
 
 # Booz Allen Team
 src/applications/static-pages/school-resources @department-of-veterans-affairs/bah-code-reviewers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -44,6 +44,7 @@ src/applications/caregivers @department-of-veterans-affairs/vsa-caregiver-fronte
 
 # Other
 src/applications/vaos @department-of-veterans-affairs/vfs-vaos
+src/applications/coronovirus-screener @department-of-veterans-affairs/va-cto-health-products
 
 # Booz Allen Team
 src/applications/static-pages/school-resources @department-of-veterans-affairs/bah-code-reviewers


### PR DESCRIPTION
## Description

Adds @department-of-veterans-affairs/va-cto-health-products as codeowner for `/src/applications/coronavirus-screener`.

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
