### PR TITLE
Prevent entering edit mode if already editing another profile field

### DIFF
--- a/src/platform/user/profile/vet360/components/VAPEmail.jsx
+++ b/src/platform/user/profile/vet360/components/VAPEmail.jsx
@@ -2,8 +2,13 @@ import React from 'react';
 
 import EmailField from './EmailField/VAPEmailField';
 
-import { FIELD_NAMES } from '../constants';
+import { FIELD_NAMES, FIELD_TITLES } from '../constants';
 
 export default function Email() {
-  return <EmailField title="Email address" fieldName={FIELD_NAMES.EMAIL} />;
+  return (
+    <EmailField
+      title={FIELD_TITLES[FIELD_NAMES.EMAIL]}
+      fieldName={FIELD_NAMES.EMAIL}
+    />
+  );
 }

--- a/src/platform/user/profile/vet360/components/VAPFaxNumber.jsx
+++ b/src/platform/user/profile/vet360/components/VAPFaxNumber.jsx
@@ -2,8 +2,13 @@ import React from 'react';
 
 import PhoneField from './PhoneField/VAPPhoneField';
 
-import { FIELD_NAMES } from '../constants';
+import { FIELD_NAMES, FIELD_TITLES } from '../constants';
 
 export default function FaxNumber() {
-  return <PhoneField title="Fax number" fieldName={FIELD_NAMES.FAX_NUMBER} />;
+  return (
+    <PhoneField
+      title={FIELD_TITLES[FIELD_NAMES.FAX_NUMBER]}
+      fieldName={FIELD_NAMES.FAX_NUMBER}
+    />
+  );
 }

--- a/src/platform/user/profile/vet360/components/VAPHomePhone.jsx
+++ b/src/platform/user/profile/vet360/components/VAPHomePhone.jsx
@@ -2,10 +2,13 @@ import React from 'react';
 
 import PhoneField from './PhoneField/VAPPhoneField';
 
-import { FIELD_NAMES } from '../constants';
+import { FIELD_NAMES, FIELD_TITLES } from '../constants';
 
 export default function HomePhone() {
   return (
-    <PhoneField title="Home phone number" fieldName={FIELD_NAMES.HOME_PHONE} />
+    <PhoneField
+      title={FIELD_TITLES[FIELD_NAMES.HOME_PHONE]}
+      fieldName={FIELD_NAMES.HOME_PHONE}
+    />
   );
 }

--- a/src/platform/user/profile/vet360/components/VAPMailingAddress.jsx
+++ b/src/platform/user/profile/vet360/components/VAPMailingAddress.jsx
@@ -2,12 +2,12 @@ import React from 'react';
 
 import AddressField from './AddressField/VAPAddressField';
 
-import { FIELD_NAMES } from '../constants';
+import { FIELD_NAMES, FIELD_TITLES } from '../constants';
 
 export default function MailingAddress() {
   return (
     <AddressField
-      title="Mailing address"
+      title={FIELD_TITLES[FIELD_NAMES.MAILING_ADDRESS]}
       fieldName={FIELD_NAMES.MAILING_ADDRESS}
       deleteDisabled
     />

--- a/src/platform/user/profile/vet360/components/VAPMobilePhone.jsx
+++ b/src/platform/user/profile/vet360/components/VAPMobilePhone.jsx
@@ -1,12 +1,14 @@
 import React from 'react';
 import PhoneField from './PhoneField/VAPPhoneField';
-import { FIELD_NAMES } from '../constants';
+import { FIELD_NAMES, FIELD_TITLES } from '../constants';
 
 export default function MobilePhone() {
   return (
-    <PhoneField
-      title="Mobile phone number"
-      fieldName={FIELD_NAMES.MOBILE_PHONE}
-    />
+    <>
+      <PhoneField
+        title={FIELD_TITLES[FIELD_NAMES.MOBILE_PHONE]}
+        fieldName={FIELD_NAMES.MOBILE_PHONE}
+      />
+    </>
   );
 }

--- a/src/platform/user/profile/vet360/components/VAPResidentialAddress.jsx
+++ b/src/platform/user/profile/vet360/components/VAPResidentialAddress.jsx
@@ -2,12 +2,12 @@ import React from 'react';
 
 import AddressField from './AddressField/VAPAddressField';
 
-import { FIELD_NAMES } from '../constants';
+import { FIELD_NAMES, FIELD_TITLES } from '../constants';
 
 export default function ResidentialAddress() {
   return (
     <AddressField
-      title="Home address"
+      title={FIELD_TITLES[FIELD_NAMES.RESIDENTIAL_ADDRESS]}
       fieldName={FIELD_NAMES.RESIDENTIAL_ADDRESS}
     />
   );

--- a/src/platform/user/profile/vet360/components/VAPWorkPhone.jsx
+++ b/src/platform/user/profile/vet360/components/VAPWorkPhone.jsx
@@ -2,10 +2,13 @@ import React from 'react';
 
 import PhoneField from './PhoneField/VAPPhoneField';
 
-import { FIELD_NAMES } from '../constants';
+import { FIELD_NAMES, FIELD_TITLES } from '../constants';
 
 export default function WorkPhone() {
   return (
-    <PhoneField title="Work phone number" fieldName={FIELD_NAMES.WORK_PHONE} />
+    <PhoneField
+      title={FIELD_TITLES[FIELD_NAMES.WORK_PHONE]}
+      fieldName={FIELD_NAMES.WORK_PHONE}
+    />
   );
 }

--- a/src/platform/user/profile/vet360/constants/index.js
+++ b/src/platform/user/profile/vet360/constants/index.js
@@ -56,6 +56,17 @@ export const FIELD_NAMES = {
   RESIDENTIAL_ADDRESS: 'residentialAddress',
 };
 
+export const FIELD_TITLES = {
+  [FIELD_NAMES.HOME_PHONE]: 'Home phone number',
+  [FIELD_NAMES.MOBILE_PHONE]: 'Mobile phone number',
+  [FIELD_NAMES.WORK_PHONE]: 'Work phone number',
+  [FIELD_NAMES.TEMP_PHONE]: 'Temporary phone number',
+  [FIELD_NAMES.FAX_NUMBER]: 'Fax number',
+  [FIELD_NAMES.EMAIL]: 'Email address',
+  [FIELD_NAMES.MAILING_ADDRESS]: 'Mailing address',
+  [FIELD_NAMES.RESIDENTIAL_ADDRESS]: 'Home address',
+};
+
 export const PHONE_TYPE = {
   mobilePhone: 'MOBILE',
   workPhone: 'WORK',

--- a/src/platform/user/profile/vet360/tests/containers/VAPProfileField.unit.spec.jsx
+++ b/src/platform/user/profile/vet360/tests/containers/VAPProfileField.unit.spec.jsx
@@ -7,7 +7,7 @@ import {
   VAPProfileField,
   mapStateToProps,
 } from '../../containers/VAPProfileField';
-import { TRANSACTION_STATUS } from '../../constants';
+import { FIELD_NAMES, TRANSACTION_STATUS } from '../../constants';
 
 function ContentView() {
   return <h1>Content</h1>;
@@ -33,7 +33,7 @@ describe('<VAPProfileField/>', () => {
       data: { someField: 'someFieldValue' },
       EditView: () => <EditView />,
       field: null,
-      fieldName: 'someField',
+      fieldName: FIELD_NAMES.HOME_PHONE,
       showEditView: false,
       showValidationView: false,
       isEmpty: false,
@@ -160,33 +160,91 @@ describe('<VAPProfileField/>', () => {
 });
 
 describe('mapStateToProps', () => {
-  const showValidationModalState = () => ({
-    featureToggles: { vaProfileAddressValidation: true },
+  const getBasicState = () => ({
     user: {
       profile: {
         vet360: {
-          mailingAddress: '',
+          mobilePhone: '',
         },
       },
     },
     vet360: {
-      addressValidation: {
-        addressValidationType: 'mailingAddress',
-      },
+      addressValidation: {},
       formFields: {
-        mailingAddress: {},
+        mobilePhone: {},
       },
-      modal: 'addressValidation',
+      modal: null,
       transactions: [],
       fieldTransactionMap: {},
     },
   });
+  describe('#blockEditMode', () => {
+    it('should be false if no field is in edit mode', () => {
+      const state = getBasicState();
+      const mappedProps = mapStateToProps(state, {
+        fieldName: FIELD_NAMES.MOBILE_PHONE,
+      });
+      expect(mappedProps.blockEditMode).to.be.false;
+    });
+    it('should be true if currently editing another field', () => {
+      const state = getBasicState();
+      state.vet360.modal = 'homePhone';
+      const mappedProps = mapStateToProps(state, {
+        fieldName: FIELD_NAMES.MOBILE_PHONE,
+      });
+      expect(mappedProps.blockEditMode).to.be.true;
+    });
+  });
+  describe('#activeEditView', () => {
+    it('should be the field name of the field that is being edited', () => {
+      const state = getBasicState();
+      state.vet360.modal = FIELD_NAMES.RESIDENTIAL_ADDRESS;
+      const mappedProps = mapStateToProps(state, {
+        fieldName: FIELD_NAMES.MOBILE_PHONE,
+      });
+      expect(mappedProps.activeEditView).to.equal(
+        FIELD_NAMES.RESIDENTIAL_ADDRESS,
+      );
+    });
+    it('should be the field name of the address field that is being validated', () => {
+      const state = getBasicState();
+      state.vet360.modal = 'addressValidation';
+      state.vet360.addressValidation.addressValidationType =
+        FIELD_NAMES.RESIDENTIAL_ADDRESS;
+      const mappedProps = mapStateToProps(state, {
+        fieldName: FIELD_NAMES.MOBILE_PHONE,
+      });
+      expect(mappedProps.activeEditView).to.equal(
+        FIELD_NAMES.RESIDENTIAL_ADDRESS,
+      );
+    });
+  });
   describe('#showValidationView', () => {
+    const showValidationModalState = () => ({
+      user: {
+        profile: {
+          vet360: {
+            mailingAddress: '',
+          },
+        },
+      },
+      vet360: {
+        addressValidation: {
+          addressValidationType: FIELD_NAMES.MAILING_ADDRESS,
+        },
+        formFields: {
+          mailingAddress: {},
+        },
+        modal: 'addressValidation',
+        transactions: [],
+        fieldTransactionMap: {},
+      },
+    });
     describe('when all the correct conditions are met', () => {
       it('sets `showValidationView` to `true`', () => {
         const state = showValidationModalState();
         const mappedProps = mapStateToProps(state, {
-          fieldName: 'mailingAddress',
+          fieldName: FIELD_NAMES.MAILING_ADDRESS,
           ValidationView: () => {},
         });
         expect(mappedProps.showValidationView).to.be.true;
@@ -197,7 +255,7 @@ describe('mapStateToProps', () => {
         const state = showValidationModalState();
         state.vet360.modal = 'notTheValidationModal';
         const mappedProps = mapStateToProps(state, {
-          fieldName: 'mailingAddress',
+          fieldName: FIELD_NAMES.MAILING_ADDRESS,
           ValidationView: () => {},
         });
         expect(mappedProps.showValidationView).to.be.false;
@@ -207,7 +265,7 @@ describe('mapStateToProps', () => {
       it('sets `showValidationView` to `false`', () => {
         const state = showValidationModalState();
         const mappedProps = mapStateToProps(state, {
-          fieldName: 'mailingAddress',
+          fieldName: FIELD_NAMES.MAILING_ADDRESS,
         });
         expect(mappedProps.showValidationView).to.be.false;
       });
@@ -216,7 +274,7 @@ describe('mapStateToProps', () => {
       it('sets `showValidationView` to `false`', () => {
         const state = showValidationModalState();
         const mappedProps = mapStateToProps(state, {
-          fieldName: 'residentialAddress',
+          fieldName: FIELD_NAMES.RESIDENTIAL_ADDRESS,
           ValidationView: () => {},
         });
         expect(mappedProps.showValidationView).to.be.false;


### PR DESCRIPTION
## Description
Prevents a user from starting to edit a piece of profile data if they are already editing another piece of profile data.

TODO:
- [x] get the actual copy (and maybe different UX) for this modal (https://github.com/department-of-veterans-affairs/va.gov-team/issues/9784)

## Testing done


## Screenshots
![edit-warn](https://user-images.githubusercontent.com/20728956/84922731-21a2ba00-b07b-11ea-96b6-acc7e1a35dc5.gif)

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs