### PR TITLE
Show more useful error when user cannot init in VA Profile

### DIFF
--- a/src/platform/user/profile/vet360/components/base/Vet360TransactionErrorBanner.jsx
+++ b/src/platform/user/profile/vet360/components/base/Vet360TransactionErrorBanner.jsx
@@ -1,18 +1,22 @@
 import React from 'react';
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
+import Telephone, {
+  CONTACTS,
+} from '@department-of-veterans-affairs/formation-react/Telephone';
 import facilityLocator from 'applications/facility-locator/manifest.json';
 
 import {
   hasGenericUpdateError,
   hasMVIError,
   hasMVINotFoundError,
+  hasVAProfileInitError,
 } from 'vet360/util/transactions';
 
 export function GenericUpdateError(props) {
   return (
     <AlertBox
       {...props}
-      className="vads-u-margin-bottom--4"
+      className="vads-u-margin-top--0 vads-u-margin-bottom--4"
       status="error"
       headline="Your recent profile update didn’t save"
       content="We’re sorry. Something went wrong on our end and we couldn’t save the
@@ -21,11 +25,70 @@ export function GenericUpdateError(props) {
   );
 }
 
+export function VAProfileInitError(props) {
+  return (
+    <AlertBox
+      {...props}
+      className="vads-u-margin-top--0 vads-u-margin-bottom--4"
+      status="error"
+      headline="We can’t load some of your information"
+      content={
+        <div>
+          <p>
+            We’re sorry. We can’t load some of the information in your profile.
+            This may be because you have multiple IDs or accounts at VA.
+          </p>
+          <p>
+            <strong>
+              To find out if this about an account on My HealtheVet:
+            </strong>
+          </p>
+          <p>
+            Contact us at <Telephone contact={CONTACTS.MY_HEALTHEVET} />. We’re
+            here Monday - Friday, 8:00 a.m - 8:00 p.m. ET. If you have hearing
+            loss, call <Telephone contact="800-877-3399" />. Tell the
+            representative that you tried to sign in to VA.gov, but got an error
+            message that you may have more than one My HealtheVet account or ID.
+          </p>
+          <p>
+            Or, you can{' '}
+            <a
+              href="https://www.myhealth.va.gov/mhv-portal-web/contact-us"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              fill out a My HealtheVet online help form
+            </a>{' '}
+            to get help signing in.
+          </p>
+          <p>
+            <strong>
+              To find out if this is about an account with the Department of
+              Defense:
+            </strong>
+          </p>
+          <p>
+            You can{' '}
+            <a
+              href="https://www.accesstocare.va.gov/sign-in-help"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              submit a request to get help signing in
+            </a>
+            .{' '}
+          </p>
+        </div>
+      }
+    />
+  );
+}
+
 export function MVILookupFailError(props) {
   return (
     <AlertBox
       {...props}
-      className="vads-u-margin-bottom--4"
+      className="vads-u-margin-top--0 vads-u-margin-bottom--4"
       status="error"
       headline="We’re having trouble matching your information to our Veteran records"
       content={
@@ -48,7 +111,7 @@ export function MVIError(props) {
   return (
     <AlertBox
       {...props}
-      className="vads-u-margin-bottom--4"
+      className="vads-u-margin-top--0 vads-u-margin-bottom--4"
       status="error"
       headline="We can’t access your contact information right now"
       content="We’re sorry. Something went wrong on our end. Please refresh this page or try again later."
@@ -63,6 +126,10 @@ export default function Vet360TransactionErrorBanner({
   let TransactionError = null;
 
   switch (true) {
+    case hasVAProfileInitError(transaction):
+      TransactionError = VAProfileInitError;
+      break;
+
     case hasMVINotFoundError(transaction):
       TransactionError = MVILookupFailError;
       break;

--- a/src/platform/user/profile/vet360/util/transactions.js
+++ b/src/platform/user/profile/vet360/util/transactions.js
@@ -16,45 +16,46 @@ export const FAILURE_STATUSES = new Set([
   VET360.TRANSACTION_STATUS.REJECTED,
 ]);
 
+export const VA_PROFILE_INIT_ERROR_CODES = new Set(['CORE100']);
+
 export const UPDATE_ERROR_CODES = new Set([
-  'VET360_ADDR200',
-  'VET360_ADDR201',
-  'VET360_EMAIL200',
-  'VET360_EMAIL201',
-  'VET360_PHON124',
-  'VET360_PHON125',
-  'VET360_CORE100',
-  'VET360_CORE101',
-  'VET360_CORE102',
-  'VET360_CORE105',
-  'VET360_CORE106',
-  'VET360_CORE107',
-  'VET360_CORE109',
-  'VET360_CORE110',
-  'VET360_CORE500',
-  'VET360_CORE501',
-  'VET360_CORE502',
+  'ADDR200',
+  'ADDR201',
+  'EMAIL200',
+  'EMAIL201',
+  'PHON124',
+  'PHON125',
+  'CORE101',
+  'CORE102',
+  'CORE105',
+  'CORE106',
+  'CORE107',
+  'CORE109',
+  'CORE110',
+  'CORE500',
+  'CORE501',
+  'CORE502',
 ]);
 
-export const MVI_NOT_FOUND_ERROR_CODES = new Set(['VET360_MVI201']);
+export const MVI_NOT_FOUND_ERROR_CODES = new Set(['MVI201']);
 
 export const MVI_ERROR_CODES = new Set([
-  'VET360_MVI100',
-  'VET360_MVI101',
-  'VET360_MVI200',
-  'VET360_MVI202',
-  'VET360_MVI203',
+  'MVI100',
+  'MVI101',
+  'MVI200',
+  'MVI202',
+  'MVI203',
 ]);
 
 // This results as a direct error response from the API, and prior to a transaction being created.
 // For context - https://github.com/department-of-veterans-affairs/vets.gov-team/issues/11352
 export const LOW_CONFIDENCE_ADDRESS_ERROR_CODES = new Set([
-  'VET360_ADDR305',
-  'VET360_ADDR306',
-  'VET360_ADDR307',
+  'ADDR305',
+  'ADDR306',
+  'ADDR307',
 ]);
 
-export const DECEASED_ERROR_CODES = new Set(['VET360_MVI300']);
+export const DECEASED_ERROR_CODES = new Set(['MVI300']);
 
 export function isPendingTransaction(transaction) {
   return PENDING_STATUSES.has(transaction?.data.attributes.transactionStatus);
@@ -69,8 +70,19 @@ export function isFailedTransaction(transaction) {
 }
 
 function matchErrorCode(codeSet, transaction) {
-  const { metadata } = transaction?.data.attributes;
-  return metadata && metadata.some(error => codeSet.has(error.code));
+  // Create a codeSet that contains all the values of the passed-in codeSet,
+  // with and without a `VET360_` prefix. The `VET360_` prefix is added by our
+  // vets-api layer, but is only added in some cases.
+  // https://github.com/department-of-veterans-affairs/va.gov-team/issues/8847#issuecomment-635992074
+  const hydratedCodeSet = new Set(
+    Array.from(codeSet).reduce((codes, code) => {
+      codes.push(code);
+      codes.push(`VET360_${code}`);
+      return codes;
+    }, []),
+  );
+  const { metadata } = transaction?.data?.attributes;
+  return metadata?.some(error => hydratedCodeSet.has(error.code));
 }
 
 export function hasGenericUpdateError(transaction) {
@@ -79,6 +91,10 @@ export function hasGenericUpdateError(transaction) {
 
 export function hasMVINotFoundError(transaction) {
   return matchErrorCode(MVI_NOT_FOUND_ERROR_CODES, transaction);
+}
+
+export function hasVAProfileInitError(transaction) {
+  return matchErrorCode(VA_PROFILE_INIT_ERROR_CODES, transaction);
 }
 
 export function hasMVIError(transaction) {


### PR DESCRIPTION
## Description
This adds special handling of CORE100 error that occurs when a user cannot be initialized in VA Profile.

Also, this PR changes how we determine which error message to show. We previously only checked an error code against sets of codes that all started with `VET360_`. But the error codes we receive [are only sometimes prefixed with `VET360_`](https://github.com/department-of-veterans-affairs/va.gov-team/issues/8847#issuecomment-635992074).

## Testing done
Local

## Screenshots
![image](https://user-images.githubusercontent.com/20728956/83585020-9c0cff00-a4fd-11ea-9bbd-b1b5c3c458ec.png)

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs