### PR TITLE
Use flat cms export

### DIFF
--- a/src/site/stages/build/drupal/metalsmith-drupal.js
+++ b/src/site/stages/build/drupal/metalsmith-drupal.js
@@ -69,10 +69,8 @@ function pipeDrupalPagesIntoMetalsmith(contentData, files) {
       continue;
     }
 
-    const {
-      entityUrl: { path: drupalUrl },
-      entityBundle,
-    } = page;
+    const { entityBundle } = page;
+    const drupalUrl = page.path[0].alias;
 
     const pageCompiled = compilePage(page, contentData);
     const drupalPageDir = path.join('.', drupalUrl);

--- a/src/site/stages/build/drupal/page.js
+++ b/src/site/stages/build/drupal/page.js
@@ -300,6 +300,8 @@ function compilePage(page, contentData) {
   const pageIdRaw = parseInt(page.entityId, 10);
   const pageId = { pid: pageIdRaw };
 
+  // This is breaking because entityUrl doesn't exist. Unclear if I can use
+  // entity.path[0], or if this is different.
   if (!('breadcrumb' in entityUrl)) {
     page.entityUrl = generateBreadCrumbs(entityUrl.path);
   }

--- a/src/site/stages/build/process-cms-exports/helpers.js
+++ b/src/site/stages/build/process-cms-exports/helpers.js
@@ -4,6 +4,8 @@ const path = require('path');
 const get = require('lodash/get');
 const chalk = require('chalk');
 
+let missingFiles = 0;
+
 /**
  * The path to the CMS export content.
  *
@@ -122,12 +124,17 @@ module.exports = {
       // Overrides the UUID property in the contents of the entity
       entity.uuid = uuid;
       entity.contentModelType = getContentModelType(entity);
+      entity.entityBundle = entity.contentModelType.split('-')[1];
       return entity;
     } catch (e) {
-      /* eslint-disable no-console */
-      console.error(chalk.red(`Could not read entity at ${entityPath}`));
-      console.error(e);
-      /* eslint-enable no-console */
+      missingFiles++;
+      if (!noLog) {
+        /* eslint-disable no-console */
+        console.error(chalk.red(`Could not read entity at ${entityPath}`));
+        console.error(`(Missing file #${missingFiles})`);
+        console.error(e);
+        /* eslint-enable no-console */
+      }
       return undefined;
     }
   },

--- a/src/site/stages/build/process-cms-exports/index.js
+++ b/src/site/stages/build/process-cms-exports/index.js
@@ -124,8 +124,7 @@ const entityAssemblerFactory = contentDir => {
 
     // Recursively expand entity references
     for (const [key, prop] of Object.entries(filteredEntity)) {
-      // Properties with target_uuids are always arrays from tome-sync
-      if (Array.isArray(prop)) {
+      if (key.startsWith('field_') && Array.isArray(prop)) {
         prop.forEach((item, index) => {
           const { target_uuid: targetUuid, target_type: targetType } = item;
 

--- a/src/site/stages/build/process-cms-exports/index.js
+++ b/src/site/stages/build/process-cms-exports/index.js
@@ -133,7 +133,7 @@ const entityAssemblerFactory = contentDir => {
           // We found a reference! Override it with the expanded entity.
           if (targetUuid && targetType) {
             filteredEntity[key][index] = assembleTree(
-              readEntity(contentDir, targetType, targetUuid),
+              readEntity(contentDir, targetType, targetUuid, { noLog: true }),
               ancestors.concat([{ id: toId(entity), entity }]),
               key,
             );

--- a/src/site/stages/build/process-cms-exports/index.js
+++ b/src/site/stages/build/process-cms-exports/index.js
@@ -163,30 +163,20 @@ const entityAssemblerFactory = contentDir => {
    *                    with the body of the referenced entities.
    */
   const assembleEntityTree = (entity, ancestors = [], parentFieldName = '') => {
-    // Handle circular references
+    // If readEntity returns undefined because there there was an error
+    if (!entity) return undefined;
+
     const a = findCircularReference(entity, ancestors);
     if (a) return a;
 
-    validateInput(entity);
+    try {
+      validateInput(entity);
+    } catch (e) {
+      // Ignore it; we've already logged the output but want to continue on for
+      // the sake of this experiment
+    }
 
-    const expandedEntity = expandEntityReferences(
-      entity,
-      ancestors,
-      assembleEntityTree,
-    );
-
-    // Post-transformation JSON schema validation
-    const transformedEntity = transformEntity(expandedEntity, {
-      uuid: entity.uuid[0].value,
-      ancestors,
-      parentFieldName,
-      contentDir,
-      assembleEntityTree,
-    });
-
-    validateOutput(entity, transformedEntity);
-
-    return transformedEntity;
+    return expandEntityReferences(entity, ancestors, assembleEntityTree);
   };
 
   return assembleEntityTree;

--- a/src/site/stages/build/process-cms-exports/index.js
+++ b/src/site/stages/build/process-cms-exports/index.js
@@ -166,8 +166,11 @@ const entityAssemblerFactory = contentDir => {
     // If readEntity returns undefined because there there was an error
     if (!entity) return undefined;
 
+    // If we found a circular reference, return undefined for now. This isn't
+    // liable to be the way we handle this later, but it's causing problems for
+    // this prototype.
     const a = findCircularReference(entity, ancestors);
-    if (a) return a;
+    if (a) return undefined;
 
     try {
       validateInput(entity);

--- a/src/site/stages/build/process-cms-exports/index.js
+++ b/src/site/stages/build/process-cms-exports/index.js
@@ -53,27 +53,29 @@ const findCircularReference = (entity, ancestors) => {
  * @param {Object} entity - The entity we're validating
  * @throws {Error} If the entity is invalid
  */
-const validateInput = entity => {
+const validateInput = (entity, { noLog }) => {
   // Pre-transformation JSON schema validation
   const rawErrors = validateRawEntity(entity);
   if (rawErrors.length) {
-    /* eslint-disable no-console */
-    console.warn(
-      chalk.yellow(
-        `${toId(entity)} (${getContentModelType(
-          entity,
-        )}) is invalid before transformation:`,
-      ),
-    );
-    console.warn(`${rawErrors.map(e => JSON.stringify(e, null, 2))}`);
-    rawErrors.forEach(e => {
+    if (!noLog) {
+      /* eslint-disable no-console */
       console.warn(
-        chalk.yellow(`Data found at ${e.dataPath}:`),
-        JSON.stringify(get(entity, e.dataPath.slice(1))),
+        chalk.yellow(
+          `${toId(entity)} (${getContentModelType(
+            entity,
+          )}) is invalid before transformation:`,
+        ),
       );
-    });
-    console.warn(`-------------------`);
-    /* eslint-enable no-console */
+      console.warn(`${rawErrors.map(e => JSON.stringify(e, null, 2))}`);
+      rawErrors.forEach(e => {
+        console.warn(
+          chalk.yellow(`Data found at ${e.dataPath}:`),
+          JSON.stringify(get(entity, e.dataPath.slice(1))),
+        );
+      });
+      console.warn(`-------------------`);
+      /* eslint-enable no-console */
+    }
 
     // Abort! (We may want to change this later)
     throw new Error(`${toId(entity)} is invalid before transformation`);
@@ -173,7 +175,7 @@ const entityAssemblerFactory = contentDir => {
     if (a) return undefined;
 
     try {
-      validateInput(entity);
+      validateInput(entity, { noLog: true });
     } catch (e) {
       // Ignore it; we've already logged the output but want to continue on for
       // the sake of this experiment


### PR DESCRIPTION
## Description
This is mostly an experiment for now to see how feasible it would be to use the CMS export without any transformation.

Currently, I'm trying to get the (relatively) flat JSON _to_ the templates, but keep running into problems where the Metalsmith plugins expect the data to be in a certain shape.

## Testing done
I've been using `node --inspect script/build-content.js --use-cms-export` with the [Node inspector](https://nodejs.org/en/docs/guides/debugging-getting-started/).

## Screenshots
N/A