### PR TITLE
Metalsmith debug emit to files

### DIFF
--- a/script/content-build-help.js
+++ b/script/content-build-help.js
@@ -92,6 +92,12 @@ const helpSections = [
         type: Boolean,
         description: 'Lint HTML files for plain language.',
       },
+      {
+        name: 'generate-files',
+        type: Boolean,
+        description:
+          'Emit files for debugging with the Metalsmith emitToFiles plugin during the build pipeline.',
+      },
     ],
   },
 ];

--- a/src/site/stages/build/index.js
+++ b/src/site/stages/build/index.js
@@ -42,6 +42,7 @@ const rewriteDrupalPages = require('./plugins/rewrite-drupal-pages');
 const rewriteVaDomains = require('./plugins/rewrite-va-domains');
 const updateExternalLinks = require('./plugins/update-external-links');
 const updateRobots = require('./plugins/update-robots');
+const emitToFiles = require('./plugins/emit-to-files');
 
 /**
  * Immediately copies the Webpack build output to a directory outside of
@@ -159,6 +160,11 @@ function build(BUILD_OPTIONS) {
   // permalinks() and navigation() filters making the variable stores uniform between inPlace()
   // and layout().
   smith.use(
+    emitToFiles(
+      path.resolve(__dirname, '../../../../build/', 'before-inPlace'),
+    ),
+  );
+  smith.use(
     inPlace({ engine: 'liquid', pattern: '*.{md,html}' }),
     'Plug the content into the templates',
   );
@@ -212,6 +218,10 @@ function build(BUILD_OPTIONS) {
       pattern: '**/*.{md,html}',
     }),
     'Apply layouts',
+  );
+
+  smith.use(
+    emitToFiles(path.resolve(__dirname, '../../../../build/', 'after-layouts')),
   );
 
   /*

--- a/src/site/stages/build/index.js
+++ b/src/site/stages/build/index.js
@@ -161,8 +161,10 @@ function build(BUILD_OPTIONS) {
   // and layout().
   smith.use(
     emitToFiles(
+      BUILD_OPTIONS,
       path.resolve(__dirname, '../../../../build/', 'before-inPlace'),
     ),
+    'Emit debug files to build/before-inPlace',
   );
   smith.use(
     inPlace({ engine: 'liquid', pattern: '*.{md,html}' }),
@@ -221,7 +223,11 @@ function build(BUILD_OPTIONS) {
   );
 
   smith.use(
-    emitToFiles(path.resolve(__dirname, '../../../../build/', 'after-layouts')),
+    emitToFiles(
+      BUILD_OPTIONS,
+      path.resolve(__dirname, '../../../../build/', 'after-layouts'),
+    ),
+    'Emit debug files to build/after-layouts',
   );
 
   /*

--- a/src/site/stages/build/index.js
+++ b/src/site/stages/build/index.js
@@ -118,6 +118,14 @@ function build(BUILD_OPTIONS) {
 
   smith.use(createReactPages(BUILD_OPTIONS), 'Create React pages');
   smith.use(getDrupalContent(BUILD_OPTIONS), 'Get Drupal content');
+  smith.use(
+    emitToFiles(
+      BUILD_OPTIONS,
+      path.resolve(__dirname, '../../../../build/', 'after-getDrupalContent'),
+      file => file.debug,
+    ),
+    'Emit Drupal debug data for each file',
+  );
   smith.use(addDrupalPrefix(BUILD_OPTIONS), 'Add Drupal Prefix');
   smith.use(
     createOutreachAssetsData(BUILD_OPTIONS),
@@ -159,13 +167,15 @@ function build(BUILD_OPTIONS) {
   // translating .md files which would allow inPlace() and markdown() to be moved under the
   // permalinks() and navigation() filters making the variable stores uniform between inPlace()
   // and layout().
-  smith.use(
-    emitToFiles(
-      BUILD_OPTIONS,
-      path.resolve(__dirname, '../../../../build/', 'before-inPlace'),
-    ),
-    'Emit debug files to build/before-inPlace',
-  );
+
+  // smith.use(
+  //   emitToFiles(
+  //     BUILD_OPTIONS,
+  //     path.resolve(__dirname, '../../../../build/', 'before-inPlace'),
+  //   ),
+  //   'Emit debug files to build/before-inPlace',
+  // );
+
   smith.use(
     inPlace({ engine: 'liquid', pattern: '*.{md,html}' }),
     'Plug the content into the templates',
@@ -226,8 +236,9 @@ function build(BUILD_OPTIONS) {
     emitToFiles(
       BUILD_OPTIONS,
       path.resolve(__dirname, '../../../../build/', 'after-layouts'),
+      file => file.contents,
     ),
-    'Emit debug files to build/after-layouts',
+    'Emit contents of files to build/after-layouts',
   );
 
   /*

--- a/src/site/stages/build/options.js
+++ b/src/site/stages/build/options.js
@@ -55,6 +55,7 @@ const COMMAND_LINE_OPTIONS_DEFINITIONS = [
   { name: 'local-css-sourcemaps', type: Boolean, defaultValue: false },
   { name: 'accessibility', type: Boolean, defaultValue: false },
   { name: 'lint-plain-language', type: Boolean, defaultValue: false },
+  { name: 'generate-files', type: Boolean, defaultValue: false },
   { name: 'unexpected', type: String, multile: true, defaultOption: true },
 ];
 

--- a/src/site/stages/build/plugins/emit-to-files.js
+++ b/src/site/stages/build/plugins/emit-to-files.js
@@ -2,17 +2,21 @@
 const path = require('path');
 const fs = require('fs-extra');
 
-const emitToFiles = (buildOptions, directory) =>
+const stringify = data => JSON.stringify(data, null, 2);
+
+const emitToFiles = (buildOptions, directory, getData = stringify) =>
   buildOptions['generate-files']
-    ? () => {}
-    : files => {
+    ? files => {
         fs.emptyDirSync(directory);
 
         Object.keys(files).forEach(filePath => {
           const p = path.join(directory, filePath);
           console.log(`Writing file to ${p}`);
-          fs.outputFileSync(p, files[filePath].contents.toString('utf-8'));
+          fs.outputFileSync(p, getData(files[filePath]));
         });
+      }
+    : () => {
+        console.log('Skipping...');
       };
 
 module.exports = emitToFiles;

--- a/src/site/stages/build/plugins/emit-to-files.js
+++ b/src/site/stages/build/plugins/emit-to-files.js
@@ -1,0 +1,15 @@
+/* eslint-disable no-console */
+const path = require('path');
+const fs = require('fs-extra');
+
+const emitToFiles = directory => files => {
+  fs.emptyDirSync(directory);
+
+  Object.keys(files).forEach(filePath => {
+    const p = path.join(directory, filePath);
+    console.log(`Writing file to ${p}`);
+    fs.outputFileSync(p, files[filePath].contents.toString('utf-8'));
+  });
+};
+
+module.exports = emitToFiles;

--- a/src/site/stages/build/plugins/emit-to-files.js
+++ b/src/site/stages/build/plugins/emit-to-files.js
@@ -2,14 +2,17 @@
 const path = require('path');
 const fs = require('fs-extra');
 
-const emitToFiles = directory => files => {
-  fs.emptyDirSync(directory);
+const emitToFiles = (buildOptions, directory) =>
+  buildOptions['generate-files']
+    ? () => {}
+    : files => {
+        fs.emptyDirSync(directory);
 
-  Object.keys(files).forEach(filePath => {
-    const p = path.join(directory, filePath);
-    console.log(`Writing file to ${p}`);
-    fs.outputFileSync(p, files[filePath].contents.toString('utf-8'));
-  });
-};
+        Object.keys(files).forEach(filePath => {
+          const p = path.join(directory, filePath);
+          console.log(`Writing file to ${p}`);
+          fs.outputFileSync(p, files[filePath].contents.toString('utf-8'));
+        });
+      };
 
 module.exports = emitToFiles;


### PR DESCRIPTION
## Description
Using the `emitToFiles` plugin, we can dump the contents of the files to disk at various points of the build process. This will aid in debugging.

Enable this functionality with `yarn build:content --generate-files`

## Testing done
Tested manually.

## Screenshots
Not really applicable, but I did add it to the `yarn build:content help` command:
![image](https://user-images.githubusercontent.com/12970166/84815288-ab914b00-afc7-11ea-88d2-63c4e51256b0.png)