### PR TITLE
Fix loading state connected apps

### DIFF
--- a/src/applications/personalization/profile-2/components/connected-apps/ConnectedApp.jsx
+++ b/src/applications/personalization/profile-2/components/connected-apps/ConnectedApp.jsx
@@ -25,7 +25,6 @@ export class ConnectedApp extends Component {
       'account-section': 'connected-accounts',
     });
     this.props.confirmDelete(this.props.id);
-    this.closeModal();
   };
 
   render() {
@@ -68,6 +67,7 @@ export class ConnectedApp extends Component {
             onCloseModal={this.closeModal}
             onConfirmDelete={this.confirmDelete}
           />
+
           <AdditionalInfo triggerText={`Learn about ${title}`}>
             <p>
               <strong>{title}</strong>
@@ -88,5 +88,4 @@ ConnectedApp.propTypes = {
   type: PropTypes.string.isRequired,
   attributes: PropTypes.object.isRequired,
   confirmDelete: PropTypes.func.isRequired,
-  isLast: PropTypes.bool,
 };

--- a/src/applications/personalization/profile-2/components/connected-apps/ConnectedApps.jsx
+++ b/src/applications/personalization/profile-2/components/connected-apps/ConnectedApps.jsx
@@ -77,7 +77,6 @@ export class ConnectedApps extends Component {
           <ConnectedApp
             key={app.id}
             confirmDelete={this.confirmDelete}
-            isLast={idx + 1 === activeApps.length}
             {...app}
           />
         ))}


### PR DESCRIPTION
## Description
This PR ensures the modal no longer closes when the user clicks on 'Disconnect'.

## Testing done
Works locally.

## Screenshots
![image](https://user-images.githubusercontent.com/14869324/83770411-4429e180-a63e-11ea-96e3-667ef996b0ef.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
