### PR TITLE
bradl3yC - refactor prop mapping

### DIFF
--- a/src/platform/forms/save-in-progress/RoutedSavablePage.jsx
+++ b/src/platform/forms/save-in-progress/RoutedSavablePage.jsx
@@ -58,7 +58,7 @@ class RoutedSavablePage extends React.Component {
           saveAndRedirectToReturnUrl={this.props.saveAndRedirectToReturnUrl}
           toggleLoginModal={this.props.toggleLoginModal}
         >
-          {form.finishLaterLinkText}
+          {this.props.route.formConfig.finishLaterLinkText}
         </SaveFormLink>
       </div>
     );

--- a/src/platform/forms/save-in-progress/helpers.js
+++ b/src/platform/forms/save-in-progress/helpers.js
@@ -31,7 +31,10 @@ export function createRoutesWithSaveInProgress(formConfig) {
 
     // rewrite page component
     if (!protectedRoutes.has(route.path)) {
-      newRoute = Object.assign({}, route, { component: RoutedSavablePage });
+      newRoute = Object.assign({}, route, {
+        component: RoutedSavablePage,
+        formConfig,
+      });
       newRoutes[index] = newRoute;
     }
 

--- a/src/platform/forms/save-in-progress/reducers.js
+++ b/src/platform/forms/save-in-progress/reducers.js
@@ -131,7 +131,6 @@ export function createSaveInProgressInitialState(formConfig, initialState) {
     migrations: formConfig.migrations,
     prefillTransformer: formConfig.prefillTransformer,
     trackingPrefix: formConfig.trackingPrefix,
-    finishLaterLinkText: formConfig.finishLaterLinkText,
     additionalRoutes: formConfig.additionalRoutes,
   });
 }

--- a/src/platform/forms/tests/save-in-progress/RoutedSavablePage.unit.spec.jsx
+++ b/src/platform/forms/tests/save-in-progress/RoutedSavablePage.unit.spec.jsx
@@ -12,6 +12,9 @@ describe('Schemaform <RoutedSavablePage>', () => {
 
   it('should include SaveLink and SaveStatus', () => {
     const route = {
+      formConfig: {
+        finishLaterLinkText: 'foo',
+      },
       pageConfig: {
         pageKey: 'testPage',
         schema: {},
@@ -62,6 +65,9 @@ describe('Schemaform <RoutedSavablePage>', () => {
 
   it('should pass correct text to SaveFormlink', () => {
     const route = {
+      formConfig: {
+        finishLaterLinkText: 'foo',
+      },
       pageConfig: {
         pageKey: 'testPage',
         schema: {},
@@ -77,7 +83,6 @@ describe('Schemaform <RoutedSavablePage>', () => {
     };
     const form = {
       disableSave: false,
-      finishLaterLinkText: 'foo',
       pages: {
         testPage: {
           schema: {},
@@ -118,6 +123,9 @@ describe('Schemaform <RoutedSavablePage>', () => {
 
   it('should auto save on change', () => {
     const route = {
+      formConfig: {
+        finishLaterLinkText: 'foo',
+      },
       pageConfig: {
         pageKey: 'testPage',
         schema: {},


### PR DESCRIPTION
## Description
Add formConfig to the route prop that is already passed instead of explicitly mapping props from the formconfig in the reducer

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
