### PR TITLE
Sanlouise 10422 hide military section

### DIFF
--- a/src/applications/personalization/profile-2/components/Profile2Router.jsx
+++ b/src/applications/personalization/profile-2/components/Profile2Router.jsx
@@ -115,12 +115,13 @@ class Profile2Router extends Component {
 
   // content to show after data has loaded
   mainContent = () => {
-    const routesConfig = {
-      showDirectDeposit: this.props.shouldShowDirectDeposit,
-      showMilitaryInformation: this.props.shouldShowMilitaryInformation,
+    const routesOptions = {
+      removeDirectDeposit: !this.props.shouldShowDirectDeposit,
+      removeMilitaryInformation: !this.props.shouldShowMilitaryInformation,
     };
 
-    const routes = getRoutes(routesConfig);
+    // We need to pass in a config to hide forbidden routes
+    const routes = getRoutes(routesOptions);
 
     return (
       <BrowserRouter>

--- a/src/applications/personalization/profile-2/components/Profile2Router.jsx
+++ b/src/applications/personalization/profile-2/components/Profile2Router.jsx
@@ -103,7 +103,12 @@ class Profile2Router extends Component {
 
   // content to show after data has loaded
   mainContent = () => {
-    const routes = getRoutes(this.props.shouldShowDirectDeposit);
+    const shouldShowMilitaryInformation = this.props.user?.profile
+      ?.veteranStatus?.servedInMilitary;
+    const routes = getRoutes(
+      this.props.shouldShowDirectDeposit,
+      shouldShowMilitaryInformation,
+    );
     return (
       <BrowserRouter>
         <Profile2Wrapper routes={routes}>
@@ -113,6 +118,15 @@ class Profile2Router extends Component {
               if (
                 (route.requiresLOA3 && !this.props.isLOA3) ||
                 (route.requiresMVI && !this.props.isInMVI)
+              ) {
+                return (
+                  <Redirect from={route.path} to="/profile/account-security" />
+                );
+              }
+
+              if (
+                route.path === '/profile/military-information' &&
+                !shouldShowMilitaryInformation
               ) {
                 return (
                   <Redirect from={route.path} to="/profile/account-security" />
@@ -159,6 +173,7 @@ class Profile2Router extends Component {
   };
 
   render() {
+    console.log('This is user', this.props.user);
     return (
       <RequiredLoginView
         serviceRequired={backendServices.USER_PROFILE}

--- a/src/applications/personalization/profile-2/components/Profile2Router.jsx
+++ b/src/applications/personalization/profile-2/components/Profile2Router.jsx
@@ -34,6 +34,7 @@ import {
 } from 'applications/personalization/profile360/selectors';
 import { fetchPaymentInformation as fetchPaymentInformationAction } from 'applications/personalization/profile360/actions/paymentInformation';
 import getRoutes from '../routes';
+import { PROFILE_PATHS } from '../constants';
 
 import Profile2Wrapper from './Profile2Wrapper';
 
@@ -114,10 +115,13 @@ class Profile2Router extends Component {
 
   // content to show after data has loaded
   mainContent = () => {
-    const routes = getRoutes(
-      this.props.shouldShowDirectDeposit,
-      this.props.shouldShowMilitaryInformation,
-    );
+    const routesConfig = {
+      showDirectDeposit: this.props.shouldShowDirectDeposit,
+      showMilitaryInformation: this.props.shouldShowMilitaryInformation,
+    };
+
+    const routes = getRoutes(routesConfig);
+
     return (
       <BrowserRouter>
         <Profile2Wrapper routes={routes}>
@@ -131,18 +135,21 @@ class Profile2Router extends Component {
                 return (
                   <Redirect
                     from={route.path}
-                    to="/profile/account-security"
+                    to={PROFILE_PATHS.ACCOUNT_SECURITY}
                     key={route.path}
                   />
                 );
               }
 
               if (
-                route.path === '/profile/military-information' &&
+                route.path === PROFILE_PATHS.MILITARY_INFORMATION &&
                 !this.props.shouldShowMilitaryInformation
               ) {
                 return (
-                  <Redirect to="/profile/account-security" key={route.path} />
+                  <Redirect
+                    to={PROFILE_PATHS.ACCOUNT_SECURITY}
+                    key={route.path}
+                  />
                 );
               }
 
@@ -159,18 +166,18 @@ class Profile2Router extends Component {
             <Redirect
               exact
               from="/profile#contact-information"
-              to="/profile/personal-information"
+              to={PROFILE_PATHS.PERSONAL_INFORMATION}
             />
 
             <Redirect
               exact
-              from="/profile"
-              to="/profile/personal-information"
+              from={PROFILE_PATHS.PROFILE_ROOT}
+              to={PROFILE_PATHS.PERSONAL_INFORMATION}
             />
 
             {/* fallback handling: redirect to root route */}
             <Route path="*">
-              <Redirect to="/profile" />
+              <Redirect to={PROFILE_PATHS.PROFILE_ROOT} />
             </Route>
           </Switch>
         </Profile2Wrapper>

--- a/src/applications/personalization/profile-2/components/Profile2Router.jsx
+++ b/src/applications/personalization/profile-2/components/Profile2Router.jsx
@@ -146,10 +146,7 @@ class Profile2Router extends Component {
                 !this.props.shouldShowMilitaryInformation
               ) {
                 return (
-                  <Redirect
-                    to={PROFILE_PATHS.ACCOUNT_SECURITY}
-                    key={route.path}
-                  />
+                  <Redirect to={PROFILE_PATHS.PROFILE_ROOT} key={route.path} />
                 );
               }
 

--- a/src/applications/personalization/profile-2/components/Profile2Wrapper.jsx
+++ b/src/applications/personalization/profile-2/components/Profile2Wrapper.jsx
@@ -7,6 +7,7 @@ import { isWideScreen } from 'platform/utilities/accessibility/index';
 import ProfileHeader from './ProfileHeader';
 import ProfileSideNav from './ProfileSideNav';
 import MobileMenuTrigger from './MobileMenuTrigger';
+import { PROFILE_PATHS } from '../constants';
 
 const Profile2 = ({ children, routes }) => {
   const location = useLocation();
@@ -21,7 +22,7 @@ const Profile2 = ({ children, routes }) => {
 
   // We do not want to display 'Profile' on the mobile personal-information route
   const onPersonalInformationMobile =
-    activeLocation === '/profile/personal-information' && !isWideScreen();
+    activeLocation === PROFILE_PATHS.PERSONAL_INFORMATION && !isWideScreen();
 
   return (
     <>

--- a/src/applications/personalization/profile-2/constants.js
+++ b/src/applications/personalization/profile-2/constants.js
@@ -21,3 +21,20 @@ export const BREAKPOINTS = Object.freeze({
 });
 
 export const PROFILE_VERSION = 'PROFILE_VERSION';
+
+export const PROFILE_PATHS = Object.freeze({
+  PROFILE_ROOT: '/profile',
+  DIRECT_DEPOSIT: '/profile/direct-deposit',
+  PERSONAL_INFORMATION: '/profile/personal-information',
+  MILITARY_INFORMATION: '/profile/military-information',
+  CONNECTED_APPLICATIONS: '/profile/connected-applications',
+  ACCOUNT_SECURITY: '/profile/account-security',
+});
+
+export const PROFILE_PATH_NAMES = Object.freeze({
+  DIRECT_DEPOSIT: 'Direct deposit',
+  PERSONAL_INFORMATION: 'Personal and contact information',
+  MILITARY_INFORMATION: 'Military information',
+  CONNECTED_APPLICATIONS: 'Connected applications',
+  ACCOUNT_SECURITY: 'Account security',
+});

--- a/src/applications/personalization/profile-2/routes.js
+++ b/src/applications/personalization/profile-2/routes.js
@@ -4,7 +4,7 @@ import MilitaryInformation from './components/MilitaryInformation';
 import DirectDeposit from './components/direct-deposit/DirectDeposit';
 import ConnectedApplications from './components/connected-apps/ConnectedApps';
 
-const getRoutes = showDirectDeposit => {
+const getRoutes = (showDirectDeposit, showMilitaryInformation) => {
   const routes = [
     {
       component: PersonalInformation,
@@ -45,6 +45,11 @@ const getRoutes = showDirectDeposit => {
   if (!showDirectDeposit) {
     return routes.filter(route => {
       return route.component !== DirectDeposit;
+    });
+  }
+  if (!showMilitaryInformation) {
+    return routes.filter(route => {
+      return route.component !== MilitaryInformation;
     });
   }
   return routes;

--- a/src/applications/personalization/profile-2/routes.js
+++ b/src/applications/personalization/profile-2/routes.js
@@ -5,65 +5,51 @@ import DirectDeposit from './components/direct-deposit/DirectDeposit';
 import ConnectedApplications from './components/connected-apps/ConnectedApps';
 import { PROFILE_PATHS, PROFILE_PATH_NAMES } from './constants';
 
-const DirectDepositRoute = {
-  component: DirectDeposit,
-  name: PROFILE_PATH_NAMES.DIRECT_DEPOSIT,
-  path: PROFILE_PATHS.DIRECT_DEPOSIT,
-  requiresLOA3: true,
-  requiresMVI: true,
-};
-
-const MilitaryInformationRoute = {
-  component: MilitaryInformation,
-  name: PROFILE_PATH_NAMES.MILITARY_INFORMATION,
-  path: PROFILE_PATHS.MILITARY_INFORMATION,
-  requiresLOA3: true,
-  requiresMVI: true,
-};
-
-const PersonalInformationRoute = {
-  component: PersonalInformation,
-  name: PROFILE_PATH_NAMES.PERSONAL_INFORMATION,
-  path: PROFILE_PATHS.PERSONAL_INFORMATION,
-  requiresLOA3: true,
-  requiresMVI: true,
-};
-
-const AccountSecurityRoute = {
-  component: AccountSecurity,
-  name: PROFILE_PATH_NAMES.ACCOUNT_SECURITY,
-  path: PROFILE_PATHS.ACCOUNT_SECURITY,
-  requiresLOA3: false,
-  requiresMVI: false,
-};
-
-const ConnectedApplicationsRoute = {
-  component: ConnectedApplications,
-  name: PROFILE_PATH_NAMES.CONNECTED_APPLICATIONS,
-  path: PROFILE_PATHS.CONNECTED_APPLICATIONS,
-  requiresLOA3: true,
-  requiresMVI: true,
-};
-
 const getRoutes = config => {
   let routes = [
-    PersonalInformationRoute,
-    MilitaryInformationRoute,
-    DirectDepositRoute,
-    AccountSecurityRoute,
-    ConnectedApplicationsRoute,
+    {
+      component: PersonalInformation,
+      name: PROFILE_PATH_NAMES.PERSONAL_INFORMATION,
+      path: PROFILE_PATHS.PERSONAL_INFORMATION,
+      requiresLOA3: true,
+      requiresMVI: true,
+    },
+    {
+      component: MilitaryInformation,
+      name: PROFILE_PATH_NAMES.MILITARY_INFORMATION,
+      path: PROFILE_PATHS.MILITARY_INFORMATION,
+      requiresLOA3: true,
+      requiresMVI: true,
+    },
+    {
+      component: DirectDeposit,
+      name: PROFILE_PATH_NAMES.DIRECT_DEPOSIT,
+      path: PROFILE_PATHS.DIRECT_DEPOSIT,
+      requiresLOA3: true,
+      requiresMVI: true,
+    },
+    {
+      component: AccountSecurity,
+      name: PROFILE_PATH_NAMES.ACCOUNT_SECURITY,
+      path: PROFILE_PATHS.ACCOUNT_SECURITY,
+      requiresLOA3: false,
+      requiresMVI: false,
+    },
+    {
+      component: ConnectedApplications,
+      name: PROFILE_PATH_NAMES.CONNECTED_APPLICATIONS,
+      path: PROFILE_PATHS.CONNECTED_APPLICATIONS,
+      requiresLOA3: true,
+      requiresMVI: true,
+    },
   ];
 
   if (!config.showDirectDeposit) {
-    routes = routes.filter(
-      route => route.name !== PROFILE_PATH_NAMES.DIRECT_DEPOSIT,
-    );
+    routes = routes.filter(route => route.component !== DirectDeposit);
   }
 
   if (!config.showMilitaryInformation) {
-    routes = routes.filter(
-      route => route.name !== PROFILE_PATH_NAMES.MILITARY_INFORMATION,
-    );
+    routes = routes.filter(route => route.component !== MilitaryInformation);
   }
 
   return routes;

--- a/src/applications/personalization/profile-2/routes.js
+++ b/src/applications/personalization/profile-2/routes.js
@@ -3,55 +3,69 @@ import PersonalInformation from './components/personal-information/PersonalInfor
 import MilitaryInformation from './components/MilitaryInformation';
 import DirectDeposit from './components/direct-deposit/DirectDeposit';
 import ConnectedApplications from './components/connected-apps/ConnectedApps';
+import { PROFILE_PATHS, PROFILE_PATH_NAMES } from './constants';
 
-const getRoutes = (showDirectDeposit, showMilitaryInformation) => {
-  const routes = [
-    {
-      component: PersonalInformation,
-      name: 'Personal and contact information',
-      path: '/profile/personal-information',
-      requiresLOA3: true,
-      requiresMVI: true,
-    },
-    {
-      component: MilitaryInformation,
-      name: 'Military information',
-      path: '/profile/military-information',
-      requiresLOA3: true,
-      requiresMVI: true,
-    },
-    {
-      component: DirectDeposit,
-      name: 'Direct deposit',
-      path: '/profile/direct-deposit',
-      requiresLOA3: true,
-      requiresMVI: true,
-    },
-    {
-      component: AccountSecurity,
-      name: 'Account security',
-      path: '/profile/account-security',
-      requiresLOA3: false,
-      requiresMVI: false,
-    },
-    {
-      component: ConnectedApplications,
-      name: 'Connected apps',
-      path: '/profile/connected-applications',
-      requiresLOA3: true,
-      requiresMVI: true,
-    },
+const DirectDepositRoute = {
+  component: DirectDeposit,
+  name: PROFILE_PATH_NAMES.DIRECT_DEPOSIT,
+  path: PROFILE_PATHS.DIRECT_DEPOSIT,
+  requiresLOA3: true,
+  requiresMVI: true,
+};
+
+const MilitaryInformationRoute = {
+  component: MilitaryInformation,
+  name: PROFILE_PATH_NAMES.MILITARY_INFORMATION,
+  path: PROFILE_PATHS.MILITARY_INFORMATION,
+  requiresLOA3: true,
+  requiresMVI: true,
+};
+
+const PersonalInformationRoute = {
+  component: PersonalInformation,
+  name: PROFILE_PATH_NAMES.PERSONAL_INFORMATION,
+  path: PROFILE_PATHS.PERSONAL_INFORMATION,
+  requiresLOA3: true,
+  requiresMVI: true,
+};
+
+const AccountSecurityRoute = {
+  component: AccountSecurity,
+  name: PROFILE_PATH_NAMES.ACCOUNT_SECURITY,
+  path: PROFILE_PATHS.ACCOUNT_SECURITY,
+  requiresLOA3: false,
+  requiresMVI: false,
+};
+
+const ConnectedApplicationsRoute = {
+  component: ConnectedApplications,
+  name: PROFILE_PATH_NAMES.CONNECTED_APPLICATIONS,
+  path: PROFILE_PATHS.CONNECTED_APPLICATIONS,
+  requiresLOA3: true,
+  requiresMVI: true,
+};
+
+const getRoutes = config => {
+  let routes = [
+    PersonalInformationRoute,
+    MilitaryInformationRoute,
+    DirectDepositRoute,
+    AccountSecurityRoute,
+    ConnectedApplicationsRoute,
   ];
-  if (!showDirectDeposit) {
-    return routes.filter(route => {
-      return route.component !== DirectDeposit;
-    });
+
+  if (!config.showDirectDeposit) {
+    routes = routes.filter(
+      route => route.name !== PROFILE_PATH_NAMES.DIRECT_DEPOSIT,
+    );
   }
-  if (!showMilitaryInformation) {
-    return routes.filter(route => {
-      return route.component !== MilitaryInformation;
-    });
+
+  if (!config.showMilitaryInformation) {
+    routes = routes.filter(
+      route => route.name !== PROFILE_PATH_NAMES.MILITARY_INFORMATION,
+    );
   }
+
   return routes;
 };
 

--- a/src/applications/personalization/profile-2/routes.js
+++ b/src/applications/personalization/profile-2/routes.js
@@ -5,7 +5,7 @@ import DirectDeposit from './components/direct-deposit/DirectDeposit';
 import ConnectedApplications from './components/connected-apps/ConnectedApps';
 import { PROFILE_PATHS, PROFILE_PATH_NAMES } from './constants';
 
-const getRoutes = config => {
+const getRoutes = options => {
   let routes = [
     {
       component: PersonalInformation,
@@ -44,11 +44,11 @@ const getRoutes = config => {
     },
   ];
 
-  if (!config.showDirectDeposit) {
+  if (options.removeDirectDeposit) {
     routes = routes.filter(route => route.component !== DirectDeposit);
   }
 
-  if (!config.showMilitaryInformation) {
+  if (options.removeMilitaryInformation) {
     routes = routes.filter(route => route.component !== MilitaryInformation);
   }
 

--- a/src/applications/personalization/profile-2/tests/components/Profile2.unit.spec.js
+++ b/src/applications/personalization/profile-2/tests/components/Profile2.unit.spec.js
@@ -4,14 +4,16 @@ import { expect } from 'chai';
 
 import Profile2 from '../../components/Profile2Wrapper';
 import getRoutes from '../../routes';
+import { PROFILE_PATHS } from '../../constants';
 
 import { renderWithProfileReducers as render } from '../unit-test-helpers';
 
 describe('Profile2', () => {
   it('should render the correct breadcrumb (Personal and contact Information)', () => {
+    const config = {};
     const ui = (
-      <MemoryRouter initialEntries={['/profile/personal-information']}>
-        <Profile2 routes={getRoutes()} />
+      <MemoryRouter initialEntries={[PROFILE_PATHS.PERSONAL_INFORMATION]}>
+        <Profile2 routes={getRoutes(config)} />
       </MemoryRouter>
     );
     const { getByTestId } = render(ui);

--- a/src/applications/personalization/profile-2/tests/components/Profile2Router.unit.spec.js
+++ b/src/applications/personalization/profile-2/tests/components/Profile2Router.unit.spec.js
@@ -33,6 +33,7 @@ describe('Profile2Router', () => {
       fetchPaymentInformation: fetchPaymentInfoSpy,
       fetchPersonalInformation: fetchPersonalInfoSpy,
       shouldFetchDirectDepositInformation: true,
+      shouldShowMilitaryInformation: true,
       showLoader: false,
       user: {},
       location: {

--- a/src/applications/personalization/profile-2/tests/components/Profile2Router.unit.spec.js
+++ b/src/applications/personalization/profile-2/tests/components/Profile2Router.unit.spec.js
@@ -125,6 +125,9 @@ describe('mapStateToProps', () => {
       errors: null,
       loading: false,
     },
+    veteranStatus: {
+      servedInMilitary: true,
+    },
   });
   const makeDefaultVaProfileState = () => ({
     hero: {
@@ -205,6 +208,7 @@ describe('mapStateToProps', () => {
       'showLoader',
       'shouldFetchDirectDepositInformation',
       'shouldShowDirectDeposit',
+      'shouldShowMilitaryInformation',
       'isDowntimeWarningDismissed',
     ];
     expect(Object.keys(props)).to.deep.equal(expectedKeys);
@@ -245,6 +249,25 @@ describe('mapStateToProps', () => {
       state.user.profile.services = [];
       const props = mapStateToProps(state);
       expect(props.shouldFetchDirectDepositInformation).to.be.false;
+    });
+  });
+
+  describe('#shouldShowMilitaryInformation', () => {
+    describe('when the user has served in the military', () => {
+      it('should be `true`', () => {
+        const state = makeDefaultState();
+        state.user.profile.veteranStatus.servedInMilitary = true;
+        const props = mapStateToProps(state);
+        expect(props.shouldShowMilitaryInformation).to.be.true;
+      });
+    });
+    describe('when the user has not served in the military', () => {
+      it('should be `false`', () => {
+        const state = makeDefaultState();
+        state.user.profile.veteranStatus.servedInMilitary = false;
+        const props = mapStateToProps(state);
+        expect(props.shouldShowMilitaryInformation).to.be.false;
+      });
     });
   });
 


### PR DESCRIPTION
## Description
In Profile 2.0 and when the user has not served, we need to hide the Military Information section from the side nav and redirect the user to `/personal-information` when they try to hit the `/military-information` route.

## Testing done
Works locally, updated unit tests.


## Acceptance criteria

When the user has not served,
- [x] Hide Military Information from the side nav
- [x] Redirect the user from `/military-information` to `/personal-information`

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
