### PR TITLE
Set page change complete event before url change

### DIFF
--- a/src/applications/vaos/actions/newAppointment.js
+++ b/src/applications/vaos/actions/newAppointment.js
@@ -836,10 +836,10 @@ export function routeToPageInFlow(flow, router, current, action) {
     }
 
     if (nextPage?.url) {
-      router.push(nextPage.url);
       dispatch({
         type: FORM_PAGE_CHANGE_COMPLETED,
       });
+      router.push(nextPage.url);
     } else if (nextPage) {
       throw new Error(`Tried to route to a page without a url: ${nextPage}`);
     } else {


### PR DESCRIPTION
## Description
JAWS seems to have some issues reading out our button loading text after the page changes. I think we can fix this by changing the order of some actions.

## Testing done
Local testing

## Acceptance criteria
- [ ] JAWS does the reasonable thing

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
