### PR TITLE
[Development] Add MVI call to add person

### DIFF
--- a/src/applications/disability-benefits/all-claims/Form526EZApp.jsx
+++ b/src/applications/disability-benefits/all-claims/Form526EZApp.jsx
@@ -6,8 +6,11 @@ import RequiredLoginView from 'platform/user/authorization/components/RequiredLo
 import backendServices from 'platform/user/profile/constants/backendServices';
 
 import formConfig from './config/form';
+import AddPerson from './containers/AddPerson';
 import ITFWrapper from './containers/ITFWrapper';
 import { MissingServices } from './containers/MissingServices';
+
+import { MVI_ADD_SUCCEEDED } from './actions';
 
 export const serviceRequired = [
   backendServices.FORM526,
@@ -17,7 +20,7 @@ export const serviceRequired = [
 export const hasRequiredServices = user =>
   serviceRequired.some(service => user.profile.services.includes(service));
 
-export function Form526Entry({ location, user, children }) {
+export function Form526Entry({ location, user, children, mvi }) {
   // wraps the app and redirects user if they are not enrolled
   const content = (
     <RoutedSavableApp formConfig={formConfig} currentLocation={location}>
@@ -29,8 +32,17 @@ export function Form526Entry({ location, user, children }) {
   if (!user.login.currentlyLoggedIn) {
     return content;
   }
+  // "add-person" service means the user has a edipi and SSN in the system, but
+  // is missing either a BIRLS or participant ID
+  if (
+    user.profile.services.includes('add-person') &&
+    mvi?.addPersonState !== MVI_ADD_SUCCEEDED
+  ) {
+    return <AddPerson />;
+  }
+
   // RequiredLoginView checks if you're verified and shows the appropriate link
-  // user 2 doesn't have the required services. Show an alert
+  // test user 2 doesn't have the required services. Show an alert
   if (user.profile.verified && !hasRequiredServices(user)) {
     return <MissingServices />;
   }
@@ -43,6 +55,7 @@ export function Form526Entry({ location, user, children }) {
 
 const mapStateToProps = state => ({
   user: state.user,
+  mvi: state.mvi,
 });
 
 export default connect(mapStateToProps)(Form526Entry);

--- a/src/applications/disability-benefits/all-claims/actions/index.js
+++ b/src/applications/disability-benefits/all-claims/actions/index.js
@@ -35,3 +35,23 @@ export function createITF() {
       });
   };
 }
+
+// "add-person" service means the user has a edipi and SSN in the system, but
+// is missing either a BIRLS or participant ID
+export const MVI_ADD_NOT_ATTEMPTED = 'MVI_ADD_NOT_ATTEMPTED';
+export const MVI_ADD_INITIATED = 'MVI_ADD_INITIATED';
+export const MVI_ADD_SUCCEEDED = 'MVI_ADD_SUCCEEDED';
+export const MVI_ADD_FAILED = 'MVI_ADD_FAILED';
+
+export function addPerson() {
+  return dispatch => {
+    dispatch({ type: MVI_ADD_INITIATED });
+
+    return apiRequest('/mvi_users/21-0966', { method: 'POST' })
+      .then(({ data }) => dispatch({ type: MVI_ADD_SUCCEEDED, data }))
+      .catch(() => {
+        Sentry.captureMessage('mvi_add_failed');
+        dispatch({ type: MVI_ADD_FAILED });
+      });
+  };
+}

--- a/src/applications/disability-benefits/all-claims/containers/AddPerson.jsx
+++ b/src/applications/disability-benefits/all-claims/containers/AddPerson.jsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+
+import LoadingIndicator from '@department-of-veterans-affairs/formation-react/LoadingIndicator';
+import { MissingServices } from './MissingServices';
+
+import {
+  addPerson as addPersonAction,
+  MVI_ADD_NOT_ATTEMPTED,
+  MVI_ADD_INITIATED,
+  MVI_ADD_SUCCEEDED,
+  MVI_ADD_FAILED,
+} from '../actions';
+
+const message =
+  'We’re doing some additional work to enable you to file a claim...';
+
+const loading = (
+  <div className="vads-u-margin--3">
+    <LoadingIndicator message={message} />
+  </div>
+);
+
+export const AddPerson = props => {
+  switch (props?.mvi?.addPersonState) {
+    case MVI_ADD_NOT_ATTEMPTED:
+      props.addPerson();
+      return null;
+    case MVI_ADD_INITIATED:
+      return loading;
+    case MVI_ADD_FAILED:
+      return <MissingServices />;
+    case MVI_ADD_SUCCEEDED:
+      // remove 'add-person' user.profile.services here?
+      return null;
+    default:
+      return null;
+  }
+};
+
+AddPerson.propTypes = {
+  addPerson: PropTypes.func.isRequired,
+};
+
+const mapDispatchToProps = {
+  addPerson: addPersonAction,
+};
+
+export default connect(
+  state => state,
+  mapDispatchToProps,
+)(AddPerson);

--- a/src/applications/disability-benefits/all-claims/reducers/index.js
+++ b/src/applications/disability-benefits/all-claims/reducers/index.js
@@ -1,4 +1,5 @@
 import itf from './itf';
+import mvi from './mvi';
 import formConfig from '../config/form';
 
 import { createSaveInProgressFormReducer } from 'platform/forms/save-in-progress/reducers';
@@ -6,4 +7,5 @@ import { createSaveInProgressFormReducer } from 'platform/forms/save-in-progress
 export default {
   form: createSaveInProgressFormReducer(formConfig),
   itf,
+  mvi,
 };

--- a/src/applications/disability-benefits/all-claims/reducers/mvi.js
+++ b/src/applications/disability-benefits/all-claims/reducers/mvi.js
@@ -1,0 +1,25 @@
+import set from 'platform/utilities/data/set';
+import {
+  MVI_ADD_NOT_ATTEMPTED,
+  MVI_ADD_INITIATED,
+  MVI_ADD_SUCCEEDED,
+  MVI_ADD_FAILED,
+} from '../actions';
+
+const initialState = {
+  addPersonState: MVI_ADD_NOT_ATTEMPTED,
+};
+
+export default (state = initialState, action) => {
+  switch (action.type) {
+    case MVI_ADD_INITIATED:
+      return set('addPersonState', MVI_ADD_INITIATED, state);
+    case MVI_ADD_SUCCEEDED: {
+      return set('addPersonState', MVI_ADD_SUCCEEDED, state);
+    }
+    case MVI_ADD_FAILED:
+      return set('addPersonState', MVI_ADD_FAILED, state);
+    default:
+      return state;
+  }
+};

--- a/src/applications/disability-benefits/all-claims/tests/actions/actions.unit.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/actions/actions.unit.spec.js
@@ -12,6 +12,10 @@ import {
   ITF_CREATION_INITIATED,
   ITF_CREATION_SUCCEEDED,
   ITF_CREATION_FAILED,
+  addPerson,
+  MVI_ADD_INITIATED,
+  MVI_ADD_SUCCEEDED,
+  MVI_ADD_FAILED,
 } from '../../actions';
 
 const originalFetch = global.fetch;
@@ -75,6 +79,37 @@ describe('ITF actions', () => {
           ITF_CREATION_INITIATED,
         );
         expect(dispatch.secondCall.args[0].type).to.eql(ITF_CREATION_FAILED);
+      });
+    });
+  });
+});
+
+describe('MVI action', () => {
+  describe('MVI add person action', () => {
+    afterEach(() => {
+      global.fetch = originalFetch;
+    });
+
+    it('should dispatch an add person succeeded action', () => {
+      const mockData = { data: 'asdf' };
+      mockApiRequest(mockData);
+      const dispatch = sinon.spy();
+      return addPerson()(dispatch).then(() => {
+        expect(dispatch.firstCall.args[0].type).to.equal(MVI_ADD_INITIATED);
+        expect(dispatch.secondCall.args[0]).to.eql({
+          type: MVI_ADD_SUCCEEDED,
+          data: mockData.data,
+        });
+      });
+    });
+
+    it('should dispatch an add person failed action', () => {
+      const mockData = { data: 'asdf' };
+      mockApiRequest(mockData, false);
+      const dispatch = sinon.spy();
+      return addPerson()(dispatch).then(() => {
+        expect(dispatch.firstCall.args[0].type).to.equal(MVI_ADD_INITIATED);
+        expect(dispatch.secondCall.args[0].type).to.equal(MVI_ADD_FAILED);
       });
     });
   });

--- a/src/applications/disability-benefits/all-claims/tests/reducers.unit.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/reducers.unit.spec.js
@@ -11,6 +11,10 @@ import {
   ITF_CREATION_INITIATED,
   ITF_CREATION_SUCCEEDED,
   ITF_CREATION_FAILED,
+  MVI_ADD_NOT_ATTEMPTED,
+  MVI_ADD_INITIATED,
+  MVI_ADD_SUCCEEDED,
+  MVI_ADD_FAILED,
 } from '../actions';
 
 import reducers from '../reducers';
@@ -164,5 +168,27 @@ describe('ITF reducer', () => {
   it('should handle ITF_CREATION_FAILED', () => {
     const newState = itf(initialState, { type: ITF_CREATION_FAILED });
     expect(newState.creationCallState).to.equal(requestStates.failed);
+  });
+});
+
+describe('MVI reducer', () => {
+  const { mvi } = reducers;
+  const mviInitialState = {
+    addPersonState: MVI_ADD_NOT_ATTEMPTED,
+  };
+
+  it('should handle ITF_CREATION_INITIATED', () => {
+    const newState = mvi(mviInitialState, { type: MVI_ADD_INITIATED });
+    expect(newState.addPersonState).to.equal(MVI_ADD_INITIATED);
+  });
+
+  it('should handle ITF_CREATION_SUCCEEDED', () => {
+    const newState = mvi(mviInitialState, { type: MVI_ADD_SUCCEEDED });
+    expect(newState.addPersonState).to.equal(MVI_ADD_SUCCEEDED);
+  });
+
+  it('should handle ITF_CREATION_FAILED', () => {
+    const newState = mvi(mviInitialState, { type: MVI_ADD_FAILED });
+    expect(newState.addPersonState).to.equal(MVI_ADD_FAILED);
   });
 });


### PR DESCRIPTION
## Description

Some users applying for disability benefits will have their SSN & EDIPI in the system, but may be missing an EDIPI or Participant ID. A new [MVI add person endpoint](https://department-of-veterans-affairs.github.io/va-digital-services-platform-docs/api-reference/#/form_526/postMviUser) has been added in attempts to add these missing IDs before the user starts the form which them immediately tries to submit an intent-to-file (which will fail without one of those IDs).

Related ticket: https://github.com/department-of-veterans-affairs/va.gov-team/issues/10237

## Testing done

Added unit tests for all new code

## Screenshots

<details><summary>Spinner while making add person call</summary>

<!-- leave a blank line above -->
![Screen Shot 2020-06-18 at 6 28 47 PM](https://user-images.githubusercontent.com/136959/85081501-c4e5f300-b191-11ea-8ef7-8f08251442c3.png)</details>

<details><summary>Error message shown when add person call fails</summary>

<!-- leave a blank line above -->
<br />
** NOTE ** This is a screenshot of the current content; there is an update to this content in https://github.com/department-of-veterans-affairs/vets-website/pull/12839 which is on hold until June 30, 2020 while the help desk personnel receive training
<br />
<br />
** NOTE 2** This same alert is shown if the user is not allowed to file form 526 for any reason

![Screen Shot 2020-06-18 at 6 21 47 PM](https://user-images.githubusercontent.com/136959/85081211-f4e0c680-b190-11ea-8a86-ceda4cb36deb.png)</details>

## Acceptance criteria
- [ ] Add person call made if user has an `add-person` service
- [ ] All unit tests passing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
