### PR TITLE
added ctFilterEnhancement feature flag

### DIFF
--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -33,4 +33,5 @@ export default Object.freeze({
   routeStLouisRPOtoBuffaloRPO: 'routeStLouisRPOtoBuffaloRPO',
   gibctSearchEnhancements: 'gibctSearchEnhancements',
   form996HigherLevelReview: 'form996HigherLevelReview',
+  ctFilterEnhancement: 'ctFilterEnhancement',
 });

--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -33,5 +33,5 @@ export default Object.freeze({
   routeStLouisRPOtoBuffaloRPO: 'routeStLouisRPOtoBuffaloRPO',
   gibctSearchEnhancements: 'gibctSearchEnhancements',
   form996HigherLevelReview: 'form996HigherLevelReview',
-  ctFilterEnhancement: 'ctFilterEnhancement',
+  gibctFilterEnhancement: 'gibctFilterEnhancement',
 });


### PR DESCRIPTION
## Description
As a developer, I need to create a feature flag that can be used to turn on and off CT filter enhancements so that it can be delivered to production in a timely manner.
https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/11344

## Testing done
Local testing @  http://localhost:3000/flipper/features

## Screenshots
![Screen Shot 2020-07-17 at 1 59 37 PM](https://user-images.githubusercontent.com/50601724/87816738-d0cae080-c835-11ea-88f4-b1cf938f63ca.png)
![Screen Shot 2020-07-17 at 1 34 22 PM](https://user-images.githubusercontent.com/50601724/87816746-d1fc0d80-c835-11ea-81fd-9810c9f1b87d.png)



## Acceptance criteria
- [x] The "ctFilterEnhancement" feature flag is created and available in all environments.
- [x] The description is "Comparison Tool Filter Enhancements to improve usability"

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
