### PR TITLE
Modify fixtures shorthand with cy.route when using cy.syncFixtures.

### DIFF
--- a/src/platform/testing/e2e/cypress/support/commands/syncFixtures.js
+++ b/src/platform/testing/e2e/cypress/support/commands/syncFixtures.js
@@ -13,8 +13,25 @@ Cypress.Commands.add('syncFixtures', fixtures => {
 
   cy.task('_syncFixtures', args, opts).then(dir => {
     if (!initialized) {
+      // `cy.fixture` should look for fixtures under the temp path.
       Cypress.Commands.overwrite('fixture', (originalFn, path, options) =>
         originalFn(`${dir}/${path}`, options),
+      );
+
+      // The fixture shorthand in `cy.route` should be relative to temp path.
+      Cypress.Commands.overwrite(
+        'route',
+        (originalFn, method, url, response, options) => {
+          const modifiedResponse =
+            typeof response === 'string'
+              ? response.replace(
+                  /^(fx:|fixture:)/,
+                  (_, pattern) => `${pattern}${dir}/`,
+                )
+              : response;
+
+          return originalFn(method, url, modifiedResponse, options);
+        },
       );
 
       initialized = true;

--- a/src/platform/testing/e2e/cypress/support/commands/syncFixtures.js
+++ b/src/platform/testing/e2e/cypress/support/commands/syncFixtures.js
@@ -5,7 +5,8 @@ let initialized = false;
 
 /**
  * Runs task to sync fixtures under a temp path in the Cypress fixtures folder
- * then overwrites cy.fixture to look for fixtures under that temp path.
+ * then overwrites `cy.fixture` and the fixture shorthand in `cy.route`
+ * to look for fixtures under that temp path.
  */
 Cypress.Commands.add('syncFixtures', fixtures => {
   const args = { fixtures, initialized };


### PR DESCRIPTION
## Description
Found that the [fixtures shorthand](https://docs.cypress.io/api/commands/route.html#Fixtures) with `cy.route` doesn't work as expected when using `cy.syncFixtures`.

We should support the shorthand when `cy.syncFixtures` is used.

## Testing done
Local testing with a test to be published in a separate PR.

## Acceptance criteria
- [ ] Using the fixtures shorthand with `cy.route` should be compatible with using `cy.syncFixtures`.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
