### PR TITLE
Use same logic for "Update benefits" click as rendering of ExtensionBeneficiaryZIP

### DIFF
--- a/src/applications/gi/components/profile/EstimateYourBenefitsForm.jsx
+++ b/src/applications/gi/components/profile/EstimateYourBenefitsForm.jsx
@@ -99,16 +99,12 @@ class EstimateYourBenefitsForm extends React.Component {
   };
 
   handleCalculateBenefitsClick = () => {
-    const {
-      beneficiaryZIPError,
-      beneficiaryZIP,
-      extension,
-      classesOutsideUS,
-    } = this.props.inputs;
+    const { beneficiaryZIPError, beneficiaryZIP } = this.props.inputs;
+
     if (
       this.props.eligibility.giBillChapter === '33' &&
-      this.props.inputs.beneficiaryLocationQuestion === 'other' &&
-      !classesOutsideUS &&
+      this.displayExtensionBeneficiaryInternationalCheckbox() &&
+      this.displayExtensionBeneficiaryZipcode() &&
       (beneficiaryZIPError || beneficiaryZIP.length !== 5)
     ) {
       this.toggleLearningFormatAndSchedule(true);
@@ -740,6 +736,17 @@ class EstimateYourBenefitsForm extends React.Component {
     );
   };
 
+  displayExtensionBeneficiaryInternationalCheckbox = () => {
+    const { beneficiaryLocationQuestion, extension } = this.props.inputs;
+    return (
+      beneficiaryLocationQuestion === 'other' ||
+      (beneficiaryLocationQuestion === 'extension' && extension === 'other')
+    );
+  };
+
+  displayExtensionBeneficiaryZipcode = () =>
+    !this.props.inputs.classesOutsideUS;
+
   renderExtensionBeneficiaryZIP = () => {
     if (!this.props.displayedInputs.beneficiaryLocationQuestion) {
       return null;
@@ -752,7 +759,7 @@ class EstimateYourBenefitsForm extends React.Component {
     let extensionSelector;
     let zipcodeLocation;
     let extensionOptions = [];
-    const zipcodeRadioOptions = [
+    const beneficiaryLocationQuestionOptions = [
       {
         value: profile.attributes.name,
         label: profile.attributes.name,
@@ -766,12 +773,15 @@ class EstimateYourBenefitsForm extends React.Component {
       });
       extensionOptions.push({ value: 'other', label: 'Other...' });
 
-      zipcodeRadioOptions.push({
+      beneficiaryLocationQuestionOptions.push({
         value: 'extension',
         label: 'An extension campus',
       });
     } else {
-      zipcodeRadioOptions.push({ value: 'other', label: 'Other location' });
+      beneficiaryLocationQuestionOptions.push({
+        value: 'other',
+        label: 'Other location',
+      });
     }
 
     const displayExtensionSelector =
@@ -791,19 +801,13 @@ class EstimateYourBenefitsForm extends React.Component {
       );
     }
 
-    const displayInternationalCheckbox =
-      inputs.beneficiaryLocationQuestion === 'other' ||
-      (inputs.beneficiaryLocationQuestion === 'extension' &&
-        inputs.extension === 'other');
-    const displayZipcode = !inputs.classesOutsideUS;
-
-    if (displayInternationalCheckbox) {
+    if (this.displayExtensionBeneficiaryInternationalCheckbox()) {
       const errorMessage = this.state.invalidZip;
 
       const errorMessageCheck =
         errorMessage !== '' ? errorMessage : inputs.beneficiaryZIPError;
 
-      if (displayZipcode) {
+      if (this.displayExtensionBeneficiaryZipcode()) {
         const label = this.isCountryInternational()
           ? "If you're taking classes in the U.S., enter the location's postal code"
           : "Please enter the postal code where you'll take your classes";
@@ -842,13 +846,16 @@ class EstimateYourBenefitsForm extends React.Component {
         />
       );
     }
-    const selectedValue = inputs.beneficiaryLocationQuestion
+    const selectedBeneficiaryLocationQuestion = inputs.beneficiaryLocationQuestion
       ? inputs.beneficiaryLocationQuestion
       : profile.attributes.name;
 
     return (
       <ExpandingGroup
-        open={displayExtensionSelector || displayInternationalCheckbox}
+        open={
+          displayExtensionSelector ||
+          this.displayExtensionBeneficiaryInternationalCheckbox()
+        }
       >
         <RadioButtons
           label={this.renderLearnMoreLabel({
@@ -857,8 +864,8 @@ class EstimateYourBenefitsForm extends React.Component {
             ariaLabel: ariaLabels.learnMore.majorityOfClasses,
           })}
           name="beneficiaryLocationQuestion"
-          options={zipcodeRadioOptions}
-          value={selectedValue}
+          options={beneficiaryLocationQuestionOptions}
+          value={selectedBeneficiaryLocationQuestion}
           onChange={this.handleInputChange}
           onFocus={this.handleEYBInputFocus}
         />


### PR DESCRIPTION
## Description
Move display logic into own functions and use in `renderExtensionBeneficiaryZIP` and `handleCalculateBenefitsClick`

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
