### PR TITLE
Fix phone number formatting. Add links.

### DIFF
--- a/src/applications/facility-locator/components/search-results/LocationPhoneLink.jsx
+++ b/src/applications/facility-locator/components/search-results/LocationPhoneLink.jsx
@@ -18,20 +18,22 @@ const renderPhoneNumber = (title, subTitle = null, phone, from) => {
   }
 
   return (
-    <>
+    <div>
       {from === 'FacilityDetail' && (
         <i aria-hidden="true" role="presentation" className="fa fa-phone" />
       )}
       {title && <strong>{title}: </strong>}
       {subTitle}
       <Telephone
-        className="vads-u-margin-left--0p25"
+        className={
+          subTitle ? 'vads-u-margin-left--0p5' : 'vads-u-margin-left--0p25'
+        }
         contact={contact}
         extension={extension}
       >
         {formattedPhoneNumber}
       </Telephone>
-    </>
+    </div>
   );
 };
 
@@ -61,7 +63,7 @@ const LocationPhoneLink = ({ location, from, query }) => {
     attributes: { phone },
   } = location;
   return (
-    <div>
+    <div className="facility-phone-group">
       {renderPhoneNumber('Main Number', null, phone.main, from)}
       {renderPhoneNumber('Mental Health', null, phone.mentalHealthClinic, from)}
     </div>

--- a/src/applications/facility-locator/components/search-results/LocationPhoneLink.jsx
+++ b/src/applications/facility-locator/components/search-results/LocationPhoneLink.jsx
@@ -1,40 +1,35 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import Telephone from '@department-of-veterans-affairs/formation-react/Telephone';
 import { LocationType } from '../../constants';
 
-const renderPhoneNumber = (
-  title,
-  subTitle = null,
-  phone,
-  icon = 'fw',
-  altPhone,
-  from,
-  isCCProvider,
-) => {
+const renderPhoneNumber = (title, subTitle = null, phone, from) => {
   if (!phone) {
     return null;
   }
 
-  const re = /^(\d{3})[ -]?(\d{3})[ -]?(\d{4})[ ]?(x?)[ ]?(\d*)/;
+  // TODO: write a unit test for this parsing logic!
+  const re = /^(\d{3})[ -]?(\d{3})[ -]?(\d{4})\s?(x|ext)[ ]?(\d*)/i;
+  const formattedPhoneNumber = phone
+    .replace(re, '$1-$2-$3 x$5')
+    .replace(/x$/, '');
+  const extension = phone.replace(re, '$5').replace(/\D/g, '');
+  const contact = phone.replace(re, '$1$2$3');
 
   return (
     <div>
-      {from === 'FacilityDetail' && <i className={`fa fa-${icon}`} />}
+      {from === 'FacilityDetail' && (
+        <i aria-hidden="true" role="presentation" className="fa fa-phone" />
+      )}
       {title && <strong>{title}: </strong>}
-      {!isCCProvider && phone.replace(re, '$1-$2-$3 $4$5').replace(/x$/, '')}
-      <br />
-      {from === 'FacilityDetail' && <i className="fa fa-fw" />}
       {subTitle}
-      {isCCProvider &&
-        ` ${phone.replace(re, '$1-$2-$3 $4$5').replace(/x$/, '')}`}
-      {from === 'FacilityDetail' ? (
-        <a
-          href={`tel:${phone.replace(/[ ]?x/, '')}`}
-          className={altPhone && 'facility-phone-alt'}
-        >
-          {phone.replace(re, '$1-$2-$3 $4$5').replace(/x$/, '')}
-        </a>
-      ) : null}
+      <Telephone
+        className="vads-u-margin-left--0p25"
+        contact={contact}
+        extension={extension}
+      >
+        {formattedPhoneNumber}
+      </Telephone>
     </div>
   );
 };
@@ -50,10 +45,7 @@ const LocationPhoneLink = ({ location, from, query }) => {
           isCCProvider ? 'If you have a referral' : null,
           isCCProvider ? 'Call this facility at' : null,
           phone,
-          'phone',
           true,
-          undefined,
-          isCCProvider,
         )}
         {isCCProvider && (
           <p>
@@ -69,20 +61,15 @@ const LocationPhoneLink = ({ location, from, query }) => {
   } = location;
   return (
     <div>
-      {renderPhoneNumber('Main Number', null, phone.main, 'phone', null, from)}
-      {renderPhoneNumber(
-        'Mental Health',
-        null,
-        phone.mentalHealthClinic,
-        null,
-        from,
-      )}
+      {renderPhoneNumber('Main Number', null, phone.main, from)}
+      {renderPhoneNumber('Mental Health', null, phone.mentalHealthClinic, from)}
     </div>
   );
 };
 
 LocationPhoneLink.propTypes = {
   location: PropTypes.object,
+  from: PropTypes.string,
 };
 
 export default LocationPhoneLink;

--- a/src/applications/facility-locator/components/search-results/LocationPhoneLink.jsx
+++ b/src/applications/facility-locator/components/search-results/LocationPhoneLink.jsx
@@ -2,22 +2,23 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Telephone from '@department-of-veterans-affairs/formation-react/Telephone';
 import { LocationType } from '../../constants';
+import { parsePhoneNumber } from '../../utils/phoneNumbers';
 
 const renderPhoneNumber = (title, subTitle = null, phone, from) => {
   if (!phone) {
     return null;
   }
 
-  // TODO: write a unit test for this parsing logic!
-  const re = /^(\d{3})[ -]?(\d{3})[ -]?(\d{4})\s?(x|ext)[ ]?(\d*)/i;
-  const formattedPhoneNumber = phone
-    .replace(re, '$1-$2-$3 x$5')
-    .replace(/x$/, '');
-  const extension = phone.replace(re, '$5').replace(/\D/g, '');
-  const contact = phone.replace(re, '$1$2$3');
+  const { formattedPhoneNumber, extension, contact } = parsePhoneNumber(phone);
+
+  // The Telephone component will throw an error if passed an invalid phone number.
+  // Since we can't use try/catch or componentDidCatch here, we'll just do this:
+  if (contact.length !== 10) {
+    return null;
+  }
 
   return (
-    <div>
+    <>
       {from === 'FacilityDetail' && (
         <i aria-hidden="true" role="presentation" className="fa fa-phone" />
       )}
@@ -30,7 +31,7 @@ const renderPhoneNumber = (title, subTitle = null, phone, from) => {
       >
         {formattedPhoneNumber}
       </Telephone>
-    </div>
+    </>
   );
 };
 

--- a/src/applications/facility-locator/sass/facility-locator.scss
+++ b/src/applications/facility-locator/sass/facility-locator.scss
@@ -820,3 +820,8 @@ $facility-locator-color-gray: #ccc;
 .icon-base {
   color: $color-base !important;
 }
+
+.facility-phone-group {
+  display: flex;
+  flex-direction: column;
+}

--- a/src/applications/facility-locator/tests/components/LocationPhoneLink.unit.spec.jsx
+++ b/src/applications/facility-locator/tests/components/LocationPhoneLink.unit.spec.jsx
@@ -12,7 +12,7 @@ describe('LocationPhoneLink', () => {
     const wrapper = shallow(
       <LocationPhoneLink location={locationWithBadPhone} />,
     );
-    expect(wrapper.html()).to.equal('<div></div>');
+    expect(wrapper.html()).to.equal('<div class="facility-phone-group"></div>');
     wrapper.unmount();
   });
 

--- a/src/applications/facility-locator/tests/components/LocationPhoneLink.unit.spec.jsx
+++ b/src/applications/facility-locator/tests/components/LocationPhoneLink.unit.spec.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+import LocationPhoneLink from '../../components/search-results/LocationPhoneLink';
+
+describe('LocationPhoneLink', () => {
+  it('should render null if bad phone number passed', () => {
+    const locationWithBadPhone = {
+      attributes: { phone: { main: '123456789' } },
+    };
+
+    const wrapper = shallow(
+      <LocationPhoneLink location={locationWithBadPhone} />,
+    );
+    expect(wrapper.html()).to.equal('<div></div>');
+    wrapper.unmount();
+  });
+
+  it('should render correctly given a proper phone', () => {
+    const locationWithGoodPhone = {
+      attributes: { phone: { main: '1234567890' } },
+    };
+
+    const wrapper = shallow(
+      <LocationPhoneLink location={locationWithGoodPhone} />,
+    );
+    expect(wrapper.find('Telephone').length).to.equal(1);
+    expect(wrapper.find('strong').text()).to.equal('Main Number: ');
+    wrapper.unmount();
+  });
+});

--- a/src/applications/facility-locator/tests/helpers/helpers.unit.spec.js
+++ b/src/applications/facility-locator/tests/helpers/helpers.unit.spec.js
@@ -4,7 +4,7 @@ import {
   formatOperatingHours,
   validateIdString,
   isVADomain,
-} from '../utils/helpers';
+} from '../../utils/helpers';
 
 describe('Locator Helper Method Tests', () => {
   describe('areBoundsEqual Tests', () => {

--- a/src/applications/facility-locator/tests/helpers/phoneNumbers.unit.spec.js
+++ b/src/applications/facility-locator/tests/helpers/phoneNumbers.unit.spec.js
@@ -1,0 +1,44 @@
+import { expect } from 'chai';
+import { parsePhoneNumber } from '../../utils/phoneNumbers';
+
+describe('parsePhoneNumber', () => {
+  it('without extension, without dashes', () => {
+    const phone = '1234567890';
+    const { formattedPhoneNumber, extension, contact } = parsePhoneNumber(
+      phone,
+    );
+    expect(formattedPhoneNumber).to.equal('123-456-7890');
+    expect(extension).to.equal('');
+    expect(contact).to.equal('1234567890');
+  });
+
+  it('with extension, without dashes', () => {
+    const phone = '1234567890 x123';
+    const { formattedPhoneNumber, extension, contact } = parsePhoneNumber(
+      phone,
+    );
+    expect(formattedPhoneNumber).to.equal('123-456-7890 x123');
+    expect(extension).to.equal('123');
+    expect(contact).to.equal('1234567890');
+  });
+
+  it('with dashes', () => {
+    const phone = '123-456--7890';
+    const { formattedPhoneNumber, extension, contact } = parsePhoneNumber(
+      phone,
+    );
+    expect(formattedPhoneNumber).to.equal('123-456-7890');
+    expect(extension).to.equal('');
+    expect(contact).to.equal('1234567890');
+  });
+
+  it('with spaces and extension', () => {
+    const phone = '123  456 7890 Extension 123';
+    const { formattedPhoneNumber, extension, contact } = parsePhoneNumber(
+      phone,
+    );
+    expect(formattedPhoneNumber).to.equal('123-456-7890 x123');
+    expect(extension).to.equal('123');
+    expect(contact).to.equal('1234567890');
+  });
+});

--- a/src/applications/facility-locator/utils/phoneNumbers.js
+++ b/src/applications/facility-locator/utils/phoneNumbers.js
@@ -1,0 +1,24 @@
+/**
+ * @typedef {Object} ParsedPhoneNumber
+ * @property {string} formattedPhoneNumber - 9-digit number with dashes added
+ * @property {string} extension - the extension, can be any number of digits
+ * @property {string} contact - the "raw" phone number, used to populate the tel: link
+ */
+
+/**
+ * Parses a phone number string for use with the Telephone component.
+ * @param phone {String} "raw" phone number. The first 9 digits are treated as the "main" number.
+ * Any remaining digits are treated as the extension.
+ * Non-digits preceding the extension are ignored.
+ * @returns {ParsedPhoneNumber}
+ */
+
+export const parsePhoneNumber = phone => {
+  const re = /^(\d{3})[ -]*?(\d{3})[ -]*?(\d{4})\s?(\D*)?[ ]?(\d*)?/;
+  const extension = phone.replace(re, '$5').replace(/\D/g, '');
+  const formattedPhoneNumber = extension
+    ? phone.replace(re, '$1-$2-$3 x$5').replace(/x$/, '')
+    : phone.replace(re, '$1-$2-$3');
+  const contact = phone.replace(re, '$1$2$3');
+  return { formattedPhoneNumber, extension, contact };
+};


### PR DESCRIPTION
## Description
Add links to all facility phone numbers on both result and detail pages.

## Testing done
Manual

## Screenshots
![Kalispell_VA_Clinic___Veterans_Affairs](https://user-images.githubusercontent.com/80267/87098633-c5fcc400-c215-11ea-980f-4a517812891d.png)

## Acceptance criteria
- [x] Unique phone numbers are displayed only once.
- [x] Any phone numbers (main and/or mental health) displayed on search result cards will have the visual appearance and functionality of a link.
- [x] Any phone numbers (main and/or mental health) displayed on facility detail pages will have the visual appearance and functionality of a link.
- [x] Any phone numbers (main and/or mental health) displayed within Facility Locator will be accessible to users with assistive technology.
- [x]  A Mental health phone number and a Main phone number is displayed whenever both are present in the data (even if the phone number itself is the same).
- [x] Axe checks for this functionality pass
- [x] Zoom testing passes
- [x]  Keyboard checks pass
- [x]  Screenreader checks pass

## Definition of done
- [x] Events are logged appropriately
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
