### PR TITLE
Fix remove buildtype vagovprod condition with hideHomeBreadcrumb

### DIFF
--- a/src/site/includes/breadcrumbs.drupal.liquid
+++ b/src/site/includes/breadcrumbs.drupal.liquid
@@ -5,7 +5,7 @@
         <li><a aria-current="page" href="/{{ path }}">{{ crumb.text }}</a></li>
       {% elsif crumb.url.path %}
         {% if crumb.url.path == '/' %}
-          {% if hideHomeBreadcrumb != true or buildtype == 'vagovprod' %}
+          {% if hideHomeBreadcrumb != true %}
             <li>
               <a href="{{ crumb.url.path }}" onClick="recordEvent({ event: 'nav-breadcrumb', 'nav-breadcrumb-section': 'home' });">{{ crumb.text }}</a>
             </li>


### PR DESCRIPTION
## Description

Issue: removed home breadcrumbs on vamc pages with  https://github.com/department-of-veterans-affairs/vets-website/pull/13177 - however will not work on production build type 


## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
