### PR TITLE
[Caregivers] Implement Flipper into the app

### DIFF
--- a/src/applications/caregivers/containers/App.jsx
+++ b/src/applications/caregivers/containers/App.jsx
@@ -1,10 +1,35 @@
 import React from 'react';
+import { connect } from 'react-redux';
+
+import LoadingIndicator from '@department-of-veterans-affairs/formation-react/LoadingIndicator';
+
+import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
+import FEATURE_FLAG_NAMES from 'platform/utilities/feature-toggles/featureFlagNames';
 
 import RoutedSavableApp from 'platform/forms/save-in-progress/RoutedSavableApp';
 import formConfig from '../config/form';
 
-export default ({ location, children }) => (
-  <RoutedSavableApp formConfig={formConfig} currentLocation={location}>
-    {children}
-  </RoutedSavableApp>
-);
+const App = ({ loading, isFormAvailable, location, children }) => {
+  if (loading) {
+    return <LoadingIndicator />;
+  }
+
+  if (isFormAvailable === false) {
+    return document.location.replace('/');
+  }
+
+  return (
+    <RoutedSavableApp formConfig={formConfig} currentLocation={location}>
+      {children}
+    </RoutedSavableApp>
+  );
+};
+
+const mapStateToProps = state => ({
+  loading: toggleValues(state).loading,
+  isFormAvailable: toggleValues(state)[
+    FEATURE_FLAG_NAMES.allowOnline1010cgSubmissions
+  ],
+});
+
+export default connect(mapStateToProps)(App);

--- a/src/applications/caregivers/containers/App.jsx
+++ b/src/applications/caregivers/containers/App.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
 import LoadingIndicator from '@department-of-veterans-affairs/formation-react/LoadingIndicator';
@@ -14,7 +15,7 @@ const App = ({ loading, isFormAvailable, location, children }) => {
     return <LoadingIndicator />;
   }
 
-  if (isFormAvailable === false) {
+  if (!isFormAvailable) {
     return document.location.replace('/');
   }
 
@@ -31,5 +32,10 @@ const mapStateToProps = state => ({
     FEATURE_FLAG_NAMES.allowOnline1010cgSubmissions
   ],
 });
+
+App.propTypes = {
+  loading: PropTypes.bool.isRequired,
+  isFormAvailable: PropTypes.bool,
+};
 
 export default connect(mapStateToProps)(App);


### PR DESCRIPTION
## Description
This PR wraps the caregivers form with a feature flag. This way a user can't directly navigate to the URL to access it without being gated through the feature flag. If the feature flag is off for a user/session, then they are redirected to the homepage.


https://github.com/department-of-veterans-affairs/va.gov-team/issues/8853

## Testing done
Tested locally by toggling the feature flag value

## Screenshots
N/A 

## Acceptance criteria
- [x] Feature flag implemented on caregivers app

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
