### PR TITLE
Update wording from revision date to form last updated

### DIFF
--- a/src/applications/find-forms/components/SearchResult.jsx
+++ b/src/applications/find-forms/components/SearchResult.jsx
@@ -73,7 +73,7 @@ const SearchResult = ({ form }) => {
       </dt>
 
       <dd className="vads-u-margin-y--1 vads-u-margin-y--1">
-        <dfn className="vads-u-font-weight--bold">Revision date:</dfn>{' '}
+        <dfn className="vads-u-font-weight--bold">Form last updated:</dfn>{' '}
         {lastRevisionOn}
       </dd>
 

--- a/src/applications/find-forms/tests/components/SearchResult.unit.spec.jsx
+++ b/src/applications/find-forms/tests/components/SearchResult.unit.spec.jsx
@@ -25,6 +25,7 @@ describe('Find VA Forms <FindVaForms>', () => {
       'Information for Pre-Complaint Processing',
       'VA10192',
       '12-22-2020',
+      'Form last updated',
     ].forEach(text => {
       expect(treeText).to.include(text);
     });


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/8633

This PR updates `Revision date` to `Form last updated`.

## Testing done
Updated unit tests

## Screenshots
N/A

## Acceptance criteria
- [x] Updates text to form last updated

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
