### PR TITLE
Add contact email section to personal information

### DIFF
--- a/src/applications/personalization/profile-2/components/personal-information/EmailInformationSection.jsx
+++ b/src/applications/personalization/profile-2/components/personal-information/EmailInformationSection.jsx
@@ -1,45 +1,77 @@
-import React from 'react';
 import PropTypes from 'prop-types';
 
+import { connect } from 'react-redux';
+import React, { Component } from 'react';
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 
 import Email from 'vet360/components/VAPEmail';
 
+import { signInServiceName as signInServiceNameSelector } from 'platform/user/authentication/selectors';
+
 import ProfileInfoTable from '../ProfileInfoTable';
 
-const EmailInformationSection = ({ className }) => (
-  <div className={className}>
-    <ProfileInfoTable
-      title="Email address"
-      fieldName="emailAddress"
-      data={[
-        {
-          title: 'Email address',
-          value: <Email />,
-        },
-      ]}
-      list
-      className="vads-u-margin-y--4"
-    />
+class EmailInformationSection extends Component {
+  render() {
+    let link;
+    let buttonText;
 
-    {/* NOTE: This whole section is going to change based on user testing */}
-    <AlertBox
-      headline="Change the email address you use to sign in"
-      backgroundOnly
-      status="info"
-    >
-      <p>The first paragraph</p>
-      <p>
-        A much longer paragraph right here. A much longer paragraph right here.
-        A much longer paragraph right here. A much longer paragraph right here.{' '}
-      </p>
-      <button className="va-button-link">Update email address on ID.me</button>
-    </AlertBox>
-  </div>
-);
+    if (this.props.signInServiceName === 'idme') {
+      link = 'https://wallet.id.me/settings';
+      buttonText = 'ID.me';
+    }
 
+    if (this.props.signInServiceName === 'dslogon') {
+      link = 'https://myaccess.dmdc.osd.mil/identitymanagement';
+      buttonText = 'DS Logon';
+    }
 EmailInformationSection.propTypes = {
   className: PropTypes.string,
 };
 
 export default EmailInformationSection;
+
+    if (this.props.signInServiceName === 'mhv') {
+      link = 'https://www.myhealth.va.gov';
+      buttonText = 'My HealtheVet';
+    }
+
+    return (
+      <div className={this.props.className}>
+        <ProfileInfoTable
+          title="Contact email address"
+          fieldName="emailAddress"
+          data={[
+            {
+              value: (
+                <>
+                  <p className="vads-u-margin-top--0">
+                    This is the email we’ll use to contact you.
+                  </p>
+                  <p>
+                    To update the email you use to sign in, go to the website
+                    where you manage your log in information.
+                  </p>
+                  <a href={link} target="_blank" rel="noopener noreferrer">
+                    Update email address on {buttonText}
+                  </a>
+                </>
+              ),
+            },
+            {
+              title: 'Contact email address',
+              value: <Email />,
+            },
+          ]}
+          list
+          className="vads-u-margin-y--4"
+        />
+      </div>
+    );
+  }
+}
+
+export const mapStateToProps = state => ({
+  signInServiceName: signInServiceNameSelector(state),
+});
+
+export default connect(mapStateToProps)(EmailInformationSection);

--- a/src/applications/personalization/profile-2/components/personal-information/EmailInformationSection.jsx
+++ b/src/applications/personalization/profile-2/components/personal-information/EmailInformationSection.jsx
@@ -24,11 +24,6 @@ class EmailInformationSection extends Component {
       link = 'https://myaccess.dmdc.osd.mil/identitymanagement';
       buttonText = 'DS Logon';
     }
-EmailInformationSection.propTypes = {
-  className: PropTypes.string,
-};
-
-export default EmailInformationSection;
 
     if (this.props.signInServiceName === 'mhv') {
       link = 'https://www.myhealth.va.gov';
@@ -69,6 +64,11 @@ export default EmailInformationSection;
     );
   }
 }
+
+EmailInformationSection.propTypes = {
+  className: PropTypes.string,
+  signInServiceName: PropTypes.string.isRequired,
+};
 
 export const mapStateToProps = state => ({
   signInServiceName: signInServiceNameSelector(state),

--- a/src/applications/personalization/profile-2/components/personal-information/EmailInformationSection.jsx
+++ b/src/applications/personalization/profile-2/components/personal-information/EmailInformationSection.jsx
@@ -10,60 +10,58 @@ import { signInServiceName as signInServiceNameSelector } from 'platform/user/au
 
 import ProfileInfoTable from '../ProfileInfoTable';
 
-class EmailInformationSection extends Component {
-  render() {
-    let link;
-    let buttonText;
+const EmailInformationSection = ({ className, signInServiceName }) => {
+  let link;
+  let buttonText;
 
-    if (this.props.signInServiceName === 'idme') {
-      link = 'https://wallet.id.me/settings';
-      buttonText = 'ID.me';
-    }
-
-    if (this.props.signInServiceName === 'dslogon') {
-      link = 'https://myaccess.dmdc.osd.mil/identitymanagement';
-      buttonText = 'DS Logon';
-    }
-
-    if (this.props.signInServiceName === 'mhv') {
-      link = 'https://www.myhealth.va.gov';
-      buttonText = 'My HealtheVet';
-    }
-
-    return (
-      <div className={this.props.className}>
-        <ProfileInfoTable
-          title="Contact email address"
-          fieldName="emailAddress"
-          data={[
-            {
-              value: (
-                <>
-                  <p className="vads-u-margin-top--0">
-                    This is the email we’ll use to contact you.
-                  </p>
-                  <p>
-                    To update the email you use to sign in, go to the website
-                    where you manage your log in information.
-                  </p>
-                  <a href={link} target="_blank" rel="noopener noreferrer">
-                    Update email address on {buttonText}
-                  </a>
-                </>
-              ),
-            },
-            {
-              title: 'Contact email address',
-              value: <Email />,
-            },
-          ]}
-          list
-          className="vads-u-margin-y--4"
-        />
-      </div>
-    );
+  if (signInServiceName === 'idme') {
+    link = 'https://wallet.id.me/settings';
+    buttonText = 'ID.me';
   }
-}
+
+  if (signInServiceName === 'dslogon') {
+    link = 'https://myaccess.dmdc.osd.mil/identitymanagement';
+    buttonText = 'DS Logon';
+  }
+
+  if (signInServiceName === 'mhv') {
+    link = 'https://www.myhealth.va.gov';
+    buttonText = 'My HealtheVet';
+  }
+
+  return (
+    <div className={className}>
+      <ProfileInfoTable
+        title="Contact email address"
+        fieldName="emailAddress"
+        data={[
+          {
+            value: (
+              <>
+                <p className="vads-u-margin-top--0">
+                  This is the email we’ll use to contact you.
+                </p>
+                <p>
+                  To update the email you use to sign in, go to the website
+                  where you manage your log in information.
+                </p>
+                <a href={link} target="_blank" rel="noopener noreferrer">
+                  Update email address on {buttonText}
+                </a>
+              </>
+            ),
+          },
+          {
+            title: 'Contact email address',
+            value: <Email />,
+          },
+        ]}
+        list
+        className="vads-u-margin-y--4"
+      />
+    </div>
+  );
+};
 
 EmailInformationSection.propTypes = {
   className: PropTypes.string,


### PR DESCRIPTION
## Description
This ticket adds the `Contact email address` section to the Personal Information page. The other part of the ticket, the adding of `Sign-in email address` to Account Security, was already done in a previous ticket.

## Testing done
Works locally

## Screenshots
![image](https://user-images.githubusercontent.com/14869324/84314304-0f79c680-ab25-11ea-834d-fc7c0e14522a.png)
![image](https://user-images.githubusercontent.com/14869324/84314351-21f40000-ab25-11ea-9cc0-a4a021890b0a.png)


## Acceptance criteria
- [x] Add `Contact email address` section to the Personal Information page.
- [x] DONE IN PREVIOUS TICKET - Add `Sign-in email address` to Account Security

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
