### PR TITLE
Update Terms and Conditions content

### DIFF
--- a/src/applications/personalization/profile-2/components/MHVTermsAndConditionsStatus.jsx
+++ b/src/applications/personalization/profile-2/components/MHVTermsAndConditionsStatus.jsx
@@ -11,34 +11,36 @@ const MHVTermsAndConditionsStatus = ({ mhvAccount }) => {
 
   if (mhvAccount.termsAndConditionsAccepted) {
     return (
-      <Verified>
-        <>
-          You’ve accepted the latest Terms and Conditions for Medical
-          Information.
-          <p className="vads-u-margin-bottom--0">
-            <a
-              href={termsAndConditionsUrl}
-              onClick={() =>
-                recordEvent({
-                  event: 'account-navigation',
-                  'account-action': 'view-link',
-                  'account-section': 'terms',
-                })
-              }
-            >
-              View terms and conditions for medical information
-            </a>
-          </p>
-        </>
-      </Verified>
+      <>
+        <Verified>
+          You’ve accepted the terms and conditions for using VA.gov health
+          tools.
+        </Verified>
+        <p className="vads-u-margin-bottom--0">
+          <a
+            href={termsAndConditionsUrl}
+            onClick={() =>
+              recordEvent({
+                event: 'account-navigation',
+                'account-action': 'view-link',
+                'account-section': 'terms',
+              })
+            }
+          >
+            View terms and conditions for medical information
+          </a>
+        </p>
+      </>
     );
   } else if (mhvAccount.accountState === 'needs_terms_acceptance') {
     return (
       <>
         <p className="vads-u-margin--0">
-          To get started using our health tools, you’ll need to read and agree
-          to the Terms and Conditions for Medical Information. This will give us
-          your permission to show you your VA medical information on this site.
+          Before using our health tools, you’ll need to read and agree to the
+          terms and conditions for medical information. This will give us
+          permission to share your VA medical information with you. Once you do
+          this, you can use the tools to refill your VA prescriptions or
+          download your VA health records.
         </p>
         <p className="vads-u-margin-bottom--0">
           <a
@@ -51,7 +53,7 @@ const MHVTermsAndConditionsStatus = ({ mhvAccount }) => {
               })
             }
           >
-            Go to the Terms and Conditions for Health Tools
+            Go to the terms and conditions for medical information
           </a>
         </p>
       </>

--- a/src/applications/personalization/profile-2/tests/components/MHVTermsAndConditionsStatus.unit.spec.jsx
+++ b/src/applications/personalization/profile-2/tests/components/MHVTermsAndConditionsStatus.unit.spec.jsx
@@ -22,15 +22,15 @@ describe('MHVTermsAndConditionsStatus', () => {
         wrapper.unmount();
       });
 
-      it('should render a <Verified> component', () => {
-        expect(wrapper.type()).to.equal(Verified);
+      it('should render a <Verified> component as its first child', () => {
+        const firstChild = wrapper.childAt(0);
+        expect(firstChild.type()).to.equal(Verified);
         expect(
-          wrapper
-            .at(0)
+          firstChild
             .dive()
             .text()
             .includes(
-              'You’ve accepted the latest Terms and Conditions for Medical Information',
+              'You’ve accepted the terms and conditions for using VA.gov health tools.',
             ),
         ).to.be.true;
       });
@@ -67,7 +67,7 @@ describe('MHVTermsAndConditionsStatus', () => {
           p
             .text()
             .includes(
-              'To get started using our health tools, you’ll need to read and agree to the Terms and Conditions for Medical Information. This will give us your permission to show you your VA medical information on this site.',
+              'Before using our health tools, you’ll need to read and agree to the terms and conditions for medical information. This will give us permission to share your VA medical information with you. Once you do this, you can use the tools to refill your VA prescriptions or download your VA health records.',
             ),
         ).to.be.true;
       });
@@ -80,7 +80,7 @@ describe('MHVTermsAndConditionsStatus', () => {
         expect(
           link
             .text()
-            .includes('Go to the Terms and Conditions for Health Tools'),
+            .includes('Go to the terms and conditions for medical information'),
         ).to.be.true;
       });
     });


### PR DESCRIPTION
## Description
Updates content for the Terms and Conditions section of Account Security

Also fixes the indentation https://github.com/department-of-veterans-affairs/va.gov-team/issues/9779

## Testing done
Local

## Screenshots
<details>
  <summary>Terms and Conditions not accepted</summary>
  
![image](https://user-images.githubusercontent.com/20728956/84452114-c3548200-ac09-11ea-980f-70163897aca7.png)

</details>

<details>
  <summary>Terms and Conditions accepted</summary>
  
![image](https://user-images.githubusercontent.com/20728956/84452129-cbacbd00-ac09-11ea-97a3-9e16527c7d53.png)

</details>

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs