### PR TITLE
Disabled jsx-a11y/label-has-for

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -145,6 +145,7 @@
     "jsx-a11y/click-events-have-key-events": 0, //10
     "jsx-a11y/anchor-is-valid": 0, //19
     "jsx-a11y/label-has-associated-control": 0, //35
+    "jsx-a11y/label-has-for": 0, //66
 
     "import/named": 0, //2
     "import/no-useless-path-segments": 0, //59  (fixable)


### PR DESCRIPTION
## Description
This rule has been temporarily disabled due to producing errors after the `eslint` update

## Testing done
Locally

## Screenshots
![Screen Shot 2020-05-28 at 11 21 34 AM](https://user-images.githubusercontent.com/55560129/83160850-b433e700-a0d5-11ea-9a9d-72b9f5753eaa.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
