### PR TITLE
[Static pages] Add analytics for default button link clicks

### DIFF
--- a/src/applications/static-pages/analytics/addButtonLinkListeners.js
+++ b/src/applications/static-pages/analytics/addButtonLinkListeners.js
@@ -1,6 +1,6 @@
 import recordEvent from 'platform/monitoring/record-event';
 
-export default function addHomepageBannerListeners() {
+export default function addButtonLinkListeners() {
   const ignoreReactWidgets = ':not([data-template="paragraphs/react_widget"])';
   const defaultButtons = 'a.usa-button';
   const ignorePrimaryButtons = ':not(.usa-button-primary)';

--- a/src/applications/static-pages/analytics/addButtonLinkListeners.js
+++ b/src/applications/static-pages/analytics/addButtonLinkListeners.js
@@ -1,7 +1,12 @@
 import recordEvent from 'platform/monitoring/record-event';
 
 export default function addHomepageBannerListeners() {
-  const buttonLinks = document.querySelectorAll('a.usa-button');
+  const ignoreReactWidgets = ':not([data-template="paragraphs/react_widget"])';
+  const defaultButtons = 'a.usa-button';
+  const ignorePrimaryButtons = ':not(.usa-button-primary)';
+  const buttonLinks = document.querySelectorAll(
+    `${ignoreReactWidgets} ${defaultButtons}${ignorePrimaryButtons}`,
+  );
 
   buttonLinks.forEach(buttonLink => {
     buttonLink.addEventListener('click', event => {

--- a/src/applications/static-pages/analytics/index.js
+++ b/src/applications/static-pages/analytics/index.js
@@ -29,10 +29,7 @@ function attachAnalytics() {
 
   // Global listeners
   addTeaserListeners();
-
-  if (!environment.isProduction()) {
-    addButtonLinkListeners();
-  }
+  addButtonLinkListeners();
 }
 
 // Prevent the window from navigating away.

--- a/src/site/facilities/facilities_health_services_buttons.drupal.liquid
+++ b/src/site/facilities/facilities_health_services_buttons.drupal.liquid
@@ -3,12 +3,12 @@
 {% endcomment %}
 <div data-template="facilities/facilities_health_services_buttons" class="vads-l-row">
     <div class="medium-screen:vads-l-col--4 vads-l-col--12 vads-u-margin-right--2p5">
-        <a class="usa-button vads-u-margin-top--1 vads-u-margin--0 vads-u-width--full vads-u-font-size--md" href="/{{ path }}/make-an-appointment" onClick="recordEvent({ event: 'cta-primary-button-click' });">Make an appointment</a>
+        <a class="usa-button vads-u-margin-top--1 vads-u-margin--0 vads-u-width--full vads-u-font-size--md" href="/{{ path }}/make-an-appointment">Make an appointment</a>
     </div>
     <div class="medium-screen:vads-l-col--4 vads-l-col--12 vads-u-margin-right--2p5">
-        <a class="usa-button vads-u-margin-top--1 vads-u-margin--0 vads-u-width--full vads-u-font-size--md" href="/{{ path }}/register-for-care" onClick="recordEvent({ event: 'cta-primary-button-click' });">Register for care</a>
+        <a class="usa-button vads-u-margin-top--1 vads-u-margin--0 vads-u-width--full vads-u-font-size--md" href="/{{ path }}/register-for-care">Register for care</a>
     </div>
     <div class="medium-screen:vads-l-col--4 vads-l-col--12 vads-u-text-align--right vads-u-flex--fill">
-        <a class="usa-button vads-u-margin-top--1 vads-u-margin--0 vads-u-margin-x--0 vads-u-width--full vads-u-font-size--md" href="/{{ path }}/pharmacy" onClick="recordEvent({ event: 'cta-primary-button-click' });">Pharmacy</a>
+        <a class="usa-button vads-u-margin-top--1 vads-u-margin--0 vads-u-margin-x--0 vads-u-width--full vads-u-font-size--md" href="/{{ path }}/pharmacy">Pharmacy</a>
     </div>
 </div>


### PR DESCRIPTION
## Description
This is a follow up to https://github.com/department-of-veterans-affairs/vets-website/pull/12832.

This revises the click-tracking to -

- Omit React widgets bc they should have their own analytics
- Omit clicks for primary buttons (we should only track default button clicks) 

## Testing done
Locally, tested against several pages containing button llinks -

`/pittsburgh-health-care/`
- `/decision-reviews/board-appeal/`

## Screenshots
N/A

## Acceptance criteria
- [ ] Link clicks are tracked for non-React default buttons

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
