### PR TITLE
Fix a couple Profile 2.0 bugs

### DIFF
--- a/src/applications/personalization/profile-2/components/direct-deposit/DirectDeposit.jsx
+++ b/src/applications/personalization/profile-2/components/direct-deposit/DirectDeposit.jsx
@@ -25,6 +25,7 @@ const DirectDeposit = () => {
         benefits
       </h2>
       <DowntimeNotification
+        appTitle="direct deposit"
         render={handleDowntimeForSection('direct deposit')}
         dependencies={[externalServices.evss]}
       >

--- a/src/applications/personalization/profile-2/routes.js
+++ b/src/applications/personalization/profile-2/routes.js
@@ -1,20 +1,8 @@
-import { lazy } from 'react';
-
-const AccountSecurity = lazy(() =>
-  import('../profile-2/components/AccountSecurity'),
-);
-const ConnectedApplications = lazy(() =>
-  import('../profile-2/components/connected-apps/ConnectedApps'),
-);
-const DirectDeposit = lazy(() =>
-  import('../profile-2/components/direct-deposit/DirectDeposit'),
-);
-const MilitaryInformation = lazy(() =>
-  import('../profile-2/components/MilitaryInformation'),
-);
-const PersonalInformation = lazy(() =>
-  import('../profile-2/components/personal-information/PersonalInformation'),
-);
+import AccountSecurity from './components/AccountSecurity';
+import PersonalInformation from './components/personal-information/PersonalInformation';
+import MilitaryInformation from './components/MilitaryInformation';
+import DirectDeposit from './components/direct-deposit/DirectDeposit';
+import ConnectedApplications from './components/connected-apps/ConnectedApps';
 
 export default [
   {

--- a/src/applications/personalization/profile-2/sass/profile-sidenav.scss
+++ b/src/applications/personalization/profile-2/sass/profile-sidenav.scss
@@ -78,7 +78,7 @@ $nav-item-padding: units-px(1) units-px(2) units-px(1) units-px(1.5);
     }
   }
 
-  h2 {
+  h1 {
     border: 1px solid $color-gray-lighter;
     border-left: none;
     border-right: none;

--- a/src/applications/personalization/profiles-wrapper/ProfilesWrapper.jsx
+++ b/src/applications/personalization/profiles-wrapper/ProfilesWrapper.jsx
@@ -37,44 +37,40 @@ const ProfilesWrapper = ({ showProfile1, isLOA1, isLOA3, isInMVI }) => {
   return (
     <BrowserRouter>
       <Suspense fallback={LoadingPage}>
-        <Switch>
-          {routes.map(route => {
-            if (
-              (route.requiresLOA3 && !isLOA3) ||
-              (route.requiresMVI && !isInMVI)
-            ) {
+        <Profile2Wrapper>
+          <Switch>
+            {routes.map(route => {
+              if (
+                (route.requiresLOA3 && !isLOA3) ||
+                (route.requiresMVI && !isInMVI)
+              ) {
+                return (
+                  <Redirect
+                    from={route.path}
+                    key="/profile/account-security"
+                    to="/profile/account-security"
+                  />
+                );
+              }
+
               return (
-                <Redirect
-                  from={route.path}
-                  key="/profile/account-security"
-                  to="/profile/account-security"
+                <Route
+                  component={route.component}
+                  exact
+                  key={route.path}
+                  path={route.path}
                 />
               );
-            }
+            })}
 
-            const Component = route.component;
-
-            return (
-              <Route
-                component={props => (
-                  <Profile2Wrapper {...props}>
-                    <Component />
-                  </Profile2Wrapper>
-                )}
-                exact
-                key={route.path}
-                path={route.path}
-              />
-            );
-          })}
-
-          <Redirect
-            exact
-            from="/profile"
-            key="/profile/personal-information"
-            to="/profile/personal-information"
-          />
-        </Switch>
+            <Redirect
+              exact
+              from="/profile"
+              key="/profile/personal-information"
+              to="/profile/personal-information"
+            />
+          </Switch>
+        </Profile2Wrapper>
       </Suspense>
     </BrowserRouter>
   );


### PR DESCRIPTION
## Description
I noticed that each time you navigated to a section in Profile 2.0, all the network requests were made because the Profile2Wrapper was being mounted again. The Profile2Wrapper was designed to be mounted once when the Profile is first loaded and load all the data the profile needs up front, but that wasn't happening.

I had also noticed some CSS issues with the side nav that this PR fixes.


- [ ] stop mounting Profile2Wrapper each time a profile section is opened
- [ ] fix CSS issues with Profile side nav

## Testing done
Local. The GET fetches happen when you first enter the Profile and do not repeat when you change sections 👍 

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs