### PR TITLE
Comparison Tool - accordion expand/collapse tracking

### DIFF
--- a/src/applications/gi/components/AccordionItem.jsx
+++ b/src/applications/gi/components/AccordionItem.jsx
@@ -42,7 +42,7 @@ class AccordionItem extends React.Component {
 
     const type = this.props.section ? 'section' : 'accordion';
     recordEvent({
-      event: expanded ? `nav-${type}-collapse` : `nav-${type}-expand`,
+      event: expanded ? `nav-${type}-expand` : `nav-${type}-collapse`,
     });
   };
 

--- a/src/applications/gi/tests/components/AccordionItem.unit.spec.jsx
+++ b/src/applications/gi/tests/components/AccordionItem.unit.spec.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { expect } from 'chai';
-import { shallow, mount } from 'enzyme';
+import { shallow } from 'enzyme';
 
 import AccordionItem from '../../components/AccordionItem';
 
@@ -16,7 +16,7 @@ describe('<AccordionItem>', () => {
   });
 
   it('should track accordion collapse', () => {
-    const wrapper = mount(
+    const wrapper = shallow(
       <AccordionItem expanded button={'test'}>
         <div />
       </AccordionItem>,
@@ -31,7 +31,7 @@ describe('<AccordionItem>', () => {
   });
 
   it('should track accordion expand', () => {
-    const wrapper = mount(
+    const wrapper = shallow(
       <AccordionItem expanded={false} button={'test'}>
         <div />
       </AccordionItem>,

--- a/src/applications/gi/tests/components/AccordionItem.unit.spec.jsx
+++ b/src/applications/gi/tests/components/AccordionItem.unit.spec.jsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { expect } from 'chai';
+import { shallow, mount } from 'enzyme';
+
+import AccordionItem from '../../components/AccordionItem';
+
+describe('<AccordionItem>', () => {
+  it('should render', () => {
+    const wrapper = shallow(
+      <AccordionItem expanded button={'test'}>
+        <div />
+      </AccordionItem>,
+    );
+    expect(wrapper.html()).to.not.be.undefined;
+    wrapper.unmount();
+  });
+
+  it('should track accordion collapse', () => {
+    const wrapper = mount(
+      <AccordionItem expanded button={'test'}>
+        <div />
+      </AccordionItem>,
+    );
+    wrapper
+      .find('button')
+      .at(0)
+      .simulate('click');
+    const recordedEvent = global.window.dataLayer[0];
+    expect(recordedEvent.event).to.eq('nav-accordion-collapse');
+    wrapper.unmount();
+  });
+
+  it('should track accordion expand', () => {
+    const wrapper = mount(
+      <AccordionItem expanded={false} button={'test'}>
+        <div />
+      </AccordionItem>,
+    );
+    wrapper
+      .find('button')
+      .at(0)
+      .simulate('click');
+    const recordedEvent = global.window.dataLayer[0];
+    expect(recordedEvent.event).to.eq('nav-accordion-expand');
+    wrapper.unmount();
+  });
+});


### PR DESCRIPTION
## Description
Flipped profile page accordion expand/collapse tracking.

[ZenHub Issue](https://github.com/department-of-veterans-affairs/va.gov-team/issues/10228#event-3444912506)

## Testing done
Tested locally and QA reviewed

## Screenshots
N/A

## Acceptance criteria
- [x] Collapsing an accordion item creates a GTM `nav-accordion-collapse` event.
- [x] Expanding an accordion item creates a GTM `nav-accordion-expand` event.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
