### PR TITLE
9980: Validation for postal code is ignored on update benefits selection

### DIFF
--- a/src/applications/gi/components/profile/EstimateYourBenefitsForm.jsx
+++ b/src/applications/gi/components/profile/EstimateYourBenefitsForm.jsx
@@ -107,7 +107,7 @@ class EstimateYourBenefitsForm extends React.Component {
     } = this.props.inputs;
     if (
       this.props.eligibility.giBillChapter === '33' &&
-      extension === 'other' &&
+      this.props.inputs.beneficiaryLocationQuestion === 'other' &&
       !classesOutsideUS &&
       (beneficiaryZIPError || beneficiaryZIP.length !== 5)
     ) {

--- a/src/applications/gi/tests/components/EstimateYourBenefitsForm.unit.spec.jsx
+++ b/src/applications/gi/tests/components/EstimateYourBenefitsForm.unit.spec.jsx
@@ -161,7 +161,7 @@ describe('<EstimateYourBenefitsForm>', () => {
 
   it('should not invoke updateEstimatedBenefits on "Update benefits" click, with invalid data', () => {
     const validInput = {
-      extension: 'other',
+      beneficiaryLocationQuestion: 'other',
       beneficiaryZIP: '#',
     };
     const updateEstimatedBenefits = sinon.spy();


### PR DESCRIPTION
## Description
Steps to reproduce:

Navigate to https://staging.va.gov/gi-bill-comparison-tool/profile/11929140
Expand Learning format and location accordion
Select Other location under Where will you take the majority of your classes? (Learn more)
Enter in an invalid postal code
Make another change to tuition under School costs and calendar
Select update benefits
Observe that your estimated benefits is updated and Learning format and location doesn't expand to show the validation error

[Originating Issue](https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/9980)

## Testing done
Testing passes locally

## Screenshots
N/A

## Acceptance criteria
- [x] Issue is resolved

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
