### PR TITLE
Add additional logging for the request message

### DIFF
--- a/src/applications/vaos/actions/newAppointment.js
+++ b/src/applications/vaos/actions/newAppointment.js
@@ -763,6 +763,12 @@ export function submitAppointmentOrRequest(router) {
           // succeeded
           captureError(error, false, 'Request message failure', {
             messageLength: newAppointment?.data?.reasonAdditionalInfo?.length,
+            hasLineBreak: newAppointment?.data?.reasonAdditionalInfo?.includes(
+              '\r\n',
+            ),
+            hasNewLine: newAppointment?.data?.reasonAdditionalInfo?.includes(
+              '\n',
+            ),
           });
         }
 


### PR DESCRIPTION
## Description
Adds some additional logging around new lines to the request message

## Testing done
Local testing

## Acceptance criteria
- [ ] Build passes

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
