### PR TITLE
Refactor event data

### DIFF
--- a/src/platform/forms-system/src/js/actions.js
+++ b/src/platform/forms-system/src/js/actions.js
@@ -143,13 +143,12 @@ export function submitToUrl(
   });
 }
 
-export function submitForm(
-  formConfig,
-  form,
-  submisisonEventData,
-  submissionSuccessEventData,
-  submissionFailedEventData,
-) {
+export function submitForm(formConfig, form, eventDataContainer) {
+  const {
+    submisisonEventData,
+    submissionSuccessEventData,
+    submissionFailedEventData,
+  } = eventDataContainer;
   const captureError = (error, errorType) => {
     Sentry.withScope(scope => {
       scope.setFingerprint([formConfig.trackingPrefix]);

--- a/src/platform/forms-system/src/js/actions.js
+++ b/src/platform/forms-system/src/js/actions.js
@@ -146,9 +146,9 @@ export function submitToUrl(
 export function submitForm(
   formConfig,
   form,
-  submisisonEventData = {},
-  submissionSuccessEventData = {},
-  submissionFailedEventData = {},
+  submisisonEventData,
+  submissionSuccessEventData,
+  submissionFailedEventData,
 ) {
   const captureError = (error, errorType) => {
     Sentry.withScope(scope => {

--- a/src/platform/forms-system/src/js/actions.js
+++ b/src/platform/forms-system/src/js/actions.js
@@ -78,7 +78,12 @@ export function setViewedPages(pageKeys) {
   };
 }
 
-export function submitToUrl(body, submitUrl, trackingPrefix, eventData) {
+export function submitToUrl(
+  body,
+  submitUrl,
+  trackingPrefix,
+  submissionSuccessEventData,
+) {
   // This item should have been set in any previous API calls
   const csrfTokenStored = localStorage.getItem('csrfToken');
   return new Promise((resolve, reject) => {
@@ -88,7 +93,7 @@ export function submitToUrl(body, submitUrl, trackingPrefix, eventData) {
       if (req.status >= 200 && req.status < 300) {
         recordEvent({
           event: `${trackingPrefix}-submission-successful`,
-          ...eventData,
+          ...submissionSuccessEventData,
         });
         // got this from the fetch polyfill, keeping it to be safe
         const responseBody =
@@ -138,7 +143,13 @@ export function submitToUrl(body, submitUrl, trackingPrefix, eventData) {
   });
 }
 
-export function submitForm(formConfig, form, eventData) {
+export function submitForm(
+  formConfig,
+  form,
+  submisisonEventData = {},
+  submissionSuccessEventData = {},
+  submissionFailedEventData = {},
+) {
   const captureError = (error, errorType) => {
     Sentry.withScope(scope => {
       scope.setFingerprint([formConfig.trackingPrefix]);
@@ -150,7 +161,7 @@ export function submitForm(formConfig, form, eventData) {
       event: `${formConfig.trackingPrefix}-submission-failed${
         errorType.startsWith('client') ? '-client' : ''
       }`,
-      ...eventData,
+      ...submissionFailedEventData,
     });
   };
 
@@ -158,7 +169,7 @@ export function submitForm(formConfig, form, eventData) {
     dispatch(setSubmission('status', 'submitPending'));
     recordEvent({
       event: `${formConfig.trackingPrefix}-submission`,
-      ...eventData,
+      ...submisisonEventData,
     });
 
     let promise;
@@ -173,6 +184,7 @@ export function submitForm(formConfig, form, eventData) {
         body,
         formConfig.submitUrl,
         formConfig.trackingPrefix,
+        submissionSuccessEventData,
       );
     }
 


### PR DESCRIPTION
## Description
Follow up PR to https://github.com/department-of-veterans-affairs/vets-website/pull/13454. Makes better sense to have an `eventDataContainer` and then destructure out the specific `eventData` per `dataLayer` push.

## Testing done
Unit tests passing

## Screenshots


## Acceptance criteria
- [ ] 

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
