### PR TITLE
Only show When to use this form header when fieldVAFormUsage is truthy

### DIFF
--- a/src/site/layouts/va_form.drupal.liquid
+++ b/src/site/layouts/va_form.drupal.liquid
@@ -35,7 +35,7 @@
               {% case fieldVaFormType %}
                 {% when 'employment' %}
                   Employment or jobs at VA
-                {% when 'Non-VA' %}
+                {% when 'non-va' %}
                   A non-VA form. For other government agency forms, go to the <a href="https://www.gsa.gov/reference/forms">GSA forms library</a>.
                 {% else %}
                   {% comment %}

--- a/src/site/layouts/va_form.drupal.liquid
+++ b/src/site/layouts/va_form.drupal.liquid
@@ -22,9 +22,9 @@
         <h1 class="vads-u-margin-bottom--0">{{ title }}</h1>
 
         <dl>
-          <div class="va-introtext vads-u-margin-bottom--4">
+          <div class="vads-u-margin-bottom--4">
             <dt class="vads-u-visibility--screen-reader">Form name:</dt>
-            <dd>{{ fieldVaFormName }}</dd>
+            <dd class="va-introtext">{{ fieldVaFormName }}</dd>
           </div>
 
           <div class="vads-u-margin-y--1">
@@ -62,15 +62,16 @@
           {% endif %}
         </dl>
 
-        <h2 class="vads-u-margin-top--4"">When to use this form</h3>
 
         {% if fieldVaFormUsage %}
+          <h2 class="vads-u-margin-top--4">When to use this form</h3>
           {{ fieldVaFormUsage.processed }}
+
+          <h3>Downloadable PDF</h3>
+          <a href="{{ fieldVaFormUrl.uri }}" download>Download VA Form {{ fieldVaFormNumber }} (PDF)</a>
+        {% else %}
+          <a class="vads-u-margin-top--4" href="{{ fieldVaFormUrl.uri }}" download>Download VA Form {{ fieldVaFormNumber }} (PDF)</a>
         {% endif %}
-
-        <h3>Downloadable PDF</h3>
-
-        <a href="{{ fieldVaFormUrl.uri }}" download>Download VA Form {{ fieldVaFormNumber }} (PDF)</a>
 
         {% if fieldVaFormToolUrl %}
           <h3>Online tool</h3>


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/11444

This PR fixes some conditional rendering in the form detail template. **It doesn't atm, but eventually it will need to fix the problem with the `Non-VA` condition not being met.**

## Testing done
N/A

## Screenshots
N/A

## Acceptance criteria
- [x] Fix conditional rendering for headers with no values
- [x] Fix `Non-VA` issue

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
