### PR TITLE
move `prefixUtilityClasses` helper to Platform

### DIFF
--- a/src/applications/personalization/profile-2/components/ProfileHeader.jsx
+++ b/src/applications/personalization/profile-2/components/ProfileHeader.jsx
@@ -3,8 +3,10 @@ import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import orderBy from 'lodash/orderBy';
 
+import prefixUtilityClasses from 'platform/utilities/prefix-utility-classes';
+
 import { SERVICE_BADGE_IMAGE_PATHS } from '../constants';
-import { getServiceBranchDisplayName, prefixUtilityClasses } from '../helpers';
+import { getServiceBranchDisplayName } from '../helpers';
 
 const ProfileHeader = ({
   userFullName: { first, middle, last, suffix },

--- a/src/applications/personalization/profile-2/components/ProfileInfoTable.jsx
+++ b/src/applications/personalization/profile-2/components/ProfileInfoTable.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { prefixUtilityClasses } from '../helpers';
+import prefixUtilityClasses from 'platform/utilities/prefix-utility-classes';
 
 const ProfileInfoTable = ({
   data,
@@ -106,7 +106,5 @@ ProfileInfoTable.propTypes = {
    */
   list: PropTypes.bool,
 };
-
-export { prefixUtilityClasses };
 
 export default ProfileInfoTable;

--- a/src/applications/personalization/profile-2/components/direct-deposit/DirectDepositContent.jsx
+++ b/src/applications/personalization/profile-2/components/direct-deposit/DirectDepositContent.jsx
@@ -29,7 +29,7 @@ import ProfileInfoTable from '../ProfileInfoTable';
 import FraudVictimAlert from './FraudVictimAlert';
 import AdditionalInformation from './DirectDepositInformation';
 
-import { prefixUtilityClasses } from '../../helpers';
+import prefixUtilityClasses from 'platform/utilities/prefix-utility-classes';
 
 export const DirectDepositContent = ({
   isAuthorized,

--- a/src/applications/personalization/profile-2/components/personal-information/AddressesTable.jsx
+++ b/src/applications/personalization/profile-2/components/personal-information/AddressesTable.jsx
@@ -5,10 +5,9 @@ import { selectVet360Field } from 'platform/user/profile/vet360/selectors';
 
 import AddressView from 'platform/user/profile/vet360/components/AddressField/AddressView';
 import { FIELD_NAMES } from 'platform/user/profile/vet360/constants';
+import prefixUtilityClasses from 'platform/utilities/prefix-utility-classes';
 
 import ProfileInfoTable from '../ProfileInfoTable';
-
-import { prefixUtilityClasses } from '../../helpers';
 
 const ContactInfoCell = props => {
   const { value } = props;

--- a/src/applications/personalization/profile-2/helpers.js
+++ b/src/applications/personalization/profile-2/helpers.js
@@ -76,20 +76,3 @@ export const transformServiceHistoryEntryIntoTableRow = entry => ({
     </>
   ),
 });
-
-/**
- * Helper that prefixes class names with an optional responsive prefix and the
- * `vads-u-` utility class prefix.
- *
- * @param {string[]} classes - Array of classes to prefix with `vads-u-`
- * @param {string} screenSize - Optional screen size
- * @returns {string[]} The input `classes` array with the correct prefixes
- * applied
- *
- * Example: `prefixUtilityClasses(['my-class'], 'medium')` returns
- * ['medium-screen:vads-u-my-class']
- */
-export const prefixUtilityClasses = (classes, screenSize = '') => {
-  const colonizedScreenSize = screenSize ? `${screenSize}-screen:` : '';
-  return classes.map(className => `${colonizedScreenSize}vads-u-${className}`);
-};

--- a/src/applications/personalization/profile-2/tests/helpers.unit.spec.js
+++ b/src/applications/personalization/profile-2/tests/helpers.unit.spec.js
@@ -4,7 +4,6 @@ import { expect } from 'chai';
 
 import {
   getServiceBranchDisplayName,
-  prefixUtilityClasses,
   transformServiceHistoryEntryIntoTableRow,
 } from '../helpers';
 
@@ -24,25 +23,6 @@ describe('getServiceBranchDisplayName', () => {
   describe('when not passed one of the five USA military branches', () => {
     it('should simply return what it was passed', () => {
       expect(getServiceBranchDisplayName('Other')).to.equal('Other');
-    });
-  });
-});
-
-describe('prefixUtilityClasses', () => {
-  const classes = ['class-1', 'class-2'];
-  it('should prefix an array of classes with `vads-u-`', () => {
-    const expectedResult = ['vads-u-class-1', 'vads-u-class-2'];
-    const result = prefixUtilityClasses(classes);
-    expect(result).to.deep.equal(expectedResult);
-  });
-  describe('when passed a screenSize', () => {
-    it('should prefix an array of classes with the responsive prefix and `vads-u-`', () => {
-      const expectedResult = [
-        'medium-screen:vads-u-class-1',
-        'medium-screen:vads-u-class-2',
-      ];
-      const result = prefixUtilityClasses(classes, 'medium');
-      expect(result).to.deep.equal(expectedResult);
     });
   });
 });

--- a/src/platform/utilities/prefix-utility-classes.js
+++ b/src/platform/utilities/prefix-utility-classes.js
@@ -1,0 +1,18 @@
+/**
+ * Helper that prefixes class names with an optional responsive prefix and the
+ * `vads-u-` utility class prefix.
+ *
+ * @param {string[]} classes - Array of classes to prefix with `vads-u-`
+ * @param {string} screenSize - Optional screen size
+ * @returns {string[]} The input `classes` array with the correct prefixes
+ * applied
+ *
+ * Example: `prefixUtilityClasses(['my-class'], 'medium')` returns
+ * ['medium-screen:vads-u-my-class']
+ */
+const prefixUtilityClasses = (classes, screenSize = '') => {
+  const colonizedScreenSize = screenSize ? `${screenSize}-screen:` : '';
+  return classes.map(className => `${colonizedScreenSize}vads-u-${className}`);
+};
+
+export default prefixUtilityClasses;

--- a/src/platform/utilities/tests/prefix-utility-classes.unit.spec.js
+++ b/src/platform/utilities/tests/prefix-utility-classes.unit.spec.js
@@ -1,0 +1,20 @@
+import { expect } from 'chai';
+
+import prefixUtilityClasses from '../prefix-utility-classes';
+
+describe('prefixUtilityClasses', () => {
+  const classes = ['class-1', 'class-2'];
+  it('should prefix an array of classes with `vads-u-`', () => {
+    const expectedResult = ['vads-u-class-1', 'vads-u-class-2'];
+    const result = prefixUtilityClasses(classes);
+    expect(result).to.deep.equal(expectedResult);
+  });
+  it('should prefix an array of classes with `vads-u-` and a responsive prefix when passed an optional screenSize', () => {
+    const expectedResult = [
+      'medium-screen:vads-u-class-1',
+      'medium-screen:vads-u-class-2',
+    ];
+    const result = prefixUtilityClasses(classes, 'medium');
+    expect(result).to.deep.equal(expectedResult);
+  });
+});

--- a/src/platform/utilities/tests/react-hooks.unit.spec.js
+++ b/src/platform/utilities/tests/react-hooks.unit.spec.js
@@ -2,7 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import { expect } from 'chai';
 
-import { usePrevious } from './react-hooks';
+import { usePrevious } from '../react-hooks';
 
 describe('usePrevious', () => {
   let container;


### PR DESCRIPTION
## Description
I have a separate branch that uses this helper in some new code that lives in `platform/` so it feels like a good time to elevate this helper up out the `applications/` folder and into `platform/`.

## Testing done
Local + existing test

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs