### PR TITLE
VACMS-TOC: Adding TOC to benefit detail pages.

### DIFF
--- a/src/site/layouts/page.drupal.liquid
+++ b/src/site/layouts/page.drupal.liquid
@@ -50,6 +50,13 @@
         </div>
         {% endif %}
 
+        {% if fieldTableOfContentsBoolean != empty and fieldTableOfContentsBoolean %}
+        <section id="table-of-contents">
+          <h2 class="vads-u-margin-bottom--2 vads-u-font-size--lg">On this page</h2>
+          <ul class="usa-unstyled-list"></ul>
+        </section>
+        {% endif %}
+
         {% for block in fieldContentBlock %}
           {% assign bundleComponent = "src/site/paragraphs/" | append: block.entity.entityBundle %}
           {% assign bundleComponentWithExtension = bundleComponent | append: ".drupal.liquid" %}

--- a/src/site/stages/build/drupal/graphql/page.graphql.js
+++ b/src/site/stages/build/drupal/graphql/page.graphql.js
@@ -30,6 +30,7 @@ module.exports = `
     ${entityElementsFromPages}
     fieldIntroText
     fieldDescription
+    fieldTableOfContentsBoolean
     fieldFeaturedContent {
       entity {
         entityType


### PR DESCRIPTION
## Description
Output TOC on Benefits detail page, e.g.: `/decision-reviews/board-appeal/after-board-appeal-decision/`

## Testing done
Visual

## Screenshots
![image](https://user-images.githubusercontent.com/2404547/83812450-90e6da00-a689-11ea-8e1c-2c303468b2dd.png)

## Acceptance criteria
- [ ] After enabling the TOC toggle on benefit detail page node form, TOC appears on front end build (below any alerts, and above main content) page.