### PR TITLE
Add single BreadCrumb to LOA1

### DIFF
--- a/src/applications/personalization/profile-2/components/Profile2Router.jsx
+++ b/src/applications/personalization/profile-2/components/Profile2Router.jsx
@@ -106,7 +106,11 @@ class Profile2Router extends Component {
     const routes = getRoutes(this.props.shouldShowDirectDeposit);
     return (
       <BrowserRouter>
-        <Profile2Wrapper routes={routes}>
+        <Profile2Wrapper
+          routes={routes}
+          isLOA3={this.props.isLOA3}
+          isInMVI={this.props.isInMVI}
+        >
           <Switch>
             {/* Redirect users to Account Security to upgrade their account if they need to */}
             {routes.map(route => {

--- a/src/applications/personalization/profile-2/components/Profile2Wrapper.jsx
+++ b/src/applications/personalization/profile-2/components/Profile2Wrapper.jsx
@@ -25,7 +25,7 @@ const Profile2 = ({ children, routes, isLOA3, isInMVI }) => {
 
   // Without a verified identity, we want to show 'Home - Account Security'
   const showLOA1BreadCrumb =
-    !isLOA3 && !isInMVI && activeLocation === '/profile/account-security';
+    (!isLOA3 || !isInMVI) && activeLocation === '/profile/account-security';
 
   return (
     <>

--- a/src/applications/personalization/profile-2/components/Profile2Wrapper.jsx
+++ b/src/applications/personalization/profile-2/components/Profile2Wrapper.jsx
@@ -8,7 +8,7 @@ import ProfileHeader from './ProfileHeader';
 import ProfileSideNav from './ProfileSideNav';
 import MobileMenuTrigger from './MobileMenuTrigger';
 
-const Profile2 = ({ children, routes }) => {
+const Profile2 = ({ children, routes, isLOA3, isInMVI }) => {
   const location = useLocation();
   const createBreadCrumbAttributes = () => {
     const activeLocation = location?.pathname;
@@ -23,14 +23,27 @@ const Profile2 = ({ children, routes }) => {
   const onPersonalInformationMobile =
     activeLocation === '/profile/personal-information' && !isWideScreen();
 
+  // Without a verified identity, we want to show 'Home - Account Security'
+  const showLOA1BreadCrumb =
+    !isLOA3 && !isInMVI && activeLocation === '/profile/account-security';
+
   return (
     <>
       {/* Breadcrumbs */}
       <div data-testid="breadcrumbs">
         <Breadcrumbs className="vads-u-padding-x--1 vads-u-padding-y--1p5 medium-screen:vads-u-padding-y--0">
           <a href="/">Home</a>
-          {!onPersonalInformationMobile && <Link to="/">Your profile</Link>}
-          <a href={activeLocation}>{activeRouteName}</a>
+
+          {showLOA1BreadCrumb && (
+            <Link to="/">Your profile - Account Security</Link>
+          )}
+
+          {!showLOA1BreadCrumb &&
+            !onPersonalInformationMobile && <Link to="/">Your profile</Link>}
+
+          {!showLOA1BreadCrumb && (
+            <a href={activeLocation}>{activeRouteName}</a>
+          )}
         </Breadcrumbs>
       </div>
 

--- a/src/applications/personalization/profile-2/components/Profile2Wrapper.jsx
+++ b/src/applications/personalization/profile-2/components/Profile2Wrapper.jsx
@@ -35,7 +35,7 @@ const Profile2 = ({ children, routes, isLOA3, isInMVI }) => {
           <a href="/">Home</a>
 
           {showLOA1BreadCrumb && (
-            <Link to="/">Your profile - Account Security</Link>
+            <Link to="/">Your profile - Account security</Link>
           )}
 
           {!showLOA1BreadCrumb &&


### PR DESCRIPTION
[TICKET](https://github.com/department-of-veterans-affairs/va.gov-team/issues/10566)

## Description
You can test this PR with user +350 in staging.

The user should not be seeing a clickable link to 'Profile' when they are LOA1 or not in MVI and are on the account security page.

## Testing done
Works locally

## Screenshots
![image](https://user-images.githubusercontent.com/14869324/86954192-c95b5700-c112-11ea-8b35-19df749d467f.png)

## Acceptance criteria
- [x] Update breadcrumbs for when the user is not in LOA1 or not in MVI and is redirected to account security

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
