### PR TITLE
Add unauth get medical records page

### DIFF
--- a/src/applications/static-pages/health-care-manage-benefits/get-medical-records-page/components/App/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/get-medical-records-page/components/App/index.js
@@ -5,15 +5,7 @@ import './styles.scss';
 import CallToActionWidget from 'platform/site-wide/cta-widget';
 
 export const App = () => (
-  <article className="usa-content">
-    <h1>Get your VA medical records online</h1>
-    <div className="va-introtext">
-      <p>
-        Our online tools can help you view, organize, and share your VA medical
-        records and personal health information. Find out if you’re eligible and
-        how to sign in to start using these tools.
-      </p>
-    </div>
+  <>
     <div
       data-template="paragraphs/wysiwyg"
       data-entity-id={3369}
@@ -561,7 +553,7 @@ export const App = () => (
         </div>
       </div>
     </div>
-  </article>
+  </>
 );
 
 export default App;

--- a/src/applications/static-pages/health-care-manage-benefits/get-medical-records-page/components/App/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/get-medical-records-page/components/App/index.js
@@ -1,0 +1,567 @@
+// Node modules.
+import React from 'react';
+// Relative imports.
+import './styles.scss';
+import CallToActionWidget from 'platform/site-wide/cta-widget';
+
+const App = () => (
+  <article className="usa-content">
+    <h1>Get your VA medical records online</h1>
+    <div className="va-introtext">
+      <p>
+        Our online tools can help you view, organize, and share your VA medical
+        records and personal health information. Find out if you’re eligible and
+        how to sign in to start using these tools.
+      </p>
+    </div>
+    <div
+      data-template="paragraphs/wysiwyg"
+      data-entity-id={3369}
+      className="processed-content"
+    >
+      <h2 id="va-blue-button">VA Blue Button</h2>
+    </div>
+    <CallToActionWidget appId="health-records" setFocus={false} />
+    <div data-template="paragraphs/q_a_section" data-entity-id={3372}>
+      <h2 id="more-about-va-blue-button">More about VA Blue Button</h2>
+      <div
+        itemScope
+        itemType="http://schema.org/Question"
+        data-template="paragraphs/q_a"
+        data-entity-id={3373}
+        data-analytics-faq-section="More about VA Blue Button"
+        data-analytics-faq-text="What's VA Blue Button, and how can it help me manage my health care?"
+      >
+        <h3 itemProp="name" id="whats-va-blue-button-and-how-c">
+          What's VA Blue Button, and how can it help me manage my health care?
+        </h3>
+        <div
+          data-entity-id={3373}
+          itemProp="acceptedAnswer"
+          itemScope
+          itemType="http://schema.org/Answer"
+        >
+          <div itemProp="text">
+            <div
+              data-template="paragraphs/wysiwyg"
+              data-entity-id={3374}
+              className="processed-content"
+            >
+              <p>
+                VA Blue Button is a feature of the health management portal
+                within My HealtheVet. It lets you view, print, save, download,
+                and share information from your VA medical record and personal
+                health record. With this tool, you can better manage your health
+                needs and communicate with your health care team.
+              </p>
+              <p>
+                <strong>With VA Blue Button, you can:</strong>
+              </p>
+              <ul>
+                <li>
+                  Download a customized Blue Button report with information from
+                  your VA medical records, personal health record, and in some
+                  cases your military service record
+                </li>
+                <li>
+                  Download a Health Summary that includes specific information
+                  from your VA medical record (like your known allergies,
+                  medications, and recent lab results)
+                </li>
+                <li>
+                  Build your own personal health record that includes
+                  information like your self-entered medical history, emergency
+                  contacts, and medicines
+                </li>
+                <li>
+                  Monitor your vital signs and track your diet and exercise with
+                  our online journals
+                </li>
+                <li>
+                  Share a digital copy of the personal health information you
+                  entered yourself with your VA health care team through Secure
+                  Messaging
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        itemScope
+        itemType="http://schema.org/Question"
+        data-template="paragraphs/q_a"
+        data-entity-id={3375}
+        data-analytics-faq-section="More about VA Blue Button"
+        data-analytics-faq-text="Am I eligible to use all the features of VA Blue Button?"
+      >
+        <h3 itemProp="name" id="am-i-eligible-to-use-all-the-f">
+          Am I eligible to use all the features of VA Blue Button?
+        </h3>
+        <div
+          data-entity-id={3375}
+          itemProp="acceptedAnswer"
+          itemScope
+          itemType="http://schema.org/Answer"
+        >
+          <div itemProp="text">
+            <div
+              data-template="paragraphs/wysiwyg"
+              data-entity-id={3376}
+              className="processed-content"
+            >
+              <p>
+                You can use all the features of this tool if you meet all of the
+                requirements listed below.
+              </p>
+              <p>
+                <strong>Both of these must be true. You’re:</strong>
+              </p>
+              <ul>
+                <li>
+                  Are enrolled in VA health care, <strong>and</strong>
+                </li>
+                <li>Are registered as a patient in a VA health facility</li>
+              </ul>
+              <p>
+                <a href="/health-care/how-to-apply/">
+                  Find out how to apply for VA health care
+                </a>
+              </p>
+              <p>
+                <strong>And you must have one of these free accounts:</strong>
+              </p>
+              <ul>
+                <li>
+                  A{' '}
+                  <a href="">
+                    Premium <strong>My HealtheVet account</strong>
+                  </a>
+                  , <strong>or</strong>
+                </li>
+                <li>
+                  A Premium <strong>DS Logon</strong> account (used for
+                  eBenefits and milConnect), <strong>or</strong>
+                </li>
+                <li>
+                  A verified <strong>ID.me</strong> account that you can create
+                  here on VA.gov
+                </li>
+              </ul>
+              <p>
+                <strong>Note:</strong> If you sign in with a Basic or Advanced
+                account, you&apos;ll see only the results you&apos;ve entered
+                yourself.
+                <br />
+                <a
+                  href="https://www.myhealth.va.gov/mhv-portal-web/my-healthevet-offers-three-account-types"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Learn about the 3 different My HealtheVet account types
+                </a>
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        itemScope
+        itemType="http://schema.org/Question"
+        data-template="paragraphs/q_a"
+        data-entity-id={3377}
+        data-analytics-faq-section="More about VA Blue Button"
+        data-analytics-faq-text="Once I’m signed in, how do I get to my medical records?"
+      >
+        <h3 itemProp="name" id="once-im-signed-in-how-do-i-get">
+          Once I’m signed in, how do I get to my medical records?
+        </h3>
+        <div
+          data-entity-id={3377}
+          itemProp="acceptedAnswer"
+          itemScope
+          itemType="http://schema.org/Answer"
+        >
+          <div itemProp="text">
+            <div
+              data-template="paragraphs/wysiwyg"
+              data-entity-id={3378}
+              className="processed-content"
+            >
+              <p>
+                Go to your Welcome page dashboard, and click on “Health
+                Records.” You’ll go to a new page.
+              </p>
+              <p>
+                From here, you can choose to access your VA Blue Button report,
+                your VA Health Summary, or your VA Medical Images and Reports.
+              </p>
+              <p>
+                If you’d like to add information to your personal health record,
+                click on “Track Health” in the blue navigation menu at the top
+                of the page. You’ll go to a new page where you can choose to
+                record information like your vital signs, health history, goals,
+                and food and exercise efforts.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        itemScope
+        itemType="http://schema.org/Question"
+        data-template="paragraphs/q_a"
+        data-entity-id={3379}
+        data-analytics-faq-section="More about VA Blue Button"
+        data-analytics-faq-text="Will my personal health information be protected?"
+      >
+        <h3 itemProp="name" id="will-my-personal-health-inform">
+          Will my personal health information be protected?
+        </h3>
+        <div
+          data-entity-id={3379}
+          itemProp="acceptedAnswer"
+          itemScope
+          itemType="http://schema.org/Answer"
+        >
+          <div itemProp="text">
+            <div
+              data-template="paragraphs/wysiwyg"
+              data-entity-id={3380}
+              className="processed-content"
+            >
+              <p>
+                Yes. This is a secure website. We follow strict security
+                policies and practices to protect your personal health
+                information.
+              </p>
+              <p>
+                If you print or download anything from the website, you’ll need
+                to take responsibility for protecting that information.
+                <br />
+                <a
+                  href="https://www.myhealth.va.gov/mhv-portal-web/web/myhealthevet/protecting-your-personal-health-information"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Get tips for protecting your personal health information
+                </a>
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        itemScope
+        itemType="http://schema.org/Question"
+        data-template="paragraphs/q_a"
+        data-entity-id={3381}
+        data-analytics-faq-section="More about VA Blue Button"
+        data-analytics-faq-text="What if I have more questions?"
+      >
+        <h3 itemProp="name" id="what-if-i-have-more-questions">
+          What if I have more questions?
+        </h3>
+        <div
+          data-entity-id={3381}
+          itemProp="acceptedAnswer"
+          itemScope
+          itemType="http://schema.org/Answer"
+        >
+          <div itemProp="text">
+            <div
+              data-template="paragraphs/wysiwyg"
+              data-entity-id={3382}
+              className="processed-content"
+            >
+              <p>
+                You can get answers to frequently asked questions about VA Blue
+                Button and related tools within My HealtheVet.
+              </p>
+              <p>
+                <a
+                  href="https://www.myhealth.va.gov/mhv-portal-web/web/myhealthevet/faqs#bbtop"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Read VA Blue Button FAQs
+                </a>
+                <br />
+                <a
+                  href="https://www.myhealth.va.gov/mhv-portal-web/faqs#CCD"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Read VA Health Summary FAQs
+                </a>
+                <br />
+                <a
+                  href="https://www.myhealth.va.gov/mhv-portal-web/faqs#VAMIR"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Read VA Medical Images and Reports FAQs
+                </a>
+              </p>
+              <p>
+                You can also contact the My HealtheVet help desk.
+                <br />
+                <a
+                  href="https://www.myhealth.va.gov/mhv-portal-web/web/myhealthevet/contact-mhv"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Find out how to contact us online
+                </a>
+              </p>
+              <p>
+                Or call us at <a href="tel:+18773270022">877-327-0022</a> (TTY:{' '}
+                <a href="tel:+18008778339">800-877-8339</a>
+                ). We’re here Monday through Friday, 8:00 a.m. to 8:00 p.m. ET.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div data-template="paragraphs/q_a_section" data-entity-id={3383}>
+      <h2 id="the-veterans-health-informatio">
+        The Veterans Health Information Exchange
+      </h2>
+      <div
+        itemScope
+        itemType="http://schema.org/Question"
+        data-template="paragraphs/q_a"
+        data-entity-id={9811}
+        data-analytics-faq-section="The Veterans Health Information Exchange"
+        data-analytics-faq-text="What's the Veterans Health Information Exchange (VHIE), and how can it help me manage my health care?"
+      >
+        <h3 itemProp="name" id="whats-the-veterans-health-info">
+          What is the Veterans Health Information Exchange (VHIE), and how can
+          it help me manage my health care?
+        </h3>
+        <div
+          data-entity-id={9811}
+          itemProp="acceptedAnswer"
+          itemScope
+          itemType="http://schema.org/Answer"
+        >
+          <div itemProp="text">
+            <div
+              data-template="paragraphs/wysiwyg"
+              data-entity-id={9810}
+              className="processed-content"
+            >
+              <p>
+                The Veterans Health Information Exchange (VHIE) program lets us
+                share your health information with participating community care
+                providers and the Department of Defense. For example, when you
+                leave activey-duty service, retire, or leave the Reserves and
+                then get health care at VA or a VA-approved community care
+                provider, your health record would electronically follow you.
+              </p>
+              <p>
+                This program is voluntary, and you can choose not to share your
+                information. If you choose not to share your information but
+                change your mind later, you can opt back in to sharing your
+                information at any time.
+              </p>
+              <p>
+                <strong>The sharing of health information:</strong>
+              </p>
+              <ul>
+                <li>
+                  Helps your VA and non-VA providers better coordinate your
+                  care.
+                </li>
+                <li>Keeps your personal health information more secure.</li>
+                <li>
+                  Improves your care by helping your providers make mroe
+                  informed decisions.
+                </li>
+                <li>
+                  Ensures your providers have up-to-date information, like your
+                  current medications and allergies.
+                </li>
+                <li>Saves you time and money.</li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        itemScope
+        itemType="http://schema.org/Question"
+        data-template="paragraphs/q_a"
+        data-entity-id={9809}
+        data-analytics-faq-section="The Veterans Health Information Exchange"
+        data-analytics-faq-text="VHIE sharing options"
+      >
+        <h3 itemProp="name" id="vhie-sharing-options">
+          Can I opt out of sharing my information?
+        </h3>
+        <div
+          data-entity-id={9809}
+          itemProp="acceptedAnswer"
+          itemScope
+          itemType="http://schema.org/Answer"
+        >
+          <div itemProp="text">
+            <div
+              data-template="paragraphs/wysiwyg"
+              data-entity-id={9808}
+              className="processed-content"
+            >
+              <p>Yes. You can opt out of sharing by mail or in person.</p>
+              <h4>To opt out by mail</h4>
+              <p>
+                Fill out, sign, and date VA Form 10-10164 (Opt Out of Sharing
+                Protected Health Information).
+              </p>
+              <p>
+                <a href="https://va.gov/vaforms/medical/pdf/10-10164-fill.pdf">
+                  Download VA Form 10-10164 (PDF)
+                </a>
+              </p>
+              <br />
+              <p>
+                Mail the completed form to the Release of Information (ROI)
+                office at your nearest VA medical center.
+              </p>
+              <p>
+                <a href="">
+                  Find the address for your nearest VA medical center
+                </a>
+              </p>
+              <h4>To opt out in person</h4>
+              <p>Visit your VA medical center&apos;s ROI office.</p>
+              <p>
+                Bring a completed VA Form 10-10164 with you, or ask for a copy
+                to fill out in the office. Give your completed, signed form to
+                an office staff member.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        itemScope
+        itemType="http://schema.org/Question"
+        data-template="paragraphs/q_a"
+        data-entity-id={9889}
+        data-analytics-faq-section="The Veterans Health Information Exchange"
+        data-analytics-faq-text="Can I change my mind if I want to share my information later?"
+      >
+        <h3 itemProp="name" id="can-i-change-my-mind-share-information-later">
+          Can I change my mind if I want to share my information later?
+        </h3>
+        <div
+          data-entity-id={9889}
+          itemProp="acceptedAnswer"
+          itemScope
+          itemType="http://schema.org/Answer"
+        >
+          <div itemProp="text">
+            <div
+              data-template="paragraphs/wysiwyg"
+              data-entity-id={9888}
+              className="processed-content"
+            >
+              <p>
+                Yes. If you change your mind and want to share your health
+                information, complete and submit VA Form 10-10163 (Request for
+                and Permission to Participate in Sharing Protected Health
+                Information).
+              </p>
+              <p>
+                <a href="https://va.gov/vaforms/medical/pdf/10-10163-fill.pdf">
+                  Download VA Form 10-10163 (PDF)
+                </a>
+              </p>
+              <p>
+                Mail or take this form in person to the Release of Information
+                (ROI) office at your nearest VA medical center.
+              </p>
+              <p>
+                <a href="">
+                  Find the address of your nearest VA medical center
+                </a>
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        itemScope
+        itemType="http://schema.org/Question"
+        data-template="paragraphs/q_a"
+        data-entity-id={9891}
+        data-analytics-faq-section="The Veterans Health Information Exchange"
+        data-analytics-faq-text="Will my personal health information be protected?"
+      >
+        <h3
+          itemProp="name"
+          id="will-my-personal-health-information-be-protected"
+        >
+          Will my personal health information be protected?
+        </h3>
+        <div
+          data-entity-id={9891}
+          itemProp="acceptedAnswer"
+          itemScope
+          itemType="http://schema.org/Answer"
+        >
+          <div itemProp="text">
+            <div
+              data-template="paragraphs/wysiwyg"
+              data-entity-id={9890}
+              className="processed-content"
+            >
+              <p>
+                Yes. The Veterans Health Information Exchange uses secure
+                technology to share information between VA and participating
+                community health care providers who treat you. We share
+                information only with community care providers and organizations
+                that have partnership agreements with us and are part of our
+                approved, trusted network.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        itemScope
+        itemType="http://schema.org/Question"
+        data-template="paragraphs/q_a"
+        data-entity-id={10274}
+        data-analytics-faq-section="The Veterans Health Information Exchange"
+        data-analytics-faq-text="What if I have more questions?"
+      >
+        <h3 itemProp="name" id="what-if-i-have-more-questions">
+          What if I have more questions?
+        </h3>
+        <div
+          data-entity-id={10274}
+          itemProp="acceptedAnswer"
+          itemScope
+          itemType="http://schema.org/Answer"
+        >
+          <div itemProp="text">
+            <div
+              data-template="paragraphs/wysiwyg"
+              data-entity-id={10273}
+              className="processed-content"
+            >
+              <p>
+                Call us toll-free at <a href="tel:+18446982311">844-698-2311</a>
+                .
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </article>
+);
+
+export default App;

--- a/src/applications/static-pages/health-care-manage-benefits/get-medical-records-page/components/App/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/get-medical-records-page/components/App/index.js
@@ -4,7 +4,7 @@ import React from 'react';
 import './styles.scss';
 import CallToActionWidget from 'platform/site-wide/cta-widget';
 
-const App = () => (
+export const App = () => (
   <article className="usa-content">
     <h1>Get your VA medical records online</h1>
     <div className="va-introtext">

--- a/src/applications/static-pages/health-care-manage-benefits/get-medical-records-page/components/App/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/get-medical-records-page/components/App/index.js
@@ -6,39 +6,23 @@ import CallToActionWidget from 'platform/site-wide/cta-widget';
 
 export const App = () => (
   <>
-    <div
-      data-template="paragraphs/wysiwyg"
-      data-entity-id={3369}
-      className="processed-content"
-    >
+    <div className="processed-content">
       <h2 id="va-blue-button">VA Blue Button</h2>
     </div>
     <CallToActionWidget appId="health-records" setFocus={false} />
-    <div data-template="paragraphs/q_a_section" data-entity-id={3372}>
+    <div>
       <h2 id="more-about-va-blue-button">More about VA Blue Button</h2>
-      <div
-        itemScope
-        itemType="http://schema.org/Question"
-        data-template="paragraphs/q_a"
-        data-entity-id={3373}
-        data-analytics-faq-section="More about VA Blue Button"
-        data-analytics-faq-text="What's VA Blue Button, and how can it help me manage my health care?"
-      >
+      <div itemScope itemType="http://schema.org/Question">
         <h3 itemProp="name" id="whats-va-blue-button-and-how-c">
           What's VA Blue Button, and how can it help me manage my health care?
         </h3>
         <div
-          data-entity-id={3373}
           itemProp="acceptedAnswer"
           itemScope
           itemType="http://schema.org/Answer"
         >
           <div itemProp="text">
-            <div
-              data-template="paragraphs/wysiwyg"
-              data-entity-id={3374}
-              className="processed-content"
-            >
+            <div className="processed-content">
               <p>
                 VA Blue Button is a feature of the health management portal
                 within My HealtheVet. It lets you view, print, save, download,
@@ -79,29 +63,17 @@ export const App = () => (
           </div>
         </div>
       </div>
-      <div
-        itemScope
-        itemType="http://schema.org/Question"
-        data-template="paragraphs/q_a"
-        data-entity-id={3375}
-        data-analytics-faq-section="More about VA Blue Button"
-        data-analytics-faq-text="Am I eligible to use all the features of VA Blue Button?"
-      >
+      <div itemScope itemType="http://schema.org/Question">
         <h3 itemProp="name" id="am-i-eligible-to-use-all-the-f">
           Am I eligible to use all the features of VA Blue Button?
         </h3>
         <div
-          data-entity-id={3375}
           itemProp="acceptedAnswer"
           itemScope
           itemType="http://schema.org/Answer"
         >
           <div itemProp="text">
-            <div
-              data-template="paragraphs/wysiwyg"
-              data-entity-id={3376}
-              className="processed-content"
-            >
+            <div className="processed-content">
               <p>
                 You can use all the features of this tool if you meet all of the
                 requirements listed below.
@@ -157,29 +129,17 @@ export const App = () => (
           </div>
         </div>
       </div>
-      <div
-        itemScope
-        itemType="http://schema.org/Question"
-        data-template="paragraphs/q_a"
-        data-entity-id={3377}
-        data-analytics-faq-section="More about VA Blue Button"
-        data-analytics-faq-text="Once I’m signed in, how do I get to my medical records?"
-      >
+      <div itemScope itemType="http://schema.org/Question">
         <h3 itemProp="name" id="once-im-signed-in-how-do-i-get">
           Once I’m signed in, how do I get to my medical records?
         </h3>
         <div
-          data-entity-id={3377}
           itemProp="acceptedAnswer"
           itemScope
           itemType="http://schema.org/Answer"
         >
           <div itemProp="text">
-            <div
-              data-template="paragraphs/wysiwyg"
-              data-entity-id={3378}
-              className="processed-content"
-            >
+            <div className="processed-content">
               <p>
                 Go to your Welcome page dashboard, and click on “Health
                 Records.” You’ll go to a new page.
@@ -199,29 +159,17 @@ export const App = () => (
           </div>
         </div>
       </div>
-      <div
-        itemScope
-        itemType="http://schema.org/Question"
-        data-template="paragraphs/q_a"
-        data-entity-id={3379}
-        data-analytics-faq-section="More about VA Blue Button"
-        data-analytics-faq-text="Will my personal health information be protected?"
-      >
+      <div itemScope itemType="http://schema.org/Question">
         <h3 itemProp="name" id="will-my-personal-health-inform">
           Will my personal health information be protected?
         </h3>
         <div
-          data-entity-id={3379}
           itemProp="acceptedAnswer"
           itemScope
           itemType="http://schema.org/Answer"
         >
           <div itemProp="text">
-            <div
-              data-template="paragraphs/wysiwyg"
-              data-entity-id={3380}
-              className="processed-content"
-            >
+            <div className="processed-content">
               <p>
                 Yes. This is a secure website. We follow strict security
                 policies and practices to protect your personal health
@@ -243,29 +191,17 @@ export const App = () => (
           </div>
         </div>
       </div>
-      <div
-        itemScope
-        itemType="http://schema.org/Question"
-        data-template="paragraphs/q_a"
-        data-entity-id={3381}
-        data-analytics-faq-section="More about VA Blue Button"
-        data-analytics-faq-text="What if I have more questions?"
-      >
+      <div itemScope itemType="http://schema.org/Question">
         <h3 itemProp="name" id="what-if-i-have-more-questions">
           What if I have more questions?
         </h3>
         <div
-          data-entity-id={3381}
           itemProp="acceptedAnswer"
           itemScope
           itemType="http://schema.org/Answer"
         >
           <div itemProp="text">
-            <div
-              data-template="paragraphs/wysiwyg"
-              data-entity-id={3382}
-              className="processed-content"
-            >
+            <div className="processed-content">
               <p>
                 You can get answers to frequently asked questions about VA Blue
                 Button and related tools within My HealtheVet.
@@ -316,34 +252,22 @@ export const App = () => (
         </div>
       </div>
     </div>
-    <div data-template="paragraphs/q_a_section" data-entity-id={3383}>
+    <div>
       <h2 id="the-veterans-health-informatio">
         The Veterans Health Information Exchange
       </h2>
-      <div
-        itemScope
-        itemType="http://schema.org/Question"
-        data-template="paragraphs/q_a"
-        data-entity-id={9811}
-        data-analytics-faq-section="The Veterans Health Information Exchange"
-        data-analytics-faq-text="What's the Veterans Health Information Exchange (VHIE), and how can it help me manage my health care?"
-      >
+      <div itemScope itemType="http://schema.org/Question">
         <h3 itemProp="name" id="whats-the-veterans-health-info">
           What is the Veterans Health Information Exchange (VHIE), and how can
           it help me manage my health care?
         </h3>
         <div
-          data-entity-id={9811}
           itemProp="acceptedAnswer"
           itemScope
           itemType="http://schema.org/Answer"
         >
           <div itemProp="text">
-            <div
-              data-template="paragraphs/wysiwyg"
-              data-entity-id={9810}
-              className="processed-content"
-            >
+            <div className="processed-content">
               <p>
                 The Veterans Health Information Exchange (VHIE) program lets us
                 share your health information with participating community care
@@ -381,29 +305,17 @@ export const App = () => (
           </div>
         </div>
       </div>
-      <div
-        itemScope
-        itemType="http://schema.org/Question"
-        data-template="paragraphs/q_a"
-        data-entity-id={9809}
-        data-analytics-faq-section="The Veterans Health Information Exchange"
-        data-analytics-faq-text="VHIE sharing options"
-      >
+      <div itemScope itemType="http://schema.org/Question">
         <h3 itemProp="name" id="vhie-sharing-options">
           Can I opt out of sharing my information?
         </h3>
         <div
-          data-entity-id={9809}
           itemProp="acceptedAnswer"
           itemScope
           itemType="http://schema.org/Answer"
         >
           <div itemProp="text">
-            <div
-              data-template="paragraphs/wysiwyg"
-              data-entity-id={9808}
-              className="processed-content"
-            >
+            <div className="processed-content">
               <p>Yes. You can opt out of sharing by mail or in person.</p>
               <h4>To opt out by mail</h4>
               <p>
@@ -436,29 +348,17 @@ export const App = () => (
           </div>
         </div>
       </div>
-      <div
-        itemScope
-        itemType="http://schema.org/Question"
-        data-template="paragraphs/q_a"
-        data-entity-id={9889}
-        data-analytics-faq-section="The Veterans Health Information Exchange"
-        data-analytics-faq-text="Can I change my mind if I want to share my information later?"
-      >
+      <div itemScope itemType="http://schema.org/Question">
         <h3 itemProp="name" id="can-i-change-my-mind-share-information-later">
           Can I change my mind if I want to share my information later?
         </h3>
         <div
-          data-entity-id={9889}
           itemProp="acceptedAnswer"
           itemScope
           itemType="http://schema.org/Answer"
         >
           <div itemProp="text">
-            <div
-              data-template="paragraphs/wysiwyg"
-              data-entity-id={9888}
-              className="processed-content"
-            >
+            <div className="processed-content">
               <p>
                 Yes. If you change your mind and want to share your health
                 information, complete and submit VA Form 10-10163 (Request for
@@ -483,14 +383,7 @@ export const App = () => (
           </div>
         </div>
       </div>
-      <div
-        itemScope
-        itemType="http://schema.org/Question"
-        data-template="paragraphs/q_a"
-        data-entity-id={9891}
-        data-analytics-faq-section="The Veterans Health Information Exchange"
-        data-analytics-faq-text="Will my personal health information be protected?"
-      >
+      <div itemScope itemType="http://schema.org/Question">
         <h3
           itemProp="name"
           id="will-my-personal-health-information-be-protected"
@@ -498,17 +391,12 @@ export const App = () => (
           Will my personal health information be protected?
         </h3>
         <div
-          data-entity-id={9891}
           itemProp="acceptedAnswer"
           itemScope
           itemType="http://schema.org/Answer"
         >
           <div itemProp="text">
-            <div
-              data-template="paragraphs/wysiwyg"
-              data-entity-id={9890}
-              className="processed-content"
-            >
+            <div className="processed-content">
               <p>
                 Yes. The Veterans Health Information Exchange uses secure
                 technology to share information between VA and participating
@@ -521,29 +409,17 @@ export const App = () => (
           </div>
         </div>
       </div>
-      <div
-        itemScope
-        itemType="http://schema.org/Question"
-        data-template="paragraphs/q_a"
-        data-entity-id={10274}
-        data-analytics-faq-section="The Veterans Health Information Exchange"
-        data-analytics-faq-text="What if I have more questions?"
-      >
+      <div itemScope itemType="http://schema.org/Question">
         <h3 itemProp="name" id="what-if-i-have-more-questions">
           What if I have more questions?
         </h3>
         <div
-          data-entity-id={10274}
           itemProp="acceptedAnswer"
           itemScope
           itemType="http://schema.org/Answer"
         >
           <div itemProp="text">
-            <div
-              data-template="paragraphs/wysiwyg"
-              data-entity-id={10273}
-              className="processed-content"
-            >
+            <div className="processed-content">
               <p>
                 Call us toll-free at <a href="tel:+18446982311">844-698-2311</a>
                 .

--- a/src/applications/static-pages/health-care-manage-benefits/get-medical-records-page/components/App/index.unit.spec.js
+++ b/src/applications/static-pages/health-care-manage-benefits/get-medical-records-page/components/App/index.unit.spec.js
@@ -1,0 +1,38 @@
+// Dependencies.
+import React from 'react';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+// Relative imports.
+import { App } from './index';
+
+describe('Get Medical Records Page <App>', () => {
+  it('renders what we expect', () => {
+    const wrapper = shallow(<App />);
+
+    const text = wrapper.text();
+    expect(text).to.include('Get your VA medical records online');
+    expect(text).to.include(
+      "What's VA Blue Button, and how can it help me manage my health care?",
+    );
+    expect(text).to.include(
+      'Am I eligible to use all the features of VA Blue Button?',
+    );
+    expect(text).to.include(
+      'Once I’m signed in, how do I get to my medical records?',
+    );
+    expect(text).to.include(
+      'Will my personal health information be protected?',
+    );
+    expect(text).to.include('What if I have more questions?');
+    expect(text).to.include(
+      'What is the Veterans Health Information Exchange (VHIE), and how can',
+    );
+    expect(text).to.include('Can I opt out of sharing my information?');
+    expect(text).to.include(
+      'Can I change my mind if I want to share my information later?',
+    );
+    expect(text).to.include('What if I have more questions?');
+
+    wrapper.unmount();
+  });
+});

--- a/src/applications/static-pages/health-care-manage-benefits/get-medical-records-page/components/App/index.unit.spec.js
+++ b/src/applications/static-pages/health-care-manage-benefits/get-medical-records-page/components/App/index.unit.spec.js
@@ -10,7 +10,6 @@ describe('Get Medical Records Page <App>', () => {
     const wrapper = shallow(<App />);
 
     const text = wrapper.text();
-    expect(text).to.include('Get your VA medical records online');
     expect(text).to.include(
       "What's VA Blue Button, and how can it help me manage my health care?",
     );

--- a/src/applications/static-pages/health-care-manage-benefits/get-medical-records-page/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/get-medical-records-page/index.js
@@ -1,0 +1,20 @@
+// Node modules.
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { Provider } from 'react-redux';
+
+export default (store, widgetType) => {
+  const root = document.querySelector(`[data-widget-type="${widgetType}"]`);
+  if (root) {
+    import(/* webpackChunkName: "App" */
+    './components/App').then(module => {
+      const App = module.default;
+      ReactDOM.render(
+        <Provider store={store}>
+          <App />
+        </Provider>,
+        root,
+      );
+    });
+  }
+};

--- a/src/applications/static-pages/health-care-manage-benefits/get-medical-records-page/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/get-medical-records-page/index.js
@@ -6,7 +6,7 @@ import { Provider } from 'react-redux';
 export default (store, widgetType) => {
   const root = document.querySelector(`[data-widget-type="${widgetType}"]`);
   if (root) {
-    import(/* webpackChunkName: "App" */
+    import(/* webpackChunkName: "get-medical-records-page" */
     './components/App').then(module => {
       const App = module.default;
       ReactDOM.render(

--- a/src/applications/static-pages/static-pages-entry.js
+++ b/src/applications/static-pages/static-pages-entry.js
@@ -33,6 +33,7 @@ import create686ContentReveal from './view-modify-dependent/686-cta/create686Cco
 import createCaregiverContentToggle from './caregiver-content-toggle/createCaregiverContentToggle';
 import createSecureMessagingPage from './health-care-manage-benefits/secure-messaging';
 import createScheduleViewVAAppointments from './health-care-manage-benefits/schedule-view-va-appointments';
+import createGetMedicalRecordsPage from './health-care-manage-benefits/get-medical-records-page';
 
 // No-react styles.
 import './sass/static-pages.scss';
@@ -144,6 +145,7 @@ createScheduleViewVAAppointments(
   store,
   widgetTypes.SCHEDULE_VIEW_VA_APPOINTMENTS,
 );
+createGetMedicalRecordsPage(store, widgetTypes.GET_MEDICAL_RECORDS_PAGE);
 
 // homepage widgets
 if (location.pathname === '/') {

--- a/src/applications/static-pages/widgetTypes.js
+++ b/src/applications/static-pages/widgetTypes.js
@@ -17,4 +17,5 @@ export default {
   CAREGIVER_CONTENT_TOGGLE: 'caregiver-content-toggle',
   SECURE_MESSAGING_PAGE: 'secure-messaging',
   SCHEDULE_VIEW_VA_APPOINTMENTS: 'schedule-view-va-appointments',
+  GET_MEDICAL_RECORDS_PAGE: 'get-medical-records-page',
 };


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/10264

This PR adds unauth Get Medical Records page content as a React widget.

## Testing done
Adds unit tests for React widget.

## Screenshots

![localhost_3001_dummy-page_](https://user-images.githubusercontent.com/12773166/85319153-6022e500-b47e-11ea-8f3c-21611325a840.png)

## Acceptance criteria
- [x] Add unauth Get Medical Records page content as a React widget.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
