### PR TITLE
[Development] Add HLR analytics

### DIFF
--- a/src/applications/disability-benefits/996/components/IntroductionPage.jsx
+++ b/src/applications/disability-benefits/996/components/IntroductionPage.jsx
@@ -64,9 +64,8 @@ export class IntroductionPage extends React.Component {
         messages={formConfig.savedFormMessages}
         pageList={route.pageList}
         startText="Start the Request for a Higher-Level Review"
-      >
-        Please complete the 20-0996 form to request a Higher-Level Review.
-      </SaveInProgressIntro>
+        gaStartEventName="decision-reviews-va20-0996-start-form"
+      />
     ) : (
       noContestableIssuesFound
     );

--- a/src/applications/disability-benefits/996/config/form.js
+++ b/src/applications/disability-benefits/996/config/form.js
@@ -8,6 +8,7 @@ import FormFooter from 'platform/forms/components/FormFooter';
 import migrations from '../migrations';
 import prefillTransformer from './prefill-transformer';
 import { transform } from './submit-transformer';
+import submitForm from './submitForm';
 
 import IntroductionPage from '../components/IntroductionPage';
 import ConfirmationPage from '../containers/ConfirmationPage';
@@ -26,8 +27,8 @@ import { errorMessages } from '../constants';
 const formConfig = {
   urlPrefix: '/',
   submitUrl: `${environment.API_URL}/v0/appeals/higher_level_reviews`,
-  // submit: () => Promise.resolve({ attributes: { status: 'processed' } }),
-  trackingPrefix: 'hlr-0996-',
+  submit: submitForm,
+  trackingPrefix: 'decision-reviews-va20-0996',
   downtime: {
     requiredForPrefill: true,
     // double check these required services

--- a/src/applications/disability-benefits/996/config/form.js
+++ b/src/applications/disability-benefits/996/config/form.js
@@ -28,7 +28,7 @@ const formConfig = {
   urlPrefix: '/',
   submitUrl: `${environment.API_URL}/v0/appeals/higher_level_reviews`,
   submit: submitForm,
-  trackingPrefix: 'decision-reviews-va20-0996',
+  trackingPrefix: 'decision-reviews-va20-0996-',
   downtime: {
     requiredForPrefill: true,
     // double check these required services

--- a/src/applications/disability-benefits/996/config/submit-transformer.js
+++ b/src/applications/disability-benefits/996/config/submit-transformer.js
@@ -3,7 +3,7 @@ import _ from 'platform/utilities/data';
 export function transform(formConfig, form) {
   // We require the user to input a 10-digit number; assuming we get a 3-digit
   // area code + 7 digit number. We're not yet supporting international numbers
-  const getPhoneNumber = phone => ({
+  const getPhoneNumber = (phone = '') => ({
     countryCode: '1',
     areaCode: phone.substring(0, 3),
     phoneNumber: phone.substring(3),
@@ -13,12 +13,12 @@ export function transform(formConfig, form) {
   const getRep = formData =>
     formData.informalConference === 'rep'
       ? {
-          name: formData.informalConferenceRep.name,
-          phone: getPhoneNumber(formData.informalConferenceRep.phone),
+          name: formData?.informalConferenceRep?.name,
+          phone: getPhoneNumber(formData?.informalConferenceRep?.phone),
         }
       : null;
 
-  const getConferenceTimes = ({ informalConferenceTimes }) => {
+  const getConferenceTimes = ({ informalConferenceTimes = [] }) => {
     const xRef = {
       // formData name: api value
       time0800to1000: '800-1000 ET',
@@ -55,7 +55,7 @@ export function transform(formConfig, form) {
     }
   }]
   */
-  const getContestedIssues = ({ contestedIssues }) => {
+  const getContestedIssues = ({ contestedIssues = [] }) => {
     const issueTransform = {
       issue: issue => {
         const hasPercentage = issue?.ratingIssuePercentNumber

--- a/src/applications/disability-benefits/996/config/submitForm.js
+++ b/src/applications/disability-benefits/996/config/submitForm.js
@@ -1,0 +1,36 @@
+import { submitToUrl } from 'platform/forms-system/src/js/actions';
+import { transformForSubmit } from 'platform/forms-system/src/js/helpers';
+import recordEvent from 'platform/monitoring/record-event';
+
+const submitForm = (form, formConfig, { mode } = {}) => {
+  const { submitUrl, trackingPrefix } = formConfig;
+  const body = formConfig.transformForSubmit
+    ? formConfig.transformForSubmit(formConfig, form)
+    : transformForSubmit(formConfig, form);
+
+  // event data needed on successful submission
+  const { sameOffice, informalConference } = form.data;
+  let informalConf = 'no';
+  if (informalConference !== 'no') {
+    informalConf = informalConference === 'rep' ? 'yes-with-rep' : 'yes';
+  }
+  const eventData = {
+    // or 'no'
+    'decision-reviews-differentOffice': sameOffice ? 'yes' : 'no',
+    // or 'no', or 'yes-with-rep'
+    'decision-reviews-informalConf': informalConf,
+  };
+  // Submission attempt event
+  recordEvent({
+    event: `${trackingPrefix}-submission`,
+    ...eventData,
+  });
+  return submitToUrl(body, submitUrl, trackingPrefix, eventData).catch(() => {
+    recordEvent({
+      event: `${trackingPrefix}-submission-failure`,
+      ...eventData,
+    });
+  });
+};
+
+export default submitForm;

--- a/src/applications/disability-benefits/996/tests/containers/IntroductionPage.unit.spec.jsx
+++ b/src/applications/disability-benefits/996/tests/containers/IntroductionPage.unit.spec.jsx
@@ -5,6 +5,7 @@ import { shallow } from 'enzyme';
 import { VA_FORM_IDS } from 'platform/forms/constants';
 
 import { IntroductionPage } from '../../components/IntroductionPage';
+import formConfig from '../../config/form';
 
 const defaultProps = {
   getContestableIssues: () => {},
@@ -43,10 +44,16 @@ const globalWin = {
 };
 
 describe('IntroductionPage', () => {
-  it('should render CallToActionWidget', () => {
-    const oldWindow = global.window;
+  let oldWindow;
+  beforeEach(() => {
+    oldWindow = global.window;
     global.window = globalWin;
+  });
+  afterEach(() => {
+    global.window = oldWindow;
+  });
 
+  it('should render CallToActionWidget', () => {
     const tree = shallow(<IntroductionPage {...defaultProps} />);
 
     const callToActionWidget = tree.find('Connect(CallToActionWidget)');
@@ -55,14 +62,9 @@ describe('IntroductionPage', () => {
       'higher-level-review',
     );
     tree.unmount();
-
-    global.window = oldWindow;
   });
 
   it('should render alert showing a server error', () => {
-    const oldWindow = global.window;
-    global.window = globalWin;
-
     const props = {
       ...defaultProps,
       contestableIssues: {
@@ -79,13 +81,8 @@ describe('IntroductionPage', () => {
     const AlertBox = tree.find('AlertBox').first();
     expect(AlertBox.render().text()).to.include('some server error');
     tree.unmount();
-
-    global.window = oldWindow;
   });
   it('should render alert showing no contestable issues', () => {
-    const oldWindow = global.window;
-    global.window = globalWin;
-
     const props = {
       ...defaultProps,
       contestableIssues: {
@@ -100,13 +97,8 @@ describe('IntroductionPage', () => {
     const AlertBox = tree.find('AlertBox').first();
     expect(AlertBox.render().text()).to.include('No Contestable Issues');
     tree.unmount();
-
-    global.window = oldWindow;
   });
   it('should render start button', () => {
-    const oldWindow = global.window;
-    global.window = globalWin;
-
     const props = {
       ...defaultProps,
       contestableIssues: {
@@ -123,7 +115,23 @@ describe('IntroductionPage', () => {
       'Start the Request for a Higher-Level Review',
     );
     tree.unmount();
+  });
+  it('should include start button with form event', () => {
+    const props = {
+      ...defaultProps,
+      contestableIssues: {
+        issues: [{}],
+        status: '',
+        error: '',
+      },
+    };
 
-    global.window = oldWindow;
+    const tree = shallow(<IntroductionPage {...props} />);
+
+    const Intro = tree.find('Connect(CallToActionWidget)').first();
+    expect(Intro.props().children.props.gaStartEventName).to.equal(
+      `${formConfig.trackingPrefix}-start-form`,
+    );
+    tree.unmount();
   });
 });

--- a/src/applications/disability-benefits/996/tests/containers/IntroductionPage.unit.spec.jsx
+++ b/src/applications/disability-benefits/996/tests/containers/IntroductionPage.unit.spec.jsx
@@ -130,7 +130,7 @@ describe('IntroductionPage', () => {
 
     const Intro = tree.find('Connect(CallToActionWidget)').first();
     expect(Intro.props().children.props.gaStartEventName).to.equal(
-      `${formConfig.trackingPrefix}-start-form`,
+      `${formConfig.trackingPrefix}start-form`,
     );
     tree.unmount();
   });

--- a/src/applications/disability-benefits/996/tests/schema/submitForm.unit.spec.js
+++ b/src/applications/disability-benefits/996/tests/schema/submitForm.unit.spec.js
@@ -1,0 +1,69 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import localStorage from 'platform/utilities/storage/localStorage';
+
+import formConfig from '../../config/form';
+
+const getFormData = (sameOffice, informalConference) => ({
+  data: {
+    sameOffice,
+    informalConference,
+    informalConferenceTimes: [],
+  },
+});
+
+const getEvent = (result, office, conf) => ({
+  event: `${formConfig.trackingPrefix}-submission${result}`,
+  'decision-reviews-differentOffice': office,
+  'decision-reviews-informalConf': conf,
+});
+
+describe('HLR submit form', () => {
+  it('should record a submission attempt & failed attempt', done => {
+    const config = {
+      ...formConfig,
+      submitUrl: '', // something that will always fail
+    };
+    formConfig.submit(getFormData(false, 'no'), config).finally(() => {
+      expect(global.window.dataLayer[0]).to.deep.equal(
+        getEvent('', 'no', 'no'),
+      );
+      expect(global.window.dataLayer[1]).to.deep.equal(
+        getEvent('-failure', 'no', 'no'),
+      );
+      done();
+    });
+  });
+  it('should record a submission attempt & failed attempt with different data', done => {
+    const config = {
+      ...formConfig,
+      submitUrl: '', // something that will always fail
+    };
+    formConfig.submit(getFormData(true, 'yes'), config).finally(() => {
+      expect(global.window.dataLayer[0]).to.deep.equal(
+        getEvent('', 'yes', 'yes'),
+      );
+      expect(global.window.dataLayer[1]).to.deep.equal(
+        getEvent('-failure', 'yes', 'yes'),
+      );
+      done();
+    });
+  });
+  it('should record a submission attempt & failed attempt with different data', done => {
+    const config = {
+      ...formConfig,
+      submitUrl: '', // something that will always fail
+    };
+    formConfig.submit(getFormData(true, 'rep'), config).finally(() => {
+      expect(global.window.dataLayer[0]).to.deep.equal(
+        getEvent('', 'yes', 'yes-with-rep'),
+      );
+      expect(global.window.dataLayer[1]).to.deep.equal(
+        getEvent('-failure', 'yes', 'yes-with-rep'),
+      );
+      done();
+    });
+  });
+  // TODO: Test successful XMLHttpRequest
+});

--- a/src/applications/personalization/dashboard/helpers.jsx
+++ b/src/applications/personalization/dashboard/helpers.jsx
@@ -162,7 +162,7 @@ export const trackingPrefixes = {
   [VA_FORM_IDS.FORM_40_10007]: 'preneed-',
   [VA_FORM_IDS.FEEDBACK_TOOL]: 'gi_bill_feedback',
   [VA_FORM_IDS.FORM_21_686C]: '686-',
-  [VA_FORM_IDS.FORM_20_0996]: 'hlr-0996-',
+  [VA_FORM_IDS.FORM_20_0996]: `${hlrConfig.trackingPrefix}-`,
   [VA_FORM_IDS.FORM_VA_2346A]: 'bam-2346a-',
 };
 

--- a/src/applications/personalization/dashboard/helpers.jsx
+++ b/src/applications/personalization/dashboard/helpers.jsx
@@ -162,7 +162,7 @@ export const trackingPrefixes = {
   [VA_FORM_IDS.FORM_40_10007]: 'preneed-',
   [VA_FORM_IDS.FEEDBACK_TOOL]: 'gi_bill_feedback',
   [VA_FORM_IDS.FORM_21_686C]: '686-',
-  [VA_FORM_IDS.FORM_20_0996]: `${hlrConfig.trackingPrefix}-`,
+  [VA_FORM_IDS.FORM_20_0996]: 'decision-reviews-va20-0996',
   [VA_FORM_IDS.FORM_VA_2346A]: 'bam-2346a-',
 };
 

--- a/src/applications/personalization/dashboard/helpers.jsx
+++ b/src/applications/personalization/dashboard/helpers.jsx
@@ -162,7 +162,7 @@ export const trackingPrefixes = {
   [VA_FORM_IDS.FORM_40_10007]: 'preneed-',
   [VA_FORM_IDS.FEEDBACK_TOOL]: 'gi_bill_feedback',
   [VA_FORM_IDS.FORM_21_686C]: '686-',
-  [VA_FORM_IDS.FORM_20_0996]: 'decision-reviews-va20-0996',
+  [VA_FORM_IDS.FORM_20_0996]: 'decision-reviews-va20-0996-',
   [VA_FORM_IDS.FORM_VA_2346A]: 'bam-2346a-',
 };
 


### PR DESCRIPTION
## Description

This PR will add Higher-Level Review (form 20-0996) analytics. Included are:

- `decision-reviews-va20-0996-start-form` event added on form start
- `decision-reviews-va20-0996-submission` event upon submission
- `decision-reviews-va20-0996-submission-success` event upon a successful submission
- `decision-reviews-va20-0996-submission-failure` event upon a failed submission

All three submission events will also include this extra event data:

```js
{
  event: 'decision-reviews-va20-0996-submission...',
  // 'no' or 'yes'
  'decision-revews-differentOffice' : 'no',
  // 'no', 'yes' or 'yes-with-rep'
  'decision-reviews-informalConf': 'no'
}  
```

Related issues:
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/9861
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/3825

## Testing done

Added unit tests to check events on start & form submission

## Screenshots

N/A

## Acceptance criteria
- [ ] Analytics events added to HLR start, submit & submission success/failure
- [ ] Submission events include required event data

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
