### PR TITLE
Add tests to confirm that Profile 2.0 sections are properly gated

### DIFF
--- a/src/applications/personalization/profile-2/tests/e2e/profile.cypress.spec.js
+++ b/src/applications/personalization/profile-2/tests/e2e/profile.cypress.spec.js
@@ -15,7 +15,7 @@ import mockFeatureToggles from '../fixtures/feature-toggles.json';
  *   and performs an aXe scan
  */
 function checkAllPages(mobile = false) {
-  cy.visit('/profile');
+  cy.visit(PROFILE_PATHS.PROFILE_ROOT);
   if (mobile) {
     cy.viewport('iphone-4');
   }
@@ -89,9 +89,8 @@ describe('Profile', () => {
       'DISMISSED_ANNOUNCEMENTS',
       JSON.stringify(['single-sign-on-intro']),
     );
-    cy.login();
+    cy.login(mockUser);
     // login() calls cy.server() so we can now mock routes
-    cy.route('GET', '/v0/user', mockUser);
     cy.route('GET', '/v0/feature_toggles*', mockFeatureToggles);
     cy.route('GET', '/v0/ppiu/payment_information', mockPaymentInfo);
   });

--- a/src/applications/personalization/profile-2/tests/e2e/profile.direct-deposit.cypress.spec.js
+++ b/src/applications/personalization/profile-2/tests/e2e/profile.direct-deposit.cypress.spec.js
@@ -1,0 +1,87 @@
+import { PROFILE_PATHS } from '../../constants';
+
+import mockFeatureToggles from '../fixtures/feature-toggles.json';
+
+import mockUserNotInEVSS from '../fixtures/users/user-non-vet.json';
+import mockUserInEVSS from '../fixtures/users/user-36.json';
+
+import mockPaymentInfoNotEligible from '../fixtures/payment-information/direct-deposit-is-not-eligible.json';
+import mockPaymentInfoIncompetent from '../fixtures/payment-information/direct-deposit-incompetent.json';
+import mockPaymentInfoDeceased from '../fixtures/payment-information/direct-deposit-deceased.json';
+import mockPaymentInfoFiduciary from '../fixtures/payment-information/direct-deposit-fiduciary.json';
+
+describe('Direct Deposit', () => {
+  function confirmDirectDepositIsBlocked() {
+    // the DD item should not exist in the sub nav
+    cy.findByRole('navigation', { name: /secondary/i }).within(() => {
+      // Just a test to make sure we can access items in the sub nav to ensure
+      // the following test isn't a false negative
+      cy.findByText(/personal.*info/i).should('exist');
+      cy.findByRole('link', { name: /direct deposit/i }).should('not.exist');
+    });
+
+    // going directly to DD should redirect to the personal info page
+    cy.visit(PROFILE_PATHS.DIRECT_DEPOSIT);
+    cy.url().should(
+      'eq',
+      `${Cypress.config().baseUrl}${PROFILE_PATHS.PERSONAL_INFORMATION}`,
+    );
+  }
+  beforeEach(() => {
+    window.localStorage.setItem(
+      'DISMISSED_ANNOUNCEMENTS',
+      JSON.stringify(['single-sign-on-intro']),
+    );
+    cy.login();
+    cy.route('GET', '/v0/feature_toggles*', mockFeatureToggles);
+  });
+  it('should be blocked if the user is not in EVSS', () => {
+    cy.route('GET', 'v0/user', mockUserNotInEVSS);
+    cy.visit(PROFILE_PATHS.PROFILE_ROOT);
+
+    // TODO: add test to make sure that GET payment_information is not called?
+
+    confirmDirectDepositIsBlocked();
+  });
+  it('should be blocked if the user is not enrolled in Direct Deposit and is not eligible to set up Direct Deposit', () => {
+    cy.route('GET', 'v0/user', mockUserInEVSS);
+    cy.route('GET', 'v0/ppiu/payment_information', mockPaymentInfoNotEligible);
+    cy.visit(PROFILE_PATHS.PROFILE_ROOT);
+
+    confirmDirectDepositIsBlocked();
+  });
+  it('should be blocked if the user is enrolled but flagged as incompetent', () => {
+    cy.route('GET', 'v0/user', mockUserInEVSS);
+    cy.route('GET', 'v0/ppiu/payment_information', mockPaymentInfoIncompetent);
+    cy.visit(PROFILE_PATHS.PROFILE_ROOT);
+
+    confirmDirectDepositIsBlocked();
+  });
+  it('should be blocked if the user is enrolled but flagged as being deceased', () => {
+    cy.route('GET', 'v0/user', mockUserInEVSS);
+    cy.route('GET', 'v0/ppiu/payment_information', mockPaymentInfoDeceased);
+    cy.visit(PROFILE_PATHS.PROFILE_ROOT);
+
+    confirmDirectDepositIsBlocked();
+  });
+  it('should be blocked if the user is enrolled but flagged as having a fiduciary', () => {
+    cy.route('GET', 'v0/user', mockUserInEVSS);
+    cy.route('GET', 'v0/ppiu/payment_information', mockPaymentInfoFiduciary);
+    cy.visit(PROFILE_PATHS.PROFILE_ROOT);
+
+    confirmDirectDepositIsBlocked();
+  });
+  it('should be blocked if the `GET payment_information` endpoint fails', () => {
+    cy.route('GET', 'v0/user', mockUserInEVSS);
+    // cy.route('GET', 'v0/ppiu/payment_information', mockPaymentInfoFiduciary);
+    cy.visit(PROFILE_PATHS.PROFILE_ROOT);
+
+    confirmDirectDepositIsBlocked();
+
+    cy.findByRole('alert').should('have.class', 'usa-alert-warning');
+    cy.findByRole('alert').within(() => {
+      cy.findByText(/we can’t access/i).should('exist');
+      cy.findByText(/something went wrong/i).should('exist');
+    });
+  });
+});

--- a/src/applications/personalization/profile-2/tests/e2e/profile.loa1.cypress.spec.js
+++ b/src/applications/personalization/profile-2/tests/e2e/profile.loa1.cypress.spec.js
@@ -1,0 +1,62 @@
+import { PROFILE_PATHS } from '../../constants';
+
+import mockLOA1User from '../fixtures/users/user-loa1.json';
+import mockFeatureToggles from '../fixtures/feature-toggles.json';
+
+describe('LOA1 users', () => {
+  beforeEach(() => {
+    window.localStorage.setItem(
+      'DISMISSED_ANNOUNCEMENTS',
+      JSON.stringify(['single-sign-on-intro']),
+    );
+    cy.login(mockLOA1User);
+    // login() calls cy.server() so we can now mock routes
+    cy.route('GET', '/v0/feature_toggles*', mockFeatureToggles);
+  });
+  it('should only have access to the Account Security section', () => {
+    cy.visit(PROFILE_PATHS.PROFILE_ROOT);
+
+    // should show a loading indicator
+    cy.findByRole('progressbar').should('exist');
+    cy.findByText(/loading your information/i).should('exist');
+
+    // and then the loading indicator should be removed
+    cy.findByRole('progressbar').should('not.exist');
+    cy.findByText(/loading your information/i).should('not.exist');
+
+    // should redirect to profile/account-security on load
+    cy.url().should(
+      'eq',
+      `${Cypress.config().baseUrl}${PROFILE_PATHS.ACCOUNT_SECURITY}`,
+    );
+
+    // Check that the sub nav does not contain anything other than the Account
+    // Security section
+    cy.findByRole('link', { name: /personal.*info/i }).should('not.exist');
+    cy.findByRole('link', { name: /military info/i }).should('not.exist');
+    cy.findByRole('link', { name: /direct deposit/i }).should('not.exist');
+    cy.findByRole('link', { name: /connected app/i }).should('not.exist');
+
+    // There should be an Account Security item in the sub nav.
+    // NOTE: There are two link elements that contain `account security` so look
+    // for the link specifically in the secondary nav
+    cy.findByRole('navigation', { name: /secondary/i }).within(() => {
+      cy.findByRole('link', { name: /account security/i }).should('exist');
+    });
+
+    // Going directly to any other  should redirect to the
+    // account security section
+    [
+      PROFILE_PATHS.CONNECTED_APPLICATIONS,
+      PROFILE_PATHS.DIRECT_DEPOSIT,
+      PROFILE_PATHS.MILITARY_INFORMATION,
+      PROFILE_PATHS.PERSONAL_INFORMATION,
+    ].forEach(path => {
+      cy.visit(path);
+      cy.url().should(
+        'eq',
+        `${Cypress.config().baseUrl}${PROFILE_PATHS.ACCOUNT_SECURITY}`,
+      );
+    });
+  });
+});

--- a/src/applications/personalization/profile-2/tests/e2e/profile.loa1.cypress.spec.js
+++ b/src/applications/personalization/profile-2/tests/e2e/profile.loa1.cypress.spec.js
@@ -44,7 +44,7 @@ describe('LOA1 users', () => {
       cy.findByRole('link', { name: /account security/i }).should('exist');
     });
 
-    // Going directly to any other  should redirect to the
+    // Going directly to any other should redirect to the
     // account security section
     [
       PROFILE_PATHS.CONNECTED_APPLICATIONS,

--- a/src/applications/personalization/profile-2/tests/e2e/profile.military-information.cypress.spec.js
+++ b/src/applications/personalization/profile-2/tests/e2e/profile.military-information.cypress.spec.js
@@ -1,0 +1,42 @@
+import { PROFILE_PATHS } from '../../constants';
+
+import mockFeatureToggles from '../fixtures/feature-toggles.json';
+
+import mockUserNotInEVSS from '../fixtures/users/user-non-vet.json';
+
+describe('Military Information', () => {
+  function confirmMilitaryInformationIsBlocked() {
+    // the Military Info item should not exist in the sub nav
+    cy.findByRole('navigation', { name: /secondary/i }).within(() => {
+      // Just a test to make sure we can access items in the sub nav to ensure
+      // the following test isn't a false negative
+      cy.findByText(/personal.*info/i).should('exist');
+      cy.findByRole('link', { name: /military information/i }).should(
+        'not.exist',
+      );
+    });
+
+    // going directly to Military Info should redirect to the personal info page
+    cy.visit(PROFILE_PATHS.MILITARY_INFORMATION);
+    cy.url().should(
+      'eq',
+      `${Cypress.config().baseUrl}${PROFILE_PATHS.PERSONAL_INFORMATION}`,
+    );
+  }
+  beforeEach(() => {
+    window.localStorage.setItem(
+      'DISMISSED_ANNOUNCEMENTS',
+      JSON.stringify(['single-sign-on-intro']),
+    );
+    cy.login();
+    cy.route('GET', '/v0/feature_toggles*', mockFeatureToggles);
+  });
+  it('should be blocked if the user is not a Veteran', () => {
+    cy.route('GET', 'v0/user', mockUserNotInEVSS);
+    cy.visit(PROFILE_PATHS.PROFILE_ROOT);
+
+    // TODO: add test to make sure that GET service_history is not called?
+
+    confirmMilitaryInformationIsBlocked();
+  });
+});

--- a/src/applications/personalization/profile-2/tests/e2e/profile.non-vet.cypress.spec.js
+++ b/src/applications/personalization/profile-2/tests/e2e/profile.non-vet.cypress.spec.js
@@ -1,0 +1,48 @@
+import { PROFILE_PATHS } from '../../constants';
+
+import mockUser from '../fixtures/users/user-non-vet.json';
+import mockPaymentInfo from '../fixtures/payment-information/direct-deposit-is-set-up.json';
+import mockFeatureToggles from '../fixtures/feature-toggles.json';
+
+describe('Non-Veterans', () => {
+  beforeEach(() => {
+    window.localStorage.setItem(
+      'DISMISSED_ANNOUNCEMENTS',
+      JSON.stringify(['single-sign-on-intro']),
+    );
+    cy.login(mockUser);
+    // login() calls cy.server() so we can now mock routes
+    cy.route('GET', '/v0/feature_toggles*', mockFeatureToggles);
+    cy.route('GET', '/v0/ppiu/payment_information', mockPaymentInfo);
+  });
+  it('should not have Military Info in the sub-nav and should be blocked from directly accessing that route', () => {
+    cy.visit(PROFILE_PATHS.PROFILE_ROOT);
+
+    // should show a loading indicator
+    cy.findByRole('progressbar').should('exist');
+    cy.findByText(/loading your information/i).should('exist');
+
+    // and then the loading indicator should be removed
+    cy.findByRole('progressbar').should('not.exist');
+    cy.findByText(/loading your information/i).should('not.exist');
+
+    // visiting /profile should redirect to profile/personal-information
+    cy.url().should(
+      'eq',
+      `${Cypress.config().baseUrl}${PROFILE_PATHS.PERSONAL_INFORMATION}`,
+    );
+
+    // There should not be a Military Information item in the sub nav
+    cy.findByRole('link', { name: /military info/i }).should('not.exist');
+
+    // TODO: maybe add tests to make sure the sub nav has the correct items?
+
+    // Going directly to the military info section should redirect to the
+    // personal info section
+    cy.visit(PROFILE_PATHS.MILITARY_INFORMATION);
+    cy.url().should(
+      'eq',
+      `${Cypress.config().baseUrl}${PROFILE_PATHS.PERSONAL_INFORMATION}`,
+    );
+  });
+});

--- a/src/applications/personalization/profile-2/tests/fixtures/payment-information/direct-deposit-deceased.json
+++ b/src/applications/personalization/profile-2/tests/fixtures/payment-information/direct-deposit-deceased.json
@@ -1,0 +1,44 @@
+{
+  "data": {
+    "id": "",
+    "type": "evss_ppiu_payment_information_responses",
+    "attributes": {
+      "responses": [
+        {
+          "controlInformation": {
+            "canUpdateAddress": true,
+            "corpAvailIndicator": true,
+            "corpRecFoundIndicator": true,
+            "hasNoBdnPaymentsIndicator": true,
+            "identityIndicator": true,
+            "isCompetentIndicator": true,
+            "indexIndicator": true,
+            "noFiduciaryAssignedIndicator": true,
+            "notDeceasedIndicator": false
+          },
+          "paymentAccount": {
+            "accountType": null,
+            "financialInstitutionName": null,
+            "accountNumber": null,
+            "financialInstitutionRoutingNumber": null
+          },
+          "paymentAddress": {
+            "type": null,
+            "addressEffectiveDate": null,
+            "addressOne": null,
+            "addressTwo": null,
+            "addressThree": null,
+            "city": null,
+            "stateCode": null,
+            "zipCode": null,
+            "zipSuffix": null,
+            "countryName": null,
+            "militaryPostOfficeTypeCode": null,
+            "militaryStateCode": null
+          },
+          "paymentType": "CNP"
+        }
+      ]
+    }
+  }
+}

--- a/src/applications/personalization/profile-2/tests/fixtures/payment-information/direct-deposit-fiduciary.json
+++ b/src/applications/personalization/profile-2/tests/fixtures/payment-information/direct-deposit-fiduciary.json
@@ -1,0 +1,44 @@
+{
+  "data": {
+    "id": "",
+    "type": "evss_ppiu_payment_information_responses",
+    "attributes": {
+      "responses": [
+        {
+          "controlInformation": {
+            "canUpdateAddress": false,
+            "corpAvailIndicator": true,
+            "corpRecFoundIndicator": true,
+            "hasNoBdnPaymentsIndicator": true,
+            "identityIndicator": true,
+            "isCompetentIndicator": true,
+            "indexIndicator": true,
+            "noFiduciaryAssignedIndicator": false,
+            "notDeceasedIndicator": true
+          },
+          "paymentAccount": {
+            "accountType": null,
+            "financialInstitutionName": null,
+            "accountNumber": null,
+            "financialInstitutionRoutingNumber": null
+          },
+          "paymentAddress": {
+            "type": null,
+            "addressEffectiveDate": null,
+            "addressOne": null,
+            "addressTwo": null,
+            "addressThree": null,
+            "city": null,
+            "stateCode": null,
+            "zipCode": null,
+            "zipSuffix": null,
+            "countryName": null,
+            "militaryPostOfficeTypeCode": null,
+            "militaryStateCode": null
+          },
+          "paymentType": "CNP"
+        }
+      ]
+    }
+  }
+}

--- a/src/applications/personalization/profile-2/tests/fixtures/payment-information/direct-deposit-incompetent.json
+++ b/src/applications/personalization/profile-2/tests/fixtures/payment-information/direct-deposit-incompetent.json
@@ -1,0 +1,44 @@
+{
+  "data": {
+    "id": "",
+    "type": "evss_ppiu_payment_information_responses",
+    "attributes": {
+      "responses": [
+        {
+          "controlInformation": {
+            "canUpdateAddress": false,
+            "corpAvailIndicator": true,
+            "corpRecFoundIndicator": true,
+            "hasNoBdnPaymentsIndicator": true,
+            "identityIndicator": true,
+            "isCompetentIndicator": false,
+            "indexIndicator": true,
+            "noFiduciaryAssignedIndicator": true,
+            "notDeceasedIndicator": true
+          },
+          "paymentAccount": {
+            "accountType": null,
+            "financialInstitutionName": null,
+            "accountNumber": null,
+            "financialInstitutionRoutingNumber": null
+          },
+          "paymentAddress": {
+            "type": null,
+            "addressEffectiveDate": null,
+            "addressOne": null,
+            "addressTwo": null,
+            "addressThree": null,
+            "city": null,
+            "stateCode": null,
+            "zipCode": null,
+            "zipSuffix": null,
+            "countryName": null,
+            "militaryPostOfficeTypeCode": null,
+            "militaryStateCode": null
+          },
+          "paymentType": "CNP"
+        }
+      ]
+    }
+  }
+}

--- a/src/applications/personalization/profile-2/tests/fixtures/payment-information/direct-deposit-is-not-eligible.json
+++ b/src/applications/personalization/profile-2/tests/fixtures/payment-information/direct-deposit-is-not-eligible.json
@@ -1,0 +1,44 @@
+{
+  "data": {
+    "id": "",
+    "type": "evss_ppiu_payment_information_responses",
+    "attributes": {
+      "responses": [
+        {
+          "controlInformation": {
+            "canUpdateAddress": true,
+            "corpAvailIndicator": true,
+            "corpRecFoundIndicator": true,
+            "hasNoBdnPaymentsIndicator": true,
+            "identityIndicator": true,
+            "isCompetentIndicator": true,
+            "indexIndicator": true,
+            "noFiduciaryAssignedIndicator": true,
+            "notDeceasedIndicator": true
+          },
+          "paymentAccount": {
+            "accountType": null,
+            "financialInstitutionName": null,
+            "accountNumber": null,
+            "financialInstitutionRoutingNumber": null
+          },
+          "paymentAddress": {
+            "type": null,
+            "addressEffectiveDate": null,
+            "addressOne": null,
+            "addressTwo": null,
+            "addressThree": null,
+            "city": null,
+            "stateCode": null,
+            "zipCode": null,
+            "zipSuffix": null,
+            "countryName": null,
+            "militaryPostOfficeTypeCode": null,
+            "militaryStateCode": null
+          },
+          "paymentType": "CNP"
+        }
+      ]
+    }
+  }
+}

--- a/src/applications/personalization/profile-2/tests/fixtures/payment-information/direct-deposit-is-not-set-up.json
+++ b/src/applications/personalization/profile-2/tests/fixtures/payment-information/direct-deposit-is-not-set-up.json
@@ -1,0 +1,44 @@
+{
+  "data": {
+    "id": "",
+    "type": "evss_ppiu_payment_information_responses",
+    "attributes": {
+      "responses": [
+        {
+          "controlInformation": {
+            "canUpdateAddress": true,
+            "corpAvailIndicator": true,
+            "corpRecFoundIndicator": true,
+            "hasNoBdnPaymentsIndicator": true,
+            "identityIndicator": true,
+            "isCompetentIndicator": true,
+            "indexIndicator": true,
+            "noFiduciaryAssignedIndicator": true,
+            "notDeceasedIndicator": true
+          },
+          "paymentAccount": {
+            "accountType": "",
+            "financialInstitutionName": null,
+            "accountNumber": "",
+            "financialInstitutionRoutingNumber": ""
+          },
+          "paymentAddress": {
+            "type": "DOMESTIC",
+            "addressEffectiveDate": "2016-12-16T06:00:00.000+00:00",
+            "addressOne": "789 SMITH CV",
+            "addressTwo": "",
+            "addressThree": "",
+            "city": "TAMPA",
+            "stateCode": "FL",
+            "zipCode": null,
+            "zipSuffix": null,
+            "countryName": "TAMPA",
+            "militaryPostOfficeTypeCode": null,
+            "militaryStateCode": null
+          },
+          "paymentType": "CNP"
+        }
+      ]
+    }
+  }
+}

--- a/src/applications/personalization/profile-2/tests/fixtures/users/user-loa1.json
+++ b/src/applications/personalization/profile-2/tests/fixtures/users/user-loa1.json
@@ -1,0 +1,77 @@
+{
+  "data": {
+    "id": "",
+    "type": "users_scaffolds",
+    "attributes": {
+      "services": [
+        "facilities",
+        "hca",
+        "edu-benefits",
+        "form-save-in-progress",
+        "form-prefill",
+        "user-profile"
+      ],
+      "account": { "accountUuid": "3b3660a5-3fc2-4928-8c3f-75ff0962c53b" },
+      "profile": {
+        "email": "vets.gov.user+350@gmail.com",
+        "firstName": null,
+        "middleName": null,
+        "lastName": null,
+        "birthDate": null,
+        "gender": null,
+        "zip": null,
+        "lastSignedIn": "2020-07-23T16:58:29.067Z",
+        "loa": { "current": 1, "highest": 1 },
+        "multifactor": false,
+        "verified": false,
+        "signIn": { "serviceName": "idme", "accountType": "N/A", "ssoe": true },
+        "authnContext": "http://idmanagement.gov/ns/assurance/loa/1/vets"
+      },
+      "vaProfile": null,
+      "veteranStatus": null,
+      "inProgressForms": [],
+      "prefillsAvailable": [
+        "21-686C",
+        "40-10007",
+        "22-1990",
+        "22-1990N",
+        "22-1990E",
+        "22-1995",
+        "22-1995S",
+        "22-5490",
+        "22-5495",
+        "22-0993",
+        "22-0994",
+        "FEEDBACK-TOOL",
+        "22-10203",
+        "21-526EZ",
+        "21-526EZ-BDD",
+        "1010ez",
+        "21P-530",
+        "21P-527EZ",
+        "686C-674",
+        "20-0996",
+        "MDOT"
+      ],
+      "vet360ContactInformation": {}
+    }
+  },
+  "meta": {
+    "errors": [
+      {
+        "externalService": "MVI",
+        "startTime": "2020-07-23T16:58:32Z",
+        "endTime": null,
+        "description": "401, 401, Not authorized, Not authorized",
+        "status": 401
+      },
+      {
+        "externalService": "EMIS",
+        "startTime": "2020-07-23T16:58:32Z",
+        "endTime": null,
+        "description": "EMISRedis::VeteranStatus::NotAuthorized, NOT_AUTHORIZED",
+        "status": 401
+      }
+    ]
+  }
+}

--- a/src/applications/personalization/profile-2/tests/fixtures/users/user-non-vet.json
+++ b/src/applications/personalization/profile-2/tests/fixtures/users/user-non-vet.json
@@ -1,0 +1,106 @@
+{
+  "data": {
+    "id": "",
+    "type": "users_scaffolds",
+    "attributes": {
+      "services": [
+        "facilities",
+        "hca",
+        "edu-benefits",
+        "form-save-in-progress",
+        "form-prefill",
+        "user-profile",
+        "appeals-status",
+        "identity-proofed",
+        "vet360",
+        "all_claims"
+      ],
+      "account": { "accountUuid": "71746456-35c3-40d2-8004-4506fdfdab45" },
+      "profile": {
+        "email": "vets.gov.user+4@gmail.com",
+        "firstName": "ALFREDO",
+        "middleName": "M",
+        "lastName": "ARMSTRONG",
+        "birthDate": "1989-11-11",
+        "gender": "M",
+        "zip": "20001",
+        "lastSignedIn": "2020-07-23T15:45:14.278Z",
+        "loa": { "current": 3, "highest": 3 },
+        "multifactor": true,
+        "verified": true,
+        "signIn": { "serviceName": "idme", "accountType": "N/A", "ssoe": true },
+        "authnContext": "http://idmanagement.gov/ns/assurance/loa/3"
+      },
+      "vaProfile": {
+        "status": "OK",
+        "birthDate": "19891111",
+        "familyName": "Armstrong",
+        "gender": null,
+        "givenNames": ["Alfredo", "M"],
+        "isCernerPatient": false,
+        "facilities": [],
+        "vaPatient": false,
+        "mhvAccountState": "NONE"
+      },
+      "veteranStatus": null,
+      "inProgressForms": [
+        {
+          "form": "21-686C",
+          "metadata": {
+            "version": 1,
+            "returnUrl": "/686-options-selection",
+            "savedAt": 1593719704400,
+            "expiresAt": 1598903705,
+            "lastUpdated": 1593719705
+          },
+          "lastUpdated": 1593719705
+        }
+      ],
+      "prefillsAvailable": [
+        "21-686C",
+        "40-10007",
+        "22-1990",
+        "22-1990N",
+        "22-1990E",
+        "22-1995",
+        "22-1995S",
+        "22-5490",
+        "22-5495",
+        "22-0993",
+        "22-0994",
+        "FEEDBACK-TOOL",
+        "22-10203",
+        "21-526EZ",
+        "21-526EZ-BDD",
+        "1010ez",
+        "21P-530",
+        "21P-527EZ",
+        "686C-674",
+        "20-0996",
+        "MDOT"
+      ],
+      "vet360ContactInformation": {
+        "email": null,
+        "residentialAddress": null,
+        "mailingAddress": null,
+        "mobilePhone": null,
+        "homePhone": null,
+        "workPhone": null,
+        "temporaryPhone": null,
+        "faxNumber": null,
+        "textPermission": null
+      }
+    }
+  },
+  "meta": {
+    "errors": [
+      {
+        "externalService": "EMIS",
+        "startTime": "2020-07-23T15:45:24Z",
+        "endTime": null,
+        "description": "EMISRedis::VeteranStatus::NotAuthorized, NOT_AUTHORIZED",
+        "status": 401
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Description
Adds Cypress tests for the following cases:
- [ ] Check that LOA1 users can _only_ access the Account Security section
- [ ] Check that users are blocked from DD if any of the following are true:
    1. They are not in EVSS
    3. They are in EVSS but not eligible for DD
    4. They are enrolled in DD but blocked due to access indicators (deceased, incompetent, has fiduciary)
    5. We are unable to connect to the `GET payment_information` endpoint
- [ ] Check that non-Vets are blocked from the Military Info section

## Testing done
Local

## Screenshots
N/A

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs