### PR TITLE
Create EC section on VAOS homepage

### DIFF
--- a/src/applications/vaos/components/RequestExpressCare.jsx
+++ b/src/applications/vaos/components/RequestExpressCare.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import environment from 'platform/utilities/environment';
+
+export default function RequestExpressCare() {
+  const legacyLink = `https://veteran.apps${
+    environment.isProduction() ? '' : '-staging'
+  }.va.gov/var/v4/#new-express-request`;
+
+  return (
+    <div className="vads-u-padding-y--3 vads-u-border-top--1px vads-u-border-bottom--1px vads-u-border-color--gray-lighter">
+      <h2 className="vads-u-font-size--h3 vads-u-margin-y--0">
+        Request an Express Care screening
+      </h2>
+      <p>
+        If you have a non-emergency health concern and want to talk to a health
+        care provider today, submit a request for same-day telehealth
+        appointment. The window for Express Care requests is 00:00 to 00:00 so
+        we can fulfill all requests during business hours.
+      </p>
+      <a
+        className="usa-button"
+        href={legacyLink}
+        target="_blank"
+        rel="noreferrer nofollow"
+      >
+        Request an Express Care screening
+      </a>
+    </div>
+  );
+}

--- a/src/applications/vaos/containers/AppointmentsPage.jsx
+++ b/src/applications/vaos/containers/AppointmentsPage.jsx
@@ -16,6 +16,7 @@ import {
   vaosPastAppts,
   vaosDirectScheduling,
   vaosCommunityCare,
+  vaosExpressCare,
   isWelcomeModalDismissed,
 } from '../utils/selectors';
 import { selectIsCernerOnlyPatient } from 'platform/user/selectors';
@@ -23,6 +24,7 @@ import { GA_PREFIX } from '../utils/constants';
 import { scrollAndFocus } from '../utils/scrollAndFocus';
 import NeedHelp from '../components/NeedHelp';
 import TabNav from '../components/TabNav';
+import RequestExpressCare from '../components/RequestExpressCare';
 
 const pageTitle = 'VA appointments';
 
@@ -57,6 +59,7 @@ export class AppointmentsPage extends Component {
       children,
       showScheduleButton,
       showCommunityCare,
+      showExpressCare,
       showDirectScheduling,
       isCernerOnlyPatient,
       showPastAppointments,
@@ -76,6 +79,7 @@ export class AppointmentsPage extends Component {
                 startNewAppointmentFlow={this.startNewAppointmentFlow}
               />
             )}
+            {showExpressCare && <RequestExpressCare />}
             {showPastAppointments && <TabNav />}
             {children}
             <NeedHelp />
@@ -110,6 +114,7 @@ function mapStateToProps(state) {
     showScheduleButton: vaosRequests(state),
     showCommunityCare: vaosCommunityCare(state),
     showDirectScheduling: vaosDirectScheduling(state),
+    showExpressCare: vaosExpressCare(state),
     isWelcomeModalDismissed: isWelcomeModalDismissed(state),
     isCernerOnlyPatient: selectIsCernerOnlyPatient(state),
   };

--- a/src/applications/vaos/tests/list/appointment-list.unit.spec.jsx
+++ b/src/applications/vaos/tests/list/appointment-list.unit.spec.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
+import { Router, Route } from 'react-router';
 import { expect } from 'chai';
 import moment from 'moment';
+import { createMemoryHistory } from 'history';
 import { renderInReduxProvider } from 'platform/testing/unit/react-testing-library-helpers';
 import environment from 'platform/utilities/environment';
 import { setFetchJSONFailure } from 'platform/testing/unit/helpers';
@@ -14,6 +16,7 @@ import { mockAppointmentInfo } from '../mocks/helpers';
 
 import reducers from '../../reducers';
 import FutureAppointmentsList from '../../components/FutureAppointmentsList';
+import AppointmentsPage from '../../containers/AppointmentsPage';
 
 const initialState = {
   featureToggles: {
@@ -176,5 +179,66 @@ describe('VAOS integration: appointment list', () => {
 
     expect(baseElement.querySelector('.usa-alert-error')).to.be.ok;
     expect(baseElement).not.to.contain.text('You don’t have any appointments');
+  });
+
+  // This will change to only show when EC is available
+  it('should show express care button when flag is on', async () => {
+    mockAppointmentInfo({});
+    const initialStateWithExpressCare = {
+      featureToggles: {
+        ...initialState.featureToggles,
+        vaOnlineSchedulingExpressCare: true,
+      },
+    };
+    const memoryHistory = createMemoryHistory();
+
+    // Mocking a route here so that components using withRouter don't fail
+    const { findAllByText, baseElement } = renderInReduxProvider(
+      <Router history={memoryHistory}>
+        <Route path="/" component={AppointmentsPage} />
+      </Router>,
+      {
+        initialState: initialStateWithExpressCare,
+        reducers,
+      },
+    );
+
+    const [header, button] = await findAllByText(
+      'Request an Express Care screening',
+    );
+
+    expect(baseElement).to.contain.text(
+      'window for Express Care requests is 00:00 to 00:00',
+    );
+    expect(header).to.have.tagName('h2');
+    expect(button).to.have.attribute(
+      'href',
+      'https://veteran.apps-staging.va.gov/var/v4/#new-express-request',
+    );
+  });
+
+  it('should not show express care action when flag is off', async () => {
+    mockAppointmentInfo({});
+    const initialStateWithExpressCare = {
+      featureToggles: {
+        ...initialState.featureToggles,
+        vaOnlineSchedulingExpressCare: false,
+      },
+    };
+    const memoryHistory = createMemoryHistory();
+
+    // Mocking a route here so that components using withRouter don't fail
+    const { findByText, queryByText } = renderInReduxProvider(
+      <Router history={memoryHistory}>
+        <Route path="/" component={AppointmentsPage} />
+      </Router>,
+      {
+        initialState: initialStateWithExpressCare,
+        reducers,
+      },
+    );
+
+    await findByText('Create a new appointment');
+    expect(queryByText(/request an express care screening/i)).to.not.be.ok;
   });
 });


### PR DESCRIPTION
## Description
This adds the EC section on the VAOS homepage. The section is behind the EC flag.

It does not:

- Check to see if user has any registered facilities using EC
- Display the time window where requests are available
- Disable the button with not within the time window
- Maintain a users session when clicking on legacy VAOS EC link

These will be incorporated in later PRs/tickets.

## Testing done
Local and unit testing

## Screenshots
![Screen Shot 2020-07-13 at 2 49 38 PM](https://user-images.githubusercontent.com/634932/87342469-4a528e00-c519-11ea-80f5-94d595dc97d4.png)


## Acceptance criteria
- [ ] Section is displayed

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
