### PR TITLE
Fix Service-type dropdown is disabled for Vet Centers facility-type.

### DIFF
--- a/src/applications/facility-locator/components/SearchControls.jsx
+++ b/src/applications/facility-locator/components/SearchControls.jsx
@@ -89,7 +89,6 @@ class SearchControls extends Component {
       LocationType.HEALTH,
       LocationType.URGENT_CARE,
       LocationType.BENEFITS,
-      LocationType.VET_CENTER,
       LocationType.CC_PROVIDER,
     ].includes(facilityType);
 
@@ -104,11 +103,6 @@ class SearchControls extends Component {
         break;
       case LocationType.BENEFITS:
         services = benefitsServices;
-        break;
-      case LocationType.VET_CENTER:
-        services = vetCenterServices.reduce(result => result, {
-          All: 'Show all facilities',
-        });
         break;
       case LocationType.CC_PROVIDER:
         return (


### PR DESCRIPTION
## Description
Issue: https://github.com/department-of-veterans-affairs/va.gov-team/issues/5967

## Testing done
Locally

## Screenshots
<img width="1291" alt="Screen Shot 2020-07-02 at 4 35 02 PM" src="https://user-images.githubusercontent.com/100468/86411300-2cb43780-bc82-11ea-86c6-1bc380a81580.png">
<img width="655" alt="Screen Shot 2020-07-02 at 4 35 28 PM" src="https://user-images.githubusercontent.com/100468/86411304-2de56480-bc82-11ea-9961-f221a89949db.png">


## Acceptance criteria
- [x] Service-type dropdown is disabled for Vet Centers facility-type.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
