### PR TITLE
Comparison Tool - Fuzzy Search feature flag fix

### DIFF
--- a/src/applications/gi/actions/index.js
+++ b/src/applications/gi/actions/index.js
@@ -205,7 +205,7 @@ export function institutionFilterChange(filter) {
 export function fetchInstitutionSearchResults(query = {}, fuzzySearch) {
   const url = appendQuery(
     `${api.url}/institutions/search`,
-    rubyifyKeys({ ...query, fuzzySearch }),
+    fuzzySearch ? rubyifyKeys({ ...query, fuzzySearch }) : rubyifyKeys(query),
   );
 
   return dispatch => {

--- a/src/applications/gi/tests/actions/index.unit.spec.js
+++ b/src/applications/gi/tests/actions/index.unit.spec.js
@@ -367,6 +367,20 @@ describe('institution search', () => {
       done();
     }, 0);
   });
+
+  it('should pass fuzzy_search flag', done => {
+    const dispatch = sinon.spy();
+    fetchInstitutionSearchResults({}, true)(dispatch);
+    expect(global.fetch.firstCall.args[0]).to.contain('fuzzy_search=true');
+    done();
+  });
+
+  it('should not pass fuzzy_search flag when fuzzySearch is false', done => {
+    const dispatch = sinon.spy();
+    fetchInstitutionSearchResults({}, false)(dispatch);
+    expect(global.fetch.firstCall.args[0]).to.not.contain('fuzzy_search');
+    done();
+  });
 });
 
 describe('constants', () => {


### PR DESCRIPTION
## Description
Update to the comparison tool institution search to make the `fuzzy_search` param only sent when feature flag is on. This will be removed when the "fuzzy search" is no longer behind a feature flag, but we don't want the param sent at all if the feature flag is turned off.

[Zenhub Issue](https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/10613)

## Testing done
Tested locally

## Screenshots
N/A

## Acceptance criteria
- [x] `fuzzy_search` param sent when feature flag is on
- [x] `fuzzy_search` param not sent when feature flag is off

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
