### PR TITLE
use inverse or outline class for unselected button

### DIFF
--- a/src/applications/coronavirus-screener/components/FormQuestion.jsx
+++ b/src/applications/coronavirus-screener/components/FormQuestion.jsx
@@ -34,8 +34,8 @@ export default function FormQuestion({
       type="button"
       className={classnames(
         'usa-button-big',
-        (question.value === option.optionValue ? 'usa-button' : null) ??
-          'usa-button-secondary',
+        'usa-button',
+        question.value === option.optionValue ? null : 'site-button-inverse',
       )}
       onClick={handleClick}
       value={option.optionValue}

--- a/src/applications/coronavirus-screener/components/FormQuestion.unit.spec.jsx
+++ b/src/applications/coronavirus-screener/components/FormQuestion.unit.spec.jsx
@@ -49,8 +49,8 @@ describe('coronavirus-screener', () => {
           clearQuestionValues={mockclearQuestionValues}
         />,
       );
-      expect(wrapper.find('.usa-button-secondary')).to.have.lengthOf(2);
-      expect(wrapper.find('.usa-button')).to.have.lengthOf(0);
+      expect(wrapper.find('.site-button-inverse')).to.have.lengthOf(2);
+      expect(wrapper.find('.usa-button')).to.have.lengthOf(2);
       wrapper.unmount();
     });
     it('sets button class when some option is selected', () => {
@@ -64,8 +64,8 @@ describe('coronavirus-screener', () => {
           clearQuestionValues={mockclearQuestionValues}
         />,
       );
-      expect(wrapper.find('.usa-button')).to.have.lengthOf(1);
-      expect(wrapper.find('.usa-button-secondary')).to.have.lengthOf(1);
+      expect(wrapper.find('.usa-button')).to.have.lengthOf(2);
+      expect(wrapper.find('.site-button-inverse')).to.have.lengthOf(1);
       wrapper.unmount();
     });
 


### PR DESCRIPTION
## Description
trying to get opaque background for unselected buttons using `site-button-inverse` or other class 
- https://design.va.gov/ uses a `site-button-inverse` class for "What's new?" button but this class does not seem to be available in the design system itself
- USWDS button https://designsystem.digital.gov/components/button/ includes an "Outline" class called `usa-button--outline` which doesn't seem to be available on `vets-website`

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
