### PR TITLE
9399-add duration from first button tap to result screen to GA

### DIFF
--- a/src/applications/coronavirus-screener/components/FormQuestion.jsx
+++ b/src/applications/coronavirus-screener/components/FormQuestion.jsx
@@ -1,11 +1,14 @@
 import React from 'react';
 import recordEvent from 'platform/monitoring/record-event';
 import _ from 'lodash/fp';
+import moment from 'moment';
 
 export default function FormQuestion({
   question,
   formState,
   setFormState,
+  resultSubmitted,
+  setResultSubmittedState,
   scrollNext,
 }) {
   function handleChange(event) {
@@ -13,6 +16,11 @@ export default function FormQuestion({
       recordEvent({
         event: 'covid-screening-tool-start',
         'screening-tool-question': question.id,
+      });
+      // starts duration timer for GA
+      setResultSubmittedState({
+        ...resultSubmitted,
+        startTime: moment().unix(),
       });
     }
     // sets the current question value in form state

--- a/src/applications/coronavirus-screener/components/FormResult.jsx
+++ b/src/applications/coronavirus-screener/components/FormResult.jsx
@@ -9,7 +9,7 @@ export default function FormResult({ formState }) {
   let resultClass = '';
   const [resultSubmitted, setResultSubmittedState] = React.useState({
     isSubmitted: false,
-    startTime: 0,
+    startTime: moment().unix(),
   });
 
   const incomplete = <div>Please answer all the questions above.</div>;
@@ -47,9 +47,7 @@ export default function FormResult({ formState }) {
 
   function recordScreeningToolEvent(screeningToolResult) {
     if (!resultSubmitted.isSubmitted) {
-      const timeToComplete = moment.duration(
-        moment().diff(resultSubmitted.startTime, 'seconds'),
-      );
+      const timeToComplete = moment().unix() - resultSubmitted.startTime;
       recordEvent({
         event: 'covid-screening-tool-result-displayed',
         'screening-tool-result': screeningToolResult,
@@ -62,10 +60,6 @@ export default function FormResult({ formState }) {
   if (Object.values(formState).length < questions.length) {
     result = incomplete;
     resultClass = 'incomplete';
-
-    if (resultSubmitted.startTime === 0) {
-      setResultSubmittedState({ ...resultSubmitted, startTime: moment() });
-    }
   } else if (Object.values(formState).includes('yes')) {
     result = fail;
     resultClass = 'fail';

--- a/src/applications/coronavirus-screener/components/FormResult.jsx
+++ b/src/applications/coronavirus-screener/components/FormResult.jsx
@@ -48,13 +48,19 @@ export default function FormResult({ formState }) {
   function recordScreeningToolEvent(screeningToolResult) {
     if (!resultSubmitted.isSubmitted) {
       const timeToComplete = moment.duration(
-        moment().diff(resultSubmitted.startTime, 'seconds'),
+        moment().diff(resultSubmitted.startTime),
       );
-      // TODO: format timeToComplete to hh:mm:ss
+      const formattedTimeToComplete = [
+        timeToComplete.hours(),
+        timeToComplete.minutes(),
+        timeToComplete.seconds(),
+      ]
+        .map(segment => segment.toString().padStart(2, '0'))
+        .join(':');
       recordEvent({
         event: 'covid-screening-tool-result-displayed',
         'screening-tool-result': screeningToolResult,
-        'time-to-complete': timeToComplete,
+        'time-to-complete': formattedTimeToComplete,
       });
       setResultSubmittedState({ ...resultSubmitted, isSubmitted: true });
     }

--- a/src/applications/coronavirus-screener/components/FormResult.jsx
+++ b/src/applications/coronavirus-screener/components/FormResult.jsx
@@ -48,19 +48,12 @@ export default function FormResult({ formState }) {
   function recordScreeningToolEvent(screeningToolResult) {
     if (!resultSubmitted.isSubmitted) {
       const timeToComplete = moment.duration(
-        moment().diff(resultSubmitted.startTime),
+        moment().diff(resultSubmitted.startTime, 'seconds'),
       );
-      const formattedTimeToComplete = [
-        timeToComplete.hours(),
-        timeToComplete.minutes(),
-        timeToComplete.seconds(),
-      ]
-        .map(segment => segment.toString().padStart(2, '0'))
-        .join(':');
       recordEvent({
         event: 'covid-screening-tool-result-displayed',
         'screening-tool-result': screeningToolResult,
-        'time-to-complete': formattedTimeToComplete,
+        'time-to-complete': timeToComplete,
       });
       setResultSubmittedState({ ...resultSubmitted, isSubmitted: true });
     }

--- a/src/applications/coronavirus-screener/components/FormResult.jsx
+++ b/src/applications/coronavirus-screener/components/FormResult.jsx
@@ -4,16 +4,15 @@ import { Element } from 'react-scroll';
 import moment from 'moment';
 import recordEvent from 'platform/monitoring/record-event';
 
-export default function FormResult({ formState }) {
+export default function FormResult({
+  formState,
+  resultSubmitted,
+  setResultSubmittedState,
+}) {
   let result;
   let resultClass = '';
-  const [resultSubmitted, setResultSubmittedState] = React.useState({
-    isSubmitted: false,
-    startTime: moment().unix(),
-  });
 
   const incomplete = <div>Please answer all the questions above.</div>;
-
   const dateText = moment().format('dddd, MMMM D, h:mm a');
 
   const pass = (

--- a/src/applications/coronavirus-screener/components/MultiQuestionForm.jsx
+++ b/src/applications/coronavirus-screener/components/MultiQuestionForm.jsx
@@ -19,6 +19,10 @@ function scrollTo(name) {
 export default function MultiQuestionForm({ questions }) {
   const [formState, setFormState] = React.useState({});
 
+  const [resultSubmitted, setResultSubmittedState] = React.useState({
+    isSubmitted: false,
+  });
+
   const formQuestions = questions.map((question, index) => (
     <div key={question.id}>
       <Element name={`multi-question-form-${index}-scroll-element`} />
@@ -26,6 +30,8 @@ export default function MultiQuestionForm({ questions }) {
         question={question}
         setFormState={setFormState}
         formState={formState}
+        resultSubmitted={resultSubmitted}
+        setResultSubmittedState={setResultSubmittedState}
         scrollNext={() =>
           scrollTo(`multi-question-form-${index + 1}-scroll-element`)
         }
@@ -36,7 +42,11 @@ export default function MultiQuestionForm({ questions }) {
   return (
     <div>
       {formQuestions}
-      <FormResult formState={formState} />
+      <FormResult
+        formState={formState}
+        resultSubmitted={resultSubmitted}
+        setResultSubmittedState={setResultSubmittedState}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Description
Add Analytics for duration from first button click to results screen

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
