### PR TITLE
keep address update alert hidden after page change

### DIFF
--- a/src/applications/vaos/actions/newAppointment.js
+++ b/src/applications/vaos/actions/newAppointment.js
@@ -134,6 +134,8 @@ export const FORM_SUBMIT = 'newAppointment/FORM_SUBMIT';
 export const FORM_SUBMIT_FAILED = 'newAppointment/FORM_SUBMIT_FAILED';
 export const FORM_UPDATE_CC_ELIGIBILITY =
   'newAppointment/FORM_UPDATE_CC_ELIGIBILITY';
+export const CLICKED_UPDATE_ADDRESS_BUTTON =
+  'newAppointment/CLICKED_UPDATE_ADDRESS_BUTTON';
 
 export function openFormPage(page, uiSchema, schema) {
   return {
@@ -147,6 +149,12 @@ export function openFormPage(page, uiSchema, schema) {
 export function startNewAppointmentFlow() {
   return {
     type: STARTED_NEW_APPOINTMENT_FLOW,
+  };
+}
+
+export function onClickedUpdateAddressButton() {
+  return {
+    type: CLICKED_UPDATE_ADDRESS_BUTTON,
   };
 }
 

--- a/src/applications/vaos/actions/newAppointment.js
+++ b/src/applications/vaos/actions/newAppointment.js
@@ -152,7 +152,7 @@ export function startNewAppointmentFlow() {
   };
 }
 
-export function onClickedUpdateAddressButton() {
+export function clickUpdateAddressButton() {
   return {
     type: CLICKED_UPDATE_ADDRESS_BUTTON,
   };

--- a/src/applications/vaos/components/UpdateAddressAlert.jsx
+++ b/src/applications/vaos/components/UpdateAddressAlert.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
+
+export default function UpdateAddressAlert({ address, showAlert, onHide }) {
+  const regexp = /^PO Box/;
+  if (showAlert && (!address || address.match(regexp))) {
+    return (
+      <AlertBox
+        status="warning"
+        headline="You need to have a home address on file to use some of the tool's features"
+        className="vads-u-margin-y--3"
+        content={
+          <p>
+            You can update your address in your VA profile. Please allow some
+            time for your address update to process through our system. <br />
+            <a
+              className="usa-button usa-button-primary vads-u-margin-top--4"
+              target="_blank"
+              rel="noopener noreferrer"
+              href="/change-address/#how-do-i-change-my-address-in-"
+              onClick={onHide}
+            >
+              Update your address
+            </a>
+          </p>
+        }
+      />
+    );
+  }
+  return null;
+}

--- a/src/applications/vaos/containers/TypeOfCarePage.jsx
+++ b/src/applications/vaos/containers/TypeOfCarePage.jsx
@@ -46,35 +46,6 @@ const uiSchema = {
 const pageKey = 'typeOfCare';
 const pageTitle = 'Choose the type of care you need';
 
-// function UpdateAddress({ address, showAlert, onHide }) {
-//   const regexp = /^PO Box/;
-//   if (showAlert && (!address || address.match(regexp))) {
-//     return (
-//       <AlertBox
-//         status="warning"
-//         headline="You need to have a home address on file to use some of the tool's features"
-//         className="vads-u-margin-y--3"
-//         content={
-//           <p>
-//             You can update your address in your VA profile. Please allow some
-//             time for your address update to process through our system. <br />
-//             <a
-//               className="usa-button usa-button-primary vads-u-margin-top--4"
-//               target="_blank"
-//               rel="noopener noreferrer"
-//               href="/change-address/#how-do-i-change-my-address-in-"
-//               onClick={onHide}
-//             >
-//               Update your address
-//             </a>
-//           </p>
-//         }
-//       />
-//     );
-//   }
-//   return null;
-// }
-
 export class TypeOfCarePage extends React.Component {
   componentDidMount() {
     this.props.openTypeOfCarePage(pageKey, uiSchema, initialSchema);

--- a/src/applications/vaos/containers/TypeOfCarePage.jsx
+++ b/src/applications/vaos/containers/TypeOfCarePage.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import SchemaForm from 'platform/forms-system/src/js/components/SchemaForm';
-import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 import { scrollAndFocus } from '../utils/scrollAndFocus';
 import { getLongTermAppointmentHistory } from '../api';
 import FormButtons from '../components/FormButtons';
 import TypeOfCareUnavailableModal from '../components/TypeOfCareUnavailableModal';
+import UpdateAddressAlert from '../components/UpdateAddressAlert';
 import {
   openTypeOfCarePage,
   updateFormData,
@@ -13,6 +13,7 @@ import {
   routeToPreviousAppointmentPage,
   showTypeOfCareUnavailableModal,
   hideTypeOfCareUnavailableModal,
+  onClickedUpdateAddressButton,
 } from '../actions/newAppointment.js';
 import {
   getFormPageInfo,
@@ -45,34 +46,34 @@ const uiSchema = {
 const pageKey = 'typeOfCare';
 const pageTitle = 'Choose the type of care you need';
 
-function UpdateAddress({ address, showAlert, onHide }) {
-  const regexp = /^PO Box/;
-  if (showAlert && (!address || address.match(regexp))) {
-    return (
-      <AlertBox
-        status="warning"
-        headline="You need to have a home address on file to use some of the tool's features"
-        className="vads-u-margin-y--3"
-        content={
-          <p>
-            You can update your address in your VA profile. Please allow some
-            time for your address update to process through our system. <br />
-            <a
-              className="usa-button usa-button-primary vads-u-margin-top--4"
-              target="_blank"
-              rel="noopener noreferrer"
-              href="/change-address/#how-do-i-change-my-address-in-"
-              onClick={onHide}
-            >
-              Update your address
-            </a>
-          </p>
-        }
-      />
-    );
-  }
-  return null;
-}
+// function UpdateAddress({ address, showAlert, onHide }) {
+//   const regexp = /^PO Box/;
+//   if (showAlert && (!address || address.match(regexp))) {
+//     return (
+//       <AlertBox
+//         status="warning"
+//         headline="You need to have a home address on file to use some of the tool's features"
+//         className="vads-u-margin-y--3"
+//         content={
+//           <p>
+//             You can update your address in your VA profile. Please allow some
+//             time for your address update to process through our system. <br />
+//             <a
+//               className="usa-button usa-button-primary vads-u-margin-top--4"
+//               target="_blank"
+//               rel="noopener noreferrer"
+//               href="/change-address/#how-do-i-change-my-address-in-"
+//               onClick={onHide}
+//             >
+//               Update your address
+//             </a>
+//           </p>
+//         }
+//       />
+//     );
+//   }
+//   return null;
+// }
 
 export class TypeOfCarePage extends React.Component {
   componentDidMount() {
@@ -90,6 +91,7 @@ export class TypeOfCarePage extends React.Component {
 
   hideAlert = () => {
     const showAlert = !this.state.showAlert;
+    this.props.onClickedUpdateAddressButton();
     this.setState({ showAlert });
   };
 
@@ -120,6 +122,7 @@ export class TypeOfCarePage extends React.Component {
       pageChangeInProgress,
       showToCUnavailableModal,
       addressLine1,
+      clickedUpdateAddressButton,
     } = this.props;
 
     if (!schema) {
@@ -129,9 +132,9 @@ export class TypeOfCarePage extends React.Component {
     return (
       <div>
         <h1 className="vads-u-font-size--h2">{pageTitle}</h1>
-        <UpdateAddress
+        <UpdateAddressAlert
           address={addressLine1}
-          showAlert={this.state.showAlert}
+          showAlert={!clickedUpdateAddressButton && this.state.showAlert}
           onHide={this.hideAlert}
         />
 
@@ -164,12 +167,14 @@ function mapStateToProps(state) {
   const formInfo = getFormPageInfo(state, pageKey);
   const newAppointment = getNewAppointment(state);
   const address = selectVet360ResidentialAddress(state);
+  const clickedUpdateAddressButton = newAppointment.clickedUpdateAddressButton;
   return {
     ...formInfo,
     ...address,
     showToCUnavailableModal: newAppointment.showTypeOfCareUnavailableModal,
     isCernerOnlyPatient: selectIsCernerOnlyPatient(state),
     showDirectScheduling: vaosDirectScheduling(state),
+    clickedUpdateAddressButton: newAppointment.clickedUpdateAddressButton,
   };
 }
 
@@ -180,6 +185,7 @@ const mapDispatchToProps = {
   routeToPreviousAppointmentPage,
   showTypeOfCareUnavailableModal,
   hideTypeOfCareUnavailableModal,
+  onClickedUpdateAddressButton,
 };
 
 export default connect(

--- a/src/applications/vaos/containers/TypeOfCarePage.jsx
+++ b/src/applications/vaos/containers/TypeOfCarePage.jsx
@@ -53,17 +53,8 @@ export class TypeOfCarePage extends React.Component {
     scrollAndFocus();
   }
 
-  constructor(props) {
-    super(props);
-    this.state = {
-      showAlert: true,
-    };
-  }
-
   hideAlert = () => {
-    const showAlert = !this.state.showAlert;
     this.props.onClickedUpdateAddressButton();
-    this.setState({ showAlert });
   };
 
   onChange = newData => {
@@ -93,7 +84,7 @@ export class TypeOfCarePage extends React.Component {
       pageChangeInProgress,
       showToCUnavailableModal,
       addressLine1,
-      clickedUpdateAddressButton,
+      hideUpdateAddressAlert,
     } = this.props;
 
     if (!schema) {
@@ -105,7 +96,7 @@ export class TypeOfCarePage extends React.Component {
         <h1 className="vads-u-font-size--h2">{pageTitle}</h1>
         <UpdateAddressAlert
           address={addressLine1}
-          showAlert={!clickedUpdateAddressButton && this.state.showAlert}
+          showAlert={!hideUpdateAddressAlert}
           onHide={this.hideAlert}
         />
 
@@ -138,14 +129,13 @@ function mapStateToProps(state) {
   const formInfo = getFormPageInfo(state, pageKey);
   const newAppointment = getNewAppointment(state);
   const address = selectVet360ResidentialAddress(state);
-  const clickedUpdateAddressButton = newAppointment.clickedUpdateAddressButton;
   return {
     ...formInfo,
     ...address,
     showToCUnavailableModal: newAppointment.showTypeOfCareUnavailableModal,
     isCernerOnlyPatient: selectIsCernerOnlyPatient(state),
     showDirectScheduling: vaosDirectScheduling(state),
-    clickedUpdateAddressButton: newAppointment.clickedUpdateAddressButton,
+    hideUpdateAddressAlert: newAppointment.hideUpdateAddressAlert,
   };
 }
 

--- a/src/applications/vaos/containers/TypeOfCarePage.jsx
+++ b/src/applications/vaos/containers/TypeOfCarePage.jsx
@@ -13,7 +13,7 @@ import {
   routeToPreviousAppointmentPage,
   showTypeOfCareUnavailableModal,
   hideTypeOfCareUnavailableModal,
-  onClickedUpdateAddressButton,
+  clickUpdateAddressButton,
 } from '../actions/newAppointment.js';
 import {
   getFormPageInfo,
@@ -54,7 +54,7 @@ export class TypeOfCarePage extends React.Component {
   }
 
   hideAlert = () => {
-    this.props.onClickedUpdateAddressButton();
+    this.props.clickUpdateAddressButton();
   };
 
   onChange = newData => {
@@ -146,7 +146,7 @@ const mapDispatchToProps = {
   routeToPreviousAppointmentPage,
   showTypeOfCareUnavailableModal,
   hideTypeOfCareUnavailableModal,
-  onClickedUpdateAddressButton,
+  clickUpdateAddressButton,
 };
 
 export default connect(

--- a/src/applications/vaos/reducers/newAppointment.js
+++ b/src/applications/vaos/reducers/newAppointment.js
@@ -46,6 +46,7 @@ import {
   FORM_SUBMIT_FAILED,
   FORM_TYPE_OF_CARE_PAGE_OPENED,
   FORM_UPDATE_CC_ELIGIBILITY,
+  CLICKED_UPDATE_ADDRESS_BUTTON,
 } from '../actions/newAppointment';
 
 import {
@@ -89,6 +90,7 @@ const initialState = {
   fetchedAppointmentSlotMonths: [],
   submitStatus: FETCH_STATUS.notStarted,
   isCCEligible: false,
+  clickedUpdateAddressButton: false,
 };
 
 function getFacilities(state, typeOfCareId, vaParent) {
@@ -198,6 +200,7 @@ export default function formReducer(state = initialState, action) {
         facilities: state.facilities,
         pastAppointments: state.pastAppointments,
         submitStatus: FETCH_STATUS.notStarted,
+        clickedUpdateAddressButton: state.clickedUpdateAddressButton,
       };
     }
     case FORM_PAGE_CHANGE_STARTED: {
@@ -262,6 +265,12 @@ export default function formReducer(state = initialState, action) {
       return {
         ...state,
         showTypeOfCareUnavailableModal: false,
+      };
+    }
+    case CLICKED_UPDATE_ADDRESS_BUTTON: {
+      return {
+        ...state,
+        clickedUpdateAddressButton: true,
       };
     }
     case FORM_UPDATE_FACILITY_TYPE: {

--- a/src/applications/vaos/reducers/newAppointment.js
+++ b/src/applications/vaos/reducers/newAppointment.js
@@ -90,7 +90,7 @@ const initialState = {
   fetchedAppointmentSlotMonths: [],
   submitStatus: FETCH_STATUS.notStarted,
   isCCEligible: false,
-  clickedUpdateAddressButton: false,
+  hideUpdateAddressAlert: false,
 };
 
 function getFacilities(state, typeOfCareId, vaParent) {
@@ -200,7 +200,7 @@ export default function formReducer(state = initialState, action) {
         facilities: state.facilities,
         pastAppointments: state.pastAppointments,
         submitStatus: FETCH_STATUS.notStarted,
-        clickedUpdateAddressButton: state.clickedUpdateAddressButton,
+        hideUpdateAddressAlert: state.hideUpdateAddressAlert,
       };
     }
     case FORM_PAGE_CHANGE_STARTED: {
@@ -270,7 +270,7 @@ export default function formReducer(state = initialState, action) {
     case CLICKED_UPDATE_ADDRESS_BUTTON: {
       return {
         ...state,
-        clickedUpdateAddressButton: true,
+        hideUpdateAddressAlert: true,
       };
     }
     case FORM_UPDATE_FACILITY_TYPE: {

--- a/src/applications/vaos/tests/actions/newAppointment.unit.spec.js
+++ b/src/applications/vaos/tests/actions/newAppointment.unit.spec.js
@@ -27,7 +27,6 @@ import {
   startDirectScheduleFlow,
   startRequestAppointmentFlow,
   requestAppointmentDateChoice,
-  onClickedUpdateAddressButton,
   FORM_PAGE_OPENED,
   FORM_DATA_UPDATED,
   FORM_PAGE_CHANGE_STARTED,
@@ -59,7 +58,6 @@ import {
   FORM_HIDE_TYPE_OF_CARE_UNAVAILABLE_MODAL,
   START_REQUEST_APPOINTMENT_FLOW,
   START_DIRECT_SCHEDULE_FLOW,
-  CLICKED_UPDATE_ADDRESS_BUTTON,
 } from '../../actions/newAppointment';
 import {
   FORM_SUBMIT_SUCCEEDED,
@@ -1735,14 +1733,6 @@ describe('VAOS newAppointment actions', () => {
       );
       expect(dispatch.firstCall.args[0].phoneNumber).to.equal('5032222222');
       expect(dispatch.firstCall.args[0].email).to.equal('test@va.gov');
-    });
-
-    it('should start update address action', () => {
-      const action = onClickedUpdateAddressButton();
-
-      expect(action).to.deep.equal({
-        type: CLICKED_UPDATE_ADDRESS_BUTTON,
-      });
     });
   });
   describe('requestAppointmentDateChoice', () => {

--- a/src/applications/vaos/tests/actions/newAppointment.unit.spec.js
+++ b/src/applications/vaos/tests/actions/newAppointment.unit.spec.js
@@ -27,6 +27,7 @@ import {
   startDirectScheduleFlow,
   startRequestAppointmentFlow,
   requestAppointmentDateChoice,
+  onClickedUpdateAddressButton,
   FORM_PAGE_OPENED,
   FORM_DATA_UPDATED,
   FORM_PAGE_CHANGE_STARTED,
@@ -58,6 +59,7 @@ import {
   FORM_HIDE_TYPE_OF_CARE_UNAVAILABLE_MODAL,
   START_REQUEST_APPOINTMENT_FLOW,
   START_DIRECT_SCHEDULE_FLOW,
+  CLICKED_UPDATE_ADDRESS_BUTTON,
 } from '../../actions/newAppointment';
 import {
   FORM_SUBMIT_SUCCEEDED,
@@ -1733,6 +1735,14 @@ describe('VAOS newAppointment actions', () => {
       );
       expect(dispatch.firstCall.args[0].phoneNumber).to.equal('5032222222');
       expect(dispatch.firstCall.args[0].email).to.equal('test@va.gov');
+    });
+
+    it('should start update address action', () => {
+      const action = onClickedUpdateAddressButton();
+
+      expect(action).to.deep.equal({
+        type: CLICKED_UPDATE_ADDRESS_BUTTON,
+      });
     });
   });
   describe('requestAppointmentDateChoice', () => {

--- a/src/applications/vaos/tests/containers/TypeOfCarePage.unit.spec.jsx
+++ b/src/applications/vaos/tests/containers/TypeOfCarePage.unit.spec.jsx
@@ -6,8 +6,14 @@ import { mount } from 'enzyme';
 import { mockFetch, setFetchJSONResponse } from 'platform/testing/unit/helpers';
 
 import { selectRadio } from 'platform/testing/unit/schemaform-utils.jsx';
-import { TypeOfCarePage } from '../../containers/TypeOfCarePage';
+import {
+  default as TypeOfCarePageRedux,
+  TypeOfCarePage,
+} from '../../containers/TypeOfCarePage';
 import { TYPES_OF_CARE } from '../../utils/constants';
+import { createTestStore } from '../mocks/form';
+import { renderInReduxProvider } from 'platform/testing/unit/react-testing-library-helpers';
+import { fireEvent } from '@testing-library/dom';
 
 const initialSchema = {
   type: 'object',
@@ -217,5 +223,21 @@ describe('VAOS <TypeOfCarePage>', () => {
 
     expect(form.find('.usa-alert').exists()).to.be.false;
     form.unmount();
+  });
+
+  it('should test redux data for update address', () => {
+    const store = createTestStore({});
+
+    const router = {
+      push: sinon.spy(),
+    };
+    const { debug, getByText, queryByText } = renderInReduxProvider(
+      <TypeOfCarePageRedux router={router} />,
+      { store },
+    );
+    expect(getByText(/You need to have a home addres/i)).to.exist;
+
+    fireEvent.click(getByText('Update your address'));
+    expect(queryByText(/You need to have a home addres/i)).to.not.exist;
   });
 });

--- a/src/applications/vaos/tests/containers/TypeOfCarePage.unit.spec.jsx
+++ b/src/applications/vaos/tests/containers/TypeOfCarePage.unit.spec.jsx
@@ -86,6 +86,28 @@ describe('VAOS <TypeOfCarePage>', () => {
     global.fetch.resetHistory();
   });
 
+  it('should call onClickedUpdateAddressButton after update button', () => {
+    const openTypeOfCarePage = sinon.spy();
+    const onClickedUpdateAddressButton = sinon.spy();
+
+    const form = mount(
+      <TypeOfCarePage
+        addressLine1={null}
+        openTypeOfCarePage={openTypeOfCarePage}
+        onClickedUpdateAddressButton={onClickedUpdateAddressButton}
+        schema={initialSchema}
+        data={{}}
+      />,
+    );
+
+    form.find('a.usa-button.usa-button-primary').simulate('click');
+
+    expect(onClickedUpdateAddressButton.called).to.be.true;
+
+    form.unmount();
+    // global.fetch.resetHistory();
+  });
+
   it('should submit with valid data', () => {
     const openTypeOfCarePage = sinon.spy();
     const routeToNextAppointmentPage = sinon.spy();
@@ -139,10 +161,10 @@ describe('VAOS <TypeOfCarePage>', () => {
     );
     expect(form.find('.usa-alert').exists()).to.be.true;
 
-    form.find('a.usa-button.usa-button-primary').simulate('click');
+    // form.find('a.usa-button.usa-button-primary').simulate('click');
 
-    expect(form.find('.usa-alert').exists()).to.be.false;
-    form.unmount();
+    // expect(form.find('.usa-alert').exists()).to.be.false;
+    // form.unmount();
   });
 
   it('should display alert message when residental address is a PO Box', () => {
@@ -179,14 +201,16 @@ describe('VAOS <TypeOfCarePage>', () => {
     form.unmount();
   });
 
-  it('should NOT display alert message once user clicks the update button', () => {
+  it('should NOT display alert message once user clicks the update address button', () => {
     const openTypeOfCarePage = sinon.spy();
     const updateFormData = sinon.spy();
+    const onClickedUpdateAddressButton = sinon.spy();
 
     const form = mount(
       <TypeOfCarePage
         addressLine1="PO Box 123"
         openTypeOfCarePage={openTypeOfCarePage}
+        onClickedUpdateAddressButton={onClickedUpdateAddressButton}
         schema={initialSchema}
         updateFormData={updateFormData}
         data={{}}

--- a/src/applications/vaos/tests/containers/TypeOfCarePage.unit.spec.jsx
+++ b/src/applications/vaos/tests/containers/TypeOfCarePage.unit.spec.jsx
@@ -161,10 +161,7 @@ describe('VAOS <TypeOfCarePage>', () => {
     );
     expect(form.find('.usa-alert').exists()).to.be.true;
 
-    // form.find('a.usa-button.usa-button-primary').simulate('click');
-
-    // expect(form.find('.usa-alert').exists()).to.be.false;
-    // form.unmount();
+    form.unmount();
   });
 
   it('should display alert message when residental address is a PO Box', () => {

--- a/src/applications/vaos/tests/containers/TypeOfCarePage.unit.spec.jsx
+++ b/src/applications/vaos/tests/containers/TypeOfCarePage.unit.spec.jsx
@@ -6,10 +6,8 @@ import { mount } from 'enzyme';
 import { mockFetch, setFetchJSONResponse } from 'platform/testing/unit/helpers';
 
 import { selectRadio } from 'platform/testing/unit/schemaform-utils.jsx';
-import {
-  default as TypeOfCarePageRedux,
-  TypeOfCarePage,
-} from '../../containers/TypeOfCarePage';
+import TypeOfCarePageRedux from '../../containers/TypeOfCarePage';
+import { TypeOfCarePage } from '../../containers/TypeOfCarePage';
 import { TYPES_OF_CARE } from '../../utils/constants';
 import { createTestStore } from '../mocks/form';
 import { renderInReduxProvider } from 'platform/testing/unit/react-testing-library-helpers';

--- a/src/applications/vaos/tests/containers/TypeOfCarePage.unit.spec.jsx
+++ b/src/applications/vaos/tests/containers/TypeOfCarePage.unit.spec.jsx
@@ -89,28 +89,6 @@ describe('VAOS <TypeOfCarePage>', () => {
     global.fetch.resetHistory();
   });
 
-  it('should call onClickedUpdateAddressButton after update button', () => {
-    const openTypeOfCarePage = sinon.spy();
-    const onClickedUpdateAddressButton = sinon.spy();
-
-    const form = mount(
-      <noRedux.TypeOfCarePage
-        addressLine1={null}
-        openTypeOfCarePage={openTypeOfCarePage}
-        onClickedUpdateAddressButton={onClickedUpdateAddressButton}
-        schema={initialSchema}
-        data={{}}
-      />,
-    );
-
-    form.find('a.usa-button.usa-button-primary').simulate('click');
-
-    expect(onClickedUpdateAddressButton.called).to.be.true;
-
-    form.unmount();
-    // global.fetch.resetHistory();
-  });
-
   it('should submit with valid data', () => {
     const openTypeOfCarePage = sinon.spy();
     const routeToNextAppointmentPage = sinon.spy();
@@ -201,28 +179,7 @@ describe('VAOS <TypeOfCarePage>', () => {
     form.unmount();
   });
 
-  it('should NOT display alert message once user clicks the update address button', () => {
-    const openTypeOfCarePage = sinon.spy();
-    const updateFormData = sinon.spy();
-    const onClickedUpdateAddressButton = sinon.spy();
-
-    const form = mount(
-      <noRedux.TypeOfCarePage
-        addressLine1="PO Box 123"
-        openTypeOfCarePage={openTypeOfCarePage}
-        onClickedUpdateAddressButton={onClickedUpdateAddressButton}
-        schema={initialSchema}
-        updateFormData={updateFormData}
-        data={{}}
-      />,
-    );
-    form.find('a.usa-button.usa-button-primary').simulate('click');
-
-    expect(form.find('.usa-alert').exists()).to.be.false;
-    form.unmount();
-  });
-
-  it('should test redux data for update address', () => {
+  it('should NOT display alert message once user clicks the update address button using redux state', () => {
     const store = createTestStore({});
 
     const router = {

--- a/src/applications/vaos/tests/containers/TypeOfCarePage.unit.spec.jsx
+++ b/src/applications/vaos/tests/containers/TypeOfCarePage.unit.spec.jsx
@@ -6,8 +6,7 @@ import { mount } from 'enzyme';
 import { mockFetch, setFetchJSONResponse } from 'platform/testing/unit/helpers';
 
 import { selectRadio } from 'platform/testing/unit/schemaform-utils.jsx';
-import TypeOfCarePageRedux from '../../containers/TypeOfCarePage';
-import { TypeOfCarePage } from '../../containers/TypeOfCarePage';
+import TypeOfCarePage, * as noRedux from '../../containers/TypeOfCarePage';
 import { TYPES_OF_CARE } from '../../utils/constants';
 import { createTestStore } from '../mocks/form';
 import { renderInReduxProvider } from 'platform/testing/unit/react-testing-library-helpers';
@@ -30,7 +29,7 @@ describe('VAOS <TypeOfCarePage>', () => {
     const updateFormData = sinon.spy();
 
     const form = mount(
-      <TypeOfCarePage
+      <noRedux.TypeOfCarePage
         openTypeOfCarePage={openTypeOfCarePage}
         updateFormData={updateFormData}
         schema={initialSchema}
@@ -49,7 +48,7 @@ describe('VAOS <TypeOfCarePage>', () => {
     };
 
     const form = mount(
-      <TypeOfCarePage
+      <noRedux.TypeOfCarePage
         openTypeOfCarePage={openTypeOfCarePage}
         schema={initialSchema}
         router={router}
@@ -74,7 +73,7 @@ describe('VAOS <TypeOfCarePage>', () => {
     };
 
     const form = mount(
-      <TypeOfCarePage
+      <noRedux.TypeOfCarePage
         openTypeOfCarePage={openTypeOfCarePage}
         updateFormData={updateFormData}
         schema={initialSchema}
@@ -95,7 +94,7 @@ describe('VAOS <TypeOfCarePage>', () => {
     const onClickedUpdateAddressButton = sinon.spy();
 
     const form = mount(
-      <TypeOfCarePage
+      <noRedux.TypeOfCarePage
         addressLine1={null}
         openTypeOfCarePage={openTypeOfCarePage}
         onClickedUpdateAddressButton={onClickedUpdateAddressButton}
@@ -117,7 +116,7 @@ describe('VAOS <TypeOfCarePage>', () => {
     const routeToNextAppointmentPage = sinon.spy();
 
     const form = mount(
-      <TypeOfCarePage
+      <noRedux.TypeOfCarePage
         openTypeOfCarePage={openTypeOfCarePage}
         schema={initialSchema}
         routeToNextAppointmentPage={routeToNextAppointmentPage}
@@ -138,7 +137,7 @@ describe('VAOS <TypeOfCarePage>', () => {
     const pageTitle = 'Choose the type of care you need';
 
     const form = mount(
-      <TypeOfCarePage
+      <noRedux.TypeOfCarePage
         openTypeOfCarePage={openTypeOfCarePage}
         schema={initialSchema}
         updateFormData={updateFormData}
@@ -155,7 +154,7 @@ describe('VAOS <TypeOfCarePage>', () => {
     const updateFormData = sinon.spy();
 
     const form = mount(
-      <TypeOfCarePage
+      <noRedux.TypeOfCarePage
         addressLine1={null}
         openTypeOfCarePage={openTypeOfCarePage}
         schema={initialSchema}
@@ -173,7 +172,7 @@ describe('VAOS <TypeOfCarePage>', () => {
     const updateFormData = sinon.spy();
 
     const form = mount(
-      <TypeOfCarePage
+      <noRedux.TypeOfCarePage
         addressLine1="PO Box 123"
         openTypeOfCarePage={openTypeOfCarePage}
         schema={initialSchema}
@@ -190,7 +189,7 @@ describe('VAOS <TypeOfCarePage>', () => {
     const updateFormData = sinon.spy();
 
     const form = mount(
-      <TypeOfCarePage
+      <noRedux.TypeOfCarePage
         addressLine1="123 Sesame St"
         openTypeOfCarePage={openTypeOfCarePage}
         schema={initialSchema}
@@ -208,7 +207,7 @@ describe('VAOS <TypeOfCarePage>', () => {
     const onClickedUpdateAddressButton = sinon.spy();
 
     const form = mount(
-      <TypeOfCarePage
+      <noRedux.TypeOfCarePage
         addressLine1="PO Box 123"
         openTypeOfCarePage={openTypeOfCarePage}
         onClickedUpdateAddressButton={onClickedUpdateAddressButton}
@@ -230,7 +229,7 @@ describe('VAOS <TypeOfCarePage>', () => {
       push: sinon.spy(),
     };
     const { debug, getByText, queryByText } = renderInReduxProvider(
-      <TypeOfCarePageRedux router={router} />,
+      <TypeOfCarePage router={router} />,
       { store },
     );
     expect(getByText(/You need to have a home addres/i)).to.exist;


### PR DESCRIPTION
## Description
create a redux state to keep track of hidden update address alert for other pages to access

## Testing done
local and unit test

## Screenshots


## Acceptance criteria
- [ ] unit test

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
