### PR TITLE
10035 remove duplicate SMS checkbox

### DIFF
--- a/src/applications/personalization/profile360/components/ContactInformation.jsx
+++ b/src/applications/personalization/profile360/components/ContactInformation.jsx
@@ -39,9 +39,7 @@ export default class ContactInformation extends React.Component {
         categoryType={TRANSACTION_CATEGORY_TYPES.PHONE}
       >
         <HomePhone />
-        <MobilePhone
-          showReceiveTextNotifications={this.props.showReceiveTextNotifications}
-        />
+        <MobilePhone />
         <WorkPhone />
         <FaxNumber />
       </Vet360PendingTransactionCategory>

--- a/src/applications/personalization/profile360/components/ProfileView.jsx
+++ b/src/applications/personalization/profile360/components/ProfileView.jsx
@@ -28,7 +28,6 @@ import {
   directDepositIsSetUp,
   directDepositAddressIsSetUp,
   directDepositIsBlocked as directDepositIsBlockedSelector,
-  profileShowReceiveTextNotifications,
 } from 'applications/personalization/profile360/selectors';
 
 const ProfileTOC = ({ militaryInformation, showDirectDepositLink }) => (
@@ -126,9 +125,7 @@ class ProfileView extends React.Component {
                 showDirectDepositLink={showDirectDepositLink}
               />
               <div id="contact-information" />
-              <ContactInformation
-                showReceiveTextNotifications={showReceiveTextNotifications}
-              />
+              <ContactInformation />
               <>
                 <div id="direct-deposit" />
                 <PaymentInformation />
@@ -206,7 +203,6 @@ function mapStateToProps(state) {
     showDirectDepositLink:
       !directDepositIsBlocked &&
       (directDepositIsSetUp(state) || directDepositAddressIsSetUp(state)),
-    showReceiveTextNotifications: profileShowReceiveTextNotifications(state),
   };
 }
 

--- a/src/applications/personalization/profile360/selectors.js
+++ b/src/applications/personalization/profile360/selectors.js
@@ -1,9 +1,6 @@
 import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
 import FEATURE_FLAG_NAMES from 'platform/utilities/feature-toggles/featureFlagNames';
 
-export const profileShowReceiveTextNotifications = state =>
-  toggleValues(state)[FEATURE_FLAG_NAMES.profileShowReceiveTextNotifications];
-
 export const directDepositInformation = state =>
   state.vaProfile?.paymentInformation;
 

--- a/src/platform/testing/local-dev-mock-api/common.js
+++ b/src/platform/testing/local-dev-mock-api/common.js
@@ -57,7 +57,6 @@ const responses = {
         { name: 'dashboardShowCovid19Alert', value: true },
         { name: 'facilityLocatorShowCommunityCares', value: true },
         { name: 'profile_show_profile_2.0', value: false },
-        { name: 'profileShowReceiveTextNotifications', value: true },
         { name: 'vaOnlineScheduling', value: true },
         { name: 'vaOnlineSchedulingCancel', value: true },
         { name: 'vaOnlineSchedulingRequests', value: true },

--- a/src/platform/user/profile/vet360/components/MobilePhone.jsx
+++ b/src/platform/user/profile/vet360/components/MobilePhone.jsx
@@ -3,19 +3,17 @@ import PhoneField from './PhoneField/PhoneField';
 import ReceiveTextMessages from '../containers/ReceiveTextMessages';
 import { FIELD_NAMES } from '../constants';
 
-export default function MobilePhone({ showReceiveTextNotifications }) {
+export default function MobilePhone() {
   return (
     <>
       <PhoneField
         title="Mobile phone number"
         fieldName={FIELD_NAMES.MOBILE_PHONE}
       />
-      {showReceiveTextNotifications && (
-        <ReceiveTextMessages
-          title="Mobile phone number"
-          fieldName={FIELD_NAMES.MOBILE_PHONE}
-        />
-      )}
+      <ReceiveTextMessages
+        title="Mobile phone number"
+        fieldName={FIELD_NAMES.MOBILE_PHONE}
+      />
     </>
   );
 }

--- a/src/platform/user/profile/vet360/components/PhoneField/PhoneEditModal.jsx
+++ b/src/platform/user/profile/vet360/components/PhoneField/PhoneEditModal.jsx
@@ -7,8 +7,6 @@ import { isEnrolledInVAHealthCare as isEnrolledInVAHealthCareSelector } from 'ap
 
 import { FIELD_NAMES } from 'vet360/constants';
 
-import { profileShowReceiveTextNotifications } from 'applications/personalization/profile360/selectors';
-
 import ContactInfoForm from '../ContactInfoForm';
 
 class PhoneEditModal extends React.Component {
@@ -65,16 +63,10 @@ class PhoneEditModal extends React.Component {
 }
 
 export function mapStateToProps(state, ownProps) {
-  const showReceiveTextNotifications = profileShowReceiveTextNotifications(
-    state,
-  );
   const isEnrolledInVAHealthCare = isEnrolledInVAHealthCareSelector(state);
   const showSMSCheckbox =
-    ownProps.fieldName === FIELD_NAMES.MOBILE_PHONE &&
-    showReceiveTextNotifications &&
-    isEnrolledInVAHealthCare;
+    ownProps.fieldName === FIELD_NAMES.MOBILE_PHONE && isEnrolledInVAHealthCare;
   return {
-    showReceiveTextNotifications,
     isEnrolledInVAHealthCare,
     showSMSCheckbox,
   };

--- a/src/platform/user/profile/vet360/components/PhoneField/PhoneEditView.jsx
+++ b/src/platform/user/profile/vet360/components/PhoneField/PhoneEditView.jsx
@@ -7,8 +7,6 @@ import { isEnrolledInVAHealthCare as isEnrolledInVAHealthCareSelector } from 'ap
 
 import { FIELD_NAMES } from 'vet360/constants';
 
-import { profileShowReceiveTextNotifications } from 'applications/personalization/profile360/selectors';
-
 import ContactInfoForm from '../ContactInfoForm';
 
 class PhoneEditView extends React.Component {

--- a/src/platform/user/profile/vet360/components/PhoneField/VAPPhoneField.jsx
+++ b/src/platform/user/profile/vet360/components/PhoneField/VAPPhoneField.jsx
@@ -8,6 +8,7 @@ import { API_ROUTES, FIELD_NAMES, PHONE_TYPE, USA } from 'vet360/constants';
 import PhoneNumberWidget from 'platform/forms-system/src/js/widgets/PhoneNumberWidget';
 
 import VAPProfileField from 'vet360/containers/VAPProfileField';
+import ReceiveTextMessages from 'vet360/containers/ReceiveTextMessages';
 
 import PhoneEditView from './PhoneEditView';
 import PhoneView from './PhoneView';
@@ -132,10 +133,21 @@ export default class PhoneField extends React.Component {
   };
 
   render() {
+    const ContentView =
+      this.props.fieldName === FIELD_NAMES.MOBILE_PHONE
+        ? ({ data }) => {
+            return (
+              <div>
+                <PhoneView data={data} />
+                <ReceiveTextMessages fieldName={FIELD_NAMES.MOBILE_PHONE} />
+              </div>
+            );
+          }
+        : PhoneView;
     return (
       <VAPProfileField
         apiRoute={API_ROUTES.TELEPHONES}
-        ContentView={PhoneView}
+        ContentView={ContentView}
         convertCleanDataToPayload={this.convertCleanDataToPayload}
         EditView={PhoneEditView}
         fieldName={this.props.fieldName}

--- a/src/platform/user/profile/vet360/components/VAPMobilePhone.jsx
+++ b/src/platform/user/profile/vet360/components/VAPMobilePhone.jsx
@@ -1,16 +1,12 @@
 import React from 'react';
 import PhoneField from './PhoneField/VAPPhoneField';
-import ReceiveTextMessages from '../containers/ReceiveTextMessages';
 import { FIELD_NAMES } from '../constants';
 
 export default function MobilePhone() {
   return (
-    <>
-      <PhoneField
-        title="Mobile phone number"
-        fieldName={FIELD_NAMES.MOBILE_PHONE}
-      />
-      <ReceiveTextMessages fieldName={FIELD_NAMES.MOBILE_PHONE} />
-    </>
+    <PhoneField
+      title="Mobile phone number"
+      fieldName={FIELD_NAMES.MOBILE_PHONE}
+    />
   );
 }

--- a/src/platform/user/profile/vet360/components/base/Vet360Transaction.jsx
+++ b/src/platform/user/profile/vet360/components/base/Vet360Transaction.jsx
@@ -21,7 +21,7 @@ function Vet360Transaction(props) {
     transactionRequest,
   } = props;
 
-  const method = transactionRequest ? transactionRequest.method : 'PUT';
+  const method = transactionRequest?.method || 'PUT';
   const hasError = isFailedTransaction(transaction);
   const classes = classNames('vet360-profile-field-content', {
     'usa-input-error': hasError,

--- a/src/platform/user/profile/vet360/components/base/Vet360TransactionPending.jsx
+++ b/src/platform/user/profile/vet360/components/base/Vet360TransactionPending.jsx
@@ -1,8 +1,5 @@
 import React from 'react';
-import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
-
-import { profileShowReceiveTextNotifications } from 'applications/personalization/profile360/selectors';
 
 class Vet360TransactionPending extends React.Component {
   static propTypes = {
@@ -30,10 +27,7 @@ class Vet360TransactionPending extends React.Component {
       </span>
     );
 
-    if (
-      this.props.showReceiveTextNotifications &&
-      this.props.title.toLowerCase() === 'mobile phone number'
-    ) {
+    if (this.props.title.toLowerCase() === 'mobile phone number') {
       content = (
         <span>
           We’re working on saving your new {this.props.title.toLowerCase()} and
@@ -63,15 +57,4 @@ class Vet360TransactionPending extends React.Component {
   }
 }
 
-export function mapStateToProps(state) {
-  return {
-    showReceiveTextNotifications: profileShowReceiveTextNotifications(state),
-  };
-}
-
-export default connect(
-  mapStateToProps,
-  null,
-)(Vet360TransactionPending);
-
-export { Vet360TransactionPending };
+export default Vet360TransactionPending;

--- a/src/platform/user/profile/vet360/containers/ReceiveTextMessages.jsx
+++ b/src/platform/user/profile/vet360/containers/ReceiveTextMessages.jsx
@@ -3,7 +3,10 @@ import { connect } from 'react-redux';
 
 import ErrorableCheckbox from '@department-of-veterans-affairs/formation-react/ErrorableCheckbox';
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
-import { selectProfile } from 'platform/user/selectors';
+import {
+  selectProfile,
+  selectVet360MobilePhone,
+} from 'platform/user/selectors';
 
 import * as VET360 from '../constants';
 import { createTransaction, clearTransactionStatus } from '../actions';
@@ -122,17 +125,11 @@ export function mapStateToProps(state, ownProps) {
   const hasError = !!isFailedTransaction(transaction);
   const isPending = !!isPendingTransaction(transaction);
   const profileState = selectProfile(state);
-  const isEmpty = !profileState.vet360.mobilePhone;
-  const isTextable =
-    !isEmpty &&
-    profileState.vet360.mobilePhone.phoneType === VET360.PHONE_TYPE.mobilePhone;
+  const mobilePhone = selectVet360MobilePhone(state);
+  const isTextable = mobilePhone?.phoneType === VET360.PHONE_TYPE.mobilePhone;
   const isVerified = profileState.verified;
   const hideCheckbox =
-    isEmpty ||
-    !isTextable ||
-    !isEnrolledInVAHealthCare(state) ||
-    hasError ||
-    isPending;
+    !isTextable || !isEnrolledInVAHealthCare(state) || hasError || isPending;
   const transactionSuccess =
     state.vet360.transactionStatus ===
     VET360.TRANSACTION_STATUS.COMPLETED_SUCCESS;

--- a/src/platform/user/profile/vet360/containers/ReceiveTextMessages.jsx
+++ b/src/platform/user/profile/vet360/containers/ReceiveTextMessages.jsx
@@ -8,7 +8,6 @@ import { selectProfile } from 'platform/user/selectors';
 import * as VET360 from '../constants';
 import { createTransaction, clearTransactionStatus } from '../actions';
 import { selectVet360Transaction } from 'platform/user/profile/vet360/selectors';
-import { profileShowReceiveTextNotifications } from 'applications/personalization/profile360/selectors';
 
 import {
   isPendingTransaction,
@@ -122,17 +121,13 @@ export function mapStateToProps(state, ownProps) {
   const { transaction } = selectVet360Transaction(state, fieldName);
   const hasError = !!isFailedTransaction(transaction);
   const isPending = !!isPendingTransaction(transaction);
-  const showReceiveTextNotifications = profileShowReceiveTextNotifications(
-    state,
-  );
   const profileState = selectProfile(state);
   const isEmpty = !profileState.vet360.mobilePhone;
   const isTextable =
     !isEmpty &&
     profileState.vet360.mobilePhone.phoneType === VET360.PHONE_TYPE.mobilePhone;
-  const isVerified = showReceiveTextNotifications && profileState.verified;
+  const isVerified = profileState.verified;
   const hideCheckbox =
-    !showReceiveTextNotifications ||
     isEmpty ||
     !isTextable ||
     !isEnrolledInVAHealthCare(state) ||

--- a/src/platform/user/profile/vet360/tests/components/Vet360TransactionPending.unit.spec.jsx
+++ b/src/platform/user/profile/vet360/tests/components/Vet360TransactionPending.unit.spec.jsx
@@ -3,7 +3,7 @@ import enzyme from 'enzyme';
 import { expect } from 'chai';
 import sinon from 'sinon';
 
-import { Vet360TransactionPending } from '../../components/base/Vet360TransactionPending';
+import Vet360TransactionPending from '../../components/base/Vet360TransactionPending';
 
 describe('<Vet360TransactionPending/>', () => {
   let props = null;

--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -5,7 +5,6 @@ export default Object.freeze({
   facilitiesPpmsSuppressPharmacies: 'facilitiesPpmsSuppressPharmacies',
   facilityLocatorFeUseV1: 'facilityLocatorFeUseV1',
   profileShowProfile2: 'profile_show_profile_2.0',
-  profileShowReceiveTextNotifications: 'profileShowReceiveTextNotifications',
   vaOnlineScheduling: 'vaOnlineScheduling',
   vaOnlineSchedulingCancel: 'vaOnlineSchedulingCancel',
   vaOnlineSchedulingRequests: 'vaOnlineSchedulingRequests',


### PR DESCRIPTION
## Description
This PR addresses both department-of-veterans-affairs/va.gov-team#9781 (remove usage of the `profile_show_receive_text_notifications` feature flag) and department-of-veterans-affairs/va.gov-team#10035 (remove the duplicate SMS checkbox when editing mobile number). It's split into two discrete commits for easier review.

## Testing done
Local

## Screenshots
![checkbox-fix](https://user-images.githubusercontent.com/20728956/84842753-cf21b900-affa-11ea-80c8-cb32bce021e8.gif)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs