### PR TITLE
CT: "School Locations" accordion is taller than the others. #9411

### DIFF
--- a/src/applications/gi/components/profile/InstitutionProfile.jsx
+++ b/src/applications/gi/components/profile/InstitutionProfile.jsx
@@ -67,10 +67,7 @@ export class InstitutionProfile extends React.Component {
               </AccordionItem>
             )}
             {this.shouldShowSchoolLocations(profile.attributes.facilityMap) && (
-              <AccordionItem
-                button="School locations"
-                headerClass="school-locations"
-              >
+              <AccordionItem button="School locations">
                 <SchoolLocations
                   institution={profile.attributes}
                   facilityMap={profile.attributes.facilityMap}


### PR DESCRIPTION
## Description
https://github.com/department-of-veterans-affairs/va.gov-team/issues/9411
CSS class being removed was doing `padding-bottom: 1rem;` on the `h2` around the button that collapses/expands the accordion.

## Testing done


## Screenshots
![Screen Shot 2020-05-21 at 11 56 14 AM](https://user-images.githubusercontent.com/1094999/82578238-22b6f900-9b5a-11ea-9eb2-93bb3a38e27c.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
