### PR TITLE
Cypress CircleCI Improvements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -155,7 +155,6 @@ jobs:
           root: ~/
           paths:
             - vets-website/build
-            - vets-website/test-results
             - .cache/Cypress
 
   eslint-check:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,12 +124,12 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - yarn-packages-{{ .Branch }}-{{ checksum "yarn.lock" }}
+            - yarn-packages-{{ checksum "yarn.lock" }}
       - run:
           name: Install Dependencies
           command: yarn install --frozen-lockfile
       - save_cache:
-          key: yarn-packages-{{ .Branch }}-{{ checksum "yarn.lock" }}
+          key: yarn-packages-{{ checksum "yarn.lock" }}
           paths:
             - ~/.cache
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,10 +58,10 @@ jobs:
           at: ~/
       - restore_cache:
           keys:
-            - yarn-packages-{{ checksum "yarn.lock" }}
+            - yarn-packages-cypress-{{ checksum "yarn.lock" }}
       - run:
           name: Installed Dependencies
-          command: yarn install --frozen-lockfile
+          command: yarn --frozen-lockfile --cache-folder ~/.cache/yarn
       - run:
           name: Make Test Results Folder
           command: mkdir -p ./test-results
@@ -124,12 +124,12 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - yarn-packages-{{ checksum "yarn.lock" }}
+            - yarn-packages-cypress-{{ checksum "yarn.lock" }}
       - run:
           name: Install Dependencies
-          command: yarn install --frozen-lockfile
+          command: yarn --frozen-lockfile --cache-folder ~/.cache/yarn
       - save_cache:
-          key: yarn-packages-{{ checksum "yarn.lock" }}
+          key: yarn-packages-cypress-{{ checksum "yarn.lock" }}
           paths:
             - ~/.cache
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,7 @@ jobs:
           at: ~/
       - restore_cache:
           keys:
-            - yarn-packages-cypress-{{ checksum "yarn.lock" }}
+            - yarn-packages-e2e-{{ checksum "yarn.lock" }}
       - run:
           name: Installed Dependencies
           command: yarn --frozen-lockfile --cache-folder ~/.cache/yarn
@@ -124,12 +124,12 @@ jobs:
       - checkout
       - restore_cache:
           keys:
-            - yarn-packages-cypress-{{ checksum "yarn.lock" }}
+            - yarn-packages-e2e-{{ checksum "yarn.lock" }}
       - run:
           name: Install Dependencies
           command: yarn --frozen-lockfile --cache-folder ~/.cache/yarn
       - save_cache:
-          key: yarn-packages-cypress-{{ checksum "yarn.lock" }}
+          key: yarn-packages-e2e-{{ checksum "yarn.lock" }}
           paths:
             - ~/.cache
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,9 +54,6 @@ jobs:
     parallelism: 2
     steps:
       - checkout
-      - restore_cache:
-          keys:
-            - node-v1-{{ .Branch }}-{{ checksum "package.json" }}
       - attach_workspace:
           at: ~/
       - run:
@@ -138,10 +135,6 @@ jobs:
           key: yarn-packages-{{ .Branch }}-{{ checksum "yarn.lock" }}
           paths:
             - ~/.cache
-      - save_cache:
-          key: node-v1-{{ .Branch }}-{{ checksum "package.json" }}
-          paths:
-            - node_modules
       - run:
           name: Install Sibling Repositories
           command: yarn install-repos

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ jobs:
           at: /root
       - run:
           name: Run Cypress Tests
-          command: ./script/run-cypress-tests-circle.sh
+          command: yarn cy:test:circle
       - store_test_results:
           path: ./test-results
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,9 +122,6 @@ jobs:
       - restore_cache:
           keys:
             - yarn-packages-{{ .Branch }}-{{ checksum "yarn.lock" }}
-      - restore_cache:
-          keys:
-            - node-v1-{{ .Branch }}-{{ checksum "package.json" }}
       - run:
           name: Install Dependencies
           command: yarn --frozen-lockfile --cache-folder ~/.cache/yarn

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,9 +125,6 @@ jobs:
       - run:
           name: Install Dependencies
           command: yarn --frozen-lockfile --cache-folder ~/.cache/yarn
-      - run:
-          name: Verify Cypress is Installed
-          command: yarn cypress verify || yarn cypress install
       - save_cache:
           key: yarn-packages-{{ .Branch }}-{{ checksum "yarn.lock" }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,13 +48,20 @@ jobs:
           path: ./test-results
 
   e2e-test:
+    working_directory: ~/vets-website
     docker:
       - image: cypress/base:10.15.3
     parallelism: 2
-    environment:
     steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - node-v1-{{ .Branch }}-{{ checksum "package.json" }}
       - attach_workspace:
-          at: /root
+          at: ~/
+      - run:
+          name: Verify Dependencies are Installed
+          command: yarn --frozen-lockfile --cache-folder ~/.cache/yarn
       - run:
           name: Run Cypress Tests
           command: yarn cy:test:circle
@@ -107,27 +114,48 @@ jobs:
       - run: yarn build:webpack
 
   build-e2e:
+    working_directory: ~/vets-website
     docker:
       - image: cypress/base:10.15.3
     steps:
       - checkout
       - restore_cache:
           keys:
-            - yarn-packages-{{ checksum "yarn.lock" }}
+            - yarn-packages-{{ .Branch }}-{{ checksum "yarn.lock" }}
+      - restore_cache:
+          keys:
+            - node-v1-{{ .Branch }}-{{ checksum "package.json" }}
       - run:
-          command: yarn install --frozen-lockfile
+          name: Install Dependencies
+          command: yarn --frozen-lockfile --cache-folder ~/.cache/yarn
+      - run:
+          name: Verify Cypress is Installed
+          command: yarn cypress verify || yarn cypress install
       - save_cache:
-          key: yarn-packages-{{ checksum "yarn.lock" }}
+          key: yarn-packages-{{ .Branch }}-{{ checksum "yarn.lock" }}
           paths:
-            - ~/.cache/yarn
-      - run: mkdir -p ./test-results
-      - run: yarn install-repos
-      - run: yarn fetch-drupal-cache
-      - run: yarn build
+            - ~/.cache
+      - save_cache:
+          key: node-v1-{{ .Branch }}-{{ checksum "package.json" }}
+          paths:
+            - node_modules
+      - run:
+          name: Make Test Results Folder
+          command: mkdir -p ./test-results
+      - run:
+          name: Install Sibling Repositories
+          command: yarn install-repos
+      - run:
+          name: Fetch the Latest Drupal Content
+          command: yarn fetch-drupal-cache
+      - run:
+          name: Build vets-website
+          command: yarn build
       - persist_to_workspace:
-          root: /root
+          root: ~/
           paths:
-            - project
+            - vets-website/build
+            - vets-website/test-results
             - .cache/Cypress
 
   eslint-check:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,6 +63,9 @@ jobs:
           name: Verify Dependencies are Installed
           command: yarn --frozen-lockfile --cache-folder ~/.cache/yarn
       - run:
+          name: Make Test Results Folder
+          command: mkdir -p ./test-results
+      - run:
           name: Run Cypress Tests
           command: yarn cy:test:circle
       - store_test_results:
@@ -139,9 +142,6 @@ jobs:
           key: node-v1-{{ .Branch }}-{{ checksum "package.json" }}
           paths:
             - node_modules
-      - run:
-          name: Make Test Results Folder
-          command: mkdir -p ./test-results
       - run:
           name: Install Sibling Repositories
           command: yarn install-repos

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,7 +127,7 @@ jobs:
             - yarn-packages-{{ .Branch }}-{{ checksum "yarn.lock" }}
       - run:
           name: Install Dependencies
-          command: yarn --frozen-lockfile --cache-folder ~/.cache/yarn
+          command: yarn install --frozen-lockfile
       - save_cache:
           key: yarn-packages-{{ .Branch }}-{{ checksum "yarn.lock" }}
           paths:
@@ -145,7 +145,6 @@ jobs:
           root: ~/
           paths:
             - vets-website/build
-            - .cache/Cypress
 
   eslint-check:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,7 +131,8 @@ jobs:
       - save_cache:
           key: yarn-packages-e2e-{{ checksum "yarn.lock" }}
           paths:
-            - ~/.cache
+            - ~/.cache/yarn
+            - ~/.cache/Cypress
       - run:
           name: Install Sibling Repositories
           command: yarn install-repos

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,7 +60,7 @@ jobs:
           keys:
             - yarn-packages-{{ checksum "yarn.lock" }}
       - run:
-          name: Verify Dependencies are Installed
+          name: Installed Dependencies
           command: yarn install --frozen-lockfile
       - run:
           name: Make Test Results Folder

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,9 +56,12 @@ jobs:
       - checkout
       - attach_workspace:
           at: ~/
+      - restore_cache:
+          keys:
+            - yarn-packages-{{ checksum "yarn.lock" }}
       - run:
           name: Verify Dependencies are Installed
-          command: yarn --frozen-lockfile --cache-folder ~/.cache/yarn
+          command: yarn install --frozen-lockfile
       - run:
           name: Make Test Results Folder
           command: mkdir -p ./test-results

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "build:content": "node --max-old-space-size=4096 script/build-content.js",
     "build:content:test": "node script/test-cms-export.js",
     "build:webpack": "NODE_OPTIONS=--max-old-space-size=4096 webpack --config config/webpack.config.js --progress",
+    "cy:test:circle": "./script/run-cypress-tests-circle.sh",
     "fetch-drupal-cache": "node script/drupal-aws-cache.js --fetch",
     "heroku-serve": "http-server",
     "prebuild": "node script/prebuild.js",

--- a/script/run-cypress-tests-circle.sh
+++ b/script/run-cypress-tests-circle.sh
@@ -10,6 +10,7 @@ else
   # Use the CircleCI CLI to get Cypress tests & split them on different machines by timing. Commas are inserted as the delimiter for file paths.
   specArgs="--spec $(echo '"$(circleci tests glob "src/**/tests/**/*.cypress.spec.js" | circleci tests split --split-by=timings | paste -sd "," -)"')"
 
-  # Start the server & wait for 'http://localhost:3001' to go live.
-  yarn start-server-and-test watch http://localhost:3001 "cypress run $reporterArgs $specArgs"
+  # Start the web server & run Cypress tests.
+  # Wait for http://localhost:3001/generated/style.css to finish bundling so Cypress doesn't start too soon.
+  yarn start-server-and-test watch http-get://localhost:3001/generated/style.css "cypress run $reporterArgs $specArgs"
 fi


### PR DESCRIPTION
## Description
Some improvements for running Cypress tests in CircleCI:
- Speed up the `e2e-test` and `build-e2e` jobs by caching `node_modules` and ` ~/.cache` (includes yarn & Cypress cache).
- Removed the `project` folder from `persist_to_workspace` in `build-e2e`.
- Wait for `yarn  watch` to finish bundling before running Cypress tests.
- Changed the working directory to `~/vets-website` for `e2e-test` and `build-e2e` jobs.
- Added names for steps.

## Testing done
Tested in another branch.

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
