### PR TITLE
Fix return link for news releases

### DIFF
--- a/src/site/layouts/press_release.drupal.liquid
+++ b/src/site/layouts/press_release.drupal.liquid
@@ -167,7 +167,7 @@
                         <section class="vads-u-margin-bottom--3">
                             {{ fieldOffice.entity.fieldPressReleaseBlurb.processed }}
                         </section>
-                        {% assign index = entityUrl.breadcrumb.length | minus: 2 %}
+                        {% assign index = entityUrl.breadcrumb.length | minus: 1 %}
                         <a onClick="recordEvent({ event: 'nav-secondary-button-click' });" href="{{ entityUrl.breadcrumb | getValueFromArrayObjPath: index, 'url.path' }}">See all news releases</a>
                     </article>
                 </div>

--- a/src/site/layouts/press_release.drupal.liquid
+++ b/src/site/layouts/press_release.drupal.liquid
@@ -238,7 +238,7 @@
                         {{ fieldOffice.entity.fieldPressReleaseBlurb.processed }}
                     </section>
                     {% assign index = entityUrl.breadcrumb.length | minus: 2 %}
-                    <a onClick="recordEvent({ event: 'nav-secondary-button-click' });" href="{{ entityUrl.breadcrumb | getValueFromArrayObjPath: index, 'url.path' }}">See all news releases</a>
+                    <a onClick="recordEvent({ event: 'nav-secondary-button-click' });" href="{{ entityUrl.breadcrumb | getValueFromArrayObjPath: 2, 'url.path' }}">See all news releases</a>
                 </article>
             </div>
         {% endif %}

--- a/src/site/layouts/press_release.drupal.liquid
+++ b/src/site/layouts/press_release.drupal.liquid
@@ -237,8 +237,8 @@
                     <section class="vads-u-margin-bottom--3">
                         {{ fieldOffice.entity.fieldPressReleaseBlurb.processed }}
                     </section>
-                    {% assign index = entityUrl.breadcrumb.length | minus: 2 %}
-                    <a onClick="recordEvent({ event: 'nav-secondary-button-click' });" href="{{ entityUrl.breadcrumb | getValueFromArrayObjPath: 2, 'url.path' }}">See all news releases</a>
+                    {% assign index = entityUrl.breadcrumb.length | minus: 1 %}
+                    <a onClick="recordEvent({ event: 'nav-secondary-button-click' });" href="{{ entityUrl.breadcrumb | getValueFromArrayObjPath: index, 'url.path' }}">See all news releases</a>
                 </article>
             </div>
         {% endif %}


### PR DESCRIPTION
## Description
Issue: https://github.com/department-of-veterans-affairs/va.gov-team/issues/10028

## Testing done
Locally

## Screenshots
![ex](https://user-images.githubusercontent.com/100468/85340177-3d5af580-b4ab-11ea-898d-3f20d8f6e18b.gif)


## Acceptance criteria
- [x] Create consistent user experience across Events, News Releases and Stories

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
