### PR TITLE
Scroll radiobuttons and checkboxes into view when selected in iOS Safari.

### DIFF
--- a/src/applications/gi/components/Checkbox.jsx
+++ b/src/applications/gi/components/Checkbox.jsx
@@ -30,12 +30,18 @@ class Checkbox extends React.Component {
   }
 
   handleChange(domEvent) {
+    this.handleFocus();
     this.props.onChange(domEvent);
   }
 
   handleFocus = e => {
-    if (window.innerWidth <= SMALL_SCREEN_WIDTH) {
-      e.target.scrollIntoView();
+    // prod flag for bah-8821
+    if (environment.isProduction()) {
+      if (window.innerWidth <= SMALL_SCREEN_WIDTH) {
+        e.target.scrollIntoView();
+      }
+    } else {
+      this.props.onFocus(this.inputId);
     }
   };
 
@@ -83,12 +89,6 @@ class Checkbox extends React.Component {
           id={this.inputId}
           name={this.props.name}
           type="checkbox"
-          onFocus={
-            // prod flag for bah-8821
-            environment.isProduction()
-              ? this.handleFocus
-              : this.props.onFocus.bind(this, this.inputId)
-          }
           onChange={this.handleChange}
         />
         <label

--- a/src/applications/gi/components/RadioButtons.jsx
+++ b/src/applications/gi/components/RadioButtons.jsx
@@ -27,13 +27,19 @@ class RadioButtons extends React.Component {
   }
 
   handleChange = domEvent => {
+    this.handleFocus();
     this.props.onChange(domEvent);
   };
 
   handleFocus = () => {
-    const field = document.getElementById(`${this.inputId}-legend`);
-    if (field && window.innerWidth <= SMALL_SCREEN_WIDTH) {
-      field.scrollIntoView();
+    // prod flag for bah-8821
+    if (environment.isProduction()) {
+      const field = document.getElementById(`${this.inputId}-legend`);
+      if (field && window.innerWidth <= SMALL_SCREEN_WIDTH) {
+        field.scrollIntoView();
+      }
+    } else {
+      this.props.onFocus(`${this.inputId}-field`);
     }
   };
 
@@ -74,12 +80,6 @@ class RadioButtons extends React.Component {
             type="radio"
             value={optionValue}
             onChange={this.handleChange}
-            onFocus={
-              // prod flag for bah-8821
-              environment.isProduction()
-                ? this.handleFocus
-                : this.props.onFocus.bind(this, `${this.inputId}-field`)
-            }
             aria-labelledby={`${this.inputId}-legend ${labelId}`}
           />
           <label

--- a/src/applications/gi/utils/helpers.js
+++ b/src/applications/gi/utils/helpers.js
@@ -121,7 +121,8 @@ export const handleInputFocusWithPotentialOverLap = (
         const scrollableField =
           document.getElementById(scrollableFieldId) || window;
         if (scrollableField) {
-          const scrollUpBy = fieldRect1.bottom - fieldRect2.top + 2;
+          const pixelOffset = 10;
+          const scrollUpBy = fieldRect1.bottom - fieldRect2.top + pixelOffset;
           scrollableField.scrollBy({
             top: scrollUpBy,
             left: 0,


### PR DESCRIPTION
## Description
https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/8821

This PR allows for radiobuttons and checkboxes to scroll up or down into view when they are slightly off screen. 

Note: Smooth scrolling isn't viable for radiobuttons or checkboxes in iOS Safari.
 
## Testing done
Dev tested in both iOS Safari and Android Chrome using emulators.

## Screenshots
![image](https://user-images.githubusercontent.com/48804654/83183123-56af9280-a0f5-11ea-80e0-93ca74f83f9f.png)

![image](https://user-images.githubusercontent.com/48804654/83183133-59aa8300-a0f5-11ea-984b-3dec1f054342.png)

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
