### PR TITLE
bradl3yC - 10363 - Remove the inelig alerts if products are shown

### DIFF
--- a/src/applications/disability-benefits/2346/components/Accessories.jsx
+++ b/src/applications/disability-benefits/2346/components/Accessories.jsx
@@ -63,7 +63,7 @@ class Accessories extends Component {
     }
     return (
       <div className="accessory-page">
-        {areAccessorySuppliesEligible && (
+        {accessorySupplies.length > 0 && (
           <h3 className="vads-u-font-size--h4 vads-u-margin-top--5">
             Select the hearing aid accessories you need
           </h3>

--- a/src/applications/disability-benefits/2346/components/Accessories.jsx
+++ b/src/applications/disability-benefits/2346/components/Accessories.jsx
@@ -171,13 +171,16 @@ class Accessories extends Component {
               </div>
               {currentDate.diff(accessorySupply.nextAvailabilityDate, 'days') <
               0 ? (
-                <AlertBox
-                  className="vads-u-color--black vads-u-background-color--white"
-                  headline={`You can't order this accessory online until ${moment(
-                    accessorySupply.nextAvailabilityDate,
-                  ).format('MMMM D, YYYY')}`}
-                  status="warning"
-                />
+                <div className="usa-alert usa-alert-warning vads-u-background-color--white vads-u-padding-x--2p5 vads-u-padding-y--2 vads-u-width--full">
+                  <div className="usa-alert-body">
+                    <h3 className="usa-alert-heading vads-u-font-family--sans">
+                      You can't order this accessory online until{' '}
+                      {moment(accessorySupply.nextAvailabilityDate).format(
+                        'MMMM D, YYYY',
+                      )}
+                    </h3>
+                  </div>
+                </div>
               ) : (
                 <div className="vads-u-max-width--226">
                   <input

--- a/src/applications/disability-benefits/2346/components/Accessories.jsx
+++ b/src/applications/disability-benefits/2346/components/Accessories.jsx
@@ -70,7 +70,8 @@ class Accessories extends Component {
         )}
         {!haveAccessoriesBeenOrderedInLastFiveMonths &&
           haveAccessoriesBeenOrderedInLastTwoYears &&
-          !areAccessorySuppliesEligible && (
+          !areAccessorySuppliesEligible &&
+          accessorySupplies.length === 0 && (
             <>
               <AlertBox
                 headline="You can't add accessories to your order at this time"

--- a/src/applications/disability-benefits/2346/components/Batteries.jsx
+++ b/src/applications/disability-benefits/2346/components/Batteries.jsx
@@ -61,7 +61,7 @@ class Batteries extends Component {
 
     return (
       <div className="battery-page">
-        {areBatterySuppliesEligible && (
+        {batterySupplies.length > 0 && (
           <h3 className="vads-u-font-size--h4 vads-u-margin-bottom--2p5">
             Select the hearing aids that need batteries
           </h3>

--- a/src/applications/disability-benefits/2346/components/Batteries.jsx
+++ b/src/applications/disability-benefits/2346/components/Batteries.jsx
@@ -188,13 +188,16 @@ class Batteries extends Component {
               </div>
               {currentDate.diff(batterySupply.nextAvailabilityDate, 'days') <
               0 ? (
-                <AlertBox
-                  className="vads-u-color--black vads-u-background-color--white"
-                  headline={`You can't reorder batteries for this device until ${moment(
-                    batterySupply.nextAvailabilityDate,
-                  ).format('MMMM D, YYYY')}`}
-                  status="warning"
-                />
+                <div className="usa-alert usa-alert-warning vads-u-background-color--white vads-u-padding-x--2p5 vads-u-padding-y--2 vads-u-width--full">
+                  <div className="usa-alert-body">
+                    <h3 className="usa-alert-heading vads-u-font-family--sans">
+                      You can't reorder batteries for this device until $
+                      {moment(batterySupply.nextAvailabilityDate).format(
+                        'MMMM D, YYYY',
+                      )}
+                    </h3>
+                  </div>
+                </div>
               ) : (
                 <div className="vads-u-max-width--293">
                   <input

--- a/src/applications/disability-benefits/2346/components/Batteries.jsx
+++ b/src/applications/disability-benefits/2346/components/Batteries.jsx
@@ -67,7 +67,8 @@ class Batteries extends Component {
           </h3>
         )}
         {haveBatteriesBeenOrderedInLastFiveMonths &&
-          !areBatterySuppliesEligible && (
+          !areBatterySuppliesEligible &&
+          batterySupplies.length === 0 && (
             <>
               <AlertBox
                 headline="You can't add batteries to your order at this time"

--- a/src/applications/disability-benefits/2346/tests/Accessories.unit.spec.jsx
+++ b/src/applications/disability-benefits/2346/tests/Accessories.unit.spec.jsx
@@ -187,7 +187,7 @@ describe('Accessories', () => {
     const wrapper = mount(
       <Accessories store={fakeStoreNoEligibility5Months} />,
     );
-    expect(wrapper.find('AlertBox').length).to.equal(3);
+    expect(wrapper.find('.usa-alert-heading').length).to.equal(3);
     wrapper.unmount();
   });
   it('should display an alert box if the Veteran is not eligible to order accessories and has not ordered in the last 2 years', () => {

--- a/src/applications/disability-benefits/2346/tests/Accessories.unit.spec.jsx
+++ b/src/applications/disability-benefits/2346/tests/Accessories.unit.spec.jsx
@@ -187,7 +187,7 @@ describe('Accessories', () => {
     const wrapper = mount(
       <Accessories store={fakeStoreNoEligibility5Months} />,
     );
-    expect(wrapper.find('AlertBox').length).to.equal(4);
+    expect(wrapper.find('AlertBox').length).to.equal(3);
     wrapper.unmount();
   });
   it('should display an alert box if the Veteran is not eligible to order accessories and has not ordered in the last 2 years', () => {


### PR DESCRIPTION
## Description
Only show the larger alertbox if there are no supplies in the array

## Testing done


## Screenshots
![Screen Shot 2020-06-17 at 2 30 01 PM](https://user-images.githubusercontent.com/6165421/84935676-0c438500-b0a7-11ea-8524-4b152eac91a2.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
