### PR TITLE
Fetch new appointment slots whenever page loads

### DIFF
--- a/src/applications/vaos/actions/newAppointment.js
+++ b/src/applications/vaos/actions/newAppointment.js
@@ -512,7 +512,7 @@ export function openClinicPage(page, uiSchema, schema) {
   };
 }
 
-export function getAppointmentSlots(startDate, endDate) {
+export function getAppointmentSlots(startDate, endDate, forceFetch = false) {
   return async (dispatch, getState) => {
     const state = getState();
     const rootOrgId = getRootIdForChosenFacility(state);
@@ -520,17 +520,21 @@ export function getAppointmentSlots(startDate, endDate) {
     const availableSlots = newAppointment.availableSlots || [];
     const { data } = newAppointment;
 
-    const fetchedAppointmentSlotMonths = [
-      ...newAppointment.fetchedAppointmentSlotMonths,
-    ];
-
     const startDateMonth = moment(startDate).format('YYYY-MM');
     const endDateMonth = moment(endDate).format('YYYY-MM');
 
-    const fetchedStartMonth = fetchedAppointmentSlotMonths.includes(
-      startDateMonth,
-    );
-    const fetchedEndMonth = fetchedAppointmentSlotMonths.includes(endDateMonth);
+    let fetchedAppointmentSlotMonths = [];
+    let fetchedStartMonth = false;
+    let fetchedEndMonth = false;
+
+    if (!forceFetch) {
+      fetchedAppointmentSlotMonths = [
+        ...newAppointment.fetchedAppointmentSlotMonths,
+      ];
+
+      fetchedStartMonth = fetchedAppointmentSlotMonths.includes(startDateMonth);
+      fetchedEndMonth = fetchedAppointmentSlotMonths.includes(endDateMonth);
+    }
 
     if (!fetchedStartMonth || !fetchedEndMonth) {
       let mappedSlots = [];

--- a/src/applications/vaos/containers/DateTimeSelectPage.jsx
+++ b/src/applications/vaos/containers/DateTimeSelectPage.jsx
@@ -88,6 +88,7 @@ export class DateTimeSelectPage extends React.Component {
         .add(1, 'months')
         .endOf('month')
         .format('YYYY-MM-DD'),
+      true,
     );
     document.title = `${pageTitle} | Veterans Affairs`;
     scrollAndFocus();

--- a/src/applications/vaos/tests/mocks/form.js
+++ b/src/applications/vaos/tests/mocks/form.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import moment from 'moment';
 import { combineReducers, applyMiddleware, createStore } from 'redux';
 import thunk from 'redux-thunk';
 import { expect } from 'chai';
@@ -12,7 +13,22 @@ import reducers from '../../reducers';
 import newAppointmentReducer from '../../reducers/newAppointment';
 
 import TypeOfCarePage from '../../containers/TypeOfCarePage';
+import VAFacilityPage from '../../containers/VAFacilityPage';
 import { cleanup } from '@testing-library/react';
+import ClinicChoicePage from '../../containers/ClinicChoicePage';
+import PreferredDatePage from '../../containers/PreferredDatePage';
+import {
+  getParentSiteMock,
+  getFacilityMock,
+  getClinicMock,
+  getAppointmentSlotMock,
+} from '../mocks/v0';
+import {
+  mockEligibilityFetches,
+  mockParentSites,
+  mockSupportedFacilities,
+  mockAppointmentSlotFetch,
+} from '../mocks/helpers';
 
 export function createTestStore(initialState) {
   return createStore(
@@ -37,6 +53,98 @@ export async function setTypeOfCare(store, label) {
 
   const radioButton = await findByLabelText(label);
   fireEvent.click(radioButton);
+  fireEvent.click(getByText(/Continue/));
+  await waitFor(() => expect(router.push.called).to.be.true);
+  await cleanup();
+
+  return router.push.firstCall.args[0];
+}
+
+export async function setVAFacility(store, facilityId) {
+  const siteCode = facilityId.substring(0, 3);
+  const typeOfCareId = store.getState().newAppointment.data.typeOfCareId;
+  const parentSite = {
+    id: siteCode,
+    attributes: {
+      ...getParentSiteMock().attributes,
+      institutionCode: siteCode,
+      rootStationCode: siteCode,
+      parentStationCode: siteCode,
+    },
+  };
+  mockParentSites([siteCode], [parentSite]);
+  const facilities = [
+    {
+      id: facilityId,
+      attributes: {
+        ...getFacilityMock().attributes,
+        institutionCode: facilityId,
+        rootStationCode: siteCode,
+        parentStationCode: siteCode,
+        requestSupported: true,
+        directSchedulingSupported: true,
+      },
+    },
+  ];
+  mockSupportedFacilities({
+    siteId: siteCode,
+    parentId: siteCode,
+    typeOfCareId,
+    data: facilities,
+  });
+
+  const router = {
+    push: sinon.spy(),
+  };
+  const { findByText } = renderInReduxProvider(
+    <VAFacilityPage router={router} />,
+    { store },
+  );
+
+  const continueButton = await findByText(/Continue/);
+  fireEvent.click(continueButton);
+  await waitFor(() => expect(router.push.called).to.be.true);
+  await cleanup();
+
+  return router.push.firstCall.args[0];
+}
+
+export async function setClinic(store, clinicLabel) {
+  const router = {
+    push: sinon.spy(),
+  };
+  const { findByText, findByLabelText } = renderInReduxProvider(
+    <ClinicChoicePage router={router} />,
+    { store },
+  );
+
+  fireEvent.click(await findByLabelText(clinicLabel));
+  fireEvent.click(await findByText(/Continue/));
+  await waitFor(() => expect(router.push.called).to.be.true);
+  await cleanup();
+
+  return router.push.firstCall.args[0];
+}
+
+export async function setPreferredDate(store, preferredDate) {
+  const router = {
+    push: sinon.spy(),
+  };
+  const { findByText, getByLabelText, getByText } = renderInReduxProvider(
+    <PreferredDatePage router={router} />,
+    { store },
+  );
+
+  await findByText(/earliest date/);
+  fireEvent.change(getByLabelText('Month'), {
+    target: { value: preferredDate.month() + 1 },
+  });
+  fireEvent.change(getByLabelText('Day'), {
+    target: { value: preferredDate.date() },
+  });
+  fireEvent.change(getByLabelText('Year'), {
+    target: { value: preferredDate.year() },
+  });
   fireEvent.click(getByText(/Continue/));
   await waitFor(() => expect(router.push.called).to.be.true);
   await cleanup();

--- a/src/applications/vaos/tests/mocks/helpers.js
+++ b/src/applications/vaos/tests/mocks/helpers.js
@@ -219,15 +219,20 @@ export function mockEligibilityFetches({
     },
   );
 
-  const appointment = getVAAppointmentMock();
-  appointment.attributes = {
-    ...appointment.attributes,
-    startDate: moment().format(),
-    facilityId: siteId,
-    sta6aid: facilityId,
-    clinicId: clinics[0]?.id,
-  };
-  appointment.attributes.vdsAppointments[0].currentStatus = 'FUTURE';
+  const pastAppointments = clinics.map(clinic => {
+    const appointment = getVAAppointmentMock();
+    appointment.attributes = {
+      ...appointment.attributes,
+      startDate: moment().format(),
+      facilityId: siteId,
+      sta6aid: facilityId,
+      clinicId: clinic.id,
+    };
+    appointment.attributes.vdsAppointments[0].currentStatus = 'FUTURE';
+
+    return appointment;
+  });
+
   setFetchJSONResponse(
     global.fetch.withArgs(
       `${environment.API_URL}/vaos/v0/appointments?start_date=${moment()
@@ -237,7 +242,7 @@ export function mockEligibilityFetches({
         .startOf('day')
         .toISOString()}&type=va`,
     ),
-    { data: pastClinics && clinics.length ? [appointment] : [] },
+    { data: pastClinics ? pastAppointments : [] },
   );
   setFetchJSONResponse(
     global.fetch.withArgs(
@@ -274,5 +279,55 @@ export function mockEligibilityFetches({
         .toISOString()}&type=va`,
     ),
     { data: [] },
+  );
+}
+
+export function mockAppointmentSlotFetch({
+  siteId,
+  typeOfCareId,
+  preferredDate,
+  length = '20',
+  clinicId,
+  slots,
+}) {
+  setFetchJSONResponse(
+    global.fetch.withArgs(
+      `${
+        environment.API_URL
+      }/vaos/v0/facilities/${siteId}/available_appointments?type_of_care_id=${typeOfCareId}&clinic_ids[]=${clinicId}` +
+        `&start_date=${preferredDate
+          .clone()
+          .startOf('month')
+          .format('YYYY-MM-DD')}` +
+        `&end_date=${preferredDate
+          .clone()
+          .add(1, 'month')
+          .endOf('month')
+          .format('YYYY-MM-DD')}`,
+    ),
+    {
+      data: [
+        {
+          id: clinicId,
+          type: 'availability',
+          attributes: {
+            clinicId,
+            clinicName: 'Fake',
+            appointmentLength: length,
+            clinicDisplayStartTime: '9',
+            displayIncrements: '3',
+            stopCode: 'fake',
+            askForCheckIn: false,
+            maxOverbooksPerDay: 3,
+            hasUserAccessToClinic: true,
+            primaryStopCode: 'fake',
+            secondaryStopCode: '',
+            listSize: slots.length,
+            empty: slots.length === 0,
+            appointmentTimeSlot: slots,
+          },
+        },
+      ],
+    },
   );
 }

--- a/src/applications/vaos/tests/mocks/v0.js
+++ b/src/applications/vaos/tests/mocks/v0.js
@@ -236,3 +236,34 @@ export function getFacilityMock() {
     },
   };
 }
+
+export function getClinicMock() {
+  return {
+    id: 'fake',
+    type: 'clinic',
+    attributes: {
+      siteCode: 'fake',
+      clinicId: 'fake',
+      clinicName: 'Fake name',
+      clinicFriendlyLocationName: 'Fake friendly name',
+      primaryStopCode: 'fake',
+      secondaryStopCode: '',
+      directSchedulingFlag: 'Y',
+      displayToPatientFlag: 'Y',
+      institutionName: 'Fake inst name',
+      institutionCode: 'fake',
+      objectType: 'CdwClinic',
+      link: [],
+    },
+  };
+}
+
+export function getAppointmentSlotMock() {
+  return {
+    startDateTime: 'fake',
+    endDateTime: 'fake',
+    bookingStatus: '1',
+    remainingAllowedOverBookings: '3',
+    availability: true,
+  };
+}

--- a/src/applications/vaos/tests/new-appointment/select-date-page.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/select-date-page.unit.spec.jsx
@@ -7,11 +7,7 @@ import { cleanup } from '@testing-library/react';
 import { renderInReduxProvider } from 'platform/testing/unit/react-testing-library-helpers';
 import { mockFetch, resetFetch } from 'platform/testing/unit/helpers';
 
-import {
-  getParentSiteMock,
-  getClinicMock,
-  getAppointmentSlotMock,
-} from '../mocks/v0';
+import { getClinicMock, getAppointmentSlotMock } from '../mocks/v0';
 import {
   createTestStore,
   setTypeOfCare,

--- a/src/applications/vaos/tests/new-appointment/select-date-page.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/select-date-page.unit.spec.jsx
@@ -38,17 +38,6 @@ const initialState = {
   },
 };
 
-const parentSite983 = {
-  id: '983',
-  attributes: {
-    ...getParentSiteMock().attributes,
-    institutionCode: '983',
-    authoritativeName: 'Some VA facility',
-    rootStationCode: '983',
-    parentStationCode: '983',
-  },
-};
-
 describe('VAOS integration: select date time slot page', () => {
   beforeEach(() => mockFetch());
   afterEach(() => resetFetch());

--- a/src/applications/vaos/tests/new-appointment/select-date-page.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/select-date-page.unit.spec.jsx
@@ -1,0 +1,177 @@
+import React from 'react';
+import { expect } from 'chai';
+import moment from 'moment';
+import { fireEvent } from '@testing-library/dom';
+import { cleanup } from '@testing-library/react';
+
+import { renderInReduxProvider } from 'platform/testing/unit/react-testing-library-helpers';
+import { mockFetch, resetFetch } from 'platform/testing/unit/helpers';
+
+import {
+  getParentSiteMock,
+  getClinicMock,
+  getAppointmentSlotMock,
+} from '../mocks/v0';
+import {
+  createTestStore,
+  setTypeOfCare,
+  setVAFacility,
+  setClinic,
+  setPreferredDate,
+} from '../mocks/form';
+import {
+  mockEligibilityFetches,
+  mockAppointmentSlotFetch,
+} from '../mocks/helpers';
+
+import DateTimeSelectPage from '../../containers/DateTimeSelectPage';
+
+const initialState = {
+  featureToggles: {
+    vaOnlineSchedulingVSPAppointmentNew: false,
+    vaOnlineSchedulingDirect: true,
+  },
+  user: {
+    profile: {
+      facilities: [{ facilityId: '983', isCerner: false }],
+    },
+  },
+};
+
+const parentSite983 = {
+  id: '983',
+  attributes: {
+    ...getParentSiteMock().attributes,
+    institutionCode: '983',
+    authoritativeName: 'Some VA facility',
+    rootStationCode: '983',
+    parentStationCode: '983',
+  },
+};
+
+describe('VAOS integration: select date time slot page', () => {
+  beforeEach(() => mockFetch());
+  afterEach(() => resetFetch());
+
+  it('should fetch new slots after clinic change', async () => {
+    const clinics = [
+      {
+        id: '308',
+        attributes: {
+          ...getClinicMock(),
+          siteCode: '983',
+          clinicId: '308',
+          institutionCode: '983',
+          clinicFriendlyLocationName: 'Green team clinic',
+        },
+      },
+      {
+        id: '309',
+        attributes: {
+          ...getClinicMock(),
+          siteCode: '983',
+          clinicId: '309',
+          institutionCode: '983',
+          clinicFriendlyLocationName: 'Red team clinic',
+        },
+      },
+    ];
+    mockEligibilityFetches({
+      siteId: '983',
+      facilityId: '983',
+      typeOfCareId: '323',
+      limit: true,
+      requestPastVisits: true,
+      directPastVisits: true,
+      clinics,
+      pastClinics: true,
+    });
+    const slot308Date = moment()
+      .day(9)
+      .hour(9)
+      .minute(0)
+      .second(0);
+    const slots308 = [
+      {
+        ...getAppointmentSlotMock(),
+        startDateTime: slot308Date.format('YYYY-MM-DDTHH:mm:ss[+00:00]'),
+        endDateTime: slot308Date
+          .clone()
+          .minute(20)
+          .format('YYYY-MM-DDTHH:mm:ss[+00:00]'),
+      },
+    ];
+
+    const slot309Date = moment()
+      .day(11)
+      .hour(13)
+      .minute(0)
+      .second(0);
+    const slots309 = [
+      {
+        ...getAppointmentSlotMock(),
+        startDateTime: slot309Date.format('YYYY-MM-DDTHH:mm:ss[+00:00]'),
+        endDateTime: slot309Date
+          .clone()
+          .minute(20)
+          .format('YYYY-MM-DDTHH:mm:ss[+00:00]'),
+      },
+    ];
+    const preferredDate = moment();
+    mockAppointmentSlotFetch({
+      siteId: '983',
+      clinicId: '308',
+      typeOfCareId: '323',
+      slots: slots308,
+      preferredDate,
+    });
+    mockAppointmentSlotFetch({
+      siteId: '983',
+      clinicId: '309',
+      typeOfCareId: '323',
+      slots: slots309,
+      preferredDate,
+    });
+    const store = createTestStore(initialState);
+    await setTypeOfCare(store, /primary care/i);
+    await setVAFacility(store, '983');
+    await setClinic(store, /green team/i);
+    await setPreferredDate(store, preferredDate);
+
+    // First pass check to make sure the slots associated with green team are displayed
+    let screen = renderInReduxProvider(<DateTimeSelectPage />, {
+      store,
+    });
+    await screen.findByText(/Next/);
+    const dayWithSlots = screen
+      .getAllByText(slot308Date.date().toString())
+      .find(
+        node =>
+          node.getAttribute('aria-label') ===
+          slot308Date.format('dddd, MMMM Do'),
+      );
+    expect(dayWithSlots).to.exist;
+    fireEvent.click(dayWithSlots);
+    expect(await screen.findByText('9:00')).to.contain.text('9:00 a.m. AM');
+
+    await cleanup();
+
+    // Second pass make sure the slots associated with red team are displayed
+    await setClinic(store, /red team/i);
+    screen = renderInReduxProvider(<DateTimeSelectPage />, {
+      store,
+    });
+
+    await screen.findByText(/Next/);
+    const newDayWithSlots = screen
+      .getAllByText(slot309Date.date().toString())
+      .find(
+        node =>
+          node.getAttribute('aria-label') ===
+          slot309Date.format('dddd, MMMM Do'),
+      );
+    expect(newDayWithSlots).to.exist;
+    fireEvent.click(newDayWithSlots);
+    expect(await screen.findByText('1:00')).to.contain.text('1:00 p.m. PM');
+  });
+});

--- a/src/platform/testing/unit/mocha-setup.js
+++ b/src/platform/testing/unit/mocha-setup.js
@@ -30,8 +30,8 @@ export default function setupJSDom() {
 
   // Prevent warnings from displaying
   /* eslint-disable no-console */
-  console.error = () => {};
-  console.warn = () => {};
+  // console.error = () => {};
+  // console.warn = () => {};
   /* eslint-enable no-console */
 
   // setup the simplest document possible

--- a/src/platform/testing/unit/mocha-setup.js
+++ b/src/platform/testing/unit/mocha-setup.js
@@ -30,8 +30,8 @@ export default function setupJSDom() {
 
   // Prevent warnings from displaying
   /* eslint-disable no-console */
-  // console.error = () => {};
-  // console.warn = () => {};
+  console.error = () => {};
+  console.warn = () => {};
   /* eslint-enable no-console */
 
   // setup the simplest document possible


### PR DESCRIPTION
## Description
Currently, we're not pulling new slots if you open the calendar page, then go back and change the clinic, and come back to the calendar page. This appears to happen because we're trying to avoid refetching slots as you move between months. 

One solution would be to cache the data like we do for other calls in Redux using a site id and clinic id, but since slots are likely to change frequently, it seems reasonable to just refetch everything whenever you come to the calendar page.

This fix isn't complicated, but I used this bug as a chance to write a bunch of the mocking code we need for different form pages, so tests are easier to write in the future.

## Testing done
Local and unit testing

## Acceptance criteria
- [ ] Slots are re-fetched

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
