### PR TITLE
[SCREENREADER]: GIBCT EYB - JAWS and IE11 SHOULD NOT announce extra information when I toggle accordions #10200

### DIFF
--- a/src/applications/gi/components/AccordionItem.jsx
+++ b/src/applications/gi/components/AccordionItem.jsx
@@ -94,7 +94,7 @@ class AccordionItem extends React.Component {
       <li className={liClassName} id={this.id}>
         {this.renderHeader()}
         <div
-          id={this.id}
+          id={`${this.id}-content`}
           className={contentClassName}
           aria-hidden={!expanded}
           hidden={!expanded}

--- a/src/applications/gi/components/AccordionItem.jsx
+++ b/src/applications/gi/components/AccordionItem.jsx
@@ -22,7 +22,7 @@ class AccordionItem extends React.Component {
     this.state = {
       expanded: props.expanded,
     };
-    this.id = _.uniqueId('accordion-item-');
+    this.id = `${createId(props.button)}-accordion`;
   }
 
   expanded = () => {
@@ -84,16 +84,21 @@ class AccordionItem extends React.Component {
 
   render() {
     const expanded = this.expanded();
-    const { button, section, children } = this.props;
+    const { section, children } = this.props;
 
     const liClassName = section ? 'section-item' : 'accordion-item';
     const contentClassName = section
       ? 'section-content'
       : 'usa-accordion-content';
     return (
-      <li className={liClassName} id={`${createId(button)}-accordion`}>
+      <li className={liClassName} id={this.id}>
         {this.renderHeader()}
-        <div id={this.id} className={contentClassName} aria-hidden={!expanded}>
+        <div
+          id={this.id}
+          className={contentClassName}
+          aria-hidden={!expanded}
+          hidden={!expanded}
+        >
           {expanded ? children : null}
         </div>
       </li>

--- a/src/applications/gi/components/profile/EstimateYourBenefitsForm.jsx
+++ b/src/applications/gi/components/profile/EstimateYourBenefitsForm.jsx
@@ -1021,7 +1021,7 @@ class EstimateYourBenefitsForm extends React.Component {
     );
   };
 
-  renderSchoolCostsAndCalendar = () => {
+  hideSchoolCostsAndCalendar = () => {
     const {
       inState,
       tuition,
@@ -1031,8 +1031,18 @@ class EstimateYourBenefitsForm extends React.Component {
       enrolledOld,
     } = this.props.displayedInputs;
 
-    if (!(inState || tuition || books || calendar || enrolled || enrolledOld))
-      return null;
+    return !(
+      inState ||
+      tuition ||
+      books ||
+      calendar ||
+      enrolled ||
+      enrolledOld
+    );
+  };
+
+  renderSchoolCostsAndCalendar = () => {
+    if (this.hideSchoolCostsAndCalendar()) return null;
 
     const name = 'School costs and calendar';
 
@@ -1090,7 +1100,7 @@ class EstimateYourBenefitsForm extends React.Component {
     );
   };
 
-  renderScholarshipsAndOtherVAFunding = () => {
+  hideScholarshipsAndOtherVAFunding = () => {
     const {
       yellowRibbon,
       tuitionAssist,
@@ -1098,8 +1108,11 @@ class EstimateYourBenefitsForm extends React.Component {
       buyUp,
       scholarships,
     } = this.props.displayedInputs;
-    if (!(yellowRibbon || tuitionAssist || kicker || buyUp || scholarships))
-      return null;
+    return !(yellowRibbon || tuitionAssist || kicker || buyUp || scholarships);
+  };
+
+  renderScholarshipsAndOtherVAFunding = () => {
+    if (this.hideScholarshipsAndOtherVAFunding()) return null;
     const name = 'Scholarships and other VA funding';
     return (
       <AccordionItem
@@ -1130,7 +1143,11 @@ class EstimateYourBenefitsForm extends React.Component {
   render() {
     const isOjt =
       _.get(this.props, 'profile.attributes.type', '').toLowerCase() === 'ojt';
-    const sectionCount = isOjt ? '3' : '4';
+
+    let sectionCount = 2;
+    if (!this.hideSchoolCostsAndCalendar()) sectionCount += 1;
+    if (!this.hideScholarshipsAndOtherVAFunding()) sectionCount += 1;
+
     const className = classNames(
       'estimate-your-benefits-form',
       'medium-5',


### PR DESCRIPTION
## Description
https://github.com/department-of-veterans-affairs/va.gov-team/issues/10200

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
