### PR TITLE
Sanlouise 10397 Add cancellation modal to Personal Information

### DIFF
--- a/src/platform/user/profile/vet360/containers/VAPProfileField.jsx
+++ b/src/platform/user/profile/vet360/containers/VAPProfileField.jsx
@@ -112,11 +112,10 @@ class VAPProfileField extends React.Component {
 
     if (!this.props.hasUnsavedEdits) {
       this.closeModal();
+      return;
     }
 
-    if (this.props.hasUnsavedEdits) {
-      this.setState({ showConfirmCancelModal: true });
-    }
+    this.setState({ showConfirmCancelModal: true });
   };
 
   onChangeFormDataAndSchemas = (value, schema, uiSchema) => {

--- a/src/platform/user/profile/vet360/containers/VAPProfileField.jsx
+++ b/src/platform/user/profile/vet360/containers/VAPProfileField.jsx
@@ -305,7 +305,10 @@ class VAPProfileField extends React.Component {
             this.setState({ showConfirmCancelModal: false });
           }}
         >
-          <p>{`You haven’t finished editing your ${activeSection}. If you cancel, your in-progress work won't be saved.`}</p>
+          <p>
+            {' '}
+            {`You haven’t finished editing your ${activeSection}. If you cancel, your in-progress work won't be saved.`}
+          </p>
           <button
             className="usa-button-secondary"
             onClick={() => {

--- a/src/platform/user/profile/vet360/containers/VAPProfileField.jsx
+++ b/src/platform/user/profile/vet360/containers/VAPProfileField.jsx
@@ -74,10 +74,12 @@ class VAPProfileField extends React.Component {
 
   static defaultProps = {
     fieldName: '',
+    showConfirmCancelModal: false,
   };
 
   state = {
     showCannotEditModal: false,
+    showConfirmCancelModal: false,
   };
 
   closeModalTimeoutID = null;
@@ -107,7 +109,14 @@ class VAPProfileField extends React.Component {
 
   onCancel = () => {
     this.captureEvent('cancel-button');
-    this.closeModal();
+
+    if (!this.props.hasUnsavedEdits) {
+      this.closeModal();
+    }
+
+    if (this.props.hasUnsavedEdits) {
+      this.setState({ showConfirmCancelModal: true });
+    }
   };
 
   onChangeFormDataAndSchemas = (value, schema, uiSchema) => {
@@ -288,6 +297,35 @@ class VAPProfileField extends React.Component {
     return (
       <div className="vet360-profile-field" data-field-name={fieldName}>
         <Modal
+          title={'Are you sure?'}
+          status="warning"
+          visible={this.state.showConfirmCancelModal}
+          onClose={() => {
+            this.setState({ showConfirmCancelModal: false });
+          }}
+        >
+          <p>{`You haven’t finished editing your ${VET360.FIELD_TITLES[
+            activeEditView
+          ]?.toLowerCase()}. If you cancel, your in-progress work won't be saved.`}</p>
+          <button
+            className="usa-button-secondary"
+            onClick={() => {
+              this.setState({ showConfirmCancelModal: false });
+            }}
+          >
+            Continue Editing
+          </button>
+          <button
+            onClick={() => {
+              this.setState({ showConfirmCancelModal: false });
+              this.closeModal();
+            }}
+          >
+            Cancel
+          </button>
+        </Modal>
+
+        <Modal
           title={`You’re currently editing your ${VET360.FIELD_TITLES[
             activeEditView
           ]?.toLowerCase()}`}
@@ -342,6 +380,7 @@ export const mapStateToProps = (state, ownProps) => {
     activeEditView === 'addressValidation';
 
   return {
+    hasUnsavedEdits: state.vet360.hasUnsavedEdits,
     analyticsSectionName: VET360.ANALYTICS_FIELD_MAP[fieldName],
     blockEditMode: !!activeEditView,
     /*
@@ -398,6 +437,7 @@ Vet360ProfileFieldContainer.propTypes = {
   title: PropTypes.string.isRequired,
   apiRoute: PropTypes.oneOf(Object.values(VET360.API_ROUTES)).isRequired,
   convertCleanDataToPayload: PropTypes.func,
+  hasUnsavedEdits: PropTypes.bool.isRequired,
 };
 
 export default Vet360ProfileFieldContainer;

--- a/src/platform/user/profile/vet360/containers/VAPProfileField.jsx
+++ b/src/platform/user/profile/vet360/containers/VAPProfileField.jsx
@@ -239,6 +239,8 @@ class VAPProfileField extends React.Component {
       ValidationView,
     } = this.props;
 
+    const activeSection = VET360.FIELD_TITLES[activeEditView]?.toLowerCase();
+
     const childProps = {
       ...this.props,
       clearErrors: this.clearErrors,
@@ -303,9 +305,7 @@ class VAPProfileField extends React.Component {
             this.setState({ showConfirmCancelModal: false });
           }}
         >
-          <p>{`You haven’t finished editing your ${VET360.FIELD_TITLES[
-            activeEditView
-          ]?.toLowerCase()}. If you cancel, your in-progress work won't be saved.`}</p>
+          <p>{`You haven’t finished editing your ${activeSection}. If you cancel, your in-progress work won't be saved.`}</p>
           <button
             className="usa-button-secondary"
             onClick={() => {
@@ -325,9 +325,7 @@ class VAPProfileField extends React.Component {
         </Modal>
 
         <Modal
-          title={`You’re currently editing your ${VET360.FIELD_TITLES[
-            activeEditView
-          ]?.toLowerCase()}`}
+          title={`You’re currently editing your ${activeSection}`}
           status="warning"
           visible={this.state.showCannotEditModal}
           onClose={() => {

--- a/src/platform/user/profile/vet360/containers/VAPProfileField.jsx
+++ b/src/platform/user/profile/vet360/containers/VAPProfileField.jsx
@@ -74,7 +74,7 @@ class VAPProfileField extends React.Component {
 
   static defaultProps = {
     fieldName: '',
-    showConfirmCancelModal: false,
+    hasUnsavedEdits: false,
   };
 
   state = {

--- a/src/platform/user/profile/vet360/tests/containers/VAPProfileField.unit.spec.jsx
+++ b/src/platform/user/profile/vet360/tests/containers/VAPProfileField.unit.spec.jsx
@@ -36,6 +36,7 @@ describe('<VAPProfileField/>', () => {
       fieldName: FIELD_NAMES.HOME_PHONE,
       showEditView: false,
       showValidationView: false,
+      showConfirmCancelModal: false,
       isEmpty: false,
       onAdd() {},
       onEdit() {},

--- a/src/platform/user/profile/vet360/tests/containers/VAPProfileField.unit.spec.jsx
+++ b/src/platform/user/profile/vet360/tests/containers/VAPProfileField.unit.spec.jsx
@@ -37,6 +37,7 @@ describe('<VAPProfileField/>', () => {
       showEditView: false,
       showValidationView: false,
       showConfirmCancelModal: false,
+      hasUnsavedEdits: false,
       isEmpty: false,
       onAdd() {},
       onEdit() {},


### PR DESCRIPTION
## Description
PROFILE 2.0 PERSONAL INFORMATION -- When a user has edited info in a section and then clicks 'Cancel', we want to show a modal to make sure the user knows that any unsaved info will be lost.

## Testing done
Works locally. We should add tests for the functionality of this modal when we write more comprehensive integration tests.

## Screenshots
![image](https://user-images.githubusercontent.com/14869324/86037473-a935e480-b9fc-11ea-8edf-6cacd35a6c5e.png)


## Acceptance criteria
- [x] PROFILE 2.0 PERSONAL INFORMATION Add a modal when the user cancels out of an unsaved section

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
