### PR TITLE
add alert when the DD endpoint fails

### DIFF
--- a/src/applications/personalization/profile-2/components/personal-information/GenderAndDOBSection.jsx
+++ b/src/applications/personalization/profile-2/components/personal-information/GenderAndDOBSection.jsx
@@ -21,6 +21,7 @@ const renderDOB = dob => (dob ? moment(dob).format('LL') : notSetText);
 const GenderAndDOBSection = ({ gender, dob, className }) => (
   <div className={className}>
     <ProfileInfoTable
+      title="Personal information"
       data={[
         { title: 'Date of birth', value: renderDOB(dob) },
         { title: 'Gender', value: renderGender(gender) },

--- a/src/applications/personalization/profile-2/components/personal-information/PersonalInformation.jsx
+++ b/src/applications/personalization/profile-2/components/personal-information/PersonalInformation.jsx
@@ -3,11 +3,28 @@ import PropTypes from 'prop-types';
 import { Prompt } from 'react-router-dom';
 import { connect } from 'react-redux';
 
+import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
+
 import { focusElement } from 'platform/utilities/ui';
+
+import { directDepositLoadError } from 'applications/personalization/profile360/selectors';
 
 import PersonalInformationContent from './PersonalInformationContent';
 
-const PersonalInformation = ({ hasUnsavedEdits }) => {
+const MyAlert = () => (
+  <AlertBox
+    status="warning"
+    headline="We can’t access all sections of your profile"
+    className="vads-u-margin-bottom--4"
+  >
+    <p>We’re sorry. Something went wrong on our end. Please try again later.</p>
+  </AlertBox>
+);
+
+const PersonalInformation = ({
+  showNotAllDataAvailableError,
+  hasUnsavedEdits,
+}) => {
   useEffect(() => {
     focusElement('[data-focus-target]');
   }, []);
@@ -28,7 +45,7 @@ const PersonalInformation = ({ hasUnsavedEdits }) => {
   return (
     <>
       <Prompt
-        message="Are you sure you want to leave? If you leave, your in-progress work won't be saved."
+        message="Are you sure you want to leave? If you leave, your in-progress work won’t be saved."
         when={hasUnsavedEdits}
       />
       <h2
@@ -38,16 +55,19 @@ const PersonalInformation = ({ hasUnsavedEdits }) => {
       >
         Personal and contact information
       </h2>
+      {showNotAllDataAvailableError && <MyAlert />}
       <PersonalInformationContent />
     </>
   );
 };
 
 PersonalInformation.propTypes = {
+  showNotAllDataAvailableError: PropTypes.bool.isRequired,
   hasUnsavedEdits: PropTypes.bool.isRequired,
 };
 
 const mapStateToProps = state => ({
+  showNotAllDataAvailableError: !!directDepositLoadError(state),
   hasUnsavedEdits: state.vet360.hasUnsavedEdits,
 });
 

--- a/src/applications/personalization/profile-2/components/personal-information/PersonalInformation.jsx
+++ b/src/applications/personalization/profile-2/components/personal-information/PersonalInformation.jsx
@@ -14,10 +14,13 @@ import PersonalInformationContent from './PersonalInformationContent';
 const MyAlert = () => (
   <AlertBox
     status="warning"
-    headline="We can’t access all sections of your profile"
+    headline="We can’t access your direct deposit information right now"
     className="vads-u-margin-bottom--4"
   >
-    <p>We’re sorry. Something went wrong on our end. Please try again later.</p>
+    <p>
+      We’re sorry. Something went wrong on our end. Please refresh this page or
+      try again later.
+    </p>
   </AlertBox>
 );
 

--- a/src/applications/personalization/profile360/actions/paymentInformation.js
+++ b/src/applications/personalization/profile360/actions/paymentInformation.js
@@ -25,6 +25,19 @@ export function fetchPaymentInformation(recordEvent = recordAnalyticsEvent) {
     recordEvent({ event: 'profile-get-direct-deposit-started' });
     const response = await getData('/ppiu/payment_information');
 
+    // sample error when getting payment information
+    // response = {
+    //   errors: [
+    //     {
+    //       title: 'Bad Gateway',
+    //       detail: 'Received an an invalid response from the upstream server',
+    //       code: 'EVSS502',
+    //       source: 'EVSS::PPIU::Service',
+    //       status: '502',
+    //     },
+    //   ],
+    // };
+
     if (response.error) {
       recordEvent({ event: 'profile-get-direct-deposit-failure' });
       dispatch({

--- a/src/applications/personalization/profile360/selectors.js
+++ b/src/applications/personalization/profile360/selectors.js
@@ -13,6 +13,9 @@ export const directDepositAccountInformation = state =>
 export const directDepositIsSetUp = state =>
   !!directDepositAccountInformation(state)?.accountNumber;
 
+export const directDepositLoadError = state =>
+  directDepositInformation(state)?.error;
+
 export const directDepositAddressInformation = state =>
   directDepositInformation(state)?.responses?.[0]?.paymentAddress;
 

--- a/src/applications/personalization/profile360/tests/selectors.unit.spec.js
+++ b/src/applications/personalization/profile360/tests/selectors.unit.spec.js
@@ -1,6 +1,18 @@
 import { expect } from 'chai';
 import * as selectors from '../selectors';
 
+const getDirectDepositInfoError = {
+  errors: [
+    {
+      title: 'Bad Gateway',
+      detail: 'Received an an invalid response from the upstream server',
+      code: 'EVSS502',
+      source: 'EVSS::PPIU::Service',
+      status: '502',
+    },
+  ],
+};
+
 describe('profile360 selectors', () => {
   describe('directDepositIsSetUp selector', () => {
     let state;
@@ -42,20 +54,51 @@ describe('profile360 selectors', () => {
       state = {
         vaProfile: {
           paymentInformation: {
-            errors: [
+            error: getDirectDepositInfoError,
+          },
+        },
+      };
+      expect(selectors.directDepositIsSetUp(state)).to.be.false;
+    });
+  });
+
+  describe('directDepositLoadError', () => {
+    it('returns the error if there is one', () => {
+      const state = {
+        vaProfile: {
+          paymentInformation: {
+            error: getDirectDepositInfoError,
+          },
+        },
+      };
+      expect(selectors.directDepositLoadError(state)).to.deep.equal(
+        getDirectDepositInfoError,
+      );
+    });
+    it('returns undefined if there are no errors', () => {
+      const state = {
+        vaProfile: {
+          paymentInformation: {
+            responses: [
               {
-                title: 'Bad Gateway',
-                detail:
-                  'Received an an invalid response from the upstream server',
-                code: 'EVSS502',
-                source: 'EVSS::PPIU::Service',
-                status: '502',
+                paymentAccount: {
+                  accountType: '',
+                  financialInstitutionName: null,
+                  accountNumber: '123123123',
+                  financialInstitutionRoutingNumber: '',
+                },
               },
             ],
           },
         },
       };
-      expect(selectors.directDepositIsSetUp(state)).to.be.false;
+      expect(selectors.directDepositLoadError(state)).to.be.undefined;
+    });
+    it('returns undefined if payment info does not exist on the state', () => {
+      let state = {};
+      expect(selectors.directDepositLoadError(state)).to.be.undefined;
+      state = { vaProfile: {} };
+      expect(selectors.directDepositLoadError(state)).to.be.undefined;
     });
   });
 
@@ -100,16 +143,7 @@ describe('profile360 selectors', () => {
       state = {
         vaProfile: {
           paymentInformation: {
-            errors: [
-              {
-                title: 'Bad Gateway',
-                detail:
-                  'Received an an invalid response from the upstream server',
-                code: 'EVSS502',
-                source: 'EVSS::PPIU::Service',
-                status: '502',
-              },
-            ],
+            error: getDirectDepositInfoError,
           },
         },
       };


### PR DESCRIPTION
## Description
Adds an alert at the top of the Personal Info section (which servers at the Profile landing page) if there is an error hitting the `GET payment_information` endpoint. If we cannot get data from that endpoint we do not know if we should show the user the Direct Deposit section. So we will hide the Direct Deposit section and let the user know that they might not have access to all of their Profile info

Also addresses https://github.com/department-of-veterans-affairs/va.gov-team/issues/10721

## Testing done
Local

## Screenshots
![image](https://user-images.githubusercontent.com/20728956/86039892-fa8fa500-b9f7-11ea-9881-2c897d77d40d.png)

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs