### PR TITLE
match keepalive response on transaction id

### DIFF
--- a/src/platform/site-wide/user-nav/containers/AutoSSO.jsx
+++ b/src/platform/site-wide/user-nav/containers/AutoSSO.jsx
@@ -14,7 +14,6 @@ function AutoSSO(props) {
   const {
     useInboundSSOe,
     hasCalledKeepAlive,
-    authenticatedWithSSOe,
     transactionId,
     loggedIn,
     profileLoading,

--- a/src/platform/site-wide/user-nav/containers/AutoSSO.jsx
+++ b/src/platform/site-wide/user-nav/containers/AutoSSO.jsx
@@ -4,7 +4,7 @@ import { checkKeepAlive } from 'platform/user/authentication/actions';
 import {
   ssoeInbound,
   hasCheckedKeepAlive,
-  isAuthenticatedWithSSOe,
+  ssoeTransactionId,
 } from 'platform/user/authentication/selectors';
 import { isLoggedIn, isProfileLoading } from 'platform/user/selectors';
 import { checkAutoSession } from 'platform/utilities/sso';
@@ -15,6 +15,7 @@ function AutoSSO(props) {
     useInboundSSOe,
     hasCalledKeepAlive,
     authenticatedWithSSOe,
+    transactionId,
     loggedIn,
     profileLoading,
   } = props;
@@ -35,7 +36,7 @@ function AutoSSO(props) {
     !profileLoading &&
     !hasCalledKeepAlive
   ) {
-    checkAutoSession(loggedIn, authenticatedWithSSOe).then(() => {
+    checkAutoSession(loggedIn, transactionId).then(() => {
       props.checkKeepAlive();
     });
   }
@@ -44,7 +45,7 @@ function AutoSSO(props) {
 }
 
 const mapStateToProps = state => ({
-  authenticatedWithSSOe: isAuthenticatedWithSSOe(state),
+  transactionId: ssoeTransactionId(state),
   hasCalledKeepAlive: hasCheckedKeepAlive(state),
   profileLoading: isProfileLoading(state),
   loggedIn: isLoggedIn(state),

--- a/src/platform/site-wide/user-nav/tests/containers/AutoSSO.unit.spec.jsx
+++ b/src/platform/site-wide/user-nav/tests/containers/AutoSSO.unit.spec.jsx
@@ -14,7 +14,7 @@ describe('<AutoSSO>', () => {
     props = {
       useInboundSSOe: false,
       hasCalledKeepAlive: false,
-      authenticatedWithSSOe: false,
+      transactionId: undefined,
       loggedIn: false,
       profileLoading: false,
       checkKeepAlive: sinon.spy(),

--- a/src/platform/user/authentication/selectors.js
+++ b/src/platform/user/authentication/selectors.js
@@ -18,3 +18,6 @@ export const signInServiceName = state =>
 
 export const isAuthenticatedWithSSOe = state =>
   selectProfile(state).signIn?.ssoe;
+
+export const ssoeTransactionId = state =>
+  selectProfile(state).signIn?.transactionid;

--- a/src/platform/user/tests/authentication/selectors.unit.spec.js
+++ b/src/platform/user/tests/authentication/selectors.unit.spec.js
@@ -27,4 +27,30 @@ describe('authentication selectors', () => {
       expect(selectors.isAuthenticatedWithSSOe(state)).to.be.undefined;
     });
   });
+
+  describe('ssoeTransactionId', () => {
+    it('pulls out state.profile.signin.transactionid', () => {
+      const state = {
+        user: {
+          profile: {
+            signIn: {
+              transactionid: 'X',
+            },
+          },
+        },
+      };
+
+      expect(selectors.ssoeTransactionId(state)).to.eq('X');
+    });
+    it('returns undefined when the transactionid is not present', () => {
+      const state = {
+        user: {
+          profile: {
+            signIn: {},
+          },
+        },
+      };
+      expect(selectors.ssoeTransactionId(state)).to.be.undefined;
+    });
+  });
 });

--- a/src/platform/utilities/sso/index.js
+++ b/src/platform/utilities/sso/index.js
@@ -50,11 +50,10 @@ export async function checkAutoSession(loggedIn, ssoeTransactionId) {
       // explicitly check to see if the TTL for the SSOe session is 0, as it
       // could also be null if we failed to get a response from the SSOe server,
       // in which case we don't want to logout the user because we don't know
-      // Additionally check to make sure that the transaction id returned from
-      // the /keepalive endpoint doesn't match that of the users VA session.
-      // If they don't match, it means we might have a different user logged in,
-      // thus we should auto log out the user, and immediately log them back in
-      // to make sure the users match
+      // Additionally, compare the transaction id from the keepalive endpoint
+      // with the existing transaction id. If they don't match, it means we might
+      // have a different user logged in. Thus, we should auto log out the user,
+      // and immediately log them back in to make sure the users match.
       logout('v1', 'sso-automatic-logout', { 'auto-logout': 'true' });
     }
   } else if (!loggedIn && ttl > 0 && !getLoginAttempted() && authn) {

--- a/src/platform/utilities/sso/keepAliveSSO.js
+++ b/src/platform/utilities/sso/keepAliveSSO.js
@@ -23,6 +23,7 @@ export default async function keepAlive() {
     const alive = resp.headers.get('session-alive') === 'true';
     return {
       ttl: alive ? Number(resp.headers.get('session-timeout')) : 0,
+      transactionid: resp.headers.get('va_eauth_transactionid'),
       // for DSLogon or mhv, use a mapped authn context value, however for
       // idme, we need to use the provided authncontextclassref as it could be
       // for LOA1 or LOA3.  Any other csid values should be ignored, and we

--- a/src/platform/utilities/tests/sso.unit.spec.js
+++ b/src/platform/utilities/tests/sso.unit.spec.js
@@ -57,15 +57,16 @@ describe('checkAutoSession', () => {
   });
 
   it('should redirect user to cerner if logged in via SSOe and on the standalone sign in page', async () => {
-    sandbox
-      .stub(keepAliveMod, 'keepAlive')
-      .returns({ sessionAlive: true, ttl: 900, authn: 'dslogon' });
+    sandbox.stub(keepAliveMod, 'keepAlive').returns({
+      sessionAlive: true,
+      ttl: 900,
+      authn: 'dslogon',
+      transactionid: 'X',
+    });
     global.window.location.origin = 'http://localhost';
     global.window.location.pathname = '/sign-in/';
     global.window.location.search = '?application=myvahealth';
-    const loggedIn = true;
-    const authenticatedWithSSOe = true;
-    await checkAutoSession(loggedIn, authenticatedWithSSOe);
+    await checkAutoSession(true, 'X');
 
     expect(global.window.location).to.eq(
       'https://ehrm-va-test.patientportal.us.healtheintent.com/',
@@ -73,16 +74,17 @@ describe('checkAutoSession', () => {
   });
 
   it('should redirect user to home page if logged in via SSOe and on the standalone sign in page', async () => {
-    sandbox
-      .stub(keepAliveMod, 'keepAlive')
-      .returns({ sessionAlive: true, ttl: 900, authn: 'dslogon' });
+    sandbox.stub(keepAliveMod, 'keepAlive').returns({
+      sessionAlive: true,
+      ttl: 900,
+      authn: 'dslogon',
+      transactionid: 'X',
+    });
     global.window.location.origin = 'http://localhost';
     global.window.location.pathname = '/sign-in/';
     global.window.location.search = '';
 
-    const loggedIn = true;
-    const authenticatedWithSSOe = true;
-    await checkAutoSession(loggedIn, authenticatedWithSSOe);
+    await checkAutoSession(true, 'X');
 
     expect(global.window.location).to.eq('http://localhost');
   });
@@ -93,9 +95,7 @@ describe('checkAutoSession', () => {
       .returns({ sessionAlive: false, ttl: 0, authn: undefined });
     const auto = sandbox.stub(authUtils, 'logout');
 
-    const loggedIn = true;
-    const authenticatedWithSSOe = true;
-    await checkAutoSession(loggedIn, authenticatedWithSSOe);
+    await checkAutoSession(true, 'X');
 
     sinon.assert.calledOnce(auto);
     sinon.assert.calledWith(auto, 'v1', 'sso-automatic-logout', {
@@ -108,21 +108,34 @@ describe('checkAutoSession', () => {
       .stub(keepAliveMod, 'keepAlive')
       .returns({ sessionAlive: false, ttl: 0, authn: undefined });
     const auto = sandbox.stub(authUtils, 'logout');
-    const loggedIn = true;
-    const authenticatedWithSSOe = undefined;
-    await checkAutoSession(loggedIn, authenticatedWithSSOe);
+
+    await checkAutoSession(true, undefined);
 
     sinon.assert.notCalled(auto);
   });
 
-  it('should not auto logout if user is logged in and they have a SSOe session', async () => {
-    sandbox
-      .stub(keepAliveMod, 'keepAlive')
-      .returns({ sessionAlive: true, ttl: 900, authn: 'dslogon' });
+  it('should auto logout if user is logged in and they have a mismatched SSOe session', async () => {
+    sandbox.stub(keepAliveMod, 'keepAlive').returns({
+      sessionAlive: true,
+      ttl: 900,
+      authn: 'dslogon',
+      transactionid: 'X',
+    });
     const auto = sandbox.stub(authUtils, 'logout');
-    const loggedIn = true;
-    const authenticatedWithSSOe = true;
-    await checkAutoSession(loggedIn, authenticatedWithSSOe);
+    await checkAutoSession(true, 'Y');
+
+    sinon.assert.calledOnce(auto);
+  });
+
+  it('should not auto logout if user is logged in and they have a matched SSOe session', async () => {
+    sandbox.stub(keepAliveMod, 'keepAlive').returns({
+      sessionAlive: true,
+      ttl: 900,
+      authn: 'dslogon',
+      transactionid: 'Y',
+    });
+    const auto = sandbox.stub(authUtils, 'logout');
+    await checkAutoSession(true, 'Y');
 
     sinon.assert.notCalled(auto);
   });
@@ -164,9 +177,12 @@ describe('checkAutoSession', () => {
   });
 
   it('should auto login if user is logged out, they have an mhv SSOe session, dont need to force auth', async () => {
-    sandbox
-      .stub(keepAliveMod, 'keepAlive')
-      .returns({ sessionAlive: true, ttl: 900, authn: 'myhealthevet' });
+    sandbox.stub(keepAliveMod, 'keepAlive').returns({
+      sessionAlive: true,
+      ttl: 900,
+      authn: 'myhealthevet',
+      transactionid: 'X',
+    });
     sandbox.stub(loginAttempted, 'getLoginAttempted').returns(undefined);
     const auto = sandbox.stub(authUtils, 'login');
     await checkAutoSession();
@@ -182,9 +198,12 @@ describe('checkAutoSession', () => {
   });
 
   it('should not auto login if user is logged out, they have a PIV SSOe session and dont need to force auth', async () => {
-    sandbox
-      .stub(keepAliveMod, 'keepAlive')
-      .returns({ sessionAlive: true, ttl: 900, authn: null });
+    sandbox.stub(keepAliveMod, 'keepAlive').returns({
+      sessionAlive: true,
+      ttl: 900,
+      authn: null,
+      transactionid: 'X',
+    });
     sandbox.stub(loginAttempted, 'getLoginAttempted').returns(undefined);
     const auto = sandbox.stub(authUtils, 'login');
     await checkAutoSession();
@@ -193,9 +212,12 @@ describe('checkAutoSession', () => {
   });
 
   it('should not auto login if user is logged out, they dont have a SSOe session and dont need to force auth', async () => {
-    sandbox
-      .stub(keepAliveMod, 'keepAlive')
-      .returns({ sessionAlive: false, ttl: 0, authn: undefined });
+    sandbox.stub(keepAliveMod, 'keepAlive').returns({
+      sessionAlive: false,
+      ttl: 0,
+      authn: undefined,
+      transactionid: undefined,
+    });
     sandbox.stub(loginAttempted, 'getLoginAttempted').returns(undefined);
     const auto = sandbox.stub(authUtils, 'login');
     await checkAutoSession();
@@ -204,9 +226,12 @@ describe('checkAutoSession', () => {
   });
 
   it('should not auto login if user is logged out, they have a SSOe session and need to force auth', async () => {
-    sandbox
-      .stub(keepAliveMod, 'keepAlive')
-      .returns({ sessionAlive: true, ttl: 900, authn: 'dslogon' });
+    sandbox.stub(keepAliveMod, 'keepAlive').returns({
+      sessionAlive: true,
+      ttl: 900,
+      authn: 'dslogon',
+      transactionid: 'X',
+    });
     sandbox.stub(loginAttempted, 'getLoginAttempted').returns(true);
     const auto = sandbox.stub(authUtils, 'login');
     await checkAutoSession();


### PR DESCRIPTION
We need to use the transaction id value returned from the `/keepalive` endpoint and match that to the transaction id in the users VA.gov profile.  If they differ we need to immediately log the user out, as it could be a different user that is logged in.

deps https://github.com/department-of-veterans-affairs/vets-api/pull/4580
fixes https://github.com/department-of-veterans-affairs/va.gov-team/issues/10303

test cases to come....
