### PR TITLE
Profile 2.0 - don't focus DD edit button on load

### DIFF
--- a/src/applications/personalization/profile-2/components/connected-apps/ConnectedApp.jsx
+++ b/src/applications/personalization/profile-2/components/connected-apps/ConnectedApp.jsx
@@ -33,7 +33,7 @@ export class ConnectedApp extends Component {
 
     return (
       <div
-        className="border-box vads-u-display--flex vads-u-align-items--flex-start vads-u-padding--3 vads-u-border-color--gray-lightest vads-u-border--2px
+        className="border-box vads-u-display--flex vads-u-align-items--flex-start vads-u-padding--3 vads-u-border-color--gray-lighter vads-u-border--1px
         vads-u-margin-y--2"
       >
         <img

--- a/src/applications/personalization/profile-2/components/direct-deposit/DirectDepositContent.jsx
+++ b/src/applications/personalization/profile-2/components/direct-deposit/DirectDepositContent.jsx
@@ -42,44 +42,38 @@ export const DirectDepositContent = ({
   const editBankInfoButton = useRef();
   const [formData, setFormData] = useState({});
   const [showSaveSucceededAlert, setShowSaveSucceededAlert] = useState(false);
-  const previousUiState = usePrevious(directDepositUiState);
+  const wasEditingBankInfo = usePrevious(directDepositUiState.isEditing);
+  const wasSavingBankInfo = usePrevious(directDepositUiState.isSaving);
 
   const isEditingBankInfo = directDepositUiState.isEditing;
+  const isSavingBankInfo = directDepositUiState.isSaving;
+  const saveError = directDepositUiState.responseError;
 
   // when we enter and exit edit mode...
   useEffect(
     () => {
-      // reset the bank info form when we enter edit mode
-      if (isEditingBankInfo) {
+      if (wasEditingBankInfo && !isEditingBankInfo) {
+        // clear the form data when exiting edit mode so it's blank when the
+        // edit form is shown again
         setFormData({});
-      }
-      // focus the edit button when we exit edit mode
-      if (isEditingBankInfo === false) {
+        // focus the edit button when we exit edit mode
         editBankInfoButton.current.focus();
       }
     },
-    [isEditingBankInfo],
+    [isEditingBankInfo, wasEditingBankInfo],
   );
 
   // show the user a success alert after their bank info has saved
   useEffect(
     () => {
-      if (
-        previousUiState?.isSaving &&
-        !directDepositUiState.isSaving &&
-        !directDepositUiState.responseError
-      ) {
+      if (wasSavingBankInfo && !isSavingBankInfo && !saveError) {
         setShowSaveSucceededAlert(true);
         setTimeout(() => {
           setShowSaveSucceededAlert(false);
         }, 6000);
       }
     },
-    [
-      previousUiState?.isSaving,
-      directDepositUiState.isSaving,
-      directDepositUiState.responseError,
-    ],
+    [wasSavingBankInfo, isSavingBankInfo, saveError],
   );
 
   const saveBankInfo = () => {
@@ -160,9 +154,9 @@ export const DirectDepositContent = ({
   const editingBankInfoContent = (
     <>
       <div id="errors" role="alert" aria-atomic="true">
-        {!!directDepositUiState.responseError && (
+        {!!saveError && (
           <PaymentInformationEditError
-            responseError={directDepositUiState.responseError}
+            responseError={saveError}
             className="vads-u-margin-top--0 vads-u-margin-bottom--2"
           />
         )}


### PR DESCRIPTION
## Description
The Direct Deposit's "edit" button was focused when the DD section loaded. The section headline should have focus instead. And the "edit" button should be focused when exiting edit mode.


## Testing done
Local

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs