### PR TITLE
bradl3yC - Correct the route and breadcrumbs

### DIFF
--- a/src/applications/disability-benefits/2346/containers/App.jsx
+++ b/src/applications/disability-benefits/2346/containers/App.jsx
@@ -23,8 +23,11 @@ class App extends Component {
           <a href="/">Home</a>
           {/* this will get updated when this route is added */}
           <a href="/health-care">Health care</a>
+          <a href="/health-care/order-hearing-aid-batteries-and-accessories">
+            Order hearing aid batteries and accessories
+          </a>
           <span className="vads-u-color--black">
-            <strong>Order hearing aid batteries and accessories</strong>
+            <strong>Order form 2346</strong>
           </span>
         </Breadcrumbs>
         {pending && (

--- a/src/applications/disability-benefits/2346/manifest.json
+++ b/src/applications/disability-benefits/2346/manifest.json
@@ -2,6 +2,6 @@
   "appName": "Order hearing aid batteries and accessories",
   "entryFile": "./app-entry.jsx",
   "entryName": "order-form-2346",
-  "rootUrl": "/health-care/order-hearing-aid-batteries-and-accessories",
+  "rootUrl": "/health-care/order-hearing-aid-batteries-and-accessories/order-form-2346",
   "e2eTestsDisabled": true
 }

--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -332,7 +332,7 @@
     "rootUrl": "/health-care/order-hearing-aid-batteries-and-accessories/order-form-2346",
     "template": {
       "layout": "page-react.html",
-      "vagovprod": false
+      "vagovprod": true
     }
   },
   {

--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -329,7 +329,7 @@
   {
     "appName": "Order hearing aid batteries and accessories",
     "entryName": "order-form-2346",
-    "rootUrl": "/health-care/order-hearing-aid-batteries-and-accessories",
+    "rootUrl": "/health-care/order-hearing-aid-batteries-and-accessories/order-form-2346",
     "template": {
       "layout": "page-react.html",
       "vagovprod": false


### PR DESCRIPTION
## Description
The current route for the mdot form was using the route for the static lander 
correct route according to this document
https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/platform/information-architecture/ia-reviews/bam2-med-device-order.md

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
