### PR TITLE
MDOT- 404 Error for if Veteran supplies not found and Veteran not found

### DIFF
--- a/src/applications/disability-benefits/2346/config/form.js
+++ b/src/applications/disability-benefits/2346/config/form.js
@@ -61,7 +61,8 @@ const formConfig = {
   title: 'Order hearing aid batteries and accessories',
   subTitle: 'VA Form 2346A',
   savedFormMessages: {
-    notFound: 'Please start over to apply for benefits.',
+    notFound:
+      'You can’t reorder your items at this time because your items aren’t available for reorder or we can’t find your records in our system. For help, please call the Denver Logistics Center (DLC) at 303-273-6200 or email us at dalc.css@va.gov.',
     noAuth: 'Please sign in again to continue your application for benefits.',
   },
   defaultDefinitions: {


### PR DESCRIPTION
## Description
This PR focuses on adding a 404 error message if the Veteran supplies are not found or if the Veteran is not found in the DLC database.

## Testing done
vets.gov.user+45@gmail.com. (Veteran supplies not found)
vets.gov.user+27@gmail.com (Veteran not found)

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
