### PR TITLE
Expand on cy.login() to accept optional mock user data

### DIFF
--- a/src/applications/disability-benefits/2346/tests/MDOT.cypress.spec.js
+++ b/src/applications/disability-benefits/2346/tests/MDOT.cypress.spec.js
@@ -74,8 +74,7 @@ const testConfig = createTestConfig(
 
     setupPerTest: () => {
       cy.get('@testKey').then(testKey => {
-        cy.login();
-        cy.route('GET', '/v0/user', dataSetToUserMap[testKey]);
+        cy.login(dataSetToUserMap[testKey]);
       });
       cy.get('@testData').then(testData => {
         cy.route('GET', '/v0/in_progress_forms/MDOT', testData);

--- a/src/platform/testing/e2e/cypress/support/commands/login.js
+++ b/src/platform/testing/e2e/cypress/support/commands/login.js
@@ -67,7 +67,7 @@ const mockUser = {
 /**
  * Simulates a logged in session.
  */
-Cypress.Commands.add('login', () => {
+Cypress.Commands.add('login', (userData = mockUser) => {
   window.localStorage.setItem('hasSession', true);
-  cy.server().route('GET', '/v0/user', mockUser);
+  cy.server().route('GET', '/v0/user', userData);
 });


### PR DESCRIPTION
## Description
This allows us to mock the call to `GET user/` and set the response in a single line. Will come in handy when writing tests for Profile 2.0 to make sure different users are handled correctly.

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs