### PR TITLE
7486 686 e2e p3

### DIFF
--- a/src/applications/disability-benefits/686c-674/tests/e2e/00-spouse-report-divorce.e2e.spec.js
+++ b/src/applications/disability-benefits/686c-674/tests/e2e/00-spouse-report-divorce.e2e.spec.js
@@ -1,0 +1,149 @@
+const Auth = require('platform/testing/e2e/auth');
+const E2eHelpers = require('platform/testing/e2e/helpers');
+const Timeouts = require('platform/testing/e2e/timeouts');
+const manifest = require('../../manifest.json');
+const testData = require('./686-test-data.json');
+const environments = require('site/constants/environments');
+
+import * as TestHelpers from './test-helpers';
+
+const runTest = E2eHelpers.createE2eTest(client => {
+  const token = Auth.getUserToken();
+  TestHelpers.initApplicationSubmitMock(token);
+  // Login
+  Auth.logIn(
+    token,
+    client,
+    '/view-change-dependents/add-remove-form-686c',
+    3,
+  ).waitForElementVisible('.process.schemaform-process', Timeouts.verySlow);
+  client.waitForElementVisible(
+    '.usa-alert.usa-alert-info.schemaform-sip-alert',
+    Timeouts.verySlow,
+  );
+  client.click('.usa-button-primary.va-button-primary.schemaform-start-button');
+
+  // select options
+  E2eHelpers.expectLocation(client, '/686-options-selection');
+  client.axeCheck('.main');
+  TestHelpers.select686Options(
+    client,
+    ['addSpouse', 'reportDivorce'],
+    testData.data,
+  );
+  client.click('button[id="4-continueButton"]');
+
+  // veteran information
+  E2eHelpers.expectLocation(client, '/veteran-information');
+  client.axeCheck('.main');
+  client.pause(Timeouts.normal);
+  client.click('button[id="4-continueButton"]');
+
+  // veteran address
+  E2eHelpers.expectLocation(client, '/veteran-address');
+  client.axeCheck('.main');
+  TestHelpers.fillVeteranDomesticAddress(client, testData.data);
+  client.click('button[id="4-continueButton"]');
+
+  // spouse information
+  E2eHelpers.expectLocation(client, '/add-spouse');
+  client.waitForElementVisible(
+    '#root_spouseInformation_fullName_first-label',
+    Timeouts.normal,
+  );
+  client.axeCheck('.main');
+  TestHelpers.fillSpousePersonalInformation(client, testData.data);
+  client.click('button[id="4-continueButton"]');
+
+  // current marriage information
+  E2eHelpers.expectLocation(client, '/current-marriage-information');
+  client.waitForElementVisible(
+    '#root_currentMarriageInformation_date-label',
+    Timeouts.normal,
+  );
+  client.axeCheck('.main');
+  TestHelpers.fillCurrentMarriageInformation(client, testData.data);
+  client.click('button[id="4-continueButton"]');
+
+  // current spouse address
+  E2eHelpers.expectLocation(client, '/current-marriage-address');
+  client.waitForElementVisible(
+    '#root_doesLiveWithSpouse_spouseDoesLiveWithVeteran-label',
+    Timeouts.normal,
+  );
+  client.axeCheck('.main');
+  TestHelpers.fillSpouseAddressInformation(client, testData.data, false);
+  client.click('button[id="4-continueButton"]');
+
+  // current spouse marriage history
+  E2eHelpers.expectLocation(client, '/current-spouse-marriage-history');
+  client.waitForElementVisible(
+    '#root_spouseWasMarriedBefore-label',
+    Timeouts.normal,
+  );
+  client.axeCheck('.main');
+  client.pause(Timeouts.normal);
+  TestHelpers.fillSpouseMarriageHistory(client, testData.data, true);
+  client.click('button[id="4-continueButton"]');
+
+  // spouse marriage history details
+  client.pause(Timeouts.normal);
+  client.waitForElementVisible('#root_startDate-label', Timeouts.normal);
+  E2eHelpers.expectLocation(client, '/current-spouse-marriage-history/0');
+  client.axeCheck('.main');
+  client.pause(Timeouts.normal);
+  TestHelpers.fillSpouseMarriageHistoryDetails(client, testData.data);
+  client.click('button[id="4-continueButton"]');
+
+  // veteran marriage history
+  E2eHelpers.expectLocation(client, '/veteran-marriage-history');
+  client.waitForElementVisible(
+    '#root_veteranWasMarriedBefore-label',
+    Timeouts.normal,
+  );
+  client.axeCheck('.main');
+  client.pause(Timeouts.normal);
+  TestHelpers.fillVeteranMarriageHistory(client, testData.data, false);
+  client.click('button[id="4-continueButton"]');
+
+  // marriage additional evidence
+  E2eHelpers.expectLocation(client, '/add-spouse-evidence');
+  client.waitForElementVisible(
+    '#root_supportingDocuments_add_label',
+    Timeouts.normal,
+  );
+  client.pause(Timeouts.normal);
+  client.click(
+    '.row.form-progress-buttons.schemaform-buttons div.small-6.medium-5.end.columns button.usa-button-primary',
+  );
+
+  // review page
+  E2eHelpers.expectLocation(client, '/review-and-submit');
+  client.waitForElementVisible(
+    '.usa-accordion-bordered.form-review-panel',
+    Timeouts.normal,
+  );
+  client.axeCheck('.main');
+  client.assert.cssClassPresent(
+    '.progress-bar-segmented div.progress-segment:nth-child(4)',
+    'progress-segment-complete',
+  );
+  // privacy agreement
+  client.waitForElementVisible(
+    'label[name="privacyAgreementAccepted-label"]',
+    Timeouts.normal,
+  );
+  client.click('.form-checkbox input[name="privacyAgreementAccepted"]');
+  client.click('.form-progress-buttons .usa-button-primary');
+  E2eHelpers.expectLocation(client, '/confirmation');
+
+  // confirmation
+  client.axeCheck('.main');
+  client.end();
+});
+
+module.exports = runTest;
+
+// TODO: Remove this when CI builds temporary landing pages to run e2e tests
+module.exports['@disabled'] =
+  manifest.e2eTestsDisabled && process.env.BUILDTYPE !== environments.LOCALHOST;

--- a/src/applications/disability-benefits/686c-674/tests/e2e/686-test-data.json
+++ b/src/applications/disability-benefits/686c-674/tests/e2e/686-test-data.json
@@ -2,7 +2,8 @@
   "data": {
     "optionsSelection": {
       "addChild": true,
-      "addSpouse": true
+      "addSpouse": true,
+      "reportDivorce": true
     },
     "veteranInformation": {
       "firstName": "John",


### PR DESCRIPTION
## Description
[Original Ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/7486)

This ticket adds an e2e test for adding a spouse and reporting a divorce using the 686c-674. The expected behaviour of this workflow combination is that a user will only fill out the add-spouse workflow, and the report-divorce workflow will be toggled off. The reasoning for this is that part of adding a spouse is reporting marriage history for the veteran.

## Testing done
- local, headless and browser

## Screenshots
<img width="970" alt="Screen Shot 2020-05-26 at 2 00 05 PM" src="https://user-images.githubusercontent.com/15097156/82942418-8b88e180-9f5d-11ea-96b3-4acab7d23780.png">


## Acceptance criteria
- [x] Test passes in browser and headless

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
