### PR TITLE
bradl3yC - refactor eligibility filtering

### DIFF
--- a/src/applications/disability-benefits/2346/components/Accessories.jsx
+++ b/src/applications/disability-benefits/2346/components/Accessories.jsx
@@ -31,7 +31,7 @@ class Accessories extends Component {
     const currentDate = moment();
     const accessorySupplies = supplies
       .filter(supply => supply.productGroup === ACCESSORIES)
-      .filter(supply => currentDate.diff(supply.lastOrderDate, 'months') > 5)
+      .filter(supply => currentDate.diff(supply.lastOrderDate, 'days') / 31 > 5)
       .filter(supply => currentDate.diff(supply.lastOrderDate, 'years') < 2);
     const areAccessorySuppliesEligible = eligibility.accessories;
     const accessorySupplyAvailabilityDates = accessorySupplies.map(
@@ -98,7 +98,7 @@ class Accessories extends Component {
               </p>
             </>
           )}
-        {!accessorySupplies.length &&
+        {!accessorySupplies.length > 0 &&
           !areAccessorySuppliesEligible && (
             <AlertBox
               headline="You can't add accessories to your order at this time"
@@ -127,7 +127,7 @@ class Accessories extends Component {
               isVisible
             />
           )}
-        {!!accessorySupplies.length &&
+        {accessorySupplies.length > 0 &&
           accessorySupplies.map(accessorySupply => (
             <div
               key={accessorySupply.productId}
@@ -193,7 +193,7 @@ class Accessories extends Component {
               )}
             </div>
           ))}
-        {!!accessorySupplies.length && (
+        {accessorySupplies.length > 0 && (
           <AdditionalInfo triggerText="What if I don't see the accessories I need?">
             <p>
               You may not see the accessories you need if you haven't placed an

--- a/src/applications/disability-benefits/2346/components/Accessories.jsx
+++ b/src/applications/disability-benefits/2346/components/Accessories.jsx
@@ -29,20 +29,11 @@ class Accessories extends Component {
   render() {
     const { supplies, order, eligibility } = this.props;
     const currentDate = moment();
-    const accessorySupplies = supplies.filter(
-      supply => supply.productGroup === ACCESSORIES,
-    );
+    const accessorySupplies = supplies
+      .filter(supply => supply.productGroup === ACCESSORIES)
+      .filter(supply => currentDate.diff(supply.lastOrderDate, 'months') > 5)
+      .filter(supply => currentDate.diff(supply.lastOrderDate, 'years') < 2);
     const areAccessorySuppliesEligible = eligibility.accessories;
-    const haveAccessoriesBeenOrderedInLastFiveMonths =
-      accessorySupplies.length > 0 &&
-      accessorySupplies.every(
-        accessory => currentDate.diff(accessory.lastOrderDate, 'months') <= 5,
-      );
-    const haveAccessoriesBeenOrderedInLastTwoYears =
-      accessorySupplies.length > 0 &&
-      accessorySupplies.every(
-        accessory => currentDate.diff(accessory.lastOrderDate, 'years') <= 2,
-      );
     const accessorySupplyAvailabilityDates = accessorySupplies.map(
       accessorySupply => accessorySupply.nextAvailabilityDate,
     );
@@ -70,8 +61,7 @@ class Accessories extends Component {
             </h3>
           </>
         )}
-        {!haveAccessoriesBeenOrderedInLastFiveMonths &&
-          haveAccessoriesBeenOrderedInLastTwoYears &&
+        {!accessorySupplies.length &&
           !areAccessorySuppliesEligible && (
             <>
               <AlertBox
@@ -108,8 +98,7 @@ class Accessories extends Component {
               </p>
             </>
           )}
-        {!haveAccessoriesBeenOrderedInLastTwoYears &&
-          !haveAccessoriesBeenOrderedInLastFiveMonths &&
+        {!accessorySupplies.length &&
           !areAccessorySuppliesEligible && (
             <AlertBox
               headline="You can't add accessories to your order at this time"
@@ -138,8 +127,7 @@ class Accessories extends Component {
               isVisible
             />
           )}
-        {accessorySupplies.length > 0 &&
-          haveAccessoriesBeenOrderedInLastTwoYears &&
+        {!!accessorySupplies.length &&
           accessorySupplies.map(accessorySupply => (
             <div
               key={accessorySupply.productId}
@@ -205,7 +193,7 @@ class Accessories extends Component {
               )}
             </div>
           ))}
-        {accessorySupplies.length > 0 && (
+        {!!accessorySupplies.length && (
           <AdditionalInfo triggerText="What if I don't see the accessories I need?">
             <p>
               You may not see the accessories you need if you haven't placed an

--- a/src/applications/disability-benefits/2346/components/Batteries.jsx
+++ b/src/applications/disability-benefits/2346/components/Batteries.jsx
@@ -31,20 +31,11 @@ class Batteries extends Component {
   render() {
     const { supplies, order, eligibility } = this.props;
     const currentDate = moment();
-    const batterySupplies = supplies.filter(
-      batterySupply => batterySupply.productGroup === BATTERIES,
-    );
+    const batterySupplies = supplies
+      .filter(supply => supply.productGroup === BATTERIES)
+      .filter(supply => currentDate.diff(supply.lastOrderDate, 'months') > 5)
+      .filter(supply => currentDate.diff(supply.lastOrderDate, 'years') > 2);
     const areBatterySuppliesEligible = eligibility.batteries;
-    const haveBatteriesBeenOrderedInLastFiveMonths =
-      batterySupplies.length > 0 &&
-      batterySupplies.every(
-        battery => currentDate.diff(battery.lastOrderDate, 'months') <= 5,
-      );
-    const haveBatteriesBeenOrderedInLastTwoYears =
-      batterySupplies.length > 0 &&
-      batterySupplies.every(
-        battery => currentDate.diff(battery.lastOrderDate, 'years') <= 2,
-      );
     const isBatterySelected = batteryProductId => {
       const selectedProductIds = order.map(
         selectedProduct => selectedProduct.productId,
@@ -80,7 +71,7 @@ class Batteries extends Component {
             </h3>
           </>
         )}
-        {haveBatteriesBeenOrderedInLastFiveMonths &&
+        {!!batterySupplies.length &&
           !areBatterySuppliesEligible && (
             <>
               <AlertBox
@@ -123,8 +114,7 @@ class Batteries extends Component {
               </p>
             </>
           )}
-        {!haveBatteriesBeenOrderedInLastFiveMonths &&
-          !haveBatteriesBeenOrderedInLastTwoYears &&
+        {!batterySupplies.length > 0 &&
           !areBatterySuppliesEligible && (
             <AlertBox
               headline="Your batteries aren't available for online ordering"
@@ -159,8 +149,7 @@ class Batteries extends Component {
               isVisible
             />
           )}
-        {batterySupplies.length > 0 &&
-          haveBatteriesBeenOrderedInLastTwoYears &&
+        {!!batterySupplies.length &&
           batterySupplies.map(batterySupply => (
             <div
               key={batterySupply.productId}
@@ -234,7 +223,7 @@ class Batteries extends Component {
               )}
             </div>
           ))}
-        {batterySupplies.length > 0 && (
+        {!!batterySupplies.length && (
           <AdditionalInfo triggerText="What if I don't see my device?">
             <p>
               You may not see your hearing aid device if you haven’t placed an

--- a/src/applications/disability-benefits/2346/components/Batteries.jsx
+++ b/src/applications/disability-benefits/2346/components/Batteries.jsx
@@ -33,8 +33,8 @@ class Batteries extends Component {
     const currentDate = moment();
     const batterySupplies = supplies
       .filter(supply => supply.productGroup === BATTERIES)
-      .filter(supply => currentDate.diff(supply.lastOrderDate, 'months') > 5)
-      .filter(supply => currentDate.diff(supply.lastOrderDate, 'years') > 2);
+      .filter(supply => currentDate.diff(supply.lastOrderDate, 'days') / 31 > 5)
+      .filter(supply => currentDate.diff(supply.lastOrderDate, 'years') < 2);
     const areBatterySuppliesEligible = eligibility.batteries;
     const isBatterySelected = batteryProductId => {
       const selectedProductIds = order.map(
@@ -71,7 +71,7 @@ class Batteries extends Component {
             </h3>
           </>
         )}
-        {!!batterySupplies.length &&
+        {!batterySupplies.length > 0 &&
           !areBatterySuppliesEligible && (
             <>
               <AlertBox
@@ -149,7 +149,7 @@ class Batteries extends Component {
               isVisible
             />
           )}
-        {!!batterySupplies.length &&
+        {batterySupplies.length > 0 &&
           batterySupplies.map(batterySupply => (
             <div
               key={batterySupply.productId}
@@ -223,7 +223,7 @@ class Batteries extends Component {
               )}
             </div>
           ))}
-        {!!batterySupplies.length && (
+        {batterySupplies.length > 0 && (
           <AdditionalInfo triggerText="What if I don't see my device?">
             <p>
               You may not see your hearing aid device if you haven’t placed an


### PR DESCRIPTION
## Description
Currently, the supplies pages show supplies even if they aren't eligible - this can be very confusing to the user.

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
