### PR TITLE
Remove documentation line that is no longer accurate

### DIFF
--- a/src/platform/site-wide/mega-menu/README.md
+++ b/src/platform/site-wide/mega-menu/README.md
@@ -11,7 +11,7 @@ The way React components work in vets-website is that they are injected into web
 startMegaMenuWidget(window.VetsGov.headerFooter.megaMenuData, commonStore);
 ```
 
-As you can see we pass in a data argument located at `window.VetsGov.headerFooter.megaMenuData`. This data is derived from a YAML file located in the ***vagov-content*** repo at ***vagov-content/fragments/megamenu/index.yaml***. There is a MetalSmith plugin that we created to add this to the global window. This is done in the build process. You can find the plugin code at */src/site/stages/build/plugins/create-header-footer.js*
+As you can see we pass in a data argument located at `window.VetsGov.headerFooter.megaMenuData`. There is a MetalSmith plugin that we created to add this to the global window. This is done in the build process. You can find the plugin code at */src/site/stages/build/plugins/create-header-footer.js*
 
 ## Redux
 The MegaMenu uses Redux to store it's state. You can find the container component at */src/platform/site-wide/mega-menu/containers/Main.jsx. This is where all logic for the component lives. You will also find all of the common Redux files (actions, reducers) in the *mega-menu* folder.


### PR DESCRIPTION
## Description

While trying to see where `vagov-content` was used in the build, I came across a line of documentation that was inaccurate. 

The documentation was referring to a file that was been deleted in https://github.com/department-of-veterans-affairs/vagov-content/pull/648. 

### References

* Commit where documentation was added: https://github.com/department-of-veterans-affairs/vets-website/blame/435e99f4e08627e6bce66724a3e9f44192e393bb/src/platform/site-wide/mega-menu/README.md#L14
* PR where file was removed: https://github.com/department-of-veterans-affairs/vagov-content/pull/648
* Slack conversation about updating docs: https://dsva.slack.com/archives/GLDNCMRSP/p1590697965073800