### PR TITLE
Enable scroll in side nav on mobile (#9942)

### DIFF
--- a/src/platform/site-wide/sass/modules/_m-side-nav.scss
+++ b/src/platform/site-wide/sass/modules/_m-side-nav.scss
@@ -172,7 +172,6 @@ $side-nav-color-dark: #323a45;
       }
     }
     .va-sidenav-level-2 {
-      touch-action: none;
       &:last-child {
         margin-bottom: 30px;
         &::after {


### PR DESCRIPTION
## Description
Fixes https://github.com/department-of-veterans-affairs/va.gov-team/issues/9942

Scrolling on side nav wasn't working because of a `touch-action: none` entry in the CSS.

## Testing done
Tested in Chrome emulator, iOS Simulator, and a physical device (iPhone).

## Screenshots


## Acceptance criteria
- [x] User can scroll in the left nav by clicking anywhere and dragging.
- [x] Menu items still work same as in prod
- [x] Desktop functionality is not affected

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
