### PR TITLE
Fix request filtering

### DIFF
--- a/src/applications/vaos/tests/utils/appointment.unit.spec.jsx
+++ b/src/applications/vaos/tests/utils/appointment.unit.spec.jsx
@@ -660,6 +660,14 @@ describe('VAOS appointment helpers', () => {
             .format('MM/DD/YYYY'),
         },
         {
+          status: 'Cancelled',
+          appointmentType: 'Primary Care',
+          optionDate1: now
+            .clone()
+            .subtract(2, 'days')
+            .format('MM/DD/YYYY'),
+        },
+        {
           status: 'Submitted',
           appointmentType: 'Primary Care',
           optionDate1: now
@@ -704,7 +712,15 @@ describe('VAOS appointment helpers', () => {
       ];
 
       const filteredRequests = requests.filter(r => filterRequests(r, now));
-      expect(filteredRequests.length).to.equal(3);
+      expect(
+        filteredRequests.filter(req => req.status === 'Cancelled').length,
+      ).to.equal(1);
+      expect(
+        filteredRequests.filter(req => req.status === 'Submitted').length,
+      ).to.equal(4);
+      expect(
+        filteredRequests.filter(req => req.status === 'Booked').length,
+      ).to.equal(0);
     });
   });
 

--- a/src/applications/vaos/utils/appointment.js
+++ b/src/applications/vaos/utils/appointment.js
@@ -247,7 +247,7 @@ export function filterRequests(request, today) {
       optionDate3.isAfter(today) &&
       optionDate3.isBefore(thirteenMonths));
 
-  return (status === 'Submitted' || status === 'Cancelled') && hasValidDate;
+  return status === 'Submitted' || (status === 'Cancelled' && hasValidDate);
 }
 
 export function sortFutureConfirmedAppointments(a, b) {


### PR DESCRIPTION
## Description
We're filtering out all requests when their requested dates past, which should not happen for Submitted requests

## Testing done
Unit testing

## Acceptance criteria
- [ ] Requests are shown properly

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
