### PR TITLE
VAVFS-9406: Fixing broken banner frequency check.

### DIFF
--- a/src/applications/static-pages/alerts-dismiss-view.js
+++ b/src/applications/static-pages/alerts-dismiss-view.js
@@ -56,7 +56,7 @@ export function alertsBuildShow() {
     date = new Date();
     date.setTime(date.getTime() + 3650 * 24 * 60 * 60 * 1000);
     expires = `expires=${date.toUTCString()}`;
-    if (frequency === 'once') {
+    if (frequency === 'always') {
       expires = '';
     }
     document.getElementById(target).classList.add('dismissed');

--- a/src/site/includes/alerts.drupal.liquid
+++ b/src/site/includes/alerts.drupal.liquid
@@ -26,7 +26,6 @@ If we have a hit, show the alert.
     <div data-template="includes/alerts" data-entity-id="{{ entity.id }}"
       aria-labelledby="usa-alert-heading-{{ entity.id }}" class="usa-alert-full-width dismissable-option-header usa-alert-full-width-{{ entity.fieldAlertType }}" id="usa-alert-full-width-{{ entity.id }}" role="region">
       <div aria-live="assertive" class="usa-alert usa-alert-{{ entity.fieldAlertType }}" id="usa-alert-{{ entity.id }}" role="alert">
-
         {% if entity.fieldAlertDismissable == true %}
         <button id="usa-alert-dismiss-{{ entity.id }}" class="va-alert-close usa-alert-dismiss" data-parentwrap="usa-alert-full-width-{{ entity.id }}" data-frequency="{{ entity.fieldAlertFrequency }}" aria-label="Close notification">
           <i aria-label="Close icon" class="fas fa-times-circle"></i>


### PR DESCRIPTION
## Description
Session only dismissable Banner is being dismissed, but not reappearing in new session.

## Testing done
Visual

## Screenshots
![image](https://user-images.githubusercontent.com/2404547/82579439-cead1400-9b5b-11ea-89e8-e72f9f7519e9.png)

## Acceptance criteria
- [ ] After dismissing covid banner on `health-care/how-to-apply/`, it should appear again when viewing the page in a new browser session

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
