### PR TITLE
[Footer] Update link to Find Forms

### DIFF
--- a/src/platform/landing-pages/header-footer-data.json
+++ b/src/platform/landing-pages/header-footer-data.json
@@ -54,7 +54,7 @@
     },
     {
       "column": 2,
-      "href": "https://staging.va.gov/vaforms/",
+      "href": "https://staging.va.gov/find-forms/",
       "order": 1,
       "target": null,
       "title": "Find a VA form"

--- a/src/platform/static-data/footer-links.json
+++ b/src/platform/static-data/footer-links.json
@@ -53,7 +53,7 @@
   },
   {
     "column": 2,
-    "href": "https://www.va.gov/vaforms/",
+    "href": "https://www.va.gov/find-forms/",
     "order": 1,
     "target": null,
     "title": "Find a VA form"


### PR DESCRIPTION
## Description
This PR updates a link in the footer to point to the modernized Find Forms instead of legacy.

https://github.com/department-of-veterans-affairs/va.gov-team/issues/5589

## Testing done
Ran content build locally

## Screenshots


## Acceptance criteria
- [ ] footer points to new forms experience

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
