### PR TITLE
focus the `add...` CTA button when exiting modal

### DIFF
--- a/src/platform/user/profile/vet360/containers/VAPProfileField.jsx
+++ b/src/platform/user/profile/vet360/containers/VAPProfileField.jsx
@@ -274,6 +274,7 @@ class VAPProfileField extends React.Component {
           type="button"
           onClick={this.onAdd}
           className="va-button-link va-profile-btn"
+          id={`${this.props.fieldName}-edit-link`}
         >
           Please add your {title.toLowerCase()}
         </button>


### PR DESCRIPTION
## Description
Previously focus did not return to the `add...` button when exiting an empty field's edit mode.

## Testing done
Local

## Screenshots
![cta-focus](https://user-images.githubusercontent.com/20728956/86157392-2f653000-babc-11ea-92fe-3d2dd6e75b69.gif)
> showing focus on the `edit` button or `add...` button when exiting a contact info field's edit mode.

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs