### PR TITLE
Change AutoSSO import from named to default import

### DIFF
--- a/src/applications/login/containers/SignInApp.jsx
+++ b/src/applications/login/containers/SignInApp.jsx
@@ -8,7 +8,7 @@ import SubmitSignInForm from 'platform/static-data/SubmitSignInForm';
 import { login, signup } from 'platform/user/authentication/utilities';
 import environment from 'platform/utilities/environment';
 
-import { AutoSSO } from 'platform/site-wide/user-nav/containers/AutoSSO';
+import AutoSSO from 'platform/site-wide/user-nav/containers/AutoSSO';
 import LogoutAlert from '../components/LogoutAlert';
 import downtimeBanners from '../utilities/downtimeBanners';
 


### PR DESCRIPTION
## Description

The named `AutoSSO` export was an unconnected component for testing purposes. This fixes it to use the default connected component.