### PR TITLE
Block DD from unauthorized users

### DIFF
--- a/src/applications/personalization/profile-2/components/Profile2Router.jsx
+++ b/src/applications/personalization/profile-2/components/Profile2Router.jsx
@@ -1,0 +1,199 @@
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { BrowserRouter, Route, Switch, Redirect } from 'react-router-dom';
+import LoadingIndicator from '@department-of-veterans-affairs/formation-react/LoadingIndicator';
+
+import RequiredLoginView from 'platform/user/authorization/components/RequiredLoginView';
+import backendServices from 'platform/user/profile/constants/backendServices';
+import {
+  createIsServiceAvailableSelector,
+  isMultifactorEnabled,
+  selectProfile,
+} from 'platform/user/selectors';
+import { fetchMHVAccount as fetchMHVAccountAction } from 'platform/user/profile/actions';
+import {
+  fetchMilitaryInformation as fetchMilitaryInformationAction,
+  fetchHero as fetchHeroAction,
+  fetchPersonalInformation as fetchPersonalInformationAction,
+} from 'applications/personalization/profile360/actions';
+import {
+  directDepositAddressIsSetUp,
+  directDepositIsBlocked,
+  directDepositIsSetUp,
+} from 'applications/personalization/profile360/selectors';
+import { fetchPaymentInformation as fetchPaymentInformationAction } from 'applications/personalization/profile360/actions/paymentInformation';
+import getRoutes from '../routes';
+
+import Profile2Wrapper from './Profile2Wrapper';
+
+class Profile2Router extends Component {
+  componentDidMount() {
+    const {
+      fetchFullName,
+      fetchMHVAccount,
+      fetchMilitaryInformation,
+      fetchPersonalInformation,
+      fetchPaymentInformation,
+      shouldFetchDirectDepositInformation,
+    } = this.props;
+    fetchMHVAccount();
+    fetchMilitaryInformation();
+    fetchFullName();
+    fetchPersonalInformation();
+    if (shouldFetchDirectDepositInformation) {
+      fetchPaymentInformation();
+    }
+  }
+
+  componentDidUpdate(prevProps) {
+    if (
+      this.props.shouldFetchDirectDepositInformation &&
+      !prevProps.shouldFetchDirectDepositInformation
+    ) {
+      this.props.fetchPaymentInformation();
+    }
+  }
+
+  // content to show if the component is waiting for data to load. This loader
+  // matches the loader shown by the RequiredLoginView component, so when the
+  // RequiredLoginView is done with its loading and this function takes over, it
+  // appears seamless to the user.
+  loadingContent = () => (
+    <div className="vads-u-margin-y--5">
+      <LoadingIndicator setFocus message="Loading your information..." />
+    </div>
+  );
+
+  // content to show after data has loaded
+  mainContent = () => {
+    const routes = getRoutes(this.props.shouldShowDirectDeposit);
+    return (
+      <BrowserRouter>
+        <Profile2Wrapper routes={routes}>
+          <Switch>
+            {/* Redirect users to Account Security to upgrade their account if they need to */}
+            {routes.map(route => {
+              if (
+                (route.requiresLOA3 && !this.props.isLOA3) ||
+                (route.requiresMVI && !this.props.isInMVI)
+              ) {
+                return (
+                  <Redirect
+                    from={route.path}
+                    key="/profile/account-security"
+                    to="/profile/account-security"
+                  />
+                );
+              }
+
+              return (
+                <Route
+                  component={route.component}
+                  exact
+                  key={route.path}
+                  path={route.path}
+                />
+              );
+            })}
+
+            <Redirect
+              exact
+              from="/profile"
+              key="/profile/personal-information"
+              to="/profile/personal-information"
+            />
+
+            {/* fallback handling: redirect to root route */}
+            <Route path="*">
+              <Redirect to="/profile" />
+            </Route>
+          </Switch>
+        </Profile2Wrapper>
+      </BrowserRouter>
+    );
+  };
+
+  renderContent = () => {
+    if (this.props.showLoader) {
+      return this.loadingContent();
+    }
+    return this.mainContent();
+  };
+
+  render() {
+    return (
+      <RequiredLoginView
+        serviceRequired={backendServices.USER_PROFILE}
+        user={this.props.user}
+      >
+        {this.renderContent()}
+      </RequiredLoginView>
+    );
+  }
+}
+
+const mapStateToProps = state => {
+  const isEvssAvailableSelector = createIsServiceAvailableSelector(
+    backendServices.EVSS_CLAIMS,
+  );
+  const isEvssAvailable = isEvssAvailableSelector(state);
+  const isDirectDepositSetUp = directDepositIsSetUp(state);
+  const isDirectDepositBlocked = directDepositIsBlocked(state);
+  const isEligibleToSignUp = directDepositAddressIsSetUp(state);
+  const is2faEnabled = isMultifactorEnabled(state);
+  const shouldFetchDirectDepositInformation = isEvssAvailable && is2faEnabled;
+
+  // this piece of state will be set if the call to load military info succeeds
+  // or fails:
+  const hasLoadedMilitaryInformation = state.vaProfile?.militaryInformation;
+
+  // when the call to load MHV fails, `errors` will be set to a non-null value
+  // when the call succeeds, the `accountState` will be set to a non-null value
+  const hasLoadedMHVInformation =
+    selectProfile(state)?.mhvAccount?.errors ||
+    selectProfile(state)?.mhvAccount?.accountState;
+
+  // this piece of state will be set if the call to load personal info succeeds
+  // or fails:
+  const hasLoadedPersonalInformation = state.vaProfile?.personalInformation;
+
+  // this piece of state will be set if the call to load name info succeeds or
+  // fails:
+  const hasLoadedFullName = state.vaProfile?.hero;
+
+  // this piece of state will be set if the call to load name info succeeds or
+  // fails:
+  const hasLoadedPaymentInformation = state.vaProfile?.paymentInformation;
+
+  const hasLoadedAllData =
+    hasLoadedFullName &&
+    hasLoadedMHVInformation &&
+    hasLoadedMilitaryInformation &&
+    hasLoadedPersonalInformation &&
+    (shouldFetchDirectDepositInformation ? hasLoadedPaymentInformation : true);
+
+  return {
+    user: state.user,
+    showLoader: !hasLoadedAllData,
+    shouldFetchDirectDepositInformation,
+    shouldShowDirectDeposit:
+      shouldFetchDirectDepositInformation &&
+      !isDirectDepositBlocked &&
+      (isDirectDepositSetUp || isEligibleToSignUp),
+  };
+};
+
+const mapDispatchToProps = {
+  fetchFullName: fetchHeroAction,
+  fetchMHVAccount: fetchMHVAccountAction,
+  fetchMilitaryInformation: fetchMilitaryInformationAction,
+  fetchPersonalInformation: fetchPersonalInformationAction,
+  fetchPaymentInformation: fetchPaymentInformationAction,
+};
+
+export { Profile2Router as Profile2, mapStateToProps };
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(Profile2Router);

--- a/src/applications/personalization/profile-2/components/Profile2Wrapper.jsx
+++ b/src/applications/personalization/profile-2/components/Profile2Wrapper.jsx
@@ -1,188 +1,51 @@
-import React, { Component } from 'react';
+import React from 'react';
 import { Link } from 'react-router';
-import { connect } from 'react-redux';
 import Breadcrumbs from '@department-of-veterans-affairs/formation-react/Breadcrumbs';
-import LoadingIndicator from '@department-of-veterans-affairs/formation-react/LoadingIndicator';
-
-import RequiredLoginView from 'platform/user/authorization/components/RequiredLoginView';
-import backendServices from 'platform/user/profile/constants/backendServices';
 import { isWideScreen } from 'platform/utilities/accessibility/index';
-import {
-  createIsServiceAvailableSelector,
-  isMultifactorEnabled,
-  selectProfile,
-} from 'platform/user/selectors';
-import { fetchMHVAccount as fetchMHVAccountAction } from 'platform/user/profile/actions';
-import {
-  fetchMilitaryInformation as fetchMilitaryInformationAction,
-  fetchHero as fetchHeroAction,
-  fetchPersonalInformation as fetchPersonalInformationAction,
-} from 'applications/personalization/profile360/actions';
-import { fetchPaymentInformation as fetchPaymentInformationAction } from 'applications/personalization/profile360/actions/paymentInformation';
+
 import ProfileHeader from './ProfileHeader';
 import ProfileSideNav from './ProfileSideNav';
 import MobileMenuTrigger from './MobileMenuTrigger';
-import routes from '../routes';
 
-class Profile2 extends Component {
-  componentDidMount() {
-    const {
-      fetchFullName,
-      fetchMHVAccount,
-      fetchMilitaryInformation,
-      fetchPersonalInformation,
-      fetchPaymentInformation,
-      shouldFetchDirectDepositInformation,
-    } = this.props;
-    fetchMHVAccount();
-    fetchMilitaryInformation();
-    fetchFullName();
-    fetchPersonalInformation();
-    if (shouldFetchDirectDepositInformation) {
-      fetchPaymentInformation();
-    }
-  }
-
-  componentDidUpdate(prevProps) {
-    if (
-      this.props.shouldFetchDirectDepositInformation &&
-      !prevProps.shouldFetchDirectDepositInformation
-    ) {
-      this.props.fetchPaymentInformation();
-    }
-  }
-
-  // content to show if the component is waiting for data to load. This loader
-  // matches the loader shown by the RequiredLoginView component, so when the
-  // RequiredLoginView is done with its loading and this function takes over, it
-  // appears seamless to the user.
-  loadingContent = () => (
-    <div className="vads-u-margin-y--5">
-      <LoadingIndicator setFocus message="Loading your information..." />
-    </div>
-  );
-
-  createBreadCrumbAttributes = () => {
-    const { location } = this.props;
+const Profile2 = ({ children, location, routes }) => {
+  const createBreadCrumbAttributes = () => {
     const activeLocation = location?.pathname;
     const activeRoute = routes.find(route => route.path === activeLocation);
 
     return { activeLocation, activeRouteName: activeRoute?.name };
   };
 
-  // content to show after data has loaded
-  // note that `children` will be passed in via React Router.
-  mainContent = () => {
-    const {
-      activeLocation,
-      activeRouteName,
-    } = this.createBreadCrumbAttributes();
+  const { activeLocation, activeRouteName } = createBreadCrumbAttributes();
 
-    // We do not want to display 'Profile' on the mobile personal-information route
-    const onPersonalInformationMobile =
-      this.props?.location?.pathname === '/personal-information' &&
-      !isWideScreen();
+  // We do not want to display 'Profile' on the mobile personal-information route
+  const onPersonalInformationMobile =
+    location?.pathname === '/personal-information' && !isWideScreen();
 
-    return (
-      <>
-        {/* Breadcrumbs */}
-        <Breadcrumbs className="vads-u-padding-x--1 vads-u-padding-y--1p5 medium-screen:vads-u-padding-y--0">
-          <a href="/">Home</a>
-          {!onPersonalInformationMobile && <Link to="/">Your profile</Link>}
-          <a href={activeLocation}>{activeRouteName}</a>
-        </Breadcrumbs>
+  return (
+    <>
+      {/* Breadcrumbs */}
+      <Breadcrumbs className="vads-u-padding-x--1 vads-u-padding-y--1p5 medium-screen:vads-u-padding-y--0">
+        <a href="/">Home</a>
+        {!onPersonalInformationMobile && <Link to="/">Your profile</Link>}
+        <a href={activeLocation}>{activeRouteName}</a>
+      </Breadcrumbs>
 
-        <MobileMenuTrigger />
+      <MobileMenuTrigger />
 
-        <div className="mobile-fixed-spacer" />
-        <ProfileHeader />
+      <div className="mobile-fixed-spacer" />
+      <ProfileHeader />
 
-        <div className="usa-grid usa-grid-full">
-          <div className="usa-width-one-fourth">
-            <ProfileSideNav />
-          </div>
-          <div className="usa-width-two-thirds vads-u-padding-bottom--4 vads-u-padding-x--1 medium-screen:vads-u-padding--0 medium-screen:vads-u-padding-bottom--6">
-            {this.props.children}
-          </div>
+      <div className="usa-grid usa-grid-full">
+        <div className="usa-width-one-fourth">
+          <ProfileSideNav routes={routes} />
         </div>
-      </>
-    );
-  };
-
-  renderContent = () => {
-    if (this.props.showLoader) {
-      return this.loadingContent();
-    }
-    return this.mainContent();
-  };
-
-  render() {
-    return (
-      <RequiredLoginView
-        serviceRequired={backendServices.USER_PROFILE}
-        user={this.props.user}
-      >
-        {this.renderContent()}
-      </RequiredLoginView>
-    );
-  }
-}
-
-const mapStateToProps = state => {
-  const isEvssAvailableSelector = createIsServiceAvailableSelector(
-    backendServices.EVSS_CLAIMS,
+        <div className="usa-width-two-thirds vads-u-padding-bottom--4 vads-u-padding-x--1 medium-screen:vads-u-padding--0 medium-screen:vads-u-padding-bottom--6">
+          {/* children will be passed in from React Router one level up */}
+          {children}
+        </div>
+      </div>
+    </>
   );
-  const isEvssAvailable = isEvssAvailableSelector(state);
-  const is2faEnabled = isMultifactorEnabled(state);
-  const shouldFetchDirectDepositInformation = isEvssAvailable && is2faEnabled;
-
-  // this piece of state will be set if the call to load military info succeeds
-  // or fails:
-  const hasLoadedMilitaryInformation = state.vaProfile?.militaryInformation;
-
-  // when the call to load MHV fails, `errors` will be set to a non-null value
-  // when the call succeeds, the `accountState` will be set to a non-null value
-  const hasLoadedMHVInformation =
-    selectProfile(state)?.mhvAccount?.errors ||
-    selectProfile(state)?.mhvAccount?.accountState;
-
-  // this piece of state will be set if the call to load personal info succeeds
-  // or fails:
-  const hasLoadedPersonalInformation = state.vaProfile?.personalInformation;
-
-  // this piece of state will be set if the call to load name info succeeds or
-  // fails:
-  const hasLoadedFullName = state.vaProfile?.hero;
-
-  // this piece of state will be set if the call to load name info succeeds or
-  // fails:
-  const hasLoadedPaymentInformation = state.vaProfile?.paymentInformation;
-
-  const hasLoadedAllData =
-    hasLoadedFullName &&
-    hasLoadedMHVInformation &&
-    hasLoadedMilitaryInformation &&
-    hasLoadedPersonalInformation &&
-    (shouldFetchDirectDepositInformation ? hasLoadedPaymentInformation : true);
-
-  return {
-    user: state.user,
-    showLoader: !hasLoadedAllData,
-    shouldFetchDirectDepositInformation,
-  };
 };
 
-const mapDispatchToProps = {
-  fetchFullName: fetchHeroAction,
-  fetchMHVAccount: fetchMHVAccountAction,
-  fetchMilitaryInformation: fetchMilitaryInformationAction,
-  fetchPersonalInformation: fetchPersonalInformationAction,
-  fetchPaymentInformation: fetchPaymentInformationAction,
-};
-
-export { Profile2, mapStateToProps };
-
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps,
-)(Profile2);
+export default Profile2;

--- a/src/applications/personalization/profile-2/components/ProfileSideNav.jsx
+++ b/src/applications/personalization/profile-2/components/ProfileSideNav.jsx
@@ -11,9 +11,8 @@ import {
 import { isLOA3 as isLOA3Selector } from 'platform/user/selectors';
 import { closeSideNav as closeSideNavAction } from '../actions';
 import { selectIsSideNavOpen } from '../selectors';
-import routes from '../routes';
 
-const ProfileSideNav = ({ closeSideNav, isSideNavOpen, isLOA3 }) => {
+const ProfileSideNav = ({ closeSideNav, isSideNavOpen, isLOA3, routes }) => {
   const closeButton = useRef(null);
   const lastMenuItem = useRef(null);
 

--- a/src/applications/personalization/profile-2/routes.js
+++ b/src/applications/personalization/profile-2/routes.js
@@ -4,40 +4,50 @@ import MilitaryInformation from './components/MilitaryInformation';
 import DirectDeposit from './components/direct-deposit/DirectDeposit';
 import ConnectedApplications from './components/connected-apps/ConnectedApps';
 
-export default [
-  {
-    component: PersonalInformation,
-    name: 'Personal and contact information',
-    path: '/profile/personal-information',
-    requiresLOA3: true,
-    requiresMVI: true,
-  },
-  {
-    component: MilitaryInformation,
-    name: 'Military information',
-    path: '/profile/military-information',
-    requiresLOA3: true,
-    requiresMVI: true,
-  },
-  {
-    component: DirectDeposit,
-    name: 'Direct deposit',
-    path: '/profile/direct-deposit',
-    requiresLOA3: true,
-    requiresMVI: true,
-  },
-  {
-    component: AccountSecurity,
-    name: 'Account security',
-    path: '/profile/account-security',
-    requiresLOA3: false,
-    requiresMVI: false,
-  },
-  {
-    component: ConnectedApplications,
-    name: 'Connected apps',
-    path: '/profile/connected-applications',
-    requiresLOA3: true,
-    requiresMVI: true,
-  },
-];
+const getRoutes = showDirectDeposit => {
+  const routes = [
+    {
+      component: PersonalInformation,
+      name: 'Personal and contact information',
+      path: '/profile/personal-information',
+      requiresLOA3: true,
+      requiresMVI: true,
+    },
+    {
+      component: MilitaryInformation,
+      name: 'Military information',
+      path: '/profile/military-information',
+      requiresLOA3: true,
+      requiresMVI: true,
+    },
+    {
+      component: DirectDeposit,
+      name: 'Direct deposit',
+      path: '/profile/direct-deposit',
+      requiresLOA3: true,
+      requiresMVI: true,
+    },
+    {
+      component: AccountSecurity,
+      name: 'Account security',
+      path: '/profile/account-security',
+      requiresLOA3: false,
+      requiresMVI: false,
+    },
+    {
+      component: ConnectedApplications,
+      name: 'Connected apps',
+      path: '/profile/connected-applications',
+      requiresLOA3: true,
+      requiresMVI: true,
+    },
+  ];
+  if (!showDirectDeposit) {
+    return routes.filter(route => {
+      return route.component !== DirectDeposit;
+    });
+  }
+  return routes;
+};
+
+export default getRoutes;

--- a/src/applications/personalization/profile-2/tests/components/Profile2.unit.spec.js
+++ b/src/applications/personalization/profile-2/tests/components/Profile2.unit.spec.js
@@ -1,349 +1,38 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import { expect } from 'chai';
-import sinon from 'sinon';
 
-import backendServices from 'platform/user/profile/constants/backendServices';
-import RequiredLoginView from 'platform/user/authorization/components/RequiredLoginView';
-
-import { Profile2, mapStateToProps } from '../../components/Profile2Wrapper';
+import Profile2 from '../../components/Profile2Wrapper';
+import getRoutes from '../../routes';
 
 describe('Profile2', () => {
   let defaultProps;
-  let fetchFullNameSpy;
-  let fetchMilitaryInfoSpy;
-  let fetchMHVAccountSpy;
-  let fetchPaymentInfoSpy;
-  let fetchPersonalInfoSpy;
 
   beforeEach(() => {
-    fetchFullNameSpy = sinon.spy();
-    fetchMilitaryInfoSpy = sinon.spy();
-    fetchMHVAccountSpy = sinon.spy();
-    fetchPaymentInfoSpy = sinon.spy();
-    fetchPersonalInfoSpy = sinon.spy();
-
     defaultProps = {
-      fetchFullName: fetchFullNameSpy,
-      fetchMHVAccount: fetchMHVAccountSpy,
-      fetchMilitaryInformation: fetchMilitaryInfoSpy,
-      fetchPaymentInformation: fetchPaymentInfoSpy,
-      fetchPersonalInformation: fetchPersonalInfoSpy,
-      shouldFetchDirectDepositInformation: true,
-      showLoader: false,
-      user: {},
       location: {
         pathname: '/profile/personal-information',
       },
+      routes: getRoutes(),
     };
   });
 
-  it('renders a RequiredLoginView component that requires the USER_PROFILE', () => {
+  it('should render BreadCrumbs', () => {
     const wrapper = shallow(<Profile2 {...defaultProps} />);
-    expect(wrapper.type()).to.equal(RequiredLoginView);
-    expect(wrapper.prop('serviceRequired')).to.equal(
-      backendServices.USER_PROFILE,
+    expect(wrapper.find('Breadcrumbs')).to.have.lengthOf(1);
+    wrapper.unmount();
+  });
+
+  it('should render the correct breadcrumb (Personal and contact Information)', () => {
+    const wrapper = shallow(<Profile2 {...defaultProps} />);
+    const BreadCrumbs = wrapper.find('Breadcrumbs');
+    const activeRouteText = BreadCrumbs.find('a')
+      .last()
+      .text();
+
+    expect(activeRouteText.toLowerCase()).to.include(
+      'personal and contact information',
     );
     wrapper.unmount();
-  });
-
-  it('should render a spinner if it is loading data', () => {
-    defaultProps.showLoader = true;
-    const wrapper = shallow(<Profile2 {...defaultProps} />);
-    wrapper.setProps({ showLoader: true });
-    const loader = wrapper.find('LoadingIndicator');
-    expect(loader.length).to.equal(1);
-    wrapper.unmount();
-  });
-
-  describe('when the component mounts', () => {
-    it('should fetch the military information data', () => {
-      const wrapper = shallow(<Profile2 {...defaultProps} />);
-      expect(fetchMilitaryInfoSpy.called).to.be.true;
-      wrapper.unmount();
-    });
-
-    it('should fetch the full name data', () => {
-      const wrapper = shallow(<Profile2 {...defaultProps} />);
-      expect(fetchFullNameSpy.called).to.be.true;
-      wrapper.unmount();
-    });
-
-    it('should fetch the personal information data', () => {
-      const wrapper = shallow(<Profile2 {...defaultProps} />);
-      expect(fetchPersonalInfoSpy.called).to.be.true;
-      wrapper.unmount();
-    });
-
-    it('should fetch the My HealtheVet data', () => {
-      const wrapper = shallow(<Profile2 {...defaultProps} />);
-      expect(fetchMHVAccountSpy.called).to.be.true;
-      wrapper.unmount();
-    });
-
-    it('should render BreadCrumbs', () => {
-      const wrapper = shallow(<Profile2 {...defaultProps} />);
-      expect(wrapper.find('Breadcrumbs')).to.have.lengthOf(1);
-      wrapper.unmount();
-    });
-
-    it('should render the correct breadcrumb (Personal and contact Information)', () => {
-      const wrapper = shallow(<Profile2 {...defaultProps} />);
-      const BreadCrumbs = wrapper.find('Breadcrumbs');
-      const activeRouteText = BreadCrumbs.find('a')
-        .last()
-        .text();
-
-      expect(activeRouteText.toLowerCase()).to.include(
-        'personal and contact information',
-      );
-      wrapper.unmount();
-    });
-
-    describe('when `shouldFetchDirectDepositInformation` is `true`', () => {
-      it('should fetch the payment information data', () => {
-        const wrapper = shallow(<Profile2 {...defaultProps} />);
-        expect(fetchPaymentInfoSpy.called).to.be.true;
-        wrapper.unmount();
-      });
-    });
-
-    describe('when `shouldFetchDirectDepositInformation` is `false`', () => {
-      it('should not fetch the payment information data', () => {
-        defaultProps.shouldFetchDirectDepositInformation = false;
-        const wrapper = shallow(<Profile2 {...defaultProps} />);
-        expect(fetchPaymentInfoSpy.called).to.be.false;
-        wrapper.unmount();
-      });
-    });
-  });
-
-  describe('when the component updates', () => {
-    describe('when `shouldFetchDirectDepositInformation` goes from `false` to `true', () => {
-      it('should fetch the payment information data', () => {
-        defaultProps.shouldFetchDirectDepositInformation = false;
-        const wrapper = shallow(<Profile2 {...defaultProps} />);
-        expect(fetchPaymentInfoSpy.called).to.be.false;
-        wrapper.setProps({ shouldFetchDirectDepositInformation: true });
-        expect(fetchPaymentInfoSpy.called).to.be.true;
-        wrapper.unmount();
-      });
-    });
-  });
-});
-
-describe('mapStateToProps', () => {
-  const makeDefaultProfileState = () => ({
-    multifactor: true,
-    services: ['evss-claims'],
-    mhvAccount: {
-      accountState: 'needs_terms_acceptance',
-      errors: null,
-      loading: false,
-    },
-  });
-  const makeDefaultVaProfileState = () => ({
-    hero: {
-      userFullName: {
-        first: 'Wesley',
-        middle: 'Watson',
-        last: 'Ford',
-        suffix: null,
-      },
-    },
-    personalInformation: {
-      gender: 'M',
-      birthDate: '1986-05-06',
-    },
-    militaryInformation: {
-      serviceHistory: {
-        serviceHistory: [
-          {
-            branchOfService: 'Air Force',
-            beginDate: '2009-04-12',
-            endDate: '2013-04-11',
-            personnelCategoryTypeCode: 'V',
-          },
-        ],
-      },
-    },
-    paymentInformation: {
-      responses: [
-        {
-          controlInformation: {},
-          paymentAccount: {},
-          paymentAddress: {},
-          paymentType: 'CNP',
-        },
-      ],
-    },
-  });
-  const makeDefaultState = () => ({
-    user: {
-      profile: makeDefaultProfileState(),
-    },
-    vaProfile: makeDefaultVaProfileState(),
-  });
-
-  it('returns an object with the correct keys', () => {
-    const state = makeDefaultState();
-    const props = mapStateToProps(state);
-    const expectedKeys = [
-      'user',
-      'showLoader',
-      'shouldFetchDirectDepositInformation',
-    ];
-    expect(Object.keys(props)).to.deep.equal(expectedKeys);
-  });
-
-  describe('#user', () => {
-    it('is pulled from state.user', () => {
-      const state = makeDefaultState();
-      const props = mapStateToProps(state);
-      expect(props.user).to.deep.equal(state.user);
-    });
-  });
-
-  describe('#shouldFetchDirectDepositInformation', () => {
-    it('is `true` when user has 2FA set and has access to EVSS', () => {
-      const state = makeDefaultState();
-      const props = mapStateToProps(state);
-      expect(props.shouldFetchDirectDepositInformation).to.be.true;
-    });
-
-    it('is `false` when user has 2FA set but does not have access to EVSS', () => {
-      const state = makeDefaultState();
-      state.user.profile.services = [];
-      const props = mapStateToProps(state);
-      expect(props.shouldFetchDirectDepositInformation).to.be.false;
-    });
-
-    it('is `false` when the user has access to EVSS but does not have 2FA set', () => {
-      const state = makeDefaultState();
-      state.user.profile.multifactor = false;
-      const props = mapStateToProps(state);
-      expect(props.shouldFetchDirectDepositInformation).to.be.false;
-    });
-
-    it('is `false` when the user does not have 2FA set and does not have access to EVSS', () => {
-      const state = makeDefaultState();
-      state.user.profile.multifactor = false;
-      state.user.profile.services = [];
-      const props = mapStateToProps(state);
-      expect(props.shouldFetchDirectDepositInformation).to.be.false;
-    });
-  });
-
-  describe('#showLoader', () => {
-    describe('when direct deposit info should be fetched', () => {
-      it('is `false` when all required data calls have resolved successfully', () => {
-        const state = makeDefaultState();
-        const props = mapStateToProps(state);
-        expect(props.showLoader).to.be.false;
-      });
-
-      it('is `false` when all required data calls have errored', () => {
-        const state = makeDefaultState();
-        state.vaProfile.paymentInformation = { error: {} };
-        state.vaProfile.userFullName = { error: {} };
-        state.vaProfile.personalInformation = { error: {} };
-        state.vaProfile.militaryInformation = { error: {} };
-        state.user.profile.mhvAccount = { errors: [] };
-        const props = mapStateToProps(state);
-        expect(props.showLoader).to.be.false;
-      });
-
-      it('is `true` when the call to fetch payment info has not resolved but all others have', () => {
-        const state = makeDefaultState();
-        delete state.vaProfile.paymentInformation;
-        const props = mapStateToProps(state);
-        expect(props.showLoader).to.be.true;
-      });
-
-      it('is `true` when the call to fetch personal info has not resolved but all others have', () => {
-        const state = makeDefaultState();
-        delete state.vaProfile.personalInformation;
-        const props = mapStateToProps(state);
-        expect(props.showLoader).to.be.true;
-      });
-
-      it('is `true` when the call to fetch military info has not resolved but all others have', () => {
-        const state = makeDefaultState();
-        delete state.vaProfile.militaryInformation;
-        const props = mapStateToProps(state);
-        expect(props.showLoader).to.be.true;
-      });
-
-      it('is `true` when the call to fetch the full name has not resolved but all others have', () => {
-        const state = makeDefaultState();
-        delete state.vaProfile.hero;
-        const props = mapStateToProps(state);
-        expect(props.showLoader).to.be.true;
-      });
-
-      it('is `true` when the call to fetch MHV info has not resolved but all others have', () => {
-        const state = makeDefaultState();
-        state.user.profile.mhvAccount = {
-          accountState: null,
-          errors: null,
-          loading: false,
-        };
-        const props = mapStateToProps(state);
-        expect(props.showLoader).to.be.true;
-      });
-    });
-
-    describe('when direct deposit info should not be fetched because the user has not set up 2FA', () => {
-      let state;
-      beforeEach(() => {
-        state = makeDefaultState();
-        state.user.profile.multifactor = false;
-        delete state.vaProfile.paymentInformation;
-      });
-
-      it('is `false` when all required data calls have resolved successfully', () => {
-        const props = mapStateToProps(state);
-        expect(props.showLoader).to.be.false;
-      });
-
-      it('is `false` when all required data calls have either resolved successfully or errored', () => {
-        state.vaProfile.personalInformation.error = {};
-        const props = mapStateToProps(state);
-        expect(props.showLoader).to.be.false;
-      });
-
-      it('is `false` when the call to fetch payment info has not resolved', () => {
-        const props = mapStateToProps(state);
-        expect(props.showLoader).to.be.false;
-      });
-
-      it('is `true` when the call to fetch personal info has not resolved', () => {
-        delete state.vaProfile.personalInformation;
-        const props = mapStateToProps(state);
-        expect(props.showLoader).to.be.true;
-      });
-
-      it('is `true` when the call to fetch military info has not resolved', () => {
-        delete state.vaProfile.militaryInformation;
-        const props = mapStateToProps(state);
-        expect(props.showLoader).to.be.true;
-      });
-
-      it('is `true` when the call to fetch the full name has not resolved', () => {
-        delete state.vaProfile.hero;
-        const props = mapStateToProps(state);
-        expect(props.showLoader).to.be.true;
-      });
-
-      it('is `true` when the call to fetch MHV info has not resolved', () => {
-        state.user.profile.mhvAccount = {
-          accountState: null,
-          errors: null,
-          loading: false,
-        };
-        const props = mapStateToProps(state);
-        expect(props.showLoader).to.be.true;
-      });
-    });
   });
 });

--- a/src/applications/personalization/profile-2/tests/components/Profile2Router.unit.spec.js
+++ b/src/applications/personalization/profile-2/tests/components/Profile2Router.unit.spec.js
@@ -1,0 +1,429 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import backendServices from 'platform/user/profile/constants/backendServices';
+import RequiredLoginView from 'platform/user/authorization/components/RequiredLoginView';
+
+import {
+  Profile2 as Profile2Router,
+  mapStateToProps,
+} from '../../components/Profile2Router';
+
+describe('Profile2Router', () => {
+  let defaultProps;
+  let fetchFullNameSpy;
+  let fetchMilitaryInfoSpy;
+  let fetchMHVAccountSpy;
+  let fetchPaymentInfoSpy;
+  let fetchPersonalInfoSpy;
+
+  beforeEach(() => {
+    fetchFullNameSpy = sinon.spy();
+    fetchMilitaryInfoSpy = sinon.spy();
+    fetchMHVAccountSpy = sinon.spy();
+    fetchPaymentInfoSpy = sinon.spy();
+    fetchPersonalInfoSpy = sinon.spy();
+
+    defaultProps = {
+      fetchFullName: fetchFullNameSpy,
+      fetchMHVAccount: fetchMHVAccountSpy,
+      fetchMilitaryInformation: fetchMilitaryInfoSpy,
+      fetchPaymentInformation: fetchPaymentInfoSpy,
+      fetchPersonalInformation: fetchPersonalInfoSpy,
+      shouldFetchDirectDepositInformation: true,
+      showLoader: false,
+      user: {},
+      location: {
+        pathname: '/profile/personal-information',
+      },
+    };
+  });
+
+  it('renders a RequiredLoginView component that requires the USER_PROFILE', () => {
+    const wrapper = shallow(<Profile2Router {...defaultProps} />);
+    expect(wrapper.type()).to.equal(RequiredLoginView);
+    expect(wrapper.prop('serviceRequired')).to.equal(
+      backendServices.USER_PROFILE,
+    );
+    wrapper.unmount();
+  });
+
+  it('should render a spinner if it is loading data', () => {
+    defaultProps.showLoader = true;
+    const wrapper = shallow(<Profile2Router {...defaultProps} />);
+    wrapper.setProps({ showLoader: true });
+    const loader = wrapper.find('LoadingIndicator');
+    expect(loader.length).to.equal(1);
+    wrapper.unmount();
+  });
+
+  describe('when the component mounts', () => {
+    it('should fetch the military information data', () => {
+      const wrapper = shallow(<Profile2Router {...defaultProps} />);
+      expect(fetchMilitaryInfoSpy.called).to.be.true;
+      wrapper.unmount();
+    });
+
+    it('should fetch the full name data', () => {
+      const wrapper = shallow(<Profile2Router {...defaultProps} />);
+      expect(fetchFullNameSpy.called).to.be.true;
+      wrapper.unmount();
+    });
+
+    it('should fetch the personal information data', () => {
+      const wrapper = shallow(<Profile2Router {...defaultProps} />);
+      expect(fetchPersonalInfoSpy.called).to.be.true;
+      wrapper.unmount();
+    });
+
+    it('should fetch the My HealtheVet data', () => {
+      const wrapper = shallow(<Profile2Router {...defaultProps} />);
+      expect(fetchMHVAccountSpy.called).to.be.true;
+      wrapper.unmount();
+    });
+
+    describe('when `shouldFetchDirectDepositInformation` is `true`', () => {
+      it('should fetch the payment information data', () => {
+        const wrapper = shallow(<Profile2Router {...defaultProps} />);
+        expect(fetchPaymentInfoSpy.called).to.be.true;
+        wrapper.unmount();
+      });
+    });
+
+    describe('when `shouldFetchDirectDepositInformation` is `false`', () => {
+      it('should not fetch the payment information data', () => {
+        defaultProps.shouldFetchDirectDepositInformation = false;
+        const wrapper = shallow(<Profile2Router {...defaultProps} />);
+        expect(fetchPaymentInfoSpy.called).to.be.false;
+        wrapper.unmount();
+      });
+    });
+  });
+
+  describe('when the component updates', () => {
+    describe('when `shouldFetchDirectDepositInformation` goes from `false` to `true', () => {
+      it('should fetch the payment information data', () => {
+        defaultProps.shouldFetchDirectDepositInformation = false;
+        const wrapper = shallow(<Profile2Router {...defaultProps} />);
+        expect(fetchPaymentInfoSpy.called).to.be.false;
+        wrapper.setProps({ shouldFetchDirectDepositInformation: true });
+        expect(fetchPaymentInfoSpy.called).to.be.true;
+        wrapper.unmount();
+      });
+    });
+  });
+});
+
+describe('mapStateToProps', () => {
+  const makeDefaultProfileState = () => ({
+    multifactor: true,
+    services: ['evss-claims'],
+    mhvAccount: {
+      accountState: 'needs_terms_acceptance',
+      errors: null,
+      loading: false,
+    },
+  });
+  const makeDefaultVaProfileState = () => ({
+    hero: {
+      userFullName: {
+        first: 'Wesley',
+        middle: 'Watson',
+        last: 'Ford',
+        suffix: null,
+      },
+    },
+    personalInformation: {
+      gender: 'M',
+      birthDate: '1986-05-06',
+    },
+    militaryInformation: {
+      serviceHistory: {
+        serviceHistory: [
+          {
+            branchOfService: 'Air Force',
+            beginDate: '2009-04-12',
+            endDate: '2013-04-11',
+            personnelCategoryTypeCode: 'V',
+          },
+        ],
+      },
+    },
+    paymentInformation: {
+      responses: [
+        {
+          controlInformation: {
+            canUpdateAddress: true,
+            corpAvailIndicator: true,
+            corpRecFoundIndicator: true,
+            hasNoBdnPaymentsIndicator: true,
+            identityIndicator: true,
+            isCompetentIndicator: true,
+            indexIndicator: true,
+            noFiduciaryAssignedIndicator: true,
+            notDeceasedIndicator: true,
+          },
+          paymentAccount: {
+            accountType: '',
+            financialInstitutionName: null,
+            accountNumber: '',
+            financialInstitutionRoutingNumber: '',
+          },
+          paymentAddress: {
+            type: 'DOMESTIC',
+            addressEffectiveDate: '2016-12-16T06:00:00.000+00:00',
+            addressOne: '123 MAIN ST',
+            addressTwo: '',
+            addressThree: '',
+            city: 'TAMPA',
+            stateCode: 'FL',
+            zipCode: '12345',
+            zipSuffix: '1234',
+            countryName: 'TAMPA',
+            militaryPostOfficeTypeCode: null,
+            militaryStateCode: null,
+          },
+          paymentType: 'CNP',
+        },
+      ],
+    },
+  });
+  const makeDefaultState = () => ({
+    user: {
+      profile: makeDefaultProfileState(),
+    },
+    vaProfile: makeDefaultVaProfileState(),
+  });
+
+  it('returns an object with the correct keys', () => {
+    const state = makeDefaultState();
+    const props = mapStateToProps(state);
+    const expectedKeys = [
+      'user',
+      'showLoader',
+      'shouldFetchDirectDepositInformation',
+      'shouldShowDirectDeposit',
+    ];
+    expect(Object.keys(props)).to.deep.equal(expectedKeys);
+  });
+
+  describe('#user', () => {
+    it('is pulled from state.user', () => {
+      const state = makeDefaultState();
+      const props = mapStateToProps(state);
+      expect(props.user).to.deep.equal(state.user);
+    });
+  });
+
+  describe('#shouldFetchDirectDepositInformation', () => {
+    it('is `true` when user has 2FA set and has access to EVSS', () => {
+      const state = makeDefaultState();
+      const props = mapStateToProps(state);
+      expect(props.shouldFetchDirectDepositInformation).to.be.true;
+    });
+
+    it('is `false` when user has 2FA set but does not have access to EVSS', () => {
+      const state = makeDefaultState();
+      state.user.profile.services = [];
+      const props = mapStateToProps(state);
+      expect(props.shouldFetchDirectDepositInformation).to.be.false;
+    });
+
+    it('is `false` when the user has access to EVSS but does not have 2FA set', () => {
+      const state = makeDefaultState();
+      state.user.profile.multifactor = false;
+      const props = mapStateToProps(state);
+      expect(props.shouldFetchDirectDepositInformation).to.be.false;
+    });
+
+    it('is `false` when the user does not have 2FA set and does not have access to EVSS', () => {
+      const state = makeDefaultState();
+      state.user.profile.multifactor = false;
+      state.user.profile.services = [];
+      const props = mapStateToProps(state);
+      expect(props.shouldFetchDirectDepositInformation).to.be.false;
+    });
+  });
+
+  describe('#shouldShowDirectDeposit', () => {
+    describe('when direct deposit info should not be fetched because EVSS is not available', () => {
+      it('should be `false`', () => {
+        const state = makeDefaultState();
+        state.user.profile.services = [];
+        const props = mapStateToProps(state);
+        expect(props.shouldShowDirectDeposit).to.be.false;
+      });
+    });
+    describe('when direct deposit info should not be fetched because user has not set up 2FA', () => {
+      it('should be `false`', () => {
+        const state = makeDefaultState();
+        state.user.profile.multifactor = false;
+        const props = mapStateToProps(state);
+        expect(props.shouldShowDirectDeposit).to.be.false;
+      });
+    });
+    describe('when user is flagged as incompetent', () => {
+      it('should be `false`', () => {
+        const state = makeDefaultState();
+        state.vaProfile.paymentInformation.responses[0].controlInformation.isCompetentIndicator = false;
+        const props = mapStateToProps(state);
+        expect(props.shouldShowDirectDeposit).to.be.false;
+      });
+    });
+    describe('when user has a fiduciary assigned', () => {
+      it('should be `false`', () => {
+        const state = makeDefaultState();
+        state.vaProfile.paymentInformation.responses[0].controlInformation.noFiduciaryAssignedIndicator = false;
+        const props = mapStateToProps(state);
+        expect(props.shouldShowDirectDeposit).to.be.false;
+      });
+    });
+    describe('when user is deceased', () => {
+      it('should be `false`', () => {
+        const state = makeDefaultState();
+        state.vaProfile.paymentInformation.responses[0].controlInformation.notDeceasedIndicator = false;
+        const props = mapStateToProps(state);
+        expect(props.shouldShowDirectDeposit).to.be.false;
+      });
+    });
+    describe('when direct deposit is not already set up and they are not eligible to sign up', () => {
+      it('should be `false`', () => {
+        const state = makeDefaultState();
+        state.vaProfile.paymentInformation.responses[0].paymentAccount = {};
+        state.vaProfile.paymentInformation.responses[0].paymentAddress = {};
+        const props = mapStateToProps(state);
+        expect(props.shouldShowDirectDeposit).to.be.false;
+      });
+    });
+    describe('when user has EVSS available, has set up 2FA, is not blocked, and has direct deposit already set up', () => {
+      it('should be `true`', () => {
+        const state = makeDefaultState();
+        const props = mapStateToProps(state);
+        expect(props.shouldShowDirectDeposit).to.be.true;
+      });
+    });
+    describe('when user has EVSS available, has set up 2FA, is not blocked, does not have direct deposit set up but does have a payment address on file', () => {
+      it('should be `true`', () => {
+        const state = makeDefaultState();
+        state.vaProfile.paymentInformation.responses[0].paymentAccount = {};
+        const props = mapStateToProps(state);
+        expect(props.shouldShowDirectDeposit).to.be.true;
+      });
+    });
+  });
+
+  describe('#showLoader', () => {
+    describe('when direct deposit info should be fetched', () => {
+      it('is `false` when all required data calls have resolved successfully', () => {
+        const state = makeDefaultState();
+        const props = mapStateToProps(state);
+        expect(props.showLoader).to.be.false;
+      });
+
+      it('is `false` when all required data calls have errored', () => {
+        const state = makeDefaultState();
+        state.vaProfile.paymentInformation = { error: {} };
+        state.vaProfile.userFullName = { error: {} };
+        state.vaProfile.personalInformation = { error: {} };
+        state.vaProfile.militaryInformation = { error: {} };
+        state.user.profile.mhvAccount = { errors: [] };
+        const props = mapStateToProps(state);
+        expect(props.showLoader).to.be.false;
+      });
+
+      it('is `true` when the call to fetch payment info has not resolved but all others have', () => {
+        const state = makeDefaultState();
+        delete state.vaProfile.paymentInformation;
+        const props = mapStateToProps(state);
+        expect(props.showLoader).to.be.true;
+      });
+
+      it('is `true` when the call to fetch personal info has not resolved but all others have', () => {
+        const state = makeDefaultState();
+        delete state.vaProfile.personalInformation;
+        const props = mapStateToProps(state);
+        expect(props.showLoader).to.be.true;
+      });
+
+      it('is `true` when the call to fetch military info has not resolved but all others have', () => {
+        const state = makeDefaultState();
+        delete state.vaProfile.militaryInformation;
+        const props = mapStateToProps(state);
+        expect(props.showLoader).to.be.true;
+      });
+
+      it('is `true` when the call to fetch the full name has not resolved but all others have', () => {
+        const state = makeDefaultState();
+        delete state.vaProfile.hero;
+        const props = mapStateToProps(state);
+        expect(props.showLoader).to.be.true;
+      });
+
+      it('is `true` when the call to fetch MHV info has not resolved but all others have', () => {
+        const state = makeDefaultState();
+        state.user.profile.mhvAccount = {
+          accountState: null,
+          errors: null,
+          loading: false,
+        };
+        const props = mapStateToProps(state);
+        expect(props.showLoader).to.be.true;
+      });
+    });
+
+    describe('when direct deposit info should not be fetched because the user has not set up 2FA', () => {
+      let state;
+      beforeEach(() => {
+        state = makeDefaultState();
+        state.user.profile.multifactor = false;
+        delete state.vaProfile.paymentInformation;
+      });
+
+      it('is `false` when all required data calls have resolved successfully', () => {
+        const props = mapStateToProps(state);
+        expect(props.showLoader).to.be.false;
+      });
+
+      it('is `false` when all required data calls have either resolved successfully or errored', () => {
+        state.vaProfile.personalInformation.error = {};
+        const props = mapStateToProps(state);
+        expect(props.showLoader).to.be.false;
+      });
+
+      it('is `false` when the call to fetch payment info has not resolved', () => {
+        const props = mapStateToProps(state);
+        expect(props.showLoader).to.be.false;
+      });
+
+      it('is `true` when the call to fetch personal info has not resolved', () => {
+        delete state.vaProfile.personalInformation;
+        const props = mapStateToProps(state);
+        expect(props.showLoader).to.be.true;
+      });
+
+      it('is `true` when the call to fetch military info has not resolved', () => {
+        delete state.vaProfile.militaryInformation;
+        const props = mapStateToProps(state);
+        expect(props.showLoader).to.be.true;
+      });
+
+      it('is `true` when the call to fetch the full name has not resolved', () => {
+        delete state.vaProfile.hero;
+        const props = mapStateToProps(state);
+        expect(props.showLoader).to.be.true;
+      });
+
+      it('is `true` when the call to fetch MHV info has not resolved', () => {
+        state.user.profile.mhvAccount = {
+          accountState: null,
+          errors: null,
+          loading: false,
+        };
+        const props = mapStateToProps(state);
+        expect(props.showLoader).to.be.true;
+      });
+    });
+  });
+});

--- a/src/applications/personalization/profiles-wrapper/ProfilesWrapper.jsx
+++ b/src/applications/personalization/profiles-wrapper/ProfilesWrapper.jsx
@@ -1,10 +1,9 @@
-import React, { Suspense } from 'react';
+import React from 'react';
 import { connect } from 'react-redux';
-import { BrowserRouter, Route, Switch, Redirect } from 'react-router-dom';
-import Profile2Wrapper from 'applications/personalization/profile-2/components/Profile2Wrapper';
+import LoadingIndicator from '@department-of-veterans-affairs/formation-react/LoadingIndicator';
+import Profile2Router from 'applications/personalization/profile-2/components/Profile2Router';
 import ProfileOneWrapper from 'applications/personalization/profile360/containers/VAProfileApp';
 import { PROFILE_VERSION } from 'applications/personalization/profile-2/constants';
-import routes from 'applications/personalization/profile-2/routes';
 
 import {
   isInMVI as isInMVISelector,
@@ -14,66 +13,25 @@ import {
 import localStorage from 'platform/utilities/storage/localStorage';
 import { selectShowProfile2 } from 'applications/personalization/profile-2/selectors';
 
-const LoadingPage = <Profile2Wrapper>Loading...</Profile2Wrapper>;
+const LoadingPage = () => (
+  <div className="vads-u-margin-y--5">
+    <LoadingIndicator setFocus message="Loading your information..." />
+  </div>
+);
 
 const ProfilesWrapper = ({ showProfile1, isLOA1, isLOA3, isInMVI }) => {
   // On initial render, both isLOA props are false.
   // We need to make sure the proper redirect is hit,
   // so we show a loading state till one value is true.
   if (!isLOA1 && !isLOA3) {
-    return (
-      <BrowserRouter>
-        <Suspense fallback={LoadingPage}>
-          <Profile2Wrapper />
-        </Suspense>
-      </BrowserRouter>
-    );
+    return <LoadingPage />;
   }
 
   if (showProfile1) {
     return <ProfileOneWrapper />;
   }
 
-  return (
-    <BrowserRouter>
-      <Suspense fallback={LoadingPage}>
-        <Profile2Wrapper>
-          <Switch>
-            {routes.map(route => {
-              if (
-                (route.requiresLOA3 && !isLOA3) ||
-                (route.requiresMVI && !isInMVI)
-              ) {
-                return (
-                  <Redirect
-                    from={route.path}
-                    key="/profile/account-security"
-                    to="/profile/account-security"
-                  />
-                );
-              }
-
-              return (
-                <Route
-                  component={route.component}
-                  exact
-                  key={route.path}
-                  path={route.path}
-                />
-              );
-            })}
-
-            <Redirect
-              exact
-              from="/profile"
-              key="/profile/personal-information"
-              to="/profile/personal-information"
-            />
-          </Switch>
-        </Profile2Wrapper>
-      </Suspense>
-    </BrowserRouter>
-  );
+  return <Profile2Router isLOA3={isLOA3} isInMVI={isInMVI} />;
 };
 
 const mapStateToProps = state => {


### PR DESCRIPTION
## Description
This PR is not as large and scary as it appears. The majority of the diff is due to moving code from one place to another.

- The new `Profile2Router` component contains the **routing logic** that used to live in `ProfilesWrapper` as well as the **data-loading logic** that used to be a part of `Profile2Wrapper`. This is because the routes need to be set up _after_ we determine if the user should have access to the Direct Deposit feature or not.

- `Profile2Wrapper` has been greatly simplified and is now a simple functional component that serves as a simple wrapper, rendering breadcrumbs and a subnav menu around main content passed in via React Router.

- The `ProfilesWrapper`, which is still the root entry-point component for the `/profile` route, has also been simplified and is only responsible for deciding if the user should see v1 or v2 of the Profile. All routing-related code has been moved to the new `Profile2Router`.

- The `routes` used to return a static array of routes, but it now exposes a function that returns a list of routes that does or doesn't contain the Direct Deposit route, depending on the arg that is passed to it.

Unit tests have also been moved to the files that correspond to where the logic now lives. And additional tests have been added to cover the new `shouldShowDirectDeposit` prop on the updated `mapStateToProps`.

## Testing done
Local + unit tests

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs