### PR TITLE
bradl3yC - Fix styling and handle another exception

### DIFF
--- a/src/applications/disability-benefits/2346/components/ErrorMessage.jsx
+++ b/src/applications/disability-benefits/2346/components/ErrorMessage.jsx
@@ -94,6 +94,7 @@ const ErrorMessage = ({ errorCode, nextAvailabilityDate }) => {
         </AlertBox>
       );
       break;
+    case 'MDOT_SERVICE_UNAVAILABLE':
     case 'MDOT_SERVER_ERROR':
       content = (
         <AlertBox

--- a/src/applications/disability-benefits/2346/containers/App.jsx
+++ b/src/applications/disability-benefits/2346/containers/App.jsx
@@ -33,7 +33,7 @@ class App extends Component {
         {isError &&
           !pending &&
           isLoggedIn && (
-            <div className="vads-u-margin-bottom--3">
+            <div className="row vads-u-margin-bottom--3">
               <ErrorMessage />
             </div>
           )}


### PR DESCRIPTION
## Description
There is no wrapper component or styling for error messages - so they take up the entire width of the page.

There is also a missing case for 500 handling

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
