### PR TITLE
Fix lost of previous element focus when exiting out of modal

### DIFF
--- a/src/applications/gi/components/Modal.jsx
+++ b/src/applications/gi/components/Modal.jsx
@@ -40,12 +40,10 @@ class Modal extends React.Component {
     }
   }
 
-  teardownModal() {
+  async teardownModal() {
     if (this.state.lastFocus) {
       // Ensure last focus is set before completing modal teardown
-      setTimeout(() => {
-        this.state.lastFocus.focus();
-      }, 0);
+      await this.state.lastFocus.focus();
     }
     document.body.classList.remove('modal-open');
     document.removeEventListener('keydown', this.handleDocumentKeyDown, false);
@@ -58,8 +56,7 @@ class Modal extends React.Component {
   handleDocumentKeyDown = event => {
     if (event.keyCode === ESCAPE_KEY) {
       this.handleClose(event);
-    }
-    if (event.keyCode === TAB_KEY) {
+    } else if (event.keyCode === TAB_KEY) {
       if (event.shiftKey) {
         this.setState({ isTabbingBackwards: true });
       } else {


### PR DESCRIPTION
## Description
https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/9241
 

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
