### PR TITLE
Removes keyboard focus logic from chatbot utils #12838  

### DIFF
--- a/src/applications/coronavirus-chatbot/utils.js
+++ b/src/applications/coronavirus-chatbot/utils.js
@@ -57,30 +57,11 @@ const handleDisableAndScroll = event => {
   }, 700);
 };
 
-/*
-https://github.com/department-of-veterans-affairs/covid19-chatbot/issues/98
-Bot framework renders button containers with tab index 0. This method sets
-tab index to -1 so button containers have javascript-only focus.
-*/
-const removeKeyboardFocusFromContainer = () => {
-  const buttonContainers = document.getElementsByClassName('ac-adaptiveCard');
-  buttonContainers.forEach(buttonContainer => {
-    if (buttonContainer.hasAttribute('tabIndex')) {
-      buttonContainer.setAttribute('tabIndex', '-1');
-    }
-  });
-};
-
-const addEventListenerToButtons = () => {
-  const buttons = document.getElementsByClassName('ac-pushButton');
-  buttons.forEach(button => {
-    button.addEventListener('click', handleDisableAndScroll);
-  });
-};
-
 export const handleButtonsPostRender = () => {
   setInterval(() => {
-    removeKeyboardFocusFromContainer();
-    addEventListenerToButtons();
+    const buttons = document.getElementsByClassName('ac-pushButton');
+    buttons.forEach(button => {
+      button.addEventListener('click', handleDisableAndScroll);
+    });
   }, 10);
 };


### PR DESCRIPTION
## Description
Related to this issue: [department-of-veterans-affairs/covid19-chatbot#253] 

The `4.9.1` release of `botframework-webchat` does not allow keyboard focus on button containers, so we no longer need custom code to remove keyboard focus post-render.

## Testing done


## Screenshots


## Acceptance criteria
- [ ] No change to button disabling, auto-scrolling, and keyboard focus

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
