### PR TITLE
Clear eligibility data after submit

### DIFF
--- a/src/applications/vaos/reducers/newAppointment.js
+++ b/src/applications/vaos/reducers/newAppointment.js
@@ -196,8 +196,6 @@ export default function formReducer(state = initialState, action) {
         ...initialState,
         parentFacilities: state.parentFacilities,
         facilities: state.facilities,
-        clinics: state.clinics,
-        eligibility: state.eligibility,
         pastAppointments: state.pastAppointments,
         submitStatus: FETCH_STATUS.notStarted,
       };

--- a/src/applications/vaos/tests/reducers/newAppointment.unit.spec.js
+++ b/src/applications/vaos/tests/reducers/newAppointment.unit.spec.js
@@ -1069,6 +1069,8 @@ describe('VAOS reducer: newAppointment', () => {
     const newState = newAppointmentReducer(currentState, action);
 
     expect(newState.data).to.deep.equal({});
+    expect(newState.eligibility).to.deep.equal({});
+    expect(newState.clinics).to.deep.equal({});
     expect(newState.parentFacilitiesStatus).to.equal(FETCH_STATUS.notStarted);
     expect(newState.eligibilityStatus).to.equal(FETCH_STATUS.notStarted);
   });


### PR DESCRIPTION
## Description
We need to clear eligibility data after submit, because something like the request limit needs to be updated after every submission.

Since all the eligibility data is in one object, there's no easy way to wipe out just a part of it. Additionally, given that the clinics are part of the eligibility calls, I've removed those as well.

## Testing done
Unit testing

## Acceptance criteria
- [ ] All eligibility is clear and refetched on subsequent appointments

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
