### PR TITLE
[Development] Show error message when no new conditions added

### DIFF
--- a/src/applications/disability-benefits/all-claims/components/NewDisability.jsx
+++ b/src/applications/disability-benefits/all-claims/components/NewDisability.jsx
@@ -5,7 +5,7 @@ import { NULL_CONDITION_STRING } from '../constants';
 export default function NewDisability({ formData }) {
   return (
     <div className="vads-u-flex--fill">
-      {typeof formData.condition === 'string'
+      {typeof formData?.condition === 'string'
         ? capitalizeEachWord(formData.condition)
         : NULL_CONDITION_STRING}
     </div>

--- a/src/applications/disability-benefits/all-claims/pages/addDisabilities.js
+++ b/src/applications/disability-benefits/all-claims/pages/addDisabilities.js
@@ -187,8 +187,8 @@ const removeDisability = (deletedElement, formData) => {
 
 // Find the old name -> change to new name
 const changeDisabilityName = (oldData, newData, changedIndex) => {
-  const oldId = sippableId(oldData.newDisabilities[changedIndex].condition);
-  const newId = sippableId(newData.newDisabilities[changedIndex].condition);
+  const oldId = sippableId(oldData.newDisabilities[changedIndex]?.condition);
+  const newId = sippableId(newData.newDisabilities[changedIndex]?.condition);
 
   let result = removeDisability(oldData.newDisabilities[changedIndex], newData);
 
@@ -224,25 +224,16 @@ const changeDisabilityName = (oldData, newData, changedIndex) => {
   return result;
 };
 
-// Strip out empty ("Unknown Condition") entries; doing this shows the user
-// an error instead of blocking progress if there are no new conditions
-const removeInvalidDisabilities = data => ({
-  ...data,
-  newDisabilities: (data?.newDisabilities || []).filter(d => d.condition),
-});
-
 export const updateFormData = (oldData, newData) => {
-  const cleanOldData = removeInvalidDisabilities(oldData);
-  const cleanNewData = removeInvalidDisabilities(newData);
-  const oldArr = cleanOldData.newDisabilities;
-  const newArr = cleanNewData.newDisabilities;
+  const oldArr = oldData.newDisabilities;
+  const newArr = newData.newDisabilities;
   // Sanity check
-  if (!Array.isArray(oldArr) || !Array.isArray(newArr)) return cleanNewData;
+  if (!Array.isArray(oldArr) || !Array.isArray(newArr)) return newData;
 
   // Disability was removed
   if (oldArr.length > newArr.length) {
     const deletedElement = deleted(oldArr, newArr);
-    return removeDisability(deletedElement, cleanNewData);
+    return removeDisability(deletedElement, newData);
   }
 
   // Disability was modified
@@ -250,8 +241,8 @@ export const updateFormData = (oldData, newData) => {
   if (oldArr.length === newArr.length && changedIndex !== undefined) {
     // Update the disability name in treatedDisabilityNames and
     // powDisabilities _if_ it exists already
-    return changeDisabilityName(cleanOldData, cleanNewData, changedIndex);
+    return changeDisabilityName(oldData, newData, changedIndex);
   }
 
-  return cleanNewData;
+  return newData;
 };

--- a/src/applications/disability-benefits/all-claims/pages/claimType.jsx
+++ b/src/applications/disability-benefits/all-claims/pages/claimType.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { validateBooleanGroup } from 'platform/forms-system/src/js/validation';
+import { hasRatedDisabilities } from '../utils';
 
 const filingClaimContent = <strong>I’m filing a claim for:</strong>;
 
@@ -38,9 +39,15 @@ export const schema = {
   },
 };
 
-export const updateFormData = (_, newData) => {
+export const updateFormData = (oldData, newData) => {
   const newCondition = newData['view:claimType']?.['view:claimingNew'];
-  // skip "Do you have any new conditions you want to add to your claim?"
-  // question if new condition claim type is selected
-  return { ...newData, 'view:newDisabilities': newCondition };
+  if (
+    newCondition !== oldData['view:claimType']?.['view:claimingNew'] &&
+    hasRatedDisabilities(newData)
+  ) {
+    // skip "Do you have any new conditions you want to add to your claim?"
+    // question if new condition claim type is selected
+    return { ...newData, 'view:newDisabilities': newCondition };
+  }
+  return newData;
 };

--- a/src/applications/disability-benefits/all-claims/tests/pages/addDisabilities.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/addDisabilities.unit.spec.jsx
@@ -84,6 +84,63 @@ describe('Add new disabilities', () => {
     form.unmount();
   });
 
+  it('should show new conditions only alert', () => {
+    const onSubmit = sinon.spy();
+    const form = mount(
+      <DefinitionTester
+        definitions={formConfig.defaultDefinitions}
+        schema={schema}
+        uiSchema={uiSchema}
+        data={{
+          claimType: {
+            'view:claimingNew': true,
+            'view:claimingIncrease': false,
+          },
+          'view:newDisabilities': true,
+          newDisabilities: [],
+          // previously selected rated disability
+          ratedDisabilities: [{}, { 'view:selected': true }],
+        }}
+        formData={{}}
+        onSubmit={onSubmit}
+      />,
+    );
+    form.find('form').simulate('submit');
+    const error = form.find('.usa-alert');
+    expect(error.length).to.equal(1);
+    expect(error.text()).to.contain('add a new disability to claim');
+    expect(onSubmit.called).to.be.false;
+    form.unmount();
+  });
+  it('should show increase & new alert', () => {
+    const onSubmit = sinon.spy();
+    const form = mount(
+      <DefinitionTester
+        definitions={formConfig.defaultDefinitions}
+        schema={schema}
+        uiSchema={uiSchema}
+        data={{
+          'view:claimType': {
+            'view:claimingNew': true,
+            'view:claimingIncrease': true,
+          },
+          'view:newDisabilities': true,
+          newDisabilities: [],
+          // no rated disability selected
+          ratedDisabilities: [{}, {}],
+        }}
+        formData={{}}
+        onSubmit={onSubmit}
+      />,
+    );
+    form.find('form').simulate('submit');
+    const error = form.find('.usa-alert');
+    expect(error.length).to.equal(1);
+    expect(error.text()).to.contain('add a new disability or choose a rated');
+    expect(onSubmit.called).to.be.false;
+    form.unmount();
+  });
+
   describe('updateFormData', () => {
     // It's a function just to make sure we're not mutating it anywhere along the way
     const oldData = () => ({
@@ -100,18 +157,19 @@ describe('Add new disabilities', () => {
       },
     });
 
-    describe('should return unmodified newData', () => {
+    describe('should return newData with empty array', () => {
+      const result = { newDisabilities: [] };
       it("if oldData.newDisabilities doesn't exist", () => {
         const newData = { newDisabilities: ['foo'] };
-        expect(updateFormData({}, newData)).to.equal(newData);
+        expect(updateFormData({}, newData)).to.deep.equal(result);
       });
       it("if newData.newDisabilities doesn't exist", () => {
         const newData = {};
-        expect(updateFormData(oldData(), newData)).to.equal(newData);
+        expect(updateFormData(oldData(), newData)).to.deep.equal(result);
       });
       it('if no disabilities changed', () => {
         const old = oldData();
-        expect(updateFormData(old, old)).to.equal(old);
+        expect(updateFormData(old, old)).to.deep.equal(old);
       });
     });
 

--- a/src/applications/disability-benefits/all-claims/tests/pages/addDisabilities.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/addDisabilities.unit.spec.jsx
@@ -157,15 +157,14 @@ describe('Add new disabilities', () => {
       },
     });
 
-    describe('should return newData with empty array', () => {
-      const result = { newDisabilities: [] };
+    describe('should return unmodified newData', () => {
       it("if oldData.newDisabilities doesn't exist", () => {
         const newData = { newDisabilities: ['foo'] };
-        expect(updateFormData({}, newData)).to.deep.equal(result);
+        expect(updateFormData({}, newData)).to.deep.equal(newData);
       });
       it("if newData.newDisabilities doesn't exist", () => {
         const newData = {};
-        expect(updateFormData(oldData(), newData)).to.deep.equal(result);
+        expect(updateFormData(oldData(), newData)).to.deep.equal(newData);
       });
       it('if no disabilities changed', () => {
         const old = oldData();

--- a/src/applications/disability-benefits/all-claims/tests/utils.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/utils.unit.spec.jsx
@@ -896,6 +896,7 @@ describe('526 v2 depends functions', () => {
     },
   };
   const empty = {
+    ratedDisabilities: [{}, {}],
     'view:claimType': {},
   };
   describe('newOnly', () => {

--- a/src/applications/disability-benefits/all-claims/tests/utils.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/utils.unit.spec.jsx
@@ -873,6 +873,7 @@ describe('526 v2 depends functions', () => {
       'view:claimingIncrease': true,
       'view:claimingNew': false,
     },
+    ratedDisabilities: [{}],
   };
   const newOnlyData = {
     'view:claimType': {
@@ -885,6 +886,7 @@ describe('526 v2 depends functions', () => {
       'view:claimingIncrease': true,
       'view:claimingNew': true,
     },
+    ratedDisabilities: [{}],
   };
   // Shouldn't be possible, but worth testing anyhow
   const noneSelected = {
@@ -892,6 +894,9 @@ describe('526 v2 depends functions', () => {
       'view:claimingIncrease': false,
       'view:claimingNew': false,
     },
+  };
+  const empty = {
+    'view:claimType': {},
   };
   describe('newOnly', () => {
     it('should return true if only new conditions are claimed', () => {
@@ -903,6 +908,7 @@ describe('526 v2 depends functions', () => {
     });
     it('should return false if no claim type is selected', () => {
       expect(newConditionsOnly(noneSelected)).to.be.false;
+      expect(newConditionsOnly(empty)).to.be.false;
     });
   });
   describe('increaseOnly', () => {
@@ -915,6 +921,7 @@ describe('526 v2 depends functions', () => {
     });
     it('should return false if no claim type is selected', () => {
       expect(increaseOnly(noneSelected)).to.be.false;
+      expect(increaseOnly(empty)).to.be.false;
     });
   });
 

--- a/src/applications/disability-benefits/all-claims/utils.jsx
+++ b/src/applications/disability-benefits/all-claims/utils.jsx
@@ -729,15 +729,15 @@ const isClaimingIncrease = formData =>
   _.get('view:claimType.view:claimingIncrease', formData, false);
 
 export const increaseOnly = formData =>
-  isClaimingIncrease(formData) && !isClaimingNew(formData);
+  (isClaimingIncrease(formData) && !isClaimingNew(formData)) || false;
 export const newConditionsOnly = formData =>
-  !isClaimingIncrease(formData) && isClaimingNew(formData);
+  (!isClaimingIncrease(formData) && isClaimingNew(formData)) || false;
 export const newAndIncrease = formData =>
-  isClaimingNew(formData) && isClaimingIncrease(formData);
+  (isClaimingNew(formData) && isClaimingIncrease(formData)) || false;
 
 // Shouldn't be possible, but just in case this requirement is lifted later...
 export const noClaimTypeSelected = formData =>
-  !isClaimingNew(formData) && !isClaimingIncrease(formData);
+  (!isClaimingNew(formData) && !isClaimingIncrease(formData)) || false;
 
 export const hasNewDisabilities = formData =>
   formData['view:newDisabilities'] === true;
@@ -792,13 +792,16 @@ export const directToCorrectForm = ({
 };
 
 export const claimingRated = formData =>
-  isClaimingIncrease(formData) &&
-  formData.ratedDisabilities &&
-  formData.ratedDisabilities.some(d => d['view:selected']);
+  (isClaimingIncrease(formData) &&
+    formData.ratedDisabilities &&
+    formData.ratedDisabilities.some(d => d['view:selected'])) ||
+  false;
 
 // TODO: Rename this to avoid collision with `isClaimingNew` above
 export const claimingNew = formData =>
-  formData.newDisabilities && formData.newDisabilities.some(d => d.condition);
+  (formData.newDisabilities &&
+    formData.newDisabilities.some(d => d.condition)) ||
+  false;
 
 export const hasClaimedConditions = formData =>
   (isClaimingIncrease(formData) && claimingRated(formData)) ||

--- a/src/applications/disability-benefits/all-claims/utils.jsx
+++ b/src/applications/disability-benefits/all-claims/utils.jsx
@@ -713,10 +713,20 @@ export const getPOWValidationMessage = servicePeriodDateRanges => (
   </span>
 );
 
-const isClaimingIncrease = formData =>
-  _.get('view:claimType.view:claimingIncrease', formData, false);
+export const hasRatedDisabilities = formData =>
+  formData.ratedDisabilities && formData.ratedDisabilities.length;
+
 const isClaimingNew = formData =>
-  _.get('view:claimType.view:claimingNew', formData, false);
+  _.get(
+    'view:claimType.view:claimingNew',
+    formData,
+    // force default to true if user has no rated disabilities
+    !hasRatedDisabilities(formData),
+  ) || _.get('view:newDisabilities', formData, false);
+
+const isClaimingIncrease = formData =>
+  hasRatedDisabilities(formData) &&
+  _.get('view:claimType.view:claimingIncrease', formData, false);
 
 export const increaseOnly = formData =>
   isClaimingIncrease(formData) && !isClaimingNew(formData);
@@ -738,6 +748,7 @@ export const hasNewDisabilities = formData =>
  * @enum {String}
  */
 export const urls = {
+  v1: DISABILITY_526_V2_ROOT_URL,
   v2: DISABILITY_526_V2_ROOT_URL,
 };
 
@@ -781,6 +792,7 @@ export const directToCorrectForm = ({
 };
 
 export const claimingRated = formData =>
+  isClaimingIncrease(formData) &&
   formData.ratedDisabilities &&
   formData.ratedDisabilities.some(d => d['view:selected']);
 
@@ -789,10 +801,8 @@ export const claimingNew = formData =>
   formData.newDisabilities && formData.newDisabilities.some(d => d.condition);
 
 export const hasClaimedConditions = formData =>
-  claimingNew(formData) || claimingRated(formData);
-
-export const hasRatedDisabilities = formData =>
-  formData.ratedDisabilities && formData.ratedDisabilities.length;
+  (isClaimingIncrease(formData) && claimingRated(formData)) ||
+  (isClaimingNew(formData) && claimingNew(formData));
 
 /**
  * Finds active service periods—those without end dates or end dates

--- a/src/applications/disability-benefits/all-claims/validations.js
+++ b/src/applications/disability-benefits/all-claims/validations.js
@@ -8,6 +8,7 @@ import {
   pathWithIndex,
   hasClaimedConditions,
   increaseOnly,
+  hasRatedDisabilities,
   claimingRated,
 } from './utils';
 
@@ -286,8 +287,11 @@ export const requireRatedDisability = (err, fieldData, formData) => {
  */
 export const requireNewDisability = (err, fieldData, formData) => {
   if (!claimingRated(formData) && !fieldData) {
+    const message = hasRatedDisabilities(formData)
+      ? 'No rated disability selected. Please add a new one'
+      : 'We didn’t find any existing rated disabilities. Please choose to add a new one';
     // The actual validation error is displayed as an alert field. The message
     // here will be shown on the review page
-    err.addError('No rated disability selected. Please add a new one');
+    err.addError(message);
   }
 };


### PR DESCRIPTION
## Description

When a user is on the form 526 add new condition page and saves the form, or clicks "Save" with an empty condition name, an "Unknown Condition" entry is shown; but it saves a non-empty object without a defined condition. When the user attempts to proceed, the form appears stuck. No alert message is shown. Additionally the "Add Another Disability" button doesn't appear to do anything. Clicking "Edit" of the "Unknown Condition" entry shows the error.

This PR, empties out the `newCondition` array of any invalid entries. It also modifies the checks so that the correct alert error message is shown: add a new condition versus add a new condition _or_ select a rated disability.

Related issue: https://github.com/department-of-veterans-affairs/va.gov-team/issues/11431

## Testing done

New unit tests

## Screenshots

<details><summary>Before (no alert shown on continue)</summary>

<!-- leave a blank line above -->
![](https://user-images.githubusercontent.com/136959/87975295-0b7c8500-ca91-11ea-936d-93965d9df234.png)</details>

<details>
<summary>Alert on continue when only new conditions are selected</summary>

<!-- leave a blank line above -->
![Screen Shot 2020-07-22 at 10 24 42 AM](https://user-images.githubusercontent.com/136959/88202173-1d376700-cc0e-11ea-89c4-5c30a0a3daf3.png)</details>

<details><summary>Alert on continue when both new & existing selected</summary>

<!-- leave a blank line above -->
![Screen Shot 2020-07-22 at 10 44 25 AM](https://user-images.githubusercontent.com/136959/88202102-fe38d500-cc0d-11ea-935b-78a32acfab57.png)</details>

## Acceptance criteria

- [x] Alert messages shown when the user attempts to continue with an undefined new condition.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
