### PR TITLE
[Form Tester] Handle detached form fields.

### DIFF
--- a/src/platform/testing/e2e/cypress/support/form-tester/README.md
+++ b/src/platform/testing/e2e/cypress/support/form-tester/README.md
@@ -436,7 +436,7 @@ const testConfig = createTestConfig(
         cy.fillPage();
 
         // Don't forget to click continue!
-        cy.findAllByTest(/continue/i, { selector: 'button' })
+        cy.findAllByText(/continue/i, { selector: 'button' })
           .first()
           .click();
       },

--- a/src/platform/testing/e2e/cypress/support/form-tester/index.js
+++ b/src/platform/testing/e2e/cypress/support/form-tester/index.js
@@ -271,17 +271,17 @@ Cypress.Commands.add('enterData', field => {
     }
 
     case 'date': {
-      const [year, month, day] = field.data.split('-');
+      const [year, month, day] = field.data
+        .split('-')
+        .map(dateComponent => parseInt(dateComponent, 10).toString());
 
       cy.get(`#${field.key}Year`)
         .clear()
         .type(year);
 
-      cy.get(`#${field.key}Month`).select(parseInt(month, 10).toString());
+      cy.get(`#${field.key}Month`).select(month);
 
-      if (day !== 'XX') {
-        cy.get(`#${field.key}Day`).select(parseInt(day, 10).toString());
-      }
+      if (day !== 'XX') cy.get(`#${field.key}Day`).select(day);
 
       break;
     }

--- a/src/platform/testing/e2e/cypress/support/form-tester/index.js
+++ b/src/platform/testing/e2e/cypress/support/form-tester/index.js
@@ -273,16 +273,16 @@ Cypress.Commands.add('enterData', field => {
     case 'date': {
       const dateComponents = field.data.split('-');
 
-      cy.get(`input[name="${field.key}Year"]`)
+      cy.get(`#${field.key}Year`)
         .clear()
         .type(dateComponents[0]);
 
-      cy.get(`select[name="${field.key}Month"]`).select(
+      cy.get(`#${field.key}Month`).select(
         parseInt(dateComponents[1], 10).toString(),
       );
 
       if (dateComponents[2] !== 'XX') {
-        cy.get(`select[name="${field.key}Day"]`).select(
+        cy.get(`#${field.key}Day`).select(
           parseInt(dateComponents[2], 10).toString(),
         );
       }
@@ -291,7 +291,7 @@ Cypress.Commands.add('enterData', field => {
     }
 
     case 'file': {
-      cy.get(`input[id="${field.key}"]`)
+      cy.get(`#${field.key}`)
         .upload('example-upload.png', 'image/png')
         .get('.schemaform-file-uploading')
         .should('not.exist');

--- a/src/platform/testing/e2e/cypress/support/form-tester/index.js
+++ b/src/platform/testing/e2e/cypress/support/form-tester/index.js
@@ -173,7 +173,6 @@ const processPage = () => {
 
 /**
  * Runs the page hook if there is one for the current page.
- *
  * @param {string} pathname - The pathname for the current URL.
  * @returns {boolean} Resolves true if a hook ran and false otherwise.
  */
@@ -200,7 +199,6 @@ Cypress.Commands.add('execHook', pathname => {
 
 /**
  * Looks up data for a field.
- *
  * @param {Field}
  * @returns {*} Resolves to the field data if found or undefined otherwise.
  */
@@ -229,18 +227,17 @@ Cypress.Commands.add('findData', field => {
 
 /**
  * Enters data for a field.
- *
  * @param {Field}
  */
 Cypress.Commands.add('enterData', field => {
   switch (field.type) {
-    // Select fields register as having a type === 'select-one'
+    // Select fields register as having type 'select-one'.
     case 'select-one':
       cy.wrap(field.element).select(field.data);
       break;
 
     case 'checkbox': {
-      // Only click the checkbox if we need to
+      // Only click the checkbox if we need to.
       const checked = field.element.prop('checked');
       if ((checked && !field.data) || (!checked && field.data)) {
         cy.wrap(field.element).click();
@@ -257,7 +254,7 @@ Cypress.Commands.add('enterData', field => {
         .clear()
         .type(field.data)
         .then(element => {
-          // Get the autocomplete menu out of the way
+          // Get the autocomplete menu out of the way.
           if (element.attr('role') === 'combobox') {
             cy.wrap(element).type('{downarrow}{enter}');
           }
@@ -267,8 +264,8 @@ Cypress.Commands.add('enterData', field => {
 
     case 'radio': {
       let value = field.data;
-      // Use 'Y' / 'N' because of the yesNo widget
-      if (typeof field.data === 'boolean') value = field.data ? 'Y' : 'N';
+      // Use 'Y' / 'N' because of the yesNo widget.
+      if (typeof value === 'boolean') value = value ? 'Y' : 'N';
       cy.get(`input[name="${field.key}"][value="${value}"]`).click();
       break;
     }
@@ -321,19 +318,31 @@ Cypress.Commands.add('fillPage', () => {
       const touchedFields = new Set();
       const snapshot = {};
 
+      /**
+       * Fills out a field (or set of fields) using the created field object,
+       * if it's eligible, and exempt it from further processing.
+       *
+       * There are several reasons a field might not be eligible:
+       * 1. No key was derived; the element has no name or id.
+       * 2. The field was already processed individually or as part of a set.
+       * 3. The element isn't part of the form schema.
+       * 4. The element detached from the DOM, possibly due to re-rendering.
+       *    It also may have changed as a result of interacting with another
+       *    field. It will be processed in a later iteration.
+       *
+       * @param {Field}
+       */
       const processFieldObject = field => {
         const shouldSkipField =
           !field.key ||
           touchedFields.has(field.key) ||
-          !field.key.startsWith('root_');
+          !field.key.startsWith('root_') ||
+          Cypress.dom.isDetached(field.element);
 
         if (shouldSkipField) return;
 
         cy.findData({ ...field, arrayItemPath }).then(data => {
-          if (typeof data !== 'undefined') {
-            cy.enterData({ ...field, data });
-          }
-
+          if (typeof data !== 'undefined') cy.enterData({ ...field, data });
           touchedFields.add(field.key);
         });
       };

--- a/src/platform/testing/e2e/cypress/support/form-tester/index.js
+++ b/src/platform/testing/e2e/cypress/support/form-tester/index.js
@@ -320,7 +320,7 @@ Cypress.Commands.add('fillPage', () => {
 
       /**
        * Fills out a field (or set of fields) using the created field object,
-       * if it's eligible, and exempt it from further processing.
+       * if it's eligible, and exempts it from further processing.
        *
        * There are several reasons a field might not be eligible:
        * 1. No key was derived; the element has no name or id.

--- a/src/platform/testing/e2e/cypress/support/form-tester/index.js
+++ b/src/platform/testing/e2e/cypress/support/form-tester/index.js
@@ -271,20 +271,16 @@ Cypress.Commands.add('enterData', field => {
     }
 
     case 'date': {
-      const dateComponents = field.data.split('-');
+      const [year, month, day] = field.data.split('-');
 
       cy.get(`#${field.key}Year`)
         .clear()
-        .type(dateComponents[0]);
+        .type(year);
 
-      cy.get(`#${field.key}Month`).select(
-        parseInt(dateComponents[1], 10).toString(),
-      );
+      cy.get(`#${field.key}Month`).select(parseInt(month, 10).toString());
 
-      if (dateComponents[2] !== 'XX') {
-        cy.get(`#${field.key}Day`).select(
-          parseInt(dateComponents[2], 10).toString(),
-        );
+      if (day !== 'XX') {
+        cy.get(`#${field.key}Day`).select(parseInt(day, 10).toString());
       }
 
       break;


### PR DESCRIPTION
## Description
Sometimes form fields can re-render (even change types) in response to another form interaction, causing the initially selected element to be detached from the DOM, breaking the automatic filler logic.

This change skips fields when they're detached so that the updated field can get processed on the next iteration of filling the page.

Also includes some refactoring, such as improved selectors.

## Testing done
Tested on foreign-address-test in HCA, where selecting a non-US address will change the "State" field from a dropdown select to a text input.

## Acceptance criteria
- [ ] The Cypress form tester should be able to handle fields that re-render.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
