### PR TITLE
Add non-MVI AlertBox in Account Security

### DIFF
--- a/src/applications/personalization/profile-2/components/AccountSecurityContent.jsx
+++ b/src/applications/personalization/profile-2/components/AccountSecurityContent.jsx
@@ -6,6 +6,7 @@ import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 import recordEvent from 'platform/monitoring/record-event';
 import {
   isLOA3 as isLOA3Selector,
+  isInMVI as isInMVISelector,
   isMultifactorEnabled as isMultifactorEnabledSelector,
   selectProfile,
 } from 'platform/user/selectors';
@@ -17,6 +18,7 @@ import {
 import ProfileInfoTable from './ProfileInfoTable';
 import TwoFactorAuthorizationStatus from './TwoFactorAuthorizationStatus';
 import IdentityNotVerified from './IdentityNotVerified';
+import NotInMVI from './NotInMVI';
 import MHVTermsAndConditionsStatus from './MHVTermsAndConditionsStatus';
 import EmailAddressNotification from './EmailAddressNotification';
 import Verified from './Verified';
@@ -28,6 +30,7 @@ export const AccountSecurityContent = ({
   showMHVTermsAndConditions,
   useSSOe,
   signInServiceName,
+  isInMVI,
 }) => {
   const securitySections = [
     {
@@ -61,7 +64,8 @@ export const AccountSecurityContent = ({
 
   return (
     <>
-      {!isIdentityVerified && <IdentityNotVerified />}
+      {!isInMVI && <NotInMVI />}
+      {!isIdentityVerified && isInMVI && <IdentityNotVerified />}
       <ProfileInfoTable data={securitySections} fieldName="accountSecurity" />
       <AlertBox
         status="info"
@@ -111,6 +115,7 @@ export const mapStateToProps = state => {
     mhvAccount,
     showMHVTermsAndConditions,
     useSSOe: ssoeSelector(state),
+    isInMVI: isInMVISelector(state),
     signInServiceName: signInServiceNameSelector(state),
   };
 };

--- a/src/applications/personalization/profile-2/components/NotInMVI.jsx
+++ b/src/applications/personalization/profile-2/components/NotInMVI.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
+import AdditionalInfo from '@department-of-veterans-affairs/formation-react/AdditionalInfo';
+import facilityLocator from 'applications/facility-locator/manifest.json';
+
+const NotInMVI = () => {
+  const content = (
+    <>
+      <p>
+        We’re sorry. We can’t match the information you entered to our Veteran records.
+        We can't give you access to health and benefit tools until we can match the information and verify your identity.
+      </p>
+      <p>
+        If you’d like to use these tools on VA.gov, please contact your nearest VA medical center to verify and update your records.
+      </p>
+
+      <a href={facilityLocator.rootUrl}>
+        Find your nearest VA medical center
+      </a>
+    </>
+  );
+
+  return (
+    <div className="vads-u-margin-bottom--3 medium-screen:vads-u-margin-bottom--4">
+      <AlertBox
+        headline="We can’t match your information with our Veteran records"
+        content={content}
+        status="warning"
+      />
+    </div>
+  );
+};
+
+export default NotInMVI;

--- a/src/applications/personalization/profile-2/components/NotInMVI.jsx
+++ b/src/applications/personalization/profile-2/components/NotInMVI.jsx
@@ -7,16 +7,16 @@ const NotInMVI = () => {
   const content = (
     <>
       <p>
-        We’re sorry. We can’t match the information you entered to our Veteran records.
-        We can’t give you access to health and benefit tools until we can match the information and verify your identity.
+        We’re sorry. We can’t match the information you entered to our Veteran
+        records. We can’t give you access to health and benefit tools until we
+        can match the information and verify your identity.
       </p>
       <p>
-        If you’d like to use these tools on VA.gov, please contact your nearest VA medical center to verify and update your records.
+        If you’d like to use these tools on VA.gov, please contact your nearest
+        VA medical center to verify and update your records.
       </p>
 
-      <a href={facilityLocator.rootUrl}>
-        Find your nearest VA medical center
-      </a>
+      <a href={facilityLocator.rootUrl}>Find your nearest VA medical center</a>
     </>
   );
 

--- a/src/applications/personalization/profile-2/components/NotInMVI.jsx
+++ b/src/applications/personalization/profile-2/components/NotInMVI.jsx
@@ -8,7 +8,7 @@ const NotInMVI = () => {
     <>
       <p>
         We’re sorry. We can’t match the information you entered to our Veteran records.
-        We can't give you access to health and benefit tools until we can match the information and verify your identity.
+        We can’t give you access to health and benefit tools until we can match the information and verify your identity.
       </p>
       <p>
         If you’d like to use these tools on VA.gov, please contact your nearest VA medical center to verify and update your records.

--- a/src/applications/personalization/profile-2/tests/components/AccountSecurityContent.unit.spec.jsx
+++ b/src/applications/personalization/profile-2/tests/components/AccountSecurityContent.unit.spec.jsx
@@ -164,7 +164,7 @@ describe('mapStateToProps', () => {
             loa: {
               current: 3,
             },
-            status: "OK",
+            status: 'OK',
           },
         },
       });

--- a/src/applications/personalization/profile-2/tests/components/AccountSecurityContent.unit.spec.jsx
+++ b/src/applications/personalization/profile-2/tests/components/AccountSecurityContent.unit.spec.jsx
@@ -23,6 +23,7 @@ describe('AccountSecurityContent', () => {
     mhvAccount: { termsAndConditionsAccepted: true },
     showMHVTermsAndConditions: true,
     useSSOe: true,
+    isInMVI: true,
   });
 
   it('should render a ProfileInfoTable as its first child', () => {
@@ -152,6 +153,35 @@ describe('mapStateToProps', () => {
         },
       });
       expect(mappedProps.isIdentityVerified).to.be.false;
+    });
+  });
+
+  describe('isInMVI', () => {
+    it('should be `true` if the user can be found in the MVI/MPI', () => {
+      const mappedProps = mapStateToProps({
+        user: {
+          profile: {
+            loa: {
+              current: 3,
+            },
+            status: "OK",
+          },
+        },
+      });
+      expect(mappedProps.isInMVI).to.be.true;
+    });
+    it('should be `false` if the user cannot be found in the MVI/MPI', () => {
+      const mappedProps = mapStateToProps({
+        user: {
+          profile: {
+            loa: {
+              current: 3,
+            },
+            status: null,
+          },
+        },
+      });
+      expect(mappedProps.isInMVI).to.be.false;
     });
   });
 

--- a/src/applications/personalization/profile-2/tests/components/NotInMVI.unit.spec.jsx
+++ b/src/applications/personalization/profile-2/tests/components/NotInMVI.unit.spec.jsx
@@ -11,14 +11,18 @@ describe('NotInMVI', () => {
   });
 
   it('should render the correct text', () => {
-    expect(wrapper.text().includes('We can’t match your information with our Veteran records'))
-      .to.be.true;
+    expect(
+      wrapper
+        .text()
+        .includes('We can’t match your information with our Veteran records'),
+    ).to.be.true;
     wrapper.unmount();
   });
 
   it('should render the correct link', () => {
     const link = wrapper.find('a');
-    expect(link.text().includes('Find your nearest VA medical center')).to.be.true;
+    expect(link.text().includes('Find your nearest VA medical center')).to.be
+      .true;
     expect(link.prop('href')).to.equal('/find-locations');
     wrapper.unmount();
   });

--- a/src/applications/personalization/profile-2/tests/components/NotInMVI.unit.spec.jsx
+++ b/src/applications/personalization/profile-2/tests/components/NotInMVI.unit.spec.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { expect } from 'chai';
+
+import NotInMVI from '../../components/NotInMVI';
+
+describe('NotInMVI', () => {
+  let wrapper;
+  beforeEach(() => {
+    wrapper = mount(<NotInMVI />);
+  });
+
+  it('should render the correct text', () => {
+    expect(wrapper.text().includes('We can’t match your information with our Veteran records'))
+      .to.be.true;
+    wrapper.unmount();
+  });
+
+  it('should render the correct link', () => {
+    const link = wrapper.find('a');
+    expect(link.text().includes('Find your nearest VA medical center')).to.be.true;
+    expect(link.prop('href')).to.equal('/find-locations');
+    wrapper.unmount();
+  });
+});


### PR DESCRIPTION
## Description
Show AlertBox when the user cannot be found in the Master Veteran Index. 

## Testing done
Updated unit tests, works locally.

## Screenshots
![image](https://user-images.githubusercontent.com/14869324/83292753-e1e96080-a1a7-11ea-8864-044c075f51a0.png)
![image](https://user-images.githubusercontent.com/14869324/83292769-eada3200-a1a7-11ea-992e-8ec4883587a6.png)


## Acceptance criteria
- [x] Update Account Security MPI error messaging

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
