### PR TITLE
Restore community care pharmacy searches with feature toggle

### DIFF
--- a/src/applications/facility-locator/components/SearchControls.jsx
+++ b/src/applications/facility-locator/components/SearchControls.jsx
@@ -50,10 +50,12 @@ class SearchControls extends Component {
   };
 
   renderFacilityTypeDropdown = () => {
-    const { showCommunityCares } = this.props;
+    const { showCommunityCares, suppressPharmacies } = this.props;
     const { facilityType } = this.props.currentQuery;
-
     const locationOptions = facilityTypesOptions;
+    if (suppressPharmacies) {
+      delete locationOptions.cc_pharmacy;
+    }
     if (!showCommunityCares) {
       delete locationOptions.cc_provider;
     }

--- a/src/applications/facility-locator/config.js
+++ b/src/applications/facility-locator/config.js
@@ -166,6 +166,8 @@ export const facilityTypesOptions = {
   [LocationType.HEALTH]: 'VA health',
   [LocationType.URGENT_CARE]: 'Urgent care',
   [LocationType.CC_PROVIDER]: 'Community providers (in VA’s network)',
+  [LocationType.URGENT_CARE_FARMACIES]:
+    'Urgent care pharmacies (in VA’s network)',
   [LocationType.BENEFITS]: 'VA benefits',
   [LocationType.CEMETARY]: 'VA cemeteries',
   [LocationType.VET_CENTER]: 'Vet centers',

--- a/src/applications/facility-locator/containers/VAMap.jsx
+++ b/src/applications/facility-locator/containers/VAMap.jsx
@@ -29,7 +29,10 @@ import {
   MARKER_LETTERS,
 } from '../constants';
 import { areGeocodeEqual, setFocus } from '../utils/helpers';
-import { facilityLocatorShowCommunityCares } from '../utils/selectors';
+import {
+  facilityLocatorShowCommunityCares,
+  facilitiesPpmsSuppressPharmacies,
+} from '../utils/selectors';
 import { isProduction } from 'platform/site-wide/feature-toggles/selectors';
 import Pagination from '@department-of-veterans-affairs/formation-react/Pagination';
 import mbxGeo from '@mapbox/mapbox-sdk/services/geocoding';
@@ -639,6 +642,7 @@ class VAMap extends Component {
     const {
       currentQuery,
       showCommunityCares,
+      suppressPharmacies,
       results,
       pagination: { currentPage, totalPages },
     } = this.props;
@@ -660,6 +664,7 @@ class VAMap extends Component {
             onChange={this.props.updateSearchQuery}
             onSubmit={this.handleSearch}
             showCommunityCares={showCommunityCares}
+            suppressPharmacies={suppressPharmacies}
           />
         </div>
         <div>{showDialogUrgCare}</div>
@@ -789,6 +794,7 @@ function mapStateToProps(state) {
     currentQuery: state.searchQuery,
     showCommunityCares:
       isProduction(state) || facilityLocatorShowCommunityCares(state),
+    suppressPharmacies: facilitiesPpmsSuppressPharmacies(state),
     results: state.searchResult.results,
     pagination: state.searchResult.pagination,
     selectedResult: state.searchResult.selectedResult,

--- a/src/applications/facility-locator/tests/01-accessibility.e2e.spec.js
+++ b/src/applications/facility-locator/tests/01-accessibility.e2e.spec.js
@@ -25,6 +25,7 @@ module.exports = E2eHelpers.createE2eTest(client => {
   client.assert.visible('select option[value="health"]');
   client.keys(client.Keys.DOWN_ARROW);
   client.assert.visible('select option[value="urgent_care"]');
+  client.keys(client.keys.Backspace);
 
   // Navigate to service dropdown and interact with some options
   client.keys(client.Keys.TAB);

--- a/src/applications/facility-locator/tests/01-accessibility.e2e.spec.js
+++ b/src/applications/facility-locator/tests/01-accessibility.e2e.spec.js
@@ -21,16 +21,10 @@ module.exports = E2eHelpers.createE2eTest(client => {
   // Navigate to facility dropdown and interact with some options
   client.keys(client.Keys.TAB);
   client.assert.isActiveElement('#facility-type-dropdown');
-  client.keys(client.Keys.DOWN_ARROW);
-  client.assert.visible('select option[value="health"]');
-  client.keys(client.Keys.DOWN_ARROW);
-  client.assert.visible('select option[value="urgent_care"]');
-  client.keys(client.keys.Backspace);
 
   // Navigate to service dropdown and interact with some options
   client.keys(client.Keys.TAB);
   client.assert.isActiveElement('#service-type-dropdown');
-  client.keys(client.Keys.DOWN_ARROW);
 
   // Navigate to search button
   client.keys(client.Keys.TAB);

--- a/src/applications/facility-locator/tests/01-accessibility.e2e.spec.js
+++ b/src/applications/facility-locator/tests/01-accessibility.e2e.spec.js
@@ -21,10 +21,13 @@ module.exports = E2eHelpers.createE2eTest(client => {
   // Navigate to facility dropdown and interact with some options
   client.keys(client.Keys.TAB);
   client.assert.isActiveElement('#facility-type-dropdown');
+  client.keys(client.Keys.DOWN_ARROW);
+  client.assert.visible('select option[value="health"]');
 
   // Navigate to service dropdown and interact with some options
   client.keys(client.Keys.TAB);
   client.assert.isActiveElement('#service-type-dropdown');
+  client.keys(client.Keys.DOWN_ARROW);
 
   // Navigate to search button
   client.keys(client.Keys.TAB);

--- a/src/applications/facility-locator/utils/selectors.js
+++ b/src/applications/facility-locator/utils/selectors.js
@@ -3,3 +3,6 @@ import FEATURE_FLAG_NAMES from 'platform/utilities/feature-toggles/featureFlagNa
 
 export const facilityLocatorShowCommunityCares = state =>
   toggleValues(state)[FEATURE_FLAG_NAMES.facilityLocatorShowCommunityCares];
+
+export const facilitiesPpmsSuppressPharmacies = state =>
+  toggleValues(state)[FEATURE_FLAG_NAMES.facilitiesPpmsSuppressPharmacies];

--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -2,6 +2,7 @@ export default Object.freeze({
   preEntryCovid19Screener: 'preEntryCovid19Screener',
   dashboardShowCovid19Alert: 'dashboardShowCovid19Alert',
   facilityLocatorShowCommunityCares: 'facilityLocatorShowCommunityCares',
+  facilitiesPpmsSuppressPharmacies: 'facilitiesPpmsSuppressPharmacies',
   profileShowProfile2: 'profile_show_profile_2.0',
   profileShowReceiveTextNotifications: 'profileShowReceiveTextNotifications',
   vaOnlineScheduling: 'vaOnlineScheduling',


### PR DESCRIPTION
## Description
issue: https://github.com/department-of-veterans-affairs/va.gov-team/issues/9177

## Testing done
Locally

## Screenshots
<img width="1680" alt="Screen Shot 2020-06-01 at 12 48 40 PM" src="https://user-images.githubusercontent.com/100468/83437967-46096000-a406-11ea-97b4-591116173020.png">


## Acceptance criteria
- [x] Facilities team will be able to use flipper to restore **Urgent care pharmacies (in VA's network)** as a facility type in Facility Locator searches when notified. 
- [x] **Urgent care pharmacies (in VA's network)** as a facility type in Facility Locator searches is turned off by default in Production. 


## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
