### PR TITLE
bradl3yC - debt letters empty state

### DIFF
--- a/src/applications/debt-letters/components/DebtLettersList.jsx
+++ b/src/applications/debt-letters/components/DebtLettersList.jsx
@@ -21,11 +21,11 @@ const DebtLettersList = ({ debts }) => (
             Check the details of your VA debts and find out the next stops to
             resolving your debt.
           </p>
-          <p className="vads-u-font-size--h2 vads-u-font-weight--bold">
-            Current debts
-          </p>
           {debts.length > 0 && (
             <>
+              <p className="vads-u-font-size--h2 vads-u-font-weight--bold">
+                Current debts
+              </p>
               {reverse(debts).map((debt, index) => (
                 <DebtLetterCard
                   key={`${index}-${debt.fileNumber}`}

--- a/src/applications/debt-letters/components/DebtLettersList.jsx
+++ b/src/applications/debt-letters/components/DebtLettersList.jsx
@@ -24,22 +24,46 @@ const DebtLettersList = ({ debts }) => (
           <p className="vads-u-font-size--h2 vads-u-font-weight--bold">
             Current debts
           </p>
-          {debts.length > 0 &&
-            reverse(debts).map((debt, index) => (
-              <DebtLetterCard key={`${index}-${debt.fileNumber}`} debt={debt} />
-            ))}
-          <h2 className="vads-u-font-size--h3">What if I don't see a debt?</h2>
-          <p className="vads-u-margin-bottom--0 vads-u-font-family--sans">
-            If you have been notified of a debt that you do not see on this page
-            or would like to get information about your debts that have been
-            resolved, call the Debt Management Center at
-          </p>
-          <p className="vads-u-margin-top--0 vads-u-font-family--sans">
-            <a href="tel: 800-827-0648" aria-label="800. 8 2 7. 0648.">
-              800-827-0648
-            </a>
-            {'.'}
-          </p>
+          {debts.length > 0 && (
+            <>
+              {reverse(debts).map((debt, index) => (
+                <DebtLetterCard
+                  key={`${index}-${debt.fileNumber}`}
+                  debt={debt}
+                />
+              ))}
+              <h2 className="vads-u-font-size--h3">
+                What if I don't see a debt?
+              </h2>
+              <p className="vads-u-margin-bottom--0 vads-u-font-family--sans">
+                If you have been notified of a debt that you do not see on this
+                page or would like to get information about your debts that have
+                been resolved, call the Debt Management Center at
+              </p>
+              <p className="vads-u-margin-top--0 vads-u-font-family--sans">
+                <a href="tel: 800-827-0648" aria-label="800. 8 2 7. 0648.">
+                  800-827-0648
+                </a>
+                {'.'}
+              </p>
+            </>
+          )}
+          {debts.length < 1 && (
+            <div className="vads-u-background-color--gray-lightest vads-u-padding--3">
+              <h4 className="vads-u-font-family--serif vads-u-margin-top--0">
+                You don't have any current Education or Compensation & Pension
+                Debts
+              </h4>
+              <p className="vads-u-font-family--sans vads-u-margin-bottom--0">
+                If you believe that you have a debt with the VA or would like to
+                get information about your debts that have been resolved, call
+                the Debt Management Center at{' '}
+                <a href="tel: 800-827-0648" aria-label="800. 8 2 7. 0648.">
+                  800-827-0648
+                </a>
+              </p>
+            </div>
+          )}
         </div>
         <div className="vads-u-display--flex vads-u-flex-direction--column vads-l-col--12 vads-u-padding-x--2p5 medium-screen:vads-l-col--4">
           <HowDoIPay />

--- a/src/applications/debt-letters/components/DebtLettersWrapper.jsx
+++ b/src/applications/debt-letters/components/DebtLettersWrapper.jsx
@@ -32,7 +32,6 @@ class DebtLettersWrapper extends Component {
 const mapStateToProps = state => ({
   isLoggedIn: state.user.login.currentlyLoggedIn,
   isFetching: state.debtLetters.isFetching,
-  debts: state.debtLetters.debts,
   isError: state.debtLetters.isError,
 });
 

--- a/src/applications/debt-letters/tests/DebtLettersList.unit.spec.js
+++ b/src/applications/debt-letters/tests/DebtLettersList.unit.spec.js
@@ -170,4 +170,41 @@ describe('DebtLettersList', () => {
     expect(wrapper.dive().find(`Connect(DebtLetterCard)`).length).to.equal(4);
     wrapper.unmount();
   });
+  it('renders correct empty state', () => {
+    const fakeStoreEmptyState = {
+      getState: () => ({
+        user: {
+          login: {
+            currentlyLoggedIn: true,
+          },
+        },
+        debtLetters: {
+          isFetching: false,
+          debts: [],
+        },
+      }),
+      subscribe: () => {},
+      dispatch: () => {},
+    };
+    const wrapper = shallow(<DebtLettersList store={fakeStoreEmptyState} />);
+    expect(wrapper.dive().find(`Connect(DebtLetterCard)`).length).to.equal(0);
+    expect(
+      wrapper
+        .dive()
+        .find('h4')
+        .text(),
+    ).to.equal(
+      "You don't have any current Education or Compensation & Pension Debts",
+    );
+    expect(
+      wrapper
+        .dive()
+        .find('p')
+        .at(1)
+        .text(),
+    ).to.equal(
+      'If you believe that you have a debt with the VA or would like to get information about your debts that have been resolved, call the Debt Management Center at 800-827-0648',
+    );
+    wrapper.unmount();
+  });
 });


### PR DESCRIPTION
## Description
Add messaging if debt letters returns an empty array

## Testing done
Unit tests

## Screenshots
![Screen Shot 2020-07-07 at 12 36 53 PM](https://user-images.githubusercontent.com/6165421/86813815-9cde0700-c04e-11ea-99f2-37788ac2b926.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
