### PR TITLE
11266 686 route gating

### DIFF
--- a/src/applications/disability-benefits/686c-674/containers/App.jsx
+++ b/src/applications/disability-benefits/686c-674/containers/App.jsx
@@ -4,7 +4,6 @@ import LoadingIndicator from '@department-of-veterans-affairs/formation-react/Lo
 import RoutedSavableApp from 'platform/forms/save-in-progress/RoutedSavableApp';
 
 import formConfig from '../config/form';
-import { verifyVaFileNumber } from '../actions';
 
 function App({ location, children, isLoggedIn, isLoading, vaFileNumber }) {
   const content = (

--- a/src/applications/disability-benefits/686c-674/containers/App.jsx
+++ b/src/applications/disability-benefits/686c-674/containers/App.jsx
@@ -1,12 +1,48 @@
 import React from 'react';
-
+import { connect } from 'react-redux';
+import LoadingIndicator from '@department-of-veterans-affairs/formation-react/LoadingIndicator';
 import RoutedSavableApp from 'platform/forms/save-in-progress/RoutedSavableApp';
-import formConfig from '../config/form';
 
-export default function App({ location, children }) {
-  return (
+import formConfig from '../config/form';
+import { verifyVaFileNumber } from '../actions';
+
+function App({ location, children, isLoggedIn, isLoading, vaFileNumber }) {
+  const content = (
     <RoutedSavableApp formConfig={formConfig} currentLocation={location}>
       {children}
     </RoutedSavableApp>
   );
+
+  // If on intro page, just return
+  if (location.pathname === '/introduction') {
+    return content;
+  }
+
+  // Handle loading
+  if (isLoading) {
+    return <LoadingIndicator message="Loading your information..." />;
+  }
+
+  // If a user is not logged in OR
+  // a user is logged in, but hasn't gone through va file number validation
+  // redirect them to the introduction page.
+  if (
+    !isLoggedIn ||
+    (isLoggedIn && !vaFileNumber?.hasVaFileNumber?.validVaFileNumber)
+  ) {
+    document.location.replace(
+      '/view-change-dependents/add-remove-form-686c/introduction',
+    );
+    return <LoadingIndicator message="Redirecting to introduction page..." />;
+  }
+
+  return content;
 }
+
+const mapStateToProps = state => ({
+  isLoggedIn: state?.user?.login?.currentlyLoggedIn,
+  isLoading: state?.user?.profile?.loading,
+  vaFileNumber: state?.vaFileNumber,
+});
+
+export default connect(mapStateToProps)(App);


### PR DESCRIPTION
## Description
Currently there's a bug in staging where if a user logs in, they can bypass the va file number check by typing in a form page url and going directly to it. We want to prevent users from doing this, and instead redirect them to the introduction page to enforce our va file number check. 

## Testing done
- local

## Acceptance criteria
- [x] redirects work as expected 

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
