### PR TITLE
SSO Announcement Modal fixes: overflow/scroll styling + content updates

### DIFF
--- a/src/platform/site-wide/announcements/components/SingleSignOnInfoModal.jsx
+++ b/src/platform/site-wide/announcements/components/SingleSignOnInfoModal.jsx
@@ -14,8 +14,8 @@ export default function SingleSignOnInfoModal({
         Sign in once to access the VA sites you use most
       </h1>
       <p>
-        Now when you sign into VA.gov, we’ll also sign you into MyHealtheVet,
-        eBenefits, and other VA sites.
+        Now when you sign into VA.gov, we’ll also sign you into MyHealtheVet and
+        other VA sites.
       </p>
       <p>
         <strong>With a single sign on, you can:</strong>

--- a/src/platform/site-wide/announcements/components/SingleSignOnInfoModal.jsx
+++ b/src/platform/site-wide/announcements/components/SingleSignOnInfoModal.jsx
@@ -10,7 +10,7 @@ export default function SingleSignOnInfoModal({
   if (!isLoggedIn || !useSSOe) return null;
 
   return (
-    <Modal visible onClose={dismiss} id="modal-announcment">
+    <Modal visible onClose={dismiss} id="modal-announcement">
       <h1 className="vads-u-font-size--h3 vads-u-margin-top--2">
         Sign in once to access the VA sites you use most
       </h1>

--- a/src/platform/site-wide/announcements/components/SingleSignOnInfoModal.jsx
+++ b/src/platform/site-wide/announcements/components/SingleSignOnInfoModal.jsx
@@ -25,8 +25,10 @@ export default function SingleSignOnInfoModal({
       </p>
       <ul>
         <li>
-          Track and manage your VA benefits and services with just one username
-          and password
+          {`Track and manage your VA ${
+            useSSOeEbenefitsLinks ? 'benefits and' : ''
+          }services with just one username
+          and password`}
         </li>
         <li>
           Access the VA sites you use most without having to sign in each time

--- a/src/platform/site-wide/announcements/components/SingleSignOnInfoModal.jsx
+++ b/src/platform/site-wide/announcements/components/SingleSignOnInfoModal.jsx
@@ -5,6 +5,7 @@ export default function SingleSignOnInfoModal({
   dismiss,
   isLoggedIn,
   useSSOe,
+  useSSOeEbenefitsLinks,
 }) {
   if (!isLoggedIn || !useSSOe) return null;
 
@@ -14,8 +15,10 @@ export default function SingleSignOnInfoModal({
         Sign in once to access the VA sites you use most
       </h1>
       <p>
-        Now when you sign into VA.gov, we’ll also sign you into MyHealtheVet and
-        other VA sites.
+        {`Now when you sign into VA.gov, we’ll also sign you into MyHealtheVet${
+          useSSOeEbenefitsLinks ? ', eBenefits,' : ''
+        } and
+        other VA sites.`}
       </p>
       <p>
         <strong>With a single sign on, you can:</strong>

--- a/src/platform/site-wide/announcements/components/SingleSignOnInfoModal.jsx
+++ b/src/platform/site-wide/announcements/components/SingleSignOnInfoModal.jsx
@@ -26,7 +26,7 @@ export default function SingleSignOnInfoModal({
       <ul>
         <li>
           {`Track and manage your VA ${
-            useSSOeEbenefitsLinks ? 'benefits and' : ''
+            useSSOeEbenefitsLinks ? 'benefits and ' : ''
           }services with just one username
           and password`}
         </li>

--- a/src/platform/site-wide/announcements/containers/Announcement.jsx
+++ b/src/platform/site-wide/announcements/containers/Announcement.jsx
@@ -3,7 +3,10 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 
-import { ssoe } from 'platform/user/authentication/selectors';
+import {
+  ssoe,
+  ssoeEbenefitsLinks,
+} from 'platform/user/authentication/selectors';
 // Relative imports.
 import { isLoggedIn, selectProfile } from '../../../user/selectors';
 import { selectAnnouncement } from '../selectors';
@@ -67,6 +70,7 @@ export class Announcement extends Component {
         dismiss={dismiss}
         isLoggedIn={this.props.isLoggedIn}
         useSSOe={this.props.useSSOe}
+        useSSOeEbenefitsLinks={this.props.useSSOeEbenefitsLinks}
         profile={profile}
       />
     );
@@ -78,6 +82,7 @@ const mapStateToProps = state => ({
   isLoggedIn: isLoggedIn(state),
   profile: selectProfile(state),
   useSSOe: ssoe(state),
+  useSSOeEbenefitsLinks: ssoeEbenefitsLinks(state),
   ...state.announcements,
 });
 

--- a/src/platform/site-wide/announcements/sass/style.scss
+++ b/src/platform/site-wide/announcements/sass/style.scss
@@ -1,4 +1,9 @@
-@import "~@department-of-veterans-affairs/formation/sass/shared-variables";
+@import '~@department-of-veterans-affairs/formation/sass/shared-variables';
+
+#modal-announcement .va-modal-inner {
+  max-height: 100vh;
+  overflow-y: scroll;
+}
 
 #modal-announcement h3 {
   margin-top: 1.5em;


### PR DESCRIPTION
## Description
closes department-of-veterans-affairs/va.gov-team#7813

When zoom sizes increase the announcement modal to a height larger than the viewport, it cuts off the headline. This fix makes sure the top of the viewport is showing the top of the modal, and any overflow is still scroll-able.



## Testing done
Manual verification w/ various zoom settings

## Screenshots

Example of one of the problem settings (250% zoom, width > 1200px), now fixed
![Screen Shot 2020-05-19 at 7 07 38 PM](https://user-images.githubusercontent.com/13280995/82390395-35b7b500-9a04-11ea-83ec-28188010b938.png)

## Acceptance criteria
- [x] Entire announcement modal is visible and/or scroll-able, regardless of browser's zoom percentage

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
