### PR TITLE
Removed caution flag filter prod flag

### DIFF
--- a/src/applications/gi/components/search/CautionaryWarningsFilter.jsx
+++ b/src/applications/gi/components/search/CautionaryWarningsFilter.jsx
@@ -22,24 +22,6 @@ class CautionaryWarningsFilter extends React.Component {
       component: this,
     });
   render() {
-    // prod flag for bah-8187. Remove after approval.
-    if (environment.isProduction()) {
-      return (
-        <div>
-          <p>
-            Cautionary warnings
-            {this.renderProfileCautionFlagModal()}
-          </p>
-          <Checkbox
-            checked={this.props.excludeCautionFlags}
-            name="excludeCautionFlags"
-            label="Exclude institutions with warnings"
-            onChange={this.props.onChange}
-            onFocus={this.props.handleInputFocus}
-          />
-        </div>
-      );
-    }
     return (
       <div>
         <p>

--- a/src/applications/gi/containers/Modals.jsx
+++ b/src/applications/gi/containers/Modals.jsx
@@ -1163,66 +1163,37 @@ export class Modals extends React.Component {
           doesn't find meaningful employment within 180 days.
         </p>
       </Modal>
-      {/* prod flag for bah-8187. Remove after approval. */}
-      {environment.isProduction() ? (
-        <Modal
-          onClose={this.props.hideModal}
-          visible={this.shouldDisplayModal('cautionaryWarnings')}
-        >
-          <h3>Cautionary warnings</h3>
-          <p>
-            When Caution Flags are displayed for an institution, they indicate
-            VA or other federal agencies like the Department of Education or
-            Department of Defense have applied increased regulatory or legal
-            scrutiny to this program. Before enrolling in a program, VA
-            recommends potential students should consider these cautionary
-            warnings.
-          </p>
-          <p>
-            {' '}
-            To learn more about Caution Flags,{' '}
-            <a
-              href="https://www.benefits.va.gov/gibill/comparison_tool/about_this_tool.asp#caution"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              visit the About this Tool page
-            </a>
-            .
-          </p>
-        </Modal>
-      ) : (
-        <Modal
-          onClose={this.props.hideModal}
-          visible={this.shouldDisplayModal('cautionaryWarnings')}
-        >
-          <h3>Cautionary warnings and school closings</h3>
-          <p>
-            VA applies caution flags when we, or another federal agency, have
-            increased regulatory or legal scrutiny of an educational program. We
-            recommend students consider these warnings before enrolling in
-            flagged programs.
-          </p>
-          <p>
-            When VA receives notice that a school or campus location will be
-            closing, we add a school closing flag to that profile. Once the
-            closing date passes, we remove the institution from the Comparison
-            Tool during the next system update.
-          </p>
-          <p>
-            {' '}
-            To learn more about caution flags,{' '}
-            <a
-              href="https://www.benefits.va.gov/gibill/comparison_tool/about_this_tool.asp#CF"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              visit the About this Tool page
-            </a>
-            .
-          </p>
-        </Modal>
-      )}
+
+      <Modal
+        onClose={this.props.hideModal}
+        visible={this.shouldDisplayModal('cautionaryWarnings')}
+      >
+        <h3>Cautionary warnings and school closings</h3>
+        <p>
+          VA applies caution flags when we, or another federal agency, have
+          increased regulatory or legal scrutiny of an educational program. We
+          recommend students consider these warnings before enrolling in flagged
+          programs.
+        </p>
+        <p>
+          When VA receives notice that a school or campus location will be
+          closing, we add a school closing flag to that profile. Once the
+          closing date passes, we remove the institution from the Comparison
+          Tool during the next system update.
+        </p>
+        <p>
+          {' '}
+          To learn more about caution flags,{' '}
+          <a
+            href="https://www.benefits.va.gov/gibill/comparison_tool/about_this_tool.asp#CF"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            visit the About this Tool page
+          </a>
+          .
+        </p>
+      </Modal>
     </span>
   );
   render() {


### PR DESCRIPTION
## Description
Remove prod flags around caution flag filter work done in [#8187](https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/8187)

[ZenHub Issue](https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/9029)

## Testing done
Tested locally and QA reviewed

## Screenshots
![image](https://user-images.githubusercontent.com/41960449/83263222-40a0e100-a18c-11ea-9c35-c4947bce0643.png)

![image](https://user-images.githubusercontent.com/41960449/83263639-ed7b5e00-a18c-11ea-9f81-0749d35821d6.png)

## Acceptance criteria
- [x] The work completed in [#8187](https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/8187) is available in the production environment.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
