### PR TITLE
Fix Immediate Return - Vaos v3

### DIFF
--- a/src/applications/vaos/services/organization/index.js
+++ b/src/applications/vaos/services/organization/index.js
@@ -31,12 +31,10 @@ export async function getOrganizations({ siteIds, useVSP = false }) {
     }
   }
 
-  const results = await fhirSearch({
+  return fhirSearch({
     query: `Organization?identifier=${siteIds.join(',')}`,
     mock: () => import('./mock.json'),
   });
-
-  return results;
 }
 /**
  * Pulls the VistA id from an Organization resource


### PR DESCRIPTION
## Description

`prefer-immediate-return` rule from SonarJS has been added to the testing stage in CircleCI (circle.esint.json)

This change should help the code to be in compliance with the rule and removes the errors from `additional-linting` CircleCI check.

## Testing done
Locally

## Screenshots

![Screen Shot 2020-05-28 at 3 29 56 PM](https://user-images.githubusercontent.com/55560129/83185001-4e0c8b80-a0f8-11ea-8c6b-e7b37c221a37.png)

