### PR TITLE
GI Bill Comparison Tool - react-router cleanup

### DIFF
--- a/src/applications/gi/components/search/SearchResult.jsx
+++ b/src/applications/gi/components/search/SearchResult.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { Link } from 'react-router';
+import appendQuery from 'append-query';
 import environment from 'platform/utilities/environment';
 import { estimatedBenefits } from '../../selectors/estimator';
 import { formatCurrency, locationInfo } from '../../utils/helpers';
@@ -43,10 +44,7 @@ export class SearchResult extends React.Component {
           pathname: `/profile/${facilityCode}`,
           query: version ? { version } : {},
         }
-      : {
-          pathname: `/profile/${facilityCode}`,
-          search: version ? `?version=${version}` : '',
-        };
+      : appendQuery(`/profile/${facilityCode}`, { version });
 
     return (
       <div id={`search-result-${facilityCode}`} className="search-result">

--- a/src/applications/gi/components/vet-tec/VetTecProgramSearchResult.jsx
+++ b/src/applications/gi/components/vet-tec/VetTecProgramSearchResult.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router';
+import appendQuery from 'append-query';
 
 import environment from 'platform/utilities/environment';
 import {
@@ -42,10 +43,7 @@ function VetTecProgramSearchResult(props) {
         pathname: `/profile/${facilityCode}/${description}`,
         query: version ? { version } : {},
       }
-    : {
-        pathname: `/profile/${facilityCode}/${description}`,
-        search: version ? `?version=${version}` : '',
-      };
+    : appendQuery(`/profile/${facilityCode}/${description}`, { version });
 
   return (
     <div id={`search-result-${createId(id)}`} className="search-result">

--- a/src/applications/gi/containers/GiBillApp.jsx
+++ b/src/applications/gi/containers/GiBillApp.jsx
@@ -13,7 +13,6 @@ import GiBillBreadcrumbs from '../components/heading/GiBillBreadcrumbs';
 import AboutThisTool from '../components/content/AboutThisTool';
 import ServiceError from '../components/ServiceError';
 import Covid19Banner from '../components/heading/Covid19Banner';
-import environment from 'platform/utilities/environment';
 
 const Disclaimer = () => (
   <div className="row disclaimer">

--- a/src/applications/gi/containers/LandingPage.jsx
+++ b/src/applications/gi/containers/LandingPage.jsx
@@ -1,7 +1,6 @@
 import _ from 'lodash';
 import React from 'react';
 import { connect } from 'react-redux';
-import { withRouter } from 'react-router';
 
 import {
   clearAutocompleteSuggestions,
@@ -220,9 +219,7 @@ const mapDispatchToProps = {
   hideModal,
 };
 
-export default withRouter(
-  connect(
-    mapStateToProps,
-    mapDispatchToProps,
-  )(LandingPage),
-);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(LandingPage);

--- a/src/applications/gi/containers/ProfilePage.jsx
+++ b/src/applications/gi/containers/ProfilePage.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import { withRouter } from 'react-router';
 import Scroll from 'react-scroll';
 import _ from 'lodash';
 
@@ -139,9 +138,7 @@ const mapDispatchToProps = {
   hideModal,
 };
 
-export default withRouter(
-  connect(
-    mapStateToProps,
-    mapDispatchToProps,
-  )(ProfilePage),
-);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(ProfilePage);

--- a/src/applications/gi/containers/SearchPage.jsx
+++ b/src/applications/gi/containers/SearchPage.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import { withRouter } from 'react-router';
 import Scroll from 'react-scroll';
 import _ from 'lodash';
 import classNames from 'classnames';
@@ -329,9 +328,7 @@ const mapDispatchToProps = {
   hideModal,
 };
 
-export default withRouter(
-  connect(
-    mapStateToProps,
-    mapDispatchToProps,
-  )(SearchPage),
-);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(SearchPage);

--- a/src/applications/gi/containers/VetTecSearchPage.jsx
+++ b/src/applications/gi/containers/VetTecSearchPage.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import { withRouter } from 'react-router';
 import Scroll from 'react-scroll';
 import _ from 'lodash';
 import classNames from 'classnames';
@@ -325,9 +324,7 @@ const mapDispatchToProps = {
   showModal,
 };
 
-export default withRouter(
-  connect(
-    mapStateToProps,
-    mapDispatchToProps,
-  )(VetTecSearchPage),
-);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(VetTecSearchPage);


### PR DESCRIPTION
## Description
Removed unnecessary wrappings of components using `withRouter`. The `GiBillApp` component is still wrapped, but usages in child components aren't needed, and they can be removed without affecting functionality.

[ZenHub Issue 1](https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/8228)
[ZenHub Issue 2](https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/7528)

## Testing done
Tested locally and QA reviewed.

## Screenshots
N/A

## Acceptance criteria
- [x] Redux state is not lost when using react-router `Link`

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
