### PR TITLE
Upgrade mocha-junit-reporter (major)

### DIFF
--- a/package.json
+++ b/package.json
@@ -191,7 +191,7 @@
     "metalsmith-date-in-filename": "^0.0.14",
     "mini-css-extract-plugin": "^0.9.0",
     "mocha": "^3.5.0",
-    "mocha-junit-reporter": "^1.17.0",
+    "mocha-junit-reporter": "^2.0.0",
     "mocker-api": "^2.1.0",
     "moment-timezone": "^0.5.27",
     "morgan": "^1.10.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10733,9 +10733,10 @@ mkpath@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/mkpath/-/mkpath-1.0.0.tgz#ebb3a977e7af1c683ae6fda12b545a6ba6c5853d"
 
-mocha-junit-reporter@^1.17.0:
-  version "1.17.0"
-  resolved "https://registry.yarnpkg.com/mocha-junit-reporter/-/mocha-junit-reporter-1.17.0.tgz#2e5149ed40fc5d2e3ca71e42db5ab1fec9c6d85c"
+mocha-junit-reporter@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/mocha-junit-reporter/-/mocha-junit-reporter-2.0.0.tgz#3bf990fce7a42c0d2b718f188553a25d9f24b9a2"
+  integrity sha512-20HoWh2HEfhqmigfXOKUhZQyX23JImskc37ZOhIjBKoBEsb+4cAFRJpAVhFpnvsztLklW/gFVzsrobjLwmX4lA==
   dependencies:
     debug "^2.2.0"
     md5 "^2.1.0"


### PR DESCRIPTION
## Description
Upgrade mocha-junit-reporter from version "^1.17.0" to "^2.0.0"

## Testing done
Locally

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
