### PR TITLE
bradl3yC - Add ability to pass finish later link text

### DIFF
--- a/src/platform/forms/save-in-progress/RoutedSavablePage.jsx
+++ b/src/platform/forms/save-in-progress/RoutedSavablePage.jsx
@@ -57,7 +57,9 @@ class RoutedSavablePage extends React.Component {
           showLoginModal={this.props.showLoginModal}
           saveAndRedirectToReturnUrl={this.props.saveAndRedirectToReturnUrl}
           toggleLoginModal={this.props.toggleLoginModal}
-        />
+        >
+          {form.finishLaterLinkText}
+        </SaveFormLink>
       </div>
     );
 

--- a/src/platform/forms/save-in-progress/reducers.js
+++ b/src/platform/forms/save-in-progress/reducers.js
@@ -131,6 +131,7 @@ export function createSaveInProgressInitialState(formConfig, initialState) {
     migrations: formConfig.migrations,
     prefillTransformer: formConfig.prefillTransformer,
     trackingPrefix: formConfig.trackingPrefix,
+    finishLaterLinkText: formConfig.finishLaterLinkText,
     additionalRoutes: formConfig.additionalRoutes,
   });
 }

--- a/src/platform/forms/tests/save-in-progress/RoutedSavablePage.unit.spec.jsx
+++ b/src/platform/forms/tests/save-in-progress/RoutedSavablePage.unit.spec.jsx
@@ -60,6 +60,62 @@ describe('Schemaform <RoutedSavablePage>', () => {
     tree.unmount();
   });
 
+  it('should pass correct text to SaveFormlink', () => {
+    const route = {
+      pageConfig: {
+        pageKey: 'testPage',
+        schema: {},
+        uiSchema: {},
+        errorMessages: {},
+        title: '',
+      },
+      pageList: [
+        {
+          path: 'testing',
+        },
+      ],
+    };
+    const form = {
+      disableSave: false,
+      finishLaterLinkText: 'foo',
+      pages: {
+        testPage: {
+          schema: {},
+          uiSchema: {},
+        },
+      },
+      data: {},
+    };
+    const user = {
+      profile: {
+        savedForms: [],
+      },
+      login: {
+        currentlyLoggedIn: true,
+      },
+    };
+
+    const tree = shallow(
+      <RoutedSavablePage
+        form={form}
+        route={route}
+        user={user}
+        location={location}
+      />,
+    )
+      .find('FormPage')
+      .dive();
+
+    expect(tree.find('SaveFormLink').exists()).to.be.true;
+    expect(
+      tree
+        .find('SaveFormLink')
+        .children()
+        .text(),
+    ).to.equal('foo');
+    tree.unmount();
+  });
+
   it('should auto save on change', () => {
     const route = {
       pageConfig: {

--- a/src/platform/forms/tests/save-in-progress/SaveFormLink.unit.spec.jsx
+++ b/src/platform/forms/tests/save-in-progress/SaveFormLink.unit.spec.jsx
@@ -63,6 +63,19 @@ describe('Schemaform <SaveFormLink>', () => {
 
     expect(tree.text()).to.contain('Finish this application later');
   });
+  it('should render overridden save message when prop is passed', () => {
+    const tree = SkinDeep.shallowRender(
+      <SaveFormLink
+        user={loggedInUser}
+        form={form}
+        toggleLoginModal={toggleLoginModalSpy}
+      >
+        Test
+      </SaveFormLink>,
+    );
+
+    expect(tree.text()).to.contain('Test');
+  });
   it('should show error message', () => {
     const tree = SkinDeep.shallowRender(
       <SaveFormLink


### PR DESCRIPTION
## Description
Currently the SaveFormLink accepts a prop to override text but there is no ability to add that text.  This will allow for a new line on the form config to override this text as a child to that component.

## Testing done


## Screenshots
![Screen Shot 2020-06-01 at 2 29 52 PM](https://user-images.githubusercontent.com/6165421/83441348-617b6780-a414-11ea-886a-2b48e40d697c.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
