### PR TITLE
Remove redirect

### DIFF
--- a/src/applications/proxy-rewrite/redirects/crossDomainRedirects.json
+++ b/src/applications/proxy-rewrite/redirects/crossDomainRedirects.json
@@ -566,11 +566,6 @@
   },
   {
     "domain": "www.benefits.va.gov",
-    "src": "/compensation/add-dependents.asp",
-    "dest": "/disability/add-remove-dependent/"
-  },
-  {
-    "domain": "www.benefits.va.gov",
     "src": "/gibill/education_programs.asp",
     "dest": "/education/"
   },


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/10026

This PR removes the following redirect:

https://benefits.va.gov/compensation/add-dependents.asp -> https://www.va.gov/disability/add-remove-dependent/

## Testing done
N/A

## Screenshots
N/A

## Acceptance criteria
- [x] Remove redirect.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
