### PR TITLE
526 and BDD Payment Information wording changes

### DIFF
--- a/src/applications/disability-benefits/all-claims/components/PaymentView.jsx
+++ b/src/applications/disability-benefits/all-claims/components/PaymentView.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import { isEqual } from 'lodash';
+import { isEqual, isEmpty } from 'lodash';
 
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 
@@ -26,16 +26,22 @@ const mask = (string, unmaskedLength) => {
   );
 };
 
-const accountsDifferContent = (
-  <p>
-    We’ll add this new bank account to your disability application.{' '}
-    <strong>
-      This new account won’t be updated in all VA systems right away.
-    </strong>{' '}
-    Your current payments will continue to be deposited into the previous
-    account we showed.
-  </p>
-);
+function accountsDifferContent(originalDataIsEmpty) {
+  return (
+    <p>
+      We’ll add this new bank account to your disability application.{' '}
+      <strong>
+        This new account won’t be updated in all VA systems right away.
+      </strong>{' '}
+      {!originalDataIsEmpty && (
+        <>
+          Your current payments will continue to be deposited into the previous
+          account we showed.
+        </>
+      )}
+    </p>
+  );
+}
 
 export const PaymentView = ({ formData = {}, originalData = {} }) => {
   const getBankData = name =>
@@ -58,6 +64,8 @@ export const PaymentView = ({ formData = {}, originalData = {} }) => {
     originalData,
   );
 
+  const originalDataIsEmpty = isEmpty(originalData);
+
   return (
     <>
       {!dataChanged && (
@@ -74,7 +82,11 @@ export const PaymentView = ({ formData = {}, originalData = {} }) => {
         <p>Bank name: {bankName || srSubstitute('', 'is blank')}</p>
       </div>
       {dataChanged && (
-        <AlertBox isVisible status="warning" content={accountsDifferContent} />
+        <AlertBox
+          isVisible
+          status="warning"
+          content={accountsDifferContent(originalDataIsEmpty)}
+        />
       )}
     </>
   );


### PR DESCRIPTION
## Description
This pull requests modifies the PaymentView component that 526 and BDD share to remove confusing wording when there was no previous banking information on file for the user.

## Acceptance criteria
- [ ] Wording mentioning previous banking information is not visible when the user had no previous banking information