### PR TITLE
Remove redirects

### DIFF
--- a/src/applications/proxy-rewrite/redirects/crossDomainRedirects.json
+++ b/src/applications/proxy-rewrite/redirects/crossDomainRedirects.json
@@ -541,81 +541,6 @@
   },
   {
     "domain": "www.benefits.va.gov",
-    "src": "/compensation/resources_comp0114.asp",
-    "dest": "/disability/compensation-rates/veteran-rates/"
-  },
-  {
-    "domain": "www.benefits.va.gov",
-    "src": "/compensation/resources_comp0113.asp",
-    "dest": "/disability/compensation-rates/veteran-rates/"
-  },
-  {
-    "domain": "www.benefits.va.gov",
-    "src": "/compensation/resources_comp0112.asp",
-    "dest": "/disability/compensation-rates/veteran-rates/"
-  },
-  {
-    "domain": "www.benefits.va.gov",
-    "src": "/compensation/resources_comp0111.asp",
-    "dest": "/disability/compensation-rates/veteran-rates/"
-  },
-  {
-    "domain": "www.benefits.va.gov",
-    "src": "/compensation/resources_comp0109.asp",
-    "dest": "/disability/compensation-rates/veteran-rates/"
-  },
-  {
-    "domain": "www.benefits.va.gov",
-    "src": "/compensation/resources_comp0108.asp",
-    "dest": "/disability/compensation-rates/veteran-rates/"
-  },
-  {
-    "domain": "www.benefits.va.gov",
-    "src": "/compensation/resources_comp0107.asp",
-    "dest": "/disability/compensation-rates/veteran-rates/"
-  },
-  {
-    "domain": "www.benefits.va.gov",
-    "src": "/compensation/resources_comp0106.asp",
-    "dest": "/disability/compensation-rates/veteran-rates/"
-  },
-  {
-    "domain": "www.benefits.va.gov",
-    "src": "/compensation/resources_comp0105.asp",
-    "dest": "/disability/compensation-rates/veteran-rates/"
-  },
-  {
-    "domain": "www.benefits.va.gov",
-    "src": "/compensation/resources_comp0104.asp",
-    "dest": "/disability/compensation-rates/veteran-rates/"
-  },
-  {
-    "domain": "www.benefits.va.gov",
-    "src": "/compensation/resources_comp0103.asp",
-    "dest": "/disability/compensation-rates/veteran-rates/"
-  },
-  {
-    "domain": "www.benefits.va.gov",
-    "src": "/compensation/resources_comp0102.asp",
-    "dest": "/disability/compensation-rates/veteran-rates/"
-  },
-  {
-    "domain": "www.benefits.va.gov",
-    "src": "/compensation/resources_comp0101.asp",
-    "dest": "/disability/compensation-rates/veteran-rates/"
-  },
-  {
-    "domain": "www.benefits.va.gov",
-    "src": "/compensation/resources_comp0100.asp",
-    "dest": "/disability/compensation-rates/veteran-rates/"
-  },
-  {
-    "domain": "www.benefits.va.gov",
-    "src": "/compensation/resources_comp0199.asp",
-    "dest": "/disability/compensation-rates/veteran-rates/"
-  },
-  {
-    "domain": "www.benefits.va.gov",
     "src": "/compensation/resources_comp0218.asp",
     "dest": "/disability/compensation-rates/special-monthly-compensation-rates/"
   },
@@ -631,61 +556,6 @@
   },
   {
     "domain": "www.benefits.va.gov",
-    "src": "/compensation/sb2009.asp",
-    "dest": "/disability/compensation-rates/birth-defect-rates/"
-  },
-  {
-    "domain": "www.benefits.va.gov",
-    "src": "/compensation/sb2008.asp",
-    "dest": "/disability/compensation-rates/birth-defect-rates/"
-  },
-  {
-    "domain": "www.benefits.va.gov",
-    "src": "/compensation/sb2007.asp",
-    "dest": "/disability/compensation-rates/birth-defect-rates/"
-  },
-  {
-    "domain": "www.benefits.va.gov",
-    "src": "/compensation/sb2006.asp",
-    "dest": "/disability/compensation-rates/birth-defect-rates/"
-  },
-  {
-    "domain": "www.benefits.va.gov",
-    "src": "/compensation/sb2005.asp",
-    "dest": "/disability/compensation-rates/birth-defect-rates/"
-  },
-  {
-    "domain": "www.benefits.va.gov",
-    "src": "/compensation/sb2004.asp",
-    "dest": "/disability/compensation-rates/birth-defect-rates/"
-  },
-  {
-    "domain": "www.benefits.va.gov",
-    "src": "/compensation/sb2003.asp",
-    "dest": "/disability/compensation-rates/birth-defect-rates/"
-  },
-  {
-    "domain": "www.benefits.va.gov",
-    "src": "/compensation/sb2002.asp",
-    "dest": "/disability/compensation-rates/birth-defect-rates/"
-  },
-  {
-    "domain": "www.benefits.va.gov",
-    "src": "/compensation/sb2001.asp",
-    "dest": "/disability/compensation-rates/birth-defect-rates/"
-  },
-  {
-    "domain": "www.benefits.va.gov",
-    "src": "/compensation/sb2000.asp",
-    "dest": "/disability/compensation-rates/birth-defect-rates/"
-  },
-  {
-    "domain": "www.benefits.va.gov",
-    "src": "/compensation/sb1999.asp",
-    "dest": "/disability/compensation-rates/birth-defect-rates/"
-  },
-  {
-    "domain": "www.benefits.va.gov",
     "src": "/compensation/special_benefit_allowances_2019.asp",
     "dest": "/disability/compensation-rates/special-benefit-allowance-rates/"
   },
@@ -693,11 +563,6 @@
     "domain": "www.benefits.va.gov",
     "src": "/compensation/special_benefit_allowances_2018.asp",
     "dest": "/disability/compensation-rates/special-benefit-allowance-rates/"
-  },
-  {
-    "domain": "www.benefits.va.gov",
-    "src": "/compensation/rates-index.asp",
-    "dest": "/disability/compensation-rates/"
   },
   {
     "domain": "www.benefits.va.gov",


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/9893#issuecomment-641308203

This PR removes the following redirects:

https://www.benefits.va.gov/compensation/resources_comp0114.asp
https://www.benefits.va.gov/compensation/resources_comp0113.asp
https://www.benefits.va.gov/compensation/resources_comp0112.asp
https://www.benefits.va.gov/compensation/resources_comp0111.asp
https://www.benefits.va.gov/compensation/resources_comp0109.asp
https://www.benefits.va.gov/compensation/resources_comp0108.asp
https://www.benefits.va.gov/compensation/resources_comp0107.asp
https://www.benefits.va.gov/compensation/resources_comp0106.asp
https://www.benefits.va.gov/compensation/resources_comp0105.asp
https://www.benefits.va.gov/compensation/resources_comp0104.asp
https://www.benefits.va.gov/compensation/resources_comp0103.asp
https://www.benefits.va.gov/compensation/resources_comp0102.asp
https://www.benefits.va.gov/compensation/resources_comp0101.asp
https://www.benefits.va.gov/compensation/resources_comp0100.asp
https://www.benefits.va.gov/compensation/resources_comp0199.asp
https://www.benefits.va.gov/compensation/rates-index.asp

https://www.benefits.va.gov/COMPENSATION/sb2009.asp
https://www.benefits.va.gov/COMPENSATION/sb2008.asp
https://www.benefits.va.gov/COMPENSATION/sb2007.asp
https://www.benefits.va.gov/COMPENSATION/sb2006.asp
https://www.benefits.va.gov/COMPENSATION/sb2005.asp
https://www.benefits.va.gov/COMPENSATION/sb2004.asp
https://www.benefits.va.gov/COMPENSATION/sb2003.asp
https://www.benefits.va.gov/COMPENSATION/sb2002.asp
https://www.benefits.va.gov/COMPENSATION/sb2001.asp
https://www.benefits.va.gov/COMPENSATION/sb2000.asp
https://www.benefits.va.gov/COMPENSATION/sb1999.asp

## Testing done
N/A

## Screenshots
N/A

## Acceptance criteria
- [x] Remove redirects.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
