### PR TITLE
Update right side padding for submenu links

### DIFF
--- a/src/platform/site-wide/sass/modules/_m-vet-nav.scss
+++ b/src/platform/site-wide/sass/modules/_m-vet-nav.scss
@@ -248,7 +248,7 @@ body.va-pos-fixed {
 }
 
 .vetnav-level2 {
-  background: $color-primary-darkest url(/img/arrow-right-white.svg) right 3rem
+  background: $color-primary-darkest url(/img/arrow-right-white.svg) right 2rem
     center no-repeat;
   background-size: 1.4rem auto;
   border-radius: 0;
@@ -492,6 +492,7 @@ body.va-pos-fixed {
 
     .mm-link-container {
       padding-left: 10px;
+      padding-right: 10px;
     }
   }
 


### PR DESCRIPTION
## Description
When tabbing through the submenu on small devices, right side padding for focused menu links is not present. This PR adds padding to the submenu links.

## Testing done
Tested locally.

## Screenshots
<details>
  <summary>Before</summary>
<img width="360" alt="Screen Shot 2020-07-13 at 12 06 33 PM" src="https://user-images.githubusercontent.com/9042882/87344101-b4ac0400-c502-11ea-9ee0-8629065b3d2e.png">
</details>

<details>
  <summary>After</summary>
<img width="360" alt="Screen Shot 2020-07-13 at 12 06 18 PM" src="https://user-images.githubusercontent.com/9042882/87344181-d1e0d280-c502-11ea-9d7f-c78a0842fc3a.png">
</details>

## Acceptance criteria
- [ ] Right side padding is present when tabbing through submenu on small devices.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
