### PR TITLE
9610 secondary button opaque bg

### DIFF
--- a/src/applications/coronavirus-screener/components/FormQuestion.jsx
+++ b/src/applications/coronavirus-screener/components/FormQuestion.jsx
@@ -34,8 +34,10 @@ export default function FormQuestion({
       type="button"
       className={classnames(
         'usa-button-big',
-        (question.value === option.optionValue ? 'usa-button' : null) ??
+        (question.value === option.optionValue ? 'usa-button' : null) ?? [
           'usa-button-secondary',
+          'vads-u-background-color--white',
+        ],
       )}
       onClick={handleClick}
       value={option.optionValue}

--- a/src/applications/coronavirus-screener/components/FormQuestion.jsx
+++ b/src/applications/coronavirus-screener/components/FormQuestion.jsx
@@ -36,7 +36,7 @@ export default function FormQuestion({
         'usa-button-big',
         (question.value === option.optionValue ? 'usa-button' : null) ?? [
           'usa-button-secondary',
-          'vads-u-background-color--white',
+          'vads-u-background-color--white', // TODO: resolve upstream design system bug https://github.com/department-of-veterans-affairs/va.gov-team/issues/9610
         ],
       )}
       onClick={handleClick}

--- a/src/applications/coronavirus-screener/components/FormQuestion.unit.spec.jsx
+++ b/src/applications/coronavirus-screener/components/FormQuestion.unit.spec.jsx
@@ -50,6 +50,9 @@ describe('coronavirus-screener', () => {
         />,
       );
       expect(wrapper.find('.usa-button-secondary')).to.have.lengthOf(2);
+      expect(wrapper.find('.vads-u-background-color--white')).to.have.lengthOf(
+        2,
+      );
       expect(wrapper.find('.usa-button')).to.have.lengthOf(0);
       wrapper.unmount();
     });
@@ -66,6 +69,9 @@ describe('coronavirus-screener', () => {
       );
       expect(wrapper.find('.usa-button')).to.have.lengthOf(1);
       expect(wrapper.find('.usa-button-secondary')).to.have.lengthOf(1);
+      expect(wrapper.find('.vads-u-background-color--white')).to.have.lengthOf(
+        1,
+      );
       wrapper.unmount();
     });
 


### PR DESCRIPTION
## Description
work around upstream design system bug of secondard button transparent background
https://github.com/department-of-veterans-affairs/va.gov-team/issues/9610

## Testing done
unit tests

## Screenshots


## Acceptance criteria
- [x] unselected button has opaque white background
