### PR TITLE
Add video instructions and update show more UI

### DIFF
--- a/src/applications/vaos/api/confirmed_va.json
+++ b/src/applications/vaos/api/confirmed_va.json
@@ -655,6 +655,7 @@
             "type": "REGULAR",
             "bookingNotes": "T+90 Testing",
             "instructionsOther": false,
+            "instructionsTitle": "Video Visit Preparation",
             "patients": [
               {
                 "name": { "firstName": "JUDY", "lastName": "MORRISON" },

--- a/src/applications/vaos/api/confirmed_va.json
+++ b/src/applications/vaos/api/confirmed_va.json
@@ -509,6 +509,7 @@
             "type": "REGULAR",
             "bookingNotes": "Follow-up/Routine: asfdasdfasdfasfasfdasdfasdfasfasfdasdfasdfasfasfdasdfasdfasfasfdasdfasdfasfasfdasdfasdfasf",
             "instructionsOther": false,
+            "instructionsTitle": "Medication Review",
             "patients": [
               {
                 "name": { "firstName": "JUDY", "lastName": "MORRISON" },

--- a/src/applications/vaos/components/AdditionalInfoRow.jsx
+++ b/src/applications/vaos/components/AdditionalInfoRow.jsx
@@ -12,9 +12,9 @@ export default function AdditionalInfoRow({
     <>
       <button
         className="va-button-link additional-info-button vads-u-margin-right--4"
-        aria-expanded={open ? 'true' : 'false'}
         id={`${id}-vaos-info-expand`}
         aria-controls={`${id}-vaos-info-content`}
+        aria-expanded={open ? 'true' : 'false'}
         onClick={onClick}
       >
         <span className="additional-info-title">{triggerText}</span>
@@ -22,7 +22,9 @@ export default function AdditionalInfoRow({
       </button>
       <ReactCSSTransitionGroup
         id={`${id}-vaos-info-content`}
-        className={`vads-u-flex--1 vads-u-order--last vads-u-margin-top--2`}
+        className={`vads-u-flex--1 vads-u-order--last ${
+          open ? 'vads-u-margin-top--2' : ''
+        }`}
         transitionName="form-expanding-group-inner"
         transitionEnterTimeout={700}
         transitionLeave={false}

--- a/src/applications/vaos/components/AdditionalInfoRow.jsx
+++ b/src/applications/vaos/components/AdditionalInfoRow.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import ReactCSSTransitionGroup from 'react-transition-group/CSSTransitionGroup';
+
+export default function AdditionalInfoRow({
+  onClick,
+  id,
+  triggerText,
+  open,
+  children,
+}) {
+  return (
+    <>
+      <button
+        className="va-button-link additional-info-button vads-u-margin-right--4"
+        aria-expanded={open ? 'true' : 'false'}
+        id={`${id}-vaos-info-expand`}
+        aria-controls={`${id}-vaos-info-content`}
+        onClick={onClick}
+      >
+        <span className="additional-info-title">{triggerText}</span>
+        <i className={`fas fa-angle-down ${open ? 'open' : ''}`} />
+      </button>
+      <ReactCSSTransitionGroup
+        id={`${id}-vaos-info-content`}
+        className={`vads-u-flex--1 vads-u-order--last vads-u-margin-top--2`}
+        transitionName="form-expanding-group-inner"
+        transitionEnterTimeout={700}
+        transitionLeave={false}
+      >
+        {open ? children : null}
+      </ReactCSSTransitionGroup>
+    </>
+  );
+}

--- a/src/applications/vaos/components/AppointmentRequestListItem.jsx
+++ b/src/applications/vaos/components/AppointmentRequestListItem.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import AdditionalInfo from '@department-of-veterans-affairs/formation-react/AdditionalInfo';
 
 import ListBestTimeToCall from './ListBestTimeToCall';
 import { sentenceCase } from '../utils/formatters';
@@ -10,6 +9,7 @@ import { APPOINTMENT_STATUS, TIME_TEXT } from '../utils/constants';
 import AppointmentStatus from './AppointmentStatus';
 import VAFacilityLocation from './VAFacilityLocation';
 import AppointmentRequestCommunityCareLocation from './AppointmentRequestCommunityCareLocation';
+import AdditionalInfoRow from './AdditionalInfoRow';
 
 export default class AppointmentRequestListItem extends React.Component {
   static propTypes = {
@@ -120,8 +120,10 @@ export default class AppointmentRequestListItem extends React.Component {
             </div>
           )}
         </div>
-        <div className="vads-u-margin-top--2">
-          <AdditionalInfo
+        <div className="vads-u-margin-top--2 vads-u-display--flex vads-u-flex-wrap--wrap">
+          <AdditionalInfoRow
+            id={appointment.id}
+            open={showMore}
             triggerText={showMore ? 'Show less' : 'Show more'}
             onClick={this.toggleShowMore}
           >
@@ -163,11 +165,9 @@ export default class AppointmentRequestListItem extends React.Component {
                 </dl>
               </div>
             </div>
-          </AdditionalInfo>
-        </div>
-        {showCancelButton &&
-          !cancelled && (
-            <div className="vads-u-margin-top--2">
+          </AdditionalInfoRow>
+          {showCancelButton &&
+            !cancelled && (
               <button
                 className="vaos-appts__cancel-btn va-button-link vads-u-margin--0 vads-u-flex--0"
                 onClick={() => cancelAppointment(appointment)}
@@ -175,8 +175,9 @@ export default class AppointmentRequestListItem extends React.Component {
               >
                 Cancel appointment
               </button>
-            </div>
-          )}
+            )}
+          <div className="vaos-flex-break" />
+        </div>
       </li>
     );
   }

--- a/src/applications/vaos/components/ConfirmedAppointmentListItem.jsx
+++ b/src/applications/vaos/components/ConfirmedAppointmentListItem.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import classNames from 'classnames';
 import moment from '../utils/moment-tz';
 import { formatFacilityAddress } from '../utils/formatters';
@@ -15,6 +15,11 @@ import {
   getVARFacilityId,
   getVAAppointmentLocationId,
 } from '../services/appointment';
+import AdditionalInfoRow from './AdditionalInfoRow';
+import {
+  MedicationReviewInstructions,
+  VideoVisitInstructions,
+} from './VideoInstructions';
 
 // Only use this when we need to pass data that comes back from one of our
 // services files to one of the older api functions
@@ -37,6 +42,7 @@ export default function ConfirmedAppointmentListItem({
   showCancelButton,
   facility,
 }) {
+  const [showMoreOpen, setShowMoreOpen] = useState(false);
   const cancelled = appointment.status === APPOINTMENT_STATUS.cancelled;
   const isPastAppointment = appointment.vaos.isPastAppointment;
   const isCommunityCare = appointment.vaos.isCommunityCare;
@@ -137,7 +143,19 @@ export default function ConfirmedAppointmentListItem({
 
       {!cancelled &&
         !isPastAppointment && (
-          <div className="vads-u-margin-top--2">
+          <div className="vads-u-margin-top--2 vads-u-display--flex vads-u-flex-wrap--wrap">
+            {isVideoAppointment &&
+              appointment.description && (
+                <AdditionalInfoRow
+                  open={showMoreOpen}
+                  triggerText="Prepare for video visit"
+                  onClick={() => setShowMoreOpen(!showMoreOpen)}
+                >
+                  <VideoVisitInstructions
+                    instructionsType={appointment.description}
+                  />
+                </AdditionalInfoRow>
+              )}
             <AddToCalendar
               summary={header}
               description={showInstructions ? appointment.comment : ''}
@@ -159,6 +177,7 @@ export default function ConfirmedAppointmentListItem({
                 </span>
               </button>
             )}
+            <div className="vaos-flex-break" />
           </div>
         )}
     </li>

--- a/src/applications/vaos/components/ConfirmedAppointmentListItem.jsx
+++ b/src/applications/vaos/components/ConfirmedAppointmentListItem.jsx
@@ -154,6 +154,7 @@ export default function ConfirmedAppointmentListItem({
             {isVideoAppointment &&
               appointment.comment && (
                 <AdditionalInfoRow
+                  id={appointment.id}
                   open={showMoreOpen}
                   triggerText="Prepare for video visit"
                   onClick={() => setShowMoreOpen(!showMoreOpen)}

--- a/src/applications/vaos/components/ConfirmedAppointmentListItem.jsx
+++ b/src/applications/vaos/components/ConfirmedAppointmentListItem.jsx
@@ -17,7 +17,7 @@ import {
 } from '../services/appointment';
 import AdditionalInfoRow from './AdditionalInfoRow';
 import {
-  MedicationReviewInstructions,
+  getVideoInstructionText,
   VideoVisitInstructions,
 } from './VideoInstructions';
 
@@ -56,6 +56,13 @@ export default function ConfirmedAppointmentListItem({
       PURPOSE_TEXT.some(purpose =>
         appointment?.comment?.startsWith(purpose.short),
       ));
+
+  let instructionText;
+  if (showInstructions) {
+    instructionText = appointment.comment;
+  } else if (isVideoAppointment && appointment.comment) {
+    instructionText = getVideoInstructionText(appointment.comment);
+  }
 
   const itemClasses = classNames(
     'vads-u-background-color--gray-lightest vads-u-padding--2p5 vads-u-margin-bottom--3',
@@ -145,20 +152,20 @@ export default function ConfirmedAppointmentListItem({
         !isPastAppointment && (
           <div className="vads-u-margin-top--2 vads-u-display--flex vads-u-flex-wrap--wrap">
             {isVideoAppointment &&
-              appointment.description && (
+              appointment.comment && (
                 <AdditionalInfoRow
                   open={showMoreOpen}
                   triggerText="Prepare for video visit"
                   onClick={() => setShowMoreOpen(!showMoreOpen)}
                 >
                   <VideoVisitInstructions
-                    instructionsType={appointment.description}
+                    instructionsType={appointment.comment}
                   />
                 </AdditionalInfoRow>
               )}
             <AddToCalendar
               summary={header}
-              description={showInstructions ? appointment.comment : ''}
+              description={instructionText}
               location={location}
               duration={appointment.minutesDuration}
               startDateTime={appointment.start}

--- a/src/applications/vaos/components/VideoInstructions.jsx
+++ b/src/applications/vaos/components/VideoInstructions.jsx
@@ -40,9 +40,9 @@ export function VideoVisitInstructions({ instructionsType }) {
         <strong>Medication review</strong>
         <p>
           During your video appointment, your provider will want to review all
-          the medications, vitamins, herbs, and supplements you’re taking—no
-          matter if you got them from another provider, VA clinic, or local
-          store.
+          the medications, vitamins, herbs, and supplements you’re taking
+          &mdash; no matter if you got them from another provider, VA clinic, or
+          local store.
         </p>
         <p>
           Please be ready to talk about your medications during your video visit

--- a/src/applications/vaos/components/VideoInstructions.jsx
+++ b/src/applications/vaos/components/VideoInstructions.jsx
@@ -1,0 +1,103 @@
+import React from 'react';
+
+const VIDEO_VISIT_PREPARATION = 'Video Visit Preparation';
+const MEDICATION_REVIEW = 'Medication Review';
+const videoVisitInstructionsText = `Before your appointment:
+
+- If you’re using an iPad or iPhone for your appointment, you’ll need to download the VA Video Connect iOS app beforehand. If you’re using any other device, you don’t need to download any software or app before your appointment.
+- You’ll need to have access to a web camera and microphone. You can use an external camera and microphone if your device doesn’t have one.
+
+To connect to your Virtual Meeting Room at the appointment time, click the "Join session" button on this page or the link that's in your confirmation email.
+
+To have the best possible video experience, we recommend you:
+
+- Connect to your video appointment from a quiet, private, and well-lighted location
+- Check to ensure you have a strong Internet connection before your appointment
+- Connect to your appointment using a Wi-Fi network if using your mobile phone, rather than your cellular data network
+`;
+
+const medicationReviewText = `Medication review
+
+During your video appointment, your provider will want to review all the medications, vitamins, herbs, and supplements you’re taking—no matter if you got them from another provider, VA clinic, or local store.
+
+Please be ready to talk about your medications during your video visit to ensure you're getting the best and safest care possible.
+`;
+
+export function getVideoInstructionText(instructionsType) {
+  if (instructionsType === MEDICATION_REVIEW) {
+    return medicationReviewText;
+  } else if (instructionsType === VIDEO_VISIT_PREPARATION) {
+    return videoVisitInstructionsText;
+  }
+
+  return null;
+}
+
+export function VideoVisitInstructions({ instructionsType }) {
+  if (instructionsType === MEDICATION_REVIEW) {
+    return (
+      <div>
+        <strong>Medication review</strong>
+        <p>
+          During your video appointment, your provider will want to review all
+          the medications, vitamins, herbs, and supplements you’re taking—no
+          matter if you got them from another provider, VA clinic, or local
+          store.
+        </p>
+        <p>
+          Please be ready to talk about your medications during your video visit
+          to ensure you're getting the best and safest care possible.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <strong>Before your appointment:</strong>
+      <ul>
+        <li>
+          If you’re using an iPad or iPhone for your appointment, you’ll need to
+          download the{' '}
+          <a
+            target="_blank"
+            rel="noreferrer nofollow"
+            href="https://itunes.apple.com/us/app/va-video-connect/id1224250949?mt=8"
+          >
+            VA Video Connect iOS app
+          </a>{' '}
+          beforehand. If you’re using any other device, you don’t need to
+          download any software or app before your appointment.
+        </li>
+        <li>
+          You’ll need to have access to a web camera and microphone. You can use
+          an external camera and microphone if your device doesn’t have one.
+        </li>
+      </ul>
+
+      <p>
+        To connect to your Virtual Meeting Room at the appointment time, click
+        the "Join session" button on this page or the link that's in your
+        confirmation email.
+      </p>
+
+      <strong>
+        To have the best possible video experience, we recommend you:
+      </strong>
+      <ul>
+        <li>
+          Connect to your video appointment from a quiet, private, and
+          well-lighted location
+        </li>
+        <li>
+          Check to ensure you have a strong Internet connection before your
+          appointment
+        </li>
+        <li>
+          Connect to your appointment using a Wi-Fi network if using your mobile
+          phone, rather than your cellular data network
+        </li>
+      </ul>
+    </div>
+  );
+}

--- a/src/applications/vaos/components/VideoVisitSection.jsx
+++ b/src/applications/vaos/components/VideoVisitSection.jsx
@@ -20,7 +20,7 @@ export default function VideoVisitSection({ appointment }) {
       ?.value
   ) {
     const url = appointment.contained?.[0]?.telecom?.[0]?.value;
-    const diff = moment(appointment.start).diff(moment(), 'minutes');
+    const diff = moment().diff(moment(appointment.start), 'minutes');
 
     // Button is enabled 30 minutes prior to start time, until 4 hours after start time
     const disableVideoLink = diff < -30 || diff > 240;

--- a/src/applications/vaos/sass/vaos.scss
+++ b/src/applications/vaos/sass/vaos.scss
@@ -11,7 +11,7 @@
   width: 50%;
   display: flex;
 
-  @include media($medium-screen) {
+  @include media($medium-screen) { 
     width: 200px;
   }
 }
@@ -32,9 +32,7 @@
   align-items: center;
   justify-content: center;
 
-  &:hover,
-  &:focus,
-  &:active {
+  &:hover, &:focus, &:active {
     color: $color-gray-dark;
     text-decoration: none;
     background: $color-gray-lighter;
@@ -289,8 +287,7 @@
       cursor: not-allowed;
     }
 
-    input[type="checkbox"],
-    input[type="checkbox"] + label::before {
+    input[type="checkbox"], input[type="checkbox"] + label::before {
       box-shadow: 0 0 0 1px $color-gray-light;
       background: $color-gray-lightest;
       cursor: not-allowed;

--- a/src/applications/vaos/sass/vaos.scss
+++ b/src/applications/vaos/sass/vaos.scss
@@ -11,7 +11,7 @@
   width: 50%;
   display: flex;
 
-  @include media($medium-screen) { 
+  @include media($medium-screen) {
     width: 200px;
   }
 }

--- a/src/applications/vaos/sass/vaos.scss
+++ b/src/applications/vaos/sass/vaos.scss
@@ -11,7 +11,7 @@
   width: 50%;
   display: flex;
 
-  @include media($medium-screen) { 
+  @include media($medium-screen) {
     width: 200px;
   }
 }
@@ -32,7 +32,9 @@
   align-items: center;
   justify-content: center;
 
-  &:hover, &:focus, &:active {
+  &:hover,
+  &:focus,
+  &:active {
     color: $color-gray-dark;
     text-decoration: none;
     background: $color-gray-lighter;
@@ -287,7 +289,8 @@
       cursor: not-allowed;
     }
 
-    input[type="checkbox"], input[type="checkbox"] + label::before {
+    input[type="checkbox"],
+    input[type="checkbox"] + label::before {
       box-shadow: 0 0 0 1px $color-gray-light;
       background: $color-gray-lightest;
       cursor: not-allowed;
@@ -311,4 +314,9 @@ h1:focus {
 
 .vaos-u-word-break--break-word {
   word-break: break-word;
+}
+
+.vaos-flex-break {
+  flex-basis: 100%;
+  height: 0;
 }

--- a/src/applications/vaos/services/appointment/transformers.js
+++ b/src/applications/vaos/services/appointment/transformers.js
@@ -340,7 +340,7 @@ export function transformConfirmedAppointments(appointments) {
       comment:
         appt.instructionsToVeteran ||
         appt.vdsAppointments?.[0]?.bookingNote ||
-        appt.vvsAppointments?.[0]?.bookingNotes,
+        appt.vvsAppointments?.[0]?.instructionsTitle,
       participant: setParticipant(appt),
       contained: setContained(appt),
       legacyVAR: setLegacyVAR(appt),

--- a/src/applications/vaos/tests/components/AppointmentRequestListItem.unit.spec.jsx
+++ b/src/applications/vaos/tests/components/AppointmentRequestListItem.unit.spec.jsx
@@ -67,7 +67,7 @@ describe('VAOS <AppointmentRequestListItem>', () => {
     );
 
     const toggleExpand = tree
-      .find('AdditionalInfo')
+      .find('AdditionalInfoRow')
       .find('.additional-info-button');
     toggleExpand.simulate('click');
 
@@ -191,7 +191,7 @@ describe('VAOS <AppointmentRequestListItem>', () => {
       'Cancel appointment',
     );
 
-    const toggleExpand = tree.find('AdditionalInfo');
+    const toggleExpand = tree.find('AdditionalInfoRow');
     toggleExpand.props().onClick();
     const preferredDates = tree
       .find('ul')

--- a/src/applications/vaos/tests/components/ConfirmedAppointmentListItem.unit.spec.jsx
+++ b/src/applications/vaos/tests/components/ConfirmedAppointmentListItem.unit.spec.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { expect } from 'chai';
 import { mount } from 'enzyme';
+import { render, fireEvent } from '@testing-library/react';
 import sinon from 'sinon';
 import moment from 'moment';
 
@@ -28,32 +29,7 @@ describe('VAOS <ConfirmedAppointmentListItem> Regular Appointment', () => {
       },
     ],
     contained: null,
-    legacyVAR: {
-      id: '17dd714287e151195b99164cc1a8e49a',
-      apiData: {
-        startDate: '2020-11-07T17:00:00Z',
-        clinicId: '455',
-        clinicFriendlyName: null,
-        facilityId: '983',
-        communityCare: false,
-        vdsAppointments: [
-          {
-            bookingNote: null,
-            appointmentLength: '60',
-            appointmentTime: '2020-11-07T17:00:00Z',
-            clinic: {
-              name: 'CHY OPT VAR1',
-              askForCheckIn: false,
-              facilityCode: '983',
-            },
-            type: 'REGULAR',
-            currentStatus: 'NO ACTION TAKEN/TODAY',
-          },
-        ],
-        vvsAppointments: [],
-        id: '17dd714287e151195b99164cc1a8e49a',
-      },
-    },
+    id: '17dd714287e151195b99164cc1a8e49a',
     vaos: {
       isPastAppointment: false,
       appointmentType: APPOINTMENT_TYPES.vaAppointment,
@@ -82,10 +58,8 @@ describe('VAOS <ConfirmedAppointmentListItem> Regular Appointment', () => {
 
   const cancelAppointment = sinon.spy();
 
-  let tree;
-
-  beforeEach(() => {
-    tree = mount(
+  it('should render all expected information', () => {
+    const { getByText, baseElement } = render(
       <ConfirmedAppointmentListItem
         showCancelButton
         cancelAppointment={cancelAppointment}
@@ -93,52 +67,19 @@ describe('VAOS <ConfirmedAppointmentListItem> Regular Appointment', () => {
         facility={facility}
       />,
     );
-  });
 
-  afterEach(() => {
-    tree.unmount();
-  });
+    expect(getByText(/Confirmed/)).to.be.ok;
+    expect(baseElement.querySelector('.fa-check-circle')).to.be.ok;
 
-  it('should have a status of "confirmed"', () => {
-    expect(
-      tree
-        .find('span')
-        .at(2)
-        .text(),
-    ).to.contain('Confirmed');
-  });
+    expect(getByText(/Wednesday, December 11, 2019/).nodeName).to.equal('H3');
+    expect(getByText('C&P BEV AUDIO FTC1')).to.be.ok;
+    expect(getByText(/Cheyenne VA Medical Center/)).to.be.ok;
+    expect(getByText(/2360 East Pershing Boulevard/)).to.be.ok;
+    expect(getByText(/Cheyenne, WY 82001-5356/)).to.be.ok;
+    expect(getByText(/Follow-up\/Routine/)).to.be.ok;
+    expect(getByText(/Instructions/)).to.be.ok;
 
-  it('should have an h3 with date', () => {
-    expect(
-      tree
-        .find('h3')
-        .text()
-        .trim(),
-    ).to.contain('December 11, 2019');
-  });
-
-  it('should display clinic name', () => {
-    expect(tree.text()).to.contain('C&P BEV AUDIO FTC1');
-  });
-
-  it('should show facility address', () => {
-    expect(tree.find('FacilityAddress').exists()).to.be.true;
-  });
-
-  it('should show instructions', () => {
-    expect(tree.text()).to.contain('Follow-up/Routine');
-    expect(tree.text()).to.contain('Instructions');
-  });
-
-  it('should show cancel link', () => {
-    expect(tree.text()).to.contain('Cancel appointment');
-  });
-
-  it('should cancel appointment', () => {
-    tree
-      .find('button')
-      .props()
-      .onClick();
+    fireEvent.click(getByText('Cancel appointment'));
     expect(cancelAppointment.called).to.be.true;
   });
 
@@ -148,7 +89,7 @@ describe('VAOS <ConfirmedAppointmentListItem> Regular Appointment', () => {
       comment: 'some comment',
     };
 
-    const component = mount(
+    const { queryByText } = render(
       <ConfirmedAppointmentListItem
         showCancelButton
         cancelAppointment={cancelAppointment}
@@ -157,10 +98,7 @@ describe('VAOS <ConfirmedAppointmentListItem> Regular Appointment', () => {
       />,
     );
 
-    expect(component.text()).not.to.contain('some comment');
-    expect(component.text()).not.to.contain('Instructions');
-
-    component.unmount();
+    expect(queryByText(/some comment/)).to.not.be.ok;
   });
 });
 
@@ -199,9 +137,7 @@ describe('VAOS <ConfirmedAppointmentListItem> Community Care Appointment', () =>
         },
       },
     ],
-    legacyVAR: {
-      id: '8a4885896a22f88f016a2cb7f5de0062',
-    },
+    id: '8a4885896a22f88f016a2cb7f5de0062',
     vaos: {
       isPastAppointment: false,
       appointmentType: APPOINTMENT_TYPES.ccAppointment,
@@ -281,7 +217,7 @@ describe('VAOS <ConfirmedAppointmentListItem> Video Appointment', () => {
     description: 'FUTURE',
     start: apptTime,
     minutesDuration: 20,
-    comment: 'T+90 Testing',
+    comment: '',
     participant: null,
     contained: [
       {
@@ -305,88 +241,11 @@ describe('VAOS <ConfirmedAppointmentListItem> Video Appointment', () => {
       },
     ],
     legacyVAR: {
-      id: '05760f00c80ae60ce49879cf37a05fc8',
       apiData: {
-        startDate: '2020-11-25T15:17:00Z',
-        clinicId: null,
-        clinicFriendlyName: null,
         facilityId: '983',
-        communityCare: false,
-        vdsAppointments: [],
-        vvsAppointments: [
-          {
-            id: '8a74bdfa-0e66-4848-87f5-0d9bb413ae6d',
-            appointmentKind: 'ADHOC',
-            sourceSystem: 'SM',
-            dateTime: '2020-11-25T15:17:00Z',
-            duration: 20,
-            status: {
-              description: 'F',
-              code: 'FUTURE',
-            },
-            schedulingRequestType: 'NEXT_AVAILABLE_APPT',
-            type: 'REGULAR',
-            bookingNotes: 'T+90 Testing',
-            instructionsOther: false,
-            patients: [
-              {
-                name: {
-                  firstName: 'JUDY',
-                  lastName: 'MORRISON',
-                },
-                contactInformation: {
-                  mobile: '7036520000',
-                  preferredEmail: 'marcy.nadeau@va.gov',
-                },
-                location: {
-                  type: 'NonVA',
-                  facility: {
-                    name: 'CHEYENNE VAMC',
-                    siteCode: '983',
-                    timeZone: '10',
-                  },
-                },
-                patientAppointment: true,
-                virtualMeetingRoom: {
-                  conference: 'VVC8275247',
-                  pin: '3242949390#',
-                  url:
-                    'https://care2.evn.va.gov/vvc-app/?join=1&media=1&escalate=1&conference=VVC8275247@care2.evn.va.gov&pin=3242949390#',
-                },
-              },
-            ],
-            providers: [
-              {
-                name: {
-                  firstName: 'Test T+90',
-                  lastName: 'Test',
-                },
-                contactInformation: {
-                  mobile: '8888888888',
-                  preferredEmail: 'marcy.nadeau@va.gov',
-                  timeZone: '10',
-                },
-                location: {
-                  type: 'VA',
-                  facility: {
-                    name: 'CHEYENNE VAMC',
-                    siteCode: '983',
-                    timeZone: '10',
-                  },
-                },
-                virtualMeetingRoom: {
-                  conference: 'VVC8275247',
-                  pin: '7172705#',
-                  url:
-                    'https://care2.evn.va.gov/vvc-app/?name=Test%2CTest+T%2B90&join=1&media=1&escalate=1&conference=VVC8275247@care2.evn.va.gov&pin=7172705#',
-                },
-              },
-            ],
-          },
-        ],
-        id: '05760f00c80ae60ce49879cf37a05fc8',
       },
     },
+    id: '05760f00c80ae60ce49879cf37a05fc8',
     vaos: {
       isPastAppointment: false,
       appointmentType: APPOINTMENT_TYPES.vaAppointment,
@@ -396,17 +255,45 @@ describe('VAOS <ConfirmedAppointmentListItem> Video Appointment', () => {
     },
   };
 
-  const tree = mount(
-    <ConfirmedAppointmentListItem appointment={appointment} />,
-  );
+  it('should render expected video information', () => {
+    const { getByText, queryByText } = render(
+      <ConfirmedAppointmentListItem appointment={appointment} />,
+    );
 
-  it('should contain link to video conference', () => {
-    expect(tree.find('VideoVisitSection').length).to.equal(1);
+    expect(getByText(/join session/i).getAttribute('disabled')).not.to.be.ok;
+    expect(queryByText(/prepare for video visit/i)).not.to.be.ok;
   });
 
-  it('should not show booking note', () => {
-    expect(tree.text()).not.to.contain('Booking note');
-    expect(tree.text()).not.to.contain('My reason isn’t listed');
+  it('should reveal medication review instructions', () => {
+    const { getByText, queryByText, findByText } = render(
+      <ConfirmedAppointmentListItem
+        appointment={{
+          ...appointment,
+          comment: 'Medication Review',
+        }}
+      />,
+    );
+
+    expect(queryByText(/medication review/i)).to.not.be.ok;
+    fireEvent.click(getByText(/prepare for video visit/i));
+
+    return expect(findByText(/medication review/i)).to.eventually.be.ok;
+  });
+
+  it('should reveal video visit instructions', () => {
+    const { getByText, queryByText, findByText } = render(
+      <ConfirmedAppointmentListItem
+        appointment={{
+          ...appointment,
+          comment: 'Video Visit Preparation',
+        }}
+      />,
+    );
+
+    expect(queryByText(/before your appointment/i)).to.not.be.ok;
+    fireEvent.click(getByText(/prepare for video visit/i));
+
+    return expect(findByText('Before your appointment:')).to.eventually.be.ok;
   });
 });
 

--- a/src/applications/vaos/tests/components/VideoVisitSection.unit.spec.jsx
+++ b/src/applications/vaos/tests/components/VideoVisitSection.unit.spec.jsx
@@ -177,10 +177,10 @@ describe('Video visit', () => {
     tree.unmount();
   });
 
-  it('should disable video link if appointment is over 4 hours away', () => {
+  it('should disable video link if appointment is over 4 hours in the past', () => {
     const futureAppointment = {
       ...appointment,
-      start: moment().add(245, 'minutes'),
+      start: moment().add(-245, 'minutes'),
     };
 
     const tree = shallow(<VideoVisitSection appointment={futureAppointment} />);

--- a/src/applications/vaos/tests/components/VideoVisitSection.unit.spec.jsx
+++ b/src/applications/vaos/tests/components/VideoVisitSection.unit.spec.jsx
@@ -146,7 +146,7 @@ describe('Video visit', () => {
   it('should enable video link if appointment is less than 30 minutes away', () => {
     const pastAppointment = {
       ...appointment,
-      start: moment().add(-20, 'minutes'),
+      start: moment().add(20, 'minutes'),
     };
 
     const tree = shallow(<VideoVisitSection appointment={pastAppointment} />);
@@ -156,6 +156,24 @@ describe('Video visit', () => {
     expect(link.props()['aria-disabled']).to.equal('false');
     expect(tree.exists('span')).to.equal(false);
     expect(tree.exists('.usa-button-disabled')).to.equal(false);
+    tree.unmount();
+  });
+
+  it('should disable video link if appointment is more than 30 minutes away', () => {
+    const futureAppointment = {
+      ...appointment,
+      start: moment().add(32, 'minutes'),
+    };
+
+    const tree = shallow(<VideoVisitSection appointment={futureAppointment} />);
+    expect(tree.exists('.usa-button')).to.equal(true);
+    expect(tree.exists('.usa-button-disabled')).to.equal(true);
+
+    const describedById = 'description-join-link-123';
+    const link = tree.find('.usa-button');
+    expect(link.props()['aria-describedby']).to.equal(describedById);
+    expect(link.props()['aria-disabled']).to.equal('true');
+    expect(tree.exists(`span#${describedById}`)).to.be.true;
     tree.unmount();
   });
 

--- a/src/applications/vaos/tests/e2e/vaos-helpers.js
+++ b/src/applications/vaos/tests/e2e/vaos-helpers.js
@@ -155,7 +155,10 @@ function showMoreTest(client) {
     .click(
       'li[data-request-id="8a48912a6cab0202016cb4fcaa8b0038"] .additional-info-button.va-button-link',
     )
-    .waitForElementVisible('.additional-info-content', Timeouts.slow)
+    .waitForElementVisible(
+      '#8a48912a6cab0202016cb4fcaa8b0038-vaos-info-content',
+      Timeouts.slow,
+    )
     .pause(Timeouts.normal)
     .axeCheck('.main')
     .assert.containsText('.vaos_appts__message dd', 'Request 2 Message 1 Text');

--- a/src/applications/vaos/tests/e2e/vaos-helpers.js
+++ b/src/applications/vaos/tests/e2e/vaos-helpers.js
@@ -156,7 +156,7 @@ function showMoreTest(client) {
       'li[data-request-id="8a48912a6cab0202016cb4fcaa8b0038"] .additional-info-button.va-button-link',
     )
     .waitForElementVisible(
-      '#8a48912a6cab0202016cb4fcaa8b0038-vaos-info-content',
+      '[id="8a48912a6cab0202016cb4fcaa8b0038-vaos-info-content"]',
       Timeouts.slow,
     )
     .pause(Timeouts.normal)

--- a/src/applications/vaos/tests/services/appointment/transformers.unit.spec.js
+++ b/src/applications/vaos/tests/services/appointment/transformers.unit.spec.js
@@ -73,6 +73,7 @@ const videoAppt = {
       type: 'REGULAR',
       bookingNotes: 'T+90 Testing',
       instructionsOther: false,
+      instructionsTitle: 'Medication Review',
       patients: [
         {
           name: { firstName: 'JUDY', lastName: 'MORRISON' },
@@ -275,7 +276,7 @@ describe('VAOS Appointment transformer', () => {
       });
 
       it('should set comment', () => {
-        expect(data.comment).to.equal('T+90 Testing');
+        expect(data.comment).to.equal('Medication Review');
       });
 
       it('should not set clinic as HealthcareService', () => {

--- a/src/applications/vaos/tests/utils/appointment.unit.spec.jsx
+++ b/src/applications/vaos/tests/utils/appointment.unit.spec.jsx
@@ -944,5 +944,41 @@ describe('VAOS appointment helpers', () => {
       expect(ics).to.contain('END:VEVENT');
       expect(ics).to.contain('END:VCALENDAR');
     });
+    it('should properly chunk long descriptions', () => {
+      const momentDate = moment(now);
+      const dtStamp = momentDate.format('YYYYMMDDTHHmmss');
+      const dtStart = momentDate.format('YYYYMMDDTHHmmss');
+      const dtEnd = momentDate
+        .clone()
+        .add(60, 'minutes')
+        .format('YYYYMMDDTHHmmss');
+      const description = `Testing long line descriptions
+Testing long descriptions Testing long descriptions Testing long descriptions
+Testing long descriptions Testing long descriptions Testing long descriptions
+Testing long descriptions`;
+
+      const ics = generateICS(
+        'Community Care',
+        description,
+        'Address 1 City, State Zip',
+        dtStart,
+        dtEnd,
+      );
+      expect(ics).to.contain('BEGIN:VCALENDAR');
+      expect(ics).to.contain('VERSION:2.0');
+      expect(ics).to.contain('PRODID:VA');
+      expect(ics).to.contain('BEGIN:VEVENT');
+      expect(ics).to.contain('UID:');
+      expect(ics).to.contain('SUMMARY:Community Care');
+      expect(ics).to.contain(
+        'DESCRIPTION:Testing long line descriptions\\nTesting long descriptions Test\r\n\ting long descriptions Testing long descriptions\\nTesting long descriptions\r\n\t Testing long descriptions Testing long descriptions\\nTesting long descrip\r\n\ttions',
+      );
+      expect(ics).to.contain('LOCATION:Address 1 City, State Zip');
+      expect(ics).to.contain(`DTSTAMP:${dtStamp}`);
+      expect(ics).to.contain(`DTSTART:${dtStart}`);
+      expect(ics).to.contain(`DTEND:${dtEnd}`);
+      expect(ics).to.contain('END:VEVENT');
+      expect(ics).to.contain('END:VCALENDAR');
+    });
   });
 });

--- a/src/applications/vaos/utils/appointment.js
+++ b/src/applications/vaos/utils/appointment.js
@@ -306,16 +306,35 @@ function getAppointmentDuration(appt) {
   return isNaN(appointmentLength) ? 60 : appointmentLength;
 }
 
+const ICS_LINE_LIMIT = 74;
+function formatDescription(description) {
+  if (!description) {
+    return description;
+  }
+
+  const descWithEscapedBreaks = description
+    .replace(/\r/g, '')
+    .replace(/\n/g, '\\n');
+
+  const chunked = [];
+  let restOfDescription = `DESCRIPTION:${descWithEscapedBreaks}`;
+  while (restOfDescription.length > ICS_LINE_LIMIT) {
+    chunked.push(restOfDescription.substring(0, ICS_LINE_LIMIT));
+    restOfDescription = restOfDescription.substring(ICS_LINE_LIMIT);
+  }
+  chunked.push(restOfDescription);
+
+  return chunked.join('\r\n\t');
+}
 /**
  * Function to generate ICS.
  *
- * @param {*} summary - summary or subject of invite
- * @param {*} description - additional detials
- * @param {*} location - address / location
- * @param {*} startDateTime - start datetime in js date format
- * @param {*} endDateTime - end datetime in js date format
+ * @param {String} summary - summary or subject of invite
+ * @param {String} description - additional detials
+ * @param {Object} location - address / location
+ * @param {Date} startDateTime - start datetime in js date format
+ * @param {Date} endDateTime - end datetime in js date format
  */
-
 export function generateICS(
   summary,
   description,
@@ -331,7 +350,7 @@ PRODID:VA
 BEGIN:VEVENT
 UID:${guid()}
 SUMMARY:${summary}
-DESCRIPTION:${description}
+${formatDescription(description)}
 LOCATION:${location}
 DTSTAMP:${startDate}
 DTSTART:${startDate}

--- a/src/applications/vaos/utils/appointment.js
+++ b/src/applications/vaos/utils/appointment.js
@@ -306,6 +306,13 @@ function getAppointmentDuration(appt) {
   return isNaN(appointmentLength) ? 60 : appointmentLength;
 }
 
+/*
+ * ICS files have a 75 character line limit. Longer fields need to be broken
+ * into 75 character chunks with a CRLF in between. They also apparenly need to have a tab
+ * character at the start of each new line, which is why I set the limit to 74
+ * 
+ * Additionally, any actual line breaks in the text need to be escaped
+ */
 const ICS_LINE_LIMIT = 74;
 function formatDescription(description) {
   if (!description) {


### PR DESCRIPTION
## Description
This adds our video visit messages and also updates the request Show more links are inline with the cancel link.

## Testing done
Unit and local testing

## Screenshots
![Screen Shot 2020-06-17 at 12 27 36 PM](https://user-images.githubusercontent.com/634932/84923978-f37ea380-b095-11ea-8a8c-eeb2d8833470.png)
![Screen Shot 2020-06-17 at 12 27 29 PM](https://user-images.githubusercontent.com/634932/84923981-f4173a00-b095-11ea-92e8-7c10adbdc7ae.png)
![Screen Shot 2020-06-17 at 12 27 18 PM](https://user-images.githubusercontent.com/634932/84923983-f4173a00-b095-11ea-94e5-ce54c6169f51.png)


## Acceptance criteria
- [ ] Instruction text is shown

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
