### PR TITLE
VAVFS-10242: Add situation updates back to op status page

### DIFF
--- a/src/site/layouts/vamc_operating_status_and_alerts.drupal.liquid
+++ b/src/site/layouts/vamc_operating_status_and_alerts.drupal.liquid
@@ -70,7 +70,7 @@
                         </ul>
                     </section>
 
-                    {% if fieldBannerAlert.0.entity.status != false and fieldBannerAlert.0.entity.fieldSituationUpdates.0.entity %}
+                    {% if fieldBannerAlert %}
                     {% include "src/site/components/situation_updates.drupal.liquid" with fieldBannerAlert %}
                     {% endif %}
 


### PR DESCRIPTION
## Description
Situation updates aren't appearing, here: `pittsburgh-health-care/operating-status/`

## Testing done
Visual

## Acceptance criteria
- [ ] Situation updates should appear
