### PR TITLE
CT: Fuzzy Search and autocomplete improvements

### DIFF
--- a/src/applications/gi/actions/index.js
+++ b/src/applications/gi/actions/index.js
@@ -20,6 +20,8 @@ export const AUTOCOMPLETE_FAILED = 'AUTOCOMPLETE_FAILED';
 export const AUTOCOMPLETE_SUCCEEDED = 'AUTOCOMPLETE_SUCCEEDED';
 export const AUTOCOMPLETE_CLEARED = 'AUTOCOMPLETE_CLEARED';
 export const AUTOCOMPLETE_TERM_CHANGED = 'AUTOCOMPLETE_TERM_CHANGED';
+export const AUTOCOMPLETE_SUGGESTION_SELECTED =
+  'AUTOCOMPLETE_SUGGESTION_SELECTED';
 export const ELIGIBILITY_CHANGED = 'ELIGIBILITY_CHANGED';
 export const SEARCH_STARTED = 'SEARCH_STARTED';
 export const SEARCH_FAILED = 'SEARCH_FAILED';
@@ -122,6 +124,12 @@ export function updateAutocompleteSearchTerm(searchTerm) {
   return {
     type: AUTOCOMPLETE_TERM_CHANGED,
     searchTerm,
+  };
+}
+
+export function autocompleteSuggestionSelected() {
+  return {
+    type: AUTOCOMPLETE_SUGGESTION_SELECTED,
   };
 }
 

--- a/src/applications/gi/components/search/InstitutionSearchForm.jsx
+++ b/src/applications/gi/components/search/InstitutionSearchForm.jsx
@@ -44,6 +44,9 @@ function InstitutionSearchForm(props) {
             onFetchAutocompleteSuggestions={props.fetchAutocompleteSuggestions}
             onFilterChange={props.handleFilterChange}
             onUpdateAutocompleteSearchTerm={props.updateAutocompleteSearchTerm}
+            autocompleteSuggestionSelected={
+              props.autocompleteSuggestionSelected
+            }
           />
           <InstitutionFilterForm
             search={props.search}

--- a/src/applications/gi/components/search/KeywordSearch.jsx
+++ b/src/applications/gi/components/search/KeywordSearch.jsx
@@ -54,6 +54,7 @@ export class KeywordSearch extends React.Component {
       event: 'gibct-autosuggest',
       'gibct-autosuggest-value': searchQuery,
     });
+    this.props.autocompleteSuggestionSelected();
     this.props.onFilterChange(searchQuery);
   };
 
@@ -159,6 +160,7 @@ KeywordSearch.propTypes = {
   onUpdateAutocompleteSearchTerm: PropTypes.func,
   searchError: PropTypes.bool,
   validateSearchQuery: PropTypes.func,
+  autocompleteSuggestionSelected: PropTypes.func,
 };
 
 export default KeywordSearch;

--- a/src/applications/gi/components/vet-tec/VetTecSearchForm.jsx
+++ b/src/applications/gi/components/vet-tec/VetTecSearchForm.jsx
@@ -180,6 +180,9 @@ class VetTecSearchForm extends React.Component {
               onUpdateAutocompleteSearchTerm={
                 this.props.updateAutocompleteSearchTerm
               }
+              autocompleteSuggestionSelected={
+                this.props.autocompleteSuggestionSelected
+              }
             />
 
             {this.renderCountryFilter()}

--- a/src/applications/gi/containers/LandingPage.jsx
+++ b/src/applications/gi/containers/LandingPage.jsx
@@ -11,6 +11,7 @@ import {
   eligibilityChange,
   showModal,
   hideModal,
+  autocompleteSuggestionSelected,
 } from '../actions';
 import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
 import FEATURE_FLAG_NAMES from 'platform/utilities/feature-toggles/featureFlagNames';
@@ -186,6 +187,9 @@ export class LandingPage extends React.Component {
                   }
                   searchError={this.state.searchError}
                   validateSearchQuery={this.validateSearchQuery}
+                  autocompleteSuggestionSelected={
+                    this.props.autocompleteSuggestionSelected
+                  }
                 />
               )}
               <button
@@ -229,6 +233,7 @@ const mapDispatchToProps = {
   eligibilityChange,
   showModal,
   hideModal,
+  autocompleteSuggestionSelected,
 };
 
 export default connect(

--- a/src/applications/gi/containers/SearchPage.jsx
+++ b/src/applications/gi/containers/SearchPage.jsx
@@ -17,6 +17,7 @@ import {
   eligibilityChange,
   showModal,
   hideModal,
+  autocompleteSuggestionSelected,
 } from '../actions';
 import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
 import FEATURE_FLAG_NAMES from 'platform/utilities/feature-toggles/featureFlagNames';
@@ -117,10 +118,11 @@ export class SearchPage extends React.Component {
     });
 
     this.props.institutionFilterChange(institutionFilter);
-    this.props.fetchInstitutionSearchResults(
-      query,
-      this.props.gibctSearchEnhancements,
-    );
+    const fuzzySearch = this.props.autocomplete.suggestionSelected
+      ? false
+      : this.props.gibctSearchEnhancements;
+
+    this.props.fetchInstitutionSearchResults(query, fuzzySearch);
   };
 
   autocomplete = (value, version) => {
@@ -273,6 +275,9 @@ export class SearchPage extends React.Component {
         eligibilityChange={this.props.eligibilityChange}
         gibctEstimateYourBenefits={this.props.gibctEstimateYourBenefits}
         hideModal={this.props.hideModal}
+        autocompleteSuggestionSelected={
+          this.props.autocompleteSuggestionSelected
+        }
       />
     </div>
   );
@@ -332,6 +337,7 @@ const mapDispatchToProps = {
   eligibilityChange,
   showModal,
   hideModal,
+  autocompleteSuggestionSelected,
 };
 
 export default connect(

--- a/src/applications/gi/containers/VetTecSearchPage.jsx
+++ b/src/applications/gi/containers/VetTecSearchPage.jsx
@@ -14,6 +14,7 @@ import {
   updateAutocompleteSearchTerm,
   eligibilityChange,
   showModal,
+  autocompleteSuggestionSelected,
 } from '../actions';
 
 import LoadingIndicator from '@department-of-veterans-affairs/formation-react/LoadingIndicator';
@@ -294,6 +295,9 @@ export class VetTecSearchPage extends React.Component {
               eligibility={this.props.eligibility}
               showModal={this.props.showModal}
               eligibilityChange={this.props.eligibilityChange}
+              autocompleteSuggestionSelected={
+                this.props.autocompleteSuggestionSelected
+              }
             />
           </div>
         )}
@@ -322,6 +326,7 @@ const mapDispatchToProps = {
   updateAutocompleteSearchTerm,
   eligibilityChange,
   showModal,
+  autocompleteSuggestionSelected,
 };
 
 export default connect(

--- a/src/applications/gi/reducers/autocomplete.js
+++ b/src/applications/gi/reducers/autocomplete.js
@@ -6,6 +6,7 @@ import {
   AUTOCOMPLETE_SUCCEEDED,
   SEARCH_STARTED,
   AUTOCOMPLETE_CLEARED,
+  AUTOCOMPLETE_SUGGESTION_SELECTED,
 } from '../actions';
 import camelCaseKeysRecursive from 'camelcase-keys-recursive';
 import get from 'platform/utilities/data/get';
@@ -16,6 +17,7 @@ const INITIAL_STATE = {
   searchTerm: '',
   facilityCode: null,
   suggestions: [],
+  suggestionSelected: false,
 };
 
 export default function(state = INITIAL_STATE, action) {
@@ -25,12 +27,14 @@ export default function(state = INITIAL_STATE, action) {
         ...state,
         searchTerm: action.searchTerm,
         facilityCode: null,
+        suggestionSelected: false,
       };
     case AUTOCOMPLETE_STARTED:
       return {
         ...state,
         inProgress: true,
         suggestions: [],
+        suggestionSelected: false,
       };
     case AUTOCOMPLETE_FAILED:
       return {
@@ -38,6 +42,7 @@ export default function(state = INITIAL_STATE, action) {
         ...action.err,
         searchTerm: action.value,
         inProgress: false,
+        suggestionSelected: false,
       };
     case AUTOCOMPLETE_SUCCEEDED:
       const camelPayload = camelCaseKeysRecursive(action.payload);
@@ -59,16 +64,23 @@ export default function(state = INITIAL_STATE, action) {
         suggestions,
         previewVersion: camelPayload.meta.version,
         inProgress: false,
+        suggestionSelected: false,
       };
     case AUTOCOMPLETE_CLEARED:
       return {
         ...state,
         suggestions: [],
+        suggestionSelected: false,
       };
     case SEARCH_STARTED:
       return {
         ...state,
         searchTerm: get('query.name', action, ''),
+      };
+    case AUTOCOMPLETE_SUGGESTION_SELECTED:
+      return {
+        ...state,
+        suggestionSelected: true,
       };
     default:
       return state;

--- a/src/applications/gi/tests/components/KeywordSearch.unit.spec.jsx
+++ b/src/applications/gi/tests/components/KeywordSearch.unit.spec.jsx
@@ -75,6 +75,7 @@ describe('<KeywordSearch>', () => {
         onFilterChange={onFilterChange}
         onUpdateAutocompleteSearchTerm={() => {}}
         validateSearchQuery={validateSearchQuery}
+        autocompleteSuggestionSelected={() => {}}
       />,
     );
 


### PR DESCRIPTION
## Description
If the user selects an autocomplete suggestion do not use fuzzy searching as this will return a large amount of results and results in the selected suggestion not appearing on the first page

## Testing done
- Go to CT Landing Page > type in search box > select suggested institution
- Go to CT Landing Page > type in full name of an institution > hit enter/click search button

## Screenshots
Search results after select an autocomplete suggestion
![Screen Shot 2020-07-20 at 3 56 17 PM](https://user-images.githubusercontent.com/1094999/87980569-d75d9000-caa1-11ea-9081-ff0ad573b573.png)

Search results after manually typing in a full institutions name
![Screen Shot 2020-07-20 at 3 57 03 PM](https://user-images.githubusercontent.com/1094999/87980575-d88ebd00-caa1-11ea-9c5b-f1407906faf7.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
