### PR TITLE
Add manage your VA debt widget

### DIFF
--- a/src/platform/site-wide/cta-widget/helpers.js
+++ b/src/platform/site-wide/cta-widget/helpers.js
@@ -17,6 +17,7 @@ export const widgetTypes = {
   HEARING_AID_SUPPLIES: 'hearing-aid-supplies',
   LAB_AND_TEST_RESULTS: 'lab-and-test-results',
   LETTERS: 'letters',
+  MANAGE_VA_DEBT: 'manage-va-debt',
   MESSAGING: 'messaging',
   RX: 'rx',
   SCHEDULE_APPOINTMENTS: 'schedule-appointments',
@@ -177,6 +178,12 @@ export const toolUrl = (appId, authenticatedWithSSOe = false) => {
         redirect: false,
       };
 
+    case widgetTypes.MANAGE_VA_DEBT:
+      return {
+        url: '/manage-va-debt/debt-letters',
+        redirect: false,
+      };
+
     default:
       return {};
   }
@@ -271,6 +278,9 @@ export const serviceDescription = appId => {
 
     case widgetTypes.VIEW_DEPENDENTS:
       return 'view current dependents';
+
+    case widgetTypes.MANAGE_VA_DEBT:
+      return 'manage your VA debt';
 
     default:
       return 'use this service';


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/11414

This PR adds a new CTA widget for managing your VA debt.

## Testing done
N/A

## Screenshots
N/A

## Acceptance criteria
- [x] Adds CTA widget for managing your VA debt.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
