### PR TITLE
[Development] Add message for users missing an ID

### DIFF
--- a/src/applications/disability-benefits/all-claims/Form526EZApp.jsx
+++ b/src/applications/disability-benefits/all-claims/Form526EZApp.jsx
@@ -8,7 +8,7 @@ import backendServices from 'platform/user/profile/constants/backendServices';
 import formConfig from './config/form';
 import AddPerson from './containers/AddPerson';
 import ITFWrapper from './containers/ITFWrapper';
-import { MissingServices } from './containers/MissingServices';
+import { MissingServices, MissingId } from './containers/MissingServices';
 
 import { MVI_ADD_SUCCEEDED } from './actions';
 
@@ -17,8 +17,18 @@ export const serviceRequired = [
   backendServices.ORIGINAL_CLAIMS,
 ];
 
+export const idRequired = [
+  // checks if EDIPI & SSN exists
+  backendServices.EVSS_CLAIMS,
+  // checks if EDIPI, SSN & either a BIRLS ID or Participant ID exists
+  backendServices.ORIGINAL_CLAIMS,
+];
+
 export const hasRequiredServices = user =>
   serviceRequired.some(service => user.profile.services.includes(service));
+
+export const hasRequiredId = user =>
+  idRequired.some(service => user.profile.services.includes(service));
 
 export function Form526Entry({ location, user, children, mvi }) {
   // wraps the app and redirects user if they are not enrolled
@@ -27,6 +37,7 @@ export function Form526Entry({ location, user, children, mvi }) {
       {children}
     </RoutedSavableApp>
   );
+
   // Not logged in, so show the rendered content. The RoutedSavableApp shows
   // an alert with the sign in button
   if (!user.login.currentlyLoggedIn) {
@@ -41,11 +52,19 @@ export function Form526Entry({ location, user, children, mvi }) {
     return <AddPerson />;
   }
 
-  // RequiredLoginView checks if you're verified and shows the appropriate link
-  // test user 2 doesn't have the required services. Show an alert
-  if (user.profile.verified && !hasRequiredServices(user)) {
-    return <MissingServices />;
+  // RequiredLoginView will handle unverified users by showing the
+  // appropriate link
+  if (user.profile.verified) {
+    // User is missing either their SSN, EDIPI, or BIRLS ID
+    if (!hasRequiredId(user)) {
+      return <MissingId />;
+    }
+    // User doesn't have the required services. Show an alert
+    if (!hasRequiredServices(user)) {
+      return <MissingServices />;
+    }
   }
+
   return (
     <RequiredLoginView serviceRequired={serviceRequired} user={user} verify>
       <ITFWrapper location={location}>{content}</ITFWrapper>

--- a/src/applications/disability-benefits/all-claims/containers/MissingServices.jsx
+++ b/src/applications/disability-benefits/all-claims/containers/MissingServices.jsx
@@ -44,17 +44,13 @@ export const MissingId = ({ children }) => {
       <p>
         It may expedite the process to inform the support representative that
         you are missing either your{' '}
-        <dfn>
-          <abbr title="Electronic Data Interchange Personal Identifier">
-            EDIPI
-          </abbr>
-        </dfn>
+        <abbr title="Electronic Data Interchange Personal Identifier">
+          EDIPI
+        </abbr>
         {' or '}
-        <dfn>
-          <abbr title="Beneficiary Identification and Records Locator (Sub)System">
-            BIRLS ID
-          </abbr>
-        </dfn>{' '}
+        <abbr title="Beneficiary Identification and Records Locator (Sub)System">
+          BIRLS ID
+        </abbr>{' '}
         - this is necessary tech information they will need to fix the issue. We
         apologize for the inconvenience.
       </p>

--- a/src/applications/disability-benefits/all-claims/containers/MissingServices.jsx
+++ b/src/applications/disability-benefits/all-claims/containers/MissingServices.jsx
@@ -4,23 +4,61 @@ import Telephone, {
   CONTACTS,
 } from '@department-of-veterans-affairs/formation-react/Telephone';
 
-export const MissingServices = ({ children }) => {
+const Alert = ({ content }) => (
+  <div className="vads-l-grid-container vads-u-padding-bottom--5">
+    <div className="usa-content">
+      <h1>File for Disability Compensation</h1>
+      <AlertBox isVisible content={content} status="error" />
+    </div>
+  </div>
+);
+
+export const MissingServices = () => {
   const content = (
     <>
-      For help with your application, please call Veterans Benefits Assistance
-      at <Telephone contact={CONTACTS.VA_BENEFITS} />, Monday through Friday,
-      8:00 a.m. to 9:00 p.m. ET.
+      <h2 className="vads-u-display--inline-block vads-u-font-size--h3 vads-u-margin-top--0">
+        We’re sorry. It looks like we’re missing some information needed for
+        your application
+      </h2>
+      <p>
+        For help with your application, please call Veterans Benefits Assistance
+        at <Telephone contact={CONTACTS.VA_BENEFITS} />, Monday through Friday,
+        8:00 a.m. to 9:00 p.m. ET.
+      </p>
     </>
   );
-  return (
-    <div className="usa-grid full-page-alert">
-      <AlertBox
-        isVisible
-        headline="We’re sorry. It looks like we’re missing some information needed for your application"
-        content={content}
-        status="error"
-      />
-      {children}
-    </div>
+  return <Alert content={content} />;
+};
+
+export const MissingId = ({ children }) => {
+  const content = (
+    <>
+      <h2 className="vads-u-display--inline-block vads-u-font-size--h3 vads-u-margin-top--0">
+        A technical error has occurred
+      </h2>
+      <p>
+        Some important technical details are missing from your account,
+        preventing you from using this tool. Please call us at <TelephoneLink />{' '}
+        so we can fix this issue for you.
+      </p>
+      <p>
+        It may expedite the process to inform the support representative that
+        you are missing either your{' '}
+        <dfn>
+          <abbr title="Electronic Data Interchange Personal Identifier">
+            EDIPI
+          </abbr>
+        </dfn>
+        {' or '}
+        <dfn>
+          <abbr title="Beneficiary Identification and Records Locator (Sub)System">
+            BIRLS ID
+          </abbr>
+        </dfn>{' '}
+        - this is necessary tech information they will need to fix the issue. We
+        apologize for the inconvenience.
+      </p>
+    </>
   );
+  return <Alert content={content} />;
 };

--- a/src/applications/disability-benefits/all-claims/containers/MissingServices.jsx
+++ b/src/applications/disability-benefits/all-claims/containers/MissingServices.jsx
@@ -17,13 +17,13 @@ export const MissingServices = () => {
   const content = (
     <>
       <h2 className="vads-u-display--inline-block vads-u-font-size--h3 vads-u-margin-top--0">
-        We’re sorry. It looks like we’re missing some information needed for
-        your application
+        We need some information for your application
       </h2>
       <p>
-        For help with your application, please call Veterans Benefits Assistance
-        at <Telephone contact={CONTACTS.VA_BENEFITS} />, Monday through Friday,
-        8:00 a.m. to 9:00 p.m. ET.
+        We need more information from you before you can file for disability
+        compensation. Please call Veterans Benefits Assistance at{' '}
+        <Telephone contact={CONTACTS.VA_BENEFITS} /> (TTY: 711), Monday through
+        Friday, 8:00 a.m. to 9:00 p.m. ET to update your account.
       </p>
     </>
   );
@@ -34,25 +34,25 @@ export const MissingId = ({ children }) => {
   const content = (
     <>
       <h2 className="vads-u-display--inline-block vads-u-font-size--h3 vads-u-margin-top--0">
-        A technical error has occurred
+        We need more information for your application
       </h2>
       <p>
-        Some important technical details are missing from your account,
-        preventing you from using this tool. Please call us at <TelephoneLink />{' '}
-        so we can fix this issue for you.
+        We don’t have all of your ID information for your account. We need this
+        information before you can file for disability compensation. To update
+        your account, please call Veterans Benefits Assistance at{' '}
+        <Telephone contact={CONTACTS.VA_BENEFITS} /> (TTY: 711). We’re here
+        Monday through Friday, 8:00 a.m. to 9:00 p.m. ET.
       </p>
       <p>
-        It may expedite the process to inform the support representative that
-        you are missing either your{' '}
+        Tell the representative that you may be missing your{' '}
         <abbr title="Electronic Data Interchange Personal Identifier">
           EDIPI
         </abbr>
-        {' or '}
+        {' number or '}
         <abbr title="Beneficiary Identification and Records Locator (Sub)System">
           BIRLS ID
-        </abbr>{' '}
-        - this is necessary tech information they will need to fix the issue. We
-        apologize for the inconvenience.
+        </abbr>
+        .
       </p>
     </>
   );

--- a/src/applications/disability-benefits/all-claims/sass/disability-benefits.scss
+++ b/src/applications/disability-benefits/all-claims/sass/disability-benefits.scss
@@ -13,6 +13,10 @@
   margin-bottom: 2em;
 }
 
+.no-wrap {
+  white-space: nowrap;
+}
+
 ul.original-disability-list {
   li {
     margin-bottom: 0;

--- a/src/applications/disability-benefits/all-claims/tests/containers/Form526EZApp.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/containers/Form526EZApp.unit.spec.jsx
@@ -114,7 +114,7 @@ describe('Form 526EZ Entry Page', () => {
     });
     expect(tree.find('main')).to.have.lengthOf(0);
     expect(tree.find('AlertBox')).to.have.lengthOf(1);
-    expect(tree.find('AlertBox').text()).to.contain('missing some information');
+    expect(tree.find('AlertBox').text()).to.contain('need some information');
     tree.unmount();
   });
 

--- a/src/applications/disability-benefits/all-claims/tests/containers/Form526EZApp.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/containers/Form526EZApp.unit.spec.jsx
@@ -8,7 +8,7 @@ import { combineReducers, createStore } from 'redux';
 import { commonReducer } from 'platform/startup/store';
 import localStorage from 'platform/utilities/storage/localStorage';
 
-import Form526Entry, { serviceRequired } from '../../Form526EZApp';
+import Form526Entry, { serviceRequired, idRequired } from '../../Form526EZApp';
 import reducers from '../../reducers';
 import {
   MVI_ADD_INITIATED,
@@ -91,11 +91,26 @@ describe('Form 526EZ Entry Page', () => {
     tree.unmount();
   });
 
-  // Logged in & verified, but missing services
+  // Logged in & verified, but missing ID
+  it('should render Missing ID page', () => {
+    const tree = testPage({
+      currentlyLoggedIn: true,
+      verified: true,
+      services: [],
+    });
+    expect(tree.find('main')).to.have.lengthOf(0);
+    expect(tree.find('AlertBox')).to.have.lengthOf(1);
+    expect(tree.find('AlertBox').text()).to.contain('BIRLS ID');
+    tree.unmount();
+  });
+
+  // Logged in & verified, but missing 526 services
   it('should render Missing services page', () => {
     const tree = testPage({
       currentlyLoggedIn: true,
       verified: true,
+      // only include 'EVSS_CLAIMS' service
+      services: [idRequired[0]],
     });
     expect(tree.find('main')).to.have.lengthOf(0);
     expect(tree.find('AlertBox')).to.have.lengthOf(1);

--- a/src/applications/disability-benefits/all-claims/tests/containers/Form526EZApp.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/containers/Form526EZApp.unit.spec.jsx
@@ -184,7 +184,9 @@ describe('Form 526EZ Entry Page', () => {
     });
     expect(tree.find('main')).to.have.lengthOf(0);
     expect(tree.find('AlertBox')).to.have.lengthOf(1);
-    expect(tree.find('AlertBox').text()).to.contain('missing some information');
+    expect(tree.find('AlertBox p').text()).to.contain(
+      'We need more information',
+    );
     tree.unmount();
   });
 });


### PR DESCRIPTION
## Description

When a user is missing either their EDIPI or BIRLS ID, they need to be shown a message letting them know that they need to contact the help desk.

This code checks that a user has either the `evss-claims` or `original-claims` service available, if not, then an alert message is shown (see screenshot; test this with user 2)

- `evss-claims` - is set when the user has an EDIPI and SSN
- `original-claims` - is set when the user has an EDIPI, SSN and either a BIRLS ID or Participant ID.

<details><summary>Missing ID message screenshot</summary>

<!-- leave a blank line above -->
![Screen Shot 2020-05-28 at 11 44 03 AM](https://user-images.githubusercontent.com/136959/83180711-7476fa80-a0e9-11ea-9c83-ebaab1528e22.png)</details>

This PR also fixes an accessibility issue (adding an `h1`) for the message that is shown when the user doesn't have either the `original_claims` or `form526` service available. 

This user is not allowed to file a form 526 for whatever reason. **I did not find a test user that matches this criteria**.

<details>
<summary>Missing 526 service message screenshot</summary>

<!-- leave a blank line above -->
![Screen Shot 2020-05-28 at 11 45 00 AM](https://user-images.githubusercontent.com/136959/83181051-f109d900-a0e9-11ea-8331-6ee2340c00f1.png)</details>

Related ticket: https://github.com/department-of-veterans-affairs/va.gov-team/issues/9263

## Testing done

Updated unit tests

## Screenshots

See dropdowns in the description

## Acceptance criteria
- [ ] Users missing EDIPI will be alerted to contact the help desk
- [ ] Alert message content reviewed
- [ ] Accessibility checks are passing 

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
