### PR TITLE
HCA Cypress Form Test

### DIFF
--- a/src/applications/hca/tests/hca.cypress.spec.js
+++ b/src/applications/hca/tests/hca.cypress.spec.js
@@ -1,0 +1,70 @@
+import path from 'path';
+
+import testForm from 'platform/testing/e2e/cypress/support/form-tester';
+import { createTestConfig } from 'platform/testing/e2e/cypress/support/form-tester/utilities';
+
+import formConfig from '../config/form';
+import manifest from '../manifest.json';
+
+const testConfig = createTestConfig(
+  {
+    dataPrefix: 'data',
+    dataSets: ['minimal-test', 'maximal-test', 'foreign-address-test'],
+    fixtures: { data: path.join(__dirname, 'schema') },
+
+    pageHooks: {
+      introduction: () => {
+        cy.findAllByText(/start.+without signing in/i, { selector: 'button' })
+          .first()
+          .click();
+      },
+
+      'id-form': () => {
+        cy.get('@testData').then(data => {
+          cy.findByLabelText(/first name/i).type(data.veteranFullName.first);
+          cy.findByLabelText(/last name/i).type(data.veteranFullName.last);
+
+          const [year, month, day] = data.veteranDateOfBirth
+            .split('-')
+            .map(dateComponent => parseInt(dateComponent, 10).toString());
+          cy.findByLabelText(/month/i).select(month);
+          cy.findByLabelText(/day/i).select(day);
+          cy.findByLabelText(/year/i).type(year);
+
+          cy.findByLabelText(/social security/i).type(
+            data.veteranSocialSecurityNumber,
+          );
+
+          cy.findAllByText(/continue/i, { selector: 'button' }).click();
+        });
+      },
+    },
+
+    setupPerTest: () => {
+      cy.route({
+        method: 'GET',
+        url: '/v0/health_care_applications/enrollment_status*',
+        status: 404,
+        response: {
+          errors: [
+            {
+              title: 'Record not found',
+              detail: 'The record identified by  could not be found',
+              code: '404',
+              status: '404',
+            },
+          ],
+        },
+      });
+
+      cy.route('POST', '/v0/health_care_applications', {
+        formSubmissionId: '123fake-submission-id-567',
+        timestamp: '2016-05-16',
+      });
+    },
+  },
+  manifest,
+  formConfig,
+);
+
+testForm(testConfig);

--- a/src/applications/hca/tests/schema/foreign-address-test.json
+++ b/src/applications/hca/tests/schema/foreign-address-test.json
@@ -17,7 +17,7 @@
     "veteranAddress": {
       "street": "123 elm st",
       "city": "Northampton",
-      "country": "UK",
+      "country": "GBR",
       "state": "MA",
       "postalCode": "01060"
     },


### PR DESCRIPTION
## Description
This is an example of using the form tester to test the 1010ez health care pplication form.

### References
- Main Cypress branch: #12718
- [Form tester documentation](https://github.com/department-of-veterans-affairs/vets-website/blob/94fd3c9e2d07ae4962bbdf595ae3e820f6556a03/src/platform/testing/e2e/cypress/support/form-tester/README.md)

## Testing done
Ran the test, which passed.

## Acceptance criteria
- [ ] The included spec file should serve as an example of writing form tester tests.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
