### PR TITLE
New transformer for node-story_listing

### DIFF
--- a/src/site/stages/build/process-cms-exports/schemas/input/node-story_listing.js
+++ b/src/site/stages/build/process-cms-exports/schemas/input/node-story_listing.js
@@ -1,0 +1,37 @@
+/* eslint-disable camelcase */
+
+module.exports = {
+  type: 'object',
+  properties: {
+    title: { $ref: 'GenericNestedString' },
+    created: { $ref: 'GenericNestedString' },
+    changed: { $ref: 'GenericNestedString' },
+    metatag: { $ref: 'RawMetaTags' },
+    path: { $ref: 'RawPath' },
+    field_administration: {
+      type: 'array',
+      maxItems: 1,
+      items: { $ref: 'EntityReference' },
+    },
+    field_description: { $ref: 'GenericNestedString' },
+    field_intro_text: { $ref: 'GenericNestedString' },
+    field_meta_title: { $ref: 'GenericNestedString' },
+    field_office: {
+      type: 'array',
+      maxItems: 1,
+      items: { $ref: 'EntityReference' },
+    },
+  },
+  required: [
+    'title',
+    'created',
+    'changed',
+    'metatag',
+    'path',
+    'field_administration',
+    'field_description',
+    'field_intro_text',
+    'field_meta_title',
+    'field_office',
+  ],
+};

--- a/src/site/stages/build/process-cms-exports/schemas/output/node-story_listing.js
+++ b/src/site/stages/build/process-cms-exports/schemas/output/node-story_listing.js
@@ -1,0 +1,27 @@
+module.exports = {
+  type: 'object',
+  properties: {
+    entityType: { type: 'string', enum: ['node'] },
+    entityBundle: { type: 'string', enum: ['story_listing'] },
+    title: { type: 'string' },
+    created: { type: 'number' },
+    changed: { type: 'number' },
+    entityMetatags: { $ref: 'MetaTags' },
+    fieldAdministration: { $ref: 'output/taxonomy_term-administration' },
+    fieldDescription: { type: 'string' },
+    fieldIntroText: { type: 'string' },
+    fieldMetaTitle: { type: 'string' },
+    fieldOffice: { $ref: 'output/node-health_care_region_page' },
+  },
+  required: [
+    'title',
+    'created',
+    'changed',
+    'entityMetatags',
+    'fieldAdministration',
+    'fieldDescription',
+    'fieldIntroText',
+    'fieldMetaTitle',
+    'fieldOffice',
+  ],
+};

--- a/src/site/stages/build/process-cms-exports/transformers/node-story_listing.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-story_listing.js
@@ -1,0 +1,35 @@
+const {
+  createMetaTagArray,
+  getDrupalValue,
+  utcToEpochTime,
+} = require('./helpers');
+
+const transform = entity => ({
+  entityType: 'node',
+  entityBundle: 'story_listing',
+  title: getDrupalValue(entity.title),
+  created: utcToEpochTime(getDrupalValue(entity.created)),
+  changed: utcToEpochTime(getDrupalValue(entity.changed)),
+  entityMetatags: createMetaTagArray(entity.metatag.value),
+  fieldAdministration: entity.fieldAdministration[0],
+  fieldDescription: getDrupalValue(entity.fieldDescription),
+  fieldIntroText: getDrupalValue(entity.fieldIntroText),
+  fieldMetaTitle: getDrupalValue(entity.fieldMetaTitle),
+  fieldOffice: entity.fieldOffice[0],
+});
+
+module.exports = {
+  filter: [
+    'title',
+    'created',
+    'changed',
+    'metatag',
+    'path',
+    'field_administration',
+    'field_description',
+    'field_intro_text',
+    'field_meta_title',
+    'field_office',
+  ],
+  transform,
+};


### PR DESCRIPTION
## Description
Created a new transformer for `node-story_listing`

## Testing done
Compared to graphQL output after running `node script/cms/test-bundle-transformers.js --bundle "node-story_listing" --print 6`

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
