### PR TITLE
Update MyVA311 to just VA311

### DIFF
--- a/src/site/stages/build/process-cms-exports/tests/entities/node.79938f13-7be8-4ce6-92ea-35671532c645.json
+++ b/src/site/stages/build/process-cms-exports/tests/entities/node.79938f13-7be8-4ce6-92ea-35671532c645.json
@@ -40,7 +40,7 @@
     ],
     "title": [
         {
-            "value": "Call MyVA311 for help:"
+            "value": "Call VA311 for help:"
         }
     ],
     "uid": [
@@ -84,12 +84,12 @@
     ],
     "metatag": {
         "value": {
-            "title": "Call MyVA311 for help: | Veterans Affairs",
+            "title": "Call VA311 for help: | Veterans Affairs",
             "twitter_cards_type": "summary_large_image",
             "og_site_name": "Veterans Affairs",
-            "twitter_cards_title": "Call MyVA311 for help: | Veterans Affairs",
+            "twitter_cards_title": "Call VA311 for help: | Veterans Affairs",
             "twitter_cards_site": "@DeptVetAffairs",
-            "og_title": "Call MyVA311 for help: | Veterans Affairs"
+            "og_title": "Call VA311 for help: | Veterans Affairs"
         }
     },
     "path": [

--- a/src/site/stages/build/process-cms-exports/tests/transformed-entities/node-landing_page.json
+++ b/src/site/stages/build/process-cms-exports/tests/transformed-entities/node-landing_page.json
@@ -713,7 +713,7 @@
       "entity": {
         "entityBundle": "support_service",
         "entityType": "node",
-        "title": "Call MyVA311 for help:",
+        "title": "Call VA311 for help:",
         "fieldLink": {
           "url": {
             "path": "tel:1-844-698-2311"


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/8851

This PR updates all references of MyVA311 to just VA311. This PR probably isn't needed since the updates in Drupal will affect the tome-sync data but sending it up just in case.

## Testing done
N/A

## Screenshots
N/A

## Acceptance criteria
- [x] Update all references of MyVA311 to just VA311.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
