### PR TITLE
Restore facility search results summary

### DIFF
--- a/src/applications/facility-locator/components/FacilityTypeDescription.jsx
+++ b/src/applications/facility-locator/components/FacilityTypeDescription.jsx
@@ -16,20 +16,10 @@ const facilityName = (query, location) => {
 };
 
 const FacilityTypeDescription = ({ location, from, query }) => (
-  <p>
-    <div>
-      {from === 'SearchResult' ? (
-        <div>
-          {facilityName(query, location) &&
-            facilityName(query, location).toUpperCase()}
-        </div>
-      ) : (
-        <div>
-          <strong>Facility type:</strong> {facilityName(query, location)}
-        </div>
-      )}
-    </div>
-  </p>
+  <div className="vads-u-margin-bottom--1">
+    {from === 'FacilityDetail' && <strong>Facility type: </strong>}
+    {facilityName(query, location)}
+  </div>
 );
 
 export default FacilityTypeDescription;

--- a/src/applications/facility-locator/components/SearchControls.jsx
+++ b/src/applications/facility-locator/components/SearchControls.jsx
@@ -185,7 +185,7 @@ class SearchControls extends Component {
                   {this.renderServiceTypeDropdown()}
                 </div>
                 <div className="columns medium-1-2">
-                  <input type="submit" value="Search" />
+                  <input id="facility-search" type="submit" value="Search" />
                 </div>
               </div>
             </div>

--- a/src/applications/facility-locator/components/SearchResultsHeader.jsx
+++ b/src/applications/facility-locator/components/SearchResultsHeader.jsx
@@ -14,6 +14,7 @@ const SearchResultsHeader = ({
 
   return (
     <h2
+      id="facility-search-results"
       className="vads-u-padding-left--2  vads-u-font-size--md vads-u-margin-y--1"
       tabIndex="-1"
     >

--- a/src/applications/facility-locator/components/SearchResultsHeader.jsx
+++ b/src/applications/facility-locator/components/SearchResultsHeader.jsx
@@ -2,25 +2,38 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { facilityTypes } from '../config';
 
-const SearchResultsHeader = ({ results, facilityType, context }) => {
-  return results.length > 0 ? (
-    <h2 className="search-result-title" tabIndex="-1">
+const SearchResultsHeader = ({
+  results,
+  facilityType,
+  context,
+  inProgress,
+}) => {
+  if (inProgress || !results.length) {
+    return <div style={{ height: '38px' }} />;
+  }
+
+  return (
+    <h2
+      className="vads-u-padding-left--2  vads-u-font-size--md vads-u-margin-y--1"
+      tabIndex="-1"
+    >
       {`Results for ${facilityTypes[facilityType]} near ${context}`}
     </h2>
-  ) : (
-    <br />
   );
 };
 
 SearchResultsHeader.propTypes = {
-  results: PropTypes.object,
+  results: PropTypes.array,
   facilityType: PropTypes.string,
   context: PropTypes.string,
 };
 
-// Only re-render if the results have changed
+// Only re-render if results or inProgress props have changed
 const areEqual = (prevProps, nextProps) => {
-  return nextProps.results === prevProps.results;
+  return (
+    nextProps.results === prevProps.results &&
+    nextProps.inProgress === prevProps.inProgress
+  );
 };
 
 export default React.memo(SearchResultsHeader, areEqual);

--- a/src/applications/facility-locator/components/SearchResultsHeader.jsx
+++ b/src/applications/facility-locator/components/SearchResultsHeader.jsx
@@ -12,13 +12,20 @@ const SearchResultsHeader = ({
     return <div style={{ height: '38px' }} />;
   }
 
+  const location = context.replace(', United States', '');
+
   return (
     <h2
       id="facility-search-results"
-      className="vads-u-padding-left--2  vads-u-font-size--md vads-u-margin-y--1"
+      className="vads-u-font-family--sans vads-u-font-weight--normal vads-u-font-size--base vads-u-padding--0p5 vads-u-margin-y--1"
+      style={{ 'margin-left': '12px' }}
       tabIndex="-1"
     >
-      {`Results for ${facilityTypes[facilityType]} near ${context}`}
+      Results for &quot;
+      <b>{facilityTypes[facilityType]}</b>
+      &quot; near&nbsp; &quot;
+      <b>{location}</b>
+      &quot;
     </h2>
   );
 };

--- a/src/applications/facility-locator/components/SearchResultsHeader.jsx
+++ b/src/applications/facility-locator/components/SearchResultsHeader.jsx
@@ -1,0 +1,26 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import { facilityTypes } from '../config';
+
+const SearchResultsHeader = ({ results, facilityType, context }) => {
+  return results.length > 0 ? (
+    <h2 className="search-result-title" tabIndex="-1">
+      {`Results for ${facilityTypes[facilityType]} near ${context}`}
+    </h2>
+  ) : (
+    <br />
+  );
+};
+
+SearchResultsHeader.propTypes = {
+  results: PropTypes.object,
+  facilityType: PropTypes.string,
+  context: PropTypes.string,
+};
+
+// Only re-render if the results have changed
+const areEqual = (prevProps, nextProps) => {
+  return nextProps.results === prevProps.results;
+};
+
+export default React.memo(SearchResultsHeader, areEqual);

--- a/src/applications/facility-locator/components/search-results/LocationInfoBlock.jsx
+++ b/src/applications/facility-locator/components/search-results/LocationInfoBlock.jsx
@@ -60,17 +60,7 @@ const LocationInfoBlock = ({ location, from, query }) => {
       {isProvider ? (
         <span>
           <ProviderServiceDescription provider={location} query={query} />
-          {query.facilityType === 'cc_pharmacy' ||
-          query.serviceType === 'NonVAUrgentCare' ||
-          query.serviceType === CLINIC_URGENTCARE_SERVICE ? (
-            <p>
-              <span>
-                <strong>{name}</strong>
-              </span>
-            </p>
-          ) : (
-            <h2 className="vads-u-font-size--h5 no-marg-top">{name}</h2>
-          )}
+          <h2 className="vads-u-font-size--h5 no-marg-top">{name}</h2>
           {location.attributes.orgName && (
             <h6>{location.attributes.orgName}</h6>
           )}
@@ -84,12 +74,12 @@ const LocationInfoBlock = ({ location, from, query }) => {
           />
           {isVADomain(website) ? (
             <a href={website}>
-              <h2 className="vads-u-font-size--h5 no-marg-top">{name}</h2>
+              <h3 className="vads-u-font-size--h5 no-marg-top">{name}</h3>
             </a>
           ) : (
-            <h2 className="vads-u-font-size--h5 no-marg-top">
+            <h3 className="vads-u-font-size--h5 no-marg-top">
               <Link to={`facility/${location.id}`}>{name}</Link>
-            </h2>
+            </h3>
           )}
         </span>
       )}

--- a/src/applications/facility-locator/containers/FacilityDetail.jsx
+++ b/src/applications/facility-locator/containers/FacilityDetail.jsx
@@ -117,7 +117,7 @@ class FacilityDetail extends Component {
         <h1>{name}</h1>
         {this.showOperationStatus(operatingStatus, website, facilityType)}
         <div className="p1">
-          <FacilityTypeDescription location={facility} />
+          <FacilityTypeDescription from="FacilityDetail" location={facility} />
           <LocationAddress location={facility} />
         </div>
         <div>

--- a/src/applications/facility-locator/containers/VAMap.jsx
+++ b/src/applications/facility-locator/containers/VAMap.jsx
@@ -518,14 +518,14 @@ class VAMap extends Component {
     return mapMarkers;
   };
 
-  renderResultsHeader = (results, facilityType, queryContext) =>
-    !this.props.currentQuery.inProgress && (
-      <SearchResultsHeader
-        results={results}
-        facilityType={facilityType}
-        context={queryContext}
-      />
-    );
+  renderResultsHeader = (results, facilityType, queryContext) => (
+    <SearchResultsHeader
+      results={results}
+      facilityType={facilityType}
+      context={queryContext}
+      inProgress={this.props.currentQuery.inProgress}
+    />
+  );
 
   renderMobileView = () => {
     const coords = this.props.currentQuery.position;

--- a/src/applications/facility-locator/containers/VAMap.jsx
+++ b/src/applications/facility-locator/containers/VAMap.jsx
@@ -182,9 +182,15 @@ class VAMap extends Component {
     const { currentQuery: prevQuery } = prevProps;
     const updatedQuery = this.props.currentQuery;
 
-    const shouldZoomOut = // ToTriggerNewSearch
-      !updatedQuery.searchBoundsInProgress &&
-      prevQuery.searchBoundsInProgress && // search completed
+    const searchCompleted =
+      !updatedQuery.searchBoundsInProgress && prevQuery.searchBoundsInProgress;
+
+    if (searchCompleted && this.searchResultTitle.current) {
+      setFocus(this.searchResultTitle.current);
+    }
+
+    const shouldZoomOut =
+      searchCompleted &&
       isEmpty(this.props.results) &&
       updatedQuery.bounds &&
       parseInt(updatedQuery.zoomLevel, 10) > 2 &&
@@ -331,9 +337,6 @@ class VAMap extends Component {
     });
 
     this.props.genBBoxFromAddress(currentQuery);
-    if (this.searchResultTitle.current) {
-      setFocus(this.searchResultTitle.current);
-    }
   };
 
   handleBoundsChanged = () => {
@@ -515,13 +518,14 @@ class VAMap extends Component {
     return mapMarkers;
   };
 
-  renderResultsHeader = (results, facilityType, queryContext) => (
-    <SearchResultsHeader
-      results={results}
-      facilityType={facilityType}
-      context={queryContext}
-    />
-  );
+  renderResultsHeader = (results, facilityType, queryContext) =>
+    !this.props.currentQuery.inProgress && (
+      <SearchResultsHeader
+        results={results}
+        facilityType={facilityType}
+        context={queryContext}
+      />
+    );
 
   renderMobileView = () => {
     const coords = this.props.currentQuery.position;

--- a/src/applications/facility-locator/containers/VAMap.jsx
+++ b/src/applications/facility-locator/containers/VAMap.jsx
@@ -511,6 +511,16 @@ class VAMap extends Component {
     return mapMarkers;
   };
 
+  renderResultsHeader = (results, facilityType, queryContext) => {
+    return results.length > 0 ? (
+      <h2 className="search-result-title">
+        {`Results for ${facilityTypes[facilityType]} near ${queryContext}`}
+      </h2>
+    ) : (
+      <br />
+    );
+  };
+
   renderMobileView = () => {
     const coords = this.props.currentQuery.position;
     const position = [coords.latitude, coords.longitude];
@@ -533,22 +543,9 @@ class VAMap extends Component {
             isMobile
           />
           <div>{showDialogUrgCare(currentQuery)}</div>
-          {/* <div ref={this.searchResultTitle}>
-            {results.length > 0 ? (
-              <p className="search-result-title">
-                <strong>{totalEntries} results</strong>
-                {` for `}
-                <strong>
-                  {facilityTypes[this.props.currentQuery.facilityType]}
-                </strong>
-                {` near `}
-                <strong>“{this.props.currentQuery.context}”</strong>
-              </p>
-            ) : (
-              <br />
-            )}
-          </div> */}
-          <br />
+          <div ref={this.searchResultTitle}>
+            {this.renderResultsHeader(results)}
+          </div>
           <Tabs onSelect={this.centerMap}>
             <TabList>
               <Tab className="small-6 tab">View List</Tab>
@@ -571,7 +568,6 @@ class VAMap extends Component {
               )}
             </TabPanel>
             <TabPanel>
-              {otherToolsLink}
               <Map
                 ref="map"
                 center={position}
@@ -606,6 +602,7 @@ class VAMap extends Component {
               )}
             </TabPanel>
           </Tabs>
+          {otherToolsLink}
         </div>
       </div>
     );
@@ -620,6 +617,9 @@ class VAMap extends Component {
       results,
       pagination: { currentPage, totalPages },
     } = this.props;
+    const facilityType = currentQuery.facilityType.slice();
+    const queryContext = currentQuery.context.slice();
+
     const coords = this.props.currentQuery.position;
     const position = [coords.latitude, coords.longitude];
     const facilityLocatorMarkers = this.renderMapMarkers();
@@ -635,22 +635,9 @@ class VAMap extends Component {
           />
         </div>
         <div>{showDialogUrgCare(currentQuery)}</div>
-        {/* <div ref={this.searchResultTitle} style={{ paddingLeft: '15px' }}>
-          {results.length > 0 ? (
-            <p className="search-result-title">
-              <strong>{totalEntries} results</strong>
-              {` for `}
-              <strong>
-                {facilityTypes[this.props.currentQuery.facilityType]}
-              </strong>
-              {` near `}
-              <strong>“{this.props.currentQuery.context}”</strong>
-            </p>
-          ) : (
-            <br >
-          )}
-        </div> */}
-        <br />
+        <div ref={this.searchResultTitle} style={{ paddingLeft: '15px' }}>
+          {this.renderResultsHeader(results, facilityType, queryContext)}
+        </div>
         <div className="row">
           <div
             className="columns usa-width-one-third medium-4 small-12"
@@ -670,7 +657,6 @@ class VAMap extends Component {
             className="columns usa-width-two-thirds medium-8 small-12"
             style={{ minHeight: '75vh', paddingLeft: '0px' }}
           >
-            {otherToolsLink}
             <Map
               ref="map"
               center={position}
@@ -693,6 +679,7 @@ class VAMap extends Component {
                 </FeatureGroup>
               )}
             </Map>
+            {otherToolsLink}
           </div>
         </div>
         {currentPage &&

--- a/src/applications/facility-locator/containers/VAMap.jsx
+++ b/src/applications/facility-locator/containers/VAMap.jsx
@@ -37,6 +37,7 @@ import { isProduction } from 'platform/site-wide/feature-toggles/selectors';
 import Pagination from '@department-of-veterans-affairs/formation-react/Pagination';
 import mbxGeo from '@mapbox/mapbox-sdk/services/geocoding';
 import { distBetween } from '../utils/facilityDistance';
+import SearchResultsHeader from '../components/SearchResultsHeader';
 
 const mbxClient = mbxGeo(mapboxClient);
 
@@ -330,6 +331,9 @@ class VAMap extends Component {
     });
 
     this.props.genBBoxFromAddress(currentQuery);
+    if (this.searchResultTitle.current) {
+      setFocus(this.searchResultTitle.current);
+    }
   };
 
   handleBoundsChanged = () => {
@@ -511,15 +515,13 @@ class VAMap extends Component {
     return mapMarkers;
   };
 
-  renderResultsHeader = (results, facilityType, queryContext) => {
-    return results.length > 0 ? (
-      <h2 className="search-result-title">
-        {`Results for ${facilityTypes[facilityType]} near ${queryContext}`}
-      </h2>
-    ) : (
-      <br />
-    );
-  };
+  renderResultsHeader = (results, facilityType, queryContext) => (
+    <SearchResultsHeader
+      results={results}
+      facilityType={facilityType}
+      context={queryContext}
+    />
+  );
 
   renderMobileView = () => {
     const coords = this.props.currentQuery.position;
@@ -532,6 +534,9 @@ class VAMap extends Component {
       pagination: { currentPage, totalPages },
     } = this.props;
     const facilityLocatorMarkers = this.renderMapMarkers();
+    const facilityType = currentQuery.facilityType;
+    const queryContext = currentQuery.context;
+
     return (
       <div>
         <div className="columns small-12">
@@ -544,7 +549,7 @@ class VAMap extends Component {
           />
           <div>{showDialogUrgCare(currentQuery)}</div>
           <div ref={this.searchResultTitle}>
-            {this.renderResultsHeader(results)}
+            {this.renderResultsHeader(results, facilityType, queryContext)}
           </div>
           <Tabs onSelect={this.centerMap}>
             <TabList>
@@ -617,8 +622,8 @@ class VAMap extends Component {
       results,
       pagination: { currentPage, totalPages },
     } = this.props;
-    const facilityType = currentQuery.facilityType.slice();
-    const queryContext = currentQuery.context.slice();
+    const facilityType = currentQuery.facilityType;
+    const queryContext = currentQuery.context;
 
     const coords = this.props.currentQuery.position;
     const position = [coords.latitude, coords.longitude];
@@ -635,7 +640,7 @@ class VAMap extends Component {
           />
         </div>
         <div>{showDialogUrgCare(currentQuery)}</div>
-        <div ref={this.searchResultTitle} style={{ paddingLeft: '15px' }}>
+        <div ref={this.searchResultTitle}>
           {this.renderResultsHeader(results, facilityType, queryContext)}
         </div>
         <div className="row">

--- a/src/applications/facility-locator/sass/facility-locator.scss
+++ b/src/applications/facility-locator/sass/facility-locator.scss
@@ -80,6 +80,10 @@ $facility-locator-color-gray: #ccc;
     border-bottom: solid thin $color-gray-lightest;
   }
 
+  .search-result-title {
+    font-size: 18px;
+  }
+
   .search-result-title:focus {
     @include focus-gold-light-outline(0);
     outline-offset: 2px;

--- a/src/applications/facility-locator/sass/facility-locator.scss
+++ b/src/applications/facility-locator/sass/facility-locator.scss
@@ -80,12 +80,6 @@ $facility-locator-color-gray: #ccc;
     border-bottom: solid thin $color-gray-lightest;
   }
 
-  .search-result-title {
-    padding-left: 15px;
-    font-size: 18px;
-    margin-bottom: 1.5em;
-  }
-
   .search-result-title:focus {
     @include focus-gold-light-outline(0);
     outline-offset: 2px;

--- a/src/applications/facility-locator/sass/facility-locator.scss
+++ b/src/applications/facility-locator/sass/facility-locator.scss
@@ -81,7 +81,9 @@ $facility-locator-color-gray: #ccc;
   }
 
   .search-result-title {
+    padding-left: 15px;
     font-size: 18px;
+    margin-bottom: 1.5em;
   }
 
   .search-result-title:focus {

--- a/src/applications/facility-locator/tests/components/FacilityTypeDescription.unit.spec.jsx
+++ b/src/applications/facility-locator/tests/components/FacilityTypeDescription.unit.spec.jsx
@@ -22,12 +22,13 @@ describe('FacilityTypeDescription', () => {
   it('should render with facility type VA benefits in facility page', () => {
     const wrapper = shallow(
       <FacilityTypeDescription
+        from="FacilityDetail"
         location={vaBenefitsLocation}
         query={queryBenefits}
       />,
     );
-    expect(wrapper.find('strong').text()).to.equal('Facility type:');
-    expect(wrapper.find('p').text()).to.equal('Facility type: Benefits');
+    expect(wrapper.find('strong').text()).to.equal('Facility type: ');
+    expect(wrapper.find('div').text()).to.equal('Facility type: Benefits');
     wrapper.unmount();
   });
 
@@ -39,9 +40,7 @@ describe('FacilityTypeDescription', () => {
         from={'SearchResult'}
       />,
     );
-    expect(wrapper.find('p').text()).to.equal(
-      LocationType.BENEFITS.toUpperCase(),
-    );
+    expect(wrapper.find('div').text()).to.equal('Benefits');
     wrapper.unmount();
   });
 
@@ -54,7 +53,7 @@ describe('FacilityTypeDescription', () => {
         from={'SearchResult'}
       />,
     );
-    expect(wrapper.find('p').text()).to.equal('VA URGENT CARE');
+    expect(wrapper.find('div').text()).to.equal('VA URGENT CARE');
     wrapper.unmount();
   });
 
@@ -62,12 +61,13 @@ describe('FacilityTypeDescription', () => {
     const queryUrgentCare = { facilityType: FacilityType.VA_HEALTH_FACILITY };
     const wrapper = shallow(
       <FacilityTypeDescription
+        from="FacilityDetail"
         location={vaLocationUrgentCare}
         query={queryUrgentCare}
       />,
     );
-    expect(wrapper.find('strong').text()).to.equal('Facility type:');
-    expect(wrapper.find('p').text()).to.equal('Facility type: VA health');
+    expect(wrapper.find('strong').text()).to.equal('Facility type: ');
+    expect(wrapper.find('div').text()).to.equal('Facility type: VA health');
     wrapper.unmount();
   });
 });

--- a/src/applications/facility-locator/tests/components/search-results/SearchResultsHeader.unit.spec.jsx
+++ b/src/applications/facility-locator/tests/components/search-results/SearchResultsHeader.unit.spec.jsx
@@ -28,8 +28,8 @@ describe('SearchResultsHeader', () => {
       />,
     );
 
-    expect(wrapper.find('h2').text()).to.equal(
-      'Results for VA health near new york',
+    expect(wrapper.find('h2').text()).to.match(
+      /Results for "VA health" near\s+"new york"/,
     );
     wrapper.unmount();
   });

--- a/src/applications/facility-locator/tests/components/search-results/SearchResultsHeader.unit.spec.jsx
+++ b/src/applications/facility-locator/tests/components/search-results/SearchResultsHeader.unit.spec.jsx
@@ -12,6 +12,13 @@ describe('SearchResultsHeader', () => {
     wrapper.unmount();
   });
 
+  it('should not render header if inProgress is true', () => {
+    const wrapper = shallow(<SearchResultsHeader results={[{}]} inProgress />);
+
+    expect(wrapper.find('h2').length).to.equal(0);
+    wrapper.unmount();
+  });
+
   it('should render header if results exist', () => {
     const wrapper = shallow(
       <SearchResultsHeader

--- a/src/applications/facility-locator/tests/components/search-results/SearchResultsHeader.unit.spec.jsx
+++ b/src/applications/facility-locator/tests/components/search-results/SearchResultsHeader.unit.spec.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+import SearchResultsHeader from '../../../components/SearchResultsHeader';
+import { FacilityType } from '../../../constants';
+
+describe('SearchResultsHeader', () => {
+  it('should not render header if results are empty', () => {
+    const wrapper = shallow(<SearchResultsHeader results={[]} />);
+
+    expect(wrapper.find('h2').length).to.equal(0);
+    wrapper.unmount();
+  });
+
+  it('should render header if results exist', () => {
+    const wrapper = shallow(
+      <SearchResultsHeader
+        results={[{}]}
+        facilityType={FacilityType.VA_HEALTH_FACILITY}
+        context={'new york'}
+      />,
+    );
+
+    expect(wrapper.find('h2').text()).to.equal(
+      'Results for VA health near new york',
+    );
+    wrapper.unmount();
+  });
+
+  // TODO: find a way to unit test the React.memo behavior
+});

--- a/src/applications/facility-locator/tests/e2e/search.cypress.spec.js
+++ b/src/applications/facility-locator/tests/e2e/search.cypress.spec.js
@@ -1,0 +1,18 @@
+describe('Facility Search', () => {
+  it('displays search results header after searching', () => {
+    cy.visit(
+      '/find-locations/?address=new%20york&context=New%20York%2C%20New%20York%2C%20United%20States&facilityType=health&location=40.7648%2C-73.9808',
+    );
+
+    cy.get('h2.search-result-title').should('exist');
+    cy.injectAxe();
+    cy.axeCheck();
+  });
+
+  it('does not show search result header if no results are found', () => {
+    cy.visit('/find-locations?fail=true');
+    cy.get('h2.search-result-title').should('not.exist');
+    cy.injectAxe();
+    cy.axeCheck();
+  });
+});

--- a/src/applications/facility-locator/tests/e2e/search.cypress.spec.js
+++ b/src/applications/facility-locator/tests/e2e/search.cypress.spec.js
@@ -4,14 +4,14 @@ describe('Facility Search', () => {
       '/find-locations/?address=new%20york&context=New%20York%2C%20New%20York%2C%20United%20States&facilityType=health&location=40.7648%2C-73.9808',
     );
 
-    cy.get('h2.search-result-title').should('exist');
+    cy.get('#facility-search-results').should('exist');
     cy.injectAxe();
     cy.axeCheck();
   });
 
   it('does not show search result header if no results are found', () => {
     cy.visit('/find-locations?fail=true');
-    cy.get('h2.search-result-title').should('not.exist');
+    cy.get('#facility-search-results').should('not.exist');
     cy.injectAxe();
     cy.axeCheck();
   });


### PR DESCRIPTION
https://github.com/department-of-veterans-affairs/va.gov-team/issues/7555

## Description
Restore the facility search results summary, but without the number of results, since this can be inaccurate.

## Testing done
Manual + Unit + e2e (Cypress!)

## Screenshots
![Find_VA_Locations___Veterans_Affairs](https://user-images.githubusercontent.com/80267/88596310-d3e27f80-d032-11ea-98a0-70b2cdfc0fce.png)

## Acceptance criteria
For all Facility Locator searches:
- [x] Results summary subhead displays when search results are returned. 
- [x] Results summary subhead does not prematurely load
- [x] When changing criteria after a previous search, the result summary is not updated until the new search is executed
- [x] Heading levels do not skip
- [x] Focus moves from the Search button to this heading, as indicated in ticket #7240
- [x] Heading includes user search criteria (**Search results** for <**VA facility type**> near **"location parameters"**)
- [x] Heading updates with new search criteria if new search is initiated
- [x] No heading is seen while a search is in progress
- [x] Only the standard error displays if no search results are found (no heading displays)
- [x] Veterans using screenreaders understand the context of the search results list
- [x] Responsive design: all elements are fully visible
- [x] Keyboard test confirms focus
- [x] New functionality is covered by E2E test

## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs

