### PR TITLE
Remove detail page links from community care provider search results

### DIFF
--- a/src/applications/facility-locator/components/search-results/LocationDirectionsLink.jsx
+++ b/src/applications/facility-locator/components/search-results/LocationDirectionsLink.jsx
@@ -21,10 +21,10 @@ function LocationDirectionsLink({ location, from }) {
         }&daddr=${address}`}
         rel="noopener noreferrer"
         target="_blank"
-        style={{ textDecoration: 'underline' }}
       >
         {from === 'FacilityDetail' && <i className="fa fa-road" />}
         Directions
+        <span className="sr-only">to {location.attributes.name}</span>
       </a>
     </span>
   );

--- a/src/applications/facility-locator/components/search-results/LocationInfoBlock.jsx
+++ b/src/applications/facility-locator/components/search-results/LocationInfoBlock.jsx
@@ -69,9 +69,7 @@ const LocationInfoBlock = ({ location, from, query }) => {
               </span>
             </p>
           ) : (
-            <h2 className="vads-u-font-size--h5 no-marg-top">
-              <Link to={`provider/${location.id}`}>{name}</Link>
-            </h2>
+            <h2 className="vads-u-font-size--h5 no-marg-top">{name}</h2>
           )}
           {location.attributes.orgName && (
             <h6>{location.attributes.orgName}</h6>

--- a/src/applications/facility-locator/sass/facility-locator.scss
+++ b/src/applications/facility-locator/sass/facility-locator.scss
@@ -101,7 +101,6 @@ $facility-locator-color-gray: #ccc;
 
     a {
       color: $color-link-default;
-      text-decoration: none;
 
       &:focus {
         h5 {
@@ -195,10 +194,6 @@ $facility-locator-color-gray: #ccc;
       p {
         color: $color-black;
       }
-    }
-
-    a {
-      text-decoration: none;
     }
   }
 

--- a/src/applications/facility-locator/tests/components/search-results/LocationInfoBlock.unit.spec.jsx
+++ b/src/applications/facility-locator/tests/components/search-results/LocationInfoBlock.unit.spec.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+import LocationInfoBlock from '../../../components/search-results/LocationInfoBlock';
+import { LocationType } from '../../../constants';
+
+describe('LocationInfoBlock', () => {
+  it('should render a link to regular VA facility detail page', () => {
+    const vaProviderLocation = {
+      id: 'vha_558GF',
+      attributes: {},
+    };
+
+    const wrapper = shallow(
+      <LocationInfoBlock location={vaProviderLocation} />,
+    );
+    expect(wrapper.find('Link[to="facility/vha_558GF"]').length).to.equal(1);
+    wrapper.unmount();
+  });
+
+  it('should NOT render a link to CCP detail page', () => {
+    const ccpProviderLocation = {
+      id: 'vha_558GF',
+      type: LocationType.CC_PROVIDER,
+      attributes: {},
+    };
+
+    const wrapper = shallow(
+      <LocationInfoBlock location={ccpProviderLocation} query={{}} />,
+    );
+    expect(wrapper.find('Link[to="facility/vha_558GF"]').length).to.equal(0);
+    wrapper.unmount();
+  });
+});

--- a/src/applications/facility-locator/tests/components/search-results/LocationPhoneLink.unit.spec.jsx
+++ b/src/applications/facility-locator/tests/components/search-results/LocationPhoneLink.unit.spec.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
-import LocationPhoneLink from '../../components/search-results/LocationPhoneLink';
+import LocationPhoneLink from '../../../components/search-results/LocationPhoneLink';
 
 describe('LocationPhoneLink', () => {
   it('should render null if bad phone number passed', () => {


### PR DESCRIPTION
## Description
Remove detail page links from community care provider search results.

https://github.com/department-of-veterans-affairs/va.gov-team/issues/10324

Also, knock out a few minor UI issues:
1. ensure that all links in search results are underlined
1. add an `sr-only` element to the Directions link for screen readers - this addresses both of the following issues:
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/6894
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/8243

## Testing done
Manual + unit tests added

## Screenshots
![Find_VA_Locations___Veterans_Affairs](https://user-images.githubusercontent.com/80267/87480754-fb315980-c5fb-11ea-81ee-739b2f8e629d.png)

## Acceptance criteria
- [x]  When facility type = Community care providers (in VA's network): 
Community care search results cards will not have links to Facility Detail pages 
- [x] Existing functionality for VA facility detail pages is maintained (for each VA facility type: health, benefits, cemetery, Vet Centers)
- [x] ensure that all links in search results are underlined
- [x] add an sr-only element to the Directions link for screen readers

## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
