### PR TITLE
COVID screener custom question content

### DIFF
--- a/src/applications/coronavirus-screener/config/questions.jsx
+++ b/src/applications/coronavirus-screener/config/questions.jsx
@@ -68,8 +68,7 @@ export const questions = [
   },
   {
     id: 'travel-459GF',
-    text:
-      'In the past 14 days, have you traveled outside of American Samoa (Faleomavaega Eni Faíauaía Hunkin)?',
+    text: 'In the past 14 days, have you traveled outside of American Samoa?',
     customId: ['459GF'],
   },
   {
@@ -77,6 +76,17 @@ export const questions = [
     text:
       'In the past 14 days, have you traveled outside of the Northern Mariana Islands?',
     customId: ['459GH'],
+  },
+  {
+    id: 'travel-new-england-ma-ct-ri',
+    text: 'In the past 14 days, have you traveled outside of New England?',
+    customId: ['523', '650', '689', '402', '405', '631', '518', '608', '478'],
+  },
+  {
+    id: 'travel-ny',
+    text:
+      'In the past 14 days, have you traveled outside of New York and its surrounding states?',
+    customId: ['526', '528', '620', '630', '632'],
   },
 ];
 


### PR DESCRIPTION
## Description
- Adds custom questions for MA, CT, RI, and NY regarding travel outside the region.
- Minor update to American Samoa question.


## Testing done
- Unit tests run w/ CI
- Manually tested at /covid19screen/523.

## Screenshots
<img width="813" alt="Screen Shot 2020-07-10 at 12 49 56 PM" src="https://user-images.githubusercontent.com/7645362/87178898-e2e3d680-c2ab-11ea-990c-e421a49cc512.png">

## Acceptance criteria
- [ ] Users navigating to any of the following URLs are asked an additional question about travel outside of a particular place:

https://www.va.gov/covid19screen/402
https://www.va.gov/covid19screen/405
https://www.va.gov/covid19screen/478
https://www.va.gov/covid19screen/518
https://www.va.gov/covid19screen/523
https://www.va.gov/covid19screen/608
https://www.va.gov/covid19screen/631
https://www.va.gov/covid19screen/650
https://www.va.gov/covid19screen/689
https://www.va.gov/covid19screen/459
https://www.va.gov/covid19screen/459GE
https://www.va.gov/covid19screen/459GF
https://www.va.gov/covid19screen/459GH
https://www.va.gov/covid19screen/526
https://www.va.gov/covid19screen/528
https://www.va.gov/covid19screen/620
https://www.va.gov/covid19screen/630
https://www.va.gov/covid19screen/632

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
