### PR TITLE
[Development] Accessibility fixes on review page

### DIFF
--- a/src/platform/forms-system/src/js/review/ObjectField.jsx
+++ b/src/platform/forms-system/src/js/review/ObjectField.jsx
@@ -130,7 +130,7 @@ class ObjectField extends React.Component {
         divWrapper = objectFields.some(name => {
           const options = uiSchema?.[name]?.['ui:options'] || {};
           return (
-            options.volatileData || // ReviewCardField
+            (options.volatileData && !formContext.reviewMode) || // ReviewCardField
             options.customTitle || // SelectArrayItemsWidget
             (options.addAnotherLabel && formContext.reviewMode) // fileUiSchema
           );

--- a/src/platform/forms-system/src/js/widgets/DateWidget.jsx
+++ b/src/platform/forms-system/src/js/widgets/DateWidget.jsx
@@ -87,7 +87,6 @@ export default class DateWidget extends React.Component {
             Month
           </label>
           <select
-            aria-describedby={`${this.props.id}-label`}
             name={`${id}Month`}
             id={`${id}Month`}
             value={month}
@@ -107,7 +106,6 @@ export default class DateWidget extends React.Component {
               Day
             </label>
             <select
-              aria-describedby={`${this.props.id}-label`}
               name={`${id}Day`}
               id={`${id}Day`}
               value={day}
@@ -128,7 +126,6 @@ export default class DateWidget extends React.Component {
             Year
           </label>
           <input
-            aria-describedby={`${this.props.id}-label`}
             type="number"
             autoComplete={options.autocomplete}
             name={`${id}Year`}

--- a/src/platform/forms-system/test/js/review/ObjectField.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/review/ObjectField.unit.spec.jsx
@@ -411,6 +411,43 @@ describe('Schemaform review: ObjectField', () => {
     expect(review.type).to.equal('div');
     expect(review.props.className).to.equal('review');
   });
+  it('should render a dl when rendering a ReviewCardField content with volatileData in reviewMode', () => {
+    const onChange = sinon.spy();
+    const onBlur = sinon.spy();
+    const schema = {
+      type: 'object',
+      properties: {
+        test: {
+          type: 'string',
+        },
+      },
+    };
+    const uiSchema = {
+      test: {
+        'ui:options': {
+          volatileData: true,
+        },
+      },
+    };
+    const formData = {
+      test: { foo: 'test' },
+    };
+    const tree = SkinDeep.shallowRender(
+      <ObjectField
+        schema={schema}
+        uiSchema={uiSchema}
+        formContext={{ pageTitle: 'Blah', reviewMode: true }}
+        idSchema={{ $id: 'root' }}
+        formData={formData}
+        onChange={onChange}
+        onBlur={onBlur}
+      />,
+    );
+    // expecting a "div.review" instead of a "dl.review"
+    const review = tree.props.children[1];
+    expect(review.type).to.equal('dl');
+    expect(review.props.className).to.equal('review');
+  });
   it('should render a div when rendering a custom title, like in the SelectArrayItemsWidget', () => {
     const onChange = sinon.spy();
     const onBlur = sinon.spy();


### PR DESCRIPTION
## Description

This PR includes two fixes:

- Remove invalid `aria-describedby` attributes in the `DateWidget`; the label already has a `htmlFor` targeting the ID of the associated select & input.
- Prevent `ObjectField` from rendering a `div` wrapper when on the review & submit page while in `reviewMode`. This was causing some issues when a `ReviewCardField` has the `volatileData` option set to `true`

Related ticket: https://github.com/department-of-veterans-affairs/va.gov-team/issues/9799

## Testing done

Added unit test for the `ObjectField` change

## Screenshots

<details><summary>Invalid aria-label message from axe-coconut</summary>

<!-- leave a blank line above -->
![Screen Shot 2020-06-17 at 2 38 27 PM](https://user-images.githubusercontent.com/136959/84960610-bfbc7180-b0c7-11ea-93f5-0ccbfdafb6dd.png)
</details>

## Acceptance criteria
- [ ] Remove invalid `aria-describedby`
- [ ] Prevent `ObjectField` rendering a `div` in review mode.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
