### PR TITLE
Change provider detail facility type to match search type

### DIFF
--- a/src/applications/facility-locator/containers/ProviderDetail.jsx
+++ b/src/applications/facility-locator/containers/ProviderDetail.jsx
@@ -54,7 +54,8 @@ class ProviderDetail extends Component {
         <div className="p1">
           <p>
             <span>
-              <strong>Facility type:</strong> Community Care (Non-VA Health)
+              <strong>Facility type:</strong> Community provider (in VA’s
+              network)
             </span>
           </p>
           <LocationAddress location={location} />


### PR DESCRIPTION
## Description
Given the facility type in the search = **Community providers (in VA’s network)**, when user selects a search result to view the Facility Detail page, then the facility type is shown as **Community provider (in VA’s network)**.

## Testing done
View a provider detail page and confirm facility type label.

## Screenshots


## Acceptance criteria
- [x]  Community provider facility type is shown as **Community provider (in VA’s network)**.

## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
