### PR TITLE
[Templates] Add a Schema.org PoC for Coronavirus FAQ page

### DIFF
--- a/src/site/includes/coronavirus-schema-org.json.liquid
+++ b/src/site/includes/coronavirus-schema-org.json.liquid
@@ -1,0 +1,47 @@
+{% comment %}
+  https://github.com/department-of-veterans-affairs/va.gov-team/issues/9163
+  This is proof-of-concept for implementing schema.org into our Coronavirus response.
+  The extension is .liquid because if we used .json the quotes and other characters
+  would be replaced by HTML entities.
+{% endcomment %}
+
+<script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    "mainEntity": [
+      {
+        "@type": "Question",
+        "name": "How will COVID-19 affect my VA health care and benefit services?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "&lt;p&gt;Visit our &lt;a href=&quot;https://www.va.gov/coronavirus-chatbot/&quot;&gt;coronavirus chatbot&lt;/a&gt; or &lt;a href=&quot;https://www.va.gov/coronavirus-veteran-frequently-asked-questions/&quot;&gt;frequently asked questions (FAQs)&lt;/a&gt; for up-to-date answers.&lt;/p&gt;"
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Is my local VA health facility or regional office open?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "&lt;p&gt;Get the latest information about hours, services, and COVID-19 safety measures for &lt;a href=&quot;https://www.va.gov/find-locations&quot;&gt;VA locations&lt;/a&gt;.&lt;/p&gt;"
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "How many COVID-19 patients have been tested or treated at VA facilities?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "&lt;p&gt;Review our &lt;a href=&quot;https://www.accesstocare.va.gov/Healthcare/COVID19NationalSummary&quot;&gt;COVID-19 national summary&lt;/a&gt; for data by state and VA facility.&lt;/p&gt;"
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "What's VA doing to deal with COVID-19?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "&lt;p&gt;Learn&nbsp;about our &lt;a href=&quot;https://www.publichealth.va.gov/n-coronavirus/&quot;&gt;public health response&lt;/a&gt; to the coronavirus pandemic.&lt;/p&gt;"
+        }
+      }
+    ]
+  }
+</script>

--- a/src/site/includes/coronavirus-schema-org.json.liquid
+++ b/src/site/includes/coronavirus-schema-org.json.liquid
@@ -5,6 +5,7 @@
   would be replaced by HTML entities.
 {% endcomment %}
 
+{% if path == 'coronavirus-veteran-frequently-asked-questions' %}
 <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -45,3 +46,4 @@
     ]
   }
 </script>
+{% endif %}

--- a/src/site/includes/header.html
+++ b/src/site/includes/header.html
@@ -67,6 +67,10 @@
     <script nonce="**CSP_NONCE**" src="{{ botframework_cdn }}"></script>
   {% endif %}
 
+  {% if path == 'coronavirus-veteran-frequently-asked-questions' %}
+    {% include "src/site/includes/coronavirus-schema-org.json.liquid" %}
+  {% endif %}
+
   <script defer nomodule data-entry-name="polyfills.js"></script>
   <script defer data-entry-name="vendor.js"></script>
   <script defer data-entry-name="{{ entryname | default: 'static-pages' }}.js"></script>

--- a/src/site/includes/header.html
+++ b/src/site/includes/header.html
@@ -67,9 +67,7 @@
     <script nonce="**CSP_NONCE**" src="{{ botframework_cdn }}"></script>
   {% endif %}
 
-  {% if path == 'coronavirus-veteran-frequently-asked-questions' %}
-    {% include "src/site/includes/coronavirus-schema-org.json.liquid" %}
-  {% endif %}
+  {% include "src/site/includes/coronavirus-schema-org.json.liquid" %}
 
   <script defer nomodule data-entry-name="polyfills.js"></script>
   <script defer data-entry-name="vendor.js"></script>


### PR DESCRIPTION
## Description
This PR adds a JSON data structure onto the Coronavirus FAQ to define a Schema.org FAQPage. This will serve as a proof of concept for potential use cases for schema.org more widely on the website.

https://github.com/department-of-veterans-affairs/va.gov-team/issues/9163

## Testing done
Checked page source of Coronavirus FAQ page to confirm the JSON data is there and another page to confirm JSON data is _not_ there

## Screenshots
![image](https://user-images.githubusercontent.com/1915775/84064960-85e5bf80-a991-11ea-85cf-40eb013b9c90.png)


## Acceptance criteria
- [ ] JSON data included on Coronavirus FAQ page

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
