### PR TITLE
update getNonArraySchema to remove keys from uiSchema.ui:order which …

### DIFF
--- a/src/platform/forms-system/src/js/helpers.js
+++ b/src/platform/forms-system/src/js/helpers.js
@@ -375,7 +375,10 @@ export function getNonArraySchema(schema, uiSchema = {}) {
     schema.type === 'array' &&
     !_.get('ui:options.keepInPageOnReview', uiSchema)
   ) {
-    return undefined;
+    return {
+      schema: undefined,
+      uiSchema,
+    };
   }
 
   if (schema.type === 'object') {
@@ -386,11 +389,11 @@ export function getNonArraySchema(schema, uiSchema = {}) {
           uiSchema[next],
         );
 
-        if (typeof newSchema === 'undefined') {
+        if (typeof newSchema.schema === 'undefined') {
           return _.unset(next, current);
         }
 
-        if (newSchema !== schema.properties[next]) {
+        if (newSchema.schema !== schema.properties[next]) {
           return _.set(next, newSchema, current);
         }
 
@@ -400,7 +403,10 @@ export function getNonArraySchema(schema, uiSchema = {}) {
     );
 
     if (Object.keys(newProperties).length === 0) {
-      return undefined;
+      return {
+        schema: undefined,
+        uiSchema,
+      };
     }
 
     if (newProperties !== schema.properties) {
@@ -415,11 +421,23 @@ export function getNonArraySchema(schema, uiSchema = {}) {
         }
       }
 
-      return newSchema;
+      const schemaPropertyKeys = Object.keys(newSchema.properties);
+      const newUiSchema = Object.assign({}, uiSchema);
+      newUiSchema['ui:order'] = uiSchema['ui:order']?.filter(item => {
+        return schemaPropertyKeys.includes(item);
+      });
+
+      return {
+        schema: newSchema,
+        uiSchema: newUiSchema,
+      };
     }
   }
 
-  return schema;
+  return {
+    schema,
+    uiSchema,
+  };
 }
 
 export const pureWithDeepEquals = shouldUpdate(

--- a/src/platform/forms-system/src/js/review/ReviewCollapsibleChapter.jsx
+++ b/src/platform/forms-system/src/js/review/ReviewCollapsibleChapter.jsx
@@ -128,11 +128,12 @@ export default class ReviewCollapsibleChapter extends React.Component {
               arrayFields = getArrayFields(pageState, page);
               // This will be undefined if there are no fields other than an array
               // in a page, in which case we won’t render the form, just the array
-              pageSchema = getNonArraySchema(
+              const pageSchemaObjects = getNonArraySchema(
                 pageState.schema,
                 pageState.uiSchema,
               );
-              pageUiSchema = pageState.uiSchema;
+              pageSchema = pageSchemaObjects.schema;
+              pageUiSchema = pageSchemaObjects.uiSchema;
               pageData = form.data;
               fullPageKey = page.pageKey;
             }

--- a/src/platform/forms-system/test/js/helpers.unit.spec.js
+++ b/src/platform/forms-system/test/js/helpers.unit.spec.js
@@ -627,7 +627,7 @@ describe('Schemaform helpers:', () => {
     it('should return undefined if array', () => {
       const result = getNonArraySchema({ type: 'array' });
 
-      expect(result).to.be.undefined;
+      expect(result.schema).to.be.undefined;
     });
     it('should skip array fields using option', () => {
       const result = getNonArraySchema(
@@ -635,7 +635,7 @@ describe('Schemaform helpers:', () => {
         { 'ui:option': { keepInPageOnReview: true } },
       );
 
-      expect(result).to.be.undefined;
+      expect(result.schema).to.be.undefined;
     });
     it('should return undefined if nested array', () => {
       const result = getNonArraySchema({
@@ -647,7 +647,7 @@ describe('Schemaform helpers:', () => {
         },
       });
 
-      expect(result).to.be.undefined;
+      expect(result.schema).to.be.undefined;
     });
     it('should return fields without array', () => {
       const result = getNonArraySchema({
@@ -663,7 +663,7 @@ describe('Schemaform helpers:', () => {
         },
       });
 
-      expect(result).to.eql({
+      expect(result.schema).to.eql({
         type: 'object',
         required: ['field'],
         properties: {
@@ -671,6 +671,41 @@ describe('Schemaform helpers:', () => {
             type: 'string',
           },
         },
+      });
+    });
+    it('should return fields without array', () => {
+      const result = getNonArraySchema({
+        type: 'object',
+        required: ['field1', 'field2'],
+        properties: {
+          'field1': {
+            type: 'string',
+            properties: {}
+          },
+          'field2': {
+            type: 'object',
+            properties: {}
+          }
+        },
+      },
+      {
+        'ui:order': ['field1', 'field2'],
+        'field1': {
+          'ui:description': 'My field1 text'
+        },
+        'field2': {
+          'ui:description': 'My field2 text'
+        }
+      });
+
+      expect(result.uiSchema).to.eql({
+        'ui:order': ['field1'],
+        'field1': {
+          'ui:description': 'My field1 text'
+        },
+        'field2': {
+          'ui:description': 'My field2 text'
+        }
       });
     });
   });

--- a/src/platform/forms-system/test/js/helpers.unit.spec.js
+++ b/src/platform/forms-system/test/js/helpers.unit.spec.js
@@ -674,38 +674,40 @@ describe('Schemaform helpers:', () => {
       });
     });
     it('should return fields without array', () => {
-      const result = getNonArraySchema({
-        type: 'object',
-        required: ['field1', 'field2'],
-        properties: {
-          'field1': {
-            type: 'string',
-            properties: {}
+      const result = getNonArraySchema(
+        {
+          type: 'object',
+          required: ['field1', 'field2'],
+          properties: {
+            field1: {
+              type: 'string',
+              properties: {},
+            },
+            field2: {
+              type: 'object',
+              properties: {},
+            },
           },
-          'field2': {
-            type: 'object',
-            properties: {}
-          }
         },
-      },
-      {
-        'ui:order': ['field1', 'field2'],
-        'field1': {
-          'ui:description': 'My field1 text'
+        {
+          'ui:order': ['field1', 'field2'],
+          field1: {
+            'ui:description': 'My field1 text',
+          },
+          field2: {
+            'ui:description': 'My field2 text',
+          },
         },
-        'field2': {
-          'ui:description': 'My field2 text'
-        }
-      });
+      );
 
       expect(result.uiSchema).to.eql({
         'ui:order': ['field1'],
-        'field1': {
-          'ui:description': 'My field1 text'
+        field1: {
+          'ui:description': 'My field1 text',
         },
-        'field2': {
-          'ui:description': 'My field2 text'
-        }
+        field2: {
+          'ui:description': 'My field2 text',
+        },
       });
     });
   });


### PR DESCRIPTION
…have been removed from schema. ensures both are synced

## Description
Update the `getNonArraySchema` helper to also update the uiSchema.ui:order array. When a key exists in the `ui:order` and not the `schema`, the review page will crash when attempting to render that data.

Details in ticket: [#9565](https://app.zenhub.com/workspaces/vsp-5cedc9cce6e3335dc5a49fc4/issues/department-of-veterans-affairs/va.gov-team/)

## Testing done
Manual testing and updated unit test to account for updated helper.

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
