### PR TITLE
MDOT 500 Alert on Intro Page

### DIFF
--- a/src/applications/disability-benefits/2346/actions/index.js
+++ b/src/applications/disability-benefits/2346/actions/index.js
@@ -50,7 +50,7 @@ export const fetchFormStatus = () => async dispatch => {
         // In the event there are multiple errors - but I don't think that is possible
         const firstError = head(body.errors);
         if (firstError.code === '500') {
-          return dispatch(resetError());
+          return dispatch(handleError('MDOT_SERVER_ERROR'));
         }
         return dispatch(handleError(firstError.code.toUpperCase()));
       }

--- a/src/applications/disability-benefits/2346/components/ErrorMessage.jsx
+++ b/src/applications/disability-benefits/2346/components/ErrorMessage.jsx
@@ -94,6 +94,30 @@ const ErrorMessage = ({ errorCode, nextAvailabilityDate }) => {
         </AlertBox>
       );
       break;
+    case 'MDOT_SERVER_ERROR':
+      content = (
+        <AlertBox
+          status="error"
+          headline="We're sorry. Something went wrong on our end."
+        >
+          <div>
+            <p>
+              You can't place an order for hearing aid batteries and accessories
+              because something went wrong on our end.
+            </p>
+            <p className="vads-u-font-weight--bold">What you can do</p>
+            <p>
+              For help ordering hearing aid batteries and accessories, please
+              call the DLC Customer Service Section at{' '}
+              <a aria-label="3 0 3. 2 7 3. 6 2 0 0." href="tel:303-273-6200">
+                303-273-6200
+              </a>{' '}
+              or email <a href="mailto:dalc.css@va.gov">dalc.css@va.gov</a>.
+            </p>
+          </div>
+        </AlertBox>
+      );
+      break;
     default:
       break;
   }

--- a/src/applications/disability-benefits/2346/components/ErrorMessage.jsx
+++ b/src/applications/disability-benefits/2346/components/ErrorMessage.jsx
@@ -100,7 +100,7 @@ const ErrorMessage = ({ errorCode, nextAvailabilityDate }) => {
           status="error"
           headline="We're sorry. Something went wrong on our end."
         >
-          <div>
+          <div className="mdot-server-error-alert">
             <p>
               You can't place an order for hearing aid batteries and accessories
               because something went wrong on our end.

--- a/src/applications/disability-benefits/2346/tests/ErrorMessage.unit.spec.jsx
+++ b/src/applications/disability-benefits/2346/tests/ErrorMessage.unit.spec.jsx
@@ -156,4 +156,19 @@ describe('ErrorMessage', () => {
     );
     errorMessage.unmount();
   });
+  it('should render server error content', () => {
+    const fakeStore = {
+      getState: () => ({
+        mdot: {
+          errorCode: 'MDOT_SERVER_ERROR',
+          nextAvailabilityDate: '',
+        },
+      }),
+      subscribe: () => {},
+      dispatch: () => {},
+    };
+    const errorMessage = mount(<ErrorMessage store={fakeStore} />);
+    expect(errorMessage.find('.mdot-server-error-alert')).length.to.be(1);
+    errorMessage.unmount();
+  });
 });


### PR DESCRIPTION
## Description
This adds a 500 alert on the introduction page.

## Testing done
Unit tests have been added

## Screenshots
![screenshot-localhost_3001-2020 06 23-15_19_44](https://user-images.githubusercontent.com/12755283/85448752-ff220c80-b564-11ea-956f-d66410546e1f.png)


## Acceptance criteria
- [ ] Design team approval

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
