### PR TITLE
Add unauth prescription refills content

### DIFF
--- a/src/applications/static-pages/health-care-manage-benefits/prescriptions-refill-content/components/App/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/prescriptions-refill-content/components/App/index.js
@@ -7,31 +7,19 @@ import CallToActionWidget from 'platform/site-wide/cta-widget';
 export const App = () => (
   <>
     <CallToActionWidget appId="rx" setFocus={false} />
-    <div data-template="paragraphs/q_a_section" data-entity-id={3258}>
-      <div
-        itemScope
-        itemType="http://schema.org/Question"
-        data-template="paragraphs/q_a"
-        data-entity-id={3257}
-        data-analytics-faq-section
-        data-analytics-faq-text="How can the VA Prescription Refill and Tracking tool help me manage my health care?"
-      >
+    <div>
+      <div itemScope itemType="http://schema.org/Question">
         <h2 itemProp="name" id="how-can-the-va-prescription-re">
           How can the VA Prescription Refill and Tracking tool help me manage my
           health care?
         </h2>
         <div
-          data-entity-id={3257}
           itemProp="acceptedAnswer"
           itemScope
           itemType="http://schema.org/Answer"
         >
           <div itemProp="text">
-            <div
-              data-template="paragraphs/wysiwyg"
-              data-entity-id={3259}
-              className="processed-content"
-            >
+            <div className="processed-content">
               <p>
                 Our Prescription Refill and Tracking tool is a web-based service
                 that helps you manage your VA prescriptions online.
@@ -60,29 +48,17 @@ export const App = () => (
           </div>
         </div>
       </div>
-      <div
-        itemScope
-        itemType="http://schema.org/Question"
-        data-template="paragraphs/q_a"
-        data-entity-id={3260}
-        data-analytics-faq-section
-        data-analytics-faq-text="Am I eligible to use this tool?"
-      >
+      <div itemScope itemType="http://schema.org/Question">
         <h2 itemProp="name" id="am-i-eligible-to-use-this-tool">
           Am I eligible to use this tool?
         </h2>
         <div
-          data-entity-id={3260}
           itemProp="acceptedAnswer"
           itemScope
           itemType="http://schema.org/Answer"
         >
           <div itemProp="text">
-            <div
-              data-template="paragraphs/wysiwyg"
-              data-entity-id={3261}
-              className="processed-content"
-            >
+            <div className="processed-content">
               <p>
                 You can use this tool if you meet all of the requirements listed
                 below.
@@ -133,29 +109,17 @@ export const App = () => (
           </div>
         </div>
       </div>
-      <div
-        itemScope
-        itemType="http://schema.org/Question"
-        data-template="paragraphs/q_a"
-        data-entity-id={3262}
-        data-analytics-faq-section
-        data-analytics-faq-text="Once I’m signed in, how do I get started?"
-      >
+      <div itemScope itemType="http://schema.org/Question">
         <h2 itemProp="name" id="once-im-signed-in-how-do-i-get">
           Once I’m signed in, how do I get started?
         </h2>
         <div
-          data-entity-id={3262}
           itemProp="acceptedAnswer"
           itemScope
           itemType="http://schema.org/Answer"
         >
           <div itemProp="text">
-            <div
-              data-template="paragraphs/wysiwyg"
-              data-entity-id={3263}
-              className="processed-content"
-            >
+            <div className="processed-content">
               <p>
                 On your Welcome page, you’ll see a module for “Pharmacy.” Within
                 that module, you’ll see these options:
@@ -173,29 +137,17 @@ export const App = () => (
           </div>
         </div>
       </div>
-      <div
-        itemScope
-        itemType="http://schema.org/Question"
-        data-template="paragraphs/q_a"
-        data-entity-id={3264}
-        data-analytics-faq-section
-        data-analytics-faq-text="Can I use this tool to refill and track all my VA prescriptions?"
-      >
+      <div itemScope itemType="http://schema.org/Question">
         <h2 itemProp="name" id="can-i-use-this-tool-to-refill-">
           Can I use this tool to refill and track all my VA prescriptions?
         </h2>
         <div
-          data-entity-id={3264}
           itemProp="acceptedAnswer"
           itemScope
           itemType="http://schema.org/Answer"
         >
           <div itemProp="text">
-            <div
-              data-template="paragraphs/wysiwyg"
-              data-entity-id={3265}
-              className="processed-content"
-            >
+            <div className="processed-content">
               <p>
                 <strong>
                   You can refill and track most of your VA prescriptions,
@@ -227,29 +179,17 @@ export const App = () => (
           </div>
         </div>
       </div>
-      <div
-        itemScope
-        itemType="http://schema.org/Question"
-        data-template="paragraphs/q_a"
-        data-entity-id={3266}
-        data-analytics-faq-section
-        data-analytics-faq-text="Where will VA send my prescriptions?"
-      >
+      <div itemScope itemType="http://schema.org/Question">
         <h2 itemProp="name" id="where-will-va-send-my-prescrip">
           Where will VA send my prescriptions?
         </h2>
         <div
-          data-entity-id={3266}
           itemProp="acceptedAnswer"
           itemScope
           itemType="http://schema.org/Answer"
         >
           <div itemProp="text">
-            <div
-              data-template="paragraphs/wysiwyg"
-              data-entity-id={3267}
-              className="processed-content"
-            >
+            <div className="processed-content">
               <p>
                 Our mail order pharmacy will send your prescriptions to the
                 address we have on file for you. We ship to all addresses in the
@@ -269,30 +209,18 @@ export const App = () => (
           </div>
         </div>
       </div>
-      <div
-        itemScope
-        itemType="http://schema.org/Question"
-        data-template="paragraphs/q_a"
-        data-entity-id={3268}
-        data-analytics-faq-section
-        data-analytics-faq-text="How long will my prescriptions take to arrive, and when should I reorder?"
-      >
+      <div itemScope itemType="http://schema.org/Question">
         <h2 itemProp="name" id="how-long-will-my-prescriptions">
           How long will my prescriptions take to arrive, and when should I
           reorder?
         </h2>
         <div
-          data-entity-id={3268}
           itemProp="acceptedAnswer"
           itemScope
           itemType="http://schema.org/Answer"
         >
           <div itemProp="text">
-            <div
-              data-template="paragraphs/wysiwyg"
-              data-entity-id={3269}
-              className="processed-content"
-            >
+            <div className="processed-content">
               <p>
                 Prescriptions usually arrive within 3 to 5 days. But you’ll be
                 able to find specific information about your order on the
@@ -307,29 +235,17 @@ export const App = () => (
           </div>
         </div>
       </div>
-      <div
-        itemScope
-        itemType="http://schema.org/Question"
-        data-template="paragraphs/q_a"
-        data-entity-id={3270}
-        data-analytics-faq-section
-        data-analytics-faq-text="Will my personal health information be protected?"
-      >
+      <div itemScope itemType="http://schema.org/Question">
         <h2 itemProp="name" id="will-my-personal-health-inform">
           Will my personal health information be protected?
         </h2>
         <div
-          data-entity-id={3270}
           itemProp="acceptedAnswer"
           itemScope
           itemType="http://schema.org/Answer"
         >
           <div itemProp="text">
-            <div
-              data-template="paragraphs/wysiwyg"
-              data-entity-id={3271}
-              className="processed-content"
-            >
+            <div className="processed-content">
               <p>
                 Yes. This is a secure website. We follow strict security
                 policies and practices to protect your personal health
@@ -352,29 +268,17 @@ export const App = () => (
           </div>
         </div>
       </div>
-      <div
-        itemScope
-        itemType="http://schema.org/Question"
-        data-template="paragraphs/q_a"
-        data-entity-id={3272}
-        data-analytics-faq-section
-        data-analytics-faq-text="What if I have more questions?"
-      >
+      <div itemScope itemType="http://schema.org/Question">
         <h2 itemProp="name" id="what-if-i-have-more-questions">
           What if I have more questions?
         </h2>
         <div
-          data-entity-id={3272}
           itemProp="acceptedAnswer"
           itemScope
           itemType="http://schema.org/Answer"
         >
           <div itemProp="text">
-            <div
-              data-template="paragraphs/wysiwyg"
-              data-entity-id={3273}
-              className="processed-content"
-            >
+            <div className="processed-content">
               <p>
                 If you have questions about prescriptions and refills on
                 MyHealtheVet, please go to the{' '}

--- a/src/applications/static-pages/health-care-manage-benefits/prescriptions-refill-content/components/App/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/prescriptions-refill-content/components/App/index.js
@@ -91,7 +91,10 @@ export const App = () => (
               <ul>
                 <li>
                   A{' '}
-                  <a href="">
+                  <a
+                    href="https://www.myhealth.va.gov/mhv-portal-web/upgrading-your-my-healthevet-account-through-in-person-or-online-authentication"
+                    rel="noreferrer noopener"
+                  >
                     Premium <strong>My HealtheVet account</strong>
                   </a>
                   , <strong>or</strong>

--- a/src/applications/static-pages/health-care-manage-benefits/prescriptions-refill-content/components/App/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/prescriptions-refill-content/components/App/index.js
@@ -1,0 +1,424 @@
+// Node modules.
+import React from 'react';
+// Relative imports.
+import './styles.scss';
+import CallToActionWidget from 'platform/site-wide/cta-widget';
+
+const App = () => (
+  <article className="usa-content">
+    <h1>VA Prescription Refill and Tracking</h1>
+    <div className="va-introtext">
+      <p>
+        With our VA Prescription Refill and Tracking tool, you can refill your
+        VA prescriptions, track their delivery, and create lists to organize
+        your medicines. Find out if you’re eligible and how to sign up to begin
+        using this tool in our health management portal within My HealtheVet.
+      </p>
+    </div>
+    <CallToActionWidget appId="rx" setFocus={false} />
+    <div data-template="paragraphs/q_a_section" data-entity-id={3258}>
+      <div
+        itemScope
+        itemType="http://schema.org/Question"
+        data-template="paragraphs/q_a"
+        data-entity-id={3257}
+        data-analytics-faq-section
+        data-analytics-faq-text="How can the VA Prescription Refill and Tracking tool help me manage my health care?"
+      >
+        <h2 itemProp="name" id="how-can-the-va-prescription-re">
+          How can the VA Prescription Refill and Tracking tool help me manage my
+          health care?
+        </h2>
+        <div
+          data-entity-id={3257}
+          itemProp="acceptedAnswer"
+          itemScope
+          itemType="http://schema.org/Answer"
+        >
+          <div itemProp="text">
+            <div
+              data-template="paragraphs/wysiwyg"
+              data-entity-id={3259}
+              className="processed-content"
+            >
+              <p>
+                Our Prescription Refill and Tracking tool is a web-based service
+                that helps you manage your VA prescriptions online.
+              </p>
+              <p>
+                <strong>With this tool, you can:</strong>
+              </p>
+              <ul>
+                <li>Refill your VA prescriptions online</li>
+                <li>View your past and current VA prescriptions</li>
+                <li>
+                  Track the delivery of each prescription mailed within the past
+                  30 days
+                </li>
+                <li>
+                  Get email notifications to let you know when to expect your
+                  prescriptions
+                </li>
+                <li>
+                  Create lists to keep track of all your medicines (including
+                  prescriptions, over-the-counter medicines, herbal remedies,
+                  and supplements)
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        itemScope
+        itemType="http://schema.org/Question"
+        data-template="paragraphs/q_a"
+        data-entity-id={3260}
+        data-analytics-faq-section
+        data-analytics-faq-text="Am I eligible to use this tool?"
+      >
+        <h2 itemProp="name" id="am-i-eligible-to-use-this-tool">
+          Am I eligible to use this tool?
+        </h2>
+        <div
+          data-entity-id={3260}
+          itemProp="acceptedAnswer"
+          itemScope
+          itemType="http://schema.org/Answer"
+        >
+          <div itemProp="text">
+            <div
+              data-template="paragraphs/wysiwyg"
+              data-entity-id={3261}
+              className="processed-content"
+            >
+              <p>
+                You can use this tool if you meet all of the requirements listed
+                below.
+              </p>
+              <p>
+                <strong>All of these must be true. You:</strong>
+              </p>
+              <ul>
+                <li>
+                  Are enrolled in VA health care, <strong>and</strong>
+                </li>
+                <li>
+                  Are registered as a patient in a VA health facility,{' '}
+                  <strong>and</strong>
+                </li>
+                <li>
+                  Have a refillable prescription from a VA doctor that you’ve
+                  filled at a VA pharmacy and that’s being handled by the VA
+                  Mail Order Pharmacy
+                </li>
+              </ul>
+              <p>
+                <a href="/health-care/how-to-apply/">
+                  Find out how to apply for VA health care
+                </a>
+              </p>
+              <p>
+                <strong>And you must have one of these free accounts:</strong>
+              </p>
+              <ul>
+                <li>
+                  A{' '}
+                  <a href="">
+                    Premium <strong>My HealtheVet account</strong>
+                  </a>
+                  , <strong>or</strong>
+                </li>
+                <li>
+                  A Premium <strong>DS Logon</strong> account (used for
+                  eBenefits and milConnect), <strong>or</strong>
+                </li>
+                <li>
+                  A verified <strong>ID.me</strong> account that you can create
+                  here on VA.gov
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        itemScope
+        itemType="http://schema.org/Question"
+        data-template="paragraphs/q_a"
+        data-entity-id={3262}
+        data-analytics-faq-section
+        data-analytics-faq-text="Once I’m signed in, how do I get started?"
+      >
+        <h2 itemProp="name" id="once-im-signed-in-how-do-i-get">
+          Once I’m signed in, how do I get started?
+        </h2>
+        <div
+          data-entity-id={3262}
+          itemProp="acceptedAnswer"
+          itemScope
+          itemType="http://schema.org/Answer"
+        >
+          <div itemProp="text">
+            <div
+              data-template="paragraphs/wysiwyg"
+              data-entity-id={3263}
+              className="processed-content"
+            >
+              <p>
+                On your Welcome page, you’ll see a module for “Pharmacy.” Within
+                that module, you’ll see these options:
+              </p>
+              <ul>
+                <li>“Refill VA Prescriptions”</li>
+                <li>“Track Delivery”</li>
+                <li>“Medications List”</li>
+              </ul>
+              <p>
+                Click on the link you want, and you’ll get instructions on the
+                next page to get started.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        itemScope
+        itemType="http://schema.org/Question"
+        data-template="paragraphs/q_a"
+        data-entity-id={3264}
+        data-analytics-faq-section
+        data-analytics-faq-text="Can I use this tool to refill and track all my VA prescriptions?"
+      >
+        <h2 itemProp="name" id="can-i-use-this-tool-to-refill-">
+          Can I use this tool to refill and track all my VA prescriptions?
+        </h2>
+        <div
+          data-entity-id={3264}
+          itemProp="acceptedAnswer"
+          itemScope
+          itemType="http://schema.org/Answer"
+        >
+          <div itemProp="text">
+            <div
+              data-template="paragraphs/wysiwyg"
+              data-entity-id={3265}
+              className="processed-content"
+            >
+              <p>
+                <strong>
+                  You can refill and track most of your VA prescriptions,
+                  including:
+                </strong>
+              </p>
+              <ul>
+                <li>VA medicines that were refilled or renewed</li>
+                <li>Wound care supplies</li>
+                <li>Diabetic supplies</li>
+                <li>
+                  Other products and supplies sent through the VA Mail Order
+                  Pharmacy
+                </li>
+              </ul>
+              <p>
+                Your VA health care team may decide not to ship medicines that
+                you don’t need right away, medicines that are not commonly
+                prescribed, or those that require you to be closely monitored.
+                In these cases, you’ll need to pick up your prescription from
+                the VA health facility where you get care.
+              </p>
+              <p>
+                You can’t refill some medicines, like certain pain medication
+                and narcotics. You’ll need to get a new prescription from your
+                VA provider each time you need more of these medicines.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        itemScope
+        itemType="http://schema.org/Question"
+        data-template="paragraphs/q_a"
+        data-entity-id={3266}
+        data-analytics-faq-section
+        data-analytics-faq-text="Where will VA send my prescriptions?"
+      >
+        <h2 itemProp="name" id="where-will-va-send-my-prescrip">
+          Where will VA send my prescriptions?
+        </h2>
+        <div
+          data-entity-id={3266}
+          itemProp="acceptedAnswer"
+          itemScope
+          itemType="http://schema.org/Answer"
+        >
+          <div itemProp="text">
+            <div
+              data-template="paragraphs/wysiwyg"
+              data-entity-id={3267}
+              className="processed-content"
+            >
+              <p>
+                Our mail order pharmacy will send your prescriptions to the
+                address we have on file for you. We ship to all addresses in the
+                United States and its territories. We don’t ship prescriptions
+                to foreign countries.
+              </p>
+              <p>
+                <strong>Important note:</strong> If you change your address
+                within My HealtheVet, it does <strong>not</strong> change your
+                address for prescription shipments. Please contact the VA health
+                facility where you get care to have them update your address on
+                file.
+                <br />
+                <a href="/find-locations/">Find your VA health facility</a>
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        itemScope
+        itemType="http://schema.org/Question"
+        data-template="paragraphs/q_a"
+        data-entity-id={3268}
+        data-analytics-faq-section
+        data-analytics-faq-text="How long will my prescriptions take to arrive, and when should I reorder?"
+      >
+        <h2 itemProp="name" id="how-long-will-my-prescriptions">
+          How long will my prescriptions take to arrive, and when should I
+          reorder?
+        </h2>
+        <div
+          data-entity-id={3268}
+          itemProp="acceptedAnswer"
+          itemScope
+          itemType="http://schema.org/Answer"
+        >
+          <div itemProp="text">
+            <div
+              data-template="paragraphs/wysiwyg"
+              data-entity-id={3269}
+              className="processed-content"
+            >
+              <p>
+                Prescriptions usually arrive within 3 to 5 days. But you’ll be
+                able to find specific information about your order on the
+                website of the delivery service shown in your Rx Tracker.
+              </p>
+              <p>
+                To make sure you have your medicine in time, you’ll want to
+                request your refill at least 10 days before you’ll run out of
+                your current prescription.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        itemScope
+        itemType="http://schema.org/Question"
+        data-template="paragraphs/q_a"
+        data-entity-id={3270}
+        data-analytics-faq-section
+        data-analytics-faq-text="Will my personal health information be protected?"
+      >
+        <h2 itemProp="name" id="will-my-personal-health-inform">
+          Will my personal health information be protected?
+        </h2>
+        <div
+          data-entity-id={3270}
+          itemProp="acceptedAnswer"
+          itemScope
+          itemType="http://schema.org/Answer"
+        >
+          <div itemProp="text">
+            <div
+              data-template="paragraphs/wysiwyg"
+              data-entity-id={3271}
+              className="processed-content"
+            >
+              <p>
+                Yes. This is a secure website. We follow strict security
+                policies and practices to protect your personal health
+                information.
+              </p>
+              <p>
+                If you print or download anything from the website (like
+                prescription details), you’ll need to take responsibility for
+                protecting that information.
+                <br />
+                <a
+                  href="https://www.myhealth.va.gov/mhv-portal-web/web/myhealthevet/protecting-your-personal-health-information"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Get tips for protecting your personal health information
+                </a>
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        itemScope
+        itemType="http://schema.org/Question"
+        data-template="paragraphs/q_a"
+        data-entity-id={3272}
+        data-analytics-faq-section
+        data-analytics-faq-text="What if I have more questions?"
+      >
+        <h2 itemProp="name" id="what-if-i-have-more-questions">
+          What if I have more questions?
+        </h2>
+        <div
+          data-entity-id={3272}
+          itemProp="acceptedAnswer"
+          itemScope
+          itemType="http://schema.org/Answer"
+        >
+          <div itemProp="text">
+            <div
+              data-template="paragraphs/wysiwyg"
+              data-entity-id={3273}
+              className="processed-content"
+            >
+              <p>
+                If you have questions about prescriptions and refills on
+                MyHealtheVet, please go to the{' '}
+                <a
+                  href="https://www.myhealth.va.gov/mhv-portal-web/web/myhealthevet/faqs#PrescriptionRefill"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Prescription refills FAQs
+                </a>{' '}
+                on the My HealtheVet web portal.
+              </p>
+              <p>
+                Or contact the My HealtheVet help desk at{' '}
+                <a href="tel:+18773270022">877-327-0022</a> (TTY:{' '}
+                <a href="tel:+18008778339">800-877-8339</a>. We&apos;re here
+                Monday through Friday, 7:00 a.m. to 7:00 p.m. CT.
+              </p>
+              <p>
+                You can also{' '}
+                <a
+                  href="https://www.myhealth.va.gov/mhv-portal-web/web/myhealthevet/contact-mhv"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  contact us online
+                </a>
+                .
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </article>
+);
+
+export default App;

--- a/src/applications/static-pages/health-care-manage-benefits/prescriptions-refill-content/components/App/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/prescriptions-refill-content/components/App/index.js
@@ -4,7 +4,7 @@ import React from 'react';
 import './styles.scss';
 import CallToActionWidget from 'platform/site-wide/cta-widget';
 
-const App = () => (
+export const App = () => (
   <article className="usa-content">
     <h1>VA Prescription Refill and Tracking</h1>
     <div className="va-introtext">

--- a/src/applications/static-pages/health-care-manage-benefits/prescriptions-refill-content/components/App/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/prescriptions-refill-content/components/App/index.js
@@ -5,16 +5,7 @@ import './styles.scss';
 import CallToActionWidget from 'platform/site-wide/cta-widget';
 
 export const App = () => (
-  <article className="usa-content">
-    <h1>VA Prescription Refill and Tracking</h1>
-    <div className="va-introtext">
-      <p>
-        With our VA Prescription Refill and Tracking tool, you can refill your
-        VA prescriptions, track their delivery, and create lists to organize
-        your medicines. Find out if you’re eligible and how to sign up to begin
-        using this tool in our health management portal within My HealtheVet.
-      </p>
-    </div>
+  <>
     <CallToActionWidget appId="rx" setFocus={false} />
     <div data-template="paragraphs/q_a_section" data-entity-id={3258}>
       <div
@@ -418,7 +409,7 @@ export const App = () => (
         </div>
       </div>
     </div>
-  </article>
+  </>
 );
 
 export default App;

--- a/src/applications/static-pages/health-care-manage-benefits/prescriptions-refill-content/components/App/index.unit.spec.js
+++ b/src/applications/static-pages/health-care-manage-benefits/prescriptions-refill-content/components/App/index.unit.spec.js
@@ -1,0 +1,33 @@
+// Dependencies.
+import React from 'react';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+// Relative imports.
+import { App } from './index';
+
+describe('Prescriptions Refill Page <App>', () => {
+  it('renders what we expect', () => {
+    const wrapper = shallow(<App />);
+
+    const text = wrapper.text();
+    expect(text).to.include('VA Prescription Refill and Tracking');
+    expect(text).to.include(
+      'How can the VA Prescription Refill and Tracking tool help me manage my',
+    );
+    expect(text).to.include('Am I eligible to use this tool?');
+    expect(text).to.include('Once I’m signed in, how do I get started?');
+    expect(text).to.include(
+      'Can I use this tool to refill and track all my VA prescriptions?',
+    );
+    expect(text).to.include('Where will VA send my prescriptions?');
+    expect(text).to.include(
+      'How long will my prescriptions take to arrive, and when should I',
+    );
+    expect(text).to.include(
+      'Will my personal health information be protected?',
+    );
+    expect(text).to.include('What if I have more questions?');
+
+    wrapper.unmount();
+  });
+});

--- a/src/applications/static-pages/health-care-manage-benefits/prescriptions-refill-content/components/App/index.unit.spec.js
+++ b/src/applications/static-pages/health-care-manage-benefits/prescriptions-refill-content/components/App/index.unit.spec.js
@@ -10,7 +10,6 @@ describe('Prescriptions Refill Page <App>', () => {
     const wrapper = shallow(<App />);
 
     const text = wrapper.text();
-    expect(text).to.include('VA Prescription Refill and Tracking');
     expect(text).to.include(
       'How can the VA Prescription Refill and Tracking tool help me manage my',
     );

--- a/src/applications/static-pages/health-care-manage-benefits/prescriptions-refill-content/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/prescriptions-refill-content/index.js
@@ -1,0 +1,20 @@
+// Node modules.
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { Provider } from 'react-redux';
+
+export default (store, widgetType) => {
+  const root = document.querySelector(`[data-widget-type="${widgetType}"]`);
+  if (root) {
+    import(/* webpackChunkName: "App" */
+    './components/App').then(module => {
+      const App = module.default;
+      ReactDOM.render(
+        <Provider store={store}>
+          <App />
+        </Provider>,
+        root,
+      );
+    });
+  }
+};

--- a/src/applications/static-pages/health-care-manage-benefits/prescriptions-refill-content/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/prescriptions-refill-content/index.js
@@ -6,7 +6,7 @@ import { Provider } from 'react-redux';
 export default (store, widgetType) => {
   const root = document.querySelector(`[data-widget-type="${widgetType}"]`);
   if (root) {
-    import(/* webpackChunkName: "App" */
+    import(/* webpackChunkName: "prescriptions-refill-content" */
     './components/App').then(module => {
       const App = module.default;
       ReactDOM.render(

--- a/src/applications/static-pages/static-pages-entry.js
+++ b/src/applications/static-pages/static-pages-entry.js
@@ -35,6 +35,7 @@ import createSecureMessagingPage from './health-care-manage-benefits/secure-mess
 import createScheduleViewVAAppointments from './health-care-manage-benefits/schedule-view-va-appointments';
 import createGetMedicalRecordsPage from './health-care-manage-benefits/get-medical-records-page';
 import createViewTestLabResultsPage from './health-care-manage-benefits/view-test-lab-results-page';
+import createPrescriptionsRefillContent from './health-care-manage-benefits/prescriptions-refill-content';
 
 // No-react styles.
 import './sass/static-pages.scss';
@@ -148,6 +149,10 @@ createScheduleViewVAAppointments(
 );
 createGetMedicalRecordsPage(store, widgetTypes.GET_MEDICAL_RECORDS_PAGE);
 createViewTestLabResultsPage(store, widgetTypes.VIEW_TEST_LAB_RESULTS_PAGE);
+createPrescriptionsRefillContent(
+  store,
+  widgetTypes.PRESCRIPTIONS_REFILL_CONTENT,
+);
 
 // homepage widgets
 if (location.pathname === '/') {

--- a/src/applications/static-pages/widgetTypes.js
+++ b/src/applications/static-pages/widgetTypes.js
@@ -19,4 +19,5 @@ export default {
   SCHEDULE_VIEW_VA_APPOINTMENTS: 'schedule-view-va-appointments',
   GET_MEDICAL_RECORDS_PAGE: 'get-medical-records-page',
   VIEW_TEST_LAB_RESULTS_PAGE: 'view-test-lab-results-page',
+  PRESCRIPTIONS_REFILL_CONTENT: 'prescriptions-refill-content',
 };


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/10264

This PR adds unauth prescription refills content as a React widget.

## Testing done
Adds unit tests for React widget.

## Screenshots

![localhost_3001_dummy-page_ (1)](https://user-images.githubusercontent.com/12773166/85318988-23ef8480-b47e-11ea-9e03-fb59edb53389.png)

## Acceptance criteria
- [x] Add unauth prescription refills content as a React widget.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
