### PR TITLE
add optional `addNameAttribute` prop to SchemaForm

### DIFF
--- a/src/platform/forms-system/src/js/components/SchemaForm.jsx
+++ b/src/platform/forms-system/src/js/components/SchemaForm.jsx
@@ -177,6 +177,8 @@ class SchemaForm extends React.Component {
       onSubmit,
       onChange,
       safeRenderCompletion,
+      name,
+      addNameAttribute,
     } = this.props;
 
     const useReviewMode = reviewMode && !editModeOnReviewPage;
@@ -200,6 +202,7 @@ class SchemaForm extends React.Component {
         widgets={useReviewMode ? reviewWidgets : widgets}
         fields={useReviewMode ? this.reviewFields : this.fields}
         transformErrors={this.transformErrors}
+        name={addNameAttribute ? name : null}
       >
         {children}
       </Form>
@@ -219,12 +222,19 @@ SchemaForm.propTypes = {
   onSubmit: PropTypes.func,
   onChange: PropTypes.func,
   hideTitle: PropTypes.bool,
+  addNameAttribute: PropTypes.bool,
 };
 
 SchemaForm.defaultProps = {
   // This is required when running tests, but we'd prefer not to force
   // everyone to be aware of it when writing tests that use SchemaForm
   safeRenderCompletion: navigator.userAgent === 'node.js',
+  // When `true` the rendered `Form` is passed a `name` prop so that the `form`
+  // that's rendered to the DOM will have a `name` attribute. A `form` without a
+  // `name` attribute will have its implicit `role="form"` disabled. More info
+  // re: the implicit role:
+  // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form
+  addNameAttribute: false,
 };
 
 export default SchemaForm;


### PR DESCRIPTION
## Description
I was trying to use React Testing Library's `*ByRole` queries to fine a `<form>` element that I knew was in the DOM. The queries failed because the `SchemaForm` component was rendering a `<form>` without a `name` attribute which led to its implicit `role` being disabled.

In the future we could flip the default value of this to `true`. I made it optional for now because if it was true all of our benefit application forms that use `SchemaForm` under the hook would end up with camelCase `name` values like `"veteranInformation"` which seems less than ideal. It might not matter but it should be revisited in the future.

<details>
  <summary>Health Care Application form with `name="veteranInformation"`</summary>
  
![image](https://user-images.githubusercontent.com/20728956/85620940-571a4b00-b619-11ea-963c-fa0e6bc27660.png)

</details>

## Testing done
Local

## Screenshots
![image](https://user-images.githubusercontent.com/20728956/85621107-9c3e7d00-b619-11ea-9663-517bdd39caf0.png)
> rendered `form` when `SchemaForm.addNameAttribute` is `true`

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs