### PR TITLE
Fix core-js warning

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -25,6 +25,7 @@
           ]
         },
         "useBuiltIns": "entry",
+        "corejs": "2.0.0",
         "modules": false,
         "debug": false
       }


### PR DESCRIPTION
## Description
After the `@babel` dependencies update. Babel requires to specify the `core-js` version. This will remove this warning

`core-js` version 3 is available but it creates conflict with the current version of `babel/core`. They are currently working on fixing that.

## Testing done
Locally

## Screenshots

<img width="1105" alt="core-js error" src="https://user-images.githubusercontent.com/55560129/83193482-1d7f1e80-a105-11ea-96d4-cdf4f9f21ed7.png">


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
