### PR TITLE
Update ESLint ecmaVersion

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,7 +2,7 @@
   // All rules should be disabled or they should produce errors. No warnings.
   "parser": "babel-eslint",
   "parserOptions": {
-    "ecmaVersion": 6,
+    "ecmaVersion": 11,
     "sourceType": "module"
   },
   "settings": {

--- a/.eslintrc
+++ b/.eslintrc
@@ -15,7 +15,7 @@
   "env": {
     "browser": true,
     "commonjs": true,
-    "es6": true,
+    "es2020": true,
     "mocha": true,
     "jest": true
   },


### PR DESCRIPTION
## Description
With the new upgrade of `ESlint` to version `7.0.0` and `@babel/core` to `7.9.6`. ESLint has updated the `ecmaVersion` to the latest [2020/11](https://github.com/eslint/eslint/pull/12833/files). This PR will update `ecmaVersion` to the latest.

## Testing done
Locally running `yarn lint`

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
