### PR TITLE
bradl3yC - 9865 - 508 Use id instead of name

### DIFF
--- a/src/applications/disability-benefits/2346/components/Batteries.jsx
+++ b/src/applications/disability-benefits/2346/components/Batteries.jsx
@@ -212,7 +212,7 @@ class Batteries extends Component {
               ) : (
                 <div className="vads-u-max-width--293">
                   <input
-                    name={batterySupply.productId}
+                    id={batterySupply.productId}
                     className="vads-u-margin-left--0 vads-u-max-width--293"
                     type="checkbox"
                     onChange={e =>


### PR DESCRIPTION
## Description
The use of a name prop instead of an id was causing an axe error

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
