### PR TITLE
VACMS-2235: Adding filter to prevent expired events from being featured.

### DIFF
--- a/src/site/layouts/health_care_region_page.drupal.liquid
+++ b/src/site/layouts/health_care_region_page.drupal.liquid
@@ -310,7 +310,7 @@ Example data:
             <a onClick="recordEvent({ event: 'nav-secondary-button-click' });"
               class="usa-button usa-button-secondary vads-facility-hub-button vads-u-width--full medium-screen:vads-u-width--auto vads-u-font-size--md vads-u-margin--0"
               href="{{ entityUrl.path }}/events">
-              See all events <i class="fa fa-chevron-right va-l-font-size--12px"></i>
+              See all events <i class="fa fa-chevron-right va-l-font-size--12px" aria-hidden="true"></i>
             </a>
           </section>
           {% endif %}

--- a/src/site/layouts/health_care_region_page.drupal.liquid
+++ b/src/site/layouts/health_care_region_page.drupal.liquid
@@ -298,6 +298,21 @@ Example data:
                 class="fa fa-chevron-right va-l-font-size--12px"></i>
             </a>
           </section>
+          {% elsif eventTeasersAll.entities.0.reverseFieldListingNode.entities.length %}
+          <section>
+            <h2
+              class="vads-u-margin-top--4 vads-u-margin-bottom--2 medium-screen:vads-u-margin-bottom--2p5">
+              Events</h2>
+            {% for event in eventTeasersAll.entities.0.reverseFieldListingNode.entities %}
+            {% assign node = event %}
+            {% include "src/site/teasers/event.drupal.liquid" %}
+            {% endfor %}
+            <a onClick="recordEvent({ event: 'nav-secondary-button-click' });"
+              class="usa-button usa-button-secondary vads-facility-hub-button vads-u-width--full medium-screen:vads-u-width--auto vads-u-font-size--md vads-u-margin--0"
+              href="{{ entityUrl.path }}/events">
+              See all events <i class="fa fa-chevron-right va-l-font-size--12px"></i>
+            </a>
+          </section>
           {% endif %}
 
           <!-- Social Links -->

--- a/src/site/stages/build/drupal/graphql/healthCareRegionPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/healthCareRegionPage.graphql.js
@@ -117,10 +117,51 @@ module.exports = `
     fieldPressReleaseBlurb {
       processed
     }
+    eventTeasersAll: reverseFieldOfficeNode(limit: 1000, filter: {conditions: [{field: "type", value: "event_listing"}]}) {
+      entities {
+        ... on NodeEventListing {
+          reverseFieldListingNode(sort: {field: "field_date", direction: ASC }, limit: 1, filter: {conditions: [{field: "type", value: "event"}, {field: "status", value: "1"}, { field: "field_date", value: [$today], operator: GREATER_THAN}]}) {
+            entities {
+              ... on NodeEvent {
+                title
+                uid {
+                  targetId
+                  ... on FieldNodeUid {
+                    entity {
+                      name
+                      timezone
+                    }
+                  }
+                }
+                fieldDate {
+                  startDate
+                  value
+                  endDate
+                  endValue
+                }
+                fieldDescription
+                fieldLocationHumanreadable
+                fieldFacilityLocation {
+                  entity {
+                    title
+                    entityUrl {
+                      path
+                    }
+                  }
+                }
+              }
+              entityUrl {
+                path
+              }
+            }
+          }
+        }
+      }
+    }
     eventTeasersFeatured: reverseFieldOfficeNode(limit: 1000, filter: {conditions: [{field: "type", value: "event_listing"}]}) {
       entities {
         ... on NodeEventListing {
-          reverseFieldListingNode(limit: 1000, filter: {conditions: [{field: "type", value: "event"}, {field: "status", value: "1"}, {field: "field_featured", value: "1"}]}) {
+          reverseFieldListingNode(limit: 1000, filter: {conditions: [{field: "type", value: "event"}, {field: "status", value: "1"}, {field: "field_featured", value: "1"}, { field: "field_date", value: [$today], operator: GREATER_THAN}]}) {
             entities {
               ... on NodeEvent {
                 title


### PR DESCRIPTION
## Description
Add filter to system page to prevent expired events from being featured.

## Testing done
Visual

## Screenshots
![image](https://user-images.githubusercontent.com/2404547/87186011-baaea480-c2b8-11ea-897c-908d9567970e.png)

## Acceptance criteria
- [ ] Go to `/pittsburgh-health-care/` and visually verify that featured events with date prior to today's date do not appear