### PR TITLE
Clear timeout to exit edit mode

### DIFF
--- a/src/platform/user/profile/vet360/containers/VAPProfileField.jsx
+++ b/src/platform/user/profile/vet360/containers/VAPProfileField.jsx
@@ -74,16 +74,19 @@ class VAPProfileField extends React.Component {
     fieldName: '',
   };
 
+  closeModalTimeoutID = null;
+
   componentDidUpdate(prevProps) {
-    // Just close the edit modal if it takes more than 5 seconds for the update
-    // transaction to resolve. ie, give it 5 seconds before reverting to the old
-    // behavior of showing the "we're saving your new information..." message on
-    // the Profile page
+    // Exit the edit view if it takes more than 5 seconds for the update/save
+    // transaction to resolve. If the transaction has not resolved after 5
+    // seconds we will show a "we're saving your new information..." message on
+    // the Profile
     if (!prevProps.transaction && this.props.transaction) {
-      setTimeout(() => this.props.openModal(), 5000);
+      this.closeModalTimeoutID = setTimeout(() => this.closeModal(), 5000);
     }
 
     if (this.justClosedModal(prevProps, this.props)) {
+      clearTimeout(this.closeModalTimeoutID);
       if (this.props.transaction) {
         focusElement(`div#${this.props.fieldName}-transaction-status`);
       }


### PR DESCRIPTION
## Description
Prevents an edge case where a user might be in edit mode for a different
contact info field and _that_ field would edit edit mode shortly after
the user had entered into it.

## Testing done
Local. First replicated the bug locally and confirmed that the code resolved the bug.

## Screenshots
N/A

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs