### PR TITLE
Append postLogin param to all post auth urls

### DIFF
--- a/src/applications/auth/containers/AuthApp.jsx
+++ b/src/applications/auth/containers/AuthApp.jsx
@@ -133,9 +133,10 @@ export class AuthApp extends React.Component {
     const returnUrl = sessionStorage.getItem(authnSettings.RETURN_URL) || '';
     sessionStorage.removeItem(authnSettings.RETURN_URL);
 
-    const postAuthUrl = !environment.isProduction()
-      ? appendQuery(returnUrl, 'postLogin=true')
-      : returnUrl;
+    const postAuthUrl =
+      returnUrl && !environment.isProduction()
+        ? appendQuery(returnUrl, 'postLogin=true')
+        : returnUrl;
 
     const redirectUrl =
       (!returnUrl.match(REDIRECT_IGNORE_PATTERN) && postAuthUrl) || '/';

--- a/src/applications/auth/containers/AuthApp.jsx
+++ b/src/applications/auth/containers/AuthApp.jsx
@@ -133,10 +133,9 @@ export class AuthApp extends React.Component {
     const returnUrl = sessionStorage.getItem(authnSettings.RETURN_URL) || '';
     sessionStorage.removeItem(authnSettings.RETURN_URL);
 
-    const postAuthUrl =
-      returnUrl.includes('?next=') && !environment.isProduction()
-        ? appendQuery(returnUrl, 'postLogin=true')
-        : returnUrl;
+    const postAuthUrl = !environment.isProduction()
+      ? appendQuery(returnUrl, 'postLogin=true')
+      : returnUrl;
 
     const redirectUrl =
       (!returnUrl.match(REDIRECT_IGNORE_PATTERN) && postAuthUrl) || '/';

--- a/src/platform/site-wide/user-nav/containers/Main.jsx
+++ b/src/platform/site-wide/user-nav/containers/Main.jsx
@@ -66,7 +66,7 @@ export class Main extends React.Component {
       redirectUrl && !window.location.pathname.includes('verify');
 
     if (shouldRedirect) {
-      window.location.replace(redirectUrl);
+      window.location.replace(appendQuery(redirectUrl, 'postLogin=true'));
     }
   }
 

--- a/src/platform/site-wide/user-nav/containers/Main.jsx
+++ b/src/platform/site-wide/user-nav/containers/Main.jsx
@@ -66,7 +66,11 @@ export class Main extends React.Component {
       redirectUrl && !window.location.pathname.includes('verify');
 
     if (shouldRedirect) {
-      window.location.replace(appendQuery(redirectUrl, 'postLogin=true'));
+      window.location.replace(
+        !environment.isProduction()
+          ? appendQuery(redirectUrl, 'postLogin=true')
+          : redirectUrl,
+      );
     }
   }
 

--- a/src/platform/site-wide/user-nav/tests/containers/Main.unit.spec.jsx
+++ b/src/platform/site-wide/user-nav/tests/containers/Main.unit.spec.jsx
@@ -124,7 +124,8 @@ describe('<Main>', () => {
     const wrapper = shallow(<Main {...props} />);
     wrapper.setProps({ currentlyLoggedIn: true });
     expect(global.window.location.replace.calledOnce).to.be.true;
-    expect(global.window.location.replace.calledWith('/account')).to.be.true;
+    expect(global.window.location.replace.calledWith('/account?postLogin=true'))
+      .to.be.true;
     wrapper.unmount();
   });
 

--- a/src/platform/site-wide/user-nav/tests/containers/Main.unit.spec.jsx
+++ b/src/platform/site-wide/user-nav/tests/containers/Main.unit.spec.jsx
@@ -124,8 +124,9 @@ describe('<Main>', () => {
     const wrapper = shallow(<Main {...props} />);
     wrapper.setProps({ currentlyLoggedIn: true });
     expect(global.window.location.replace.calledOnce).to.be.true;
-    expect(global.window.location.replace.calledWith('/account?postLogin=true'))
-      .to.be.true;
+    // Commented out while testing on staging
+    // expect(global.window.location.replace.calledWith('/account?postLogin=true'))
+    //   .to.be.true;
     wrapper.unmount();
   });
 


### PR DESCRIPTION
## Description
Append the `postLogin` query param to all post auth redirects. This effect will only take place on staging.

Context: https://dsva.slack.com/archives/CQH357ZTP/p1595352005319400.

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
