### PR TITLE
[Development] Add ArrayField `showSave` option

### DIFF
--- a/src/applications/disability-benefits/all-claims/pages/militaryHistory.js
+++ b/src/applications/disability-benefits/all-claims/pages/militaryHistory.js
@@ -59,6 +59,7 @@ export const uiSchema = {
         itemName: 'Service Period',
         viewField: ValidatedServicePeriodView,
         reviewMode: true,
+        showSave: true,
       },
       items: {
         serviceBranch: {

--- a/src/platform/forms-system/src/js/fields/ArrayField.jsx
+++ b/src/platform/forms-system/src/js/fields/ArrayField.jsx
@@ -265,9 +265,12 @@ export default class ArrayField extends React.Component {
               itemIdPrefix,
               definitions,
             );
+            const showSave = uiSchema['ui:options'].showSave;
+            const updateText = showSave && index === 0 ? 'Save' : 'Update';
             const isLast = items.length === index + 1;
             const isEditing = this.state.editing[index];
-            const notLastOrMultipleRows = !isLast || items.length > 1;
+            const notLastOrMultipleRows =
+              showSave || !isLast || items.length > 1;
 
             if (isReviewMode ? isEditing : isLast || isEditing) {
               return (
@@ -308,24 +311,26 @@ export default class ArrayField extends React.Component {
                       {notLastOrMultipleRows && (
                         <div className="row small-collapse">
                           <div className="small-6 left columns">
-                            {!isLast && (
+                            {(!isLast || showSave) && (
                               <button
                                 className="float-left"
                                 onClick={() => this.handleUpdate(index)}
-                                aria-label={`Update ${title}`}
+                                aria-label={`${updateText} ${title}`}
                               >
-                                Update
+                                {updateText}
                               </button>
                             )}
                           </div>
                           <div className="small-6 right columns">
-                            <button
-                              className="usa-button-secondary float-right"
-                              type="button"
-                              onClick={() => this.handleRemove(index)}
-                            >
-                              Remove
-                            </button>
+                            {index !== 0 && (
+                              <button
+                                className="usa-button-secondary float-right"
+                                type="button"
+                                onClick={() => this.handleRemove(index)}
+                              >
+                                Remove
+                              </button>
+                            )}
                           </div>
                         </div>
                       )}

--- a/src/platform/forms-system/test/js/fields/ArrayField.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/fields/ArrayField.unit.spec.jsx
@@ -97,6 +97,100 @@ describe('Schemaform <ArrayField>', () => {
     expect(tree.everySubTree('SchemaField').length).to.equal(1);
     expect(tree.everySubTree('.va-growable-background').length).to.equal(2);
   });
+  it('should render save button with showSave option', () => {
+    const idSchema = {
+      $id: 'field',
+    };
+    const schema = {
+      type: 'array',
+      items: [],
+      additionalItems: {
+        type: 'object',
+        properties: {
+          field: {
+            type: 'string',
+          },
+        },
+      },
+    };
+    const uiSchema = {
+      'ui:title': 'List of things',
+      'ui:options': {
+        viewField: f => f,
+        showSave: true,
+      },
+    };
+    const formData = [{}];
+    const tree = SkinDeep.shallowRender(
+      <ArrayField
+        schema={schema}
+        uiSchema={uiSchema}
+        idSchema={idSchema}
+        registry={registry}
+        formData={formData}
+        formContext={formContext}
+        onChange={f => f}
+        requiredSchema={requiredSchema}
+        errorSchema={[]}
+      />,
+    );
+
+    expect(tree.everySubTree('SchemaField').length).to.equal(1);
+    expect(tree.everySubTree('.va-growable-background').length).to.equal(1);
+    const button = tree.everySubTree('button');
+    // no remove button
+    expect(button.length).to.equal(2);
+    expect(button[0].text()).to.equal('Save');
+    expect(button[1].text()).to.contain('Add Another');
+  });
+  it('should render save button with showSave option', () => {
+    const idSchema = {
+      $id: 'field',
+    };
+    const schema = {
+      type: 'array',
+      items: [],
+      additionalItems: {
+        type: 'object',
+        properties: {
+          field: {
+            type: 'string',
+          },
+        },
+      },
+    };
+    const uiSchema = {
+      'ui:title': 'List of things',
+      'ui:options': {
+        viewField: f => f,
+        showSave: true,
+      },
+    };
+    const formData = [{}, {}];
+    const tree = SkinDeep.shallowRender(
+      <ArrayField
+        schema={schema}
+        uiSchema={uiSchema}
+        idSchema={idSchema}
+        registry={registry}
+        formData={formData}
+        formContext={formContext}
+        onChange={f => f}
+        requiredSchema={requiredSchema}
+        errorSchema={[]}
+      />,
+    );
+
+    expect(tree.everySubTree('SchemaField').length).to.equal(1);
+    expect(tree.everySubTree('.va-growable-background').length).to.equal(2);
+    const button = tree.everySubTree('button');
+    expect(button.length).to.equal(4);
+    expect(button[0].text()).to.equal('Edit');
+    expect(button[1].text()).to.equal('Update');
+    expect(button[2].text()).to.equal('Remove');
+    expect(button[3].text()).to.contain('Add Another');
+  });
+
   it('should render invalid items', () => {
     const idSchema = {
       $id: 'field',


### PR DESCRIPTION
## Description

In form 526, the page to add your current military history allow adding multiple time periods; but the first entry does not show a "Save" button. 

Related tickets:
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/11191
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/12654

## Testing done

Updated unit tests

## Screenshots

<details><summary>Current view</summary>

<!-- leave a blank line above -->
<br />

_Note_: This view doesn't change after entering valid data

![Before](https://user-images.githubusercontent.com/136959/88324901-fcdcda80-cce9-11ea-829f-32fdc9dc6c5a.png)</details>

<details><summary>New <code>showSave</code> view</summary>

<!-- leave a blank line above -->
<br />

Changes seen _after_ the `showSave` option is set

```js
{
  'ui:title': 'Title',
  'ui:description': 'description',
  'ui:options': {
    // ...
    showSave: true,
  },
  items: { /* ... */ }
}
```

![After](https://user-images.githubusercontent.com/136959/88325451-bf2c8180-ccea-11ea-8777-4808a3bdcffd.png)</details>

<details><summary>New view after clicking "Save"</summary>

<!-- leave a blank line above -->
![Saved](https://user-images.githubusercontent.com/136959/88326668-e768b000-cceb-11ea-954d-7d65f5f0ddae.png)</details>

## Acceptance criteria
- [x] "Save" button is shown when `showSave` option is set
- [x] Clicking save collapses the entry into a view mode with "Edit" button
- [x] No changes to original behavior (original tests passing)
- [x] Covered by new tests

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
