### PR TITLE
Banner set to landing page only

### DIFF
--- a/src/applications/gi/containers/GiBillApp.jsx
+++ b/src/applications/gi/containers/GiBillApp.jsx
@@ -90,10 +90,12 @@ export class GiBillApp extends React.Component {
     } else {
       content = this.props.children;
     }
-
     return (
       <div className="gi-app">
-        {!environment.isProduction() && <Covid19Banner />}
+        {!environment.isProduction() &&
+          this.props.children.props.location.pathname === '/' && (
+            <Covid19Banner />
+          )}
         <div className="row">
           <div className="columns small-12">
             {preview.display && (

--- a/src/applications/gi/containers/GiBillApp.jsx
+++ b/src/applications/gi/containers/GiBillApp.jsx
@@ -93,7 +93,7 @@ export class GiBillApp extends React.Component {
     return (
       <div className="gi-app">
         {!environment.isProduction() &&
-          this.props.children.props.location.pathname === '/' && (
+          location.pathname === '/gi-bill-comparison-tool/' && (
             <Covid19Banner />
           )}
         <div className="row">


### PR DESCRIPTION
## Description
The notification implemented in #9257 Should only display on the GIBCT Landing Page at https://staging.va.gov/gi-bill-comparison-tool/. Currently, it shows on all pages in the Comparison Tool.

https://github.com/department-of-veterans-affairs/va.gov-team/issues/9582

## Testing done
local testing

## Screenshots
![Screen Shot 2020-05-28 at 11 00 32 AM](https://user-images.githubusercontent.com/50601724/83158188-7a151600-a0d2-11ea-9f4b-92657d86bb99.png)


## Acceptance criteria
- [x] Banner only appears on landing page

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
