### PR TITLE
bradl3yC - 9867 - fix dl dt nesting for supplies review widget

### DIFF
--- a/src/applications/disability-benefits/2346/components/ReviewPageSupplies.jsx
+++ b/src/applications/disability-benefits/2346/components/ReviewPageSupplies.jsx
@@ -7,8 +7,8 @@ const ReviewPageSupplies = ({
   selectedBatteryProductInfo,
   selectedAccessoryProductInfo,
 }) => (
-  <div>
-    <div className="vads-u-display--flex vads-u-flex-direction--column vads-u-margin-bottom--2">
+  <>
+    <dt className="vads-u-display--flex vads-u-flex-direction--column vads-u-margin-bottom--2">
       <span className="vads-u-font-weight--bold">
         You have requested to receive supplies for the following hearing aids:
       </span>
@@ -16,11 +16,11 @@ const ReviewPageSupplies = ({
         ({selectedBatteryProductInfo?.length || 0} out of{' '}
         {batterySupplies?.length || 0} selected)
       </span>
-    </div>
+    </dt>
     <div className="vads-u-margin-bottom--3">
       {selectedBatteryProductInfo &&
         selectedBatteryProductInfo.map((product, index) => (
-          <div
+          <dd
             key={`${product.productId}_${index}`}
             className="vads-u-background-color--gray-light-alt vads-u-width--full vads-u-padding--4 vads-u-display--flex vads-u-flex-direction--column vads-u-margin-bottom--1p5"
           >
@@ -30,10 +30,10 @@ const ReviewPageSupplies = ({
             <span>
               {product.productName} batteries (Quantity: {product.quantity})
             </span>
-          </div>
+          </dd>
         ))}
     </div>
-    <div className="vads-u-display--flex vads-u-flex-direction--column vads-u-margin-bottom--2">
+    <dd className="vads-u-display--flex vads-u-flex-direction--column vads-u-margin-bottom--2">
       <span className="vads-u-font-weight--bold">
         You have requested to receive the following accessories:
       </span>
@@ -41,11 +41,11 @@ const ReviewPageSupplies = ({
         ({selectedAccessoryProductInfo?.length || 0} out of{' '}
         {accessorySupplies?.length || 0} selected)
       </span>
-    </div>
+    </dd>
     <div className="vads-u-margin-bottom--3">
       {selectedAccessoryProductInfo &&
         selectedAccessoryProductInfo.map((product, index) => (
-          <div
+          <dd
             key={`${product.productId}_${index}`}
             className="vads-u-background-color--gray-light-alt vads-u-width--full vads-u-padding--4 vads-u-display--flex vads-u-flex-direction--column vads-u-margin-bottom--1p5"
           >
@@ -53,10 +53,10 @@ const ReviewPageSupplies = ({
               {product.productName}
             </h5>
             <span>Quantity: {product.quantity}</span>
-          </div>
+          </dd>
         ))}
     </div>
-  </div>
+  </>
 );
 
 const mapStateToProps = state => {

--- a/src/applications/disability-benefits/2346/schemas/2346UI.js
+++ b/src/applications/disability-benefits/2346/schemas/2346UI.js
@@ -144,6 +144,7 @@ export default {
         widgetClassNames: 'va-input-large',
         inputType: 'email',
         hideOnReview: true,
+        useDlWrap: true,
       },
       'ui:validations': [
         {


### PR DESCRIPTION
## Description
Because you cannot turn off dl wrapping for custom review widgets - a refactor of the supplies review page needed to contain proper dl dd dt nesting

## Testing done


## Screenshots
![Screen Shot 2020-06-19 at 11 51 18 AM](https://user-images.githubusercontent.com/6165421/85152625-3b7f0100-b223-11ea-8b16-cc264f579324.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
