### PR TITLE
Add AutoSSO component to sign-in page to enable inbound SSO

### DIFF
--- a/src/applications/login/containers/SignInApp.jsx
+++ b/src/applications/login/containers/SignInApp.jsx
@@ -8,6 +8,7 @@ import SubmitSignInForm from 'platform/static-data/SubmitSignInForm';
 import { login, signup } from 'platform/user/authentication/utilities';
 import environment from 'platform/utilities/environment';
 
+import { AutoSSO } from 'platform/site-wide/user-nav/containers/AutoSSO';
 import LogoutAlert from '../components/LogoutAlert';
 import downtimeBanners from '../utilities/downtimeBanners';
 
@@ -65,6 +66,7 @@ class SignInPage extends React.Component {
 
     return (
       <main className="login">
+        <AutoSSO />
         <div className="container">
           <div className="row">
             {loggedOut && <LogoutAlert />}

--- a/src/applications/login/containers/SignInApp.jsx
+++ b/src/applications/login/containers/SignInApp.jsx
@@ -12,13 +12,13 @@ import { AutoSSO } from 'platform/site-wide/user-nav/containers/AutoSSO';
 import LogoutAlert from '../components/LogoutAlert';
 import downtimeBanners from '../utilities/downtimeBanners';
 
-function loginHandler(loginType, application = null, redirect = null) {
+function loginHandler(loginType, application = null, to = null) {
   recordEvent({ event: `login-attempted-${loginType}` });
-  login(loginType, 'v1', application, redirect);
+  login(loginType, 'v1', application, to);
 }
 
-function signupHandler(application = null, redirect = null) {
-  signup('v1', application, redirect);
+function signupHandler(application = null, to = null) {
+  signup('v1', application, to);
 }
 
 const vaGovFullDomain = environment.BASE_URL;
@@ -62,11 +62,11 @@ class SignInPage extends React.Component {
     const { query } = this.props.location;
     const loggedOut = query.auth === 'logged_out';
     const application = query.application;
-    const redirect = query.to;
+    const to = query.to;
 
     return (
       <main className="login">
-        <AutoSSO />
+        <AutoSSO application={application} to={to} />
         <div className="container">
           <div className="row">
             {loggedOut && <LogoutAlert />}
@@ -109,9 +109,7 @@ class SignInPage extends React.Component {
                     <button
                       disabled={globalDowntime}
                       className="dslogon"
-                      onClick={() =>
-                        loginHandler('dslogon', application, redirect)
-                      }
+                      onClick={() => loginHandler('dslogon', application, to)}
                     >
                       <img
                         alt="DS Logon"
@@ -122,7 +120,7 @@ class SignInPage extends React.Component {
                     <button
                       disabled={globalDowntime}
                       className="mhv"
-                      onClick={() => loginHandler('mhv', application, redirect)}
+                      onClick={() => loginHandler('mhv', application, to)}
                     >
                       <img
                         alt="My HealtheVet"
@@ -133,9 +131,7 @@ class SignInPage extends React.Component {
                     <button
                       disabled={globalDowntime}
                       className="usa-button-primary va-button-primary"
-                      onClick={() =>
-                        loginHandler('idme', application, redirect)
-                      }
+                      onClick={() => loginHandler('idme', application, to)}
                     >
                       <img
                         alt="ID.me"
@@ -149,7 +145,7 @@ class SignInPage extends React.Component {
                       <button
                         disabled={globalDowntime}
                         className="idme-create usa-button usa-button-secondary"
-                        onClick={() => signupHandler(application, redirect)}
+                        onClick={() => signupHandler(application, to)}
                       >
                         <img
                           alt="ID.me"

--- a/src/platform/site-wide/user-nav/containers/AutoSSO.jsx
+++ b/src/platform/site-wide/user-nav/containers/AutoSSO.jsx
@@ -15,7 +15,14 @@ import {
 } from 'platform/utilities/sso/forceAuth';
 
 function AutoSSO(props) {
-  const { useSSOe, useInboundSSOe, hasCalledKeepAlive, userLoggedIn } = props;
+  const {
+    useSSOe,
+    useInboundSSOe,
+    hasCalledKeepAlive,
+    userLoggedIn,
+    application = null,
+    to = null,
+  } = props;
   const params = new URLSearchParams(window.location.search);
 
   if (userLoggedIn) {
@@ -27,7 +34,7 @@ function AutoSSO(props) {
   }
 
   if (useSSOe && useInboundSSOe && !hasCalledKeepAlive) {
-    checkAutoSession().then(() => {
+    checkAutoSession(application, to).then(() => {
       props.checkKeepAlive();
     });
   }

--- a/src/platform/utilities/sso/index.js
+++ b/src/platform/utilities/sso/index.js
@@ -27,7 +27,7 @@ export async function ssoKeepAliveSession() {
   }
 }
 
-export async function checkAutoSession() {
+export async function checkAutoSession(application = null, to = null) {
   await ssoKeepAliveSession();
   if (hasSession() && hasSessionSSO() === false) {
     // explicitly check to see if the SSOe session is false, as it could also
@@ -35,7 +35,14 @@ export async function checkAutoSession() {
     // case we don't want to logout the user because we don't know
     logout('v1', 'sso-automatic-logout');
   } else if (!hasSession() && hasSessionSSO() && !getForceAuth()) {
-    login('idme', 'v1', null, null, { inbound: 'true' }, 'sso-automatic-login');
+    login(
+      'idme',
+      'v1',
+      application,
+      to,
+      { inbound: 'true' },
+      'sso-automatic-login',
+    );
   }
 }
 


### PR DESCRIPTION
## Description
Adds the `<AutoSSO />` component to the standalone sign-in page. This page doesn't render the user-nav, where `<AutoSSO />` is currently rendered, so it needs to be added on its own for inbound SSO to work on this page.

Additionally, this adds work to pass query parameters from the URL into the `AutoSSO` component, so that inbound traffic will behave the same as outbound-initiated SSO.

E.g. navigating to `va.gov/sign-in?application=myvahealth&to=some_subroute` will ensure that any automatic login attempts pass on those parameters

@ericbuckley I still need to test the redirect. Idk what `vets-api` looks at for redirect logic but there's nothing implicitly done here from the FE for specific query params to be added. If you look at `<SignInApp />`, the appliication query param is passed in via the individual login buttons right now.

## Testing done

