### PR TITLE
added gibctCh33BenefitRateUpdate feature flag to vets-website

### DIFF
--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -34,4 +34,5 @@ export default Object.freeze({
   gibctSearchEnhancements: 'gibctSearchEnhancements',
   form996HigherLevelReview: 'form996HigherLevelReview',
   gibctFilterEnhancement: 'gibctFilterEnhancement',
+  gibctCh33BenefitRateUpdate: 'gibctCh33BenefitRateUpdate',
 });


### PR DESCRIPTION
## Description
As a developer, I need to create a feature flag that can be used to turn on and off CT post-9/11 gi bill benefit rate updates so that it can be delivered to production in a timely manner.

https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/11534

Backend PR: https://github.com/department-of-veterans-affairs/vets-api/pull/4570

## Testing done

local testing completed http://localhost:3000/flipper/features/gibct_ch33_benefit_rate_update
## Screenshots


## Acceptance criteria
- [x] The "gibctCh33BenefitRateUpdate" feature flag is created and available in all environments.
- [x] The description is "Update to Chapter 33/Post-9/11 GI Bill benefit rates set to go live 8/1"


## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
