### PR TITLE
Remove unneeded height on address validation input

### DIFF
--- a/src/applications/personalization/profile-2/components/Verified.jsx
+++ b/src/applications/personalization/profile-2/components/Verified.jsx
@@ -10,6 +10,7 @@ const Verified = ({ children }) => (
     <i
       className="fa fa-check vads-u-color--green vads-u-margin-top--0p5"
       aria-hidden="true"
+      role="img"
     />
     <p className="vads-u-margin--0 vads-u-padding-left--1 medium-screen:vads-u-padding-left--3">
       {children}

--- a/src/applications/personalization/profile360/sass/profile-360.scss
+++ b/src/applications/personalization/profile360/sass/profile-360.scss
@@ -82,9 +82,6 @@ input.usa-only-phone {
   width: 100%;
   padding: 0 5px;
 
-  .address-validation-input {
-    height: 75%;
-  }
 
   [type=radio] + label::before {
     min-width: 1.4rem;

--- a/src/platform/user/profile/vet360/containers/AddressValidationModal.jsx
+++ b/src/platform/user/profile/vet360/containers/AddressValidationModal.jsx
@@ -159,7 +159,6 @@ class AddressValidationModal extends React.Component {
         {isFirstOptionOrEnabled &&
           hasConfirmedSuggestions && (
             <input
-              className="address-validation-input"
               type="radio"
               id={id}
               onChange={

--- a/src/platform/user/profile/vet360/containers/AddressValidationView.jsx
+++ b/src/platform/user/profile/vet360/containers/AddressValidationView.jsx
@@ -175,7 +175,6 @@ class AddressValidationView extends React.Component {
         {isFirstOptionOrEnabled &&
           hasConfirmedSuggestions && (
             <input
-              className="address-validation-input"
               type="radio"
               id={id}
               onChange={() => {


### PR DESCRIPTION
## Description
A set height was interfering with the click area of the Edit link.

## Testing done
Looks good locally on both Profile 1 and 2.

## Acceptance criteria
- [x] Ensure the 'Edit address' link is now fully clickable and no longer overlapped by the input above it

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
