### PR TITLE
Set autocomplete to false in Mapbox API Geocode query

### DIFF
--- a/src/applications/facility-locator/actions/index.js
+++ b/src/applications/facility-locator/actions/index.js
@@ -231,6 +231,7 @@ export const genBBoxFromAddress = query => {
       .forwardGeocode({
         countries: ['us', 'pr', 'ph', 'gu', 'as', 'mp'],
         types,
+        autocomplete: false,
         query: query.searchString,
       })
       .send()

--- a/src/applications/facility-locator/api/index.js
+++ b/src/applications/facility-locator/api/index.js
@@ -2,6 +2,8 @@ import MockApi from './MockLocatorApi';
 import LiveApi from './LocatorApi';
 import environment from 'platform/utilities/environment';
 
+// To use vets-api data locally, replace the following with this:
+// export default LiveApi;
 export default (environment.isLocalhost() &&
 !environment.API_URL.includes('review.vetsgov')
   ? MockApi


### PR DESCRIPTION
This results in greatly improved searches. For example,
"Glendale, CO" now finds facilities in Colorado, not Connecticut.

## Description


## Testing done


## Screenshots
![Find_VA_Locations___Veterans_Affairs](https://user-images.githubusercontent.com/80267/86490946-2cc23f00-bd37-11ea-8cce-d409949e1451.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
