### PR TITLE
Derives CTA tool URL after feature flags load

### DIFF
--- a/src/applications/vaos/tests/utils/appointment.unit.spec.jsx
+++ b/src/applications/vaos/tests/utils/appointment.unit.spec.jsx
@@ -639,8 +639,8 @@ describe('VAOS appointment helpers', () => {
   describe('sortFutureConfirmedAppointments', () => {
     it('should sort future confirmed appointments', () => {
       const confirmed = [
-        { appointmentDate: moment('2099-04-30T05:35:00'), facilityId: '984' },
-        { appointmentDate: moment('2099-04-27T05:35:00'), facilityId: '983' },
+        { start: moment('2099-04-30T05:35:00'), facilityId: '984' },
+        { start: moment('2099-04-27T05:35:00'), facilityId: '983' },
       ];
 
       const sorted = confirmed.sort(sortFutureConfirmedAppointments);

--- a/src/platform/site-wide/cta-widget/index.js
+++ b/src/platform/site-wide/cta-widget/index.js
@@ -54,15 +54,13 @@ import VAOnlineScheduling from './components/messages/VAOnlineScheduling';
 export class CallToActionWidget extends React.Component {
   constructor(props) {
     super(props);
-    const { appId, useSSOe } = props;
-    const { url, redirect } = toolUrl(appId, useSSOe);
+    const { appId } = props;
 
-    this._hasRedirect = redirect;
     this._popup = null;
     this._requiredServices = requiredServices(appId);
     this._serviceDescription = serviceDescription(appId);
     this._mhvToolName = mhvToolName(appId);
-    this._toolUrl = url;
+    this._toolUrl = null;
     this._gaPrefix = 'register-mhv';
   }
 
@@ -82,7 +80,10 @@ export class CallToActionWidget extends React.Component {
     }
 
     if (this.isAccessible()) {
-      if (this._hasRedirect && !this._popup) this.goToTool();
+      const { appId, useSSOe } = this.props;
+      const { url, redirect } = toolUrl(appId, useSSOe);
+      this._toolUrl = url;
+      if (redirect && !this._popup) this.goToTool();
     } else if (this.isHealthTool()) {
       const { accountLevel, accountState, loading } = this.props.mhvAccount;
 
@@ -443,6 +444,10 @@ export class CallToActionWidget extends React.Component {
         />
       );
     }
+
+    const { appId, useSSOe } = this.props;
+    const { url } = toolUrl(appId, useSSOe);
+    this._toolUrl = url;
 
     const content = this.getContent();
 

--- a/src/platform/site-wide/cta-widget/tests/helpers.unit.spec.js
+++ b/src/platform/site-wide/cta-widget/tests/helpers.unit.spec.js
@@ -6,43 +6,48 @@ import environment from '../../../utilities/environment';
 
 describe('CTA helpers', () => {
   describe('A signed-in SSO user', () => {
+    const useSSO = true;
+
     it('Download my data', () => {
-      expect(toolUrl(widgetTypes.HEALTH_RECORDS, true).url).to.equal(
+      expect(toolUrl(widgetTypes.HEALTH_RECORDS, useSSO).url).to.equal(
         `https://${
           eauthEnvironmentPrefixes[environment.BUILDTYPE]
         }eauth.va.gov/mhv-portal-web/eauth?deeplinking=download_my_data`,
       );
     });
     it('Prescription Refill', () => {
-      expect(toolUrl(widgetTypes.RX, true).url).to.equal(
+      expect(toolUrl(widgetTypes.RX, useSSO).url).to.equal(
         `https://${
           eauthEnvironmentPrefixes[environment.BUILDTYPE]
         }eauth.va.gov/mhv-portal-web/eauth?deeplinking=prescription_refill`,
       );
     });
     it('Secure Messaging', () => {
-      expect(toolUrl(widgetTypes.MESSAGING, true).url).to.equal(
+      expect(toolUrl(widgetTypes.MESSAGING, useSSO).url).to.equal(
         `https://${
           eauthEnvironmentPrefixes[environment.BUILDTYPE]
         }eauth.va.gov/mhv-portal-web/eauth?deeplinking=secure_messaging`,
       );
     });
     it('Appointments', () => {
-      expect(toolUrl(widgetTypes.VIEW_APPOINTMENTS, true).url).to.equal(
+      expect(toolUrl(widgetTypes.VIEW_APPOINTMENTS, useSSO).url).to.equal(
         `https://${
           eauthEnvironmentPrefixes[environment.BUILDTYPE]
         }eauth.va.gov/mhv-portal-web/eauth?deeplinking=appointments`,
       );
-      expect(toolUrl(widgetTypes.SCHEDULE_APPOINTMENTS, true).url).to.equal(
+      expect(toolUrl(widgetTypes.SCHEDULE_APPOINTMENTS, useSSO).url).to.equal(
         `https://${
           eauthEnvironmentPrefixes[environment.BUILDTYPE]
         }eauth.va.gov/mhv-portal-web/eauth?deeplinking=appointments`,
       );
     });
-    // TODO add this test once we have a valid URL to check
-    // it('Lab Tests', () => {
-    //   expect(toolUrl(widgetTypes.LAB_AND_TEST_RESULTS).url).to.equal();
-    // });
+    it('Lab Tests', () => {
+      expect(toolUrl(widgetTypes.LAB_AND_TEST_RESULTS, useSSO).url).to.equal(
+        `https://${
+          eauthEnvironmentPrefixes[environment.BUILDTYPE]
+        }eauth.va.gov/mhv-portal-web/eauth`,
+      );
+    });
   });
   describe('A signed-in non-SSO user', () => {
     it('Download my data', () => {

--- a/src/platform/site-wide/mhv/utilities.js
+++ b/src/platform/site-wide/mhv/utilities.js
@@ -4,7 +4,7 @@ import { eauthEnvironmentPrefixes } from 'platform/utilities/sso/constants';
 const eauthPrefix = eauthEnvironmentPrefixes[environment.BUILDTYPE];
 const mhvPrefix = environment.isProduction() ? 'www' : 'mhv-syst';
 
-// TODO: Add labs-and-tests route
+// TODO: Update labs-and-tests route once deep link is provided
 const mhvToEauthRoutes = {
   'download-my-data': 'eauth?deeplinking=download_my_data',
   'web/myhealthevet/refill-prescriptions':
@@ -12,6 +12,7 @@ const mhvToEauthRoutes = {
   'secure-messaging': 'eauth?deeplinking=secure_messaging',
   appointments: 'eauth?deeplinking=appointments',
   home: 'eauth',
+  'labs-tests': 'eauth',
 };
 
 // An MHV URL is a function of the following parameters:


### PR DESCRIPTION
Calculating the toolURL in the constructor meant that it
was occurring before feature flags were loaded and thus
the value of useSSOe was incorrect. This inlines the logic
to the two places where it is used - componentDidUpdate
and render.

While I was in there, fixed a dangling mhvUrl case for the labs-and-tests feature.

Fixes https://github.com/department-of-veterans-affairs/va.gov-team/issues/9609

