### PR TITLE
Update otherHealthInsurnceName to be optionally required

### DIFF
--- a/src/applications/caregivers/config/form.js
+++ b/src/applications/caregivers/config/form.js
@@ -341,7 +341,6 @@ const formConfig = {
               primaryCaregiverFields.tricareEnrolled,
               primaryCaregiverFields.champvaEnrolled,
               primaryCaregiverFields.otherHealthInsurance,
-              primaryCaregiverFields.otherHealthInsuranceName,
             ],
             properties: {
               [primaryCaregiverFields.medicaidEnrolled]:

--- a/src/applications/caregivers/definitions/caregiverUI.js
+++ b/src/applications/caregivers/definitions/caregiverUI.js
@@ -234,6 +234,8 @@ export default {
     otherHealthInsuranceNameUI: {
       'ui:title':
         'Name of health insurance (If there are multiple policies, please separate them with commas.)',
+      'ui:required': formData =>
+        formData[primaryCaregiverFields.otherHealthInsurance] === true,
       'ui:options': {
         expandUnder: primaryCaregiverFields.otherHealthInsurance,
       },


### PR DESCRIPTION
## Description
Fixes this bug from [Issue #10238](https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/10238)


## Screenshots
![image](https://user-images.githubusercontent.com/23741323/85982217-70255200-b9b3-11ea-94e3-4591d6d22fdd.png)


## Acceptance criteria
- [x] otherHealthInsurnceName is optionally required depending on hasOtherHealthInsurance

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
