### PR TITLE
[CTA widget] Add widget for upcoming Order Hearing Aid Supplies

### DIFF
--- a/src/platform/site-wide/cta-widget/helpers.js
+++ b/src/platform/site-wide/cta-widget/helpers.js
@@ -1,5 +1,6 @@
 import backendServices from 'platform/user/profile/constants/backendServices';
 import { mhvUrl } from 'platform/site-wide/mhv/utilities';
+import { rootUrl as hearingAidSuppliesFormUrl } from 'applications/disability-benefits/2346/manifest.json';
 
 /**
  * These are the valid values for the Widget Type field in the Drupal CMS when
@@ -12,6 +13,7 @@ export const widgetTypes = {
   DISABILITY_RATINGS: 'disability-ratings',
   GI_BILL_BENEFITS: 'gi-bill-benefits',
   HEALTH_RECORDS: 'health-records',
+  HEARING_AID_SUPPLIES: 'hearing-aid-supplies',
   LAB_AND_TEST_RESULTS: 'lab-and-test-results',
   LETTERS: 'letters',
   MESSAGING: 'messaging',
@@ -158,6 +160,12 @@ export const toolUrl = (appId, useSSOe = false) => {
         redirect: false,
       };
 
+    case widgetTypes.HEARING_AID_SUPPLIES:
+      return {
+        url: hearingAidSuppliesFormUrl,
+        redirect: false,
+      };
+
     default:
       return {};
   }
@@ -246,6 +254,9 @@ export const serviceDescription = appId => {
 
     case widgetTypes.DISABILITY_RATINGS:
       return 'view your VA disability rating';
+
+    case widgetTypes.HEARING_AID_SUPPLIES:
+      return 'order hearing aid supplies';
 
     default:
       return 'use this service';


### PR DESCRIPTION
## Description
This PR adds a call-to-action widget for the upcoming Hearing Aid Supplies page leading to the new form.

https://github.com/department-of-veterans-affairs/va.gov-team/issues/10282

## Testing done
N/A

## Screenshots

### Unauthenticated
![image.png](https://images.zenhubusercontent.com/59cb9de1b0222d5de47953d8/e649d67e-4dac-4b9a-8eb1-f0838e032dac)

### Authenticated
![image](https://user-images.githubusercontent.com/1915775/85442240-f2e68100-b55d-11ea-867d-fcbebbd5e0fd.png)


## Acceptance criteria
- [ ] CTA widget is available for new page

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
