### PR TITLE
Remove https://benefits.va.gov/compensation/claimexam.asp redirects

### DIFF
--- a/src/applications/proxy-rewrite/redirects/crossDomainRedirects.json
+++ b/src/applications/proxy-rewrite/redirects/crossDomainRedirects.json
@@ -271,11 +271,6 @@
   },
   {
     "domain": "www.benefits.va.gov",
-    "src": "/compensation/claimexam.asp",
-    "dest": "/disability/va-claim-exam/"
-  },
-  {
-    "domain": "www.benefits.va.gov",
     "src": "/compensation/NPRC1973Fire.asp",
     "dest": "/records/get-military-service-records/reconstruct-records/"
   },
@@ -703,11 +698,6 @@
     "domain": "www.benefits.va.gov",
     "src": "/compensation/rates-index.asp",
     "dest": "/disability/compensation-rates/"
-  },
-  {
-    "domain": "www.benefits.va.gov",
-    "src": "/compensation/claimexam.asp",
-    "dest": "/disability/va-claim-exam/"
   },
   {
     "domain": "www.benefits.va.gov",


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/9966

This PR removes the redirects for `src` = `https://benefits.va.gov/compensation/claimexam.asp`.

## Testing done
N/A

## Screenshots
N/A

## Acceptance criteria
- [x] Remove redirect.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
