### PR TITLE
Remove home "/" breadcrumb accorss VAMC pages

### DIFF
--- a/src/site/layouts/bios_page.drupal.liquid
+++ b/src/site/layouts/bios_page.drupal.liquid
@@ -36,7 +36,7 @@
 {% include "src/site/includes/header.html" with drupalTags = true %}
 {% include "src/site/includes/alerts.drupal.liquid" %}
 {% include "src/site/includes/preview-edit.drupal.liquid" %}
-{% include "src/site/includes/breadcrumbs.drupal.liquid" %}
+{% include "src/site/includes/breadcrumbs.drupal.liquid" with hideHomeBreadcrumb = true %}
 <div id="content" class="interior">
     <main class="va-l-detail-page va-facility-page">
         <div class="usa-grid usa-grid-full">

--- a/src/site/layouts/event_listing.drupal.liquid
+++ b/src/site/layouts/event_listing.drupal.liquid
@@ -1,7 +1,7 @@
 {% include "src/site/includes/header.html" with drupalTags = true %}
 {% include "src/site/includes/alerts.drupal.liquid" %}
 {% include "src/site/includes/preview-edit.drupal.liquid" %}
-{% include "src/site/includes/breadcrumbs.drupal.liquid" %}
+{% include "src/site/includes/breadcrumbs.drupal.liquid" with hideHomeBreadcrumb = true %}
 
 <div class="interior" id="content">
   <main class="va-l-detail-page va-facility-page">

--- a/src/site/layouts/health_care_facility_status.drupal.liquid
+++ b/src/site/layouts/health_care_facility_status.drupal.liquid
@@ -1,7 +1,7 @@
 {% include "src/site/includes/header.html" with drupalTags = true %}
 {% include "src/site/includes/alerts.drupal.liquid" %}
 {% include "src/site/includes/preview-edit.drupal.liquid" %}
-{% include "src/site/includes/breadcrumbs.drupal.liquid" %}
+{% include "src/site/includes/breadcrumbs.drupal.liquid" with hideHomeBreadcrumb = true %}
 <div id="content" class="interior">
     <main class="va-l-detail-page va-facility-page">
         <div class="usa-grid usa-grid-full">

--- a/src/site/layouts/health_care_local_facility.drupal.liquid
+++ b/src/site/layouts/health_care_local_facility.drupal.liquid
@@ -211,7 +211,7 @@ more.\r\n",
 {% include "src/site/includes/header.html" with drupalTags = true %}
 {% include "src/site/includes/alerts.drupal.liquid" %}
 {% include "src/site/includes/preview-edit.drupal.liquid" %}
-{% include "src/site/includes/breadcrumbs.drupal.liquid" %}
+{% include "src/site/includes/breadcrumbs.drupal.liquid" with hideHomeBreadcrumb = true %}
 <div class="interior" id="content">
   <main class="va-l-detail-page va-facility-page">
     <div class="usa-grid usa-grid-full">

--- a/src/site/layouts/health_care_region_detail_page.drupal.liquid
+++ b/src/site/layouts/health_care_region_detail_page.drupal.liquid
@@ -1,7 +1,7 @@
 {% include "src/site/includes/header.html" with drupalTags = true %}
 {% include "src/site/includes/alerts.drupal.liquid" %}
 {% include "src/site/includes/preview-edit.drupal.liquid" %}
-{% include "src/site/includes/breadcrumbs.drupal.liquid" %}
+{% include "src/site/includes/breadcrumbs.drupal.liquid" with hideHomeBreadcrumb = true%}
 <div class="interior" id="content">
   <main class="va-l-detail-page va-facility-page">
     <div class="usa-grid usa-grid-full">

--- a/src/site/layouts/health_care_region_page.drupal.liquid
+++ b/src/site/layouts/health_care_region_page.drupal.liquid
@@ -123,7 +123,7 @@ Example data:
 {% include "src/site/includes/header.html" with drupalTags = true %}
 {% include "src/site/includes/alerts.drupal.liquid" %}
 {% include "src/site/includes/preview-edit.drupal.liquid" %}
-{% include "src/site/includes/breadcrumbs.drupal.liquid" %}
+{% include "src/site/includes/breadcrumbs.drupal.liquid" with hideHomeBreadcrumb = true %}
 <div id="content" class="interior">
   <main class="va-l-detail-page va-facility-page">
     <div class="usa-grid usa-grid-full">

--- a/src/site/layouts/leadership_listing.drupal.liquid
+++ b/src/site/layouts/leadership_listing.drupal.liquid
@@ -37,7 +37,7 @@ Example data:
 {% include "src/site/includes/header.html" with drupalTags = true %}
 {% include "src/site/includes/alerts.drupal.liquid" %}
 {% include "src/site/includes/preview-edit.drupal.liquid" %}
-{% include "src/site/includes/breadcrumbs.drupal.liquid" %}
+{% include "src/site/includes/breadcrumbs.drupal.liquid" with hideHomeBreadcrumb = true %}
 <div class="interior" id="content">
     <main class="va-l-detail-page va-facility-page">
         <div class="usa-grid usa-grid-full">

--- a/src/site/layouts/person_profile.drupal.liquid
+++ b/src/site/layouts/person_profile.drupal.liquid
@@ -37,7 +37,7 @@
 {% include "src/site/includes/header.html" with drupalTags = true %}
 {% include "src/site/includes/alerts.drupal.liquid" %}
 {% include "src/site/includes/preview-edit.drupal.liquid" %}
-{% include "src/site/includes/breadcrumbs.drupal.liquid" %}
+{% include "src/site/includes/breadcrumbs.drupal.liquid" with hideHomeBreadcrumb = true %}
 <div id="content" class="interior">
     <main class="va-l-detail-page va-facility-page">
         <div class="usa-grid usa-grid-full">

--- a/src/site/layouts/publication_listing.drupal.liquid
+++ b/src/site/layouts/publication_listing.drupal.liquid
@@ -2,7 +2,7 @@
 {% include "src/site/includes/header.html" with drupalTags = true %}
 {% include "src/site/includes/alerts.drupal.liquid" %}
 {% include "src/site/includes/preview-edit.drupal.liquid" %}
-{% include "src/site/includes/breadcrumbs.drupal.liquid" %}
+{% include "src/site/includes/breadcrumbs.drupal.liquid" with hideHomeBreadcrumb = true %}
 
 <div class="interior" id="content">
   <main class="va-l-detail-page va-facility-page">

--- a/src/site/layouts/vamc_operating_status_and_alerts.drupal.liquid
+++ b/src/site/layouts/vamc_operating_status_and_alerts.drupal.liquid
@@ -6,7 +6,7 @@
 {% include "src/site/includes/header.html" with drupalTags = true %}
 {% include "src/site/includes/alerts.drupal.liquid" %}
 {% include "src/site/includes/preview-edit.drupal.liquid" %}
-{% include "src/site/includes/breadcrumbs.drupal.liquid" %}
+{% include "src/site/includes/breadcrumbs.drupal.liquid" with hideHomeBreadcrumb = true %}
 <div id="content" class="interior">
     <main class="va-l-detail-page va-facility-page">
         <div class="usa-grid usa-grid-full">


### PR DESCRIPTION
## Description
issue: https://github.com/department-of-veterans-affairs/va.gov-team/issues/10038

TODO: remove [build prod check](https://github.com/department-of-veterans-affairs/vets-website/blob/8bad1aebc6d83ebc555d7bf7ad2de2bd64298063/src/site/includes/breadcrumbs.drupal.liquid#L8) when fully tested - 
## Testing done
Review instance : http://12dc4c77f42f213b4c9048866fef935f.review.vetsgov-internal/pittsburgh-health-care/

## Screenshots


## Acceptance criteria
- [x] Remove Home > across https://www.va.gov/pittsburgh-health-care/ for VAMC products only

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
