### PR TITLE
[Development] Add contact info to HLR review

### DIFF
--- a/src/applications/disability-benefits/996/config/form.js
+++ b/src/applications/disability-benefits/996/config/form.js
@@ -18,6 +18,7 @@ import prefillTransformer from './prefill-transformer';
 import IntroductionPage from '../components/IntroductionPage';
 import ConfirmationPage from '../containers/ConfirmationPage';
 import GetFormHelp from '../components/GetFormHelp';
+import ReviewDescription from '../containers/ReviewDescription';
 
 // Pages
 import veteranInformation from '../pages/veteranInformation';
@@ -72,6 +73,7 @@ const formConfig = {
   chapters: {
     infoPages: {
       title: 'Veteran information',
+      reviewDescription: ReviewDescription,
       pages: {
         veteranInformation: {
           title: 'Veteran information',

--- a/src/applications/disability-benefits/996/config/prefill-transformer.js
+++ b/src/applications/disability-benefits/996/config/prefill-transformer.js
@@ -1,4 +1,4 @@
 export default function prefillTransformer(pages, formData, metadata) {
-  const veteran = formData.data.attributes.veteran;
+  const veteran = formData?.data?.attributes?.veteran || {};
   return { pages, formData: { veteran }, metadata };
 }

--- a/src/applications/disability-benefits/996/config/prefill-transformer.js
+++ b/src/applications/disability-benefits/996/config/prefill-transformer.js
@@ -1,4 +1,4 @@
 export default function prefillTransformer(pages, formData, metadata) {
   const veteran = formData.data.attributes.veteran;
-  return { pages, formData: veteran, metadata };
+  return { pages, formData: { veteran }, metadata };
 }

--- a/src/applications/disability-benefits/996/containers/ReviewDescription.jsx
+++ b/src/applications/disability-benefits/996/containers/ReviewDescription.jsx
@@ -1,0 +1,57 @@
+import React from 'react';
+
+import {
+  changeCase,
+  formatPhone,
+  getCountryName,
+} from '../content/contactInformation';
+
+const ReviewDescription = ({ formData }) => {
+  const veteran = formData?.veteran;
+  if (!veteran) {
+    return null;
+  }
+  // Label: formatted value
+  const display = {
+    'Phone number': () => formatPhone(veteran?.phoneNumber),
+    'Email address': () => veteran?.emailAddress,
+    Country: () => getCountryName(veteran?.countryCode),
+    'Street address': () => changeCase(veteran?.addressLine1),
+    'Line 2': () => changeCase(veteran?.addressLine2),
+    'Line 3': () => changeCase(veteran?.addressLine3),
+    City: () => changeCase(veteran?.city),
+    State: () => veteran?.stateOrProvinceCode,
+    'Postal code': () => veteran?.zipPostalCode,
+  };
+
+  return (
+    <>
+      <div className="form-review-panel-page-header-row">
+        <h2 className="vads-u-font-size--h4 vads-u-margin--0">
+          Contact information
+        </h2>
+        <a
+          href="/profile"
+          target="_blank"
+          className="edit-btn primary-outline usa-button"
+          aria-label="Edit on Profile"
+        >
+          Edit on Profile
+        </a>
+      </div>
+      <dl className="review">
+        {Object.entries(display).map(([label, getValue]) => {
+          const value = getValue() || '';
+          return value ? (
+            <div key={label} className="review-row">
+              <dt>{label}</dt>
+              <dd>{value}</dd>
+            </div>
+          ) : null;
+        })}
+      </dl>
+    </>
+  );
+};
+
+export default ReviewDescription;

--- a/src/applications/disability-benefits/996/content/contactInformation.jsx
+++ b/src/applications/disability-benefits/996/content/contactInformation.jsx
@@ -19,7 +19,7 @@ export const getCountryName = (countryCode = 'USA') =>
     ? ''
     : countries.find(country => country.value === countryCode)?.label || '';
 
-export const contactInfoDescription = ({ formData }) => {
+export const contactInfoDescription = ({ formData: { veteran = {} } }) => {
   const {
     phoneNumber,
     emailAddress,
@@ -30,7 +30,7 @@ export const contactInfoDescription = ({ formData }) => {
     stateOrProvinceCode = '',
     zipPostalCode,
     countryCode = 'USA',
-  } = formData.veteran;
+  } = veteran;
 
   let postalString = zipPostalCode || '';
   if (countryCode === 'USA' && zipPostalCode) {

--- a/src/applications/disability-benefits/996/content/contactInformation.jsx
+++ b/src/applications/disability-benefits/996/content/contactInformation.jsx
@@ -25,7 +25,7 @@ export const contactInfoDescription = ({ formData }) => {
     stateOrProvinceCode = '',
     zipPostalCode,
     countryCode = 'USA',
-  } = formData;
+  } = formData.veteran;
 
   let postalString = zipPostalCode || '';
   if (countryCode === 'USA' && zipPostalCode) {

--- a/src/applications/disability-benefits/996/content/contactInformation.jsx
+++ b/src/applications/disability-benefits/996/content/contactInformation.jsx
@@ -5,14 +5,19 @@ import titleCase from 'platform/utilities/data/titleCase';
 import { makeTitle } from '../helpers';
 
 // Much of the mock data is in all caps; not good for a11y
-const changeCase = string => makeTitle(string || '');
+export const changeCase = string => makeTitle(string || '');
 const addBrAfter = line => line && [changeCase(line), <br key={line} />];
 const addBrBefore = line => line && [<br key={line} />, changeCase(line)];
 
-const formatPhone = number => {
+export const formatPhone = number => {
   let i = 0;
   return '###-###-####'.replace(/#/g, () => number[i++] || '');
 };
+
+export const getCountryName = (countryCode = 'USA') =>
+  countryCode === 'USA'
+    ? ''
+    : countries.find(country => country.value === countryCode)?.label || '';
 
 export const contactInfoDescription = ({ formData }) => {
   const {
@@ -33,11 +38,6 @@ export const contactInfoDescription = ({ formData }) => {
       zipPostalCode.length > 5 ? `-${zipPostalCode.slice(5)}` : '';
     postalString = `${zipPostalCode.slice(0, 5)}${lastChunk}`;
   }
-
-  const displayedCountry =
-    countryCode === 'USA'
-      ? ''
-      : countries.find(country => country.value === countryCode)?.label || '';
 
   return (
     <>
@@ -67,7 +67,7 @@ export const contactInfoDescription = ({ formData }) => {
           {addBrAfter(addressLine3)}
           {changeCase(city)}
           {city && ','} {titleCase(stateOrProvinceCode)} {postalString}
-          {addBrBefore(displayedCountry)}
+          {addBrBefore(getCountryName(countryCode))}
           &nbsp;
         </p>
       </div>

--- a/src/applications/disability-benefits/996/sass/0996-higher-level-review.scss
+++ b/src/applications/disability-benefits/996/sass/0996-higher-level-review.scss
@@ -178,11 +178,6 @@ article[data-location="request-informal-conference"] {
 
 /* Step 4 Review Application */
 article[data-location="review-and-submit"] {
-  /* Hide veteran information accordion (it's empty) */
-  .usa-accordion-bordered[data-chapter="infoPages"] {
-    display: none;
-  }
-
   /* reduce huge gaps where text should be rendered */
   .schemaform-field-template {
     margin-top: 0;

--- a/src/applications/disability-benefits/996/tests/components/contactInfo.unit.spec.jsx
+++ b/src/applications/disability-benefits/996/tests/components/contactInfo.unit.spec.jsx
@@ -34,7 +34,7 @@ describe('Higher-Level Review 0996 contact information', () => {
       <DefinitionTester
         definitions={{}}
         schema={contactInfo.schema}
-        data={data}
+        data={{ veteran: data }}
         formData={{}}
         uiSchema={contactInfo.uiSchema}
       />,
@@ -63,7 +63,7 @@ describe('Higher-Level Review 0996 contact information', () => {
       <DefinitionTester
         definitions={{}}
         schema={contactInfo.schema}
-        data={data}
+        data={{ veteran: data }}
         formData={{}}
         uiSchema={contactInfo.uiSchema}
       />,

--- a/src/applications/disability-benefits/996/tests/containers/ReviewDescription.unit.spec.jsx
+++ b/src/applications/disability-benefits/996/tests/containers/ReviewDescription.unit.spec.jsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+
+import ReviewDescription from '../../containers/ReviewDescription';
+
+const formData = {
+  veteran: {
+    phoneNumber: '1234567890',
+    emailAddress: 'foo@bar.com',
+    countryCode: 'USA',
+    addressLine1: '123 MAIN Street',
+    city: 'TownsVILLE',
+    stateOrProvinceCode: 'AB',
+    zipPostalCode: '98765',
+  },
+};
+
+// Displayed on the review & submit page
+describe('Review description', () => {
+  it('should render contact info', () => {
+    const tree = shallow(<ReviewDescription formData={formData} />);
+
+    const rows = tree.find('.review-row');
+    // country is not shown if it's the U.S.
+    expect(rows.length).to.equal(6);
+    expect(rows.at(0).text()).to.contain('Phone number123-456-7890');
+    expect(rows.at(1).text()).to.contain('Email addressfoo@bar.com');
+    expect(rows.at(2).text()).to.contain('Street address123 Main Street');
+    expect(rows.at(3).text()).to.contain('CityTownsville');
+    expect(rows.at(4).text()).to.contain('StateAB');
+    expect(rows.at(5).text()).to.contain('Postal code98765');
+    tree.unmount();
+  });
+
+  it('should render country & other street address lines', () => {
+    const extendedData = {
+      veteran: {
+        ...formData.veteran,
+        countryCode: 'AUS',
+        addressLine2: 'SECTION 5',
+        addressLine3: 'UNIT A33',
+      },
+    };
+    const tree = shallow(<ReviewDescription formData={extendedData} />);
+
+    const rows = tree.find('.review-row');
+    expect(rows.length).to.equal(9);
+    expect(rows.at(0).text()).to.contain('Phone number123-456-7890');
+    expect(rows.at(1).text()).to.contain('Email addressfoo@bar.com');
+    expect(rows.at(2).text()).to.contain('CountryAustralia');
+    expect(rows.at(3).text()).to.contain('Street address123 Main Street');
+    expect(rows.at(4).text()).to.contain('Line 2Section 5');
+    expect(rows.at(5).text()).to.contain('Line 3Unit A33');
+    expect(rows.at(6).text()).to.contain('CityTownsville');
+    expect(rows.at(7).text()).to.contain('StateAB');
+    expect(rows.at(8).text()).to.contain('Postal code98765');
+    tree.unmount();
+  });
+});

--- a/src/applications/disability-benefits/996/tests/prefill-transformer.unit.spec.js
+++ b/src/applications/disability-benefits/996/tests/prefill-transformer.unit.spec.js
@@ -1,0 +1,69 @@
+import { expect } from 'chai';
+import prefillTransformer from '../config/prefill-transformer';
+
+// This is the nesting of the prefill data; transformation flattens it
+const buildData = veteran => ({
+  data: {
+    attributes: {
+      veteran,
+    },
+  },
+});
+
+describe('HLR prefill transformer', () => {
+  const noTransformData = {
+    metadata: { test: 'Test Metadata' },
+    formData: {
+      testData: 'This is not getting transformed',
+      data: {},
+    },
+    pages: { testPage: 'Page 1' },
+  };
+
+  it('should return a copy of the prefill data', () => {
+    const { pages, formData, metadata } = noTransformData;
+    const noTransformActual = prefillTransformer(pages, formData, metadata);
+    // ensure transformed data is not the same object as input data
+    expect(noTransformActual).to.not.equal(noTransformData);
+    expect(noTransformActual).to.deep.equal({
+      metadata: noTransformData.metadata,
+      formData: { veteran: {} },
+      pages: noTransformData.pages,
+    });
+  });
+
+  describe('prefill veteran information', () => {
+    it('should transform contact info when present', () => {
+      const { pages, metadata } = noTransformData;
+      const formData = buildData({
+        phoneNumber: '1123123123',
+        emailAddress: 'a@b.c',
+        countryCode: 'USA',
+        addressLine1: '123 Any Street',
+        city: 'Anyville',
+        stateOrProvineCode: 'AK',
+        zipPostalCode: '12345',
+      });
+
+      const transformedData = prefillTransformer(pages, formData, metadata)
+        .formData;
+
+      expect(transformedData).to.deep.equal({
+        veteran: formData.data.attributes.veteran,
+      });
+    });
+
+    it('should transform partial contact info', () => {
+      const { pages, metadata } = noTransformData;
+      const emailAddress = 'a@b.c';
+      const formData = buildData({ emailAddress });
+
+      const transformedData = prefillTransformer(pages, formData, metadata)
+        .formData;
+
+      expect(transformedData).to.deep.equal({
+        veteran: { emailAddress },
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Description

Add read-only contact information data to the Higher-Level Review review & submit page.

This change also required an update to the prefill transformer.

Design: https://vsateams.invisionapp.com/share/W5U21BDFTQK#/screens/420361477
Ticket: https://github.com/department-of-veterans-affairs/va.gov-team/issues/9831

## Testing done

- Added contact info accordion block unit tests
- Added prefill transformer unit tests

## Screenshots

<details><summary>New veteran detail accordion content</summary>

<!-- leave a blank line above -->
![Screen Shot 2020-06-04 at 10 11 38 AM](https://user-images.githubusercontent.com/136959/83776587-f9b06100-a64d-11ea-92ff-866e6166ecc2.png)</details>

## Acceptance criteria

- [x] Veteran info accordion content matches design
- [x] All unit tests passing
- [x] Passing accessibility checks

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
