### PR TITLE
10167: Add aria-label to Estimate Your Benefits CalculatorResultRow

### DIFF
--- a/src/applications/gi/components/profile/EstimatedBenefits.jsx
+++ b/src/applications/gi/components/profile/EstimatedBenefits.jsx
@@ -38,7 +38,7 @@ const CalculatorResultRow = ({
       <div className="small-6 columns vads-u-text-align--right">
         {header ? (
           <div>
-            <h5>
+            <h5 aria-label={value}>
               {value}
               {screenReaderSpan}
             </h5>

--- a/src/applications/gi/components/profile/EstimatedBenefits.jsx
+++ b/src/applications/gi/components/profile/EstimatedBenefits.jsx
@@ -38,10 +38,14 @@ const CalculatorResultRow = ({
       <div className="small-6 columns vads-u-text-align--right">
         {header ? (
           <div>
-            <h5 aria-label={value}>
+            <p
+              className="vads-u-font-size--h5 vads-u-font-family--serif
+              vads-u-font-weight--bold eyb-value-header"
+              aria-label={value}
+            >
               {value}
               {screenReaderSpan}
-            </h5>
+            </p>
           </div>
         ) : (
           <div>{value}</div>

--- a/src/applications/gi/sass/partials/_gi-profile-page.scss
+++ b/src/applications/gi/sass/partials/_gi-profile-page.scss
@@ -162,6 +162,10 @@
     hr {
       border: 1px solid $color-primary-darkest;
     }
+    .eyb-value-header {
+      margin-top: 22.5px;
+      margin-bottom: 7.5px;
+    }
   }
 
   .program-name {
@@ -435,10 +439,5 @@
 
   .secondary-sco-list {
     padding-left: 0;
-  }
-
-  .eyb-value-header {
-    margin-top: 22.5px;
-    margin-bottom: 7.5px;
   }
 }

--- a/src/applications/gi/sass/partials/_gi-profile-page.scss
+++ b/src/applications/gi/sass/partials/_gi-profile-page.scss
@@ -359,13 +359,13 @@
   }
 
   .eyb-button {
-    &.usa-accordion-button[aria-expanded="false"] {
-      background-image: url("/img/arrow-up.png");
-      background-image: url("/img/arrow-up.svg");
+    &.usa-accordion-button[aria-expanded='false'] {
+      background-image: url('/img/arrow-up.png');
+      background-image: url('/img/arrow-up.svg');
     }
-    &.usa-accordion-button[aria-expanded="true"] {
-      background-image: url("/img/arrow-down.png");
-      background-image: url("/img/arrow-down.svg");
+    &.usa-accordion-button[aria-expanded='true'] {
+      background-image: url('/img/arrow-down.png');
+      background-image: url('/img/arrow-down.svg');
     }
   }
 

--- a/src/applications/gi/sass/partials/_gi-profile-page.scss
+++ b/src/applications/gi/sass/partials/_gi-profile-page.scss
@@ -355,13 +355,13 @@
   }
 
   .eyb-button {
-    &.usa-accordion-button[aria-expanded='false'] {
-      background-image: url('/img/arrow-up.png');
-      background-image: url('/img/arrow-up.svg');
+    &.usa-accordion-button[aria-expanded="false"] {
+      background-image: url("/img/arrow-up.png");
+      background-image: url("/img/arrow-up.svg");
     }
-    &.usa-accordion-button[aria-expanded='true'] {
-      background-image: url('/img/arrow-down.png');
-      background-image: url('/img/arrow-down.svg');
+    &.usa-accordion-button[aria-expanded="true"] {
+      background-image: url("/img/arrow-down.png");
+      background-image: url("/img/arrow-down.svg");
     }
   }
 
@@ -435,5 +435,10 @@
 
   .secondary-sco-list {
     padding-left: 0;
+  }
+
+  .eyb-value-header {
+    margin-top: 22.5px;
+    margin-bottom: 7.5px;
   }
 }


### PR DESCRIPTION
## Description
While testing the college and OTJ flows, I noticed that iOS VoiceOver was reading the wrong data points back after I made filter changes and pressed the "Update your benefits" button. Screenshot and steps to recreate below.

[Originating Issue](https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/10167)

## Testing done


## Screenshots
N/A

## Acceptance criteria
- [x] iOS VoiceOver reads the correct data before and after I have updated my benefits

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
