### PR TITLE
[SCREENREADER] Add role="alert" to submit error alert

### DIFF
--- a/src/platform/forms-system/src/js/review/SubmitButtons.jsx
+++ b/src/platform/forms-system/src/js/review/SubmitButtons.jsx
@@ -139,7 +139,9 @@ export default function SubmitButtons(props) {
     return (
       <>
         <div className="row">
-          <div className="small-12 medium-12 columns">{submitMessage}</div>
+          <div className="small-12 medium-12 columns" role="alert">
+            {submitMessage}
+          </div>
         </div>
         {preSubmitSection}
         <div className="row form-progress-buttons schemaform-back-buttons">
@@ -156,7 +158,9 @@ export default function SubmitButtons(props) {
   return (
     <>
       <div className="row">
-        <div className="columns">{submitMessage}</div>
+        <div className="columns" role="alert">
+          {submitMessage}
+        </div>
       </div>
       {preSubmitSection}
       <div className="row form-progress-buttons">

--- a/src/platform/forms-system/test/js/review/SubmitButtons.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/review/SubmitButtons.unit.spec.jsx
@@ -55,6 +55,7 @@ describe('Schemaform review: <SubmitButtons>', () => {
     );
 
     expect(tree.everySubTree('.usa-alert-error')).not.to.be.empty;
+    expect(tree.everySubTree('div', { role: 'alert' })).not.to.be.empty;
     expect(tree.everySubTree('a').length).to.equal(2);
   });
   it('should render validation error', () => {
@@ -69,6 +70,7 @@ describe('Schemaform review: <SubmitButtons>', () => {
     expect(tree.everySubTree('.usa-alert-error')[0].text()).to.contain(
       'Some information in your application is missing or not valid',
     );
+    expect(tree.everySubTree('div', { role: 'alert' })).not.to.be.empty;
     expect(tree.everySubTree('ProgressButton').length).to.equal(2);
   });
   it('should render error in prod mode', () => {
@@ -83,6 +85,7 @@ describe('Schemaform review: <SubmitButtons>', () => {
     );
 
     expect(tree.everySubTree('.usa-alert-error')).not.to.be.empty;
+    expect(tree.everySubTree('div', { role: 'alert' })).not.to.be.empty;
     expect(tree.everySubTree('a').length).to.equal(1);
 
     // Reset buildtype
@@ -115,6 +118,7 @@ describe('Schemaform review: <SubmitButtons>', () => {
     expect(tree.everySubTree('.usa-alert-error')[0].text()).to.contain(
       'too many requests',
     );
+    expect(tree.everySubTree('div', { role: 'alert' })).not.to.be.empty;
     expect(tree.everySubTree('ProgressButton').length).to.equal(2);
   });
   it('should render client error', () => {
@@ -129,6 +133,7 @@ describe('Schemaform review: <SubmitButtons>', () => {
     expect(tree.everySubTree('.usa-alert-error')[0].text()).to.contain(
       'Internet connection',
     );
+    expect(tree.everySubTree('div', { role: 'alert' })).not.to.be.empty;
     expect(tree.everySubTree('ProgressButton').length).to.equal(2);
   });
 });


### PR DESCRIPTION
## Description

Alerts shown on the review & submit page do not include a `role="alert"`. These alerts need a role of "alert" so the screenreader will announce them to the user.

![Screen Shot 2020-07-09 at 11 17 58 AM](https://user-images.githubusercontent.com/136959/87068983-0b040480-c1dc-11ea-8029-0a8320e94b8b.png)

Related
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/11080
- https://github.com/department-of-veterans-affairs/vets-design-system-documentation/issues/204

## Testing done

- MacOS Safari & VoiceOver
- Updated unit tests

## Screenshots

See above

## Acceptance criteria
- [x] Screenreader announced alert contents when visible

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
