### PR TITLE
[Form Tester] Expose testKey alias.

### DIFF
--- a/src/platform/testing/e2e/cypress/support/form-tester/index.js
+++ b/src/platform/testing/e2e/cypress/support/form-tester/index.js
@@ -487,6 +487,7 @@ const testForm = testConfig => {
     dataSets.forEach(testKey => {
       context(testKey, () => {
         beforeEach(() => {
+          cy.wrap(testKey).as('testKey');
           cy.fixture(`data/${testKey}`)
             .then(extractTestData)
             .as('testData')


### PR DESCRIPTION
## Description
Made `testKey` available so tests can be conditionally set up based on the test or data set name.

## Testing done
Tested with HCA that the alias is available.

## Acceptance criteria
- [ ] Form tests should be able to do conditional setups for specific data sets.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
