### PR TITLE
New: MDOT Updates + Display Custom Content on Forms 

### DIFF
--- a/src/applications/disability-benefits/2346/components/IntroductionPage.jsx
+++ b/src/applications/disability-benefits/2346/components/IntroductionPage.jsx
@@ -5,6 +5,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { fetchFormStatus } from '../actions';
+import formConfig from '../config/form';
 import ErrorMessage from './ErrorMessage';
 import UnverifiedPrefillAlert from './UnverifiedPrefillAlert';
 
@@ -44,6 +45,8 @@ class IntroductionPage extends Component {
               }
               unverifiedPrefillAlert={<UnverifiedPrefillAlert />}
               startText="Order hearing aid batteries and accessories"
+              unauthStartText="Sign in to start your order"
+              formConfig={formConfig}
             >
               Please complete the 2346 form to apply for ordering hearing aid
               batteries and accessories.
@@ -140,9 +143,12 @@ class IntroductionPage extends Component {
             <SaveInProgressIntro
               buttonOnly
               hideUnauthedStartLink
+              prefillEnabled={this.props.route.formConfig.prefillEnabled}
               messages={this.props.route.formConfig.savedFormMessages}
               pageList={this.props.route.pageList}
               startText="Order hearing aid batteries and accessories"
+              unauthStartText="Sign in to start your order"
+              formConfig={formConfig}
             />
           </div>
         )}

--- a/src/applications/disability-benefits/2346/config/form.js
+++ b/src/applications/disability-benefits/2346/config/form.js
@@ -125,7 +125,6 @@ const formConfig = {
   version: 0,
   prefillEnabled: true,
   title: 'Order hearing aid batteries and accessories',
-  finishLaterLinkText: 'Finish this order later.',
   subTitle: 'VA Form 2346A',
   savedFormMessages: {
     notFound:
@@ -133,6 +132,20 @@ const formConfig = {
     noAuth: 'Please sign in again to continue your application for benefits.',
     forbidden:
       'We can’t fulfill an order for this Veteran because they are deceased in our records. If this information is incorrect, please call Veterans Benefits Assistance at 800-827-1000, Monday through Friday, 8:00 a.m. to 9:00 p.m. ET.',
+    reviewPageTitle: 'Review order details',
+    appSavedSuccessfullyMessage: 'Order has been saved.',
+    startNewAppButtonText: 'Start a new order',
+    continueAppButtonText: 'Continue your order',
+    finishAppLaterMessage: 'Finish this order later.',
+    appType: 'order',
+  },
+  customText: {
+    reviewPageTitle: 'Review order details',
+    appSavedSuccessfullyMessage: 'Order has been saved.',
+    startNewAppButtonText: 'Start a new order',
+    continueAppButtonText: 'Continue your order',
+    finishAppLaterMessage: 'Finish this order later.',
+    appType: 'order',
   },
   defaultDefinitions: {
     email,

--- a/src/applications/personalization/dashboard/helpers.jsx
+++ b/src/applications/personalization/dashboard/helpers.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-
 import * as Sentry from '@sentry/browser';
 import { isPlainObject } from 'lodash';
 
@@ -25,6 +24,7 @@ import pensionManifest from 'applications/pensions/manifest.json';
 import { DISABILITY_526_V2_ROOT_URL } from 'applications/disability-benefits/all-claims/constants';
 import { BDD_FORM_ROOT_URL } from 'applications/disability-benefits/bdd/constants';
 import hlrManifest from 'applications/disability-benefits/996/manifest.json';
+import mdotManifest from 'applications/disability-benefits/2346/manifest.json';
 
 import hcaConfig from 'applications/hca/config/form.js';
 import dependentStatusConfig from 'applications/disability-benefits/686/config/form';
@@ -43,6 +43,7 @@ import pensionConfig from 'applications/pensions/config/form.js';
 import disability526Config from 'applications/disability-benefits/526EZ/config/form.js';
 import bddConfig from 'applications/disability-benefits/bdd/config/form.js';
 import hlrConfig from 'applications/disability-benefits/996/config/form';
+import mdotConfig from 'applications/disability-benefits/2346/config/form';
 
 export const formConfigs = {
   [VA_FORM_IDS.FORM_10_10EZ]: hcaConfig,
@@ -62,6 +63,7 @@ export const formConfigs = {
   [VA_FORM_IDS.FORM_40_10007]: preneedConfig,
   [VA_FORM_IDS.FEEDBACK_TOOL]: feedbackConfig,
   [VA_FORM_IDS.FORM_20_0996]: hlrConfig,
+  [VA_FORM_IDS.FORM_VA_2346A]: mdotConfig,
 };
 
 export const formBenefits = {
@@ -83,6 +85,8 @@ export const formBenefits = {
   [VA_FORM_IDS.FEEDBACK_TOOL]: 'feedback',
   [VA_FORM_IDS.FORM_21_686C]: 'dependent status',
   [VA_FORM_IDS.FORM_20_0996]: 'Higher-level review',
+  [VA_FORM_IDS.FORM_VA_2346A]:
+    'order for hearing aid batteries and accessories',
 };
 
 export const formTitles = Object.keys(formBenefits).reduce((titles, key) => {
@@ -111,9 +115,11 @@ export const formDescriptions = Object.keys(formBenefits).reduce(
     } else {
       formNumber = `(${key})`;
     }
-    const formDescription = `${formBenefits[key]} application ${formNumber}`;
-    descriptions[key] = formDescription; // eslint-disable-line no-param-reassign
-    return descriptions;
+    let formDescription = `${formBenefits[key]} application ${formNumber}`;
+    if (key === VA_FORM_IDS.FORM_VA_2346A) {
+      formDescription = `${formBenefits[key]} ${formNumber}`;
+    }
+    return { ...descriptions, [key]: formDescription };
   },
   {},
 );
@@ -136,6 +142,7 @@ export const formLinks = {
   [VA_FORM_IDS.FEEDBACK_TOOL]: `${feedbackManifest.rootUrl}/`,
   [VA_FORM_IDS.FORM_21_686C]: `${dependentStatusManifest.rootUrl}/`,
   [VA_FORM_IDS.FORM_20_0996]: `${hlrManifest.rootUrl}/`,
+  [VA_FORM_IDS.FORM_VA_2346A]: `${mdotManifest.rootUrl}/`,
 };
 
 export const trackingPrefixes = {
@@ -156,6 +163,7 @@ export const trackingPrefixes = {
   [VA_FORM_IDS.FEEDBACK_TOOL]: 'gi_bill_feedback',
   [VA_FORM_IDS.FORM_21_686C]: '686-',
   [VA_FORM_IDS.FORM_20_0996]: 'hlr-0996-',
+  [VA_FORM_IDS.FORM_VA_2346A]: 'bam-2346a-',
 };
 
 export const sipEnabledForms = new Set([
@@ -176,6 +184,7 @@ export const sipEnabledForms = new Set([
   VA_FORM_IDS.FORM_40_10007,
   VA_FORM_IDS.FEEDBACK_TOOL,
   VA_FORM_IDS.FORM_20_0996,
+  VA_FORM_IDS.FORM_VA_2346A,
 ]);
 
 // A dict of presentable form IDs. Generally this is just the form ID itself

--- a/src/platform/forms-system/src/js/components/FormNav.jsx
+++ b/src/platform/forms-system/src/js/components/FormNav.jsx
@@ -10,6 +10,9 @@ import {
   getActiveExpandedPages,
 } from '../helpers';
 
+import PropTypes from 'prop-types';
+import { REVIEW_APP_DEFAULT_MESSAGE } from '../constants';
+
 export default class FormNav extends React.Component {
   // The formConfig transforming is a little heavy, so skip it if we can
   shouldComponentUpdate(newProps) {
@@ -46,7 +49,7 @@ export default class FormNav extends React.Component {
       // The review page is always part of our forms, but isn’t listed in chapter list
       chapterName =
         page.chapterKey === 'review'
-          ? 'Review Application'
+          ? formConfig.customText.reviewPageTitle || REVIEW_APP_DEFAULT_MESSAGE
           : formConfig.chapters[page.chapterKey].title;
       if (typeof chapterName === 'function') {
         chapterName = chapterName();
@@ -77,3 +80,21 @@ export default class FormNav extends React.Component {
     );
   }
 }
+
+FormNav.defaultProps = {
+  formConfig: {
+    customText: {
+      reviewPageTitle: '',
+    },
+  },
+  currentPath: '',
+  formData: {},
+};
+
+FormNav.propTypes = {
+  formConfig: PropTypes.shape({
+    customText: PropTypes.shape({
+      reviewPageTitle: PropTypes.string,
+    }),
+  }).isRequired,
+};

--- a/src/platform/forms-system/src/js/constants.js
+++ b/src/platform/forms-system/src/js/constants.js
@@ -1,0 +1,1 @@
+export const REVIEW_APP_DEFAULT_MESSAGE = 'Review Application';

--- a/src/platform/forms-system/test/js/components/FormNav.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/components/FormNav.unit.spec.jsx
@@ -5,41 +5,73 @@ import SkinDeep from 'skin-deep';
 import FormNav from '../../../src/js/components/FormNav';
 
 describe('Schemaform FormNav', () => {
-  it('should render current chapter data', () => {
-    const formConfig = {
-      chapters: {
-        chapter1: {
-          title: 'Testing',
-          pages: {
-            page1: {
-              path: 'testing',
-            },
-          },
-        },
-        chapter2: {
-          pages: {
-            page2: {
-              path: 'testing',
-            },
-          },
-        },
-        chapter3: {
-          pages: {
-            page3: {
-              path: 'testing',
-            },
+  const getDefaultData = () => ({
+    chapters: {
+      chapter1: {
+        title: 'Testing',
+        pages: {
+          page1: {
+            path: 'testing',
           },
         },
       },
-    };
-    const currentPath = 'testing';
+      chapter2: {
+        pages: {
+          page2: {
+            path: 'testing',
+          },
+        },
+      },
+      chapter3: {
+        pages: {
+          page3: {
+            path: 'testing',
+          },
+        },
+      },
+    },
+  });
+  const getReviewData = () => ({
+    chapters: {
+      chapter1: {
+        title: 'Testing',
+        pages: {
+          page1: {
+            path: 'testing',
+          },
+        },
+      },
+      chapter2: {
+        pages: {
+          page2: {
+            path: 'testing',
+          },
+        },
+      },
+    },
+    customText: {
+      reviewPageTitle: 'Custom Review Page Title',
+    },
+  });
 
+  it('should render current chapter data', () => {
+    const currentPath = 'testing';
+    const formConfigDefaultData = getDefaultData();
     const tree = SkinDeep.shallowRender(
-      <FormNav formConfig={formConfig} currentPath={currentPath} />,
+      <FormNav formConfig={formConfigDefaultData} currentPath={currentPath} />,
     );
 
     expect(tree.subTree('SegmentedProgressBar').props.total).to.equal(4);
     expect(tree.subTree('SegmentedProgressBar').props.current).to.equal(1);
     expect(tree.subTree('.nav-header').text()).to.equal('1 of 4 Testing');
+  });
+  it('should display a custom review page title', () => {
+    const formConfigReviewData = getReviewData();
+    const currentPath = 'review-and-submit';
+
+    const tree = SkinDeep.shallowRender(
+      <FormNav formConfig={formConfigReviewData} currentPath={currentPath} />,
+    );
+    expect(tree.text()).to.include('Custom Review Page Title');
   });
 });

--- a/src/platform/forms/save-in-progress/ApplicationStatus.jsx
+++ b/src/platform/forms/save-in-progress/ApplicationStatus.jsx
@@ -13,6 +13,11 @@ import ProgressButton from '@department-of-veterans-affairs/formation-react/Prog
 import Modal from '@department-of-veterans-affairs/formation-react/Modal';
 import { removeSavedForm } from '../../user/profile/actions';
 
+import {
+  CONTINUE_APP_DEFAULT_MESSAGE,
+  START_NEW_APP_DEFAULT_MESSAGE,
+} from './constants';
+
 export class ApplicationStatus extends React.Component {
   constructor(props) {
     super(props);
@@ -73,7 +78,14 @@ export class ApplicationStatus extends React.Component {
 
     let savedForm;
     let { formId } = this.props;
+    const { formConfig } = this.props;
     let multipleForms = false;
+    const startNewAppButtonText =
+      formConfig.customText?.startNewAppButtonText ||
+      START_NEW_APP_DEFAULT_MESSAGE;
+    const continueAppButtonText =
+      formConfig.customText?.continueAppButtonText ||
+      CONTINUE_APP_DEFAULT_MESSAGE;
     if (formIds) {
       const matchingForms = profile.savedForms.filter(({ form }) =>
         formIds.has(form),
@@ -127,13 +139,13 @@ export class ApplicationStatus extends React.Component {
                 className="usa-button-primary"
                 href={`${formLinks[formId]}resume`}
               >
-                Continue your application
+                {continueAppButtonText}
               </a>
               <button
                 className="usa-button-secondary"
                 onClick={this.toggleModal}
               >
-                Start a new application
+                {startNewAppButtonText}
               </button>
             </p>
             {multipleForms && (
@@ -155,7 +167,7 @@ export class ApplicationStatus extends React.Component {
               <p>Are you sure you want to start over?</p>
               <ProgressButton
                 onButtonClick={() => this.removeForm(formId)}
-                buttonText="Start a new application"
+                buttonText={startNewAppButtonText}
                 buttonClass="usa-button-primary"
               />
               <ProgressButton
@@ -177,7 +189,7 @@ export class ApplicationStatus extends React.Component {
           <br />
           <p>
             <button className="usa-button-primary" onClick={this.toggleModal}>
-              Start a new application
+              {startNewAppButtonText}
             </button>
           </p>
           {multipleForms && (
@@ -199,7 +211,7 @@ export class ApplicationStatus extends React.Component {
             <p>Are you sure you want to start over?</p>
             <ProgressButton
               onButtonClick={() => this.removeForm(formId)}
-              buttonText="Start a new application"
+              buttonText={startNewAppButtonText}
               buttonClass="usa-button-primary"
             />
             <ProgressButton
@@ -263,18 +275,25 @@ ApplicationStatus.propTypes = {
   }),
   stayAfterDelete: PropTypes.bool,
   showLearnMoreLink: PropTypes.bool,
+  formConfig: PropTypes.shape({
+    customText: PropTypes.shape({
+      continueAppButtonText: PropTypes.string,
+      startNewAppButtonText: PropTypes.string,
+    }),
+  }).isRequired,
 };
 
 ApplicationStatus.defaultProps = {
   applyHeading: 'Ready to apply?',
 };
 
-function mapStateToProps(state) {
+function mapStateToProps(state, ownProps) {
   const { login, profile } = state.user;
 
   return {
     login,
     profile,
+    formConfig: ownProps.formConfig,
   };
 }
 

--- a/src/platform/forms/save-in-progress/FormStartControls.jsx
+++ b/src/platform/forms/save-in-progress/FormStartControls.jsx
@@ -1,10 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { withRouter } from 'react-router';
-
 import ProgressButton from '@department-of-veterans-affairs/formation-react/ProgressButton';
 import Modal from '@department-of-veterans-affairs/formation-react/Modal';
 import recordEvent from 'platform/monitoring/record-event';
+import {
+  CONTINUE_APP_DEFAULT_MESSAGE,
+  START_NEW_APP_DEFAULT_MESSAGE,
+} from './constants';
 
 class FormStartControls extends React.Component {
   constructor(props) {
@@ -64,20 +67,28 @@ class FormStartControls extends React.Component {
   };
 
   render() {
+    // get access to the formConfig object through this route
+    const { formConfig } = this.props.routes[1];
+    const startNewAppButtonText =
+      formConfig.customText?.startNewAppButtonText ||
+      START_NEW_APP_DEFAULT_MESSAGE;
+    const continueAppButtonText =
+      formConfig.customText?.continueAppButtonText ||
+      CONTINUE_APP_DEFAULT_MESSAGE;
     if (this.props.formSaved) {
       return (
         <div>
           {!this.props.isExpired && (
             <ProgressButton
               onButtonClick={this.handleLoadForm}
-              buttonText="Continue your application"
+              buttonText={continueAppButtonText}
               buttonClass="usa-button-primary no-text-transform"
             />
           )}
           {!this.props.resumeOnly && (
             <ProgressButton
               onButtonClick={this.toggleModal}
-              buttonText="Start a new application"
+              buttonText={startNewAppButtonText}
               buttonClass={
                 this.props.isExpired
                   ? 'usa-button-primary'
@@ -95,7 +106,7 @@ class FormStartControls extends React.Component {
             <p>Are you sure you want to start over?</p>
             <ProgressButton
               onButtonClick={this.startOver}
-              buttonText="Start a new application"
+              buttonText={startNewAppButtonText}
               buttonClass="usa-button-primary"
             />
             <ProgressButton
@@ -135,10 +146,22 @@ FormStartControls.propTypes = {
   startText: PropTypes.string,
   resumeOnly: PropTypes.bool,
   gaStartEventName: PropTypes.string,
+  formConfig: PropTypes.shape({
+    customText: PropTypes.shape({
+      startNewAppButtonText: PropTypes.string,
+      continueAppButtonText: PropTypes.string,
+    }),
+  }).isRequired,
 };
 
 FormStartControls.defaultProps = {
   gaStartEventName: 'login-successful-start-form',
+  formConfig: {
+    customText: {
+      startNewAppButtonText: '',
+      continueAppButtonText: '',
+    },
+  },
 };
 
 export default withRouter(FormStartControls);

--- a/src/platform/forms/save-in-progress/RoutedSavablePage.jsx
+++ b/src/platform/forms/save-in-progress/RoutedSavablePage.jsx
@@ -17,6 +17,7 @@ import {
 } from './actions';
 import { getFormContext } from './selectors';
 import { toggleLoginModal } from '../../site-wide/user-nav/actions';
+import { FINISH_APP_LATER_DEFAULT_MESSAGE } from './constants';
 
 class RoutedSavablePage extends React.Component {
   constructor(props) {
@@ -41,7 +42,7 @@ class RoutedSavablePage extends React.Component {
   }
 
   render() {
-    const { user, form } = this.props;
+    const { user, form, formConfig } = this.props;
     const contentAfterButtons = (
       <div>
         <SaveStatus
@@ -49,6 +50,7 @@ class RoutedSavablePage extends React.Component {
           showLoginModal={this.props.showLoginModal}
           toggleLoginModal={this.props.toggleLoginModal}
           form={form}
+          formConfig={formConfig}
         />
         <SaveFormLink
           locationPathname={this.props.location.pathname}
@@ -58,7 +60,8 @@ class RoutedSavablePage extends React.Component {
           saveAndRedirectToReturnUrl={this.props.saveAndRedirectToReturnUrl}
           toggleLoginModal={this.props.toggleLoginModal}
         >
-          {this.props.route.formConfig.finishLaterLinkText}
+          {formConfig.customText?.finishAppLaterMessage ||
+            FINISH_APP_LATER_DEFAULT_MESSAGE}
         </SaveFormLink>
       </div>
     );
@@ -82,6 +85,7 @@ function mapStateToProps(state, ownProps) {
     user: state.user,
     showLoginModal: state.navigation.showLoginModal,
     appStateData: appStateSelector && appStateSelector(state),
+    formConfig: ownProps.route.formConfig,
   };
 }
 
@@ -108,6 +112,11 @@ RoutedSavablePage.propTypes = {
     ),
   }),
   setData: PropTypes.func,
+  formConfig: PropTypes.shape({
+    customText: PropTypes.shape({
+      finishAppLaterMessage: PropTypes.string,
+    }),
+  }).isRequired,
 };
 
 export default withRouter(

--- a/src/platform/forms/save-in-progress/RoutedSavableReviewPage.jsx
+++ b/src/platform/forms/save-in-progress/RoutedSavableReviewPage.jsx
@@ -173,7 +173,7 @@ class RoutedSavableReviewPage extends React.Component {
           saveAndRedirectToReturnUrl={this.props.saveAndRedirectToReturnUrl}
           toggleLoginModal={this.props.toggleLoginModal}
         >
-          {formConfig.finishLaterLinkText}
+          {formConfig.finishAppLaterMessage}
         </SaveFormLink>
       </div>
     );

--- a/src/platform/forms/save-in-progress/SaveInProgressErrorPage.jsx
+++ b/src/platform/forms/save-in-progress/SaveInProgressErrorPage.jsx
@@ -15,6 +15,7 @@ import SignInLink from '../components/SignInLink';
 import ProgressButton from '@department-of-veterans-affairs/formation-react/ProgressButton';
 
 import { toggleLoginModal } from '../../site-wide/user-nav/actions';
+import { CONTINUE_APP_DEFAULT_MESSAGE } from './constants';
 
 const DEFAULT_FORBIDDEN_MESSAGE = `
   We're sorry. We can't give you access to this information. For help, please call the VA.gov help desk at 855-574-7286 (TTY: 711). We’re here Monday–Friday, 8:00 a.m.–8:00 p.m. ET.
@@ -61,9 +62,11 @@ class SaveInProgressErrorPage extends React.Component {
   };
 
   render() {
-    const { loadedStatus } = this.props;
-    const { forbidden, noAuth, notFound } =
-      this.props.route.formConfig.savedFormMessages || {};
+    const { loadedStatus, formConfig } = this.props;
+    const { forbidden, noAuth, notFound } = formConfig.savedFormMessages || {};
+    const continueAppButtonText =
+      formConfig.customText?.continueAppButtonText ||
+      CONTINUE_APP_DEFAULT_MESSAGE;
     let content;
 
     switch (loadedStatus) {
@@ -101,7 +104,7 @@ class SaveInProgressErrorPage extends React.Component {
             <div style={{ marginTop: '30px' }}>
               {this.getBackButton()}
               <button className="usa-button-primary" onClick={this.reloadForm}>
-                Continue Your Application
+                {continueAppButtonText}
               </button>
             </div>
           </div>
@@ -127,7 +130,7 @@ class SaveInProgressErrorPage extends React.Component {
             <div style={{ marginTop: '30px' }}>
               {this.getBackButton()}
               <button className="usa-button-primary" onClick={this.reloadForm}>
-                Continue Your Application
+                {continueAppButtonText}
               </button>
             </div>
           </div>
@@ -144,7 +147,7 @@ class SaveInProgressErrorPage extends React.Component {
             <div style={{ marginTop: '30px' }}>
               {this.getBackButton()}
               <button className="usa-button-primary" onClick={this.reloadForm}>
-                Continue Your Application
+                {continueAppButtonText}
               </button>
             </div>
           </div>
@@ -174,22 +177,27 @@ class SaveInProgressErrorPage extends React.Component {
 
 SaveInProgressErrorPage.propTypes = {
   loadedStatus: PropTypes.string.isRequired,
-  savedFormMessages: PropTypes.shape({
-    notFound: PropTypes.string,
-    noAuth: PropTypes.string,
-  }),
-
   isStartingOver: PropTypes.bool.isRequired,
   // For SignInLink
   isLoggedIn: PropTypes.bool.isRequired,
+  formConfig: PropTypes.shape({
+    savedFormMessages: PropTypes.shape({
+      notFound: PropTypes.string,
+      noAuth: PropTypes.string,
+    }),
+    customText: PropTypes.shape({
+      continueAppButtonText: PropTypes.string,
+    }),
+  }).isRequired,
 };
 
-const mapStateToProps = store => ({
+const mapStateToProps = (store, ownProps) => ({
   loadedStatus: store.form.loadedStatus,
   prefillStatus: store.form.prefillStatus,
   isLoggedIn: store.user.login.currentlyLoggedIn,
   showLoginModal: store.navigation.showLoginModal,
   isStartingOver: store.form.isStartingOver,
+  formConfig: ownProps.formConfig,
 });
 
 const mapDispatchToProps = {

--- a/src/platform/forms/save-in-progress/SaveInProgressIntro.jsx
+++ b/src/platform/forms/save-in-progress/SaveInProgressIntro.jsx
@@ -21,6 +21,7 @@ import DowntimeNotification, {
   externalServiceStatus,
 } from 'platform/monitoring/DowntimeNotification';
 import DowntimeMessage from './DowntimeMessage';
+import { APP_TYPE_DEFAULT, UNAUTH_SIGN_IN_DEFAULT_MESSAGE } from './constants';
 
 class SaveInProgressIntro extends React.Component {
   getAlert = savedForm => {
@@ -32,11 +33,13 @@ class SaveInProgressIntro extends React.Component {
       verifyRequiredPrefill,
       verifiedPrefillAlert,
       unverifiedPrefillAlert,
+      formConfig,
     } = this.props;
     const { profile, login } = this.props.user;
     const prefillAvailable = !!(
       profile && profile.prefillsAvailable.includes(formId)
     );
+    const appType = formConfig.customText?.appType || APP_TYPE_DEFAULT;
     if (login.currentlyLoggedIn) {
       if (savedForm) {
         const lastUpdated =
@@ -50,6 +53,7 @@ class SaveInProgressIntro extends React.Component {
 
         if (!isExpired) {
           const lastSavedDateTime = savedAt.format('M/D/YYYY [at] h:mm a');
+
           alert = (
             <div>
               <div className="usa-alert usa-alert-info background-color-only schemaform-sip-alert">
@@ -62,11 +66,11 @@ class SaveInProgressIntro extends React.Component {
                   </span>
                   <br />
                   <span className="saved-form-item-metadata">
-                    Your application was last saved on {lastSavedDateTime}
+                    Your {appType} was last saved on {lastSavedDateTime}
                   </span>
                   <div className="expires-container">
                     You can continue applying now, or come back later to finish
-                    your application. Your application{' '}
+                    your {appType}. Your {appType}{' '}
                     <span className="expires">
                       will expire on {expirationDate}.
                     </span>
@@ -87,8 +91,8 @@ class SaveInProgressIntro extends React.Component {
                 <div className="saved-form-metadata-container">
                   <span className="saved-form-metadata">
                     Your saved {formDescriptions[formId]} has expired. If you
-                    want to apply for {formBenefits[formId]}, please start a new
-                    application.
+                    want to apply for {formBenefits[formId]}, please start a new{' '}
+                    {appType}.
                   </span>
                 </div>
                 <div>{this.props.children}</div>
@@ -103,7 +107,7 @@ class SaveInProgressIntro extends React.Component {
             <div className="usa-alert usa-alert-info schemaform-sip-alert">
               <div className="usa-alert-body">
                 <strong>Note:</strong> Since you’re signed in to your account,
-                we can prefill part of your application based on your account
+                we can prefill part of your {appType} based on your account
                 details. You can also save your form in progress and come back
                 later to finish filling it out.
               </div>
@@ -129,11 +133,11 @@ class SaveInProgressIntro extends React.Component {
     } else if (renderSignInMessage) {
       alert = renderSignInMessage(prefillEnabled);
     } else if (prefillEnabled && !verifyRequiredPrefill) {
-      const { buttonOnly, retentionPeriod, startText } = this.props;
+      const { buttonOnly, retentionPeriod, unauthStartText } = this.props;
       alert = buttonOnly ? (
         <>
           <button className="usa-button-primary" onClick={this.openLoginModal}>
-            Sign in to start your application
+            {unauthStartText || UNAUTH_SIGN_IN_DEFAULT_MESSAGE}
           </button>
           {!this.props.hideUnauthedStartLink && (
             <p>
@@ -141,7 +145,7 @@ class SaveInProgressIntro extends React.Component {
                 className="va-button-link schemaform-start-button"
                 onClick={this.goToBeginning}
               >
-                Start your application without signing in
+                Start your {appType} without signing in
               </button>
             </p>
           )}
@@ -151,33 +155,33 @@ class SaveInProgressIntro extends React.Component {
           <div className="usa-alert-body">
             <h3 className="usa-alert-heading">
               Save time—and save your work in progress—by signing in before
-              starting your application
+              starting your {appType}
             </h3>
             <div className="usa-alert-text">
               <p>When you’re signed in to your VA.gov account:</p>
               <ul>
                 <li>
-                  We can prefill part of your application based on your account
+                  We can prefill part of your {appType} based on your account
                   details.
                 </li>
                 <li>
-                  You can save your application in progress, and come back later
+                  You can save your {appType} in progress, and come back later
                   to finish filling it out. You’ll have {retentionPeriod} from
-                  the date you start or update your application to submit it.
+                  the date you start or update your {appType} to submit it.
                   After {retentionPeriod}, we’ll delete the form and you’ll need
                   to start over.
                 </li>
               </ul>
               <p>
-                <strong>Note:</strong> If you sign in after you’ve started your
-                application, you won’t be able to save the information you’ve
+                <strong>Note:</strong> If you sign in after you’ve started your{' '}
+                {appType}, you won’t be able to save the information you’ve
                 already filled in.
               </p>
               <button
                 className="usa-button-primary"
                 onClick={this.openLoginModal}
               >
-                {startText || 'Sign in to start your application'}
+                {unauthStartText || UNAUTH_SIGN_IN_DEFAULT_MESSAGE}
               </button>
               {!this.props.hideUnauthedStartLink && (
                 <p>
@@ -185,7 +189,7 @@ class SaveInProgressIntro extends React.Component {
                     className="va-button-link schemaform-start-button"
                     onClick={this.goToBeginning}
                   >
-                    Start your application without signing in
+                    Start your {appType} without signing in
                   </button>
                 </p>
               )}
@@ -246,6 +250,8 @@ class SaveInProgressIntro extends React.Component {
 
   render() {
     const { profile } = this.props.user;
+    const { formConfig } = this.props;
+    const appType = formConfig.customText?.appType || APP_TYPE_DEFAULT;
     const startPage = this.getStartPage();
     const savedForm =
       profile && profile.savedForms.find(f => f.form === this.props.formId);
@@ -262,7 +268,9 @@ class SaveInProgressIntro extends React.Component {
     if (profile.loading && !this.props.resumeOnly) {
       return (
         <div>
-          <LoadingIndicator message="Checking to see if you have a saved version of this application..." />
+          <LoadingIndicator
+            message={`Checking to see if you have a saved version of this ${appType} ...`}
+          />
           <br />
         </div>
       );
@@ -357,10 +365,22 @@ SaveInProgressIntro.propTypes = {
   gaStartEventName: PropTypes.string,
   startMessageOnly: PropTypes.bool,
   hideUnauthedStartLink: PropTypes.bool,
+  unauthStartText: PropTypes.string,
+  formConfig: PropTypes.shape({
+    customText: PropTypes.shape({
+      appType: PropTypes.string,
+    }),
+  }).isRequired,
 };
 
 SaveInProgressIntro.defaultProps = {
   retentionPeriod: '60 days',
+  unauthStartText: '',
+  formConfig: {
+    customText: {
+      appType: '',
+    },
+  },
 };
 
 function mapStateToProps(state) {

--- a/src/platform/forms/save-in-progress/SaveStatus.jsx
+++ b/src/platform/forms/save-in-progress/SaveStatus.jsx
@@ -1,12 +1,13 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import moment from 'moment';
-
 import SignInLink from '../components/SignInLink';
 import { SAVE_STATUSES, saveErrors } from './actions';
+import { APP_SAVED_SUCCESSFULLY_DEFAULT_MESSAGE } from './constants';
 
 function SaveStatus({
   form: { lastSavedDate, autoSavedStatus },
+  formConfig,
   isLoggedIn,
   showLoginModal,
   toggleLoginModal,
@@ -31,7 +32,8 @@ function SaveStatus({
       {autoSavedStatus === SAVE_STATUSES.success && (
         <div className="panel saved-success-container">
           <i className="fa fa-check-circle saved-success-icon" />
-          Application has been saved.
+          {formConfig.customText?.appSavedSuccessfullyMessage ||
+            APP_SAVED_SUCCESSFULLY_DEFAULT_MESSAGE}
           {savedAtMessage}
         </div>
       )}
@@ -71,6 +73,11 @@ function SaveStatus({
 SaveStatus.propTypes = {
   form: PropTypes.object.isRequired,
   isLoggedIn: PropTypes.bool.isRequired,
+  formConfig: PropTypes.shape({
+    customText: PropTypes.shape({
+      appSavedSuccessfullyMessage: PropTypes.string,
+    }),
+  }).isRequired,
 };
 
 export default SaveStatus;

--- a/src/platform/forms/save-in-progress/constants.js
+++ b/src/platform/forms/save-in-progress/constants.js
@@ -1,0 +1,9 @@
+export const START_NEW_APP_DEFAULT_MESSAGE = 'Start a new application';
+export const CONTINUE_APP_DEFAULT_MESSAGE = 'Continue your application';
+export const APP_SAVED_SUCCESSFULLY_DEFAULT_MESSAGE =
+  'Application has been saved.';
+export const FINISH_APP_LATER_DEFAULT_MESSAGE =
+  'Finish this application later.';
+export const UNAUTH_SIGN_IN_DEFAULT_MESSAGE =
+  'Sign in to start your application';
+export const APP_TYPE_DEFAULT = 'application';

--- a/src/platform/forms/tests/save-in-progress/ApplicationStatus.unit.spec.jsx
+++ b/src/platform/forms/tests/save-in-progress/ApplicationStatus.unit.spec.jsx
@@ -8,6 +8,16 @@ import { VA_FORM_IDS } from 'platform/forms/constants';
 import { ApplicationStatus } from '../../save-in-progress/ApplicationStatus';
 
 describe('schemaform <ApplicationStatus>', () => {
+  let formConfigDefaultData;
+  beforeEach(() => {
+    formConfigDefaultData = {
+      customText: {
+        startNewAppButtonText: '',
+        continueAppButtonText: '',
+      },
+    };
+  });
+
   it('should render loading', () => {
     const tree = SkinDeep.shallowRender(
       <ApplicationStatus
@@ -16,6 +26,7 @@ describe('schemaform <ApplicationStatus>', () => {
         profile={{
           loading: true,
         }}
+        formConfig={formConfigDefaultData}
       />,
     );
 
@@ -34,6 +45,7 @@ describe('schemaform <ApplicationStatus>', () => {
           loading: false,
           savedForms: [],
         }}
+        formConfig={formConfigDefaultData}
       />,
     );
 
@@ -63,6 +75,7 @@ describe('schemaform <ApplicationStatus>', () => {
             },
           ],
         }}
+        formConfig={formConfigDefaultData}
       />,
     );
 
@@ -96,6 +109,7 @@ describe('schemaform <ApplicationStatus>', () => {
             },
           ],
         }}
+        formConfig={formConfigDefaultData}
       />,
     );
     expect(tree.subTree('.usa-alert-warning')).to.not.be.false;
@@ -125,6 +139,7 @@ describe('schemaform <ApplicationStatus>', () => {
             },
           ],
         }}
+        formConfig={formConfigDefaultData}
       />,
     );
 
@@ -166,6 +181,7 @@ describe('schemaform <ApplicationStatus>', () => {
             },
           ],
         }}
+        formConfig={formConfigDefaultData}
       />,
     );
 
@@ -173,5 +189,70 @@ describe('schemaform <ApplicationStatus>', () => {
     expect(tree.subTree('.usa-alert-info').text()).to.contain(
       'more than one in-progress form',
     );
+  });
+  it('should display a custom button message when passing in startNewAppButtonText', () => {
+    const formConfigCustomMsgData = {
+      customText: {
+        startNewAppButtonText: 'Custom start app message',
+      },
+    };
+    const tree = SkinDeep.shallowRender(
+      <ApplicationStatus
+        formId="21P-527EZ"
+        login={{
+          currentlyLoggedIn: true,
+        }}
+        showApplyButton
+        applyText="Apply for benefit"
+        profile={{
+          loading: false,
+          savedForms: [
+            {
+              form: VA_FORM_IDS.FORM_21P_527EZ,
+              metadata: {
+                expiresAt: moment()
+                  .subtract(1, 'day')
+                  .unix(),
+              },
+            },
+          ],
+        }}
+        formConfig={formConfigCustomMsgData}
+      />,
+    );
+    expect(tree.text()).to.include('Custom start app message');
+  });
+  it('should display a custom button message when passing in continueAppButtonText', () => {
+    const formConfigContinueAppMsgData = {
+      customText: {
+        continueAppButtonText: 'Custom continue app message',
+      },
+    };
+    const tree = SkinDeep.shallowRender(
+      <ApplicationStatus
+        formId="21P-527EZ"
+        login={{
+          currentlyLoggedIn: true,
+        }}
+        showApplyButton
+        applyText="Apply for benefit"
+        profile={{
+          loading: false,
+          savedForms: [
+            {
+              form: VA_FORM_IDS.FORM_21P_527EZ,
+              metadata: {
+                expiresAt: moment()
+                  .add(+1, 'day')
+                  .unix(),
+                lastUpdated: moment().subtract(1, 'hour'),
+              },
+            },
+          ],
+        }}
+        formConfig={formConfigContinueAppMsgData}
+      />,
+    );
+    expect(tree.text()).to.include('Custom continue app message');
   });
 });

--- a/src/platform/forms/tests/save-in-progress/FormStartControls.unit.spec.jsx
+++ b/src/platform/forms/tests/save-in-progress/FormStartControls.unit.spec.jsx
@@ -10,8 +10,22 @@ import { FormStartControls } from '../../save-in-progress/FormStartControls';
 
 describe('Schemaform <FormStartControls>', () => {
   const startPage = 'testing';
-
   const oldDataLayer = global.window.dataLayer;
+  let defaultRoutes;
+
+  beforeEach(() => {
+    defaultRoutes = [
+      'dummyProp',
+      {
+        formConfig: {
+          customText: {
+            startNewAppButtonText: '',
+            continueAppButtonText: '',
+          },
+        },
+      },
+    ];
+  });
 
   afterEach(() => {
     global.window.dataLayer = oldDataLayer;
@@ -30,6 +44,7 @@ describe('Schemaform <FormStartControls>', () => {
         startPage={startPage}
         router={routerSpy}
         fetchInProgressForm={fetchSpy}
+        routes={defaultRoutes}
       />,
     );
 
@@ -48,6 +63,7 @@ describe('Schemaform <FormStartControls>', () => {
         startPage={startPage}
         router={routerSpy}
         fetchInProgressForm={fetchSpy}
+        routes={defaultRoutes}
       />,
     );
 
@@ -67,6 +83,7 @@ describe('Schemaform <FormStartControls>', () => {
         startPage={startPage}
         router={routerSpy}
         fetchInProgressForm={fetchSpy}
+        routes={defaultRoutes}
       />,
     );
     expect(tree.everySubTree('ProgressButton').length).to.equal(3);
@@ -84,6 +101,7 @@ describe('Schemaform <FormStartControls>', () => {
         startPage={startPage}
         router={routerSpy}
         fetchInProgressForm={fetchSpy}
+        routes={defaultRoutes}
       />,
     );
 
@@ -105,6 +123,7 @@ describe('Schemaform <FormStartControls>', () => {
         startPage={startPage}
         router={routerSpy}
         fetchInProgressForm={fetchSpy}
+        routes={defaultRoutes}
       />,
     );
     const findDOM = findDOMNode(tree);
@@ -126,6 +145,7 @@ describe('Schemaform <FormStartControls>', () => {
         startPage={startPage}
         router={routerSpy}
         fetchInProgressForm={fetchSpy}
+        routes={defaultRoutes}
       />,
     );
     const findDOM = findDOMNode(tree);
@@ -147,6 +167,7 @@ describe('Schemaform <FormStartControls>', () => {
         startPage={startPage}
         router={routerSpy}
         fetchInProgressForm={fetchSpy}
+        routes={defaultRoutes}
       />,
     );
     const findDOM = findDOMNode(tree);
@@ -168,6 +189,7 @@ describe('Schemaform <FormStartControls>', () => {
         router={routerSpy}
         fetchInProgressForm={fetchSpy}
         prefillAvailable
+        routes={defaultRoutes}
       />,
     );
     const formDOM = getFormDOM(tree);
@@ -189,6 +211,7 @@ describe('Schemaform <FormStartControls>', () => {
         formSaved
         removeInProgressForm={fetchSpy}
         prefillAvailable
+        routes={defaultRoutes}
       />,
     );
     const formDOM = getFormDOM(tree);
@@ -218,6 +241,7 @@ describe('Schemaform <FormStartControls>', () => {
         fetchInProgressForm={fetchSpy}
         gaStartEventName={null}
         prefillAvailable
+        routes={defaultRoutes}
       />,
     );
     const formDOM = getFormDOM(tree);
@@ -240,6 +264,7 @@ describe('Schemaform <FormStartControls>', () => {
         router={routerSpy}
         fetchInProgressForm={fetchSpy}
         prefillAvailable
+        routes={defaultRoutes}
       />,
     );
     const formDOM = getFormDOM(tree);
@@ -267,6 +292,7 @@ describe('Schemaform <FormStartControls>', () => {
         fetchInProgressForm={fetchSpy}
         gaStartEventName="testing, testing"
         prefillAvailable
+        routes={defaultRoutes}
       />,
     );
     const formDOM = getFormDOM(tree);
@@ -277,5 +303,72 @@ describe('Schemaform <FormStartControls>', () => {
         event: 'testing, testing',
       },
     ]);
+  });
+
+  it('should display the startNewAppButtonText', () => {
+    const routerSpy = {
+      push: sinon.spy(),
+    };
+    const fetchSpy = sinon.spy();
+    const startNewMsgRoute = [
+      defaultRoutes[0],
+      {
+        formConfig: {
+          customText: {
+            startNewAppButtonText: 'A custom starting new app message',
+            continueAppButtonText: '',
+          },
+        },
+      },
+    ];
+    const tree = SkinDeep.shallowRender(
+      <FormStartControls
+        formId="1010ez"
+        migrations={[]}
+        formSaved
+        startPage={startPage}
+        router={routerSpy}
+        fetchInProgressForm={fetchSpy}
+        routes={startNewMsgRoute}
+        resumeOnly={false}
+        isExpired
+      />,
+    );
+    expect(
+      tree.dive(['ProgressButton', '.usa-button-primary']).text(),
+    ).to.include('A custom starting new app message');
+  });
+  it('should display the continueAppButtonText', () => {
+    const routerSpy = {
+      push: sinon.spy(),
+    };
+    const fetchSpy = sinon.spy();
+    const startNewMsgRoute = [
+      defaultRoutes[0],
+      {
+        formConfig: {
+          customText: {
+            startNewAppButtonText: '',
+            continueAppButtonText: 'A custom continue app message',
+          },
+        },
+      },
+    ];
+    const tree = SkinDeep.shallowRender(
+      <FormStartControls
+        formId="1010ez"
+        migrations={[]}
+        formSaved
+        startPage={startPage}
+        router={routerSpy}
+        fetchInProgressForm={fetchSpy}
+        routes={startNewMsgRoute}
+        resumeOnly
+        isExpired={false}
+      />,
+    );
+    expect(
+      tree.dive(['ProgressButton', '.usa-button-primary']).text(),
+    ).to.include('A custom continue app message');
   });
 });

--- a/src/platform/forms/tests/save-in-progress/RoutedSavablePage.unit.spec.jsx
+++ b/src/platform/forms/tests/save-in-progress/RoutedSavablePage.unit.spec.jsx
@@ -10,11 +10,18 @@ describe('Schemaform <RoutedSavablePage>', () => {
     pathname: '/testing/0',
   };
 
+  let formConfigDefaultData;
+
+  beforeEach(() => {
+    formConfigDefaultData = {
+      customText: {
+        finishAppLaterMessage: '',
+      },
+    };
+  });
+
   it('should include SaveLink and SaveStatus', () => {
     const route = {
-      formConfig: {
-        finishLaterLinkText: 'foo',
-      },
       pageConfig: {
         pageKey: 'testPage',
         schema: {},
@@ -53,6 +60,7 @@ describe('Schemaform <RoutedSavablePage>', () => {
         route={route}
         user={user}
         location={location}
+        formConfig={formConfigDefaultData}
       />,
     )
       .find('FormPage')
@@ -63,11 +71,8 @@ describe('Schemaform <RoutedSavablePage>', () => {
     tree.unmount();
   });
 
-  it('should pass correct text to SaveFormlink', () => {
+  it('should display the finishAppLaterMessage if passed in', () => {
     const route = {
-      formConfig: {
-        finishLaterLinkText: 'foo',
-      },
       pageConfig: {
         pageKey: 'testPage',
         schema: {},
@@ -100,12 +105,21 @@ describe('Schemaform <RoutedSavablePage>', () => {
       },
     };
 
+    const finishLaterLinkFormConfigData = {
+      ...formConfigDefaultData,
+      customText: {
+        finishAppLaterMessage:
+          'Custom finish this application another time message.',
+      },
+    };
+
     const tree = shallow(
       <RoutedSavablePage
         form={form}
         route={route}
         user={user}
         location={location}
+        formConfig={finishLaterLinkFormConfigData}
       />,
     )
       .find('FormPage')
@@ -117,15 +131,12 @@ describe('Schemaform <RoutedSavablePage>', () => {
         .find('SaveFormLink')
         .children()
         .text(),
-    ).to.equal('foo');
+    ).to.equal('Custom finish this application another time message.');
     tree.unmount();
   });
 
   it('should auto save on change', () => {
     const route = {
-      formConfig: {
-        finishLaterLinkText: 'foo',
-      },
       pageConfig: {
         pageKey: 'testPage',
         schema: {},
@@ -168,6 +179,7 @@ describe('Schemaform <RoutedSavablePage>', () => {
         user={user}
         location={location}
         autoSave={autosave}
+        formConfig={formConfigDefaultData}
       />,
     );
     tree.instance().debouncedAutoSave = autosave;

--- a/src/platform/forms/tests/save-in-progress/SaveInProgressErrorPage.unit.spec.jsx
+++ b/src/platform/forms/tests/save-in-progress/SaveInProgressErrorPage.unit.spec.jsx
@@ -19,7 +19,15 @@ const teardown = () => {
 };
 
 describe('<SaveInProgressErrorPage>', () => {
-  beforeEach(setup);
+  let formConfigDefaultData;
+  beforeEach(() => {
+    setup();
+    formConfigDefaultData = {
+      customText: {
+        continueAppButtonText: '',
+      },
+    };
+  });
   afterEach(teardown);
 
   const route = {
@@ -46,6 +54,7 @@ describe('<SaveInProgressErrorPage>', () => {
         loginUrls={mockLoginUrl}
         route={route}
         loadedStatus={LOAD_STATUSES.noAuth}
+        formConfig={formConfigDefaultData}
       />,
     );
     const findDOM = findDOMNode(tree);
@@ -69,6 +78,7 @@ describe('<SaveInProgressErrorPage>', () => {
         loginUrls={mockLoginUrl}
         route={route}
         loadedStatus={LOAD_STATUSES.notFound}
+        formConfig={formConfigDefaultData}
       />,
     );
     const findDOM = findDOMNode(tree);
@@ -89,6 +99,7 @@ describe('<SaveInProgressErrorPage>', () => {
         loginUrls={mockLoginUrl}
         route={route}
         loadedStatus={LOAD_STATUSES.failure}
+        formConfig={formConfigDefaultData}
       />,
     );
     const findDOM = findDOMNode(tree);
@@ -100,7 +111,7 @@ describe('<SaveInProgressErrorPage>', () => {
       findDOM.querySelector('.usa-button-secondary').textContent,
     ).to.contain('Back');
     expect(findDOM.querySelector('.usa-button-primary').textContent).to.contain(
-      'Continue Your Application',
+      'Continue your application',
     );
   });
   it('should render the forbidden failure error', () => {
@@ -112,6 +123,7 @@ describe('<SaveInProgressErrorPage>', () => {
         loginUrls={mockLoginUrl}
         route={route}
         loadedStatus={LOAD_STATUSES.forbidden}
+        formConfig={formConfigDefaultData}
       />,
     );
     const findDOM = findDOMNode(tree);
@@ -131,6 +143,7 @@ describe('<SaveInProgressErrorPage>', () => {
         loginUrls={mockLoginUrl}
         route={route}
         loadedStatus={LOAD_STATUSES.noAuth}
+        formConfig={formConfigDefaultData}
       />,
     );
     const findDOM = findDOMNode(tree);
@@ -150,6 +163,7 @@ describe('<SaveInProgressErrorPage>', () => {
         route={route}
         loadedStatus={LOAD_STATUSES.failure}
         fetchInProgressForm={fetchSpy}
+        formConfig={formConfigDefaultData}
       />,
     );
     const findDOM = findDOMNode(tree);
@@ -171,6 +185,7 @@ describe('<SaveInProgressErrorPage>', () => {
         loadedStatus={LOAD_STATUSES.failure}
         removeInProgressForm={removeSpy}
         fetchInProgressForm={fetchSpy}
+        formConfig={formConfigDefaultData}
       />,
     );
     const findDOM = findDOMNode(tree);
@@ -178,5 +193,30 @@ describe('<SaveInProgressErrorPage>', () => {
     ReactTestUtils.Simulate.click(button);
     expect(fetchSpy.called).to.be.false;
     expect(removeSpy.called).to.be.true;
+  });
+  it('should display custom continueAppButtonText', () => {
+    const continueAppButtonTextFormConfigData = {
+      customText: {
+        continueAppButtonText: 'Custom message telling you to continue the app',
+      },
+    };
+    const tree = ReactTestUtils.renderIntoDocument(
+      <SaveInProgressErrorPage
+        updateLogInUrls={f => f}
+        isLoggedIn
+        router={router}
+        loginUrls={mockLoginUrl}
+        route={route}
+        loadedStatus={LOAD_STATUSES.failure}
+        formConfig={continueAppButtonTextFormConfigData}
+      />,
+    );
+    const findDOM = findDOMNode(tree);
+    const continueAppMessageButton = findDOM.querySelector(
+      '.usa-button-primary',
+    );
+    expect(continueAppMessageButton.textContent).to.equal(
+      'Custom message telling you to continue the app',
+    );
   });
 });

--- a/src/platform/forms/tests/save-in-progress/SaveInProgressIntro.unit.spec.jsx
+++ b/src/platform/forms/tests/save-in-progress/SaveInProgressIntro.unit.spec.jsx
@@ -4,7 +4,6 @@ import { expect } from 'chai';
 import { shallow } from 'enzyme';
 import sinon from 'sinon';
 import { VA_FORM_IDS } from 'platform/forms/constants';
-
 import { SaveInProgressIntro } from '../../save-in-progress/SaveInProgressIntro';
 
 describe('Schemaform <SaveInProgressIntro>', () => {
@@ -19,6 +18,12 @@ describe('Schemaform <SaveInProgressIntro>', () => {
   const fetchInProgressForm = () => {};
   const removeInProgressForm = () => {};
   const toggleLoginModal = () => {};
+
+  const formConfig = {
+    customText: {
+      appType: '',
+    },
+  };
 
   it('should render in progress message', () => {
     const user = {
@@ -51,12 +56,16 @@ describe('Schemaform <SaveInProgressIntro>', () => {
         fetchInProgressForm={fetchInProgressForm}
         removeInProgressForm={removeInProgressForm}
         toggleLoginModal={toggleLoginModal}
+        formConfig={formConfig}
       />,
     );
 
     expect(
-      tree.find('.saved-form-item-metadata').get(1).props.children[1],
-    ).to.equal(moment.unix(946684800).format('M/D/YYYY [at] h:mm a'));
+      tree
+        .find('.saved-form-item-metadata')
+        .last()
+        .text(),
+    ).to.include(moment.unix(946684800).format('M/D/YYYY [at] h:mm a'));
 
     expect(tree.find('.usa-alert').text()).to.contain(
       'Your form is in progress',
@@ -95,6 +104,7 @@ describe('Schemaform <SaveInProgressIntro>', () => {
         fetchInProgressForm={fetchInProgressForm}
         removeInProgressForm={removeInProgressForm}
         toggleLoginModal={toggleLoginModal}
+        formConfig={formConfig}
       />,
     );
 
@@ -130,6 +140,7 @@ describe('Schemaform <SaveInProgressIntro>', () => {
         fetchInProgressForm={fetchInProgressForm}
         removeInProgressForm={removeInProgressForm}
         toggleLoginModal={toggleLoginModal}
+        formConfig={formConfig}
       />,
     );
 
@@ -170,6 +181,7 @@ describe('Schemaform <SaveInProgressIntro>', () => {
         fetchInProgressForm={fetchInProgressForm}
         removeInProgressForm={removeInProgressForm}
         toggleLoginModal={toggleLoginModal}
+        formConfig={formConfig}
       />,
     );
 
@@ -206,6 +218,7 @@ describe('Schemaform <SaveInProgressIntro>', () => {
         fetchInProgressForm={fetchInProgressForm}
         removeInProgressForm={removeInProgressForm}
         toggleLoginModal={toggleLoginModal}
+        formConfig={formConfig}
       />,
     );
 
@@ -236,6 +249,7 @@ describe('Schemaform <SaveInProgressIntro>', () => {
         fetchInProgressForm={fetchInProgressForm}
         removeInProgressForm={removeInProgressForm}
         toggleLoginModal={toggleLoginModal}
+        formConfig={formConfig}
       />,
     );
 
@@ -277,6 +291,7 @@ describe('Schemaform <SaveInProgressIntro>', () => {
         removeInProgressForm={removeInProgressForm}
         toggleLoginModal={toggleLoginModal}
         retentionPeriod={'1 year'}
+        formConfig={formConfig}
       />,
     );
 
@@ -311,6 +326,7 @@ describe('Schemaform <SaveInProgressIntro>', () => {
         fetchInProgressForm={fetchInProgressForm}
         removeInProgressForm={removeInProgressForm}
         toggleLoginModal={toggleLoginModal}
+        formConfig={formConfig}
       />,
     );
 
@@ -344,6 +360,7 @@ describe('Schemaform <SaveInProgressIntro>', () => {
         fetchInProgressForm={fetchInProgressForm}
         removeInProgressForm={removeInProgressForm}
         toggleLoginModal={toggleLoginModal}
+        formConfig={formConfig}
       />,
     );
 
@@ -384,6 +401,7 @@ describe('Schemaform <SaveInProgressIntro>', () => {
         removeInProgressForm={removeInProgressForm}
         renderSignInMessage={renderSpy}
         toggleLoginModal={toggleLoginModal}
+        formConfig={formConfig}
       />,
     );
 
@@ -424,6 +442,7 @@ describe('Schemaform <SaveInProgressIntro>', () => {
         removeInProgressForm={removeInProgressForm}
         renderSignInMessage={renderSpy}
         toggleLoginModal={toggleLoginModal}
+        formConfig={formConfig}
       />,
     );
 
@@ -463,6 +482,7 @@ describe('Schemaform <SaveInProgressIntro>', () => {
         removeInProgressForm={removeInProgressForm}
         renderSignInMessage={renderSpy}
         toggleLoginModal={toggleLoginModal}
+        formConfig={formConfig}
       />,
     );
 
@@ -499,6 +519,7 @@ describe('Schemaform <SaveInProgressIntro>', () => {
         removeInProgressForm={removeInProgressForm}
         toggleLoginModal={toggleLoginModal}
         startMessageOnly
+        formConfig={formConfig}
       />,
     );
 
@@ -533,11 +554,47 @@ describe('Schemaform <SaveInProgressIntro>', () => {
         removeInProgressForm={removeInProgressForm}
         toggleLoginModal={toggleLoginModal}
         startMessageOnly
+        formConfig={formConfig}
       />,
     );
 
     expect(tree.find('.schemaform-start-button').exists()).to.be.false;
 
+    tree.unmount();
+  });
+  it('should display an unauthStartText message', () => {
+    const user = {
+      profile: {
+        savedForms: [],
+        prefillsAvailable: [],
+      },
+      login: {
+        currentlyLoggedIn: false,
+        loginUrls: {
+          idme: '/mockLoginUrl',
+        },
+      },
+    };
+
+    const tree = shallow(
+      <SaveInProgressIntro
+        saveInProgress={{ formData: {} }}
+        pageList={pageList}
+        formId="1010ez"
+        user={user}
+        prefillEnabled
+        hideUnauthedStartLink
+        fetchInProgressForm={fetchInProgressForm}
+        removeInProgressForm={removeInProgressForm}
+        toggleLoginModal={toggleLoginModal}
+        startMessageOnly
+        unauthStartText="Custom message displayed to non-signed-in users"
+        formConfig={formConfig}
+      />,
+    );
+    expect(tree.find('.usa-button-primary').text()).to.equal(
+      'Custom message displayed to non-signed-in users',
+    );
     tree.unmount();
   });
 });

--- a/src/platform/forms/tests/save-in-progress/SaveStatus.unit.spec.jsx
+++ b/src/platform/forms/tests/save-in-progress/SaveStatus.unit.spec.jsx
@@ -17,6 +17,11 @@ describe('<SaveStatus>', () => {
         currentlyLoggedIn: true,
       },
     },
+    formConfig: {
+      customText: {
+        appSavedSuccessfullyMessage: '',
+      },
+    },
   };
   it('should render', () => {
     const tree = SkinDeep.shallowRender(<SaveStatus {...props} />);
@@ -54,5 +59,27 @@ describe('<SaveStatus>', () => {
     props.form.autoSavedStatus = SAVE_STATUSES.failure;
     const tree = SkinDeep.shallowRender(<SaveStatus {...props} />);
     expect(tree.text()).to.have.string('having some issues');
+  });
+  it('should display the appSavedSuccessfullyMessage', () => {
+    const appSavedSuccessfullyMessageProps = {
+      ...props,
+      form: {
+        formId: VA_FORM_IDS.FORM_10_10EZ,
+        lastSavedDate: 1505770055,
+        autoSavedStatus: 'success',
+      },
+      formConfig: {
+        customText: {
+          appSavedSuccessfullyMessage:
+            'Custom message saying your app has been saved.',
+        },
+      },
+    };
+    const tree = SkinDeep.shallowRender(
+      <SaveStatus {...appSavedSuccessfullyMessageProps} />,
+    );
+    expect(tree.subTree('.panel').text()).to.include(
+      'Custom message saying your app has been saved.',
+    );
   });
 });


### PR DESCRIPTION
## Description
This PR gives the ability to pass in custom messages to the forms-library, using form 2346 as an example. It also adds in the 2346 form on the helpers file to display the correct copy when the application is in progress.

In the `formConfig` object in `form.js`, the following keys were created:

`reviewPageTitle`: allows you to display a custom review page title
`appSavedSuccessfullyMessage`: allows you to display a custom message when the form has been saved successfully
`startNewAppButtonText`: allows you to display custom button text for starting a new application
`continueAppButtonText`: allows you to display custom button text for continuing an application
`finishAppLaterMessage`: allows you to display custom text for finishing the application later

For the `SaveInProgressIntro` page, `unauthStartText` is for displaying button text to unauthenticated users.

## Testing done
Unit tests were updated to support these changes.

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
