### PR TITLE
[Development] Show back pay details in CST complete step

### DIFF
--- a/src/applications/claims-status/components/ClaimComplete.jsx
+++ b/src/applications/claims-status/components/ClaimComplete.jsx
@@ -2,6 +2,8 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import moment from 'moment';
 
+import CompleteDetails from './CompleteDetails';
+
 function ClaimComplete({ completedDate }) {
   return (
     <>
@@ -13,19 +15,7 @@ function ClaimComplete({ completedDate }) {
             : null}
         </h3>
       </div>
-      <div className="vads-u-margin--2">
-        <p>
-          A decision packet has been mailed to you. Typically, decision notices
-          are received within 10 days, but this is dependent upon U.S. Postal
-          Service timeframes.
-        </p>
-        <h4>Payments</h4>
-        <p>
-          If you are entitled to back payment (based on an effective date), you
-          can expect to receive payment within 1 month of your claim’s decision
-          date.
-        </p>
-      </div>
+      <CompleteDetails className="vads-u-margin--2" />
     </>
   );
 }

--- a/src/applications/claims-status/components/ClaimComplete.jsx
+++ b/src/applications/claims-status/components/ClaimComplete.jsx
@@ -4,14 +4,29 @@ import moment from 'moment';
 
 function ClaimComplete({ completedDate }) {
   return (
-    <div className="usa-alert usa-alert-info background-color-only claims-alert-status">
-      <h4 className="claims-alert-header">
-        Your claim was closed{' '}
-        {completedDate
-          ? `on ${moment(completedDate).format('MMM D, YYYY')}`
-          : null}
-      </h4>
-    </div>
+    <>
+      <div className="usa-alert usa-alert-info background-color-only claims-alert-status">
+        <h3 className="claims-alert-header vads-u-font-size--h4">
+          Your claim was closed{' '}
+          {completedDate
+            ? `on ${moment(completedDate).format('MMM D, YYYY')}`
+            : null}
+        </h3>
+      </div>
+      <div className="vads-u-margin--2">
+        <p>
+          A decision packet has been mailed to you. Typically, decision notices
+          are received within 10 days, but this is dependent upon U.S. Postal
+          Service timeframes.
+        </p>
+        <h4>Payments</h4>
+        <p>
+          If you are entitled to back payment (based on an effective date), you
+          can expect to receive payment within 1 month of your claim’s decision
+          date.
+        </p>
+      </div>
+    </>
   );
 }
 

--- a/src/applications/claims-status/components/ClaimDetailLayout.jsx
+++ b/src/applications/claims-status/components/ClaimDetailLayout.jsx
@@ -41,7 +41,9 @@ export default function ClaimDetailLayout(props) {
         <h1 className="claim-title">Your {getClaimType(claim)} claim</h1>
         {!synced && <ClaimSyncWarning olderVersion={!synced} />}
         <div className="claim-contentions">
-          <h6 className="claim-contentions-header">What you’ve claimed:</h6>
+          <h2 className="claim-contentions-header vads-u-font-size--h6">
+            What you’ve claimed:
+          </h2>
           <span>
             {claim.attributes.contentionList &&
             claim.attributes.contentionList.length

--- a/src/applications/claims-status/components/ClaimDetailLayout.jsx
+++ b/src/applications/claims-status/components/ClaimDetailLayout.jsx
@@ -1,13 +1,15 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { Link } from 'react-router';
+import LoadingIndicator from '@department-of-veterans-affairs/formation-react/LoadingIndicator';
+
 import TabNav from '../components/TabNav';
 import ClaimSyncWarning from '../components/ClaimSyncWarning';
 import AskVAQuestions from '../components/AskVAQuestions';
-import LoadingIndicator from '@department-of-veterans-affairs/formation-react/LoadingIndicator';
 import AddingDetails from '../components/AddingDetails';
 import Notification from '../components/Notification';
 import ClaimsBreadcrumbs from './ClaimsBreadcrumbs';
+import ClaimsUnavailable from '../components/ClaimsUnavailable';
 import { isPopulatedClaim, getClaimType } from '../utils/helpers';
 
 const MAX_CONTENTIONS = 3;
@@ -27,7 +29,11 @@ export default function ClaimDetailLayout(props) {
 
   let bodyContent;
   let headingContent;
-  if (!loading) {
+  if (loading) {
+    bodyContent = (
+      <LoadingIndicator setFocus message="Loading your claim information..." />
+    );
+  } else if (claim !== null) {
     headingContent = (
       <>
         {message && (
@@ -45,7 +51,7 @@ export default function ClaimDetailLayout(props) {
             What you’ve claimed:
           </h2>
           <span>
-            {claim.attributes.contentionList &&
+            {claim?.attributes?.contentionList &&
             claim.attributes.contentionList.length
               ? claim.attributes.contentionList
                   .slice(0, MAX_CONTENTIONS)
@@ -53,7 +59,7 @@ export default function ClaimDetailLayout(props) {
                   .join(', ')
               : 'Not available'}
           </span>
-          {claim.attributes.contentionList &&
+          {claim?.attributes?.contentionList &&
           claim.attributes.contentionList.length > MAX_CONTENTIONS ? (
             <span>
               <br />
@@ -79,7 +85,8 @@ export default function ClaimDetailLayout(props) {
           >
             {currentTab === tab && (
               <div className="va-tab-content claim-tab-content">
-                {isPopulatedClaim(claim) || !claim.attributes.open ? null : (
+                {isPopulatedClaim(claim || {}) ||
+                !claim?.attributes.open ? null : (
                   <AddingDetails />
                 )}
                 {props.children}
@@ -91,7 +98,10 @@ export default function ClaimDetailLayout(props) {
     );
   } else {
     bodyContent = (
-      <LoadingIndicator setFocus message="Loading your claim information..." />
+      <>
+        <h1>We encountered a problem</h1>
+        <ClaimsUnavailable headerLevel={2} />
+      </>
     );
   }
 

--- a/src/applications/claims-status/components/ClaimPhase.jsx
+++ b/src/applications/claims-status/components/ClaimPhase.jsx
@@ -167,7 +167,7 @@ export default class ClaimPhase extends React.Component {
   render() {
     const { phase, current, children } = this.props;
     const expandCollapseIcon =
-      phase <= current && phase !== COMPLETE_PHASE ? (
+      phase <= current ? (
         <i
           aria-hidden="true"
           className={
@@ -188,15 +188,16 @@ export default class ClaimPhase extends React.Component {
         className={`${getClasses(phase, current)}`}
       >
         {expandCollapseIcon}
-        <h5 className="section-header">
+        <h3 className="section-header vads-u-font-size--h4">
           <button
             className="section-header-button"
             aria-expanded={this.state.open}
           >
             {getUserPhaseDescription(phase)}
           </button>
-        </h5>
-        {this.state.open || phase === COMPLETE_PHASE ? (
+        </h3>
+        {this.state.open ||
+        (current !== COMPLETE_PHASE && phase === COMPLETE_PHASE) ? (
           <div>
             {children}
             {this.displayActivity()}

--- a/src/applications/claims-status/components/ClaimsTimeline.jsx
+++ b/src/applications/claims-status/components/ClaimsTimeline.jsx
@@ -1,9 +1,11 @@
-import PropTypes from 'prop-types';
 import React from 'react';
+import PropTypes from 'prop-types';
+
 import ClaimPhase from './ClaimPhase';
-import { getUserPhase, groupTimelineActivity } from '../utils/helpers';
-import ClaimEstimate from '../components/ClaimEstimate';
+import ClaimEstimate from './ClaimEstimate';
 import PhaseBackWarning from './PhaseBackWarning';
+import CompleteDetails from './CompleteDetails';
+import { getUserPhase, groupTimelineActivity } from '../utils/helpers';
 
 const LAST_EVIDENCE_GATHERING_PHASE = 6;
 
@@ -71,7 +73,9 @@ export default function ClaimsTimeline(props) {
       >
         {userPhase !== 5 ? (
           <ClaimEstimate maxDate={estimatedDate} id={id} />
-        ) : null}
+        ) : (
+          <CompleteDetails />
+        )}
       </ClaimPhase>
     </ol>
   );

--- a/src/applications/claims-status/components/ClaimsUnavailable.jsx
+++ b/src/applications/claims-status/components/ClaimsUnavailable.jsx
@@ -1,10 +1,13 @@
 import React from 'react';
 
-function ClaimsUnavailable() {
+function ClaimsUnavailable({ headerLevel = '4' }) {
+  const Tag = `h${headerLevel}`;
   return (
     <div className="usa-alert usa-alert-warning claims-unavailable">
       <div className="usa-alert-body">
-        <h4 className="claims-alert-header">Claim status is unavailable</h4>
+        <Tag className="claims-alert-header vads-u-font-size--h4">
+          Claim status is unavailable
+        </Tag>
         <p className="usa-alert-text">
           VA.gov is having trouble loading claims information at this time.
           Please check back again in a hour. Please note: You are still able to

--- a/src/applications/claims-status/components/CompleteDetails.jsx
+++ b/src/applications/claims-status/components/CompleteDetails.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+export default function CompleteDetails({ className }) {
+  return (
+    <div className={className}>
+      <p>
+        A decision packet has been mailed to you. Typically, decision notices
+        are received within 10 days, but this is dependent upon U.S. Postal
+        Service timeframes.
+      </p>
+      <h4>Payments</h4>
+      <p>
+        If you are entitled to back payment (based on an effective date), you
+        can expect to receive payment within 1 month of your claim’s decision
+        date.
+      </p>
+    </div>
+  );
+}

--- a/src/applications/claims-status/components/NeedFilesFromYou.jsx
+++ b/src/applications/claims-status/components/NeedFilesFromYou.jsx
@@ -7,9 +7,9 @@ function NeedFilesFromYou({ files, claimId }) {
     <div className="usa-alert usa-alert-warning claims-alert claims-alert-status need-files-alert">
       <div className="usa-alert-body alert-with-details">
         <div className="item-container">
-          <h4 className="usa-alert-heading">
+          <h2 className="usa-alert-heading">
             {files} {files === 1 ? 'item needs' : 'items need'} your attention
-          </h4>
+          </h2>
         </div>
         <div className="button-container">
           <Link

--- a/src/applications/claims-status/components/appeals-v2/AppealListItemV2.jsx
+++ b/src/applications/claims-status/components/appeals-v2/AppealListItemV2.jsx
@@ -92,7 +92,9 @@ export default function AppealListItem({ appeal, name, external = false }) {
 
   return (
     <div className="claim-list-item-container">
-      <h3 className="claim-list-item-header-v2">{appealTitle}</h3>
+      <h2 className="claim-list-item-header-v2 vads-u-font-size--h3">
+        {appealTitle}
+      </h2>
       <div className="card-status">
         {!external && (
           <div

--- a/src/applications/claims-status/components/appeals-v2/ClaimsListItemV2.jsx
+++ b/src/applications/claims-status/components/appeals-v2/ClaimsListItemV2.jsx
@@ -20,12 +20,12 @@ export default function ClaimsListItem({ claim }) {
   );
   return (
     <div className="claim-list-item-container">
-      <h3 className="claim-list-item-header-v2">
+      <h2 className="claim-list-item-header-v2 vads-u-font-size--h3">
         Claim for {getClaimType(claim)}
         <br />
         updated on{' '}
         {moment(claim.attributes.phaseChangeDate).format('MMMM D, YYYY')}
-      </h3>
+      </h2>
       <div className="card-status">
         <div
           className={`status-circle ${

--- a/src/applications/claims-status/containers/ClaimStatusPage.jsx
+++ b/src/applications/claims-status/containers/ClaimStatusPage.jsx
@@ -52,15 +52,17 @@ class ClaimStatusPage extends React.Component {
     const { claim, loading, message, synced } = this.props;
 
     let content = null;
+    // claim can be null
+    const attributes = (claim && claim.attributes) || {};
     if (!loading) {
-      const phase = claim.attributes.phase;
+      const phase = attributes.phase;
       const filesNeeded = itemsNeedingAttentionFromVet(
-        claim.attributes.eventsTimeline,
+        attributes.eventsTimeline,
       );
       const showDocsNeeded =
-        !claim.attributes.decisionLetterSent &&
-        claim.attributes.open &&
-        claim.attributes.documentsNeeded &&
+        !attributes.decisionLetterSent &&
+        attributes.open &&
+        attributes.documentsNeeded &&
         filesNeeded > 0;
 
       content = (
@@ -68,20 +70,20 @@ class ClaimStatusPage extends React.Component {
           {showDocsNeeded ? (
             <NeedFilesFromYou claimId={claim.id} files={filesNeeded} />
           ) : null}
-          {claim.attributes.decisionLetterSent && !claim.attributes.open ? (
+          {attributes.decisionLetterSent && !attributes.open ? (
             <ClaimsDecision completedDate={getCompletedDate(claim)} />
           ) : null}
-          {!claim.attributes.decisionLetterSent && !claim.attributes.open ? (
+          {!attributes.decisionLetterSent && !attributes.open ? (
             <ClaimComplete completedDate={getCompletedDate(claim)} />
           ) : null}
-          {phase !== null && claim.attributes.open ? (
+          {phase !== null && attributes.open ? (
             <ClaimsTimeline
               id={claim.id}
-              estimatedDate={claim.attributes.maxEstDate}
+              estimatedDate={attributes.maxEstDate}
               phase={phase}
-              currentPhaseBack={claim.attributes.currentPhaseBack}
-              everPhaseBack={claim.attributes.everPhaseBack}
-              events={claim.attributes.eventsTimeline}
+              currentPhaseBack={attributes.currentPhaseBack}
+              everPhaseBack={attributes.everPhaseBack}
+              events={attributes.eventsTimeline}
             />
           ) : null}
         </div>

--- a/src/applications/claims-status/reducers/claim-detail.js
+++ b/src/applications/claims-status/reducers/claim-detail.js
@@ -1,6 +1,10 @@
 import _ from 'lodash/fp';
 
-import { GET_CLAIM_DETAIL, SET_CLAIM_DETAIL } from '../actions/index.jsx';
+import {
+  GET_CLAIM_DETAIL,
+  SET_CLAIM_DETAIL,
+  SET_CLAIMS_UNAVAILABLE,
+} from '../actions/index.jsx';
 
 const initialState = {
   detail: null,
@@ -17,6 +21,12 @@ export default function claimDetailReducer(state = initialState, action) {
     }
     case GET_CLAIM_DETAIL: {
       return _.set('loading', true, state);
+    }
+    case SET_CLAIMS_UNAVAILABLE: {
+      return _.assign(state, {
+        detail: null,
+        loading: false,
+      });
     }
     default:
       return state;

--- a/src/applications/claims-status/sass/claims-status.scss
+++ b/src/applications/claims-status/sass/claims-status.scss
@@ -594,8 +594,8 @@ h1:focus {
     }
   }
 
-  > .section-current:not(.last),
-  > .section-complete:not(.last) {
+  > .section-current,
+  > .section-complete {
     cursor: pointer;
   }
 }

--- a/src/applications/claims-status/tests/components/ClaimComplete.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/ClaimComplete.unit.spec.jsx
@@ -9,6 +9,8 @@ describe('<ClaimComplete>', () => {
     const date = '2010-03-01';
     const tree = SkinDeep.shallowRender(<ClaimComplete completedDate={date} />);
 
-    expect(tree.text()).to.contain('Your claim was closed on March 1, 2010');
+    const text = tree.text();
+    expect(text).to.contain('Your claim was closed on March 1, 2010');
+    expect(text).to.contain('expect to receive payment');
   });
 });

--- a/src/applications/claims-status/tests/components/ClaimComplete.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/ClaimComplete.unit.spec.jsx
@@ -9,8 +9,7 @@ describe('<ClaimComplete>', () => {
     const date = '2010-03-01';
     const tree = SkinDeep.shallowRender(<ClaimComplete completedDate={date} />);
 
-    const text = tree.text();
-    expect(text).to.contain('Your claim was closed on March 1, 2010');
-    expect(text).to.contain('expect to receive payment');
+    expect(tree.text()).to.contain('Your claim was closed on March 1, 2010');
+    expect(tree.everySubTree('CompleteDetails')).to.not.be.false;
   });
 });

--- a/src/applications/claims-status/tests/components/ClaimsTimeline.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/ClaimsTimeline.unit.spec.jsx
@@ -53,4 +53,10 @@ describe('<ClaimsTimeline>', () => {
 
     expect(tree.subTree('PhaseBackWarning')).to.be.false;
   });
+  it('should render CompleteDetails for phase 5', () => {
+    const tree = SkinDeep.shallowRender(
+      <ClaimsTimeline events={[]} phase={5} />,
+    );
+    expect(tree.everySubTree('CompleteDetails')).not.to.be.false;
+  });
 });

--- a/src/applications/claims-status/tests/components/appeals-v2/AppealListItemV2.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/appeals-v2/AppealListItemV2.unit.spec.jsx
@@ -79,7 +79,7 @@ describe('<AppealListItemV2/>', () => {
     const wrapper = shallow(<AppealListItemV2 {...defaultProps} />);
     expect(
       wrapper
-        .find('h3.claim-list-item-header-v2')
+        .find('.claim-list-item-header-v2')
         .render()
         .text(),
     ).to.contain('May 1, 2016');
@@ -101,7 +101,7 @@ describe('<AppealListItemV2/>', () => {
     const wrapper = shallow(<AppealListItemV2 {...vhaScProps} />);
     expect(
       wrapper
-        .find('h3.claim-list-item-header-v2')
+        .find('.claim-list-item-header-v2')
         .render()
         .text(),
     ).to.equal('Supplemental claim for health care updated on May 1, 2016');

--- a/src/applications/claims-status/tests/components/appeals-v2/ClaimListItemV2.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/appeals-v2/ClaimListItemV2.unit.spec.jsx
@@ -179,7 +179,7 @@ describe('<ClaimsListItemV2>', () => {
       },
     };
     const tree = shallow(<ClaimsListItemV2 claim={claim} />);
-    expect(tree.find('h3').text()).to.contain('updated on August 20, 2019');
+    expect(tree.find('h2').text()).to.contain('updated on August 20, 2019');
     expect(
       tree
         .find('p')

--- a/src/applications/claims-status/tests/e2e/01.claim-status.e2e.spec.js
+++ b/src/applications/claims-status/tests/e2e/01.claim-status.e2e.spec.js
@@ -59,7 +59,7 @@ module.exports = E2eHelpers.createE2eTest(client => {
     .axeCheck('.main');
 
   // files needed
-  client.expect.element('.usa-alert-body h4').text.to.contain('your attention');
+  client.expect.element('.usa-alert-body h2').text.to.contain('your attention');
 
   client.end();
 });

--- a/src/applications/claims-status/utils/helpers.js
+++ b/src/applications/claims-status/utils/helpers.js
@@ -241,7 +241,7 @@ export function isClaimComplete(claim) {
 }
 
 export function itemsNeedingAttentionFromVet(events) {
-  return events.filter(
+  return events?.filter(
     event =>
       event.status === 'NEEDED' && event.type === 'still_need_from_you_list',
   ).length;
@@ -302,7 +302,7 @@ export function makeAuthRequest(
 }
 
 export function getCompletedDate(claim) {
-  if (claim.attributes && claim.attributes.eventsTimeline) {
+  if (claim?.attributes && claim.attributes.eventsTimeline) {
     const completedEvents = claim.attributes.eventsTimeline.filter(
       event => event.type === 'completed',
     );
@@ -316,7 +316,7 @@ export function getCompletedDate(claim) {
 
 export function getClaimType(claim) {
   return (
-    claim.attributes.claimType || 'disability compensation'
+    claim?.attributes.claimType || 'disability compensation'
   ).toLowerCase();
 }
 

--- a/src/applications/claims-status/utils/helpers.js
+++ b/src/applications/claims-status/utils/helpers.js
@@ -302,7 +302,7 @@ export function makeAuthRequest(
 }
 
 export function getCompletedDate(claim) {
-  if (claim?.attributes && claim.attributes.eventsTimeline) {
+  if (claim?.attributes?.eventsTimeline) {
     const completedEvents = claim.attributes.eventsTimeline.filter(
       event => event.type === 'completed',
     );
@@ -316,7 +316,7 @@ export function getCompletedDate(claim) {
 
 export function getClaimType(claim) {
   return (
-    claim?.attributes.claimType || 'disability compensation'
+    claim?.attributes?.claimType || 'disability compensation'
   ).toLowerCase();
 }
 


### PR DESCRIPTION
## Description

Add further details to claim status tool complete step to better inform the user about how back (retroactive) pay is handled once the claim has completed.

This content was added in two views:

<details><summary>Timeline "Complete" step details (collapsible section)</summary>

<!-- leave a blank line above -->
![Screen Shot 2020-07-02 at 4 34 28 PM](https://user-images.githubusercontent.com/136959/86414490-a8fe4900-bc89-11ea-97d1-7711ce144b9d.png)</details>

<details><summary>Closed claim status tab</summary>

<!-- leave a blank line above -->
![Screen Shot 2020-07-01 at 5 13 01 PM](https://user-images.githubusercontent.com/136959/86414512-b9162880-bc89-11ea-95de-283d06474477.png)</details>

Additionally, this PR fixes a few accessibility issues found in the headers - _I'm not sure why the e2e axe checks didn't catch these issues!_

Lastly, failed sync evss calls continued to show the loading indicator. This PR also fixes that issue

<details><summary>Claim status error</summary>

<!-- leave a blank line above -->
![Screen Shot 2020-07-02 at 2 45 16 PM](https://user-images.githubusercontent.com/136959/86414805-abad6e00-bc8a-11ea-99b9-a1deb761f810.png)</details>

Related issues:
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/10292
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/8625 (maybe?)

## Testing done

Updated unit & e2e tests

## Screenshots

See descriptions section

## Acceptance criteria

- [x] Back payment details shown in both complete & closed claims
- [x] Fix header a11y issues

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
