### PR TITLE
Hide new condition if claimType set

### DIFF
--- a/src/applications/disability-benefits/all-claims/config/form.js
+++ b/src/applications/disability-benefits/all-claims/config/form.js
@@ -184,6 +184,8 @@ const formConfig = {
           uiSchema: claimType.uiSchema,
           schema: claimType.schema,
           onContinue: captureEvents.claimType,
+          // set newDisabilities value from claimType
+          updateFormData: claimType.updateFormData,
         },
         servedInCombatZone: {
           title: 'Combat status',
@@ -251,7 +253,10 @@ const formConfig = {
         newDisabilities: {
           title: 'New disabilities',
           path: 'new-disabilities',
-          depends: formData => !increaseOnly(formData),
+          depends: formData =>
+            // Don't show new disability question if claimType already selected
+            !formData['view:claimType']?.['view:claimingNew'] &&
+            !increaseOnly(formData),
           uiSchema: newDisabilities.uiSchema,
           schema: newDisabilities.schema,
         },

--- a/src/applications/disability-benefits/all-claims/pages/claimType.jsx
+++ b/src/applications/disability-benefits/all-claims/pages/claimType.jsx
@@ -37,3 +37,10 @@ export const schema = {
     },
   },
 };
+
+export const updateFormData = (_, newData) => {
+  const newCondition = newData['view:claimType']?.['view:claimingNew'];
+  // skip "Do you have any new conditions you want to add to your claim?"
+  // question if new condition claim type is selected
+  return { ...newData, 'view:newDisabilities': newCondition };
+};


### PR DESCRIPTION
## Description

These changes will set the value for (`view:newDisabilities`) & hide the "Do you have any new conditions you want to add to your claim?" step,

<details><summary>screenshot</summary>

<!-- leave a blank line above -->
![Screen Shot 2020-07-20 at 1 02 59 PM](https://user-images.githubusercontent.com/136959/87970632-a07b8000-ca89-11ea-8d27-43d1e43e3663.png)
**NOTE: this step is not visible is the user does not have any rated disabilities**
</details>

but only if the user has already selected the add "A new condition" checkbox from a previous step

<details><summary>screenshot</summary>

<!-- leave a blank line above -->
![Screen Shot 2020-07-20 at 1 02 45 PM](https://user-images.githubusercontent.com/136959/87970637-a1141680-ca89-11ea-9e87-09dc04f39a0d.png)</details>

so that the user isn't exposed to redundant questions.

Related ticket: https://github.com/department-of-veterans-affairs/va.gov-team/issues/11193

## Testing done

Unit tests

## Screenshots

See above

## Acceptance criteria
- [x] Repeated "new condition" question is hidden if previous choice was made

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
