### PR TITLE
Fix loading screen issue on profile

### DIFF
--- a/src/applications/personalization/profiles-wrapper/ProfilesWrapper.jsx
+++ b/src/applications/personalization/profiles-wrapper/ProfilesWrapper.jsx
@@ -9,6 +9,7 @@ import {
   isInMVI as isInMVISelector,
   isLOA1 as isLOA1Selector,
   isLOA3 as isLOA3Selector,
+  isLoggedIn,
 } from 'platform/user/selectors';
 import localStorage from 'platform/utilities/storage/localStorage';
 import { selectShowProfile2 } from 'applications/personalization/profile-2/selectors';
@@ -19,11 +20,18 @@ const LoadingPage = () => (
   </div>
 );
 
-const ProfilesWrapper = ({ showProfile1, isLOA1, isLOA3, isInMVI }) => {
+const ProfilesWrapper = ({
+  showProfile1,
+  isLOA1,
+  isLOA3,
+  isInMVI,
+  currentlyLoggedIn,
+}) => {
   // On initial render, both isLOA props are false.
   // We need to make sure the proper redirect is hit,
   // so we show a loading state till one value is true.
-  if (!isLOA1 && !isLOA3) {
+
+  if (!isLOA1 && !isLOA3 && currentlyLoggedIn) {
     return <LoadingPage />;
   }
 
@@ -40,6 +48,7 @@ const mapStateToProps = state => {
   const localStorageProfile2 = profileVersion === '2';
   const FFProfile2 = selectShowProfile2(state);
   return {
+    currentlyLoggedIn: isLoggedIn(state),
     isLOA1: isLOA1Selector(state),
     isLOA3: isLOA3Selector(state),
     isInMVI: isInMVISelector(state),


### PR DESCRIPTION
## Description
When the user is not logged in and navigates to the profile, they should see the 'login screen' rather than a loading spinner.

## Testing done
Works locally

## Screenshots


## Acceptance criteria
- [x] When the user is not logged in and navigates to the profile, they should see the 'login screen' rather than a loading spinner

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
