### PR TITLE
Add FHIR service and transformer for appointment request

### DIFF
--- a/src/applications/vaos/services/appointment/index.js
+++ b/src/applications/vaos/services/appointment/index.js
@@ -1,6 +1,9 @@
 import moment from 'moment';
-import { getConfirmedAppointments } from '../../api';
-import { transformConfirmedAppointments } from './transformers';
+import { getConfirmedAppointments, getPendingAppointments } from '../../api';
+import {
+  transformConfirmedAppointments,
+  transformPendingAppointments,
+} from './transformers';
 import { mapToFHIRErrors } from '../../utils/fhir';
 import { APPOINTMENT_TYPES } from '../../utils/constants';
 
@@ -10,7 +13,7 @@ import { APPOINTMENT_TYPES } from '../../utils/constants';
  * @export
  * @param {String} startDate Date in YYYY-MM-DD format
  * @param {String} endDate Date in YYYY-MM-DD format
- * @returns {Object} A FHIR searchset of Appointment resources
+ * @returns {Object} A FHIR searchset of booked Appointment resources
  */
 export async function getBookedAppointments({ startDate, endDate }) {
   try {
@@ -27,6 +30,28 @@ export async function getBookedAppointments({ startDate, endDate }) {
       ...appointments[0],
       ...appointments[1],
     ]);
+  } catch (e) {
+    if (e.errors) {
+      throw mapToFHIRErrors(e.errors);
+    }
+
+    throw e;
+  }
+}
+
+/**
+ * Fetch the logged in user's pending appointments that fall between a startDate and endDate
+ *
+ * @export
+ * @param {String} startDate Date in YYYY-MM-DD format
+ * @param {String} endDate Date in YYYY-MM-DD format
+ * @returns {Object} A FHIR searchset of pending Appointment resources
+ */
+export async function getAppointmentRequests({ startDate, endDate }) {
+  try {
+    const appointments = await getPendingAppointments(startDate, endDate);
+
+    return transformPendingAppointments(appointments);
   } catch (e) {
     if (e.errors) {
       throw mapToFHIRErrors(e.errors);

--- a/src/applications/vaos/services/appointment/transformers.js
+++ b/src/applications/vaos/services/appointment/transformers.js
@@ -262,8 +262,8 @@ function setParticipant(appt) {
   switch (type) {
     case APPOINTMENT_TYPES.vaAppointment: {
       if (!isVideoVisit(appt)) {
-        const participants = [];
-        participants.push({
+        const participant = [];
+        participant.push({
           actor: {
             reference: `HealthcareService/var${appt.facilityId}_${
               appt.clinicId
@@ -275,14 +275,14 @@ function setParticipant(appt) {
         });
 
         if (appt.sta6aid) {
-          participants.push({
+          participant.push({
             actor: {
               reference: `Location/var${appt.sta6aid}`,
             },
           });
         }
 
-        return participants;
+        return participant;
       }
       return null;
     }
@@ -300,20 +300,39 @@ function setParticipant(appt) {
       return null;
     }
     case APPOINTMENT_TYPES.request: {
-      if (appt.facility) {
-        return [
-          {
-            actor: {
-              reference: `HealthcareService/var${
-                appt.facility.parentSiteCode
-              }_${appt.facility.facilityCode}`,
-              display: appt.friendlyLocationName || appt.facility?.name,
-            },
+      const participant = [
+        {
+          actor: {
+            reference: 'Patient/PATIENT_ID',
+            display:
+              appt.patient?.displayName ||
+              `${appt.patient?.firstName} ${appt.patient?.lastName}`,
+            telecom: [
+              {
+                system: 'phone',
+                value: appt.phoneNumber,
+              },
+              {
+                system: 'email',
+                value: appt.email,
+              },
+            ],
           },
-        ];
+        },
+      ];
+
+      if (appt.facility) {
+        participant.push({
+          actor: {
+            reference: `HealthcareService/var${appt.facility.parentSiteCode}_${
+              appt.facility.facilityCode
+            }`,
+            display: appt.friendlyLocationName || appt.facility?.name,
+          },
+        });
       }
 
-      return null;
+      return participant;
     }
     default:
       return null;
@@ -471,7 +490,6 @@ export function transformPendingAppointments(requests) {
         isCommunityCare: isCC,
         dateOptions: getRequestDateOptions(appt),
         bestTimeToCall: appt.bestTimetoCall,
-        patientPhone: appt.phoneNumber,
       },
     };
   });

--- a/src/applications/vaos/services/appointment/transformers.js
+++ b/src/applications/vaos/services/appointment/transformers.js
@@ -1,5 +1,6 @@
 import moment from '../../utils/moment-tz';
 
+import titleCase from 'platform/utilities/data/titleCase';
 import {
   APPOINTMENT_STATUS,
   APPOINTMENT_TYPES,
@@ -185,7 +186,7 @@ function getVideoVisitLink(appt) {
  * Returns appointment duration in minutes. The default is 60 minutes.
  *
  * @param {Object} appt VAR appointment object
- * @returns
+ * @returns {Number} appointment duration in minutes
  */
 function getAppointmentDuration(appt) {
   const appointmentLength = parseInt(
@@ -196,6 +197,12 @@ function getAppointmentDuration(appt) {
   return isNaN(appointmentLength) ? 60 : appointmentLength;
 }
 
+/**
+ * Gets a purpose of visit that matches our array of purpose constant
+ *
+ * @param {Object} appt VAR appointment object
+ * @returns {String} purpose of visit string
+ */
 function getPurposeOfVisit(appt) {
   switch (getAppointmentType(appt)) {
     case APPOINTMENT_TYPES.ccRequest:
@@ -210,6 +217,12 @@ function getPurposeOfVisit(appt) {
   }
 }
 
+/**
+ * Returns formatted user selected Date, AM/PM date options in an array
+ *
+ * @param {Object} appt VAR appointment object
+ * @returns {Array} returns formatted date options
+ */
 function getRequestDateOptions(appt) {
   const format = 'MM/DD/YYYY';
   return [
@@ -457,7 +470,7 @@ export function transformPendingAppointments(requests) {
         appointmentType: getAppointmentType(appt),
         isCommunityCare: isCC,
         dateOptions: getRequestDateOptions(appt),
-        bestTimeToCall: appt.bestTimeToCall,
+        bestTimeToCall: appt.bestTimetoCall,
         patientPhone: appt.phoneNumber,
       },
     };

--- a/src/applications/vaos/services/appointment/transformers.js
+++ b/src/applications/vaos/services/appointment/transformers.js
@@ -248,9 +248,7 @@ function getRequestedPeriods(appt) {
     }
   }
 
-  return requestedPeriods.sort(
-    (a, b) => (moment(a.start).isBefore(moment(b.start)) ? -1 : 1),
-  );
+  return requestedPeriods.sort((a, b) => (a.start < b.start ? -1 : 1));
 }
 
 /**

--- a/src/applications/vaos/services/appointment/transformers.js
+++ b/src/applications/vaos/services/appointment/transformers.js
@@ -300,13 +300,18 @@ function setParticipant(appt) {
       return null;
     }
     case APPOINTMENT_TYPES.request: {
+      const hasName =
+        appt.patient?.displayName ||
+        (!!appt.patient?.firstName && !!appt.patient?.lastName);
+
       const participant = [
         {
           actor: {
             reference: 'Patient/PATIENT_ID',
-            display:
-              appt.patient?.displayName ||
-              `${appt.patient?.firstName} ${appt.patient?.lastName}`,
+            display: hasName
+              ? appt.patient?.displayName ||
+                `${appt.patient?.firstName} ${appt.patient?.lastName}`
+              : null,
             telecom: [
               {
                 system: 'phone',

--- a/src/applications/vaos/tests/services/appointment/index.unit.spec.js
+++ b/src/applications/vaos/tests/services/appointment/index.unit.spec.js
@@ -6,8 +6,12 @@ import {
   setFetchJSONFailure,
 } from 'platform/testing/unit/helpers';
 
-import { getBookedAppointments } from '../../../services/appointment';
+import {
+  getBookedAppointments,
+  getAppointmentRequests,
+} from '../../../services/appointment';
 import confirmed from '../../../api/confirmed_va.json';
+import requests from '../../../api/requests.json';
 
 describe('VAOS Appointment service', () => {
   describe('getBookedAppointments', () => {
@@ -59,6 +63,50 @@ describe('VAOS Appointment service', () => {
       );
       expect(global.fetch.secondCall.args[0]).to.contain(
         '/vaos/v0/appointments?start_date=2020-05-01&end_date=2020-06-30&type=cc',
+      );
+      expect(error?.resourceType).to.equal('OperationOutcome');
+    });
+  });
+
+  describe('getAppointmentRequests', () => {
+    it('should make successful request', async () => {
+      mockFetch();
+      setFetchJSONResponse(global.fetch, requests);
+
+      const startDate = '2020-05-01';
+      const endDate = '2020-06-30';
+
+      const data = await getAppointmentRequests({
+        startDate,
+        endDate,
+      });
+
+      expect(global.fetch.firstCall.args[0]).to.contain(
+        '/vaos/v0/appointment_requests?start_date=2020-05-01&end_date=2020-06-30',
+      );
+      expect(data[0].status).to.equal('pending');
+    });
+
+    it('should return OperationOutcome error', async () => {
+      mockFetch();
+      setFetchJSONFailure(global.fetch, {
+        errors: [],
+      });
+      const startDate = '2020-05-01';
+      const endDate = '2020-06-30';
+
+      let error;
+      try {
+        await getAppointmentRequests({
+          startDate,
+          endDate,
+        });
+      } catch (e) {
+        error = e;
+      }
+
+      expect(global.fetch.firstCall.args[0]).to.contain(
+        '/vaos/v0/appointment_requests?start_date=2020-05-01&end_date=2020-06-30',
       );
       expect(error?.resourceType).to.equal('OperationOutcome');
     });

--- a/src/applications/vaos/tests/services/appointment/transformers.unit.spec.js
+++ b/src/applications/vaos/tests/services/appointment/transformers.unit.spec.js
@@ -441,6 +441,10 @@ describe('VAOS Appointment transformer', () => {
         expect(data.vaos.dateOptions[0].optionTime).to.equal('AM');
         expect(data.vaos.dateOptions.length).to.equal(3);
       });
+
+      it('should set bestTimeToCall', () => {
+        expect(data.vaos.bestTimeToCall).to.deep.equal(['Morning']);
+      });
     });
 
     describe('isPastAppointment', () => {

--- a/src/applications/vaos/tests/services/appointment/transformers.unit.spec.js
+++ b/src/applications/vaos/tests/services/appointment/transformers.unit.spec.js
@@ -481,12 +481,17 @@ describe('VAOS Appointment transformer', () => {
         expect(data.legacyVAR.bestTimeToCall).to.deep.equal(['Morning']);
       });
 
-      it('should set express care reasonForVisit', () => {
+      it('should set isExpressCare to false', () => {
+        expect(data.vaos.isExpressCare).to.equal(false);
+      });
+
+      it('should set express care reasonForVisit and isExpressCare', () => {
         const expressData = transformPendingAppointments([
           { ...vaRequest, typeOfCareId: 'CR1', reasonForVisit: 'some reason' },
-        ]);
+        ])[0];
 
-        expect(expressData[0].reason).to.equal('some reason');
+        expect(expressData.reason).to.equal('some reason');
+        expect(expressData.vaos.isExpressCare).to.equal(true);
       });
     });
 

--- a/src/applications/vaos/tests/services/appointment/transformers.unit.spec.js
+++ b/src/applications/vaos/tests/services/appointment/transformers.unit.spec.js
@@ -143,6 +143,7 @@ const vaRequest = {
     parentSiteCode: '983',
   },
   patient: {
+    displayName: 'MORRISON, JUDY',
     inpatient: false,
     textMessagingAllowed: false,
   },
@@ -428,6 +429,7 @@ describe('VAOS Appointment transformer', () => {
         const patientActor = data.participant.filter(p =>
           p.actor.reference.includes('Patient'),
         )[0];
+        expect(patientActor.actor.display).to.equal('MORRISON, JUDY');
         const telecomPhone = patientActor.actor.telecom.filter(
           t => t.system === 'phone',
         )[0];

--- a/src/applications/vaos/tests/services/appointment/transformers.unit.spec.js
+++ b/src/applications/vaos/tests/services/appointment/transformers.unit.spec.js
@@ -8,7 +8,10 @@ import {
   PAST_APPOINTMENTS_HIDE_STATUS_SET,
   FUTURE_APPOINTMENTS_HIDE_STATUS_SET,
 } from '../../../utils/constants';
-import { transformConfirmedAppointments } from '../../../services/appointment/transformers';
+import {
+  transformConfirmedAppointments,
+  transformPendingAppointments,
+} from '../../../services/appointment/transformers';
 
 const appt = {
   id: '22cdc6741c00ac67b6cbf6b972d084c0',
@@ -123,6 +126,58 @@ const videoAppt = {
       ],
     },
   ],
+};
+
+const now = moment();
+
+const vaRequest = {
+  id: '8a4829dc7281184e017285000ab700cf',
+  type: 'appointment_requests',
+  facility: {
+    type: null,
+    address: null,
+    name: 'CHYSHR-Cheyenne VA Medical Center',
+    facilityCode: '983',
+    state: 'WY',
+    city: 'Cheyenne',
+    parentSiteCode: '983',
+  },
+  patient: {
+    inpatient: false,
+    textMessagingAllowed: false,
+  },
+  lastUpdatedAt: null,
+  createdDate: '06/05/2020 09:01:11',
+  appointmentDate: '06/17/2020',
+  appointmentTime: 'AM',
+  optionDate1: now,
+  optionTime1: 'PM',
+  optionDate2: now,
+  optionTime2: 'AM',
+  optionDate3: moment().add(1, 'days'),
+  optionTime3: 'PM',
+  status: 'Booked',
+  appointmentType: 'Primary Care',
+  visitType: 'Office Visit',
+  reasonForVisit: null,
+  email: 'aarathi.poldass@va.gov',
+  textMessagingAllowed: false,
+  phoneNumber: '(999) 999-9999',
+  purposeOfVisit: 'New Issue',
+  providerId: '0',
+  secondRequest: false,
+  secondRequestSubmitted: false,
+  bestTimetoCall: ['Morning'],
+  hasVeteranNewMessage: true,
+  hasProviderNewMessage: false,
+  providerSeenAppointmentRequest: true,
+  requestedPhoneCall: false,
+  bookedApptDateTime: '06/17/2020 14:00:00',
+  typeOfCareId: '323',
+  friendlyLocationName: 'CHYSHR-Cheyenne VA Medical Center',
+  ccAppointmentRequest: null,
+  date: '2020-06-05T09:01:11.000+0000',
+  assigningAuthority: 'ICN',
 };
 
 describe('VAOS Appointment transformer', () => {
@@ -331,6 +386,60 @@ describe('VAOS Appointment transformer', () => {
           },
         ])[0];
         expect(gfeData.vaos.videoType).to.equal(VIDEO_TYPES.gfe);
+      });
+    });
+
+    describe('VA Request', () => {
+      const data = transformPendingAppointments([vaRequest])[0];
+
+      it('should set resourceType', () => {
+        expect(data.resourceType).to.equal('Appointment');
+      });
+
+      it('should set id', () => {
+        expect(data.id).to.equal('var8a4829dc7281184e017285000ab700cf');
+      });
+
+      it('should set status to "pending"', () => {
+        expect(data.status).to.equal(APPOINTMENT_STATUS.pending);
+      });
+
+      it('should set minutesDuration', () => {
+        expect(data.minutesDuration).to.equal(60);
+      });
+
+      it('should set reason', () => {
+        expect(data.reason).to.equal('New issue');
+      });
+
+      it('should set facility as Location in participants', () => {
+        expect(data.participant[0].actor.reference).to.equal(
+          'HealthcareService/var983_983',
+        );
+        expect(data.participant[0].actor.display).to.equal(
+          'CHYSHR-Cheyenne VA Medical Center',
+        );
+      });
+
+      it('should return vaos.isPastAppointment', () => {
+        expect(data.vaos.isPastAppointment).to.equal(false);
+      });
+
+      it('should return vaos.isCommunityCare', () => {
+        expect(data.vaos.isCommunityCare).to.equal(false);
+      });
+
+      it('should return vaos.appointmentType', () => {
+        expect(data.vaos.appointmentType).to.equal(APPOINTMENT_TYPES.request);
+      });
+
+      it('should not return vaos.videoType', () => {
+        expect(data.vaos.videoType).to.equal(undefined);
+      });
+
+      it('should set dateOptions', () => {
+        expect(data.vaos.dateOptions[0].optionTime).to.equal('AM');
+        expect(data.vaos.dateOptions.length).to.equal(3);
       });
     });
 

--- a/src/applications/vaos/tests/services/appointment/transformers.unit.spec.js
+++ b/src/applications/vaos/tests/services/appointment/transformers.unit.spec.js
@@ -413,12 +413,29 @@ describe('VAOS Appointment transformer', () => {
       });
 
       it('should set facility as Location in participants', () => {
-        expect(data.participant[0].actor.reference).to.equal(
+        const healthcareActor = data.participant.filter(p =>
+          p.actor.reference.includes('HealthcareService'),
+        )[0];
+        expect(healthcareActor.actor.reference).to.equal(
           'HealthcareService/var983_983',
         );
-        expect(data.participant[0].actor.display).to.equal(
+        expect(healthcareActor.actor.display).to.equal(
           'CHYSHR-Cheyenne VA Medical Center',
         );
+      });
+
+      it('should set patient info in participants', () => {
+        const patientActor = data.participant.filter(p =>
+          p.actor.reference.includes('Patient'),
+        )[0];
+        const telecomPhone = patientActor.actor.telecom.filter(
+          t => t.system === 'phone',
+        )[0];
+        expect(telecomPhone.value).to.equal('(999) 999-9999');
+        const telecomEmail = patientActor.actor.telecom.filter(
+          t => t.system === 'email',
+        )[0];
+        expect(telecomEmail.value).to.equal('aarathi.poldass@va.gov');
       });
 
       it('should return vaos.isPastAppointment', () => {

--- a/src/applications/vaos/tests/services/appointment/transformers.unit.spec.js
+++ b/src/applications/vaos/tests/services/appointment/transformers.unit.spec.js
@@ -480,6 +480,14 @@ describe('VAOS Appointment transformer', () => {
       it('should set bestTimeToCall', () => {
         expect(data.legacyVAR.bestTimeToCall).to.deep.equal(['Morning']);
       });
+
+      it('should set express care reasonForVisit', () => {
+        const expressData = transformPendingAppointments([
+          { ...vaRequest, typeOfCareId: 'CR1', reasonForVisit: 'some reason' },
+        ]);
+
+        expect(expressData[0].reason).to.equal('some reason');
+      });
     });
 
     describe('isPastAppointment', () => {

--- a/src/applications/vaos/tests/services/appointment/transformers.unit.spec.js
+++ b/src/applications/vaos/tests/services/appointment/transformers.unit.spec.js
@@ -129,6 +129,7 @@ const videoAppt = {
 };
 
 const now = moment();
+const tomorrow = moment().add(1, 'days');
 
 const vaRequest = {
   id: '8a4829dc7281184e017285000ab700cf',
@@ -151,12 +152,12 @@ const vaRequest = {
   createdDate: '06/05/2020 09:01:11',
   appointmentDate: '06/17/2020',
   appointmentTime: 'AM',
-  optionDate1: now,
+  optionDate1: tomorrow,
   optionTime1: 'PM',
-  optionDate2: now,
+  optionDate2: tomorrow,
   optionTime2: 'AM',
-  optionDate3: moment().add(1, 'days'),
-  optionTime3: 'PM',
+  optionDate3: now,
+  optionTime3: 'AM',
   status: 'Booked',
   appointmentType: 'Primary Care',
   visitType: 'Office Visit',
@@ -414,13 +415,11 @@ describe('VAOS Appointment transformer', () => {
       });
 
       it('should set facility as Location in participants', () => {
-        const healthcareActor = data.participant.filter(p =>
-          p.actor.reference.includes('HealthcareService'),
+        const locationActor = data.participant.filter(p =>
+          p.actor.reference.includes('Location'),
         )[0];
-        expect(healthcareActor.actor.reference).to.equal(
-          'HealthcareService/var983_983',
-        );
-        expect(healthcareActor.actor.display).to.equal(
+        expect(locationActor.actor.reference).to.equal('Location/var983');
+        expect(locationActor.actor.display).to.equal(
           'CHYSHR-Cheyenne VA Medical Center',
         );
       });
@@ -456,13 +455,30 @@ describe('VAOS Appointment transformer', () => {
         expect(data.vaos.videoType).to.equal(undefined);
       });
 
-      it('should set dateOptions', () => {
-        expect(data.vaos.dateOptions[0].optionTime).to.equal('AM');
-        expect(data.vaos.dateOptions.length).to.equal(3);
+      it('should set requestedPeriods', () => {
+        expect(data.requestedPeriod.length).to.equal(3);
+        expect(data.requestedPeriod[0].start).to.equal(
+          `${now.format('YYYY-MM-DD')}T00:00:00.000Z`,
+        );
+        expect(data.requestedPeriod[0].end).to.equal(
+          `${now.format('YYYY-MM-DD')}T11:59:99.999Z`,
+        );
+        expect(data.requestedPeriod[1].start).to.equal(
+          `${tomorrow.format('YYYY-MM-DD')}T00:00:00.000Z`,
+        );
+        expect(data.requestedPeriod[1].end).to.equal(
+          `${tomorrow.format('YYYY-MM-DD')}T11:59:99.999Z`,
+        );
+        expect(data.requestedPeriod[2].start).to.equal(
+          `${tomorrow.format('YYYY-MM-DD')}T12:00:00.000Z`,
+        );
+        expect(data.requestedPeriod[2].end).to.equal(
+          `${tomorrow.format('YYYY-MM-DD')}T23:59:99.999Z`,
+        );
       });
 
       it('should set bestTimeToCall', () => {
-        expect(data.vaos.bestTimeToCall).to.deep.equal(['Morning']);
+        expect(data.legacyVAR.bestTimeToCall).to.deep.equal(['Morning']);
       });
     });
 

--- a/src/applications/vaos/utils/constants.js
+++ b/src/applications/vaos/utils/constants.js
@@ -327,6 +327,7 @@ export const CALENDAR_INDICATOR_TYPES = {
 export const DISABLED_LIMIT_VALUE = 0;
 export const PRIMARY_CARE = '323';
 export const MENTAL_HEALTH = '502';
+export const EXPRESS_CARE = 'CR1';
 
 export const GA_PREFIX = 'vaos';
 export const GA_FLOWS = {


### PR DESCRIPTION
## Description
Maps VA appointment request into FHIR format.  There are still some unknowns that I've stuck into the vaos field such as dateOptions and bestTimetoCall.  Here is an example of a transformed request:

```
{
  "resourceType": "Appointment",
  "id": "var8a4829dc7281184e017285000ab700cf",
  "status": "pending",
  "minutesDuration": 60,
  "type": {
    "coding": [
      {
        "code": "Primary Care"
      }
    ]
  },
  "reason": "New issue",
  "participant": [
    {
      "actor": {
        "reference": "Patient/PATIENT_ID",
        "display": "MORRISON, JUDY",
        "telecom": [
          {
            "system": "phone",
            "value": "(999) 999-9999"
          },
          {
            "system": "email",
            "value": "aarathi.poldass@va.gov"
          }
        ]
      }
    },
    {
      "actor": {
        "reference": "HealthcareService/var983_983",
        "display": "CHYSHR-Cheyenne VA Medical Center"
      }
    }
  ],
  "contained": null,
  "legacyVAR": {
    "apiData": {...}
  },
  "vaos": {
    "isPastAppointment": false,
    "appointmentType": "request",
    "isCommunityCare": false,
    "dateOptions": [
      {
        "date": "2020-06-10T16:47:37.114Z",
        "optionTime": "AM"
      },
      {
        "date": "2020-06-10T16:47:37.114Z",
        "optionTime": "PM"
      },
      {
        "date": "2020-06-11T16:47:37.115Z",
        "optionTime": "PM"
      }
    ],
    "bestTimeToCall": [
      "Morning"
    ]
  }
}
```

## Testing done
Local and unit


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
