### PR TITLE
Fix a few Profile 2.0 typos

### DIFF
--- a/src/applications/personalization/profile-2/components/Profile2Wrapper.jsx
+++ b/src/applications/personalization/profile-2/components/Profile2Wrapper.jsx
@@ -88,7 +88,7 @@ class Profile2 extends Component {
         {/* Breadcrumbs */}
         <Breadcrumbs className="vads-u-padding-x--1 vads-u-padding-y--1p5 medium-screen:vads-u-padding-y--0">
           <a href="/">Home</a>
-          {!onPersonalInformationMobile && <Link to="/">Profile</Link>}
+          {!onPersonalInformationMobile && <Link to="/">Your profile</Link>}
           <a href={activeLocation}>{activeRouteName}</a>
         </Breadcrumbs>
 

--- a/src/applications/personalization/profile-2/components/ProfileSideNav.jsx
+++ b/src/applications/personalization/profile-2/components/ProfileSideNav.jsx
@@ -83,7 +83,7 @@ const ProfileSideNav = ({ closeSideNav, isSideNavOpen, isLOA3 }) => {
             closeSideNav(true);
           }}
         />
-        <h1 className="vads-u-font-size--h4">Your Profile</h1>
+        <h1 className="vads-u-font-size--h4">Your profile</h1>
         <ul>
           {routes.map(route => {
             // Do not render route if it is not isLOA3

--- a/src/applications/personalization/profile-2/components/personal-information/ContactInformationSection.jsx
+++ b/src/applications/personalization/profile-2/components/personal-information/ContactInformationSection.jsx
@@ -15,7 +15,7 @@ const ContactInformationSection = ({ className }) => (
     <AdditionalInfo triggerText="Which of my benefits will use this contact information?">
       We’ll use this information to contact you about certain benefits and
       services, including disability compensation, pension benefits, and claims
-      and appeals. If you’re enrolled in VA health care, We’ll send your
+      and appeals. If you’re enrolled in VA health care, we’ll send your
       prescriptions to the mailing address listed. Your health care team may
       also use this contact information to communicate with you.
     </AdditionalInfo>

--- a/src/applications/personalization/profile-2/routes.js
+++ b/src/applications/personalization/profile-2/routes.js
@@ -7,7 +7,7 @@ import ConnectedApplications from './components/connected-apps/ConnectedApps';
 export default [
   {
     component: PersonalInformation,
-    name: 'Personal and contact Information',
+    name: 'Personal and contact information',
     path: '/profile/personal-information',
     requiresLOA3: true,
     requiresMVI: true,

--- a/src/applications/personalization/profile-2/tests/components/Profile2.unit.spec.js
+++ b/src/applications/personalization/profile-2/tests/components/Profile2.unit.spec.js
@@ -94,7 +94,9 @@ describe('Profile2', () => {
         .last()
         .text();
 
-      expect(activeRouteText).to.include('Personal and contact Information');
+      expect(activeRouteText.toLowerCase()).to.include(
+        'personal and contact information',
+      );
       wrapper.unmount();
     });
 

--- a/src/platform/user/profile/vet360/components/base/Vet360EditModalActionButtons.jsx
+++ b/src/platform/user/profile/vet360/components/base/Vet360EditModalActionButtons.jsx
@@ -81,9 +81,6 @@ class Vet360EditModalActionButtons extends React.Component {
   render() {
     const alertContent = (
       <div>
-        <h3 tabIndex="-1" id="deleteConfirmationHeading">
-          Are you sure?
-        </h3>
         <p>
           This will delete your {toLower(this.props.title)} across many VA
           records. You can always come back to your profile later if you'd like
@@ -108,7 +105,18 @@ class Vet360EditModalActionButtons extends React.Component {
     );
 
     if (this.state.deleteInitiated) {
-      return <AlertBox isVisible status="warning" content={alertContent} />;
+      return (
+        <AlertBox
+          isVisible
+          status="warning"
+          headline={
+            <span tabIndex="-1" id="deleteConfirmationHeading">
+              Are you sure?
+            </span>
+          }
+          content={alertContent}
+        />
+      );
     }
 
     return (


### PR DESCRIPTION
## Description
Addresses some of the low-hanging fruit from https://github.com/department-of-veterans-affairs/va.gov-team/issues/5353#issuecomment-637857627

## Testing done
- confirmed that the AlertBox headline is still an H3 and is focused when the AlertBox appears.

## Screenshots
![image](https://user-images.githubusercontent.com/20728956/83677325-d8d60600-a590-11ea-8cb5-1a04606bcc25.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs