### PR TITLE
Remove check for if submit exists inside submitForm

### DIFF
--- a/src/platform/forms-system/src/js/actions.js
+++ b/src/platform/forms-system/src/js/actions.js
@@ -161,20 +161,15 @@ export function submitForm(formConfig, form, eventData) {
       ...eventData,
     });
 
-    let promise;
-    if (formConfig.submit) {
-      promise = formConfig.submit(form, formConfig);
-    } else {
-      const body = formConfig.transformForSubmit
-        ? formConfig.transformForSubmit(formConfig, form)
-        : transformForSubmit(formConfig, form);
+    const body = formConfig.transformForSubmit
+      ? formConfig.transformForSubmit(formConfig, form)
+      : transformForSubmit(formConfig, form);
 
-      promise = submitToUrl(
-        body,
-        formConfig.submitUrl,
-        formConfig.trackingPrefix,
-      );
-    }
+    const promise = submitToUrl(
+      body,
+      formConfig.submitUrl,
+      formConfig.trackingPrefix,
+    );
 
     return promise
       .then(resp => dispatch(setSubmitted(resp)))

--- a/src/platform/forms-system/test/js/actions.unit.spec.js
+++ b/src/platform/forms-system/test/js/actions.unit.spec.js
@@ -214,38 +214,6 @@ describe('Schemaform actions:', () => {
 
       return promise;
     });
-    it('should use submit function instead of url when provided', () => {
-      const response = { data: {} };
-      const formConfig = {
-        submit: sinon.stub().resolves(response),
-        chapters: {},
-      };
-      const form = {
-        pages: {
-          testing: {},
-        },
-        data: {
-          test: 1,
-        },
-      };
-      const thunk = submitForm(formConfig, form);
-      const dispatch = sinon.spy();
-
-      return thunk(dispatch).then(() => {
-        expect(dispatch.firstCall.args[0]).to.eql({
-          type: SET_SUBMISSION,
-          field: 'status',
-          value: 'submitPending',
-          extra: null,
-        });
-        expect(formConfig.submit.called).to.be.true;
-        expect(requests).to.be.empty;
-        expect(dispatch.secondCall.args[0]).to.eql({
-          type: SET_SUBMITTED,
-          response: response.data,
-        });
-      });
-    });
   });
   describe('uploadFile', () => {
     let xhr;


### PR DESCRIPTION
## Description

It doesn't make sense to check if `formData.submit` exists when inside of `submitForm`. Where else would it make sense for  `submitForm` to be called?  It should be a standard that you place `submitForm` as a value for your `formConfig.submit`.

Benefits of this change:

- Have `submitUrl` called inherently, giving you access to error handling, error UI, and GA with one call

Let me know if there are downsides to this change.

## Testing done
Unit tests updated

## Screenshots


## Acceptance criteria
- [ ] 

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
