### PR TITLE
[Frozen til June 29th] Remove "message us" from the landing page right rail.

### DIFF
--- a/src/applications/claims-status/components/AskVAQuestions.jsx
+++ b/src/applications/claims-status/components/AskVAQuestions.jsx
@@ -11,9 +11,6 @@ function AskVAQuestions() {
         </a>
       </p>
       <p>Monday &#8211; Friday, 8:00 a.m. &#8211; 9:00 p.m. ET</p>
-      <p>
-        <a href="https://iris.custhelp.com/">Submit a question to VA</a>
-      </p>
     </div>
   );
 }

--- a/src/applications/letters/containers/LetterList.jsx
+++ b/src/applications/letters/containers/LetterList.jsx
@@ -7,7 +7,7 @@ import DownloadLetterLink from '../components/DownloadLetterLink';
 import VeteranBenefitSummaryLetter from './VeteranBenefitSummaryLetter';
 
 import { focusElement } from 'platform/utilities/ui';
-import { letterContent, bslHelpInstructions } from '../utils/helpers';
+import { letterContent } from '../utils/helpers';
 import { AVAILABILITY_STATUSES, LETTER_TYPES } from '../utils/constants';
 
 export class LetterList extends React.Component {
@@ -20,11 +20,9 @@ export class LetterList extends React.Component {
     const letterItems = (this.props.letters || []).map((letter, index) => {
       let content;
       let letterTitle;
-      let helpText;
       if (letter.letterType === LETTER_TYPES.benefitSummary) {
         letterTitle = 'Benefit Summary and Service Verification Letter';
         content = <VeteranBenefitSummaryLetter />;
-        helpText = bslHelpInstructions;
       } else if (letter.letterType === LETTER_TYPES.proofOfService) {
         letterTitle = 'Proof of Service Card';
         content = letterContent[letter.letterType] || '';
@@ -55,7 +53,6 @@ export class LetterList extends React.Component {
         >
           <div>{content}</div>
           {conditionalDownloadButton}
-          {helpText}
         </CollapsiblePanel>
       );
     });

--- a/src/applications/letters/utils/helpers.jsx
+++ b/src/applications/letters/utils/helpers.jsx
@@ -95,24 +95,6 @@ const commissaryLetterContent = (
   </div>
 );
 
-// Benefit Summary Letter Help Instructions
-export const bslHelpInstructions = (
-  <div>
-    <p>
-      If your service period or disability status information is incorrect,
-      please send us a message through VA’s{' '}
-      <a
-        target="_blank"
-        rel="noopener noreferrer"
-        href="https://iris.custhelp.com/app/ask"
-      >
-        Inquiry Routing & Information System (IRIS)
-      </a>
-      . VA will respond within 5 business days.
-    </p>
-  </div>
-);
-
 // Map values returned by vets-api to display text.
 export const letterContent = {
   commissary: commissaryLetterContent,

--- a/src/applications/personalization/profile-2/components/MilitaryInformation.jsx
+++ b/src/applications/personalization/profile-2/components/MilitaryInformation.jsx
@@ -56,14 +56,6 @@ const MilitaryInformationContent = ({ militaryInformation }) => {
                 Find your nearest VA regional office
               </a>
               .
-              <p>
-                You can also request to be added to DEERS through our online
-                customer help center.
-              </p>
-              <a href="https://iris.custhelp.va.gov/app/answers/detail/a_id/3036/~/not-registered-in-deers%2C-or-received-and-error-message-while-trying-to">
-                Get instructions from our help center
-              </a>
-              .
             </div>
           }
         />

--- a/src/applications/personalization/profile360/components/MilitaryInformation.jsx
+++ b/src/applications/personalization/profile360/components/MilitaryInformation.jsx
@@ -43,14 +43,6 @@ class MilitaryInformationContent extends React.Component {
                   Find your nearest VA regional office
                 </a>
                 .
-                <p>
-                  You can also request to be added to DEERS through our online
-                  customer help center.
-                </p>
-                <a href="https://iris.custhelp.va.gov/app/answers/detail/a_id/3036/~/not-registered-in-deers%2C-or-received-and-error-message-while-trying-to">
-                  Get instructions from our help center
-                </a>
-                .
               </div>
             }
           />

--- a/src/applications/validate-mhv-account/components/errors/NeedsSSNResolution.jsx
+++ b/src/applications/validate-mhv-account/components/errors/NeedsSSNResolution.jsx
@@ -51,40 +51,6 @@ const NeedsSSNResolution = () => {
             </li>
           </ul>
         </CollapsiblePanel>
-
-        <CollapsiblePanel panelName="Ask us a question online" borderless>
-          <p>
-            Ask us a question online through our online help center, known as
-            the Inquiry Routing &amp; Information System (or IRIS).
-          </p>
-          <p>
-            <strong>Fill in the form fields as below:</strong>
-          </p>
-          <ul>
-            <li>
-              <strong>Question:</strong> Type in <strong>Not in DEERS</strong>.
-            </li>
-            <li>
-              <strong>Topic:</strong> Select{' '}
-              <strong>Veteran not in DEERS (Add)</strong>.
-            </li>
-            <li>
-              <strong>Inquiry type:</strong> Select <strong>Question</strong>
-            </li>
-          </ul>
-          <p>
-            Then, complete the rest of the form and click{' '}
-            <strong>Submit</strong>
-          </p>
-          <p>We’ll contact you within 2 to 3 days.</p>
-          <a
-            href="https://iris.custhelp.va.gov/app/ask"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Go to the IRIS website question form
-          </a>
-        </CollapsiblePanel>
       </>
     ),
   };

--- a/src/applications/validate-mhv-account/components/errors/VerificationFailed.jsx
+++ b/src/applications/validate-mhv-account/components/errors/VerificationFailed.jsx
@@ -52,39 +52,6 @@ const VerificationFailed = () => {
             </li>
           </ul>
         </CollapsiblePanel>
-
-        <CollapsiblePanel panelName="Ask us a question online" borderless>
-          <p>
-            Ask us a question online through our online help center, known as
-            the Inquiry Routing &amp; Information System (or IRIS).
-          </p>
-          <p>
-            <strong>Fill in the form fields as below:</strong>
-          </p>
-          <ul>
-            <li>
-              <strong>Question:</strong> Type in “Not in DEERS.”
-            </li>
-            <li>
-              <strong>Topic:</strong> Select “Veteran not in DEERS (Add)”
-            </li>
-            <li>
-              <strong>Inquiry type:</strong> Select “Question”
-            </li>
-          </ul>
-          <p>
-            Then, complete the rest of the form and click{' '}
-            <strong>Submit</strong>
-          </p>
-          <p>We’ll contact you within 2 to 3 days.</p>
-          <a
-            href="https://iris.custhelp.va.gov/app/ask"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Go to the IRIS website question form
-          </a>
-        </CollapsiblePanel>
       </>
     ),
   };

--- a/src/platform/landing-pages/header-footer-data.json
+++ b/src/platform/landing-pages/header-footer-data.json
@@ -189,14 +189,6 @@
     },
     {
       "column": 4,
-      "href": "https://iris.custhelp.va.gov/app/ask",
-      "order": 2,
-      "target": null,
-      "title": "Ask a question",
-      "rel": "noopener noreferrer"
-    },
-    {
-      "column": 4,
       "label": "Call VA311:",
       "href": "tel:18446982311",
       "order": 3,

--- a/src/platform/site-wide/cta-widget/components/messages/NeedsSSNResolution.jsx
+++ b/src/platform/site-wide/cta-widget/components/messages/NeedsSSNResolution.jsx
@@ -47,45 +47,6 @@ const NeedsSSNResolution = () => {
             </li>
           </ul>
         </AdditionalInfo>
-        <div className="vads-u-margin-top--1p5">
-          <AdditionalInfo triggerText="Or ask us a question online">
-            <p>
-              Ask us a question through our online help center, known as the
-              Inquiry Routing & Information System (IRIS).
-            </p>
-            <p>
-              <strong>Fill in the form fields as below:</strong>
-            </p>
-            <ul>
-              <li>
-                <strong>Question: </strong>
-                Type in <strong>Not in DEERS</strong>.
-              </li>
-              <li>
-                <strong>Topic: </strong>
-                Select <strong>Veteran not in DEERS (Add)</strong>.
-              </li>
-              <li>
-                <strong>Inquiry type: </strong> Select <strong>Question</strong>
-                .
-              </li>
-            </ul>
-            <p>
-              Then, complete the rest of the form and click{' '}
-              <strong>Submit</strong>.
-            </p>
-            <p>We’ll contact you within 2 to 3 days.</p>
-            <p>
-              <a
-                href="https://iris.custhelp.va.gov/app/ask"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                Go to the IRIS website question form
-              </a>
-            </p>
-          </AdditionalInfo>
-        </div>
       </div>
     ),
     status: 'error',

--- a/src/platform/site-wide/cta-widget/components/messages/mvi/NotFound.jsx
+++ b/src/platform/site-wide/cta-widget/components/messages/mvi/NotFound.jsx
@@ -40,40 +40,6 @@ const NotFound = () => {
             (EFT)
           </li>
         </ul>
-        <h5>Or ask us a question online</h5>
-        <p>
-          Ask us a question through our online help center, known as the Inquiry
-          Routing & Information System (IRIS).
-        </p>
-        <p>
-          <strong>Fill in the form fields as below:</strong>
-        </p>
-        <ul>
-          <li>
-            <strong>Question: </strong>
-            Type in <strong>Not in DEERS</strong>.
-          </li>
-          <li>
-            <strong>Topic: </strong>
-            Select <strong>Veteran not in DEERS (Add)</strong>.
-          </li>
-          <li>
-            <strong>Inquiry type: </strong> Select <strong>Question</strong>.
-          </li>
-        </ul>
-        <p>
-          Then, complete the rest of the form and click <strong>Submit</strong>.
-        </p>
-        <p>We’ll contact you within 2 to 3 days.</p>
-        <p>
-          <a
-            href="https://iris.custhelp.va.gov/app/ask"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Go to the IRIS website question form
-          </a>
-        </p>
       </div>
     ),
     status: 'error',

--- a/src/platform/site-wide/user-nav/components/HelpMenu.jsx
+++ b/src/platform/site-wide/user-nav/components/HelpMenu.jsx
@@ -22,9 +22,6 @@ function HelpMenu({ clickHandler, cssClass, isOpen }) {
         <a href={`${facilityLocatorUrl}`}>Find a VA Location</a>
       </p>
       <p>
-        <a href="https://iris.custhelp.va.gov/app/ask">Ask a Question</a>
-      </p>
-      <p>
         <a href="tel:18446982311">Call VA311: 844-698-2311</a>
       </p>
       <p>TTY: 711</p>

--- a/src/platform/static-data/footer-links.json
+++ b/src/platform/static-data/footer-links.json
@@ -188,14 +188,6 @@
   },
   {
     "column": 4,
-    "href": "https://iris.custhelp.va.gov/app/ask",
-    "order": 2,
-    "target": null,
-    "title": "Ask a question",
-    "rel": "noopener noreferrer"
-  },
-  {
-    "column": 4,
     "label": "Call VA311:",
     "href": "tel:18446982311",
     "order": 3,

--- a/src/site/layouts/landing_page.drupal.liquid
+++ b/src/site/layouts/landing_page.drupal.liquid
@@ -81,17 +81,6 @@
               Ask questions
             </button>
             <div id="a1" class="usa-accordion-content" aria-hidden="false">
-              <section>
-                <h4>Message us</h4>
-                <ul class="va-nav-linkslist-list social">
-                  <li>
-                    <a href="https://iris.custhelp.va.gov/app/ask"
-                      onclick="recordEvent({ 'event': 'nav-hub-rail', 'nav-path': 'Ask questions' });">
-                      Ask a question online
-                    </a>
-                  </li>
-                </ul>
-              </section>
 
               {% if fieldSupportServices != empty %}
               <section>


### PR DESCRIPTION
## Description

@AnneHurley asked about removing this content via CMS, but it's actually baked into the liquid template.

This should only be merged if the intent is to remove the link to Iris from every hub landing page. 

## Testing done

None, yet. 

## Screenshots

![Careers_And_Employment___Veterans_Affairs_and_3__bash_and_GitHub_Desktop_and_Grey_County_Maps](https://user-images.githubusercontent.com/643678/84971751-6c5c1a80-b0eb-11ea-8b61-79a9d3a3ca9e.jpg)

## Acceptance criteria
- [ ] Message us disappears from every hub landing page. 
