### PR TITLE
bradl3yC - 9626 - Fix invalid state and add default props

### DIFF
--- a/src/applications/disability-benefits/2346/components/ErrorMessage.jsx
+++ b/src/applications/disability-benefits/2346/components/ErrorMessage.jsx
@@ -27,7 +27,7 @@ const ErrorMessage = ({ errorCode, nextAvailabilityDate }) => {
         </AlertBox>
       );
       break;
-    case 'MDOT_VETERAN_NOT_FOUND':
+    case 'MDOT_INVALID':
       content = (
         <AlertBox
           status="warning"

--- a/src/applications/disability-benefits/2346/components/VeteranInfoBox.jsx
+++ b/src/applications/disability-benefits/2346/components/VeteranInfoBox.jsx
@@ -58,6 +58,16 @@ VeteranInfoBox.propTypes = {
   ssnLastFour: PropTypes.string.isRequired,
 };
 
+VeteranInfoBox.defaultProps = {
+  first: '',
+  last: '',
+  middle: '',
+  suffix: '',
+  gender: '',
+  dateOfBirth: '',
+  ssnLastFour: '',
+};
+
 const mapStateToProps = state => ({
   first: state.form?.data?.fullName?.first,
   middle: state.form?.data?.fullName?.middle,

--- a/src/applications/disability-benefits/2346/tests/ErrorMessage.unit.spec.jsx
+++ b/src/applications/disability-benefits/2346/tests/ErrorMessage.unit.spec.jsx
@@ -92,7 +92,7 @@ describe('ErrorMessage', () => {
     const fakeStore = {
       getState: () => ({
         mdot: {
-          errorCode: 'MDOT_VETERAN_NOT_FOUND',
+          errorCode: 'MDOT_INVALID',
           nextAvailabilityDate: '2019-04-01',
         },
       }),


### PR DESCRIPTION
## Description
Change a constant key for accessing the veteran missing in DB error messaging.  Originally this was mocked to `Veteran not found` but the DLC is returning `invalid` instead

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
