### PR TITLE
disable single quote prettier rule for sass files in favor of sass-lint rule

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -7,5 +7,13 @@
   "trailingComma": "all",
   "bracketSpacing": true,
   "jsxBracketSameLine": false,
-  "proseWrap": "preserve"
+  "proseWrap": "preserve",
+  "overrides": [
+    {
+      "files": "*.scss",
+      "options": {
+        "singleQuote": false
+      }
+    }
+  ]
 }


### PR DESCRIPTION
## Description
https://github.com/department-of-veterans-affairs/vets-website/issues/13012#issuecomment-640907963