### PR TITLE
[Development] Disable CST DurationCard

### DIFF
--- a/src/applications/claims-status/components/appeals-v2/DurationCard.jsx
+++ b/src/applications/claims-status/components/appeals-v2/DurationCard.jsx
@@ -1,9 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-const DurationCard = ({ durationText, cardDescription }) => {
+// Disabling duration card view (for now) per
+// https://github.com/department-of-veterans-affairs/va.gov-team/issues/10293
+const DurationCard = ({ durationText, cardDescription, isDisabled = true }) => {
   // Card's not very helpful without any actual duration information
-  if (!durationText) {
+  if (!durationText || isDisabled) {
     return null;
   }
 

--- a/src/applications/claims-status/tests/components/appeals-v2/Duration.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/appeals-v2/Duration.unit.spec.jsx
@@ -7,6 +7,7 @@ describe('<DurationCard/>', () => {
   const defaultProps = {
     durationText: '1-2 Months',
     cardDescription: 'Hey There, this is some text',
+    isDisabled: false,
   };
 
   it('should render', () => {


### PR DESCRIPTION
## Description

Disable the Claim status tool's duration cards, for now.

This course of action was decided by the NCC. Please refer to:

- related issue: https://github.com/department-of-veterans-affairs/va.gov-team/issues/10293
- Slack conversation: https://dsva.slack.com/archives/CDHBKAL9W/p1589344568495100?thread_ts=1589299198.475700&cid=CDHBKAL9W

## Testing done

Unit tests for the duration card still work, but use a flag to enable visibility of the component

## Screenshots

<details><summary>Before</summary>

<!-- leave a blank line above -->
![Screen Shot 2020-07-01 at 3 55 50 PM](https://user-images.githubusercontent.com/136959/86294093-8270dd00-bbb9-11ea-847a-dafaea6b52cf.png)</details>

<details><summary>After</summary>

<!-- leave a blank line above -->
![Screen Shot 2020-07-01 at 4 28 21 PM](https://user-images.githubusercontent.com/136959/86294116-90266280-bbb9-11ea-8ad4-538e3eb88094.png)</details>

## Acceptance criteria
- [x] Claim status tools duration cards are no longer visible

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
