### PR TITLE
MDOT: Remove 5 month alerts

### DIFF
--- a/src/applications/disability-benefits/2346/components/Accessories.jsx
+++ b/src/applications/disability-benefits/2346/components/Accessories.jsx
@@ -80,7 +80,7 @@ class Accessories extends Component {
             <AlertBox
               headline="You can't add accessories to your order at this time"
               content={
-                <>
+                <div className="accessories-two-year-alert-content">
                   <p>
                     You can only order accessories that you've received in the
                     past 2 years.
@@ -98,7 +98,7 @@ class Accessories extends Component {
                     or email{' '}
                     <a href="mailto:dalc.css@va.gov">dalc.css@va.gov</a>.
                   </p>
-                </>
+                </div>
               }
               status="info"
               isVisible

--- a/src/applications/disability-benefits/2346/components/Accessories.jsx
+++ b/src/applications/disability-benefits/2346/components/Accessories.jsx
@@ -52,11 +52,6 @@ class Accessories extends Component {
       supply => supply.productGroup === ACCESSORIES,
     );
     const areAccessorySuppliesEligible = eligibility.accessories;
-    const haveAccessoriesBeenOrderedInLastFiveMonths =
-      accessorySupplies.length > 0 &&
-      accessorySupplies.every(
-        accessory => currentDate.diff(accessory.lastOrderDate, 'months') <= 5,
-      );
     const haveAccessoriesBeenOrderedInLastTwoYears =
       accessorySupplies.length > 0 &&
       accessorySupplies.every(
@@ -80,47 +75,7 @@ class Accessories extends Component {
             Select the hearing aid accessories you need
           </h3>
         )}
-        {!haveAccessoriesBeenOrderedInLastFiveMonths &&
-          haveAccessoriesBeenOrderedInLastTwoYears &&
-          !areAccessorySuppliesEligible &&
-          accessorySupplies.length === 0 && (
-            <>
-              <AlertBox
-                headline="You can't add accessories to your order at this time"
-                content={
-                  <>
-                    <p>
-                      Our records show that your accessories aren't available
-                      for reorder until{' '}
-                      {moment(earliestAvailableDateForReordering).format(
-                        'MMMM D, YYYY',
-                      )}
-                      . You can only order items once every 5 months.
-                    </p>
-                    <p>
-                      If you need unavailable batteries sooner, call the DLC
-                      Customer Service Section at{' '}
-                      <a
-                        aria-label="3 0 3. 2 7 3. 6 2 0 0."
-                        href="tel:303-273-6200"
-                      >
-                        303-273-6200
-                      </a>{' '}
-                      or email{' '}
-                      <a href="mailto:dalc.css@va.gov">dalc.css@va.gov</a>.
-                    </p>
-                  </>
-                }
-                status="info"
-                isVisible
-              />
-              <p className="vads-u-font-weight--bold">
-                These are the hearing aid accessories we have on file fo you:
-              </p>
-            </>
-          )}
         {!haveAccessoriesBeenOrderedInLastTwoYears &&
-          !haveAccessoriesBeenOrderedInLastFiveMonths &&
           !areAccessorySuppliesEligible && (
             <AlertBox
               headline="You can't add accessories to your order at this time"

--- a/src/applications/disability-benefits/2346/components/Batteries.jsx
+++ b/src/applications/disability-benefits/2346/components/Batteries.jsx
@@ -78,7 +78,7 @@ class Batteries extends Component {
             <AlertBox
               headline="Your batteries aren't available for online ordering"
               content={
-                <>
+                <div className="batteries-two-year-alert-content">
                   <p>You can't add batteries for your hearing aids because:</p>
                   <ul>
                     <li>
@@ -102,7 +102,7 @@ class Batteries extends Component {
                     or email{' '}
                     <a href="mailto:dalc.css@va.gov">dalc.css@va.gov</a>.
                   </p>
-                </>
+                </div>
               }
               status="info"
               isVisible

--- a/src/applications/disability-benefits/2346/components/Batteries.jsx
+++ b/src/applications/disability-benefits/2346/components/Batteries.jsx
@@ -54,11 +54,6 @@ class Batteries extends Component {
       batterySupply => batterySupply.productGroup === BATTERIES,
     );
     const areBatterySuppliesEligible = eligibility.batteries;
-    const haveBatteriesBeenOrderedInLastFiveMonths =
-      batterySupplies.length > 0 &&
-      batterySupplies.every(
-        battery => currentDate.diff(battery.lastOrderDate, 'months') <= 5,
-      );
     const haveBatteriesBeenOrderedInLastTwoYears =
       batterySupplies.length > 0 &&
       batterySupplies.every(
@@ -78,52 +73,7 @@ class Batteries extends Component {
             Select the hearing aids that need batteries
           </h3>
         )}
-        {haveBatteriesBeenOrderedInLastFiveMonths &&
-          !areBatterySuppliesEligible &&
-          batterySupplies.length === 0 && (
-            <>
-              <AlertBox
-                headline="You can't add batteries to your order at this time"
-                content={
-                  <>
-                    <p>
-                      You can't add batteries for your hearing aids because:
-                    </p>
-                    <ul>
-                      <li>
-                        They don't require batteries,{' '}
-                        <span className="vads-u-font-weight--bold">or</span>
-                      </li>
-                      <li>
-                        You recently reordered batteries for this device. You
-                        can only reorder batteries for each device once every 5
-                        months.
-                      </li>
-                    </ul>
-                    <p>
-                      If you need unavailable batteries sooner, call the DLC
-                      Customer Service Section at{' '}
-                      <a
-                        aria-label="3 0 3. 2 7 3. 6 2 0 0."
-                        href="tel:303-273-6200"
-                      >
-                        303-273-6200
-                      </a>{' '}
-                      or email{' '}
-                      <a href="mailto:dalc.css@va.gov">dalc.css@va.gov</a>.
-                    </p>
-                  </>
-                }
-                status="info"
-                isVisible
-              />
-              <p className="vads-u-font-weight--bold">
-                These are the hearing aids we have on file fo you:
-              </p>
-            </>
-          )}
-        {!haveBatteriesBeenOrderedInLastFiveMonths &&
-          !haveBatteriesBeenOrderedInLastTwoYears &&
+        {!haveBatteriesBeenOrderedInLastTwoYears &&
           !areBatterySuppliesEligible && (
             <AlertBox
               headline="Your batteries aren't available for online ordering"

--- a/src/applications/disability-benefits/2346/tests/Accessories.unit.spec.jsx
+++ b/src/applications/disability-benefits/2346/tests/Accessories.unit.spec.jsx
@@ -49,52 +49,6 @@ const fakeStore = {
   dispatch: () => {},
 };
 
-const fakeStoreNoEligibility5Months = {
-  getState: () => ({
-    form: {
-      data: {
-        supplies: [
-          {
-            productName: 'DOME',
-            productGroup: 'ACCESSORIES',
-            productId: 3,
-            availableForReorder: true,
-            lastOrderDate: '2019-12-30',
-            nextAvailabilityDate: '2099-09-15',
-            quantity: 10,
-            size: '6mm',
-          },
-          {
-            productName: 'fake name 1',
-            productGroup: 'ACCESSORIES',
-            productId: 4,
-            availableForReorder: true,
-            lastOrderDate: '2019-10-18',
-            nextAvailabilityDate: '2099-07-10',
-            quantity: 5,
-            size: '3mm',
-          },
-          {
-            productName: 'fake name 2',
-            productGroup: 'ACCESSORIES',
-            productId: 9,
-            availableForReorder: false,
-            lastOrderDate: '2099-03-02',
-            nextAvailabilityDate: '2099-05-25',
-            quantity: 2,
-          },
-        ],
-        selectedProducts: [{ productId: 3 }],
-        eligibility: {
-          accessories: false,
-        },
-      },
-    },
-  }),
-  subscribe: () => {},
-  dispatch: () => {},
-};
-
 const fakeStoreNoEligibility2Years = {
   getState: () => ({
     form: {
@@ -183,16 +137,11 @@ describe('Accessories', () => {
     ).to.equal(3);
     wrapper.unmount();
   });
-  it('should display alert boxes if the Veteran is not eligible to order accessories but has ordered in the last 5 months', () => {
-    const wrapper = mount(
-      <Accessories store={fakeStoreNoEligibility5Months} />,
-    );
-    expect(wrapper.find('.usa-alert-heading').length).to.equal(3);
-    wrapper.unmount();
-  });
   it('should display an alert box if the Veteran is not eligible to order accessories and has not ordered in the last 2 years', () => {
     const wrapper = mount(<Accessories store={fakeStoreNoEligibility2Years} />);
-    expect(wrapper.find('AlertBox').length).to.equal(1);
+    expect(wrapper.find('.accessories-two-year-alert-content').length).to.equal(
+      1,
+    );
     wrapper.unmount();
   });
 });

--- a/src/applications/disability-benefits/2346/tests/Batteries.unit.spec.jsx
+++ b/src/applications/disability-benefits/2346/tests/Batteries.unit.spec.jsx
@@ -42,34 +42,6 @@ const fakeStore = {
   dispatch: () => {},
 };
 
-const fakeStoreNoEligibility5Months = {
-  getState: () => ({
-    form: {
-      data: {
-        supplies: [
-          {
-            deviceName: 'OMEGAX d3241',
-            productName: 'ZA1239',
-            productGroup: 'BATTERIES',
-            productId: 1,
-            availableForReorder: true,
-            lastOrderDate: '2020-01-01',
-            nextAvailabilityDate: '2020-01-01',
-            quantity: 60,
-            prescribedDate: '2020-12-20',
-          },
-        ],
-        selectedProducts: [],
-        eligibility: {
-          batteries: false,
-        },
-      },
-    },
-  }),
-  subscribe: () => {},
-  dispatch: () => {},
-};
-
 const fakeStoreNoEligibility2Years = {
   getState: () => ({
     form: {
@@ -136,7 +108,7 @@ describe('Batteries', () => {
   });
   it('should display an alert box if the Veteran does not have eligible battery orders within the last 2 years', () => {
     const wrapper = mount(<Batteries store={fakeStoreNoEligibility2Years} />);
-    const twoYearAlert = wrapper.find('AlertBox');
+    const twoYearAlert = wrapper.find('.batteries-two-year-alert-content');
     expect(twoYearAlert.length).to.equal(1);
     expect(twoYearAlert.text()).to.include(
       "You haven't placed an order for hearing aid batteries within the past 2 years.",


### PR DESCRIPTION
## Description
Due to batteries and accessories being on the same page with always-displayed copy about items being eligible for reordering supplies within 5 months, there is no further need for 5 month alerts.

## Testing done
Unit tests updated

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
