### PR TITLE
Show express care reason for visit field

### DIFF
--- a/src/applications/vaos/api/requests.json
+++ b/src/applications/vaos/api/requests.json
@@ -576,14 +576,14 @@
           "assigningAuthority": "ICN"
         },
         "surrogateIdentifier": {},
-        "lastUpdatedDate": "12/16/2019 12:58:41",
-        "optionDate1": "12/16/2019",
+        "lastUpdatedDate": "12/16/2020 12:58:41",
+        "optionDate1": "12/16/2020",
         "optionTime1": "PM",
         "optionDate2": "No Date Selected",
         "optionTime2": "No Time Selected",
         "optionDate3": "No Date Selected",
         "optionTime3": "No Time Selected",
-        "status": "Booked",
+        "status": "Submitted",
         "appointmentType": "Express Care",
         "visitType": "Express Care",
         "facility": {

--- a/src/applications/vaos/components/AppointmentRequestListItem.jsx
+++ b/src/applications/vaos/components/AppointmentRequestListItem.jsx
@@ -28,7 +28,7 @@ export default class AppointmentRequestListItem extends React.Component {
     const id = appointment.id;
     const showMore = !this.state.showMore;
 
-    if (showMore && !messages[id]) {
+    if (showMore && !messages[id] && !appointment.isExpressCare) {
       fetchMessages(id);
     }
 
@@ -100,23 +100,25 @@ export default class AppointmentRequestListItem extends React.Component {
               />
             )}
           </div>
-          <div className="vads-u-flex--1 vaos-u-word-break--break-word">
-            <dl className="vads-u-margin--0">
-              <dt className="vads-u-font-weight--bold">
-                Preferred date and time
-              </dt>
-              <dd>
-                <ul className="usa-unstyled-list">
-                  {appointment.dateOptions.map((option, optionIndex) => (
-                    <li key={`${appointment.id}-option-${optionIndex}`}>
-                      {option.date.format('ddd, MMMM D, YYYY')}{' '}
-                      {TIME_TEXT[option.optionTime]}
-                    </li>
-                  ))}
-                </ul>
-              </dd>
-            </dl>
-          </div>
+          {!appointment.isExpressCare && (
+            <div className="vads-u-flex--1 vaos-u-word-break--break-word">
+              <dl className="vads-u-margin--0">
+                <dt className="vads-u-font-weight--bold">
+                  Preferred date and time
+                </dt>
+                <dd>
+                  <ul className="usa-unstyled-list">
+                    {appointment.dateOptions.map((option, optionIndex) => (
+                      <li key={`${appointment.id}-option-${optionIndex}`}>
+                        {option.date.format('ddd, MMMM D, YYYY')}{' '}
+                        {TIME_TEXT[option.optionTime]}
+                      </li>
+                    ))}
+                  </ul>
+                </dd>
+              </dl>
+            </div>
+          )}
         </div>
         <div className="vads-u-margin-top--2">
           <AdditionalInfo
@@ -125,12 +127,22 @@ export default class AppointmentRequestListItem extends React.Component {
           >
             <div className="vads-u-display--flex vads-u-flex-direction--column small-screen:vads-u-flex-direction--row">
               <div className="vaos_appts__message vads-u-flex--1 vads-u-margin-right--1 vaos-u-word-break--break-word">
-                <dl className="vads-u-margin--0">
-                  <dt className="vads-u-font-weight--bold">
-                    {appointment.purposeOfVisit}
-                  </dt>
-                  <dd>{firstMessage}</dd>
-                </dl>
+                {appointment.isExpressCare && (
+                  <dl className="vads-u-margin--0">
+                    <dt className="vads-u-font-weight--bold">
+                      Reason for appointment
+                    </dt>
+                    <dd>{appointment.reason}</dd>
+                  </dl>
+                )}
+                {!appointment.isExpressCare && (
+                  <dl className="vads-u-margin--0">
+                    <dt className="vads-u-font-weight--bold">
+                      {appointment.reason}
+                    </dt>
+                    <dd>{firstMessage}</dd>
+                  </dl>
+                )}
               </div>
               <div className="vads-u-flex--1 vads-u-margin-top--2 small-screen:vads-u-margin-top--0 vaos-u-word-break--break-word">
                 <dl className="vads-u-margin--0">

--- a/src/applications/vaos/components/AppointmentStatus.jsx
+++ b/src/applications/vaos/components/AppointmentStatus.jsx
@@ -48,7 +48,10 @@ export default function AppointmentStatus({
   return (
     <div className="vads-u-display--flex vads-u-justify-content--space-between vads-u-margin-y--2">
       <div className="vads-u-margin-right--1">
-        <i aria-hidden="true" className={`fas ${iconClass}`} />
+        <i
+          aria-hidden="true"
+          className={`fas ${iconClass} vads-u-line-height--4`}
+        />
       </div>
       <span className="vads-u-font-weight--bold vads-u-flex--1">
         <div className="vaos-appts__status-text vads-u-font-size--base vads-u-font-family--sans">

--- a/src/applications/vaos/tests/components/AppointmentRequestListItem.unit.spec.jsx
+++ b/src/applications/vaos/tests/components/AppointmentRequestListItem.unit.spec.jsx
@@ -26,7 +26,7 @@ describe('VAOS <AppointmentRequestListItem>', () => {
       facilityName: 'Some location',
       status: APPOINTMENT_STATUS.pending,
       bestTimetoCall: ['Morning'],
-      purposeOfVisit: 'Follow-up/Routine',
+      reason: 'Follow-up/Routine',
       facility: {
         city: 'Northampton',
         state: 'MA',
@@ -142,7 +142,7 @@ describe('VAOS <AppointmentRequestListItem>', () => {
       facilityName: 'Some location',
       status: APPOINTMENT_STATUS.pending,
       bestTimetoCall: ['Morning'],
-      purposeOfVisit: 'Routine Follow-up',
+      reason: 'Routine Follow-up',
       facility: {
         city: 'Northampton',
         state: 'MA',

--- a/src/applications/vaos/tests/e2e/vaos-helpers.js
+++ b/src/applications/vaos/tests/e2e/vaos-helpers.js
@@ -158,7 +158,7 @@ function showMoreTest(client) {
     .waitForElementVisible('.additional-info-content', Timeouts.slow)
     .pause(Timeouts.normal)
     .axeCheck('.main')
-    .assert.containsText('#tooltip-11 dd', 'Request 2 Message 1 Text');
+    .assert.containsText('.vaos_appts__message dd', 'Request 2 Message 1 Text');
 
   return client;
 }

--- a/src/applications/vaos/tests/utils/appointment.unit.spec.jsx
+++ b/src/applications/vaos/tests/utils/appointment.unit.spec.jsx
@@ -353,13 +353,13 @@ describe('VAOS appointment helpers', () => {
         expect(appt.dateOptions.length).to.equal(3);
       });
     });
-    describe('purposeOfVisit', () => {
+    describe('reason', () => {
       it('should be set for community care appointment request', () => {
         const appt = transformRequest({
           ...ccData,
           purposeOfVisit: 'routine-follow-up',
         });
-        expect(appt.purposeOfVisit).to.equal('Follow-up/Routine');
+        expect(appt.reason).to.equal('Follow-up/Routine');
       });
 
       it('should be set for VA appointment request', () => {
@@ -367,7 +367,16 @@ describe('VAOS appointment helpers', () => {
           ...vaData,
           purposeOfVisit: 'Routine Follow-up',
         });
-        expect(appt.purposeOfVisit).to.equal('Follow-up/Routine');
+        expect(appt.reason).to.equal('Follow-up/Routine');
+      });
+      it('should be set from reasonForVisit for expresss care appointment request', () => {
+        const appt = transformRequest({
+          ...vaData,
+          typeOfCareId: 'CR1',
+          purposeOfVisit: 'Routine Follow-up',
+          reasonForVisit: 'Testing',
+        });
+        expect(appt.reason).to.equal('Testing');
       });
     });
   });

--- a/src/applications/vaos/utils/appointment.js
+++ b/src/applications/vaos/utils/appointment.js
@@ -11,6 +11,7 @@ import {
   PAST_APPOINTMENTS_HIDDEN_SET,
   PAST_APPOINTMENTS_HIDE_STATUS_SET,
   FUTURE_APPOINTMENTS_HIDE_STATUS_SET,
+  EXPRESS_CARE,
 } from './constants';
 
 import {
@@ -278,6 +279,10 @@ function getPurposeOfVisit(appt) {
       return PURPOSE_TEXT.find(purpose => purpose.id === appt.purposeOfVisit)
         ?.short;
     case APPOINTMENT_TYPES.request:
+      if (appt.typeOfCareId === EXPRESS_CARE) {
+        return appt.reasonForVisit;
+      }
+
       return PURPOSE_TEXT.find(
         purpose => purpose.serviceName === appt.purposeOfVisit,
       )?.short;
@@ -451,11 +456,12 @@ export function transformRequest(appointment) {
     apiData: appointment,
     id: appointment.id,
     isPastAppointment: false,
+    isExpressCare: appointment.typeOfCareId === EXPRESS_CARE,
     duration: 60,
     dateOptions: getRequestDateOptions(appointment),
     status: getAppointmentStatus(appointment),
     typeOfCare: appointment.appointmentType,
-    purposeOfVisit: getPurposeOfVisit(appointment),
+    reason: getPurposeOfVisit(appointment),
     facility: appointment.facility,
     facilityName:
       appointment.friendlyLocationName || appointment.facility?.name,

--- a/src/applications/vaos/utils/constants.js
+++ b/src/applications/vaos/utils/constants.js
@@ -327,6 +327,7 @@ export const CALENDAR_INDICATOR_TYPES = {
 export const DISABLED_LIMIT_VALUE = 0;
 export const PRIMARY_CARE = '323';
 export const MENTAL_HEALTH = '502';
+export const EXPRESS_CARE = 'CR1';
 
 export const GA_PREFIX = 'vaos';
 export const GA_FLOWS = {


### PR DESCRIPTION
## Description
Express care requests have a separate reason for visit field, which we should show instead of the message, because that's not where express care requests accept reason for appointment info in legacy. I've put a "Reason for appointment" header above the reason text that we get from reasonForVisit.

Also, since express care requests don't let a user choose a preferred time, I've hidden those fields.

## Testing done
Local and unit testing

## Screenshots
![Screen Shot 2020-06-11 at 11 28 49 AM](https://user-images.githubusercontent.com/634932/84406216-3bee1b00-abd7-11ea-8603-0838ac28172f.png)

## Acceptance criteria
- [ ] Reason info shows up

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
