### PR TITLE
Fix fl ccp still to use v0 

### DIFF
--- a/src/applications/facility-locator/api/LocatorApi.js
+++ b/src/applications/facility-locator/api/LocatorApi.js
@@ -63,7 +63,7 @@ class LocatorApi {
    * @param {string} id The ID of the CC Provider
    */
   static fetchProviderDetail(id) {
-    const url = `${api.baseUrl}/ccp/${id}`;
+    const url = `${api.baseUrlV0}/ccp/${id}`;
 
     return new Promise((resolve, reject) => {
       fetch(url, api.settings)

--- a/src/applications/facility-locator/api/LocatorApi.js
+++ b/src/applications/facility-locator/api/LocatorApi.js
@@ -76,8 +76,7 @@ class LocatorApi {
    * Get all known services available from all CC Providers.
    */
   static getProviderSvcs() {
-    const url = `${api.baseUrl}/services`;
-
+    const url = `${api.baseUrlV0}/services`;
     return new Promise((resolve, reject) => {
       fetch(url, api.settings)
         .then(res => res.json())


### PR DESCRIPTION
## Description
Fix, ccp still to use v0 
https://github.com/department-of-veterans-affairs/va.gov-team/issues/10286
## Testing done
Locally

## Screenshots

<img width="1384" alt="Screen Shot 2020-06-16 at 11 20 49 AM" src="https://user-images.githubusercontent.com/100468/84801076-556ed880-afc4-11ea-849c-24b8311d32fb.png">
<img width="1415" alt="Screen Shot 2020-06-16 at 11 20 56 AM" src="https://user-images.githubusercontent.com/100468/84801093-5a338c80-afc4-11ea-9baa-40fb16911078.png">


## Acceptance criteria
- [x] Fix, ccp still to use v0 

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
