### PR TITLE
Fix Inbound SSOe feature flag check

### DIFF
--- a/src/platform/site-wide/user-nav/containers/AutoSSO.jsx
+++ b/src/platform/site-wide/user-nav/containers/AutoSSO.jsx
@@ -20,7 +20,7 @@ function AutoSSO(props) {
 
   if (userLoggedIn) {
     removeForceAuth();
-  } else if (!useInboundSSOe) {
+  } else if (useInboundSSOe === false) {
     // if inbound ssoe is disabled, always force the user to re enter their
     // credentials when they attempt to authenticate
     setForceAuth();

--- a/src/platform/site-wide/user-nav/tests/containers/AutoSSO.unit.spec.jsx
+++ b/src/platform/site-wide/user-nav/tests/containers/AutoSSO.unit.spec.jsx
@@ -42,11 +42,22 @@ describe('<AutoSSO>', () => {
   it('should call setForceAuth if inbound ssoe is disabled', () => {
     const stub = sinon.stub(forceAuth, 'setForceAuth');
     Object.assign(props, {
-      userInboundSSOe: false,
+      useInboundSSOe: false,
     });
     const wrapper = shallow(<AutoSSO {...props} />);
     stub.restore();
     sinon.assert.calledOnce(stub);
+    wrapper.unmount();
+  });
+
+  it('should not call setForceAuth if the inbound ssoe flag is undefined', () => {
+    const stub = sinon.stub(forceAuth, 'setForceAuth');
+    Object.assign(props, {
+      useInboundSSOe: undefined,
+    });
+    const wrapper = shallow(<AutoSSO {...props} />);
+    stub.restore();
+    sinon.assert.notCalled(stub);
     wrapper.unmount();
   });
 


### PR DESCRIPTION
## Description

Right now, the inbound SSO checks the inbound feature flag variable to determine if `setForceAuth` should be called. However, since on first render, feature flags have not been yet fetched, it is giving a false positive when evaluating `!undefined`, which executes `setForceAuth` and blocks any inbound SSO that might be valid.

Fix: explicitly check for `useInboundSSOe` to be false.

## Testing done

Manually verified bug and added new unit test for the offending scenario
