### PR TITLE
Added Cypress instructions to README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,19 @@ yarn cy:run --spec "src/applications/my-app/tests/**/*"
 yarn cy:run --spec "src/applications/a/tests/**/*,src/applications/b/tests/**/*"
 ```
 
+To **run Cypress tests from the command line on a specific browser**:
+
+```sh
+yarn cy:run --headless --browser chrome
+yarn cy:run --headless --browser firefox
+
+# Without --headless, the test runner will open and run the test.
+yarn cy:run --browser chrome
+yarn cy:run --browser firefox
+```
+
+**For other options with `yarn cy:run`,** [the same options for `cypress run` are applicable](https://docs.cypress.io/guides/guides/command-line.html#Commands).
+
 To **run Nightwatch tests**, you first need three things:
 1. Install the Java JDK on MacOS (if needed):
     ```

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ yarn build
 ## Running tests
 
 ### Unit tests
-To **run all unit tests,** use:
+To **run all unit tests**, use:
 
 ``` sh
 yarn test:unit
@@ -114,8 +114,40 @@ To **run all tests in a directory**, you can use a glob pattern:
 yarn test:unit src/applications/path/to/tests/**/*.unit.spec.js*
 ```
 
-### Browser tests
-To **run all browser tests**, you first need three things:
+### End-to-end (E2E) / Browser tests
+- E2E or browser tests primarily run in Cypress.
+- Some older, existing tests run in Nightwatch, but those are deprecated.
+
+To **open the Cypress test runner UI and run any tests within it**:
+
+```sh
+yarn cy:open
+```
+
+To **run Cypress tests from the command line**:
+
+```sh
+yarn cy:run
+```
+
+To **run specific Cypress tests from the command line**:
+
+```sh
+# Running one specific test.
+yarn cy:run --spec "path/to/test-file.cypress.spec.js"
+
+# Running multiple specific tests.
+yarn cy:run --spec "path/to/test-a.cypress.spec.js,path/to/test-b.cypress.spec.js"
+
+# Running tests that match a glob pattern.
+yarn cy:run --spec "src/applications/my-app/tests/*"
+yarn cy:run --spec "src/applications/my-app/tests/**/*"
+
+# Running tests that match multiple glob patterns.
+yarn cy:run --spec "src/applications/a/tests/**/*,src/applications/b/tests/**/*"
+```
+
+To **run Nightwatch tests**, you first need three things:
 1. Install the Java JDK on MacOS (if needed):
     ```
     brew update


### PR DESCRIPTION
## Description
Updated the README with instructions for running Cypress. Ready to merge when Cypress is officially rolled out.

## Testing done
Ran commands in the listed formats to test them out. 

## Acceptance criteria
- [ ] The `vets-website` README should include instructions for running Cypress.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
