### PR TITLE
Sanlouise 11152 enrollment status

### DIFF
--- a/src/applications/personalization/profile-2/components/personal-information/PersonalInformationContent.jsx
+++ b/src/applications/personalization/profile-2/components/personal-information/PersonalInformationContent.jsx
@@ -4,7 +4,7 @@ import GenderAndDOBSection from './GenderAndDOBSection';
 import ContactInformationSection from './ContactInformationSection';
 import EmailInformationSection from './EmailInformationSection';
 
-const ContactInformationContent = () => (
+const PersonalInformationContent = () => (
   <>
     <GenderAndDOBSection className="vads-u-margin-bottom--6" />
 
@@ -14,4 +14,4 @@ const ContactInformationContent = () => (
   </>
 );
 
-export default memo(ContactInformationContent);
+export default memo(PersonalInformationContent);

--- a/src/applications/personalization/profile-2/components/personal-information/PersonalInformationContent.jsx
+++ b/src/applications/personalization/profile-2/components/personal-information/PersonalInformationContent.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { memo } from 'react';
 
 import GenderAndDOBSection from './GenderAndDOBSection';
 import ContactInformationSection from './ContactInformationSection';
@@ -14,4 +14,4 @@ const ContactInformationContent = () => (
   </>
 );
 
-export default ContactInformationContent;
+export default memo(ContactInformationContent);

--- a/src/platform/user/profile/vet360/components/base/VAPEditView.jsx
+++ b/src/platform/user/profile/vet360/components/base/VAPEditView.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Component, memo } from 'react';
 import PropTypes from 'prop-types';
 
 import LoadingButton from 'platform/site-wide/loading-button/LoadingButton';
@@ -9,7 +9,7 @@ import {
 import Vet360EditModalActionButtons from './Vet360EditModalActionButtons';
 import Vet360EditModalErrorMessage from './Vet360EditModalErrorMessage';
 
-export default class VAPEditView extends React.Component {
+class VAPEditView extends Component {
   static propTypes = {
     analyticsSectionName: PropTypes.string.isRequired,
     clearErrors: PropTypes.func.isRequired,
@@ -129,3 +129,5 @@ export default class VAPEditView extends React.Component {
     );
   }
 }
+
+export default memo(VAPEditView);

--- a/src/platform/user/profile/vet360/containers/VAPProfileField.jsx
+++ b/src/platform/user/profile/vet360/containers/VAPProfileField.jsx
@@ -450,7 +450,7 @@ Vet360ProfileFieldContainer.propTypes = {
   title: PropTypes.string.isRequired,
   apiRoute: PropTypes.oneOf(Object.values(VET360.API_ROUTES)).isRequired,
   convertCleanDataToPayload: PropTypes.func,
-  hasUnsavedEdits: PropTypes.bool.isRequired,
+  hasUnsavedEdits: PropTypes.bool,
 };
 
 export default Vet360ProfileFieldContainer;


### PR DESCRIPTION
## Description
This PR prevents `PersonalInformationContent` from re rendering when `hasUnsavedEdits` changes in value, and also prevents `VAPEditView` from re rendering when props in its parent component have updated. https://reactjs.org/docs/react-api.html#reactmemo

## Testing done
Works locally

## Acceptance criteria
- [x] Ensure that the call to `/enrollment_status` is not made when `hasUnsavedEdits` switches value.
- [x] Ensure that the call to `/enrollment_status` is not made every time `VAPEditView` renders (opening/closing the edit view).

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
