### PR TITLE
Add education benefits section and shorten DD header

### DIFF
--- a/src/applications/personalization/profile-2/components/direct-deposit/DirectDeposit.jsx
+++ b/src/applications/personalization/profile-2/components/direct-deposit/DirectDeposit.jsx
@@ -21,8 +21,7 @@ const DirectDeposit = () => {
         className="vads-u-margin-y--2 medium-screen:vads-u-margin-bottom--4 medium-screen:vads-u-margin-top--3"
         data-focus-target
       >
-        Direct deposit information for disability compensation and pension
-        benefits
+        Direct deposit information
       </h2>
       <DowntimeNotification
         appTitle="direct deposit"

--- a/src/applications/personalization/profile-2/components/direct-deposit/DirectDepositContent.jsx
+++ b/src/applications/personalization/profile-2/components/direct-deposit/DirectDepositContent.jsx
@@ -278,7 +278,7 @@ export const DirectDepositContent = ({
       <FraudVictimAlert />
       <AdditionalInformation />
       <ProfileInfoTable
-        title="Education Benefits"
+        title="Education benefits"
         data={educationBenefitsData()}
       />
     </>

--- a/src/applications/personalization/profile-2/components/direct-deposit/DirectDepositContent.jsx
+++ b/src/applications/personalization/profile-2/components/direct-deposit/DirectDepositContent.jsx
@@ -195,7 +195,7 @@ export const DirectDepositContent = ({
     return notSetUpContent;
   };
 
-  const getTableData = () => [
+  const directDepositData = () => [
     // top row of the table can show multiple states so we set its value with
     // the getBankInfo() helper
     {
@@ -208,6 +208,40 @@ export const DirectDepositContent = ({
         <EbenefitsLink path="ebenefits/about/feature?feature=payment-history">
           View your payment history
         </EbenefitsLink>
+      ),
+    },
+  ];
+
+  const educationBenefitsData = () => [
+    {
+      value: (
+        <div className="vads-u-display--flex vads-u-flex-direction--column">
+          <p className="vads-u-margin-top--0">
+            You’ll need to sign in to the eBenefits website with your Premium DS
+            Logon account to change your direct deposit information for GI Bill
+            and other education benefits online.
+          </p>{' '}
+          <p>
+            If you don’t have a Premium DS Logon account, you can register for
+            one or upgrade your Basic account to Premium. Your MyHealtheVet or
+            ID.me credentials won’t work on eBenefits.
+          </p>
+          <a
+            target="_blank"
+            rel="noopener noreferrer"
+            href="https://www.ebenefits.va.gov/ebenefits/about/feature?feature=direct-deposit-and-contact-information"
+          >
+            Go to eBenefits to change your information
+          </a>
+          <a
+            className="vads-u-margin-top--2"
+            target="_blank"
+            rel="noopener noreferrer"
+            href="https://va.gov/change-direct-deposit/"
+          >
+            Find out how to change your information by mail or phone
+          </a>
+        </div>
       ),
     },
   ];
@@ -240,13 +274,13 @@ export const DirectDepositContent = ({
           )}
         </ReactCSSTransitionGroup>
       </div>
-      <ProfileInfoTable
-        title="Bank information"
-        data={getTableData()}
-        fieldName="directDeposit"
-      />
+      <ProfileInfoTable title="Bank information" data={directDepositData()} />
       <FraudVictimAlert />
       <AdditionalInformation />
+      <ProfileInfoTable
+        title="Education Benefits"
+        data={educationBenefitsData()}
+      />
     </>
   );
 };

--- a/src/applications/personalization/profile-2/components/direct-deposit/DirectDepositInformation.jsx
+++ b/src/applications/personalization/profile-2/components/direct-deposit/DirectDepositInformation.jsx
@@ -12,36 +12,7 @@ const recordProfileNavEvent = (customProps = {}) => {
 };
 
 const AdditionalInformation = () => (
-  <>
-    <div className="vads-u-margin-bottom--2">
-      <AdditionalInfo
-        triggerText="How do I change my direct deposit information for GI Bill and other education benefits?"
-        onClick={() =>
-          recordProfileNavEvent({
-            'profile-action': 'view-link',
-            'profile-section': 'how-to-change-direct-deposit',
-          })
-        }
-      >
-        <p>
-          You’ll need to sign in to the eBenefits website with your Premium DS
-          Logon account to change your direct deposit information for GI Bill
-          and other education benefits online.
-        </p>
-        <p>
-          If you don’t have a Premium DS Logon account, you can register for one
-          or upgrade your Basic account to Premium. Your MyHealtheVet or ID.me
-          credentials won’t work on eBenefits.
-        </p>
-        <EbenefitsLink path="ebenefits/about/feature?feature=direct-deposit-and-contact-information">
-          Go to eBenefits to change your information
-        </EbenefitsLink>
-        <br />
-        <a href="/change-direct-deposit/#are-there-other-ways-to-change">
-          Find out how to change your information by mail or phone
-        </a>
-      </AdditionalInfo>
-    </div>
+  <div className="vads-u-margin-bottom--4">
     <AdditionalInfo
       triggerText="What’s my bank’s routing number?"
       onClick={() =>
@@ -60,7 +31,7 @@ const AdditionalInformation = () => (
         account.
       </p>
     </AdditionalInfo>
-  </>
+  </div>
 );
 
 export default AdditionalInformation;

--- a/src/applications/personalization/profile-2/components/direct-deposit/FraudVictimAlert.jsx
+++ b/src/applications/personalization/profile-2/components/direct-deposit/FraudVictimAlert.jsx
@@ -3,7 +3,7 @@ import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 
 const FraudVictimAlert = () => (
   <AlertBox
-    className="vads-u-margin-bottom--2 medium-screen:vads-u-margin-y--4"
+    className="vads-u-margin-bottom--2 medium-screen:vads-u-margin-top--4 medium-screen:vads-u--margin-bottom--3"
     backgroundOnly
   >
     <strong>Note:</strong> If you think you’ve been the victim of bank fraud,

--- a/src/applications/personalization/profile-2/sass/profile-info-table.scss
+++ b/src/applications/personalization/profile-2/sass/profile-info-table.scss
@@ -6,10 +6,6 @@ $corner-size: 4px;
     border-top-right-radius: $corner-size;
   }
 
-  ol {
-    padding: 0;
-  }
-
   // there is a bug that prevents setting an overall 1px border with a 0px
   // top-border override using the utility classes. And applying three utility
   // classes - one each for left, right, and bottom - felt like the wrong kind

--- a/src/applications/personalization/profile-2/sass/profile-info-table.scss
+++ b/src/applications/personalization/profile-2/sass/profile-info-table.scss
@@ -6,6 +6,10 @@ $corner-size: 4px;
     border-top-right-radius: $corner-size;
   }
 
+  ol {
+    padding: 0;
+  }
+
   // there is a bug that prevents setting an overall 1px border with a 0px
   // top-border override using the utility classes. And applying three utility
   // classes - one each for left, right, and bottom - felt like the wrong kind


### PR DESCRIPTION
## Description
This ticket accomplishes 2 things:

1) Shorten the DD header from `Direct deposit information for disability compensation and pension benefits` to `Direct deposit information`
2) Add an Education Benefits section in lieu of the `<a>` tag that used to say `How do I change my direct deposit information for GI Bill and other education benefits?`

## Testing done
Works locally

## Screenshots
![image](https://user-images.githubusercontent.com/14869324/84311783-20c0d400-ab21-11ea-9c81-b4ddd32962b1.png)

![image](https://user-images.githubusercontent.com/14869324/84311804-29b1a580-ab21-11ea-9a25-983539bd91fa.png)


## Acceptance criteria
- [x] Update header
- [x] Add Education Benefits section

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
