### PR TITLE
Add Express Care related feature toggles

### DIFF
--- a/src/applications/vaos/utils/selectors.js
+++ b/src/applications/vaos/utils/selectors.js
@@ -387,6 +387,10 @@ export const vaosPastAppts = state =>
   toggleValues(state).vaOnlineSchedulingPast;
 export const vaosVSPAppointmentNew = state =>
   toggleValues(state).vaOnlineSchedulingVspAppointmentNew;
+export const vaosExpressCare = state =>
+  toggleValues(state).vaOnlineSchedulingExpressCare;
+export const vaosExpressCareNew = state =>
+  toggleValues(state).vaOnlineSchedulingExpressCareNew;
 export const selectFeatureToggleLoading = state => toggleValues(state).loading;
 
 export const isWelcomeModalDismissed = state =>

--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -18,6 +18,8 @@ export default Object.freeze({
   vaOnlineSchedulingCCSPRequestNew: 'vaOnlineSchedulingCcspRequestNew',
   vaOnlineSchedulingVSPRequestList: 'vaOnlineSchedulingVspRequestList',
   vaOnlineSchedulingVSPRequestNew: 'vaOnlineSchedulingVspRequestNew',
+  vaOnlineSchedulingExpressCare: 'vaOnlineSchedulingExpressCare',
+  vaOnlineSchedulingExpressCareNew: 'vaOnlineSchedulingExpressCareNew',
   vaGlobalDowntimeNotification: 'vaGlobalDowntimeNotification',
   ssoe: 'ssoe',
   ssoeInbound: 'ssoeInbound',


### PR DESCRIPTION
## Description
This adds feature toggle names and selectors for the two express care toggles added in https://github.com/department-of-veterans-affairs/vets-api/pull/4500

Test coverage is low because unit testing the selectors feels pointless until they're being used.

## Acceptance criteria
- [ ] Toggles exist

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
