### PR TITLE
[Development] Add HLR feature flipper flag

### DIFF
--- a/src/applications/disability-benefits/996/components/HLRWizard.jsx
+++ b/src/applications/disability-benefits/996/components/HLRWizard.jsx
@@ -1,8 +1,10 @@
 import React, { useState } from 'react';
+import { connect } from 'react-redux';
 
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 import ErrorableRadioButtons from '@department-of-veterans-affairs/formation-react/ErrorableRadioButtons';
 
+import { higherLevelReviewFeature } from '../helpers';
 import { BASE_URL } from '../constants';
 
 import {
@@ -19,14 +21,21 @@ import {
 export const name = 'higher-level-review';
 
 // initChoice & initExpanded set for testing
-const HLRWizard = ({
+export const HLRWizard = ({
   initExpanded = false,
   initClaimChoice = null,
   initLegacyChoice = null,
+  allowHlr = false,
+  testHlr = false,
 }) => {
   const [claimChoice, setClaimChoice] = useState(initClaimChoice);
   const [legacyChoice, setLegacyChoice] = useState(initLegacyChoice);
   const [expanded, setExpanded] = useState(initExpanded);
+
+  if (!(allowHlr || testHlr)) {
+    // Don't render if feature isn't set for the user
+    return null;
+  }
 
   const claimOptions = [
     { value: 'compensation', label: wizardLabels.compensation },
@@ -105,4 +114,8 @@ const HLRWizard = ({
   );
 };
 
-export default HLRWizard;
+const mapStateToProps = state => ({
+  allowHlr: higherLevelReviewFeature(state),
+});
+
+export default connect(mapStateToProps)(HLRWizard);

--- a/src/applications/disability-benefits/996/components/IntroductionPage.jsx
+++ b/src/applications/disability-benefits/996/components/IntroductionPage.jsx
@@ -12,9 +12,11 @@ import { toggleLoginModal } from 'platform/site-wide/user-nav/actions';
 import { setData } from 'platform/forms-system/src/js/actions';
 import { getContestableIssues as getContestableIssuesAction } from '../actions';
 
+import { higherLevelReviewFeature } from '../helpers';
 import {
   noContestableIssuesFound,
   showContestableIssueError,
+  showWorkInProgress,
 } from '../content/contestableIssueAlerts';
 
 export class IntroductionPage extends React.Component {
@@ -52,7 +54,11 @@ export class IntroductionPage extends React.Component {
   };
 
   getCallToActionContent = () => {
-    const { route, contestableIssues } = this.props;
+    const { route, contestableIssues, allowHlr } = this.props;
+    // check feature flag
+    if (!allowHlr) {
+      return showWorkInProgress;
+    }
     const { formConfig } = route;
     if (contestableIssues?.error) {
       return showContestableIssueError(contestableIssues.error.errors);
@@ -201,6 +207,7 @@ function mapStateToProps(state) {
     form,
     user,
     contestableIssues,
+    allowHlr: higherLevelReviewFeature(state),
   };
 }
 

--- a/src/applications/disability-benefits/996/components/IntroductionPage.jsx
+++ b/src/applications/disability-benefits/996/components/IntroductionPage.jsx
@@ -54,9 +54,9 @@ export class IntroductionPage extends React.Component {
   };
 
   getCallToActionContent = () => {
-    const { route, contestableIssues, allowHlr } = this.props;
+    const { route, contestableIssues, allowHlr, testHlr } = this.props;
     // check feature flag
-    if (!allowHlr) {
+    if (!(allowHlr || testHlr)) {
       return showWorkInProgress;
     }
     const { formConfig } = route;

--- a/src/applications/disability-benefits/996/content/contestableIssueAlerts.jsx
+++ b/src/applications/disability-benefits/996/content/contestableIssueAlerts.jsx
@@ -14,7 +14,7 @@ const networkError = errors => {
       </ul>
     ) : (
       <p>
-        <strong>{errors[0].title}</strong>
+        <strong>{errors?.[0].title}</strong>
       </p>
     );
   return (

--- a/src/applications/disability-benefits/996/content/contestableIssueAlerts.jsx
+++ b/src/applications/disability-benefits/996/content/contestableIssueAlerts.jsx
@@ -43,3 +43,12 @@ export const showContestableIssueError = errors => (
     content={networkError(errors)}
   />
 );
+
+export const showWorkInProgress = (
+  <AlertBox
+    status="info"
+    headline="We’re still working on this feature"
+    content={`We’re rolling out the Higher-Level Review form in stages. It’s
+      not quite ready yet, so please check back again soon.`}
+  />
+);

--- a/src/applications/disability-benefits/996/helpers.js
+++ b/src/applications/disability-benefits/996/helpers.js
@@ -1,3 +1,10 @@
+// import the toggleValues helper
+import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
+import FEATURE_FLAG_NAMES from 'platform/utilities/feature-toggles/featureFlagNames';
+
+export const higherLevelReviewFeature = state =>
+  toggleValues(state)[FEATURE_FLAG_NAMES.form996HigherLevelReview];
+
 // testing
 export const $ = (selector, DOM) => DOM.querySelector(selector);
 export const $$ = (selector, DOM) => DOM.querySelectorAll(selector);

--- a/src/applications/disability-benefits/996/tests/containers/HLR-wizard.unit.spec.jsx
+++ b/src/applications/disability-benefits/996/tests/containers/HLR-wizard.unit.spec.jsx
@@ -3,7 +3,7 @@ import SkinDeep from 'skin-deep';
 import { expect } from 'chai';
 
 import { BASE_URL } from '../../constants';
-import HLRWizard, { name } from '../../components/HLRWizard';
+import { HLRWizard, name } from '../../components/HLRWizard';
 
 const getSelected = (tree, group) => {
   // return tree.subTree(`.higher-level-review-${name}`).props.value.value;
@@ -15,7 +15,7 @@ const getSelected = (tree, group) => {
 
 describe('<HLRWizard>', () => {
   it('should show button and no questions (collapsed)', () => {
-    const tree = SkinDeep.shallowRender(<HLRWizard />);
+    const tree = SkinDeep.shallowRender(<HLRWizard testHlr />);
     const button = tree.subTree('button');
     expect(button).not.to.be.false;
     expect(button.props['aria-expanded']).to.be.false;
@@ -25,7 +25,7 @@ describe('<HLRWizard>', () => {
 
   // Claim choices
   it('should show empty claim button choices (expanded)', () => {
-    const tree = SkinDeep.shallowRender(<HLRWizard initExpanded />);
+    const tree = SkinDeep.shallowRender(<HLRWizard testHlr initExpanded />);
     const button = tree.subTree('button');
     expect(button).not.to.be.false;
     expect(button.props['aria-expanded']).not.to.be.false;
@@ -38,7 +38,7 @@ describe('<HLRWizard>', () => {
   });
   it('should show alert when "other" is chosen', () => {
     const tree = SkinDeep.shallowRender(
-      <HLRWizard initExpanded initClaimChoice={'other'} />,
+      <HLRWizard testHlr initExpanded initClaimChoice={'other'} />,
     );
     expect(tree.subTree('button')).not.to.be.false;
     expect(tree.subTree('#wizardOptions')).not.to.be.false;
@@ -50,7 +50,7 @@ describe('<HLRWizard>', () => {
 
   it('should show legacy choices when "compensation" is chosen', () => {
     const tree = SkinDeep.shallowRender(
-      <HLRWizard initExpanded initClaimChoice={'compensation'} />,
+      <HLRWizard testHlr initExpanded initClaimChoice={'compensation'} />,
     );
     expect(tree.subTree('button')).not.to.be.false;
     expect(tree.subTree('#wizardOptions')).not.to.be.false;
@@ -63,6 +63,7 @@ describe('<HLRWizard>', () => {
   it('should show alert when "other" & "yes" is chosen', () => {
     const tree = SkinDeep.shallowRender(
       <HLRWizard
+        testHlr
         initExpanded
         initClaimChoice={'compensation'}
         initLegacyChoice={'yes'}
@@ -78,6 +79,7 @@ describe('<HLRWizard>', () => {
   it('should show link to HLR when "compensation" & "no" is chosen', () => {
     const tree = SkinDeep.shallowRender(
       <HLRWizard
+        testHlr
         initExpanded
         initClaimChoice={'compensation'}
         initLegacyChoice={'no'}

--- a/src/applications/disability-benefits/996/tests/containers/IntroductionPage.unit.spec.jsx
+++ b/src/applications/disability-benefits/996/tests/containers/IntroductionPage.unit.spec.jsx
@@ -8,6 +8,7 @@ import { IntroductionPage } from '../../components/IntroductionPage';
 
 const defaultProps = {
   getContestableIssues: () => {},
+  testHlr: true,
   user: {
     profile: {
       // need to have a saved form or else form will redirect to v2

--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -30,4 +30,5 @@ export default Object.freeze({
   gibctEybBottomSheet: 'gibctEybBottomSheet',
   routeStLouisRPOtoBuffaloRPO: 'routeStLouisRPOtoBuffaloRPO',
   gibctSearchEnhancements: 'gibctSearchEnhancements',
+  form996HigherLevelReview: 'form996HigherLevelReview',
 });


### PR DESCRIPTION
## Description

Adding a feature flipper for Higher-Level Review form 20-0996 in anticipation of launch

When the feature flag prevents the user from seeing the form:

- The wizard, shown on the landing page, will not render a button 
- The introduction page, if the user somehow gets the URL, will render an alert box

  <details><summary>Work in progress alert</summary>

  <!-- leave a blank line above -->
  ![Screen Shot 2020-07-08 at 9 09 42 AM](https://user-images.githubusercontent.com/136959/86932222-b0e14180-c0fe-11ea-8d0f-1404ae4601e4.png)</details>

Related tickets:
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/10709
- https://github.com/department-of-veterans-affairs/vets-api/pull/4490 (vets-api)

## Testing done

Updated wizard unit tests

## Screenshots

See description

## Acceptance criteria
- [x] HLR feature flag will prevent progress to and starting of the form

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
