### PR TITLE
10888 vaos past appointments focus should be set on the updated label when results are returned

### DIFF
--- a/src/applications/vaos/components/PastAppointmentsDateDropdown.jsx
+++ b/src/applications/vaos/components/PastAppointmentsDateDropdown.jsx
@@ -37,8 +37,9 @@ export default function PastAppointmentsDateDropdown({
         onClick={() => {
           if (currentRange !== dateRangeIndex) {
             onChange(dateRangeIndex);
+          } else {
+            focusElement('#queryResultLabel');
           }
-          focusElement('#queryResultLabel');
         }}
       >
         Update

--- a/src/applications/vaos/components/PastAppointmentsDateDropdown.jsx
+++ b/src/applications/vaos/components/PastAppointmentsDateDropdown.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
+import { focusElement } from 'platform/utilities/ui';
 
 export default function PastAppointmentsDateDropdown({
   currentRange,
@@ -37,6 +38,7 @@ export default function PastAppointmentsDateDropdown({
           if (currentRange !== dateRangeIndex) {
             onChange(dateRangeIndex);
           }
+          focusElement('#queryResultLabel');
         }}
       >
         Update

--- a/src/applications/vaos/components/PastAppointmentsList.jsx
+++ b/src/applications/vaos/components/PastAppointmentsList.jsx
@@ -72,7 +72,12 @@ export class PastAppointmentsList extends React.Component {
     } else if (pastStatus === FETCH_STATUS.succeeded && past?.length > 0) {
       content = (
         <>
-          <span className="vads-u-font-size--sm vads-u-display--block vads-u-margin-bottom--1">
+          <span
+            id="queryResultLabel"
+            tabIndex="-1"
+            className="vads-u-font-size--sm vads-u-display--block vads-u-margin-bottom--1"
+            style={{ outline: 'none' }}
+          >
             Showing appointments for:{' '}
             {this.dateRangeOptions[appointments.pastSelectedIndex].label}
           </span>

--- a/src/applications/vaos/components/PastAppointmentsList.jsx
+++ b/src/applications/vaos/components/PastAppointmentsList.jsx
@@ -44,7 +44,7 @@ export class PastAppointmentsList extends React.Component {
       prevProps.appointments.pastStatus === FETCH_STATUS.loading &&
       this.props.appointments.pastStatus === FETCH_STATUS.succeeded
     ) {
-      focusElement('#pastAppts');
+      focusElement('#queryResultLabel');
     }
   }
 

--- a/src/applications/vaos/components/PastAppointmentsList.jsx
+++ b/src/applications/vaos/components/PastAppointmentsList.jsx
@@ -74,7 +74,6 @@ export class PastAppointmentsList extends React.Component {
         <>
           <span
             id="queryResultLabel"
-            tabIndex="-1"
             className="vads-u-font-size--sm vads-u-display--block vads-u-margin-bottom--1"
             style={{ outline: 'none' }}
           >

--- a/src/applications/vaos/tests/components/PastAppointmentsList.unit.spec.jsx
+++ b/src/applications/vaos/tests/components/PastAppointmentsList.unit.spec.jsx
@@ -204,8 +204,8 @@ describe('VAOS <PastAppointmentsList>', () => {
 
     expect(tree.find('h2[tabIndex="-1"]').exists()).to.be.true;
     expect(tree.find('h2[tabIndex="-1"]').text()).to.equal('Past appointments');
-    expect(document.activeElement.id).to.equal('pastAppts');
-    expect(document.activeElement.nodeName).to.equal('H2');
+    expect(document.activeElement.id).to.equal('queryResultLabel');
+    expect(document.activeElement.nodeName).to.equal('SPAN');
 
     tree.unmount();
   });


### PR DESCRIPTION
## Description
VAOS past appointments focus should be set on the updated label when results are returned

## Testing done
Unit and VoiceOver test

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
