### PR TITLE
Move connected app error upward

### DIFF
--- a/src/applications/personalization/profile-2/components/connected-apps/ConnectedApps.jsx
+++ b/src/applications/personalization/profile-2/components/connected-apps/ConnectedApps.jsx
@@ -73,6 +73,15 @@ export class ConnectedApps extends Component {
           </>
         )}
 
+        {!isEmpty(errors) && (
+          <AlertBox
+            className="vads-u-margin-bottom--2"
+            headline="We couldn’t retrieve your connected apps"
+            status="warning"
+            content="We’re sorry. Something went wrong on our end and we couldn’t access your connected apps. Please try again later."
+          />
+        )}
+
         {deletedApps.map(app => (
           <AppDeletedAlert
             id={app.id}
@@ -118,14 +127,6 @@ export class ConnectedApps extends Component {
               }. Please try again later.`}
             />
           ))}
-        {!isEmpty(errors) && (
-          <AlertBox
-            className="vads-u-margin-bottom--2"
-            headline="We couldn’t retrieve your connected apps"
-            status="warning"
-            content="We’re sorry. Something went wrong on our end and we couldn’t access your connected apps. Please try again later."
-          />
-        )}
 
         {activeApps.map((app, idx) => (
           <ConnectedApp


### PR DESCRIPTION
## Description
We need to move the error when retrieving apps to above the 'Third-party apps to connect to' section

## Testing done
Works locally

## Screenshots
![image](https://user-images.githubusercontent.com/14869324/87958289-95ffbd00-ca6e-11ea-946c-6aa818fe0162.png)


## Acceptance criteria
- [x] move the error when retrieving apps to above the 'Third-party apps to connect to' section

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
