### PR TITLE
added alternate path name staging uses for banner

### DIFF
--- a/src/applications/gi/containers/GiBillApp.jsx
+++ b/src/applications/gi/containers/GiBillApp.jsx
@@ -93,7 +93,8 @@ export class GiBillApp extends React.Component {
     return (
       <div className="gi-app">
         {!environment.isProduction() &&
-          location.pathname === '/gi-bill-comparison-tool/' && (
+          (location.pathname === '/gi-bill-comparison-tool/' ||
+            location.pathname === '/gi-bill-comparison-tool') && (
             <Covid19Banner />
           )}
         <div className="row">


### PR DESCRIPTION
## Description
On the GIBCT Landing Page, the COVID notification implemented in #9257 should be displayed. Currently it is not

https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/9632
## Testing done
local testing completed

## Screenshots


## Acceptance criteria
- [x] Banner is present only on the landing page

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
