### PR TITLE
Add common properties to entities after transformation

### DIFF
--- a/src/site/stages/build/process-cms-exports/helpers.js
+++ b/src/site/stages/build/process-cms-exports/helpers.js
@@ -41,6 +41,33 @@ function getContentModelType(entity) {
   return [entity.baseType, subType].filter(x => x).join('-');
 }
 
+/**
+ * Add common properties to the entity. Does not mutate `entity`; instead,
+ * returns a new object.
+ * @param {Object} entity - The entity to add the common properties to
+ * @param {String} baseType - The type of entity; corresponds to the name of
+ *                            the file.
+ * @param {String} uuid - The UUID of the entity; corresponds to the name of
+ *                        the file.
+ * @returns {Object} - The new entity with the added properties
+ */
+function addCommonProperties(entity, baseType, uuid) {
+  const newEntity = Object.assign({}, entity, {
+    baseType,
+    uuid,
+  });
+  // getContentModelType uses baseType
+  const contentModelType = getContentModelType(newEntity);
+  const entityBundle = contentModelType.includes('-')
+    ? contentModelType.split('-')[1]
+    : contentModelType;
+  Object.assign(newEntity, {
+    contentModelType,
+    entityBundle,
+  });
+  return newEntity;
+}
+
 module.exports = {
   defaultCMSExportContentDir,
   typeProperties,
@@ -111,12 +138,7 @@ module.exports = {
         .readFileSync(path.join(dir, `${baseType}.${uuid}.json`))
         .toString('utf8'),
     );
-    // Add what we already know about the entity
-    entity.baseType = baseType;
-    // Overrides the UUID property in the contents of the entity
-    entity.uuid = uuid;
-    entity.contentModelType = getContentModelType(entity);
-    return entity;
+    return addCommonProperties(entity, baseType, uuid);
   },
 
   /**

--- a/src/site/stages/build/process-cms-exports/index.js
+++ b/src/site/stages/build/process-cms-exports/index.js
@@ -106,6 +106,29 @@ const validateOutput = (entity, transformedEntity) => {
   }
 };
 
+/**
+ * Add common properties to the transformed entity. Mutates `transformedEntity`
+ * to save memory.
+ * @param {Object} transformedEntity - The entity after transformation
+ * @param {Object} originalEntity - The entity before transformation
+ * @returns {void}
+ */
+const addCommonProperties = (transformedEntity, originalEntity) => {
+  /* eslint-disable no-param-reassign */
+  transformedEntity.contentModelType =
+    transformedEntity.contentModelType || getContentModelType(originalEntity);
+  const [
+    entityType,
+    entityBundle,
+  ] = transformedEntity.contentModelType.includes('-')
+    ? transformedEntity.contentModelType.split('-')
+    : [transformedEntity.contentModelType, transformedEntity.contentModelType];
+  transformedEntity.entityType = entityType;
+  transformedEntity.entityBundle = entityBundle;
+  transformedEntity.entityUrl = originalEntity.entityUrl;
+  /* eslint-enable no-param-reassign */
+};
+
 const entityAssemblerFactory = contentDir => {
   /**
    * @param {Object} entity - The entity with entity references
@@ -228,6 +251,9 @@ const entityAssemblerFactory = contentDir => {
       );
       throw e;
     }
+
+    // Mutates transformedEntity
+    addCommonProperties(transformedEntity, entity);
 
     validateOutput(entity, transformedEntity);
 

--- a/src/site/stages/build/process-cms-exports/index.js
+++ b/src/site/stages/build/process-cms-exports/index.js
@@ -126,6 +126,11 @@ const addCommonProperties = (transformedEntity, originalEntity) => {
   transformedEntity.entityType = entityType;
   transformedEntity.entityBundle = entityBundle;
   transformedEntity.entityUrl = originalEntity.entityUrl;
+  transformedEntity.entityId = (originalEntity.nid ||
+    originalEntity.tid ||
+    originalEntity.id ||
+    originalEntity.mid ||
+    originalEntity.fid)[0].value.toString();
   /* eslint-enable no-param-reassign */
 };
 

--- a/src/site/stages/build/process-cms-exports/index.js
+++ b/src/site/stages/build/process-cms-exports/index.js
@@ -123,9 +123,11 @@ const addCommonProperties = (transformedEntity, originalEntity) => {
   ] = transformedEntity.contentModelType.includes('-')
     ? transformedEntity.contentModelType.split('-')
     : [transformedEntity.contentModelType, transformedEntity.contentModelType];
-  transformedEntity.entityType = entityType;
-  transformedEntity.entityBundle = entityBundle;
-  transformedEntity.entityUrl = originalEntity.entityUrl;
+  transformedEntity.entityType = transformedEntity.entityType || entityType;
+  transformedEntity.entityBundle =
+    transformedEntity.entityBundle || entityBundle;
+  transformedEntity.entityUrl =
+    transformedEntity.entityUrl || originalEntity.entityUrl;
   transformedEntity.entityId = (originalEntity.nid ||
     originalEntity.tid ||
     originalEntity.id ||

--- a/src/site/stages/build/process-cms-exports/transformers/node-event.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-event.js
@@ -25,11 +25,6 @@ const transform = entity => ({
   // Unsure why this was in the transformer in the first place, but it's possibly used in the templates somewhere?
   // uid: entity.uid[0],
   changed: utcToEpochTime(getDrupalValue(entity.changed)),
-  entityUrl: {
-    // TODO: Get the breadcrumb from the CMS export when it's available
-    breadcrumb: [],
-    path: entity.path[0].alias,
-  },
   entityMetatags: createMetaTagArray(entity.metatag.value),
   // TODO: Verify this is how to derive the entityPublished state
   entityPublished: entity.moderationState[0].value === 'published',

--- a/src/site/stages/build/process-cms-exports/transformers/node-health_care_local_facility.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-health_care_local_facility.js
@@ -22,11 +22,6 @@ const transform = entity => ({
   changed: utcToEpochTime(getDrupalValue(entity.changed)),
   entityPublished: isPublished(getDrupalValue(entity.moderationState)),
   entityMetatags: createMetaTagArray(entity.metatag.value),
-  entityUrl: {
-    // TODO: Get the breadcrumb from the CMS export when it's available
-    breadcrumb: [],
-    path: entity.path[0].alias,
-  },
   // The keys of fieldAddress[0] are snake_case, but we want camelCase
   fieldAddress: mapKeys(entity.fieldAddress[0], (v, k) => camelCase(k)),
   fieldEmailSubscription: getDrupalValue(entity.fieldEmailSubscription),

--- a/src/site/stages/build/process-cms-exports/transformers/node-health_care_region_detail_page.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-health_care_region_detail_page.js
@@ -12,9 +12,6 @@ const transform = entity => ({
   changed: utcToEpochTime(getDrupalValue(entity.changed)),
   entityPublished: isPublished(getDrupalValue(entity.moderationState)),
   entityMetatags: createMetaTagArray(entity.metatag.value),
-  entityUrl: {
-    path: entity.path[0].alias,
-  },
   fieldAlert: getDrupalValue(entity.fieldAlert),
   fieldContentBlock: entity.fieldContentBlock,
   fieldFeaturedContent: entity.fieldFeaturedContent,

--- a/src/site/stages/build/process-cms-exports/transformers/node-health_care_region_page.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-health_care_region_page.js
@@ -21,9 +21,6 @@ const transform = ({
     entityPublished: getDrupalValue(moderationState) === 'published',
     entityLabel: getDrupalValue(title),
     title: getDrupalValue(title),
-    entityUrl: {
-      path: path[0].alias,
-    },
     fieldNicknameForThisFacility: getDrupalValue(fieldNicknameForThisFacility),
     fieldLinkFacilityEmergList:
       fieldLinkFacilityEmergList && fieldLinkFacilityEmergList[0]

--- a/src/site/stages/build/process-cms-exports/transformers/node-landing_page.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-landing_page.js
@@ -12,10 +12,6 @@ const transform = entity => ({
   title: getDrupalValue(entity.title),
   changed: utcToEpochTime(getDrupalValue(entity.changed)),
   entityMetatags: createMetaTagArray(entity.metatag.value),
-  entityUrl: {
-    breadcrumb: [],
-    path: entity.path[0].alias,
-  },
   entityPublished: isPublished(getDrupalValue(entity.moderationState)),
   fieldAdministration: entity.fieldAdministration[0],
   fieldAlert: entity.fieldAlert[0] || null,

--- a/src/site/stages/build/process-cms-exports/transformers/node-news_story.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-news_story.js
@@ -14,11 +14,6 @@ const transform = entity => ({
   promote: getDrupalValue(entity.promote),
   entityMetatags: createMetaTagArray(entity.metatag.value),
   entityPublished: isPublished(getDrupalValue(entity.moderationState)),
-  entityUrl: {
-    // TODO: Get the breadcrumb from the CMS export when it's available
-    breadcrumb: [],
-    path: entity.path[0].alias,
-  },
   fieldAuthor: entity.fieldAuthor[0] || null,
   fieldFullStory: {
     processed: getWysiwygString(getDrupalValue(entity.fieldFullStory)),

--- a/src/site/stages/build/process-cms-exports/transformers/node-page.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-page.js
@@ -22,9 +22,6 @@ function pageTransform(entity) {
   const transformed = Object.assign({}, entity, {
     title: getDrupalValue(title),
     entityBundle: 'page',
-    entityUrl: {
-      path: entity.path[0].alias,
-    },
     fieldAdministration: entity.fieldAdministration[0],
 
     fieldIntroText: getDrupalValue(fieldIntroText),

--- a/src/site/stages/build/process-cms-exports/transformers/node-person_profile.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-person_profile.js
@@ -3,9 +3,6 @@ const { getDrupalValue } = require('./helpers');
 const transform = entity => ({
   entityType: 'node',
   entityBundle: 'person_profile',
-  entityUrl: {
-    path: entity.path[0].alias,
-  },
   title: `${getDrupalValue(entity.fieldNameFirst)} ${getDrupalValue(
     entity.fieldLastName,
   )}`,

--- a/src/site/stages/build/process-cms-exports/transformers/node-press_release.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-press_release.js
@@ -13,9 +13,6 @@ const transform = entity => ({
   entityBundle: 'press_release',
   title: getDrupalValue(entity.title),
   entityMetatags: createMetaTagArray(entity.metatag.value),
-  entityUrl: {
-    path: entity.path[0].alias,
-  },
   fieldAddress: entity.fieldAddress[0]
     ? mapKeys(entity.fieldAddress[0], (v, k) => camelCase(k))
     : null,

--- a/src/site/stages/build/process-cms-exports/transformers/node-publication_listing.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-publication_listing.js
@@ -12,10 +12,6 @@ const transform = entity => ({
   changed: utcToEpochTime(getDrupalValue(entity.changed)),
   entityPublished: isPublished(getDrupalValue(entity.moderationState)),
   entityMetatags: createMetaTagArray(entity.metatag.value),
-  entityUrl: {
-    breadcrumb: [],
-    path: entity.path[0].alias,
-  },
   fieldIntroText: getDrupalValue(entity.fieldIntroText),
   fieldOffice: entity.fieldOffice[0],
 });

--- a/src/site/stages/build/process-cms-exports/transformers/node-vamc_operating_status_and_alerts.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-vamc_operating_status_and_alerts.js
@@ -10,10 +10,6 @@ const transform = entity => ({
   title: getDrupalValue(entity.title),
   entityPublished: isPublished(getDrupalValue(entity.moderationState)),
   entityMetatags: createMetaTagArray(entity.metatag.value),
-  entityUrl: {
-    breadcrumb: [],
-    path: entity.path[0].alias,
-  },
   fieldBannerAlert: (entity.fieldBannerAlert || []).filter(
     // Apparently sometimes we get an array of alerts with array items:
     // "field_banner_alert": [


### PR DESCRIPTION
## Description
Like it says on the tin, this adds some common properties to entities after transformation. This is to reduce the boilerplate needed.

**Note:** This does more than the connected ticket asked for. :man_shrugging: 

## Testing done
`node script/cms/test-bundle-transformers.js` transforms all the entities successfully.

## Acceptance criteria
- [x] The `entityUrl` and some other properties are added to every entity after transformation _if_ the properties didn't exist on the entity already