### PR TITLE
adding query parameter to auto logout call

### DIFF
--- a/src/platform/user/authentication/utilities.js
+++ b/src/platform/user/authentication/utilities.js
@@ -118,9 +118,13 @@ export function verify(version = 'v0') {
   return redirect(sessionTypeUrl('verify', version), 'verify-link-clicked');
 }
 
-export function logout(version = 'v0', clickedEvent = 'logout-link-clicked') {
+export function logout(
+  version = 'v0',
+  clickedEvent = 'logout-link-clicked',
+  queryParams = {},
+) {
   clearSentryLoginType();
-  return redirect(sessionTypeUrl('slo', version), clickedEvent);
+  return redirect(sessionTypeUrl('slo', version, queryParams), clickedEvent);
 }
 
 export function signup(version = 'v0') {

--- a/src/platform/utilities/sso/index.js
+++ b/src/platform/utilities/sso/index.js
@@ -70,7 +70,7 @@ export async function checkAutoSession() {
       // explicitly check to see if the TTL for the SSO3 session is 0, as it
       // could also be null if we failed to get a response from the SSOe server,
       // in which case we don't want to logout the user because we don't know
-      logout('v1', 'sso-automatic-logout');
+      logout('v1', 'sso-automatic-logout', { 'auto-logout': 'true' });
     }
   } else if (!userProfile && ttl > 0 && !getLoginAttempted() && authn) {
     // only attempt an auto login if the user is

--- a/src/platform/utilities/tests/sso.unit.spec.js
+++ b/src/platform/utilities/tests/sso.unit.spec.js
@@ -141,7 +141,9 @@ describe('checkAutoSession', () => {
     await checkAutoSession();
 
     sinon.assert.calledOnce(auto);
-    sinon.assert.calledWith(auto, 'v1', 'sso-automatic-logout');
+    sinon.assert.calledWith(auto, 'v1', 'sso-automatic-logout', {
+      'auto-logout': 'true',
+    });
   });
 
   it('should not auto logout if user is logged without SSOe and they do not have a SSOe session', async () => {


### PR DESCRIPTION
To distinguish between manual and auto logout calls in the access logs
