### PR TITLE
Run aXe checks in Cypress without deprecated rules.

### DIFF
--- a/src/platform/testing/e2e/cypress/support/commands/axeCheck.js
+++ b/src/platform/testing/e2e/cypress/support/commands/axeCheck.js
@@ -26,8 +26,9 @@ const processAxeCheckResults = violations => {
 
 /**
  * Checks the current page for aXe violations.
+ * @param {string} [context] - Selector for the container element to aXe check.
  */
-Cypress.Commands.add('axeCheck', () => {
+Cypress.Commands.add('axeCheck', (context = 'main') => {
   Cypress.log({
     name: 'axeCheck',
     message: '',
@@ -37,5 +38,5 @@ Cypress.Commands.add('axeCheck', () => {
     includedImpacts: ['critical'],
   };
 
-  cy.checkA11y('.main', options, processAxeCheckResults);
+  cy.checkA11y(context, options, processAxeCheckResults);
 });

--- a/src/platform/testing/e2e/cypress/support/commands/axeCheck.js
+++ b/src/platform/testing/e2e/cypress/support/commands/axeCheck.js
@@ -26,28 +26,16 @@ const processAxeCheckResults = violations => {
 
 /**
  * Checks the current page for aXe violations.
- *
- * @param {boolean} assert - Flag for how tests handle aXe violations.
- *   If true, tests will stop and fail when there are violations.
- *   If false, tests will skip over violations and continue running.
  */
-Cypress.Commands.add('axeCheck', (assert = true) => {
+Cypress.Commands.add('axeCheck', () => {
   Cypress.log({
     name: 'axeCheck',
     message: '',
-    consoleProps: () => ({ 'Fail test on violations': assert }),
   });
 
-  cy.checkA11y(
-    '.main',
-    {
-      includedImpacts: ['critical'],
-      runOnly: {
-        type: 'tag',
-        values: ['section508', 'wcag2a', 'wcag2aa', 'best-practice'],
-      },
-    },
-    processAxeCheckResults,
-    !assert,
-  );
+  const options = {
+    includedImpacts: ['critical'],
+  };
+
+  cy.checkA11y('.main', options, processAxeCheckResults);
 });

--- a/src/platform/testing/e2e/cypress/support/form-tester/index.js
+++ b/src/platform/testing/e2e/cypress/support/form-tester/index.js
@@ -12,9 +12,6 @@ const LOADING_SELECTOR = '.loading-indicator';
 // that are mainly there to support more specific operations.
 const COMMAND_OPTIONS = { log: false };
 
-// Allow tests to continue running even when there are aXe violations.
-const FAIL_ON_AXE_VIOLATIONS = false;
-
 /**
  * Builds an object from a form field with attributes that are used
  * to look up test data and enter that data into the field.
@@ -130,7 +127,7 @@ const performPageActions = (pathname, autofill = true) => {
     if (!hookExecuted && autofill) cy.fillPage();
 
     cy.expandAccordions();
-    cy.axeCheck(FAIL_ON_AXE_VIOLATIONS);
+    cy.axeCheck();
 
     if (!hookExecuted && autofill) {
       cy.findByText(/continue/i, { selector: 'button' }).click();
@@ -144,7 +141,7 @@ const performPageActions = (pathname, autofill = true) => {
  */
 const processPage = () => {
   // Run aXe check before doing anything on the page.
-  cy.axeCheck(FAIL_ON_AXE_VIOLATIONS);
+  cy.axeCheck();
 
   cy.location('pathname', COMMAND_OPTIONS).then(pathname => {
     if (pathname.endsWith('review-and-submit')) {
@@ -155,7 +152,7 @@ const processPage = () => {
       // The form should end up at the confirmation page after submitting.
       cy.location('pathname').then(endPathname => {
         expect(endPathname).to.match(/confirmation$/);
-        cy.axeCheck(FAIL_ON_AXE_VIOLATIONS);
+        cy.axeCheck();
         performPageActions(endPathname, false);
       });
     } else {


### PR DESCRIPTION
## Description
`cy.axeCheck` was failing form tests with complaints about radio groups. I previously made it optional for violations to fail tests, since every form seemed to have this issue.

```
┌─────────┬──────────────┬────────────┬───────────────────────────────────────────────────────────────────────────────────────────────────────────┬───────┐

│ (index) │      id      │   impact   │                                                description                                                │ nodes │

├─────────┼──────────────┼────────────┼───────────────────────────────────────────────────────────────────────────────────────────────────────────┼───────┤

│    0    │ 'radiogroup' │ 'critical' │ 'Ensures related <input type="radio"> elements have a group and that the group designation is consistent' │   1   │

└─────────┴──────────────┴────────────┴───────────────────────────────────────────────────────────────────────────────────────────────────────────┴───────┘
```

As it turns out, [the rule is deprecated](https://github.com/dequelabs/axe-core/blob/9255afbf09a56ed7169b1cf00df924e13697e6fe/doc/rule-descriptions.md#deprecated-rules).

It seems to get ignored properly if I don't specify any rule-related options. The check is already running [all of the non-experimental (and non-deprecated) rules by default](https://www.deque.com/axe/axe-for-web/documentation/api-documentation/#options-parameter), so specifying the different accessibility standards wasn't adding anything.

> The default operation for axe.run is to run all rules except for rules with the "experimental" tag.

## Testing done
Tested with Cypress form tester

## Acceptance criteria
- [ ] Cypress aXe checks should only use standard rules.
- [ ] Cypress aXe checks should fail tests if there violations.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
