### PR TITLE
Cypress Tab Plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -151,6 +151,7 @@
     "css-loader": "^0.28.10",
     "cypress": "^4.5.0",
     "cypress-axe": "^0.8.1",
+    "cypress-plugin-tab": "^1.0.5",
     "decompress": "^4.2.0",
     "enhanced-resolve": "^0.7.6",
     "enzyme": "^3.11.0",

--- a/src/platform/testing/e2e/cypress/support/index.js
+++ b/src/platform/testing/e2e/cypress/support/index.js
@@ -1,5 +1,6 @@
 import '@testing-library/cypress/add-commands';
 import 'cypress-axe';
+import 'cypress-plugin-tab';
 
 import './commands';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1915,6 +1915,14 @@ align-text@^0.1.1, align-text@^0.1.3:
     longest "^1.0.1"
     repeat-string "^1.5.2"
 
+ally.js@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/ally.js/-/ally.js-1.4.1.tgz#9fb7e6ba58efac4ee9131cb29aa9ee3b540bcf1e"
+  integrity sha1-n7fmuljvrE7pExyymqnuO1QLzx4=
+  dependencies:
+    css.escape "^1.5.0"
+    platform "1.3.3"
+
 alphanum-sort@^1.0.1, alphanum-sort@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/alphanum-sort/-/alphanum-sort-1.0.2.tgz#97a1119649b211ad33691d9f9f486a8ec9fbe0a3"
@@ -4602,6 +4610,11 @@ css-what@2.1:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-2.1.0.tgz#9467d032c38cfaefb9f2d79501253062f87fa1bd"
 
+css.escape@^1.5.0:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/css.escape/-/css.escape-1.5.1.tgz#42e27d4fa04ae32f931a4b4d4191fa9cddee97cb"
+  integrity sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s=
+
 cssesc@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/cssesc/-/cssesc-0.1.0.tgz#c814903e45623371a0477b40109aaafbeeaddbb4"
@@ -4685,6 +4698,13 @@ cypress-axe@^0.8.1:
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/cypress-axe/-/cypress-axe-0.8.1.tgz#ddb37dca6570c0642dda2388daf678e83b3e8d3f"
   integrity sha512-hX48+r5n7Ns7CHkn601Ag0JiCG1vby5+g7QhlP8X+mkiVYpTLpXAPiiaKFj9QTTCdZSI5+0UqwIxA+ShTsr5tA==
+
+cypress-plugin-tab@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/cypress-plugin-tab/-/cypress-plugin-tab-1.0.5.tgz#a40714148104004bb05ed62b1bf46bb544f8eb4a"
+  integrity sha512-QtTJcifOVwwbeMP3hsOzQOKf3EqKsLyjtg9ZAGlYDntrCRXrsQhe4ZQGIthRMRLKpnP6/tTk6G0gJ2sZUfRliQ==
+  dependencies:
+    ally.js "^1.4.1"
 
 cypress@*, cypress@^4.5.0:
   version "4.5.0"
@@ -12528,6 +12548,11 @@ pkg-up@^2.0.0:
   resolved "https://registry.yarnpkg.com/pkg-up/-/pkg-up-2.0.0.tgz#c819ac728059a461cab1c3889a2be3c49a004d7f"
   dependencies:
     find-up "^2.1.0"
+
+platform@1.3.3:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/platform/-/platform-1.3.3.tgz#646c77011899870b6a0903e75e997e8e51da7461"
+  integrity sha1-ZGx3ARiZhwtqCQPnXpl+jlHadGE=
 
 pluralize@^1.2.1:
   version "1.2.1"


### PR DESCRIPTION
## Description
Currently Cypress does not natively [support](https://github.com/cypress-io/cypress/issues/299) the `tab` key. There is [work in progress](https://github.com/cypress-io/cypress/issues/311) for adding this, but in the meantime the `cypress-plugin-tab` [command](https://github.com/Bkucera/cypress-plugin-tab) solves this problem.

## Testing done
Verified cypress still works.

## Screenshots


## Acceptance criteria
- [ ] The `cypress-plugin-tab` is installed.
- [ ] The `cypress-plugin-tab` is imported in `src/platform/testing/e2e/cypress/support/index.js`.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
