### PR TITLE
Adds GA events for clicks on chatbot buttons and links

### DIFF
--- a/src/applications/coronavirus-chatbot/index.js
+++ b/src/applications/coronavirus-chatbot/index.js
@@ -1,6 +1,6 @@
 import { apiRequest } from 'platform/utilities/api';
 import recordEvent from 'platform/monitoring/record-event';
-import { GA_PREFIX, handleButtonsPostRender } from './utils';
+import { recordLinkClicks, GA_PREFIX, handleButtonsPostRender } from './utils';
 import * as Sentry from '@sentry/browser';
 import localStorage from 'platform/utilities/storage/localStorage';
 
@@ -162,6 +162,7 @@ const chatRequested = async scenario => {
 };
 
 export async function initializeChatbot() {
+  recordLinkClicks();
   handleButtonsPostRender();
   return chatRequested('va_coronavirus_chatbot');
 }

--- a/src/applications/coronavirus-chatbot/utils.js
+++ b/src/applications/coronavirus-chatbot/utils.js
@@ -1,7 +1,25 @@
+import recordEvent from 'platform/monitoring/record-event';
+
+export const GA_PREFIX = 'chatbot';
+
+export const recordLinkClicks = () => {
+  const root = document.getElementById('webchat');
+  root.addEventListener('click', event => {
+    if (event.target.tagName.toLowerCase() === 'a') {
+      recordEvent({
+        event: `${GA_PREFIX}-resource-link-click`,
+        'error-key': undefined,
+      });
+    }
+  });
+};
+
 const disableButtons = event => {
   // if user clicked the div, bubble up to parent to disable the button
   const targetButton =
-    event.target.tagName === 'BUTTON' ? event.target : event.target.parentNode;
+    event.target.tagName.toLowerCase() === 'button'
+      ? event.target
+      : event.target.parentNode;
   const siblingButtons = targetButton.parentNode.childNodes;
 
   for (let i = 0; i < siblingButtons.length; i++) {
@@ -28,6 +46,11 @@ const scrollToNewMessage = () => {
 };
 
 const handleDisableAndScroll = event => {
+  recordEvent({
+    event: `${GA_PREFIX}-button-click`,
+    'error-key': undefined,
+  });
+
   disableButtons(event);
   disableCheckboxes();
   setTimeout(() => {
@@ -62,5 +85,3 @@ export const handleButtonsPostRender = () => {
     addEventListenerToButtons();
   }, 10);
 };
-
-export const GA_PREFIX = 'chatbot';


### PR DESCRIPTION
## Description
[department-of-veterans-affairs/covid-chatbot#241](https://github.com/department-of-veterans-affairs/covid19-chatbot/issues/241) 
[va.gov-team issue](https://github.com/department-of-veterans-affairs/va.gov-team/issues/9621)

- Configures `chatbot-button-click` event for all clicks on buttons
- Configures `chatbot-resource-link-click` event for all clicks on links (including phone numbers)

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
