### PR TITLE
[Development] Fix HLR a11y issues discovered with WAVE

### DIFF
--- a/src/applications/disability-benefits/996/components/HLRWizard.jsx
+++ b/src/applications/disability-benefits/996/components/HLRWizard.jsx
@@ -65,7 +65,7 @@ export const HLRWizard = ({
           className="form-expanding-group-open wizard-content vads-u-margin-top--2"
           id="wizardOptions"
         >
-          <div className="wizard-content-inner" role="presentation">
+          <div className="wizard-content-inner">
             <ErrorableRadioButtons
               id={`${name}-claim`}
               label={claimDescription}

--- a/src/applications/disability-benefits/996/components/IntroductionPage.jsx
+++ b/src/applications/disability-benefits/996/components/IntroductionPage.jsx
@@ -189,10 +189,7 @@ export class IntroductionPage extends React.Component {
         </CallToActionWidget>
         {/* TODO: Remove inline style after I figure out why
           .omb-info--container has a left padding */}
-        <div
-          className="omb-info--container vads-u-padding-left--0"
-          role="presentation"
-        >
+        <div className="omb-info--container vads-u-padding-left--0">
           <OMBInfo resBurden={15} ombNumber="2900-0862" expDate="02/28/2022" />
         </div>
       </article>

--- a/src/applications/disability-benefits/996/containers/ConfirmationPage.jsx
+++ b/src/applications/disability-benefits/996/containers/ConfirmationPage.jsx
@@ -54,12 +54,10 @@ export class ConfirmationPage extends React.Component {
             Please print this page for your records.
           </em>
         </p>
-        <div className="inset" role="presentation">
+        <div className="inset">
           <h3 className="vads-u-margin-top--0 vads-u-font-size--h4">
             Higher-Level Review{' '}
-            <span className="additional" role="presentation">
-              (Form {formId})
-            </span>
+            <span className="additional">(Form {formId})</span>
           </h3>
           for {fullName}
           {name.suffix && `, ${name.suffix}`}
@@ -68,9 +66,7 @@ export class ConfirmationPage extends React.Component {
               <p>
                 <strong>Date submitted</strong>
                 <br />
-                <span role="presentation">
-                  {moment(response.timestamp).format('MMM D, YYYY')}
-                </span>
+                <span>{moment(response.timestamp).format('MMM D, YYYY')}</span>
               </p>
               <strong>
                 Issue

--- a/src/applications/disability-benefits/996/containers/SelectArrayItemsWidget.jsx
+++ b/src/applications/disability-benefits/996/containers/SelectArrayItemsWidget.jsx
@@ -110,9 +110,13 @@ export default class SelectArrayItemsWidget extends React.Component {
                       }
                     />
                   )}
-                  <label className={labelClass} htmlFor={elementId}>
-                    {labelWithData}
-                  </label>
+                  {inReviewMode ? (
+                    <div className={labelClass}>{labelWithData}</div>
+                  ) : (
+                    <label className={labelClass} htmlFor={elementId}>
+                      {labelWithData}
+                    </label>
+                  )}
                 </dt>
                 <dd />
               </React.Fragment>

--- a/src/applications/disability-benefits/996/content/InformalConference.jsx
+++ b/src/applications/disability-benefits/996/content/InformalConference.jsx
@@ -53,13 +53,11 @@ export const informalConferenceTimeAllLabels = {
 
 // These labels are hidden on the review page
 export const InformalConferenceTimeLabels = key => (
-  <span className="time-title" role="presentation">
-    {informalConferenceTimeAllLabels[key]}
-  </span>
+  <span className="time-title">{informalConferenceTimeAllLabels[key]}</span>
 );
 
 export const InformalConferenceAvailability = contact => (
-  <span className="time-contact" role="presentation">
+  <span className="time-contact">
     {contact === 'me' ? 'My' : 'Representative’s'} availability for scheduling
   </span>
 );

--- a/src/applications/disability-benefits/996/pages/informalConference.js
+++ b/src/applications/disability-benefits/996/pages/informalConference.js
@@ -75,7 +75,7 @@ const informalConference = {
         },
       },
       'view:TimesForRep': {
-        'ui:title': () => InformalConferenceTimes({ isRep: true }),
+        'ui:description': () => InformalConferenceTimes({ isRep: true }),
       },
     },
     // 'view:ContactYouInfo': {

--- a/src/applications/disability-benefits/996/sass/0996-higher-level-review.scss
+++ b/src/applications/disability-benefits/996/sass/0996-higher-level-review.scss
@@ -68,7 +68,7 @@
  * This could go in the schemaform css, it's used in form 526 & HLR
  */
 .widget-outline {
-  padding: 1em;
+  padding: 0;
   border: solid 4px $color-primary-alt-light;
   border-radius: 7px;
   margin-top: 0.5em;
@@ -81,14 +81,11 @@
     margin-bottom: 1em;
   }
 
-  label {
-    display: inline-block;
-  }
-
   /* long descriptions cause the content to shift down, using flex to fix it */
   .widget-content {
     display: flex;
     flex-direction: column;
+    padding: 1em;
   }
 
   h4 {
@@ -101,10 +98,15 @@
     // the outside of the border.
     margin-top: 0em;
     margin-bottom: 0em;
+    padding: 1em;
 
     // Eliminate unnecessary margin inside the label component
     > div *:last-child {
       margin-bottom: 0em;
+    }
+
+    .widget-content {
+      padding: 0;
     }
   }
 }

--- a/src/applications/disability-benefits/996/sass/0996-higher-level-review.scss
+++ b/src/applications/disability-benefits/996/sass/0996-higher-level-review.scss
@@ -60,7 +60,7 @@
 
 /* global definitions */
 // hide Required label (added to description)
-#root_contestedIssues-label .schemaform-required-span {
+#root_contestedIssues-label {
   display: none;
 }
 


### PR DESCRIPTION
## Description

Fixing some Higher-Level Review form accessibility issues that showed up while running [WAVE tool](https://wave.webaim.org/) tests.

- Replaced unassociated `label`, inside a contested issue card while in "review" mode (no visible checkbox), with a `div`.
- Removed unnecessary `role="presentation"` attributes
- Make the entire contested issue card label clickable while in "edit" mode (CSS only).
- Hide `label` (instead of the `span`) containing a "Required" indicator (CSS only)

Related issues:
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/11024 (HLR spot check)
- https://github.com/department-of-veterans-affairs/vets-website/pull/13321 (fixes `fieldset` missing `legend` issue)

## Testing done

Local unit tests

## Screenshots

N/A

## Acceptance criteria
- [x] Resolve WAVE tool alert messages

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
