### PR TITLE
Add cancellation modal to Direct Deposit

### DIFF
--- a/src/applications/personalization/profile-2/components/direct-deposit/DirectDepositContent.jsx
+++ b/src/applications/personalization/profile-2/components/direct-deposit/DirectDepositContent.jsx
@@ -3,9 +3,11 @@ import PropTypes from 'prop-types';
 import { Prompt } from 'react-router-dom';
 import { connect } from 'react-redux';
 
+
 import ReactCSSTransitionGroup from 'react-transition-group/CSSTransitionGroup';
 
 import AdditionalInfo from '@department-of-veterans-affairs/formation-react/AdditionalInfo';
+import Modal from '@department-of-veterans-affairs/formation-react/Modal';
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 
 import EbenefitsLink from 'platform/site-wide/ebenefits/containers/EbenefitsLink';
@@ -42,6 +44,7 @@ export const DirectDepositContent = ({
   const editBankInfoButton = useRef();
   const [formData, setFormData] = useState({});
   const [showSaveSucceededAlert, setShowSaveSucceededAlert] = useState(false);
+  const [showConfirmCancelModal, setShowConfirmCancelModal] = useState(false)
   const wasEditingBankInfo = usePrevious(directDepositUiState.isEditing);
   const wasSavingBankInfo = usePrevious(directDepositUiState.isSaving);
 
@@ -128,6 +131,15 @@ export const DirectDepositContent = ({
     editButton: [...editButtonClasses, ...editButtonClassesMedium].join(' '),
   };
 
+  const closeDDForm = () => {
+    if (!isEmptyForm) {
+      setShowConfirmCancelModal(true)
+      return;
+    }
+
+    toggleEditState()
+  }
+
   // When direct deposit is already set up we will show the current bank info
   const bankInfoContent = (
     <div className={classes.bankInfo}>
@@ -194,7 +206,7 @@ export const DirectDepositContent = ({
         formData={formData}
         formSubmit={saveBankInfo}
         isSaving={directDepositUiState.isSaving}
-        onClose={toggleEditState}
+        onClose={closeDDForm}
         cancelButtonClasses={['va-button-link', 'vads-u-margin-left--1']}
       />
     </>
@@ -276,6 +288,32 @@ export const DirectDepositContent = ({
 
   return (
     <>
+      <Modal
+        title={'Are you sure?'}
+        status="warning"
+        visible={showConfirmCancelModal}
+        onClose={() => {
+          setShowConfirmCancelModal(false);
+        }}
+      >
+        <p>{`You haven’t finished editing your direct deposit information. If you cancel, your in-progress work won't be saved.`}</p>
+        <button
+          className="usa-button-secondary"
+          onClick={() => {
+            setShowConfirmCancelModal(false);
+          }}
+        >
+          Continue Editing
+        </button>
+        <button
+          onClick={() => {
+            setShowConfirmCancelModal(false);
+            toggleEditState();
+          }}
+        >
+          Cancel
+        </button>
+      </Modal>
       <Prompt
         message="Are you sure you want to leave? If you leave, your in-progress work won't be saved."
         when={!isEmptyForm}

--- a/src/applications/personalization/profile-2/components/direct-deposit/DirectDepositContent.jsx
+++ b/src/applications/personalization/profile-2/components/direct-deposit/DirectDepositContent.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import { Prompt } from 'react-router-dom';
 import { connect } from 'react-redux';
 
-
 import ReactCSSTransitionGroup from 'react-transition-group/CSSTransitionGroup';
 
 import AdditionalInfo from '@department-of-veterans-affairs/formation-react/AdditionalInfo';
@@ -44,7 +43,7 @@ export const DirectDepositContent = ({
   const editBankInfoButton = useRef();
   const [formData, setFormData] = useState({});
   const [showSaveSucceededAlert, setShowSaveSucceededAlert] = useState(false);
-  const [showConfirmCancelModal, setShowConfirmCancelModal] = useState(false)
+  const [showConfirmCancelModal, setShowConfirmCancelModal] = useState(false);
   const wasEditingBankInfo = usePrevious(directDepositUiState.isEditing);
   const wasSavingBankInfo = usePrevious(directDepositUiState.isSaving);
 
@@ -133,12 +132,12 @@ export const DirectDepositContent = ({
 
   const closeDDForm = () => {
     if (!isEmptyForm) {
-      setShowConfirmCancelModal(true)
+      setShowConfirmCancelModal(true);
       return;
     }
 
-    toggleEditState()
-  }
+    toggleEditState();
+  };
 
   // When direct deposit is already set up we will show the current bank info
   const bankInfoContent = (
@@ -296,7 +295,10 @@ export const DirectDepositContent = ({
           setShowConfirmCancelModal(false);
         }}
       >
-        <p>{`You haven’t finished editing your direct deposit information. If you cancel, your in-progress work won't be saved.`}</p>
+        <p>
+          {' '}
+          {`You haven’t finished editing your direct deposit information. If you cancel, your in-progress work won't be saved.`}
+        </p>
         <button
           className="usa-button-secondary"
           onClick={() => {


### PR DESCRIPTION
## Description
PROFILE 2.0 DIRECT DEPOSIT -- When a user has edited info in a section and then clicks 'Cancel', we want to show a modal to make sure the user knows that any unsaved info will be lost.

## Testing done
Works locally. We should add tests for the functionality of this modal when we write more comprehensive integration tests.

## Screenshots
![image](https://user-images.githubusercontent.com/14869324/86041075-58c18580-ba02-11ea-8c33-ae88e487ad61.png)

## Acceptance criteria
- [x] PROFILE 2.0 DIRECT DEPOSIT Add a modal when the user cancels out of an unsaved section

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
