### PR TITLE
bradl3yC - 9949 - 508 Edit address links not keyboard accessible

### DIFF
--- a/src/applications/disability-benefits/2346/components/ReviewCardField.jsx
+++ b/src/applications/disability-benefits/2346/components/ReviewCardField.jsx
@@ -338,25 +338,25 @@ class ReviewCardField extends React.Component {
             street &&
             city &&
             country && (
-              <a
-                className={editLink}
+              <button
+                className={`${editLink} va-button-link`}
                 style={{ minWidth: '8rem' }}
                 onClick={this.startEditing}
               >
                 Edit {title.toLowerCase()}
-              </a>
+              </button>
             )}
           {!volatileData &&
             !street &&
             !city &&
             !country && (
-              <a
-                className={editLink}
+              <button
+                className={`${editLink} va-button-link`}
                 style={{ minWidth: '8rem' }}
                 onClick={this.startEditing}
               >
                 Add a {title.toLowerCase()}
-              </a>
+              </button>
             )}
           {isTempAddressMissing &&
             street &&

--- a/src/applications/disability-benefits/2346/components/ReviewCardField.jsx
+++ b/src/applications/disability-benefits/2346/components/ReviewCardField.jsx
@@ -342,6 +342,7 @@ class ReviewCardField extends React.Component {
                 className={`${editLink} va-button-link`}
                 style={{ minWidth: '8rem' }}
                 onClick={this.startEditing}
+                type="button"
               >
                 Edit {title.toLowerCase()}
               </button>
@@ -354,6 +355,7 @@ class ReviewCardField extends React.Component {
                 className={`${editLink} va-button-link`}
                 style={{ minWidth: '8rem' }}
                 onClick={this.startEditing}
+                type="button"
               >
                 Add a {title.toLowerCase()}
               </button>
@@ -417,7 +419,8 @@ class ReviewCardField extends React.Component {
     );
   };
 
-  startEditing = () => {
+  startEditing = event => {
+    event.preventDefault();
     const newState = { editing: true };
 
     // If the data is volatile, cache the original data before clearing it out so we

--- a/src/applications/disability-benefits/2346/components/ReviewCardField.jsx
+++ b/src/applications/disability-benefits/2346/components/ReviewCardField.jsx
@@ -419,8 +419,7 @@ class ReviewCardField extends React.Component {
     );
   };
 
-  startEditing = event => {
-    event.preventDefault();
+  startEditing = () => {
     const newState = { editing: true };
 
     // If the data is volatile, cache the original data before clearing it out so we


### PR DESCRIPTION
## Description
The Edit / Add links for addresses are not tab accessible - I swapped them to buttons and styled them to look like links

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
