### PR TITLE
Process cms exports refactor

### DIFF
--- a/src/site/stages/build/process-cms-exports/helpers.js
+++ b/src/site/stages/build/process-cms-exports/helpers.js
@@ -51,8 +51,10 @@ module.exports = {
    * and put them into an object indexed by filename
    *
    * @param {String} dir - The directory to import all files from
-   * @param {String} prop - The name of the exported property to put into the dict
-   * @return {Object} - The dict of filenam -> exported prop mappings
+   * @param {String} [prop] - The name of the exported property to put into the
+   *                          dict. If undefined, the default export will be
+   *                          used.
+   * @return {Object} - The dict of filename -> exported prop mappings
    */
   getAllImportsFrom(dir, prop) {
     return fs
@@ -60,8 +62,9 @@ module.exports = {
       .filter(name => name.endsWith('.js'))
       .reduce((t, fileName) => {
         const contentModelType = path.parse(fileName).name;
+        const exp = require(path.join(dir, fileName));
         // eslint-disable-next-line no-param-reassign
-        t[contentModelType] = require(path.join(dir, fileName))[prop];
+        t[contentModelType] = prop ? exp[prop] : exp;
         return t;
       }, {});
   },

--- a/src/site/stages/build/process-cms-exports/index.js
+++ b/src/site/stages/build/process-cms-exports/index.js
@@ -170,10 +170,8 @@ const entityAssemblerFactory = contentDir => {
 
     validateInput(entity);
 
-    const filteredEntity = getFilteredEntity(entity);
-
     const expandedEntity = expandEntityReferences(
-      filteredEntity,
+      entity,
       ancestors,
       assembleEntityTree,
     );

--- a/src/site/stages/build/process-cms-exports/index.js
+++ b/src/site/stages/build/process-cms-exports/index.js
@@ -21,7 +21,7 @@ const {
  * @param {Object} entity - The current entity
  * @param {Ancestor[]} ancestors - A list of all ancestors
  * @return {Object|bool} If the current entity is a circular reference, return the original
- * @return {false} If the current entity is not a circular reference, return false
+ * If the current entity is not a circular reference, return false
  */
 const findCircularReference = (entity, ancestors) => {
   const ancestorIds = ancestors.map(a => a.id);

--- a/src/site/stages/build/process-cms-exports/index.js
+++ b/src/site/stages/build/process-cms-exports/index.js
@@ -77,6 +77,36 @@ const validateInput = entity => {
   }
 };
 
+/**
+ * @param {Object} transformedEntity - The entity after transformation
+ * @throws {Error} If the entity is invalid
+ */
+const validateOutput = (entity, transformedEntity) => {
+  const transformedErrors = validateTransformedEntity(transformedEntity);
+  if (transformedErrors.length) {
+    /* eslint-disable no-console */
+    console.warn(
+      chalk.yellow(
+        `${toId(entity)} (${getContentModelType(
+          entity,
+        )}) is invalid after transformation:`,
+      ),
+    );
+    console.warn(`${transformedErrors.map(e => JSON.stringify(e, null, 2))}`);
+    transformedErrors.forEach(e => {
+      console.warn(
+        chalk.yellow(`Data found at ${e.dataPath}:`),
+        JSON.stringify(get(transformedEntity, e.dataPath.slice(1))),
+      );
+    });
+    console.warn(`-------------------`);
+    /* eslint-enable no-console */
+
+    // Abort! (We may want to change this later)
+    throw new Error(`${toId(entity)} is invalid after transformation`);
+  }
+};
+
 const entityAssemblerFactory = contentDir => {
   /**
    * Takes an entity type and uuid, reads the corresponding file,
@@ -133,29 +163,7 @@ const entityAssemblerFactory = contentDir => {
       contentDir,
       assembleEntityTree,
     });
-    const transformedErrors = validateTransformedEntity(transformedEntity);
-    if (transformedErrors.length) {
-      /* eslint-disable no-console */
-      console.warn(
-        chalk.yellow(
-          `${toId(entity)} (${getContentModelType(
-            entity,
-          )}) is invalid after transformation:`,
-        ),
-      );
-      console.warn(`${transformedErrors.map(e => JSON.stringify(e, null, 2))}`);
-      transformedErrors.forEach(e => {
-        console.warn(
-          chalk.yellow(`Data found at ${e.dataPath}:`),
-          JSON.stringify(get(transformedEntity, e.dataPath.slice(1))),
-        );
-      });
-      console.warn(`-------------------`);
-      /* eslint-enable no-console */
-
-      // Abort! (We may want to change this later)
-      throw new Error(`${toId(entity)} is invalid after transformation`);
-    }
+    validateOutput(entity, transformedEntity);
 
     return transformedEntity;
   };

--- a/src/site/stages/build/process-cms-exports/schema-validation.js
+++ b/src/site/stages/build/process-cms-exports/schema-validation.js
@@ -4,7 +4,7 @@ const fs = require('fs');
 const path = require('path');
 
 const validate = require('./validator');
-const { getContentModelType } = require('./helpers');
+const { getContentModelType, getAllImportsFrom } = require('./helpers');
 
 // Read all the schemas
 const rawSchemasDir = path.join(__dirname, 'schemas', 'raw');
@@ -14,15 +14,7 @@ const validateEntityFactory = schemasDir => {
   /**
    * { page: { <schema> }, ... }
    */
-  const schemas = fs
-    .readdirSync(schemasDir)
-    .filter(name => name.endsWith('.js'))
-    .reduce((s, fileName) => {
-      const contentModelType = fileName.slice(0, -3); // Take of the '.js'
-      // eslint-disable-next-line no-param-reassign
-      s[contentModelType] = require(path.join(schemasDir, fileName));
-      return s;
-    }, {});
+  const schemas = getAllImportsFrom(schemasDir);
 
   const missingSchemas = new Set();
 

--- a/src/site/stages/build/process-cms-exports/transform.js
+++ b/src/site/stages/build/process-cms-exports/transform.js
@@ -40,22 +40,22 @@ function getEntityTransformer(entityType, verbose = true) {
  *                          transformation.
  * @param {Object} rest - Contains the lesser-used arguments for the
  *                        transformers.
- * @property {string} uuid - The UUID of the current entity
- * @property {Array<Object>} ancestors - All the current entity's
+ * @property {string} rest.uuid - The UUID of the current entity
+ * @property {Array<Object>} rest.ancestors - All the current entity's
  *                        ancestors. ancestors[1] is the child of
  *                        ancestors[0], etc.
  *                        ancestors[ancestors.length - 1] is the
  *                        current entity's direct parent.
  *                        Each item in the array is like:
  *                        { id: toId(entity), entity: entity }
- * @property {string} parentFieldName - The name of the field in the
- *                        entity's parent in which the current entity
- *                        can be found.
- * @property {string} contentDir - The path to the tome-sync content
+ * @property {string} rest.parentFieldName - The name of the field in the
+ *                        entity's parent in which the current entity can be
+ *                        found.
+ * @property {string} rest.contentDir - The path to the tome-sync content
  *                        directory.
- * @property {function} assembleEntityTree - The function to assemble
- *                        the entity tree. This is usually the
- *                        caller of transformEntity.
+ * @property {function} rest.assembleEntityTree - The function to assemble the
+ *                        entity tree. This is usually the caller of
+ *                        transformEntity.
  *
  * @return {Object} - The entity with modified properties based on
  *                    the specific content model type.

--- a/src/site/stages/build/process-cms-exports/transform.js
+++ b/src/site/stages/build/process-cms-exports/transform.js
@@ -41,7 +41,7 @@ function getEntityTransformer(entityType, verbose = true) {
  * @param {Object} rest - Contains the lesser-used arguments for the
  *                        transformers.
  * @property {string} rest.uuid - The UUID of the current entity
- * @property {Array<Object>} rest.ancestors - All the current entity's
+ * @property {Object[]} rest.ancestors - All the current entity's
  *                        ancestors. ancestors[1] is the child of
  *                        ancestors[0], etc.
  *                        ancestors[ancestors.length - 1] is the


### PR DESCRIPTION
## Description
I saw a couple opportunities to clear some things up, so I took them. Specifically, I extracted chunks of `assembleEntityTree` into separate functions to make it clearer what the logic in there is doing. Additionally, I added some clarity to the `transformEntity` JSDoc.