### PR TITLE
test get-apps success and failure

### DIFF
--- a/src/applications/personalization/profile-2/components/connected-apps/actions/index.js
+++ b/src/applications/personalization/profile-2/components/connected-apps/actions/index.js
@@ -35,7 +35,7 @@ export function loadConnectedApps(mockRequest) {
       return;
     }
 
-    apiRequest(grantsUrl)
+    await apiRequest(grantsUrl)
       .then(({ data }) =>
         dispatch({ type: FINISHED_LOADING_CONNECTED_APPS, data }),
       )

--- a/src/applications/personalization/profile-2/tests/components/connected-apps/actions.unit.spec.js
+++ b/src/applications/personalization/profile-2/tests/components/connected-apps/actions.unit.spec.js
@@ -1,6 +1,8 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
 
+import { mockApiRequest } from 'platform/testing/unit/helpers.js';
+
 import * as actions from '../../../components/connected-apps/actions';
 
 describe('Connected Apps actions', () => {
@@ -8,9 +10,11 @@ describe('Connected Apps actions', () => {
   const mockRequest = true;
 
   describe('loadConnectedApps', () => {
-    it('creates the correct action', async () => {
+    it('creates the correct action when the call succeeds', async () => {
+      const mockResponse = { data: 'data' };
       const dispatch = sinon.stub();
-      const thunk = await actions.loadConnectedApps(mockRequest);
+      mockApiRequest(mockResponse);
+      const thunk = await actions.loadConnectedApps();
       await thunk(dispatch);
 
       expect(
@@ -18,10 +22,27 @@ describe('Connected Apps actions', () => {
       ).to.be.true;
 
       const secondCallAction = dispatch.secondCall.args[0];
-      expect(secondCallAction.type).to.be.oneOf([
+      expect(secondCallAction.type).to.equal(
         actions.FINISHED_LOADING_CONNECTED_APPS,
+      );
+      expect(secondCallAction.data).to.deep.equal(mockResponse.data);
+    });
+
+    it('creates the correct action when the call fails', async () => {
+      const mockResponse = { errors: [{ code: '300' }] };
+      const dispatch = sinon.stub();
+      mockApiRequest(mockResponse, false);
+      const thunk = await actions.loadConnectedApps();
+      await thunk(dispatch);
+
+      expect(
+        dispatch.firstCall.calledWith({ type: actions.LOADING_CONNECTED_APPS }),
+      ).to.be.true;
+
+      const secondCallAction = dispatch.secondCall.args[0];
+      expect(secondCallAction.type).to.equal(
         actions.ERROR_LOADING_CONNECTED_APPS,
-      ]);
+      );
     });
   });
 


### PR DESCRIPTION
## Description


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs