### PR TITLE
change prefill alert message on 10203 form

### DIFF
--- a/src/applications/edu-benefits/10203/content/ApplicantDescription.jsx
+++ b/src/applications/edu-benefits/10203/content/ApplicantDescription.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import PrefillMessage from './PrefillMessage';
+
+export default function ApplicantDescription({ formContext }) {
+  return (
+    <div>
+      <p>
+        You aren’t required to fill in all fields, but we can review your
+        application faster if you provide more information.
+      </p>
+      <PrefillMessage formContext={formContext} />
+    </div>
+  );
+}

--- a/src/applications/edu-benefits/10203/content/PrefillMessage.jsx
+++ b/src/applications/edu-benefits/10203/content/PrefillMessage.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+const message =
+  "We've prefilled this application with information from your account. If you need to correct anything, you can edit the form fields.";
+
+export default function PrefillMessage({ children, formContext }) {
+  if (!formContext.prefilled) {
+    return null;
+  }
+
+  return (
+    <div className="usa-alert usa-alert-info background-color-only schemaform-prefill-message">
+      {children || message}
+    </div>
+  );
+}

--- a/src/applications/edu-benefits/10203/pages/applicantInformation.js
+++ b/src/applications/edu-benefits/10203/pages/applicantInformation.js
@@ -1,5 +1,5 @@
 import ssnUI from 'platform/forms-system/src/js/definitions/ssn';
-import ApplicantDescription from 'platform/forms/components/ApplicantDescription';
+import ApplicantDescription from '../content/ApplicantDescription';
 
 export const uiSchema = {
   'ui:description': ApplicantDescription,


### PR DESCRIPTION
## Description
https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/11451



## Testing done
Dev tested

## Screenshots
![image](https://user-images.githubusercontent.com/48804654/88211450-b9b83400-cc23-11ea-8813-203df6b0c580.png)


## Acceptance criteria
- [x] On the STEM Chapter 1 page, if a user is logged in a blue info alert is displayed. This warning alert has been updated:

    > We've prefilled some of your information from your account. If you need to correct anything, you can edit the form fields below.

    is replaced with: 

    > We've prefilled this application with information from your account. If you need to correct anything, you can edit the form fields.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
