### PR TITLE
[Development] Ensure users verify their identity form 526

### DIFF
--- a/src/applications/disability-benefits/all-claims/Form526EZApp.jsx
+++ b/src/applications/disability-benefits/all-claims/Form526EZApp.jsx
@@ -1,20 +1,48 @@
 import React from 'react';
+import { connect } from 'react-redux';
 
 import RoutedSavableApp from 'platform/forms/save-in-progress/RoutedSavableApp';
+import RequiredLoginView from 'platform/user/authorization/components/RequiredLoginView';
+import backendServices from 'platform/user/profile/constants/backendServices';
+
 import formConfig from './config/form';
-
 import ITFWrapper from './containers/ITFWrapper';
-import RequiredServicesGate from './containers/RequiredServicesGate';
+import { MissingServices } from './containers/MissingServices';
 
-export default function Form526Entry({ location, children }) {
+export const serviceRequired = [
+  backendServices.FORM526,
+  backendServices.ORIGINAL_CLAIMS,
+];
+
+export const hasRequiredServices = user =>
+  serviceRequired.some(service => user.profile.services.includes(service));
+
+export function Form526Entry({ location, user, children }) {
   // wraps the app and redirects user if they are not enrolled
+  const content = (
+    <RoutedSavableApp formConfig={formConfig} currentLocation={location}>
+      {children}
+    </RoutedSavableApp>
+  );
+  // Not logged in, so show the rendered content. The RoutedSavableApp shows
+  // an alert with the sign in button
+  if (!user.login.currentlyLoggedIn) {
+    return content;
+  }
+  // RequiredLoginView checks if you're verified and shows the appropriate link
+  // user 2 doesn't have the required services. Show an alert
+  if (user.profile.verified && !hasRequiredServices(user)) {
+    return <MissingServices />;
+  }
   return (
-    <RequiredServicesGate location={location}>
-      <ITFWrapper location={location}>
-        <RoutedSavableApp formConfig={formConfig} currentLocation={location}>
-          {children}
-        </RoutedSavableApp>
-      </ITFWrapper>
-    </RequiredServicesGate>
+    <RequiredLoginView serviceRequired={serviceRequired} user={user} verify>
+      <ITFWrapper location={location}>{content}</ITFWrapper>
+    </RequiredLoginView>
   );
 }
+
+const mapStateToProps = state => ({
+  user: state.user,
+});
+
+export default connect(mapStateToProps)(Form526Entry);

--- a/src/applications/disability-benefits/all-claims/containers/MissingServices.jsx
+++ b/src/applications/disability-benefits/all-claims/containers/MissingServices.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
+
+export const MissingServices = ({ children }) => {
+  const content = (
+    <>
+      For help with your application, please call Veterans Benefits Assistance
+      at{' '}
+      <a
+        href="tel:+18008271000"
+        aria-label="8 0 0. 8 2 7. 1 0 0 0."
+        className="no-wrap"
+      >
+        800-827-1000
+      </a>
+      , Monday through Friday, 8:00 a.m. to 9:00 p.m. ET.
+    </>
+  );
+  return (
+    <div className="usa-grid full-page-alert">
+      <AlertBox
+        isVisible
+        headline="We’re sorry. It looks like we’re missing some information needed for your application"
+        content={content}
+        status="error"
+      />
+      {children}
+    </div>
+  );
+};

--- a/src/applications/disability-benefits/all-claims/tests/containers/Form526EZApp.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/containers/Form526EZApp.unit.spec.jsx
@@ -1,0 +1,121 @@
+import React from 'react';
+import { expect } from 'chai';
+import { mount } from 'enzyme';
+
+import { Provider } from 'react-redux';
+import { combineReducers, createStore } from 'redux';
+
+import { commonReducer } from 'platform/startup/store';
+import reducers from '../../reducers';
+import localStorage from 'platform/utilities/storage/localStorage';
+
+import Form526Entry, { serviceRequired } from '../../Form526EZApp';
+
+const fakeSipsIntro = user => {
+  const { profile, login } = user;
+  if (!login.currentlyLoggedIn) {
+    return 'Log in to continue';
+  }
+  if (!profile.verified) {
+    return 'Need to be verified';
+  }
+  // 'Not authorized' shouldn't be seen (an alert will show instead)
+  return profile.services.length ? 'Start the form' : 'Not authorized';
+};
+
+describe('Form 526EZ Entry Page', () => {
+  const testPage = ({
+    verified = false,
+    currentlyLoggedIn = true,
+    services = [],
+  } = {}) => {
+    const initialState = {
+      form: {
+        loadedStatus: 'success',
+        savedStatus: '',
+        loadedData: {
+          metadata: {},
+        },
+      },
+      user: {
+        login: {
+          currentlyLoggedIn,
+        },
+        profile: {
+          verified,
+          services,
+          loading: false,
+          status: '',
+        },
+      },
+      currentLocation: {
+        pathname: '/introduction',
+        search: '',
+      },
+    };
+    const fakeStore = createStore(
+      combineReducers({
+        ...commonReducer,
+        ...reducers,
+      }),
+      initialState,
+    );
+    return mount(
+      <Provider store={fakeStore}>
+        <Form526Entry
+          location={initialState.currentLocation}
+          user={initialState.user}
+        >
+          <main>{fakeSipsIntro(initialState.user)}</main>
+        </Form526Entry>
+      </Provider>,
+    );
+  };
+
+  // Not logged in
+  it('should render content when not logged in', () => {
+    const tree = testPage({
+      currentlyLoggedIn: false,
+    });
+    expect(tree.find('RoutedSavableApp')).to.have.lengthOf(1);
+    expect(tree.find('main').text()).to.contain('Log in');
+    tree.unmount();
+  });
+
+  // Logged in & verified, but missing services
+  it('should render Missing services page', () => {
+    const tree = testPage({
+      currentlyLoggedIn: true,
+      verified: true,
+    });
+    expect(tree.find('main')).to.have.lengthOf(0);
+    expect(tree.find('AlertBox')).to.have.lengthOf(1);
+    expect(tree.find('AlertBox').text()).to.contain('missing some information');
+    tree.unmount();
+  });
+
+  // Logged in & verified & has services
+  it('should render form app content', () => {
+    const tree = testPage({
+      currentlyLoggedIn: true,
+      verified: true,
+      services: serviceRequired,
+    });
+    expect(tree.find('main').text()).to.contain('Start the form');
+    tree.unmount();
+  });
+
+  // Logged in & not verified (missing services)
+  it('should render verify your identity page', () => {
+    localStorage.setItem('hasSession', true);
+    const tree = testPage({
+      currentlyLoggedIn: true,
+      verified: false,
+      services: serviceRequired,
+    });
+    localStorage.removeItem('hasSession');
+    expect(tree.find('main').text()).to.contain('Need to be verified');
+
+    tree.unmount();
+  });
+});

--- a/src/applications/disability-benefits/all-claims/tests/containers/Form526EZApp.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/containers/Form526EZApp.unit.spec.jsx
@@ -105,7 +105,7 @@ describe('Form 526EZ Entry Page', () => {
     tree.unmount();
   });
 
-  // Logged in & not verified (missing services)
+  // Logged in & not verified (has services to allow proceeding)
   it('should render verify your identity page', () => {
     localStorage.setItem('hasSession', true);
     const tree = testPage({


### PR DESCRIPTION
## Description

Previously form 526 would bypass verification checks on the introduction page, allowing users that had not been verified to progress through the form and submit, but submission would be rejected by EVSS.

This PR reworks the form 526 app entry component to ensure the verification screen is shown to unverified users. These users might be missing a BIRLS ID or EDIPI. And will need to call the help desk

<details><summary>User is not logged in</summary>

<!-- leave a blank line above -->
![Screen Shot 2020-05-27 at 1 29 00 PM](https://user-images.githubusercontent.com/136959/83059930-4a0d3a80-a020-11ea-8b77-b09afdba3932.png)</details>

<details><summary>User logged in, but not verified</summary>

<!-- leave a blank line above -->
<br />

To duplicate this, create a new user with ID.me, but skip the verification process

![Screen Shot 2020-05-27 at 1 30 09 PM](https://user-images.githubusercontent.com/136959/83059847-2a761200-a020-11ea-80f4-66e085e8ef57.png)</details>

<details><summary>User logged in & verified but is not allowed to submit form 526</summary>

<!-- leave a blank line above -->
<br />

**User 2** is LOA3 verified, but does not have form 526 services available

![Screen Shot 2020-05-27 at 1 31 46 PM](https://user-images.githubusercontent.com/136959/83059698-eedb4800-a01f-11ea-80cc-de9420408448.png)</details>

<details><summary>User logged in, is verified & has form 526 service</summary>

<!-- leave a blank line above -->
![Screen Shot 2020-05-27 at 1 36 31 PM](https://user-images.githubusercontent.com/136959/83059598-c5bab780-a01f-11ea-9843-47906c7c660b.png)</details>

Related ticket: https://github.com/department-of-veterans-affairs/va.gov-team/issues/9448

## Testing done

Added new form 526 app unit test

## Screenshots

See above

## Acceptance criteria
- [ ] Users not allowed to submit a form 526 should be alerted to this fact.
- [ ] Unverified users should not be allowed to proceed with form 526 submission

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
