### PR TITLE
[Form Tester] Page processing improvements and fixes

### DIFF
--- a/src/platform/testing/e2e/cypress/support/form-tester/README.md
+++ b/src/platform/testing/e2e/cypress/support/form-tester/README.md
@@ -319,9 +319,9 @@ Default stubs (like the maintenance windows request) can be overriden simply by 
 
 This is also generally the place to set anything in `localStorage` and `sessionStorage` before the test runs.
 
-Authenticated sessions are generally set up here as well with `cy.login()`. This is a custom command that sets the `hasSession` flag in `localStorage` and stubs the `GET v0/user` endpoint.
+Authenticated sessions are typically set up here as well with `cy.login()`. This is a custom command that sets the `hasSession` flag in `localStorage` and stubs the `GET v0/user` endpoint.
 
-If your test requires a specific `localStorage` or `sessionStorage` state or authenticated session at a later point in the test, as in the middle instead of the beginning, you may set those on a page hook, but be aware that you **may need to reload the page for see the effects**.
+If your test requires a specific `localStorage` or `sessionStorage` state or authenticated session at a later point in the test, as in the middle instead of the beginning, you may set those in a page hook, but you **may need to reload the page (`cy.reload()`) to see the effects**.
 
 In particular, the `hasSession` flag to activate an authenticated session needs to be `true` when the page loads, so setting it to `true` after it has already loaded will not change the page to a logged in state.
 
@@ -446,12 +446,13 @@ const testConfig = createTestConfig(
         cy.fixture('sample-file').then(fileContent => {
         });
 
-        cy.fixture('sample-folder/json-file').then(fileContent => {
+        cy.fixture('sample-folder/json-file').then(({ attrA, attrB }) => {
         });
 
         // Example of uploading a fixture. For general uploading purposes,
-        // 'example-file.png' is already included in the form tester by default
-        // if you don't have any specific requirements for file upload data.
+        // 'example-file.png' is already included in the form tester by default,
+        // and `cy.fillPage()` automatically fills upload fields with that file.
+        // Use those if you have no specific requirements for file upload data.
         cy.get(`input[id="root_upload_field"]`)
           .upload('sample-folder/png-file', 'image/png')
           .get('.schemaform-file-uploading')

--- a/src/platform/testing/e2e/cypress/support/form-tester/index.js
+++ b/src/platform/testing/e2e/cypress/support/form-tester/index.js
@@ -4,8 +4,9 @@ import get from 'platform/utilities/data/get';
 
 const ARRAY_ITEM_SELECTOR =
   'div[name^="topOfTable_"] ~ div.va-growable-background';
-
 const FIELD_SELECTOR = 'input, select, textarea';
+const FORM_SELECTOR = 'form.rjsf';
+const LOADING_SELECTOR = '.loading-indicator';
 
 // Suppress logs for most commands, particularly calls to wrap and get
 // that are mainly there to support more specific operations.
@@ -338,7 +339,7 @@ Cypress.Commands.add('fillPage', () => {
       };
 
       const fillAvailableFields = () => {
-        cy.get('form.rjsf', COMMAND_OPTIONS)
+        cy.get(FORM_SELECTOR, COMMAND_OPTIONS)
           .then($form => {
             // Get the starting number of array items and fields to compare
             // after filling out all currently visible fields, as new fields
@@ -470,7 +471,7 @@ const testForm = testConfig => {
 
         it('fills the form', () => {
           cy.visit(rootUrl).injectAxe();
-          cy.get('.loading-indicator')
+          cy.get(LOADING_SELECTOR)
             .should('not.exist')
             .then(processPage);
         });

--- a/src/platform/testing/e2e/cypress/support/form-tester/index.js
+++ b/src/platform/testing/e2e/cypress/support/form-tester/index.js
@@ -149,14 +149,17 @@ const processPage = () => {
       // If there's a page hook, it overrides the automatic form filling.
       // Run the aXe check after either running the hook or filling the page.
       cy.execHook(pathname).then(hookExecuted => {
-        if (!hookExecuted) cy.fillPage();
+        if (!hookExecuted) {
+          cy.fillPage()
+            .findByText(/continue/i, { selector: 'button' })
+            .click();
+        }
+
         cy.expandAccordions();
         cy.axeCheck(FAIL_ON_AXE_VIOLATIONS);
       });
 
-      cy.findByText(/continue/i, { selector: 'button' })
-        .click()
-        .location('pathname', COMMAND_OPTIONS)
+      cy.location('pathname', COMMAND_OPTIONS)
         .then(newPathname => {
           if (pathname === newPathname) {
             throw new Error(`Expected to navigate away from ${pathname}`);

--- a/src/platform/testing/e2e/cypress/support/form-tester/index.js
+++ b/src/platform/testing/e2e/cypress/support/form-tester/index.js
@@ -161,7 +161,7 @@ const processPage = () => {
     } else {
       performPageActions(pathname);
       cy.location('pathname', COMMAND_OPTIONS)
-        .then(newPathname => {
+        .should(newPathname => {
           if (pathname === newPathname) {
             throw new Error(`Expected to navigate away from ${pathname}`);
           }

--- a/src/platform/testing/e2e/cypress/support/form-tester/index.js
+++ b/src/platform/testing/e2e/cypress/support/form-tester/index.js
@@ -147,16 +147,17 @@ const processPage = () => {
       });
     } else {
       // If there's a page hook, it overrides the automatic form filling.
-      // Run the aXe check after either running the hook or filling the page.
+      // Run the aXe check after running the hook or filling the page.
+      // Continue to the next page after everything.
       cy.execHook(pathname).then(hookExecuted => {
-        if (!hookExecuted) {
-          cy.fillPage()
-            .findByText(/continue/i, { selector: 'button' })
-            .click();
-        }
+        if (!hookExecuted) cy.fillPage();
 
         cy.expandAccordions();
         cy.axeCheck(FAIL_ON_AXE_VIOLATIONS);
+
+        if (!hookExecuted) {
+          cy.findByText(/continue/i, { selector: 'button' }).click();
+        }
       });
 
       cy.location('pathname', COMMAND_OPTIONS)


### PR DESCRIPTION
## Description
- Resolves a minor bug where the form tester would click on a continue button even if a page hook ran.
- Runs aXe checks at the right times for review and confirmation pages.
- Refactoring.
- Updated documentation.

## Testing done
Tested on example HCA form test.

## Acceptance criteria
- [ ] Form tester should not click continue if the page handling is overriden by a hook.
- [ ] Review and confirmation pages should aXe check at the appropriate times.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
