### PR TITLE
[Development] CST: Show message when no claims present

### DIFF
--- a/src/applications/claims-status/containers/YourClaimsPageV2.jsx
+++ b/src/applications/claims-status/containers/YourClaimsPageV2.jsx
@@ -138,7 +138,7 @@ class YourClaimsPageV2 extends React.Component {
     const bothRequestsLoaded = !claimsLoading && !appealsLoading;
     const bothRequestsLoading = claimsLoading && appealsLoading;
     const atLeastOneRequestLoading = claimsLoading || appealsLoading;
-    const emptyList = !list || !list.length;
+    const emptyList = !(list && list.length);
     if (bothRequestsLoading || (atLeastOneRequestLoading && emptyList)) {
       content = (
         <LoadingIndicator
@@ -169,7 +169,7 @@ class YourClaimsPageV2 extends React.Component {
             </div>
           </div>
         );
-      } else if (!this.props.canAccessClaims && bothRequestsLoaded) {
+      } else if (bothRequestsLoaded) {
         content = <NoClaims />;
       }
       content = <div className="va-tab-content">{content}</div>;

--- a/src/applications/claims-status/tests/components/YourClaimsPageV2.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/YourClaimsPageV2.unit.spec.jsx
@@ -81,7 +81,6 @@ describe('<YourClaimsPageV2>', () => {
 
   it('should render a no claims message when no claims or appeals present', () => {
     const props = _.cloneDeep(defaultProps);
-    props.canAccessClaims = false;
     props.list = [];
     const wrapper = shallow(<YourClaimsPageV2 {...props} />);
     expect(wrapper.find('NoClaims').length).to.equal(1);

--- a/src/applications/claims-status/tests/e2e/00.claims-list-empty.e2e.spec.js
+++ b/src/applications/claims-status/tests/e2e/00.claims-list-empty.e2e.spec.js
@@ -1,0 +1,25 @@
+const E2eHelpers = require('platform/testing/e2e/helpers');
+const Timeouts = require('platform/testing/e2e/timeouts.js');
+const Auth = require('platform/testing/e2e/auth');
+const DisabilityHelpers = require('./claims-status-helpers');
+
+module.exports = E2eHelpers.createE2eTest(client => {
+  const token = Auth.getUserToken();
+
+  DisabilityHelpers.initClaimsListEmptyMock(token);
+
+  // Claim is visible
+  Auth.logIn(token, client, '/track-claims', 3).waitForElementVisible(
+    '.claims-container-title',
+    Timeouts.slow,
+  );
+
+  // Verify text on page
+  client.expect
+    .element('.claims-alert')
+    .text.to.contain('You do not have any submitted claims');
+
+  client.axeCheck('.main');
+
+  client.end();
+});

--- a/src/applications/claims-status/tests/e2e/claims-status-helpers.js
+++ b/src/applications/claims-status/tests/e2e/claims-status-helpers.js
@@ -8,6 +8,19 @@ function initAskVAMock(token) {
   });
 }
 
+function initClaimsListEmptyMock(token) {
+  mock(token, {
+    path: '/v0/evss_claims_async',
+    verb: 'get',
+    value: {
+      data: [],
+      meta: {
+        syncStatus: 'SUCCESS',
+      },
+    },
+  });
+}
+
 function initClaimsListMock(token) {
   mock(token, {
     path: '/v0/evss_claims_async',
@@ -235,6 +248,7 @@ function initClaimDetailMocks(
   });
 }
 module.exports = {
+  initClaimsListEmptyMock,
   initClaimsListMock,
   initClaimDetailMocks,
   initAskVAMock,


### PR DESCRIPTION
## Description

The Claim status tool currently shows an empty section when a user has no claims or appeals

<details><summary>No claims or appeals screenshot (before)</summary>

<!-- leave a blank line above -->
![](https://user-images.githubusercontent.com/136959/80751548-9c297180-8aef-11ea-9fa8-101604b45440.png)</details>

This PR reveals the already existing no claims message (includes appeals) & adds more tests

<details><summary>No claims or appeals screenshot (after)</summary>

<!-- leave a blank line above -->
![](https://user-images.githubusercontent.com/136959/87165889-5f68bc00-c290-11ea-9045-d834a02a883e.png)</details>

Related issue: https://github.com/department-of-veterans-affairs/va.gov-team/issues/8625

## Testing done

Added new unit & e2e tests

## Screenshots

See description

## Acceptance criteria
- [x] A user with an empty list of claims & appeals will see an appropriate message

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
