### PR TITLE
update logic for blocking users from Direct Deposit

### DIFF
--- a/src/applications/personalization/profile360/selectors.js
+++ b/src/applications/personalization/profile360/selectors.js
@@ -29,8 +29,11 @@ export const directDepositAddressIsSetUp = state => {
 };
 
 export const directDepositIsBlocked = state => {
-  const controlInfo = directDepositInformation(state)?.responses?.[0]
-    ?.controlInformation;
-  if (!controlInfo) return false;
-  return controlInfo.canUpdateAddress !== true;
+  const controlInfo =
+    directDepositInformation(state)?.responses?.[0]?.controlInformation || {};
+  return (
+    !controlInfo.isCompetentIndicator ||
+    !controlInfo.noFiduciaryAssignedIndicator ||
+    !controlInfo.notDeceasedIndicator
+  );
 };

--- a/src/applications/personalization/profile360/tests/selectors.unit.spec.js
+++ b/src/applications/personalization/profile360/tests/selectors.unit.spec.js
@@ -118,20 +118,16 @@ describe('profile360 selectors', () => {
   });
 
   describe('directDepositIsBlocked', () => {
-    it('returns `false` if the `paymentInformation` is not set`', () => {
-      const state = {
-        vaProfile: {},
-      };
-      expect(selectors.directDepositIsBlocked(state)).to.be.false;
-    });
-    it('returns `false` if the `canUpdateAddress` flag is `true`', () => {
+    it('returns `false` if the isCompetentIndicator, noFiduciaryAssignedIndicator, and notDeceasedIndicator flags are all `true`', () => {
       const state = {
         vaProfile: {
           paymentInformation: {
             responses: [
               {
                 controlInformation: {
-                  canUpdateAddress: true,
+                  isCompetentIndicator: true,
+                  noFiduciaryAssignedIndicator: true,
+                  notDeceasedIndicator: true,
                 },
               },
             ],
@@ -140,14 +136,58 @@ describe('profile360 selectors', () => {
       };
       expect(selectors.directDepositIsBlocked(state)).to.be.false;
     });
-    it('returns `true` if the `canUpdateAddress` flag is not `true`', () => {
+    it('returns `true` if the control information is not set', () => {
+      const state = {
+        vaProfile: {
+          paymentInformation: {
+            responses: [{ paymentInformation: {} }],
+          },
+        },
+      };
+      expect(selectors.directDepositIsBlocked(state)).to.be.true;
+    });
+    it('returns `true` if the `isCompetentIndicator` is not true', () => {
       const state = {
         vaProfile: {
           paymentInformation: {
             responses: [
               {
                 controlInformation: {
-                  canUpdateAddress: null,
+                  isCompetentIndicator: null,
+                  noFiduciaryAssignedIndicator: true,
+                },
+              },
+            ],
+          },
+        },
+      };
+      expect(selectors.directDepositIsBlocked(state)).to.be.true;
+    });
+    it('returns `true` if the `noFiduciaryAssignedIndicator` is not true', () => {
+      const state = {
+        vaProfile: {
+          paymentInformation: {
+            responses: [
+              {
+                controlInformation: {
+                  isCompetentIndicator: true,
+                },
+              },
+            ],
+          },
+        },
+      };
+      expect(selectors.directDepositIsBlocked(state)).to.be.true;
+    });
+    it('returns `true` if the `notDeceasedIndicator` is not true', () => {
+      const state = {
+        vaProfile: {
+          paymentInformation: {
+            responses: [
+              {
+                controlInformation: {
+                  isCompetentIndicator: true,
+                  noFiduciaryAssignedIndicator: true,
                 },
               },
             ],


### PR DESCRIPTION
## Description
We had apparently been looking at the wrong flag to determine if we should block Vets from the Direct Deposit feature on the Profile. It's likely we have been showing a lot of GIB recipients that they were not allowed access to the Direct Deposit feature :-/

## Testing done
Local + updated unit tests

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs