### PR TITLE
Update profile header styles

### DIFF
--- a/src/applications/personalization/profile-2/components/ProfileHeader.jsx
+++ b/src/applications/personalization/profile-2/components/ProfileHeader.jsx
@@ -39,12 +39,9 @@ const ProfileHeader = ({
     'medium',
   );
 
-  const serviceBadgeClasses = prefixUtilityClasses([
-    'text-align--center',
-    'margin-bottom--2',
-  ]);
+  const serviceBadgeClasses = prefixUtilityClasses(['display--none']);
   const serviceBadgeClassesMedium = prefixUtilityClasses(
-    ['text-align--right', 'margin-bottom--0', 'padding-right--2'],
+    ['display--flex', 'justify-content--flex-end', 'margin-bottom--0'],
     'medium',
   );
 
@@ -113,14 +110,13 @@ const ProfileHeader = ({
             <img
               src={SERVICE_BADGE_IMAGE_PATHS.get(latestBranchOfService)}
               alt={`${latestBranchOfService} seal`}
-              className="profile-service-badge"
+              className="profile-service-badge vads-u-padding-right--1"
               aria-hidden="true"
               role="presentation"
             />
           )}
         </div>
         <div className="name-and-title-wrapper">
-          <h1 className={classes.title}>Your Profile</h1>
           <dl className="vads-u-margin-y--0">
             <dt className="sr-only">Name: </dt>
             <dd className={classes.fullName}>{fullName}</dd>

--- a/src/applications/personalization/profile-2/components/ProfileHeader.jsx
+++ b/src/applications/personalization/profile-2/components/ProfileHeader.jsx
@@ -22,7 +22,7 @@ const ProfileHeader = ({
     'padding-y--2',
   ]);
   const wrapperClassesMedium = prefixUtilityClasses(
-    ['padding-y--3', 'margin-bottom--2'],
+    ['padding-y--2p5', 'margin-bottom--2'],
     'medium',
   );
 
@@ -90,11 +90,9 @@ const ProfileHeader = ({
       'usa-grid',
       'usa-grid-full',
     ].join(' '),
-    serviceBadge: [
-      ...serviceBadgeClasses,
-      ...serviceBadgeClassesMedium,
-      'usa-width-one-fourth',
-    ].join(' '),
+    serviceBadge: [...serviceBadgeClasses, ...serviceBadgeClassesMedium].join(
+      ' ',
+    ),
     title: [...titleClasses, ...titleClassesMedium].join(' '),
     fullName: [...fullNameClasses, ...fullNameClassesMedium].join(' '),
     latestBranch: [...latestBranchClasses, ...latestBranchClassesMedium].join(
@@ -110,7 +108,7 @@ const ProfileHeader = ({
             <img
               src={SERVICE_BADGE_IMAGE_PATHS.get(latestBranchOfService)}
               alt={`${latestBranchOfService} seal`}
-              className="profile-service-badge vads-u-padding-right--1"
+              className="profile-service-badge vads-u-padding-right--3"
               aria-hidden="true"
               role="presentation"
             />

--- a/src/applications/personalization/profile-2/components/ProfileSideNav.jsx
+++ b/src/applications/personalization/profile-2/components/ProfileSideNav.jsx
@@ -83,7 +83,7 @@ const ProfileSideNav = ({ closeSideNav, isSideNavOpen, isLOA3 }) => {
             closeSideNav(true);
           }}
         />
-        <h2 className="vads-u-font-size--h4">Profile</h2>
+        <h1 className="vads-u-font-size--h4">Your Profile</h1>
         <ul>
           {routes.map(route => {
             // Do not render route if it is not isLOA3

--- a/src/applications/personalization/profile-2/sass/profile-2.scss
+++ b/src/applications/personalization/profile-2/sass/profile-2.scss
@@ -5,7 +5,7 @@
 @import "./mobile-sidenav-trigger";
 
 .profile-service-badge {
-  max-height: 108px;
+  max-height: 75px;
 }
 
 [tabindex="-1"]:focus {


### PR DESCRIPTION
[TICKET](https://github.com/department-of-veterans-affairs/va.gov-team/issues/9059)

## Description
We want to remove 'Your profile' from both mobile and desktop, and remove the badge on mobile. On Desktop we decided to make the badge smaller, 75px.

We add the h1 to the 'Your Profile' text in the side nav.

## Testing done
Works locally

## Screenshots
![image](https://user-images.githubusercontent.com/14869324/82689102-32e0de00-9c17-11ea-856f-183579bdb68a.png)
![image](https://user-images.githubusercontent.com/14869324/82689135-3e340980-9c17-11ea-9211-2970a423e0e8.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
