### PR TITLE
Fix broken VAOS tests

### DIFF
--- a/src/applications/vaos/tests/utils/eligibility.unit.spec.js
+++ b/src/applications/vaos/tests/utils/eligibility.unit.spec.js
@@ -105,16 +105,6 @@ describe('VAOS scheduling eligibility logic', () => {
         'hasMatchingClinics',
         'pastAppointments',
       );
-
-      eligibilityData.clinics?.forEach((clinic, index) => {
-        const nextClinic = eligibilityData.clinics[index + 1];
-        if (nextClinic) {
-          expect(
-            clinic.clinicFriendlyLocationName.toUpperCase() <
-              nextClinic.clinicFriendlyLocationName.toUpperCase(),
-          );
-        }
-      });
       expect(eligibilityData.hasMatchingClinics).to.be.true;
       expect('startDate' in eligibilityData.pastAppointments[0]).to.be.true;
       expect(eligibilityData.pastAppointments.length).to.be.greaterThan(0);

--- a/src/applications/vaos/utils/eligibility.js
+++ b/src/applications/vaos/utils/eligibility.js
@@ -96,15 +96,6 @@ export async function getEligibilityData(
 
   const results = await promiseAllFromObject(eligibilityChecks);
 
-  if (results.clinics?.length) {
-    // This sorting will be handled by the HealthcareService service once implemented
-    results.clinics = results.clinics.sort((a, b) => {
-      const aName = a.clinicFriendlyLocationName || a.clinicName;
-      const bName = b.clinicFriendlyLocationName || b.clinicName;
-      return aName.toUpperCase() < bName.toUpperCase() ? -1 : 1;
-    });
-  }
-
   const eligibility = {
     ...results,
     hasMatchingClinics: !!results.clinics?.length,


### PR DESCRIPTION
## Description
Removing the sorting of clinics in `eligibility.js` since @vbahinwillit's PR turns on HealthcareService, which handles the sorting.

This was caused by a merge conflict.

## Testing done
Local and unit

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
