### PR TITLE
bradl3yC - 9624 - error if missing eligibility object

### DIFF
--- a/src/applications/disability-benefits/2346/actions/index.js
+++ b/src/applications/disability-benefits/2346/actions/index.js
@@ -56,7 +56,10 @@ export const fetchFormStatus = () => async dispatch => {
       }
       const eligibility = body.formData.eligibility;
 
-      if (eligibility && !eligibility.accessories && !eligibility.batteries) {
+      if (
+        !eligibility ||
+        (eligibility && !eligibility.accessories && !eligibility.batteries)
+      ) {
         const sortedSuppliesByAvailability = sortBy(
           body.formData.supplies,
           'nextAvailabilityDate',


### PR DESCRIPTION
## Description
Currently the form handler on the backend will filter out any falsey keys in its response.  So if both eligibility states are false, the entire eligibility key will be missing.  If this happens, we need to make the assumption that both are false and return the error state.

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
