### PR TITLE
[Static pages] Fix for runtime error while attaching analytics

### DIFF
--- a/src/applications/static-pages/analytics/addButtonLinkListeners.js
+++ b/src/applications/static-pages/analytics/addButtonLinkListeners.js
@@ -4,9 +4,11 @@ export default function addButtonLinkListeners() {
   const ignoreReactWidgets = ':not([data-template="paragraphs/react_widget"])';
   const defaultButtons = 'a.usa-button';
   const ignorePrimaryButtons = ':not(.usa-button-primary)';
-  const buttonLinks = document.querySelectorAll(
-    `${ignoreReactWidgets} ${defaultButtons}${ignorePrimaryButtons}`,
-  );
+  const buttonLinks = [
+    ...document.querySelectorAll(
+      `${ignoreReactWidgets} ${defaultButtons}${ignorePrimaryButtons}`,
+    ),
+  ];
 
   buttonLinks.forEach(buttonLink => {
     buttonLink.addEventListener('click', event => {

--- a/src/applications/static-pages/analytics/index.js
+++ b/src/applications/static-pages/analytics/index.js
@@ -1,5 +1,3 @@
-import environment from 'platform/utilities/environment';
-
 import addJumplinkListeners from './addJumpLinkListeners';
 import addQaSectionListeners from './addQaSectionListeners';
 import addTeaserListeners from './addTeaserListeners';
@@ -22,16 +20,18 @@ PAGE_EVENT_LISTENERS.set('/', [addHomepageBannerListeners]);
 
 function attachAnalytics() {
   try {
-    const specialListeners = PAGE_EVENT_LISTENERS.get(document.location.pathname);
+    const specialListeners = PAGE_EVENT_LISTENERS.get(
+      document.location.pathname,
+    );
 
     if (specialListeners) {
-      specialListeners?.forEach(f => f());
+      specialListeners.forEach(f => f());
     }
 
     // Global listeners
     addTeaserListeners();
     addButtonLinkListeners();
-  } catch(error) {
+  } catch (error) {
     // Catch any error that might occur while trying to attach listeners.
   }
 }

--- a/src/applications/static-pages/analytics/index.js
+++ b/src/applications/static-pages/analytics/index.js
@@ -21,15 +21,19 @@ PAGE_EVENT_LISTENERS.set('/coronavirus-veteran-frequently-asked-questions/', [
 PAGE_EVENT_LISTENERS.set('/', [addHomepageBannerListeners]);
 
 function attachAnalytics() {
-  const specialListeners = PAGE_EVENT_LISTENERS.get(document.location.pathname);
+  try {
+    const specialListeners = PAGE_EVENT_LISTENERS.get(document.location.pathname);
 
-  if (specialListeners) {
-    specialListeners.forEach(f => f());
+    if (specialListeners) {
+      specialListeners?.forEach(f => f());
+    }
+
+    // Global listeners
+    addTeaserListeners();
+    addButtonLinkListeners();
+  } catch(error) {
+    // Catch any error that might occur while trying to attach listeners.
   }
-
-  // Global listeners
-  addTeaserListeners();
-  addButtonLinkListeners();
 }
 
 // Prevent the window from navigating away.


### PR DESCRIPTION
## Description
Follow up to https://github.com/department-of-veterans-affairs/vets-website/pull/12883. I forgot to convert the DOM node list into a true array. This fixes an IE error, although the error doesn't seem to have any effect besides not attaching the event listener to the button.

## Testing done
Ran locally to confirm

## Screenshots
![image](https://user-images.githubusercontent.com/1915775/84313214-34c20100-ab34-11ea-927e-075af3d1910c.png)


## Acceptance criteria
- [ ] Runtime error fixed

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
