### PR TITLE
Add timezone formatting to past appointment list test

### DIFF
--- a/src/applications/vaos/tests/list/past-appointments.unit.spec.jsx
+++ b/src/applications/vaos/tests/list/past-appointments.unit.spec.jsx
@@ -195,7 +195,13 @@ describe('VAOS integration: past appointments', () => {
 
   it('should show comment for self-scheduled appointments', async () => {
     const appointment = getVAAppointmentMock();
-    appointment.attributes.startDate = pastDate.format();
+    appointment.attributes = {
+      ...appointment.attributes,
+      startDate: pastDate.format(),
+      clinicFriendlyName: 'Some clinic',
+      facilityId: '983',
+      sta6aid: '983GC',
+    };
     appointment.attributes.vdsAppointments[0].currentStatus = 'CHECKED OUT';
     appointment.attributes.vdsAppointments[0].bookingNote =
       'Follow-up/Routine: Do not eat for 24 hours';
@@ -221,7 +227,13 @@ describe('VAOS integration: past appointments', () => {
 
   it('should have correct status when previously cancelled', async () => {
     const appointment = getVAAppointmentMock();
-    appointment.attributes.startDate = pastDate.format();
+    appointment.attributes = {
+      ...appointment.attributes,
+      startDate: pastDate.format(),
+      clinicFriendlyName: 'Some clinic',
+      facilityId: '983',
+      sta6aid: '983GC',
+    };
     appointment.attributes.vdsAppointments[0].currentStatus =
       'CANCELLED BY CLINIC';
     mockPastAppointmentInfo({ va: [appointment] });

--- a/src/applications/vaos/tests/list/past-appointments.unit.spec.jsx
+++ b/src/applications/vaos/tests/list/past-appointments.unit.spec.jsx
@@ -209,7 +209,12 @@ describe('VAOS integration: past appointments', () => {
       },
     );
 
-    await findByText(new RegExp(pastDate.format('dddd, MMMM D, YYYY'), 'i'));
+    await findByText(
+      new RegExp(
+        pastDate.tz('America/Denver').format('dddd, MMMM D, YYYY'),
+        'i',
+      ),
+    );
     expect(baseElement).to.contain.text('Follow-up/Routine');
     expect(baseElement).to.contain.text('Do not eat for 24 hours');
   });
@@ -229,7 +234,12 @@ describe('VAOS integration: past appointments', () => {
       },
     );
 
-    await findByText(new RegExp(pastDate.format('dddd, MMMM D, YYYY'), 'i'));
+    await findByText(
+      new RegExp(
+        pastDate.tz('America/Denver').format('dddd, MMMM D, YYYY'),
+        'i',
+      ),
+    );
 
     expect(baseElement).to.contain.text('Canceled');
     expect(baseElement).to.contain('.fa-exclamation-circle');


### PR DESCRIPTION
## Description
Jenkins tests are failing when it's tomorrow in UTC: https://dsva.slack.com/archives/CMNQT72LX/p1594520881338300

Some of the tests were missing timezones in the check, so adding a timezone to the findByText _should_ fix this. 

## Testing done
Local/unit


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
