### PR TITLE
VACMS-13211: Fail build if internal-dsva-vagov* links are detected

### DIFF
--- a/src/site/stages/build/plugins/check-cms-urls.js
+++ b/src/site/stages/build/plugins/check-cms-urls.js
@@ -21,12 +21,12 @@ function checkForCMSUrls(BUILD_OPTIONS) {
 
     if (filesWithBadUrls.length) {
       console.log(
-        'The following pages have an internal AWS, cms.va.gov, or va.agile6.com url referenced:',
+        "The following pages have an 'internal-dsva-vagov-*' or '*.cms.va.gov' URL referenced:",
       );
       console.log(filesWithBadUrls.join('\n'));
 
       if (BUILD_OPTIONS.buildtype === ENVIRONMENTS.VAGOVPROD) {
-        throw new Error('Pages found that reference internal CMS urls');
+        throw new Error('Pages found that reference internal CMS URLs');
       }
     }
 

--- a/src/site/stages/build/plugins/check-cms-urls.js
+++ b/src/site/stages/build/plugins/check-cms-urls.js
@@ -11,9 +11,8 @@ function checkForCMSUrls(BUILD_OPTIONS) {
       if (file.isDrupalPage && !ignoredPages.has(fileName)) {
         const contents = file.contents.toString();
         if (
-          contents.includes('cms.va.gov') ||
-          contents.includes('-vagovcms-3000') ||
-          contents.includes('va.agile6.com')
+          contents.includes('internal-dsva-vagov') ||
+          contents.includes('cms.va.gov')
         ) {
           filesWithBadUrls.push(fileName);
         }


### PR DESCRIPTION
## Description
Follow up of #13211. This must not be merged until a solution for #13211 is created and merged or it will start failing all builds. 

This PR makes the build fail if `internal-dsva-vagov*` or `*.cms.va.gov` links are found in the built HTML. 


## Testing done

In api.js, I changed:

```
usingProxy:
      address.includes('cms.va.gov') && !buildOptions['no-drupal-proxy'],
```
to
```
    usingProxy: true,
```
and ran `yarn build:content --buildtype=vagovprod --pull-drupal --drupal-address=http://internal-dsva-vagov-prod-cms-2000800896.us-gov-west-1.elb.amazonaws.com`. 

Then I got the new expected failure as we still have 2 existing broken file links. This wasn't failing before and is what allowed the broken links to make it to www.va.gov:

> Step 27 start: Check for CMS URLs
> The following pages have an 'internal-dsva-vagov-*' or '*.cms.va.gov' URL referenced:
> pittsburgh-health-care/events/introduction-to-whole-health/index.html
> pittsburgh-health-care/locations/h-john-heinz-iii-department-of-veterans-affairs-medical-center/index.html
> /home/elijah/Projects/va.gov/vets-website/src/site/stages/build/index.js:272
>     if (err) throw err;
>              ^
> 
> Error: Pages found that reference internal CMS URLs
>     at Ware.<anonymous> (/home/elijah/Projects/va.gov/vets-website/src/site/stages/build/plugins/check-cms-urls.js:29:15)
>     at Ware.<anonymous> (/home/elijah/Projects/va.gov/vets-website/node_modules/wrap-fn/index.js:45:19)
>     at next (/home/elijah/Projects/va.gov/vets-website/node_modules/ware/lib/index.js:85:20)
>     at /home/elijah/Projects/va.gov/vets-website/node_modules/wrap-fn/index.js:121:18
>     at Ware.<anonymous> (/home/elijah/Projects/va.gov/vets-website/node_modules/wrap-fn/index.js:83:42)
>     at Ware.<anonymous> (/home/elijah/Projects/va.gov/vets-website/node_modules/wrap-fn/index.js:57:27)
>     at next (/home/elijah/Projects/va.gov/vets-website/node_modules/ware/lib/index.js:85:20)
>     at /home/elijah/Projects/va.gov/vets-website/node_modules/wrap-fn/index.js:121:18
>     at Ware.<anonymous> (/home/elijah/Projects/va.gov/vets-website/node_modules/wrap-fn/index.js:83:42)
>     at Ware.<anonymous> (/home/elijah/Projects/va.gov/vets-website/node_modules/wrap-fn/index.js:57:27)
>     at next (/home/elijah/Projects/va.gov/vets-website/node_modules/ware/lib/index.js:85:20)
>     at /home/elijah/Projects/va.gov/vets-website/node_modules/wrap-fn/index.js:121:18
>     at Ware.<anonymous> (/home/elijah/Projects/va.gov/vets-website/node_modules/wrap-fn/index.js:83:42)
>     at Ware.<anonymous> (/home/elijah/Projects/va.gov/vets-website/node_modules/wrap-fn/index.js:57:27)
>     at next (/home/elijah/Projects/va.gov/vets-website/node_modules/ware/lib/index.js:85:20)
>     at /home/elijah/Projects/va.gov/vets-website/node_modules/wrap-fn/index.js:121:18
> error Command failed with exit code 1.


**THEN lastly**, I ran `yarn build:content --buildtype=vagovprod --pull-drupal` (no --drupal-address as it defaults to prod.cms.va.gov). Running it this way produces no errors as the links are all relative links now. 

![image](https://user-images.githubusercontent.com/1504756/85184943-bad1fc00-b246-11ea-8b64-bbc73f4fb4b2.png)




## Screenshots

![image](https://user-images.githubusercontent.com/1504756/85184853-31222e80-b246-11ea-88df-53cd08b9c95c.png)



## Acceptance criteria
- [ ]

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs