### PR TITLE
[Development] Add copy of exam info to CST sidebar

### DIFF
--- a/src/applications/claims-status/components/AskVAQuestions.jsx
+++ b/src/applications/claims-status/components/AskVAQuestions.jsx
@@ -1,16 +1,17 @@
 import React from 'react';
+import Telephone, {
+  CONTACTS,
+} from '@department-of-veterans-affairs/formation-react/Telephone';
 
 function AskVAQuestions() {
   return (
     <div>
       <h2 className="help-heading">Need help?</h2>
       <p>Call Veterans Affairs Benefits and Services:</p>
-      <p className="help-phone-number">
-        <a className="help-phone-number-link" href="tel:+1-800-827-1000">
-          800-827-1000
-        </a>
+      <p>
+        <Telephone contact={CONTACTS.VA_BENEFITS} />
       </p>
-      <p>Monday &#8211; Friday, 8:00 a.m. &#8211; 9:00 p.m. ET</p>
+      <p>Monday through Friday, 8:00 a.m. to 9:00 p.m. ET</p>
       <p>
         <a href="https://iris.custhelp.com/">Submit a question to VA</a>
       </p>

--- a/src/applications/claims-status/components/CopyOfExam.jsx
+++ b/src/applications/claims-status/components/CopyOfExam.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+export default function CopyOfExam() {
+  return (
+    <>
+      <h2 className="help-heading">Want a copy of your claim exam?</h2>
+      <p>
+        You can obtain a copy of your claim exam (also known as a compensation
+        and pension, or C&amp;P, exam) by{' '}
+        <a href="/find-locations/?facilityType=benefits">
+          contacting your nearest regional office
+        </a>
+        .
+      </p>
+    </>
+  );
+}

--- a/src/applications/claims-status/components/appeals-v2/AppealHelpSidebar.jsx
+++ b/src/applications/claims-status/components/appeals-v2/AppealHelpSidebar.jsx
@@ -1,31 +1,20 @@
 import React from 'react';
 import * as Sentry from '@sentry/browser';
+import Telephone, {
+  CONTACTS,
+} from '@department-of-veterans-affairs/formation-react/Telephone';
 
 import { AOJS } from '../../utils/appeals-v2-helpers';
-
-const vbaVersion = (
-  <div>
-    <h2 className="help-heading">Need help?</h2>
-    <p>Call Veterans Affairs Benefits and Services</p>
-    <p className="help-phone-number">
-      <a className="help-phone-number-link" href="tel:1-800-827-1000">
-        800-827-1000
-      </a>
-    </p>
-    <p>Monday - Friday, 8:00am - 9:00pm ET</p>
-  </div>
-);
+import AskVAQuestions from '../AskVAQuestions';
 
 const vhaVersion = (
   <div>
     <h2 className="help-heading">Need help?</h2>
     <p>Call Health Care Benefits</p>
     <p className="help-phone-number">
-      <a className="help-phone-number-link" href="tel:1-877-222-8387">
-        877-222-VETS (8387)
-      </a>
+      <Telephone contact={CONTACTS['222_VETS']} pattern="###-###-VETS (####)" />
     </p>
-    <p>Monday - Friday, 8:00am - 8:00pm ET</p>
+    <p>Monday through Friday, 8:00 a.m. to 8:00 p.m. ET</p>
   </div>
 );
 
@@ -40,7 +29,7 @@ const vhaVersion = (
 export default function AppealHelpSidebar({ aoj }) {
   switch (aoj) {
     case AOJS.vba:
-      return vbaVersion;
+      return <AskVAQuestions />;
     case AOJS.vha:
       return vhaVersion;
     case AOJS.nca:

--- a/src/applications/claims-status/containers/AppealInfo.jsx
+++ b/src/applications/claims-status/containers/AppealInfo.jsx
@@ -12,6 +12,7 @@ import { getAppealsV2 } from '../actions/index.jsx';
 import AppealHeader from '../components/appeals-v2/AppealHeader';
 import AppealsV2TabNav from '../components/appeals-v2/AppealsV2TabNav';
 import AppealHelpSidebar from '../components/appeals-v2/AppealHelpSidebar';
+import CopyOfExam from '../components/CopyOfExam';
 import { setUpPage, scrollToTop } from '../utils/page';
 
 import {
@@ -187,6 +188,7 @@ export class AppealInfo extends React.Component {
                   aoj={appeal.attributes.aoj}
                 />
               )}
+              <CopyOfExam />
             </div>
           </div>
         </div>

--- a/src/applications/claims-status/tests/components/appeals-v2/AppealHelpSidebar.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/appeals-v2/AppealHelpSidebar.unit.spec.jsx
@@ -1,27 +1,24 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 import { expect } from 'chai';
 import AppealHelpSidebar from '../../../components/appeals-v2/AppealHelpSidebar';
 
 describe('<AppealHelpSidebar>', () => {
   it('should render', () => {
     const props = { aoj: 'vba' };
-    const wrapper = shallow(<AppealHelpSidebar {...props} />);
+    const wrapper = mount(<AppealHelpSidebar {...props} />);
 
-    expect(wrapper.type()).to.equal('div');
+    expect(wrapper.find('AskVAQuestions')).to.not.be.false;
     wrapper.unmount();
   });
 
   it('should render the vba version', () => {
     const props = { aoj: 'vba' };
-    const wrapper = shallow(<AppealHelpSidebar {...props} />);
+    const wrapper = mount(<AppealHelpSidebar {...props} />);
 
-    expect(
-      wrapper
-        .find('p')
-        .first()
-        .text(),
-    ).to.equal('Call Veterans Affairs Benefits and Services');
+    expect(wrapper.find('AskVAQuestions').text()).to.contain(
+      'Call Veterans Affairs Benefits and Services',
+    );
     wrapper.unmount();
   });
 

--- a/src/applications/claims-status/tests/components/appeals-v2/AppealInfo.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/appeals-v2/AppealInfo.unit.spec.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 import { expect } from 'chai';
 import { merge } from 'lodash';
 import { AppealInfo } from '../../../containers/AppealInfo';
@@ -65,6 +65,14 @@ describe('<AppealInfo/>', () => {
     const props = merge({}, { children }, defaultProps);
     const wrapper = shallow(<AppealInfo {...props} />);
     expect(wrapper.find('span.test').length).to.equal(1);
+    wrapper.unmount();
+  });
+
+  it('should render CopyOfExam block', () => {
+    const children = <span className="test">Child Goes Here</span>;
+    const props = merge({}, { children }, defaultProps);
+    const wrapper = mount(<AppealInfo {...props} />);
+    expect(wrapper.find('CopyOfExam').length).to.equal(1);
     wrapper.unmount();
   });
 


### PR DESCRIPTION
## Description

Add "Want a copy of your claim exam" information in the claim status tool sidebar

- Also completed:
 - Updated telephone links to use the Telephone component
 - Removed dashes in office times. Changed "Monday - Friday" to "Monday through Friday"

Related ticket: https://github.com/department-of-veterans-affairs/va.gov-team/issues/10288

## Testing done

Added unit tests

## Screenshots

![Screen Shot 2020-07-01 at 12 13 56 PM](https://user-images.githubusercontent.com/136959/86274205-eb932900-bb96-11ea-967a-53bf60f33479.png)

## Acceptance criteria

- [x] CST sidebar incudes information about getting a copy of the user's C&P exam

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
