### PR TITLE
Fix use-resolved-path - DB

### DIFF
--- a/src/applications/disability-benefits/2346/config/form.js
+++ b/src/applications/disability-benefits/2346/config/form.js
@@ -4,7 +4,7 @@ import { VA_FORM_IDS } from 'platform/forms/constants';
 import recordEvent from 'platform/monitoring/record-event';
 import React from 'react';
 import fullSchema from 'vets-json-schema/dist/MDOT-schema.json';
-import { apiRequest } from '../../../../platform/utilities/api';
+import { apiRequest } from 'platform/utilities/api';
 import FooterInfo from '../components/FooterInfo';
 import IntroductionPage from '../components/IntroductionPage';
 import PersonalInfoBox from '../components/PersonalInfoBox';


### PR DESCRIPTION
## Description

`va/use-resolved-path` rule from the `va custom plugin` has been added to the testing stage in CircleCI (`circle.esint.json`)

The purpose of this rule is to resolve the path to use the existing aliases generated in babel.

This change should help the code to be in compliance with the rule and removes the errors from `additional-linting` CircleCI check.

## Testing done
Locally

## Screenshots

<img width="1003" alt="Screen Shot 2020-06-12 at 1 21 46 PM" src="https://user-images.githubusercontent.com/55560129/84529851-2ac50d00-acb0-11ea-81ca-121397c63ab5.png">
