### PR TITLE
Update announcements.json

### DIFF
--- a/src/applications/static-pages/school-resources/constants/announcements.json
+++ b/src/applications/static-pages/school-resources/constants/announcements.json
@@ -1,5 +1,12 @@
 [
    {    
+    "name": "California State Approving Agency for Veterans Education (CSAAVE) will return to its role as the “State Approving Agency” (SAA) for the State of California",
+    "url": "https://www.benefits.va.gov/gibill/#20200630",
+    "date": "2020-06-30",
+    "displayStartDate": "2020-06-30",
+    "displayEndDate": "2020-07-30"
+  },
+   {
     "name": "School Certifying Official (SCO) Handbook Update",
     "url": "https://www.benefits.va.gov/GIBILL/docs/job_aids/SCO_Handbook.pdf",
     "date": "2020-06-08",


### PR DESCRIPTION
Add California State Approving Agency for Veterans Education (CSAAVE) will return to its role as the “State Approving Agency” (SAA) for the State of California Announcement

## Description


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
