### PR TITLE
Remove unused key-value pairs from bucket consts

### DIFF
--- a/src/site/constants/buckets.js
+++ b/src/site/constants/buckets.js
@@ -1,20 +1,6 @@
-const {
-  DEVELOPMENT,
-  PRODUCTION,
-  STAGING,
-  VAGOVDEV,
-  VAGOVSTAGING,
-  VAGOVPROD,
-} = require('./environments');
-
-const hostnames = require('./hostnames');
-
-const bucket = 'https://s3-us-gov-west-1.amazonaws.com';
+const { VAGOVDEV, VAGOVSTAGING, VAGOVPROD } = require('./environments');
 
 module.exports = {
-  [DEVELOPMENT]: `${bucket}/${hostnames[DEVELOPMENT]}`,
-  [PRODUCTION]: `${bucket}/${hostnames[PRODUCTION]}`,
-  [STAGING]: `${bucket}/${hostnames[STAGING]}`,
   [VAGOVDEV]: 'https://dev-va-gov-assets.s3-us-gov-west-1.amazonaws.com',
   [VAGOVSTAGING]:
     'https://staging-va-gov-assets.s3-us-gov-west-1.amazonaws.com',


### PR DESCRIPTION
## Description

We had been importing the `DEVELOPMENT`, `PRODUCTION`, and `STAGING` values from the `environments` file and using them as keys to set bucket values, but those values were not being exported from the environments file.  Having keys like `STAGING` and `VAGOVSTAGING` only adds confusion, so this PR removes the keys that are no longer used.

The exported values:

https://github.com/department-of-veterans-affairs/vets-website/blob/5836f211f0033506ff3c07836d39a7612cc9d1e2/src/site/constants/environments.js#L6-L18

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
