### PR TITLE
Kelsonic 10859 legacy content

### DIFF
--- a/src/applications/static-pages/health-care-manage-benefits/get-medical-records-page/components/App/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/get-medical-records-page/components/App/index.js
@@ -4,10 +4,16 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 // Relative imports.
 import AuthContent from '../AuthContent';
+import LegacyContent from '../LegacyContent';
 import UnauthContent from '../UnauthContent';
+import environment from 'platform/utilities/environment';
 import { selectIsCernerPatient } from 'platform/user/selectors';
 
 export const App = ({ isCernerPatient }) => {
+  if (environment.isProduction()) {
+    return <LegacyContent />;
+  }
+
   if (isCernerPatient) {
     return <AuthContent />;
   }

--- a/src/applications/static-pages/health-care-manage-benefits/get-medical-records-page/components/LegacyContent/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/get-medical-records-page/components/LegacyContent/index.js
@@ -1,0 +1,434 @@
+// Node modules.
+import React from 'react';
+// Relative imports.
+import CallToActionWidget from 'platform/site-wide/cta-widget';
+
+const LegacyContent = () => (
+  <>
+    <div className="processed-content">
+      <h2 id="va-blue-button">VA Blue Button</h2>
+    </div>
+    <CallToActionWidget appId="health-records" setFocus={false} />
+    <div>
+      <h2 id="more-about-va-blue-button">More about VA Blue Button</h2>
+      <div itemScope itemType="http://schema.org/Question">
+        <h3 itemProp="name" id="whats-va-blue-button-and-how-c">
+          What's VA Blue Button, and how can it help me manage my health care?
+        </h3>
+        <div
+          itemProp="acceptedAnswer"
+          itemScope
+          itemType="http://schema.org/Answer"
+        >
+          <div itemProp="text">
+            <div className="processed-content">
+              <p>
+                VA Blue Button is a feature of the health management portal
+                within My HealtheVet. It lets you view, print, save, download,
+                and share information from your VA medical record and personal
+                health record. With this tool, you can better manage your health
+                needs and communicate with your health care team.
+              </p>
+              <p>
+                <strong>With VA Blue Button, you can:</strong>
+              </p>
+              <ul>
+                <li>
+                  Download a customized Blue Button report with information from
+                  your VA medical records, personal health record, and in some
+                  cases your military service record
+                </li>
+                <li>
+                  Download a Health Summary that includes specific information
+                  from your VA medical record (like your known allergies,
+                  medications, and recent lab results)
+                </li>
+                <li>
+                  Build your own personal health record that includes
+                  information like your self-entered medical history, emergency
+                  contacts, and medicines
+                </li>
+                <li>
+                  Monitor your vital signs and track your diet and exercise with
+                  our online journals
+                </li>
+                <li>
+                  Share a digital copy of the personal health information you
+                  entered yourself with your VA health care team through Secure
+                  Messaging
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div itemScope itemType="http://schema.org/Question">
+        <h3 itemProp="name" id="am-i-eligible-to-use-all-the-f">
+          Am I eligible to use all the features of VA Blue Button?
+        </h3>
+        <div
+          itemProp="acceptedAnswer"
+          itemScope
+          itemType="http://schema.org/Answer"
+        >
+          <div itemProp="text">
+            <div className="processed-content">
+              <p>
+                You can use all the features of this tool if you meet all of the
+                requirements listed below.
+              </p>
+              <p>
+                <strong>Both of these must be true. You’re:</strong>
+              </p>
+              <ul>
+                <li>
+                  Are enrolled in VA health care, <strong>and</strong>
+                </li>
+                <li>Are registered as a patient in a VA health facility</li>
+              </ul>
+              <p>
+                <a href="/health-care/how-to-apply/">
+                  Find out how to apply for VA health care
+                </a>
+              </p>
+              <p>
+                <strong>And you must have one of these free accounts:</strong>
+              </p>
+              <ul>
+                <li>
+                  A{' '}
+                  <a href="">
+                    Premium <strong>My HealtheVet account</strong>
+                  </a>
+                  , <strong>or</strong>
+                </li>
+                <li>
+                  A Premium <strong>DS Logon</strong> account (used for
+                  eBenefits and milConnect), <strong>or</strong>
+                </li>
+                <li>
+                  A verified <strong>ID.me</strong> account that you can create
+                  here on VA.gov
+                </li>
+              </ul>
+              <p>
+                <strong>Note:</strong> If you sign in with a Basic or Advanced
+                account, you&apos;ll see only the results you&apos;ve entered
+                yourself.
+                <br />
+                <a
+                  href="https://www.myhealth.va.gov/mhv-portal-web/my-healthevet-offers-three-account-types"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Learn about the 3 different My HealtheVet account types
+                </a>
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div itemScope itemType="http://schema.org/Question">
+        <h3 itemProp="name" id="once-im-signed-in-how-do-i-get">
+          Once I’m signed in, how do I get to my medical records?
+        </h3>
+        <div
+          itemProp="acceptedAnswer"
+          itemScope
+          itemType="http://schema.org/Answer"
+        >
+          <div itemProp="text">
+            <div className="processed-content">
+              <p>
+                Go to your Welcome page dashboard, and click on “Health
+                Records.” You’ll go to a new page.
+              </p>
+              <p>
+                From here, you can choose to access your VA Blue Button report,
+                your VA Health Summary, or your VA Medical Images and Reports.
+              </p>
+              <p>
+                If you’d like to add information to your personal health record,
+                click on “Track Health” in the blue navigation menu at the top
+                of the page. You’ll go to a new page where you can choose to
+                record information like your vital signs, health history, goals,
+                and food and exercise efforts.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div itemScope itemType="http://schema.org/Question">
+        <h3 itemProp="name" id="will-my-personal-health-inform">
+          Will my personal health information be protected?
+        </h3>
+        <div
+          itemProp="acceptedAnswer"
+          itemScope
+          itemType="http://schema.org/Answer"
+        >
+          <div itemProp="text">
+            <div className="processed-content">
+              <p>
+                Yes. This is a secure website. We follow strict security
+                policies and practices to protect your personal health
+                information.
+              </p>
+              <p>
+                If you print or download anything from the website, you’ll need
+                to take responsibility for protecting that information.
+                <br />
+                <a
+                  href="https://www.myhealth.va.gov/mhv-portal-web/web/myhealthevet/protecting-your-personal-health-information"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Get tips for protecting your personal health information
+                </a>
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div itemScope itemType="http://schema.org/Question">
+        <h3 itemProp="name" id="what-if-i-have-more-questions">
+          What if I have more questions?
+        </h3>
+        <div
+          itemProp="acceptedAnswer"
+          itemScope
+          itemType="http://schema.org/Answer"
+        >
+          <div itemProp="text">
+            <div className="processed-content">
+              <p>
+                You can get answers to frequently asked questions about VA Blue
+                Button and related tools within My HealtheVet.
+              </p>
+              <p>
+                <a
+                  href="https://www.myhealth.va.gov/mhv-portal-web/web/myhealthevet/faqs#bbtop"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Read VA Blue Button FAQs
+                </a>
+                <br />
+                <a
+                  href="https://www.myhealth.va.gov/mhv-portal-web/faqs#CCD"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Read VA Health Summary FAQs
+                </a>
+                <br />
+                <a
+                  href="https://www.myhealth.va.gov/mhv-portal-web/faqs#VAMIR"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Read VA Medical Images and Reports FAQs
+                </a>
+              </p>
+              <p>
+                You can also contact the My HealtheVet help desk.
+                <br />
+                <a
+                  href="https://www.myhealth.va.gov/mhv-portal-web/web/myhealthevet/contact-mhv"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Find out how to contact us online
+                </a>
+              </p>
+              <p>
+                Or call us at <a href="tel:+18773270022">877-327-0022</a> (TTY:{' '}
+                <a href="tel:+18008778339">800-877-8339</a>
+                ). We’re here Monday through Friday, 8:00 a.m. to 8:00 p.m. ET.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div>
+      <h2 id="the-veterans-health-informatio">
+        The Veterans Health Information Exchange
+      </h2>
+      <div itemScope itemType="http://schema.org/Question">
+        <h3 itemProp="name" id="whats-the-veterans-health-info">
+          What is the Veterans Health Information Exchange (VHIE), and how can
+          it help me manage my health care?
+        </h3>
+        <div
+          itemProp="acceptedAnswer"
+          itemScope
+          itemType="http://schema.org/Answer"
+        >
+          <div itemProp="text">
+            <div className="processed-content">
+              <p>
+                The Veterans Health Information Exchange (VHIE) program lets us
+                share your health information with participating community care
+                providers and the Department of Defense. For example, when you
+                leave activey-duty service, retire, or leave the Reserves and
+                then get health care at VA or a VA-approved community care
+                provider, your health record would electronically follow you.
+              </p>
+              <p>
+                This program is voluntary, and you can choose not to share your
+                information. If you choose not to share your information but
+                change your mind later, you can opt back in to sharing your
+                information at any time.
+              </p>
+              <p>
+                <strong>The sharing of health information:</strong>
+              </p>
+              <ul>
+                <li>
+                  Helps your VA and non-VA providers better coordinate your
+                  care.
+                </li>
+                <li>Keeps your personal health information more secure.</li>
+                <li>
+                  Improves your care by helping your providers make mroe
+                  informed decisions.
+                </li>
+                <li>
+                  Ensures your providers have up-to-date information, like your
+                  current medications and allergies.
+                </li>
+                <li>Saves you time and money.</li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div itemScope itemType="http://schema.org/Question">
+        <h3 itemProp="name" id="vhie-sharing-options">
+          Can I opt out of sharing my information?
+        </h3>
+        <div
+          itemProp="acceptedAnswer"
+          itemScope
+          itemType="http://schema.org/Answer"
+        >
+          <div itemProp="text">
+            <div className="processed-content">
+              <p>Yes. You can opt out of sharing by mail or in person.</p>
+              <h4>To opt out by mail</h4>
+              <p>
+                Fill out, sign, and date VA Form 10-10164 (Opt Out of Sharing
+                Protected Health Information).
+              </p>
+              <p>
+                <a href="https://va.gov/vaforms/medical/pdf/10-10164-fill.pdf">
+                  Download VA Form 10-10164 (PDF)
+                </a>
+              </p>
+              <br />
+              <p>
+                Mail the completed form to the Release of Information (ROI)
+                office at your nearest VA medical center.
+              </p>
+              <p>
+                <a href="">
+                  Find the address for your nearest VA medical center
+                </a>
+              </p>
+              <h4>To opt out in person</h4>
+              <p>Visit your VA medical center&apos;s ROI office.</p>
+              <p>
+                Bring a completed VA Form 10-10164 with you, or ask for a copy
+                to fill out in the office. Give your completed, signed form to
+                an office staff member.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div itemScope itemType="http://schema.org/Question">
+        <h3 itemProp="name" id="can-i-change-my-mind-share-information-later">
+          Can I change my mind if I want to share my information later?
+        </h3>
+        <div
+          itemProp="acceptedAnswer"
+          itemScope
+          itemType="http://schema.org/Answer"
+        >
+          <div itemProp="text">
+            <div className="processed-content">
+              <p>
+                Yes. If you change your mind and want to share your health
+                information, complete and submit VA Form 10-10163 (Request for
+                and Permission to Participate in Sharing Protected Health
+                Information).
+              </p>
+              <p>
+                <a href="https://va.gov/vaforms/medical/pdf/10-10163-fill.pdf">
+                  Download VA Form 10-10163 (PDF)
+                </a>
+              </p>
+              <p>
+                Mail or take this form in person to the Release of Information
+                (ROI) office at your nearest VA medical center.
+              </p>
+              <p>
+                <a href="">
+                  Find the address of your nearest VA medical center
+                </a>
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div itemScope itemType="http://schema.org/Question">
+        <h3
+          itemProp="name"
+          id="will-my-personal-health-information-be-protected"
+        >
+          Will my personal health information be protected?
+        </h3>
+        <div
+          itemProp="acceptedAnswer"
+          itemScope
+          itemType="http://schema.org/Answer"
+        >
+          <div itemProp="text">
+            <div className="processed-content">
+              <p>
+                Yes. The Veterans Health Information Exchange uses secure
+                technology to share information between VA and participating
+                community health care providers who treat you. We share
+                information only with community care providers and organizations
+                that have partnership agreements with us and are part of our
+                approved, trusted network.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div itemScope itemType="http://schema.org/Question">
+        <h3 itemProp="name" id="what-if-i-have-more-questions">
+          What if I have more questions?
+        </h3>
+        <div
+          itemProp="acceptedAnswer"
+          itemScope
+          itemType="http://schema.org/Answer"
+        >
+          <div itemProp="text">
+            <div className="processed-content">
+              <p>
+                Call us toll-free at <a href="tel:+18446982311">844-698-2311</a>
+                .
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </>
+);
+
+export default LegacyContent;

--- a/src/applications/static-pages/health-care-manage-benefits/get-medical-records-page/components/LegacyContent/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/get-medical-records-page/components/LegacyContent/index.js
@@ -5,23 +5,39 @@ import CallToActionWidget from 'platform/site-wide/cta-widget';
 
 const LegacyContent = () => (
   <>
-    <div className="processed-content">
+    <div
+      data-template="paragraphs/wysiwyg"
+      data-entity-id={3369}
+      className="processed-content"
+    >
       <h2 id="va-blue-button">VA Blue Button</h2>
     </div>
     <CallToActionWidget appId="health-records" setFocus={false} />
-    <div>
+    <div data-template="paragraphs/q_a_section" data-entity-id={3372}>
       <h2 id="more-about-va-blue-button">More about VA Blue Button</h2>
-      <div itemScope itemType="http://schema.org/Question">
+      <div
+        itemScope
+        itemType="http://schema.org/Question"
+        data-template="paragraphs/q_a"
+        data-entity-id={3373}
+        data-analytics-faq-section="More about VA Blue Button"
+        data-analytics-faq-text="What's VA Blue Button, and how can it help me manage my health care?"
+      >
         <h3 itemProp="name" id="whats-va-blue-button-and-how-c">
           What's VA Blue Button, and how can it help me manage my health care?
         </h3>
         <div
+          data-entity-id={3373}
           itemProp="acceptedAnswer"
           itemScope
           itemType="http://schema.org/Answer"
         >
           <div itemProp="text">
-            <div className="processed-content">
+            <div
+              data-template="paragraphs/wysiwyg"
+              data-entity-id={3374}
+              className="processed-content"
+            >
               <p>
                 VA Blue Button is a feature of the health management portal
                 within My HealtheVet. It lets you view, print, save, download,
@@ -62,17 +78,29 @@ const LegacyContent = () => (
           </div>
         </div>
       </div>
-      <div itemScope itemType="http://schema.org/Question">
+      <div
+        itemScope
+        itemType="http://schema.org/Question"
+        data-template="paragraphs/q_a"
+        data-entity-id={3375}
+        data-analytics-faq-section="More about VA Blue Button"
+        data-analytics-faq-text="Am I eligible to use all the features of VA Blue Button?"
+      >
         <h3 itemProp="name" id="am-i-eligible-to-use-all-the-f">
           Am I eligible to use all the features of VA Blue Button?
         </h3>
         <div
+          data-entity-id={3375}
           itemProp="acceptedAnswer"
           itemScope
           itemType="http://schema.org/Answer"
         >
           <div itemProp="text">
-            <div className="processed-content">
+            <div
+              data-template="paragraphs/wysiwyg"
+              data-entity-id={3376}
+              className="processed-content"
+            >
               <p>
                 You can use all the features of this tool if you meet all of the
                 requirements listed below.
@@ -82,9 +110,9 @@ const LegacyContent = () => (
               </p>
               <ul>
                 <li>
-                  Are enrolled in VA health care, <strong>and</strong>
+                  Enrolled in VA health care, <strong>and</strong>
                 </li>
-                <li>Are registered as a patient in a VA health facility</li>
+                <li>Registered as a patient in a VA health facility</li>
               </ul>
               <p>
                 <a href="/health-care/how-to-apply/">
@@ -96,11 +124,8 @@ const LegacyContent = () => (
               </p>
               <ul>
                 <li>
-                  A{' '}
-                  <a href="">
-                    Premium <strong>My HealtheVet account</strong>
-                  </a>
-                  , <strong>or</strong>
+                  An Advanced or Premium <strong>My HealtheVet</strong> account,{' '}
+                  <strong>or</strong>
                 </li>
                 <li>
                   A Premium <strong>DS Logon</strong> account (used for
@@ -112,10 +137,6 @@ const LegacyContent = () => (
                 </li>
               </ul>
               <p>
-                <strong>Note:</strong> If you sign in with a Basic or Advanced
-                account, you&apos;ll see only the results you&apos;ve entered
-                yourself.
-                <br />
                 <a
                   href="https://www.myhealth.va.gov/mhv-portal-web/my-healthevet-offers-three-account-types"
                   target="_blank"
@@ -128,17 +149,29 @@ const LegacyContent = () => (
           </div>
         </div>
       </div>
-      <div itemScope itemType="http://schema.org/Question">
+      <div
+        itemScope
+        itemType="http://schema.org/Question"
+        data-template="paragraphs/q_a"
+        data-entity-id={3377}
+        data-analytics-faq-section="More about VA Blue Button"
+        data-analytics-faq-text="Once I’m signed in, how do I get to my medical records?"
+      >
         <h3 itemProp="name" id="once-im-signed-in-how-do-i-get">
           Once I’m signed in, how do I get to my medical records?
         </h3>
         <div
+          data-entity-id={3377}
           itemProp="acceptedAnswer"
           itemScope
           itemType="http://schema.org/Answer"
         >
           <div itemProp="text">
-            <div className="processed-content">
+            <div
+              data-template="paragraphs/wysiwyg"
+              data-entity-id={3378}
+              className="processed-content"
+            >
               <p>
                 Go to your Welcome page dashboard, and click on “Health
                 Records.” You’ll go to a new page.
@@ -158,17 +191,29 @@ const LegacyContent = () => (
           </div>
         </div>
       </div>
-      <div itemScope itemType="http://schema.org/Question">
+      <div
+        itemScope
+        itemType="http://schema.org/Question"
+        data-template="paragraphs/q_a"
+        data-entity-id={3379}
+        data-analytics-faq-section="More about VA Blue Button"
+        data-analytics-faq-text="Will my personal health information be protected?"
+      >
         <h3 itemProp="name" id="will-my-personal-health-inform">
           Will my personal health information be protected?
         </h3>
         <div
+          data-entity-id={3379}
           itemProp="acceptedAnswer"
           itemScope
           itemType="http://schema.org/Answer"
         >
           <div itemProp="text">
-            <div className="processed-content">
+            <div
+              data-template="paragraphs/wysiwyg"
+              data-entity-id={3380}
+              className="processed-content"
+            >
               <p>
                 Yes. This is a secure website. We follow strict security
                 policies and practices to protect your personal health
@@ -190,22 +235,33 @@ const LegacyContent = () => (
           </div>
         </div>
       </div>
-      <div itemScope itemType="http://schema.org/Question">
+      <div
+        itemScope
+        itemType="http://schema.org/Question"
+        data-template="paragraphs/q_a"
+        data-entity-id={3381}
+        data-analytics-faq-section="More about VA Blue Button"
+        data-analytics-faq-text="What if I have more questions?"
+      >
         <h3 itemProp="name" id="what-if-i-have-more-questions">
           What if I have more questions?
         </h3>
         <div
+          data-entity-id={3381}
           itemProp="acceptedAnswer"
           itemScope
           itemType="http://schema.org/Answer"
         >
           <div itemProp="text">
-            <div className="processed-content">
+            <div
+              data-template="paragraphs/wysiwyg"
+              data-entity-id={3382}
+              className="processed-content"
+            >
               <p>
                 You can get answers to frequently asked questions about VA Blue
                 Button and related tools within My HealtheVet.
-              </p>
-              <p>
+                <br />
                 <a
                   href="https://www.myhealth.va.gov/mhv-portal-web/web/myhealthevet/faqs#bbtop"
                   target="_blank"
@@ -240,10 +296,18 @@ const LegacyContent = () => (
                 >
                   Find out how to contact us online
                 </a>
-              </p>
-              <p>
-                Or call us at <a href="tel:+18773270022">877-327-0022</a> (TTY:{' '}
-                <a href="tel:+18008778339">800-877-8339</a>
+                <br />
+                Or call us at{' '}
+                <a aria-label="8 7 7. 3 2 7. 0 0 2 2." href="tel:18773270022">
+                  877-327-0022
+                </a>{' '}
+                (TTY:{' '}
+                <a
+                  aria-label="TTY. 8 0 0. 8 7 7. 8 3 3 9."
+                  href="tel:18008778339"
+                >
+                  800-877-8339
+                </a>
                 ). We’re here Monday through Friday, 8:00 a.m. to 8:00 p.m. ET.
               </p>
             </div>
@@ -251,177 +315,244 @@ const LegacyContent = () => (
         </div>
       </div>
     </div>
-    <div>
+    <div data-template="paragraphs/q_a_section" data-entity-id={3383}>
       <h2 id="the-veterans-health-informatio">
         The Veterans Health Information Exchange
       </h2>
-      <div itemScope itemType="http://schema.org/Question">
+      <p>
+        The Veterans Health Information Exchange (VHIE) program lets us
+        automatically and securely share your health information with
+        participating community care providers as well as the Department of
+        Defense.{' '}
+      </p>
+      <div
+        itemScope
+        itemType="http://schema.org/Question"
+        data-template="paragraphs/q_a"
+        data-entity-id={9811}
+        data-analytics-faq-section="The Veterans Health Information Exchange"
+        data-analytics-faq-text="What's the Veterans Health Information Exchange (VHIE), and how can it help me manage my health care?"
+      >
         <h3 itemProp="name" id="whats-the-veterans-health-info">
-          What is the Veterans Health Information Exchange (VHIE), and how can
-          it help me manage my health care?
+          What's the Veterans Health Information Exchange (VHIE), and how can it
+          help me manage my health care?
         </h3>
         <div
+          data-entity-id={9811}
           itemProp="acceptedAnswer"
           itemScope
           itemType="http://schema.org/Answer"
         >
           <div itemProp="text">
-            <div className="processed-content">
+            <div
+              data-template="paragraphs/wysiwyg"
+              data-entity-id={9810}
+              className="processed-content"
+            >
               <p>
-                The Veterans Health Information Exchange (VHIE) program lets us
-                share your health information with participating community care
-                providers and the Department of Defense. For example, when you
-                leave activey-duty service, retire, or leave the Reserves and
-                then get health care at VA or a VA-approved community care
-                provider, your health record would electronically follow you.
+                VHIE gives your health care providers a more complete view of
+                your health record to help them make more informed treatment
+                decisions. Through VHIE, community providers who are a part of
+                your care team can safely and securely receive your VA health
+                information electronically.&nbsp;
+                <br />
+                <br />
+                VHIE helps improve continuity of your care, reduce test
+                duplication, and avoid clinical error. That's because you can
+                see all your&nbsp;health care providers from different practices
+                or networks in one place. Our&nbsp;secure system also eliminates
+                the need to send paper medical records by mail, and to carry
+                your records to appointments with community providers.
+                <br />
+                <br />
+                We only&nbsp;share&nbsp;your health information with
+                participating community providers via VHIE when they're treating
+                you. Visit the <a href="https://www.va.gov/VHIE/">
+                  VHIE page
+                </a>{' '}
+                to learn more about how the&nbsp;program helps your providers
+                better understand your health history and develop safer, more
+                effective treatment plans.&nbsp;
               </p>
-              <p>
-                This program is voluntary, and you can choose not to share your
-                information. If you choose not to share your information but
-                change your mind later, you can opt back in to sharing your
-                information at any time.
-              </p>
-              <p>
-                <strong>The sharing of health information:</strong>
-              </p>
-              <ul>
-                <li>
-                  Helps your VA and non-VA providers better coordinate your
-                  care.
-                </li>
-                <li>Keeps your personal health information more secure.</li>
-                <li>
-                  Improves your care by helping your providers make mroe
-                  informed decisions.
-                </li>
-                <li>
-                  Ensures your providers have up-to-date information, like your
-                  current medications and allergies.
-                </li>
-                <li>Saves you time and money.</li>
-              </ul>
             </div>
           </div>
         </div>
       </div>
-      <div itemScope itemType="http://schema.org/Question">
+      <div
+        itemScope
+        itemType="http://schema.org/Question"
+        data-template="paragraphs/q_a"
+        data-entity-id={9809}
+        data-analytics-faq-section="The Veterans Health Information Exchange"
+        data-analytics-faq-text="VHIE sharing options"
+      >
         <h3 itemProp="name" id="vhie-sharing-options">
-          Can I opt out of sharing my information?
+          VHIE sharing options
         </h3>
         <div
+          data-entity-id={9809}
           itemProp="acceptedAnswer"
           itemScope
           itemType="http://schema.org/Answer"
         >
           <div itemProp="text">
-            <div className="processed-content">
-              <p>Yes. You can opt out of sharing by mail or in person.</p>
-              <h4>To opt out by mail</h4>
+            <div
+              data-template="paragraphs/wysiwyg"
+              data-entity-id={9808}
+              className="processed-content"
+            >
               <p>
-                Fill out, sign, and date VA Form 10-10164 (Opt Out of Sharing
-                Protected Health Information).
-              </p>
-              <p>
-                <a href="https://va.gov/vaforms/medical/pdf/10-10164-fill.pdf">
-                  Download VA Form 10-10164 (PDF)
-                </a>
-              </p>
-              <br />
-              <p>
-                Mail the completed form to the Release of Information (ROI)
-                office at your nearest VA medical center.
-              </p>
-              <p>
-                <a href="">
-                  Find the address for your nearest VA medical center
-                </a>
-              </p>
-              <h4>To opt out in person</h4>
-              <p>Visit your VA medical center&apos;s ROI office.</p>
-              <p>
-                Bring a completed VA Form 10-10164 with you, or ask for a copy
-                to fill out in the office. Give your completed, signed form to
-                an office staff member.
+                If you don't want your community providers to receive your
+                information via VHIE, you may opt out of electronic sharing at
+                any time. And if&nbsp;you previously opted out but want to
+                resume secure, seamless sharing, you may opt back in. Visit the{' '}
+                <a href="https://www.va.gov/VHIE/VHIE_Sharing_Options.asp">
+                  VHIE Sharing Options page
+                </a>{' '}
+                to learn more.
               </p>
             </div>
           </div>
         </div>
       </div>
-      <div itemScope itemType="http://schema.org/Question">
-        <h3 itemProp="name" id="can-i-change-my-mind-share-information-later">
-          Can I change my mind if I want to share my information later?
+      <div
+        itemScope
+        itemType="http://schema.org/Question"
+        data-template="paragraphs/q_a"
+        data-entity-id={9889}
+        data-analytics-faq-section="The Veterans Health Information Exchange"
+        data-analytics-faq-text="How do I opt out?"
+      >
+        <h3 itemProp="name" id="how-do-i-opt-out">
+          How do I opt out?
         </h3>
         <div
+          data-entity-id={9889}
           itemProp="acceptedAnswer"
           itemScope
           itemType="http://schema.org/Answer"
         >
           <div itemProp="text">
-            <div className="processed-content">
+            <div
+              data-template="paragraphs/wysiwyg"
+              data-entity-id={9888}
+              className="processed-content"
+            >
               <p>
-                Yes. If you change your mind and want to share your health
-                information, complete and submit VA Form 10-10163 (Request for
-                and Permission to Participate in Sharing Protected Health
-                Information).
-              </p>
-              <p>
-                <a href="https://va.gov/vaforms/medical/pdf/10-10163-fill.pdf">
-                  Download VA Form 10-10163 (PDF)
+                If you would prefer to opt out of sharing your health
+                information electronically, you can do so at any time. You must
+                complete and submit{' '}
+                <a href="https://www.va.gov/vaforms/medical/pdf/10-10164-fill.pdf">
+                  VA Form 10-10164
+                </a>{' '}
+                to your facility’s Release of Information Office (ROI). You may
+                also opt out via{' '}
+                <a
+                  href="https://www.myhealth.va.gov/mhv-portal-web/home"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  My HealtheVet
                 </a>
-              </p>
-              <p>
-                Mail or take this form in person to the Release of Information
-                (ROI) office at your nearest VA medical center.
-              </p>
-              <p>
-                <a href="">
-                  Find the address of your nearest VA medical center
-                </a>
-              </p>
-            </div>
-          </div>
-        </div>
-      </div>
-      <div itemScope itemType="http://schema.org/Question">
-        <h3
-          itemProp="name"
-          id="will-my-personal-health-information-be-protected"
-        >
-          Will my personal health information be protected?
-        </h3>
-        <div
-          itemProp="acceptedAnswer"
-          itemScope
-          itemType="http://schema.org/Answer"
-        >
-          <div itemProp="text">
-            <div className="processed-content">
-              <p>
-                Yes. The Veterans Health Information Exchange uses secure
-                technology to share information between VA and participating
-                community health care providers who treat you. We share
-                information only with community care providers and organizations
-                that have partnership agreements with us and are part of our
-                approved, trusted network.
-              </p>
-            </div>
-          </div>
-        </div>
-      </div>
-      <div itemScope itemType="http://schema.org/Question">
-        <h3 itemProp="name" id="what-if-i-have-more-questions">
-          What if I have more questions?
-        </h3>
-        <div
-          itemProp="acceptedAnswer"
-          itemScope
-          itemType="http://schema.org/Answer"
-        >
-          <div itemProp="text">
-            <div className="processed-content">
-              <p>
-                Call us toll-free at <a href="tel:+18446982311">844-698-2311</a>
                 .
+              </p>
+              <p>
+                <strong>Note:</strong> If you haven't already done so, you'll
+                need to upgrade your My HealtheVet account to Premium
+                status&nbsp;to opt out. Visit{' '}
+                <a
+                  href="https://www.myhealth.va.gov/mhv-portal-web/home"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  My HealtheVet
+                </a>{' '}
+                to learn more.&nbsp;
+              </p>
+              <p>
+                Choosing to opt out will not affect your access to care from
+                community providers. However, if you opt out, your community
+                providers may not receive your medical records before you
+                receive treatment. This may put you at risk. Also, if you visit
+                any emergency room, your information may still be shared via
+                VHIE so that you can receive the care you need.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        itemScope
+        itemType="http://schema.org/Question"
+        data-template="paragraphs/q_a"
+        data-entity-id={9891}
+        data-analytics-faq-section="The Veterans Health Information Exchange"
+        data-analytics-faq-text="If I opt out, how can I opt back in?"
+      >
+        <h3 itemProp="name" id="if-i-opt-out-how-can-i-opt-bac">
+          If I opt out, how can I opt back in?
+        </h3>
+        <div
+          data-entity-id={9891}
+          itemProp="acceptedAnswer"
+          itemScope
+          itemType="http://schema.org/Answer"
+        >
+          <div itemProp="text">
+            <div
+              data-template="paragraphs/wysiwyg"
+              data-entity-id={9890}
+              className="processed-content"
+            >
+              <p>
+                If you previously opted out, but want to resume secure, seamless
+                sharing, you may do so at any time. Simply complete&nbsp;
+                <a href="https://www.va.gov/vaforms/medical/pdf/10-10163-fill.pdf">
+                  VA Form 10-10163
+                </a>
+                &nbsp;and return it to your VA facility's ROI office, or submit
+                it online though{' '}
+                <a
+                  href="https://www.myhealth.va.gov/mhv-portal-web/web/myhealthevet/home"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  My HealtheVet
+                </a>
+                .
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        itemScope
+        itemType="http://schema.org/Question"
+        data-template="paragraphs/q_a"
+        data-entity-id={10274}
+        data-analytics-faq-section="The Veterans Health Information Exchange"
+        data-analytics-faq-text="Can I check my sharing preference status?"
+      >
+        <h3 itemProp="name" id="can-i-check-my-sharing-prefere">
+          Can I check my sharing preference status?
+        </h3>
+        <div
+          data-entity-id={10274}
+          itemProp="acceptedAnswer"
+          itemScope
+          itemType="http://schema.org/Answer"
+        >
+          <div itemProp="text">
+            <div
+              data-template="paragraphs/wysiwyg"
+              data-entity-id={10273}
+              className="processed-content"
+            >
+              <p>
+                Yes. Please contact your VA facility's&nbsp;ROI office.&nbsp;If
+                you've already&nbsp;submitted your form to opt out, or to opt
+                back in, to the electronic sharing program, your request may be
+                in process.
               </p>
             </div>
           </div>

--- a/src/applications/static-pages/health-care-manage-benefits/get-medical-records-page/components/LegacyContent/index.unit.spec.js
+++ b/src/applications/static-pages/health-care-manage-benefits/get-medical-records-page/components/LegacyContent/index.unit.spec.js
@@ -1,0 +1,37 @@
+// Dependencies.
+import React from 'react';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+// Relative imports.
+import LegacyContent from '.';
+
+describe('Get Medical Records Page <LegacyContent>', () => {
+  it('renders what we expect', () => {
+    const wrapper = shallow(<LegacyContent />);
+
+    const text = wrapper.text();
+    expect(text).to.include(
+      "What's VA Blue Button, and how can it help me manage my health care?",
+    );
+    expect(text).to.include(
+      'Am I eligible to use all the features of VA Blue Button?',
+    );
+    expect(text).to.include(
+      'Once I’m signed in, how do I get to my medical records?',
+    );
+    expect(text).to.include(
+      'Will my personal health information be protected?',
+    );
+    expect(text).to.include('What if I have more questions?');
+    expect(text).to.include(
+      'What is the Veterans Health Information Exchange (VHIE), and how can',
+    );
+    expect(text).to.include('Can I opt out of sharing my information?');
+    expect(text).to.include(
+      'Can I change my mind if I want to share my information later?',
+    );
+    expect(text).to.include('What if I have more questions?');
+
+    wrapper.unmount();
+  });
+});

--- a/src/applications/static-pages/health-care-manage-benefits/get-medical-records-page/components/LegacyContent/index.unit.spec.js
+++ b/src/applications/static-pages/health-care-manage-benefits/get-medical-records-page/components/LegacyContent/index.unit.spec.js
@@ -23,11 +23,11 @@ describe('Get Medical Records Page <LegacyContent>', () => {
       'Will my personal health information be protected?',
     );
     expect(text).to.include('What if I have more questions?');
-    expect(text).to.include(
+    expect(text).to.not.include(
       'What is the Veterans Health Information Exchange (VHIE), and how can',
     );
-    expect(text).to.include('Can I opt out of sharing my information?');
-    expect(text).to.include(
+    expect(text).to.not.include('Can I opt out of sharing my information?');
+    expect(text).to.not.include(
       'Can I change my mind if I want to share my information later?',
     );
     expect(text).to.include('What if I have more questions?');

--- a/src/applications/static-pages/health-care-manage-benefits/refill-track-prescriptions-page/components/App/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/refill-track-prescriptions-page/components/App/index.js
@@ -4,10 +4,16 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 // Relative imports.
 import AuthContent from '../AuthContent';
+import LegacyContent from '../LegacyContent';
 import UnauthContent from '../UnauthContent';
+import environment from 'platform/utilities/environment';
 import { selectIsCernerPatient } from 'platform/user/selectors';
 
 export const App = ({ isCernerPatient }) => {
+  if (environment.isProduction()) {
+    return <LegacyContent />;
+  }
+
   if (isCernerPatient) {
     return <AuthContent />;
   }

--- a/src/applications/static-pages/health-care-manage-benefits/refill-track-prescriptions-page/components/LegacyContent/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/refill-track-prescriptions-page/components/LegacyContent/index.js
@@ -6,22 +6,35 @@ import CallToActionWidget from 'platform/site-wide/cta-widget';
 export const LegacyContent = () => (
   <>
     <CallToActionWidget appId="rx" setFocus={false} />
-    <div>
-      <div itemScope itemType="http://schema.org/Question">
+    <div data-template="paragraphs/q_a_section" data-entity-id={3258}>
+      <div
+        itemScope
+        itemType="http://schema.org/Question"
+        data-template="paragraphs/q_a"
+        data-entity-id={3257}
+        data-analytics-faq-section
+        data-analytics-faq-text="How can the VA Prescription Refill and Tracking tool help me manage my health care?"
+      >
         <h2 itemProp="name" id="how-can-the-va-prescription-re">
           How can the VA Prescription Refill and Tracking tool help me manage my
           health care?
         </h2>
         <div
+          data-entity-id={3257}
           itemProp="acceptedAnswer"
           itemScope
           itemType="http://schema.org/Answer"
         >
           <div itemProp="text">
-            <div className="processed-content">
+            <div
+              data-template="paragraphs/wysiwyg"
+              data-entity-id={3259}
+              className="processed-content"
+            >
               <p>
-                Our Prescription Refill and Tracking tool is a web-based service
-                that helps you manage your VA prescriptions online.
+                Our Prescription Refill and Tracking tool, sometimes called “Rx
+                Refill” or “Rx Tracker,” is a web-based service that helps you
+                manage your VA prescriptions online.
               </p>
               <p>
                 <strong>With this tool, you can:</strong>
@@ -47,17 +60,29 @@ export const LegacyContent = () => (
           </div>
         </div>
       </div>
-      <div itemScope itemType="http://schema.org/Question">
+      <div
+        itemScope
+        itemType="http://schema.org/Question"
+        data-template="paragraphs/q_a"
+        data-entity-id={3260}
+        data-analytics-faq-section
+        data-analytics-faq-text="Am I eligible to use this tool?"
+      >
         <h2 itemProp="name" id="am-i-eligible-to-use-this-tool">
           Am I eligible to use this tool?
         </h2>
         <div
+          data-entity-id={3260}
           itemProp="acceptedAnswer"
           itemScope
           itemType="http://schema.org/Answer"
         >
           <div itemProp="text">
-            <div className="processed-content">
+            <div
+              data-template="paragraphs/wysiwyg"
+              data-entity-id={3261}
+              className="processed-content"
+            >
               <p>
                 You can use this tool if you meet all of the requirements listed
                 below.
@@ -89,14 +114,8 @@ export const LegacyContent = () => (
               </p>
               <ul>
                 <li>
-                  A{' '}
-                  <a
-                    href="https://www.myhealth.va.gov/mhv-portal-web/upgrading-your-my-healthevet-account-through-in-person-or-online-authentication"
-                    rel="noreferrer noopener"
-                  >
-                    Premium <strong>My HealtheVet account</strong>
-                  </a>
-                  , <strong>or</strong>
+                  An Advanced or Premium <strong>My HealtheVet</strong> account,{' '}
+                  <strong>or</strong>
                 </li>
                 <li>
                   A Premium <strong>DS Logon</strong> account (used for
@@ -111,17 +130,29 @@ export const LegacyContent = () => (
           </div>
         </div>
       </div>
-      <div itemScope itemType="http://schema.org/Question">
+      <div
+        itemScope
+        itemType="http://schema.org/Question"
+        data-template="paragraphs/q_a"
+        data-entity-id={3262}
+        data-analytics-faq-section
+        data-analytics-faq-text="Once I’m signed in, how do I get started?"
+      >
         <h2 itemProp="name" id="once-im-signed-in-how-do-i-get">
           Once I’m signed in, how do I get started?
         </h2>
         <div
+          data-entity-id={3262}
           itemProp="acceptedAnswer"
           itemScope
           itemType="http://schema.org/Answer"
         >
           <div itemProp="text">
-            <div className="processed-content">
+            <div
+              data-template="paragraphs/wysiwyg"
+              data-entity-id={3263}
+              className="processed-content"
+            >
               <p>
                 On your Welcome page, you’ll see a module for “Pharmacy.” Within
                 that module, you’ll see these options:
@@ -139,17 +170,29 @@ export const LegacyContent = () => (
           </div>
         </div>
       </div>
-      <div itemScope itemType="http://schema.org/Question">
+      <div
+        itemScope
+        itemType="http://schema.org/Question"
+        data-template="paragraphs/q_a"
+        data-entity-id={3264}
+        data-analytics-faq-section
+        data-analytics-faq-text="Can I use this tool to refill and track all my VA prescriptions?"
+      >
         <h2 itemProp="name" id="can-i-use-this-tool-to-refill-">
           Can I use this tool to refill and track all my VA prescriptions?
         </h2>
         <div
+          data-entity-id={3264}
           itemProp="acceptedAnswer"
           itemScope
           itemType="http://schema.org/Answer"
         >
           <div itemProp="text">
-            <div className="processed-content">
+            <div
+              data-template="paragraphs/wysiwyg"
+              data-entity-id={3265}
+              className="processed-content"
+            >
               <p>
                 <strong>
                   You can refill and track most of your VA prescriptions,
@@ -181,17 +224,29 @@ export const LegacyContent = () => (
           </div>
         </div>
       </div>
-      <div itemScope itemType="http://schema.org/Question">
+      <div
+        itemScope
+        itemType="http://schema.org/Question"
+        data-template="paragraphs/q_a"
+        data-entity-id={3266}
+        data-analytics-faq-section
+        data-analytics-faq-text="Where will VA send my prescriptions?"
+      >
         <h2 itemProp="name" id="where-will-va-send-my-prescrip">
           Where will VA send my prescriptions?
         </h2>
         <div
+          data-entity-id={3266}
           itemProp="acceptedAnswer"
           itemScope
           itemType="http://schema.org/Answer"
         >
           <div itemProp="text">
-            <div className="processed-content">
+            <div
+              data-template="paragraphs/wysiwyg"
+              data-entity-id={3267}
+              className="processed-content"
+            >
               <p>
                 Our mail order pharmacy will send your prescriptions to the
                 address we have on file for you. We ship to all addresses in the
@@ -211,18 +266,30 @@ export const LegacyContent = () => (
           </div>
         </div>
       </div>
-      <div itemScope itemType="http://schema.org/Question">
+      <div
+        itemScope
+        itemType="http://schema.org/Question"
+        data-template="paragraphs/q_a"
+        data-entity-id={3268}
+        data-analytics-faq-section
+        data-analytics-faq-text="How long will my prescriptions take to arrive, and when should I reorder?"
+      >
         <h2 itemProp="name" id="how-long-will-my-prescriptions">
           How long will my prescriptions take to arrive, and when should I
           reorder?
         </h2>
         <div
+          data-entity-id={3268}
           itemProp="acceptedAnswer"
           itemScope
           itemType="http://schema.org/Answer"
         >
           <div itemProp="text">
-            <div className="processed-content">
+            <div
+              data-template="paragraphs/wysiwyg"
+              data-entity-id={3269}
+              className="processed-content"
+            >
               <p>
                 Prescriptions usually arrive within 3 to 5 days. But you’ll be
                 able to find specific information about your order on the
@@ -237,17 +304,29 @@ export const LegacyContent = () => (
           </div>
         </div>
       </div>
-      <div itemScope itemType="http://schema.org/Question">
+      <div
+        itemScope
+        itemType="http://schema.org/Question"
+        data-template="paragraphs/q_a"
+        data-entity-id={3270}
+        data-analytics-faq-section
+        data-analytics-faq-text="Will my personal health information be protected?"
+      >
         <h2 itemProp="name" id="will-my-personal-health-inform">
           Will my personal health information be protected?
         </h2>
         <div
+          data-entity-id={3270}
           itemProp="acceptedAnswer"
           itemScope
           itemType="http://schema.org/Answer"
         >
           <div itemProp="text">
-            <div className="processed-content">
+            <div
+              data-template="paragraphs/wysiwyg"
+              data-entity-id={3271}
+              className="processed-content"
+            >
               <p>
                 Yes. This is a secure website. We follow strict security
                 policies and practices to protect your personal health
@@ -270,45 +349,61 @@ export const LegacyContent = () => (
           </div>
         </div>
       </div>
-      <div itemScope itemType="http://schema.org/Question">
+      <div
+        itemScope
+        itemType="http://schema.org/Question"
+        data-template="paragraphs/q_a"
+        data-entity-id={3272}
+        data-analytics-faq-section
+        data-analytics-faq-text="What if I have more questions?"
+      >
         <h2 itemProp="name" id="what-if-i-have-more-questions">
           What if I have more questions?
         </h2>
         <div
+          data-entity-id={3272}
           itemProp="acceptedAnswer"
           itemScope
           itemType="http://schema.org/Answer"
         >
           <div itemProp="text">
-            <div className="processed-content">
+            <div
+              data-template="paragraphs/wysiwyg"
+              data-entity-id={3273}
+              className="processed-content"
+            >
               <p>
-                If you have questions about prescriptions and refills on
-                MyHealtheVet, please go to the{' '}
+                You can get answers to your questions about this tool within our
+                My HealtheVet web portal.
+                <br />
                 <a
                   href="https://www.myhealth.va.gov/mhv-portal-web/web/myhealthevet/faqs#PrescriptionRefill"
                   target="_blank"
                   rel="noopener noreferrer"
                 >
-                  Prescription refills FAQs
-                </a>{' '}
-                on the My HealtheVet web portal.
+                  Read Prescription Refill FAQs
+                </a>
               </p>
               <p>
-                Or contact the My HealtheVet help desk at{' '}
-                <a href="tel:+18773270022">877-327-0022</a> (TTY:{' '}
-                <a href="tel:+18008778339">800-877-8339</a>. We&apos;re here
-                Monday through Friday, 7:00 a.m. to 7:00 p.m. CT.
-              </p>
-              <p>
-                You can also{' '}
+                You can also contact the My HealtheVet help desk.
+                <br />
                 <a
                   href="https://www.myhealth.va.gov/mhv-portal-web/web/myhealthevet/contact-mhv"
                   target="_blank"
                   rel="noopener noreferrer"
                 >
-                  contact us online
+                  Find out how to contact us online
                 </a>
-                .
+                <br />
+                Or call us at{' '}
+                <a aria-label="8 7 7. 3 2 7. 0 0 2 2." href="tel:18773270022">
+                  877-327-0022
+                </a>{' '}
+                (TTY:{' '}
+                <a aria-label="8 0 0. 8 7 7. 8 3 3 9." href="tel:18008778339">
+                  800-877-8339
+                </a>
+                ). We’re here Monday through Friday, 7:00 a.m. to 7:00 p.m. CT.
               </p>
             </div>
           </div>

--- a/src/applications/static-pages/health-care-manage-benefits/refill-track-prescriptions-page/components/LegacyContent/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/refill-track-prescriptions-page/components/LegacyContent/index.js
@@ -1,0 +1,321 @@
+// Node modules.
+import React from 'react';
+// Relative imports.
+import CallToActionWidget from 'platform/site-wide/cta-widget';
+
+export const LegacyContent = () => (
+  <>
+    <CallToActionWidget appId="rx" setFocus={false} />
+    <div>
+      <div itemScope itemType="http://schema.org/Question">
+        <h2 itemProp="name" id="how-can-the-va-prescription-re">
+          How can the VA Prescription Refill and Tracking tool help me manage my
+          health care?
+        </h2>
+        <div
+          itemProp="acceptedAnswer"
+          itemScope
+          itemType="http://schema.org/Answer"
+        >
+          <div itemProp="text">
+            <div className="processed-content">
+              <p>
+                Our Prescription Refill and Tracking tool is a web-based service
+                that helps you manage your VA prescriptions online.
+              </p>
+              <p>
+                <strong>With this tool, you can:</strong>
+              </p>
+              <ul>
+                <li>Refill your VA prescriptions online</li>
+                <li>View your past and current VA prescriptions</li>
+                <li>
+                  Track the delivery of each prescription mailed within the past
+                  30 days
+                </li>
+                <li>
+                  Get email notifications to let you know when to expect your
+                  prescriptions
+                </li>
+                <li>
+                  Create lists to keep track of all your medicines (including
+                  prescriptions, over-the-counter medicines, herbal remedies,
+                  and supplements)
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div itemScope itemType="http://schema.org/Question">
+        <h2 itemProp="name" id="am-i-eligible-to-use-this-tool">
+          Am I eligible to use this tool?
+        </h2>
+        <div
+          itemProp="acceptedAnswer"
+          itemScope
+          itemType="http://schema.org/Answer"
+        >
+          <div itemProp="text">
+            <div className="processed-content">
+              <p>
+                You can use this tool if you meet all of the requirements listed
+                below.
+              </p>
+              <p>
+                <strong>All of these must be true. You:</strong>
+              </p>
+              <ul>
+                <li>
+                  Are enrolled in VA health care, <strong>and</strong>
+                </li>
+                <li>
+                  Are registered as a patient in a VA health facility,{' '}
+                  <strong>and</strong>
+                </li>
+                <li>
+                  Have a refillable prescription from a VA doctor that you’ve
+                  filled at a VA pharmacy and that’s being handled by the VA
+                  Mail Order Pharmacy
+                </li>
+              </ul>
+              <p>
+                <a href="/health-care/how-to-apply/">
+                  Find out how to apply for VA health care
+                </a>
+              </p>
+              <p>
+                <strong>And you must have one of these free accounts:</strong>
+              </p>
+              <ul>
+                <li>
+                  A{' '}
+                  <a
+                    href="https://www.myhealth.va.gov/mhv-portal-web/upgrading-your-my-healthevet-account-through-in-person-or-online-authentication"
+                    rel="noreferrer noopener"
+                  >
+                    Premium <strong>My HealtheVet account</strong>
+                  </a>
+                  , <strong>or</strong>
+                </li>
+                <li>
+                  A Premium <strong>DS Logon</strong> account (used for
+                  eBenefits and milConnect), <strong>or</strong>
+                </li>
+                <li>
+                  A verified <strong>ID.me</strong> account that you can create
+                  here on VA.gov
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div itemScope itemType="http://schema.org/Question">
+        <h2 itemProp="name" id="once-im-signed-in-how-do-i-get">
+          Once I’m signed in, how do I get started?
+        </h2>
+        <div
+          itemProp="acceptedAnswer"
+          itemScope
+          itemType="http://schema.org/Answer"
+        >
+          <div itemProp="text">
+            <div className="processed-content">
+              <p>
+                On your Welcome page, you’ll see a module for “Pharmacy.” Within
+                that module, you’ll see these options:
+              </p>
+              <ul>
+                <li>“Refill VA Prescriptions”</li>
+                <li>“Track Delivery”</li>
+                <li>“Medications List”</li>
+              </ul>
+              <p>
+                Click on the link you want, and you’ll get instructions on the
+                next page to get started.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div itemScope itemType="http://schema.org/Question">
+        <h2 itemProp="name" id="can-i-use-this-tool-to-refill-">
+          Can I use this tool to refill and track all my VA prescriptions?
+        </h2>
+        <div
+          itemProp="acceptedAnswer"
+          itemScope
+          itemType="http://schema.org/Answer"
+        >
+          <div itemProp="text">
+            <div className="processed-content">
+              <p>
+                <strong>
+                  You can refill and track most of your VA prescriptions,
+                  including:
+                </strong>
+              </p>
+              <ul>
+                <li>VA medicines that were refilled or renewed</li>
+                <li>Wound care supplies</li>
+                <li>Diabetic supplies</li>
+                <li>
+                  Other products and supplies sent through the VA Mail Order
+                  Pharmacy
+                </li>
+              </ul>
+              <p>
+                Your VA health care team may decide not to ship medicines that
+                you don’t need right away, medicines that are not commonly
+                prescribed, or those that require you to be closely monitored.
+                In these cases, you’ll need to pick up your prescription from
+                the VA health facility where you get care.
+              </p>
+              <p>
+                You can’t refill some medicines, like certain pain medication
+                and narcotics. You’ll need to get a new prescription from your
+                VA provider each time you need more of these medicines.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div itemScope itemType="http://schema.org/Question">
+        <h2 itemProp="name" id="where-will-va-send-my-prescrip">
+          Where will VA send my prescriptions?
+        </h2>
+        <div
+          itemProp="acceptedAnswer"
+          itemScope
+          itemType="http://schema.org/Answer"
+        >
+          <div itemProp="text">
+            <div className="processed-content">
+              <p>
+                Our mail order pharmacy will send your prescriptions to the
+                address we have on file for you. We ship to all addresses in the
+                United States and its territories. We don’t ship prescriptions
+                to foreign countries.
+              </p>
+              <p>
+                <strong>Important note:</strong> If you change your address
+                within My HealtheVet, it does <strong>not</strong> change your
+                address for prescription shipments. Please contact the VA health
+                facility where you get care to have them update your address on
+                file.
+                <br />
+                <a href="/find-locations/">Find your VA health facility</a>
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div itemScope itemType="http://schema.org/Question">
+        <h2 itemProp="name" id="how-long-will-my-prescriptions">
+          How long will my prescriptions take to arrive, and when should I
+          reorder?
+        </h2>
+        <div
+          itemProp="acceptedAnswer"
+          itemScope
+          itemType="http://schema.org/Answer"
+        >
+          <div itemProp="text">
+            <div className="processed-content">
+              <p>
+                Prescriptions usually arrive within 3 to 5 days. But you’ll be
+                able to find specific information about your order on the
+                website of the delivery service shown in your Rx Tracker.
+              </p>
+              <p>
+                To make sure you have your medicine in time, you’ll want to
+                request your refill at least 10 days before you’ll run out of
+                your current prescription.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div itemScope itemType="http://schema.org/Question">
+        <h2 itemProp="name" id="will-my-personal-health-inform">
+          Will my personal health information be protected?
+        </h2>
+        <div
+          itemProp="acceptedAnswer"
+          itemScope
+          itemType="http://schema.org/Answer"
+        >
+          <div itemProp="text">
+            <div className="processed-content">
+              <p>
+                Yes. This is a secure website. We follow strict security
+                policies and practices to protect your personal health
+                information.
+              </p>
+              <p>
+                If you print or download anything from the website (like
+                prescription details), you’ll need to take responsibility for
+                protecting that information.
+                <br />
+                <a
+                  href="https://www.myhealth.va.gov/mhv-portal-web/web/myhealthevet/protecting-your-personal-health-information"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Get tips for protecting your personal health information
+                </a>
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div itemScope itemType="http://schema.org/Question">
+        <h2 itemProp="name" id="what-if-i-have-more-questions">
+          What if I have more questions?
+        </h2>
+        <div
+          itemProp="acceptedAnswer"
+          itemScope
+          itemType="http://schema.org/Answer"
+        >
+          <div itemProp="text">
+            <div className="processed-content">
+              <p>
+                If you have questions about prescriptions and refills on
+                MyHealtheVet, please go to the{' '}
+                <a
+                  href="https://www.myhealth.va.gov/mhv-portal-web/web/myhealthevet/faqs#PrescriptionRefill"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Prescription refills FAQs
+                </a>{' '}
+                on the My HealtheVet web portal.
+              </p>
+              <p>
+                Or contact the My HealtheVet help desk at{' '}
+                <a href="tel:+18773270022">877-327-0022</a> (TTY:{' '}
+                <a href="tel:+18008778339">800-877-8339</a>. We&apos;re here
+                Monday through Friday, 7:00 a.m. to 7:00 p.m. CT.
+              </p>
+              <p>
+                You can also{' '}
+                <a
+                  href="https://www.myhealth.va.gov/mhv-portal-web/web/myhealthevet/contact-mhv"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  contact us online
+                </a>
+                .
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </>
+);
+
+export default LegacyContent;

--- a/src/applications/static-pages/health-care-manage-benefits/refill-track-prescriptions-page/components/LegacyContent/index.unit.spec.js
+++ b/src/applications/static-pages/health-care-manage-benefits/refill-track-prescriptions-page/components/LegacyContent/index.unit.spec.js
@@ -1,0 +1,32 @@
+// Dependencies.
+import React from 'react';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+// Relative imports.
+import LegacyContent from '.';
+
+describe('Prescriptions Page <LegacyContent>', () => {
+  it('renders what we expect', () => {
+    const wrapper = shallow(<LegacyContent />);
+
+    const text = wrapper.text();
+    expect(text).to.include(
+      'How can the VA Prescription Refill and Tracking tool help me manage my',
+    );
+    expect(text).to.include('Am I eligible to use this tool?');
+    expect(text).to.include('Once I’m signed in, how do I get started?');
+    expect(text).to.include(
+      'Can I use this tool to refill and track all my VA prescriptions?',
+    );
+    expect(text).to.include('Where will VA send my prescriptions?');
+    expect(text).to.include(
+      'How long will my prescriptions take to arrive, and when should I',
+    );
+    expect(text).to.include(
+      'Will my personal health information be protected?',
+    );
+    expect(text).to.include('What if I have more questions?');
+
+    wrapper.unmount();
+  });
+});

--- a/src/applications/static-pages/health-care-manage-benefits/schedule-view-va-appointments-page/components/App/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/schedule-view-va-appointments-page/components/App/index.js
@@ -4,10 +4,16 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 // Relative imports.
 import AuthContent from '../AuthContent';
+import LegacyContent from '../LegacyContent';
 import UnauthContent from '../UnauthContent';
+import environment from 'platform/utilities/environment';
 import { selectIsCernerPatient } from 'platform/user/selectors';
 
 export const App = ({ isCernerPatient }) => {
+  if (environment.isProduction()) {
+    return <LegacyContent />;
+  }
+
   if (isCernerPatient) {
     return <AuthContent />;
   }

--- a/src/applications/static-pages/health-care-manage-benefits/schedule-view-va-appointments-page/components/LegacyContent/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/schedule-view-va-appointments-page/components/LegacyContent/index.js
@@ -25,522 +25,518 @@ export const LegacyContent = () => (
           request routine appointments right now.
         </p>
       </div>
+    </div>
+    <div
+      data-template="paragraphs/wysiwyg"
+      data-entity-id={3457}
+      className="processed-content"
+    >
+      <p>&nbsp;</p>
+      <p>
+        <strong>Please note:</strong> The fastest way to make all your VA
+        appointments is usually to call the VA health facility where you want to
+        receive care. If you can’t keep an existing appointment, please contact
+        the facility as soon as possible to reschedule or cancel.
+        <br />
+        <a href="/find-locations/">
+          Find your VA health facility’s phone number
+        </a>
+      </p>
+      <h2 id="view-schedule-or-cancel-a-va-a">
+        View, schedule, or cancel a VA appointment&nbsp;online
+      </h2>
+    </div>
+    <CallToActionWidget appId="view-appointments" setFocus={false} />
+    <div data-template="paragraphs/q_a_section" data-entity-id={3462}>
       <div
-        data-template="paragraphs/wysiwyg"
-        data-entity-id={3457}
-        className="processed-content"
+        itemScope
+        itemType="http://schema.org/Question"
+        data-template="paragraphs/q_a"
+        data-entity-id={3461}
+        data-analytics-faq-section
+        data-analytics-faq-text="How can VA appointment tools help me manage my health care?"
       >
-        <p>&nbsp;</p>
-        <p>
-          <strong>Please note:</strong> The fastest way to make all your VA
-          appointments is usually to call the VA health facility where you want
-          to receive care. If you can’t keep an existing appointment, please
-          contact the facility as soon as possible to reschedule or cancel.
-          <br />
-          <a href="/find-locations/">
-            Find your VA health facility’s phone number
-          </a>
-        </p>
-        <h2 id="view-schedule-or-cancel-a-va-a">
-          View, schedule, or cancel a VA appointment&nbsp;online
+        <h2 itemProp="name" id="how-can-va-appointment-tools-h">
+          How can VA appointment tools help me manage my health care?
         </h2>
-      </div>
-      <CallToActionWidget appId="view-appointments" setFocus={false} />
-      <div data-template="paragraphs/q_a_section" data-entity-id={3462}>
         <div
-          itemScope
-          itemType="http://schema.org/Question"
-          data-template="paragraphs/q_a"
           data-entity-id={3461}
-          data-analytics-faq-section
-          data-analytics-faq-text="How can VA appointment tools help me manage my health care?"
-        >
-          <h2 itemProp="name" id="how-can-va-appointment-tools-h">
-            How can VA appointment tools help me manage my health care?
-          </h2>
-          <div
-            data-entity-id={3461}
-            itemProp="acceptedAnswer"
-            itemScope
-            itemType="http://schema.org/Answer"
-          >
-            <div itemProp="text">
-              <div
-                data-template="paragraphs/wysiwyg"
-                data-entity-id={3463}
-                className="processed-content"
-              >
-                <p>
-                  VA appointment&nbsp;tools offer a secure, online&nbsp;way to
-                  schedule, view, and organize your VA appointments. The
-                  appointments you can schedule online depends on your facility,
-                  the type of health service, and other factors.
-                </p>
-                <p>
-                  <strong>You can use these tools to:</strong>
-                </p>
-                <ul>
-                  <li>Schedule some of your VA medical appointments online</li>
-                  <li>Cancel appointments made online</li>
-                  <li>View appointments on your health calendar</li>
-                  <li>
-                    Find the location of the VA facility for your appointments
-                  </li>
-                  <li>Set up email reminders for upcoming appointments</li>
-                  <li>Print a list of your future appointments</li>
-                  <li>Look up past appointments from the last 2 years</li>
-                </ul>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div
+          itemProp="acceptedAnswer"
           itemScope
-          itemType="http://schema.org/Question"
-          data-template="paragraphs/q_a"
-          data-entity-id={3464}
-          data-analytics-faq-section
-          data-analytics-faq-text="Am I eligible to use the VA appointment tools?"
+          itemType="http://schema.org/Answer"
         >
-          <h2 itemProp="name" id="am-i-eligible-to-use-the-va-ap">
-            Am I eligible to use the VA appointment tools?
-          </h2>
-          <div
-            data-entity-id={3464}
-            itemProp="acceptedAnswer"
-            itemScope
-            itemType="http://schema.org/Answer"
-          >
-            <div itemProp="text">
-              <div
-                data-template="paragraphs/wysiwyg"
-                data-entity-id={3465}
-                className="processed-content"
-              >
-                <p>
-                  You can use the&nbsp;online appointment tools if you meet all
-                  of the requirements listed below.
-                </p>
-                <p>
-                  <strong>All of these must be true:</strong>
-                </p>
-                <ul>
-                  <li>
-                    You're{' '}
-                    <a
-                      data-entity-substitution="canonical"
-                      data-entity-type="node"
-                      data-entity-uuid="f8323733-28cd-497d-b536-349005be9b71"
-                      href="/health-care/how-to-apply"
-                      title="How to apply for VA health care"
-                    >
-                      enrolled in VA health care
-                    </a>
-                    , <strong>and</strong>
-                  </li>
-                  <li>
-                    You're scheduling your appointment with a VA health facility
-                    that uses online scheduling, <strong>and</strong>
-                  </li>
-                  <li>
-                    You're registered or you’ve had an appointment at that
-                    facility before
-                  </li>
-                </ul>
-                <p>
-                  <strong>
-                    And, you must have one of these free accounts:
-                  </strong>
-                </p>
-                <ul>
-                  <li>
-                    A{' '}
-                    <a
-                      href="https://www.myhealth.va.gov/mhv-portal-web/my-healthevet-offers-three-account-types"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                    >
-                      Premium <strong>My HealtheVet</strong> account
-                    </a>
-                    , <strong>or</strong>
-                  </li>
-                  <li>
-                    A Premium <strong>DS Logon</strong> account (used for
-                    eBenefits and milConnect), <strong>or</strong>
-                  </li>
-                  <li>
-                    A verified <strong>ID.me</strong> account that you can
-                    create here on VA.gov
-                  </li>
-                </ul>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div
-          itemScope
-          itemType="http://schema.org/Question"
-          data-template="paragraphs/q_a"
-          data-entity-id={3466}
-          data-analytics-faq-section
-          data-analytics-faq-text="How do I know if my VA health facility uses online scheduling?"
-        >
-          <h2 itemProp="name" id="how-do-i-know-if-my-va-health-">
-            How do I know if my VA health facility uses online scheduling?
-          </h2>
-          <div
-            data-entity-id={3466}
-            itemProp="acceptedAnswer"
-            itemScope
-            itemType="http://schema.org/Answer"
-          >
-            <div itemProp="text">
-              <div
-                data-template="paragraphs/wysiwyg"
-                data-entity-id={3467}
-                className="processed-content"
-              >
-                <p>
-                  Online scheduling&nbsp;is available at all VA facilities
-                  except at the following locations:
-                </p>
-                <ul>
-                  <li>
-                    <p>Columbus, OH</p>
-                  </li>
-                  <li>
-                    <p>Indianapolis, IN</p>
-                  </li>
-                  <li>
-                    <p>Manila, Philippines</p>
-                  </li>
-                </ul>
-                <p>
-                  Veterans who get care at the Chalmers P. Wylie Ambulatory Care
-                  Center in Columbus, Ohio,&nbsp;can currently use{' '}
-                  <a href="https://access.va.gov/accessva/?cspSelectFor=mass">
-                    MyChart Online
-                  </a>
-                  &nbsp;to schedule, reschedule, and cancel their appointments
-                  online.
-                </p>
-                <p>
-                  <strong>Note: </strong>
-                  Online scheduling is available for some types of health
-                  services. We hope to expand the types of appointments and
-                  health services available through online scheduling&nbsp;in
-                  the future.
-                </p>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div
-          itemScope
-          itemType="http://schema.org/Question"
-          data-template="paragraphs/q_a"
-          data-entity-id={3468}
-          data-analytics-faq-section
-          data-analytics-faq-text="What types of medical appointments can I schedule online?"
-        >
-          <h2 itemProp="name" id="what-types-of-medical-appointm">
-            What types of medical appointments can I schedule online?
-          </h2>
-          <div
-            data-entity-id={3468}
-            itemProp="acceptedAnswer"
-            itemScope
-            itemType="http://schema.org/Answer"
-          >
-            <div itemProp="text">
-              <div
-                data-template="paragraphs/wysiwyg"
-                data-entity-id={3469}
-                className="processed-content"
-              >
-                <p>
-                  It depends on the VA health facility where you’re receiving
-                  care. You can typically schedule an appointment online for the
-                  types of care that don’t require a referral.
-                </p>
-                <p>
-                  Once you’re signed in to the appointments tool, you’ll be able
-                  to see what types of appointments you can schedule online at
-                  your registered health facility.&nbsp;&nbsp;You can also check
-                  with the facility where you receive care about scheduling
-                  appointments online.&nbsp;
-                </p>
-                <p>
-                  <a href="/find-locations/">Find a VA health facility</a>
-                </p>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div
-          itemScope
-          itemType="http://schema.org/Question"
-          data-template="paragraphs/q_a"
-          data-entity-id={3470}
-          data-analytics-faq-section
-          data-analytics-faq-text="Can I use this tool to schedule non-VA appointments?"
-        >
-          <h2 itemProp="name" id="can-i-use-this-tool-to-schedul">
-            Can I use this tool to schedule non-VA appointments?
-          </h2>
-          <div
-            data-entity-id={3470}
-            itemProp="acceptedAnswer"
-            itemScope
-            itemType="http://schema.org/Answer"
-          >
-            <div itemProp="text">
-              <div
-                data-template="paragraphs/wysiwyg"
-                data-entity-id={3471}
-                className="processed-content"
-              >
-                <p>No. At this time you can only schedule a VA appointment.</p>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div
-          itemScope
-          itemType="http://schema.org/Question"
-          data-template="paragraphs/q_a"
-          data-entity-id={3472}
-          data-analytics-faq-section
-          data-analytics-faq-text="Can I schedule appointments through VA Secure Messaging?"
-        >
-          <h2 itemProp="name" id="can-i-schedule-appointments-th">
-            Can I schedule appointments through VA Secure Messaging?
-          </h2>
-          <div
-            data-entity-id={3472}
-            itemProp="acceptedAnswer"
-            itemScope
-            itemType="http://schema.org/Answer"
-          >
-            <div itemProp="text">
-              <div
-                data-template="paragraphs/wysiwyg"
-                data-entity-id={3473}
-                className="processed-content"
-              >
-                <p>
-                  If you use Secure Messaging with your VA health care team, you
-                  may be able to use this service to schedule and cancel
-                  appointments.&nbsp;
-                  <a href="/health-care/secure-messaging/">
-                    Learn more about Secure Messaging
-                  </a>
-                </p>
-                <p>
-                  <strong>Please note:</strong> The fastest way to make all your
-                  VA appointments is usually to call the VA health facility
-                  where you&nbsp;get care. To reschedule or cancel an existing
-                  appointment, please contact your facility as soon as
-                  possible.&nbsp;
-                  <a href="/find-locations/">
-                    Find your VA health facility’s phone number
-                  </a>
-                </p>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div
-          itemScope
-          itemType="http://schema.org/Question"
-          data-template="paragraphs/q_a"
-          data-entity-id={3474}
-          data-analytics-faq-section
-          data-analytics-faq-text="Will my personal health information be protected?"
-        >
-          <h2 itemProp="name" id="will-my-personal-health-inform">
-            Will my personal health information be protected?
-          </h2>
-          <div
-            data-entity-id={3474}
-            itemProp="acceptedAnswer"
-            itemScope
-            itemType="http://schema.org/Answer"
-          >
-            <div itemProp="text">
-              <div
-                data-template="paragraphs/wysiwyg"
-                data-entity-id={3475}
-                className="processed-content"
-              >
-                <p>
-                  Yes. This is a secure website. We follow strict security
-                  policies and practices to protect your personal health
-                  information. And only you and your VA health care team will
-                  have access to your secure messages.
-                </p>
-                <p>
-                  If you print or download any messages, you’ll need to take
-                  responsibility for protecting that information.
-                  <br />
-                  <a
-                    href="https://www.myhealth.va.gov/mhv-portal-web/web/myhealthevet/protecting-your-personal-health-information"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    Get tips for protecting your personal health information
-                  </a>
-                </p>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div
-          itemScope
-          itemType="http://schema.org/Question"
-          data-template="paragraphs/q_a"
-          data-entity-id={3476}
-          data-analytics-faq-section
-          data-analytics-faq-text="What if I have more questions?"
-        >
-          <h2 itemProp="name" id="what-if-i-have-more-questions">
-            What if I have more questions?
-          </h2>
-          <div
-            data-entity-id={3476}
-            itemProp="acceptedAnswer"
-            itemScope
-            itemType="http://schema.org/Answer"
-          >
-            <div itemProp="text">
-              <div
-                data-template="paragraphs/wysiwyg"
-                data-entity-id={3477}
-                className="processed-content"
-              >
-                <p>
-                  You can get answers to your questions about these tools within
-                  our My HealtheVet web portal.
-                  <br />
-                  <a
-                    href="https://www.myhealth.va.gov/mhv-portal-web/faqs#Appointments"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    Read VA Appointments FAQs
-                  </a>
-                </p>
-                <p>
-                  You can also contact the My HealtheVet Help Desk.
-                  <br />
-                  <a
-                    href="https://www.myhealth.va.gov/mhv-portal-web/web/myhealthevet/contact-mhv"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    Find out how to contact us online
-                  </a>
-                </p>
-                <p>
-                  Or call us at{' '}
-                  <a aria-label="8 7 7. 3 2 7. 0 0 2 2." href="tel:18773270022">
-                    877-327-0022
-                  </a>{' '}
-                  (TTY:{' '}
-                  <a aria-label="8 0 0. 8 7 7. 8 3 3 9." href="tel:18008778339">
-                    800-877-8339
-                  </a>
-                  ). We’re here Monday through Friday, 7:00 a.m. to 7:00 p.m.
-                  CT.
-                </p>
-              </div>
+          <div itemProp="text">
+            <div
+              data-template="paragraphs/wysiwyg"
+              data-entity-id={3463}
+              className="processed-content"
+            >
+              <p>
+                VA appointment&nbsp;tools offer a secure, online&nbsp;way to
+                schedule, view, and organize your VA appointments. The
+                appointments you can schedule online depends on your facility,
+                the type of health service, and other factors.
+              </p>
+              <p>
+                <strong>You can use these tools to:</strong>
+              </p>
+              <ul>
+                <li>Schedule some of your VA medical appointments online</li>
+                <li>Cancel appointments made online</li>
+                <li>View appointments on your health calendar</li>
+                <li>
+                  Find the location of the VA facility for your appointments
+                </li>
+                <li>Set up email reminders for upcoming appointments</li>
+                <li>Print a list of your future appointments</li>
+                <li>Look up past appointments from the last 2 years</li>
+              </ul>
             </div>
           </div>
         </div>
       </div>
-      <div className="row">
-        <div className="usa-content columns">
-          <aside className="va-nav-linkslist va-nav-linkslist--related">
-            <section
-              data-template="paragraphs/list_of_link_teasers"
-              data-entity-id={3452}
-              className="field_related_links"
+      <div
+        itemScope
+        itemType="http://schema.org/Question"
+        data-template="paragraphs/q_a"
+        data-entity-id={3464}
+        data-analytics-faq-section
+        data-analytics-faq-text="Am I eligible to use the VA appointment tools?"
+      >
+        <h2 itemProp="name" id="am-i-eligible-to-use-the-va-ap">
+          Am I eligible to use the VA appointment tools?
+        </h2>
+        <div
+          data-entity-id={3464}
+          itemProp="acceptedAnswer"
+          itemScope
+          itemType="http://schema.org/Answer"
+        >
+          <div itemProp="text">
+            <div
+              data-template="paragraphs/wysiwyg"
+              data-entity-id={3465}
+              className="processed-content"
             >
-              <h2
-                id="more-information-about-your-benefits"
-                className="va-nav-linkslist-heading"
-              >
-                More information about your benefits
-              </h2>
-              <ul className="va-nav-linkslist-list">
-                <li
-                  data-template="paragraphs/linkTeaser"
-                  data-entity-id={3453}
-                  data-links-list-header="Health care benefits eligibility"
-                  data-links-list-section-header="More information about your benefits"
-                >
-                  <a href="/health-care/eligibility">
-                    <h4 className="va-nav-linkslist-title">
-                      Health care benefits eligibility
-                    </h4>
-                    <p className="va-nav-linkslist-description">
-                      Not sure if you qualify? Find out if you can get VA health
-                      care benefits.
-                    </p>
+              <p>
+                You can use the&nbsp;online appointment tools if you meet all of
+                the requirements listed below.
+              </p>
+              <p>
+                <strong>All of these must be true:</strong>
+              </p>
+              <ul>
+                <li>
+                  You're{' '}
+                  <a
+                    data-entity-substitution="canonical"
+                    data-entity-type="node"
+                    data-entity-uuid="f8323733-28cd-497d-b536-349005be9b71"
+                    href="/health-care/how-to-apply"
+                    title="How to apply for VA health care"
+                  >
+                    enrolled in VA health care
                   </a>
+                  , <strong>and</strong>
                 </li>
-                <li
-                  data-template="paragraphs/linkTeaser"
-                  data-entity-id={3454}
-                  data-links-list-header="How to apply for health care benefits"
-                  data-links-list-section-header="More information about your benefits"
-                >
-                  <a href="/health-care/how-to-apply">
-                    <h4 className="va-nav-linkslist-title">
-                      How to apply for health care benefits
-                    </h4>
-                    <p className="va-nav-linkslist-description">
-                      Ready to apply? Get started now.
-                    </p>
-                  </a>
+                <li>
+                  You're scheduling your appointment with a VA health facility
+                  that uses online scheduling, <strong>and</strong>
                 </li>
-                <li
-                  data-template="paragraphs/linkTeaser"
-                  data-entity-id={3455}
-                  data-links-list-header="Health needs and conditions"
-                  data-links-list-section-header="More information about your benefits"
-                >
-                  <a href="/health-care/health-needs-conditions">
-                    <h4 className="va-nav-linkslist-title">
-                      Health needs and conditions
-                    </h4>
-                    <p className="va-nav-linkslist-description">
-                      Learn how to access VA services for mental health, women’s
-                      health, and other specific needs.
-                    </p>
-                  </a>
-                </li>
-                <li
-                  data-template="paragraphs/linkTeaser"
-                  data-entity-id={3456}
-                  data-links-list-header="Disability benefits"
-                  data-links-list-section-header="More information about your benefits"
-                >
-                  <a href="/disability">
-                    <h4 className="va-nav-linkslist-title">
-                      Disability benefits
-                    </h4>
-                    <p className="va-nav-linkslist-description">
-                      Have an illness or injury that was caused—or made worse—by
-                      your active-duty service? Find out if you can get
-                      disability compensation (monthly payments) from VA.
-                    </p>
-                  </a>
+                <li>
+                  You're registered or you’ve had an appointment at that
+                  facility before
                 </li>
               </ul>
-            </section>
-          </aside>
+              <p>
+                <strong>And, you must have one of these free accounts:</strong>
+              </p>
+              <ul>
+                <li>
+                  A{' '}
+                  <a
+                    href="https://www.myhealth.va.gov/mhv-portal-web/my-healthevet-offers-three-account-types"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    Premium <strong>My HealtheVet</strong> account
+                  </a>
+                  , <strong>or</strong>
+                </li>
+                <li>
+                  A Premium <strong>DS Logon</strong> account (used for
+                  eBenefits and milConnect), <strong>or</strong>
+                </li>
+                <li>
+                  A verified <strong>ID.me</strong> account that you can create
+                  here on VA.gov
+                </li>
+              </ul>
+            </div>
+          </div>
         </div>
+      </div>
+      <div
+        itemScope
+        itemType="http://schema.org/Question"
+        data-template="paragraphs/q_a"
+        data-entity-id={3466}
+        data-analytics-faq-section
+        data-analytics-faq-text="How do I know if my VA health facility uses online scheduling?"
+      >
+        <h2 itemProp="name" id="how-do-i-know-if-my-va-health-">
+          How do I know if my VA health facility uses online scheduling?
+        </h2>
+        <div
+          data-entity-id={3466}
+          itemProp="acceptedAnswer"
+          itemScope
+          itemType="http://schema.org/Answer"
+        >
+          <div itemProp="text">
+            <div
+              data-template="paragraphs/wysiwyg"
+              data-entity-id={3467}
+              className="processed-content"
+            >
+              <p>
+                Online scheduling&nbsp;is available at all VA facilities except
+                at the following locations:
+              </p>
+              <ul>
+                <li>
+                  <p>Columbus, OH</p>
+                </li>
+                <li>
+                  <p>Indianapolis, IN</p>
+                </li>
+                <li>
+                  <p>Manila, Philippines</p>
+                </li>
+              </ul>
+              <p>
+                Veterans who get care at the Chalmers P. Wylie Ambulatory Care
+                Center in Columbus, Ohio,&nbsp;can currently use{' '}
+                <a href="https://access.va.gov/accessva/?cspSelectFor=mass">
+                  MyChart Online
+                </a>
+                &nbsp;to schedule, reschedule, and cancel their appointments
+                online.
+              </p>
+              <p>
+                <strong>Note: </strong>
+                Online scheduling is available for some types of health
+                services. We hope to expand the types of appointments and health
+                services available through online scheduling&nbsp;in the future.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        itemScope
+        itemType="http://schema.org/Question"
+        data-template="paragraphs/q_a"
+        data-entity-id={3468}
+        data-analytics-faq-section
+        data-analytics-faq-text="What types of medical appointments can I schedule online?"
+      >
+        <h2 itemProp="name" id="what-types-of-medical-appointm">
+          What types of medical appointments can I schedule online?
+        </h2>
+        <div
+          data-entity-id={3468}
+          itemProp="acceptedAnswer"
+          itemScope
+          itemType="http://schema.org/Answer"
+        >
+          <div itemProp="text">
+            <div
+              data-template="paragraphs/wysiwyg"
+              data-entity-id={3469}
+              className="processed-content"
+            >
+              <p>
+                It depends on the VA health facility where you’re receiving
+                care. You can typically schedule an appointment online for the
+                types of care that don’t require a referral.
+              </p>
+              <p>
+                Once you’re signed in to the appointments tool, you’ll be able
+                to see what types of appointments you can schedule online at
+                your registered health facility.&nbsp;&nbsp;You can also check
+                with the facility where you receive care about scheduling
+                appointments online.&nbsp;
+              </p>
+              <p>
+                <a href="/find-locations/">Find a VA health facility</a>
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        itemScope
+        itemType="http://schema.org/Question"
+        data-template="paragraphs/q_a"
+        data-entity-id={3470}
+        data-analytics-faq-section
+        data-analytics-faq-text="Can I use this tool to schedule non-VA appointments?"
+      >
+        <h2 itemProp="name" id="can-i-use-this-tool-to-schedul">
+          Can I use this tool to schedule non-VA appointments?
+        </h2>
+        <div
+          data-entity-id={3470}
+          itemProp="acceptedAnswer"
+          itemScope
+          itemType="http://schema.org/Answer"
+        >
+          <div itemProp="text">
+            <div
+              data-template="paragraphs/wysiwyg"
+              data-entity-id={3471}
+              className="processed-content"
+            >
+              <p>No. At this time you can only schedule a VA appointment.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        itemScope
+        itemType="http://schema.org/Question"
+        data-template="paragraphs/q_a"
+        data-entity-id={3472}
+        data-analytics-faq-section
+        data-analytics-faq-text="Can I schedule appointments through VA Secure Messaging?"
+      >
+        <h2 itemProp="name" id="can-i-schedule-appointments-th">
+          Can I schedule appointments through VA Secure Messaging?
+        </h2>
+        <div
+          data-entity-id={3472}
+          itemProp="acceptedAnswer"
+          itemScope
+          itemType="http://schema.org/Answer"
+        >
+          <div itemProp="text">
+            <div
+              data-template="paragraphs/wysiwyg"
+              data-entity-id={3473}
+              className="processed-content"
+            >
+              <p>
+                If you use Secure Messaging with your VA health care team, you
+                may be able to use this service to schedule and cancel
+                appointments.&nbsp;
+                <a href="/health-care/secure-messaging/">
+                  Learn more about Secure Messaging
+                </a>
+              </p>
+              <p>
+                <strong>Please note:</strong> The fastest way to make all your
+                VA appointments is usually to call the VA health facility where
+                you&nbsp;get care. To reschedule or cancel an existing
+                appointment, please contact your facility as soon as
+                possible.&nbsp;
+                <a href="/find-locations/">
+                  Find your VA health facility’s phone number
+                </a>
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        itemScope
+        itemType="http://schema.org/Question"
+        data-template="paragraphs/q_a"
+        data-entity-id={3474}
+        data-analytics-faq-section
+        data-analytics-faq-text="Will my personal health information be protected?"
+      >
+        <h2 itemProp="name" id="will-my-personal-health-inform">
+          Will my personal health information be protected?
+        </h2>
+        <div
+          data-entity-id={3474}
+          itemProp="acceptedAnswer"
+          itemScope
+          itemType="http://schema.org/Answer"
+        >
+          <div itemProp="text">
+            <div
+              data-template="paragraphs/wysiwyg"
+              data-entity-id={3475}
+              className="processed-content"
+            >
+              <p>
+                Yes. This is a secure website. We follow strict security
+                policies and practices to protect your personal health
+                information. And only you and your VA health care team will have
+                access to your secure messages.
+              </p>
+              <p>
+                If you print or download any messages, you’ll need to take
+                responsibility for protecting that information.
+                <br />
+                <a
+                  href="https://www.myhealth.va.gov/mhv-portal-web/web/myhealthevet/protecting-your-personal-health-information"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Get tips for protecting your personal health information
+                </a>
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        itemScope
+        itemType="http://schema.org/Question"
+        data-template="paragraphs/q_a"
+        data-entity-id={3476}
+        data-analytics-faq-section
+        data-analytics-faq-text="What if I have more questions?"
+      >
+        <h2 itemProp="name" id="what-if-i-have-more-questions">
+          What if I have more questions?
+        </h2>
+        <div
+          data-entity-id={3476}
+          itemProp="acceptedAnswer"
+          itemScope
+          itemType="http://schema.org/Answer"
+        >
+          <div itemProp="text">
+            <div
+              data-template="paragraphs/wysiwyg"
+              data-entity-id={3477}
+              className="processed-content"
+            >
+              <p>
+                You can get answers to your questions about these tools within
+                our My HealtheVet web portal.
+                <br />
+                <a
+                  href="https://www.myhealth.va.gov/mhv-portal-web/faqs#Appointments"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Read VA Appointments FAQs
+                </a>
+              </p>
+              <p>
+                You can also contact the My HealtheVet Help Desk.
+                <br />
+                <a
+                  href="https://www.myhealth.va.gov/mhv-portal-web/web/myhealthevet/contact-mhv"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Find out how to contact us online
+                </a>
+              </p>
+              <p>
+                Or call us at{' '}
+                <a aria-label="8 7 7. 3 2 7. 0 0 2 2." href="tel:18773270022">
+                  877-327-0022
+                </a>{' '}
+                (TTY:{' '}
+                <a aria-label="8 0 0. 8 7 7. 8 3 3 9." href="tel:18008778339">
+                  800-877-8339
+                </a>
+                ). We’re here Monday through Friday, 7:00 a.m. to 7:00 p.m. CT.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div className="row">
+      <div className="usa-content columns">
+        <aside className="va-nav-linkslist va-nav-linkslist--related">
+          <section
+            data-template="paragraphs/list_of_link_teasers"
+            data-entity-id={3452}
+            className="field_related_links"
+          >
+            <h2
+              id="more-information-about-your-benefits"
+              className="va-nav-linkslist-heading"
+            >
+              More information about your benefits
+            </h2>
+            <ul className="va-nav-linkslist-list">
+              <li
+                data-template="paragraphs/linkTeaser"
+                data-entity-id={3453}
+                data-links-list-header="Health care benefits eligibility"
+                data-links-list-section-header="More information about your benefits"
+              >
+                <a href="/health-care/eligibility">
+                  <h4 className="va-nav-linkslist-title">
+                    Health care benefits eligibility
+                  </h4>
+                  <p className="va-nav-linkslist-description">
+                    Not sure if you qualify? Find out if you can get VA health
+                    care benefits.
+                  </p>
+                </a>
+              </li>
+              <li
+                data-template="paragraphs/linkTeaser"
+                data-entity-id={3454}
+                data-links-list-header="How to apply for health care benefits"
+                data-links-list-section-header="More information about your benefits"
+              >
+                <a href="/health-care/how-to-apply">
+                  <h4 className="va-nav-linkslist-title">
+                    How to apply for health care benefits
+                  </h4>
+                  <p className="va-nav-linkslist-description">
+                    Ready to apply? Get started now.
+                  </p>
+                </a>
+              </li>
+              <li
+                data-template="paragraphs/linkTeaser"
+                data-entity-id={3455}
+                data-links-list-header="Health needs and conditions"
+                data-links-list-section-header="More information about your benefits"
+              >
+                <a href="/health-care/health-needs-conditions">
+                  <h4 className="va-nav-linkslist-title">
+                    Health needs and conditions
+                  </h4>
+                  <p className="va-nav-linkslist-description">
+                    Learn how to access VA services for mental health, women’s
+                    health, and other specific needs.
+                  </p>
+                </a>
+              </li>
+              <li
+                data-template="paragraphs/linkTeaser"
+                data-entity-id={3456}
+                data-links-list-header="Disability benefits"
+                data-links-list-section-header="More information about your benefits"
+              >
+                <a href="/disability">
+                  <h4 className="va-nav-linkslist-title">
+                    Disability benefits
+                  </h4>
+                  <p className="va-nav-linkslist-description">
+                    Have an illness or injury that was caused—or made worse—by
+                    your active-duty service? Find out if you can get disability
+                    compensation (monthly payments) from VA.
+                  </p>
+                </a>
+              </li>
+            </ul>
+          </section>
+        </aside>
       </div>
     </div>
   </>

--- a/src/applications/static-pages/health-care-manage-benefits/schedule-view-va-appointments-page/components/LegacyContent/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/schedule-view-va-appointments-page/components/LegacyContent/index.js
@@ -5,7 +5,12 @@ import CallToActionWidget from 'platform/site-wide/cta-widget';
 
 export const LegacyContent = () => (
   <>
-    <div className="usa-alert usa-alert-info" role="alert">
+    <div
+      data-template="blocks/alert"
+      data-entity-id={38}
+      className="usa-alert usa-alert-info"
+      role="alert"
+    >
       <div className="usa-alert-body">
         <h3 className="usa-alert-heading" id="due-to-covid-19-you-can-only-r">
           Due to COVID-19, you can only request an appointment online
@@ -20,331 +25,521 @@ export const LegacyContent = () => (
           request routine appointments right now.
         </p>
       </div>
-    </div>
-    <div className="processed-content">
-      <p>&nbsp;</p>
-      <p>
-        <strong>Please note:</strong> The fastest way to make all your VA
-        appointments is usually to call the VA health facility where you want to
-        receive care. If you can’t keep an existing appointment, please contact
-        the facility as soon as possible to reschedule or cancel.
-        <br />
-        <a href="/find-locations/">
-          Find your VA health facility’s phone number
-        </a>
-      </p>
-      <h2 id="view-schedule-or-cancel-a-va-a">
-        View, schedule, or cancel a VA appointment&nbsp;online
-      </h2>
-    </div>
-    <CallToActionWidget appId="view-appointments" setFocus={false} />
-    <div>
-      <div itemScope itemType="http://schema.org/Question">
-        <h2 itemProp="name" id="how-can-va-appointment-tools-h">
-          How can VA appointment tools help me manage my health care?
+      <div
+        data-template="paragraphs/wysiwyg"
+        data-entity-id={3457}
+        className="processed-content"
+      >
+        <p>&nbsp;</p>
+        <p>
+          <strong>Please note:</strong> The fastest way to make all your VA
+          appointments is usually to call the VA health facility where you want
+          to receive care. If you can’t keep an existing appointment, please
+          contact the facility as soon as possible to reschedule or cancel.
+          <br />
+          <a href="/find-locations/">
+            Find your VA health facility’s phone number
+          </a>
+        </p>
+        <h2 id="view-schedule-or-cancel-a-va-a">
+          View, schedule, or cancel a VA appointment&nbsp;online
         </h2>
+      </div>
+      <CallToActionWidget appId="view-appointments" setFocus={false} />
+      <div data-template="paragraphs/q_a_section" data-entity-id={3462}>
         <div
-          itemProp="acceptedAnswer"
           itemScope
-          itemType="http://schema.org/Answer"
+          itemType="http://schema.org/Question"
+          data-template="paragraphs/q_a"
+          data-entity-id={3461}
+          data-analytics-faq-section
+          data-analytics-faq-text="How can VA appointment tools help me manage my health care?"
         >
-          <div itemProp="text">
-            <div className="processed-content">
-              <p>
-                These appointment tools offer a secure, online way to schedule,
-                view, and organize your VA appointments. The appointments you
-                can schedule online depends on the facility, the type of health
-                service, and other factors.
-              </p>
-              <p>
-                <strong>You can use these tools to:</strong>
-              </p>
-              <ul>
-                <li>Schedule some of your VA medical appointments online</li>
-                <li>Cancel appointments made online</li>
-                <li>View appointments on your health calendar</li>
-                <li>
-                  Find the location of the VA facility for your appointments
-                </li>
-                <li>Print a list of your future appointments</li>
-              </ul>
+          <h2 itemProp="name" id="how-can-va-appointment-tools-h">
+            How can VA appointment tools help me manage my health care?
+          </h2>
+          <div
+            data-entity-id={3461}
+            itemProp="acceptedAnswer"
+            itemScope
+            itemType="http://schema.org/Answer"
+          >
+            <div itemProp="text">
+              <div
+                data-template="paragraphs/wysiwyg"
+                data-entity-id={3463}
+                className="processed-content"
+              >
+                <p>
+                  VA appointment&nbsp;tools offer a secure, online&nbsp;way to
+                  schedule, view, and organize your VA appointments. The
+                  appointments you can schedule online depends on your facility,
+                  the type of health service, and other factors.
+                </p>
+                <p>
+                  <strong>You can use these tools to:</strong>
+                </p>
+                <ul>
+                  <li>Schedule some of your VA medical appointments online</li>
+                  <li>Cancel appointments made online</li>
+                  <li>View appointments on your health calendar</li>
+                  <li>
+                    Find the location of the VA facility for your appointments
+                  </li>
+                  <li>Set up email reminders for upcoming appointments</li>
+                  <li>Print a list of your future appointments</li>
+                  <li>Look up past appointments from the last 2 years</li>
+                </ul>
+              </div>
             </div>
           </div>
         </div>
-      </div>
-      <div itemScope itemType="http://schema.org/Question">
-        <h2 itemProp="name" id="am-i-eligible-to-use-the-va-ap">
-          Am I eligible to use the VA appointment tools?
-        </h2>
         <div
-          itemProp="acceptedAnswer"
           itemScope
-          itemType="http://schema.org/Answer"
+          itemType="http://schema.org/Question"
+          data-template="paragraphs/q_a"
+          data-entity-id={3464}
+          data-analytics-faq-section
+          data-analytics-faq-text="Am I eligible to use the VA appointment tools?"
         >
-          <div itemProp="text">
-            <div className="processed-content">
-              <p>
-                You can use the&nbsp;online appointment tools if you meet all of
-                the requirements listed below.
-              </p>
-              <p>
-                <strong>All of these must be true:</strong>
-              </p>
-              <ul>
-                <li>
-                  You're{' '}
-                  <a
-                    href="/health-care/how-to-apply"
-                    title="How to apply for VA health care"
-                  >
-                    enrolled in VA health care
+          <h2 itemProp="name" id="am-i-eligible-to-use-the-va-ap">
+            Am I eligible to use the VA appointment tools?
+          </h2>
+          <div
+            data-entity-id={3464}
+            itemProp="acceptedAnswer"
+            itemScope
+            itemType="http://schema.org/Answer"
+          >
+            <div itemProp="text">
+              <div
+                data-template="paragraphs/wysiwyg"
+                data-entity-id={3465}
+                className="processed-content"
+              >
+                <p>
+                  You can use the&nbsp;online appointment tools if you meet all
+                  of the requirements listed below.
+                </p>
+                <p>
+                  <strong>All of these must be true:</strong>
+                </p>
+                <ul>
+                  <li>
+                    You're{' '}
+                    <a
+                      data-entity-substitution="canonical"
+                      data-entity-type="node"
+                      data-entity-uuid="f8323733-28cd-497d-b536-349005be9b71"
+                      href="/health-care/how-to-apply"
+                      title="How to apply for VA health care"
+                    >
+                      enrolled in VA health care
+                    </a>
+                    , <strong>and</strong>
+                  </li>
+                  <li>
+                    You're scheduling your appointment with a VA health facility
+                    that uses online scheduling, <strong>and</strong>
+                  </li>
+                  <li>
+                    You're registered or you’ve had an appointment at that
+                    facility before
+                  </li>
+                </ul>
+                <p>
+                  <strong>
+                    And, you must have one of these free accounts:
+                  </strong>
+                </p>
+                <ul>
+                  <li>
+                    A{' '}
+                    <a
+                      href="https://www.myhealth.va.gov/mhv-portal-web/my-healthevet-offers-three-account-types"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      Premium <strong>My HealtheVet</strong> account
+                    </a>
+                    , <strong>or</strong>
+                  </li>
+                  <li>
+                    A Premium <strong>DS Logon</strong> account (used for
+                    eBenefits and milConnect), <strong>or</strong>
+                  </li>
+                  <li>
+                    A verified <strong>ID.me</strong> account that you can
+                    create here on VA.gov
+                  </li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          itemScope
+          itemType="http://schema.org/Question"
+          data-template="paragraphs/q_a"
+          data-entity-id={3466}
+          data-analytics-faq-section
+          data-analytics-faq-text="How do I know if my VA health facility uses online scheduling?"
+        >
+          <h2 itemProp="name" id="how-do-i-know-if-my-va-health-">
+            How do I know if my VA health facility uses online scheduling?
+          </h2>
+          <div
+            data-entity-id={3466}
+            itemProp="acceptedAnswer"
+            itemScope
+            itemType="http://schema.org/Answer"
+          >
+            <div itemProp="text">
+              <div
+                data-template="paragraphs/wysiwyg"
+                data-entity-id={3467}
+                className="processed-content"
+              >
+                <p>
+                  Online scheduling&nbsp;is available at all VA facilities
+                  except at the following locations:
+                </p>
+                <ul>
+                  <li>
+                    <p>Columbus, OH</p>
+                  </li>
+                  <li>
+                    <p>Indianapolis, IN</p>
+                  </li>
+                  <li>
+                    <p>Manila, Philippines</p>
+                  </li>
+                </ul>
+                <p>
+                  Veterans who get care at the Chalmers P. Wylie Ambulatory Care
+                  Center in Columbus, Ohio,&nbsp;can currently use{' '}
+                  <a href="https://access.va.gov/accessva/?cspSelectFor=mass">
+                    MyChart Online
                   </a>
-                  , <strong>and</strong>
-                </li>
-                <li>
-                  You're scheduling your appointment with a VA health facility
-                  that uses online scheduling, <strong>and</strong>
-                </li>
-                <li>
-                  You're registered or you’ve had an appointment at that
-                  facility before
-                </li>
-              </ul>
-              <p>
-                <strong>And you must have one of these free accounts:</strong>
-              </p>
-              <ul>
-                <li>
-                  A{' '}
+                  &nbsp;to schedule, reschedule, and cancel their appointments
+                  online.
+                </p>
+                <p>
+                  <strong>Note: </strong>
+                  Online scheduling is available for some types of health
+                  services. We hope to expand the types of appointments and
+                  health services available through online scheduling&nbsp;in
+                  the future.
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          itemScope
+          itemType="http://schema.org/Question"
+          data-template="paragraphs/q_a"
+          data-entity-id={3468}
+          data-analytics-faq-section
+          data-analytics-faq-text="What types of medical appointments can I schedule online?"
+        >
+          <h2 itemProp="name" id="what-types-of-medical-appointm">
+            What types of medical appointments can I schedule online?
+          </h2>
+          <div
+            data-entity-id={3468}
+            itemProp="acceptedAnswer"
+            itemScope
+            itemType="http://schema.org/Answer"
+          >
+            <div itemProp="text">
+              <div
+                data-template="paragraphs/wysiwyg"
+                data-entity-id={3469}
+                className="processed-content"
+              >
+                <p>
+                  It depends on the VA health facility where you’re receiving
+                  care. You can typically schedule an appointment online for the
+                  types of care that don’t require a referral.
+                </p>
+                <p>
+                  Once you’re signed in to the appointments tool, you’ll be able
+                  to see what types of appointments you can schedule online at
+                  your registered health facility.&nbsp;&nbsp;You can also check
+                  with the facility where you receive care about scheduling
+                  appointments online.&nbsp;
+                </p>
+                <p>
+                  <a href="/find-locations/">Find a VA health facility</a>
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          itemScope
+          itemType="http://schema.org/Question"
+          data-template="paragraphs/q_a"
+          data-entity-id={3470}
+          data-analytics-faq-section
+          data-analytics-faq-text="Can I use this tool to schedule non-VA appointments?"
+        >
+          <h2 itemProp="name" id="can-i-use-this-tool-to-schedul">
+            Can I use this tool to schedule non-VA appointments?
+          </h2>
+          <div
+            data-entity-id={3470}
+            itemProp="acceptedAnswer"
+            itemScope
+            itemType="http://schema.org/Answer"
+          >
+            <div itemProp="text">
+              <div
+                data-template="paragraphs/wysiwyg"
+                data-entity-id={3471}
+                className="processed-content"
+              >
+                <p>No. At this time you can only schedule a VA appointment.</p>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          itemScope
+          itemType="http://schema.org/Question"
+          data-template="paragraphs/q_a"
+          data-entity-id={3472}
+          data-analytics-faq-section
+          data-analytics-faq-text="Can I schedule appointments through VA Secure Messaging?"
+        >
+          <h2 itemProp="name" id="can-i-schedule-appointments-th">
+            Can I schedule appointments through VA Secure Messaging?
+          </h2>
+          <div
+            data-entity-id={3472}
+            itemProp="acceptedAnswer"
+            itemScope
+            itemType="http://schema.org/Answer"
+          >
+            <div itemProp="text">
+              <div
+                data-template="paragraphs/wysiwyg"
+                data-entity-id={3473}
+                className="processed-content"
+              >
+                <p>
+                  If you use Secure Messaging with your VA health care team, you
+                  may be able to use this service to schedule and cancel
+                  appointments.&nbsp;
+                  <a href="/health-care/secure-messaging/">
+                    Learn more about Secure Messaging
+                  </a>
+                </p>
+                <p>
+                  <strong>Please note:</strong> The fastest way to make all your
+                  VA appointments is usually to call the VA health facility
+                  where you&nbsp;get care. To reschedule or cancel an existing
+                  appointment, please contact your facility as soon as
+                  possible.&nbsp;
+                  <a href="/find-locations/">
+                    Find your VA health facility’s phone number
+                  </a>
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          itemScope
+          itemType="http://schema.org/Question"
+          data-template="paragraphs/q_a"
+          data-entity-id={3474}
+          data-analytics-faq-section
+          data-analytics-faq-text="Will my personal health information be protected?"
+        >
+          <h2 itemProp="name" id="will-my-personal-health-inform">
+            Will my personal health information be protected?
+          </h2>
+          <div
+            data-entity-id={3474}
+            itemProp="acceptedAnswer"
+            itemScope
+            itemType="http://schema.org/Answer"
+          >
+            <div itemProp="text">
+              <div
+                data-template="paragraphs/wysiwyg"
+                data-entity-id={3475}
+                className="processed-content"
+              >
+                <p>
+                  Yes. This is a secure website. We follow strict security
+                  policies and practices to protect your personal health
+                  information. And only you and your VA health care team will
+                  have access to your secure messages.
+                </p>
+                <p>
+                  If you print or download any messages, you’ll need to take
+                  responsibility for protecting that information.
+                  <br />
                   <a
-                    href="https://www.myhealth.va.gov/mhv-portal-web/my-healthevet-offers-three-account-types"
+                    href="https://www.myhealth.va.gov/mhv-portal-web/web/myhealthevet/protecting-your-personal-health-information"
                     target="_blank"
                     rel="noopener noreferrer"
                   >
-                    Premium <strong>My HealtheVet account</strong>
+                    Get tips for protecting your personal health information
                   </a>
-                  , <strong>or</strong>
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div
+          itemScope
+          itemType="http://schema.org/Question"
+          data-template="paragraphs/q_a"
+          data-entity-id={3476}
+          data-analytics-faq-section
+          data-analytics-faq-text="What if I have more questions?"
+        >
+          <h2 itemProp="name" id="what-if-i-have-more-questions">
+            What if I have more questions?
+          </h2>
+          <div
+            data-entity-id={3476}
+            itemProp="acceptedAnswer"
+            itemScope
+            itemType="http://schema.org/Answer"
+          >
+            <div itemProp="text">
+              <div
+                data-template="paragraphs/wysiwyg"
+                data-entity-id={3477}
+                className="processed-content"
+              >
+                <p>
+                  You can get answers to your questions about these tools within
+                  our My HealtheVet web portal.
+                  <br />
+                  <a
+                    href="https://www.myhealth.va.gov/mhv-portal-web/faqs#Appointments"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    Read VA Appointments FAQs
+                  </a>
+                </p>
+                <p>
+                  You can also contact the My HealtheVet Help Desk.
+                  <br />
+                  <a
+                    href="https://www.myhealth.va.gov/mhv-portal-web/web/myhealthevet/contact-mhv"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    Find out how to contact us online
+                  </a>
+                </p>
+                <p>
+                  Or call us at{' '}
+                  <a aria-label="8 7 7. 3 2 7. 0 0 2 2." href="tel:18773270022">
+                    877-327-0022
+                  </a>{' '}
+                  (TTY:{' '}
+                  <a aria-label="8 0 0. 8 7 7. 8 3 3 9." href="tel:18008778339">
+                    800-877-8339
+                  </a>
+                  ). We’re here Monday through Friday, 7:00 a.m. to 7:00 p.m.
+                  CT.
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div className="row">
+        <div className="usa-content columns">
+          <aside className="va-nav-linkslist va-nav-linkslist--related">
+            <section
+              data-template="paragraphs/list_of_link_teasers"
+              data-entity-id={3452}
+              className="field_related_links"
+            >
+              <h2
+                id="more-information-about-your-benefits"
+                className="va-nav-linkslist-heading"
+              >
+                More information about your benefits
+              </h2>
+              <ul className="va-nav-linkslist-list">
+                <li
+                  data-template="paragraphs/linkTeaser"
+                  data-entity-id={3453}
+                  data-links-list-header="Health care benefits eligibility"
+                  data-links-list-section-header="More information about your benefits"
+                >
+                  <a href="/health-care/eligibility">
+                    <h4 className="va-nav-linkslist-title">
+                      Health care benefits eligibility
+                    </h4>
+                    <p className="va-nav-linkslist-description">
+                      Not sure if you qualify? Find out if you can get VA health
+                      care benefits.
+                    </p>
+                  </a>
                 </li>
-                <li>
-                  A Premium <strong>DS Logon</strong> account (used for
-                  eBenefits and milConnect), <strong>or</strong>
+                <li
+                  data-template="paragraphs/linkTeaser"
+                  data-entity-id={3454}
+                  data-links-list-header="How to apply for health care benefits"
+                  data-links-list-section-header="More information about your benefits"
+                >
+                  <a href="/health-care/how-to-apply">
+                    <h4 className="va-nav-linkslist-title">
+                      How to apply for health care benefits
+                    </h4>
+                    <p className="va-nav-linkslist-description">
+                      Ready to apply? Get started now.
+                    </p>
+                  </a>
                 </li>
-                <li>
-                  A verified <strong>ID.me</strong> account that you can create
-                  here on VA.gov
+                <li
+                  data-template="paragraphs/linkTeaser"
+                  data-entity-id={3455}
+                  data-links-list-header="Health needs and conditions"
+                  data-links-list-section-header="More information about your benefits"
+                >
+                  <a href="/health-care/health-needs-conditions">
+                    <h4 className="va-nav-linkslist-title">
+                      Health needs and conditions
+                    </h4>
+                    <p className="va-nav-linkslist-description">
+                      Learn how to access VA services for mental health, women’s
+                      health, and other specific needs.
+                    </p>
+                  </a>
+                </li>
+                <li
+                  data-template="paragraphs/linkTeaser"
+                  data-entity-id={3456}
+                  data-links-list-header="Disability benefits"
+                  data-links-list-section-header="More information about your benefits"
+                >
+                  <a href="/disability">
+                    <h4 className="va-nav-linkslist-title">
+                      Disability benefits
+                    </h4>
+                    <p className="va-nav-linkslist-description">
+                      Have an illness or injury that was caused—or made worse—by
+                      your active-duty service? Find out if you can get
+                      disability compensation (monthly payments) from VA.
+                    </p>
+                  </a>
                 </li>
               </ul>
-            </div>
-          </div>
-        </div>
-      </div>
-      <div itemScope itemType="http://schema.org/Question">
-        <h2 itemProp="name" id="how-do-i-know-if-my-va-health-">
-          How do I know if my VA health facility uses online scheduling?
-        </h2>
-        <div
-          itemProp="acceptedAnswer"
-          itemScope
-          itemType="http://schema.org/Answer"
-        >
-          <div itemProp="text">
-            <div className="processed-content">
-              <p>
-                Online scheduling&nbsp;is available at all VA facilities except
-                at the following locations:
-              </p>
-              <ul>
-                <li>
-                  <p>Columbus, OH</p>
-                </li>
-                <li>
-                  <p>Indianapolis, IN</p>
-                </li>
-                <li>
-                  <p>Manila, Philippines</p>
-                </li>
-              </ul>
-              <p>
-                Veterans who get care at the Chalmers P. Wylie Ambulatory Care
-                Center in Columbus, Ohio,&nbsp;can currently use{' '}
-                <a href="https://access.va.gov/accessva/?cspSelectFor=mass">
-                  MyChart Online
-                </a>
-                &nbsp;to schedule, reschedule, and cancel their appointments
-                online.
-              </p>
-              <p>
-                <strong>Note: </strong>
-                Online scheduling is available for some types of health
-                services. We hope to expand the types of appointments and health
-                services available through online scheduling&nbsp;in the future.
-              </p>
-            </div>
-          </div>
-        </div>
-      </div>
-
-      <div itemScope itemType="http://schema.org/Question">
-        <h2 itemProp="name" id="what-types-of-medical-appointm">
-          What types of medical appointments can I schedule online?
-        </h2>
-        <div
-          itemProp="acceptedAnswer"
-          itemScope
-          itemType="http://schema.org/Answer"
-        >
-          <div itemProp="text">
-            <div className="processed-content">
-              <p>
-                It depends on the VA health facility where you’re receiving
-                care. You can typically schedule an appointment online for the
-                types of care that don’t require a referral.
-              </p>
-              <p>
-                Once you’re signed in to the appointments tool, you’ll be able
-                to see what types of appointments you can schedule online at
-                your registered health facility.&nbsp;&nbsp;You can also check
-                with the facility where you receive care about scheduling
-                appointments online.&nbsp;
-              </p>
-              <p>
-                <a href="/find-locations/">Find a VA health facility</a>
-              </p>
-            </div>
-          </div>
-        </div>
-      </div>
-
-      <div itemScope itemType="http://schema.org/Question">
-        <h2 itemProp="name" id="can-i-use-this-tool-to-schedul">
-          Can I use this tool to schedule non-VA appointments?
-        </h2>
-        <div
-          itemProp="acceptedAnswer"
-          itemScope
-          itemType="http://schema.org/Answer"
-        >
-          <div itemProp="text">
-            <div className="processed-content">
-              <p>
-                It depends on the VA health management portal you are using.
-                Once you&apos;re signed in to the appointments tool, you&apos;ll
-                be able to see what providers you can schedule with online.
-              </p>
-            </div>
-          </div>
-        </div>
-      </div>
-      <div itemScope itemType="http://schema.org/Question">
-        <h2 itemProp="name" id="can-i-schedule-appointments-th">
-          Can I schedule appointments through VA Secure Messaging?
-        </h2>
-        <div
-          itemProp="acceptedAnswer"
-          itemScope
-          itemType="http://schema.org/Answer"
-        >
-          <div itemProp="text">
-            <div className="processed-content">
-              <p>
-                If you use Secure Messaging with your VA health care team, you
-                may be able to use this service to schedule and cancel
-                appointments.&nbsp;
-                <a href="/health-care/secure-messaging/">
-                  Learn more about Secure Messaging
-                </a>
-              </p>
-              <p>
-                <strong>Please note:</strong> The fastest way to make all your
-                VA appointments is usually to call the VA health facility where
-                you&nbsp;get care. To reschedule or cancel an existing
-                appointment, please contact your facility as soon as
-                possible.&nbsp;
-                <a href="/find-locations/">
-                  Find your VA health facility’s phone number
-                </a>
-              </p>
-            </div>
-          </div>
-        </div>
-      </div>
-      <div itemScope itemType="http://schema.org/Question">
-        <h2 itemProp="name" id="will-my-personal-health-inform">
-          Will my personal health information be protected?
-        </h2>
-        <div
-          itemProp="acceptedAnswer"
-          itemScope
-          itemType="http://schema.org/Answer"
-        >
-          <div itemProp="text">
-            <div className="processed-content">
-              <p>
-                Yes. This is a secure website. We follow strict security
-                policies and practices to protect your personal health
-                information. And only you and your VA health care team will have
-                access to your secure messages.
-              </p>
-              <p>
-                If you print or download any messages, you’ll need to take
-                responsibility for protecting that information.
-                <br />
-                <a
-                  href="https://www.myhealth.va.gov/mhv-portal-web/web/myhealthevet/protecting-your-personal-health-information"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  Get tips for protecting your personal health information
-                </a>
-              </p>
-            </div>
-          </div>
-        </div>
-      </div>
-      <div itemScope itemType="http://schema.org/Question">
-        <h2 itemProp="name" id="what-if-i-have-more-questions">
-          What if I have more questions?
-        </h2>
-        <div
-          itemProp="acceptedAnswer"
-          itemScope
-          itemType="http://schema.org/Answer"
-        >
-          <div itemProp="text">
-            <div className="processed-content">
-              <p>
-                <strong>
-                  If you have questions about scheduling an appointment
-                </strong>
-                , please go to the{' '}
-                <a
-                  href="https://www.myhealth.va.gov/mhv-portal-web/faqs#Appointments"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  VA Appointments FAQs
-                </a>{' '}
-                on the My HealtheVet web portal.
-              </p>
-              <p>
-                Or contact the My HealtheVet help desk at{' '}
-                <a href="tel:+18773270022">877-327-0022</a> (TTY:{' '}
-                <a href="tel:+18008778339">800-877-8339</a>. We&apos;re here
-                Monday through Friday, 7:00 a.m. to 7:00 p.m. CT.
-              </p>
-              <p>
-                You can also{' '}
-                <a
-                  href="https://www.myhealth.va.gov/mhv-portal-web/web/myhealthevet/contact-mhv"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  contact us online
-                </a>
-                .
-              </p>
-            </div>
-          </div>
+            </section>
+          </aside>
         </div>
       </div>
     </div>

--- a/src/applications/static-pages/health-care-manage-benefits/schedule-view-va-appointments-page/components/LegacyContent/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/schedule-view-va-appointments-page/components/LegacyContent/index.js
@@ -1,0 +1,354 @@
+// Node modules.
+import React from 'react';
+// Relative imports.
+import CallToActionWidget from 'platform/site-wide/cta-widget';
+
+export const LegacyContent = () => (
+  <>
+    <div className="usa-alert usa-alert-info" role="alert">
+      <div className="usa-alert-body">
+        <h3 className="usa-alert-heading" id="due-to-covid-19-you-can-only-r">
+          Due to COVID-19, you can only request an appointment online
+        </h3>
+        <p>
+          You can’t directly schedule an appointment online at this time. Once
+          you request your appointment, a scheduler will get back to you to
+          confirm your request.
+        </p>
+        <p>
+          To help us address the most urgent needs first, we ask that you don’t
+          request routine appointments right now.
+        </p>
+      </div>
+    </div>
+    <div className="processed-content">
+      <p>&nbsp;</p>
+      <p>
+        <strong>Please note:</strong> The fastest way to make all your VA
+        appointments is usually to call the VA health facility where you want to
+        receive care. If you can’t keep an existing appointment, please contact
+        the facility as soon as possible to reschedule or cancel.
+        <br />
+        <a href="/find-locations/">
+          Find your VA health facility’s phone number
+        </a>
+      </p>
+      <h2 id="view-schedule-or-cancel-a-va-a">
+        View, schedule, or cancel a VA appointment&nbsp;online
+      </h2>
+    </div>
+    <CallToActionWidget appId="view-appointments" setFocus={false} />
+    <div>
+      <div itemScope itemType="http://schema.org/Question">
+        <h2 itemProp="name" id="how-can-va-appointment-tools-h">
+          How can VA appointment tools help me manage my health care?
+        </h2>
+        <div
+          itemProp="acceptedAnswer"
+          itemScope
+          itemType="http://schema.org/Answer"
+        >
+          <div itemProp="text">
+            <div className="processed-content">
+              <p>
+                These appointment tools offer a secure, online way to schedule,
+                view, and organize your VA appointments. The appointments you
+                can schedule online depends on the facility, the type of health
+                service, and other factors.
+              </p>
+              <p>
+                <strong>You can use these tools to:</strong>
+              </p>
+              <ul>
+                <li>Schedule some of your VA medical appointments online</li>
+                <li>Cancel appointments made online</li>
+                <li>View appointments on your health calendar</li>
+                <li>
+                  Find the location of the VA facility for your appointments
+                </li>
+                <li>Print a list of your future appointments</li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div itemScope itemType="http://schema.org/Question">
+        <h2 itemProp="name" id="am-i-eligible-to-use-the-va-ap">
+          Am I eligible to use the VA appointment tools?
+        </h2>
+        <div
+          itemProp="acceptedAnswer"
+          itemScope
+          itemType="http://schema.org/Answer"
+        >
+          <div itemProp="text">
+            <div className="processed-content">
+              <p>
+                You can use the&nbsp;online appointment tools if you meet all of
+                the requirements listed below.
+              </p>
+              <p>
+                <strong>All of these must be true:</strong>
+              </p>
+              <ul>
+                <li>
+                  You're{' '}
+                  <a
+                    href="/health-care/how-to-apply"
+                    title="How to apply for VA health care"
+                  >
+                    enrolled in VA health care
+                  </a>
+                  , <strong>and</strong>
+                </li>
+                <li>
+                  You're scheduling your appointment with a VA health facility
+                  that uses online scheduling, <strong>and</strong>
+                </li>
+                <li>
+                  You're registered or you’ve had an appointment at that
+                  facility before
+                </li>
+              </ul>
+              <p>
+                <strong>And you must have one of these free accounts:</strong>
+              </p>
+              <ul>
+                <li>
+                  A{' '}
+                  <a
+                    href="https://www.myhealth.va.gov/mhv-portal-web/my-healthevet-offers-three-account-types"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    Premium <strong>My HealtheVet account</strong>
+                  </a>
+                  , <strong>or</strong>
+                </li>
+                <li>
+                  A Premium <strong>DS Logon</strong> account (used for
+                  eBenefits and milConnect), <strong>or</strong>
+                </li>
+                <li>
+                  A verified <strong>ID.me</strong> account that you can create
+                  here on VA.gov
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div itemScope itemType="http://schema.org/Question">
+        <h2 itemProp="name" id="how-do-i-know-if-my-va-health-">
+          How do I know if my VA health facility uses online scheduling?
+        </h2>
+        <div
+          itemProp="acceptedAnswer"
+          itemScope
+          itemType="http://schema.org/Answer"
+        >
+          <div itemProp="text">
+            <div className="processed-content">
+              <p>
+                Online scheduling&nbsp;is available at all VA facilities except
+                at the following locations:
+              </p>
+              <ul>
+                <li>
+                  <p>Columbus, OH</p>
+                </li>
+                <li>
+                  <p>Indianapolis, IN</p>
+                </li>
+                <li>
+                  <p>Manila, Philippines</p>
+                </li>
+              </ul>
+              <p>
+                Veterans who get care at the Chalmers P. Wylie Ambulatory Care
+                Center in Columbus, Ohio,&nbsp;can currently use{' '}
+                <a href="https://access.va.gov/accessva/?cspSelectFor=mass">
+                  MyChart Online
+                </a>
+                &nbsp;to schedule, reschedule, and cancel their appointments
+                online.
+              </p>
+              <p>
+                <strong>Note: </strong>
+                Online scheduling is available for some types of health
+                services. We hope to expand the types of appointments and health
+                services available through online scheduling&nbsp;in the future.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div itemScope itemType="http://schema.org/Question">
+        <h2 itemProp="name" id="what-types-of-medical-appointm">
+          What types of medical appointments can I schedule online?
+        </h2>
+        <div
+          itemProp="acceptedAnswer"
+          itemScope
+          itemType="http://schema.org/Answer"
+        >
+          <div itemProp="text">
+            <div className="processed-content">
+              <p>
+                It depends on the VA health facility where you’re receiving
+                care. You can typically schedule an appointment online for the
+                types of care that don’t require a referral.
+              </p>
+              <p>
+                Once you’re signed in to the appointments tool, you’ll be able
+                to see what types of appointments you can schedule online at
+                your registered health facility.&nbsp;&nbsp;You can also check
+                with the facility where you receive care about scheduling
+                appointments online.&nbsp;
+              </p>
+              <p>
+                <a href="/find-locations/">Find a VA health facility</a>
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div itemScope itemType="http://schema.org/Question">
+        <h2 itemProp="name" id="can-i-use-this-tool-to-schedul">
+          Can I use this tool to schedule non-VA appointments?
+        </h2>
+        <div
+          itemProp="acceptedAnswer"
+          itemScope
+          itemType="http://schema.org/Answer"
+        >
+          <div itemProp="text">
+            <div className="processed-content">
+              <p>
+                It depends on the VA health management portal you are using.
+                Once you&apos;re signed in to the appointments tool, you&apos;ll
+                be able to see what providers you can schedule with online.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div itemScope itemType="http://schema.org/Question">
+        <h2 itemProp="name" id="can-i-schedule-appointments-th">
+          Can I schedule appointments through VA Secure Messaging?
+        </h2>
+        <div
+          itemProp="acceptedAnswer"
+          itemScope
+          itemType="http://schema.org/Answer"
+        >
+          <div itemProp="text">
+            <div className="processed-content">
+              <p>
+                If you use Secure Messaging with your VA health care team, you
+                may be able to use this service to schedule and cancel
+                appointments.&nbsp;
+                <a href="/health-care/secure-messaging/">
+                  Learn more about Secure Messaging
+                </a>
+              </p>
+              <p>
+                <strong>Please note:</strong> The fastest way to make all your
+                VA appointments is usually to call the VA health facility where
+                you&nbsp;get care. To reschedule or cancel an existing
+                appointment, please contact your facility as soon as
+                possible.&nbsp;
+                <a href="/find-locations/">
+                  Find your VA health facility’s phone number
+                </a>
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div itemScope itemType="http://schema.org/Question">
+        <h2 itemProp="name" id="will-my-personal-health-inform">
+          Will my personal health information be protected?
+        </h2>
+        <div
+          itemProp="acceptedAnswer"
+          itemScope
+          itemType="http://schema.org/Answer"
+        >
+          <div itemProp="text">
+            <div className="processed-content">
+              <p>
+                Yes. This is a secure website. We follow strict security
+                policies and practices to protect your personal health
+                information. And only you and your VA health care team will have
+                access to your secure messages.
+              </p>
+              <p>
+                If you print or download any messages, you’ll need to take
+                responsibility for protecting that information.
+                <br />
+                <a
+                  href="https://www.myhealth.va.gov/mhv-portal-web/web/myhealthevet/protecting-your-personal-health-information"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Get tips for protecting your personal health information
+                </a>
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div itemScope itemType="http://schema.org/Question">
+        <h2 itemProp="name" id="what-if-i-have-more-questions">
+          What if I have more questions?
+        </h2>
+        <div
+          itemProp="acceptedAnswer"
+          itemScope
+          itemType="http://schema.org/Answer"
+        >
+          <div itemProp="text">
+            <div className="processed-content">
+              <p>
+                <strong>
+                  If you have questions about scheduling an appointment
+                </strong>
+                , please go to the{' '}
+                <a
+                  href="https://www.myhealth.va.gov/mhv-portal-web/faqs#Appointments"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  VA Appointments FAQs
+                </a>{' '}
+                on the My HealtheVet web portal.
+              </p>
+              <p>
+                Or contact the My HealtheVet help desk at{' '}
+                <a href="tel:+18773270022">877-327-0022</a> (TTY:{' '}
+                <a href="tel:+18008778339">800-877-8339</a>. We&apos;re here
+                Monday through Friday, 7:00 a.m. to 7:00 p.m. CT.
+              </p>
+              <p>
+                You can also{' '}
+                <a
+                  href="https://www.myhealth.va.gov/mhv-portal-web/web/myhealthevet/contact-mhv"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  contact us online
+                </a>
+                .
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </>
+);
+
+export default LegacyContent;

--- a/src/applications/static-pages/health-care-manage-benefits/schedule-view-va-appointments-page/components/LegacyContent/index.unit.spec.js
+++ b/src/applications/static-pages/health-care-manage-benefits/schedule-view-va-appointments-page/components/LegacyContent/index.unit.spec.js
@@ -1,0 +1,37 @@
+// Dependencies.
+import React from 'react';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+// Relative imports.
+import LegacyContent from '.';
+
+describe('Scheduling Page <LegacyContent>', () => {
+  it('renders what we expect', () => {
+    const wrapper = shallow(<LegacyContent />);
+
+    const text = wrapper.text();
+    expect(text).to.include('View, schedule, or cancel a VA appointment');
+    expect(text).to.include(
+      'How can VA appointment tools help me manage my health care?',
+    );
+    expect(text).to.include('Am I eligible to use the VA appointment tools?');
+    expect(text).to.include(
+      'How do I know if my VA health facility uses online scheduling?',
+    );
+    expect(text).to.include(
+      'What types of medical appointments can I schedule online?',
+    );
+    expect(text).to.include(
+      'Can I use this tool to schedule non-VA appointments?',
+    );
+    expect(text).to.include(
+      'Can I schedule appointments through VA Secure Messaging?',
+    );
+    expect(text).to.include(
+      'Will my personal health information be protected?',
+    );
+    expect(text).to.include('What if I have more questions?');
+
+    wrapper.unmount();
+  });
+});

--- a/src/applications/static-pages/health-care-manage-benefits/secure-messaging-page/components/App/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/secure-messaging-page/components/App/index.js
@@ -4,10 +4,16 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 // Relative imports.
 import AuthContent from '../AuthContent';
+import LegacyContent from '../LegacyContent';
 import UnauthContent from '../UnauthContent';
+import environment from 'platform/utilities/environment';
 import { selectIsCernerPatient } from 'platform/user/selectors';
 
 export const App = ({ isCernerPatient }) => {
+  if (environment.isProduction()) {
+    return <LegacyContent />;
+  }
+
   if (isCernerPatient) {
     return <AuthContent />;
   }

--- a/src/applications/static-pages/health-care-manage-benefits/secure-messaging-page/components/LegacyContent/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/secure-messaging-page/components/LegacyContent/index.js
@@ -7,18 +7,30 @@ import MoreInfoAboutBenefits from '../../../components/MoreInfoAboutBenefits';
 export const LegacyContent = () => (
   <>
     <CallToActionWidget appId="messaging" setFocus={false} />
-    <div>
-      <div itemScope itemType="http://schema.org/Question">
+    <div data-template="paragraphs/q_a_section" data-entity-id={3480}>
+      <div
+        itemScope
+        itemType="http://schema.org/Question"
+        data-template="paragraphs/q_a"
+        data-entity-id={3479}
+        data-analytics-faq-section
+        data-analytics-faq-text="How can VA Secure Messaging help me manage my health care?"
+      >
         <h2 itemProp="name" id="how-can-va-secure-messaging-he">
           How can VA Secure Messaging help me manage my health care?
         </h2>
         <div
+          data-entity-id={3479}
           itemProp="acceptedAnswer"
           itemScope
           itemType="http://schema.org/Answer"
         >
           <div itemProp="text">
-            <div className="processed-content">
+            <div
+              data-template="paragraphs/wysiwyg"
+              data-entity-id={3481}
+              className="processed-content"
+            >
               <p>
                 Secure Messaging is a web-based service that protects your
                 sensitive information so you can safely and easily communicate
@@ -47,17 +59,29 @@ export const LegacyContent = () => (
           </div>
         </div>
       </div>
-      <div itemScope itemType="http://schema.org/Question">
+      <div
+        itemScope
+        itemType="http://schema.org/Question"
+        data-template="paragraphs/q_a"
+        data-entity-id={3482}
+        data-analytics-faq-section
+        data-analytics-faq-text="Am I eligible to use Secure Messaging?"
+      >
         <h2 itemProp="name" id="am-i-eligible-to-use-secure-me">
           Am I eligible to use Secure Messaging?
         </h2>
         <div
+          data-entity-id={3482}
           itemProp="acceptedAnswer"
           itemScope
           itemType="http://schema.org/Answer"
         >
           <div itemProp="text">
-            <div className="processed-content">
+            <div
+              data-template="paragraphs/wysiwyg"
+              data-entity-id={3483}
+              className="processed-content"
+            >
               <p>
                 You can use this tool if you meet all of the requirements listed
                 below.
@@ -113,21 +137,34 @@ export const LegacyContent = () => (
           </div>
         </div>
       </div>
-      <div itemScope itemType="http://schema.org/Question">
+      <div
+        itemScope
+        itemType="http://schema.org/Question"
+        data-template="paragraphs/q_a"
+        data-entity-id={3484}
+        data-analytics-faq-section
+        data-analytics-faq-text="How does Secure Messaging work within My HealtheVet?"
+      >
         <h2 itemProp="name" id="how-does-secure-messaging-work">
           How does Secure Messaging work within My HealtheVet?
         </h2>
         <div
+          data-entity-id={3484}
           itemProp="acceptedAnswer"
           itemScope
           itemType="http://schema.org/Answer"
         >
           <div itemProp="text">
-            <div className="processed-content">
+            <div
+              data-template="paragraphs/wysiwyg"
+              data-entity-id={3485}
+              className="processed-content"
+            >
               <p>
-                With Secure Messaging, you can write messages, save drafts,
-                review your sent messages, and keep a record of your
-                conversations.
+                You’ll sign in to your account and access your Secure Messaging
+                folder through your account Welcome page dashboard. There, you
+                can write messages, save drafts, review your sent messages, and
+                keep a record of your conversations.
               </p>
               <p>
                 You can use Secure Messaging to communicate with any VA health
@@ -145,17 +182,29 @@ export const LegacyContent = () => (
           </div>
         </div>
       </div>
-      <div itemScope itemType="http://schema.org/Question">
+      <div
+        itemScope
+        itemType="http://schema.org/Question"
+        data-template="paragraphs/q_a"
+        data-entity-id={3486}
+        data-analytics-faq-section
+        data-analytics-faq-text="Can I use Secure Messaging for medical emergencies or urgent needs?"
+      >
         <h2 itemProp="name" id="can-i-use-secure-messaging-for">
           Can I use Secure Messaging for medical emergencies or urgent needs?
         </h2>
         <div
+          data-entity-id={3486}
           itemProp="acceptedAnswer"
           itemScope
           itemType="http://schema.org/Answer"
         >
           <div itemProp="text">
-            <div className="processed-content">
+            <div
+              data-template="paragraphs/wysiwyg"
+              data-entity-id={3487}
+              className="processed-content"
+            >
               <p>
                 No. You shouldn’t use Secure Messaging when you have an urgent
                 need, because it may take a few days for you to get a reply.
@@ -188,8 +237,11 @@ export const LegacyContent = () => (
               </p>
               <ul>
                 <li>
-                  Call <a href="tel:+18002738255">800-273-8255</a>, then select
-                  1.
+                  Call{' '}
+                  <a aria-label="8 0 0. 2 7 3. 8 2 5 5." href="tel:18002738255">
+                    800-273-8255
+                  </a>
+                  , then select 1.
                 </li>
                 <li>
                   Start a{' '}
@@ -206,17 +258,29 @@ export const LegacyContent = () => (
           </div>
         </div>
       </div>
-      <div itemScope itemType="http://schema.org/Question">
+      <div
+        itemScope
+        itemType="http://schema.org/Question"
+        data-template="paragraphs/q_a"
+        data-entity-id={3488}
+        data-analytics-faq-section
+        data-analytics-faq-text="Can I use Secure Messaging to communicate with non-VA providers?"
+      >
         <h2 itemProp="name" id="can-i-use-secure-messaging-to-">
           Can I use Secure Messaging to communicate with non-VA providers?
         </h2>
         <div
+          data-entity-id={3488}
           itemProp="acceptedAnswer"
           itemScope
           itemType="http://schema.org/Answer"
         >
           <div itemProp="text">
-            <div className="processed-content">
+            <div
+              data-template="paragraphs/wysiwyg"
+              data-entity-id={3489}
+              className="processed-content"
+            >
               <p>
                 No. You can communicate only with your VA providers who’ve
                 agreed to participate in Secure Messaging.
@@ -225,17 +289,29 @@ export const LegacyContent = () => (
           </div>
         </div>
       </div>
-      <div itemScope itemType="http://schema.org/Question">
+      <div
+        itemScope
+        itemType="http://schema.org/Question"
+        data-template="paragraphs/q_a"
+        data-entity-id={3490}
+        data-analytics-faq-section
+        data-analytics-faq-text="Will my personal health information be protected?"
+      >
         <h2 itemProp="name" id="will-my-personal-health-inform">
           Will my personal health information be protected?
         </h2>
         <div
+          data-entity-id={3490}
           itemProp="acceptedAnswer"
           itemScope
           itemType="http://schema.org/Answer"
         >
           <div itemProp="text">
-            <div className="processed-content">
+            <div
+              data-template="paragraphs/wysiwyg"
+              data-entity-id={3491}
+              className="processed-content"
+            >
               <p>
                 Yes. This is a secure website. We follow strict security
                 policies and practices to protect your personal health
@@ -258,45 +334,61 @@ export const LegacyContent = () => (
           </div>
         </div>
       </div>
-      <div itemScope itemType="http://schema.org/Question">
+      <div
+        itemScope
+        itemType="http://schema.org/Question"
+        data-template="paragraphs/q_a"
+        data-entity-id={3492}
+        data-analytics-faq-section
+        data-analytics-faq-text="What if I have more questions?"
+      >
         <h2 itemProp="name" id="what-if-i-have-more-questions">
           What if I have more questions?
         </h2>
         <div
+          data-entity-id={3492}
           itemProp="acceptedAnswer"
           itemScope
           itemType="http://schema.org/Answer"
         >
           <div itemProp="text">
-            <div className="processed-content">
+            <div
+              data-template="paragraphs/wysiwyg"
+              data-entity-id={3493}
+              className="processed-content"
+            >
               <p>
-                If you have more questions about Secure Messaging on
-                MyHealtheVet, please got to the{' '}
+                You can get answers to your questions about this tool within our
+                My HealtheVet web portal.
+                <br />
                 <a
                   href="https://www.myhealth.va.gov/mhv-portal-web/web/myhealthevet/faqs#smGeneralFAQ"
                   target="_blank"
                   rel="noopener noreferrer"
                 >
-                  Secure Messaging FAQs
-                </a>{' '}
-                on the My HealtheVet web portal.
+                  Read Secure Messaging FAQs
+                </a>
               </p>
               <p>
-                Or contact the My HealtheVet help desk at{' '}
-                <a href="tel:+18773270022">877-327-0022</a> (TTY:{' '}
-                <a href="tel:+18008778339">800-877-8339</a>. We&apos;re here
-                Monday through Friday, 7:00 a.m. to 7:00 p.m. CT.
-              </p>
-              <p>
-                You can also{' '}
+                You can also contact the My HealtheVet help desk.
+                <br />
                 <a
                   href="https://www.myhealth.va.gov/mhv-portal-web/web/myhealthevet/contact-mhv"
                   target="_blank"
                   rel="noopener noreferrer"
                 >
-                  contact us online
+                  Find out how to contact us online
                 </a>
-                .
+                <br />
+                Or call us at{' '}
+                <a aria-label="8 7 7. 3 2 7. 0 0 2 2." href="tel:18773270022">
+                  877-327-0022
+                </a>{' '}
+                (TTY:{' '}
+                <a aria-label="8 0 0. 8 7 7. 8 3 3 9." href="tel:18008778339">
+                  800-877-8339
+                </a>
+                ). We’re here Monday through Friday, 7:00 a.m. to 7:00 p.m. CT.
               </p>
             </div>
           </div>

--- a/src/applications/static-pages/health-care-manage-benefits/secure-messaging-page/components/LegacyContent/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/secure-messaging-page/components/LegacyContent/index.js
@@ -1,0 +1,309 @@
+// Node modules.
+import React from 'react';
+// Relative imports.
+import CallToActionWidget from 'platform/site-wide/cta-widget';
+import MoreInfoAboutBenefits from '../../../components/MoreInfoAboutBenefits';
+
+export const LegacyContent = () => (
+  <>
+    <CallToActionWidget appId="messaging" setFocus={false} />
+    <div>
+      <div itemScope itemType="http://schema.org/Question">
+        <h2 itemProp="name" id="how-can-va-secure-messaging-he">
+          How can VA Secure Messaging help me manage my health care?
+        </h2>
+        <div
+          itemProp="acceptedAnswer"
+          itemScope
+          itemType="http://schema.org/Answer"
+        >
+          <div itemProp="text">
+            <div className="processed-content">
+              <p>
+                Secure Messaging is a web-based service that protects your
+                sensitive information so you can safely and easily communicate
+                electronically with your VA health care team.
+              </p>
+              <p>
+                <strong>You can use Secure Messaging to:</strong>
+              </p>
+              <ul>
+                <li>Ask non-urgent, non-emergency health-related questions</li>
+                <li>Give your health care team updates on your condition</li>
+                <li>
+                  Request VA referrals, test results, and prescription renewals
+                </li>
+                <li>Manage your VA appointments</li>
+                <li>
+                  Ask routine administrative questions about topics like
+                  scheduling appointments or getting directions
+                </li>
+                <li>
+                  Get health education information from the Veterans Health
+                  Library
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div itemScope itemType="http://schema.org/Question">
+        <h2 itemProp="name" id="am-i-eligible-to-use-secure-me">
+          Am I eligible to use Secure Messaging?
+        </h2>
+        <div
+          itemProp="acceptedAnswer"
+          itemScope
+          itemType="http://schema.org/Answer"
+        >
+          <div itemProp="text">
+            <div className="processed-content">
+              <p>
+                You can use this tool if you meet all of the requirements listed
+                below.
+              </p>
+              <p>
+                <strong>All of these must be true:</strong>
+              </p>
+              <ul>
+                <li>
+                  You’re enrolled in VA health care, <strong>and</strong>
+                </li>
+                <li>
+                  You’re registered as a patient at a VA health facility,{' '}
+                  <strong>and</strong>
+                </li>
+                <li>
+                  Your VA health care provider has agreed to communicate with
+                  you through Secure Messaging
+                </li>
+              </ul>
+              <p>
+                <a href="/health-care/how-to-apply/">
+                  Find out how to apply for VA health care
+                </a>
+              </p>
+              <p>
+                <strong>And you must have one of these free accounts:</strong>
+              </p>
+              <ul>
+                <li>
+                  A Premium <strong>My HealtheVet</strong> account,{' '}
+                  <strong>or</strong>
+                </li>
+                <li>
+                  A Premium <strong>DS Logon</strong> account (used for
+                  eBenefits and milConnect), <strong>or</strong>
+                </li>
+                <li>
+                  A verified <strong>ID.me</strong> account that you can create
+                  here on VA.gov
+                </li>
+              </ul>
+              <p>
+                <a
+                  href="https://www.myhealth.va.gov/mhv-portal-web/my-healthevet-offers-three-account-types"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Learn about the 3 different My HealtheVet account types
+                </a>
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div itemScope itemType="http://schema.org/Question">
+        <h2 itemProp="name" id="how-does-secure-messaging-work">
+          How does Secure Messaging work within My HealtheVet?
+        </h2>
+        <div
+          itemProp="acceptedAnswer"
+          itemScope
+          itemType="http://schema.org/Answer"
+        >
+          <div itemProp="text">
+            <div className="processed-content">
+              <p>
+                With Secure Messaging, you can write messages, save drafts,
+                review your sent messages, and keep a record of your
+                conversations.
+              </p>
+              <p>
+                You can use Secure Messaging to communicate with any VA health
+                care team member who has signed up to participate.
+              </p>
+              <p>
+                You can send non-urgent, non-emergency messages at any time of
+                the day or night. Your VA health care team should respond within
+                3 business days (Monday through Friday, 8:00 a.m. - 5:00 p.m.,
+                except federal holidays). If you’d like, you can set up your
+                account to send a notification to your personal email when you
+                receive a new secure message.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div itemScope itemType="http://schema.org/Question">
+        <h2 itemProp="name" id="can-i-use-secure-messaging-for">
+          Can I use Secure Messaging for medical emergencies or urgent needs?
+        </h2>
+        <div
+          itemProp="acceptedAnswer"
+          itemScope
+          itemType="http://schema.org/Answer"
+        >
+          <div itemProp="text">
+            <div className="processed-content">
+              <p>
+                No. You shouldn’t use Secure Messaging when you have an urgent
+                need, because it may take a few days for you to get a reply.
+              </p>
+              <p>
+                <strong>If you think you have a medical emergency,</strong> call
+                911 or go to the nearest emergency room.
+              </p>
+              <p>
+                <strong>
+                  If you don’t have an emergency, but you’re not sure what type
+                  of care you need,
+                </strong>{' '}
+                call your nearest VA health facility.
+                <br />
+                <a href="/find-locations/">
+                  Find your nearest VA health facility
+                </a>
+              </p>
+              <p>
+                <strong>If you need to talk with someone right away,</strong>{' '}
+                contact the Veterans Crisis Line. Whatever you’re struggling
+                with—chronic pain, anxiety, depression, trouble sleeping, anger,
+                or even homelessness—we can support you. Our Veterans Crisis
+                Line is confidential (private), free, and available 24/7.
+              </p>
+              <p>
+                To connect with a Veterans Crisis Line responder anytime, day or
+                night:
+              </p>
+              <ul>
+                <li>
+                  Call <a href="tel:+18002738255">800-273-8255</a>, then select
+                  1.
+                </li>
+                <li>
+                  Start a{' '}
+                  <a href="https://www.veteranscrisisline.net/get-help/chat">
+                    confidential Veterans Chat
+                  </a>
+                  .
+                </li>
+                <li>
+                  Text <a href="tel:+1838255">838255</a>.
+                </li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div itemScope itemType="http://schema.org/Question">
+        <h2 itemProp="name" id="can-i-use-secure-messaging-to-">
+          Can I use Secure Messaging to communicate with non-VA providers?
+        </h2>
+        <div
+          itemProp="acceptedAnswer"
+          itemScope
+          itemType="http://schema.org/Answer"
+        >
+          <div itemProp="text">
+            <div className="processed-content">
+              <p>
+                No. You can communicate only with your VA providers who’ve
+                agreed to participate in Secure Messaging.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div itemScope itemType="http://schema.org/Question">
+        <h2 itemProp="name" id="will-my-personal-health-inform">
+          Will my personal health information be protected?
+        </h2>
+        <div
+          itemProp="acceptedAnswer"
+          itemScope
+          itemType="http://schema.org/Answer"
+        >
+          <div itemProp="text">
+            <div className="processed-content">
+              <p>
+                Yes. This is a secure website. We follow strict security
+                policies and practices to protect your personal health
+                information. And only you and your VA health care team will have
+                access to your secure messages.
+              </p>
+              <p>
+                If you print or download any messages, you’ll need to take
+                responsibility for protecting that information.
+                <br />
+                <a
+                  href="https://www.myhealth.va.gov/mhv-portal-web/web/myhealthevet/protecting-your-personal-health-information"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Get tips for protecting your personal health information
+                </a>
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div itemScope itemType="http://schema.org/Question">
+        <h2 itemProp="name" id="what-if-i-have-more-questions">
+          What if I have more questions?
+        </h2>
+        <div
+          itemProp="acceptedAnswer"
+          itemScope
+          itemType="http://schema.org/Answer"
+        >
+          <div itemProp="text">
+            <div className="processed-content">
+              <p>
+                If you have more questions about Secure Messaging on
+                MyHealtheVet, please got to the{' '}
+                <a
+                  href="https://www.myhealth.va.gov/mhv-portal-web/web/myhealthevet/faqs#smGeneralFAQ"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Secure Messaging FAQs
+                </a>{' '}
+                on the My HealtheVet web portal.
+              </p>
+              <p>
+                Or contact the My HealtheVet help desk at{' '}
+                <a href="tel:+18773270022">877-327-0022</a> (TTY:{' '}
+                <a href="tel:+18008778339">800-877-8339</a>. We&apos;re here
+                Monday through Friday, 7:00 a.m. to 7:00 p.m. CT.
+              </p>
+              <p>
+                You can also{' '}
+                <a
+                  href="https://www.myhealth.va.gov/mhv-portal-web/web/myhealthevet/contact-mhv"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  contact us online
+                </a>
+                .
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </>
+);
+
+export default LegacyContent;

--- a/src/applications/static-pages/health-care-manage-benefits/secure-messaging-page/components/LegacyContent/index.unit.spec.js
+++ b/src/applications/static-pages/health-care-manage-benefits/secure-messaging-page/components/LegacyContent/index.unit.spec.js
@@ -1,0 +1,33 @@
+// Dependencies.
+import React from 'react';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+// Relative imports.
+import LegacyContent from '.';
+
+describe('Secure Messaging Page <LegacyContent>', () => {
+  it('renders what we expect', () => {
+    const wrapper = shallow(<LegacyContent />);
+
+    const text = wrapper.text();
+    expect(text).to.include(
+      'How can VA Secure Messaging help me manage my health care?',
+    );
+    expect(text).to.include('Am I eligible to use Secure Messaging?');
+    expect(text).to.include(
+      'How does Secure Messaging work within My HealtheVet?',
+    );
+    expect(text).to.include(
+      'Can I use Secure Messaging for medical emergencies or urgent needs?',
+    );
+    expect(text).to.include(
+      'Can I use Secure Messaging to communicate with non-VA providers?',
+    );
+    expect(text).to.include(
+      'Will my personal health information be protected?',
+    );
+    expect(text).to.include('What if I have more questions?');
+
+    wrapper.unmount();
+  });
+});

--- a/src/applications/static-pages/health-care-manage-benefits/view-test-and-lab-results-page/components/App/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/view-test-and-lab-results-page/components/App/index.js
@@ -4,10 +4,16 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 // Relative imports.
 import AuthContent from '../AuthContent';
+import LegacyContent from '../LegacyContent';
 import UnauthContent from '../UnauthContent';
+import environment from 'platform/utilities/environment';
 import { selectIsCernerPatient } from 'platform/user/selectors';
 
 export const App = ({ isCernerPatient }) => {
+  if (environment.isProduction()) {
+    return <LegacyContent />;
+  }
+
   if (isCernerPatient) {
     return <AuthContent />;
   }

--- a/src/applications/static-pages/health-care-manage-benefits/view-test-and-lab-results-page/components/LegacyContent/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/view-test-and-lab-results-page/components/LegacyContent/index.js
@@ -1,0 +1,277 @@
+// Node modules.
+import React from 'react';
+// Relative imports.
+import CallToActionWidget from 'platform/site-wide/cta-widget';
+import MoreInfoAboutBenefits from '../../../components/MoreInfoAboutBenefits';
+
+export const LegacyContent = () => (
+  <>
+    <CallToActionWidget appId="lab-and-test-results" setFocus={false} />
+    <div>
+      <div itemScope itemType="http://schema.org/Question">
+        <h2 itemProp="name" id="how-can-this-tool-help-me-mana">
+          How can this tool help me manage my health care?
+        </h2>
+        <div
+          itemProp="acceptedAnswer"
+          itemScope
+          itemType="http://schema.org/Answer"
+        >
+          <div itemProp="text">
+            <div className="processed-content">
+              <p>
+                With this tool, you&apos;ll be able to view and keep a record of
+                your VA lab and test results.
+              </p>
+              <p>
+                <strong>You can use the tool to:</strong>
+              </p>
+              <ul>
+                <li>
+                  View some of your VA lab and test results (like blood tests)
+                </li>
+                <li>Add results from non-VA health care providers and labs</li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div itemScope itemType="http://schema.org/Question">
+        <h2 itemProp="name" id="am-i-eligible-to-use-this-tool">
+          Am I eligible to use this tool?
+        </h2>
+        <div
+          itemProp="acceptedAnswer"
+          itemScope
+          itemType="http://schema.org/Answer"
+        >
+          <div itemProp="text">
+            <div className="processed-content">
+              <p>
+                You can use this tool to view and track your VA lab and test
+                results if you meet all of the requirements listed below.
+              </p>
+              <p>
+                <strong>Both of these must be true. You’re:</strong>
+              </p>
+              <ul>
+                <li>
+                  Enrolled in VA health care, <strong>and</strong>
+                </li>
+                <li>Registered as a patient at a VA health facility</li>
+              </ul>
+              <p>
+                <a href="/health-care/how-to-apply/">
+                  Find out how to apply for VA health care
+                </a>
+              </p>
+              <p>
+                <strong>And you must have one of these free accounts:</strong>
+              </p>
+              <ul>
+                <li>
+                  A{' '}
+                  <a
+                    href="https://www.myhealth.va.gov/mhv-portal-web/upgrading-your-my-healthevet-account-through-in-person-or-online-authentication"
+                    rel="noreferrer noopener"
+                  >
+                    Premium <strong>My HealtheVet account</strong>
+                  </a>
+                  , <strong>or</strong>
+                </li>
+                <li>
+                  A Premium <strong>DS Logon</strong> account (used for
+                  eBenefits and milConnect), <strong>or</strong>
+                </li>
+                <li>
+                  A verified <strong>ID.me</strong> account that you can create
+                  here on VA.gov
+                </li>
+              </ul>
+              <p>
+                <strong>Note:</strong> If you sign in with a Basic or Advanced
+                account, you’ll see only the results you’ve entered yourself.
+                <br />
+                <a
+                  href="https://www.myhealth.va.gov/mhv-portal-web/my-healthevet-offers-three-account-types"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Learn about the 3 different My HealtheVet account types
+                </a>
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div itemScope itemType="http://schema.org/Question">
+        <h2 itemProp="name" id="can-i-view-all-my-va-lab-and-t">
+          Can I view all my VA lab and test information using this tool?
+        </h2>
+        <div
+          itemProp="acceptedAnswer"
+          itemScope
+          itemType="http://schema.org/Answer"
+        >
+          <div itemProp="text">
+            <div className="processed-content">
+              <p>
+                At this time, you can view only your VA chemistry/hematology
+                results. These include tests for blood sugar, liver function, or
+                blood cell counts.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div itemScope itemType="http://schema.org/Question">
+        <h2 itemProp="name" id="can-i-view-results-from-non-va">
+          Can I view results from non-VA providers or labs?
+        </h2>
+        <div
+          itemProp="acceptedAnswer"
+          itemScope
+          itemType="http://schema.org/Answer"
+        >
+          <div itemProp="text">
+            <div className="processed-content">
+              <p>
+                No. But you can enter this information yourself to keep all your
+                results in one place.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div itemScope itemType="http://schema.org/Question">
+        <h2 itemProp="name" id="once-im-signed-in-within-my-he">
+          Once I’m signed in within My HealtheVet, how do I view my results?
+        </h2>
+        <div
+          itemProp="acceptedAnswer"
+          itemScope
+          itemType="http://schema.org/Answer"
+        >
+          <div itemProp="text">
+            <div className="processed-content">
+              <p>
+                On your Welcome page dashboard, you’ll see a module for “Health
+                Records.” Within that module, click on “Labs and Tests.”
+              </p>
+              <p>
+                This will take you to a new page with links to view test
+                results.
+              </p>
+              <p>If you’re signed in with a Premium account, you’ll see:</p>
+              <ul>
+                <li>
+                  <strong>VA chemistry/hematology results:</strong> Your tests
+                  will be listed by date and specimen. A specimen is the sample
+                  studied by the test (like blood, urine, a tissue biopsy, or a
+                  throat swab). You can click on each to view details from your
+                  VA medical record.
+                </li>
+                <li>
+                  <strong>Test results you’ve entered yourself:</strong> You can
+                  add and view results from non-VA providers and labs.
+                </li>
+              </ul>
+              <p>
+                <strong>Note:</strong> If you’re signed in with a Basic or
+                Advanced account, you’ll see only the test results you’ve
+                entered yourself.
+                <br />
+                <a
+                  href="https://www.myhealth.va.gov/mhv-portal-web/my-healthevet-offers-three-account-types"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Learn about the 3 different My HealtheVet account types
+                </a>
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div itemScope itemType="http://schema.org/Question">
+        <h2 itemProp="name" id="will-my-personal-health-inform">
+          Will my personal health information be protected?
+        </h2>
+        <div
+          itemProp="acceptedAnswer"
+          itemScope
+          itemType="http://schema.org/Answer"
+        >
+          <div itemProp="text">
+            <div className="processed-content">
+              <p>
+                Yes. This is a secure website. We follow strict security
+                policies and practices to protect your personal health
+                information.
+              </p>
+              <p>
+                If you print or download anything from the website (like lab
+                results), you’ll need to take responsibility for protecting that
+                information.
+                <br />
+                <a
+                  href="https://www.myhealth.va.gov/mhv-portal-web/web/myhealthevet/protecting-your-personal-health-information"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Get tips for protecting your personal health information
+                </a>
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div itemScope itemType="http://schema.org/Question">
+        <h2 itemProp="name" id="what-if-i-have-more-questions">
+          What if I have more questions?
+        </h2>
+        <div
+          itemProp="acceptedAnswer"
+          itemScope
+          itemType="http://schema.org/Answer"
+        >
+          <div itemProp="text">
+            <div className="processed-content">
+              <p>
+                If you have questions about lab and test results on
+                MyHealtheVet, please got to the{' '}
+                <a
+                  href="https://www.myhealth.va.gov/mhv-portal-web/web/myhealthevet/faqs#smGeneralFAQ"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Lab + Tests Results FAQs
+                </a>{' '}
+                on the My HealtheVet web portal.
+              </p>
+              <p>
+                Or contact the My HealtheVet help desk at{' '}
+                <a href="tel:+18773270022">877-327-0022</a> (TTY:{' '}
+                <a href="tel:+18008778339">800-877-8339</a>. We&apos;re here
+                Monday through Friday, 7:00 a.m. to 7:00 p.m. CT.
+              </p>
+              <p>
+                You can also{' '}
+                <a
+                  href="https://www.myhealth.va.gov/mhv-portal-web/web/myhealthevet/contact-mhv"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  contact us online
+                </a>
+                .
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </>
+);
+
+export default LegacyContent;

--- a/src/applications/static-pages/health-care-manage-benefits/view-test-and-lab-results-page/components/LegacyContent/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/view-test-and-lab-results-page/components/LegacyContent/index.js
@@ -7,24 +7,37 @@ import MoreInfoAboutBenefits from '../../../components/MoreInfoAboutBenefits';
 export const LegacyContent = () => (
   <>
     <CallToActionWidget appId="lab-and-test-results" setFocus={false} />
-    <div>
-      <div itemScope itemType="http://schema.org/Question">
+    <div data-template="paragraphs/q_a_section" data-entity-id={3507}>
+      <div
+        itemScope
+        itemType="http://schema.org/Question"
+        data-template="paragraphs/q_a"
+        data-entity-id={3506}
+        data-analytics-faq-section
+        data-analytics-faq-text="How can this tool help me manage my health care?"
+      >
         <h2 itemProp="name" id="how-can-this-tool-help-me-mana">
           How can this tool help me manage my health care?
         </h2>
         <div
+          data-entity-id={3506}
           itemProp="acceptedAnswer"
           itemScope
           itemType="http://schema.org/Answer"
         >
           <div itemProp="text">
-            <div className="processed-content">
+            <div
+              data-template="paragraphs/wysiwyg"
+              data-entity-id={3508}
+              className="processed-content"
+            >
               <p>
-                With this tool, you&apos;ll be able to view and keep a record of
-                your VA lab and test results.
+                The Labs + Tests tool is part of the My HealtheVet personal
+                health record. It can help you view and keep a record of your
+                lab and test results.
               </p>
               <p>
-                <strong>You can use the tool to:</strong>
+                <strong>You can use the Labs + Tests tool to:</strong>
               </p>
               <ul>
                 <li>
@@ -36,20 +49,33 @@ export const LegacyContent = () => (
           </div>
         </div>
       </div>
-      <div itemScope itemType="http://schema.org/Question">
+      <div
+        itemScope
+        itemType="http://schema.org/Question"
+        data-template="paragraphs/q_a"
+        data-entity-id={3509}
+        data-analytics-faq-section
+        data-analytics-faq-text="Am I eligible to use this tool?"
+      >
         <h2 itemProp="name" id="am-i-eligible-to-use-this-tool">
           Am I eligible to use this tool?
         </h2>
         <div
+          data-entity-id={3509}
           itemProp="acceptedAnswer"
           itemScope
           itemType="http://schema.org/Answer"
         >
           <div itemProp="text">
-            <div className="processed-content">
+            <div
+              data-template="paragraphs/wysiwyg"
+              data-entity-id={3510}
+              className="processed-content"
+            >
               <p>
-                You can use this tool to view and track your VA lab and test
-                results if you meet all of the requirements listed below.
+                You can use this tool to view your VA lab and test results and
+                information you enter yourself if you meet all of the
+                requirements listed below.
               </p>
               <p>
                 <strong>Both of these must be true. You’re:</strong>
@@ -70,14 +96,8 @@ export const LegacyContent = () => (
               </p>
               <ul>
                 <li>
-                  A{' '}
-                  <a
-                    href="https://www.myhealth.va.gov/mhv-portal-web/upgrading-your-my-healthevet-account-through-in-person-or-online-authentication"
-                    rel="noreferrer noopener"
-                  >
-                    Premium <strong>My HealtheVet account</strong>
-                  </a>
-                  , <strong>or</strong>
+                  A Premium <strong>My HealtheVet</strong> account,{' '}
+                  <strong>or</strong>
                 </li>
                 <li>
                   A Premium <strong>DS Logon</strong> account (used for
@@ -104,17 +124,29 @@ export const LegacyContent = () => (
           </div>
         </div>
       </div>
-      <div itemScope itemType="http://schema.org/Question">
+      <div
+        itemScope
+        itemType="http://schema.org/Question"
+        data-template="paragraphs/q_a"
+        data-entity-id={3511}
+        data-analytics-faq-section
+        data-analytics-faq-text="Can I view all my VA lab and test information using this tool?"
+      >
         <h2 itemProp="name" id="can-i-view-all-my-va-lab-and-t">
           Can I view all my VA lab and test information using this tool?
         </h2>
         <div
+          data-entity-id={3511}
           itemProp="acceptedAnswer"
           itemScope
           itemType="http://schema.org/Answer"
         >
           <div itemProp="text">
-            <div className="processed-content">
+            <div
+              data-template="paragraphs/wysiwyg"
+              data-entity-id={3512}
+              className="processed-content"
+            >
               <p>
                 At this time, you can view only your VA chemistry/hematology
                 results. These include tests for blood sugar, liver function, or
@@ -124,17 +156,29 @@ export const LegacyContent = () => (
           </div>
         </div>
       </div>
-      <div itemScope itemType="http://schema.org/Question">
+      <div
+        itemScope
+        itemType="http://schema.org/Question"
+        data-template="paragraphs/q_a"
+        data-entity-id={3513}
+        data-analytics-faq-section
+        data-analytics-faq-text="Can I view results from non-VA providers or labs?"
+      >
         <h2 itemProp="name" id="can-i-view-results-from-non-va">
           Can I view results from non-VA providers or labs?
         </h2>
         <div
+          data-entity-id={3513}
           itemProp="acceptedAnswer"
           itemScope
           itemType="http://schema.org/Answer"
         >
           <div itemProp="text">
-            <div className="processed-content">
+            <div
+              data-template="paragraphs/wysiwyg"
+              data-entity-id={3514}
+              className="processed-content"
+            >
               <p>
                 No. But you can enter this information yourself to keep all your
                 results in one place.
@@ -143,17 +187,29 @@ export const LegacyContent = () => (
           </div>
         </div>
       </div>
-      <div itemScope itemType="http://schema.org/Question">
+      <div
+        itemScope
+        itemType="http://schema.org/Question"
+        data-template="paragraphs/q_a"
+        data-entity-id={3515}
+        data-analytics-faq-section
+        data-analytics-faq-text="Once I’m signed in within My HealtheVet, how do I view my results?"
+      >
         <h2 itemProp="name" id="once-im-signed-in-within-my-he">
           Once I’m signed in within My HealtheVet, how do I view my results?
         </h2>
         <div
+          data-entity-id={3515}
           itemProp="acceptedAnswer"
           itemScope
           itemType="http://schema.org/Answer"
         >
           <div itemProp="text">
-            <div className="processed-content">
+            <div
+              data-template="paragraphs/wysiwyg"
+              data-entity-id={3516}
+              className="processed-content"
+            >
               <p>
                 On your Welcome page dashboard, you’ll see a module for “Health
                 Records.” Within that module, click on “Labs and Tests.”
@@ -162,7 +218,11 @@ export const LegacyContent = () => (
                 This will take you to a new page with links to view test
                 results.
               </p>
-              <p>If you’re signed in with a Premium account, you’ll see:</p>
+              <p>
+                <strong>
+                  If you’re signed in with a Premium account, you’ll see:
+                </strong>
+              </p>
               <ul>
                 <li>
                   <strong>VA chemistry/hematology results:</strong> Your tests
@@ -193,17 +253,29 @@ export const LegacyContent = () => (
           </div>
         </div>
       </div>
-      <div itemScope itemType="http://schema.org/Question">
+      <div
+        itemScope
+        itemType="http://schema.org/Question"
+        data-template="paragraphs/q_a"
+        data-entity-id={3517}
+        data-analytics-faq-section
+        data-analytics-faq-text="Will my personal health information be protected?"
+      >
         <h2 itemProp="name" id="will-my-personal-health-inform">
           Will my personal health information be protected?
         </h2>
         <div
+          data-entity-id={3517}
           itemProp="acceptedAnswer"
           itemScope
           itemType="http://schema.org/Answer"
         >
           <div itemProp="text">
-            <div className="processed-content">
+            <div
+              data-template="paragraphs/wysiwyg"
+              data-entity-id={3518}
+              className="processed-content"
+            >
               <p>
                 Yes. This is a secure website. We follow strict security
                 policies and practices to protect your personal health
@@ -226,45 +298,61 @@ export const LegacyContent = () => (
           </div>
         </div>
       </div>
-      <div itemScope itemType="http://schema.org/Question">
+      <div
+        itemScope
+        itemType="http://schema.org/Question"
+        data-template="paragraphs/q_a"
+        data-entity-id={3519}
+        data-analytics-faq-section
+        data-analytics-faq-text="What if I have more questions?"
+      >
         <h2 itemProp="name" id="what-if-i-have-more-questions">
           What if I have more questions?
         </h2>
         <div
+          data-entity-id={3519}
           itemProp="acceptedAnswer"
           itemScope
           itemType="http://schema.org/Answer"
         >
           <div itemProp="text">
-            <div className="processed-content">
+            <div
+              data-template="paragraphs/wysiwyg"
+              data-entity-id={3520}
+              className="processed-content"
+            >
               <p>
-                If you have questions about lab and test results on
-                MyHealtheVet, please got to the{' '}
+                You can get answers to your questions about this tool within our
+                My HealtheVet web portal.
+                <br />
                 <a
-                  href="https://www.myhealth.va.gov/mhv-portal-web/web/myhealthevet/faqs#smGeneralFAQ"
+                  href="https://www.myhealth.va.gov/mhv-portal-web/web/myhealthevet/faqs#LabsandTests"
                   target="_blank"
                   rel="noopener noreferrer"
                 >
-                  Lab + Tests Results FAQs
-                </a>{' '}
-                on the My HealtheVet web portal.
+                  Read the Labs + Tests FAQs
+                </a>
               </p>
               <p>
-                Or contact the My HealtheVet help desk at{' '}
-                <a href="tel:+18773270022">877-327-0022</a> (TTY:{' '}
-                <a href="tel:+18008778339">800-877-8339</a>. We&apos;re here
-                Monday through Friday, 7:00 a.m. to 7:00 p.m. CT.
-              </p>
-              <p>
-                You can also{' '}
+                You can also contact the My HealtheVet help desk.
+                <br />
                 <a
                   href="https://www.myhealth.va.gov/mhv-portal-web/web/myhealthevet/contact-mhv"
                   target="_blank"
                   rel="noopener noreferrer"
                 >
-                  contact us online
+                  Find out how to contact us online
                 </a>
-                .
+                <br />
+                Or call us at{' '}
+                <a aria-label="8 7 7. 3 2 7. 0 0 2 2." href="tel:18773270022">
+                  877-327-0022
+                </a>{' '}
+                (TTY:{' '}
+                <a aria-label="8 0 0. 8 7 7. 8 3 3 9." href="tel:18008778339">
+                  800-877-8339
+                </a>
+                ). We’re here Monday through Friday, 7:00 a.m. to 7:00 p.m. CT.
               </p>
             </div>
           </div>

--- a/src/applications/static-pages/health-care-manage-benefits/view-test-and-lab-results-page/components/LegacyContent/index.unit.spec.js
+++ b/src/applications/static-pages/health-care-manage-benefits/view-test-and-lab-results-page/components/LegacyContent/index.unit.spec.js
@@ -1,0 +1,31 @@
+// Dependencies.
+import React from 'react';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+// Relative imports.
+import LegacyContent from '.';
+
+describe('View Test + Lab Results Page <LegacyContent>', () => {
+  it('renders what we expect', () => {
+    const wrapper = shallow(<LegacyContent />);
+
+    const text = wrapper.text();
+    expect(text).to.include('How can this tool help me manage my health care?');
+    expect(text).to.include('Am I eligible to use this tool?');
+    expect(text).to.include(
+      'Can I view all my VA lab and test information using this tool?',
+    );
+    expect(text).to.include(
+      'Can I view results from non-VA providers or labs?',
+    );
+    expect(text).to.include(
+      'Once I’m signed in within My HealtheVet, how do I view my results?',
+    );
+    expect(text).to.include(
+      'Will my personal health information be protected?',
+    );
+    expect(text).to.include('What if I have more questions?');
+
+    wrapper.unmount();
+  });
+});


### PR DESCRIPTION
## Description
**Issue:** 
https://github.com/department-of-veterans-affairs/va.gov-team/issues/10859
https://github.com/department-of-veterans-affairs/va.gov-team/issues/10869

This PR adds `LegacyContent` components to all Cerner page React widgets.

## Testing done
Adds unit tests for each.

## Screenshots

Screenshots are of the new `LegacyContent` components that will display in production. It should be analogous to the content you see on va.gov production.

### get-medical-records-page

![localhost_3001_dummy-page_](https://user-images.githubusercontent.com/12773166/86317350-72262580-bbec-11ea-877d-fd6d3bd3a56c.png)

### refill-track-prescriptions-page

![localhost_3001_dummy-page_ (1)](https://user-images.githubusercontent.com/12773166/86317827-a817d980-bbed-11ea-8cca-bc58c161821a.png)

### schedule-view-va-appointments-page

![localhost_3001_dummy-page_ (2)](https://user-images.githubusercontent.com/12773166/86318022-1e1c4080-bbee-11ea-9679-28c309759f18.png)

### secure-messaging-page

![localhost_3001_dummy-page_ (3)](https://user-images.githubusercontent.com/12773166/86318105-502da280-bbee-11ea-8cdb-04502dfda8e1.png)

### view-test-and-lab-results-page

![localhost_3001_dummy-page_ (4)](https://user-images.githubusercontent.com/12773166/86318210-8ec35d00-bbee-11ea-88e2-e2e784f4e8aa.png)

## Acceptance criteria
- [x] Create `LegacyContent` components for each Cerner page used on production only.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
