### PR TITLE
Revert mockkeepalive to named export

### DIFF
--- a/src/platform/utilities/sso/index.js
+++ b/src/platform/utilities/sso/index.js
@@ -3,7 +3,7 @@ import environment from 'platform/utilities/environment';
 import localStorage from '../storage/localStorage';
 import { hasSessionSSO } from '../../user/profile/utilities';
 import { login, logout } from 'platform/user/authentication/utilities';
-import { keepAlive as mockKeepAlive } from './mockKeepAliveSSO';
+import mockKeepAlive from './mockKeepAliveSSO';
 import { keepAlive as liveKeepAlive } from './keepAliveSSO';
 import { getLoginAttempted } from './loginAttempted';
 


### PR DESCRIPTION
## Description

`sso/index.js` was attempting to import a named export, but `mockKeepAliveSSO` only has a default export. this should fix that warning
