### PR TITLE
bradl3yC - 9867 - Fix dl nesting on review page

### DIFF
--- a/src/applications/disability-benefits/2346/sass/form-2346.scss
+++ b/src/applications/disability-benefits/2346/sass/form-2346.scss
@@ -79,13 +79,15 @@ div.review {
     border-top: 1px solid $color-gray-light;
     padding: 1.5rem;
     padding-left: 0;
-  }
-  .review-row dd {
-    font-weight: bold;
-    text-align: right;
-  }
-  .review-row dt p {
-    margin-top: 0;
-    margin-bottom: 0;
+
+    dd {
+      font-weight: bold;
+      text-align: right;
+    }
+    dt p {
+      margin-top: 0;
+      margin-bottom: 0;
+    }
   }
 }
+

--- a/src/applications/disability-benefits/2346/sass/form-2346.scss
+++ b/src/applications/disability-benefits/2346/sass/form-2346.scss
@@ -69,3 +69,23 @@ dt {
     margin-top: 0;
   }
 }
+
+div.review {
+  border-bottom: 1px solid $color-gray-light;
+  .review-row {
+    display: flex;
+    justify-content: space-between;
+    flex-direction: row;
+    border-top: 1px solid $color-gray-light;
+    padding: 1.5rem;
+    padding-left: 0;
+  }
+  .review-row dd {
+    font-weight: bold;
+    text-align: right;
+  }
+  .review-row dt p {
+    margin-top: 0;
+    margin-bottom: 0;
+  }
+}

--- a/src/applications/disability-benefits/2346/schemas/2346UI.js
+++ b/src/applications/disability-benefits/2346/schemas/2346UI.js
@@ -105,6 +105,7 @@ export default {
       'ui:options': {
         classNames: 'vads-u-display--none',
         hideOnReview: true,
+        customTitle: ' ',
       },
     },
     emailUI: {
@@ -119,6 +120,7 @@ export default {
         classNames: 'vads-u-margin-bottom--3',
         widgetClassNames: 'va-input-large',
         inputType: 'email',
+        useDlWrap: true,
       },
       'ui:validations': [
         {

--- a/src/applications/disability-benefits/2346/schemas/address-schema.js
+++ b/src/applications/disability-benefits/2346/schemas/address-schema.js
@@ -442,6 +442,7 @@ export const addressUISchema = (
             pattern: '^.*\\S.*',
           };
         },
+        useDlWrap: true,
       },
     },
     state: {

--- a/src/applications/disability-benefits/2346/schemas/address-schema.js
+++ b/src/applications/disability-benefits/2346/schemas/address-schema.js
@@ -360,6 +360,7 @@ export const addressUISchema = (
       'ui:options': {
         hideIf: () => !isMilitaryBaseAddress,
         hideOnReviewIfFalse: true,
+        useDlWrap: true,
       },
     },
     'view:livesOnMilitaryBaseInfo': {
@@ -368,6 +369,7 @@ export const addressUISchema = (
       'ui:options': {
         hideIf: () => !isMilitaryBaseAddress,
         hideOnReviewIfFalse: true,
+        useDlWrap: true,
       },
     },
     country: {
@@ -392,6 +394,7 @@ export const addressUISchema = (
             enum: countries.map(country => country.label),
           };
         },
+        useDlWrap: true,
       },
       'ui:errorMessages': {
         required: 'Please select a country',
@@ -404,11 +407,15 @@ export const addressUISchema = (
         required: 'Please enter a street address',
         pattern: 'Street address must be under 100 characters',
       },
+      'ui:options': {
+        useDlWrap: true,
+      },
     },
     street2: {
       'ui:title': 'Line 2',
       'ui:options': {
         hideOnReviewIfFalse: true,
+        useDlWrap: true,
       },
     },
     city: {
@@ -469,6 +476,7 @@ export const addressUISchema = (
           const countryName = get(countryNamePath, formData);
           return countryName && countryName !== USA.label;
         },
+        useDlWrap: true,
         hideOnReviewIfFalse: true,
         updateSchema: formData => {
           const livesOnMilitaryBase = get(livesOnMilitaryBasePath, formData);
@@ -512,6 +520,7 @@ export const addressUISchema = (
           return countryName === USA.label || !countryName;
         },
         hideOnReviewIfFalse: true,
+        useDlWrap: true,
       },
     },
     postalCode: {
@@ -550,6 +559,7 @@ export const addressUISchema = (
           return countryName && countryName !== USA.label;
         },
         hideOnReviewIfFalse: true,
+        useDlWrap: true,
       },
     },
     internationalPostalCode: {
@@ -580,6 +590,7 @@ export const addressUISchema = (
           return countryName === USA.label || !countryName;
         },
         hideOnReviewIfFalse: true,
+        useDlWrap: true,
       },
     },
   };


### PR DESCRIPTION
## Description
Axe scan revealed an error with proper element nesting dl / dt / dd and friends

## Testing done


## Screenshots
passing axe (with relation to dd nesting - just pretend the heading level stuff isn't there - its not related):
![Screen Shot 2020-06-18 at 2 48 22 PM](https://user-images.githubusercontent.com/6165421/85060337-159a2380-b173-11ea-84c3-efa3edd5e4c4.png)



## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
