### PR TITLE
Sanlouise 9060 email updates acc security

### DIFF
--- a/src/applications/personalization/profile-2/components/AccountSecurityContent.jsx
+++ b/src/applications/personalization/profile-2/components/AccountSecurityContent.jsx
@@ -16,6 +16,7 @@ import ProfileInfoTable from './ProfileInfoTable';
 import TwoFactorAuthorizationStatus from './TwoFactorAuthorizationStatus';
 import IdentityVerificationStatus from './IdentityVerificationStatus';
 import MHVTermsAndConditionsStatus from './MHVTermsAndConditionsStatus';
+import EmailAddressNotification from './EmailAddressNotification';
 
 export const AccountSecurityContent = ({
   isIdentityVerified,
@@ -39,6 +40,10 @@ export const AccountSecurityContent = ({
           useSSOe={useSSOe}
         />
       ),
+    },
+    {
+      title: 'Sign-in email address',
+      value: <EmailAddressNotification />,
     },
   ];
 

--- a/src/applications/personalization/profile-2/components/AccountSecurityContent.jsx
+++ b/src/applications/personalization/profile-2/components/AccountSecurityContent.jsx
@@ -10,7 +10,10 @@ import {
   isMultifactorEnabled as isMultifactorEnabledSelector,
   selectProfile,
 } from 'platform/user/selectors';
-import { ssoe as ssoeSelector } from 'platform/user/authentication/selectors';
+import {
+  ssoe as ssoeSelector,
+  signInServiceName as signInServiceNameSelector,
+} from 'platform/user/authentication/selectors';
 
 import ProfileInfoTable from './ProfileInfoTable';
 import TwoFactorAuthorizationStatus from './TwoFactorAuthorizationStatus';
@@ -24,8 +27,9 @@ export const AccountSecurityContent = ({
   mhvAccount,
   showMHVTermsAndConditions,
   useSSOe,
+  signInServiceName,
 }) => {
-  const data = [
+  const securitySections = [
     {
       title: 'Identity verification',
       value: (
@@ -43,12 +47,12 @@ export const AccountSecurityContent = ({
     },
     {
       title: 'Sign-in email address',
-      value: <EmailAddressNotification />,
+      value: <EmailAddressNotification signInServiceName={signInServiceName} />,
     },
   ];
 
   if (showMHVTermsAndConditions) {
-    data.push({
+    securitySections.push({
       title: 'Terms and conditions',
       value: <MHVTermsAndConditionsStatus mhvAccount={mhvAccount} />,
     });
@@ -56,7 +60,7 @@ export const AccountSecurityContent = ({
 
   return (
     <>
-      <ProfileInfoTable data={data} fieldName="accountSecurity" />
+      <ProfileInfoTable data={securitySections} fieldName="accountSecurity" />
       <AlertBox
         status="info"
         headline="Have questions about signing in to VA.gov?"
@@ -105,6 +109,7 @@ export const mapStateToProps = state => {
     mhvAccount,
     showMHVTermsAndConditions,
     useSSOe: ssoeSelector(state),
+    signInServiceName: signInServiceNameSelector(state),
   };
 };
 

--- a/src/applications/personalization/profile-2/components/EmailAddressNotification.jsx
+++ b/src/applications/personalization/profile-2/components/EmailAddressNotification.jsx
@@ -29,14 +29,7 @@ const EmailAddressNotification = ({ signInServiceName }) => {
         make there will automatically update on VA.gov.
       </p>
       <p className="vads-u-margin-bottom--0">
-        <a
-          href={link}
-          target="_blank"
-          rel="noopener noreferrer"
-          onClick={() => {
-            recordEvent({ event: 'update-sign-in-email-address-clicked' });
-          }}
-        >
+        <a href={link} target="_blank" rel="noopener noreferrer">
           Update email address on {buttonText}
         </a>
       </p>

--- a/src/applications/personalization/profile-2/components/EmailAddressNotification.jsx
+++ b/src/applications/personalization/profile-2/components/EmailAddressNotification.jsx
@@ -11,7 +11,7 @@ const EmailAddressNotification = () => (
     </p>
     <p className="vads-u-margin-bottom--0">
       <a
-        href="/verify?next=/profile"
+        href="https://wallet.id.me/settings"
         target="_blank"
         rel="noopener noreferrer"
         onClick={() => {

--- a/src/applications/personalization/profile-2/components/EmailAddressNotification.jsx
+++ b/src/applications/personalization/profile-2/components/EmailAddressNotification.jsx
@@ -2,26 +2,46 @@ import React from 'react';
 
 import recordEvent from 'platform/monitoring/record-event';
 
-const EmailAddressNotification = () => (
-  <>
-    <p className="vads-u-margin--0">
-      To update the email address you use to sign in, go to the account where
-      you manage your settings and identity information. Any email updates you
-      make there will automatically update on VA.gov.
-    </p>
-    <p className="vads-u-margin-bottom--0">
-      <a
-        href="https://wallet.id.me/settings"
-        target="_blank"
-        rel="noopener noreferrer"
-        onClick={() => {
-          recordEvent({ event: 'update-sign-in-email-address-clicked' });
-        }}
-      >
-        Update email address on ID.me
-      </a>
-    </p>
-  </>
-);
+const EmailAddressNotification = ({ signInServiceName }) => {
+  let link;
+  let buttonText;
+
+  if (signInServiceName === 'idme') {
+    link = 'https://wallet.id.me/settings';
+    buttonText = 'ID.me';
+  }
+
+  if (signInServiceName === 'dslogon') {
+    link = 'https://myaccess.dmdc.osd.mil/identitymanagement';
+    buttonText = 'DS Logon';
+  }
+
+  if (signInServiceName === 'mhv') {
+    link = 'https://www.myhealth.va.gov';
+    buttonText = 'My HealtheVet';
+  }
+
+  return (
+    <>
+      <p className="vads-u-margin--0">
+        To update the email address you use to sign in, go to the account where
+        you manage your settings and identity information. Any email updates you
+        make there will automatically update on VA.gov.
+      </p>
+      <p className="vads-u-margin-bottom--0">
+        <a
+          href={link}
+          target="_blank"
+          rel="noopener noreferrer"
+          onClick={() => {
+            recordEvent({ event: 'update-sign-in-email-address-clicked' });
+          }}
+        >
+          Update email address on {buttonText}
+        </a>
+      </p>
+    </>
+  );
+};
 
 export default EmailAddressNotification;

--- a/src/applications/personalization/profile-2/components/EmailAddressNotification.jsx
+++ b/src/applications/personalization/profile-2/components/EmailAddressNotification.jsx
@@ -12,6 +12,8 @@ const EmailAddressNotification = () => (
     <p className="vads-u-margin-bottom--0">
       <a
         href="/verify?next=/profile"
+        target="_blank"
+        rel="noopener noreferrer"
         onClick={() => {
           recordEvent({ event: 'update-sign-in-email-address-clicked' });
         }}

--- a/src/applications/personalization/profile-2/components/EmailAddressNotification.jsx
+++ b/src/applications/personalization/profile-2/components/EmailAddressNotification.jsx
@@ -1,7 +1,5 @@
 import React from 'react';
 
-import recordEvent from 'platform/monitoring/record-event';
-
 const EmailAddressNotification = ({ signInServiceName }) => {
   let link;
   let buttonText;

--- a/src/applications/personalization/profile-2/components/EmailAddressNotification.jsx
+++ b/src/applications/personalization/profile-2/components/EmailAddressNotification.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+import recordEvent from 'platform/monitoring/record-event';
+
+const EmailAddressNotification = () => (
+  <>
+    <p className="vads-u-margin--0">
+      To update the email address you use to sign in, go to the account where
+      you manage your settings and identity information. Any email updates you
+      make there will automatically update on VA.gov.
+    </p>
+    <p className="vads-u-margin-bottom--0">
+      <a
+        href="/verify?next=/profile"
+        onClick={() => {
+          recordEvent({ event: 'update-sign-in-email-address-clicked' });
+        }}
+      >
+        Update email address on ID.me
+      </a>
+    </p>
+  </>
+);
+
+export default EmailAddressNotification;

--- a/src/applications/personalization/profile-2/tests/components/AccountSecurityContent.unit.spec.jsx
+++ b/src/applications/personalization/profile-2/tests/components/AccountSecurityContent.unit.spec.jsx
@@ -12,6 +12,7 @@ import ProfileInfoTable from '../../components/ProfileInfoTable';
 import IdentityVerificationStatus from '../../components/IdentityVerificationStatus';
 import TwoFactorAuthorizationStatus from '../../components/TwoFactorAuthorizationStatus';
 import MHVTermsAndConditionsStatus from '../../components/MHVTermsAndConditionsStatus';
+import EmailAddressNotification from '../../components/EmailAddressNotification';
 
 describe('AccountSecurityContent', () => {
   let wrapper;
@@ -41,13 +42,14 @@ describe('AccountSecurityContent', () => {
       afterEach(() => {
         wrapper.unmount();
       });
-      it('should pass in three rows of data', () => {
-        expect(infoTableData.length).to.equal(3);
+      it('should pass in four rows of data', () => {
+        expect(infoTableData.length).to.equal(4);
       });
       it('should have the correct row titles', () => {
         const expectedTitles = [
           'Identity verification',
           '2-factor authentication',
+          'Sign-in email address',
           'Terms and conditions',
         ];
         infoTableData.forEach((row, rowIndex) => {
@@ -68,19 +70,23 @@ describe('AccountSecurityContent', () => {
           props.isMultifactorEnabled,
         );
       });
-      it('should pass the `mhvAccount` prop to the `MHVTermsAndConditionsStatus` component in the second row', () => {
-        const thirdRowComponent = infoTableData[2].value;
+      it('should render the `EmailAddressNotification` component in the third row', () => {
+        const secondRowComponent = infoTableData[2].value;
+        expect(secondRowComponent.type).to.equal(EmailAddressNotification);
+      });
+      it('should pass the `mhvAccount` prop to the `MHVTermsAndConditionsStatus` component in the fourth row', () => {
+        const thirdRowComponent = infoTableData[3].value;
         expect(thirdRowComponent.type).to.equal(MHVTermsAndConditionsStatus);
         expect(thirdRowComponent.props.mhvAccount).to.equal(props.mhvAccount);
       });
     });
     describe('when `showMHVTermsAndConditions` is `false`', () => {
-      it('should pass in two rows of data', () => {
+      it('should pass in three rows of data', () => {
         props = makeDefaultProps();
         props.showMHVTermsAndConditions = false;
         wrapper = shallow(<AccountSecurityContent {...props} />);
         infoTableData = wrapper.find('ProfileInfoTable').prop('data');
-        expect(infoTableData.length).to.equal(2);
+        expect(infoTableData.length).to.equal(3);
         wrapper.unmount();
       });
     });

--- a/src/applications/personalization/profile-2/tests/components/EmailAddressNotification.unit.spec.jsx
+++ b/src/applications/personalization/profile-2/tests/components/EmailAddressNotification.unit.spec.jsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { expect } from 'chai';
+
+import EmailAddressNotification from '../../components/EmailAddressNotification';
+
+describe('EmailAddressNotification', () => {
+  describe('when `signInServiceName` is `dslogon`', () => {
+    const wrapper = shallow(
+      <EmailAddressNotification signInServiceName="dslogon" />,
+    );
+
+    const anchor = wrapper.find('a');
+
+    it('should render the correct button text', () => {
+      expect(anchor.text().includes('DS Logon')).to.be.true;
+    });
+    it('should render the correct link url', () => {
+      expect(anchor.props().href).to.equal(
+        'https://myaccess.dmdc.osd.mil/identitymanagement',
+      );
+    });
+    wrapper.unmount();
+  });
+
+  describe('when `signInServiceName` is `idme`', () => {
+    const wrapper = shallow(
+      <EmailAddressNotification signInServiceName="idme" />,
+    );
+
+    const anchor = wrapper.find('a');
+
+    it('should render the correct button text', () => {
+      expect(anchor.text().includes('ID.me')).to.be.true;
+    });
+    it('should render the correct link url', () => {
+      expect(anchor.props().href).to.equal('https://wallet.id.me/settings');
+    });
+    wrapper.unmount();
+  });
+
+  describe('when `signInServiceName` is `mhv`', () => {
+    const wrapper = shallow(
+      <EmailAddressNotification signInServiceName="mhv" />,
+    );
+
+    const anchor = wrapper.find('a');
+
+    it('should render the correct button text', () => {
+      expect(anchor.text().includes('My HealtheVet')).to.be.true;
+    });
+    it('should render the correct link url', () => {
+      expect(anchor.props().href).to.equal('https://www.myhealth.va.gov');
+    });
+    wrapper.unmount();
+  });
+});

--- a/src/platform/user/authentication/selectors.js
+++ b/src/platform/user/authentication/selectors.js
@@ -13,4 +13,4 @@ export const hasCheckedKeepAlive = state =>
   state.user.login.hasCheckedKeepAlive;
 
 export const signInServiceName = state =>
-  selectProfile(state).signIn.serviceName;
+  selectProfile(state).signIn?.serviceName;

--- a/src/platform/user/authentication/selectors.js
+++ b/src/platform/user/authentication/selectors.js
@@ -1,5 +1,6 @@
 import environment from 'platform/utilities/environment';
 import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
+import { selectProfile } from 'platform/user/selectors';
 import FEATURE_FLAG_NAMES from 'platform/utilities/feature-toggles/featureFlagNames';
 
 export const ssoe = state => toggleValues(state)[FEATURE_FLAG_NAMES.ssoe];
@@ -11,4 +12,5 @@ export const ssoeEbenefitsLinks = state =>
 export const hasCheckedKeepAlive = state =>
   state.user.login.hasCheckedKeepAlive;
 
-export const signInServiceName = state => state.user.profile.signIn.serviceName;
+export const signInServiceName = state =>
+  selectProfile(state).signIn.serviceName;

--- a/src/platform/user/authentication/selectors.js
+++ b/src/platform/user/authentication/selectors.js
@@ -10,3 +10,5 @@ export const ssoeEbenefitsLinks = state =>
   toggleValues(state)[FEATURE_FLAG_NAMES.ssoeEbenefitsLinks];
 export const hasCheckedKeepAlive = state =>
   state.user.login.hasCheckedKeepAlive;
+
+export const signInServiceName = state => state.user.profile.signIn.serviceName;


### PR DESCRIPTION
## Description
Add 'Sign-in email address' section to Account security above T&C.

## Testing done
Works locally. Updated relevant unit tests.

## Screenshots
![image](https://user-images.githubusercontent.com/14869324/82695902-39755280-9c23-11ea-8fb1-0400bc851106.png)
![image](https://user-images.githubusercontent.com/14869324/82695933-42feba80-9c23-11ea-9baa-f7c9c6eb1b91.png)

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
