### PR TITLE
bradl3yC - 10637 - Conditionally render the form errors and spinner

### DIFF
--- a/src/applications/disability-benefits/2346/components/IntroductionPage.jsx
+++ b/src/applications/disability-benefits/2346/components/IntroductionPage.jsx
@@ -1,173 +1,118 @@
-import LoadingIndicator from '@department-of-veterans-affairs/formation-react/LoadingIndicator';
 import FormTitle from 'platform/forms-system/src/js/components/FormTitle';
 import SaveInProgressIntro from 'platform/forms/save-in-progress/SaveInProgressIntro';
 import React, { Component } from 'react';
-import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
-import { fetchFormStatus } from '../actions';
 import formConfig from '../config/form';
-import ErrorMessage from './ErrorMessage';
 import UnverifiedPrefillAlert from './UnverifiedPrefillAlert';
 
-class IntroductionPage extends Component {
-  componentDidMount() {
-    this.props.fetchFormStatus();
-  }
+const IntroductionPage = props => {
+  return (
+    <>
+      {' '}
+      <FormTitle title="Order hearing aid batteries and accessories" />
+      <p>Equal to VA Form 2346A (Request for Batteries and Accessories).</p>
+      <div className="schemaform-intro">
+        <SaveInProgressIntro
+          hideUnauthedStartLink
+          prefillEnabled={props.route.formConfig.prefillEnabled}
+          messages={props.route.formConfig.savedFormMessages}
+          pageList={props.route.pageList}
+          verifyRequiredPrefill={props.route.formConfig.verifyRequiredPrefill}
+          unverifiedPrefillAlert={<UnverifiedPrefillAlert />}
+          startText="Order hearing aid batteries and accessories"
+          unauthStartText="Sign in to start your order"
+          formConfig={formConfig}
+        >
+          Please complete the 2346 form to apply for ordering hearing aid
+          batteries and accessories.
+        </SaveInProgressIntro>
+        <h2
+          className="vads-u-font-size--h3"
+          itemProp="name"
+          id="am-i-eligible-to-order-prosthe"
+        >
+          Follow the steps below to order hearing aid batteries and accessories.
+        </h2>
+        <div className="process schemaform-process">
+          <ol>
+            <li className="process-step list-one">
+              <h3 className="vads-u-font-size--h4">Prepare</h3>
+              <p>To place an order, you’ll need your:</p>
+              <ul>
+                <li>Shipping address</li>
+                <li>Email address</li>
+                <li>Hearing aid information</li>
+              </ul>
+              <p className="vads-u-font-weight--bold">
+                What if I need help with my order?
+              </p>
+              <p>
+                If you need help ordering hearing aid batteries and accessories,
+                you can call the Denver Logistics Center Customer Service
+                Section at{' '}
+                <a aria-label="3 0 3. 2 7 3. 6 2 0 0." href="tel:303-273-6200">
+                  303-273-6200
+                </a>{' '}
+                or email <a href="mailto:dalc.css@va.gov">dalc.css@va.gov</a>.
+              </p>
+            </li>
+            <li className="process-step list-two">
+              <h3 className="vads-u-font-size--h4">Place your order</h3>
+              <p>
+                Complete this hearing aid batteries and accessories order form.
+              </p>
+              <p>These are the steps you can expect when placing an order:</p>
+              <ul>
+                <li>Confirm your personal information</li>
+                <li>Confirm or edit your shipping address and email address</li>
+                <li>Select any hearing aids that need batteries</li>
+                <li>Select any hearing aid accessories you need</li>
+                <li>Review and submit order</li>
+              </ul>
+              <p>
+                After submitting the order form, you’ll get a confirmation
+                message. You can print this for your records.
+              </p>
+            </li>
+            <li className="process-step list-three">
+              <h3 className="vads-u-font-size--h4">Track your order </h3>
+              <p>
+                You’ll receive an email with an order tracking number 1 to 2
+                days after you submit your order.
+              </p>
+            </li>
+            <li className="process-step list-four">
+              <h3 className="vads-u-font-size--h4">Receive your order</h3>
+              <p>
+                You should receive your order within the time frame shown on
+                your order tracking number.
+              </p>
+              <p className="vads-u-font-weight--bold">
+                What if I have questions about my order?
+              </p>
+              <p>
+                If you have questions about your order, you can call the DLC
+                Customer Service Section at{' '}
+                <a aria-label="3 0 3. 2 7 3. 6 2 0 0." href="tel:303-273-6200">
+                  303-273-6200
+                </a>{' '}
+                or email <a href="mailto:dalc.css@va.gov">dalc.css@va.gov</a>.{' '}
+              </p>
+            </li>
+          </ol>
+        </div>
+        <SaveInProgressIntro
+          buttonOnly
+          hideUnauthedStartLink
+          prefillEnabled={props.route.formConfig.prefillEnabled}
+          messages={props.route.formConfig.savedFormMessages}
+          pageList={props.route.pageList}
+          startText="Order hearing aid batteries and accessories"
+          unauthStartText="Sign in to start your order"
+          formConfig={formConfig}
+        />
+      </div>
+    </>
+  );
+};
 
-  render() {
-    const { isError, isLoggedIn, pending } = this.props;
-    const showMainContent = !pending && !isError;
-
-    return (
-      <>
-        {' '}
-        <FormTitle title="Order hearing aid batteries and accessories" />
-        <p>Equal to VA Form 2346A (Request for Batteries and Accessories).</p>
-        {pending && (
-          <LoadingIndicator setFocus message="Loading your information..." />
-        )}
-        {isError &&
-          !pending &&
-          isLoggedIn && (
-            <div className="vads-u-margin-bottom--3">
-              <ErrorMessage />
-            </div>
-          )}
-        {showMainContent && (
-          <div className="schemaform-intro">
-            <SaveInProgressIntro
-              hideUnauthedStartLink
-              prefillEnabled={this.props.route.formConfig.prefillEnabled}
-              messages={this.props.route.formConfig.savedFormMessages}
-              pageList={this.props.route.pageList}
-              verifyRequiredPrefill={
-                this.props.route.formConfig.verifyRequiredPrefill
-              }
-              unverifiedPrefillAlert={<UnverifiedPrefillAlert />}
-              startText="Order hearing aid batteries and accessories"
-              unauthStartText="Sign in to start your order"
-              formConfig={formConfig}
-            >
-              Please complete the 2346 form to apply for ordering hearing aid
-              batteries and accessories.
-            </SaveInProgressIntro>
-            <h2
-              className="vads-u-font-size--h3"
-              itemProp="name"
-              id="am-i-eligible-to-order-prosthe"
-            >
-              Follow the steps below to order hearing aid batteries and
-              accessories.
-            </h2>
-            <div className="process schemaform-process">
-              <ol>
-                <li className="process-step list-one">
-                  <h3 className="vads-u-font-size--h4">Prepare</h3>
-                  <p>To place an order, you’ll need your:</p>
-                  <ul>
-                    <li>Shipping address</li>
-                    <li>Email address</li>
-                    <li>Hearing aid information</li>
-                  </ul>
-                  <p className="vads-u-font-weight--bold">
-                    What if I need help with my order?
-                  </p>
-                  <p>
-                    If you need help ordering hearing aid batteries and
-                    accessories, you can call the Denver Logistics Center
-                    Customer Service Section at{' '}
-                    <a
-                      aria-label="3 0 3. 2 7 3. 6 2 0 0."
-                      href="tel:303-273-6200"
-                    >
-                      303-273-6200
-                    </a>{' '}
-                    or email{' '}
-                    <a href="mailto:dalc.css@va.gov">dalc.css@va.gov</a>.
-                  </p>
-                </li>
-                <li className="process-step list-two">
-                  <h3 className="vads-u-font-size--h4">Place your order</h3>
-                  <p>
-                    Complete this hearing aid batteries and accessories order
-                    form.
-                  </p>
-                  <p>
-                    These are the steps you can expect when placing an order:
-                  </p>
-                  <ul>
-                    <li>Confirm your personal information</li>
-                    <li>
-                      Confirm or edit your shipping address and email address
-                    </li>
-                    <li>Select any hearing aids that need batteries</li>
-                    <li>Select any hearing aid accessories you need</li>
-                    <li>Review and submit order</li>
-                  </ul>
-                  <p>
-                    After submitting the order form, you’ll get a confirmation
-                    message. You can print this for your records.
-                  </p>
-                </li>
-                <li className="process-step list-three">
-                  <h3 className="vads-u-font-size--h4">Track your order </h3>
-                  <p>
-                    You’ll receive an email with an order tracking number 1 to 2
-                    days after you submit your order.
-                  </p>
-                </li>
-                <li className="process-step list-four">
-                  <h3 className="vads-u-font-size--h4">Receive your order</h3>
-                  <p>
-                    You should receive your order within the time frame shown on
-                    your order tracking number.
-                  </p>
-                  <p className="vads-u-font-weight--bold">
-                    What if I have questions about my order?
-                  </p>
-                  <p>
-                    If you have questions about your order, you can call the DLC
-                    Customer Service Section at{' '}
-                    <a
-                      aria-label="3 0 3. 2 7 3. 6 2 0 0."
-                      href="tel:303-273-6200"
-                    >
-                      303-273-6200
-                    </a>{' '}
-                    or email{' '}
-                    <a href="mailto:dalc.css@va.gov">dalc.css@va.gov</a>.{' '}
-                  </p>
-                </li>
-              </ol>
-            </div>
-            <SaveInProgressIntro
-              buttonOnly
-              hideUnauthedStartLink
-              prefillEnabled={this.props.route.formConfig.prefillEnabled}
-              messages={this.props.route.formConfig.savedFormMessages}
-              pageList={this.props.route.pageList}
-              startText="Order hearing aid batteries and accessories"
-              unauthStartText="Sign in to start your order"
-              formConfig={formConfig}
-            />
-          </div>
-        )}
-      </>
-    );
-  }
-}
-
-const mapStateToProps = state => ({
-  isLoggedIn: state.user.login.currentlyLoggedIn,
-  isError: state.mdot.isError,
-  pending: state.mdot.pending,
-});
-
-const mapDispatchToProps = dispatch => ({
-  ...bindActionCreators({ fetchFormStatus }, dispatch),
-});
-
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps,
-)(IntroductionPage);
+export default IntroductionPage;

--- a/src/applications/disability-benefits/2346/config/form.js
+++ b/src/applications/disability-benefits/2346/config/form.js
@@ -52,15 +52,6 @@ addressWithIsMilitaryBase.properties['view:livesOnMilitaryBaseInfo'] = {
   type: 'string',
 };
 
-// the following two properties have to be added to our MDOT-schema.json.  Remove these props once they are added.
-addressWithIsMilitaryBase.properties.country = {
-  type: 'string',
-};
-
-addressWithIsMilitaryBase.properties.state = {
-  type: 'string',
-};
-
 const submit = form => {
   const currentAddress = form.data['view:currentAddress'];
   const itemQuantities = form.data?.selectedProducts?.length;

--- a/src/applications/disability-benefits/2346/containers/App.jsx
+++ b/src/applications/disability-benefits/2346/containers/App.jsx
@@ -1,22 +1,63 @@
-import React from 'react';
+import React, { Component } from 'react';
 import Breadcrumbs from '@department-of-veterans-affairs/formation-react/Breadcrumbs';
 import RoutedSavableApp from 'platform/forms/save-in-progress/RoutedSavableApp';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+import { fetchFormStatus } from '../actions';
 import formConfig from '../config/form';
+import LoadingIndicator from '@department-of-veterans-affairs/formation-react/LoadingIndicator';
+import ErrorMessage from '../components/ErrorMessage';
 
-export default function App({ location, children }) {
-  return (
-    <>
-      <Breadcrumbs>
-        <a href="/">Home</a>
-        {/* this will get updated when this route is added */}
-        <a href="/health-care">Health care</a>
-        <span className="vads-u-color--black">
-          <strong>Order hearing aid batteries and accessories</strong>
-        </span>
-      </Breadcrumbs>
-      <RoutedSavableApp formConfig={formConfig} currentLocation={location}>
-        {children}
-      </RoutedSavableApp>
-    </>
-  );
+class App extends Component {
+  componentDidMount() {
+    this.props.fetchFormStatus();
+  }
+
+  render() {
+    const { location, children, isError, pending, isLoggedIn } = this.props;
+    const showMainContent = !pending && !isError;
+
+    return (
+      <>
+        <Breadcrumbs>
+          <a href="/">Home</a>
+          {/* this will get updated when this route is added */}
+          <a href="/health-care">Health care</a>
+          <span className="vads-u-color--black">
+            <strong>Order hearing aid batteries and accessories</strong>
+          </span>
+        </Breadcrumbs>
+        {pending && (
+          <LoadingIndicator setFocus message="Loading your information..." />
+        )}
+        {isError &&
+          !pending &&
+          isLoggedIn && (
+            <div className="vads-u-margin-bottom--3">
+              <ErrorMessage />
+            </div>
+          )}
+        {showMainContent && (
+          <RoutedSavableApp formConfig={formConfig} currentLocation={location}>
+            {children}
+          </RoutedSavableApp>
+        )}
+      </>
+    );
+  }
 }
+
+const mapStateToProps = state => ({
+  isLoggedIn: state.user.login.currentlyLoggedIn,
+  isError: state.mdot.isError,
+  pending: state.mdot.pending,
+});
+
+const mapDispatchToProps = dispatch => ({
+  ...bindActionCreators({ fetchFormStatus }, dispatch),
+});
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(App);

--- a/src/applications/disability-benefits/2346/schemas/address-schema.js
+++ b/src/applications/disability-benefits/2346/schemas/address-schema.js
@@ -247,6 +247,14 @@ const addressSchema = {
         },
       },
     },
+    {
+      properties: {
+        isMilitaryBase: {
+          type: 'boolean',
+          default: false,
+        },
+      },
+    },
   ],
   properties: {
     isMilitaryBase: {


### PR DESCRIPTION
## Description
To stay congruent with the 526EZ behavior, we do not want to render the footer content if the form is in an error state

This PR will only render the form if there is not an error state thus hiding the footer that you cannot otherwise hide in the formConfig

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
