### PR TITLE
[Development] CST: Update uploaded evidence alert content

### DIFF
--- a/src/applications/claims-status/actions/index.jsx
+++ b/src/applications/claims-status/actions/index.jsx
@@ -403,7 +403,10 @@ export function submitFiles(claimId, trackedItem, files) {
                         {trackedItem
                           ? trackedItem.displayName
                           : 'additional evidence'}
-                        . We’ll let you know when we’ve reviewed it.
+                        . We will associate it with your record in a matter of
+                        days. If the submitted evidence impacts the status of
+                        your claim, then you will see that change within 30 days
+                        of submission.
                         <br />
                         Note: It may take a few minutes for your uploaded file
                         to show here. If you don’t see your file, please try


### PR DESCRIPTION
## Description

The claim status tool shows an alert after the user uploads new evidence.

![](https://user-images.githubusercontent.com/54544300/86017346-f19bd500-b9f1-11ea-842f-e7b8ae00bc38.png)

This PR updates the content to read

> **We have your evidence**

> Thank you for sending us additional evidence. We will associate it with your record in a matter of days. If the submitted evidence impacts the status of your claim, then you will see that change within 30 days of submission.

> Note: It may take a few minutes for your uploaded file to show here. If you don’t see your file, please try refreshing the page.

Related issue: https://github.com/department-of-veterans-affairs/va.gov-team/issues/10287

## Testing done

Unit & e2e testing

## Screenshots

Not available; unable to find a user with file upload capability

## Acceptance criteria

- [ ] Content has been updated

## Definition of done

- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
