### PR TITLE
[Development] Add HLR print confirmation button

### DIFF
--- a/src/applications/caregivers/containers/ConfirmationPage.jsx
+++ b/src/applications/caregivers/containers/ConfirmationPage.jsx
@@ -19,7 +19,7 @@ const ConfirmationPage = props => {
   const PrintDetails = () => (
     <div className="print-details">
       <img
-        src="/img/design/logo/logo-black-and-white.png"
+        src="https://www.va.gov/img/design/logo/logo-black-and-white.png"
         alt="VA logo"
         width="300"
       />

--- a/src/applications/caregivers/containers/ConfirmationPage.jsx
+++ b/src/applications/caregivers/containers/ConfirmationPage.jsx
@@ -19,7 +19,7 @@ const ConfirmationPage = props => {
   const PrintDetails = () => (
     <div className="print-details">
       <img
-        src="https://www.va.gov/img/design/logo/logo-black-and-white.png"
+        src="/img/design/logo/logo-black-and-white.png"
         alt="VA logo"
         width="300"
       />

--- a/src/applications/disability-benefits/996/containers/ConfirmationPage.jsx
+++ b/src/applications/disability-benefits/996/containers/ConfirmationPage.jsx
@@ -40,13 +40,23 @@ export class ConfirmationPage extends React.Component {
 
     return (
       <div>
+        <div className="print-only">
+          <img
+            src="https://va.gov/img/design/logo/logo-black-and-white.png"
+            alt="VA logo"
+            width="300"
+          />
+          <h2>Request for Higher-Level Review</h2>
+        </div>
         <h2 className="confirmation-page-title vads-u-font-size--h3">
           Your request has been submitted
         </h2>
         <p>
           We may contact you for more information or documents.
-          <br />
-          <em>Please print this page for your records.</em>
+          <br className="screen-only" />
+          <em className="screen-only">
+            Please print this page for your records.
+          </em>
         </p>
         <div className="inset" role="presentation">
           <h3 className="vads-u-margin-top--0 vads-u-font-size--h4">
@@ -71,6 +81,12 @@ export class ConfirmationPage extends React.Component {
                 {issues.length > 1 ? 's' : ''} contested
               </strong>
               <ul className="vads-u-margin-top--0">{issues}</ul>
+              <button
+                className="usa-button screen-only"
+                onClick={() => window.print()}
+              >
+                Print for your records
+              </button>
             </>
           )}
         </div>

--- a/src/applications/disability-benefits/996/sass/0996-higher-level-review.scss
+++ b/src/applications/disability-benefits/996/sass/0996-higher-level-review.scss
@@ -209,4 +209,32 @@ article[data-location="confirmation"] {
   h1[tabindex="-1"] {
     outline: none;
   }
+  @media print {
+    .confirmation-page-title, a {
+      text-align: left;
+      padding-left: 0;
+    }
+  }
+}
+
+.print-only {
+  display: none;
+}
+
+@media print {
+  .usa-width-two-thirds {
+    width: 100%;
+  }
+  .schemaform-title,
+  .schemaform-subtitle,
+  .screen-only {
+    display: none;
+  }
+  .print-only {
+    display: block;
+  }
+  /* Include href when printing */
+  a:not([href^="tel"]):after {
+    content: " (https://va.gov" attr(href) ")";
+  }
 }


### PR DESCRIPTION
## Description

Add a print button on the Higher-Level Review confirmation page.

Design: https://vsateams.invisionapp.com/share/W5U21BDFTQK#/screens/404690149
Associated ticket: https://github.com/department-of-veterans-affairs/va.gov-team/issues/8827

## Testing done

Local unit tests

## Screenshots

<details><summary>Confirmation page</summary>

<!-- leave a blank line above -->
![Screen Shot 2020-06-01 at 1 36 29 PM](https://user-images.githubusercontent.com/136959/83441947-fa0de980-a40c-11ea-85c8-5e8d66ea8316.png)
</details>
<details><summary>Print preview</summary>

<!-- leave a blank line above -->
![Screen Shot 2020-06-01 at 1 07 26 PM](https://user-images.githubusercontent.com/136959/83441988-0bef8c80-a40d-11ea-807c-f5749c5dcd31.png)
</details>

## Acceptance criteria

- [ ] Page & design match

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
