### PR TITLE
Display more accurate error message for 400 errors

### DIFF
--- a/src/applications/vaos/actions/appointments.js
+++ b/src/applications/vaos/actions/appointments.js
@@ -375,7 +375,9 @@ export function confirmCancelAppointment() {
       });
       resetDataLayer();
     } catch (e) {
+      let isVaos400Error = false;
       if (e?.errors?.[0]?.code === 'VAOS_400') {
+        isVaos400Error = true;
         Sentry.withScope(scope => {
           scope.setExtra('error', e);
           scope.setExtra('cancelReasons', cancelReasons);
@@ -387,6 +389,7 @@ export function confirmCancelAppointment() {
       }
       dispatch({
         type: CANCEL_APPOINTMENT_CONFIRMED_FAILED,
+        isVaos400Error,
       });
 
       recordEvent({

--- a/src/applications/vaos/actions/appointments.js
+++ b/src/applications/vaos/actions/appointments.js
@@ -375,9 +375,8 @@ export function confirmCancelAppointment() {
       });
       resetDataLayer();
     } catch (e) {
-      let isVaos400Error = false;
-      if (e?.errors?.[0]?.code === 'VAOS_400') {
-        isVaos400Error = true;
+      const isVaos400Error = e?.errors?.[0]?.code === 'VAOS_400';
+      if (isVaos400Error) {
         Sentry.withScope(scope => {
           scope.setExtra('error', e);
           scope.setExtra('cancelReasons', cancelReasons);

--- a/src/applications/vaos/actions/appointments.js
+++ b/src/applications/vaos/actions/appointments.js
@@ -26,7 +26,7 @@ function parseFakeFHIRId(id) {
   return id.replace('var', '');
 }
 
-import { captureError } from '../utils/error';
+import { captureError, getErrorCodes } from '../utils/error';
 import { STARTED_NEW_APPOINTMENT_FLOW } from './sitewide';
 
 export const FETCH_FUTURE_APPOINTMENTS = 'vaos/FETCH_FUTURE_APPOINTMENTS';
@@ -375,7 +375,7 @@ export function confirmCancelAppointment() {
       });
       resetDataLayer();
     } catch (e) {
-      const isVaos400Error = e?.errors?.[0]?.code === 'VAOS_400';
+      const isVaos400Error = getErrorCodes(e).includes('VAOS_400');
       if (isVaos400Error) {
         Sentry.withScope(scope => {
           scope.setExtra('error', e);

--- a/src/applications/vaos/actions/newAppointment.js
+++ b/src/applications/vaos/actions/newAppointment.js
@@ -702,11 +702,10 @@ export function submitAppointmentOrRequest(router) {
         resetDataLayer();
         router.push('/new-appointment/confirmation');
       } catch (error) {
-        const isVaos400Error = error?.errors?.[0]?.code === 'VAOS_400';
         captureError(error, true);
         dispatch({
           type: FORM_SUBMIT_FAILED,
-          isVaos400Error,
+          isVaos400Error: error?.errors?.[0]?.code === 'VAOS_400',
         });
 
         // Remove parse function when converting this call to FHIR service
@@ -790,6 +789,7 @@ export function submitAppointmentOrRequest(router) {
         captureError(error, true, 'Request submission failure', extraData);
         dispatch({
           type: FORM_SUBMIT_FAILED,
+          isVaos400Error: error?.errors?.[0]?.code === 'VAOS_400',
         });
 
         // Remove parse function when converting this call to FHIR service

--- a/src/applications/vaos/actions/newAppointment.js
+++ b/src/applications/vaos/actions/newAppointment.js
@@ -702,9 +702,11 @@ export function submitAppointmentOrRequest(router) {
         resetDataLayer();
         router.push('/new-appointment/confirmation');
       } catch (error) {
+        const isVaos400Error = error?.errors?.[0]?.code === 'VAOS_400';
         captureError(error, true);
         dispatch({
           type: FORM_SUBMIT_FAILED,
+          isVaos400Error,
         });
 
         // Remove parse function when converting this call to FHIR service

--- a/src/applications/vaos/actions/newAppointment.js
+++ b/src/applications/vaos/actions/newAppointment.js
@@ -789,7 +789,7 @@ export function submitAppointmentOrRequest(router) {
         captureError(error, true, 'Request submission failure', extraData);
         dispatch({
           type: FORM_SUBMIT_FAILED,
-          isVaos400Error: error?.errors?.[0]?.code === 'VAOS_400',
+          isVaos400Error: getErrorCodes(error).includes('VAOS_400'),
         });
 
         // Remove parse function when converting this call to FHIR service

--- a/src/applications/vaos/actions/newAppointment.js
+++ b/src/applications/vaos/actions/newAppointment.js
@@ -56,7 +56,7 @@ import {
 
 import { recordEligibilityFailure, resetDataLayer } from '../utils/events';
 
-import { captureError } from '../utils/error';
+import { captureError, getErrorCodes } from '../utils/error';
 
 import {
   STARTED_NEW_APPOINTMENT_FLOW,
@@ -705,7 +705,7 @@ export function submitAppointmentOrRequest(router) {
         captureError(error, true);
         dispatch({
           type: FORM_SUBMIT_FAILED,
-          isVaos400Error: error?.errors?.[0]?.code === 'VAOS_400',
+          isVaos400Error: getErrorCodes(error).includes('VAOS_400'),
         });
 
         // Remove parse function when converting this call to FHIR service

--- a/src/applications/vaos/components/cancel/CancelAppointmentFailedModal.jsx
+++ b/src/applications/vaos/components/cancel/CancelAppointmentFailedModal.jsx
@@ -7,7 +7,7 @@ import FacilityAddress from '../FacilityAddress';
 export default function CancelAppointmentFailedModal({
   appointment,
   facility,
-  cancelAppointmentStatus,
+  status,
   onClose,
 }) {
   return (
@@ -18,7 +18,7 @@ export default function CancelAppointmentFailedModal({
       onClose={onClose}
       title="We couldn’t cancel your appointment"
     >
-      {cancelAppointmentStatus === FETCH_STATUS.failedVaos400 ? (
+      {status === FETCH_STATUS.failedVaos400 ? (
         <p>
           We’re sorry. You can’t cancel your appointment on the VA appointments
           tool. Please contact your local VA medical center to cancel this

--- a/src/applications/vaos/components/cancel/CancelAppointmentFailedModal.jsx
+++ b/src/applications/vaos/components/cancel/CancelAppointmentFailedModal.jsx
@@ -1,11 +1,13 @@
 import React from 'react';
 import Modal from '@department-of-veterans-affairs/formation-react/Modal';
 
+import { FETCH_STATUS } from '../../utils/constants';
 import FacilityAddress from '../FacilityAddress';
 
 export default function CancelAppointmentFailedModal({
   appointment,
   facility,
+  cancelAppointmentStatus,
   onClose,
 }) {
   return (
@@ -16,10 +18,18 @@ export default function CancelAppointmentFailedModal({
       onClose={onClose}
       title="We couldn’t cancel your appointment"
     >
-      <p>
-        Something went wrong when we tried to cancel this appointment. Please
-        contact your medical center to cancel:
-      </p>
+      {cancelAppointmentStatus === FETCH_STATUS.failedVaos400 ? (
+        <p>
+          We’re sorry. You can’t cancel your appointment on the VA appointments
+          tool. Please contact your local VA medical center to cancel this
+          appointment:
+        </p>
+      ) : (
+        <p>
+          Something went wrong when we tried to cancel this appointment. Please
+          contact your medical center to cancel:
+        </p>
+      )}
       <p>
         {appointment.clinicName ? (
           <>

--- a/src/applications/vaos/components/cancel/CancelAppointmentFailedModal.jsx
+++ b/src/applications/vaos/components/cancel/CancelAppointmentFailedModal.jsx
@@ -7,7 +7,7 @@ import FacilityAddress from '../FacilityAddress';
 export default function CancelAppointmentFailedModal({
   appointment,
   facility,
-  status,
+  isBadRequest,
   onClose,
 }) {
   return (
@@ -18,7 +18,7 @@ export default function CancelAppointmentFailedModal({
       onClose={onClose}
       title="We couldn’t cancel your appointment"
     >
-      {status === FETCH_STATUS.failedVaos400 ? (
+      {isBadRequest ? (
         <p>
           We’re sorry. You can’t cancel your appointment on the VA appointments
           tool. Please contact your local VA medical center to cancel this

--- a/src/applications/vaos/components/cancel/CancelAppointmentModal.jsx
+++ b/src/applications/vaos/components/cancel/CancelAppointmentModal.jsx
@@ -15,6 +15,7 @@ export default function CancelAppointmentModal(props) {
     showCancelModal,
     appointmentToCancel,
     cancelAppointmentStatus,
+    cancelAppointmentStatusVaos400,
     onClose,
     onConfirm,
     facility,
@@ -56,14 +57,12 @@ export default function CancelAppointmentModal(props) {
     );
   }
 
-  if (
-    cancelAppointmentStatus === FETCH_STATUS.failed ||
-    cancelAppointmentStatus === FETCH_STATUS.failedVaos400
-  ) {
+  if (cancelAppointmentStatus === FETCH_STATUS.failed) {
     return (
       <CancelAppointmentFailedModal
         appointment={appointmentToCancel}
         status={cancelAppointmentStatus}
+        isBadRequest={cancelAppointmentStatusVaos400}
         facility={facility}
         onClose={onClose}
       />

--- a/src/applications/vaos/components/cancel/CancelAppointmentModal.jsx
+++ b/src/applications/vaos/components/cancel/CancelAppointmentModal.jsx
@@ -56,10 +56,14 @@ export default function CancelAppointmentModal(props) {
     );
   }
 
-  if (cancelAppointmentStatus === FETCH_STATUS.failed) {
+  if (
+    cancelAppointmentStatus === FETCH_STATUS.failed ||
+    cancelAppointmentStatus === FETCH_STATUS.failedVaos400
+  ) {
     return (
       <CancelAppointmentFailedModal
         appointment={appointmentToCancel}
+        cancelAppointmentStatus={cancelAppointmentStatus}
         facility={facility}
         onClose={onClose}
       />

--- a/src/applications/vaos/components/cancel/CancelAppointmentModal.jsx
+++ b/src/applications/vaos/components/cancel/CancelAppointmentModal.jsx
@@ -63,7 +63,7 @@ export default function CancelAppointmentModal(props) {
     return (
       <CancelAppointmentFailedModal
         appointment={appointmentToCancel}
-        cancelAppointmentStatus={cancelAppointmentStatus}
+        status={cancelAppointmentStatus}
         facility={facility}
         onClose={onClose}
       />

--- a/src/applications/vaos/containers/ReviewPage.jsx
+++ b/src/applications/vaos/containers/ReviewPage.jsx
@@ -43,11 +43,10 @@ export class ReviewPage extends React.Component {
       flowType,
       router,
       submitStatus,
+      submitStatusVaos400,
       systemId,
     } = this.props;
     const isDirectSchedule = flowType === FLOW_TYPES.DIRECT;
-    const submitFailed = submitStatus === FETCH_STATUS.failed;
-    const isVaos400Error = submitStatus === FETCH_STATUS.failedVaos400;
 
     return (
       <div>
@@ -70,7 +69,10 @@ export class ReviewPage extends React.Component {
         )}
         <div className="vads-u-margin-y--2">
           <LoadingButton
-            disabled={submitStatus === FETCH_STATUS.succeeded || submitFailed}
+            disabled={
+              submitStatus === FETCH_STATUS.succeeded ||
+              submitStatus === FETCH_STATUS.failed
+            }
             isLoading={submitStatus === FETCH_STATUS.loading}
             onClick={() => this.props.submitAppointmentOrRequest(router)}
             className="usa-button usa-button-primary"
@@ -78,11 +80,11 @@ export class ReviewPage extends React.Component {
             {isDirectSchedule ? 'Confirm appointment' : 'Request appointment'}
           </LoadingButton>
         </div>
-        {(submitFailed || isVaos400Error) && (
+        {submitStatus === FETCH_STATUS.failed && (
           <AlertBox
             status="error"
             headline={
-              isVaos400Error
+              submitStatusVaos400
                 ? 'We can’t schedule your appointment'
                 : `Your ${
                     isDirectSchedule ? 'appointment' : 'request'
@@ -90,7 +92,7 @@ export class ReviewPage extends React.Component {
             }
             content={
               <>
-                {isVaos400Error ? (
+                {submitStatusVaos400 ? (
                   <p>
                     We’re sorry. You can’t schedule your appointment on the VA
                     appointments tool. Please contact your local VA medical
@@ -114,7 +116,7 @@ export class ReviewPage extends React.Component {
                         data.vaFacility || data.communityCareSystemId,
                       )}`}
                     >
-                      {isVaos400Error
+                      {submitStatusVaos400
                         ? 'Find facility contact information'
                         : 'Contact your local VA medical center'}
                     </a>
@@ -151,6 +153,7 @@ function mapStateToProps(state) {
     vaCityState: getChosenVACityState(state),
     flowType: getFlowType(state),
     submitStatus: state.newAppointment.submitStatus,
+    submitStatusVaos400: state.newAppointment.submitStatusVaos400,
     systemId: getSiteIdForChosenFacility(state),
   };
 }

--- a/src/applications/vaos/containers/ReviewPage.jsx
+++ b/src/applications/vaos/containers/ReviewPage.jsx
@@ -79,21 +79,34 @@ export class ReviewPage extends React.Component {
             {isDirectSchedule ? 'Confirm appointment' : 'Request appointment'}
           </LoadingButton>
         </div>
-        {submitStatus === FETCH_STATUS.failed && (
+        {(submitStatus === FETCH_STATUS.failed ||
+          submitStatus === FETCH_STATUS.failedVaos400) && (
           <AlertBox
             status="error"
-            headline={`Your ${
-              isDirectSchedule ? 'appointment' : 'request'
-            } didn’t go through`}
+            headline={
+              submitStatus === FETCH_STATUS.failedVaos400
+                ? 'We can’t schedule your appointment'
+                : `Your ${
+                    isDirectSchedule ? 'appointment' : 'request'
+                  } didn’t go through`
+            }
             content={
               <>
-                <p>
-                  Something went wrong when we tried to submit your{' '}
-                  {isDirectSchedule ? 'appointment' : 'request'} and you’ll need
-                  to start over. We suggest you wait a day to try again or you
-                  can call your medical center to help with your{' '}
-                  {isDirectSchedule ? 'appointment' : 'request'}.
-                </p>
+                {submitStatus === FETCH_STATUS.failedVaos400 ? (
+                  <p>
+                    We’re sorry. You can’t schedule your appointment on the VA
+                    appointments tool. Please contact your local VA medical
+                    center to schedule this appointment:
+                  </p>
+                ) : (
+                  <p>
+                    Something went wrong when we tried to submit your{' '}
+                    {isDirectSchedule ? 'appointment' : 'request'} and you’ll
+                    need to start over. We suggest you wait a day to try again
+                    or you can call your medical center to help with your{' '}
+                    {isDirectSchedule ? 'appointment' : 'request'}.
+                  </p>
+                )}
                 <p>
                   {!facilityDetails && (
                     <a
@@ -103,7 +116,9 @@ export class ReviewPage extends React.Component {
                         data.vaFacility || data.communityCareSystemId,
                       )}`}
                     >
-                      Contact your local VA medical center
+                      {submitStatus === FETCH_STATUS.failedVaos400
+                        ? 'Find facility contact information'
+                        : 'Contact your local VA medical center'}
                     </a>
                   )}
                   {!!facilityDetails && (

--- a/src/applications/vaos/containers/ReviewPage.jsx
+++ b/src/applications/vaos/containers/ReviewPage.jsx
@@ -46,6 +46,8 @@ export class ReviewPage extends React.Component {
       systemId,
     } = this.props;
     const isDirectSchedule = flowType === FLOW_TYPES.DIRECT;
+    const submitFailed = submitStatus === FETCH_STATUS.failed;
+    const isVaos400Error = submitStatus === FETCH_STATUS.failedVaos400;
 
     return (
       <div>
@@ -68,10 +70,7 @@ export class ReviewPage extends React.Component {
         )}
         <div className="vads-u-margin-y--2">
           <LoadingButton
-            disabled={
-              submitStatus === FETCH_STATUS.succeeded ||
-              submitStatus === FETCH_STATUS.failed
-            }
+            disabled={submitStatus === FETCH_STATUS.succeeded || submitFailed}
             isLoading={submitStatus === FETCH_STATUS.loading}
             onClick={() => this.props.submitAppointmentOrRequest(router)}
             className="usa-button usa-button-primary"
@@ -79,12 +78,11 @@ export class ReviewPage extends React.Component {
             {isDirectSchedule ? 'Confirm appointment' : 'Request appointment'}
           </LoadingButton>
         </div>
-        {(submitStatus === FETCH_STATUS.failed ||
-          submitStatus === FETCH_STATUS.failedVaos400) && (
+        {(submitFailed || isVaos400Error) && (
           <AlertBox
             status="error"
             headline={
-              submitStatus === FETCH_STATUS.failedVaos400
+              isVaos400Error
                 ? 'We can’t schedule your appointment'
                 : `Your ${
                     isDirectSchedule ? 'appointment' : 'request'
@@ -92,7 +90,7 @@ export class ReviewPage extends React.Component {
             }
             content={
               <>
-                {submitStatus === FETCH_STATUS.failedVaos400 ? (
+                {isVaos400Error ? (
                   <p>
                     We’re sorry. You can’t schedule your appointment on the VA
                     appointments tool. Please contact your local VA medical
@@ -116,7 +114,7 @@ export class ReviewPage extends React.Component {
                         data.vaFacility || data.communityCareSystemId,
                       )}`}
                     >
-                      {submitStatus === FETCH_STATUS.failedVaos400
+                      {isVaos400Error
                         ? 'Find facility contact information'
                         : 'Contact your local VA medical center'}
                     </a>

--- a/src/applications/vaos/reducers/appointments.js
+++ b/src/applications/vaos/reducers/appointments.js
@@ -185,15 +185,15 @@ export default function appointmentsReducer(state = initialState, action) {
         showCancelModal: true,
         future,
         cancelAppointmentStatus: FETCH_STATUS.succeeded,
+        cancelAppointmentStatusVaos400: false,
       };
     }
     case CANCEL_APPOINTMENT_CONFIRMED_FAILED:
       return {
         ...state,
         showCancelModal: true,
-        cancelAppointmentStatus: action.isVaos400Error
-          ? FETCH_STATUS.failedVaos400
-          : FETCH_STATUS.failed,
+        cancelAppointmentStatus: FETCH_STATUS.failed,
+        cancelAppointmentStatusVaos400: action.isVaos400Error,
       };
     case CANCEL_APPOINTMENT_CLOSED:
       return {

--- a/src/applications/vaos/reducers/appointments.js
+++ b/src/applications/vaos/reducers/appointments.js
@@ -191,7 +191,9 @@ export default function appointmentsReducer(state = initialState, action) {
       return {
         ...state,
         showCancelModal: true,
-        cancelAppointmentStatus: FETCH_STATUS.failed,
+        cancelAppointmentStatus: action.isVaos400Error
+          ? FETCH_STATUS.failedVaos400
+          : FETCH_STATUS.failed,
       };
     case CANCEL_APPOINTMENT_CLOSED:
       return {

--- a/src/applications/vaos/reducers/newAppointment.js
+++ b/src/applications/vaos/reducers/newAppointment.js
@@ -775,7 +775,9 @@ export default function formReducer(state = initialState, action) {
     case FORM_SUBMIT_FAILED:
       return {
         ...state,
-        submitStatus: FETCH_STATUS.failed,
+        submitStatus: action.isVaos400Error
+          ? FETCH_STATUS.failedVaos400
+          : FETCH_STATUS.failed,
       };
     case FORM_UPDATE_CC_ELIGIBILITY: {
       return {

--- a/src/applications/vaos/reducers/newAppointment.js
+++ b/src/applications/vaos/reducers/newAppointment.js
@@ -771,13 +771,13 @@ export default function formReducer(state = initialState, action) {
       return {
         ...state,
         submitStatus: FETCH_STATUS.succeeded,
+        submitStatusVaos400: false,
       };
     case FORM_SUBMIT_FAILED:
       return {
         ...state,
-        submitStatus: action.isVaos400Error
-          ? FETCH_STATUS.failedVaos400
-          : FETCH_STATUS.failed,
+        submitStatus: FETCH_STATUS.failed,
+        submitStatusVaos400: action.isVaos400Error,
       };
     case FORM_UPDATE_CC_ELIGIBILITY: {
       return {

--- a/src/applications/vaos/services/appointment/index.js
+++ b/src/applications/vaos/services/appointment/index.js
@@ -85,7 +85,7 @@ export function getVARClinicId(appointment) {
  *
  * @export
  * @param {Object} appointment A FHIR appointment resource
- * @returns The location id where the video appointment is located
+ * @returns {String} The location id where the video appointment is located
  */
 export function getVideoAppointmentLocation(appointment) {
   const locationReference = appointment.contained?.[0]?.location?.reference;

--- a/src/applications/vaos/services/slot/index.js
+++ b/src/applications/vaos/services/slot/index.js
@@ -22,6 +22,7 @@ function parseId(id) {
  * @param {string} slotsRequest.clinicId clinic id
  * @param {string} slotsRequest.startDate start date to search for appointments lots formatted as YYYY-MM-DD
  * @param {string} slotsRequest.endDate end date to search for appointments lots formatted as YYYY-MM-DD
+ * @returns {Array} A FHIR searchset of Slot resources
  */
 export async function getSlots({
   siteId,

--- a/src/applications/vaos/tests/actions/appointments.unit.spec.js
+++ b/src/applications/vaos/tests/actions/appointments.unit.spec.js
@@ -600,6 +600,7 @@ describe('VAOS actions: appointments', () => {
       );
       expect(dispatch.secondCall.args[0]).to.deep.equal({
         type: CANCEL_APPOINTMENT_CONFIRMED_FAILED,
+        isVaos400Error: false,
       });
       const dataLayer = global.window.dataLayer;
 
@@ -615,6 +616,78 @@ describe('VAOS actions: appointments', () => {
         'error-key': undefined,
         appointmentType: undefined,
         facilityType: undefined,
+      });
+    });
+
+    it('should send fail action if cancel fails with vaos 400', async () => {
+      setFetchJSONFailure(global.fetch, { errors: [{ code: 'VAOS_400' }] });
+      const state = {
+        appointments: {
+          appointmentToCancel: {
+            resourceType: 'Appointment',
+            status: 'booked',
+            description: 'NO ACTION TAKEN/TODAY',
+            start: '2019-12-11T10:00:00-07:00',
+            minutesDuration: 60,
+            comment: 'Follow-up/Routine: Instructions',
+            participant: [
+              {
+                actor: {
+                  reference: 'HealthcareService/var983_455',
+                  display: 'C&P BEV AUDIO FTC1',
+                },
+              },
+            ],
+            contained: null,
+            legacyVAR: {
+              id: '17dd714287e151195b99164cc1a8e49a',
+              facilityId: '983',
+              clinicId: '455',
+              apiData: {
+                startDate: '2020-11-07T17:00:00Z',
+                clinicId: '455',
+                clinicFriendlyName: null,
+                facilityId: '983',
+                communityCare: false,
+                vdsAppointments: [
+                  {
+                    bookingNote: null,
+                    appointmentLength: '60',
+                    appointmentTime: '2020-11-07T17:00:00Z',
+                    clinic: {
+                      name: 'CHY OPT VAR1',
+                      askForCheckIn: false,
+                      facilityCode: '983',
+                    },
+                    type: 'REGULAR',
+                    currentStatus: 'NO ACTION TAKEN/TODAY',
+                  },
+                ],
+                vvsAppointments: [],
+                id: '17dd714287e151195b99164cc1a8e49a',
+              },
+            },
+            vaos: {
+              isPastAppointment: false,
+              appointmentType: 'vaAppointment',
+              videoType: null,
+              isCommunityCare: false,
+              timeZone: null,
+            },
+          },
+        },
+      };
+      const dispatch = sinon.spy();
+      const thunk = confirmCancelAppointment();
+
+      await thunk(dispatch, () => state);
+
+      expect(dispatch.firstCall.args[0].type).to.equal(
+        CANCEL_APPOINTMENT_CONFIRMED,
+      );
+      expect(dispatch.secondCall.args[0]).to.deep.equal({
+        type: CANCEL_APPOINTMENT_CONFIRMED_FAILED,
+        isVaos400Error: true,
       });
     });
 

--- a/src/applications/vaos/tests/actions/newAppointment.unit.spec.js
+++ b/src/applications/vaos/tests/actions/newAppointment.unit.spec.js
@@ -1317,7 +1317,9 @@ describe('VAOS newAppointment actions', () => {
     });
 
     it('should send fail action if request fails', async () => {
-      setFetchJSONFailure(global.fetch, { data: { attributes: {} } });
+      setFetchJSONFailure(global.fetch, {
+        data: { attributes: {} },
+      });
       const router = {
         push: sinon.spy(),
       };
@@ -1377,6 +1379,89 @@ describe('VAOS newAppointment actions', () => {
 
       expect(dispatch.firstCall.args[0].type).to.equal(FORM_SUBMIT);
       expect(dispatch.secondCall.args[0].type).to.equal(FORM_SUBMIT_FAILED);
+      expect(dispatch.secondCall.args[0].isVaos400Error).to.equal(false);
+      expect(global.window.dataLayer[1]).to.deep.equal({
+        event: 'vaos-request-submission-failed',
+        flow: 'va-request',
+        'health-TypeOfCare': 'Primary care',
+        'health-ReasonForAppointment': 'routine-follow-up',
+      });
+      expect(global.window.dataLayer[2]).to.deep.equal({
+        flow: undefined,
+        'health-TypeOfCare': undefined,
+        'health-ReasonForAppointment': undefined,
+        'error-key': undefined,
+        appointmentType: undefined,
+        facilityType: undefined,
+      });
+      expect(router.push.called).to.be.false;
+    });
+
+    it('should set isVaos400Error if request fails with VAOS_400', async () => {
+      setFetchJSONFailure(global.fetch, {
+        data: { attributes: {} },
+        errors: [{ code: 'VAOS_400' }],
+      });
+      const router = {
+        push: sinon.spy(),
+      };
+
+      const thunk = submitAppointmentOrRequest(router);
+      const dispatch = sinon.spy();
+      const getState = () => ({
+        newAppointment: {
+          data: {
+            typeOfCareId: '323',
+            facilityType: 'vamc',
+            vaParent: 'var983',
+            vaFacility: 'var983',
+            calendarData: {
+              selectedDates: [],
+            },
+            reasonForAppointment: 'routine-follow-up',
+            reasonAdditionalInfo: 'test',
+            bestTimeToCall: [],
+          },
+          parentFacilities: [
+            {
+              id: 'var983',
+              identifier: [
+                {
+                  system: VHA_FHIR_ID,
+                  value: '983',
+                },
+              ],
+              address: {},
+            },
+          ],
+          facilities: {
+            '323_var983': [
+              {
+                id: 'var983',
+                identifier: [
+                  {
+                    system: VHA_FHIR_ID,
+                    value: '983',
+                  },
+                ],
+                name: 'CHYSHR-Cheyenne VA Medical Center',
+                address: {
+                  city: 'Cheyenne',
+                  state: 'WY',
+                },
+                legacyVAR: {
+                  institutionTimezone: 'America/Denver',
+                },
+              },
+            ],
+          },
+        },
+      });
+      await thunk(dispatch, getState);
+
+      expect(dispatch.firstCall.args[0].type).to.equal(FORM_SUBMIT);
+      expect(dispatch.secondCall.args[0].type).to.equal(FORM_SUBMIT_FAILED);
+      expect(dispatch.secondCall.args[0].isVaos400Error).to.equal(true);
       expect(global.window.dataLayer[1]).to.deep.equal({
         event: 'vaos-request-submission-failed',
         flow: 'va-request',
@@ -1395,7 +1480,9 @@ describe('VAOS newAppointment actions', () => {
     });
 
     it('should send fail action if direct schedule fails', async () => {
-      setFetchJSONFailure(global.fetch, { data: { attributes: {} } });
+      setFetchJSONFailure(global.fetch, {
+        data: { attributes: {} },
+      });
       const router = {
         push: sinon.spy(),
       };
@@ -1462,6 +1549,82 @@ describe('VAOS newAppointment actions', () => {
 
       expect(dispatch.firstCall.args[0].type).to.equal(FORM_SUBMIT);
       expect(dispatch.secondCall.args[0].type).to.equal(FORM_SUBMIT_FAILED);
+      expect(dispatch.secondCall.args[0].isVaos400Error).to.equal(false);
+      expect(router.push.called).to.be.false;
+    });
+
+    it('should set isVaos400Error if error code is VAOS_400', async () => {
+      setFetchJSONFailure(global.fetch, {
+        data: { attributes: {} },
+        errors: [{ code: 'VAOS_400' }],
+      });
+      const router = {
+        push: sinon.spy(),
+      };
+
+      const thunk = submitAppointmentOrRequest(router);
+      const dispatch = sinon.spy();
+      const getState = () => ({
+        newAppointment: {
+          flowType: FLOW_TYPES.DIRECT,
+          clinics: {
+            // eslint-disable-next-line camelcase
+            var983_323: [
+              {
+                clinicId: '123',
+              },
+            ],
+          },
+          facilities: {
+            '323_var983': [
+              {
+                id: 'var983',
+                legacyVAR: {},
+              },
+            ],
+          },
+          parentFacilities: [
+            {
+              id: 'var983',
+              identifier: [
+                {
+                  system: VHA_FHIR_ID,
+                  value: '983',
+                },
+              ],
+              address: {},
+            },
+          ],
+          availableSlots: [
+            {
+              start: '2019-01-01T04:00:00',
+              end: '2019-01-01T04:20:00',
+            },
+          ],
+          data: {
+            vaParent: 'var983',
+            vaFacility: 'var983',
+            typeOfCareId: '323',
+            clinicId: '123',
+            facilityType: 'vamc',
+            calendarData: {
+              selectedDates: [
+                {
+                  date: '2019-01-01',
+                  datetime: '2019-01-01T04:00:00',
+                },
+              ],
+            },
+            reasonForAppointment: 'routine-follow-up',
+            bestTimeToCall: [],
+          },
+        },
+      });
+      await thunk(dispatch, getState);
+
+      expect(dispatch.firstCall.args[0].type).to.equal(FORM_SUBMIT);
+      expect(dispatch.secondCall.args[0].type).to.equal(FORM_SUBMIT_FAILED);
+      expect(dispatch.secondCall.args[0].isVaos400Error).to.equal(true);
       expect(router.push.called).to.be.false;
     });
   });

--- a/src/applications/vaos/tests/components/cancel/CancelAppointmentFailedModal.unit.spec.jsx
+++ b/src/applications/vaos/tests/components/cancel/CancelAppointmentFailedModal.unit.spec.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { expect } from 'chai';
 import { mount } from 'enzyme';
 import sinon from 'sinon';
+import { FETCH_STATUS } from '../../../utils/constants';
 
 import CancelAppointmentFailedModal from '../../../components/cancel/CancelAppointmentFailedModal';
 
@@ -28,6 +29,36 @@ describe('VAOS <CancelAppointmentFailedModal>', () => {
     expect(tree.find('Modal').props().status).to.equal('error');
     expect(tree.text()).to.contain(
       'Something went wrong when we tried to cancel this appointment',
+    );
+    expect(tree.text()).to.contain('Facility name');
+    expect(tree.find('dl').text()).to.contain('234-244-4444');
+
+    tree.unmount();
+  });
+
+  it('should display vaos 400 error message', () => {
+    const appointment = {};
+    const facility = {
+      name: 'Facility name',
+      telecom: [
+        {
+          system: 'phone',
+          value: '234-244-4444',
+        },
+      ],
+      address: {},
+    };
+    const tree = mount(
+      <CancelAppointmentFailedModal
+        facility={facility}
+        appointment={appointment}
+        status={FETCH_STATUS.failedVaos400}
+      />,
+    );
+
+    expect(tree.find('Modal').props().status).to.equal('error');
+    expect(tree.text()).to.contain(
+      'You can’t cancel your appointment on the VA appointments tool.',
     );
     expect(tree.text()).to.contain('Facility name');
     expect(tree.find('dl').text()).to.contain('234-244-4444');

--- a/src/applications/vaos/tests/components/cancel/CancelAppointmentFailedModal.unit.spec.jsx
+++ b/src/applications/vaos/tests/components/cancel/CancelAppointmentFailedModal.unit.spec.jsx
@@ -52,7 +52,7 @@ describe('VAOS <CancelAppointmentFailedModal>', () => {
       <CancelAppointmentFailedModal
         facility={facility}
         appointment={appointment}
-        status={FETCH_STATUS.failedVaos400}
+        isBadRequest
       />,
     );
 

--- a/src/applications/vaos/tests/containers/ReviewPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/containers/ReviewPage.unit.spec.jsx
@@ -90,17 +90,45 @@ describe('VAOS <ReviewPage>', () => {
         facilityDetails={{}}
       />,
     );
+    const alertBox = tree.find('AlertBox');
 
     expect(tree.find('LoadingButton').props().isLoading).to.be.false;
-    expect(tree.find('AlertBox').props().status).to.equal('error');
+    expect(alertBox.props().status).to.equal('error');
     expect(
-      tree
-        .find('AlertBox')
+      alertBox
         .dive()
         .find('FacilityAddress')
         .exists(),
     ).to.be.true;
+    expect(alertBox.dive().text()).contain('Something went wrong');
+    tree.unmount();
+  });
 
+  it('should render submit error with facility', () => {
+    const flowType = FLOW_TYPES.REQUEST;
+    const data = {};
+
+    const tree = shallow(
+      <ReviewPage
+        submitStatus={FETCH_STATUS.failedVaos400}
+        flowType={flowType}
+        data={data}
+        facilityDetails={{}}
+      />,
+    );
+    const alertBox = tree.find('AlertBox');
+
+    expect(tree.find('LoadingButton').props().isLoading).to.be.false;
+    expect(alertBox.props().status).to.equal('error');
+    expect(
+      alertBox
+        .dive()
+        .find('FacilityAddress')
+        .exists(),
+    ).to.be.true;
+    expect(alertBox.dive().text()).contain(
+      'We’re sorry. You can’t schedule your appointment on the VA appointments tool.',
+    );
     tree.unmount();
   });
 

--- a/src/applications/vaos/tests/containers/ReviewPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/containers/ReviewPage.unit.spec.jsx
@@ -110,7 +110,8 @@ describe('VAOS <ReviewPage>', () => {
 
     const tree = shallow(
       <ReviewPage
-        submitStatus={FETCH_STATUS.failedVaos400}
+        submitStatus={FETCH_STATUS.failed}
+        submitStatusVaos400
         flowType={flowType}
         data={data}
         facilityDetails={{}}

--- a/src/applications/vaos/tests/reducers/appointments.unit.spec.js
+++ b/src/applications/vaos/tests/reducers/appointments.unit.spec.js
@@ -299,16 +299,19 @@ describe('VAOS reducer: appointments', () => {
       expect(newState.cancelAppointmentStatus).to.equal(FETCH_STATUS.succeeded);
       expect(newState.future[0].apiData).to.equal(action.apiData);
       expect(newState.future[0].status).to.equal(APPOINTMENT_STATUS.cancelled);
+      expect(newState.cancelAppointmentStatusVaos400).to.equal(false);
     });
 
     it('should set status to failed', () => {
       const action = {
         type: CANCEL_APPOINTMENT_CONFIRMED_FAILED,
+        isVaos400Error: false,
       };
       const newState = appointmentsReducer(initialState, action);
 
       expect(newState.showCancelModal).to.be.true;
       expect(newState.cancelAppointmentStatus).to.equal(FETCH_STATUS.failed);
+      expect(newState.cancelAppointmentStatusVaos400).to.equal(false);
     });
 
     it('should set status to failed', () => {
@@ -319,9 +322,8 @@ describe('VAOS reducer: appointments', () => {
       const newState = appointmentsReducer(initialState, action);
 
       expect(newState.showCancelModal).to.be.true;
-      expect(newState.cancelAppointmentStatus).to.equal(
-        FETCH_STATUS.failedVaos400,
-      );
+      expect(newState.cancelAppointmentStatus).to.equal(FETCH_STATUS.failed);
+      expect(newState.cancelAppointmentStatusVaos400).to.equal(true);
     });
 
     it('should close modal', () => {

--- a/src/applications/vaos/tests/reducers/appointments.unit.spec.js
+++ b/src/applications/vaos/tests/reducers/appointments.unit.spec.js
@@ -311,6 +311,19 @@ describe('VAOS reducer: appointments', () => {
       expect(newState.cancelAppointmentStatus).to.equal(FETCH_STATUS.failed);
     });
 
+    it('should set status to failed', () => {
+      const action = {
+        type: CANCEL_APPOINTMENT_CONFIRMED_FAILED,
+        isVaos400Error: true,
+      };
+      const newState = appointmentsReducer(initialState, action);
+
+      expect(newState.showCancelModal).to.be.true;
+      expect(newState.cancelAppointmentStatus).to.equal(
+        FETCH_STATUS.failedVaos400,
+      );
+    });
+
     it('should close modal', () => {
       const action = {
         type: CANCEL_APPOINTMENT_CLOSED,

--- a/src/applications/vaos/tests/reducers/newAppointment.unit.spec.js
+++ b/src/applications/vaos/tests/reducers/newAppointment.unit.spec.js
@@ -959,6 +959,7 @@ describe('VAOS reducer: newAppointment', () => {
 
       const newState = newAppointmentReducer({}, action);
       expect(newState.submitStatus).to.equal(FETCH_STATUS.succeeded);
+      expect(newState.submitStatusVaos400).to.equal(false);
     });
     it('should set error', () => {
       const action = {
@@ -967,6 +968,7 @@ describe('VAOS reducer: newAppointment', () => {
 
       const newState = newAppointmentReducer({}, action);
       expect(newState.submitStatus).to.equal(FETCH_STATUS.failed);
+      expect(newState.submitStatusVaos400).to.equal(undefined);
     });
 
     it('should set vaos 400 error', () => {
@@ -976,7 +978,8 @@ describe('VAOS reducer: newAppointment', () => {
       };
 
       const newState = newAppointmentReducer({}, action);
-      expect(newState.submitStatus).to.equal(FETCH_STATUS.failedVaos400);
+      expect(newState.submitStatus).to.equal(FETCH_STATUS.failed);
+      expect(newState.submitStatusVaos400).to.equal(true);
     });
   });
 

--- a/src/applications/vaos/tests/reducers/newAppointment.unit.spec.js
+++ b/src/applications/vaos/tests/reducers/newAppointment.unit.spec.js
@@ -968,7 +968,18 @@ describe('VAOS reducer: newAppointment', () => {
       const newState = newAppointmentReducer({}, action);
       expect(newState.submitStatus).to.equal(FETCH_STATUS.failed);
     });
+
+    it('should set vaos 400 error', () => {
+      const action = {
+        type: FORM_SUBMIT_FAILED,
+        isVaos400Error: true,
+      };
+
+      const newState = newAppointmentReducer({}, action);
+      expect(newState.submitStatus).to.equal(FETCH_STATUS.failedVaos400);
+    });
   });
+
   it('should open the type of care page and prefill contact info', () => {
     const currentState = {
       data: {},

--- a/src/applications/vaos/tests/utils/error.unit.spec.js
+++ b/src/applications/vaos/tests/utils/error.unit.spec.js
@@ -1,0 +1,14 @@
+import { expect } from 'chai';
+import { getErrorCodes } from '../../utils/error';
+
+describe('Error utils', () => {
+  describe('getErrorCodes', () => {
+    it('should return array of error codes', () => {
+      const error = {
+        errors: [{ code: 'VAOS_400' }, { code: 'code1' }],
+      };
+
+      expect(getErrorCodes(error)).to.deep.equal(['VAOS_400', 'code1']);
+    });
+  });
+});

--- a/src/applications/vaos/utils/constants.js
+++ b/src/applications/vaos/utils/constants.js
@@ -3,7 +3,6 @@ export const FETCH_STATUS = {
   notStarted: 'notStarted',
   succeeded: 'succeeded',
   failed: 'failed',
-  failedVaos400: 'failedVaos400',
 };
 
 export const APPOINTMENT_TYPES = {

--- a/src/applications/vaos/utils/constants.js
+++ b/src/applications/vaos/utils/constants.js
@@ -3,6 +3,7 @@ export const FETCH_STATUS = {
   notStarted: 'notStarted',
   succeeded: 'succeeded',
   failed: 'failed',
+  failedVaos400: 'failedVaos400',
 };
 
 export const APPOINTMENT_TYPES = {

--- a/src/applications/vaos/utils/error.js
+++ b/src/applications/vaos/utils/error.js
@@ -37,3 +37,7 @@ export function captureError(
     console.error(err);
   }
 }
+
+export function getErrorCodes(error) {
+  return error?.errors?.map(e => e.code) || [];
+}

--- a/src/applications/vaos/utils/selectors.js
+++ b/src/applications/vaos/utils/selectors.js
@@ -327,6 +327,7 @@ export function getCancelInfo(state) {
     appointmentToCancel,
     showCancelModal,
     cancelAppointmentStatus,
+    cancelAppointmentStatusVaos400,
     facilityData,
     systemClinicToFacilityMap,
   } = state.appointments;
@@ -360,6 +361,7 @@ export function getCancelInfo(state) {
     appointmentToCancel,
     showCancelModal,
     cancelAppointmentStatus,
+    cancelAppointmentStatusVaos400,
     cernerFacilities,
   };
 }


### PR DESCRIPTION
## Description
Updated newAppointment and appointments actions and reducers to check for `VAOS_400` error code. 

## Testing done
Local and unit

## Screenshots
<img width="610" alt="Screen Shot 2020-06-08 at 9 07 49 AM" src="https://user-images.githubusercontent.com/786704/84054250-f972d700-a967-11ea-84b1-96ebfa3f59f8.png">
<img width="648" alt="Screen Shot 2020-06-08 at 9 08 55 AM" src="https://user-images.githubusercontent.com/786704/84054254-fb3c9a80-a967-11ea-9297-ab32e43612cc.png">


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
