### PR TITLE
Rewrite Appointment List e2e Test in Cypress

### DIFF
--- a/src/applications/vaos/tests/e2e/appointment-list.cypress.spec.js
+++ b/src/applications/vaos/tests/e2e/appointment-list.cypress.spec.js
@@ -1,0 +1,35 @@
+import { initAppointmentListMock } from './vaos-cypress-helpers';
+
+describe('Appointment List', () => {
+  beforeEach(() => {
+    initAppointmentListMock();
+  });
+
+  it('should render appointments list', () => {
+    cy.get('#appointments-list').should('exist');
+  });
+
+  it('should allow for cancelling of appointments', () => {
+    cy.get('li[data-is-cancelable="true"] button.vaos-appts__cancel-btn')
+      .first()
+      .click();
+
+    cy.get('#cancelAppt .usa-button').click();
+
+    cy.get('#cancelAppt button:not([disabled])')
+      .first()
+      .click();
+
+    cy.get('#cancelAppt').should('not.exist');
+  });
+
+  it('should show more info for appointments', () => {
+    cy.get(
+      'li[data-request-id="8a48912a6cab0202016cb4fcaa8b0038"] .additional-info-button.va-button-link',
+    ).click();
+
+    cy.get('[id="8a48912a6cab0202016cb4fcaa8b0038-vaos-info-content"]');
+
+    cy.contains('Request 2 Message 1 Text');
+  });
+});

--- a/src/applications/vaos/tests/e2e/appointment-list.cypress.spec.js
+++ b/src/applications/vaos/tests/e2e/appointment-list.cypress.spec.js
@@ -3,6 +3,8 @@ import { initAppointmentListMock } from './vaos-cypress-helpers';
 describe('Appointment List', () => {
   beforeEach(() => {
     initAppointmentListMock();
+    cy.visit('health-care/schedule-view-va-appointments/appointments/');
+    cy.get('.va-modal-body button').click();
   });
 
   it('should render appointments list', () => {
@@ -13,13 +15,11 @@ describe('Appointment List', () => {
     cy.get('li[data-is-cancelable="true"] button.vaos-appts__cancel-btn')
       .first()
       .click();
-
     cy.get('#cancelAppt .usa-button').click();
-
+    cy.get('.usa-alert-success').should('exist');
     cy.get('#cancelAppt button:not([disabled])')
       .first()
       .click();
-
     cy.get('#cancelAppt').should('not.exist');
   });
 
@@ -27,9 +27,7 @@ describe('Appointment List', () => {
     cy.get(
       'li[data-request-id="8a48912a6cab0202016cb4fcaa8b0038"] .additional-info-button.va-button-link',
     ).click();
-
     cy.get('[id="8a48912a6cab0202016cb4fcaa8b0038-vaos-info-content"]');
-
     cy.contains('Request 2 Message 1 Text');
   });
 });

--- a/src/applications/vaos/tests/e2e/vaos-cypress-helpers.js
+++ b/src/applications/vaos/tests/e2e/vaos-cypress-helpers.js
@@ -7,10 +7,6 @@ import confirmedCC from '../../api/confirmed_cc.json';
 import requests from '../../api/requests.json';
 import cancelReasons from '../../api/cancel_reasons.json';
 import supportedSites from '../../api/sites-supporting-var.json';
-import facilities from '../../api/facilities.json';
-import facilities983 from '../../api/facilities_983.json';
-import clinicList983 from '../../api/clinicList983.json';
-import slots from '../../api/slots.json';
 
 function updateConfirmedVADates(data) {
   data.data.forEach(item => {
@@ -49,31 +45,6 @@ function updateRequestDates(data) {
   });
   return data;
 }
-
-function updateTimeslots(data) {
-  const startDateTime = moment()
-    .add(4, 'days')
-    .day(9)
-    .format('YYYY-MM-DDTHH:mm:ss[+00:00]');
-  const endDateTime = moment()
-    .add(4, 'days')
-    .day(9)
-    .add(60, 'minutes')
-    .format('YYYY-MM-DDTHH:mm:ss[+00:00]');
-
-  const newSlot = {
-    bookingStatus: '1',
-    remainingAllowedOverBookings: '3',
-    availability: true,
-    startDateTime,
-    endDateTime,
-  };
-
-  data.data[0].attributes.appointmentTimeSlot = [newSlot];
-
-  return data;
-}
-
 export function initAppointmentListMock() {
   cy.server();
   cy.login();

--- a/src/applications/vaos/tests/e2e/vaos-cypress-helpers.js
+++ b/src/applications/vaos/tests/e2e/vaos-cypress-helpers.js
@@ -11,7 +11,6 @@ import facilities from '../../api/facilities.json';
 import facilities983 from '../../api/facilities_983.json';
 import clinicList983 from '../../api/clinicList983.json';
 import slots from '../../api/slots.json';
-import Helpers from './vaos-helpers';
 
 function updateConfirmedVADates(data) {
   data.data.forEach(item => {

--- a/src/applications/vaos/tests/e2e/vaos-cypress-helpers.js
+++ b/src/applications/vaos/tests/e2e/vaos-cypress-helpers.js
@@ -143,7 +143,4 @@ export function initAppointmentListMock() {
       ],
     },
   });
-
-  cy.visit('health-care/schedule-view-va-appointments/appointments/');
-  cy.get('.va-modal-body button').click();
 }

--- a/src/applications/vaos/tests/e2e/vaos-cypress-helpers.js
+++ b/src/applications/vaos/tests/e2e/vaos-cypress-helpers.js
@@ -1,0 +1,179 @@
+/* eslint-disable no-param-reassign */
+import moment from 'moment';
+
+import pact from '../../api/pact.json';
+import confirmedVA from '../../api/confirmed_va.json';
+import confirmedCC from '../../api/confirmed_cc.json';
+import requests from '../../api/requests.json';
+import cancelReasons from '../../api/cancel_reasons.json';
+import supportedSites from '../../api/sites-supporting-var.json';
+import facilities from '../../api/facilities.json';
+import facilities983 from '../../api/facilities_983.json';
+import clinicList983 from '../../api/clinicList983.json';
+import slots from '../../api/slots.json';
+import Helpers from './vaos-helpers';
+
+function updateConfirmedVADates(data) {
+  data.data.forEach(item => {
+    const futureDateStr = moment()
+      .add(3, 'days')
+      .toISOString();
+
+    item.attributes.startDate = futureDateStr;
+    if (item.attributes.vdsAppointments[0]) {
+      item.attributes.vdsAppointments[0].appointmentTime = futureDateStr;
+    } else {
+      item.attributes.vvsAppointments[0].dateTime = futureDateStr;
+    }
+  });
+  return data;
+}
+
+function updateConfirmedCCDates(data) {
+  data.data.forEach(item => {
+    const futureDateStr = moment()
+      .add(4, 'days')
+      .format('MM/DD/YYYY HH:mm:ss');
+
+    item.attributes.appointmentTime = futureDateStr;
+  });
+  return data;
+}
+
+function updateRequestDates(data) {
+  data.data.forEach(item => {
+    const futureDateStr = moment()
+      .add(5, 'days')
+      .format('MM/DD/YYYY');
+
+    item.attributes.optionDate1 = futureDateStr;
+  });
+  return data;
+}
+
+function updateTimeslots(data) {
+  const startDateTime = moment()
+    .add(4, 'days')
+    .day(9)
+    .format('YYYY-MM-DDTHH:mm:ss[+00:00]');
+  const endDateTime = moment()
+    .add(4, 'days')
+    .day(9)
+    .add(60, 'minutes')
+    .format('YYYY-MM-DDTHH:mm:ss[+00:00]');
+
+  const newSlot = {
+    bookingStatus: '1',
+    remainingAllowedOverBookings: '3',
+    availability: true,
+    startDateTime,
+    endDateTime,
+  };
+
+  data.data[0].attributes.appointmentTimeSlot = [newSlot];
+
+  return data;
+}
+
+export function initAppointmentListMock() {
+  cy.server();
+  cy.login();
+  cy.route({
+    method: 'GET',
+    url: '**/v0/feature_toggles*',
+    status: 200,
+    response: {
+      data: {
+        features: [
+          {
+            name: 'vaOnlineScheduling',
+            value: true,
+          },
+          {
+            name: 'vaOnlineSchedulingCancel',
+            value: true,
+          },
+          {
+            name: 'vaOnlineSchedulingRequests',
+            value: true,
+          },
+          {
+            name: 'vaOnlineSchedulingCommunityCare',
+            value: true,
+          },
+          {
+            name: 'vaOnlineSchedulingDirect',
+            value: true,
+          },
+          {
+            name: 'vaOnlineSchedulingPast',
+            value: true,
+          },
+        ],
+      },
+    },
+  });
+
+  cy.route({
+    method: 'GET',
+    url: '**/vaos/v0/community_care/supported_sites',
+    response: supportedSites,
+  });
+
+  cy.route({
+    method: 'GET',
+    url: '**/vaos/v0/appointment_requests**',
+    response: updateRequestDates(requests),
+  });
+
+  cy.route({
+    method: 'GET',
+    url: /.*\/v0\/appointments.*type=va$/,
+    response: updateConfirmedVADates(confirmedVA),
+  });
+
+  cy.route({
+    method: 'GET',
+    url: /.*\/v0\/appointments.*type=cc$/,
+    response: updateConfirmedCCDates(confirmedCC),
+  });
+
+  cy.route({
+    method: 'GET',
+    url: '**/vaos/v0/facilities/983/cancel_reasons',
+    response: cancelReasons,
+  });
+
+  cy.route({
+    method: 'PUT',
+    url: '**/vaos/v0/appointments/cancel',
+    response: '',
+  });
+
+  cy.route({
+    method: 'GET',
+    url:
+      '**/vaos/v0/appointment_requests/8a48912a6cab0202016cb4fcaa8b0038/messages',
+    response: {
+      data: [
+        {
+          id: '8a48912a6cab0202016cb4fcaa8b0038',
+          type: 'messages',
+          attributes: {
+            surrogateIdentifier: {},
+            messageText: 'Request 2 Message 1 Text',
+            messageDateTime: '11/11/2019 12:26:13',
+            senderId: '1012845331V153043',
+            appointmentRequestId: '8a48912a6cab0202016cb4fcaa8b0038',
+            date: '2019-11-11T12:26:13.931+0000',
+            assigningAuthority: 'ICN',
+            systemId: 'var',
+          },
+        },
+      ],
+    },
+  });
+
+  cy.visit('health-care/schedule-view-va-appointments/appointments/');
+  cy.get('.va-modal-body button').click();
+}

--- a/src/applications/vaos/tests/e2e/vaos-cypress-helpers.js
+++ b/src/applications/vaos/tests/e2e/vaos-cypress-helpers.js
@@ -50,7 +50,7 @@ export function initAppointmentListMock() {
   cy.login();
   cy.route({
     method: 'GET',
-    url: '**/v0/feature_toggles*',
+    url: '/v0/feature_toggles*',
     status: 200,
     response: {
       data: {
@@ -86,13 +86,13 @@ export function initAppointmentListMock() {
 
   cy.route({
     method: 'GET',
-    url: '**/vaos/v0/community_care/supported_sites',
+    url: '/vaos/v0/community_care/supported_sites',
     response: supportedSites,
   });
 
   cy.route({
     method: 'GET',
-    url: '**/vaos/v0/appointment_requests**',
+    url: '/vaos/v0/appointment_requests*',
     response: updateRequestDates(requests),
   });
 
@@ -110,20 +110,20 @@ export function initAppointmentListMock() {
 
   cy.route({
     method: 'GET',
-    url: '**/vaos/v0/facilities/983/cancel_reasons',
+    url: '/vaos/v0/facilities/983/cancel_reasons',
     response: cancelReasons,
   });
 
   cy.route({
     method: 'PUT',
-    url: '**/vaos/v0/appointments/cancel',
+    url: '/vaos/v0/appointments/cancel',
     response: '',
   });
 
   cy.route({
     method: 'GET',
     url:
-      '**/vaos/v0/appointment_requests/8a48912a6cab0202016cb4fcaa8b0038/messages',
+      '/vaos/v0/appointment_requests/8a48912a6cab0202016cb4fcaa8b0038/messages',
     response: {
       data: [
         {

--- a/src/platform/testing/e2e/cypress/support/commands/login.js
+++ b/src/platform/testing/e2e/cypress/support/commands/login.js
@@ -47,6 +47,16 @@ const mockUser = {
         gender: 'M',
         given_names: ['Julio', 'E'],
         active_status: 'active',
+        facilities: [
+          {
+            facility_id: '983',
+            isCerner: false,
+          },
+          {
+            facility_id: '984',
+            isCerner: false,
+          },
+        ],
       },
     },
   },


### PR DESCRIPTION
## Description
Explore Cypress test runner by re-writing appointment list e2e test.

I wanted to import and reuse some of the helper functions in vaos-helpers.js but I was running into a strange error when trying to import it.

Also I was unable to implement the axe checks in these tests as there seems to be an issue with our axe plugin documented in the [Cypress migration guide](https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/teams/vsp/teams/tools/frontend/cypress-migration-guide.md).

## Testing done
E2E

## Screenshots
<img width="1115" alt="Screen Shot 2020-06-22 at 10 39 43 PM" src="https://user-images.githubusercontent.com/786704/85365094-7b6f0e00-b4d9-11ea-9a64-0c53edfcc57c.png">


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
