### PR TITLE
Add YR redirects

### DIFF
--- a/src/applications/proxy-rewrite/redirects/crossDomainRedirects.json
+++ b/src/applications/proxy-rewrite/redirects/crossDomainRedirects.json
@@ -301,11 +301,6 @@
   },
   {
     "domain": "www.benefits.va.gov",
-    "src": "/gibill/yellow_ribbon/yrp_list_2019.asp",
-    "dest": "/education/about-gi-bill-benefits/post-9-11/yellow-ribbon-program/#does-my-school-participate-in-"
-  },
-  {
-    "domain": "www.benefits.va.gov",
     "src": "/insurance/disabledvet.asp",
     "dest": "/life-insurance/options-eligibility/"
   },

--- a/src/applications/proxy-rewrite/redirects/crossDomainRedirects.json
+++ b/src/applications/proxy-rewrite/redirects/crossDomainRedirects.json
@@ -723,5 +723,275 @@
     "domain": "www.benefits.va.gov",
     "src": "/gibill/fgib/vettec_veteran.asp",
     "dest": "/education/about-gi-bill-benefits/how-to-use-benefits/vettec-high-tech-program/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/gibill/yellow_ribbon/yrp_list_2019.asp",
+    "dest": "/education/yellow-ribbon-participating-schools/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/gibill/yellow_ribbon/2019/states/ak.asp",
+    "dest": "/education/yellow-ribbon-participating-schools/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/gibill/yellow_ribbon/2019/states/al.asp",
+    "dest": "/education/yellow-ribbon-participating-schools/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/gibill/yellow_ribbon/2019/states/ar.asp",
+    "dest": "/education/yellow-ribbon-participating-schools/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/gibill/yellow_ribbon/2019/states/az.asp",
+    "dest": "/education/yellow-ribbon-participating-schools/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/gibill/yellow_ribbon/2019/states/ca.asp",
+    "dest": "/education/yellow-ribbon-participating-schools/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/gibill/yellow_ribbon/2019/states/co.asp",
+    "dest": "/education/yellow-ribbon-participating-schools/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/gibill/yellow_ribbon/2019/states/ct.asp",
+    "dest": "/education/yellow-ribbon-participating-schools/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/gibill/yellow_ribbon/2019/states/dc.asp",
+    "dest": "/education/yellow-ribbon-participating-schools/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/gibill/yellow_ribbon/2019/states/de.asp",
+    "dest": "/education/yellow-ribbon-participating-schools/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/gibill/yellow_ribbon/2019/states/fl.asp",
+    "dest": "/education/yellow-ribbon-participating-schools/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/gibill/yellow_ribbon/2019/states/ga.asp",
+    "dest": "/education/yellow-ribbon-participating-schools/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/gibill/yellow_ribbon/2019/states/hi.asp",
+    "dest": "/education/yellow-ribbon-participating-schools/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/gibill/yellow_ribbon/2019/states/ia.asp",
+    "dest": "/education/yellow-ribbon-participating-schools/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/gibill/yellow_ribbon/2019/states/id.asp",
+    "dest": "/education/yellow-ribbon-participating-schools/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/gibill/yellow_ribbon/2019/states/il.asp",
+    "dest": "/education/yellow-ribbon-participating-schools/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/gibill/yellow_ribbon/2019/states/in.asp",
+    "dest": "/education/yellow-ribbon-participating-schools/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/gibill/yellow_ribbon/2019/states/ks.asp",
+    "dest": "/education/yellow-ribbon-participating-schools/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/gibill/yellow_ribbon/2019/states/ky.asp",
+    "dest": "/education/yellow-ribbon-participating-schools/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/gibill/yellow_ribbon/2019/states/la.asp",
+    "dest": "/education/yellow-ribbon-participating-schools/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/gibill/yellow_ribbon/2019/states/ma.asp",
+    "dest": "/education/yellow-ribbon-participating-schools/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/gibill/yellow_ribbon/2019/states/md.asp",
+    "dest": "/education/yellow-ribbon-participating-schools/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/gibill/yellow_ribbon/2019/states/me.asp",
+    "dest": "/education/yellow-ribbon-participating-schools/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/gibill/yellow_ribbon/2019/states/mi.asp",
+    "dest": "/education/yellow-ribbon-participating-schools/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/gibill/yellow_ribbon/2019/states/mn.asp",
+    "dest": "/education/yellow-ribbon-participating-schools/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/gibill/yellow_ribbon/2019/states/mo.asp",
+    "dest": "/education/yellow-ribbon-participating-schools/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/gibill/yellow_ribbon/2019/states/ms.asp",
+    "dest": "/education/yellow-ribbon-participating-schools/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/gibill/yellow_ribbon/2019/states/mt.asp",
+    "dest": "/education/yellow-ribbon-participating-schools/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/gibill/yellow_ribbon/2019/states/nc.asp",
+    "dest": "/education/yellow-ribbon-participating-schools/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/gibill/yellow_ribbon/2019/states/nd.asp",
+    "dest": "/education/yellow-ribbon-participating-schools/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/gibill/yellow_ribbon/2019/states/ne.asp",
+    "dest": "/education/yellow-ribbon-participating-schools/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/gibill/yellow_ribbon/2019/states/nh.asp",
+    "dest": "/education/yellow-ribbon-participating-schools/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/gibill/yellow_ribbon/2019/states/nj.asp",
+    "dest": "/education/yellow-ribbon-participating-schools/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/gibill/yellow_ribbon/2019/states/nm.asp",
+    "dest": "/education/yellow-ribbon-participating-schools/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/gibill/yellow_ribbon/2019/states/nv.asp",
+    "dest": "/education/yellow-ribbon-participating-schools/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/gibill/yellow_ribbon/2019/states/ny.asp",
+    "dest": "/education/yellow-ribbon-participating-schools/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/gibill/yellow_ribbon/2019/states/oh.asp",
+    "dest": "/education/yellow-ribbon-participating-schools/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/gibill/yellow_ribbon/2019/states/ok.asp",
+    "dest": "/education/yellow-ribbon-participating-schools/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/gibill/yellow_ribbon/2019/states/or.asp",
+    "dest": "/education/yellow-ribbon-participating-schools/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/gibill/yellow_ribbon/2019/states/overseas.asp",
+    "dest": "/education/yellow-ribbon-participating-schools/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/gibill/yellow_ribbon/2019/states/pa.asp",
+    "dest": "/education/yellow-ribbon-participating-schools/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/gibill/yellow_ribbon/2019/states/pr.asp",
+    "dest": "/education/yellow-ribbon-participating-schools/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/gibill/yellow_ribbon/2019/states/ri.asp",
+    "dest": "/education/yellow-ribbon-participating-schools/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/gibill/yellow_ribbon/2019/states/sc.asp",
+    "dest": "/education/yellow-ribbon-participating-schools/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/gibill/yellow_ribbon/2019/states/sd.asp",
+    "dest": "/education/yellow-ribbon-participating-schools/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/gibill/yellow_ribbon/2019/states/tn.asp",
+    "dest": "/education/yellow-ribbon-participating-schools/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/gibill/yellow_ribbon/2019/states/tx.asp",
+    "dest": "/education/yellow-ribbon-participating-schools/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/gibill/yellow_ribbon/2019/states/ut.asp",
+    "dest": "/education/yellow-ribbon-participating-schools/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/gibill/yellow_ribbon/2019/states/va.asp",
+    "dest": "/education/yellow-ribbon-participating-schools/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/gibill/yellow_ribbon/2019/states/vt.asp",
+    "dest": "/education/yellow-ribbon-participating-schools/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/gibill/yellow_ribbon/2019/states/wa.asp",
+    "dest": "/education/yellow-ribbon-participating-schools/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/gibill/yellow_ribbon/2019/states/wi.asp",
+    "dest": "/education/yellow-ribbon-participating-schools/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/gibill/yellow_ribbon/2019/states/wv.asp",
+    "dest": "/education/yellow-ribbon-participating-schools/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/gibill/yellow_ribbon/2019/states/wy.asp",
+    "dest": "/education/yellow-ribbon-participating-schools/"
   }
 ]


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/4975

This PR implements the following redirects:

Current URL  |  Redirect to new URL
---  |  ---
www.benefits.va.gov/gibill/yellow_ribbon/yrp_list_2019.asp <br> **Update this existing redirect** | https://www.va.gov/education/yellow-ribbon-participating-schools/
*https://www.benefits.va.gov/gibill/yellow_ribbon/2019/states/ak.asp* | *https://www.va.gov/education/yellow-ribbon-participating-schools/*
*https://www.benefits.va.gov/gibill/yellow_ribbon/2019/states/al.asp* | *https://www.va.gov/education/yellow-ribbon-participating-schools/*
*https://www.benefits.va.gov/gibill/yellow_ribbon/2019/states/ar.asp* | *https://www.va.gov/education/yellow-ribbon-participating-schools/*
*https://www.benefits.va.gov/gibill/yellow_ribbon/2019/states/az.asp* | *https://www.va.gov/education/yellow-ribbon-participating-schools/*
*https://www.benefits.va.gov/gibill/yellow_ribbon/2019/states/ca.asp* | *https://www.va.gov/education/yellow-ribbon-participating-schools/*
*https://www.benefits.va.gov/gibill/yellow_ribbon/2019/states/co.asp* | *https://www.va.gov/education/yellow-ribbon-participating-schools/*
*https://www.benefits.va.gov/gibill/yellow_ribbon/2019/states/ct.asp* | *https://www.va.gov/education/yellow-ribbon-participating-schools/*
*https://www.benefits.va.gov/gibill/yellow_ribbon/2019/states/dc.asp* | *https://www.va.gov/education/yellow-ribbon-participating-schools/*
*https://www.benefits.va.gov/gibill/yellow_ribbon/2019/states/de.asp* | *https://www.va.gov/education/yellow-ribbon-participating-schools/*
*https://www.benefits.va.gov/gibill/yellow_ribbon/2019/states/fl.asp* | *https://www.va.gov/education/yellow-ribbon-participating-schools/*
*https://www.benefits.va.gov/gibill/yellow_ribbon/2019/states/ga.asp* | *https://www.va.gov/education/yellow-ribbon-participating-schools/*
*https://www.benefits.va.gov/gibill/yellow_ribbon/2019/states/hi.asp* | *https://www.va.gov/education/yellow-ribbon-participating-schools/*
*https://www.benefits.va.gov/gibill/yellow_ribbon/2019/states/ia.asp* | *https://www.va.gov/education/yellow-ribbon-participating-schools/*
*https://www.benefits.va.gov/gibill/yellow_ribbon/2019/states/id.asp* | *https://www.va.gov/education/yellow-ribbon-participating-schools/*
*https://www.benefits.va.gov/gibill/yellow_ribbon/2019/states/il.asp* | *https://www.va.gov/education/yellow-ribbon-participating-schools/*
*https://www.benefits.va.gov/gibill/yellow_ribbon/2019/states/in.asp* | *https://www.va.gov/education/yellow-ribbon-participating-schools/*
*https://www.benefits.va.gov/gibill/yellow_ribbon/2019/states/ks.asp* | *https://www.va.gov/education/yellow-ribbon-participating-schools/*
*https://www.benefits.va.gov/gibill/yellow_ribbon/2019/states/ky.asp* | *https://www.va.gov/education/yellow-ribbon-participating-schools/*
*https://www.benefits.va.gov/gibill/yellow_ribbon/2019/states/la.asp* | *https://www.va.gov/education/yellow-ribbon-participating-schools/*
*https://www.benefits.va.gov/gibill/yellow_ribbon/2019/states/ma.asp* | *https://www.va.gov/education/yellow-ribbon-participating-schools/*
*https://www.benefits.va.gov/gibill/yellow_ribbon/2019/states/md.asp* | *https://www.va.gov/education/yellow-ribbon-participating-schools/*
*https://www.benefits.va.gov/gibill/yellow_ribbon/2019/states/me.asp* | *https://www.va.gov/education/yellow-ribbon-participating-schools/*
*https://www.benefits.va.gov/gibill/yellow_ribbon/2019/states/mi.asp* | *https://www.va.gov/education/yellow-ribbon-participating-schools/*
*https://www.benefits.va.gov/gibill/yellow_ribbon/2019/states/mn.asp* | *https://www.va.gov/education/yellow-ribbon-participating-schools/*
*https://www.benefits.va.gov/gibill/yellow_ribbon/2019/states/mo.asp* | *https://www.va.gov/education/yellow-ribbon-participating-schools/*
*https://www.benefits.va.gov/gibill/yellow_ribbon/2019/states/ms.asp* | *https://www.va.gov/education/yellow-ribbon-participating-schools/*
*https://www.benefits.va.gov/gibill/yellow_ribbon/2019/states/mt.asp* | *https://www.va.gov/education/yellow-ribbon-participating-schools/*
*https://www.benefits.va.gov/gibill/yellow_ribbon/2019/states/nc.asp* | *https://www.va.gov/education/yellow-ribbon-participating-schools/*
*https://www.benefits.va.gov/gibill/yellow_ribbon/2019/states/nd.asp* | *https://www.va.gov/education/yellow-ribbon-participating-schools/*
*https://www.benefits.va.gov/gibill/yellow_ribbon/2019/states/ne.asp* | *https://www.va.gov/education/yellow-ribbon-participating-schools/*
*https://www.benefits.va.gov/gibill/yellow_ribbon/2019/states/nh.asp* | *https://www.va.gov/education/yellow-ribbon-participating-schools/*
*https://www.benefits.va.gov/gibill/yellow_ribbon/2019/states/nj.asp* | *https://www.va.gov/education/yellow-ribbon-participating-schools/*
*https://www.benefits.va.gov/gibill/yellow_ribbon/2019/states/nm.asp* | *https://www.va.gov/education/yellow-ribbon-participating-schools/*
*https://www.benefits.va.gov/gibill/yellow_ribbon/2019/states/nv.asp* | *https://www.va.gov/education/yellow-ribbon-participating-schools/*
*https://www.benefits.va.gov/gibill/yellow_ribbon/2019/states/ny.asp* | *https://www.va.gov/education/yellow-ribbon-participating-schools/*
*https://www.benefits.va.gov/gibill/yellow_ribbon/2019/states/oh.asp* | *https://www.va.gov/education/yellow-ribbon-participating-schools/*
*https://www.benefits.va.gov/gibill/yellow_ribbon/2019/states/ok.asp* | *https://www.va.gov/education/yellow-ribbon-participating-schools/*
*https://www.benefits.va.gov/gibill/yellow_ribbon/2019/states/or.asp* | *https://www.va.gov/education/yellow-ribbon-participating-schools/*
*https://www.benefits.va.gov/gibill/yellow_ribbon/2019/states/overseas.asp* | *https://www.va.gov/education/yellow-ribbon-participating-schools/*
*https://www.benefits.va.gov/gibill/yellow_ribbon/2019/states/pa.asp* | *https://www.va.gov/education/yellow-ribbon-participating-schools/*
*https://www.benefits.va.gov/gibill/yellow_ribbon/2019/states/pr.asp* | *https://www.va.gov/education/yellow-ribbon-participating-schools/*
*https://www.benefits.va.gov/gibill/yellow_ribbon/2019/states/ri.asp* | *https://www.va.gov/education/yellow-ribbon-participating-schools/*
*https://www.benefits.va.gov/gibill/yellow_ribbon/2019/states/sc.asp* | *https://www.va.gov/education/yellow-ribbon-participating-schools/*
*https://www.benefits.va.gov/gibill/yellow_ribbon/2019/states/sd.asp* | *https://www.va.gov/education/yellow-ribbon-participating-schools/*
*https://www.benefits.va.gov/gibill/yellow_ribbon/2019/states/tn.asp* | *https://www.va.gov/education/yellow-ribbon-participating-schools/*
*https://www.benefits.va.gov/gibill/yellow_ribbon/2019/states/tx.asp* | *https://www.va.gov/education/yellow-ribbon-participating-schools/*
*https://www.benefits.va.gov/gibill/yellow_ribbon/2019/states/ut.asp* | *https://www.va.gov/education/yellow-ribbon-participating-schools/*
*https://www.benefits.va.gov/gibill/yellow_ribbon/2019/states/va.asp* | *https://www.va.gov/education/yellow-ribbon-participating-schools/*
*https://www.benefits.va.gov/gibill/yellow_ribbon/2019/states/vt.asp* | *https://www.va.gov/education/yellow-ribbon-participating-schools/*
*https://www.benefits.va.gov/gibill/yellow_ribbon/2019/states/wa.asp* | *https://www.va.gov/education/yellow-ribbon-participating-schools/*
*https://www.benefits.va.gov/gibill/yellow_ribbon/2019/states/wi.asp* | *https://www.va.gov/education/yellow-ribbon-participating-schools/*
*https://www.benefits.va.gov/gibill/yellow_ribbon/2019/states/wv.asp* | *https://www.va.gov/education/yellow-ribbon-participating-schools/*
*https://www.benefits.va.gov/gibill/yellow_ribbon/2019/states/wy.asp* | *https://www.va.gov/education/yellow-ribbon-participating-schools/*

## Testing done
N/A

## Screenshots
N/A

## Acceptance criteria
- [x] Implement YR redirects.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
