### PR TITLE
Improve screen reader behavior for left nav "In this section" link

### DIFF
--- a/src/platform/site-wide/side-nav/components/SideNav.js
+++ b/src/platform/site-wide/side-nav/components/SideNav.js
@@ -120,7 +120,6 @@ class SideNav extends Component {
       >
         <button
           type="button"
-          aria-describedby="va-sidenav-ul-container"
           className={classNames(
             'medium-screen:vads-u-display--none',
             'va-sidenav-default-trigger',
@@ -128,7 +127,9 @@ class SideNav extends Component {
           )}
           onClick={this.toggleUlClass}
         >
-          In this section <i className="fa fa-bars" />
+          <span className="sr-only">View sub-navigation for </span>
+          In this section
+          <i className="fa fa-bars" aria-hidden="true" role="img" />
         </button>
         <ul
           id="va-sidenav-ul-container"


### PR DESCRIPTION
## Description
Screen readers should give a better description of the "In this section" link, and should NOT read the hidden line items.

## Testing done
Open a DMAC facility page. Resize the window to mobile width. Turn on VoiceOver (cmd-fn-F5) and use the tab key to focus the "In This Section" button. VO should read "View sub-navigation for In This Section".

## Screenshots
n/a

## Acceptance criteria
- [x] Screen readers read link as  "View sub-navigation for In This Section", and do NOT read the hidden line items.

## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
