### PR TITLE
[Development] Route BDD to all-claims

### DIFF
--- a/src/applications/disability-benefits/wizard/pages/file-bdd.jsx
+++ b/src/applications/disability-benefits/wizard/pages/file-bdd.jsx
@@ -3,7 +3,7 @@ import moment from 'moment';
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 import { pageNames } from './pageList';
 import { BDD_INFO_URL } from '../../constants';
-import { BDD_FORM_ROOT_URL } from 'applications/disability-benefits/bdd/constants';
+import { DISABILITY_526_V2_ROOT_URL } from 'applications/disability-benefits/all-claims/constants';
 
 function alertContent(getPageStateFromPageName) {
   const stateBDD = getPageStateFromPageName('bdd');
@@ -63,7 +63,7 @@ function alertContent(getPageStateFromPageName) {
         </a>
       </p>
       <a
-        href={`${BDD_FORM_ROOT_URL}/introduction`}
+        href={`${DISABILITY_526_V2_ROOT_URL}/introduction`}
         className="usa-button-primary va-button-primary"
       >
         File a Benefits Delivery at Discharge claim

--- a/src/applications/personalization/dashboard/helpers.jsx
+++ b/src/applications/personalization/dashboard/helpers.jsx
@@ -22,7 +22,6 @@ import edu0994Manifest from 'applications/edu-benefits/0994/manifest.json';
 import preneedManifest from 'applications/pre-need/manifest.json';
 import pensionManifest from 'applications/pensions/manifest.json';
 import { DISABILITY_526_V2_ROOT_URL } from 'applications/disability-benefits/all-claims/constants';
-import { BDD_FORM_ROOT_URL } from 'applications/disability-benefits/bdd/constants';
 import hlrManifest from 'applications/disability-benefits/996/manifest.json';
 import mdotManifest from 'applications/disability-benefits/2346/manifest.json';
 
@@ -41,14 +40,12 @@ import edu0994Config from 'applications/edu-benefits/0994/config/form.js';
 import preneedConfig from 'applications/pre-need/config/form.jsx';
 import pensionConfig from 'applications/pensions/config/form.js';
 import disability526Config from 'applications/disability-benefits/all-claims/config/form.js';
-import bddConfig from 'applications/disability-benefits/bdd/config/form.js';
 import hlrConfig from 'applications/disability-benefits/996/config/form';
 import mdotConfig from 'applications/disability-benefits/2346/config/form';
 
 export const formConfigs = {
   [VA_FORM_IDS.FORM_10_10EZ]: hcaConfig,
   [VA_FORM_IDS.FORM_21_526EZ]: disability526Config,
-  [VA_FORM_IDS.FORM_21_526EZ_BDD]: bddConfig,
   [VA_FORM_IDS.FORM_21_686C]: dependentStatusConfig,
   [VA_FORM_IDS.FORM_21P_527EZ]: pensionConfig,
   [VA_FORM_IDS.FORM_21P_530]: burialsConfig,
@@ -68,7 +65,6 @@ export const formConfigs = {
 
 export const formBenefits = {
   [VA_FORM_IDS.FORM_21_526EZ]: 'disability compensation',
-  [VA_FORM_IDS.FORM_21_526EZ_BDD]: 'Benefits Delivery at Discharge',
   [VA_FORM_IDS.FORM_21P_527EZ]: 'Veterans pension benefits',
   [VA_FORM_IDS.FORM_21P_530]: 'burial benefits',
   [VA_FORM_IDS.FORM_10_10EZ]: 'health care benefits',
@@ -125,7 +121,6 @@ export const formDescriptions = Object.keys(formBenefits).reduce(
 
 export const formLinks = {
   [VA_FORM_IDS.FORM_21_526EZ]: `${DISABILITY_526_V2_ROOT_URL}/`,
-  [VA_FORM_IDS.FORM_21_526EZ_BDD]: `${BDD_FORM_ROOT_URL}/`,
   [VA_FORM_IDS.FORM_21P_527EZ]: `${pensionManifest.rootUrl}/`,
   [VA_FORM_IDS.FORM_21P_530]: `${burialsManifest.rootUrl}/`,
   [VA_FORM_IDS.FORM_10_10EZ]: `${hcaManifest.rootUrl}/`,
@@ -146,7 +141,6 @@ export const formLinks = {
 
 export const trackingPrefixes = {
   [VA_FORM_IDS.FORM_21_526EZ]: 'disability-526EZ-',
-  [VA_FORM_IDS.FORM_21_526EZ_BDD]: 'disability-526EZ-bdd-',
   [VA_FORM_IDS.FORM_21P_527EZ]: 'pensions-527EZ-',
   [VA_FORM_IDS.FORM_21P_530]: 'burials-530-',
   [VA_FORM_IDS.FORM_10_10EZ]: 'hca-',
@@ -169,7 +163,6 @@ export const sipEnabledForms = new Set([
   VA_FORM_IDS.FORM_10_10EZ,
   VA_FORM_IDS.FORM_21_686C,
   VA_FORM_IDS.FORM_21_526EZ,
-  VA_FORM_IDS.FORM_21_526EZ_BDD,
   VA_FORM_IDS.FORM_21P_527EZ,
   VA_FORM_IDS.FORM_21P_530,
   VA_FORM_IDS.FORM_22_0993,

--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -304,29 +304,6 @@
     }
   },
   {
-    "appName": "21-526EZ Benefits Delivery at Discharge",
-    "entryName": "bdd",
-    "rootUrl": "/disability/file-benefits-delivery-at-discharge-form-21-526ez",
-    "template": {
-      "title": "File for benefits delivery at discharge",
-      "layout": "page-react.html",
-      "description": "Learn how to apply online for benefits delivery at discharge.",
-      "hideFromSidebar": true,
-      "includeBreadcrumbs": true,
-      "breadcrumbs_override": [
-        {
-          "name": "Disability Benefits",
-          "path": "disability/"
-        },
-        {
-          "name": "File for Benefits Delivery at Discharge",
-          "path": "disability/file-benefits-delivery-at-discharge-form-21-526ez"
-        }
-      ],
-      "vagovprod": false
-    }
-  },
-  {
     "appName": "Order hearing aid batteries and accessories",
     "entryName": "order-form-2346",
     "rootUrl": "/health-care/order-hearing-aid-batteries-and-accessories/order-form-2346",


### PR DESCRIPTION
## Description

Benefits Delivery at Discharge has been merged into the form 526 all-claims flow. This PR changes the route from a separate BDD-only path to the all-claims path.

BDD is not in production, but there is a in production check made before displaying any BDD exclusive pages.

Related:
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/11189
- https://github.com/department-of-veterans-affairs/devops/pull/7315 (remove path)

## Testing done

Local unit test

## Screenshots

N/A

## Acceptance criteria
- [x] All paths to the previous BDD url changed to 526 all-claims

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
