### PR TITLE
focus back to button after closing modal in additional info section

### DIFF
--- a/src/applications/gi/components/Modal.jsx
+++ b/src/applications/gi/components/Modal.jsx
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
+import { focusElement } from 'platform/utilities/ui';
 
 const ESCAPE_KEY = 27;
 const TAB_KEY = 9;
@@ -43,7 +44,11 @@ class Modal extends React.Component {
   async teardownModal() {
     if (this.state.lastFocus) {
       // Ensure last focus is set before completing modal teardown
-      await this.state.lastFocus.focus();
+      if (this.props.elementToFocusOnClose) {
+        await focusElement(`#${this.props.elementToFocusOnClose}`);
+      } else {
+        await focusElement(this.state.lastFocus);
+      }
     }
     document.body.classList.remove('modal-open');
     document.removeEventListener('keydown', this.handleDocumentKeyDown, false);
@@ -92,10 +97,10 @@ class Modal extends React.Component {
       this.props.focusSelector,
     );
     if (this.state.lastFocus) {
-      this.state.lastFocus.focus();
+      focusElement(this.state.lastFocus);
     }
     if (focusableElement) {
-      focusableElement.focus();
+      focusElement(focusableElement);
     }
   }
 
@@ -107,10 +112,10 @@ class Modal extends React.Component {
       this.element.contains(el),
     );
     if (this.state.lastFocus) {
-      this.state.lastFocus.focus();
+      focusElement(this.state.lastFocus);
     }
     if (focusableModalElements.length) {
-      focusableModalElements[focusableModalElements.length - 1].focus();
+      focusElement(focusableModalElements[focusableModalElements.length - 1]);
     }
   }
 
@@ -254,6 +259,12 @@ Modal.propTypes = {
    * modal is opened
    */
   focusSelector: PropTypes.string,
+  /**
+   * The id of the element that called the modal to be opened. Necessary so
+   * focus can be placed back to this element when modal is closed.
+   * Specifically when using IE11 and navigating with JAWS 2019 virtual keyboard.
+   */
+  elementToFocusOnClose: PropTypes.string,
 };
 
 Modal.defaultProps = {

--- a/src/applications/gi/components/profile/AdditionalInformation.jsx
+++ b/src/applications/gi/components/profile/AdditionalInformation.jsx
@@ -13,6 +13,7 @@ export class AdditionalInformation extends React.Component {
     <div className="section-103-message">
       <strong>
         <button
+          id="section103-button"
           type="button"
           className="va-button-link learn-more-button"
           onClick={() => {
@@ -51,6 +52,7 @@ export class AdditionalInformation extends React.Component {
         <div>
           <strong>
             <button
+              id="typeAccredited-button"
               type="button"
               className="va-button-link learn-more-button"
               onClick={this.props.onShowModal.bind(this, 'typeAccredited')}
@@ -83,6 +85,7 @@ export class AdditionalInformation extends React.Component {
         <div>
           <strong>
             <button
+              id="accredited-button"
               type="button"
               className="va-button-link learn-more-button"
               onClick={this.props.onShowModal.bind(this, 'accredited')}
@@ -132,6 +135,7 @@ export class AdditionalInformation extends React.Component {
         <div>
           <strong>
             <button
+              id="creditTraining-button"
               type="button"
               className="va-button-link learn-more-button"
               onClick={this.props.onShowModal.bind(this, 'creditTraining')}
@@ -145,6 +149,7 @@ export class AdditionalInformation extends React.Component {
         <div>
           <strong>
             <button
+              id="iStudy-button"
               type="button"
               className="va-button-link learn-more-button"
               onClick={this.props.onShowModal.bind(this, 'iStudy')}
@@ -158,6 +163,7 @@ export class AdditionalInformation extends React.Component {
         <div>
           <strong>
             <button
+              id="stemIndicator-button"
               type="button"
               className="va-button-link learn-more-button"
               onClick={this.props.onShowModal.bind(this, 'stemIndicator')}
@@ -172,6 +178,7 @@ export class AdditionalInformation extends React.Component {
           <div>
             <strong>
               <button
+                id="singleContact-button"
                 type="button"
                 className="va-button-link learn-more-button"
                 onClick={this.props.onShowModal.bind(this, 'singleContact')}
@@ -257,6 +264,7 @@ export class AdditionalInformation extends React.Component {
             <div>
               <strong>
                 <button
+                  id="facilityCode-button"
                   type="button"
                   className="va-button-link learn-more-button"
                   onClick={this.props.onShowModal.bind(this, 'facilityCode')}
@@ -270,6 +278,7 @@ export class AdditionalInformation extends React.Component {
             <div>
               <strong>
                 <button
+                  id="ipedsCode-button"
                   type="button"
                   className="va-button-link learn-more-button"
                   onClick={this.props.onShowModal.bind(this, 'ipedsCode')}
@@ -283,6 +292,7 @@ export class AdditionalInformation extends React.Component {
             <div>
               <strong>
                 <button
+                  id="opeCode-button"
                   type="button"
                   className="va-button-link learn-more-button"
                   onClick={this.props.onShowModal.bind(this, 'opeCode')}

--- a/src/applications/gi/components/vet-tec/VetTecAdditionalInformation.jsx
+++ b/src/applications/gi/components/vet-tec/VetTecAdditionalInformation.jsx
@@ -12,6 +12,7 @@ export const VetTecAdditionalInformation = ({
         <div>
           <strong>
             <button
+              id="facilityCode-button"
               type="button"
               className="va-button-link learn-more-button"
               onClick={() => showModal('facilityCode')}

--- a/src/applications/gi/containers/Modals.jsx
+++ b/src/applications/gi/containers/Modals.jsx
@@ -434,6 +434,7 @@ export class Modals extends React.Component {
       <Modal
         onClose={this.props.hideModal}
         visible={this.shouldDisplayModal('accredited')}
+        elementToFocusOnClose="accredited-button"
       >
         <h3>Is your school accredited</h3>
         <p>
@@ -472,6 +473,7 @@ export class Modals extends React.Component {
       <Modal
         onClose={this.props.hideModal}
         visible={this.shouldDisplayModal('typeAccredited')}
+        elementToFocusOnClose="typeAccredited-button"
       >
         <h3>Accreditation types (regional vs. national vs. hybrid)</h3>
         <p>
@@ -505,6 +507,7 @@ export class Modals extends React.Component {
       <Modal
         onClose={this.props.hideModal}
         visible={this.shouldDisplayModal('singleContact')}
+        elementToFocusOnClose="singleContact-button"
       >
         <h3>Single point of contact for Veterans</h3>
         <p>
@@ -516,6 +519,7 @@ export class Modals extends React.Component {
       <Modal
         onClose={this.props.hideModal}
         visible={this.shouldDisplayModal('creditTraining')}
+        elementToFocusOnClose="creditTraining-button"
       >
         <h3>Credit for military training</h3>
         <p>
@@ -526,6 +530,7 @@ export class Modals extends React.Component {
       <Modal
         onClose={this.props.hideModal}
         visible={this.shouldDisplayModal('stemIndicator')}
+        elementToFocusOnClose="stemIndicator-button"
       >
         <h3>The Rogers STEM Scholarship</h3>
         <div>
@@ -556,6 +561,7 @@ export class Modals extends React.Component {
       <Modal
         onClose={this.props.hideModal}
         visible={this.shouldDisplayModal('iStudy')}
+        elementToFocusOnClose="iStudy-button"
       >
         <h3>Independent study</h3>
         <p>
@@ -572,6 +578,7 @@ export class Modals extends React.Component {
       <Modal
         onClose={this.props.hideModal}
         visible={this.shouldDisplayModal('section103')}
+        elementToFocusOnClose="section103-button"
       >
         <div className="align-left">
           <h3>Protection against late VA payments</h3>
@@ -630,6 +637,7 @@ export class Modals extends React.Component {
       <Modal
         onClose={this.props.hideModal}
         visible={this.shouldDisplayModal('facilityCode')}
+        elementToFocusOnClose="facilityCode-button"
       >
         <h3>VA facility code</h3>
         <p>Unique identifier for VA-approved facilities.</p>
@@ -638,6 +646,7 @@ export class Modals extends React.Component {
       <Modal
         onClose={this.props.hideModal}
         visible={this.shouldDisplayModal('ipedsCode')}
+        elementToFocusOnClose="ipedsCode-button"
       >
         <h3>ED IPEDS code</h3>
         <p>
@@ -650,6 +659,7 @@ export class Modals extends React.Component {
       <Modal
         onClose={this.props.hideModal}
         visible={this.shouldDisplayModal('opeCode')}
+        elementToFocusOnClose="opeCode-button"
       >
         <h3>ED OPE code</h3>
         <p>


### PR DESCRIPTION
## Description
https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/9241

This addresses a specific bug when using JAWS 2019's virtual keyboard in IE11. When a user closes a modal in the Additional Info section of the profile page, we want the focus to return to the button that opened the modal. 

## Testing done
Dev tested in Win10 using IE11 and Chrome using JAWS 2019, JAWS 2020 and NVDA.
OSX using Chrome and VoiceOver.

## Screenshots


## Acceptance criteria
- [x] When modal closes, focus returns back to button that opened it.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
