### PR TITLE
bradl3yC - 9625 - deceased vet returning 200 instead of 403

### DIFF
--- a/src/applications/disability-benefits/2346/actions/index.js
+++ b/src/applications/disability-benefits/2346/actions/index.js
@@ -36,7 +36,7 @@ export const fetchFormStatus = () => async dispatch => {
     // always result in that error so we can go ahead and return
     return dispatch(resetError());
   }
-  fetch(`${environment.API_URL}/v0/in_progress_forms/MDOT`, {
+  fetch(`${environment.API_URL}/v0/in_progress_forms/mdot`, {
     credentials: 'include',
     headers: {
       'Content-Type': 'application/json',

--- a/src/applications/disability-benefits/2346/components/ErrorMessage.jsx
+++ b/src/applications/disability-benefits/2346/components/ErrorMessage.jsx
@@ -77,7 +77,7 @@ const ErrorMessage = ({ errorCode, nextAvailabilityDate }) => {
         </AlertBox>
       );
       break;
-    case 'MDOT_DECEASED_VETERAN':
+    case 'MDOT_DECEASED':
       content = (
         <AlertBox
           status="warning"

--- a/src/applications/disability-benefits/2346/config/form.js
+++ b/src/applications/disability-benefits/2346/config/form.js
@@ -18,7 +18,6 @@ const {
 
 const {
   vetEmailField,
-  fullNameField,
   viewConfirmationEmailField,
   suppliesField,
   permanentAddressField,

--- a/src/applications/disability-benefits/2346/schemas/2346UI.js
+++ b/src/applications/disability-benefits/2346/schemas/2346UI.js
@@ -8,11 +8,7 @@ import VeteranInfoBox from '../components/VeteranInfoBox';
 import { schemaFields } from '../constants';
 import { addressUISchema } from './address-schema';
 
-const {
-  permanentAddressField,
-  temporaryAddressField,
-  viewCurrentAddressField,
-} = schemaFields;
+const { permanentAddressField, temporaryAddressField } = schemaFields;
 
 const emailUITitle = <h4>Email address</h4>;
 

--- a/src/applications/disability-benefits/2346/tests/ErrorMessage.unit.spec.jsx
+++ b/src/applications/disability-benefits/2346/tests/ErrorMessage.unit.spec.jsx
@@ -59,7 +59,7 @@ describe('ErrorMessage', () => {
     const fakeStore = {
       getState: () => ({
         mdot: {
-          errorCode: 'MDOT_DECEASED_VETERAN',
+          errorCode: 'MDOT_DECEASED',
           pending: false,
           nextAvailabilityDate: '2019-04-01',
         },


### PR DESCRIPTION
## Description
The uri used included `/MDOT` which returned a 200 - when swapped to `/mdot` it returns the correct 403 response

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
