### PR TITLE
Add CernerCTA

### DIFF
--- a/src/applications/static-pages/health-care-manage-benefits/components/CernerCallToAction/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/components/CernerCallToAction/index.js
@@ -10,7 +10,7 @@ import environment from 'platform/utilities/environment';
 import { apiRequest } from 'platform/utilities/api';
 import { getCernerURL } from 'platform/utilities/constants';
 
-class CernerCallToAction extends Component {
+export class CernerCallToAction extends Component {
   static propTypes = {
     callToActions: PropTypes.arrayOf(
       PropTypes.shape({
@@ -94,6 +94,7 @@ class CernerCallToAction extends Component {
 
     // Escape early if there was an error fetching the Cerner facilities.
     if (error || isEmpty(facilities)) {
+      // WARNING: Add sentry logging here if there is an error fetching Cerner facilities.
       return (
         <AlertBox
           headline="Something went wrong"

--- a/src/applications/static-pages/health-care-manage-benefits/components/CernerCallToAction/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/components/CernerCallToAction/index.js
@@ -8,6 +8,7 @@ import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 import LoadingIndicator from '@department-of-veterans-affairs/formation-react/LoadingIndicator';
 import environment from 'platform/utilities/environment';
 import { apiRequest } from 'platform/utilities/api';
+import { getCernerURL } from 'platform/utilities/constants';
 
 class CernerCallToAction extends Component {
   static propTypes = {
@@ -114,8 +115,8 @@ class CernerCallToAction extends Component {
             View {type} from {joinedFacilityNames}
           </h3>
           <a
-            className="usa-button"
-            href="https://ehrm-va-test.patientportal.us.healtheintent.com/pages/health_record/results/labs"
+            className="usa-button vads-u-color--white"
+            href={getCernerURL('/pages/health_record/results/labs')}
             rel="noopener noreferrer"
           >
             View results on My VA Health
@@ -125,7 +126,7 @@ class CernerCallToAction extends Component {
           </h3>
           <a
             className="usa-button usa-button-secondary"
-            href="https://www.myhealth.va.gov/mhv-portal-web/home"
+            href={getCernerURL('/pages/health_record/results/labs')}
             rel="noopener noreferrer"
           >
             View results on My HealtheVet

--- a/src/applications/static-pages/health-care-manage-benefits/components/CernerCallToAction/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/components/CernerCallToAction/index.js
@@ -126,7 +126,7 @@ class CernerCallToAction extends Component {
           </h3>
           <a
             className="usa-button usa-button-secondary"
-            href={getCernerURL('/pages/health_record/results/labs')}
+            href="https://www.myhealth.va.gov/mhv-portal-web/home"
             rel="noopener noreferrer"
           >
             View results on My HealtheVet

--- a/src/applications/static-pages/health-care-manage-benefits/components/CernerCallToAction/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/components/CernerCallToAction/index.js
@@ -1,0 +1,142 @@
+// Node modules.
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { isEmpty } from 'lodash';
+// Relative imports.
+import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
+import LoadingIndicator from '@department-of-veterans-affairs/formation-react/LoadingIndicator';
+import environment from 'platform/utilities/environment';
+import { apiRequest } from 'platform/utilities/api';
+
+class CernerCallToAction extends Component {
+  static propTypes = {
+    type: PropTypes.string.isRequired,
+    text: PropTypes.string.isRequired,
+    // From mapStateToProps.
+    facilities: PropTypes.arrayOf(
+      PropTypes.shape({
+        facilityId: PropTypes.string.isRequired,
+        isCerner: PropTypes.bool.isRequired,
+      }).isRequired,
+    ).isRequired,
+  };
+
+  constructor(props) {
+    super(props);
+    this.state = {
+      error: '',
+      facilities: [],
+      fetching: true,
+    };
+  }
+
+  componentDidMount() {
+    const { facilities } = this.props;
+
+    // Escape early if there are no facilities.
+    if (isEmpty(facilities)) {
+      return;
+    }
+
+    // Derive the cerner facilities.
+    const cernerFacilities = facilities.filter(facility => facility.isCerner);
+
+    // Escape early if there are no cerner facilities.
+    if (isEmpty(cernerFacilities)) {
+      // WARNING: Add sentry logging here if there are no cerner facilities found, this should never happen as the component only renders when there ARE cerner facilities.
+      return;
+    }
+
+    // Derive the list of facility IDs.
+    const cernerFacilityIDs = cernerFacilities.map(
+      facility => `vha_${facility.facilityId}`,
+    );
+
+    // Fetch cerner facilities.
+    this.fetchFacilities(cernerFacilityIDs);
+  }
+
+  fetchFacilities = async facilityIDs => {
+    // Show loading state.
+    this.setState({ fetching: true });
+
+    try {
+      // Fetch facilities and store them in state.
+      const response = await apiRequest(
+        `${environment.API_URL}/v1/facilities/va?ids=${facilityIDs.join(',')}`,
+      );
+      this.setState({ facilities: response?.data, fetching: false });
+
+      // Log any API errors.
+    } catch (error) {
+      this.setState({ error: error.message, fetching: false });
+    }
+  };
+
+  render() {
+    const { text, type } = this.props;
+    const { error, fetching, facilities } = this.state;
+
+    // Escape early if we are fetching.
+    if (fetching) {
+      return <LoadingIndicator message="Loading your information..." />;
+    }
+
+    // Escape early if there was an error fetching the Cerner facilities.
+    if (error || isEmpty(facilities)) {
+      return (
+        <AlertBox
+          headline="Something went wrong"
+          content="We’re sorry. Something went wrong on our end. Please try again later."
+          status="error"
+        />
+      );
+    }
+
+    // Derive the Cerner facility names.
+    const facilityNames = facilities.map(
+      facility => facility?.attributes?.name || 'unknown facility name',
+    );
+    const joinedFacilityNames =
+      facilityNames.join(', ') || 'unknown cerner facility(s)';
+
+    return (
+      <div className="usa-alert usa-alert-warning">
+        <div className="usa-alert-body">
+          <h3 className="usa-alert-heading">
+            According to our records, you are registered at a clinic within{' '}
+            {joinedFacilityNames}. VA providers at this facility and its clinics
+            are using the new My VA Health portal.
+          </h3>
+          <p className="usa-alert-text vads-u-margin-y--4">{text}</p>
+          <h3 className="usa-alert-heading">
+            View {type} from {joinedFacilityNames}
+          </h3>
+          <a className="usa-button" href="" rel="noopener noreferrer">
+            View results on My VA Health
+          </a>
+          <h3 className="usa-alert-heading vads-u-margin-top--2">
+            View {type} from another VA medical center
+          </h3>
+          <a
+            className="usa-button usa-button-secondary"
+            href=""
+            rel="noopener noreferrer"
+          >
+            View results on My HealtheVet
+          </a>
+        </div>
+      </div>
+    );
+  }
+}
+
+const mapStateToProps = state => ({
+  facilities: state?.user?.profile?.facilities,
+});
+
+export default connect(
+  mapStateToProps,
+  null,
+)(CernerCallToAction);

--- a/src/applications/static-pages/health-care-manage-benefits/components/CernerCallToAction/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/components/CernerCallToAction/index.js
@@ -110,7 +110,7 @@ export class CernerCallToAction extends Component {
       facility => facility?.attributes?.name || 'unknown facility name',
     );
     const joinedFacilityNames =
-      facilityNames.join(', ') || 'cerner facility(s)';
+      facilityNames.join(', ') || 'Cerner facility(s)';
 
     return (
       <div className="usa-alert usa-alert-warning">

--- a/src/applications/static-pages/health-care-manage-benefits/components/CernerCallToAction/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/components/CernerCallToAction/index.js
@@ -113,7 +113,11 @@ class CernerCallToAction extends Component {
           <h3 className="usa-alert-heading">
             View {type} from {joinedFacilityNames}
           </h3>
-          <a className="usa-button" href="" rel="noopener noreferrer">
+          <a
+            className="usa-button"
+            href="https://ehrm-va-test.patientportal.us.healtheintent.com/pages/health_record/results/labs"
+            rel="noopener noreferrer"
+          >
             View results on My VA Health
           </a>
           <h3 className="usa-alert-heading vads-u-margin-top--2">
@@ -121,7 +125,7 @@ class CernerCallToAction extends Component {
           </h3>
           <a
             className="usa-button usa-button-secondary"
-            href=""
+            href="https://www.myhealth.va.gov/mhv-portal-web/home"
             rel="noopener noreferrer"
           >
             View results on My HealtheVet

--- a/src/applications/static-pages/health-care-manage-benefits/components/CernerCallToAction/index.unit.spec.js
+++ b/src/applications/static-pages/health-care-manage-benefits/components/CernerCallToAction/index.unit.spec.js
@@ -1,0 +1,55 @@
+// Dependencies.
+import React from 'react';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+// Relative imports.
+import { CernerCallToAction } from '.';
+
+describe('<CernerCallToAction>', () => {
+  it('renders what we expect on its initial render', () => {
+    const wrapper = shallow(<CernerCallToAction />);
+
+    const text = wrapper.text();
+    expect(text).to.include('<LoadingIndicator />');
+
+    wrapper.unmount();
+  });
+
+  it('renders what we expect on when there is an error', () => {
+    const wrapper = shallow(<CernerCallToAction />);
+    wrapper.setState({ fetching: false, error: 'Some error' });
+
+    const text = wrapper.text();
+    expect(text).to.include('<AlertBox />');
+
+    wrapper.unmount();
+  });
+
+  it('renders what we expect when it finished fetching facilities and there are none', () => {
+    const wrapper = shallow(<CernerCallToAction />);
+    wrapper.setState({ fetching: false });
+
+    const text = wrapper.text();
+    expect(text).to.include('<AlertBox />');
+
+    wrapper.unmount();
+  });
+
+  it('renders what we expect when it finished fetching facilities and there are facilities', () => {
+    const wrapper = shallow(<CernerCallToAction />);
+    wrapper.setState({
+      fetching: false,
+      facilities: [
+        { attributes: { name: 'Example Facility 1' } },
+        { attributes: { name: 'Example Facility 2' } },
+      ],
+    });
+
+    const text = wrapper.text();
+    expect(text).to.include(
+      "According to our records, you are registered at a clinic within Example Facility 1, Example Facility 2. VA providers at this facility and its clinics are using the new My VA Health portal.You may need to sign in again to view your VA lab and test results. If you do, please sign in with the same account you used to sign in here on VA.gov. You also may need to disable your browser's pop-up blocker so that  tools are able to open.",
+    );
+
+    wrapper.unmount();
+  });
+});

--- a/src/applications/static-pages/health-care-manage-benefits/get-medical-records-page/components/AuthContent/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/get-medical-records-page/components/AuthContent/index.js
@@ -14,7 +14,8 @@ const callToActions = [
   {
     deriveHeaderText: () =>
       `Get your medical record from another VA Medical Center`,
-    href: '',
+    href:
+      'https://sqa.eauth.va.gov/mhv-portal-web/eauth?deeplinking=download_my_data',
     label: 'Get record on My HealtheVet',
   },
 ];

--- a/src/applications/static-pages/health-care-manage-benefits/get-medical-records-page/components/AuthContent/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/get-medical-records-page/components/AuthContent/index.js
@@ -2,6 +2,22 @@
 import React from 'react';
 // Relative imports.
 import CallToActionWidget from 'platform/site-wide/cta-widget';
+import CernerCallToAction from '../../../components/CernerCallToAction';
+
+const callToActions = [
+  {
+    deriveHeaderText: facilityNames =>
+      `Get your medical record from ${facilityNames}`,
+    href: '',
+    label: 'Get record on My VA Health',
+  },
+  {
+    deriveHeaderText: () =>
+      `Get your medical record from another VA Medical Center`,
+    href: '',
+    label: 'Get record on My HealtheVet',
+  },
+];
 
 const AuthContent = () => (
   <>
@@ -10,7 +26,7 @@ const AuthContent = () => (
         Get your VA medical records online
       </h2>
     </div>
-    <CallToActionWidget appId="health-records" setFocus={false} />
+    <CernerCallToAction callToActions={callToActions} type="medical records" />
     <div>
       <h2 id="how-are-my-va-health-and-va-blue">
         How are My VA Health and VA Blue Button different?

--- a/src/applications/static-pages/health-care-manage-benefits/get-medical-records-page/components/AuthContent/index.unit.spec.js
+++ b/src/applications/static-pages/health-care-manage-benefits/get-medical-records-page/components/AuthContent/index.unit.spec.js
@@ -10,6 +10,7 @@ describe('Get Medical Records Page <AuthContent>', () => {
     const wrapper = shallow(<AuthContent />);
 
     const text = wrapper.text();
+    expect(text).to.include('CernerCallToAction');
     expect(text).to.include(
       "What's VA Blue Button, and how can it help me manage my health care?",
     );

--- a/src/applications/static-pages/health-care-manage-benefits/refill-track-prescriptions-page/components/AuthContent/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/refill-track-prescriptions-page/components/AuthContent/index.js
@@ -2,10 +2,29 @@
 import React from 'react';
 // Relative imports.
 import CallToActionWidget from 'platform/site-wide/cta-widget';
+import CernerCallToAction from '../../../components/CernerCallToAction';
+
+const callToActions = [
+  {
+    deriveHeaderText: facilityNames =>
+      `Refill prescriptions from ${facilityNames}`,
+    href: '',
+    label: 'Refill prescriptions on My VA Health',
+  },
+  {
+    deriveHeaderText: () =>
+      `Refill prescriptions from another VA Medical Center`,
+    href: '',
+    label: 'Refill prescriptions on My HealtheVet',
+  },
+];
 
 export const AuthContent = () => (
   <>
-    <CallToActionWidget appId="rx" setFocus={false} />
+    <CernerCallToAction
+      callToActions={callToActions}
+      type="VA Prescription Refill and Tracking"
+    />
     <div>
       <div itemScope itemType="http://schema.org/Question">
         <h2 itemProp="name" id="how-can-the-va-prescription-re">

--- a/src/applications/static-pages/health-care-manage-benefits/refill-track-prescriptions-page/components/AuthContent/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/refill-track-prescriptions-page/components/AuthContent/index.js
@@ -3,18 +3,20 @@ import React from 'react';
 // Relative imports.
 import CallToActionWidget from 'platform/site-wide/cta-widget';
 import CernerCallToAction from '../../../components/CernerCallToAction';
+import { getCernerURL } from 'platform/utilities/constants';
 
 const callToActions = [
   {
     deriveHeaderText: facilityNames =>
       `Refill prescriptions from ${facilityNames}`,
-    href: '',
+    href: getCernerURL('/pages/medications/current'),
     label: 'Refill prescriptions on My VA Health',
   },
   {
     deriveHeaderText: () =>
       `Refill prescriptions from another VA Medical Center`,
-    href: '',
+    href:
+      'https://sqa.eauth.va.gov/mhv-portal-web/eauth?deeplinking=prescription_refill',
     label: 'Refill prescriptions on My HealtheVet',
   },
 ];

--- a/src/applications/static-pages/health-care-manage-benefits/refill-track-prescriptions-page/components/AuthContent/index.unit.spec.js
+++ b/src/applications/static-pages/health-care-manage-benefits/refill-track-prescriptions-page/components/AuthContent/index.unit.spec.js
@@ -10,6 +10,7 @@ describe('Prescriptions Page <AuthContent>', () => {
     const wrapper = shallow(<AuthContent />);
 
     const text = wrapper.text();
+    expect(text).to.include('CernerCallToAction');
     expect(text).to.not.include(
       'How can the VA Prescription Refill and Tracking tool help me manage my',
     );

--- a/src/applications/static-pages/health-care-manage-benefits/schedule-view-va-appointments-page/components/AuthContent/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/schedule-view-va-appointments-page/components/AuthContent/index.js
@@ -4,18 +4,20 @@ import React from 'react';
 import CallToActionWidget from 'platform/site-wide/cta-widget';
 import CernerCallToAction from '../../../components/CernerCallToAction';
 import MoreInfoAboutBenefits from '../../../components/MoreInfoAboutBenefits';
+import { getCernerURL } from 'platform/utilities/constants';
 
 const callToActions = [
   {
     deriveHeaderText: facilityNames =>
       `Manage appointments with ${facilityNames}`,
-    href: '',
+    href: getCernerURL('/pages/scheduling/upcoming'),
     label: 'Go to My VA Health',
   },
   {
     deriveHeaderText: () =>
       `Manage appointments at all other VA medical centers`,
-    href: '',
+    href:
+      'https://staging.va.gov/health-care/schedule-view-va-appointments/appointments',
     label: 'Go to My HealtheVet',
   },
 ];

--- a/src/applications/static-pages/health-care-manage-benefits/schedule-view-va-appointments-page/components/AuthContent/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/schedule-view-va-appointments-page/components/AuthContent/index.js
@@ -5,6 +5,21 @@ import CallToActionWidget from 'platform/site-wide/cta-widget';
 import CernerCallToAction from '../../../components/CernerCallToAction';
 import MoreInfoAboutBenefits from '../../../components/MoreInfoAboutBenefits';
 
+const callToActions = [
+  {
+    deriveHeaderText: facilityNames =>
+      `Manage appointments with ${facilityNames}`,
+    href: '',
+    label: 'Go to My VA Health',
+  },
+  {
+    deriveHeaderText: () =>
+      `Manage appointments at all other VA medical centers`,
+    href: '',
+    label: 'Go to My HealtheVet',
+  },
+];
+
 export const AuthContent = () => (
   <>
     <div className="usa-alert usa-alert-info" role="alert">
@@ -39,10 +54,7 @@ export const AuthContent = () => (
         View, schedule, or cancel a VA appointment&nbsp;online
       </h2>
     </div>
-    <CernerCallToAction
-      text="You may need to sign in again to view your VA lab and test results. If you do, please sign in with the same account you used to sign in here on VA.gov. You also may need to disable your browser's pop-up blocker so that lab and test results tools are able to open."
-      type="lab and test results"
-    />
+    <CernerCallToAction callToActions={callToActions} type="these" />
     <div>
       <div itemScope itemType="http://schema.org/Question">
         <h2 itemProp="name" id="how-can-va-appointment-tools-h">

--- a/src/applications/static-pages/health-care-manage-benefits/schedule-view-va-appointments-page/components/AuthContent/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/schedule-view-va-appointments-page/components/AuthContent/index.js
@@ -2,6 +2,7 @@
 import React from 'react';
 // Relative imports.
 import CallToActionWidget from 'platform/site-wide/cta-widget';
+import CernerCallToAction from '../../../components/CernerCallToAction';
 import MoreInfoAboutBenefits from '../../../components/MoreInfoAboutBenefits';
 
 export const AuthContent = () => (
@@ -38,7 +39,10 @@ export const AuthContent = () => (
         View, schedule, or cancel a VA appointment&nbsp;online
       </h2>
     </div>
-    <CallToActionWidget appId="view-appointments" setFocus={false} />
+    <CernerCallToAction
+      text="You may need to sign in again to view your VA lab and test results. If you do, please sign in with the same account you used to sign in here on VA.gov. You also may need to disable your browser's pop-up blocker so that lab and test results tools are able to open."
+      type="lab and test results"
+    />
     <div>
       <div itemScope itemType="http://schema.org/Question">
         <h2 itemProp="name" id="how-can-va-appointment-tools-h">

--- a/src/applications/static-pages/health-care-manage-benefits/schedule-view-va-appointments-page/components/AuthContent/index.unit.spec.js
+++ b/src/applications/static-pages/health-care-manage-benefits/schedule-view-va-appointments-page/components/AuthContent/index.unit.spec.js
@@ -10,6 +10,7 @@ describe('Scheduling Page <AuthContent>', () => {
     const wrapper = shallow(<AuthContent />);
 
     const text = wrapper.text();
+    expect(text).to.include('CernerCallToAction');
     expect(text).to.include('View, schedule, or cancel a VA appointment');
     expect(text).to.include(
       'How can VA appointment tools help me manage my health care?',

--- a/src/applications/static-pages/health-care-manage-benefits/secure-messaging-page/components/AuthContent/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/secure-messaging-page/components/AuthContent/index.js
@@ -2,11 +2,19 @@
 import React from 'react';
 // Relative imports.
 import CallToActionWidget from 'platform/site-wide/cta-widget';
+import CernerCallToAction from '../../../components/CernerCallToAction';
 import MoreInfoAboutBenefits from '../../../components/MoreInfoAboutBenefits';
 
 export const AuthContent = () => (
   <>
-    <CallToActionWidget appId="messaging" setFocus={false} />
+    <CernerCallToAction
+      text="You may need to sign in again to view your VA lab and test
+      results. If you do, please sign in with the same account you used
+      to sign in here on VA.gov. You also may need to disable your
+      browser's pop-up blocker so that lab and test results tools
+      are able to open."
+      type="lab and test results"
+    />
     <div>
       <div itemScope itemType="http://schema.org/Question">
         <h2 itemProp="name" id="how-can-va-secure-messaging-he">

--- a/src/applications/static-pages/health-care-manage-benefits/secure-messaging-page/components/AuthContent/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/secure-messaging-page/components/AuthContent/index.js
@@ -4,17 +4,19 @@ import React from 'react';
 import CallToActionWidget from 'platform/site-wide/cta-widget';
 import CernerCallToAction from '../../../components/CernerCallToAction';
 import MoreInfoAboutBenefits from '../../../components/MoreInfoAboutBenefits';
+import { getCernerURL } from 'platform/utilities/constants';
 
 const callToActions = [
   {
     deriveHeaderText: facilityNames => `Secure Message ${facilityNames}`,
-    href: '',
+    href: getCernerURL('/pages/messaging/inbox'),
     label: 'Secure Message on My VA Health',
   },
   {
     deriveHeaderText: () =>
       `Secure Message a provider at another VA Medical Center`,
-    href: '',
+    href:
+      'https://sqa.eauth.va.gov/mhv-portal-web/eauth?deeplinking=secure_messaging',
     label: 'Secure Message on My HealtheVet',
   },
 ];

--- a/src/applications/static-pages/health-care-manage-benefits/secure-messaging-page/components/AuthContent/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/secure-messaging-page/components/AuthContent/index.js
@@ -5,16 +5,23 @@ import CallToActionWidget from 'platform/site-wide/cta-widget';
 import CernerCallToAction from '../../../components/CernerCallToAction';
 import MoreInfoAboutBenefits from '../../../components/MoreInfoAboutBenefits';
 
+const callToActions = [
+  {
+    deriveHeaderText: facilityNames => `Secure Message ${facilityNames}`,
+    href: '',
+    label: 'Secure Message on My VA Health',
+  },
+  {
+    deriveHeaderText: () =>
+      `Secure Message a provider at another VA Medical Center`,
+    href: '',
+    label: 'Secure Message on My HealtheVet',
+  },
+];
+
 export const AuthContent = () => (
   <>
-    <CernerCallToAction
-      text="You may need to sign in again to view your VA lab and test
-      results. If you do, please sign in with the same account you used
-      to sign in here on VA.gov. You also may need to disable your
-      browser's pop-up blocker so that lab and test results tools
-      are able to open."
-      type="lab and test results"
-    />
+    <CernerCallToAction callToActions={callToActions} type="Secure Messaging" />
     <div>
       <div itemScope itemType="http://schema.org/Question">
         <h2 itemProp="name" id="how-can-va-secure-messaging-he">

--- a/src/applications/static-pages/health-care-manage-benefits/secure-messaging-page/components/AuthContent/index.unit.spec.js
+++ b/src/applications/static-pages/health-care-manage-benefits/secure-messaging-page/components/AuthContent/index.unit.spec.js
@@ -10,6 +10,7 @@ describe('Secure Messaging Page <AuthContent>', () => {
     const wrapper = shallow(<AuthContent />);
 
     const text = wrapper.text();
+    expect(text).to.include('CernerCallToAction');
     expect(text).to.include(
       'How can VA Secure Messaging help me manage my health care?',
     );

--- a/src/applications/static-pages/health-care-manage-benefits/view-test-and-lab-results-page/components/AuthContent/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/view-test-and-lab-results-page/components/AuthContent/index.js
@@ -5,14 +5,25 @@ import CallToActionWidget from 'platform/site-wide/cta-widget';
 import MoreInfoAboutBenefits from '../../../components/MoreInfoAboutBenefits';
 import CernerCallToAction from '../../../components/CernerCallToAction';
 
+const callToActions = [
+  {
+    deriveHeaderText: facilityNames =>
+      `View lab and test results from ${facilityNames}`,
+    href: '',
+    label: 'View results on My VA Health',
+  },
+  {
+    deriveHeaderText: () =>
+      `View lab and test results from another VA Medical Center`,
+    href: '',
+    label: 'View results on My HealtheVet',
+  },
+];
+
 export const AuthContent = () => (
   <>
     <CernerCallToAction
-      text="You may need to sign in again to view your VA lab and test
-      results. If you do, please sign in with the same account you used
-      to sign in here on VA.gov. You also may need to disable your
-      browser's pop-up blocker so that lab and test results tools
-      are able to open."
+      callToActions={callToActions}
       type="lab and test results"
     />
     <div>

--- a/src/applications/static-pages/health-care-manage-benefits/view-test-and-lab-results-page/components/AuthContent/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/view-test-and-lab-results-page/components/AuthContent/index.js
@@ -3,10 +3,18 @@ import React from 'react';
 // Relative imports.
 import CallToActionWidget from 'platform/site-wide/cta-widget';
 import MoreInfoAboutBenefits from '../../../components/MoreInfoAboutBenefits';
+import CernerCallToAction from '../../../components/CernerCallToAction';
 
 export const AuthContent = () => (
   <>
-    <CallToActionWidget appId="lab-and-test-results" setFocus={false} />
+    <CernerCallToAction
+      text="You may need to sign in again to view your VA lab and test
+      results. If you do, please sign in with the same account you used
+      to sign in here on VA.gov. You also may need to disable your
+      browser's pop-up blocker so that lab and test results tools
+      are able to open."
+      type="lab and test results"
+    />
     <div>
       <div itemScope itemType="http://schema.org/Question">
         <h2

--- a/src/applications/static-pages/health-care-manage-benefits/view-test-and-lab-results-page/components/AuthContent/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/view-test-and-lab-results-page/components/AuthContent/index.js
@@ -4,18 +4,19 @@ import React from 'react';
 import CallToActionWidget from 'platform/site-wide/cta-widget';
 import MoreInfoAboutBenefits from '../../../components/MoreInfoAboutBenefits';
 import CernerCallToAction from '../../../components/CernerCallToAction';
+import { getCernerURL } from 'platform/utilities/constants';
 
 const callToActions = [
   {
     deriveHeaderText: facilityNames =>
       `View lab and test results from ${facilityNames}`,
-    href: '',
+    href: getCernerURL('/pages/health_record/results/labs'),
     label: 'View results on My VA Health',
   },
   {
     deriveHeaderText: () =>
       `View lab and test results from another VA Medical Center`,
-    href: '',
+    href: 'https://sqa.eauth.va.gov/mhv-portal-web/eauth',
     label: 'View results on My HealtheVet',
   },
 ];

--- a/src/applications/static-pages/health-care-manage-benefits/view-test-and-lab-results-page/components/AuthContent/index.unit.spec.js
+++ b/src/applications/static-pages/health-care-manage-benefits/view-test-and-lab-results-page/components/AuthContent/index.unit.spec.js
@@ -10,6 +10,7 @@ describe('View Test + Lab Results Page <AuthContent>', () => {
     const wrapper = shallow(<AuthContent />);
 
     const text = wrapper.text();
+    expect(text).to.include('CernerCallToAction');
     expect(text).to.not.include(
       'How can this tool help me manage my health care?',
     );

--- a/src/platform/utilities/constants.js
+++ b/src/platform/utilities/constants.js
@@ -1,7 +1,18 @@
+// Relative imports.
+import environment from 'platform/utilities/environment';
+
 // TODO: Rename this to something that makes more sense
 export const requestStates = {
   notCalled: 'not called',
   pending: 'pending',
   succeeded: 'succeeded',
   failed: 'failed',
+};
+
+export const getCernerUrl = path => {
+  const root = environment.isProduction()
+    ? 'https://patientportal.myhealth.va.gov/'
+    : 'https://ehrm-va-test.patientportal.us.healtheintent.com/';
+
+  return `${root}${path}`;
 };

--- a/src/platform/utilities/constants.js
+++ b/src/platform/utilities/constants.js
@@ -9,10 +9,10 @@ export const requestStates = {
   failed: 'failed',
 };
 
-export const getCernerUrl = path => {
+export const getCernerURL = path => {
   const root = environment.isProduction()
-    ? 'https://patientportal.myhealth.va.gov/'
-    : 'https://ehrm-va-test.patientportal.us.healtheintent.com/';
+    ? 'https://patientportal.myhealth.va.gov'
+    : 'https://ehrm-va-test.patientportal.us.healtheintent.com';
 
   return `${root}${path}`;
 };


### PR DESCRIPTION
## Description

**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/10250

**Design Spec:** https://adhoc.invisionapp.com/share/DYVMI5OXEQN#/screens/405218216

This PR adds a call to action widget for when the user is 1) authenticated, 2) belongs to 1 or more Cerner facilities, and 3) is on one of the following pages:

https://www.va.gov/health-care/refill-track-prescriptions/
https://www.va.gov/health-care/secure-messaging/
https://www.va.gov/health-care/schedule-view-va-appointments
https://www.va.gov/health-care/view-test-and-lab-results
https://www.va.gov/health-care/get-medical-records

## Testing done

Added unit tests.

## Screenshots

### Loading state
![image](https://user-images.githubusercontent.com/12773166/86052864-e0b08b00-ba14-11ea-9c13-9dfa0bf7223b.png)

### Error state
![image](https://user-images.githubusercontent.com/12773166/86052822-d1314200-ba14-11ea-9dcc-ba5a304ee6cb.png)

### Success state

![image](https://user-images.githubusercontent.com/12773166/86052748-b3fc7380-ba14-11ea-8d4e-40c1d2dfe22f.png)

## Acceptance criteria
- [x] Add Cerner CTA.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
