### PR TITLE
[Development] HLR updates

### DIFF
--- a/src/applications/disability-benefits/996/components/GetFormHelp.jsx
+++ b/src/applications/disability-benefits/996/components/GetFormHelp.jsx
@@ -4,10 +4,6 @@ import Telephone, {
   PATTERNS,
 } from '@department-of-veterans-affairs/formation-react/Telephone';
 
-import Telephone, {
-  CONTACTS,
-} from '@department-of-veterans-affairs/formation-react/Telephone';
-
 const GetFormHelp = () => (
   <p className="help-talk">
     Need help filling out the form or have questions about eligibility? Please

--- a/src/applications/disability-benefits/996/components/GetFormHelp.jsx
+++ b/src/applications/disability-benefits/996/components/GetFormHelp.jsx
@@ -4,18 +4,15 @@ import Telephone, {
   PATTERNS,
 } from '@department-of-veterans-affairs/formation-react/Telephone';
 
+import Telephone, {
+  CONTACTS,
+} from '@department-of-veterans-affairs/formation-react/Telephone';
+
 const GetFormHelp = () => (
   <p className="help-talk">
     Need help filling out the form or have questions about eligibility? Please
     call VA Benefits and Services at{' '}
-    <a
-      href="tel:1-800-827-1000"
-      aria-label="8 0 0. 8 2 7. 1 0 0 0."
-      className="nowrap"
-    >
-      800-827-1000
-    </a>
-    .<br />
+    <Telephone contact={CONTACTS.VA_BENEFITS} />.<br />
     <br />
     If you have hearing loss, call TTY:{' '}
     <Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />.

--- a/src/applications/disability-benefits/996/components/IntroductionPage.jsx
+++ b/src/applications/disability-benefits/996/components/IntroductionPage.jsx
@@ -7,6 +7,9 @@ import FormTitle from 'platform/forms-system/src/js/components/FormTitle';
 import SaveInProgressIntro from 'platform/forms/save-in-progress/SaveInProgressIntro';
 import CallToActionWidget from 'platform/site-wide/cta-widget';
 import { focusElement } from 'platform/utilities/ui';
+import Telephone, {
+  CONTACTS,
+} from '@department-of-veterans-affairs/formation-react/Telephone';
 
 import { toggleLoginModal } from 'platform/site-wide/user-nav/actions';
 import { setData } from 'platform/forms-system/src/js/actions';
@@ -140,13 +143,7 @@ export class IntroductionPage extends React.Component {
                 If you need help requesting a Higher-Level Review, you can
                 contact a VA regional office and ask to speak to a
                 representative. To find the nearest regional office, please call{' '}
-                <a
-                  href="tel:1-800-827-1000"
-                  aria-label="8 0 0. 8 2 7. 1 0 0 0."
-                  className="nowrap"
-                >
-                  800-827-1000
-                </a>
+                <Telephone contact={CONTACTS.VA_BENEFITS} />
                 {' or '}
                 <a href="/find-locations">visit our facility locator tool</a>.
               </p>

--- a/src/applications/disability-benefits/996/components/IntroductionPage.jsx
+++ b/src/applications/disability-benefits/996/components/IntroductionPage.jsx
@@ -64,7 +64,7 @@ export class IntroductionPage extends React.Component {
     }
     const { formConfig } = route;
     if (contestableIssues?.error) {
-      return showContestableIssueError();
+      return showContestableIssueError;
     }
     return contestableIssues?.issues?.length > 0 ? (
       <SaveInProgressIntro

--- a/src/applications/disability-benefits/996/components/IntroductionPage.jsx
+++ b/src/applications/disability-benefits/996/components/IntroductionPage.jsx
@@ -64,7 +64,7 @@ export class IntroductionPage extends React.Component {
     }
     const { formConfig } = route;
     if (contestableIssues?.error) {
-      return showContestableIssueError(contestableIssues.error.errors);
+      return showContestableIssueError();
     }
     return contestableIssues?.issues?.length > 0 ? (
       <SaveInProgressIntro

--- a/src/applications/disability-benefits/996/constants.js
+++ b/src/applications/disability-benefits/996/constants.js
@@ -4,6 +4,9 @@ export const BASE_URL =
 
 export const FORM_URL = 'https://www.vba.va.gov/pubs/forms/VBA-20-0996-ARE.pdf';
 
+export const COVID_FAQ_URL =
+  'https://www.va.gov/coronavirus-veteran-frequently-asked-questions/#more-benefit-and-claim-questio';
+
 export const errorMessages = {
   savedFormNotFound: 'Please start over to request a Higher-Level Review',
   savedFormNoAuth:

--- a/src/applications/disability-benefits/996/containers/ConfirmationPage.jsx
+++ b/src/applications/disability-benefits/996/containers/ConfirmationPage.jsx
@@ -5,6 +5,9 @@ import Scroll from 'react-scroll';
 
 import { focusElement } from 'platform/utilities/ui';
 import { selectProfile } from 'platform/user/selectors';
+import Telephone, {
+  CONTACTS,
+} from '@department-of-veterans-affairs/formation-react/Telephone';
 
 const scroller = Scroll.scroller;
 const scrollToTop = () => {
@@ -104,14 +107,7 @@ export class ConfirmationPage extends React.Component {
         <p>
           If you requested a decision review and haven’t heard back from VA yet,
           please don’t request another review. Call VA at{' '}
-          <a
-            href="tel:1-800-827-1000"
-            aria-label="8 0 0. 8 2 7. 1 0 0 0."
-            className="nowrap"
-          >
-            800-827-1000
-          </a>
-          .
+          <Telephone contact={CONTACTS.VA_BENEFITS} />.
         </p>
         <br />
         <a

--- a/src/applications/disability-benefits/996/content/contestableIssueAlerts.jsx
+++ b/src/applications/disability-benefits/996/content/contestableIssueAlerts.jsx
@@ -4,53 +4,37 @@ import Telephone, {
   CONTACTS,
 } from '@department-of-veterans-affairs/formation-react/Telephone';
 
-import { disabilitiesExplanation } from './contestedIssues';
+import { disabilitiesExplanationAlert } from './contestedIssues';
 
 const noIssuesMessage = (
   <>
-    Our records show that you don’t have any issues eligible for a Higher-Level
-    Review. If you think this is an error, please call{' '}
-    <Telephone contact={CONTACTS.VA_BENEFITS} />.
-    {disabilitiesExplanation({ introPageAlert: true })}
+    We don’t have any issues on file for you that are eligible for Higher-Level
+    Review. These are called contestable issues. If you think this is an error,
+    please call us at <Telephone contact={CONTACTS.VA_BENEFITS} />.
+    {disabilitiesExplanationAlert}
   </>
 );
 
-const networkError = errors => {
-  const messages =
-    errors?.length > 1 ? (
-      <ul>
-        {errors.map(error => (
-          <li key={error.title}>{error.title}</li>
-        ))}
-      </ul>
-    ) : (
-      <p>
-        <strong>{errors?.[0].title}</strong>
-      </p>
-    );
-  return (
-    <>
-      We’re having some connection issues on our end.
-      <p />
-      {messages}
-      <p>Please refresh this page to try again.</p>
-    </>
-  );
-};
+const networkError = (
+  <p>
+    We’re having some connection issues on our end. Please refresh this page to
+    try again.
+  </p>
+);
 
 export const noContestableIssuesFound = (
   <AlertBox
     status="warning"
-    headline="We don’t have any contestable issues for you"
+    headline="You have no issues eligible for a Higher-Level Review"
     content={noIssuesMessage}
   />
 );
 
-export const showContestableIssueError = errors => (
+export const showContestableIssueError = (
   <AlertBox
     status="error"
-    headline="We can’t load your contestable issues"
-    content={networkError(errors)}
+    headline="We can’t load your issues"
+    content={networkError}
   />
 );
 

--- a/src/applications/disability-benefits/996/content/contestableIssueAlerts.jsx
+++ b/src/applications/disability-benefits/996/content/contestableIssueAlerts.jsx
@@ -1,8 +1,19 @@
 import React from 'react';
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
+import Telephone, {
+  CONTACTS,
+} from '@department-of-veterans-affairs/formation-react/Telephone';
 
-const noIssuesMessage = `We’re sorry. We were unable to locate any contestable
-  issues that are eligible to request a Higher-Level Review`;
+import { disabilitiesExplanation } from './contestedIssues';
+
+const noIssuesMessage = (
+  <>
+    Our records show that you don’t have any issues eligible for a Higher-Level
+    Review. If you think this is an error, please call{' '}
+    <Telephone contact={CONTACTS.VA_BENEFITS} />.
+    {disabilitiesExplanation({ introPageAlert: true })}
+  </>
+);
 
 const networkError = errors => {
   const messages =
@@ -19,11 +30,10 @@ const networkError = errors => {
     );
   return (
     <>
-      We’re sorry. We’re having some problems on our end when we try to get
-      information about your contestable issues:
+      We’re having some connection issues on our end.
       <p />
       {messages}
-      <p>Please try again later.</p>
+      <p>Please refresh this page to try again.</p>
     </>
   );
 };
@@ -31,7 +41,7 @@ const networkError = errors => {
 export const noContestableIssuesFound = (
   <AlertBox
     status="warning"
-    headline="No Contestable Issues"
+    headline="We don’t have any contestable issues for you"
     content={noIssuesMessage}
   />
 );
@@ -39,7 +49,7 @@ export const noContestableIssuesFound = (
 export const showContestableIssueError = errors => (
   <AlertBox
     status="error"
-    headline="We’re having some connection problems"
+    headline="We can’t load your contestable issues"
     content={networkError(errors)}
   />
 );

--- a/src/applications/disability-benefits/996/content/contestedIssues.jsx
+++ b/src/applications/disability-benefits/996/content/contestedIssues.jsx
@@ -50,7 +50,7 @@ const downloadLink = (
   <a
     href={FORM_URL}
     download="VBA-20-0996-ARE.pdf"
-    title="download Decision Review Request: Higher-Level Review PDF"
+    title="download VA Form 20-0996"
     type="application/pdf"
   >
     <i
@@ -58,9 +58,9 @@ const downloadLink = (
       className="fas fa-download vads-u-padding-right--0p5"
       role="img"
     />
-    download Decision Review Request: Higher-Level Review{' '}
+    download VA Form 20-0996{' '}
     <dfn>
-      <abbr title="Portable Document Format">PDF</abbr> (VA Form 20-0996, 1.5
+      <abbr title="Portable Document Format">PDF</abbr> (1.5
       <abbr title="Megabytes">MB</abbr>)
     </dfn>
   </a>
@@ -75,20 +75,20 @@ const disabilitiesList = (
     <li>
       Your issue is for a benefit type other than compensation or pension. To
       request a Higher-Level Review for another benefit type like health care,
-      insurance, or education, you'll need to {downloadLink}, fill out and
-      submit it by mail or in person.
+      insurance, or education, you’ll need to {downloadLink} and submit a
+      completed application by mail or in person.
     </li>
     <li>
       The issue or decision isn’t in our system yet. Please refer to your
-      decision letter about what form you'll need to submit to request a
+      decision letter about what form you’ll need to submit to request a
       Higher-Level Review.
     </li>
     <li>
-      You’re unable to request a Higher-Level Review within 1 year from the date
+      You’re unable to request a Higher-Level Review within 1 year of the date
       on your decision letter due to the COVID-19 pandemic. To request a good
-      cause extension, you'll need to {downloadLink}, fill out and attach a note
-      to your application that you’re requesting an exemption for timely filing
-      due to COVID-19.
+      cause extension, you’ll need to {downloadLink} fill it out and attach a
+      note to your application that you’re requesting an exemption for timely
+      filing due to COVID-19.
       <br />
       <br />
       To learn more about how COVID-19 affect claims or appeals, please visit

--- a/src/applications/disability-benefits/996/content/contestedIssues.jsx
+++ b/src/applications/disability-benefits/996/content/contestedIssues.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import AdditionalInfo from '@department-of-veterans-affairs/formation-react/AdditionalInfo';
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
-import { FORM_URL, NULL_CONDITION_STRING } from '../constants';
+import { FORM_URL, COVID_FAQ_URL, NULL_CONDITION_STRING } from '../constants';
 
 export const contestedIssuesTitle = (
   <>
-    <strong>Select the issue(s) you would like to contest</strong>
+    <strong>Select the issue you would like to have reviewed</strong>
     <span className="schemaform-required-span vads-u-font-weight--normal vads-u-font-size--base">
       (*Required)
     </span>
@@ -46,52 +46,76 @@ export const disabilityOption = ({ attributes }) => {
   );
 };
 
-export const disabilitiesExplanation = ({ introPageAlert = false } = {}) => {
-  const title = introPageAlert
-    ? 'Why don’t I see my issue?'
-    : 'Don’t see the issue you’re looking for?';
-  const firstSentenceEnding = introPageAlert
-    ? 'be available:'
-    : 'appear in the list above:';
-  return (
-    <>
-      <p className="vads-u-margin-top--2p5" />
-      <AdditionalInfo triggerText={title}>
-        There are several reasons your issue or decision might not{' '}
-        {firstSentenceEnding}
-        <ul>
-          <li>
-            If we made the decision over a year ago, it’s not eligible for a
-            Higher-Level Review.
-          </li>
-          <li>
-            The decision might be for another benefit type, like health care,
-            insurance, or education. Decisions for these benefit types won’t
-            appear on this list. If you want to request Higher-Level Review for
-            benefit types other than compensation, you’ll need to fill out a{' '}
-            <a href={FORM_URL}>
-              Decision Review Request: Higher-Level Review (VA Form 20-0996)
-            </a>
-            .
-          </li>
-          <li>
-            The issue or decision might not be in our system. Please refer to
-            your decision letter about what form you’ll need to submit.
-          </li>
-          <li>
-            If you were unable to file a Higher-Level Review claim before the
-            deadline and need to request an extension based on good cause,
-            you’ll need to fill out a paper{' '}
-            <a href={FORM_URL}>
-              VA Form 20-0996, Decision Review Request: Higher-Level Review
-            </a>{' '}
-            with your request for an extension.
-          </li>
-        </ul>
-      </AdditionalInfo>
-    </>
-  );
-};
+const downloadLink = (
+  <a
+    href={FORM_URL}
+    download="VBA-20-0996-ARE.pdf"
+    title="download Decision Review Request: Higher-Level Review PDF"
+    type="application/pdf"
+  >
+    <i
+      aria-hidden="true"
+      className="fas fa-download vads-u-padding-right--0p5"
+      role="img"
+    />
+    download Decision Review Request: Higher-Level Review{' '}
+    <dfn>
+      <abbr title="Portable Document Format">PDF</abbr> (VA Form 20-0996, 1.5
+      <abbr title="Megabytes">MB</abbr>)
+    </dfn>
+  </a>
+);
+
+const disabilitiesList = (
+  <ul>
+    <li>
+      We made the decision over a year ago. You have 1 year from the date on
+      your decision letter to request a Higher-Level Review.
+    </li>
+    <li>
+      Your issue is for a benefit type other than compensation or pension. To
+      request a Higher-Level Review for another benefit type like health care,
+      insurance, or education, you'll need to {downloadLink}, fill out and
+      submit it by mail or in person.
+    </li>
+    <li>
+      The issue or decision isn’t in our system yet. Please refer to your
+      decision letter about what form you'll need to submit to request a
+      Higher-Level Review.
+    </li>
+    <li>
+      You’re unable to request a Higher-Level Review within 1 year from the date
+      on your decision letter due to the COVID-19 pandemic. To request a good
+      cause extension, you'll need to {downloadLink}, fill out and attach a note
+      to your application that you’re requesting an exemption for timely filing
+      due to COVID-19.
+      <br />
+      <br />
+      To learn more about how COVID-19 affect claims or appeals, please visit
+      our <a href={COVID_FAQ_URL}>Coronavirus FAQ page</a>.
+    </li>
+  </ul>
+);
+
+export const disabilitiesExplanationAlert = (
+  <>
+    <p className="vads-u-margin-top--2p5" />
+    <AdditionalInfo triggerText={'Why isn’t my issue eligible?'}>
+      Your issue may not be eligible for a Higher-Level Review if:
+      {disabilitiesList}
+    </AdditionalInfo>
+  </>
+);
+
+export const disabilitiesExplanation = (
+  <>
+    <p className="vads-u-margin-top--2p5" />
+    <AdditionalInfo triggerText={'Don’t see the issue you’re looking for?'}>
+      Your issue may not be eligible for a Higher-Level Review if:
+      {disabilitiesList}
+    </AdditionalInfo>
+  </>
+);
 
 /**
  * Shows the alert box only if the form has been submitted

--- a/src/applications/disability-benefits/996/content/contestedIssues.jsx
+++ b/src/applications/disability-benefits/996/content/contestedIssues.jsx
@@ -58,7 +58,7 @@ const downloadLink = (
       className="fas fa-download vads-u-padding-right--0p5"
       role="img"
     />
-    download VA Form 20-0996{' '}
+    download and fill out VA Form 20-0996{' '}
     <dfn>
       <abbr title="Portable Document Format">PDF</abbr> (1.5
       <abbr title="Megabytes">MB</abbr>)
@@ -67,41 +67,54 @@ const downloadLink = (
 );
 
 const disabilitiesList = (
-  <ul>
-    <li>
-      We made the decision over a year ago. You have 1 year from the date on
-      your decision letter to request a Higher-Level Review.
-    </li>
-    <li>
-      Your issue is for a benefit type other than compensation or pension. To
-      request a Higher-Level Review for another benefit type like health care,
-      insurance, or education, you’ll need to {downloadLink} and submit a
-      completed application by mail or in person.
-    </li>
-    <li>
-      The issue or decision isn’t in our system yet. Please refer to your
-      decision letter about what form you’ll need to submit to request a
-      Higher-Level Review.
-    </li>
-    <li>
-      You’re unable to request a Higher-Level Review within 1 year of the date
-      on your decision letter due to the COVID-19 pandemic. To request a good
-      cause extension, you’ll need to {downloadLink} fill it out and attach a
-      note to your application that you’re requesting an exemption for timely
-      filing due to COVID-19.
-      <br />
-      <br />
-      To learn more about how COVID-19 affect claims or appeals, please visit
+  <div>
+    <ul>
+      <li>
+        We made the decision over a year ago. You have 1 year from the date on
+        your decision letter to request a Higher-Level Review.{' '}
+        <strong>**Note:**</strong> If you weren’t able to request a timely
+        review due to COVID-19 pandemic, we may grant you an extension of the
+        deadline. To request an extension, {downloadLink} and attach a note that
+        you’re requesting a filing extension due to COVID-19.
+      </li>
+      <li>
+        Your issue isn’t related to monthly compensation, pension, or survivor
+        benefits. For all other benefits, like health care, insurance or
+        education, you’ll need to {downloadLink} and submit it by mail or in
+        person.
+      </li>
+      <li>
+        The issue or decision isn’t in our system yet. You’ll need to{' '}
+        {downloadLink} and submit it by fax or mail.
+      </li>
+      <li>
+        You’re applying for a benefit that another surviving dependent of the
+        Veteran is also applying for. And by law, only 1 of you can receive the
+        benefit. You’ll need to appeal to the Board of Veterans’ Appeals.
+      </li>
+      <li>
+        You’re requesting a review of a Board of Veterans’ Appeals decision.
+        You’ll need to refer to the Board’s decision notice for your review
+        options.
+      </li>
+      <li>
+        You’re requesting a review of another Higher-Level Review. You can
+        either submit a supplmental claim or appeal to the Board of Veterans’
+        Appeals.
+      </li>
+    </ul>
+    <p>
+      To learn more about how COVID-19 affects claims or appeals, please visit
       our <a href={COVID_FAQ_URL}>Coronavirus FAQ page</a>.
-    </li>
-  </ul>
+    </p>
+  </div>
 );
 
 export const disabilitiesExplanationAlert = (
   <>
     <p className="vads-u-margin-top--2p5" />
     <AdditionalInfo triggerText={'Why isn’t my issue eligible?'}>
-      Your issue may not be eligible for a Higher-Level Review if:
+      <p>Your issue may not be eligible for a Higher-Level Review if:</p>
       {disabilitiesList}
     </AdditionalInfo>
   </>
@@ -111,7 +124,9 @@ export const disabilitiesExplanation = (
   <>
     <p className="vads-u-margin-top--2p5" />
     <AdditionalInfo triggerText={'Don’t see the issue you’re looking for?'}>
-      Your issue may not be eligible for a Higher-Level Review if:
+      <p>
+        There are many reasons a decision might not appear in the list above.
+      </p>
       {disabilitiesList}
     </AdditionalInfo>
   </>

--- a/src/applications/disability-benefits/996/content/contestedIssues.jsx
+++ b/src/applications/disability-benefits/996/content/contestedIssues.jsx
@@ -46,44 +46,52 @@ export const disabilityOption = ({ attributes }) => {
   );
 };
 
-export const disabilitiesExplanation = (
-  <>
-    <p className="vads-u-margin-top--2p5" />
-    <AdditionalInfo triggerText="Don’t see the issue you’re looking for?">
-      There are several reasons your issue or decision might not appear in the
-      list above:
-      <ul>
-        <li>
-          If we made the decision over a year ago, it’s not eligible for a
-          Higher-Level Review.
-        </li>
-        <li>
-          The decision might be for another benefit type, like health care,
-          insurance, or education. Decisions for these benefit types won’t
-          appear on this list. If you want to request Higher-Level Review for
-          benefit types other than compensation, you’ll need to fill out a{' '}
-          <a href={FORM_URL}>
-            Decision Review Request: Higher-Level Review (VA Form 20-0996)
-          </a>
-          .
-        </li>
-        <li>
-          The issue or decision might not be in our system. Please refer to your
-          decision letter about what form you’ll need to submit.
-        </li>
-        <li>
-          If you were unable to file a Higher-Level Review claim before the
-          deadline and need to request an extension based on good cause, you’ll
-          need to fill out a paper{' '}
-          <a href={FORM_URL}>
-            VA Form 20-0996, Decision Review Request: Higher-Level Review
-          </a>{' '}
-          with your request for an extension.
-        </li>
-      </ul>
-    </AdditionalInfo>
-  </>
-);
+export const disabilitiesExplanation = ({ introPageAlert = false } = {}) => {
+  const title = introPageAlert
+    ? 'Why don’t I see my issue?'
+    : 'Don’t see the issue you’re looking for?';
+  const firstSentenceEnding = introPageAlert
+    ? 'be available:'
+    : 'appear in the list above:';
+  return (
+    <>
+      <p className="vads-u-margin-top--2p5" />
+      <AdditionalInfo triggerText={title}>
+        There are several reasons your issue or decision might not{' '}
+        {firstSentenceEnding}
+        <ul>
+          <li>
+            If we made the decision over a year ago, it’s not eligible for a
+            Higher-Level Review.
+          </li>
+          <li>
+            The decision might be for another benefit type, like health care,
+            insurance, or education. Decisions for these benefit types won’t
+            appear on this list. If you want to request Higher-Level Review for
+            benefit types other than compensation, you’ll need to fill out a{' '}
+            <a href={FORM_URL}>
+              Decision Review Request: Higher-Level Review (VA Form 20-0996)
+            </a>
+            .
+          </li>
+          <li>
+            The issue or decision might not be in our system. Please refer to
+            your decision letter about what form you’ll need to submit.
+          </li>
+          <li>
+            If you were unable to file a Higher-Level Review claim before the
+            deadline and need to request an extension based on good cause,
+            you’ll need to fill out a paper{' '}
+            <a href={FORM_URL}>
+              VA Form 20-0996, Decision Review Request: Higher-Level Review
+            </a>{' '}
+            with your request for an extension.
+          </li>
+        </ul>
+      </AdditionalInfo>
+    </>
+  );
+};
 
 /**
  * Shows the alert box only if the form has been submitted

--- a/src/applications/disability-benefits/996/content/veteranInformation.jsx
+++ b/src/applications/disability-benefits/996/content/veteranInformation.jsx
@@ -5,6 +5,9 @@ import moment from 'moment';
 import { srSubstitute } from '../../all-claims/utils';
 import { genderLabels } from 'platform/static-data/labels';
 import { selectProfile } from 'platform/user/selectors';
+import Telephone, {
+  CONTACTS,
+} from '@department-of-veterans-affairs/formation-react/Telephone';
 
 const mask = srSubstitute('●●●–●●–', 'ending with');
 
@@ -48,14 +51,8 @@ export const veteranInfoView = ({ profile = {}, veteran = {} }) => {
       <p>
         <strong>Note:</strong> If you need to update your personal information,
         please call Veterans Benefits Assistance toll free at{' '}
-        <a
-          href="tel:1-800-827-1000"
-          aria-label="8 0 0. 8 2 7. 1 0 0 0."
-          className="nowrap"
-        >
-          800-827-1000
-        </a>
-        , Monday through Friday, 8:00 a.m. to 9:00 p.m. ET.
+        <Telephone contact={CONTACTS.VA_BENEFITS} />, Monday through Friday,
+        8:00 a.m. to 9:00 p.m. ET.
       </p>
     </>
   );

--- a/src/applications/disability-benefits/996/pages/contestedIssues.js
+++ b/src/applications/disability-benefits/996/pages/contestedIssues.js
@@ -40,7 +40,7 @@ const contestedIssuesPage = {
       },
     },
     'view:disabilitiesExplanation': {
-      'ui:description': disabilitiesExplanation,
+      'ui:description': disabilitiesExplanation(),
     },
     sameOffice: {
       'ui:title': OfficeForReviewTitle,

--- a/src/applications/disability-benefits/996/pages/contestedIssues.js
+++ b/src/applications/disability-benefits/996/pages/contestedIssues.js
@@ -40,7 +40,7 @@ const contestedIssuesPage = {
       },
     },
     'view:disabilitiesExplanation': {
-      'ui:description': disabilitiesExplanation(),
+      'ui:description': disabilitiesExplanation,
     },
     sameOffice: {
       'ui:title': OfficeForReviewTitle,

--- a/src/applications/disability-benefits/996/tests/containers/IntroductionPage.unit.spec.jsx
+++ b/src/applications/disability-benefits/996/tests/containers/IntroductionPage.unit.spec.jsx
@@ -80,7 +80,9 @@ describe('IntroductionPage', () => {
     const tree = shallow(<IntroductionPage {...props} />);
 
     const AlertBox = tree.find('AlertBox').first();
-    expect(AlertBox.render().text()).to.include('some server error');
+    expect(AlertBox.render().text()).to.include(
+      'can’t load your contestable issues',
+    );
     tree.unmount();
   });
   it('should render alert showing no contestable issues', () => {
@@ -96,7 +98,9 @@ describe('IntroductionPage', () => {
     const tree = shallow(<IntroductionPage {...props} />);
 
     const AlertBox = tree.find('AlertBox').first();
-    expect(AlertBox.render().text()).to.include('No Contestable Issues');
+    expect(AlertBox.render().text()).to.include(
+      'don’t have any contestable issues',
+    );
     tree.unmount();
   });
   it('should render start button', () => {

--- a/src/applications/disability-benefits/996/tests/containers/IntroductionPage.unit.spec.jsx
+++ b/src/applications/disability-benefits/996/tests/containers/IntroductionPage.unit.spec.jsx
@@ -72,7 +72,7 @@ describe('IntroductionPage', () => {
         issues: [],
         status: '',
         error: {
-          errors: [{ title: 'some server error' }],
+          errors: [{ title: 'We can’t load your issues' }],
         },
       },
     };
@@ -80,9 +80,7 @@ describe('IntroductionPage', () => {
     const tree = shallow(<IntroductionPage {...props} />);
 
     const AlertBox = tree.find('AlertBox').first();
-    expect(AlertBox.render().text()).to.include(
-      'can’t load your contestable issues',
-    );
+    expect(AlertBox.render().text()).to.include('can’t load your issues');
     tree.unmount();
   });
   it('should render alert showing no contestable issues', () => {
@@ -99,7 +97,7 @@ describe('IntroductionPage', () => {
 
     const AlertBox = tree.find('AlertBox').first();
     expect(AlertBox.render().text()).to.include(
-      'don’t have any contestable issues',
+      'don’t have any issues on file for you',
     );
     tree.unmount();
   });


### PR DESCRIPTION
## Description

- Updated content per recommendations
  - Included the Additional info dropdown from the contestable issues page inside the alert
  - Changed the title & first sentence of the dropdown (when compared to the component on the contestable issues page - included a screenshot for comparison).
- Switch telephone links to use the Telephone component

Related issues:
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/10713
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/11255

## Testing done

Unit tests

## Screenshots

<details><summary>Introduction page - No contestable issues alert (full screen; collapsed)</summary>

<!-- leave a blank line above -->
![](https://user-images.githubusercontent.com/136959/87567176-9c1a2600-c689-11ea-92c3-bcbd852dfd3e.png)
</details>

<details><summary>Introduction page - No contestable issues alert (expanded)</summary>

<!-- leave a blank line above -->
![Screen Shot 2020-07-15 at 10 32 35 AM](https://user-images.githubusercontent.com/136959/87567195-9fadad00-c689-11ea-8ecd-0f7e29532fe9.png)</details>

<details><summary>Introduction page - Network error alert</summary>

<!-- leave a blank line above -->
<br />
The actual error message (in bold) is included between the two sentences.

![Screen Shot 2020-07-15 at 10 36 15 AM](https://user-images.githubusercontent.com/136959/87567196-a0464380-c689-11ea-8da5-739e4bec47a0.png)</details>

<details><summary>Contestable issues page</summary>

<!-- leave a blank line above -->
![Screen Shot 2020-07-15 at 10 28 54 AM](https://user-images.githubusercontent.com/136959/87567193-9fadad00-c689-11ea-9855-451b1f0334d1.png)</details>

## Acceptance criteria
- [ ] Content updates are acceptable

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
