### PR TITLE
[Static pages] Capture events for links that look like buttons

### DIFF
--- a/src/applications/static-pages/analytics/addButtonLinkListeners.js
+++ b/src/applications/static-pages/analytics/addButtonLinkListeners.js
@@ -3,11 +3,12 @@ import recordEvent from 'platform/monitoring/record-event';
 export default function addHomepageBannerListeners() {
   const buttonLinks = document.querySelectorAll('a.usa-button');
 
-  buttonLinks.addEventListener('click', event => {
-    event.preventDefault();
-    recordEvent({
-      event: 'cta-default-button-click',
-      buttonText: event.target.text
-    });
-  });
+  buttonLinks.forEach(buttonLink => {
+    buttonLink.addEventListener('click', event => {
+      recordEvent({
+        event: 'cta-default-button-click',
+        buttonText: event.target.text
+      });
+    })
+  })
 }

--- a/src/applications/static-pages/analytics/addButtonLinkListeners.js
+++ b/src/applications/static-pages/analytics/addButtonLinkListeners.js
@@ -7,8 +7,8 @@ export default function addHomepageBannerListeners() {
     buttonLink.addEventListener('click', event => {
       recordEvent({
         event: 'cta-default-button-click',
-        buttonText: event.target.text
+        buttonText: event.target.text,
       });
-    })
-  })
+    });
+  });
 }

--- a/src/applications/static-pages/analytics/addButtonLinkListeners.js
+++ b/src/applications/static-pages/analytics/addButtonLinkListeners.js
@@ -1,22 +1,13 @@
 import recordEvent from 'platform/monitoring/record-event';
-import { isAnchor } from './utilities';
 
 export default function addHomepageBannerListeners() {
-  const container = document.querySelector('main');
+  const buttonLinks = document.querySelectorAll('a.usa-button');
 
-  if (!container) return;
-
-  container.addEventListener('click', event => {
-    if (!isAnchor(event.target)) {
-      return;
-    }
-
-    if (event.target.classList?.contains('usa-button')) {
-      event.preventDefault();
-      recordEvent({
-        event: 'cta-default-button-click',
-        buttonText: event.target.text
-      });
-    }
+  buttonLinks.addEventListener('click', event => {
+    event.preventDefault();
+    recordEvent({
+      event: 'cta-default-button-click',
+      buttonText: event.target.text
+    });
   });
 }

--- a/src/applications/static-pages/analytics/addButtonLinkListeners.js
+++ b/src/applications/static-pages/analytics/addButtonLinkListeners.js
@@ -1,0 +1,22 @@
+import recordEvent from 'platform/monitoring/record-event';
+import { isAnchor } from './utilities';
+
+export default function addHomepageBannerListeners() {
+  const container = document.querySelector('main');
+
+  if (!container) return;
+
+  container.addEventListener('click', event => {
+    if (!isAnchor(event.target)) {
+      return;
+    }
+
+    if (event.target.classList?.contains('usa-button')) {
+      event.preventDefault();
+      recordEvent({
+        event: 'cta-default-button-click',
+        buttonText: event.target.text
+      });
+    }
+  });
+}

--- a/src/applications/static-pages/analytics/index.js
+++ b/src/applications/static-pages/analytics/index.js
@@ -1,7 +1,10 @@
+import environment from 'platform/utilities/environment';
+
 import addJumplinkListeners from './addJumpLinkListeners';
 import addQaSectionListeners from './addQaSectionListeners';
 import addTeaserListeners from './addTeaserListeners';
 import addHomepageBannerListeners from './addHomepageBannerListeners';
+import addButtonLinkListeners from './addButtonLinkListeners';
 
 /**
  * Use pageListenersMap.set(<page path>, <array of functions>) to register
@@ -26,6 +29,10 @@ function attachAnalytics() {
 
   // Global listeners
   addTeaserListeners();
+
+  if (!environment.isProduction()) {
+    addButtonLinkListeners();
+  }
 }
 
 // Prevent the window from navigating away.


### PR DESCRIPTION
## Description
This PR implements analytics across static pages (Drupal-backed content) to capture when a user clicks a link that looks like a button. For example -

http://localhost:3001/decision-reviews/board-appeal/after-board-appeal-decision/
![image](https://user-images.githubusercontent.com/1915775/83166289-b483b080-a0dc-11ea-996f-7d04da287525.png)

This content comes from a WYSIWYG, so it's just a block of content dropped into the page, so we can't directly bind an event. Instead, we have to select the elements and bind the listeners on page load.

https://github.com/department-of-veterans-affairs/va.gov-team/issues/7558
https://github.com/department-of-veterans-affairs/va.gov-team/issues/7345

## Testing done
Clicked buttons/links locally and observed events were firing correctly. I'm also feature flagging this to staging so the analytics crew can check it out first.

## Screenshots
![image](https://user-images.githubusercontent.com/1915775/83167395-33c5b400-a0de-11ea-8df5-9c13edf75a4e.png)


## Acceptance criteria
- [ ] Analytics are set up to track button-link clicks

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
