### PR TITLE
Fix initial form fields bug in phone section

### DIFF
--- a/src/platform/user/profile/vet360/containers/VAPProfileField.jsx
+++ b/src/platform/user/profile/vet360/containers/VAPProfileField.jsx
@@ -438,7 +438,7 @@ Vet360ProfileFieldContainer.propTypes = {
   title: PropTypes.string.isRequired,
   apiRoute: PropTypes.oneOf(Object.values(VET360.API_ROUTES)).isRequired,
   convertCleanDataToPayload: PropTypes.func,
-  hasUnsavedEdits: PropTypes.bool.isRequired,
+  hasUnsavedEdits: PropTypes.bool,
 };
 
 export default Vet360ProfileFieldContainer;

--- a/src/platform/user/profile/vet360/reducers/index.js
+++ b/src/platform/user/profile/vet360/reducers/index.js
@@ -221,7 +221,6 @@ export default function vet360(state = initialState, action) {
         : state.initialFormFields;
 
       const modalName = state?.modal;
-      const initialFormFieldValues = state.initialFormFields[modalName]?.value;
       let formFieldValues = formFields[modalName]?.value;
 
       // Initial form fields does not have 'view' properties, those get added to formFields
@@ -229,6 +228,11 @@ export default function vet360(state = initialState, action) {
       formFieldValues = pickBy(formFieldValues, value => value !== undefined);
       formFieldValues = pickBy(
         formFieldValues,
+        (value, key) => !key.startsWith('view:'),
+      );
+
+      const initialFormFieldValues = pickBy(
+        state.initialFormFields[modalName]?.value,
         (value, key) => !key.startsWith('view:'),
       );
 


### PR DESCRIPTION
## Description
This PR fixes the issue that after saving a phone number successfully, users would still see the alert notifying them that they had unsaved changes.

The issue was that `hasUnsavedEdits` was set to true in `src/platform/user/profile/vet360/reducers/index.js` `UPDATE_PROFILE_FORM_FIELD` because `formFieldValues` and `initialFormFieldValues` were never equal do to the `view` property on `initualFormFields`.
![image](https://user-images.githubusercontent.com/14869324/86606033-b2770200-bf64-11ea-9a4d-135c6eeadcc0.png)

## Testing done
Works locally

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
