### PR TITLE
bradl3yC - add text override for unauthenticated state

### DIFF
--- a/src/applications/disability-benefits/2346/components/IntroductionPage.jsx
+++ b/src/applications/disability-benefits/2346/components/IntroductionPage.jsx
@@ -140,8 +140,10 @@ class IntroductionPage extends Component {
             <SaveInProgressIntro
               buttonOnly
               hideUnauthedStartLink
+              prefillEnabled={this.props.route.formConfig.prefillEnabled}
               messages={this.props.route.formConfig.savedFormMessages}
               pageList={this.props.route.pageList}
+              unverifiedStartText="Sign in to start your order"
               startText="Order hearing aid batteries and accessories"
             />
           </div>

--- a/src/platform/forms/save-in-progress/SaveInProgressIntro.jsx
+++ b/src/platform/forms/save-in-progress/SaveInProgressIntro.jsx
@@ -129,11 +129,11 @@ class SaveInProgressIntro extends React.Component {
     } else if (renderSignInMessage) {
       alert = renderSignInMessage(prefillEnabled);
     } else if (prefillEnabled && !verifyRequiredPrefill) {
-      const { buttonOnly, retentionPeriod, startText } = this.props;
+      const { buttonOnly, retentionPeriod, unverifiedStartText } = this.props;
       alert = buttonOnly ? (
         <>
           <button className="usa-button-primary" onClick={this.openLoginModal}>
-            Sign in to start your application
+            {unverifiedStartText || 'Sign in to start your application'}
           </button>
           {!this.props.hideUnauthedStartLink && (
             <p>
@@ -177,7 +177,7 @@ class SaveInProgressIntro extends React.Component {
                 className="usa-button-primary"
                 onClick={this.openLoginModal}
               >
-                {startText || 'Sign in to start your application'}
+                {unverifiedStartText || 'Sign in to start your application'}
               </button>
               {!this.props.hideUnauthedStartLink && (
                 <p>
@@ -357,6 +357,7 @@ SaveInProgressIntro.propTypes = {
   gaStartEventName: PropTypes.string,
   startMessageOnly: PropTypes.bool,
   hideUnauthedStartLink: PropTypes.bool,
+  unverifiedStartText: PropTypes.string,
 };
 
 SaveInProgressIntro.defaultProps = {


### PR DESCRIPTION
## Description
- [x] - added a prop to platform to override button text for unauthenticated users

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
