### PR TITLE
BDD: Gating and Exam Information Changes

### DIFF
--- a/src/applications/disability-benefits/all-claims/content/claimExamsInfo.jsx
+++ b/src/applications/disability-benefits/all-claims/content/claimExamsInfo.jsx
@@ -14,10 +14,9 @@ export const claimExamsDescription = (
       content="You’ll receive a phone call from a VA third-party vendor or from VA to schedule your exam. It’s important that you answer any calls you receive after you file a disability claim."
       status="warning"
     />
-    <p>At this time we partner with 4 vendors:</p>
+    <p>At this time we partner with 3 vendors:</p>
     <ul>
       <li>QTC Medical Services (QTC)</li>
-      <li>VetFed Resources (VetFed)</li>
       <li>Veterans Evaluation Services (VES)</li>
       <li>Logistics Health Inc. (LHI)</li>
     </ul>

--- a/src/applications/disability-benefits/wizard/pages/file-bdd.jsx
+++ b/src/applications/disability-benefits/wizard/pages/file-bdd.jsx
@@ -19,6 +19,10 @@ function alertContent(getPageStateFromPageName) {
     dateDischarge.diff(dateToday, 'days') + 1;
 
   const daysRemainingToFileBDD = differenceBetweenDatesInDays - 90;
+  const isLastDayToFileBDD = daysRemainingToFileBDD === 0;
+  const dateOfLastBDDEligibility = moment()
+    .add(daysRemainingToFileBDD, 'days')
+    .format('MMM D, YYYY');
 
   return (
     <>
@@ -28,14 +32,26 @@ function alertContent(getPageStateFromPageName) {
         disability benefits prior to separation.
       </p>
       <p>
-        {daysRemainingToFileBDD === 0 ? (
-          <>This is your last day</>
+        {isLastDayToFileBDD ? (
+          <>
+            This is your <b>last day</b>
+          </>
         ) : (
           <>
             You have <b>{daysRemainingToFileBDD}</b> day(s) left
           </>
         )}{' '}
-        to file a BDD claim.
+        to file a BDD claim.{' '}
+        {isLastDayToFileBDD ? (
+          <>
+            You have until <b>11:59 p.m. CST</b>
+          </>
+        ) : (
+          <>
+            You have until <b>{dateOfLastBDDEligibility} at 11:59 p.m. CST</b>
+          </>
+        )}{' '}
+        to complete and submit the form.
       </p>
       <p>
         Please be aware that you will need to be available for 45 days after you


### PR DESCRIPTION
## Description
This pull request updates the gating information for BDD to show the exact date and time the user has as a final date to submit a BDD claim. Also updated is the exam information page to only list three vendors.

## Screenshots
![bdd30days](https://user-images.githubusercontent.com/53942725/86150429-6262f000-bacb-11ea-8277-8cb0b888fea0.PNG)

![bddlastday](https://user-images.githubusercontent.com/53942725/86150440-64c54a00-bacb-11ea-91a3-21702de4435a.PNG)

![bddsupporting](https://user-images.githubusercontent.com/53942725/86150450-6727a400-bacb-11ea-8ba1-127c0dbd4042.PNG)

## Acceptance criteria
- [ ] BDD gating updated to show exact final date and time
- [ ] BDD/526 exam information updated to list only three vendors