### PR TITLE
Add connected apps errors

### DIFF
--- a/src/applications/personalization/profile-2/components/connected-apps/ConnectedApps.jsx
+++ b/src/applications/personalization/profile-2/components/connected-apps/ConnectedApps.jsx
@@ -95,7 +95,7 @@ export class ConnectedApps extends Component {
             <AlertBox
               key={`${app.attributes?.title}`}
               className="vads-u-margin-bottom--2"
-              headline={`We couldn't disconnect ${app.attributes?.title}`}
+              headline={`We couldn’t disconnect ${app.attributes?.title}`}
               status="error"
               content={`We’re sorry. Something went wrong on our end and we couldn’t disconnect ${
                 app.attributes?.title
@@ -105,7 +105,7 @@ export class ConnectedApps extends Component {
         {!isEmpty(errors) && (
           <AlertBox
             className="vads-u-margin-bottom--2"
-            headline="We couldn't retrieve your connected apps"
+            headline="We couldn’t retrieve your connected apps"
             status="warning"
             content="We’re sorry. Something went wrong on our end and we couldn’t access your connected apps. Please try again later."
           />

--- a/src/applications/personalization/profile-2/components/connected-apps/ConnectedApps.jsx
+++ b/src/applications/personalization/profile-2/components/connected-apps/ConnectedApps.jsx
@@ -95,17 +95,17 @@ export class ConnectedApps extends Component {
             <AlertBox
               key={`${app.attributes?.title}`}
               className="vads-u-margin-bottom--2"
-              headline={`We are unable to disconnect ${app.attributes?.title}`}
-              status="warning"
+              headline={`We couldn't disconnect ${app.attributes?.title}`}
+              status="error"
               content={`We’re sorry. Something went wrong on our end and we couldn’t disconnect ${
                 app.attributes?.title
               }. Please try again later.`}
             />
           ))}
-        {isEmpty(errors) && (
+        {!isEmpty(errors) && (
           <AlertBox
             className="vads-u-margin-bottom--2"
-            headline="We are unable to retrieve your connected apps"
+            headline="We couldn't retrieve your connected apps"
             status="warning"
             content="We’re sorry. Something went wrong on our end and we couldn’t access your connected apps. Please try again later."
           />

--- a/src/applications/personalization/profile-2/components/connected-apps/ConnectedApps.jsx
+++ b/src/applications/personalization/profile-2/components/connected-apps/ConnectedApps.jsx
@@ -36,11 +36,8 @@ export class ConnectedApps extends Component {
     const allAppsDeleted = deletedApps?.length === apps?.length;
     const showHasNoConnectedApps = !apps || (allAppsDeleted && !loading);
     const showHasConnectedApps = apps && !allAppsDeleted;
-
     // Check if any of the active apps have errors
-    const disconnectErrorApps = activeApps.filter(
-      activeApp => !isEmpty(activeApp.errors),
-    );
+    const disconnectErrorApps = activeApps.filter(app => !isEmpty(app.errors));
 
     return (
       <div className="va-connected-apps">
@@ -96,17 +93,18 @@ export class ConnectedApps extends Component {
         {!isEmpty(disconnectErrorApps) &&
           disconnectErrorApps.map(app => (
             <AlertBox
-              key={`${app.attributes.title}`}
-              headline={`We are unable to disconnect ${app.attributes.title}`}
+              key={`${app.attributes?.title}`}
+              className="vads-u-margin-bottom--2"
+              headline={`We are unable to disconnect ${app.attributes?.title}`}
               status="warning"
               content={`We’re sorry. Something went wrong on our end and we couldn’t disconnect ${
-                app.attributes.title
+                app.attributes?.title
               }. Please try again later.`}
             />
           ))}
-
-        {!isEmpty(errors) && (
+        {isEmpty(errors) && (
           <AlertBox
+            className="vads-u-margin-bottom--2"
             headline="We are unable to retrieve your connected apps"
             status="warning"
             content="We’re sorry. Something went wrong on our end and we couldn’t access your connected apps. Please try again later."


### PR DESCRIPTION
## Description
This PR adds 2 error states to the connected apps feature.

## Testing done
Works locally, will need integration tests.

## Screenshots
![image](https://user-images.githubusercontent.com/14869324/87188987-08bdab00-c2ad-11ea-8149-aae4935f2c6f.png)
![image](https://user-images.githubusercontent.com/14869324/87189101-49b5bf80-c2ad-11ea-9acc-6eb9572303f5.png)


## Acceptance criteria
- [x] Add error state when there is an error fetching connected apps
- [x] Add error state when there is an error disconnecting from an app

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
