### PR TITLE
Add optional chaining to props.downtime.message access

### DIFF
--- a/src/platform/forms/components/AuthorizationComponent.jsx
+++ b/src/platform/forms/components/AuthorizationComponent.jsx
@@ -32,7 +32,7 @@ class AuthorizationComponent extends React.Component {
 
   renderDowntime = (downtime, children) => {
     if (downtime.status === externalServiceStatus.down) {
-      const Message = this.props.downtime.message || DowntimeMessage;
+      const Message = this.props.downtime?.message || DowntimeMessage;
 
       return (
         <Message isAfterSteps={this.props.buttonOnly} downtime={downtime} />


### PR DESCRIPTION
## Description
This fixes an issue with the AuthorizationComponent doing some unsafe prop drilling.

Fixes the following error we saw in staging when EVSS downtime was approaching and the My VA Dashboard was loaded:

```
TypeError: Cannot read property 'message' of undefined
    at Object.render (AuthorizationComponent.jsx:35)
```
<img width="1548" alt="Screen Shot 2020-06-01 at 10 26 45 AM" src="https://user-images.githubusercontent.com/20728956/83436551-e6558980-a3f2-11ea-8f27-2d04572cfa1c.png">


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs