### PR TITLE
Update 10203 submit transformer

### DIFF
--- a/src/applications/edu-benefits/10203/submit-transformer.js
+++ b/src/applications/edu-benefits/10203/submit-transformer.js
@@ -19,6 +19,12 @@ export function transform(formConfig, form) {
     return clonedData;
   };
 
+  const entitlementTransform = formData => {
+    const clonedData = _.cloneDeep(formData);
+    delete clonedData['view:remainingEntitlement'];
+    return clonedData;
+  };
+
   // This needs to be last function call in array below
   const usFormTransform = formData =>
     transformForSubmit(formConfig, { ...form, data: formData });
@@ -33,6 +39,7 @@ export function transform(formConfig, form) {
 
   const transformedData = [
     benefitsTransform,
+    entitlementTransform,
     contactInfoTransform,
     usFormTransform, // This needs to be last function call in array
   ].reduce((formData, transformer) => transformer(formData), form.data);

--- a/src/applications/edu-benefits/10203/tests/schema/maximal-test.json
+++ b/src/applications/edu-benefits/10203/tests/schema/maximal-test.json
@@ -39,6 +39,11 @@
     "schoolState": "MA",
     "view:benefit": {
       "chapter33": true
+    },
+    "view:remainingEntitlement": {
+      "days": 1,
+      "months": 1,
+      "totalDays": 31
     }
   }
 }

--- a/src/applications/edu-benefits/10203/tests/schema/minimal-test.json
+++ b/src/applications/edu-benefits/10203/tests/schema/minimal-test.json
@@ -34,6 +34,7 @@
     "schoolState": "MA",
     "view:benefit": {
       "chapter33": true
-    }
+    },
+    "view:remainingEntitlement": {}
   }
 }


### PR DESCRIPTION
## Description
Update submit transformer to remove `view:remainingEntitlement` from form data.  View-fields are removed automatically, but non-view child fields are copied to parent objects, which was causing `day`, `months`, and `totalDays` to be present on the submission (which failed schema validation)

## Testing done
Tested locally and QA reviewed.

## Screenshots
N/A

## Acceptance criteria
- [x] 10203 submits without error

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
