### PR TITLE
remove progressbar role from header

### DIFF
--- a/src/platform/forms-system/src/js/components/FormNav.jsx
+++ b/src/platform/forms-system/src/js/components/FormNav.jsx
@@ -58,7 +58,6 @@ export default class FormNav extends React.Component {
         <SegmentedProgressBar total={chapters.length} current={current} />
         <div className="schemaform-chapter-progress">
           <div
-            role="progressbar"
             aria-valuenow={current}
             aria-valuemin="1"
             aria-valuetext={`Step ${current} of ${


### PR DESCRIPTION
## Description
Remove unneeded role attribute from progressbar header. [#317](https://app.zenhub.com/workspaces/vsp-5cedc9cce6e3335dc5a49fc4/issues/department-of-veterans-affairs/va.gov-team/317)

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
