### PR TITLE
Convert necessary nightwatch commands to cypress

### DIFF
--- a/src/platform/testing/e2e/cypress/support/commands/clickIf.js
+++ b/src/platform/testing/e2e/cypress/support/commands/clickIf.js
@@ -1,0 +1,18 @@
+/**
+ * Clicks the input specified if the condition evaluates to true.
+ *
+ * @param {string} selector The css selector for the element to click
+ * @param {function} condition Function that will be run to determine
+ * whether or not to click the element
+ * @param {...any} params Parameters that will be passed to condition
+ */
+Cypress.Commands.add('clickIf', (selector, condition, ...params) => {
+  let shouldClick = !!condition;
+  if (typeof condition === 'function') {
+    shouldClick = !!condition(...params);
+  }
+
+  if (shouldClick) {
+    cy.get(selector).click();
+  }
+});

--- a/src/platform/testing/e2e/cypress/support/commands/fillAddress.js
+++ b/src/platform/testing/e2e/cypress/support/commands/fillAddress.js
@@ -1,0 +1,31 @@
+/**
+ * Fills the address form elements.
+ *
+ * @param {string} baseName The start of the field name for the address elements
+ * @param {object} address The address object
+ */
+Cypress.Commands.add('fillAddress', (baseName, address) => {
+  if (address.country) {
+    cy.get(`select[name="${baseName}_country"]`).select(address.country);
+  }
+
+  if (address.street) {
+    cy.get(`input[name="${baseName}_street"]`).type(address.street);
+  }
+
+  if (address.street2) {
+    cy.get(`input[name="${baseName}_street2"]`).type(address.street2);
+  }
+
+  if (address.city) {
+    cy.get(`input[name="${baseName}_city"]`).type(address.city);
+  }
+
+  if (address.state) {
+    cy.get(`select[name="${baseName}_state"]`).select(address.state);
+  }
+
+  if (address.postalCode) {
+    cy.get(`input[name="${baseName}_postalCode"]`).type(address.postalCode);
+  }
+});

--- a/src/platform/testing/e2e/cypress/support/commands/fillCheckbox.js
+++ b/src/platform/testing/e2e/cypress/support/commands/fillCheckbox.js
@@ -1,0 +1,21 @@
+/**
+ * Checks a checkbox if a condition is true
+ *
+ * @param {string} selector The css selector for the checkbox to fill
+ * @param {function} condition Function that will be run to determine
+ * whether or not to check the checkbox
+ * @param {...any} params Parameters that will be passed to condition
+ */
+Cypress.Commands.add(
+  'fillCheckbox',
+  (selector, condition = true, ...params) => {
+    let shouldClick = !!condition;
+    if (typeof condition === 'function') {
+      shouldClick = !!condition(...params);
+    }
+
+    if (shouldClick) {
+      cy.get(selector).check();
+    }
+  },
+);

--- a/src/platform/testing/e2e/cypress/support/commands/fillDate.js
+++ b/src/platform/testing/e2e/cypress/support/commands/fillDate.js
@@ -1,0 +1,20 @@
+/**
+ * Fills in a date.
+ *
+ * @param {String} fieldName The name the field without the Month, Day, or Year
+ *                           e.g. root_spouseInfo_remarriageDate
+ * @param {String} dateString The date as a string
+ *                            e.g. 1990-1-28
+ */
+Cypress.Commands.add('fillDate', (fieldName, dateString) => {
+  const date = dateString.split('-');
+  cy.get(`#${fieldName}Month`)
+    .select(parseInt(date[1], 10).toString())
+    .should('have.value', parseInt(date[1], 10).toString());
+
+  cy.get(`#${fieldName}Day`)
+    .select(parseInt(date[2], 10).toString())
+    .should('have.value', parseInt(date[2], 10).toString());
+
+  cy.get(`#${fieldName}Year`).type(parseInt(date[0], 10).toString());
+});

--- a/src/platform/testing/e2e/cypress/support/commands/fillMonthYear.js
+++ b/src/platform/testing/e2e/cypress/support/commands/fillMonthYear.js
@@ -1,0 +1,15 @@
+/**
+ * Fills in a month year date.
+ *
+ * @param {String} fieldName The name the field without the Month, Day, or Year
+ *                           e.g. root_spouseInfo_remarriageDate
+ * @param {String} dateString The date as a string
+ *                            e.g. 1990-1-28
+ */
+Cypress.Commands.add('fillMonthYear', (fieldName, dateString) => {
+  const date = dateString.split('-');
+  cy.get(`select[name="${fieldName}Month"]`)
+    .select(parseInt(date[1], 10).toString())
+    .get(`input[name="${fieldName}Year"]`)
+    .type(parseInt(date[0], 10).toString());
+});

--- a/src/platform/testing/e2e/cypress/support/commands/fillName.js
+++ b/src/platform/testing/e2e/cypress/support/commands/fillName.js
@@ -1,0 +1,16 @@
+/**
+ * Fills the name form elements.
+ *
+ * @param {string} baseName The start of the field name for the name elements
+ * @param {object} name The name object
+ */
+Cypress.Commands.add('fillName', (baseName, name) => {
+  cy.get(`input[name="${baseName}_first"]`)
+    .type(name.first)
+    .get(`input[name="${baseName}_middle"]`)
+    .type(name.middle)
+    .get(`input[name="${baseName}_last"]`)
+    .type(name.last)
+    .get(`select[name="${baseName}_suffix"]`)
+    .select(name.suffix);
+});

--- a/src/platform/testing/e2e/cypress/support/commands/index.js
+++ b/src/platform/testing/e2e/cypress/support/commands/index.js
@@ -1,3 +1,10 @@
 import './axeCheck';
+import './clickIf';
+import './fillAddress';
+import './fillCheckbox';
+import './fillDate';
+import './fillMonthYear';
+import './fillName';
+import './selectYesNo';
 import './syncFixtures';
 import './upload';

--- a/src/platform/testing/e2e/cypress/support/commands/selectYesNo.js
+++ b/src/platform/testing/e2e/cypress/support/commands/selectYesNo.js
@@ -1,0 +1,10 @@
+/**
+ * Selects the appropriate option for yesNo widgets.
+ *
+ * @param {string} fieldName The name of the field without Yes or No
+ *                           e.g. root_spouseInfo_divorcePending
+ * @param {bool} condition Determines whether to select Yes or No
+ */
+Cypress.Commands.add('selectYesNo', (fieldName, condition) => {
+  cy.get(`#${fieldName}${condition ? 'Yes' : 'No'}`).click();
+});


### PR DESCRIPTION
## Description
This PR converts the necessary nightwatch command to cypress commands.

## Testing done
Local testing of commands.

## Screenshots


## Acceptance criteria
- [ ] The cypress custom commands match the original nightwatch commands in functionality.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
