### PR TITLE
Feature/9209 covid screener analytics

### DIFF
--- a/src/applications/coronavirus-screener/components/FormQuestion.jsx
+++ b/src/applications/coronavirus-screener/components/FormQuestion.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import recordEvent from 'platform/monitoring/record-event';
+import _ from 'lodash/fp';
 
 export default function FormQuestion({
   question,
@@ -8,10 +9,12 @@ export default function FormQuestion({
   scrollNext,
 }) {
   function handleChange(event) {
-    recordEvent({
-      event: 'covid-screening-tool-button-click',
-      'screening-tool-question': question.id,
-    });
+    if (_.isEmpty(formState)) {
+      recordEvent({
+        event: 'covid-screening-tool-button-click',
+        'screening-tool-question': question.id,
+      });
+    }
     // sets the current question value in form state
     setFormState({
       ...formState,

--- a/src/applications/coronavirus-screener/components/FormQuestion.jsx
+++ b/src/applications/coronavirus-screener/components/FormQuestion.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import recordEvent from 'platform/monitoring/record-event';
 
 export default function FormQuestion({
   question,
@@ -7,6 +8,10 @@ export default function FormQuestion({
   scrollNext,
 }) {
   function handleChange(event) {
+    recordEvent({
+      event: 'covid-screening-tool-button-click',
+      'screening-tool-question': question.id,
+    });
     // sets the current question value in form state
     setFormState({
       ...formState,

--- a/src/applications/coronavirus-screener/components/FormQuestion.jsx
+++ b/src/applications/coronavirus-screener/components/FormQuestion.jsx
@@ -11,7 +11,7 @@ export default function FormQuestion({
   function handleChange(event) {
     if (_.isEmpty(formState)) {
       recordEvent({
-        event: 'covid-screening-tool-button-click',
+        event: 'covid-screening-tool-start',
         'screening-tool-question': question.id,
       });
     }

--- a/src/applications/coronavirus-screener/components/FormResult.jsx
+++ b/src/applications/coronavirus-screener/components/FormResult.jsx
@@ -6,6 +6,7 @@ import recordEvent from 'platform/monitoring/record-event';
 
 export default function FormResult({ formState }) {
   let result;
+  const [resultSubmitted, setResultSubmittedState] = React.useState(false);
 
   const incomplete = <div>Please answer all the questions above.</div>;
 
@@ -36,10 +37,13 @@ export default function FormResult({ formState }) {
   );
 
   function recordScreeningToolEvent(screeningToolResult) {
-    recordEvent({
-      event: 'covid-screening-tool-result-displayed',
-      'screening-tool-result': screeningToolResult,
-    });
+    if (!resultSubmitted) {
+      recordEvent({
+        event: 'covid-screening-tool-result-displayed',
+        'screening-tool-result': screeningToolResult,
+      });
+      setResultSubmittedState(true);
+    }
   }
   if (Object.values(formState).length < questions.length) {
     result = incomplete;

--- a/src/applications/coronavirus-screener/components/FormResult.jsx
+++ b/src/applications/coronavirus-screener/components/FormResult.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { questions } from '../config/questions';
 import { Element } from 'react-scroll';
 import moment from 'moment';
+import recordEvent from 'platform/monitoring/record-event';
 
 export default function FormResult({ formState }) {
   let result;
@@ -34,12 +35,20 @@ export default function FormResult({ formState }) {
     </div>
   );
 
+  function recordScreeningToolEvent(screeningToolResult) {
+    recordEvent({
+      event: 'covid-screening-tool-result-displayed',
+      'screening-tool-result': screeningToolResult,
+    });
+  }
   if (Object.values(formState).length < questions.length) {
     result = incomplete;
   } else if (Object.values(formState).includes('yes')) {
     result = fail;
+    recordScreeningToolEvent('More screening needed');
   } else {
     result = pass;
+    recordScreeningToolEvent('Pass');
   }
 
   return (


### PR DESCRIPTION
## Description
Add initial GA events for start and complete

## Testing done


## Screenshots


## Acceptance criteria
- [x] start event is sent correctly
- [x] finish event is sent correctly 
- [x] finish event includes 'More Screening' results

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
