### PR TITLE
added /mo visually and per month for screen readers

### DIFF
--- a/src/applications/gi/components/profile/SchoolLocations.jsx
+++ b/src/applications/gi/components/profile/SchoolLocations.jsx
@@ -117,6 +117,12 @@ export class SchoolLocations extends React.Component {
   };
 
   renderRow = (institution, type, name = institution.institution) => {
+    const month = (
+      <React.Fragment key="months">
+        <span className="sr-only">per month</span>
+        <span aria-hidden="true">/mo</span>
+      </React.Fragment>
+    );
     const {
       facilityCode,
       physicalCity,
@@ -142,7 +148,10 @@ export class SchoolLocations extends React.Component {
             physicalZip,
           )}
         </td>
-        <td>{this.estimatedHousingRow(institution)}</td>
+        <td>
+          {this.estimatedHousingRow(institution)}
+          {month}
+        </td>
       </tr>
     );
   };


### PR DESCRIPTION
## Description
The /mo is missing from estimated housing. Navigate to https://www.va.gov/gi-bill-comparison-tool/profile/11806124. Observe.

https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/11141

## Testing done
local testing

## Screenshots
![Screen Shot 2020-07-13 at 7 35 22 AM](https://user-images.githubusercontent.com/50601724/87300866-9d5a2000-c4dc-11ea-86b8-b837551549f7.png)


## Acceptance criteria
- [x] /mo is visbible with estimated housing 

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
