### PR TITLE
Adds chatbot-admin team as codeowners for chatbot directory

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -46,6 +46,7 @@ src/applications/caregivers @department-of-veterans-affairs/vsa-caregiver-fronte
 # Other
 src/applications/vaos @department-of-veterans-affairs/vfs-vaos
 src/applications/coronavirus-screener @department-of-veterans-affairs/va-cto-health-products
+src/applications/coronavirus-chatbot @department-of-veterans-affairs/chatbot-admin
 
 # Booz Allen Team
 src/applications/static-pages/school-resources @department-of-veterans-affairs/bah-code-reviewers


### PR DESCRIPTION
## Description
Adds members of the `chatbot-admin` team as codeowners for the chatbot directory in `vets-website`.

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
