### PR TITLE
Fix Left Nav loading behavior

### DIFF
--- a/src/platform/site-wide/side-nav/components/NavItem.js
+++ b/src/platform/site-wide/side-nav/components/NavItem.js
@@ -6,7 +6,7 @@ import classNames from 'classnames';
 import NavItemRow from './NavItemRow';
 import { NavItemPropTypes } from '../prop-types';
 
-const NavItem = ({ depth, item, renderChildItems, toggleItemExpanded }) => {
+const NavItem = ({ depth, item, renderChildItems, trackEvents }) => {
   // Derive the item properties.
   const { expanded, hasChildren, id, isSelected } = item;
 
@@ -36,11 +36,7 @@ const NavItem = ({ depth, item, renderChildItems, toggleItemExpanded }) => {
       key={id}
     >
       {/* Nav Item Row */}
-      <NavItemRow
-        depth={depth}
-        item={item}
-        toggleItemExpanded={toggleItemExpanded}
-      />
+      <NavItemRow depth={depth} item={item} trackEvents={trackEvents} />
 
       {/* Child Items */}
       {(expanded || depth >= 3) &&
@@ -55,14 +51,14 @@ NavItem.propTypes = {
   index: PropTypes.number.isRequired,
   renderChildItems: PropTypes.func.isRequired,
   sortedNavItems: PropTypes.arrayOf(NavItemPropTypes).isRequired,
-  toggleItemExpanded: PropTypes.func.isRequired,
+  trackEvents: PropTypes.func.isRequired,
 };
 
 NavItem.defaultProps = {
   item: {},
   renderChildItems: () => {},
   sortedNavItems: [],
-  toggleItemExpanded: () => {},
+  trackEvents: () => {},
 };
 
 export default NavItem;

--- a/src/platform/site-wide/side-nav/components/NavItemRow.js
+++ b/src/platform/site-wide/side-nav/components/NavItemRow.js
@@ -5,7 +5,7 @@ import classNames from 'classnames';
 // Relative
 import { NavItemPropTypes } from '../prop-types';
 
-const NavItemRow = ({ depth, item, toggleItemExpanded }) => {
+const NavItemRow = ({ depth, item, trackEvents }) => {
   // Derive item properties.
   const { expanded, hasChildren, href, id, isSelected, label } = item;
 
@@ -55,7 +55,7 @@ const NavItemRow = ({ depth, item, toggleItemExpanded }) => {
           open: moreThanLevel2SelectedExpanded,
         })}
         href={href}
-        onClick={toggleItemExpanded(id)}
+        onClick={trackEvents(id)}
         rel="noopener noreferrer"
         style={{ paddingLeft: indentation }}
       >
@@ -80,7 +80,7 @@ const NavItemRow = ({ depth, item, toggleItemExpanded }) => {
         open: !!(depth >= 2 && isSelected),
       })}
       href={href}
-      onClick={toggleItemExpanded(id)}
+      onClick={trackEvents(id)}
       rel="noopener noreferrer"
       style={{ paddingLeft: indentation }}
     >
@@ -100,7 +100,7 @@ const NavItemRow = ({ depth, item, toggleItemExpanded }) => {
 NavItemRow.propTypes = {
   depth: PropTypes.number.isRequired,
   item: NavItemPropTypes,
-  toggleItemExpanded: PropTypes.func.isRequired,
+  trackEvents: PropTypes.func.isRequired,
 };
 
 export default NavItemRow;

--- a/src/platform/site-wide/side-nav/components/NavItemRow.js
+++ b/src/platform/site-wide/side-nav/components/NavItemRow.js
@@ -41,6 +41,10 @@ const NavItemRow = ({ depth, item, trackEvents }) => {
     );
   }
 
+  const handleClick = () => {
+    trackEvents(id);
+  };
+
   // Render the row not as a link when there are child nav items.
   if (hasChildren) {
     return (
@@ -55,7 +59,7 @@ const NavItemRow = ({ depth, item, trackEvents }) => {
           open: moreThanLevel2SelectedExpanded,
         })}
         href={href}
-        onClick={trackEvents(id)}
+        onClick={handleClick}
         rel="noopener noreferrer"
         style={{ paddingLeft: indentation }}
       >
@@ -80,7 +84,7 @@ const NavItemRow = ({ depth, item, trackEvents }) => {
         open: !!(depth >= 2 && isSelected),
       })}
       href={href}
-      onClick={trackEvents(id)}
+      onClick={handleClick}
       rel="noopener noreferrer"
       style={{ paddingLeft: indentation }}
     >

--- a/src/platform/site-wide/side-nav/components/SideNav.js
+++ b/src/platform/site-wide/side-nav/components/SideNav.js
@@ -20,13 +20,12 @@ class SideNav extends Component {
     };
   }
 
-  toggleItemExpanded = id => () => {
+  trackEvents = id => () => {
     const { navItemsLookup } = this.state;
 
     // Derive the nav item and its properties.
     const navItem = get(navItemsLookup, `[${id}]`);
     const hasChildren = get(navItem, 'hasChildren');
-    const expanded = get(navItem, 'expanded');
     const depth = get(navItem, 'depth');
     const parentID = get(navItem, 'parentID');
 
@@ -44,16 +43,6 @@ class SideNav extends Component {
 
     // Escape early if the item has children.
     if (hasChildren) {
-      // Flip the item's expanded property.
-      this.setState({
-        navItemsLookup: {
-          ...navItemsLookup,
-          [id]: {
-            ...navItemsLookup[id],
-            expanded: !expanded,
-          },
-        },
-      });
       recordEvent({ event: 'nav-sidenav' });
       return;
     }
@@ -95,7 +84,7 @@ class SideNav extends Component {
         key={get(item, 'id')}
         renderChildItems={this.renderChildItems}
         sortedNavItems={sortedNavItems}
-        toggleItemExpanded={this.toggleItemExpanded}
+        trackEvents={this.trackEvents}
       />
     ));
   };

--- a/src/platform/site-wide/side-nav/components/SideNav.js
+++ b/src/platform/site-wide/side-nav/components/SideNav.js
@@ -20,7 +20,7 @@ class SideNav extends Component {
     };
   }
 
-  trackEvents = id => () => {
+  trackEvents = id => {
     const { navItemsLookup } = this.state;
 
     // Derive the nav item and its properties.

--- a/src/platform/site-wide/side-nav/tests/components/NavItem.unit.spec.js
+++ b/src/platform/site-wide/side-nav/tests/components/NavItem.unit.spec.js
@@ -34,7 +34,7 @@ describe('<NavItem>', () => {
       index: 1,
       renderChildItems: noop,
       sortedNavItems: [item],
-      toggleItemExpanded: noop,
+      trackEvents: noop,
     };
 
     const wrapper = shallow(<NavItem {...defaultProps} />);

--- a/src/platform/site-wide/side-nav/tests/components/NavItemRow.unit.spec.js
+++ b/src/platform/site-wide/side-nav/tests/components/NavItemRow.unit.spec.js
@@ -5,38 +5,49 @@ import { expect } from 'chai';
 import { uniqueId } from 'lodash';
 // Relative
 import NavItemRow from '../../components/NavItemRow';
+import sinon from 'sinon';
 
 describe('<NavItemRow>', () => {
+  const trackEventsSpy = sinon.spy();
+
+  const itemWithChildren = {
+    description: 'Some description',
+    expanded: true,
+    hasChildren: true,
+    href: '/pittsburgh-health-care',
+    id: uniqueId('sidenav_'),
+    isSelected: true,
+    label: 'Location',
+    order: 0,
+    parentID: uniqueId('sidenav_'),
+  };
+
+  const defaultProps = (item = itemWithChildren) => ({
+    depth: 2,
+    item,
+    trackEvents: trackEventsSpy,
+  });
+
+  beforeEach(() => {
+    trackEventsSpy.reset();
+  });
+
+  it('should fire trackEvents when href clicked', () => {
+    const wrapper = shallow(<NavItemRow {...defaultProps()} />);
+    expect(trackEventsSpy.called).to.equal(false);
+    wrapper.find('a').simulate('click');
+    expect(trackEventsSpy.calledOnce).to.equal(true);
+    wrapper.unmount();
+  });
+
   it('should render a hyperlink tag only when there are child nav items.', () => {
-    const noop = () => {};
-
-    const item = {
-      description: 'Some description',
-      expanded: true,
-      hasChildren: true,
-      href: '/pittsburgh-health-care',
-      id: uniqueId('sidenav_'),
-      isSelected: true,
-      label: 'Location',
-      order: 0,
-      parentID: uniqueId('sidenav_'),
-    };
-
-    const defaultProps = {
-      depth: 2,
-      item,
-      trackEvents: noop,
-    };
-
-    const wrapper = shallow(<NavItemRow {...defaultProps} />);
+    const wrapper = shallow(<NavItemRow {...defaultProps()} />);
     expect(wrapper.exists('a')).to.equal(true);
     wrapper.unmount();
   });
 
   it('should render a hyperlink tag when there are not child nav items.', () => {
-    const noop = () => {};
-
-    const item = {
+    const itemWithoutChildren = {
       description: 'Some description',
       expanded: true,
       hasChildren: false,
@@ -48,13 +59,9 @@ describe('<NavItemRow>', () => {
       parentID: uniqueId('sidenav_'),
     };
 
-    const defaultProps = {
-      depth: 2,
-      item,
-      trackEvents: noop,
-    };
-
-    const wrapper = shallow(<NavItemRow {...defaultProps} />);
+    const wrapper = shallow(
+      <NavItemRow {...defaultProps(itemWithoutChildren)} />,
+    );
     expect(wrapper.exists('a')).to.equal(true);
     wrapper.unmount();
   });

--- a/src/platform/site-wide/side-nav/tests/components/NavItemRow.unit.spec.js
+++ b/src/platform/site-wide/side-nav/tests/components/NavItemRow.unit.spec.js
@@ -25,7 +25,7 @@ describe('<NavItemRow>', () => {
     const defaultProps = {
       depth: 2,
       item,
-      toggleItemExpanded: noop,
+      trackEvents: noop,
     };
 
     const wrapper = shallow(<NavItemRow {...defaultProps} />);
@@ -51,7 +51,7 @@ describe('<NavItemRow>', () => {
     const defaultProps = {
       depth: 2,
       item,
-      toggleItemExpanded: noop,
+      trackEvents: noop,
     };
 
     const wrapper = shallow(<NavItemRow {...defaultProps} />);


### PR DESCRIPTION
## Description
issue: https://github.com/department-of-veterans-affairs/va.gov-team/issues/9943

## Testing done
Locally

## GIF
![loadingUniform](https://user-images.githubusercontent.com/100468/85070179-f99a8000-b17a-11ea-8ebd-573b40daa854.gif)


## Acceptance criteria
- [x] When an element from the left nav is selected, the relevant page should load before the navigation menu appears.


## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
