### PR TITLE
fix spacing between learn more button and label text

### DIFF
--- a/src/applications/gi/components/search/CautionaryWarningsFilter.jsx
+++ b/src/applications/gi/components/search/CautionaryWarningsFilter.jsx
@@ -25,8 +25,7 @@ class CautionaryWarningsFilter extends React.Component {
     return (
       <div>
         <p>
-          Warnings and school closings
-          {this.renderProfileCautionFlagModal()}
+          Warnings and school closings {this.renderProfileCautionFlagModal()}
         </p>
         <Checkbox
           checked={this.props.excludeWarnings}


### PR DESCRIPTION
## Description
https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/9829


## Testing done
Dev tested

## Screenshots
![image](https://user-images.githubusercontent.com/48804654/83788851-d8f30600-a663-11ea-8bd9-9f33e67d99a9.png)


## Acceptance criteria
- [x] There is a space between the learn more button and text.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
