### PR TITLE
MDOT: Update e2e now that MDOT is in prod

### DIFF
--- a/src/applications/disability-benefits/2346/tests/MDOT.cypress.spec.js
+++ b/src/applications/disability-benefits/2346/tests/MDOT.cypress.spec.js
@@ -73,18 +73,59 @@ const testConfig = createTestConfig(
     },
 
     setupPerTest: () => {
+      let postData = [];
       cy.get('@testKey').then(testKey => {
         cy.login();
         cy.route('GET', '/v0/user', dataSetToUserMap[testKey]);
+        if (testKey === 'noBatteries') {
+          postData = [
+            {
+              status: 'Order Processed',
+              orderId: 2324,
+              productId: 3,
+            },
+            {
+              status: 'Order Processed',
+              orderId: 2325,
+              productId: 5,
+            },
+          ];
+        } else if (testKey === 'noAccessories') {
+          postData = [
+            {
+              status: 'Order Processed',
+              orderId: 2326,
+              productId: 1,
+            },
+          ];
+        } else {
+          postData = [
+            {
+              status: 'Order Processed',
+              orderId: 2329,
+              productId: 1,
+            },
+            {
+              status: 'Order Processed',
+              orderId: 2330,
+              productId: 3,
+            },
+            {
+              status: 'Order Processed',
+              orderId: 2331,
+              productId: 5,
+            },
+          ];
+        }
       });
       cy.get('@testData').then(testData => {
         cy.route('GET', '/v0/in_progress_forms/MDOT', testData);
       });
-      cy.route('POST', '/v0/mdot/supplies', null);
+      cy.get('@testKey').then(testKey => {
+        cy.route('POST', '/v0/mdot/supplies', postData);
+      });
     },
-
-    // Skip tests until MDOT is in production
-    skip: true,
+    skip: false,
   },
   manifest,
   formConfig,

--- a/src/applications/disability-benefits/2346/tests/data/happyPath.json
+++ b/src/applications/disability-benefits/2346/tests/data/happyPath.json
@@ -32,7 +32,7 @@
       {
         "deviceName": "OMEGAX d3241",
         "productName": "ZA1239",
-        "productGroup": "BATTERIES",
+        "productGroup": "Battery",
         "productId": 1,
         "availableForReorder": true,
         "lastOrderDate": "2019-12-25",
@@ -42,7 +42,7 @@
       },
       {
         "productName": "DOME",
-        "productGroup": "ACCESSORIES",
+        "productGroup": "Accessory",
         "productId": 3,
         "availableForReorder": true,
         "lastOrderDate": "2019-06-30",
@@ -52,7 +52,7 @@
       },
       {
         "productName": "DOME",
-        "productGroup": "ACCESSORIES",
+        "productGroup": "Accessory",
         "productId": 4,
         "availableForReorder": true,
         "lastOrderDate": "2019-06-30",
@@ -62,7 +62,7 @@
       },
       {
         "productName": "WaxBuster Single Unit",
-        "productGroup": "ACCESSORIES",
+        "productGroup": "Accessory",
         "productId": 5,
         "availableForReorder": true,
         "lastOrderDate": "2019-06-30",

--- a/src/applications/disability-benefits/2346/tests/data/noAccessories.json
+++ b/src/applications/disability-benefits/2346/tests/data/noAccessories.json
@@ -31,7 +31,7 @@
       {
         "deviceName": "OMEGAX d3241",
         "productName": "ZA1239",
-        "productGroup": "BATTERIES",
+        "productGroup": "Battery",
         "productId": 1,
         "availableForReorder": true,
         "lastOrderDate": "2020-01-01",
@@ -41,7 +41,7 @@
       },
       {
         "productName": "DOME",
-        "productGroup": "ACCESSORIES",
+        "productGroup": "Accessory",
         "productId": 3,
         "lastOrderDate": "2019-06-30",
         "nextAvailabilityDate": "2022-12-15",
@@ -50,7 +50,7 @@
       },
       {
         "productName": "DOME",
-        "productGroup": "ACCESSORIES",
+        "productGroup": "Accessory",
         "productId": 4,
         "lastOrderDate": "2019-06-30",
         "nextAvailabilityDate": "2022-12-15",
@@ -59,7 +59,7 @@
       },
       {
         "productName": "WaxBuster Single Unit",
-        "productGroup": "ACCESSORIES",
+        "productGroup": "Accessory",
         "productId": 5,
         "lastOrderDate": "2019-06-30",
         "nextAvailabilityDate": "2022-12-15",

--- a/src/applications/disability-benefits/2346/tests/data/noBatteries.json
+++ b/src/applications/disability-benefits/2346/tests/data/noBatteries.json
@@ -31,7 +31,7 @@
       {
         "deviceName": "OMEGAX d3241",
         "productName": "ZA1239",
-        "productGroup": "BATTERIES",
+        "productGroup": "Battery",
         "productId": 1,
         "lastOrderDate": "2020-01-01",
         "nextAvailabilityDate": "2022-09-01",
@@ -40,7 +40,7 @@
       },
       {
         "productName": "DOME",
-        "productGroup": "ACCESSORIES",
+        "productGroup": "Accessory",
         "productId": 3,
         "availableForReorder": true,
         "lastOrderDate": "2019-06-30",
@@ -50,7 +50,7 @@
       },
       {
         "productName": "DOME",
-        "productGroup": "ACCESSORIES",
+        "productGroup": "Accessory",
         "productId": 4,
         "availableForReorder": true,
         "lastOrderDate": "2019-06-30",
@@ -60,7 +60,7 @@
       },
       {
         "productName": "WaxBuster Single Unit",
-        "productGroup": "ACCESSORIES",
+        "productGroup": "Accessory",
         "productId": 5,
         "availableForReorder": true,
         "lastOrderDate": "2019-06-30",

--- a/src/applications/disability-benefits/2346/tests/data/noTempAddress.json
+++ b/src/applications/disability-benefits/2346/tests/data/noTempAddress.json
@@ -25,7 +25,7 @@
       {
         "deviceName": "OMEGAX d3241",
         "productName": "ZA1239",
-        "productGroup": "BATTERIES",
+        "productGroup": "Battery",
         "productId": 1,
         "availableForReorder": true,
         "lastOrderDate": "2019-12-25",
@@ -35,7 +35,7 @@
       },
       {
         "productName": "DOME",
-        "productGroup": "ACCESSORIES",
+        "productGroup": "Accessory",
         "productId": 3,
         "availableForReorder": true,
         "lastOrderDate": "2019-06-30",
@@ -45,7 +45,7 @@
       },
       {
         "productName": "DOME",
-        "productGroup": "ACCESSORIES",
+        "productGroup": "Accessory",
         "productId": 4,
         "availableForReorder": true,
         "lastOrderDate": "2019-06-30",
@@ -55,7 +55,7 @@
       },
       {
         "productName": "WaxBuster Single Unit",
-        "productGroup": "ACCESSORIES",
+        "productGroup": "Accessory",
         "productId": 5,
         "availableForReorder": true,
         "lastOrderDate": "2019-06-30",


### PR DESCRIPTION
## Description
Now that MDOT is in production, we can turn on end to end testing. Also there were data updates since this was last pushed to master so this adjusts the json files.

## Testing done
E2E tests are passing.

## Screenshots


## Acceptance criteria
- [x] The end to end testing should run now that MDOT is in production

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
