### PR TITLE
Use the useLocation hook in Profile2Wrapper

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,6 +121,7 @@
     "@department-of-veterans-affairs/generator-vets-website": "^3.3.5",
     "@octokit/rest": "^16.43.1",
     "@sentry/browser": "^5.4.0",
+    "@testing-library/react": "^10.2.1",
     "ajv": "^6.12.2",
     "append-query": "2.0.1",
     "ascii-table": "^0.0.9",

--- a/src/applications/personalization/profile-2/components/Profile2Wrapper.jsx
+++ b/src/applications/personalization/profile-2/components/Profile2Wrapper.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Link } from 'react-router';
+import { Link, useLocation } from 'react-router-dom';
 import Breadcrumbs from '@department-of-veterans-affairs/formation-react/Breadcrumbs';
 import { isWideScreen } from 'platform/utilities/accessibility/index';
 
@@ -8,7 +8,8 @@ import ProfileHeader from './ProfileHeader';
 import ProfileSideNav from './ProfileSideNav';
 import MobileMenuTrigger from './MobileMenuTrigger';
 
-const Profile2 = ({ children, location, routes }) => {
+const Profile2 = ({ children, routes }) => {
+  const location = useLocation();
   const createBreadCrumbAttributes = () => {
     const activeLocation = location?.pathname;
     const activeRoute = routes.find(route => route.path === activeLocation);
@@ -20,16 +21,18 @@ const Profile2 = ({ children, location, routes }) => {
 
   // We do not want to display 'Profile' on the mobile personal-information route
   const onPersonalInformationMobile =
-    location?.pathname === '/personal-information' && !isWideScreen();
+    activeLocation === '/profile/personal-information' && !isWideScreen();
 
   return (
     <>
       {/* Breadcrumbs */}
-      <Breadcrumbs className="vads-u-padding-x--1 vads-u-padding-y--1p5 medium-screen:vads-u-padding-y--0">
-        <a href="/">Home</a>
-        {!onPersonalInformationMobile && <Link to="/">Your profile</Link>}
-        <a href={activeLocation}>{activeRouteName}</a>
-      </Breadcrumbs>
+      <div data-testid="breadcrumbs">
+        <Breadcrumbs className="vads-u-padding-x--1 vads-u-padding-y--1p5 medium-screen:vads-u-padding-y--0">
+          <a href="/">Home</a>
+          {!onPersonalInformationMobile && <Link to="/">Your profile</Link>}
+          <a href={activeLocation}>{activeRouteName}</a>
+        </Breadcrumbs>
+      </div>
 
       <MobileMenuTrigger />
 

--- a/src/applications/personalization/profile-2/tests/components/Profile2.unit.spec.js
+++ b/src/applications/personalization/profile-2/tests/components/Profile2.unit.spec.js
@@ -1,38 +1,24 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { MemoryRouter } from 'react-router-dom';
 import { expect } from 'chai';
 
 import Profile2 from '../../components/Profile2Wrapper';
 import getRoutes from '../../routes';
 
+import { renderWithProfileReducers as render } from '../unit-test-helpers.spec';
+
 describe('Profile2', () => {
-  let defaultProps;
-
-  beforeEach(() => {
-    defaultProps = {
-      location: {
-        pathname: '/profile/personal-information',
-      },
-      routes: getRoutes(),
-    };
-  });
-
-  it('should render BreadCrumbs', () => {
-    const wrapper = shallow(<Profile2 {...defaultProps} />);
-    expect(wrapper.find('Breadcrumbs')).to.have.lengthOf(1);
-    wrapper.unmount();
-  });
-
   it('should render the correct breadcrumb (Personal and contact Information)', () => {
-    const wrapper = shallow(<Profile2 {...defaultProps} />);
-    const BreadCrumbs = wrapper.find('Breadcrumbs');
-    const activeRouteText = BreadCrumbs.find('a')
-      .last()
-      .text();
-
-    expect(activeRouteText.toLowerCase()).to.include(
-      'personal and contact information',
+    const ui = (
+      <MemoryRouter initialEntries={['/profile/personal-information']}>
+        <Profile2 routes={getRoutes()} />
+      </MemoryRouter>
     );
-    wrapper.unmount();
+    const { getByTestId } = render(ui);
+
+    const breadcrumbs = getByTestId('breadcrumbs');
+
+    expect(breadcrumbs.textContent.match(/personal and contact information/i))
+      .not.to.be.null;
   });
 });

--- a/src/applications/personalization/profile-2/tests/unit-test-helpers.spec.js
+++ b/src/applications/personalization/profile-2/tests/unit-test-helpers.spec.js
@@ -1,0 +1,22 @@
+import { renderInReduxProvider } from 'platform/testing/unit/react-testing-library-helpers';
+
+import profile from 'applications/personalization/profile360/reducers';
+import connectedApps from 'applications/personalization/profile-2/components/connected-apps/reducers/connectedApps';
+import profileUi from '../reducers';
+
+/**
+ * A custom React Testing Library render function that allows for easy rendering
+ * of Profile-related components. This helper sets up the reducers used by the
+ * Profile application, as shown in the profile entry file
+ * src/applications/personalization/profile360/profile-360-entry.jsx
+ */
+export function renderWithProfileReducers(
+  ui,
+  { initialState = {}, reducers = {}, ...renderOptions } = {},
+) {
+  return renderInReduxProvider(ui, {
+    reducers: { profile, profileUi, connectedApps, ...reducers },
+    initialState,
+    ...renderOptions,
+  });
+}

--- a/src/platform/testing/unit/react-testing-library-helpers.js
+++ b/src/platform/testing/unit/react-testing-library-helpers.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+import { combineReducers, applyMiddleware, createStore } from 'redux';
+import thunk from 'redux-thunk';
+import { render as rtlRender } from '@testing-library/react';
+
+import { commonReducer } from 'platform/startup/store';
+
+/**
+ * A custom React Testing Library render function that wraps the desired
+ * UI/component in a Redux Provider. This allows for easy testing of
+ * Redux-connected components. Adding the thunk middleware allows for writing
+ * integration tests that rely on async Redux actions.
+ *
+ * Based on the [custom render function described in the official
+ * docs](https://testing-library.com/docs/example-react-redux), but with the
+ * ability to customize the reducers and initial state via the options param.
+ */
+export function renderInReduxProvider(
+  ui,
+  { initialState = {}, reducers = {}, ...renderOptions } = {},
+) {
+  const store = createStore(
+    combineReducers({ ...commonReducer, ...reducers }),
+    initialState,
+    applyMiddleware(thunk),
+  );
+  const Wrapper = ({ children }) => {
+    return <Provider store={store}>{children}</Provider>;
+  };
+  return rtlRender(ui, { wrapper: Wrapper, ...renderOptions });
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -973,6 +973,14 @@
     pirates "^4.0.0"
     source-map-support "^0.5.16"
 
+"@babel/runtime-corejs3@^7.7.4":
+  version "7.10.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime-corejs3/-/runtime-corejs3-7.10.2.tgz#3511797ddf9a3d6f3ce46b99cc835184817eaa4e"
+  integrity sha512-+a2M/u7r15o3dV1NEizr9bRi+KUVnrs/qYxF0Z06DAPx/4VCWaz1WA7EcbE+uqGgt39lp5akWGmHsTseIkHkHg==
+  dependencies:
+    core-js-pure "^3.0.0"
+    regenerator-runtime "^0.13.4"
+
 "@babel/runtime-corejs3@^7.8.3":
   version "7.9.6"
   resolved "https://registry.yarnpkg.com/@babel/runtime-corejs3/-/runtime-corejs3-7.9.6.tgz#67aded13fffbbc2cb93247388cf84d77a4be9a71"
@@ -994,6 +1002,13 @@
   dependencies:
     regenerator-runtime "^0.12.0"
 
+"@babel/runtime@^7.10.2", "@babel/runtime@^7.7.4", "@babel/runtime@^7.9.2":
+  version "7.10.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.10.2.tgz#d103f21f2602497d38348a32e008637d506db839"
+  integrity sha512-6sF3uQw2ivImfVIl62RZ7MXhO2tap69WeWK57vAaimT6AZbE4FbqjdEJIN1UqoD6wI6B+1n9UiagafH1sxjOtg==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/runtime@^7.4.5":
   version "7.5.5"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.5.5.tgz#74fba56d35efbeca444091c7850ccd494fd2f132"
@@ -1005,13 +1020,6 @@
   version "7.10.1"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.10.1.tgz#b6eb75cac279588d3100baecd1b9894ea2840822"
   integrity sha512-nQbbCbQc9u/rpg1XCxoMYQTbSMVZjCDxErQ1ClCn9Pvcmv1lGads19ep0a2VsEiIJeHqjZley6EQGEC3Yo1xMA==
-  dependencies:
-    regenerator-runtime "^0.13.4"
-
-"@babel/runtime@^7.9.2":
-  version "7.10.2"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.10.2.tgz#d103f21f2602497d38348a32e008637d506db839"
-  integrity sha512-6sF3uQw2ivImfVIl62RZ7MXhO2tap69WeWK57vAaimT6AZbE4FbqjdEJIN1UqoD6wI6B+1n9UiagafH1sxjOtg==
   dependencies:
     regenerator-runtime "^0.13.4"
 
@@ -1155,6 +1163,16 @@
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/@istanbuljs/schema/-/schema-0.1.2.tgz#26520bf09abe4a5644cd5414e37125a8954241dd"
   integrity sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw==
+
+"@jest/types@^25.5.0":
+  version "25.5.0"
+  resolved "https://registry.yarnpkg.com/@jest/types/-/types-25.5.0.tgz#4d6a4793f7b9599fc3680877b856a97dbccf2a9d"
+  integrity sha512-OXD0RgQ86Tu3MazKo8bnrkDRaDXXMGUqd+kTtLtK1Zb7CRzQcaSRPPPV37SvYTdevXEBVxe0HXylEjs8ibkmCw==
+  dependencies:
+    "@types/istanbul-lib-coverage" "^2.0.0"
+    "@types/istanbul-reports" "^1.1.1"
+    "@types/yargs" "^15.0.0"
+    chalk "^3.0.0"
 
 "@mapbox/fusspot@^0.4.0":
   version "0.4.0"
@@ -1376,6 +1394,24 @@
   resolved "https://registry.yarnpkg.com/@testim/chrome-version/-/chrome-version-1.0.7.tgz#0cd915785ec4190f08a3a6acc9b61fc38fb5f1a9"
   integrity sha512-8UT/J+xqCYfn3fKtOznAibsHpiuDshCb0fwgWxRazTT19Igp9ovoXMPhXyLD6m3CKQGTMHgqoxaFfMWaL40Rnw==
 
+"@testing-library/dom@^7.9.0":
+  version "7.11.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-7.11.0.tgz#db8678bc55aef7cd6091d1510e8d0949d77d79fd"
+  integrity sha512-2j+zfA6dwnzozReA2XrbZs3e9DD9UdetONrWmumIY2QdGH0h08hRW+SaLE8kIytM6KPO5yzypHZhK5AZNFEtiw==
+  dependencies:
+    "@babel/runtime" "^7.10.2"
+    aria-query "^4.0.2"
+    dom-accessibility-api "^0.4.5"
+    pretty-format "^25.5.0"
+
+"@testing-library/react@^10.2.1":
+  version "10.2.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-10.2.1.tgz#f0c5ac9072ad54c29672150943f35d6617263f26"
+  integrity sha512-pv2jZhiZgN1/alz1aImhSasZAOPg3er2Kgcfg9fzuw7aKPLxVengqqR1n0CJANeErR1DqORauQaod+gGUgAJOQ==
+  dependencies:
+    "@babel/runtime" "^7.10.2"
+    "@testing-library/dom" "^7.9.0"
+
 "@types/anymatch@*":
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/@types/anymatch/-/anymatch-1.3.1.tgz#336badc1beecb9dacc38bea2cf32adf627a8421a"
@@ -1445,6 +1481,26 @@
   integrity sha512-IrSHl2u6AWXduUaDLqYpt45tLVCtYv7o4Z0s1KghBCDgIIS9oW5K1H8mZG/A2CfeLdEa7rTd1ACOiHBc1EMT2Q==
   dependencies:
     "@types/node" "*"
+
+"@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz#4ba8ddb720221f432e443bd5f9117fd22cfd4762"
+  integrity sha512-sz7iLqvVUg1gIedBOvlkxPlc8/uVzyS5OwGz1cKjXzkl3FpL3al0crU8YGU1WoHkxn0Wxbw5tyi6hvzJKNzFsw==
+
+"@types/istanbul-lib-report@*":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz#c14c24f18ea8190c118ee7562b7ff99a36552686"
+  integrity sha512-plGgXAPfVKFoYfa9NpYDAkseG+g6Jr294RqeqcqDixSbU34MZVJRi/P+7Y8GDpzkEwLaGZZOpKIEmeVZNtKsrg==
+  dependencies:
+    "@types/istanbul-lib-coverage" "*"
+
+"@types/istanbul-reports@^1.1.1":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@types/istanbul-reports/-/istanbul-reports-1.1.2.tgz#e875cc689e47bce549ec81f3df5e6f6f11cfaeb2"
+  integrity sha512-P/W9yOX/3oPZSpaYOCQzGqgCQRXn0FFO/V8bWrCQs+wLmvVVxk6CRBXALEvNs9OHIatlnlFokfhuDo2ug01ciw==
+  dependencies:
+    "@types/istanbul-lib-coverage" "*"
+    "@types/istanbul-lib-report" "*"
 
 "@types/json-schema@^7.0.3", "@types/json-schema@^7.0.4":
   version "7.0.4"
@@ -1545,6 +1601,18 @@
     "@types/uglify-js" "*"
     "@types/webpack-sources" "*"
     source-map "^0.6.0"
+
+"@types/yargs-parser@*":
+  version "15.0.0"
+  resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-15.0.0.tgz#cb3f9f741869e20cce330ffbeb9271590483882d"
+  integrity sha512-FA/BWv8t8ZWJ+gEOnLLd8ygxH/2UFbAvgEonyfN6yWGLKc7zVjbpl2Y4CTjid9h2RfgPP6SEt6uHwEOply00yw==
+
+"@types/yargs@^15.0.0":
+  version "15.0.5"
+  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-15.0.5.tgz#947e9a6561483bdee9adffc983e91a6902af8b79"
+  integrity sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==
+  dependencies:
+    "@types/yargs-parser" "*"
 
 "@types/yauzl@^2.9.1":
   version "2.9.1"
@@ -2114,6 +2182,14 @@ aria-query@^3.0.0:
   dependencies:
     ast-types-flow "0.0.7"
     commander "^2.11.0"
+
+aria-query@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-4.0.2.tgz#250687b4ccde1ab86d127da0432ae3552fc7b145"
+  integrity sha512-S1G1V790fTaigUSM/Gd0NngzEfiMy9uTUfMyHhKhVyy4cH5O/eTuR01ydhGL0z4Za1PXFTRGH3qL8VhUQuEO5w==
+  dependencies:
+    "@babel/runtime" "^7.7.4"
+    "@babel/runtime-corejs3" "^7.7.4"
 
 arr-diff@^2.0.0:
   version "2.0.0"
@@ -5085,6 +5161,11 @@ doctrine@^3.0.0:
   integrity sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==
   dependencies:
     esutils "^2.0.2"
+
+dom-accessibility-api@^0.4.5:
+  version "0.4.5"
+  resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.4.5.tgz#d9c1cefa89f509d8cf132ab5d250004d755e76e3"
+  integrity sha512-HcPDilI95nKztbVikaN2vzwvmv0sE8Y2ZJFODy/m15n7mGXLeOKGiys9qWVbFbh+aq/KYj2lqMLybBOkYAEXqg==
 
 dom-converter@^0.2:
   version "0.2.0"
@@ -12735,6 +12816,16 @@ pretty-format@^23.6.0:
     ansi-regex "^3.0.0"
     ansi-styles "^3.2.0"
 
+pretty-format@^25.5.0:
+  version "25.5.0"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-25.5.0.tgz#7873c1d774f682c34b8d48b6743a2bf2ac55791a"
+  integrity sha512-kbo/kq2LQ/A/is0PQwsEHM7Ca6//bGPPvU6UnsdDRSKTWxT/ru/xb88v4BJf6a69H+uTytOEsTusT9ksd/1iWQ==
+  dependencies:
+    "@jest/types" "^25.5.0"
+    ansi-regex "^5.0.0"
+    ansi-styles "^4.0.0"
+    react-is "^16.12.0"
+
 private@^0.1.6, private@^0.1.8, private@~0.1.5:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/private/-/private-0.1.8.tgz#2381edb3689f7a53d653190060fcf822d2f368ff"
@@ -16382,7 +16473,7 @@ verror@1.3.6:
     extsprintf "1.0.2"
 
 "vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#9692bc6298b6d25ea0b2c950c527e7336f5a3d37":
-  version "6.0.3"
+  version "6.0.1"
   resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#9692bc6298b6d25ea0b2c950c527e7336f5a3d37"
 
 vinyl-file@^2.0.0:


### PR DESCRIPTION
## Description
So the component can easily see which route we are currently on and it
can update the breadcrumbs accordingly

Using the useLocation hook broke the existing unit tests that used
shallow mounting. I ran into errors using enzyme's full mount as well.
Specifically the useEffect hook used in the Profile2Wrapper's child
ProfileSideNav was causing enzyme.mount() to blow up. But the component
mounts just fine with React Testing Library.

Full error I saw when trying to mount with enzyme:
```
Error: An error was thrown inside one of your components, but React doesn't know what it was. This is likely due to browser flakiness. React does its best to preserve the "Pause on exceptions" behavior of the DevTools, which requires some DEV-mode only tricks. It's possible that these don't work in your browser. Try triggering the error in production mode, or switching to a modern browser. If you suspect that this is actually an issue with React, please file an issue.
```

## Testing done
Local. The final piece of the breadcrumbs work again!

## Screenshots
![ScreenFlow](https://user-images.githubusercontent.com/20728956/84300654-67a1d000-ab07-11ea-8a3e-c0bb12f65fa6.gif)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs