### PR TITLE
Add unauth view-test-and-lab-results page

### DIFF
--- a/src/applications/static-pages/health-care-manage-benefits/view-test-lab-results-page/components/App/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/view-test-lab-results-page/components/App/index.js
@@ -4,7 +4,7 @@ import React from 'react';
 import './styles.scss';
 import CallToActionWidget from 'platform/site-wide/cta-widget';
 
-const App = () => (
+export const App = () => (
   <article className="usa-content">
     <h1>View your VA lab and test results online</h1>
     <div className="va-introtext">

--- a/src/applications/static-pages/health-care-manage-benefits/view-test-lab-results-page/components/App/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/view-test-lab-results-page/components/App/index.js
@@ -7,30 +7,18 @@ import CallToActionWidget from 'platform/site-wide/cta-widget';
 export const App = () => (
   <>
     <CallToActionWidget appId="lab-and-test-results" setFocus={false} />
-    <div data-template="paragraphs/q_a_section" data-entity-id={3507}>
-      <div
-        itemScope
-        itemType="http://schema.org/Question"
-        data-template="paragraphs/q_a"
-        data-entity-id={3506}
-        data-analytics-faq-section
-        data-analytics-faq-text="How can this tool help me manage my health care?"
-      >
+    <div>
+      <div itemScope itemType="http://schema.org/Question">
         <h2 itemProp="name" id="how-can-this-tool-help-me-mana">
           How can this tool help me manage my health care?
         </h2>
         <div
-          data-entity-id={3506}
           itemProp="acceptedAnswer"
           itemScope
           itemType="http://schema.org/Answer"
         >
           <div itemProp="text">
-            <div
-              data-template="paragraphs/wysiwyg"
-              data-entity-id={3508}
-              className="processed-content"
-            >
+            <div className="processed-content">
               <p>
                 With this tool, you&apos;ll be able to view and keep a record of
                 your VA lab and test results.
@@ -48,29 +36,17 @@ export const App = () => (
           </div>
         </div>
       </div>
-      <div
-        itemScope
-        itemType="http://schema.org/Question"
-        data-template="paragraphs/q_a"
-        data-entity-id={3509}
-        data-analytics-faq-section
-        data-analytics-faq-text="Am I eligible to use this tool?"
-      >
+      <div itemScope itemType="http://schema.org/Question">
         <h2 itemProp="name" id="am-i-eligible-to-use-this-tool">
           Am I eligible to use this tool?
         </h2>
         <div
-          data-entity-id={3509}
           itemProp="acceptedAnswer"
           itemScope
           itemType="http://schema.org/Answer"
         >
           <div itemProp="text">
-            <div
-              data-template="paragraphs/wysiwyg"
-              data-entity-id={3510}
-              className="processed-content"
-            >
+            <div className="processed-content">
               <p>
                 You can use this tool to view and track your VA lab and test
                 results if you meet all of the requirements listed below.
@@ -125,29 +101,17 @@ export const App = () => (
           </div>
         </div>
       </div>
-      <div
-        itemScope
-        itemType="http://schema.org/Question"
-        data-template="paragraphs/q_a"
-        data-entity-id={3511}
-        data-analytics-faq-section
-        data-analytics-faq-text="Can I view all my VA lab and test information using this tool?"
-      >
+      <div itemScope itemType="http://schema.org/Question">
         <h2 itemProp="name" id="can-i-view-all-my-va-lab-and-t">
           Can I view all my VA lab and test information using this tool?
         </h2>
         <div
-          data-entity-id={3511}
           itemProp="acceptedAnswer"
           itemScope
           itemType="http://schema.org/Answer"
         >
           <div itemProp="text">
-            <div
-              data-template="paragraphs/wysiwyg"
-              data-entity-id={3512}
-              className="processed-content"
-            >
+            <div className="processed-content">
               <p>
                 At this time, you can view only your VA chemistry/hematology
                 results. These include tests for blood sugar, liver function, or
@@ -157,29 +121,17 @@ export const App = () => (
           </div>
         </div>
       </div>
-      <div
-        itemScope
-        itemType="http://schema.org/Question"
-        data-template="paragraphs/q_a"
-        data-entity-id={3513}
-        data-analytics-faq-section
-        data-analytics-faq-text="Can I view results from non-VA providers or labs?"
-      >
+      <div itemScope itemType="http://schema.org/Question">
         <h2 itemProp="name" id="can-i-view-results-from-non-va">
           Can I view results from non-VA providers or labs?
         </h2>
         <div
-          data-entity-id={3513}
           itemProp="acceptedAnswer"
           itemScope
           itemType="http://schema.org/Answer"
         >
           <div itemProp="text">
-            <div
-              data-template="paragraphs/wysiwyg"
-              data-entity-id={3514}
-              className="processed-content"
-            >
+            <div className="processed-content">
               <p>
                 No. But you can enter this information yourself to keep all your
                 results in one place.
@@ -188,29 +140,17 @@ export const App = () => (
           </div>
         </div>
       </div>
-      <div
-        itemScope
-        itemType="http://schema.org/Question"
-        data-template="paragraphs/q_a"
-        data-entity-id={3515}
-        data-analytics-faq-section
-        data-analytics-faq-text="Once I’m signed in within My HealtheVet, how do I view my results?"
-      >
+      <div itemScope itemType="http://schema.org/Question">
         <h2 itemProp="name" id="once-im-signed-in-within-my-he">
           Once I’m signed in within My HealtheVet, how do I view my results?
         </h2>
         <div
-          data-entity-id={3515}
           itemProp="acceptedAnswer"
           itemScope
           itemType="http://schema.org/Answer"
         >
           <div itemProp="text">
-            <div
-              data-template="paragraphs/wysiwyg"
-              data-entity-id={3516}
-              className="processed-content"
-            >
+            <div className="processed-content">
               <p>
                 On your Welcome page dashboard, you’ll see a module for “Health
                 Records.” Within that module, click on “Labs and Tests.”
@@ -250,29 +190,17 @@ export const App = () => (
           </div>
         </div>
       </div>
-      <div
-        itemScope
-        itemType="http://schema.org/Question"
-        data-template="paragraphs/q_a"
-        data-entity-id={3517}
-        data-analytics-faq-section
-        data-analytics-faq-text="Will my personal health information be protected?"
-      >
+      <div itemScope itemType="http://schema.org/Question">
         <h2 itemProp="name" id="will-my-personal-health-inform">
           Will my personal health information be protected?
         </h2>
         <div
-          data-entity-id={3517}
           itemProp="acceptedAnswer"
           itemScope
           itemType="http://schema.org/Answer"
         >
           <div itemProp="text">
-            <div
-              data-template="paragraphs/wysiwyg"
-              data-entity-id={3518}
-              className="processed-content"
-            >
+            <div className="processed-content">
               <p>
                 Yes. This is a secure website. We follow strict security
                 policies and practices to protect your personal health
@@ -295,29 +223,17 @@ export const App = () => (
           </div>
         </div>
       </div>
-      <div
-        itemScope
-        itemType="http://schema.org/Question"
-        data-template="paragraphs/q_a"
-        data-entity-id={3519}
-        data-analytics-faq-section
-        data-analytics-faq-text="What if I have more questions?"
-      >
+      <div itemScope itemType="http://schema.org/Question">
         <h2 itemProp="name" id="what-if-i-have-more-questions">
           What if I have more questions?
         </h2>
         <div
-          data-entity-id={3519}
           itemProp="acceptedAnswer"
           itemScope
           itemType="http://schema.org/Answer"
         >
           <div itemProp="text">
-            <div
-              data-template="paragraphs/wysiwyg"
-              data-entity-id={3520}
-              className="processed-content"
-            >
+            <div className="processed-content">
               <p>
                 If you have questions about lab and test results on
                 MyHealtheVet, please got to the{' '}

--- a/src/applications/static-pages/health-care-manage-benefits/view-test-lab-results-page/components/App/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/view-test-lab-results-page/components/App/index.js
@@ -71,7 +71,10 @@ export const App = () => (
               <ul>
                 <li>
                   A{' '}
-                  <a href="">
+                  <a
+                    href="https://www.myhealth.va.gov/mhv-portal-web/upgrading-your-my-healthevet-account-through-in-person-or-online-authentication"
+                    rel="noreferrer noopener"
+                  >
                     Premium <strong>My HealtheVet account</strong>
                   </a>
                   , <strong>or</strong>

--- a/src/applications/static-pages/health-care-manage-benefits/view-test-lab-results-page/components/App/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/view-test-lab-results-page/components/App/index.js
@@ -1,0 +1,366 @@
+// Node modules.
+import React from 'react';
+// Relative imports.
+import './styles.scss';
+import CallToActionWidget from 'platform/site-wide/cta-widget';
+
+const App = () => (
+  <article className="usa-content">
+    <h1>View your VA lab and test results online</h1>
+    <div className="va-introtext">
+      <p>
+        You can view your VA lab and test results online with our lab and test
+        tool. Find out if you&apos;re eligible to use this tool and how to sign
+        in to view your results.
+      </p>
+    </div>
+    <CallToActionWidget appId="lab-and-test-results" setFocus={false} />
+    <div data-template="paragraphs/q_a_section" data-entity-id={3507}>
+      <div
+        itemScope
+        itemType="http://schema.org/Question"
+        data-template="paragraphs/q_a"
+        data-entity-id={3506}
+        data-analytics-faq-section
+        data-analytics-faq-text="How can this tool help me manage my health care?"
+      >
+        <h2 itemProp="name" id="how-can-this-tool-help-me-mana">
+          How can this tool help me manage my health care?
+        </h2>
+        <div
+          data-entity-id={3506}
+          itemProp="acceptedAnswer"
+          itemScope
+          itemType="http://schema.org/Answer"
+        >
+          <div itemProp="text">
+            <div
+              data-template="paragraphs/wysiwyg"
+              data-entity-id={3508}
+              className="processed-content"
+            >
+              <p>
+                With this tool, you&apos;ll be able to view and keep a record of
+                your VA lab and test results.
+              </p>
+              <p>
+                <strong>You can use the tool to:</strong>
+              </p>
+              <ul>
+                <li>
+                  View some of your VA lab and test results (like blood tests)
+                </li>
+                <li>Add results from non-VA health care providers and labs</li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        itemScope
+        itemType="http://schema.org/Question"
+        data-template="paragraphs/q_a"
+        data-entity-id={3509}
+        data-analytics-faq-section
+        data-analytics-faq-text="Am I eligible to use this tool?"
+      >
+        <h2 itemProp="name" id="am-i-eligible-to-use-this-tool">
+          Am I eligible to use this tool?
+        </h2>
+        <div
+          data-entity-id={3509}
+          itemProp="acceptedAnswer"
+          itemScope
+          itemType="http://schema.org/Answer"
+        >
+          <div itemProp="text">
+            <div
+              data-template="paragraphs/wysiwyg"
+              data-entity-id={3510}
+              className="processed-content"
+            >
+              <p>
+                You can use this tool to view and track your VA lab and test
+                results if you meet all of the requirements listed below.
+              </p>
+              <p>
+                <strong>Both of these must be true. You’re:</strong>
+              </p>
+              <ul>
+                <li>
+                  Enrolled in VA health care, <strong>and</strong>
+                </li>
+                <li>Registered as a patient at a VA health facility</li>
+              </ul>
+              <p>
+                <a href="/health-care/how-to-apply/">
+                  Find out how to apply for VA health care
+                </a>
+              </p>
+              <p>
+                <strong>And you must have one of these free accounts:</strong>
+              </p>
+              <ul>
+                <li>
+                  A{' '}
+                  <a href="">
+                    Premium <strong>My HealtheVet account</strong>
+                  </a>
+                  , <strong>or</strong>
+                </li>
+                <li>
+                  A Premium <strong>DS Logon</strong> account (used for
+                  eBenefits and milConnect), <strong>or</strong>
+                </li>
+                <li>
+                  A verified <strong>ID.me</strong> account that you can create
+                  here on VA.gov
+                </li>
+              </ul>
+              <p>
+                <strong>Note:</strong> If you sign in with a Basic or Advanced
+                account, you’ll see only the results you’ve entered yourself.
+                <br />
+                <a
+                  href="https://www.myhealth.va.gov/mhv-portal-web/my-healthevet-offers-three-account-types"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Learn about the 3 different My HealtheVet account types
+                </a>
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        itemScope
+        itemType="http://schema.org/Question"
+        data-template="paragraphs/q_a"
+        data-entity-id={3511}
+        data-analytics-faq-section
+        data-analytics-faq-text="Can I view all my VA lab and test information using this tool?"
+      >
+        <h2 itemProp="name" id="can-i-view-all-my-va-lab-and-t">
+          Can I view all my VA lab and test information using this tool?
+        </h2>
+        <div
+          data-entity-id={3511}
+          itemProp="acceptedAnswer"
+          itemScope
+          itemType="http://schema.org/Answer"
+        >
+          <div itemProp="text">
+            <div
+              data-template="paragraphs/wysiwyg"
+              data-entity-id={3512}
+              className="processed-content"
+            >
+              <p>
+                At this time, you can view only your VA chemistry/hematology
+                results. These include tests for blood sugar, liver function, or
+                blood cell counts.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        itemScope
+        itemType="http://schema.org/Question"
+        data-template="paragraphs/q_a"
+        data-entity-id={3513}
+        data-analytics-faq-section
+        data-analytics-faq-text="Can I view results from non-VA providers or labs?"
+      >
+        <h2 itemProp="name" id="can-i-view-results-from-non-va">
+          Can I view results from non-VA providers or labs?
+        </h2>
+        <div
+          data-entity-id={3513}
+          itemProp="acceptedAnswer"
+          itemScope
+          itemType="http://schema.org/Answer"
+        >
+          <div itemProp="text">
+            <div
+              data-template="paragraphs/wysiwyg"
+              data-entity-id={3514}
+              className="processed-content"
+            >
+              <p>
+                No. But you can enter this information yourself to keep all your
+                results in one place.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        itemScope
+        itemType="http://schema.org/Question"
+        data-template="paragraphs/q_a"
+        data-entity-id={3515}
+        data-analytics-faq-section
+        data-analytics-faq-text="Once I’m signed in within My HealtheVet, how do I view my results?"
+      >
+        <h2 itemProp="name" id="once-im-signed-in-within-my-he">
+          Once I’m signed in within My HealtheVet, how do I view my results?
+        </h2>
+        <div
+          data-entity-id={3515}
+          itemProp="acceptedAnswer"
+          itemScope
+          itemType="http://schema.org/Answer"
+        >
+          <div itemProp="text">
+            <div
+              data-template="paragraphs/wysiwyg"
+              data-entity-id={3516}
+              className="processed-content"
+            >
+              <p>
+                On your Welcome page dashboard, you’ll see a module for “Health
+                Records.” Within that module, click on “Labs and Tests.”
+              </p>
+              <p>
+                This will take you to a new page with links to view test
+                results.
+              </p>
+              <p>If you’re signed in with a Premium account, you’ll see:</p>
+              <ul>
+                <li>
+                  <strong>VA chemistry/hematology results:</strong> Your tests
+                  will be listed by date and specimen. A specimen is the sample
+                  studied by the test (like blood, urine, a tissue biopsy, or a
+                  throat swab). You can click on each to view details from your
+                  VA medical record.
+                </li>
+                <li>
+                  <strong>Test results you’ve entered yourself:</strong> You can
+                  add and view results from non-VA providers and labs.
+                </li>
+              </ul>
+              <p>
+                <strong>Note:</strong> If you’re signed in with a Basic or
+                Advanced account, you’ll see only the test results you’ve
+                entered yourself.
+                <br />
+                <a
+                  href="https://www.myhealth.va.gov/mhv-portal-web/my-healthevet-offers-three-account-types"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Learn about the 3 different My HealtheVet account types
+                </a>
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        itemScope
+        itemType="http://schema.org/Question"
+        data-template="paragraphs/q_a"
+        data-entity-id={3517}
+        data-analytics-faq-section
+        data-analytics-faq-text="Will my personal health information be protected?"
+      >
+        <h2 itemProp="name" id="will-my-personal-health-inform">
+          Will my personal health information be protected?
+        </h2>
+        <div
+          data-entity-id={3517}
+          itemProp="acceptedAnswer"
+          itemScope
+          itemType="http://schema.org/Answer"
+        >
+          <div itemProp="text">
+            <div
+              data-template="paragraphs/wysiwyg"
+              data-entity-id={3518}
+              className="processed-content"
+            >
+              <p>
+                Yes. This is a secure website. We follow strict security
+                policies and practices to protect your personal health
+                information.
+              </p>
+              <p>
+                If you print or download anything from the website (like lab
+                results), you’ll need to take responsibility for protecting that
+                information.
+                <br />
+                <a
+                  href="https://www.myhealth.va.gov/mhv-portal-web/web/myhealthevet/protecting-your-personal-health-information"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Get tips for protecting your personal health information
+                </a>
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        itemScope
+        itemType="http://schema.org/Question"
+        data-template="paragraphs/q_a"
+        data-entity-id={3519}
+        data-analytics-faq-section
+        data-analytics-faq-text="What if I have more questions?"
+      >
+        <h2 itemProp="name" id="what-if-i-have-more-questions">
+          What if I have more questions?
+        </h2>
+        <div
+          data-entity-id={3519}
+          itemProp="acceptedAnswer"
+          itemScope
+          itemType="http://schema.org/Answer"
+        >
+          <div itemProp="text">
+            <div
+              data-template="paragraphs/wysiwyg"
+              data-entity-id={3520}
+              className="processed-content"
+            >
+              <p>
+                If you have questions about lab and test results on
+                MyHealtheVet, please got to the{' '}
+                <a
+                  href="https://www.myhealth.va.gov/mhv-portal-web/web/myhealthevet/faqs#smGeneralFAQ"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Lab + Tests Results FAQs
+                </a>{' '}
+                on the My HealtheVet web portal.
+              </p>
+              <p>
+                Or contact the My HealtheVet help desk at{' '}
+                <a href="tel:+18773270022">877-327-0022</a> (TTY:{' '}
+                <a href="tel:+18008778339">800-877-8339</a>. We&apos;re here
+                Monday through Friday, 7:00 a.m. to 7:00 p.m. CT.
+              </p>
+              <p>
+                You can also{' '}
+                <a
+                  href="https://www.myhealth.va.gov/mhv-portal-web/web/myhealthevet/contact-mhv"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  contact us online
+                </a>
+                .
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </article>
+);
+
+export default App;

--- a/src/applications/static-pages/health-care-manage-benefits/view-test-lab-results-page/components/App/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/view-test-lab-results-page/components/App/index.js
@@ -5,15 +5,7 @@ import './styles.scss';
 import CallToActionWidget from 'platform/site-wide/cta-widget';
 
 export const App = () => (
-  <article className="usa-content">
-    <h1>View your VA lab and test results online</h1>
-    <div className="va-introtext">
-      <p>
-        You can view your VA lab and test results online with our lab and test
-        tool. Find out if you&apos;re eligible to use this tool and how to sign
-        in to view your results.
-      </p>
-    </div>
+  <>
     <CallToActionWidget appId="lab-and-test-results" setFocus={false} />
     <div data-template="paragraphs/q_a_section" data-entity-id={3507}>
       <div
@@ -360,7 +352,7 @@ export const App = () => (
         </div>
       </div>
     </div>
-  </article>
+  </>
 );
 
 export default App;

--- a/src/applications/static-pages/health-care-manage-benefits/view-test-lab-results-page/components/App/index.unit.spec.js
+++ b/src/applications/static-pages/health-care-manage-benefits/view-test-lab-results-page/components/App/index.unit.spec.js
@@ -10,7 +10,6 @@ describe('View Test Lab Results Page <App>', () => {
     const wrapper = shallow(<App />);
 
     const text = wrapper.text();
-    expect(text).to.include('View your VA lab and test results online');
     expect(text).to.include('How can this tool help me manage my health care?');
     expect(text).to.include('Am I eligible to use this tool?');
     expect(text).to.include(

--- a/src/applications/static-pages/health-care-manage-benefits/view-test-lab-results-page/components/App/index.unit.spec.js
+++ b/src/applications/static-pages/health-care-manage-benefits/view-test-lab-results-page/components/App/index.unit.spec.js
@@ -1,0 +1,32 @@
+// Dependencies.
+import React from 'react';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+// Relative imports.
+import { App } from './index';
+
+describe('View Test Lab Results Page <App>', () => {
+  it('renders what we expect', () => {
+    const wrapper = shallow(<App />);
+
+    const text = wrapper.text();
+    expect(text).to.include('View your VA lab and test results online');
+    expect(text).to.include('How can this tool help me manage my health care?');
+    expect(text).to.include('Am I eligible to use this tool?');
+    expect(text).to.include(
+      'Can I view all my VA lab and test information using this tool?',
+    );
+    expect(text).to.include(
+      'Can I view results from non-VA providers or labs?',
+    );
+    expect(text).to.include(
+      'Once I’m signed in within My HealtheVet, how do I view my results?',
+    );
+    expect(text).to.include(
+      'Will my personal health information be protected?',
+    );
+    expect(text).to.include('What if I have more questions?');
+
+    wrapper.unmount();
+  });
+});

--- a/src/applications/static-pages/health-care-manage-benefits/view-test-lab-results-page/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/view-test-lab-results-page/index.js
@@ -1,0 +1,20 @@
+// Node modules.
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { Provider } from 'react-redux';
+
+export default (store, widgetType) => {
+  const root = document.querySelector(`[data-widget-type="${widgetType}"]`);
+  if (root) {
+    import(/* webpackChunkName: "App" */
+    './components/App').then(module => {
+      const App = module.default;
+      ReactDOM.render(
+        <Provider store={store}>
+          <App />
+        </Provider>,
+        root,
+      );
+    });
+  }
+};

--- a/src/applications/static-pages/health-care-manage-benefits/view-test-lab-results-page/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/view-test-lab-results-page/index.js
@@ -6,7 +6,7 @@ import { Provider } from 'react-redux';
 export default (store, widgetType) => {
   const root = document.querySelector(`[data-widget-type="${widgetType}"]`);
   if (root) {
-    import(/* webpackChunkName: "App" */
+    import(/* webpackChunkName: "view-test-lab-results-page" */
     './components/App').then(module => {
       const App = module.default;
       ReactDOM.render(

--- a/src/applications/static-pages/static-pages-entry.js
+++ b/src/applications/static-pages/static-pages-entry.js
@@ -34,6 +34,7 @@ import createCaregiverContentToggle from './caregiver-content-toggle/createCareg
 import createSecureMessagingPage from './health-care-manage-benefits/secure-messaging';
 import createScheduleViewVAAppointments from './health-care-manage-benefits/schedule-view-va-appointments';
 import createGetMedicalRecordsPage from './health-care-manage-benefits/get-medical-records-page';
+import createViewTestLabResultsPage from './health-care-manage-benefits/view-test-lab-results-page';
 
 // No-react styles.
 import './sass/static-pages.scss';
@@ -146,6 +147,7 @@ createScheduleViewVAAppointments(
   widgetTypes.SCHEDULE_VIEW_VA_APPOINTMENTS,
 );
 createGetMedicalRecordsPage(store, widgetTypes.GET_MEDICAL_RECORDS_PAGE);
+createViewTestLabResultsPage(store, widgetTypes.VIEW_TEST_LAB_RESULTS_PAGE);
 
 // homepage widgets
 if (location.pathname === '/') {

--- a/src/applications/static-pages/widgetTypes.js
+++ b/src/applications/static-pages/widgetTypes.js
@@ -18,4 +18,5 @@ export default {
   SECURE_MESSAGING_PAGE: 'secure-messaging',
   SCHEDULE_VIEW_VA_APPOINTMENTS: 'schedule-view-va-appointments',
   GET_MEDICAL_RECORDS_PAGE: 'get-medical-records-page',
+  VIEW_TEST_LAB_RESULTS_PAGE: 'view-test-lab-results-page',
 };


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/10264

This PR adds unauth View Test & Lab Results page content as a React widget.

## Testing done
Adds unit tests for React widget.

## Screenshots

![localhost_3001_dummy-page_](https://user-images.githubusercontent.com/12773166/85318724-b93e4900-b47d-11ea-9388-8b396a869201.png)

## Acceptance criteria
- [x] Add unauth View Test & Lab Results page content as a React widget.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
