### PR TITLE
Handle upcoming and active downtime for Profile 2.0 services

### DIFF
--- a/src/applications/personalization/profile-2/components/AccountSecurity.jsx
+++ b/src/applications/personalization/profile-2/components/AccountSecurity.jsx
@@ -4,6 +4,8 @@ import DowntimeNotification, {
 } from 'platform/monitoring/DowntimeNotification';
 import { focusElement } from 'platform/utilities/ui';
 
+import { handleDowntimeForSection } from 'applications/personalization/profile360/components/DowntimeBanner';
+
 import AccountSecurityContent from './AccountSecurityContent';
 
 // using a class instead of functional component + useEffect hook since we would
@@ -27,7 +29,7 @@ class AccountSecurity extends Component {
           Account security
         </h2>
         <DowntimeNotification
-          appTitle="Account Security"
+          render={handleDowntimeForSection('account security')}
           dependencies={[externalServices.emis, externalServices.mvi]}
         >
           <AccountSecurityContent />

--- a/src/applications/personalization/profile-2/components/Profile2Router.jsx
+++ b/src/applications/personalization/profile-2/components/Profile2Router.jsx
@@ -81,6 +81,8 @@ class Profile2Router extends Component {
               </h3>
             ),
           }}
+          // default for className prop is `row-padded` and we do not want that
+          // class applied to the wrapper div DowntimeApproaching renders
           className=""
           content={children}
         />

--- a/src/applications/personalization/profile-2/components/Profile2Router.jsx
+++ b/src/applications/personalization/profile-2/components/Profile2Router.jsx
@@ -4,6 +4,16 @@ import { connect } from 'react-redux';
 import { BrowserRouter, Route, Switch, Redirect } from 'react-router-dom';
 import LoadingIndicator from '@department-of-veterans-affairs/formation-react/LoadingIndicator';
 
+import DowntimeNotification, {
+  externalServices,
+  externalServiceStatus,
+} from 'platform/monitoring/DowntimeNotification';
+import DowntimeApproaching from 'platform/monitoring/DowntimeNotification/components/DowntimeApproaching';
+import {
+  initializeDowntimeWarnings,
+  dismissDowntimeWarning,
+} from 'platform/monitoring/DowntimeNotification/actions';
+
 import RequiredLoginView from 'platform/user/authorization/components/RequiredLoginView';
 import backendServices from 'platform/user/profile/constants/backendServices';
 import {
@@ -54,6 +64,30 @@ class Profile2Router extends Component {
       this.props.fetchPaymentInformation();
     }
   }
+
+  handleDowntimeApproaching = (downtime, children) => {
+    if (downtime.status === externalServiceStatus.downtimeApproaching) {
+      return (
+        <DowntimeApproaching
+          {...downtime}
+          appTitle="profile"
+          isDowntimeWarningDismissed={this.props.isDowntimeWarningDismissed}
+          dismissDowntimeWarning={this.props.dismissDowntimeWarning}
+          initializeDowntimeWarnings={this.props.initializeDowntimeWarnings}
+          messaging={{
+            title: (
+              <h3>
+                Some parts of the profile will be down for maintenance soon
+              </h3>
+            ),
+          }}
+          className=""
+          content={children}
+        />
+      );
+    }
+    return children;
+  };
 
   // content to show if the component is waiting for data to load. This loader
   // matches the loader shown by the RequiredLoginView component, so when the
@@ -128,7 +162,19 @@ class Profile2Router extends Component {
         serviceRequired={backendServices.USER_PROFILE}
         user={this.props.user}
       >
-        {this.renderContent()}
+        <DowntimeNotification
+          appTitle="profile"
+          render={this.handleDowntimeApproaching}
+          loadingIndicator={this.loadingContent()}
+          dependencies={[
+            externalServices.emis,
+            externalServices.evss,
+            externalServices.mvi,
+            externalServices.vet360,
+          ]}
+        >
+          {this.renderContent()}
+        </DowntimeNotification>
       </RequiredLoginView>
     );
   }
@@ -194,6 +240,9 @@ const mapStateToProps = state => {
       shouldFetchDirectDepositInformation &&
       !isDirectDepositBlocked &&
       (isDirectDepositSetUp || isEligibleToSignUp),
+    isDowntimeWarningDismissed: state.scheduledDowntime?.dismissedDowntimeWarnings?.includes(
+      'profile',
+    ),
   };
 };
 
@@ -203,6 +252,8 @@ const mapDispatchToProps = {
   fetchMilitaryInformation: fetchMilitaryInformationAction,
   fetchPersonalInformation: fetchPersonalInformationAction,
   fetchPaymentInformation: fetchPaymentInformationAction,
+  initializeDowntimeWarnings,
+  dismissDowntimeWarning,
 };
 
 export { Profile2Router as Profile2, mapStateToProps };

--- a/src/applications/personalization/profile-2/components/personal-information/PersonalInformation.jsx
+++ b/src/applications/personalization/profile-2/components/personal-information/PersonalInformation.jsx
@@ -5,8 +5,12 @@ import { connect } from 'react-redux';
 
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 
+import DowntimeNotification, {
+  externalServices,
+} from 'platform/monitoring/DowntimeNotification';
 import { focusElement } from 'platform/utilities/ui';
 
+import { handleDowntimeForSection } from 'applications/personalization/profile360/components/DowntimeBanner';
 import { directDepositLoadError } from 'applications/personalization/profile360/selectors';
 
 import PersonalInformationContent from './PersonalInformationContent';
@@ -58,8 +62,13 @@ const PersonalInformation = ({
       >
         Personal and contact information
       </h2>
-      {showNotAllDataAvailableError && <MyAlert />}
-      <PersonalInformationContent />
+      <DowntimeNotification
+        render={handleDowntimeForSection('personal and contact')}
+        dependencies={[externalServices.mvi, externalServices.vet360]}
+      >
+        {showNotAllDataAvailableError && <MyAlert />}
+        <PersonalInformationContent />
+      </DowntimeNotification>
     </>
   );
 };

--- a/src/applications/personalization/profile-2/tests/components/Profile2Router.unit.spec.js
+++ b/src/applications/personalization/profile-2/tests/components/Profile2Router.unit.spec.js
@@ -205,6 +205,7 @@ describe('mapStateToProps', () => {
       'showLoader',
       'shouldFetchDirectDepositInformation',
       'shouldShowDirectDeposit',
+      'isDowntimeWarningDismissed',
     ];
     expect(Object.keys(props)).to.deep.equal(expectedKeys);
   });

--- a/src/platform/monitoring/DowntimeNotification/components/DowntimeApproaching.jsx
+++ b/src/platform/monitoring/DowntimeNotification/components/DowntimeApproaching.jsx
@@ -17,11 +17,13 @@ class DowntimeApproaching extends React.Component {
       children,
       content,
       messaging = {},
+      className = 'row-padded',
     } = this.props;
     const close = () => dismissDowntimeWarning(appTitle);
     return (
       <DowntimeNotificationWrapper
         status={externalServiceStatus.downtimeApproaching}
+        className={className}
       >
         <Modal
           id="downtime-approaching-modal"

--- a/src/platform/monitoring/DowntimeNotification/components/Wrapper.jsx
+++ b/src/platform/monitoring/DowntimeNotification/components/Wrapper.jsx
@@ -1,8 +1,13 @@
 import React from 'react';
 
-export default function DowntimeNotificationWrapper({ status, children }) {
+export default function DowntimeNotificationWrapper({
+  status,
+  children,
+  className,
+}) {
+  const classes = `downtime-notification ${className}`;
   return (
-    <div className="downtime-notification row-padded" data-status={status}>
+    <div className={classes} data-status={status}>
       {children}
     </div>
   );

--- a/src/platform/monitoring/DowntimeNotification/containers/DowntimeNotification.jsx
+++ b/src/platform/monitoring/DowntimeNotification/containers/DowntimeNotification.jsx
@@ -32,7 +32,7 @@ import { getSoonestDowntime } from '../util/helpers';
  * @property {boolean} isReady - [Provided by container] A flag for indicating whether the downtime array has been retrieved from the API and if the component can render.
  * @property {Node} [loadingIndicator] - A React component that will be rendered while the request to the API for downtime information is pending.
  * @property {function} [render] - A function that may be supplied for custom rendering, useful for customizing how downtime/downtime approaching is handled. Receives the derived status, downtimeWindow, downtimeMap, children as arguments.
- * @module platorm/monitoring/DowntimeNotification
+ * @module platform/monitoring/DowntimeNotification
  */
 class DowntimeNotification extends React.Component {
   static propTypes = {


### PR DESCRIPTION
## Description
This adds support for upcoming downtime and active downtime for all Profile 2.0 sections

## Testing done
Local

## Screenshots
<details>
  <summary>Upcoming downtime</summary>
  
![downtime approaching](https://user-images.githubusercontent.com/20728956/86082813-88e24600-ba4d-11ea-9a16-d623844c0251.gif)

</details>

<details>
  <summary>Downtime for each section</summary>

<img width="954" alt="downtime-personal" src="https://user-images.githubusercontent.com/20728956/86082784-7962fd00-ba4d-11ea-82c2-0cf95fef6a7f.png">
<img width="964" alt="downtime-dd" src="https://user-images.githubusercontent.com/20728956/86082791-7d8f1a80-ba4d-11ea-9166-8689e1e9fc73.png">
<img width="961" alt="downtime-military" src="https://user-images.githubusercontent.com/20728956/86082794-7e27b100-ba4d-11ea-87f1-48436ed64036.png">
<img width="948" alt="downtime-account" src="https://user-images.githubusercontent.com/20728956/86082789-7c5ded80-ba4d-11ea-87ea-82ab45808106.png">

</details>

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs