### PR TITLE
Bah jawsbug 10200

### DIFF
--- a/src/applications/gi/components/profile/AdditionalInformation.jsx
+++ b/src/applications/gi/components/profile/AdditionalInformation.jsx
@@ -10,7 +10,7 @@ export class AdditionalInformation extends React.Component {
   }
 
   renderSection103Info = section103Message => (
-    <div className="section-103-message">
+    <div aria-live="off" className="section-103-message">
       <strong>
         <button
           id="section103-button"
@@ -49,7 +49,7 @@ export class AdditionalInformation extends React.Component {
 
     const typeOfAccreditation = institution.accredited &&
       institution.accreditationType && (
-        <div>
+        <div aria-live="off">
           <strong>
             <button
               id="typeAccredited-button"
@@ -80,9 +80,9 @@ export class AdditionalInformation extends React.Component {
     );
 
     return (
-      <div className="institution-summary">
+      <div aria-live="off" className="institution-summary">
         <h3>Institution summary</h3>
-        <div>
+        <div aria-live="off">
           <strong>
             <button
               id="accredited-button"
@@ -116,7 +116,7 @@ export class AdditionalInformation extends React.Component {
         {vetTuitionPolicy}
         {institution.section103Message &&
           this.renderSection103Info(institution.section103Message)}
-        <div>
+        <div aria-live="off">
           <strong>
             <button
               id="creditTraining-button"
@@ -130,7 +130,7 @@ export class AdditionalInformation extends React.Component {
           &nbsp;
           {institution.creditForMilTraining ? 'Yes' : 'No'}
         </div>
-        <div>
+        <div aria-live="off">
           <strong>
             <button
               id="iStudy-button"
@@ -144,7 +144,7 @@ export class AdditionalInformation extends React.Component {
           &nbsp;
           {institution.independentStudy ? 'Yes' : 'No'}
         </div>
-        <div>
+        <div aria-live="off">
           <strong>
             <button
               id="stemIndicator-button"
@@ -242,7 +242,7 @@ export class AdditionalInformation extends React.Component {
           </div>
           <div className="institution-codes">
             <h3>Institution codes</h3>
-            <div>
+            <div aria-live="off">
               <strong>
                 <button
                   id="facilityCode-button"
@@ -256,7 +256,7 @@ export class AdditionalInformation extends React.Component {
               </strong>
               {it.facilityCode || 'N/A'}
             </div>
-            <div>
+            <div aria-live="off">
               <strong>
                 <button
                   id="ipedsCode-button"
@@ -270,7 +270,7 @@ export class AdditionalInformation extends React.Component {
               </strong>
               {it.cross || 'N/A'}
             </div>
-            <div>
+            <div aria-live="off">
               <strong>
                 <button
                   id="opeCode-button"

--- a/src/applications/gi/components/profile/EstimateYourBenefitsForm.jsx
+++ b/src/applications/gi/components/profile/EstimateYourBenefitsForm.jsx
@@ -1196,12 +1196,14 @@ class EstimateYourBenefitsForm extends React.Component {
     );
 
     return (
-      <div className={className}>
-        <p className="vads-u-margin-bottom--3 vads-u-margin-top--0">
-          The {sectionCount} sections below include questions that will refine
-          your benefits estimate. Use the fields in each section to make your
-          updates.
-        </p>
+      <div aria-live="off" className={className}>
+        <div>
+          <p className="vads-u-margin-bottom--3 vads-u-margin-top--0">
+            The {sectionCount} sections below include questions that will refine
+            your benefits estimate. Use the fields in each section to make your
+            updates.
+          </p>
+        </div>
         <ul className="vads-u-padding--0">
           {this.renderMilitaryDetails()}
           {this.renderSchoolCostsAndCalendar()}

--- a/src/applications/gi/components/vet-tec/VetTecAdditionalInformation.jsx
+++ b/src/applications/gi/components/vet-tec/VetTecAdditionalInformation.jsx
@@ -7,9 +7,9 @@ export const VetTecAdditionalInformation = ({
 }) => (
   <div className="additional-information row vads-u-margin-top--1">
     <div className="usa-width-one-half medium-6 columns">
-      <div className="institution-codes usa-width-one-whole">
+      <div aria-live="off" className="institution-codes usa-width-one-whole">
         <h3>Institution codes</h3>
-        <div>
+        <div aria-live="off">
           <strong>
             <button
               id="facilityCode-button"


### PR DESCRIPTION
## Description
JAWS and IE11 read out a lot of extra information when users expand/collapse the benefits filters or the larger gray accordions. I've heard this off and on, but could never pinpoint it. I think it has to do with the aria-hidden="true | false" attributes on the accordions. If we can prevent JAWS from reading this extra information, it would be a big boost for this subset of users.
https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/10200
## Testing done
Local testing with Windows VM, Axe, IE11 and JAWS

## Screenshots


## Acceptance criteria
- [x] JAWS + IE11 does not read out extra information when I toggle the accordions open or closed
- [x] Updated page throws no axe errors

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
