### PR TITLE
[Development] Add collapsible chapter attribute

### DIFF
--- a/src/platform/forms-system/src/js/review/ReviewCollapsibleChapter.jsx
+++ b/src/platform/forms-system/src/js/review/ReviewCollapsibleChapter.jsx
@@ -245,7 +245,11 @@ export default class ReviewCollapsibleChapter extends React.Component {
     });
 
     return (
-      <div id={`${this.id}-collapsiblePanel`} className={classes}>
+      <div
+        id={`${this.id}-collapsiblePanel`}
+        className={classes}
+        data-chapter={this.props.chapterKey}
+      >
         <Element name={`chapter${this.props.chapterKey}ScrollElement`} />
         <ul className="usa-unstyled-list">
           <li>

--- a/src/platform/forms-system/test/js/review/ReviewCollapsibleChapter.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/review/ReviewCollapsibleChapter.unit.spec.jsx
@@ -7,6 +7,43 @@ import sinon from 'sinon';
 import ReviewCollapsibleChapter from '../../../src/js/review/ReviewCollapsibleChapter';
 
 describe('<ReviewCollapsibleChapter>', () => {
+  it('should add a data-attribute with the chapterKey', () => {
+    const pages = [
+      {
+        title: '',
+        pageKey: 'test2',
+      },
+    ];
+    const chapterKey = 'chapterX';
+    const chapter = {};
+    const form = {
+      pages: {
+        test: {
+          title: '',
+          schema: {
+            properties: {},
+          },
+          uiSchema: {},
+        },
+      },
+      data: {},
+    };
+
+    const wrapper = mount(
+      <ReviewCollapsibleChapter
+        viewedPages={new Set()}
+        expandedPages={pages}
+        chapterKey={chapterKey}
+        chapterFormConfig={chapter}
+        form={form}
+      />,
+    );
+
+    const accordion = wrapper.find('.usa-accordion-bordered');
+    expect(accordion.length).to.equal(1);
+    expect(accordion.props()['data-chapter']).to.equal('chapterX');
+    wrapper.unmount();
+  });
   it('should handle editing', () => {
     const onEdit = sinon.spy();
     const pages = [


### PR DESCRIPTION
## Description

In the Higher-Level Review form, a chapter contains two pages that are all completely read-only. When on the final `review-and-submit` page

<details><summary>Empty accordion chapter</summary>

<!-- leave a blank line above -->
![Screen Shot 2020-05-22 at 1 59 56 PM](https://user-images.githubusercontent.com/136959/82713714-92f47600-9c51-11ea-90d2-516239644d34.png)</details>

The `ReviewCollapsibleChapter` component renders a div with an id plus `-collapsiblePanel`, but I'd rather not rely on an index that may change in the future. 

This PR adds a `data-chapter` attribute that contains the unique chapter name, thus allowing the use of CSS to target the empty accordion and hide it, e.g.

```html
<div
  id="8-collapsiblePanel"
  class="usa-accordion-bordered form-review-panel"
  data-attribute="whatever"
>
  <!-- ... -->
</div>
```

```css
.usa-accordion-bordered[data-chapter="whatever"] {
  display: none;
}
```

Associated ticket: https://github.com/department-of-veterans-affairs/va.gov-team/issues/8827

## Testing done

Visual & added a unit test

## Screenshots

See description

## Acceptance criteria
- [ ] `data-chapter` attribute added to accordion wrapper which includes the unique chapter name

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
