### PR TITLE
Remove yellow ribbon content update prod flag

### DIFF
--- a/src/applications/gi/containers/Modals.jsx
+++ b/src/applications/gi/containers/Modals.jsx
@@ -239,60 +239,12 @@ export class Modals extends React.Component {
         </p>
       </Modal>
 
-      {/* prod flag for 8524 */}
-      {environment.isProduction() && (
-        <Modal
-          onClose={this.props.hideModal}
-          visible={this.shouldDisplayModal('yribbon')}
-        >
-          <h3>Yellow Ribbon</h3>
-          <p>
-            The{' '}
-            <a
-              title="Post-9/11 GI Bill"
-              href="http://www.benefits.va.gov/gibill/post911_gibill.asp"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              Post-9/11 GI Bill
-            </a>{' '}
-            can cover all in-state tuition and fees at public degree granting
-            schools, but may not cover all private degree granting schools and
-            out-of-state tuition. The Yellow Ribbon Program provides additional
-            support in those situations. Institutions voluntarily enter into an
-            agreement with VA to fund uncovered charges. VA matches each dollar
-            of unmet charges the institution agrees to contribute, up to the
-            total cost of the tuition and fees.{' '}
-            <a
-              title="Click here for FAQs about the Yellow Ribbon Program"
-              href="http://www.benefits.va.gov/gibill/docs/factsheets/2012_Yellow_Ribbon_Student_FAQs.pdf"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              Click here for FAQs about the Yellow Ribbon Program
-            </a>
-          </p>
-          <p>
-            Veterans and Fry Scholarship and Purple Heart recipients are
-            entitled to the maximum benefit rate or their designated transferees
-            can receive this funding. Active-duty service members and their
-            spouses aren’t eligible for this program (child transferees of
-            active-duty service members may be eligible if the service member is
-            qualified at the 100% rate). This information will be updated
-            quarterly.
-          </p>
-        </Modal>
-      )}
-
-      {/* prod flag for 8524 */}
-      {!environment.isProduction() && (
-        <Modal
-          onClose={this.props.hideModal}
-          visible={this.shouldDisplayModal('yribbon')}
-        >
-          <YellowRibbonModalContent />
-        </Modal>
-      )}
+      <Modal
+        onClose={this.props.hideModal}
+        visible={this.shouldDisplayModal('yribbon')}
+      >
+        <YellowRibbonModalContent />
+      </Modal>
 
       <Modal
         onClose={this.props.hideModal}
@@ -918,53 +870,12 @@ export class Modals extends React.Component {
           </p>
         </Modal>
 
-        {/* prod flag for 8524 */}
-        {environment.isProduction() && (
-          <Modal
-            onClose={this.props.hideModal}
-            visible={this.shouldDisplayModal('calcYr')}
-          >
-            <h3>Yellow Ribbon</h3>
-            <p>
-              The Post-9/11 GI Bill can cover all in-state tuition and fees at
-              public degree granting schools, but may not cover all private
-              degree granting schools and out-of-state tuition. The Yellow
-              Ribbon Program provides additional support in those situations.
-              Institutions voluntarily enter into an agreement with VA to fund
-              uncovered charges. VA matches each dollar of unmet charges that
-              the institution agrees to contribute, up to the total cost of the
-              tuition and fees. For Frequently Asked Questions about the Yellow
-              Ribbon Program, visit{' '}
-              <a
-                title="Click here for FAQs about the Yellow Ribbon Program"
-                href="http://www.benefits.va.gov/gibill/docs/factsheets/2012_Yellow_Ribbon_Student_FAQs.pdf"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                this page.
-              </a>
-            </p>
-            <p>
-              Veterans and Fry Scholarship and Purple Heart recipients are
-              entitled to the maximum benefit rate or their designated
-              transferees can receive this funding. Active-duty service members
-              and their spouses are not eligible for this program (child
-              transferees of active-duty service members may be eligible if the
-              service member is qualified at the 100% rate). This information
-              will be updated quarterly.
-            </p>
-          </Modal>
-        )}
-
-        {/* prod flag for 8524 */}
-        {!environment.isProduction() && (
-          <Modal
-            onClose={this.props.hideModal}
-            visible={this.shouldDisplayModal('calcYr')}
-          >
-            <YellowRibbonModalContent />
-          </Modal>
-        )}
+        <Modal
+          onClose={this.props.hideModal}
+          visible={this.shouldDisplayModal('calcYr')}
+        >
+          <YellowRibbonModalContent />
+        </Modal>
 
         <Modal
           onClose={this.props.hideModal}


### PR DESCRIPTION
## Description
Remove prod flags around updated yellow flag ribbon modal content

[ZenHub Issue #9401](https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/9401)

## Testing done
Tested locally and QA reviewed

## Screenshots
![image](https://user-images.githubusercontent.com/41960449/82590878-729ebb80-9b6c-11ea-82f7-58871272f249.png)

## Acceptance criteria
- [x] The work completed in [8524](https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/8524) is available in the production environment.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
