### PR TITLE
Update order account security for a11y

### DIFF
--- a/src/applications/personalization/profile-2/components/AccountSecurityContent.jsx
+++ b/src/applications/personalization/profile-2/components/AccountSecurityContent.jsx
@@ -42,10 +42,6 @@ export const AccountSecurityContent = ({
         />
       ),
     },
-    {
-      title: 'Sign-in email address',
-      value: <EmailAddressNotification signInServiceName={signInServiceName} />,
-    },
   ];
 
   if (isIdentityVerified && isInMVI) {
@@ -61,6 +57,11 @@ export const AccountSecurityContent = ({
       value: <MHVTermsAndConditionsStatus mhvAccount={mhvAccount} />,
     });
   }
+
+  securitySections.push({
+    title: 'Sign-in email address',
+    value: <EmailAddressNotification signInServiceName={signInServiceName} />,
+  });
 
   return (
     <>

--- a/src/applications/personalization/profile-2/components/EmailAddressNotification.jsx
+++ b/src/applications/personalization/profile-2/components/EmailAddressNotification.jsx
@@ -23,9 +23,9 @@ const EmailAddressNotification = ({ signInServiceName }) => {
   return (
     <>
       <p className="vads-u-margin--0">
-        To update the email address you use to sign in, go to the website where
-        you manage your settings and identity information. Any email updates you
-        make there will automatically update on VA.gov.
+        To view or update your sign in email, go to the website where you manage
+        your account information. Any email updates you make there will
+        automatically update on VA.gov.
       </p>
       <p className="vads-u-margin-bottom--0">
         <a href={link} target="_blank" rel="noopener noreferrer">

--- a/src/applications/personalization/profile-2/tests/components/AccountSecurityContent.unit.spec.jsx
+++ b/src/applications/personalization/profile-2/tests/components/AccountSecurityContent.unit.spec.jsx
@@ -60,8 +60,8 @@ describe('AccountSecurityContent', () => {
         const expectedTitles = [
           'Identity verification',
           '2-factor authentication',
-          'Sign-in email address',
           'Terms and conditions',
+          'Sign-in email address',
         ];
         infoTableData.forEach((row, rowIndex) => {
           expect(row.title).to.equal(expectedTitles[rowIndex]);
@@ -78,12 +78,12 @@ describe('AccountSecurityContent', () => {
           props.isMultifactorEnabled,
         );
       });
-      it('should render the `EmailAddressNotification` component in the third row', () => {
-        const secondRowComponent = infoTableData[2].value;
+      it('should render the `EmailAddressNotification` component in the fourth row', () => {
+        const secondRowComponent = infoTableData[3].value;
         expect(secondRowComponent.type).to.equal(EmailAddressNotification);
       });
-      it('should pass the `mhvAccount` prop to the `MHVTermsAndConditionsStatus` component in the fourth row', () => {
-        const thirdRowComponent = infoTableData[3].value;
+      it('should pass the `mhvAccount` prop to the `MHVTermsAndConditionsStatus` component in the third row', () => {
+        const thirdRowComponent = infoTableData[2].value;
         expect(thirdRowComponent.type).to.equal(MHVTermsAndConditionsStatus);
         expect(thirdRowComponent.props.mhvAccount).to.equal(props.mhvAccount);
       });


### PR DESCRIPTION
## Description
This PR ensures that the sign-in-email address is the last section in account security.

## Testing done
Works locally, updated related unit tests.

## Screenshots
![image](https://user-images.githubusercontent.com/14869324/87453871-7248fc80-c5c0-11ea-8ce8-9a8048cc0655.png)


## Acceptance criteria
- [x] Update copy 'sign-in email address'
- [x] Ensure 'sign-in email address' is rendered in the last row

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
