### PR TITLE
526: Move Military History and Alternate Names to 2nd and 3rd Pages

### DIFF
--- a/src/applications/disability-benefits/all-claims/config/form.js
+++ b/src/applications/disability-benefits/all-claims/config/form.js
@@ -162,14 +162,6 @@ const formConfig = {
           uiSchema: { 'ui:description': veteranInfoDescription },
           schema: { type: 'object', properties: {} },
         },
-        claimType: {
-          title: 'Claim type',
-          path: 'claim-type',
-          depends: formData => hasRatedDisabilities(formData),
-          uiSchema: claimType.uiSchema,
-          schema: claimType.schema,
-          onContinue: captureEvents.claimType,
-        },
         alternateNames: {
           title: 'Service under another name',
           path: 'alternate-names',
@@ -184,6 +176,14 @@ const formConfig = {
           schema: militaryHistory.schema,
           onContinue: captureEvents.militaryHistory,
           appStateSelector: state => ({ dob: state.user.profile.dob }),
+        },
+        claimType: {
+          title: 'Claim type',
+          path: 'claim-type',
+          depends: formData => hasRatedDisabilities(formData),
+          uiSchema: claimType.uiSchema,
+          schema: claimType.schema,
+          onContinue: captureEvents.claimType,
         },
         servedInCombatZone: {
           title: 'Combat status',


### PR DESCRIPTION
## Description
This PR moves military history and alternate names to the 2nd and 3rd pages in the 526 form. This is done in preparation to move the BDD flow into all-claims.

## Acceptance criteria
- [ ] Military history and alternate names are the 2nd and 3rd pages in all-claims