### PR TITLE
Focus on next viewable in table when "view all", "view less" or "show next 10" is pressed

### DIFF
--- a/src/applications/gi/components/profile/SchoolLocations.jsx
+++ b/src/applications/gi/components/profile/SchoolLocations.jsx
@@ -57,35 +57,43 @@ export class SchoolLocations extends React.Component {
     return <a href={`${facilityCode}${query}`}>{name}</a>;
   };
 
-  handleViewAllClicked = () => {
-    this.setState({
+  handleViewAllClicked = async () => {
+    const previousRowCount = this.state.viewableRowCount;
+    await this.setState({
       viewableRowCount: this.state.totalRowCount,
       viewAll: true,
     });
+    this.setFocusToSchoolNameCell(previousRowCount);
   };
 
-  handleViewLessClicked = () => {
+  handleViewLessClicked = async () => {
     if (this.props.onViewLess) {
       this.props.onViewLess();
     }
-    this.setState({
+    await this.setState({
       viewableRowCount: this.state.initialRowCount,
       viewAll: false,
     });
+    this.setFocusToSchoolNameCell(0);
   };
 
-  showMoreClicked = () => {
+  showMoreClicked = async () => {
+    const previousRowCount = this.state.viewableRowCount;
     const remainingRowCount =
       this.state.totalRowCount - this.state.viewableRowCount;
-    if (remainingRowCount >= NEXT_ROWS_VIEWABLE) {
-      this.setState({
-        viewableRowCount: this.state.viewableRowCount + NEXT_ROWS_VIEWABLE,
-      });
-    } else {
-      this.setState({
-        viewableRowCount: this.state.viewableRowCount + remainingRowCount,
-      });
-    }
+    const newViewableRowCount =
+      remainingRowCount >= NEXT_ROWS_VIEWABLE
+        ? this.state.viewableRowCount + NEXT_ROWS_VIEWABLE
+        : this.state.viewableRowCount + remainingRowCount;
+    await this.setState({
+      viewableRowCount: newViewableRowCount,
+    });
+    this.setFocusToSchoolNameCell(previousRowCount);
+  };
+
+  // Necessary so screen reader users are aware that the school locations table has changed.
+  setFocusToSchoolNameCell = elementIndex => {
+    document.getElementsByClassName('school-name-cell')[elementIndex].focus();
   };
 
   schoolLocationTableInfo = (city, state, country, zip) => {
@@ -123,7 +131,9 @@ export class SchoolLocations extends React.Component {
     );
     return (
       <tr key={`${facilityCode}-${type}`} className={`${type}-row`}>
-        <td>{nameLabel}</td>
+        <td tabIndex="-1" className="school-name-cell">
+          {nameLabel}
+        </td>
         <td className={'location-cell'}>
           {this.schoolLocationTableInfo(
             physicalCity,

--- a/src/applications/gi/components/vet-tec/VetTecApprovedProgramsList.jsx
+++ b/src/applications/gi/components/vet-tec/VetTecApprovedProgramsList.jsx
@@ -65,36 +65,46 @@ class VetTecApprovedProgramsList extends React.Component {
     }
   };
 
-  handleViewAllClicked = () => {
-    this.setState({
+  handleViewAllClicked = async () => {
+    const { displayAmount } = this.state;
+    await this.setState({
       displayAmount: this.props.programs.length,
       viewAll: true,
     });
+    this.setFocusToProgramNameCell(displayAmount);
   };
 
-  handleViewLessClicked = () => {
-    this.setState({
+  handleViewLessClicked = async () => {
+    await this.setState({
       displayAmount: DEFAULT_ROWS_VIEWABLE,
       viewAll: false,
     });
     this.handleAccordionFocus();
+    this.setFocusToProgramNameCell(0);
   };
 
-  handleShowMoreClicked = () => {
+  handleShowMoreClicked = async () => {
     const { programs } = this.props;
     const { displayAmount } = this.state;
-
     const remainingRowCount = programs.length - displayAmount;
     if (remainingRowCount > NEXT_ROWS_VIEWABLE) {
-      this.setState({
+      await this.setState({
         displayAmount: displayAmount + NEXT_ROWS_VIEWABLE,
       });
     } else {
-      this.setState({
+      await this.setState({
         displayAmount: programs.length,
         viewAll: true,
       });
     }
+    this.setFocusToProgramNameCell(displayAmount);
+  };
+
+  // Necessary so screen reader users are aware that the approved programs table has changed.
+  setFocusToProgramNameCell = elementIndex => {
+    document
+      .getElementsByClassName('program-description-header')
+      [elementIndex].focus();
   };
 
   renderProgramRows = () => {
@@ -102,8 +112,9 @@ class VetTecApprovedProgramsList extends React.Component {
       return (
         <tr key={`${index}-table`}>
           <th
+            tabIndex="-1"
             scope="row"
-            className="vads-u-padding-left--0 vads-l-grid-container"
+            className="vads-u-padding-left--0 vads-l-grid-container program-description-header"
           >
             <div className="program-description vads-l-row">
               {this.programDescription(program, 'vads-l-col--10')}


### PR DESCRIPTION
## Description
https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/9953

This is specific to VETTEC Approved Programs table and School Locations table on the profile page. 

## Testing done
Dev tested.

## Screenshots
Note: Yellow box indicates the current focused element. 
![image](https://user-images.githubusercontent.com/48804654/84178494-81cda680-aa52-11ea-90c7-52478aa5b071.png)

![image](https://user-images.githubusercontent.com/48804654/84178585-a9bd0a00-aa52-11ea-9f9a-62ee83dd0d08.png)


## Acceptance criteria
- [x] Focus is set on the first link or text of the first added row
- [x]  Screen readers announce the added item properly. This will probably be only the first cell of information, but should give screen reader users an understanding things have changed.
- [x] Tables should announce the correct number of rows after appending the new rows
- [x] No axe errors when the axe plugin is run or CI/CD axe checks are run

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
