### PR TITLE
Show alert when there are unsaved changes and a navigation event

### DIFF
--- a/src/applications/personalization/profile-2/components/personal-information/PersonalInformation.jsx
+++ b/src/applications/personalization/profile-2/components/personal-information/PersonalInformation.jsx
@@ -8,10 +8,6 @@ import { focusElement } from 'platform/utilities/ui';
 import PersonalInformationContent from './PersonalInformationContent';
 
 class PersonalInformation extends Component {
-  static propTypes = {
-    hasUnsavedEdits: PropTypes.bool.isRequired,
-  };
-
   componentDidUpdate() {
     // Show alert when navigating away.
     if (this.props.hasUnsavedEdits) {
@@ -42,6 +38,10 @@ class PersonalInformation extends Component {
     );
   }
 }
+
+PersonalInformation.propTypes = {
+  hasUnsavedEdits: PropTypes.bool.isRequired,
+};
 
 const mapStateToProps = state => ({
   hasUnsavedEdits: state.vet360.hasUnsavedEdits,

--- a/src/applications/personalization/profile-2/components/personal-information/PersonalInformation.jsx
+++ b/src/applications/personalization/profile-2/components/personal-information/PersonalInformation.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { Prompt } from 'react-router-dom';
 import { connect } from 'react-redux';
@@ -7,41 +7,41 @@ import { focusElement } from 'platform/utilities/ui';
 
 import PersonalInformationContent from './PersonalInformationContent';
 
-class PersonalInformation extends Component {
-  componentDidMount() {
+const PersonalInformation = ({ hasUnsavedEdits }) => {
+  useEffect(() => {
     focusElement('[data-focus-target]');
-  }
+  }, []);
 
-  componentDidUpdate() {
-    // Show alert when navigating away.
-    if (this.props.hasUnsavedEdits) {
-      window.onbeforeunload = () => true;
-      return;
-    }
+  useEffect(
+    () => {
+      // Show alert when navigating away
+      if (hasUnsavedEdits) {
+        window.onbeforeunload = () => true;
+        return;
+      }
 
-    // Do not show alert when navigating away.
-    window.onbeforeunload = undefined;
-  }
+      window.onbeforeunload = undefined;
+    },
+    [hasUnsavedEdits],
+  );
 
-  render() {
-    return (
-      <>
-        <Prompt
-          message="Are you sure you want to leave? If you leave, your in-progress work won't be saved."
-          when={this.props.hasUnsavedEdits}
-        />
-        <h2
-          tabIndex="-1"
-          className="vads-u-margin-y--2 medium-screen:vads-u-margin-bottom--4 medium-screen:vads-u-margin-top--3"
-          data-focus-target
-        >
-          Personal and contact information
-        </h2>
-        <PersonalInformationContent />
-      </>
-    );
-  }
-}
+  return (
+    <>
+      <Prompt
+        message="Are you sure you want to leave? If you leave, your in-progress work won't be saved."
+        when={hasUnsavedEdits}
+      />
+      <h2
+        tabIndex="-1"
+        className="vads-u-margin-y--2 medium-screen:vads-u-margin-bottom--4 medium-screen:vads-u-margin-top--3"
+        data-focus-target
+      >
+        Personal and contact information
+      </h2>
+      <PersonalInformationContent />
+    </>
+  );
+};
 
 PersonalInformation.propTypes = {
   hasUnsavedEdits: PropTypes.bool.isRequired,

--- a/src/applications/personalization/profile-2/components/personal-information/PersonalInformation.jsx
+++ b/src/applications/personalization/profile-2/components/personal-information/PersonalInformation.jsx
@@ -8,9 +8,11 @@ import { focusElement } from 'platform/utilities/ui';
 import PersonalInformationContent from './PersonalInformationContent';
 
 class PersonalInformation extends Component {
-  componentDidUpdate() {
+  componentDidMount() {
     focusElement('[data-focus-target]');
+  }
 
+  componentDidUpdate() {
     // Show alert when navigating away.
     if (this.props.hasUnsavedEdits) {
       window.onbeforeunload = () => true;

--- a/src/applications/personalization/profile-2/components/personal-information/PersonalInformation.jsx
+++ b/src/applications/personalization/profile-2/components/personal-information/PersonalInformation.jsx
@@ -9,6 +9,8 @@ import PersonalInformationContent from './PersonalInformationContent';
 
 class PersonalInformation extends Component {
   componentDidUpdate() {
+    focusElement('[data-focus-target]');
+
     // Show alert when navigating away.
     if (this.props.hasUnsavedEdits) {
       window.onbeforeunload = () => true;

--- a/src/applications/personalization/profile-2/components/personal-information/PersonalInformation.jsx
+++ b/src/applications/personalization/profile-2/components/personal-information/PersonalInformation.jsx
@@ -23,7 +23,7 @@ class PersonalInformation extends Component {
     return (
       <>
         <Prompt
-          message="You have unsaved changes, are you sure you want to leave?"
+          message="Are you sure you want to leave? If you leave, your in-progress work won't be saved."
           when={this.props.hasUnsavedEdits}
         />
         <h2

--- a/src/applications/personalization/profile-2/components/personal-information/PersonalInformation.jsx
+++ b/src/applications/personalization/profile-2/components/personal-information/PersonalInformation.jsx
@@ -1,26 +1,53 @@
-import React, { useEffect } from 'react';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { Prompt } from 'react-router-dom';
+import { connect } from 'react-redux';
 
 import { focusElement } from 'platform/utilities/ui';
 
 import PersonalInformationContent from './PersonalInformationContent';
 
-const PersonalInformation = () => {
-  useEffect(() => {
-    focusElement('[data-focus-target]');
-  }, []);
+class PersonalInformation extends Component {
+  static propTypes = {
+    hasUnsavedEdits: PropTypes.bool.isRequired,
+  };
 
-  return (
-    <>
-      <h2
-        tabIndex="-1"
-        className="vads-u-margin-y--2 medium-screen:vads-u-margin-bottom--4 medium-screen:vads-u-margin-top--3"
-        data-focus-target
-      >
-        Personal and contact information
-      </h2>
-      <PersonalInformationContent />
-    </>
-  );
-};
+  componentDidUpdate() {
+    // Show alert when navigating away.
+    if (this.props.hasUnsavedEdits) {
+      window.onbeforeunload = () => true;
+      return;
+    }
 
-export default PersonalInformation;
+    // Do not show alert when navigating away.
+    window.onbeforeunload = undefined;
+  }
+
+  render() {
+    return (
+      <>
+        <Prompt
+          message="You have unsaved changes, are you sure you want to leave?"
+          when={this.props.hasUnsavedEdits}
+        />
+        <h2
+          tabIndex="-1"
+          className="vads-u-margin-y--2 medium-screen:vads-u-margin-bottom--4 medium-screen:vads-u-margin-top--3"
+          data-focus-target
+        >
+          Personal and contact information
+        </h2>
+        <PersonalInformationContent />
+      </>
+    );
+  }
+}
+
+const mapStateToProps = state => ({
+  hasUnsavedEdits: state.vet360.hasUnsavedEdits,
+});
+
+export default connect(
+  mapStateToProps,
+  null,
+)(PersonalInformation);

--- a/src/platform/user/profile/vet360/actions/ui.js
+++ b/src/platform/user/profile/vet360/actions/ui.js
@@ -28,6 +28,7 @@ export const updateFormFieldWithSchema = (
     value,
     true,
   );
+
   return {
     type: UPDATE_PROFILE_FORM_FIELD,
     field: fieldName,

--- a/src/platform/user/profile/vet360/reducers/index.js
+++ b/src/platform/user/profile/vet360/reducers/index.js
@@ -19,7 +19,7 @@ import {
   ADDRESS_VALIDATION_UPDATE,
 } from '../actions';
 
-import { isEqual, pickBy } from 'lodash';
+import { isEmpty, isEqual, pickBy } from 'lodash';
 
 import { isFailedTransaction } from '../util/transactions';
 
@@ -44,7 +44,7 @@ const initialAddressValidationState = {
 
 const initialState = {
   hasUnsavedEdits: false,
-  initialFormState: {},
+  initialFormFields: {},
   modal: null,
   modalData: null,
   formFields: {},
@@ -115,7 +115,7 @@ export default function vet360(state = initialState, action) {
             transactionId: action.transaction.data.attributes.transactionId,
           },
         },
-        initialFormState: {},
+        initialFormFields: {},
         hasUnsavedEdits: false,
       };
     }
@@ -209,13 +209,13 @@ export default function vet360(state = initialState, action) {
     }
 
     case UPDATE_PROFILE_FORM_FIELD: {
-      let initialFormState = state.initialFormState || {};
+      let initialFormFields = state.initialFormFields || {};
 
       const emptyInitialFormState =
-        Object.keys(state.initialFormState).length === 0;
+        Object.keys(state.initialFormFields).length === 0;
 
       if (emptyInitialFormState) {
-        initialFormState = state.formFields;
+        initialFormFields = state.formFields;
       }
 
       const formFields = {
@@ -224,12 +224,11 @@ export default function vet360(state = initialState, action) {
       };
 
       const modalName = state?.modal;
-      const initialFormFieldValues = state.initialFormState[modalName]?.value;
+      const initialFormFieldValues = state.initialFormFields[modalName]?.value;
       let formFieldValues = formFields[modalName]?.value;
 
       formFieldValues = pickBy(formFieldValues, value => value !== undefined);
 
-      // eslint-disable-next-line no-restricted-syntax
       for (const key in formFieldValues) {
         if (key.startsWith('view')) {
           delete formFieldValues[key];
@@ -244,7 +243,7 @@ export default function vet360(state = initialState, action) {
         ...state,
         formFields,
         hasUnsavedEdits,
-        initialFormState,
+        initialFormFields,
       };
     }
 

--- a/src/platform/user/profile/vet360/reducers/index.js
+++ b/src/platform/user/profile/vet360/reducers/index.js
@@ -224,17 +224,17 @@ export default function vet360(state = initialState, action) {
       };
 
       const modalName = state?.modal;
+      const initialFormFieldValues = state.initialFormState[modalName]?.value;
       let formFieldValues = formFields[modalName]?.value;
 
       formFieldValues = pickBy(formFieldValues, value => value !== undefined);
 
+      // eslint-disable-next-line no-restricted-syntax
       for (const key in formFieldValues) {
         if (key.startsWith('view')) {
           delete formFieldValues[key];
         }
       }
-
-      const initialFormFieldValues = state.initialFormState[modalName]?.value;
 
       const hasUnsavedEdits =
         !emptyInitialFormState &&

--- a/src/platform/user/profile/vet360/reducers/index.js
+++ b/src/platform/user/profile/vet360/reducers/index.js
@@ -209,14 +209,11 @@ export default function vet360(state = initialState, action) {
     }
 
     case UPDATE_PROFILE_FORM_FIELD: {
-      let initialFormFields = state.initialFormFields || {};
-
-      const emptyInitialFormState =
-        Object.keys(state.initialFormFields).length === 0;
-
-      if (emptyInitialFormState) {
-        initialFormFields = state.formFields;
-      }
+      // The action gets fired upon initial opening of the edit modal
+      // We only want to capture initialFormFields once, it should not update
+      const initialFormFields = isEmpty(state.initialFormFields)
+        ? state.formFields
+        : state.initialFormFields;
 
       const formFields = {
         ...state.formFields,
@@ -229,6 +226,9 @@ export default function vet360(state = initialState, action) {
 
       formFieldValues = pickBy(formFieldValues, value => value !== undefined);
 
+      // Initial form fields does not have 'view' properties, those get added to formFields
+      // After editing a field. So we need to strip of those 'view' fields to be able to compare
+      // eslint-disable-next-line no-restricted-syntax
       for (const key in formFieldValues) {
         if (key.startsWith('view')) {
           delete formFieldValues[key];
@@ -236,7 +236,7 @@ export default function vet360(state = initialState, action) {
       }
 
       const hasUnsavedEdits =
-        !emptyInitialFormState &&
+        !isEmpty(state.initialFormFields) &&
         !isEqual(formFieldValues, initialFormFieldValues);
 
       return {

--- a/src/platform/user/profile/vet360/reducers/index.js
+++ b/src/platform/user/profile/vet360/reducers/index.js
@@ -233,7 +233,7 @@ export default function vet360(state = initialState, action) {
       );
 
       const hasUnsavedEdits =
-        !isEmpty(state.initialFormFields) &&
+        !isEmpty(initialFormFields) &&
         !isEqual(formFieldValues, initialFormFieldValues);
 
       return {

--- a/src/platform/user/profile/vet360/reducers/index.js
+++ b/src/platform/user/profile/vet360/reducers/index.js
@@ -42,6 +42,7 @@ const initialAddressValidationState = {
 
 const initialState = {
   hasUnsavedEdits: false,
+  initialFormState: {},
   modal: null,
   modalData: null,
   formFields: {},
@@ -205,15 +206,38 @@ export default function vet360(state = initialState, action) {
     }
 
     case UPDATE_PROFILE_FORM_FIELD: {
+      let updatedInitialFormState = {};
+
+      if (Object.keys(state.initialFormState).length === 0) {
+        console.log('Do I get logged?');
+        updatedInitialFormState = state.formFields;
+      }
+
+      console.log('This is initialFormState ', state.initialFormState);
+
+      // if (state.initialFormState === {}) {
+      console.log('This is formFields', state.formFields);
+      // }
+
       const formFields = {
         ...state.formFields,
         [action.field]: action.newState,
       };
-      return { ...state, formFields, hasUnsavedEdits: true };
+
+      return {
+        ...state,
+        formFields,
+        hasUnsavedEdits: true,
+        initialFormState: updatedInitialFormState,
+      };
     }
 
     case OPEN_MODAL:
-      return { ...state, modal: action.modal, modalData: action.modalData };
+      return {
+        ...state,
+        modal: action.modal,
+        modalData: action.modalData,
+      };
 
     case ADDRESS_VALIDATION_INITIALIZE:
       return {

--- a/src/platform/user/profile/vet360/reducers/index.js
+++ b/src/platform/user/profile/vet360/reducers/index.js
@@ -41,6 +41,7 @@ const initialAddressValidationState = {
 };
 
 const initialState = {
+  hasUnsavedEdits: false,
   modal: null,
   modalData: null,
   formFields: {},
@@ -111,6 +112,7 @@ export default function vet360(state = initialState, action) {
             transactionId: action.transaction.data.attributes.transactionId,
           },
         },
+        hasUnsavedEdits: false,
       };
     }
 
@@ -207,7 +209,7 @@ export default function vet360(state = initialState, action) {
         ...state.formFields,
         [action.field]: action.newState,
       };
-      return { ...state, formFields };
+      return { ...state, formFields, hasUnsavedEdits: true };
     }
 
     case OPEN_MODAL:

--- a/src/platform/user/profile/vet360/reducers/index.js
+++ b/src/platform/user/profile/vet360/reducers/index.js
@@ -224,16 +224,19 @@ export default function vet360(state = initialState, action) {
       const initialFormFieldValues = state.initialFormFields[modalName]?.value;
       let formFieldValues = formFields[modalName]?.value;
 
-      formFieldValues = pickBy(formFieldValues, value => value !== undefined);
-
       // Initial form fields does not have 'view' properties, those get added to formFields
       // After editing a field. So we need to strip of those 'view' fields to be able to compare
-      // eslint-disable-next-line no-restricted-syntax
-      for (const key in formFieldValues) {
-        if (key.startsWith('view')) {
-          delete formFieldValues[key];
+      formFieldValues = pickBy(formFieldValues, (value, key) => {
+        if (value !== undefined) {
+          return true;
         }
-      }
+
+        if (key.startsWith('view')) {
+          return true;
+        }
+
+        return false;
+      });
 
       const hasUnsavedEdits =
         !isEmpty(state.initialFormFields) &&

--- a/src/platform/user/profile/vet360/reducers/index.js
+++ b/src/platform/user/profile/vet360/reducers/index.js
@@ -209,16 +209,16 @@ export default function vet360(state = initialState, action) {
     }
 
     case UPDATE_PROFILE_FORM_FIELD: {
-      // The action gets fired upon initial opening of the edit modal
-      // We only want to capture initialFormFields once, it should not update
-      const initialFormFields = isEmpty(state.initialFormFields)
-        ? state.formFields
-        : state.initialFormFields;
-
       const formFields = {
         ...state.formFields,
         [action.field]: action.newState,
       };
+
+      // The action gets fired upon initial opening of the edit modal
+      // We only want to capture initialFormFields once, it should not update
+      const initialFormFields = isEmpty(state.initialFormFields)
+        ? formFields
+        : state.initialFormFields;
 
       const modalName = state?.modal;
       const initialFormFieldValues = state.initialFormFields[modalName]?.value;
@@ -233,7 +233,7 @@ export default function vet360(state = initialState, action) {
       );
 
       const hasUnsavedEdits =
-        !isEmpty(initialFormFields) &&
+        !isEmpty(initialFormFieldValues) &&
         !isEqual(formFieldValues, initialFormFieldValues);
 
       return {

--- a/src/platform/user/profile/vet360/reducers/index.js
+++ b/src/platform/user/profile/vet360/reducers/index.js
@@ -226,17 +226,11 @@ export default function vet360(state = initialState, action) {
 
       // Initial form fields does not have 'view' properties, those get added to formFields
       // After editing a field. So we need to strip of those 'view' fields to be able to compare
-      formFieldValues = pickBy(formFieldValues, (value, key) => {
-        if (value !== undefined) {
-          return true;
-        }
-
-        if (key.startsWith('view:')) {
-          return true;
-        }
-
-        return false;
-      });
+      formFieldValues = pickBy(formFieldValues, value => value !== undefined);
+      formFieldValues = pickBy(
+        formFieldValues,
+        (value, key) => !key.startsWith('view:'),
+      );
 
       const hasUnsavedEdits =
         !isEmpty(state.initialFormFields) &&
@@ -255,6 +249,7 @@ export default function vet360(state = initialState, action) {
         ...state,
         modal: action.modal,
         modalData: action.modalData,
+        hasUnsavedEdits: false,
       };
 
     case ADDRESS_VALIDATION_INITIALIZE:

--- a/src/platform/user/profile/vet360/reducers/index.js
+++ b/src/platform/user/profile/vet360/reducers/index.js
@@ -19,7 +19,7 @@ import {
   ADDRESS_VALIDATION_UPDATE,
 } from '../actions';
 
-import { union, keys, isEqual, reduce, pickBy } from 'lodash';
+import { isEqual, pickBy } from 'lodash';
 
 import { isFailedTransaction } from '../util/transactions';
 
@@ -226,8 +226,6 @@ export default function vet360(state = initialState, action) {
       const modalName = state?.modal;
       let formFieldValues = formFields[modalName]?.value;
 
-      console.log('Before', formFieldValues);
-
       formFieldValues = pickBy(formFieldValues, value => value !== undefined);
 
       for (const key in formFieldValues) {
@@ -236,18 +234,11 @@ export default function vet360(state = initialState, action) {
         }
       }
 
-      // console.log('After', formFieldValues);
-
       const initialFormFieldValues = state.initialFormState[modalName]?.value;
-
-      // console.log('This is form field values', formFieldValues);
-      // console.log('This is initial form field values', initialFormFieldValues);
 
       const hasUnsavedEdits =
         !emptyInitialFormState &&
-        isEqual(formFieldValues, initialFormFieldValues);
-
-      console.log(isEqual(formFieldValues, initialFormFieldValues));
+        !isEqual(formFieldValues, initialFormFieldValues);
 
       return {
         ...state,

--- a/src/platform/user/profile/vet360/reducers/index.js
+++ b/src/platform/user/profile/vet360/reducers/index.js
@@ -231,7 +231,7 @@ export default function vet360(state = initialState, action) {
           return true;
         }
 
-        if (key.startsWith('view')) {
+        if (key.startsWith('view:')) {
           return true;
         }
 

--- a/src/platform/user/profile/vet360/reducers/index.js
+++ b/src/platform/user/profile/vet360/reducers/index.js
@@ -250,6 +250,7 @@ export default function vet360(state = initialState, action) {
         modal: action.modal,
         modalData: action.modalData,
         hasUnsavedEdits: false,
+        initialFormFields: {},
       };
 
     case ADDRESS_VALIDATION_INITIALIZE:

--- a/src/platform/user/profile/vet360/reducers/index.js
+++ b/src/platform/user/profile/vet360/reducers/index.js
@@ -206,18 +206,11 @@ export default function vet360(state = initialState, action) {
     }
 
     case UPDATE_PROFILE_FORM_FIELD: {
-      let updatedInitialFormState = {};
+      let initialFormState = state.initialFormState || {};
 
       if (Object.keys(state.initialFormState).length === 0) {
-        console.log('Do I get logged?');
-        updatedInitialFormState = state.formFields;
+        initialFormState = state.formFields;
       }
-
-      console.log('This is initialFormState ', state.initialFormState);
-
-      // if (state.initialFormState === {}) {
-      console.log('This is formFields', state.formFields);
-      // }
 
       const formFields = {
         ...state.formFields,
@@ -228,7 +221,7 @@ export default function vet360(state = initialState, action) {
         ...state,
         formFields,
         hasUnsavedEdits: true,
-        initialFormState: updatedInitialFormState,
+        initialFormState,
       };
     }
 

--- a/src/platform/user/profile/vet360/tests/reducers/index.unit.spec.js
+++ b/src/platform/user/profile/vet360/tests/reducers/index.unit.spec.js
@@ -263,7 +263,7 @@ describe('vet360 reducer', () => {
   it('should update profile form fields', () => {
     const state = vet360(
       {
-        initialFormState: {
+        initialFormFields: {
           mailingAddress: {
             value: 'value',
           },

--- a/src/platform/user/profile/vet360/tests/reducers/index.unit.spec.js
+++ b/src/platform/user/profile/vet360/tests/reducers/index.unit.spec.js
@@ -262,7 +262,19 @@ describe('vet360 reducer', () => {
 
   it('should update profile form fields', () => {
     const state = vet360(
-      {},
+      {
+        initialFormState: {
+          mailingAddress: {
+            value: 'value',
+          },
+        },
+        formFields: {
+          mailingAddress: {
+            value: 'value',
+          },
+        },
+        modal: 'emailAddress',
+      },
       {
         type: 'UPDATE_PROFILE_FORM_FIELD',
         field: 'fieldName',


### PR DESCRIPTION
[TICKET](https://github.com/department-of-veterans-affairs/va.gov-team/issues/9436)

## Description
We need to add an alert when the user navigates away from the Personal Information page while having unsaved edits.

## Testing done
Works locally

## Acceptance criteria
- [x] Add an alert when the user navigates away from the Personal Information page while having unsaved edits.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
