### PR TITLE
Update vets-json-schema to v6.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -326,7 +326,7 @@
     "url-search-params-polyfill": "^8.1.0",
     "uswds": "1.6.10",
     "vanilla-lazyload": "^16.1.0",
-    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#dfee66d46dcbd9bcc7631c02d25db39eed43b4f0",
+    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#458cb0a240755dbdd165f699cf061651124d9eed",
     "whatwg-fetch": "^2.0.3"
   },
   "resolutions": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -17057,9 +17057,9 @@ verror@1.3.6:
   dependencies:
     extsprintf "1.0.2"
 
-"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#dfee66d46dcbd9bcc7631c02d25db39eed43b4f0":
-  version "6.3.0"
-  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#dfee66d46dcbd9bcc7631c02d25db39eed43b4f0"
+"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#458cb0a240755dbdd165f699cf061651124d9eed":
+  version "6.4.0"
+  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#458cb0a240755dbdd165f699cf061651124d9eed"
 
 vinyl-file@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## Description
Bring vets-json-schema up to current version, [6.4.0](https://github.com/department-of-veterans-affairs/vets-json-schema/blob/master/package.json#L3)

vets-api will be using 6.4.0 version when related PR is merged https://github.com/department-of-veterans-affairs/vets-api/pull/4587

## Testing done


## Screenshots


## Acceptance criteria

## Definition of done
- [n/a] Events are logged appropriately
- [n/a] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
