### PR TITLE
Update rootUrl and breadcrumbs

### DIFF
--- a/src/applications/disability-benefits/view-payments/containers/helpers.js
+++ b/src/applications/disability-benefits/view-payments/containers/helpers.js
@@ -5,13 +5,13 @@ export const breadcrumbLinks = [
     Home
   </a>,
   <a
-    href="/view-change-dependents/"
+    href="/va-payment-history/"
     aria-label="View your VA payment history"
     key="3"
   >
-    View your VA payment history
+    VA payment history
   </a>,
-  <a href="/view-change-dependents/view" key="4">
-    your VA payment history
+  <a href="/va-payment-history/payments" key="4">
+    Payments
   </a>,
 ];

--- a/src/applications/disability-benefits/view-payments/manifest.json
+++ b/src/applications/disability-benefits/view-payments/manifest.json
@@ -2,6 +2,6 @@
   "appName": "View Payments",
   "entryFile": "./app-entry.jsx",
   "entryName": "view-payments",
-  "rootUrl": "/disability-benefits/view-payments",
+  "rootUrl": "/va-payment-history/payments",
   "production": false
 }

--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -859,7 +859,7 @@
   {
     "appName": "View Payments",
     "entryName": "view-payments",
-    "rootUrl": "/disability-benefits/view-payments",
+    "rootUrl": "/va-payment-history/payments",
     "template": {
       "includeBreadcrumbs": true,
       "vagovprod": false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -7234,6 +7234,11 @@ fn.name@1.x.x:
   resolved "https://registry.yarnpkg.com/fn.name/-/fn.name-1.1.0.tgz#26cad8017967aea8731bc42961d04a3d5988accc"
   integrity sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==
 
+focus-lock@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/focus-lock/-/focus-lock-0.7.0.tgz#b2bfb0ca7beacc8710a1ff74275fe0dc60a1d88a"
+  integrity sha512-LI7v2mH02R55SekHYdv9pRHR9RajVNyIJ2N5IEkWbg7FT5ZmJ9Hw4mWxHeEUcd+dJo0QmzztHvDvWcc7prVFsw==
+
 follow-redirects@1.5.10:
   version "1.5.10"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.10.tgz#7b7a9f9aea2fdff36786a94ff643ed07f4ff5e2a"
@@ -13783,6 +13788,13 @@ rc@^1.0.1, rc@^1.1.6, rc@^1.2.7, rc@^1.2.8:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
+react-clientside-effect@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/react-clientside-effect/-/react-clientside-effect-1.2.2.tgz#6212fb0e07b204e714581dd51992603d1accc837"
+  integrity sha512-nRmoyxeok5PBO6ytPvSjKp9xwXg9xagoTK1mMjwnQxqM9Hd7MNPl+LS1bOSOe+CV2+4fnEquc7H/S8QD3q697A==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+
 react-dom@^16.13.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.13.1.tgz#c1bd37331a0486c078ee54c4740720993b2e0e7f"
@@ -13806,6 +13818,18 @@ react-element-to-string@^1.0.2:
   dependencies:
     indent-string "^2.1.0"
     json-stringify-pretty-compact "^1.0.1"
+
+react-focus-lock@^2.4.0:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/react-focus-lock/-/react-focus-lock-2.4.1.tgz#e842cc93da736b5c5d331799012544295cbcee4f"
+  integrity sha512-c5ZP56KSpj9EAxzScTqQO7bQQNPltf/W1ZEBDqNDOV1XOIwvAyHX0O7db9ekiAtxyKgnqZjQlLppVg94fUeL9w==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    focus-lock "^0.7.0"
+    prop-types "^15.6.2"
+    react-clientside-effect "^1.2.2"
+    use-callback-ref "^1.2.1"
+    use-sidecar "^1.0.1"
 
 react-is@^16.12.0, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.9.0:
   version "16.13.1"
@@ -16893,6 +16917,19 @@ url@0.11.0, url@^0.11.0, url@~0.11.0:
   dependencies:
     punycode "1.3.2"
     querystring "0.2.0"
+
+use-callback-ref@^1.2.1:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/use-callback-ref/-/use-callback-ref-1.2.4.tgz#d86d1577bfd0b955b6e04aaf5971025f406bea3c"
+  integrity sha512-rXpsyvOnqdScyied4Uglsp14qzag1JIemLeTWGKbwpotWht57hbP78aNT+Q4wdFKQfQibbUX4fb6Qb4y11aVOQ==
+
+use-sidecar@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/use-sidecar/-/use-sidecar-1.0.2.tgz#e72f582a75842f7de4ef8becd6235a4720ad8af6"
+  integrity sha512-287RZny6m5KNMTb/Kq9gmjafi7lQL0YHO1lYolU6+tY1h9+Z3uCtkJJ3OSOq3INwYf2hBryCcDh4520AhJibMA==
+  dependencies:
+    detect-node "^2.0.4"
+    tslib "^1.9.3"
 
 use@^2.0.0:
   version "2.0.2"


### PR DESCRIPTION
## Description
This pull request updates the rootUrl property for view-payments, and the breadcrumbs used in the application.

## Testing done
- local

## Screenshots
<img width="915" alt="Screen Shot 2020-07-22 at 11 43 30 AM" src="https://user-images.githubusercontent.com/15097156/88197864-1100d900-cc11-11ea-85c6-ac105146b75b.png">


## Acceptance criteria
- [x] url has been updated and the application is accessible. 

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
