### PR TITLE
[Development] Show submission id for 526 non-retryable errors

### DIFF
--- a/src/applications/disability-benefits/all-claims/containers/ConfirmationPage.jsx
+++ b/src/applications/disability-benefits/all-claims/containers/ConfirmationPage.jsx
@@ -57,4 +57,5 @@ ConfirmationPage.propTypes = {
   submittedAt: PropTypes.string.isRequired,
   claimId: PropTypes.string,
   jobId: PropTypes.string,
+  submissionId: PropTypes.string,
 };

--- a/src/applications/disability-benefits/all-claims/content/confirmation-page.jsx
+++ b/src/applications/disability-benefits/all-claims/content/confirmation-page.jsx
@@ -193,8 +193,8 @@ export const submitErrorContent = props =>
           <a href="tel:+18008271000" aria-label="800. 8 2 7. 1000">
             800-827-1000
           </a>
-          , Monday through Friday, 8:30 a.m. to 4:30 p.m. ET,{' '}
-          <strong>or</strong>
+          , Monday through Friday, 8:30 a.m. to 4:30 p.m. ET and provide this
+          reference number {props.submissionId}, <strong>or</strong>
         </li>
         <li>
           Get in touch with your nearest Veterans Service Officer (VSO).{' '}


### PR DESCRIPTION
## Description

Currently, when form 526 is submitted and a retryable error occurs, the user is shown a "job id" so that they can provide a reference number when calling the help desk.

No such reference number is provided when a non-retyable error occurs.

This PR shows the user a "submission id" that can be used as a reference to the submission.

The submission id is:
- Unique to the application
- Is not PII
- Can be used by back-end engineers to look up the application and the full error

Related issues:
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/7483
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/8719

## Testing done

Local unit tests

## Screenshots

None available; EVSS is down for dev & staging

## Acceptance criteria
- [ ] User is provided a "submission id" that can be provided to the help desk.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
