### PR TITLE
added analytics to Stem 22-1995 form review screen

### DIFF
--- a/src/platform/forms-system/src/js/review/ReviewChapters.jsx
+++ b/src/platform/forms-system/src/js/review/ReviewChapters.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router';
 import Scroll from 'react-scroll';
+import recordEvent from 'platform/monitoring/record-event';
 
 import ReviewCollapsibleChapter from './ReviewCollapsibleChapter';
 import {
@@ -32,8 +33,18 @@ class ReviewChapters extends React.Component {
   handleToggleChapter({ name, open, pageKeys }) {
     if (open) {
       this.props.closeReviewChapter(name, pageKeys);
+      if (this.props.form.formId === '22-1995') {
+        recordEvent({
+          event: 'nav-accordion-collapse',
+        });
+      }
     } else {
       this.props.openReviewChapter(name);
+      if (this.props.form.formId === '22-1995') {
+        recordEvent({
+          event: 'nav-accordion-expand',
+        });
+      }
       this.scrollToChapter(name);
     }
   }

--- a/src/platform/forms-system/test/js/review/ReviewChapters.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/review/ReviewChapters.unit.spec.jsx
@@ -102,6 +102,7 @@ describe('Schemaform review: ReviewChapters', () => {
     const tree = mount(
       <ReviewChapters
         chapters={chapters}
+        form={{ formId: '22-1995' }}
         closeReviewChapter={closeReviewChapter}
         openReviewChapter={openReviewChapter}
         pageList={pageList}


### PR DESCRIPTION
## Description
Implement accordion expand / collapse tracking on Form 1995 Summary page
https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/7462
## Testing done
Local testing

## Screenshots
![Screen Shot 2020-06-11 at 12 50 41 PM](https://user-images.githubusercontent.com/50601724/84416684-888b2380-abe2-11ea-9416-1fbbf40fee4f.png)

## Acceptance criteria
- [x] Analytics are added to 1995 review accordions

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
