### PR TITLE
10578: Create Feature Flag for RPO Routing Update

### DIFF
--- a/src/applications/disability-benefits/bdd/tests/fixtures/mocks/feature-toggles.json
+++ b/src/applications/disability-benefits/bdd/tests/fixtures/mocks/feature-toggles.json
@@ -1,131 +1,96 @@
 {
   "data": {
     "type": "feature_toggles",
-    "features": [
-      {
-        "name": "preEntryCovid19Screener",
-        "value": false
-      },
-      {
-        "name": "dashboardShowCovid19Alert",
-        "value": true
-      },
-      {
-        "name": "facilityLocatorShowCommunityCares",
-        "value": true
-      },
-      {
-        "name": "facilitiesPpmsSuppressPharmacies",
-        "value": true
-      },
-      {
-        "name": "facilityLocatorFeUseV1",
-        "value": true
-      },
-      {
-        "name": "profile_show_profile_2.0",
-        "value": false
-      },
-      {
-        "name": "profileShowReceiveTextNotifications",
-        "value": true
-      },
-      {
-        "name": "vaOnlineScheduling",
-        "value": true
-      },
-      {
-        "name": "vaOnlineSchedulingCancel",
-        "value": true
-      },
-      {
-        "name": "vaOnlineSchedulingRequests",
-        "value": true
-      },
-      {
-        "name": "vaOnlineSchedulingCommunityCare",
-        "value": true
-      },
-      {
-        "name": "vaOnlineSchedulingDirect",
-        "value": true
-      },
-      {
-        "name": "vaOnlineSchedulingPast",
-        "value": true
-      },
-      {
-        "name": "vaOnlineSchedulingVspAppointmentList",
-        "value": false
-      },
-      {
-        "name": "vaOnlineSchedulingVspAppointmentNew",
-        "value": false
-      },
-      {
-        "name": "vaOnlineSchedulingCcspAppointmentList",
-        "value": false
-      },
-      {
-        "name": "vaOnlineSchedulingCcspRequestNew",
-        "value": false
-      },
-      {
-        "name": "vaOnlineSchedulingVspRequestList",
-        "value": false
-      },
-      {
-        "name": "vaOnlineSchedulingVspRequestNew",
-        "value": false
-      },
-      {
-        "name": "vaGlobalDowntimeNotification",
-        "value": false
-      },
-      {
-        "name": "ssoe",
-        "value": true
-      },
-      {
-        "name": "ssoeInbound",
-        "value": false
-      },
-      {
-        "name": "ssoeEbenefitsLinks",
-        "value": true
-      },
-      {
-        "name": "eduBenefitsStemScholarship",
-        "value": true
-      },
-      {
-        "name": "edu_section_103",
-        "value": true
-      },
-      {
-        "name": "gibctEstimateYourBenefits",
-        "value": true
-      },
-      {
-        "name": "form526OriginalClaims",
-        "value": false
-      },
-      {
-        "name": "vaViewDependentsAccess",
-        "value": false
-      },
-      {
-        "name": "allow_online_10_10cg_submissions",
-        "value": true
-      },
-      {
-        "name": "gibctEybBottomSheet",
-        "value": false
-      },
-      {
-        "name": "routeStLouisRPOtoBuffaloRPO",
-        "value": true
-      }
-    ]
+    "features": [{
+      "name": "preEntryCovid19Screener",
+      "value": false
+    }, {
+      "name": "dashboardShowCovid19Alert",
+      "value": true
+    }, {
+      "name": "facilityLocatorShowCommunityCares",
+      "value": true
+    }, {
+      "name": "facilitiesPpmsSuppressPharmacies",
+      "value": true
+    }, {
+      "name": "facilityLocatorFeUseV1",
+      "value": true
+    }, {
+      "name": "profile_show_profile_2.0",
+      "value": false
+    }, {
+      "name": "profileShowReceiveTextNotifications",
+      "value": true
+    }, {
+      "name": "vaOnlineScheduling",
+      "value": true
+    }, {
+      "name": "vaOnlineSchedulingCancel",
+      "value": true
+    }, {
+      "name": "vaOnlineSchedulingRequests",
+      "value": true
+    }, {
+      "name": "vaOnlineSchedulingCommunityCare",
+      "value": true
+    }, {
+      "name": "vaOnlineSchedulingDirect",
+      "value": true
+    }, {
+      "name": "vaOnlineSchedulingPast",
+      "value": true
+    }, {
+      "name": "vaOnlineSchedulingVspAppointmentList",
+      "value": false
+    }, {
+      "name": "vaOnlineSchedulingVspAppointmentNew",
+      "value": false
+    }, {
+      "name": "vaOnlineSchedulingCcspAppointmentList",
+      "value": false
+    }, {
+      "name": "vaOnlineSchedulingCcspRequestNew",
+      "value": false
+    }, {
+      "name": "vaOnlineSchedulingVspRequestList",
+      "value": false
+    }, {
+      "name": "vaOnlineSchedulingVspRequestNew",
+      "value": false
+    }, {
+      "name": "vaGlobalDowntimeNotification",
+      "value": false
+    }, {
+      "name": "ssoe",
+      "value": true
+    }, {
+      "name": "ssoeInbound",
+      "value": false
+    }, {
+      "name": "ssoeEbenefitsLinks",
+      "value": true
+    }, {
+      "name": "eduBenefitsStemScholarship",
+      "value": true
+    }, {
+      "name": "edu_section_103",
+      "value": true
+    }, {
+      "name": "gibctEstimateYourBenefits",
+      "value": true
+    }, {
+      "name": "form526OriginalClaims",
+      "value": false
+    }, {
+      "name": "vaViewDependentsAccess",
+      "value": false
+    }, {
+      "name": "allow_online_10_10cg_submissions",
+      "value": true
+    }, {
+      "name": "gibctEybBottomSheet",
+      "value": false
+    }]
   }
 }

--- a/src/applications/disability-benefits/bdd/tests/fixtures/mocks/feature-toggles.json
+++ b/src/applications/disability-benefits/bdd/tests/fixtures/mocks/feature-toggles.json
@@ -1,96 +1,131 @@
 {
   "data": {
     "type": "feature_toggles",
-    "features": [{
-      "name": "preEntryCovid19Screener",
-      "value": false
-    }, {
-      "name": "dashboardShowCovid19Alert",
-      "value": true
-    }, {
-      "name": "facilityLocatorShowCommunityCares",
-      "value": true
-    }, {
-      "name": "facilitiesPpmsSuppressPharmacies",
-      "value": true
-    }, {
-      "name": "facilityLocatorFeUseV1",
-      "value": true
-    }, {
-      "name": "profile_show_profile_2.0",
-      "value": false
-    }, {
-      "name": "profileShowReceiveTextNotifications",
-      "value": true
-    }, {
-      "name": "vaOnlineScheduling",
-      "value": true
-    }, {
-      "name": "vaOnlineSchedulingCancel",
-      "value": true
-    }, {
-      "name": "vaOnlineSchedulingRequests",
-      "value": true
-    }, {
-      "name": "vaOnlineSchedulingCommunityCare",
-      "value": true
-    }, {
-      "name": "vaOnlineSchedulingDirect",
-      "value": true
-    }, {
-      "name": "vaOnlineSchedulingPast",
-      "value": true
-    }, {
-      "name": "vaOnlineSchedulingVspAppointmentList",
-      "value": false
-    }, {
-      "name": "vaOnlineSchedulingVspAppointmentNew",
-      "value": false
-    }, {
-      "name": "vaOnlineSchedulingCcspAppointmentList",
-      "value": false
-    }, {
-      "name": "vaOnlineSchedulingCcspRequestNew",
-      "value": false
-    }, {
-      "name": "vaOnlineSchedulingVspRequestList",
-      "value": false
-    }, {
-      "name": "vaOnlineSchedulingVspRequestNew",
-      "value": false
-    }, {
-      "name": "vaGlobalDowntimeNotification",
-      "value": false
-    }, {
-      "name": "ssoe",
-      "value": true
-    }, {
-      "name": "ssoeInbound",
-      "value": false
-    }, {
-      "name": "ssoeEbenefitsLinks",
-      "value": true
-    }, {
-      "name": "eduBenefitsStemScholarship",
-      "value": true
-    }, {
-      "name": "edu_section_103",
-      "value": true
-    }, {
-      "name": "gibctEstimateYourBenefits",
-      "value": true
-    }, {
-      "name": "form526OriginalClaims",
-      "value": false
-    }, {
-      "name": "vaViewDependentsAccess",
-      "value": false
-    }, {
-      "name": "allow_online_10_10cg_submissions",
-      "value": true
-    }, {
-      "name": "gibctEybBottomSheet",
-      "value": false
-    }]
+    "features": [
+      {
+        "name": "preEntryCovid19Screener",
+        "value": false
+      },
+      {
+        "name": "dashboardShowCovid19Alert",
+        "value": true
+      },
+      {
+        "name": "facilityLocatorShowCommunityCares",
+        "value": true
+      },
+      {
+        "name": "facilitiesPpmsSuppressPharmacies",
+        "value": true
+      },
+      {
+        "name": "facilityLocatorFeUseV1",
+        "value": true
+      },
+      {
+        "name": "profile_show_profile_2.0",
+        "value": false
+      },
+      {
+        "name": "profileShowReceiveTextNotifications",
+        "value": true
+      },
+      {
+        "name": "vaOnlineScheduling",
+        "value": true
+      },
+      {
+        "name": "vaOnlineSchedulingCancel",
+        "value": true
+      },
+      {
+        "name": "vaOnlineSchedulingRequests",
+        "value": true
+      },
+      {
+        "name": "vaOnlineSchedulingCommunityCare",
+        "value": true
+      },
+      {
+        "name": "vaOnlineSchedulingDirect",
+        "value": true
+      },
+      {
+        "name": "vaOnlineSchedulingPast",
+        "value": true
+      },
+      {
+        "name": "vaOnlineSchedulingVspAppointmentList",
+        "value": false
+      },
+      {
+        "name": "vaOnlineSchedulingVspAppointmentNew",
+        "value": false
+      },
+      {
+        "name": "vaOnlineSchedulingCcspAppointmentList",
+        "value": false
+      },
+      {
+        "name": "vaOnlineSchedulingCcspRequestNew",
+        "value": false
+      },
+      {
+        "name": "vaOnlineSchedulingVspRequestList",
+        "value": false
+      },
+      {
+        "name": "vaOnlineSchedulingVspRequestNew",
+        "value": false
+      },
+      {
+        "name": "vaGlobalDowntimeNotification",
+        "value": false
+      },
+      {
+        "name": "ssoe",
+        "value": true
+      },
+      {
+        "name": "ssoeInbound",
+        "value": false
+      },
+      {
+        "name": "ssoeEbenefitsLinks",
+        "value": true
+      },
+      {
+        "name": "eduBenefitsStemScholarship",
+        "value": true
+      },
+      {
+        "name": "edu_section_103",
+        "value": true
+      },
+      {
+        "name": "gibctEstimateYourBenefits",
+        "value": true
+      },
+      {
+        "name": "form526OriginalClaims",
+        "value": false
+      },
+      {
+        "name": "vaViewDependentsAccess",
+        "value": false
+      },
+      {
+        "name": "allow_online_10_10cg_submissions",
+        "value": true
+      },
+      {
+        "name": "gibctEybBottomSheet",
+        "value": false
+      },
+      {
+        "name": "routeStLouisRPOtoBuffaloRPO",
+        "value": true
+      }
+    ]
   }
 }

--- a/src/platform/testing/local-dev-mock-api/common.js
+++ b/src/platform/testing/local-dev-mock-api/common.js
@@ -73,6 +73,7 @@ const responses = {
         { name: 'form526OriginalClaims', value: false },
         { name: 'vaViewDependentsAccess', value: false },
         { name: 'gibctEybBottomSheet', value: true },
+        { name: 'routeStLouisRPOtoBuffaloRPO', value: true },
       ],
     },
   },

--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -29,5 +29,5 @@ export default Object.freeze({
   vaViewDependentsAccess: 'vaViewDependentsAccess',
   allowOnline1010cgSubmissions: 'allow_online_10_10cg_submissions',
   gibctEybBottomSheet: 'gibctEybBottomSheet',
-  routeStLouisRPOtoBuffaloRPO: 'route_st_louis_rpo_to_buffalo_rpo',
+  routeStLouisRPOtoBuffaloRPO: 'routeStLouisRPOtoBuffaloRPO',
 });

--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -29,4 +29,5 @@ export default Object.freeze({
   vaViewDependentsAccess: 'vaViewDependentsAccess',
   allowOnline1010cgSubmissions: 'allow_online_10_10cg_submissions',
   gibctEybBottomSheet: 'gibctEybBottomSheet',
+  routeStLouisRPOtoBuffaloRPO: 'route_st_louis_rpo_to_buffalo_rpo',
 });


### PR DESCRIPTION
## Description
As a developer, I need to create a feature flag that can be used to turn on and off routing files to the St. Louis RPO so that it can be delivered to production in a timely manner.

[Originating Issue](https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/10578)

## Testing done
Testing Passes Locally

## Screenshots
N/A

## Acceptance criteria
- [x] The Feature Flag routeStLouisRPOtoBuffaloRPO is available to be used for altering submission routing.
- [x] The Feature Flag description is: "All submission data that was previously routed to St Louis RPO is routed to the Buffalo RPO"
- [x] The Feature Flag is defaulted to the OFF state.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
