### PR TITLE
gitignore contents of tmp dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 node_modules/
 /build/
 logs/
+tmp/
 
 # Files to ignore
 ._*


### PR DESCRIPTION
## Description
the `tmp/` dir gets written to during `yarn build` and if there is a build error git will consider the repo to be in an unclean state

someone in this situation doing a `git add` could accidentally commit these temporary files
 