### PR TITLE
Fix sentence case issues on Facility Locator pages

### DIFF
--- a/src/applications/facility-locator/components/LocationHours.jsx
+++ b/src/applications/facility-locator/components/LocationHours.jsx
@@ -27,7 +27,7 @@ const LocationHours = ({ location }) => {
 
   return (
     <div>
-      <h3 className="highlight">Hours of Operation</h3>
+      <h3 className="highlight">Hours of operation</h3>
 
       {/* Sunday */}
       {sunday && (

--- a/src/applications/facility-locator/components/LocationMap.jsx
+++ b/src/applications/facility-locator/components/LocationMap.jsx
@@ -24,7 +24,7 @@ function LocationMap({ info }) {
 
   return (
     <div className="mb2">
-      <h3 className="highlight">View on Map</h3>
+      <h3 className="highlight">View on map</h3>
       <img src={mapUrl} alt="Static map" />
     </div>
   );

--- a/src/applications/facility-locator/components/SearchControls.jsx
+++ b/src/applications/facility-locator/components/SearchControls.jsx
@@ -163,7 +163,7 @@ class SearchControls extends Component {
                     htmlFor="street-city-state-zip"
                     id="street-city-state-zip-label"
                   >
-                    Search by city, state or postal Code
+                    Search by city, state or postal code
                   </label>
                   <input
                     id="street-city-state-zip"

--- a/src/applications/facility-locator/components/search-results/LocationPhoneLink.jsx
+++ b/src/applications/facility-locator/components/search-results/LocationPhoneLink.jsx
@@ -64,8 +64,8 @@ const LocationPhoneLink = ({ location, from, query }) => {
   } = location;
   return (
     <div className="facility-phone-group">
-      {renderPhoneNumber('Main Number', null, phone.main, from)}
-      {renderPhoneNumber('Mental Health', null, phone.mentalHealthClinic, from)}
+      {renderPhoneNumber('Main number', null, phone.main, from)}
+      {renderPhoneNumber('Mental health', null, phone.mentalHealthClinic, from)}
     </div>
   );
 };

--- a/src/applications/facility-locator/containers/VAMap.jsx
+++ b/src/applications/facility-locator/containers/VAMap.jsx
@@ -43,7 +43,7 @@ const mbxClient = mbxGeo(mapboxClient);
 
 const otherToolsLink = (
   <p>
-    Can’t find what you’re looking for?
+    Can’t find what you’re looking for?&nbsp;&nbsp;
     <a href="https://www.va.gov/directory/guide/home.asp">
       Try using our other tools to search.
     </a>

--- a/src/applications/facility-locator/tests/components/LocationPhoneLink.unit.spec.jsx
+++ b/src/applications/facility-locator/tests/components/LocationPhoneLink.unit.spec.jsx
@@ -25,7 +25,7 @@ describe('LocationPhoneLink', () => {
       <LocationPhoneLink location={locationWithGoodPhone} />,
     );
     expect(wrapper.find('Telephone').length).to.equal(1);
-    expect(wrapper.find('strong').text()).to.equal('Main Number: ');
+    expect(wrapper.find('strong').text()).to.equal('Main number: ');
     wrapper.unmount();
   });
 });


### PR DESCRIPTION
## Description
Fix sentence case issues on Facility Locator pages
issue: https://github.com/department-of-veterans-affairs/va.gov-team/issues/10289
## Testing done
Manual

## Screenshots
Will provide if needed.

## Acceptance criteria
When a Veteran visits https://www.va.gov/find-locations, sentence case will appear for all search parameter field labels, including

- [x] `Search by city, state or postal code`

When a Veteran visits https://www.va.gov/find-locations, 
- [x] there will be a space between `Can’t find what you’re looking for?` and `Try using our other tools to search.`

For **all** facility types, any reference to phone number, map or hours of operation on the search results card or detail page will use sentence case, including: 
- [x] `Main number`
- [x]  `Mental health`
- [x]  `Hours of operation`
- [x]  `View on map` 


## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
