### PR TITLE
Add fully featured URLSearchParams polyfill to fix iOS SSO bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -321,6 +321,7 @@
     "tar-fs": "^2.0.1",
     "tinyliquid": "^0.2.33",
     "url-search-params": "^1.1.0",
+    "url-search-params-polyfill": "^8.1.0",
     "uswds": "1.6.10",
     "vanilla-lazyload": "^16.1.0",
     "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#a8176c1d1837b389e9dd367f3a87aa47bbd3bc59",

--- a/src/platform/user/authentication/utilities.js
+++ b/src/platform/user/authentication/utilities.js
@@ -1,6 +1,6 @@
 import appendQuery from 'append-query';
 import * as Sentry from '@sentry/browser';
-import URLSearchParams from 'url-search-params';
+import 'url-search-params-polyfill';
 
 import recordEvent from '../../monitoring/record-event';
 import environment from '../../utilities/environment';

--- a/src/platform/utilities/sso/mockKeepAliveSSO.js
+++ b/src/platform/utilities/sso/mockKeepAliveSSO.js
@@ -1,3 +1,9 @@
+import 'url-search-params-polyfill';
+
 export default function keepAlive() {
-  return Promise.resolve({});
+  const params = new URLSearchParams(window.location.search);
+  return Promise.resolve({
+    ttl: params.get('keepalive-ttl'),
+    authn: params.get('keepalive-authn'),
+  });
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -16850,6 +16850,11 @@ url-parse@^1.4.3:
     querystringify "^2.1.1"
     requires-port "^1.0.0"
 
+url-search-params-polyfill@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/url-search-params-polyfill/-/url-search-params-polyfill-8.1.0.tgz#5c15b69687165bfd4f6c7d8a161d70d85385885b"
+  integrity sha512-MRG3vzXyG20BJ2fox50/9ZRoe+2h3RM7DIudVD2u/GY9MtayO1Dkrna76IUOak+uoUPVWbyR0pHCzxctP/eDYQ==
+
 url-search-params@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/url-search-params/-/url-search-params-1.1.0.tgz#865669a6e4e9e5543f86fc972b27c91485375326"


### PR DESCRIPTION
## Description

The existing polyfill for URLSearchParams has a known bug that the SSO team has encountered, and the package itself is deprecated. This transitions that dependency to a more widely used and up-to-date polyfill.

While this addresses the immediate need for this package, department-of-veterans-affairs/vets-website#13412 fully deprecates the old package, but requires more thorough manual testing before it can be merged

fixes https://github.com/department-of-veterans-affairs/va.gov-team/issues/11048

## Testing done
- Unit Tests Pass
- Manually verified in IE and mobile Safari