### PR TITLE
Chatbot UI tests

### DIFF
--- a/src/applications/coronavirus-chatbot/components/ChatbotLoadError.jsx
+++ b/src/applications/coronavirus-chatbot/components/ChatbotLoadError.jsx
@@ -18,7 +18,7 @@ export default function ChatbotLoadError() {
 
   return (
     <AlertBox
-      headline="We can’t load the chatbot"
+      headline="We can't load the chatbot"
       content={alertMessage}
       status="error"
     />

--- a/src/applications/coronavirus-chatbot/tests/00-first-question.e2e.spec.js
+++ b/src/applications/coronavirus-chatbot/tests/00-first-question.e2e.spec.js
@@ -1,0 +1,28 @@
+const E2eHelpers = require('platform/testing/e2e/helpers');
+const Timeouts = require('platform/testing/e2e/timeouts');
+
+const vaAvatarMatcher = 'div#webchat div.webchat__imageAvatar__image';
+const webchatBubbleContent = 'div.webchat__bubble__content';
+const covid19PreventionButton =
+  "div#webchat button[aria-label='COVID-19 prevention']";
+const responseBubble =
+  "//div[@id='webchat']//div[@class='webchat__bubble__content']//strong[contains(text(), 'What question')]";
+const coronavirusChatbotPath = '/coronavirus-chatbot/';
+
+module.exports = E2eHelpers.createE2eTest(client => {
+  client
+    .openUrl(`${E2eHelpers.baseUrl}${coronavirusChatbotPath}`)
+    .waitForElementVisible('body', Timeouts.verySlow)
+    .assert.title('VA coronavirus chatbot | Veterans Affairs')
+    .waitForElementVisible(vaAvatarMatcher, 45000)
+    .assert.containsText(webchatBubbleContent, 'Before we get started')
+    .click(covid19PreventionButton)
+    .useXpath()
+    .waitForElementVisible(responseBubble, Timeouts.normal)
+    .assert.containsText(
+      responseBubble,
+      'What question can we answer for you first?',
+    )
+    .axeCheck('.main')
+    .end();
+});

--- a/src/applications/coronavirus-chatbot/tests/00-first-question.e2e.spec.js
+++ b/src/applications/coronavirus-chatbot/tests/00-first-question.e2e.spec.js
@@ -17,6 +17,7 @@ module.exports = E2eHelpers.createE2eTest(client => {
     .waitForElementVisible(vaAvatarMatcher, 45000)
     .assert.containsText(webchatBubbleContent, 'Before we get started')
     .click(covid19PreventionButton)
+    .assert.attributeEquals(covid19PreventionButton, 'disabled', 'true')
     .useXpath()
     .waitForElementVisible(responseBubble, Timeouts.normal)
     .assert.containsText(

--- a/src/applications/coronavirus-chatbot/tests/00-load-error.e2e.spec.js
+++ b/src/applications/coronavirus-chatbot/tests/00-load-error.e2e.spec.js
@@ -21,7 +21,7 @@ module.exports = E2eHelpers.createE2eTest(client => {
     .openUrl(`${E2eHelpers.baseUrl}${coronavirusChatbotPath}`)
     .waitForElementVisible('body', Timeouts.verySlow)
     .assert.title('VA coronavirus chatbot | Veterans Affairs')
-    .waitForElementVisible(loadError, 45000)
+    .waitForElementVisible(loadError, Timeouts.normal)
     .assert.containsText(loadErrorHeading, "We can't load the chatbot")
     .axeCheck('.main')
     .end();

--- a/src/applications/coronavirus-chatbot/tests/00-load-error.e2e.spec.js
+++ b/src/applications/coronavirus-chatbot/tests/00-load-error.e2e.spec.js
@@ -1,0 +1,28 @@
+const E2eHelpers = require('platform/testing/e2e/helpers');
+const Timeouts = require('platform/testing/e2e/timeouts');
+
+const loadError = 'div.usa-alert.usa-alert-error';
+const loadErrorHeading = 'h3.usa-alert-heading';
+const coronavirusChatbotPath = '/coronavirus-chatbot/';
+
+module.exports = E2eHelpers.createE2eTest(client => {
+  client.mockData({
+    path: '/v0/feature_toggles',
+    verb: 'get',
+    value: {
+      data: {
+        features: [],
+        type: 'feature_toggles',
+      },
+    },
+  });
+
+  client
+    .openUrl(`${E2eHelpers.baseUrl}${coronavirusChatbotPath}`)
+    .waitForElementVisible('body', Timeouts.verySlow)
+    .assert.title('VA coronavirus chatbot | Veterans Affairs')
+    .waitForElementVisible(loadError, 45000)
+    .assert.containsText(loadErrorHeading, "We can't load the chatbot")
+    .axeCheck('.main')
+    .end();
+});

--- a/src/applications/coronavirus-chatbot/tests/01-first-question.e2e.spec.js
+++ b/src/applications/coronavirus-chatbot/tests/01-first-question.e2e.spec.js
@@ -5,6 +5,9 @@ const vaAvatarMatcher = 'div#webchat div.webchat__imageAvatar__image';
 const webchatBubbleContent = 'div.webchat__bubble__content';
 const covid19PreventionButton =
   "div#webchat button[aria-label='COVID-19 prevention']";
+const benefitsAndClaimsButton =
+  "div#webchat button[aria-label='Benefits and claims']";
+const wearMaskButton = "div#webchat button[aria-label='Should I wear a mask?']";
 const responseBubble =
   "//div[@id='webchat']//div[@class='webchat__bubble__content']//strong[contains(text(), 'What question')]";
 const coronavirusChatbotPath = '/coronavirus-chatbot/';
@@ -17,13 +20,21 @@ module.exports = E2eHelpers.createE2eTest(client => {
     .waitForElementVisible(vaAvatarMatcher, 45000)
     .assert.containsText(webchatBubbleContent, 'Before we get started')
     .click(covid19PreventionButton)
-    .assert.attributeEquals(covid19PreventionButton, 'disabled', 'true')
+    .assert.isDisabledElement(covid19PreventionButton, true)
+    .assert.isDisabledElement(benefitsAndClaimsButton, true)
     .useXpath()
     .waitForElementVisible(responseBubble, Timeouts.normal)
     .assert.containsText(
       responseBubble,
       'What question can we answer for you first?',
     )
+    .useCss()
+    .assert.isDisabledElement(wearMaskButton, false)
+    .click(wearMaskButton)
+    .assert.isDisabledElement(wearMaskButton, true)
     .axeCheck('.main')
     .end();
 });
+
+// Note: This test requires the real API. Run locally with yarn watch --env.api=https://dev-api.va.gov
+module.exports['@disabled'] = true;

--- a/src/applications/coronavirus-chatbot/tests/components/ChatbotLoadError.unit.spec.jsx
+++ b/src/applications/coronavirus-chatbot/tests/components/ChatbotLoadError.unit.spec.jsx
@@ -14,7 +14,7 @@ describe('ChatbotLoadError <ChatbotLoadError>', () => {
       'If it still doesn’t work, you may need to clear your internet browser’s history (sometimes called “cached data”). You can find how to do this within your browser’s privacy and security settings.';
 
     expect(alertBox.length).to.equal(1);
-    expect(alertBox.prop('headline')).to.equal('We can’t load the chatbot');
+    expect(alertBox.prop('headline')).to.equal("We can't load the chatbot");
     expect(alertMessageContent.children[0].props.children).to.equal(
       alertMessageParagraphOne,
     );


### PR DESCRIPTION
## Description
[department-of-veterans-affairs/covid19-chatbot#265]

- UI test for error component that will run in CI
- UI test for happy path (checks button clicks & disabling) disabled in CI because it requires the real API to get a token and run chatbot

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
