### PR TITLE
MDOT Address Page Display Full Country Names

### DIFF
--- a/src/applications/disability-benefits/2346/components/AddressViewField.jsx
+++ b/src/applications/disability-benefits/2346/components/AddressViewField.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import { countries } from 'vets-json-schema/dist/constants.json';
 
 const getField = (formData, possibilities) =>
   possibilities.reduce((value, field) => {
@@ -13,7 +14,9 @@ const addLine = line => line && [line, <br key={line} />];
 
 const AddressViewField = ({ formData }) => {
   // unchanged address variable names
-  const { country, city, state, postalCode } = formData;
+  const { city, state, postalCode, country } = formData;
+  const fullCountryName =
+    countries.find(countryObj => countryObj.value === country)?.label || '';
   // this should cover all current address use cases
   // street, line2, line3, postalCode = platform address schema
   // addressLine1, addressLine2, addressLine3 = 526 & HLR
@@ -27,8 +30,8 @@ const AddressViewField = ({ formData }) => {
   const province = getField(formData, ['province']);
 
   const getAddressFormat = () => {
-    if (country) {
-      return country === 'USA' ? 'domestic' : 'international';
+    if (fullCountryName) {
+      return fullCountryName === 'United States' ? 'domestic' : 'international';
     }
     return undefined;
   };
@@ -44,7 +47,7 @@ const AddressViewField = ({ formData }) => {
   /* eslint-enable no-unused-vars */
 
   const isAddressMissing = Object.values(alteredAddress).every(prop => !prop);
-  const isBaseAddressDataValid = street && country && city;
+  const isBaseAddressDataValid = street && fullCountryName && city;
   const isDomesticAddressValid =
     addressFormat === 'domestic' && state && postalCode;
   const isInternationalAddressValid =
@@ -75,7 +78,7 @@ const AddressViewField = ({ formData }) => {
                 {isDomesticAddressValid && `${city}, ${state} ${postalString}`}
                 {isInternationalAddressValid &&
                   `${city}, ${province} ${internationalPostalCode}`}
-                <span className="vads-u-display--block">{country}</span>
+                <span className="vads-u-display--block">{fullCountryName}</span>
               </>
             )}
           </p>
@@ -98,7 +101,7 @@ AddressViewField.defaultProps = {
 
 AddressViewField.propTypes = {
   formData: PropTypes.shape({
-    country: PropTypes.string,
+    fullCountryName: PropTypes.string,
     city: PropTypes.string,
     state: PropTypes.string,
 

--- a/src/applications/disability-benefits/2346/tests/AddressViewField.unit.spec.jsx
+++ b/src/applications/disability-benefits/2346/tests/AddressViewField.unit.spec.jsx
@@ -19,7 +19,7 @@ describe('AddressViewField', () => {
     };
     const wrapper = shallow(<AddressViewField formData={formData} />);
     expect(wrapper.html()).to.equal(
-      '<div class="vads-u-border-left--7px vads-u-border-color--primary"><p class="vads-u-margin-left--2 vads-u-margin-top--0">s1<br/>s2<br/>city, state 12345<span class="vads-u-display--block">USA</span></p></div>',
+      '<div class="vads-u-border-left--7px vads-u-border-color--primary"><p class="vads-u-margin-left--2 vads-u-margin-top--0">s1<br/>s2<br/>city, state 12345<span class="vads-u-display--block">United States</span></p></div>',
     );
     wrapper.unmount();
   });
@@ -58,7 +58,7 @@ describe('AddressViewField', () => {
   it('should render all non-USA fields', () => {
     const formData = {
       ...baseData,
-      country: 'zland',
+      country: 'CAN',
       street: 's1',
       street2: 's2',
       internationalPostalCode: '123456789',
@@ -66,7 +66,7 @@ describe('AddressViewField', () => {
     };
     const wrapper = shallow(<AddressViewField formData={formData} />);
     expect(wrapper.html()).to.equal(
-      '<div class="vads-u-border-left--7px vads-u-border-color--primary"><p class="vads-u-margin-left--2 vads-u-margin-top--0">s1<br/>s2<br/>city, p1 123456789<span class="vads-u-display--block">zland</span></p></div>',
+      '<div class="vads-u-border-left--7px vads-u-border-color--primary"><p class="vads-u-margin-left--2 vads-u-margin-top--0">s1<br/>s2<br/>city, p1 123456789<span class="vads-u-display--block">Canada</span></p></div>',
     );
     wrapper.unmount();
   });


### PR DESCRIPTION
## Description
This PR focuses on displaying the full country names on the address page.

## Testing done


## Screenshots
![screenshot-localhost_3001-2020 06 01-16_23_40](https://user-images.githubusercontent.com/12755283/83450998-4b75a300-a424-11ea-9958-905bebb48cfd.png)


## Acceptance criteria
- [ ] The full country name should be displayed

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
