### PR TITLE
add "set up direct deposit" state

### DIFF
--- a/src/applications/personalization/profile-2/components/direct-deposit/DirectDepositContent.jsx
+++ b/src/applications/personalization/profile-2/components/direct-deposit/DirectDepositContent.jsx
@@ -138,15 +138,15 @@ export const DirectDepositContent = ({
 
   // When direct deposit is not set up, we will show
   const notSetUpContent = (
-    <>
-      <button
-        onClick={() => {
-          toggleEditState();
-        }}
-      >
-        Set up direct deposit
-      </button>
-    </>
+    <button
+      className="va-button-link"
+      ref={editBankInfoButton}
+      onClick={() => {
+        toggleEditState();
+      }}
+    >
+      Please add your bank information
+    </button>
   );
 
   // When editing/setting up direct deposit, we'll show a form that accepts bank
@@ -195,22 +195,27 @@ export const DirectDepositContent = ({
     return notSetUpContent;
   };
 
-  const directDepositData = () => [
-    // top row of the table can show multiple states so we set its value with
-    // the getBankInfo() helper
-    {
-      title: 'Account',
-      value: getBankInfo(),
-    },
-    {
-      title: 'Payment history',
-      value: (
-        <EbenefitsLink path="ebenefits/about/feature?feature=payment-history">
-          View your payment history
-        </EbenefitsLink>
-      ),
-    },
-  ];
+  const directDepositData = () => {
+    const data = [
+      // top row of the table can show multiple states so we set its value with
+      // the getBankInfo() helper
+      {
+        title: 'Account',
+        value: getBankInfo(),
+      },
+    ];
+    if (isDirectDepositSetUp) {
+      data.push({
+        title: 'Payment history',
+        value: (
+          <EbenefitsLink path="ebenefits/about/feature?feature=payment-history">
+            View your payment history
+          </EbenefitsLink>
+        ),
+      });
+    }
+    return data;
+  };
 
   const educationBenefitsData = () => [
     {

--- a/src/applications/personalization/profile-2/tests/components/DirectDepositContent.unit.spec.jsx
+++ b/src/applications/personalization/profile-2/tests/components/DirectDepositContent.unit.spec.jsx
@@ -32,6 +32,13 @@ const emptyPaymentAccount = {
   financialInstitutionRoutingNumber: '',
 };
 
+const newPaymentAccount = {
+  accountType: 'Savings',
+  financialInstitutionName: 'COMERICA BANK',
+  accountNumber: '*****6789',
+  financialInstitutionRoutingNumber: '*****4321',
+};
+
 function createBasicInitialState() {
   return {
     user: {
@@ -172,6 +179,47 @@ describe('DirectDepositContent', () => {
       editForm = wrapper.find('form');
       expect(editForm.exists()).to.be.false;
     });
+    it('should handle a successful attempt to update bank info', async () => {
+      mockFetch();
+      setFetchJSONResponse(global.fetch.onFirstCall(), {
+        data: {
+          attributes: {
+            responses: [
+              {
+                paymentAccount: newPaymentAccount,
+              },
+            ],
+          },
+        },
+      });
+
+      // find and click on the set up button
+      findSetUpBankInfoButton(wrapper).simulate('click');
+
+      // fill out form info
+      fillOutAndSubmitBankInfoForm(wrapper.find('form'));
+
+      await asyncFlush();
+      wrapper.update();
+
+      // the form should be removed
+      expect(wrapper.find('form').exists()).to.be.false;
+
+      // a success alert should appear
+      expect(
+        wrapper.text().includes('We’ve saved your direct deposit information'),
+      ).to.be.true;
+
+      // and the bank info from the mocked call should be shown
+      expect(
+        wrapper.text().includes(newPaymentAccount.financialInstitutionName),
+      ).to.be.true;
+      expect(wrapper.text().includes(newPaymentAccount.accountNumber)).to.be
+        .true;
+      expect(wrapper.text().includes(newPaymentAccount.accountType)).to.be.true;
+
+      resetFetch();
+    });
   });
 
   describe('when bank info is already set up', () => {
@@ -206,12 +254,6 @@ describe('DirectDepositContent', () => {
       expect(editForm.exists()).to.be.false;
     });
     it('should handle a successful attempt to update bank info', async () => {
-      const newPaymentAccount = {
-        accountType: 'Savings',
-        financialInstitutionName: 'COMERICA BANK',
-        accountNumber: '*****6789',
-        financialInstitutionRoutingNumber: '*****4321',
-      };
       mockFetch();
       setFetchJSONResponse(global.fetch.onFirstCall(), {
         data: {

--- a/src/applications/personalization/profile-2/tests/components/DirectDepositContent.unit.spec.jsx
+++ b/src/applications/personalization/profile-2/tests/components/DirectDepositContent.unit.spec.jsx
@@ -18,6 +18,20 @@ import reducer from 'applications/personalization/profile360/reducers';
 import profileUi from '../../reducers';
 import DirectDepositContent from '../../components/direct-deposit/DirectDepositContent';
 
+const paymentAccount = {
+  accountType: 'Checking',
+  financialInstitutionName: 'Bank of EVSS',
+  accountNumber: '****5678',
+  financialInstitutionRoutingNumber: '*****0021',
+};
+
+const emptyPaymentAccount = {
+  accountType: '',
+  financialInstitutionName: null,
+  accountNumber: '',
+  financialInstitutionRoutingNumber: '',
+};
+
 function createBasicInitialState() {
   return {
     user: {
@@ -33,12 +47,7 @@ function createBasicInitialState() {
       paymentInformation: {
         responses: [
           {
-            paymentAccount: {
-              accountType: 'Checking',
-              financialInstitutionName: 'Bank of EVSS',
-              accountNumber: '****5678',
-              financialInstitutionRoutingNumber: '*****0021',
-            },
+            paymentAccount,
           },
         ],
       },
@@ -79,6 +88,26 @@ function fillOutAndSubmitBankInfoForm(form) {
   form.simulate('submit');
 }
 
+function findSetUpBankInfoButton(wrapper) {
+  return wrapper.find(
+    'button.va-button-link[children="Please add your bank information"]',
+  );
+}
+
+function findEditBankInfoButton(wrapper) {
+  return wrapper.find(
+    'button[aria-label^="Edit your direct deposit bank information"]',
+  );
+}
+
+function findPaymentHistoryLink(wrapper) {
+  return wrapper.find('a[children="View your payment history"]');
+}
+
+function findCancelEditButton(wrapper) {
+  return wrapper.find('form button[children="Cancel"]');
+}
+
 // Thanks Pivotal http://engineering.pivotal.io/post/react-integration-tests-with-enzyme/
 function asyncFlush() {
   return new Promise(resolve => setTimeout(resolve, 0));
@@ -109,134 +138,168 @@ describe('DirectDepositContent', () => {
     expect(wrapper.isEmptyRender()).to.be.true;
     wrapper.unmount();
   });
-  it('should show the current bank info if it is set up', () => {
-    const wrapper = setUpWithInitialState();
-
-    expect(wrapper.text().includes('Bank of EVSS')).to.be.true;
-    expect(wrapper.text().includes('****5678')).to.be.true;
-    expect(wrapper.text().includes('Checking')).to.be.true;
-
-    wrapper.unmount();
-  });
-  it('should allow switching to the "edit bank info" form and cancelling out of the "edit bank info" form', () => {
-    const wrapper = setUpWithInitialState();
-
-    // find and click on the edit button
-    const editButton = wrapper.find('button[aria-label^="Edit"]');
-    editButton.simulate('click');
-
-    // ensure that the edit form is visible
-    let editForm = wrapper.find('form');
-    expect(editForm.length).to.equal(1);
-
-    // find and click on the cancel button
-    const cancelButton = wrapper.find('form button[children="Cancel"]');
-    cancelButton.simulate('click');
-
-    // ensure that the edit form is not visible
-    editForm = wrapper.find('form');
-    expect(editForm.length).to.equal(0);
-
-    wrapper.unmount();
-  });
-  it('should handle a successful attempt to update bank info', async () => {
-    mockFetch();
-    setFetchJSONResponse(global.fetch.onFirstCall(), {
-      data: {
-        attributes: {
-          responses: [
-            {
-              paymentAccount: {
-                accountType: 'Savings',
-                financialInstitutionName: 'COMERICA BANK',
-                accountNumber: '*****6789',
-                financialInstitutionRoutingNumber: '*****4321',
-              },
-            },
-          ],
-        },
-      },
+  describe('when bank info is not set up yet', () => {
+    let wrapper;
+    beforeEach(() => {
+      initialState = createBasicInitialState();
+      initialState.vaProfile.paymentInformation.responses[0].paymentAccount = emptyPaymentAccount;
+      wrapper = setUpWithInitialState(initialState);
     });
-    const wrapper = setUpWithInitialState();
+    afterEach(() => {
+      wrapper.unmount();
+    });
+    it('should not show the link to payment history', () => {
+      expect(findPaymentHistoryLink(wrapper).exists()).to.be.false;
+    });
+    it('should not show any bank info', () => {
+      expect(wrapper.text().includes(paymentAccount.financialInstitutionName))
+        .to.be.false;
+      expect(wrapper.text().includes(paymentAccount.accountNumber)).to.be.false;
+      expect(wrapper.text().includes(paymentAccount.accountType)).to.be.false;
+    });
+    it('should allow switching to the "edit bank info" form and cancelling out of the "edit bank info" form', () => {
+      // find and click on the set up button
+      findSetUpBankInfoButton(wrapper).simulate('click');
 
-    // find and click on the edit button
-    // so sad that this doesn't support case-insensitive matches :(
-    const editButton = wrapper.find('button[aria-label^="Edit"]');
-    editButton.simulate('click');
+      // ensure that the edit form is visible
+      let editForm = wrapper.find('form');
+      expect(editForm.exists()).to.be.true;
 
-    // fill out form info
-    fillOutAndSubmitBankInfoForm(wrapper.find('form'));
+      // find and click on the cancel button
+      findCancelEditButton(wrapper).simulate('click');
 
-    await asyncFlush();
-    wrapper.update();
-
-    // the form should be removed
-    expect(wrapper.find('form').length).to.equal(0);
-
-    // a success alert should appear
-    expect(
-      wrapper.text().includes('We’ve saved your direct deposit information'),
-    ).to.be.true;
-
-    // and the bank info from the mocked call should be shown
-    expect(wrapper.text().includes('COMERICA')).to.be.true;
-    expect(wrapper.text().includes('****6789')).to.be.true;
-    expect(wrapper.text().includes('Savings')).to.be.true;
-
-    resetFetch();
-    wrapper.unmount();
+      // ensure that the edit form is not visible
+      editForm = wrapper.find('form');
+      expect(editForm.exists()).to.be.false;
+    });
   });
-  it('should handle a failed attempt to update bank info', async () => {
-    mockFetch();
-    setFetchJSONFailure(global.fetch.onFirstCall(), {
-      errors: [
-        {
-          title: 'Unprocessable Entity',
-          detail: 'One or more unprocessable user payment properties',
-          code: '126',
-          source: 'EVSS::PPIU::Service',
-          status: '422',
-          meta: {
-            messages: [
+
+  describe('when bank info is already set up', () => {
+    let wrapper;
+    beforeEach(() => {
+      wrapper = setUpWithInitialState();
+    });
+    afterEach(() => {
+      wrapper.unmount();
+    });
+    it('should show the current bank info and a link to payment history', () => {
+      expect(wrapper.text().includes(paymentAccount.financialInstitutionName))
+        .to.be.true;
+      expect(wrapper.text().includes(paymentAccount.accountNumber)).to.be.true;
+      expect(wrapper.text().includes(paymentAccount.accountType)).to.be.true;
+      expect(findPaymentHistoryLink(wrapper).exists()).to.be.true;
+      expect(findSetUpBankInfoButton(wrapper).exists()).to.be.false;
+    });
+    it('should allow switching to the "edit bank info" form and cancelling out of the "edit bank info" form', () => {
+      // find and click on the edit button
+      findEditBankInfoButton(wrapper).simulate('click');
+
+      // ensure that the edit form is visible
+      let editForm = wrapper.find('form');
+      expect(editForm.exists()).to.be.true;
+
+      // find and click on the cancel button
+      findCancelEditButton(wrapper).simulate('click');
+
+      // ensure that the edit form is not visible
+      editForm = wrapper.find('form');
+      expect(editForm.exists()).to.be.false;
+    });
+    it('should handle a successful attempt to update bank info', async () => {
+      const newPaymentAccount = {
+        accountType: 'Savings',
+        financialInstitutionName: 'COMERICA BANK',
+        accountNumber: '*****6789',
+        financialInstitutionRoutingNumber: '*****4321',
+      };
+      mockFetch();
+      setFetchJSONResponse(global.fetch.onFirstCall(), {
+        data: {
+          attributes: {
+            responses: [
               {
-                key: 'cnp.payment.generic.error.message',
-                severity: 'ERROR',
-                text:
-                  'Generic CnP payment update error. Update response: Update Failed: Night area number is invalid, must be 3 digits',
+                paymentAccount: newPaymentAccount,
               },
             ],
           },
         },
-      ],
+      });
+
+      // find and click on the edit button
+      findEditBankInfoButton(wrapper).simulate('click');
+
+      // fill out form info
+      fillOutAndSubmitBankInfoForm(wrapper.find('form'));
+
+      await asyncFlush();
+      wrapper.update();
+
+      // the form should be removed
+      expect(wrapper.find('form').exists()).to.be.false;
+
+      // a success alert should appear
+      expect(
+        wrapper.text().includes('We’ve saved your direct deposit information'),
+      ).to.be.true;
+
+      // and the bank info from the mocked call should be shown
+      expect(
+        wrapper.text().includes(newPaymentAccount.financialInstitutionName),
+      ).to.be.true;
+      expect(wrapper.text().includes(newPaymentAccount.accountNumber)).to.be
+        .true;
+      expect(wrapper.text().includes(newPaymentAccount.accountType)).to.be.true;
+
+      resetFetch();
     });
-    const wrapper = setUpWithInitialState();
+    it('should handle a failed attempt to update bank info', async () => {
+      mockFetch();
+      setFetchJSONFailure(global.fetch.onFirstCall(), {
+        errors: [
+          {
+            title: 'Unprocessable Entity',
+            detail: 'One or more unprocessable user payment properties',
+            code: '126',
+            source: 'EVSS::PPIU::Service',
+            status: '422',
+            meta: {
+              messages: [
+                {
+                  key: 'cnp.payment.generic.error.message',
+                  severity: 'ERROR',
+                  text:
+                    'Generic CnP payment update error. Update response: Update Failed: Night area number is invalid, must be 3 digits',
+                },
+              ],
+            },
+          },
+        ],
+      });
 
-    // find and click on the edit button
-    // so sad that this doesn't support case-insensitive matches :(
-    const editButton = wrapper.find('button[aria-label^="Edit"]');
-    editButton.simulate('click');
+      // find and click on the edit button
+      findEditBankInfoButton(wrapper).simulate('click');
 
-    // fill out form info
-    fillOutAndSubmitBankInfoForm(wrapper.find('form'));
+      // fill out form info
+      fillOutAndSubmitBankInfoForm(wrapper.find('form'));
 
-    await asyncFlush();
-    wrapper.update();
+      await asyncFlush();
+      wrapper.update();
 
-    // the form should remain
-    expect(wrapper.find('form').length).to.equal(1);
-    // an error appears
-    expect(
-      wrapper
-        .text()
-        .includes('We couldn’t update your direct deposit bank information'),
-    ).to.be.true;
+      // the form should remain
+      expect(wrapper.find('form').exists()).to.be.true;
+      // an error appears
+      expect(
+        wrapper
+          .text()
+          .includes('We couldn’t update your direct deposit bank information'),
+      ).to.be.true;
 
-    // a success alert should not appear
-    expect(
-      wrapper.text().includes('We’ve saved your direct deposit information'),
-    ).to.be.false;
+      // a success alert should not appear
+      expect(
+        wrapper.text().includes('We’ve saved your direct deposit information'),
+      ).to.be.false;
 
-    resetFetch();
-    wrapper.unmount();
+      resetFetch();
+    });
   });
 });


### PR DESCRIPTION
## Description
Updates the view users see when they are eligible to set up Direct Deposit but have not yet done so.

## Testing done
Local + unit tests. Refactored the existing unit tests and added new tests to make sure that the "not set up" state renders correctly and moving from the "not set up" state to the "edit" state and back works.

## Screenshots
<img width="944" alt="direct deposit not set up" src="https://user-images.githubusercontent.com/20728956/85058644-43716f00-b157-11ea-9bdc-54500e05af36.png">

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs