### PR TITLE
Sanlouise profile wrapper fix

### DIFF
--- a/src/applications/personalization/profiles-wrapper/ProfilesWrapper.jsx
+++ b/src/applications/personalization/profiles-wrapper/ProfilesWrapper.jsx
@@ -16,25 +16,15 @@ import { selectShowProfile2 } from 'applications/personalization/profile-2/selec
 
 const LoadingPage = <Profile2Wrapper>Loading...</Profile2Wrapper>;
 
-const ProfilesWrapper = ({ showProfile1, isLOA1, isLOA3, isInMVI }) => {
-  // On initial render, both isLOA props are false.
-  // We need to make sure the proper redirect is hit,
-  // so we show a loading state till one value is true.
-  if (!isLOA1 && !isLOA3) {
-    return (
-      <BrowserRouter>
-        <Suspense fallback={LoadingPage}>
-          <Profile2Wrapper />
-        </Suspense>
-      </BrowserRouter>
-    );
-  }
-
-  if (showProfile1) {
-    return <ProfileOneWrapper />;
-  }
-
-  return (
+const ProfilesWrapper = ({
+  FFProfile2,
+  isLOA1,
+  isLOA3,
+  isInMVI,
+  localStorageProfile1,
+  localStorageProfile2,
+}) => {
+  const profile2 = (
     <BrowserRouter>
       <Suspense fallback={LoadingPage}>
         <Switch>
@@ -75,6 +65,39 @@ const ProfilesWrapper = ({ showProfile1, isLOA1, isLOA3, isInMVI }) => {
       </Suspense>
     </BrowserRouter>
   );
+
+  // On initial render, both isLOA props are false.
+  // We need to make sure the proper redirect is hit,
+  // so we show a loading state till one value is true.
+  if (!isLOA1 && !isLOA3) {
+    return (
+      <BrowserRouter>
+        <Suspense fallback={LoadingPage}>
+          <Profile2Wrapper />
+        </Suspense>
+      </BrowserRouter>
+    );
+  }
+
+  // Feature flag is turned off, but localStorage value PROFILE_VERSION is set to 2
+  if (!FFProfile2 && localStorageProfile2) {
+    return profile2;
+  }
+
+  // Feature flag is turned on, and localStorage value PROFILE_VERSION is not set to 1
+  if (FFProfile2 && !localStorageProfile1) {
+    return profile2;
+  }
+
+  // Feature flag is turned off, and localStorage value PROFILE_VERSION is not set to 2
+  if (!FFProfile2 && !localStorageProfile2) {
+    return <ProfileOneWrapper />;
+  }
+
+  // Feature flag is turned on, and localStorage value PROFILE_VERSION is set to 1
+  if (FFProfile2 && localStorageProfile1) {
+    return <ProfileOneWrapper />;
+  }
 };
 
 const mapStateToProps = state => {
@@ -84,7 +107,9 @@ const mapStateToProps = state => {
     isLOA1: isLOA1Selector(state),
     isLOA3: isLOA3Selector(state),
     isInMVI: isInMVISelector(state),
-    showProfile1: !selectShowProfile2(state) || profileVersion === '1',
+    localStorageProfile1: profileVersion === '1',
+    localStorageProfile2: profileVersion === '2',
+    FFProfile2: selectShowProfile2(state),
   };
 };
 

--- a/src/applications/personalization/profiles-wrapper/ProfilesWrapper.jsx
+++ b/src/applications/personalization/profiles-wrapper/ProfilesWrapper.jsx
@@ -24,48 +24,6 @@ const ProfilesWrapper = ({
   localStorageProfile1,
   localStorageProfile2,
 }) => {
-  const profile2 = (
-    <BrowserRouter>
-      <Suspense fallback={LoadingPage}>
-        <Switch>
-          {routes.map(route => {
-            if ((route.requiresLOA3 && !isLOA3) || !isInMVI) {
-              return (
-                <Redirect
-                  from={route.path}
-                  key="/profile/account-security"
-                  to="/profile/account-security"
-                />
-              );
-            }
-
-            const Component = route.component;
-
-            return (
-              <Route
-                component={props => (
-                  <Profile2Wrapper {...props}>
-                    <Component />
-                  </Profile2Wrapper>
-                )}
-                exact
-                key={route.path}
-                path={route.path}
-              />
-            );
-          })}
-
-          <Redirect
-            exact
-            from="/profile"
-            key="/profile/personal-information"
-            to="/profile/personal-information"
-          />
-        </Switch>
-      </Suspense>
-    </BrowserRouter>
-  );
-
   // On initial render, both isLOA props are false.
   // We need to make sure the proper redirect is hit,
   // so we show a loading state till one value is true.
@@ -79,24 +37,64 @@ const ProfilesWrapper = ({
     );
   }
 
-  // Feature flag is turned off, but localStorage value PROFILE_VERSION is set to 2
-  if (!FFProfile2 && localStorageProfile2) {
-    return profile2;
-  }
-
-  // Feature flag is turned on, and localStorage value PROFILE_VERSION is not set to 1
-  if (FFProfile2 && !localStorageProfile1) {
-    return profile2;
-  }
-
-  // Feature flag is turned off, and localStorage value PROFILE_VERSION is not set to 2
-  if (!FFProfile2 && !localStorageProfile2) {
-    return <ProfileOneWrapper />;
-  }
-
+  // Feature flag is turned off, and localStorage value PROFILE_VERSION is not set to 2 OR
   // Feature flag is turned on, and localStorage value PROFILE_VERSION is set to 1
-  if (FFProfile2 && localStorageProfile1) {
+  const showProfile1 =
+    (!FFProfile2 && !localStorageProfile2) ||
+    (FFProfile2 && localStorageProfile1);
+
+  // Feature flag is turned off, but localStorage value PROFILE_VERSION is set to 2 OR
+  // Feature flag is turned on, and localStorage value PROFILE_VERSION is not set to 1
+  const showProfile2 =
+    (!FFProfile2 && localStorageProfile2) ||
+    (FFProfile2 && !localStorageProfile1);
+
+  if (showProfile1) {
     return <ProfileOneWrapper />;
+  }
+
+  if (showProfile2) {
+    return (
+      <BrowserRouter>
+        <Suspense fallback={LoadingPage}>
+          <Switch>
+            {routes.map(route => {
+              if ((route.requiresLOA3 && !isLOA3) || !isInMVI) {
+                return (
+                  <Redirect
+                    from={route.path}
+                    key="/profile/account-security"
+                    to="/profile/account-security"
+                  />
+                );
+              }
+
+              const Component = route.component;
+
+              return (
+                <Route
+                  component={props => (
+                    <Profile2Wrapper {...props}>
+                      <Component />
+                    </Profile2Wrapper>
+                  )}
+                  exact
+                  key={route.path}
+                  path={route.path}
+                />
+              );
+            })}
+
+            <Redirect
+              exact
+              from="/profile"
+              key="/profile/personal-information"
+              to="/profile/personal-information"
+            />
+          </Switch>
+        </Suspense>
+      </BrowserRouter>
+    );
   }
 };
 


### PR DESCRIPTION
## Description
Update logic to show profile 2 when the feature flag is set to false.

Current logic:

**Show profile 1 when:**

1. Feature flag of Profile 2 is turned off, and localStorage value PROFILE_VERSION is not set to 2 OR
2. Feature flag of Profile 2 is turned on, and localStorage value PROFILE_VERSION is set to 1

**Show profile 2 when:**

1. Feature flag of Profile 2 is turned off, but localStorage value PROFILE_VERSION is set to 2 OR
2. Feature flag of Profile 2 is turned on, and localStorage value PROFILE_VERSION is not set to 1

## Testing done
Works locally

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
