### PR TITLE
Add eventData to submitForm

### DIFF
--- a/src/platform/forms-system/src/js/actions.js
+++ b/src/platform/forms-system/src/js/actions.js
@@ -138,7 +138,7 @@ export function submitToUrl(body, submitUrl, trackingPrefix, eventData) {
   });
 }
 
-export function submitForm(formConfig, form) {
+export function submitForm(formConfig, form, eventData) {
   const captureError = (error, errorType) => {
     Sentry.withScope(scope => {
       scope.setFingerprint([formConfig.trackingPrefix]);
@@ -150,6 +150,7 @@ export function submitForm(formConfig, form) {
       event: `${formConfig.trackingPrefix}-submission-failed${
         errorType.startsWith('client') ? '-client' : ''
       }`,
+      ...eventData,
     });
   };
 
@@ -157,6 +158,7 @@ export function submitForm(formConfig, form) {
     dispatch(setSubmission('status', 'submitPending'));
     recordEvent({
       event: `${formConfig.trackingPrefix}-submission`,
+      ...eventData,
     });
 
     let promise;


### PR DESCRIPTION
## Description
This PR adds `eventData` as a parameter to the `submitForm` function to allow extra tracking information for `dataLayer` pushes.

## Testing done


## Screenshots


## Acceptance criteria
- [x] You should be able to pass in extra tracking info to the `recordEvents` inside of `submitForm`

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
