### PR TITLE
Hide Header when errors fetching full name

### DIFF
--- a/src/applications/personalization/profile-2/components/Profile2Wrapper.jsx
+++ b/src/applications/personalization/profile-2/components/Profile2Wrapper.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { Link, useLocation } from 'react-router-dom';
 import Breadcrumbs from '@department-of-veterans-affairs/formation-react/Breadcrumbs';
@@ -8,8 +9,9 @@ import ProfileHeader from './ProfileHeader';
 import ProfileSubNav from './ProfileSubNav';
 import ProfileMobileSubNav from './ProfileMobileSubNav';
 import { PROFILE_PATHS } from '../constants';
+import { isEmpty } from 'lodash';
 
-const Profile2 = ({ children, routes, isLOA3, isInMVI }) => {
+const Profile2Wrapper = ({ children, routes, isLOA3, isInMVI, hero }) => {
   const location = useLocation();
   const createBreadCrumbAttributes = () => {
     const activeLocation = location?.pathname;
@@ -48,7 +50,7 @@ const Profile2 = ({ children, routes, isLOA3, isInMVI }) => {
         </Breadcrumbs>
       </div>
 
-      <ProfileHeader />
+      {isEmpty(hero.errors) && <ProfileHeader />}
 
       <div className="medium-screen:vads-u-display--none">
         <ProfileMobileSubNav routes={routes} />
@@ -69,9 +71,14 @@ const Profile2 = ({ children, routes, isLOA3, isInMVI }) => {
   );
 };
 
-Profile2.propTypes = {
+const mapStateToProps = state => ({
+  hero: state.vaProfile?.hero,
+});
+
+Profile2Wrapper.propTypes = {
   children: PropTypes.node.isRequired,
   location: PropTypes.object,
+  hero: PropTypes.object,
   routes: PropTypes.arrayOf(
     PropTypes.shape({
       component: PropTypes.func.isRequired,
@@ -83,4 +90,4 @@ Profile2.propTypes = {
   ).isRequired,
 };
 
-export default Profile2;
+export default connect(mapStateToProps)(Profile2Wrapper);

--- a/src/applications/personalization/profile-2/components/ProfileHeader.jsx
+++ b/src/applications/personalization/profile-2/components/ProfileHeader.jsx
@@ -103,7 +103,7 @@ const ProfileHeader = ({
   };
 
   return (
-    <div className={classes.wrapper}>
+    <div className={classes.wrapper} data-testid="profile-header">
       <div className={classes.innerWrapper}>
         <div className={classes.serviceBadge}>
           {showBadgeImage && (

--- a/src/applications/personalization/profile-2/tests/components/Profile2.unit.spec.js
+++ b/src/applications/personalization/profile-2/tests/components/Profile2.unit.spec.js
@@ -2,18 +2,18 @@ import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { expect } from 'chai';
 
-import Profile2 from '../../components/Profile2Wrapper';
+import Profile2Wrapper from '../../components/Profile2Wrapper';
 import getRoutes from '../../routes';
 import { PROFILE_PATHS } from '../../constants';
 
 import { renderWithProfileReducers as render } from '../unit-test-helpers';
 
-describe('Profile2', () => {
+describe('Profile2Wrapper', () => {
   it('should render the correct breadcrumb (Personal and contact Information)', () => {
     const config = {};
     const ui = (
       <MemoryRouter initialEntries={[PROFILE_PATHS.PERSONAL_INFORMATION]}>
-        <Profile2 routes={getRoutes(config)} />
+        <Profile2Wrapper routes={getRoutes(config)} />
       </MemoryRouter>
     );
     const { getByTestId } = render(ui);

--- a/src/applications/personalization/profile-2/tests/components/Profile2Wrapper.unit.spec.js
+++ b/src/applications/personalization/profile-2/tests/components/Profile2Wrapper.unit.spec.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Provider } from 'react-redux';
 import { MemoryRouter } from 'react-router-dom';
 import { expect } from 'chai';
 
@@ -7,16 +8,29 @@ import getRoutes from '../../routes';
 import { PROFILE_PATHS } from '../../constants';
 
 import { renderWithProfileReducers as render } from '../unit-test-helpers';
+import { Test } from 'mocha';
 
 describe('Profile2Wrapper', () => {
   it('should render the correct breadcrumb (Personal and contact Information)', () => {
     const config = {};
+
+    const initialState = {
+      vaProfile: {
+        hero: {
+          fullUserName: {
+            first: 'Test',
+            last: 'Test',
+          },
+        },
+      },
+    };
+
     const ui = (
       <MemoryRouter initialEntries={[PROFILE_PATHS.PERSONAL_INFORMATION]}>
         <Profile2Wrapper routes={getRoutes(config)} />
       </MemoryRouter>
     );
-    const { getByTestId } = render(ui);
+    const { getByTestId } = render(ui, { initialState });
 
     const breadcrumbs = getByTestId('breadcrumbs');
 

--- a/src/applications/personalization/profile-2/tests/components/Profile2Wrapper.unit.spec.js
+++ b/src/applications/personalization/profile-2/tests/components/Profile2Wrapper.unit.spec.js
@@ -11,30 +11,56 @@ import { renderWithProfileReducers as render } from '../unit-test-helpers';
 import { Test } from 'mocha';
 
 describe('Profile2Wrapper', () => {
-  it('should render the correct breadcrumb (Personal and contact Information)', () => {
-    const config = {};
+  const config = {};
+  const ui = (
+    <MemoryRouter initialEntries={[PROFILE_PATHS.PERSONAL_INFORMATION]}>
+      <Profile2Wrapper routes={getRoutes(config)} />
+    </MemoryRouter>
+  );
 
+  it('should render the correct breadcrumb (Personal and contact Information)', () => {
     const initialState = {
       vaProfile: {
         hero: {
-          fullUserName: {
+          userFullName: {
             first: 'Test',
             last: 'Test',
           },
         },
       },
     };
-
-    const ui = (
-      <MemoryRouter initialEntries={[PROFILE_PATHS.PERSONAL_INFORMATION]}>
-        <Profile2Wrapper routes={getRoutes(config)} />
-      </MemoryRouter>
-    );
     const { getByTestId } = render(ui, { initialState });
-
     const breadcrumbs = getByTestId('breadcrumbs');
-
-    expect(breadcrumbs.textContent.match(/personal and contact information/i))
+    expect(breadcrumbs.textContent.match(/Personal and contact information/i))
       .not.to.be.null;
+  });
+
+  it('should render ProfileHeader when the full name of the user was fetched)', () => {
+    const initialState = {
+      vaProfile: {
+        hero: {
+          userFullName: {
+            first: 'Test',
+            last: 'Test',
+          },
+        },
+      },
+    };
+    const { getByTestId } = render(ui, { initialState });
+    const profileHeader = getByTestId('profile-header');
+    expect(profileHeader.textContent.match(/Test Test/i)).not.to.be.null;
+  });
+
+  it('should not render ProfileHeader when the full name of the user could not be fetched)', () => {
+    const initialState = {
+      vaProfile: {
+        hero: {
+          errors: ['This is an error'],
+        },
+      },
+    };
+    const { queryByTestId } = render(ui, { initialState });
+    const profileHeader = queryByTestId('profile-header');
+    expect(profileHeader).to.be.null;
   });
 });

--- a/src/applications/personalization/profile-2/tests/e2e/profile.cypress.spec.js
+++ b/src/applications/personalization/profile-2/tests/e2e/profile.cypress.spec.js
@@ -28,6 +28,10 @@ function checkAllPages(mobile = false) {
   cy.findByRole('progressbar').should('not.exist');
   cy.findByText(/loading your information/i).should('not.exist');
 
+  // since we did not mock the `GET profile/full_name` endpoint, the
+  // ProfileHeader should not be rendered on the page
+  cy.findByTestId('profile-header').should('not.exist');
+
   // visiting /profile should redirect to profile/personal-information
   cy.url().should(
     'eq',

--- a/src/applications/personalization/profile360/actions/index.js
+++ b/src/applications/personalization/profile360/actions/index.js
@@ -1,5 +1,4 @@
 import { getData } from '../util';
-import environment from 'platform/utilities/environment';
 
 export const FETCH_HERO = 'FETCH_HERO';
 export const FETCH_HERO_SUCCESS = 'FETCH_HERO_SUCCESS';
@@ -16,8 +15,8 @@ export function fetchHero() {
     dispatch({ type: FETCH_HERO });
     const response = await getData('/profile/full_name');
 
-    if (response?.errors) {
-      dispatch({ type: FETCH_HERO_FAILED, hero: { response } });
+    if (response.errors || response.error) {
+      dispatch({ type: FETCH_HERO_FAILED, hero: { errors: response } });
       return;
     }
 

--- a/src/applications/personalization/profile360/actions/index.js
+++ b/src/applications/personalization/profile360/actions/index.js
@@ -16,7 +16,7 @@ export function fetchHero() {
     const response = await getData('/profile/full_name');
 
     if (response.errors || response.error) {
-      dispatch({ type: FETCH_HERO_FAILED, hero: { errors: response } });
+      dispatch({ type: FETCH_HERO_FAILED, hero: { response } });
       return;
     }
 

--- a/src/applications/personalization/profile360/actions/index.js
+++ b/src/applications/personalization/profile360/actions/index.js
@@ -1,7 +1,9 @@
 import { getData } from '../util';
 import environment from 'platform/utilities/environment';
 
+export const FETCH_HERO = 'FETCH_HERO';
 export const FETCH_HERO_SUCCESS = 'FETCH_HERO_SUCCESS';
+export const FETCH_HERO_FAILED = 'FETCH_HERO_FAILED';
 export const FETCH_PERSONAL_INFORMATION_SUCCESS =
   'FETCH_PERSONAL_INFORMATION_SUCCESS';
 export const FETCH_MILITARY_INFORMATION_SUCCESS =
@@ -11,12 +13,15 @@ export const FETCH_ADDRESS_CONSTANTS_SUCCESS =
 
 export function fetchHero() {
   return async dispatch => {
-    dispatch({
-      type: FETCH_HERO_SUCCESS,
-      hero: {
-        userFullName: await getData('/profile/full_name'),
-      },
-    });
+    dispatch({ type: FETCH_HERO });
+
+    await getData('/profile/full_name')
+      .then(data => {
+        dispatch({ type: FETCH_HERO_SUCCESS, hero: { userFullName: data } });
+      })
+      .catch(errors => {
+        dispatch({ type: FETCH_HERO_FAILED, hero: { errors } });
+      });
   };
 }
 

--- a/src/applications/personalization/profile360/actions/index.js
+++ b/src/applications/personalization/profile360/actions/index.js
@@ -14,14 +14,14 @@ export const FETCH_ADDRESS_CONSTANTS_SUCCESS =
 export function fetchHero() {
   return async dispatch => {
     dispatch({ type: FETCH_HERO });
+    const response = await getData('/profile/full_name');
 
-    await getData('/profile/full_name')
-      .then(data => {
-        dispatch({ type: FETCH_HERO_SUCCESS, hero: { userFullName: data } });
-      })
-      .catch(errors => {
-        dispatch({ type: FETCH_HERO_FAILED, hero: { errors } });
-      });
+    if (response?.errors) {
+      dispatch({ type: FETCH_HERO_FAILED, hero: { response } });
+      return;
+    }
+
+    dispatch({ type: FETCH_HERO_SUCCESS, hero: { userFullName: response } });
   };
 }
 

--- a/src/applications/personalization/profile360/actions/index.js
+++ b/src/applications/personalization/profile360/actions/index.js
@@ -16,7 +16,7 @@ export function fetchHero() {
     const response = await getData('/profile/full_name');
 
     if (response.errors || response.error) {
-      dispatch({ type: FETCH_HERO_FAILED, hero: { response } });
+      dispatch({ type: FETCH_HERO_FAILED, hero: { errors: response } });
       return;
     }
 

--- a/src/applications/personalization/profile360/reducers/index.js
+++ b/src/applications/personalization/profile360/reducers/index.js
@@ -4,6 +4,7 @@ import { hcaEnrollmentStatus } from 'applications/hca/reducer';
 
 import {
   FETCH_HERO_SUCCESS,
+  FETCH_HERO_FAILED,
   FETCH_PERSONAL_INFORMATION_SUCCESS,
   FETCH_MILITARY_INFORMATION_SUCCESS,
 } from '../actions';
@@ -32,6 +33,9 @@ const initialState = {
 function vaProfile(state = initialState, action) {
   switch (action.type) {
     case FETCH_HERO_SUCCESS:
+      return set('hero', action.hero, state);
+
+    case FETCH_HERO_FAILED:
       return set('hero', action.hero, state);
 
     case FETCH_PERSONAL_INFORMATION_SUCCESS:

--- a/src/applications/personalization/profile360/tests/reducers/index.unit.spec.js
+++ b/src/applications/personalization/profile360/tests/reducers/index.unit.spec.js
@@ -15,6 +15,17 @@ describe('index reducer', () => {
     expect(state.hero).to.eql('heroContent');
   });
 
+  it('should populate with errors when errors are present', () => {
+    const state = vaProfile(undefined, {
+      type: 'FETCH_HERO_FAILED',
+      hero: {
+        errors: ['This is an error'],
+      },
+    });
+
+    expect(state.hero).to.eql({ errors: ['This is an error'] });
+  });
+
   it('should fetch personalInformation', () => {
     const state = vaProfile(undefined, {
       type: 'FETCH_PERSONAL_INFORMATION_SUCCESS',


### PR DESCRIPTION
## Description
We want to hide the Profile header when the call to get the full user name fails.

## Testing done


## Screenshots
When the call fails, we hide the header here:
![image](https://user-images.githubusercontent.com/14869324/88425038-ebf49d80-cdab-11ea-8dab-77410dc218be.png)


## Acceptance criteria
- [x] Hide the Profile Header when the call to `GET full_name` fails

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
