### PR TITLE
Remove /mo from institution Estimate Your Benefits

### DIFF
--- a/src/applications/gi/components/profile/EstimatedBenefits.jsx
+++ b/src/applications/gi/components/profile/EstimatedBenefits.jsx
@@ -44,6 +44,7 @@ const CalculatorResultRow = ({
   bold,
   visible,
   screenReaderSpan,
+  calculator,
 }) =>
   visible ? (
     <div
@@ -103,6 +104,7 @@ const perTermSections = (outputs, calculator) => {
           </a>
           )
         </div>
+
         {terms.map(term => (
           <CalculatorResultRow
             key={`${section}${term.label}`}
@@ -112,7 +114,7 @@ const perTermSections = (outputs, calculator) => {
             }
             value={term.value}
             bold={term.label === 'Total per year'}
-            screenReaderSpan={month}
+            screenReaderSpan={calculator.type === 'OJT' ? month : ''}
             visible={term.visible}
           />
         ))}

--- a/src/applications/gi/components/profile/EstimatedBenefits.jsx
+++ b/src/applications/gi/components/profile/EstimatedBenefits.jsx
@@ -44,7 +44,6 @@ const CalculatorResultRow = ({
   bold,
   visible,
   screenReaderSpan,
-  calculator,
 }) =>
   visible ? (
     <div


### PR DESCRIPTION
## Description
/mo is added to all values under Estimated benefits per term.

https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/11158

## Testing done
local

## Screenshots
![Screen Shot 2020-07-13 at 10 33 09 AM](https://user-images.githubusercontent.com/50601724/87317307-d2726c80-c4f4-11ea-9f0c-da4e2a4df179.png)
![Screen Shot 2020-07-13 at 10 31 31 AM](https://user-images.githubusercontent.com/50601724/87317314-d4d4c680-c4f4-11ea-8a4d-c5d3ec6c43c0.png)


## Acceptance criteria
- [x] /mo removed from institutions Estimate Your Benefits

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
