### PR TITLE
Add unauth secure messaging content

### DIFF
--- a/src/applications/static-pages/health-care-manage-benefits/secure-messaging/components/App/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/secure-messaging/components/App/index.js
@@ -1,0 +1,402 @@
+// Node modules.
+import React from 'react';
+// Relative imports.
+import './styles.scss';
+import CallToActionWidget from 'platform/site-wide/cta-widget';
+
+const App = () => (
+  <article className="usa-content">
+    <h1>VA Secure Messaging</h1>
+    <div className="va-introtext">
+      <p>
+        With VA Secure Messaging, you can communicate privately online with your
+        VA health care team. Find out if you’re eligible to use Secure
+        Messaging, and how to sign in to begin using this tool in the health
+        management portal.
+      </p>
+    </div>
+    <CallToActionWidget appId="messaging" setFocus={false} />
+    <div data-template="paragraphs/q_a_section" data-entity-id={3480}>
+      <div
+        itemScope
+        itemType="http://schema.org/Question"
+        data-template="paragraphs/q_a"
+        data-entity-id={3479}
+        data-analytics-faq-section
+        data-analytics-faq-text="How can VA Secure Messaging help me manage my health care?"
+      >
+        <h2 itemProp="name" id="how-can-va-secure-messaging-he">
+          How can VA Secure Messaging help me manage my health care?
+        </h2>
+        <div
+          data-entity-id={3479}
+          itemProp="acceptedAnswer"
+          itemScope
+          itemType="http://schema.org/Answer"
+        >
+          <div itemProp="text">
+            <div
+              data-template="paragraphs/wysiwyg"
+              data-entity-id={3481}
+              className="processed-content"
+            >
+              <p>
+                Secure Messaging is a web-based service that protects your
+                sensitive information so you can safely and easily communicate
+                electronically with your VA health care team.
+              </p>
+              <p>
+                <strong>You can use Secure Messaging to:</strong>
+              </p>
+              <ul>
+                <li>Ask non-urgent, non-emergency health-related questions</li>
+                <li>Give your health care team updates on your condition</li>
+                <li>
+                  Request VA referrals, test results, and prescription renewals
+                </li>
+                <li>Manage your VA appointments</li>
+                <li>
+                  Ask routine administrative questions about topics like
+                  scheduling appointments or getting directions
+                </li>
+                <li>
+                  Get health education information from the Veterans Health
+                  Library
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        itemScope
+        itemType="http://schema.org/Question"
+        data-template="paragraphs/q_a"
+        data-entity-id={3482}
+        data-analytics-faq-section
+        data-analytics-faq-text="Am I eligible to use Secure Messaging?"
+      >
+        <h2 itemProp="name" id="am-i-eligible-to-use-secure-me">
+          Am I eligible to use Secure Messaging?
+        </h2>
+        <div
+          data-entity-id={3482}
+          itemProp="acceptedAnswer"
+          itemScope
+          itemType="http://schema.org/Answer"
+        >
+          <div itemProp="text">
+            <div
+              data-template="paragraphs/wysiwyg"
+              data-entity-id={3483}
+              className="processed-content"
+            >
+              <p>
+                You can use this tool if you meet all of the requirements listed
+                below.
+              </p>
+              <p>
+                <strong>All of these must be true:</strong>
+              </p>
+              <ul>
+                <li>
+                  You’re enrolled in VA health care, <strong>and</strong>
+                </li>
+                <li>
+                  You’re registered as a patient at a VA health facility,{' '}
+                  <strong>and</strong>
+                </li>
+                <li>
+                  Your VA health care provider has agreed to communicate with
+                  you through Secure Messaging
+                </li>
+              </ul>
+              <p>
+                <a href="/health-care/how-to-apply/">
+                  Find out how to apply for VA health care
+                </a>
+              </p>
+              <p>
+                <strong>And you must have one of these free accounts:</strong>
+              </p>
+              <ul>
+                <li>
+                  A Premium <strong>My HealtheVet</strong> account,{' '}
+                  <strong>or</strong>
+                </li>
+                <li>
+                  A Premium <strong>DS Logon</strong> account (used for
+                  eBenefits and milConnect), <strong>or</strong>
+                </li>
+                <li>
+                  A verified <strong>ID.me</strong> account that you can create
+                  here on VA.gov
+                </li>
+              </ul>
+              <p>
+                <a
+                  href="https://www.myhealth.va.gov/mhv-portal-web/my-healthevet-offers-three-account-types"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Learn about the 3 different My HealtheVet account types
+                </a>
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        itemScope
+        itemType="http://schema.org/Question"
+        data-template="paragraphs/q_a"
+        data-entity-id={3484}
+        data-analytics-faq-section
+        data-analytics-faq-text="How does Secure Messaging work within My HealtheVet?"
+      >
+        <h2 itemProp="name" id="how-does-secure-messaging-work">
+          How does Secure Messaging work within My HealtheVet?
+        </h2>
+        <div
+          data-entity-id={3484}
+          itemProp="acceptedAnswer"
+          itemScope
+          itemType="http://schema.org/Answer"
+        >
+          <div itemProp="text">
+            <div
+              data-template="paragraphs/wysiwyg"
+              data-entity-id={3485}
+              className="processed-content"
+            >
+              <p>
+                With Secure Messaging, you can write messages, save drafts,
+                review your sent messages, and keep a record of your
+                conversations.
+              </p>
+              <p>
+                You can use Secure Messaging to communicate with any VA health
+                care team member who has signed up to participate.
+              </p>
+              <p>
+                You can send non-urgent, non-emergency messages at any time of
+                the day or night. Your VA health care team should respond within
+                3 business days (Monday through Friday, 8:00 a.m. - 5:00 p.m.,
+                except federal holidays). If you’d like, you can set up your
+                account to send a notification to your personal email when you
+                receive a new secure message.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        itemScope
+        itemType="http://schema.org/Question"
+        data-template="paragraphs/q_a"
+        data-entity-id={3486}
+        data-analytics-faq-section
+        data-analytics-faq-text="Can I use Secure Messaging for medical emergencies or urgent needs?"
+      >
+        <h2 itemProp="name" id="can-i-use-secure-messaging-for">
+          Can I use Secure Messaging for medical emergencies or urgent needs?
+        </h2>
+        <div
+          data-entity-id={3486}
+          itemProp="acceptedAnswer"
+          itemScope
+          itemType="http://schema.org/Answer"
+        >
+          <div itemProp="text">
+            <div
+              data-template="paragraphs/wysiwyg"
+              data-entity-id={3487}
+              className="processed-content"
+            >
+              <p>
+                No. You shouldn’t use Secure Messaging when you have an urgent
+                need, because it may take a few days for you to get a reply.
+              </p>
+              <p>
+                <strong>If you think you have a medical emergency,</strong> call
+                911 or go to the nearest emergency room.
+              </p>
+              <p>
+                <strong>
+                  If you don’t have an emergency, but you’re not sure what type
+                  of care you need,
+                </strong>{' '}
+                call your nearest VA health facility.
+                <br />
+                <a href="/find-locations/">
+                  Find your nearest VA health facility
+                </a>
+              </p>
+              <p>
+                <strong>If you need to talk with someone right away,</strong>{' '}
+                contact the Veterans Crisis Line. Whatever you’re struggling
+                with—chronic pain, anxiety, depression, trouble sleeping, anger,
+                or even homelessness—we can support you. Our Veterans Crisis
+                Line is confidential (private), free, and available 24/7.
+              </p>
+              <p>
+                To connect with a Veterans Crisis Line responder anytime, day or
+                night:
+              </p>
+              <ul>
+                <li>
+                  Call <a href="tel:+18002738255">800-273-8255</a>, then select
+                  1.
+                </li>
+                <li>
+                  Start a{' '}
+                  <a href="https://www.veteranscrisisline.net/get-help/chat">
+                    confidential Veterans Chat
+                  </a>
+                  .
+                </li>
+                <li>
+                  Text <a href="tel:+1838255">838255</a>.
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        itemScope
+        itemType="http://schema.org/Question"
+        data-template="paragraphs/q_a"
+        data-entity-id={3488}
+        data-analytics-faq-section
+        data-analytics-faq-text="Can I use Secure Messaging to communicate with non-VA providers?"
+      >
+        <h2 itemProp="name" id="can-i-use-secure-messaging-to-">
+          Can I use Secure Messaging to communicate with non-VA providers?
+        </h2>
+        <div
+          data-entity-id={3488}
+          itemProp="acceptedAnswer"
+          itemScope
+          itemType="http://schema.org/Answer"
+        >
+          <div itemProp="text">
+            <div
+              data-template="paragraphs/wysiwyg"
+              data-entity-id={3489}
+              className="processed-content"
+            >
+              <p>
+                No. You can communicate only with your VA providers who’ve
+                agreed to participate in Secure Messaging.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        itemScope
+        itemType="http://schema.org/Question"
+        data-template="paragraphs/q_a"
+        data-entity-id={3490}
+        data-analytics-faq-section
+        data-analytics-faq-text="Will my personal health information be protected?"
+      >
+        <h2 itemProp="name" id="will-my-personal-health-inform">
+          Will my personal health information be protected?
+        </h2>
+        <div
+          data-entity-id={3490}
+          itemProp="acceptedAnswer"
+          itemScope
+          itemType="http://schema.org/Answer"
+        >
+          <div itemProp="text">
+            <div
+              data-template="paragraphs/wysiwyg"
+              data-entity-id={3491}
+              className="processed-content"
+            >
+              <p>
+                Yes. This is a secure website. We follow strict security
+                policies and practices to protect your personal health
+                information. And only you and your VA health care team will have
+                access to your secure messages.
+              </p>
+              <p>
+                If you print or download any messages, you’ll need to take
+                responsibility for protecting that information.
+                <br />
+                <a
+                  href="https://www.myhealth.va.gov/mhv-portal-web/web/myhealthevet/protecting-your-personal-health-information"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Get tips for protecting your personal health information
+                </a>
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        itemScope
+        itemType="http://schema.org/Question"
+        data-template="paragraphs/q_a"
+        data-entity-id={3492}
+        data-analytics-faq-section
+        data-analytics-faq-text="What if I have more questions?"
+      >
+        <h2 itemProp="name" id="what-if-i-have-more-questions">
+          What if I have more questions?
+        </h2>
+        <div
+          data-entity-id={3492}
+          itemProp="acceptedAnswer"
+          itemScope
+          itemType="http://schema.org/Answer"
+        >
+          <div itemProp="text">
+            <div
+              data-template="paragraphs/wysiwyg"
+              data-entity-id={3493}
+              className="processed-content"
+            >
+              <p>
+                If you have more questions about Secure Messaging on
+                MyHealtheVet, please got to the{' '}
+                <a
+                  href="https://www.myhealth.va.gov/mhv-portal-web/web/myhealthevet/faqs#smGeneralFAQ"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Secure Messaging FAQs
+                </a>{' '}
+                on the My HealtheVet web portal.
+              </p>
+              <p>
+                Or contact the My HealtheVet help desk at{' '}
+                <a href="tel:+18773270022">877-327-0022</a> (TTY:{' '}
+                <a href="tel:+18008778339">800-877-8339</a>. We&apos;re here
+                Monday through Friday, 7:00 a.m. to 7:00 p.m. CT.
+              </p>
+              <p>
+                You can also{' '}
+                <a
+                  href="https://www.myhealth.va.gov/mhv-portal-web/web/myhealthevet/contact-mhv"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  contact us online
+                </a>
+                .
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </article>
+);
+
+export default App;

--- a/src/applications/static-pages/health-care-manage-benefits/secure-messaging/components/App/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/secure-messaging/components/App/index.js
@@ -7,30 +7,18 @@ import CallToActionWidget from 'platform/site-wide/cta-widget';
 export const App = () => (
   <>
     <CallToActionWidget appId="messaging" setFocus={false} />
-    <div data-template="paragraphs/q_a_section" data-entity-id={3480}>
-      <div
-        itemScope
-        itemType="http://schema.org/Question"
-        data-template="paragraphs/q_a"
-        data-entity-id={3479}
-        data-analytics-faq-section
-        data-analytics-faq-text="How can VA Secure Messaging help me manage my health care?"
-      >
+    <div>
+      <div itemScope itemType="http://schema.org/Question">
         <h2 itemProp="name" id="how-can-va-secure-messaging-he">
           How can VA Secure Messaging help me manage my health care?
         </h2>
         <div
-          data-entity-id={3479}
           itemProp="acceptedAnswer"
           itemScope
           itemType="http://schema.org/Answer"
         >
           <div itemProp="text">
-            <div
-              data-template="paragraphs/wysiwyg"
-              data-entity-id={3481}
-              className="processed-content"
-            >
+            <div className="processed-content">
               <p>
                 Secure Messaging is a web-based service that protects your
                 sensitive information so you can safely and easily communicate
@@ -59,29 +47,17 @@ export const App = () => (
           </div>
         </div>
       </div>
-      <div
-        itemScope
-        itemType="http://schema.org/Question"
-        data-template="paragraphs/q_a"
-        data-entity-id={3482}
-        data-analytics-faq-section
-        data-analytics-faq-text="Am I eligible to use Secure Messaging?"
-      >
+      <div itemScope itemType="http://schema.org/Question">
         <h2 itemProp="name" id="am-i-eligible-to-use-secure-me">
           Am I eligible to use Secure Messaging?
         </h2>
         <div
-          data-entity-id={3482}
           itemProp="acceptedAnswer"
           itemScope
           itemType="http://schema.org/Answer"
         >
           <div itemProp="text">
-            <div
-              data-template="paragraphs/wysiwyg"
-              data-entity-id={3483}
-              className="processed-content"
-            >
+            <div className="processed-content">
               <p>
                 You can use this tool if you meet all of the requirements listed
                 below.
@@ -137,29 +113,17 @@ export const App = () => (
           </div>
         </div>
       </div>
-      <div
-        itemScope
-        itemType="http://schema.org/Question"
-        data-template="paragraphs/q_a"
-        data-entity-id={3484}
-        data-analytics-faq-section
-        data-analytics-faq-text="How does Secure Messaging work within My HealtheVet?"
-      >
+      <div itemScope itemType="http://schema.org/Question">
         <h2 itemProp="name" id="how-does-secure-messaging-work">
           How does Secure Messaging work within My HealtheVet?
         </h2>
         <div
-          data-entity-id={3484}
           itemProp="acceptedAnswer"
           itemScope
           itemType="http://schema.org/Answer"
         >
           <div itemProp="text">
-            <div
-              data-template="paragraphs/wysiwyg"
-              data-entity-id={3485}
-              className="processed-content"
-            >
+            <div className="processed-content">
               <p>
                 With Secure Messaging, you can write messages, save drafts,
                 review your sent messages, and keep a record of your
@@ -181,29 +145,17 @@ export const App = () => (
           </div>
         </div>
       </div>
-      <div
-        itemScope
-        itemType="http://schema.org/Question"
-        data-template="paragraphs/q_a"
-        data-entity-id={3486}
-        data-analytics-faq-section
-        data-analytics-faq-text="Can I use Secure Messaging for medical emergencies or urgent needs?"
-      >
+      <div itemScope itemType="http://schema.org/Question">
         <h2 itemProp="name" id="can-i-use-secure-messaging-for">
           Can I use Secure Messaging for medical emergencies or urgent needs?
         </h2>
         <div
-          data-entity-id={3486}
           itemProp="acceptedAnswer"
           itemScope
           itemType="http://schema.org/Answer"
         >
           <div itemProp="text">
-            <div
-              data-template="paragraphs/wysiwyg"
-              data-entity-id={3487}
-              className="processed-content"
-            >
+            <div className="processed-content">
               <p>
                 No. You shouldn’t use Secure Messaging when you have an urgent
                 need, because it may take a few days for you to get a reply.
@@ -254,29 +206,17 @@ export const App = () => (
           </div>
         </div>
       </div>
-      <div
-        itemScope
-        itemType="http://schema.org/Question"
-        data-template="paragraphs/q_a"
-        data-entity-id={3488}
-        data-analytics-faq-section
-        data-analytics-faq-text="Can I use Secure Messaging to communicate with non-VA providers?"
-      >
+      <div itemScope itemType="http://schema.org/Question">
         <h2 itemProp="name" id="can-i-use-secure-messaging-to-">
           Can I use Secure Messaging to communicate with non-VA providers?
         </h2>
         <div
-          data-entity-id={3488}
           itemProp="acceptedAnswer"
           itemScope
           itemType="http://schema.org/Answer"
         >
           <div itemProp="text">
-            <div
-              data-template="paragraphs/wysiwyg"
-              data-entity-id={3489}
-              className="processed-content"
-            >
+            <div className="processed-content">
               <p>
                 No. You can communicate only with your VA providers who’ve
                 agreed to participate in Secure Messaging.
@@ -285,29 +225,17 @@ export const App = () => (
           </div>
         </div>
       </div>
-      <div
-        itemScope
-        itemType="http://schema.org/Question"
-        data-template="paragraphs/q_a"
-        data-entity-id={3490}
-        data-analytics-faq-section
-        data-analytics-faq-text="Will my personal health information be protected?"
-      >
+      <div itemScope itemType="http://schema.org/Question">
         <h2 itemProp="name" id="will-my-personal-health-inform">
           Will my personal health information be protected?
         </h2>
         <div
-          data-entity-id={3490}
           itemProp="acceptedAnswer"
           itemScope
           itemType="http://schema.org/Answer"
         >
           <div itemProp="text">
-            <div
-              data-template="paragraphs/wysiwyg"
-              data-entity-id={3491}
-              className="processed-content"
-            >
+            <div className="processed-content">
               <p>
                 Yes. This is a secure website. We follow strict security
                 policies and practices to protect your personal health
@@ -330,29 +258,17 @@ export const App = () => (
           </div>
         </div>
       </div>
-      <div
-        itemScope
-        itemType="http://schema.org/Question"
-        data-template="paragraphs/q_a"
-        data-entity-id={3492}
-        data-analytics-faq-section
-        data-analytics-faq-text="What if I have more questions?"
-      >
+      <div itemScope itemType="http://schema.org/Question">
         <h2 itemProp="name" id="what-if-i-have-more-questions">
           What if I have more questions?
         </h2>
         <div
-          data-entity-id={3492}
           itemProp="acceptedAnswer"
           itemScope
           itemType="http://schema.org/Answer"
         >
           <div itemProp="text">
-            <div
-              data-template="paragraphs/wysiwyg"
-              data-entity-id={3493}
-              className="processed-content"
-            >
+            <div className="processed-content">
               <p>
                 If you have more questions about Secure Messaging on
                 MyHealtheVet, please got to the{' '}

--- a/src/applications/static-pages/health-care-manage-benefits/secure-messaging/components/App/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/secure-messaging/components/App/index.js
@@ -4,7 +4,7 @@ import React from 'react';
 import './styles.scss';
 import CallToActionWidget from 'platform/site-wide/cta-widget';
 
-const App = () => (
+export const App = () => (
   <article className="usa-content">
     <h1>VA Secure Messaging</h1>
     <div className="va-introtext">

--- a/src/applications/static-pages/health-care-manage-benefits/secure-messaging/components/App/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/secure-messaging/components/App/index.js
@@ -5,16 +5,7 @@ import './styles.scss';
 import CallToActionWidget from 'platform/site-wide/cta-widget';
 
 export const App = () => (
-  <article className="usa-content">
-    <h1>VA Secure Messaging</h1>
-    <div className="va-introtext">
-      <p>
-        With VA Secure Messaging, you can communicate privately online with your
-        VA health care team. Find out if you’re eligible to use Secure
-        Messaging, and how to sign in to begin using this tool in the health
-        management portal.
-      </p>
-    </div>
+  <>
     <CallToActionWidget appId="messaging" setFocus={false} />
     <div data-template="paragraphs/q_a_section" data-entity-id={3480}>
       <div
@@ -396,7 +387,7 @@ export const App = () => (
         </div>
       </div>
     </div>
-  </article>
+  </>
 );
 
 export default App;

--- a/src/applications/static-pages/health-care-manage-benefits/secure-messaging/components/App/index.unit.spec.js
+++ b/src/applications/static-pages/health-care-manage-benefits/secure-messaging/components/App/index.unit.spec.js
@@ -10,7 +10,6 @@ describe('Secure Messaging Page <App>', () => {
     const wrapper = shallow(<App />);
 
     const text = wrapper.text();
-    expect(text).to.include('VA Secure Messaging');
     expect(text).to.include(
       'How can VA Secure Messaging help me manage my health care?',
     );

--- a/src/applications/static-pages/health-care-manage-benefits/secure-messaging/components/App/index.unit.spec.js
+++ b/src/applications/static-pages/health-care-manage-benefits/secure-messaging/components/App/index.unit.spec.js
@@ -1,0 +1,34 @@
+// Dependencies.
+import React from 'react';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+// Relative imports.
+import { App } from './index';
+
+describe('Secure Messaging Page <App>', () => {
+  it('renders what we expect', () => {
+    const wrapper = shallow(<App />);
+
+    const text = wrapper.text();
+    expect(text).to.include('VA Secure Messaging');
+    expect(text).to.include(
+      'How can VA Secure Messaging help me manage my health care?',
+    );
+    expect(text).to.include('Am I eligible to use Secure Messaging?');
+    expect(text).to.include(
+      'How does Secure Messaging work within My HealtheVet?',
+    );
+    expect(text).to.include(
+      'Can I use Secure Messaging for medical emergencies or urgent needs?',
+    );
+    expect(text).to.include(
+      'Can I use Secure Messaging to communicate with non-VA providers?',
+    );
+    expect(text).to.include(
+      'Will my personal health information be protected?',
+    );
+    expect(text).to.include('What if I have more questions?');
+
+    wrapper.unmount();
+  });
+});

--- a/src/applications/static-pages/health-care-manage-benefits/secure-messaging/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/secure-messaging/index.js
@@ -1,0 +1,20 @@
+// Node modules.
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { Provider } from 'react-redux';
+
+export default (store, widgetType) => {
+  const root = document.querySelector(`[data-widget-type="${widgetType}"]`);
+  if (root) {
+    import(/* webpackChunkName: "App" */
+    './components/App').then(module => {
+      const App = module.default;
+      ReactDOM.render(
+        <Provider store={store}>
+          <App />
+        </Provider>,
+        root,
+      );
+    });
+  }
+};

--- a/src/applications/static-pages/static-pages-entry.js
+++ b/src/applications/static-pages/static-pages-entry.js
@@ -31,6 +31,7 @@ import createPost911GiBillStatusWidget, {
 
 import create686ContentReveal from './view-modify-dependent/686-cta/create686CcontentReveal.js';
 import createCaregiverContentToggle from './caregiver-content-toggle/createCaregiverContentToggle';
+import createSecureMessagingPage from './health-care-manage-benefits/secure-messaging';
 
 // No-react styles.
 import './sass/static-pages.scss';
@@ -137,6 +138,7 @@ createViewDependentsCTA(store, widgetTypes.VIEW_DEPENDENTS_CTA);
 create686ContentReveal(store, widgetTypes.FORM_686_CONTENT_REVEAL);
 
 createCaregiverContentToggle(store, widgetTypes.CAREGIVER_CONTENT_TOGGLE);
+createSecureMessagingPage(store, widgetTypes.SECURE_MESSAGING_PAGE);
 
 // homepage widgets
 if (location.pathname === '/') {

--- a/src/applications/static-pages/widgetTypes.js
+++ b/src/applications/static-pages/widgetTypes.js
@@ -15,4 +15,5 @@ export default {
   VIEW_DEPENDENTS_CTA: 'view-dependents-CTA',
   FORM_686_CONTENT_REVEAL: '686UnauthContentBlock',
   CAREGIVER_CONTENT_TOGGLE: 'caregiver-content-toggle',
+  SECURE_MESSAGING_PAGE: 'secure-messaging',
 };


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/10264

This PR adds unauth Secure Messaging page content as a React widget.

## Testing done
Adds unit tests for React widget.

## Screenshots

![image](https://user-images.githubusercontent.com/12773166/85317032-f3f2b200-b47a-11ea-8355-cf3af5678169.png)

![image](https://user-images.githubusercontent.com/12773166/85317065-01a83780-b47b-11ea-81c2-27de65cd7fb1.png)

![image](https://user-images.githubusercontent.com/12773166/85317090-0cfb6300-b47b-11ea-8fdd-13ace4459a58.png)

## Acceptance criteria
- [x] Add unauth Secure Messaging page content as a React widget.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
