### PR TITLE
Remove COVID-19 screening tool from sitemap

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -6,6 +6,7 @@
     "template": {
       "title": "COVID-19 screening tool",
       "layout": "page-react.html",
+      "private": true,
       "vagovprod": true
     }
   },


### PR DESCRIPTION
## Description
This PR follows up to https://github.com/department-of-veterans-affairs/vets-website/pull/12747, also removing the screening tool from the sitemap.

## Testing done
Ran build locally to confirm the page is not listed in the generated sitemap

## Screenshots
N/A

## Acceptance criteria
- [ ] Less SEO to screening tool

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
