### PR TITLE
Fix bug with Profile 2.0 contact info fields reverting to old data mid-save.

### DIFF
--- a/src/applications/personalization/profile-2/components/direct-deposit/DirectDepositContent.jsx
+++ b/src/applications/personalization/profile-2/components/direct-deposit/DirectDepositContent.jsx
@@ -318,7 +318,7 @@ export const DirectDepositContent = ({
         </button>
       </Modal>
       <Prompt
-        message="Are you sure you want to leave? If you leave, your in-progress work won't be saved."
+        message="Are you sure you want to leave? If you leave, your in-progress work won’t be saved."
         when={!isEmptyForm}
       />
       <div id="success" role="alert" aria-atomic="true">

--- a/src/platform/user/profile/vet360/components/base/VAPEditView.jsx
+++ b/src/platform/user/profile/vet360/components/base/VAPEditView.jsx
@@ -24,8 +24,10 @@ export default class VAPEditView extends React.Component {
     onChangeFormDataAndSchemas: PropTypes.func.isRequired,
     onDelete: PropTypes.func.isRequired,
     onSubmit: PropTypes.func.isRequired,
+    refreshTransaction: PropTypes.func,
     render: PropTypes.func.isRequired,
     title: PropTypes.string.isRequired,
+    transaction: PropTypes.object,
     transactionRequest: PropTypes.object,
     useSchemaForm: PropTypes.bool,
   };
@@ -38,11 +40,25 @@ export default class VAPEditView extends React.Component {
     );
   }
 
+  componentDidUpdate(prevProps) {
+    // if the transaction just became pending, start calling the
+    // refreshTransaction() on an interval
+    if (
+      isPendingTransaction(this.props.transaction) &&
+      !isPendingTransaction(prevProps.transaction)
+    ) {
+      this.interval = window.setInterval(this.props.refreshTransaction, 1000);
+    }
+  }
+
   componentWillUnmount() {
+    if (this.interval) {
+      window.clearInterval(this.interval);
+    }
     // Errors returned directly from the API request (as opposed through a transaction lookup) are
     // displayed in this modal, rather than on the page. Once the modal is closed, reset the state
     // for the next time the modal is opened by removing any existing transaction request from the store.
-    if (this.props.transactionRequest && this.props.transactionRequest.error) {
+    if (this.props.transactionRequest?.error) {
       this.props.clearErrors();
     }
   }

--- a/src/platform/user/profile/vet360/components/base/Vet360Transaction.jsx
+++ b/src/platform/user/profile/vet360/components/base/Vet360Transaction.jsx
@@ -37,7 +37,7 @@ function Vet360Transaction(props) {
             refreshTransaction={refreshTransaction}
             method={method}
           >
-            {/* if this field's modal is open, pass in the children so prevent
+            {/* if this field's modal is open, pass in the children to prevent
                the `Vet360TransactionPending` component from rendering the
                "we're saving your info..." message */}
             {isModalOpen && children}

--- a/src/platform/user/profile/vet360/containers/AddressValidationView.jsx
+++ b/src/platform/user/profile/vet360/containers/AddressValidationView.jsx
@@ -31,7 +31,21 @@ import { getValidationMessageKey } from '../../utilities';
 import { ADDRESS_VALIDATION_MESSAGES } from '../../constants/addressValidationMessages';
 
 class AddressValidationView extends React.Component {
+  componentDidUpdate(prevProps) {
+    // if the transaction just became pending, start calling the
+    // refreshTransaction() on an interval
+    if (
+      isPendingTransaction(this.props.transaction) &&
+      !isPendingTransaction(prevProps.transaction)
+    ) {
+      this.interval = window.setInterval(this.props.refreshTransaction, 1000);
+    }
+  }
+
   componentWillUnmount() {
+    if (this.interval) {
+      window.clearInterval(this.interval);
+    }
     focusElement(`#${this.props.addressValidationType}-edit-link`);
   }
 

--- a/src/platform/user/profile/vet360/containers/VAPProfileField.jsx
+++ b/src/platform/user/profile/vet360/containers/VAPProfileField.jsx
@@ -253,8 +253,23 @@ class VAPProfileField extends React.Component {
       refreshTransaction: this.refreshTransaction,
     };
 
+    const wrapInTransaction = children => {
+      return (
+        <Vet360Transaction
+          isModalOpen={showEditView || showValidationView}
+          id={`${fieldName}-transaction-status`}
+          title={title}
+          transaction={transaction}
+          transactionRequest={transactionRequest}
+          refreshTransaction={this.refreshTransaction}
+        >
+          {children}
+        </Vet360Transaction>
+      );
+    };
+
     // default the content to the read-view
-    let content = (
+    let content = wrapInTransaction(
       <div className={classes.wrapper}>
         <ContentView data={this.props.data} />
         {this.isEditLinkVisible() && (
@@ -265,11 +280,11 @@ class VAPProfileField extends React.Component {
             className={classes.editButton}
           />
         )}
-      </div>
+      </div>,
     );
 
     if (isEmpty) {
-      content = (
+      content = wrapInTransaction(
         <button
           type="button"
           onClick={this.onAdd}
@@ -277,17 +292,23 @@ class VAPProfileField extends React.Component {
           id={`${this.props.fieldName}-edit-link`}
         >
           Please add your {title.toLowerCase()}
-        </button>
+        </button>,
       );
     }
 
     if (showEditView) {
-      content = <EditView {...childProps} />;
+      content = (
+        <EditView
+          refreshTransaction={this.refreshTransaction}
+          {...childProps}
+        />
+      );
     }
 
     if (showValidationView) {
       content = (
         <ValidationView
+          refreshTransaction={this.refreshTransaction}
           transaction={transaction}
           transactionRequest={transactionRequest}
           title={title}
@@ -307,7 +328,6 @@ class VAPProfileField extends React.Component {
           }}
         >
           <p>
-            {' '}
             {`You haven’t finished editing your ${activeSection}. If you cancel, your in-progress work won't be saved.`}
           </p>
           <button
@@ -349,16 +369,8 @@ class VAPProfileField extends React.Component {
             OK
           </button>
         </Modal>
-        <Vet360Transaction
-          isModalOpen={showEditView || showValidationView}
-          id={`${fieldName}-transaction-status`}
-          title={title}
-          transaction={transaction}
-          transactionRequest={transactionRequest}
-          refreshTransaction={this.refreshTransaction}
-        >
-          {content}
-        </Vet360Transaction>
+
+        {content}
       </div>
     );
   }

--- a/src/platform/user/profile/vet360/tests/containers/VAPProfileField.unit.spec.jsx
+++ b/src/platform/user/profile/vet360/tests/containers/VAPProfileField.unit.spec.jsx
@@ -111,6 +111,7 @@ describe('<VAPProfileField/>', () => {
       title: props.title,
       transactionRequest: props.transactionRequest,
       clearErrors: props.clearErrors,
+      refreshTransaction: props.refreshTransaction,
     };
     sinon.spy(props, 'ValidationView');
 


### PR DESCRIPTION
## Description
This fixes an issue where contact info forms reverted to their initial data when you started a save. This was causes by the forms being wrapped in a `Vet360Transaction` component that re-mounted the form when a transaction started which caused the form to populate itself with the initial data. This fix changes the component hierarchy so that the `Vet360Transaction` component only wraps the "view" states which is also how it works in Profile v1.

## Testing done
Local

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs