### PR TITLE
Moved estimate your benefits feature flag work to new branch

### DIFF
--- a/src/applications/gi/components/profile/InstitutionProfile.jsx
+++ b/src/applications/gi/components/profile/InstitutionProfile.jsx
@@ -22,6 +22,7 @@ export class InstitutionProfile extends React.Component {
     calculator: PropTypes.object,
     eligibility: PropTypes.object,
     eduSection103: PropTypes.bool,
+    gibctEybBottemSheet: PropTypes.bool,
   };
 
   shouldShowSchoolLocations = facilityMap =>
@@ -41,6 +42,7 @@ export class InstitutionProfile extends React.Component {
       showModal,
       eduSection103,
       gibctEstimateYourBenefits,
+      gibctEybBottomSheet,
     } = this.props;
     return (
       <div>
@@ -53,7 +55,9 @@ export class InstitutionProfile extends React.Component {
           <ul>
             <AccordionItem button="Estimate your benefits">
               {gibctEstimateYourBenefits ? (
-                <EstimateYourBenefits />
+                <EstimateYourBenefits
+                  gibctEybBottomSheet={gibctEybBottomSheet}
+                />
               ) : (
                 <Calculator />
               )}

--- a/src/applications/gi/containers/EstimateYourBenefits.jsx
+++ b/src/applications/gi/containers/EstimateYourBenefits.jsx
@@ -92,6 +92,7 @@ export class EstimateYourBenefits extends React.Component {
     const outputs = this.props.estimatedBenefits;
     const {
       profile,
+      gibctEybBottomSheet,
       calculator: inputs,
       calculated: { inputs: displayed },
     } = this.props;
@@ -133,26 +134,30 @@ export class EstimateYourBenefits extends React.Component {
           profile={profile}
           calculator={inputs}
         />
-        {this.state.expandEybSheet && (
-          <div
-            onClick={() => this.toggleEybExpansion()}
-            className="va-modal overlay"
-          />
-        )}
-        {
-          <div id="eyb-summary-sheet" className={summarySheetClassNames}>
-            <EstimateYourBenefitsSummarySheet
-              outputs={outputs}
-              expandEybSheet={this.state.expandEybSheet}
-              showEybSheet={this.state.showEybSheet}
-              toggleEybExpansion={() => this.toggleEybExpansion()}
-              type={this.props.calculator.type}
-              yellowRibbon={
-                this.props.calculator.yellowRibbonRecipient === 'yes'
-              }
-            />
+        {gibctEybBottomSheet && (
+          <div>
+            {this.state.expandEybSheet && (
+              <div
+                onClick={() => this.toggleEybExpansion()}
+                className="va-modal overlay"
+              />
+            )}
+            {
+              <div id="eyb-summary-sheet" className={summarySheetClassNames}>
+                <EstimateYourBenefitsSummarySheet
+                  outputs={outputs}
+                  expandEybSheet={this.state.expandEybSheet}
+                  showEybSheet={this.state.showEybSheet}
+                  toggleEybExpansion={() => this.toggleEybExpansion()}
+                  type={this.props.calculator.type}
+                  yellowRibbon={
+                    this.props.calculator.yellowRibbonRecipient === 'yes'
+                  }
+                />
+              </div>
+            }
           </div>
-        }
+        )}
       </div>
     );
   }

--- a/src/applications/gi/containers/ProfilePage.jsx
+++ b/src/applications/gi/containers/ProfilePage.jsx
@@ -93,6 +93,7 @@ export class ProfilePage extends React.Component {
             version={this.props.location.query.version}
             eduSection103={this.props.eduSection103}
             gibctEstimateYourBenefits={this.props.gibctEstimateYourBenefits}
+            gibctEybBottomSheet={this.props.gibctEybBottomSheet}
           />
         );
       }
@@ -124,6 +125,9 @@ const mapStateToProps = state => {
     eduSection103: toggleValues(state)[FEATURE_FLAG_NAMES.eduSection103],
     gibctEstimateYourBenefits: toggleValues(state)[
       FEATURE_FLAG_NAMES.gibctEstimateYourBenefits
+    ],
+    gibctEybBottomSheet: toggleValues(state)[
+      FEATURE_FLAG_NAMES.gibctEybBottomSheet
     ],
   };
 };

--- a/src/applications/gi/tests/data/feature-toggles.json
+++ b/src/applications/gi/tests/data/feature-toggles.json
@@ -61,6 +61,10 @@
       {
         "name": "gibctEstimateYourBenefits",
         "value": true
+      },
+      {
+        "name": "gibctEybBottomSheet",
+        "value": true
       }
     ]
   }

--- a/src/platform/testing/local-dev-mock-api/common.js
+++ b/src/platform/testing/local-dev-mock-api/common.js
@@ -73,6 +73,7 @@ const responses = {
         { name: 'gibctEstimateYourBenefits', value: true },
         { name: 'form526OriginalClaims', value: false },
         { name: 'vaViewDependentsAccess', value: false },
+        { name: 'gibctEybBottomSheet', value: true },
       ],
     },
   },

--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -27,4 +27,5 @@ export default Object.freeze({
   form526OriginalClaims: 'form526OriginalClaims',
   vaViewDependentsAccess: 'vaViewDependentsAccess',
   allowOnline1010cgSubmissions: 'allow_online_10_10cg_submissions',
+  gibctEybBottomSheet: 'gibctEybBottomSheet',
 });


### PR DESCRIPTION
## Description
As a developer, I need to create a toggle for the Estimate Your Benefits Bottom Sheet, so that it can be enabled / disabled without requiring a deployment.
https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/9403

## Testing done
local testing complete at `http://localhost:3000/flipper/features/gibct_eyb_bottom_sheet`

## Screenshots


## Acceptance criteria
- [x] A Feature Flag is available to be used for the Estimate Your Benefits development.
- [x] The Feature Flag name is: gibctEybBottomSheet
- [x] The Feature Flag description is: "Panel that displays while the user is modifying inputs to give context to their currently estimated benefits until they reach the full your estimated benefits panel."
- [x] The Feature Flag is defaulted to the OFF state.
- [x] The bottom sheet is not displayed when the feature flag is in the off state.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
