### PR TITLE
update eslint ecmaVersion to 11 (ECMAScript 2020)

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,7 +2,7 @@
   // All rules should be disabled or they should produce errors. No warnings.
   "parser": "babel-eslint",
   "parserOptions": {
-    "ecmaVersion": 6,
+    "ecmaVersion": 11,
     "sourceType": "module"
   },
   "settings": {


### PR DESCRIPTION
## Description
update eslint config for ECMAScript 2020, already supported by Babel 7.8+ https://babeljs.io/blog/2020/01/11/7.8.0