### PR TITLE
11200 686 loaded data

### DIFF
--- a/src/applications/disability-benefits/686c-674/config/form.js
+++ b/src/applications/disability-benefits/686c-674/config/form.js
@@ -178,7 +178,8 @@ const formConfig = {
           depends: formData =>
             typeof formData?.currentMarriageInformation?.type === 'string' &&
             formData?.currentMarriageInformation?.type !==
-              MARRIAGE_TYPES.ceremonial,
+              MARRIAGE_TYPES.ceremonial &&
+            isChapterFieldRequired(formData, TASK_KEYS.addSpouse),
           title: 'Additional evidence needed to add spouse',
           path: 'add-spouse-evidence',
           uiSchema: marriageAdditionalEvidence.uiSchema,
@@ -224,7 +225,7 @@ const formConfig = {
                 child?.childStatus?.stepchild === true ||
                 child?.childStatus?.adopted === true ||
                 child?.childStatus?.notCapable === true,
-            ),
+            ) && isChapterFieldRequired(formData, TASK_KEYS.addChild),
           title: 'Additional evidence needed to add child',
           path: 'add-child-evidence',
           uiSchema: childAdditionalEvidence.uiSchema,


### PR DESCRIPTION
## Description
A bug was discovered in staging for the 686c - When a person logs in and has an existing 686c form saved in progress, navigating back to the options selection screen and deselecting workflows that include "additional evidence" pages would leave the aforementioned pages in the form flow. Expected behaviour is that they would be removed. 

The reason for this is that `loadedData` for a SIP form gets mapped to the `formData` object and hydrates it. This means that even though an option may have been deselected, the check run by `depends()` still passes, as formData has been pre-populated. 

The solution was to just update the `depends` function to include an additional check for whether or not a workflow has been selected.

## Testing done
- local

## Acceptance criteria
- [x] pages get removed properly

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
