### PR TITLE
Remove redirects

### DIFF
--- a/src/applications/proxy-rewrite/redirects/crossDomainRedirects.json
+++ b/src/applications/proxy-rewrite/redirects/crossDomainRedirects.json
@@ -626,107 +626,12 @@
   },
   {
     "domain": "www.benefits.va.gov",
-    "src": "/compensation/resources_comp0214.asp",
-    "dest": "/disability/compensation-rates/special-monthly-compensation-rates/"
-  },
-  {
-    "domain": "www.benefits.va.gov",
-    "src": "/compensation/resources_comp0213.asp",
-    "dest": "/disability/compensation-rates/special-monthly-compensation-rates/"
-  },
-  {
-    "domain": "www.benefits.va.gov",
-    "src": "/compensation/resources_comp0212.asp",
-    "dest": "/disability/compensation-rates/special-monthly-compensation-rates/"
-  },
-  {
-    "domain": "www.benefits.va.gov",
-    "src": "/compensation/resources_comp0211.asp",
-    "dest": "/disability/compensation-rates/special-monthly-compensation-rates/"
-  },
-  {
-    "domain": "www.benefits.va.gov",
-    "src": "/compensation/resources_comp0209.asp",
-    "dest": "/disability/compensation-rates/special-monthly-compensation-rates/"
-  },
-  {
-    "domain": "www.benefits.va.gov",
-    "src": "/compensation/resources_comp0208.asp",
-    "dest": "/disability/compensation-rates/special-monthly-compensation-rates/"
-  },
-  {
-    "domain": "www.benefits.va.gov",
-    "src": "/compensation/resources_comp0207.asp",
-    "dest": "/disability/compensation-rates/special-monthly-compensation-rates/"
-  },
-  {
-    "domain": "www.benefits.va.gov",
-    "src": "/compensation/resources_comp0206.asp",
-    "dest": "/disability/compensation-rates/special-monthly-compensation-rates/"
-  },
-  {
-    "domain": "www.benefits.va.gov",
-    "src": "/compensation/resources_comp0205.asp",
-    "dest": "/disability/compensation-rates/special-monthly-compensation-rates/"
-  },
-  {
-    "domain": "www.benefits.va.gov",
-    "src": "/compensation/resources_comp0204.asp",
-    "dest": "/disability/compensation-rates/special-monthly-compensation-rates/"
-  },
-  {
-    "domain": "www.benefits.va.gov",
-    "src": "/compensation/resources_comp0203.asp",
-    "dest": "/disability/compensation-rates/special-monthly-compensation-rates/"
-  },
-  {
-    "domain": "www.benefits.va.gov",
-    "src": "/compensation/resources_comp0202.asp",
-    "dest": "/disability/compensation-rates/special-monthly-compensation-rates/"
-  },
-  {
-    "domain": "www.benefits.va.gov",
-    "src": "/compensation/resources_comp0201.asp",
-    "dest": "/disability/compensation-rates/special-monthly-compensation-rates/"
-  },
-  {
-    "domain": "www.benefits.va.gov",
-    "src": "/compensation/resources_comp0200.asp",
-    "dest": "/disability/compensation-rates/special-monthly-compensation-rates/"
-  },
-  {
-    "domain": "www.benefits.va.gov",
-    "src": "/compensation/resources_comp0299.asp",
-    "dest": "/disability/compensation-rates/special-monthly-compensation-rates/"
-  },
-  {
-    "domain": "www.benefits.va.gov",
     "src": "/compensation/sb2019.asp",
     "dest": "/disability/compensation-rates/birth-defect-rates/"
   },
   {
     "domain": "www.benefits.va.gov",
     "src": "/compensation/sb2018.asp",
-    "dest": "/disability/compensation-rates/birth-defect-rates/"
-  },
-  {
-    "domain": "www.benefits.va.gov",
-    "src": "/compensation/sb2014.asp",
-    "dest": "/disability/compensation-rates/birth-defect-rates/"
-  },
-  {
-    "domain": "www.benefits.va.gov",
-    "src": "/compensation/sb2013.asp",
-    "dest": "/disability/compensation-rates/birth-defect-rates/"
-  },
-  {
-    "domain": "www.benefits.va.gov",
-    "src": "/compensation/sb2012.asp",
-    "dest": "/disability/compensation-rates/birth-defect-rates/"
-  },
-  {
-    "domain": "www.benefits.va.gov",
-    "src": "/compensation/sb2011.asp",
     "dest": "/disability/compensation-rates/birth-defect-rates/"
   },
   {
@@ -792,86 +697,6 @@
   {
     "domain": "www.benefits.va.gov",
     "src": "/compensation/special_benefit_allowances_2018.asp",
-    "dest": "/disability/compensation-rates/special-benefit-allowance-rates/"
-  },
-  {
-    "domain": "www.benefits.va.gov",
-    "src": "/compensation/special_benefit_allowances_2015.asp",
-    "dest": "/disability/compensation-rates/special-benefit-allowance-rates/"
-  },
-  {
-    "domain": "www.benefits.va.gov",
-    "src": "/compensation/special_benefit_allowances_2014.asp",
-    "dest": "/disability/compensation-rates/special-benefit-allowance-rates/"
-  },
-  {
-    "domain": "www.benefits.va.gov",
-    "src": "/compensation/special_benefit_allowances_2013.asp",
-    "dest": "/disability/compensation-rates/special-benefit-allowance-rates/"
-  },
-  {
-    "domain": "www.benefits.va.gov",
-    "src": "/compensation/special_benefit_allowances_2012.asp",
-    "dest": "/disability/compensation-rates/special-benefit-allowance-rates/"
-  },
-  {
-    "domain": "www.benefits.va.gov",
-    "src": "/compensation/special_benefit_allowances_2011.asp",
-    "dest": "/disability/compensation-rates/special-benefit-allowance-rates/"
-  },
-  {
-    "domain": "www.benefits.va.gov",
-    "src": "/compensation/special_benefit_allowances_2009.asp",
-    "dest": "/disability/compensation-rates/special-benefit-allowance-rates/"
-  },
-  {
-    "domain": "www.benefits.va.gov",
-    "src": "/compensation/special_benefit_allowances_2008.asp",
-    "dest": "/disability/compensation-rates/special-benefit-allowance-rates/"
-  },
-  {
-    "domain": "www.benefits.va.gov",
-    "src": "/compensation/special_benefit_allowances_2007.asp",
-    "dest": "/disability/compensation-rates/special-benefit-allowance-rates/"
-  },
-  {
-    "domain": "www.benefits.va.gov",
-    "src": "/compensation/special_benefit_allowances_2006.asp",
-    "dest": "/disability/compensation-rates/special-benefit-allowance-rates/"
-  },
-  {
-    "domain": "www.benefits.va.gov",
-    "src": "/compensation/special_benefit_allowances_2005.asp",
-    "dest": "/disability/compensation-rates/special-benefit-allowance-rates/"
-  },
-  {
-    "domain": "www.benefits.va.gov",
-    "src": "/compensation/special_benefit_allowances_2004.asp",
-    "dest": "/disability/compensation-rates/special-benefit-allowance-rates/"
-  },
-  {
-    "domain": "www.benefits.va.gov",
-    "src": "/compensation/special_benefit_allowances_2003.asp",
-    "dest": "/disability/compensation-rates/special-benefit-allowance-rates/"
-  },
-  {
-    "domain": "www.benefits.va.gov",
-    "src": "/compensation/special_benefit_allowances_2002.asp",
-    "dest": "/disability/compensation-rates/special-benefit-allowance-rates/"
-  },
-  {
-    "domain": "www.benefits.va.gov",
-    "src": "/compensation/special_benefit_allowances_2001.asp",
-    "dest": "/disability/compensation-rates/special-benefit-allowance-rates/"
-  },
-  {
-    "domain": "www.benefits.va.gov",
-    "src": "/compensation/special_benefit_allowances_2000.asp",
-    "dest": "/disability/compensation-rates/special-benefit-allowance-rates/"
-  },
-  {
-    "domain": "www.benefits.va.gov",
-    "src": "/compensation/special_benefit_allowances_1999.asp",
     "dest": "/disability/compensation-rates/special-benefit-allowance-rates/"
   },
   {


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/9893

This PR should undo the redirects for these pages: 

**First chunk**
https://www.benefits.va.gov/compensation/special_Benefit_Allowances_2015.asp 
https://www.benefits.va.gov/compensation/special_Benefit_Allowances_2014.asp 
https://www.benefits.va.gov/compensation/special_Benefit_Allowances_2013.asp 
https://www.benefits.va.gov/compensation/special_Benefit_Allowances_2012.asp 
https://www.benefits.va.gov/compensation/special_Benefit_Allowances_2011.asp 
https://www.benefits.va.gov/compensation/special_Benefit_Allowances_2009.asp 
https://www.benefits.va.gov/compensation/special_Benefit_Allowances_2008.asp 
https://www.benefits.va.gov/compensation/special_Benefit_Allowances_2007.asp 
https://www.benefits.va.gov/compensation/special_Benefit_Allowances_2006.asp 
https://www.benefits.va.gov/compensation/special_Benefit_Allowances_2005.asp 
https://www.benefits.va.gov/compensation/special_Benefit_Allowances_2004.asp 
https://www.benefits.va.gov/compensation/special_Benefit_Allowances_2003.asp 
https://www.benefits.va.gov/compensation/special_Benefit_Allowances_2002.asp 
https://www.benefits.va.gov/compensation/special_Benefit_Allowances_2001.asp 
https://www.benefits.va.gov/compensation/special_Benefit_Allowances_2000.asp 
https://www.benefits.va.gov/compensation/special_Benefit_Allowances_1999.asp 

**Note: DON'T do anything with these (leave as is with redirects):**
https://www.benefits.va.gov/compensation/special_Benefit_Allowances_2019.asp
https://www.benefits.va.gov/compensation/special_Benefit_Allowances_2018.asp

**Second chunk**
https://www.benefits.va.gov/COMPENSATION/resources_comp0214.asp 
https://www.benefits.va.gov/COMPENSATION/resources_comp0213.asp 
https://www.benefits.va.gov/COMPENSATION/resources_comp0212.asp 
https://www.benefits.va.gov/COMPENSATION/resources_comp0211.asp 
https://www.benefits.va.gov/COMPENSATION/resources_comp0209.asp 
https://www.benefits.va.gov/COMPENSATION/resources_comp0208.asp 
https://www.benefits.va.gov/COMPENSATION/resources_comp0207.asp 
https://www.benefits.va.gov/COMPENSATION/resources_comp0206.asp 
https://www.benefits.va.gov/COMPENSATION/resources_comp0205.asp 
https://www.benefits.va.gov/COMPENSATION/resources_comp0204.asp 
https://www.benefits.va.gov/COMPENSATION/resources_comp0203.asp 
https://www.benefits.va.gov/COMPENSATION/resources_comp0202.asp 
https://www.benefits.va.gov/COMPENSATION/resources_comp0201.asp 
https://www.benefits.va.gov/COMPENSATION/resources_comp0200.asp 
https://www.benefits.va.gov/COMPENSATION/resources_comp0299.asp 

**Note: DON'T do anything with these (leave as is with redirects):**
https://www.benefits.va.gov/COMPENSATION/resources_comp02.asp 
https://www.benefits.va.gov/COMPENSATION/resources_comp0218.asp 

**Third chunk**
https://www.benefits.va.gov/COMPENSATION/sb2014.asp 
https://www.benefits.va.gov/COMPENSATION/sb2013.asp 
https://www.benefits.va.gov/COMPENSATION/sb2012.asp 
https://www.benefits.va.gov/COMPENSATION/sb2011.asp

**Note: DON'T do anything with these (leave as is with redirects):**
https://www.benefits.va.gov/compensation/sb2019.asp 
https://www.benefits.va.gov/COMPENSATION/sb2018.asp

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
