### PR TITLE
authn context needs to be mapped for DSLogon/mhv csid values

### DIFF
--- a/src/platform/utilities/sso/index.js
+++ b/src/platform/utilities/sso/index.js
@@ -1,5 +1,4 @@
 import moment from 'moment';
-import { pickBy } from 'lodash';
 import environment from 'platform/utilities/environment';
 import localStorage from '../storage/localStorage';
 import { hasSession, hasSessionSSO } from '../../user/profile/utilities';
@@ -12,7 +11,7 @@ const keepAlive = environment.isLocalhost() ? mockKeepAlive : liveKeepAlive;
 const keepAliveThreshold = 5 * 60 * 1000; // 5 minutes, in milliseconds
 
 export async function ssoKeepAliveSession() {
-  const { ttl, type, authn } = await keepAlive();
+  const { ttl, authn } = await keepAlive();
   if (ttl > 0) {
     // ttl is positive, user has an active session
     // ttl is in seconds, add from now
@@ -26,25 +25,25 @@ export async function ssoKeepAliveSession() {
     // ttl is null, we can't determine if the user has a session or not
     localStorage.removeItem('hasSessionSSO');
   }
-  return { type, authn };
+  return authn;
 }
 
 export async function checkAutoSession(application = null, to = null) {
-  const { type, authn } = await ssoKeepAliveSession();
+  const authn = await ssoKeepAliveSession();
   if (hasSession() && hasSessionSSO() === false) {
     // explicitly check to see if the SSOe session is false, as it could also
     // be null if we failed to get a response from the SSOe server, in which
     // case we don't want to logout the user because we don't know
     logout('v1', 'sso-automatic-logout');
-  } else if (!hasSession() && hasSessionSSO() && !getForceAuth() && type) {
+  } else if (!hasSession() && hasSessionSSO() && !getForceAuth() && authn) {
     // only attempt an auto login if the user is
     // a) does not have a VA.gov session
     // b) has an SSOe session
     // c) is not required for forceAuth (meaning their environment has SSOe
     //    enabled and they have not previously tried to login)
     // d) we have a non empty type value from the keepalive call to login with
-    const params = pickBy({ inbound: 'true', authn });
-    login(type, 'v1', application, to, params, 'sso-automatic-login');
+    const params = { inbound: 'true', authn };
+    login('custom', 'v1', application, to, params, 'sso-automatic-login');
   }
 }
 

--- a/src/platform/utilities/sso/index.js
+++ b/src/platform/utilities/sso/index.js
@@ -1,5 +1,5 @@
 import moment from 'moment';
-import { pickBy, identity } from 'lodash';
+import { pickBy } from 'lodash';
 import environment from 'platform/utilities/environment';
 import localStorage from '../storage/localStorage';
 import { hasSession, hasSessionSSO } from '../../user/profile/utilities';
@@ -43,7 +43,7 @@ export async function checkAutoSession(application = null, to = null) {
     // c) is not required for forceAuth (meaning their environment has SSOe
     //    enabled and they have not previously tried to login)
     // d) we have a non empty type value from the keepalive call to login with
-    const params = pickBy({ inbound: 'true', authn }, identity);
+    const params = pickBy({ inbound: 'true', authn });
     login(type, 'v1', application, to, params, 'sso-automatic-login');
   }
 }

--- a/src/platform/utilities/sso/keepAliveSSO.js
+++ b/src/platform/utilities/sso/keepAliveSSO.js
@@ -22,6 +22,10 @@ export default async function keepAlive() {
     });
     return {
       ttl: Number(resp.headers.get('session-timeout')),
+      // for DSLogon or mhv, use a mapped authn context value, however for
+      // idme, we need to use the provided authncontextclassref as it could be
+      // for LOA1 or LOA3.  Any other csid values should be ignored, and we
+      // should return null
       authn: {
         DSLogon: 'dslogon',
         mhv: 'myhealthevet',

--- a/src/platform/utilities/sso/keepAliveSSO.js
+++ b/src/platform/utilities/sso/keepAliveSSO.js
@@ -2,17 +2,10 @@ import * as Sentry from '@sentry/browser';
 
 import { ssoKeepAliveEndpoint } from 'platform/user/authentication/utilities';
 
-const csidTypeMap = {
-  DSLogon: 'dslogon',
-  mhv: 'mhv',
-  idme: 'custom',
-};
-
 export default async function keepAlive() {
-  // Return a TTL, type and authn values from the IAM keepalive endpoint that
+  // Return a TTL and authn values from the IAM keepalive endpoint that
   // 1) indicates how long the user's current SSOe session will be alive for,
-  // 2) the type of credentials the user should authenticate with,
-  // 3_ and the AuthN context the user used when authenticating.
+  // 2) and the AuthN context the user used when authenticating.
   //
   // Any positive TTL value means the user currently has a session, a TTL of 0
   // means they don't have an active session, and a TTL of undefined means there
@@ -27,11 +20,13 @@ export default async function keepAlive() {
         'Content-Type': 'application/json',
       },
     });
-    const authn = resp.headers.get('va_eauth_authncontextclassref') || '';
     return {
       ttl: Number(resp.headers.get('session-timeout')),
-      type: csidTypeMap[resp.headers.get('va_eauth_csid')],
-      authn: authn.trim() !== 'NOT_FOUND' ? authn : null,
+      authn: {
+        DSLogon: 'dslogon',
+        mhv: 'myhealthevet',
+        idme: resp.headers.get('va_eauth_authncontextclassref'),
+      }[resp.headers.get('va_eauth_csid')],
     };
   } catch (err) {
     Sentry.withScope(scope => {

--- a/src/platform/utilities/sso/keepAliveSSO.js
+++ b/src/platform/utilities/sso/keepAliveSSO.js
@@ -25,7 +25,7 @@ export default async function keepAlive() {
       // for DSLogon or mhv, use a mapped authn context value, however for
       // idme, we need to use the provided authncontextclassref as it could be
       // for LOA1 or LOA3.  Any other csid values should be ignored, and we
-      // should return null
+      // should return undefined
       authn: {
         DSLogon: 'dslogon',
         mhv: 'myhealthevet',

--- a/src/platform/utilities/sso/keepAliveSSO.js
+++ b/src/platform/utilities/sso/keepAliveSSO.js
@@ -2,12 +2,22 @@ import * as Sentry from '@sentry/browser';
 
 import { ssoKeepAliveEndpoint } from 'platform/user/authentication/utilities';
 
+const csidTypeMap = {
+  DSLogon: 'dslogon',
+  mhv: 'mhv',
+  idme: 'custom',
+};
+
 export default async function keepAlive() {
-  // Return a TTL value from the IAM keepalive endpoint that indicates how
-  // long the user's current SSOe session will be alive for.  Any positive
-  // value means the user currently has a session, a TTL of 0 means they
-  // don't have an active session, and a TTL of null means there was a problem
-  // calling the endpoint and we can't determine if they have a session or not
+  // Return a TTL, type and authn values from the IAM keepalive endpoint that
+  // 1) indicates how long the user's current SSOe session will be alive for,
+  // 2) the type of credentials the user should authenticate with,
+  // 3_ and the AuthN context the user used when authenticating.
+  //
+  // Any positive TTL value means the user currently has a session, a TTL of 0
+  // means they don't have an active session, and a TTL of undefined means there
+  // was a problem calling the endpoint and we can't determine if they have a
+  // session or not
   try {
     const resp = await fetch(ssoKeepAliveEndpoint(), {
       method: 'GET',
@@ -17,9 +27,11 @@ export default async function keepAlive() {
         'Content-Type': 'application/json',
       },
     });
+    const authn = resp.headers.get('va_eauth_authncontextclassref') || '';
     return {
       ttl: Number(resp.headers.get('session-timeout')),
-      authn: resp.headers.get('va_eauth_authncontextclassref'),
+      type: csidTypeMap[resp.headers.get('va_eauth_csid')],
+      authn: authn.trim() !== 'NOT_FOUND' ? authn : null,
     };
   } catch (err) {
     Sentry.withScope(scope => {

--- a/src/platform/utilities/tests/sso.unit.spec.js
+++ b/src/platform/utilities/tests/sso.unit.spec.js
@@ -112,6 +112,18 @@ describe('checkAutoSession', () => {
     );
   });
 
+  it('should not auto login if user is logged out, they have a PIV SSOe session and dont need to force auth', async () => {
+    const sandbox = sinon.createSandbox();
+    sandbox.stub(profUtils, 'hasSession').returns(false);
+    sandbox.stub(profUtils, 'hasSessionSSO').returns(true);
+    sandbox.stub(forceAuth, 'getForceAuth').returns(undefined);
+    setKeepAliveResponse(global.fetch.onFirstCall(), 900, '33');
+    const auto = sandbox.stub(authUtils, 'login');
+    await checkAutoSession();
+    sandbox.restore();
+    sinon.assert.notCalled(auto);
+  });
+
   it('should not auto login if user is logged out, they dont have a SSOe session and dont need to force auth', async () => {
     const sandbox = sinon.createSandbox();
     sandbox.stub(profUtils, 'hasSession').returns(false);

--- a/src/platform/utilities/tests/sso.unit.spec.js
+++ b/src/platform/utilities/tests/sso.unit.spec.js
@@ -103,11 +103,11 @@ describe('checkAutoSession', () => {
     sinon.assert.calledOnce(auto);
     sinon.assert.calledWith(
       auto,
-      'mhv',
+      'custom',
       'v1',
       null,
       null,
-      { inbound: 'true' },
+      { authn: 'myhealthevet', inbound: 'true' },
       'sso-automatic-login',
     );
   });


### PR DESCRIPTION
In the cases of dslogon or mhv inbound authentication, the authn context
will be empty (or contain the string "NOT_FOUND").  In this case we need to explicitly map
to the correct authn context value.

refs https://github.com/department-of-veterans-affairs/va.gov-team/issues/10411
