### PR TITLE
Adds transparent border to disabled chatbot buttons

### DIFF
--- a/src/applications/coronavirus-chatbot/sass/coronavirus-chatbot.scss
+++ b/src/applications/coronavirus-chatbot/sass/coronavirus-chatbot.scss
@@ -42,7 +42,7 @@ button.ac-pushButton:hover {
   min-height: 38px !important;
   background: $color-gray-lighter !important;
   color: $color-white !important;
-  border: 0 !important;
+  border: 2px solid transparent !important;
 }
 
 #webchat input[type=checkbox] {


### PR DESCRIPTION
## Description

Related to [this issue](https://github.com/department-of-veterans-affairs/covid19-chatbot/issues/218), stops button placement from shifting when buttons are disabled.

## Testing done


## Screenshots
Enabled/disabled screenshots overlaid to compare alignment:

**BEFORE**
![Screen Shot 2020-06-01 at 10 16 16](https://user-images.githubusercontent.com/19177102/83420812-2584da00-a3f5-11ea-8ee3-ec9916697c2e.png)

**AFTER**
<img width="822" alt="Screen Shot 2020-06-01 at 10 14 03" src="https://user-images.githubusercontent.com/19177102/83420799-2158bc80-a3f5-11ea-8b8e-3124e6925113.png">

## Acceptance criteria
- [ ] The buttons should not shift in spacing when switching to a disabled state.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
