### PR TITLE
Overwrote Cypress type command to accept and simulate 0 delay inputs.

### DIFF
--- a/src/platform/testing/e2e/cypress/support/form-tester/index.js
+++ b/src/platform/testing/e2e/cypress/support/form-tester/index.js
@@ -12,6 +12,10 @@ const LOADING_SELECTOR = '.loading-indicator';
 // that are mainly there to support more specific operations.
 const COMMAND_OPTIONS = { log: false };
 
+// Cypress does not officially support typing without delay.
+// See the main support file for more details.
+const TYPE_OPTIONS = { delay: 0 };
+
 /**
  * Builds an object from a form field with attributes that are used
  * to look up test data and enter that data into the field.
@@ -259,7 +263,7 @@ Cypress.Commands.add('enterData', field => {
     case 'text': {
       cy.wrap(field.element)
         .clear()
-        .type(field.data)
+        .type(field.data, TYPE_OPTIONS)
         .then(element => {
           // Get the autocomplete menu out of the way.
           if (element.attr('role') === 'combobox') {
@@ -292,7 +296,7 @@ Cypress.Commands.add('enterData', field => {
 
       cy.get(`#${baseSelector}Year`)
         .clear()
-        .type(year);
+        .type(year, TYPE_OPTIONS);
 
       cy.get(`#${baseSelector}Month`).select(month);
 

--- a/src/platform/testing/e2e/cypress/support/index.js
+++ b/src/platform/testing/e2e/cypress/support/index.js
@@ -16,3 +16,17 @@ Cypress.on('window:before:load', window => {
   style.innerHTML = '.__acs { display: none !important; }';
   document.head.appendChild(style);
 });
+
+// Hack to allow the type command to accept and simulate an input with 0 delay.
+// The default command ignores delays under 10 (seconds).
+// https://github.com/cypress-io/cypress/issues/566#issuecomment-577763747
+Cypress.Commands.overwrite('type', (originalFn, element, text, options) => {
+  if (options?.delay === 0) {
+    element.val(text);
+    // Type and delete a character to trigger change events.
+    // Use 0 because it's expected to pass most validations.
+    return originalFn(element, '0{backspace}', options);
+  }
+
+  return originalFn(element, text, options);
+});


### PR DESCRIPTION
## Description
- The typing speed for Cypress tests is too slow and bloats the run time.
- This is an optional hack to allow tests to type with no delay, speeding up tests considerably.

## Testing done
- Tested this change on #12978.
- Jenkins: Observed about a 75% decrease in run time for a single spec file (16 minutes down to 4 minutes)
- Circle: Without the fix, the job timed out due to no output for over 10 minutes. With the fix, the time is similar to Jenkins.

## Acceptance criteria
- [ ] Cypress tests should not time out due to taking too long.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
