### PR TITLE
Redirect contact information on Profile 2.0

### DIFF
--- a/src/applications/personalization/profile-2/components/Profile2Router.jsx
+++ b/src/applications/personalization/profile-2/components/Profile2Router.jsx
@@ -79,11 +79,7 @@ class Profile2Router extends Component {
                 (route.requiresMVI && !this.props.isInMVI)
               ) {
                 return (
-                  <Redirect
-                    from={route.path}
-                    key="/profile/account-security"
-                    to="/profile/account-security"
-                  />
+                  <Redirect from={route.path} to="/profile/account-security" />
                 );
               }
 
@@ -100,14 +96,12 @@ class Profile2Router extends Component {
             <Redirect
               exact
               from="/profile#contact-information"
-              key="/profile/personal-information"
               to="/profile/personal-information"
             />
 
             <Redirect
               exact
               from="/profile"
-              key="/profile/personal-information"
               to="/profile/personal-information"
             />
 

--- a/src/applications/personalization/profile-2/components/Profile2Router.jsx
+++ b/src/applications/personalization/profile-2/components/Profile2Router.jsx
@@ -99,6 +99,13 @@ class Profile2Router extends Component {
 
             <Redirect
               exact
+              from="/profile#contact-information"
+              key="/profile/personal-information"
+              to="/profile/personal-information"
+            />
+
+            <Redirect
+              exact
               from="/profile"
               key="/profile/personal-information"
               to="/profile/personal-information"


### PR DESCRIPTION
## Description
When the user is on Profile 2.0, we need to make sure that `/profile/#contact-information` is redirected to `/profile/personal-information`.

I also removed the 'key' property on the Redirects as they appear to not be needed.

## Testing done
Works locally. Also tested in Profile 1, made sure the redirect does not happen there.

## Acceptance criteria
- [x]  Make sure that `/profile/#contact-information` is redirected to `/profile/personal-information` on profile 2.0.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
