### PR TITLE
[Find Forms] Fix attribute name

### DIFF
--- a/src/applications/find-forms/api/index.js
+++ b/src/applications/find-forms/api/index.js
@@ -24,7 +24,9 @@ export const fetchFormsApi = async (query, options = {}) => {
   }
 
   const forms = response?.data;
-  const onlyValidForms = forms?.filter(form => form.attributes?.validPDF);
+  const onlyValidForms = forms?.filter(
+    form => form.attributes?.validPDF || form.attributes?.validPdf,
+  );
 
   return sortBy(onlyValidForms, 'id');
 };

--- a/src/applications/find-forms/api/index.js
+++ b/src/applications/find-forms/api/index.js
@@ -24,7 +24,7 @@ export const fetchFormsApi = async (query, options = {}) => {
   }
 
   const forms = response?.data;
-  const onlyValidForms = forms?.filter(form => form.attributes?.validPdf);
+  const onlyValidForms = forms?.filter(form => form.attributes?.validPDF);
 
   return sortBy(onlyValidForms, 'id');
 };

--- a/src/applications/find-forms/prop-types.js
+++ b/src/applications/find-forms/prop-types.js
@@ -6,7 +6,8 @@ const Form = PropTypes.shape({
     formName: PropTypes.string.isRequired, // same as id
     title: PropTypes.string.isRequired,
     url: PropTypes.string.isRequired,
-    validPdf: PropTypes.bool.isRequired,
+    validPdf: PropTypes.bool,
+    validPDF: PropTypes.bool,
     lastRevisionOn: PropTypes.string,
     firstIssuedOn: PropTypes.string, // always null; meaningless property
     sha: PropTypes.string,


### PR DESCRIPTION
## Description
The attribute name `validPdf` changed to `validPDF` which broke our app, showing zero results every time. This data change seems to be related to https://github.com/department-of-veterans-affairs/vets-api/pull/4415.

## Testing done
Confirmed that we get results locally again

## Screenshots
N/A

## Acceptance criteria
- [ ] Find Forms shows search results

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
