### PR TITLE
Fix connected apps timestamp issue

### DIFF
--- a/src/applications/personalization/profile-2/components/connected-apps/ConnectedApp.jsx
+++ b/src/applications/personalization/profile-2/components/connected-apps/ConnectedApp.jsx
@@ -28,7 +28,7 @@ export class ConnectedApp extends Component {
   };
 
   render() {
-    const { logo, title, created, grants } = this.props.attributes;
+    const { logo, title, grants } = this.props.attributes;
 
     return (
       <div
@@ -47,7 +47,8 @@ export class ConnectedApp extends Component {
                 {title}
               </h3>
               <p className="vads-u-margin-top--0p5">
-                Connected on {moment(created).format('MMMM D, YYYY h:mm A')}
+                Connected on{' '}
+                {moment(grants[0]?.created).format('MMMM D, YYYY h:mm A')}
               </p>
             </div>
 


### PR DESCRIPTION
## Description
The `created` timestamp always showed the current time since it was always `undefined`. Created is a property on the `grants`, and not on `attributes`. All grants should have the same timestamp because you consent to all of the scopes or none, at least for now.

This should also be reflected and updated in https://department-of-veterans-affairs.github.io/va-digital-services-platform-docs/api-reference/#/profile/getConnectedApplications

## Testing done
Works locally.

## Screenshots
![image](https://user-images.githubusercontent.com/14869324/88413526-95319880-cd98-11ea-9015-4c55e6db14cb.png)

## Acceptance criteria
- [x] Use the `created` property on the first grant to determine the correct timestamp

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
