### PR TITLE
Custom markdown parser for chatbot

### DIFF
--- a/package.json
+++ b/package.json
@@ -281,6 +281,8 @@
     "leaflet-control-geocoder": "^1.13.0",
     "local-storage-fallback": "^4.1.1",
     "lodash": "^4.17.15",
+    "markdown-it": "^11.0.0",
+    "markdown-it-link-attributes": "^3.0.0",
     "metalsmith": "^2.1.0",
     "metalsmith-collections": "^0.9.0",
     "metalsmith-filenames": "^1.0.0",

--- a/src/applications/coronavirus-chatbot/index.js
+++ b/src/applications/coronavirus-chatbot/index.js
@@ -1,6 +1,11 @@
 import { apiRequest } from 'platform/utilities/api';
 import recordEvent from 'platform/monitoring/record-event';
-import { recordLinkClicks, GA_PREFIX, handleButtonsPostRender } from './utils';
+import {
+  recordLinkClicks,
+  GA_PREFIX,
+  handleButtonsPostRender,
+  markdownRenderer,
+} from './utils';
 import * as Sentry from '@sentry/browser';
 import localStorage from 'platform/utilities/storage/localStorage';
 
@@ -108,6 +113,7 @@ const initBotConversation = jsonWebToken => {
     directLine: botConnection,
     styleOptions,
     store: webchatStore,
+    renderMarkdown: text => markdownRenderer.render(text),
     userID: user.id,
     username: user.name,
     locale: user.locale,

--- a/src/applications/coronavirus-chatbot/tests/utils.unit.spec.js
+++ b/src/applications/coronavirus-chatbot/tests/utils.unit.spec.js
@@ -1,0 +1,30 @@
+import { markdownRenderer } from '../utils.js';
+import { expect } from 'chai';
+
+describe('markdownRenderer', () => {
+  it('should render markdown links to open in new tabs', () => {
+    const sampleInput = '[Example](http://www.example.com)';
+    const expectedOutput =
+      '<a href="http://www.example.com" target="_blank" rel="noopener">Example</a>';
+
+    expect(markdownRenderer.renderInline(sampleInput)).to.equal(expectedOutput);
+  });
+
+  it('should render markdown links to open in new tabs within paragraphs', () => {
+    const sampleInput =
+      "**To find your nearest VA health facility's phone number**\n\nUse our website's [**Find VA locations** tool](https://www.va.gov/find-locations).";
+    const expectedOutput =
+      '<p><strong>To find your nearest VA health facility\'s phone number</strong></p>\n<p>Use our website\'s <a href="https://www.va.gov/find-locations" target="_blank" rel="noopener"><strong>Find VA locations</strong> tool</a>.</p>\n';
+
+    expect(markdownRenderer.render(sampleInput)).to.equal(expectedOutput);
+  });
+
+  it('should render HTML links as is', () => {
+    const sampleInput =
+      '<a href="http://www.example.com" rel="noopener">Example</a>';
+    const expectedOutput =
+      '<a href="http://www.example.com" rel="noopener">Example</a>';
+
+    expect(markdownRenderer.renderInline(sampleInput)).to.equal(expectedOutput);
+  });
+});

--- a/src/applications/coronavirus-chatbot/utils.js
+++ b/src/applications/coronavirus-chatbot/utils.js
@@ -1,3 +1,5 @@
+import MarkdownIt from 'markdown-it';
+import markdownitLinkAttributes from 'markdown-it-link-attributes';
 import recordEvent from 'platform/monitoring/record-event';
 
 export const GA_PREFIX = 'chatbot';
@@ -65,3 +67,12 @@ export const handleButtonsPostRender = () => {
     });
   }, 10);
 };
+
+export const markdownRenderer = MarkdownIt({
+  html: true,
+}).use(markdownitLinkAttributes, {
+  attrs: {
+    target: '_blank',
+    rel: 'noopener',
+  },
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -5900,6 +5900,11 @@ entities@^1.1.1, entities@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.1.tgz#6e5c2d0a5621b5dadaecef80b90edfb5cd7772f0"
 
+entities@~2.0.0:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-2.0.3.tgz#5c487e5742ab93c15abb5da22759b8590ec03b7f"
+  integrity sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ==
+
 env-paths@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/env-paths/-/env-paths-1.0.0.tgz#4168133b42bb05c38a35b1ae4397c8298ab369e0"
@@ -10272,6 +10277,13 @@ linkify-it@^2.0.0:
   dependencies:
     uc.micro "^1.0.1"
 
+linkify-it@^3.0.1:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/linkify-it/-/linkify-it-3.0.2.tgz#f55eeb8bc1d3ae754049e124ab3bb56d97797fb8"
+  integrity sha512-gDBO4aHNZS6coiZCKVhSNh43F9ioIL4JwRjLZPkoLIY4yZFwg264Y5lu2x6rb1Js42Gh6Yqm2f6L2AJcnkzinQ==
+  dependencies:
+    uc.micro "^1.0.1"
+
 listr-silent-renderer@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz#924b5a3757153770bf1a8e3fbf74b8bbf3f9242e"
@@ -10934,6 +10946,22 @@ map-visit@^1.0.0:
   resolved "https://registry.yarnpkg.com/map-visit/-/map-visit-1.0.0.tgz#ecdca8f13144e660f1b5bd41f12f3479d98dfb8f"
   dependencies:
     object-visit "^1.0.0"
+
+markdown-it-link-attributes@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/markdown-it-link-attributes/-/markdown-it-link-attributes-3.0.0.tgz#12d6f403102ac22695ee2617bec109ee79426e45"
+  integrity sha512-B34ySxVeo6MuEGSPCWyIYryuXINOvngNZL87Mp7YYfKIf6DcD837+lXA8mo6EBbauKsnGz22ZH0zsbOiQRWTNg==
+
+markdown-it@^11.0.0:
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/markdown-it/-/markdown-it-11.0.0.tgz#dbfc30363e43d756ebc52c38586b91b90046b876"
+  integrity sha512-+CvOnmbSubmQFSA9dKz1BRiaSMV7rhexl3sngKqFyXSagoA3fBdJQ8oZWtRy2knXdpDXaBw44euz37DeJQ9asg==
+  dependencies:
+    argparse "^1.0.7"
+    entities "~2.0.0"
+    linkify-it "^3.0.1"
+    mdurl "^1.0.1"
+    uc.micro "^1.0.5"
 
 markdown-it@^7.0.0:
   version "7.0.1"
@@ -16629,6 +16657,11 @@ ua-parser-js@^0.7.18:
 uc.micro@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/uc.micro/-/uc.micro-1.0.3.tgz#7ed50d5e0f9a9fb0a573379259f2a77458d50192"
+
+uc.micro@^1.0.5:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/uc.micro/-/uc.micro-1.0.6.tgz#9c411a802a409a91fc6cf74081baba34b24499ac"
+  integrity sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==
 
 uglify-js@^3.1.4, uglify-js@^3.9.4:
   version "3.9.4"


### PR DESCRIPTION
## Description
[department-of-veterans-affairs/covid19-chatbot#260]

Uses custom markdown parser to render chatbot content.

Two npm packages added:
- [markdown-it](https://github.com/markdown-it/markdown-it)
- [markdown-it-link-attributes](https://www.npmjs.com/package/markdown-it-link-attributes)

## Testing done
Unit tests

## Screenshots
![Screen Shot 2020-06-16 at 12 00 37](https://user-images.githubusercontent.com/19177102/84798500-09726280-afc9-11ea-95a9-31b3284884df.png)
![Screen Shot 2020-06-16 at 11 59 49](https://user-images.githubusercontent.com/19177102/84798512-0c6d5300-afc9-11ea-94c3-7500441bba89.png)


## Acceptance criteria
- [x] Links open in new tabs (target="_blank")
- [x] Restart link (shown at timeout) should open in same tab

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
