### PR TITLE
Update dl to ol in ProfileInfoTable

### DIFF
--- a/src/applications/personalization/profile-2/components/ProfileInfoTable.jsx
+++ b/src/applications/personalization/profile-2/components/ProfileInfoTable.jsx
@@ -69,26 +69,26 @@ const ProfileInfoTable = ({
     tableRowData: [...tableRowDataClasses].join(' '),
   };
 
-  const dlAttributes = list ? { role: 'list' } : null;
-  const dtAttributes = list ? { role: 'listitem' } : null;
-
   return (
     <section className={classes.table}>
       {title && <h3 className={classes.title}>{title}</h3>}
-      <dl className="vads-u-margin--0" {...dlAttributes}>
+      {/* eslint-disable-next-line jsx-a11y/no-redundant-roles */}
+      <ol className="vads-u-margin--0" role="list">
         {data
           .map(
             element => (dataTransformer ? dataTransformer(element) : element),
           )
           .map((row, index) => (
-            <div key={index} className={classes.tableRow}>
-              <dt className={classes.tableRowTitle} {...dtAttributes}>
-                {row.title}
-              </dt>
-              <dd className={classes.tableRowData}>{row.value}</dd>
-            </div>
+            // eslint-disable-next-line jsx-a11y/no-redundant-roles
+            <li key={index} className={classes.tableRow} role="listitem">
+              {row.title && (
+                <dfn className={classes.tableRowTitle}>{row.title}</dfn>
+              )}
+
+              <span className={classes.tableRowData}>{row.value}</span>
+            </li>
           ))}
-      </dl>
+      </ol>
     </section>
   );
 };

--- a/src/applications/personalization/profile-2/components/ProfileInfoTable.jsx
+++ b/src/applications/personalization/profile-2/components/ProfileInfoTable.jsx
@@ -73,7 +73,7 @@ const ProfileInfoTable = ({
     <section className={classes.table}>
       {title && <h3 className={classes.title}>{title}</h3>}
       {/* eslint-disable-next-line jsx-a11y/no-redundant-roles */}
-      <ol className="vads-u-margin--0" role="list">
+      <ol className="vads-u-margin--0 vads-u-padding--0" role="list">
         {data
           .map(
             element => (dataTransformer ? dataTransformer(element) : element),

--- a/src/applications/personalization/profile-2/sass/profile-info-table.scss
+++ b/src/applications/personalization/profile-2/sass/profile-info-table.scss
@@ -6,10 +6,6 @@ $corner-size: 4px;
     border-top-right-radius: $corner-size;
   }
 
-  ol {
-    padding: 0;
-  }
-
   // there is a bug that prevents setting an overall 1px border with a 0px
   // top-border override using the utility classes. And applying three utility
   // classes - one each for left, right, and bottom - felt like the wrong kind

--- a/src/applications/personalization/profile-2/sass/profile-info-table.scss
+++ b/src/applications/personalization/profile-2/sass/profile-info-table.scss
@@ -6,15 +6,20 @@ $corner-size: 4px;
     border-top-right-radius: $corner-size;
   }
 
+  ol {
+    padding: 0;
+  }
+
   // there is a bug that prevents setting an overall 1px border with a 0px
   // top-border override using the utility classes. And applying three utility
   // classes - one each for left, right, and bottom - felt like the wrong kind
   // of hack.
-  div.table-row {
+  li.table-row {
     border: 1px solid;
     border-top: 0;
+    margin: 0;
 
-    dt {
+    dfn {
       @include media($medium-screen) {
         width: 208px;
         flex-shrink: 0;
@@ -22,15 +27,15 @@ $corner-size: 4px;
     }
   }
 
-  dl:first-child {
-    div.table-row:first-child {
+  ol:first-child {
+    li.table-row:first-child {
       border: 1px solid;
       border-top-left-radius: $corner-size;
       border-top-right-radius: $corner-size;
     }
   }
 
-  div.table-row:last-child {
+  li.table-row:last-child {
     border-bottom-left-radius: $corner-size;
     border-bottom-right-radius: $corner-size;
   }

--- a/src/applications/personalization/profile-2/tests/components/ProfileInfoTable.unit.spec.js
+++ b/src/applications/personalization/profile-2/tests/components/ProfileInfoTable.unit.spec.js
@@ -35,25 +35,15 @@ describe('ProfileInfoTable', () => {
   it('should render an h3 tag as the first child element', () => {
     expect(wrapper.childAt(0).type()).to.equal('h3');
   });
-  it('does not set a role on the description list', () => {
-    const dl = wrapper.find('dl');
-    expect(dl.props().role).to.be.undefined;
-  });
-  it("does not set a role on each row's dt element", () => {
-    const tableRows = wrapper.find('dl > div.table-row');
-    tableRows.forEach(row => {
-      expect(row.find('dt').props.role).to.be.undefined;
-    });
-  });
-  it('renders a table row div for each entry in the data prop', () => {
-    const tableRows = wrapper.find('dl > div.table-row');
+  it('renders a table row li for each entry in the data prop', () => {
+    const tableRows = wrapper.find('ol > li.table-row');
     expect(tableRows.length).to.equal(props.data.length);
   });
   it('calls the dataTransformer once for each row of data', () => {
     expect(dataTransformerSpy.callCount).to.equal(props.data.length);
   });
-  it("renders each data object's title and value in a `div.table-row`", () => {
-    const tableRows = wrapper.find('dl > div.table-row');
+  it("renders each data object's title and value in a `li.table-row`", () => {
+    const tableRows = wrapper.find('ol > li.table-row');
     expect(tableRows.length).to.equal(props.data.length);
     tableRows.forEach((row, index) => {
       const { title, value } = props.data[index];
@@ -79,9 +69,9 @@ describe('ProfileInfoTable', () => {
       const h3 = wrapper.find('h3');
       expect(h3.length).to.equal(0);
     });
-    it('should render a description list as its first child', () => {
+    it('should render an ordered list as its first child', () => {
       const firstChild = wrapper.childAt(0);
-      expect(firstChild.type()).to.equal('dl');
+      expect(firstChild.type()).to.equal('ol');
     });
   });
   describe('when the `list` prop is set', () => {
@@ -96,13 +86,13 @@ describe('ProfileInfoTable', () => {
     afterEach(() => {
       wrapper.unmount();
     });
-    it('adds a `roll="list"` attribute to the description list', () => {
-      const dl = wrapper.find('dl');
-      expect(dl.props().role).to.equal('list');
+    it('adds a `roll="list"` attribute to the ordered list', () => {
+      const ol = wrapper.find('ol');
+      expect(ol.props().role).to.equal('list');
     });
-    it('adds a `role="listitem"` attribute to each row\'s dt element', () => {
-      const dt = wrapper.find('dl dt');
-      expect(dt.props().role).to.equal('listitem');
+    it('adds a `role="listitem"` attribute to each row\'s li element', () => {
+      const li = wrapper.find('li');
+      expect(li.props().role).to.equal('listitem');
     });
   });
 });


### PR DESCRIPTION
[TICKET](https://github.com/department-of-veterans-affairs/va.gov-team/issues/9785)

## Description
We needed to update the `dl` to an `ol` per accessibility's request. Also, this PR ensures it is now possible to leave out the `title` so a row can consist of just text.

## Testing done
Updated unit tests, works locally. The tables look identical to how they looked prior to the implementation.

## Screenshots
![image](https://user-images.githubusercontent.com/14869324/84301060-717c0100-ab10-11ea-8908-440cc9660b26.png)


## Acceptance criteria
- [x] Update `dl` to `ol`
- [x] Make it so the table also accepts text only, leaving out title 

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
