### PR TITLE
filter subnav routes when user is LOA1

### DIFF
--- a/src/applications/personalization/profile-2/components/ProfileMobileSubNav.jsx
+++ b/src/applications/personalization/profile-2/components/ProfileMobileSubNav.jsx
@@ -10,6 +10,8 @@ import {
   isTab,
 } from 'platform/utilities/accessibility';
 
+import { isLOA3 as isLOA3Selector } from 'platform/user/selectors';
+
 import { ProfileMenuItems } from './ProfileSubNav';
 
 import {
@@ -39,6 +41,7 @@ const getElementHeight = el => {
 const ProfileMobileSubNav = ({
   openMenu,
   closeMenu,
+  isLOA3,
   isMenuPinned,
   isMenuOpen,
   pinMenu,
@@ -144,7 +147,7 @@ const ProfileMobileSubNav = ({
         document.addEventListener('keydown', closeOnEscape);
         closeMenuButton.current.focus();
         // trap the focus so that you can't tab the focus to an element behind the
-        // open mobile sidenav
+        // open mobile subnav
         closeMenuButton.current.addEventListener('keydown', overrideShiftTab);
         lastMenuItem.current = Array.from(
           getTabbableElements(document.querySelector('.menu-wrapper ul')),
@@ -201,6 +204,7 @@ const ProfileMobileSubNav = ({
                 </button>
               </div>
               <ProfileMenuItems
+                isLOA3={isLOA3}
                 routes={routes}
                 clickHandler={() => {
                   closeMenu();
@@ -222,6 +226,7 @@ export { ProfileMobileSubNav };
 
 ProfileMobileSubNav.propTypes = {
   closeMenu: PropTypes.func.isRequired,
+  isLOA3: PropTypes.bool.isRequired,
   isMenuPinned: PropTypes.bool.isRequired,
   openMenu: PropTypes.func.isRequired,
   pinMenu: PropTypes.func.isRequired,
@@ -229,6 +234,7 @@ ProfileMobileSubNav.propTypes = {
 };
 
 const mapStateToProps = state => ({
+  isLOA3: isLOA3Selector(state),
   isMenuPinned: selectIsMenuTriggerPinned(state),
   isMenuOpen: selectIsSideNavOpen(state),
 });

--- a/src/applications/personalization/profile-2/components/ProfileSubNav.jsx
+++ b/src/applications/personalization/profile-2/components/ProfileSubNav.jsx
@@ -1,12 +1,20 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import { connect } from 'react-redux';
 import { NavLink } from 'react-router-dom';
 
-export function ProfileMenuItems({ routes, clickHandler = null }) {
+import { isLOA3 as isLOA3Selector } from 'platform/user/selectors';
+
+export function ProfileMenuItems({ routes, isLOA3, clickHandler = null }) {
   return (
     <ul>
       {routes.map(route => {
+        // Do not render route if it is not isLOA3
+        if (route.requiresLOA3 && !isLOA3) {
+          return null;
+        }
+
         return (
           <li key={route.path}>
             <NavLink
@@ -24,18 +32,19 @@ export function ProfileMenuItems({ routes, clickHandler = null }) {
   );
 }
 
-const ProfileSubNav = ({ routes }) => {
+const ProfileSubNav = ({ isLOA3, routes }) => {
   return (
     <nav className="va-subnav" aria-label="Secondary">
       <div>
         <h1 className="vads-u-font-size--h4">Your profile</h1>
-        <ProfileMenuItems routes={routes} />
+        <ProfileMenuItems routes={routes} isLOA3={isLOA3} />
       </div>
     </nav>
   );
 };
 
 ProfileSubNav.propTypes = {
+  isLOA3: PropTypes.bool.isRequired,
   routes: PropTypes.arrayOf(
     PropTypes.shape({
       path: PropTypes.string.isRequired,
@@ -44,4 +53,10 @@ ProfileSubNav.propTypes = {
   ).isRequired,
 };
 
-export default ProfileSubNav;
+const mapStateToProps = state => ({
+  isLOA3: isLOA3Selector(state),
+});
+
+export { ProfileSubNav };
+
+export default connect(mapStateToProps)(ProfileSubNav);


### PR DESCRIPTION
## Description
In my last PR I had foolishly removed the existing filtering we had that removed LOA3-required routes when the user was LOA1. This PR adds that filtering back.

## Testing done
Confirmed locally with user 350

## Screenshots
![image](https://user-images.githubusercontent.com/20728956/87608652-596e4300-c6b5-11ea-8bd9-d359c2696e66.png)

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs