### PR TITLE
fixed regex

### DIFF
--- a/src/applications/gi/components/profile/EstimateYourBenefitsForm.jsx
+++ b/src/applications/gi/components/profile/EstimateYourBenefitsForm.jsx
@@ -352,7 +352,7 @@ class EstimateYourBenefitsForm extends React.Component {
         <input
           type="text"
           inputMode="decimal"
-          pattern="[0-9]*"
+          pattern="(\d*\d+)(?=\,)"
           name={inStateTuitionFeesId}
           id={inStateTuitionFeesId}
           value={formatCurrency(this.props.inputs.inStateTuitionFees)}
@@ -379,7 +379,7 @@ class EstimateYourBenefitsForm extends React.Component {
         })}
         <input
           inputMode="decimal"
-          pattern="[0-9]*"
+          pattern="(\d*\d+)(?=\,)"
           type="text"
           name={tuitionFeesId}
           id={tuitionFeesId}
@@ -400,7 +400,7 @@ class EstimateYourBenefitsForm extends React.Component {
         <label htmlFor={booksId}>Books and supplies per year</label>
         <input
           inputMode="decimal"
-          pattern="[0-9]*"
+          pattern="(\d*\d+)(?=\,)"
           type="text"
           name={booksId}
           id={booksId}
@@ -481,7 +481,7 @@ class EstimateYourBenefitsForm extends React.Component {
             </label>
             <input
               inputMode="decimal"
-              pattern="[0-9]*"
+              pattern="(\d*\d+)(?=\,)"
               id="yellowRibbonContributionAmount"
               type="text"
               name="yellowRibbonAmount"
@@ -529,7 +529,7 @@ class EstimateYourBenefitsForm extends React.Component {
         <input
           inputMode="decimal"
           type="text"
-          pattern="[0-9]*"
+          pattern="(\d*\d+)(?=\,)"
           name={scholarshipsId}
           id={scholarshipsId}
           value={formatCurrency(this.props.inputs.scholarships)}
@@ -555,7 +555,7 @@ class EstimateYourBenefitsForm extends React.Component {
         </label>
         <input
           inputMode="decimal"
-          pattern="[0-9]*"
+          pattern="(\d*\d+)(?=\,)"
           type="text"
           name={tuitionAssistId}
           id={tuitionAssistId}
@@ -703,7 +703,7 @@ class EstimateYourBenefitsForm extends React.Component {
         <label htmlFor={kickerAmountId}>How much is your kicker?</label>
         <input
           inputMode="decimal"
-          pattern="[0-9]*"
+          pattern="(\d*\d+)(?=\,)"
           type="text"
           name={kickerAmountId}
           id={kickerAmountId}
@@ -891,7 +891,7 @@ class EstimateYourBenefitsForm extends React.Component {
         </label>
         <input
           inputMode="decimal"
-          pattern="[0-9]*"
+          pattern="(\d*\d+)(?=\,)"
           type="text"
           name={buyUpAmountId}
           id={buyUpAmountId}

--- a/src/applications/gi/components/vet-tec/VetTecEstimateYourBenefitsForm.jsx
+++ b/src/applications/gi/components/vet-tec/VetTecEstimateYourBenefitsForm.jsx
@@ -108,7 +108,7 @@ class VetTecEstimateYourBenefitsForm extends React.Component {
         aria-labelledby="scholarships-label"
         inputMode="decimal"
         type="text"
-        pattern="[0-9]*"
+        pattern="(\d*\d+)(?=\,)"
         name="vetTecScholarships"
         value={formatDollarAmount(this.state.scholarships)}
         onChange={e =>
@@ -143,7 +143,7 @@ class VetTecEstimateYourBenefitsForm extends React.Component {
       <input
         aria-labelledby="tuition-fees-label"
         name="vetTecTuitionFees"
-        pattern="[0-9]*"
+        pattern="(\d*\d+)(?=\,)"
         type="text"
         inputMode="decimal"
         value={formatDollarAmount(this.state.tuitionFees)}


### PR DESCRIPTION
## Description
While testing the estimate your benefits flow, I noticed Firefox alone and Firefox with NVDA were telling me a lot of fields were in error. After some inspection, I realized it had to do with the pattern attribute on our dollar amount fields. We have a $ that is causing the browser's default error field behavior and styling to kick in.

https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/10168

## Testing done
local testing with firefox, firefox w/ NVDA, android emulator, iphone simulator

## Screenshots


## Acceptance criteria
- [x] Firefox does not show fields in error unless the pattern actually is broken
- [x] NVDA does not announce the field as having invalid entry unless I have actually entered a bad value

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
