### PR TITLE
Update generator-vets-website

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "@babel/preset-env": "^7.9.6",
     "@babel/preset-react": "^7.9.4",
     "@babel/register": "^7.9.0",
-    "@department-of-veterans-affairs/generator-vets-website": "^3.3.1",
+    "@department-of-veterans-affairs/generator-vets-website": "^3.3.5",
     "@octokit/rest": "^16.43.1",
     "@sentry/browser": "^5.4.0",
     "ajv": "^6.10.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1116,10 +1116,10 @@
     element-closest "^3.0.1"
     foundation-sites "5"
 
-"@department-of-veterans-affairs/generator-vets-website@^3.3.1":
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/generator-vets-website/-/generator-vets-website-3.3.1.tgz#de6c1606baca26a9a520b3c49b960dc1cc1e2fc4"
-  integrity sha512-gaFUzreQHlabWUOCqLHk1hgf1W+V6yfSb9X8fTzCk5OH9ZXe/1W//VD+/F7T+Wyjre6Gqe/DEnabm+mFfB432g==
+"@department-of-veterans-affairs/generator-vets-website@^3.3.5":
+  version "3.3.5"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/generator-vets-website/-/generator-vets-website-3.3.5.tgz#08d3ca8ed97990bbc81b486fe6c094b327e2ad9f"
+  integrity sha512-EtMNkXCDvmZ7MZr97KIwsWXtvr/CjBExFDnmdnIUwgJB+RoJZbmCrXcz7icZM/Ra1f4u9hsaAHrE989pjmiHCw==
   dependencies:
     chalk "^2.1.0"
     yeoman-generator "^2.0.1"


### PR DESCRIPTION
## Description
Please see [ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/9453)

when using `generator-vets-website` inside `vets-website`, it generates 200+ linting errors. This PR updates `generator-vets-website` to the latest version in which all the linting errors have been fixed. 

[`generator-vets-website` npm](https://www.npmjs.com/package/@department-of-veterans-affairs/generator-vets-website)

## Testing done
Locally

## Acceptance criteria
- [x] No linting errors

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
