### PR TITLE
Release VAMC pages with hideHomeBreadcrumb option on prod

### DIFF
--- a/src/site/includes/breadcrumbs.drupal.liquid
+++ b/src/site/includes/breadcrumbs.drupal.liquid
@@ -5,7 +5,7 @@
         <li><a aria-current="page" href="/{{ path }}">{{ crumb.text }}</a></li>
       {% elsif crumb.url.path %}
         {% if crumb.url.path == '/' %}
-          {% if hideHomeBreadcrumb != true or buildtype == 'vagovprod'%}
+          {% if hideHomeBreadcrumb != true %}
             <li>
               <a href="{{ crumb.url.path }}" onClick="recordEvent({ event: 'nav-breadcrumb', 'nav-breadcrumb-section': 'home' });">{{ crumb.text }}</a>
             </li>


### PR DESCRIPTION
## Description
Releasing change for this issue: https://github.com/department-of-veterans-affairs/vets-website/pull/13259

## Acceptance criteria
- [x] Remove Home > across https://www.va.gov/pittsburgh-health-care/ for VAMC products only


