### PR TITLE
do not show DD BLOCKED alert until API response has resolved

### DIFF
--- a/src/applications/personalization/profile360/selectors.js
+++ b/src/applications/personalization/profile360/selectors.js
@@ -29,8 +29,9 @@ export const directDepositAddressIsSetUp = state => {
 };
 
 export const directDepositIsBlocked = state => {
-  const controlInfo =
-    directDepositInformation(state)?.responses?.[0]?.controlInformation || {};
+  const controlInfo = directDepositInformation(state)?.responses?.[0]
+    ?.controlInformation;
+  if (!controlInfo) return false;
   return (
     !controlInfo.isCompetentIndicator ||
     !controlInfo.noFiduciaryAssignedIndicator ||

--- a/src/applications/personalization/profile360/tests/selectors.unit.spec.js
+++ b/src/applications/personalization/profile360/tests/selectors.unit.spec.js
@@ -136,7 +136,7 @@ describe('profile360 selectors', () => {
       };
       expect(selectors.directDepositIsBlocked(state)).to.be.false;
     });
-    it('returns `true` if the control information is not set', () => {
+    it('returns `false` if the control information is not set', () => {
       const state = {
         vaProfile: {
           paymentInformation: {
@@ -144,7 +144,7 @@ describe('profile360 selectors', () => {
           },
         },
       };
-      expect(selectors.directDepositIsBlocked(state)).to.be.true;
+      expect(selectors.directDepositIsBlocked(state)).to.be.false;
     });
     it('returns `true` if the `isCompetentIndicator` is not true', () => {
       const state = {


### PR DESCRIPTION
## Description
This fixes an issue where an alert was always being shown at the top of the profile because the data we needed to decide whether to show it had not yet been loaded yet :-/

## Testing done
Local. Confirmed that the alert does not show while the Profile is still loading.

## Screenshots
N/A

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs