### PR TITLE
Use Telephone for all TTY numbers

### DIFF
--- a/package.json
+++ b/package.json
@@ -261,7 +261,7 @@
   "private": true,
   "dependencies": {
     "@department-of-veterans-affairs/formation": "6.9.5",
-    "@department-of-veterans-affairs/formation-react": "5.4.5",
+    "@department-of-veterans-affairs/formation-react": "5.4.7",
     "@department-of-veterans-affairs/react-jsonschema-form": "^1.0.0",
     "@fortawesome/fontawesome-free": "^5.6.3",
     "@mapbox/mapbox-sdk": "^0.10.0",

--- a/src/applications/auth/containers/AuthApp.jsx
+++ b/src/applications/auth/containers/AuthApp.jsx
@@ -5,6 +5,9 @@ import appendQuery from 'append-query';
 import * as Sentry from '@sentry/browser';
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 import LoadingIndicator from '@department-of-veterans-affairs/formation-react/LoadingIndicator';
+import Telephone, {
+  CONTACTS,
+} from '@department-of-veterans-affairs/formation-react/Telephone';
 
 import recordEvent from 'platform/monitoring/record-event';
 import { toggleLoginModal } from 'platform/site-wide/user-nav/actions';
@@ -318,13 +321,7 @@ export class AuthApp extends React.Component {
                   Call us at <a href="tel:877-327-0022">877-327-0022</a>. We’re
                   here Monday through Friday, 8:00 a.m. to 8:00 p.m. ET. If you
                   have hearing loss, call TTY:{' '}
-                  <a
-                    href="tel:800-877-3399"
-                    aria-label="8 0 0. 8 7 7. 3 3 9 9."
-                  >
-                    800-877-3399
-                  </a>
-                  .
+                  <Telephone contact={CONTACTS.FEDERAL_RELAY_SERVICE} />.
                 </p>
                 <p>
                   Tell the representative that you tried to sign in to VA.gov,

--- a/src/applications/caregivers/components/NeedHelpFooter/index.jsx
+++ b/src/applications/caregivers/components/NeedHelpFooter/index.jsx
@@ -1,4 +1,7 @@
 import React from 'react';
+import Telephone, {
+  CONTACTS,
+} from '@department-of-veterans-affairs/formation-react/Telephone';
 import { links } from 'applications/caregivers/definitions/content';
 
 const NeedHelpFooter = props => {
@@ -56,10 +59,7 @@ const NeedHelpFooter = props => {
           .<br />
           <span>
             If you have hearing loss, call{' '}
-            <a href="tel:711" aria-label="TTY. 7 1 1.">
-              TTY: 711
-            </a>
-            .
+            <Telephone contact={CONTACTS['711']} />.
           </span>
         </p>
       </div>

--- a/src/applications/caregivers/components/NeedHelpFooter/index.jsx
+++ b/src/applications/caregivers/components/NeedHelpFooter/index.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import Telephone, {
   CONTACTS,
+  PATTERNS,
 } from '@department-of-veterans-affairs/formation-react/Telephone';
 import { links } from 'applications/caregivers/definitions/content';
 
@@ -59,7 +60,7 @@ const NeedHelpFooter = props => {
           .<br />
           <span>
             If you have hearing loss, call{' '}
-            <Telephone contact={CONTACTS['711']} />.
+            <Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />.
           </span>
         </p>
       </div>

--- a/src/applications/disability-benefits/2346/components/FooterInfo.jsx
+++ b/src/applications/disability-benefits/2346/components/FooterInfo.jsx
@@ -1,14 +1,13 @@
 import React from 'react';
+import Telephone, {
+  CONTACTS,
+} from '@department-of-veterans-affairs/formation-react/Telephone';
 
 const FooterInfo = () => (
   <section className="need-help-footer row vads-u-padding-x--1p5">
     For benefit-related questions, or if the form isn’t working right, please
     call VA Benefits and Services at <a href="tel:800-827-1000">800-827-1000</a>
-    . If you have hearing loss, call{' '}
-    <a href="tel:711" aria-label="TTY. 7 1 1.">
-      TTY: 711
-    </a>
-    .
+    . If you have hearing loss, call <Telephone contact={CONTACTS['711']} />.
   </section>
 );
 

--- a/src/applications/disability-benefits/2346/components/FooterInfo.jsx
+++ b/src/applications/disability-benefits/2346/components/FooterInfo.jsx
@@ -1,13 +1,15 @@
 import React from 'react';
 import Telephone, {
   CONTACTS,
+  PATTERNS,
 } from '@department-of-veterans-affairs/formation-react/Telephone';
 
 const FooterInfo = () => (
   <section className="need-help-footer row vads-u-padding-x--1p5">
     For benefit-related questions, or if the form isn’t working right, please
     call VA Benefits and Services at <a href="tel:800-827-1000">800-827-1000</a>
-    . If you have hearing loss, call <Telephone contact={CONTACTS['711']} />.
+    . If you have hearin g loss, call{' '}
+    <Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />.
   </section>
 );
 

--- a/src/applications/disability-benefits/686c-674/components/GetFormHelp.jsx
+++ b/src/applications/disability-benefits/686c-674/components/GetFormHelp.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import Telephone, {
   CONTACTS,
+  PATTERNS,
 } from '@department-of-veterans-affairs/formation-react/Telephone';
 
 const GetFormHelp = () => (
@@ -12,7 +13,8 @@ const GetFormHelp = () => (
     </a>
     .<br />
     <br />
-    If you have hearing loss, call <Telephone contact={CONTACTS['711']} />.
+    If you have hearin g loss, call{' '}
+    <Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />.
   </p>
 );
 

--- a/src/applications/disability-benefits/686c-674/components/GetFormHelp.jsx
+++ b/src/applications/disability-benefits/686c-674/components/GetFormHelp.jsx
@@ -1,4 +1,7 @@
 import React from 'react';
+import Telephone, {
+  CONTACTS,
+} from '@department-of-veterans-affairs/formation-react/Telephone';
 
 const GetFormHelp = () => (
   <p className="help-talk">
@@ -9,11 +12,7 @@ const GetFormHelp = () => (
     </a>
     .<br />
     <br />
-    If you have hearing loss, call{' '}
-    <a href="tel:711" aria-label="TTY. 7 1 1.">
-      TTY: 711
-    </a>
-    .
+    If you have hearing loss, call <Telephone contact={CONTACTS['711']} />.
   </p>
 );
 

--- a/src/applications/disability-benefits/686c-674/config/helpers.js
+++ b/src/applications/disability-benefits/686c-674/config/helpers.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import Telephone, {
   CONTACTS,
+  PATTERNS,
 } from '@department-of-veterans-affairs/formation-react/Telephone';
 
 export const isChapterFieldRequired = (formData, option) =>
@@ -54,7 +55,7 @@ export const ServerErrorAlert = (
       <a href="tel:8446982311" aria-label="8 4 4. 6 9 8. 2 3 1 1.">
         844-698-2311
       </a>{' '}
-      (<Telephone contact={CONTACTS['711']} />
+      (<Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />
       ). We’re here Monday through Friday, 8:00 a.m. to 8:00 p.m. ET.
     </p>
   </>

--- a/src/applications/disability-benefits/686c-674/config/helpers.js
+++ b/src/applications/disability-benefits/686c-674/config/helpers.js
@@ -1,4 +1,7 @@
 import React from 'react';
+import Telephone, {
+  CONTACTS,
+} from '@department-of-veterans-affairs/formation-react/Telephone';
 
 export const isChapterFieldRequired = (formData, option) =>
   formData[`view:selectable686Options`][option];
@@ -51,10 +54,7 @@ export const ServerErrorAlert = (
       <a href="tel:8446982311" aria-label="8 4 4. 6 9 8. 2 3 1 1.">
         844-698-2311
       </a>{' '}
-      (
-      <a href="tel:711" aria-label="TTY. 7 1 1.">
-        TTY: 711
-      </a>
+      (<Telephone contact={CONTACTS['711']} />
       ). We’re here Monday through Friday, 8:00 a.m. to 8:00 p.m. ET.
     </p>
   </>

--- a/src/applications/disability-benefits/996/components/GetFormHelp.jsx
+++ b/src/applications/disability-benefits/996/components/GetFormHelp.jsx
@@ -1,4 +1,7 @@
 import React from 'react';
+import Telephone, {
+  CONTACTS,
+} from '@department-of-veterans-affairs/formation-react/Telephone';
 
 const GetFormHelp = () => (
   <p className="help-talk">
@@ -13,11 +16,7 @@ const GetFormHelp = () => (
     </a>
     .<br />
     <br />
-    If you have hearing loss, call{' '}
-    <a href="tel:711" aria-label="TTY. 7 1 1.">
-      TTY: 711
-    </a>
-    .
+    If you have hearing loss, call <Telephone contact={CONTACTS['711']} />.
   </p>
 );
 

--- a/src/applications/disability-benefits/996/components/GetFormHelp.jsx
+++ b/src/applications/disability-benefits/996/components/GetFormHelp.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import Telephone, {
   CONTACTS,
+  PATTERNS,
 } from '@department-of-veterans-affairs/formation-react/Telephone';
 
 const GetFormHelp = () => (
@@ -16,7 +17,8 @@ const GetFormHelp = () => (
     </a>
     .<br />
     <br />
-    If you have hearing loss, call <Telephone contact={CONTACTS['711']} />.
+    If you have hearin g loss, call{' '}
+    <Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />.
   </p>
 );
 

--- a/src/applications/disability-benefits/all-claims/containers/MissingServices.jsx
+++ b/src/applications/disability-benefits/all-claims/containers/MissingServices.jsx
@@ -23,9 +23,7 @@ export const MissingServices = () => {
         We need more information from you before you can file for disability
         compensation. Please call Veterans Benefits Assistance at{' '}
         <Telephone contact={CONTACTS.VA_BENEFITS} /> (
-        <a href="tel:711" aria-label="TTY. 7 1 1.">
-          TTY: 711
-        </a>
+        <Telephone contact={CONTACTS['711']} />
         ), Monday through Friday, 8:00 a.m. to 9:00 p.m. ET to update your
         account.
       </p>
@@ -45,9 +43,7 @@ export const MissingId = ({ children }) => {
         information before you can file for disability compensation. To update
         your account, please call Veterans Benefits Assistance at{' '}
         <Telephone contact={CONTACTS.VA_BENEFITS} /> (
-        <a href="tel:711" aria-label="TTY. 7 1 1.">
-          TTY: 711
-        </a>
+        <Telephone contact={CONTACTS['711']} />
         ). We’re here Monday through Friday, 8:00 a.m. to 9:00 p.m. ET.
       </p>
       <p>

--- a/src/applications/disability-benefits/all-claims/containers/MissingServices.jsx
+++ b/src/applications/disability-benefits/all-claims/containers/MissingServices.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 import Telephone, {
   CONTACTS,
+  PATTERNS,
 } from '@department-of-veterans-affairs/formation-react/Telephone';
 
 const Alert = ({ content }) => (
@@ -23,7 +24,7 @@ export const MissingServices = () => {
         We need more information from you before you can file for disability
         compensation. Please call Veterans Benefits Assistance at{' '}
         <Telephone contact={CONTACTS.VA_BENEFITS} /> (
-        <Telephone contact={CONTACTS['711']} />
+        <Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />
         ), Monday through Friday, 8:00 a.m. to 9:00 p.m. ET to update your
         account.
       </p>
@@ -43,7 +44,7 @@ export const MissingId = ({ children }) => {
         information before you can file for disability compensation. To update
         your account, please call Veterans Benefits Assistance at{' '}
         <Telephone contact={CONTACTS.VA_BENEFITS} /> (
-        <Telephone contact={CONTACTS['711']} />
+        <Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />
         ). We’re here Monday through Friday, 8:00 a.m. to 9:00 p.m. ET.
       </p>
       <p>

--- a/src/applications/facility-locator/components/VABenefitsCall.jsx
+++ b/src/applications/facility-locator/components/VABenefitsCall.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { parsePhoneNumber } from '../utils/phoneNumbers';
 import Telephone, {
   CONTACTS,
+  PATTERNS,
 } from '@department-of-veterans-affairs/formation-react/Telephone';
 
 export default function VABenefitsCall() {
@@ -14,8 +15,9 @@ export default function VABenefitsCall() {
       <p className="p1">
         <strong>To get help with benefits</strong>, call{' '}
         <Telephone contact={CONTACTS.VA_BENEFITS} /> toll-free. We’re here
-        Monday through Friday, 8:00 a.m. to 9:00 p.m. ET. If you have hearing
-        loss, call <Telephone contact={CONTACTS['711']} />.
+        Monday through Friday, 8:00 a.m. to 9:00 p.m. ET. If you have hearing{' '}
+        loss, call{' '}
+        <Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />.
       </p>
       <p className="p1">
         <strong>For other benefit questions</strong>, use our online customer

--- a/src/applications/facility-locator/components/VABenefitsCall.jsx
+++ b/src/applications/facility-locator/components/VABenefitsCall.jsx
@@ -15,7 +15,7 @@ export default function VABenefitsCall() {
         <strong>To get help with benefits</strong>, call{' '}
         <Telephone contact={CONTACTS.VA_BENEFITS} /> toll-free. We’re here
         Monday through Friday, 8:00 a.m. to 9:00 p.m. ET. If you have hearing
-        loss, call TTY 711.
+        loss, call <Telephone contact={CONTACTS['711']} />.
       </p>
       <p className="p1">
         <strong>For other benefit questions</strong>, use our online customer

--- a/src/applications/facility-locator/tests/components/VABenefitsCall.unit.spec.jsx
+++ b/src/applications/facility-locator/tests/components/VABenefitsCall.unit.spec.jsx
@@ -10,7 +10,7 @@ describe('<VABenefitsCall>', () => {
     expect(wrapper.find('div').length).to.equal(1);
     expect(wrapper.find('p').length).to.equal(3);
     expect(wrapper.find('a').length).to.equal(2);
-    expect(wrapper.find('Telephone').length).to.equal(1);
+    expect(wrapper.find('Telephone').length).to.equal(2);
     wrapper.unmount();
   });
 });

--- a/src/applications/gi/components/vet-tec/VetTecApplicationProcess.jsx
+++ b/src/applications/gi/components/vet-tec/VetTecApplicationProcess.jsx
@@ -1,4 +1,7 @@
 import React from 'react';
+import Telephone, {
+  CONTACTS,
+} from '@department-of-veterans-affairs/formation-react/Telephone';
 
 class VetTecApplicationProcess extends React.Component {
   providersWebsiteLink = () => {
@@ -67,11 +70,9 @@ class VetTecApplicationProcess extends React.Component {
           <li>
             Call us at 888-GIBILL-1 (<a href="tel:+18884424551">888-442-4551</a>
             ). We’re here Monday through Friday, 8:00a.m. to 7:00 p.m. ET. If
-            you have hearing loss, call{' '}
-            <a href="tel:711" aria-label="TTY. 7 1 1.">
-              TTY: 711
-            </a>
-            , <b>or</b>
+            you have hearing loss, call <Telephone
+              contact={CONTACTS['711']}
+            />, <b>or</b>
           </li>
           <li>
             Email us at{' '}

--- a/src/applications/gi/components/vet-tec/VetTecApplicationProcess.jsx
+++ b/src/applications/gi/components/vet-tec/VetTecApplicationProcess.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import Telephone, {
   CONTACTS,
+  PATTERNS,
 } from '@department-of-veterans-affairs/formation-react/Telephone';
 
 class VetTecApplicationProcess extends React.Component {
@@ -70,8 +71,10 @@ class VetTecApplicationProcess extends React.Component {
           <li>
             Call us at 888-GIBILL-1 (<a href="tel:+18884424551">888-442-4551</a>
             ). We’re here Monday through Friday, 8:00a.m. to 7:00 p.m. ET. If
-            you have hearing loss, call <Telephone
+            you have hearing loss, call{' '}
+            <Telephone
               contact={CONTACTS['711']}
+              pattern={PATTERNS['911']}
             />, <b>or</b>
           </li>
           <li>

--- a/src/applications/hca/components/GetFormHelp.jsx
+++ b/src/applications/hca/components/GetFormHelp.jsx
@@ -1,4 +1,7 @@
 import React from 'react';
+import Telephone, {
+  CONTACTS,
+} from '@department-of-veterans-affairs/formation-react/Telephone';
 
 function GetFormHelp() {
   return (
@@ -13,13 +16,10 @@ function GetFormHelp() {
         </a>
         <br />
         TTY:{' '}
-        <a
+        <Telephone
           className="help-phone-number-link"
-          href="tel:1-800-877-8339"
-          aria-label="8 0 0. 8 7 7. 8 3 3 9."
-        >
-          800-877-8339
-        </a>
+          contact={CONTACTS.HELP_TTY}
+        />
         <br />
         Monday &#8211; Friday, 8:00 a.m. &#8211; 8:00 p.m. ET
       </p>

--- a/src/applications/hca/containers/IntroductionPage.jsx
+++ b/src/applications/hca/containers/IntroductionPage.jsx
@@ -6,6 +6,9 @@ import LoadingIndicator from '@department-of-veterans-affairs/formation-react/Lo
 import OMBInfo from '@department-of-veterans-affairs/formation-react/OMBInfo';
 import HealthcareModalContent from 'platform/forms/components/OMBInfoModalContent/HealthcareModalContent';
 import FormTitle from 'platform/forms-system/src/js/components/FormTitle';
+import Telephone, {
+  CONTACTS,
+} from '@department-of-veterans-affairs/formation-react/Telephone';
 
 import { focusElement } from 'platform/utilities/ui';
 import { toggleLoginModal } from 'platform/site-wide/user-nav/actions';
@@ -61,10 +64,8 @@ const VerificationRequiredAlert = () => (
           <li>
             Or call us at <a href="tel:+18772228387">877-222-8387</a>. If you
             have hearing loss, call TTY:{' '}
-            <a href="tel:8008778339" aria-label="8 0 0. 8 7 7. 8 3 3 9.">
-              800-877-8339
-            </a>
-            . We’re here Monday through Friday, 8:00 a.m. to 8:00 p.m. ET.
+            <Telephone contact={CONTACTS.HELP_TTY} />. We’re here Monday through
+            Friday, 8:00 a.m. to 8:00 p.m. ET.
           </li>
         </ul>
         <p>

--- a/src/applications/personalization/profile-2/components/MilitaryInformation.jsx
+++ b/src/applications/personalization/profile-2/components/MilitaryInformation.jsx
@@ -5,6 +5,9 @@ import { connect } from 'react-redux';
 
 import AdditionalInfo from '@department-of-veterans-affairs/formation-react/AdditionalInfo';
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
+import Telephone, {
+  CONTACTS,
+} from '@department-of-veterans-affairs/formation-react/Telephone';
 
 import recordEvent from 'platform/monitoring/record-event';
 import DowntimeNotification, {
@@ -135,14 +138,7 @@ const MilitaryInformationContent = ({ militaryInformation }) => {
             </a>
             , Monday through Friday (except federal holidays), 8:00 a.m. to 8:00
             p.m. ET. If you have hearing loss, call TTY:{' '}
-            <a
-              href="tel:1-866-363-2883"
-              aria-label="1. 8 6 6. 3 6 3. 2 8 8 3."
-              className="no-wrap"
-            >
-              1-866-363-2883
-            </a>
-            .
+            <Telephone contact={CONTACTS.DS_LOGON_TTY} />.
           </p>
         </AdditionalInfo>
       </div>

--- a/src/applications/personalization/profile-2/components/connected-apps/AdditionalInfoSections.jsx
+++ b/src/applications/personalization/profile-2/components/connected-apps/AdditionalInfoSections.jsx
@@ -6,6 +6,7 @@ import AdditionalInfo from '@department-of-veterans-affairs/formation-react/Addi
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 import Telephone, {
   CONTACTS,
+  PATTERNS,
 } from '@department-of-veterans-affairs/formation-react/Telephone';
 
 import { focusElement } from 'platform/utilities/ui';
@@ -109,9 +110,13 @@ export const AdditionalInfoSections = ({ activeApps }) => {
               </li>
               <li className="vads-u-padding-left--1">
                 <strong>If your information isn’t accurate:</strong> Call VA311
-                at <Telephone contact={CONTACTS.VA_311} />. If you have hearing
-                loss, call <Telephone contact={CONTACTS['711']} />. Or visit a
-                VA health facility near you and ask a staff member for help.{' '}
+                at <Telephone contact={CONTACTS.VA_311} />. If you have hearing{' '}
+                <Telephone
+                  contact={CONTACTS['711']}
+                  pattern={PATTERNS['911']}
+                />
+                . Or visit a VA health facility near you and ask a staff member
+                staff member for help.{' '}
                 <p>
                   <a href="/find-locations">
                     Find a VA health facility near you

--- a/src/applications/personalization/profile-2/components/connected-apps/AdditionalInfoSections.jsx
+++ b/src/applications/personalization/profile-2/components/connected-apps/AdditionalInfoSections.jsx
@@ -116,7 +116,7 @@ export const AdditionalInfoSections = ({ activeApps }) => {
                   pattern={PATTERNS['911']}
                 />
                 . Or visit a VA health facility near you and ask a staff member
-                staff member for help.{' '}
+                for help.{' '}
                 <p>
                   <a href="/find-locations">
                     Find a VA health facility near you

--- a/src/applications/personalization/profile-2/components/connected-apps/AdditionalInfoSections.jsx
+++ b/src/applications/personalization/profile-2/components/connected-apps/AdditionalInfoSections.jsx
@@ -110,12 +110,8 @@ export const AdditionalInfoSections = ({ activeApps }) => {
               <li className="vads-u-padding-left--1">
                 <strong>If your information isn’t accurate:</strong> Call VA311
                 at <Telephone contact={CONTACTS.VA_311} />. If you have hearing
-                loss, call{' '}
-                <a href="tel:711" aria-label="TTY. 7 1 1.">
-                  TTY: 711
-                </a>
-                . Or visit a VA health facility near you and ask a staff member
-                for help.{' '}
+                loss, call <Telephone contact={CONTACTS['711']} />. Or visit a
+                VA health facility near you and ask a staff member for help.{' '}
                 <p>
                   <a href="/find-locations">
                     Find a VA health facility near you

--- a/src/applications/personalization/profile-2/components/direct-deposit/FraudVictimAlert.jsx
+++ b/src/applications/personalization/profile-2/components/direct-deposit/FraudVictimAlert.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 import Telephone, {
   CONTACTS,
+  PATTERNS,
 } from '@department-of-veterans-affairs/formation-react/Telephone';
 
 const FraudVictimAlert = () => (
@@ -19,7 +20,7 @@ const FraudVictimAlert = () => (
     >
       800-827-1000
     </a>{' '}
-    (<Telephone contact={CONTACTS['711']} />
+    (<Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />
     ). We’re here Monday through Friday, 8:00 a.m. to 9:00 p.m. ET.
   </AlertBox>
 );

--- a/src/applications/personalization/profile-2/components/direct-deposit/FraudVictimAlert.jsx
+++ b/src/applications/personalization/profile-2/components/direct-deposit/FraudVictimAlert.jsx
@@ -1,5 +1,8 @@
 import React from 'react';
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
+import Telephone, {
+  CONTACTS,
+} from '@department-of-veterans-affairs/formation-react/Telephone';
 
 const FraudVictimAlert = () => (
   <AlertBox
@@ -16,10 +19,7 @@ const FraudVictimAlert = () => (
     >
       800-827-1000
     </a>{' '}
-    (
-    <a href="tel:711" aria-label="TTY. 7 1 1.">
-      TTY: 711
-    </a>
+    (<Telephone contact={CONTACTS['711']} />
     ). We’re here Monday through Friday, 8:00 a.m. to 9:00 p.m. ET.
   </AlertBox>
 );

--- a/src/applications/personalization/profile360/components/MilitaryInformation.jsx
+++ b/src/applications/personalization/profile360/components/MilitaryInformation.jsx
@@ -122,9 +122,8 @@ class MilitaryInformationContent extends React.Component {
             work with you to update your information in DEERS.
           </p>
           <p>
-            To reach the DMDC, call{' '}
-            <Telephone contact={CONTACTS.DS_LOGON} />
-            , Monday through Friday (except federal holidays), 8:00 a.m. to 8:00
+            To reach the DMDC, call <Telephone contact={CONTACTS.DS_LOGON} />,
+            Monday through Friday (except federal holidays), 8:00 a.m. to 8:00
             p.m. ET. If you have hearing loss, call TTY:{' '}
             <Telephone contact={CONTACTS.DMDC_DEERS} />
             <Telephone contact={CONTACTS.DS_LOGON_TTY} />.

--- a/src/applications/personalization/profile360/components/MilitaryInformation.jsx
+++ b/src/applications/personalization/profile360/components/MilitaryInformation.jsx
@@ -10,6 +10,9 @@ import LoadingSection from './LoadingSection';
 import { handleDowntimeForSection } from './DowntimeBanner';
 import AdditionalInfo from '@department-of-veterans-affairs/formation-react/AdditionalInfo';
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
+import Telephone, {
+  CONTACTS,
+} from '@department-of-veterans-affairs/formation-react/Telephone';
 
 import recordEvent from 'platform/monitoring/record-event';
 import facilityLocator from 'applications/facility-locator/manifest.json';
@@ -128,7 +131,7 @@ class MilitaryInformationContent extends React.Component {
             <a href="tel:18663632883" aria-label="1. 8 6 6. 3 6 3. 2 8 8 3.">
               1-866-363-2883
             </a>
-            .
+            <Telephone contact={CONTACTS.DS_LOGON_TTY} />.
           </p>
         </AdditionalInfo>
         <LoadingSection

--- a/src/applications/personalization/profile360/components/MilitaryInformation.jsx
+++ b/src/applications/personalization/profile360/components/MilitaryInformation.jsx
@@ -123,14 +123,10 @@ class MilitaryInformationContent extends React.Component {
           </p>
           <p>
             To reach the DMDC, call{' '}
-            <a href="tel:18005389552" aria-label="1. 8 0 0. 5 3 8. 9 5 5 2.">
-              1-800-538-9552
-            </a>
+            <Telephone contact={CONTACTS.DS_LOGON} />
             , Monday through Friday (except federal holidays), 8:00 a.m. to 8:00
             p.m. ET. If you have hearing loss, call TTY:{' '}
-            <a href="tel:18663632883" aria-label="1. 8 6 6. 3 6 3. 2 8 8 3.">
-              1-866-363-2883
-            </a>
+            <Telephone contact={CONTACTS.DMDC_DEERS} />
             <Telephone contact={CONTACTS.DS_LOGON_TTY} />.
           </p>
         </AdditionalInfo>

--- a/src/applications/personalization/profile360/components/PaymentInformationBlocked.jsx
+++ b/src/applications/personalization/profile360/components/PaymentInformationBlocked.jsx
@@ -1,5 +1,8 @@
 import React from 'react';
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
+import Telephone, {
+  CONTACTS,
+} from '@department-of-veterans-affairs/formation-react/Telephone';
 
 export default function PaymentInformationBlocked() {
   return (
@@ -23,10 +26,7 @@ export default function PaymentInformationBlocked() {
         >
           855-574-7286
         </a>{' '}
-        (
-        <a href="tel:711" aria-label="TTY. 7 1 1.">
-          TTY: 711
-        </a>
+        (<Telephone contact={CONTACTS['711']} />
         ). We’re here Monday &#8211; Friday, 8 a.m. &#8211; 8 p.m. ET.
       </p>
     </AlertBox>

--- a/src/applications/personalization/profile360/components/PaymentInformationBlocked.jsx
+++ b/src/applications/personalization/profile360/components/PaymentInformationBlocked.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 import Telephone, {
   CONTACTS,
+  PATTERNS,
 } from '@department-of-veterans-affairs/formation-react/Telephone';
 
 export default function PaymentInformationBlocked() {
@@ -26,7 +27,7 @@ export default function PaymentInformationBlocked() {
         >
           855-574-7286
         </a>{' '}
-        (<Telephone contact={CONTACTS['711']} />
+        (<Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />
         ). We’re here Monday &#8211; Friday, 8 a.m. &#8211; 8 p.m. ET.
       </p>
     </AlertBox>

--- a/src/applications/personalization/profile360/components/PaymentInformationEditModalError.jsx
+++ b/src/applications/personalization/profile360/components/PaymentInformationEditModalError.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 import Telephone, {
   CONTACTS,
+  PATTERNS,
 } from '@department-of-veterans-affairs/formation-react/Telephone';
 
 import {
@@ -28,7 +29,7 @@ function FlaggedAccount() {
         <span className="no-wrap">
           <a href="tel:1-800-827-1000">800-827-1000</a>
         </span>{' '}
-        (<Telephone contact={CONTACTS['711']} />
+        (<Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />
         ). We’re here Monday through Friday, 8:00 a.m. to 9:00 p.m. ET.
       </p>
     </>
@@ -45,7 +46,7 @@ function FlaggedRoutingNumber() {
         <span className="no-wrap">
           <a href="tel:1-800-827-1000">800-827-1000</a>
         </span>{' '}
-        (<Telephone contact={CONTACTS['711']} />
+        (<Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />
         ). We’re here Monday through Friday, 8:00 a.m. to 9:00 p.m. ET.
       </p>
       <p>

--- a/src/applications/personalization/profile360/components/PaymentInformationEditModalError.jsx
+++ b/src/applications/personalization/profile360/components/PaymentInformationEditModalError.jsx
@@ -1,5 +1,8 @@
 import React from 'react';
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
+import Telephone, {
+  CONTACTS,
+} from '@department-of-veterans-affairs/formation-react/Telephone';
 
 import {
   hasAccountFlaggedError,
@@ -25,10 +28,7 @@ function FlaggedAccount() {
         <span className="no-wrap">
           <a href="tel:1-800-827-1000">800-827-1000</a>
         </span>{' '}
-        (
-        <a href="tel:711" aria-label="TTY. 7 1 1.">
-          TTY: <span className="no-wrap">711</span>
-        </a>
+        (<Telephone contact={CONTACTS['711']} />
         ). We’re here Monday through Friday, 8:00 a.m. to 9:00 p.m. ET.
       </p>
     </>
@@ -45,10 +45,7 @@ function FlaggedRoutingNumber() {
         <span className="no-wrap">
           <a href="tel:1-800-827-1000">800-827-1000</a>
         </span>{' '}
-        (
-        <a href="tel:711" aria-label="TTY. 7 1 1.">
-          TTY: 711
-        </a>
+        (<Telephone contact={CONTACTS['711']} />
         ). We’re here Monday through Friday, 8:00 a.m. to 9:00 p.m. ET.
       </p>
       <p>

--- a/src/applications/personalization/profile360/containers/PaymentInformation.jsx
+++ b/src/applications/personalization/profile360/containers/PaymentInformation.jsx
@@ -6,6 +6,7 @@ import LoadingIndicator from '@department-of-veterans-affairs/formation-react/Lo
 import AdditionalInfo from '@department-of-veterans-affairs/formation-react/AdditionalInfo';
 import Telephone, {
   CONTACTS,
+  PATTERNS,
 } from '@department-of-veterans-affairs/formation-react/Telephone';
 
 import DowntimeNotification, {
@@ -227,7 +228,7 @@ class PaymentInformation extends React.Component {
               <a href="tel:1-800-827-1000" className="no-wrap">
                 800-827-1000
               </a>{' '}
-              (<Telephone contact={CONTACTS['711']} />
+              (<Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />
               ). We’re here Monday through Friday, 8:00 a.m. to 9:00 p.m. ET.
             </p>
           )}

--- a/src/applications/personalization/profile360/containers/PaymentInformation.jsx
+++ b/src/applications/personalization/profile360/containers/PaymentInformation.jsx
@@ -4,6 +4,9 @@ import { connect } from 'react-redux';
 
 import LoadingIndicator from '@department-of-veterans-affairs/formation-react/LoadingIndicator';
 import AdditionalInfo from '@department-of-veterans-affairs/formation-react/AdditionalInfo';
+import Telephone, {
+  CONTACTS,
+} from '@department-of-veterans-affairs/formation-react/Telephone';
 
 import DowntimeNotification, {
   externalServices,
@@ -224,10 +227,7 @@ class PaymentInformation extends React.Component {
               <a href="tel:1-800-827-1000" className="no-wrap">
                 800-827-1000
               </a>{' '}
-              (
-              <a href="tel:711" aria-label="TTY. 7 1 1.">
-                TTY: 711
-              </a>
+              (<Telephone contact={CONTACTS['711']} />
               ). We’re here Monday through Friday, 8:00 a.m. to 9:00 p.m. ET.
             </p>
           )}

--- a/src/applications/personalization/profile360/tests/components/PaymentInformationEditModalError.unit.spec.jsx
+++ b/src/applications/personalization/profile360/tests/components/PaymentInformationEditModalError.unit.spec.jsx
@@ -277,7 +277,7 @@ describe('<PaymentInformationEditModalError />', () => {
       />,
     );
     expect(wrapper.html()).to.contain(
-      'We’re sorry. The bank routing number you entered requires additional verification before we can save your information. To use this bank routing number, you’ll need to call us at <span class="no-wrap"><a href="tel:1-800-827-1000">800-827-1000</a></span> (<a href="tel:711" aria-label="TTY. 7 1 1.">TTY: 711</a>). We’re here Monday through Friday, 8:00 a.m. to 9:00 p.m. ET.',
+      'We’re sorry. The bank routing number you entered requires additional verification before we can save your information. To use this bank routing number, you’ll need to call us at <span class="no-wrap"><a href="tel:1-800-827-1000">800-827-1000</a></span> (<a class="no-wrap" href="tel:+1711" aria-label="TTY: 7 1 1.">711</a>). We’re here Monday through Friday, 8:00 a.m. to 9:00 p.m. ET.',
     );
     wrapper.unmount();
   });

--- a/src/applications/personalization/profile360/tests/components/PaymentInformationEditModalError.unit.spec.jsx
+++ b/src/applications/personalization/profile360/tests/components/PaymentInformationEditModalError.unit.spec.jsx
@@ -277,7 +277,7 @@ describe('<PaymentInformationEditModalError />', () => {
       />,
     );
     expect(wrapper.html()).to.contain(
-      'We’re sorry. The bank routing number you entered requires additional verification before we can save your information. To use this bank routing number, you’ll need to call us at <span class="no-wrap"><a href="tel:1-800-827-1000">800-827-1000</a></span> (<a class="no-wrap" href="tel:+1711" aria-label="TTY: 7 1 1.">711</a>). We’re here Monday through Friday, 8:00 a.m. to 9:00 p.m. ET.',
+      'We’re sorry. The bank routing number you entered requires additional verification before we can save your information. To use this bank routing number, you’ll need to call us at <span class="no-wrap"><a href="tel:1-800-827-1000">800-827-1000</a></span> (<a class="no-wrap " href="tel:+1711" aria-label="TTY: 7 1 1.">711</a>). We’re here Monday through Friday, 8:00 a.m. to 9:00 p.m. ET.',
     );
     wrapper.unmount();
   });

--- a/src/applications/personalization/rated-disabilities/components/RatedDisabilityList.jsx
+++ b/src/applications/personalization/rated-disabilities/components/RatedDisabilityList.jsx
@@ -4,6 +4,7 @@ import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 import LoadingIndicator from '@department-of-veterans-affairs/formation-react/LoadingIndicator';
 import Telephone, {
   CONTACTS,
+  PATTERNS,
 } from '@department-of-veterans-affairs/formation-react/Telephone';
 import moment from 'moment';
 import RatedDisabilityListItem from './RatedDisabilityListItem';
@@ -44,7 +45,7 @@ class RatedDisabilityList extends React.Component {
             >
               844-698-2311
             </a>{' '}
-            (<Telephone contact={CONTACTS['711']} />
+            (<Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />
             ). We’re here Monday-Friday, 8:00 a.m.-8:00 p.m. ET.
           </p>
         </>

--- a/src/applications/personalization/rated-disabilities/components/RatedDisabilityList.jsx
+++ b/src/applications/personalization/rated-disabilities/components/RatedDisabilityList.jsx
@@ -2,6 +2,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 import LoadingIndicator from '@department-of-veterans-affairs/formation-react/LoadingIndicator';
+import Telephone, {
+  CONTACTS,
+} from '@department-of-veterans-affairs/formation-react/Telephone';
 import moment from 'moment';
 import RatedDisabilityListItem from './RatedDisabilityListItem';
 import { isServerError } from '../util';
@@ -41,10 +44,7 @@ class RatedDisabilityList extends React.Component {
             >
               844-698-2311
             </a>{' '}
-            (
-            <a href="tel:711" aria-label="TTY. 7 1 1.">
-              TTY: 711
-            </a>
+            (<Telephone contact={CONTACTS['711']} />
             ). We’re here Monday-Friday, 8:00 a.m.-8:00 p.m. ET.
           </p>
         </>

--- a/src/applications/personalization/rated-disabilities/components/TotalRatingStates.jsx
+++ b/src/applications/personalization/rated-disabilities/components/TotalRatingStates.jsx
@@ -3,6 +3,7 @@ import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 import recordEvent from 'platform/monitoring/record-event';
 import Telephone, {
   CONTACTS,
+  PATTERNS,
 } from '@department-of-veterans-affairs/formation-react/Telephone';
 
 export const errorMessage = () => {
@@ -24,7 +25,7 @@ export const errorMessage = () => {
         >
           844-698-2311
         </a>{' '}
-        (<Telephone contact={CONTACTS['711']} />
+        (<Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />
         ). We’re here Monday-Friday, 8:00 a.m.-8:00 p.m. ET.
       </p>
     </>

--- a/src/applications/personalization/rated-disabilities/components/TotalRatingStates.jsx
+++ b/src/applications/personalization/rated-disabilities/components/TotalRatingStates.jsx
@@ -1,6 +1,9 @@
 import React from 'react';
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 import recordEvent from 'platform/monitoring/record-event';
+import Telephone, {
+  CONTACTS,
+} from '@department-of-veterans-affairs/formation-react/Telephone';
 
 export const errorMessage = () => {
   const message = (
@@ -21,10 +24,7 @@ export const errorMessage = () => {
         >
           844-698-2311
         </a>{' '}
-        (
-        <a href="tel:711" aria-label="TTY. 7 1 1.">
-          TTY: 711
-        </a>
+        (<Telephone contact={CONTACTS['711']} />
         ). We’re here Monday-Friday, 8:00 a.m.-8:00 p.m. ET.
       </p>
     </>

--- a/src/applications/personalization/view-dependents/layouts/helpers.jsx
+++ b/src/applications/personalization/view-dependents/layouts/helpers.jsx
@@ -1,4 +1,7 @@
 import React from 'react';
+import Telephone, {
+  CONTACTS,
+} from '@department-of-veterans-affairs/formation-react/Telephone';
 
 export const errorFragment = (
   <>
@@ -12,10 +15,7 @@ export const errorFragment = (
       <a aria-label="8 4 4. 6 9 8. 2 3 1 1." href="tel:8446982311">
         844-698-2311
       </a>{' '}
-      (
-      <a href="tel:711" aria-label="TTY. 7 1 1.">
-        TTY: 711
-      </a>
+      (<Telephone contact={CONTACTS['711']} />
       ). We're here Monday-Friday, 8:00a.m.-8:00p.m. ET.
     </p>
   </>

--- a/src/applications/personalization/view-dependents/layouts/helpers.jsx
+++ b/src/applications/personalization/view-dependents/layouts/helpers.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import Telephone, {
   CONTACTS,
+  PATTERNS,
 } from '@department-of-veterans-affairs/formation-react/Telephone';
 
 export const errorFragment = (
@@ -15,7 +16,7 @@ export const errorFragment = (
       <a aria-label="8 4 4. 6 9 8. 2 3 1 1." href="tel:8446982311">
         844-698-2311
       </a>{' '}
-      (<Telephone contact={CONTACTS['711']} />
+      (<Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />
       ). We're here Monday-Friday, 8:00a.m.-8:00p.m. ET.
     </p>
   </>

--- a/src/applications/static-pages/health-care-manage-benefits/get-medical-records-page/components/AuthContent/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/get-medical-records-page/components/AuthContent/index.js
@@ -1,5 +1,8 @@
 // Node modules.
 import React from 'react';
+import Telephone, {
+  CONTACTS,
+} from '@department-of-veterans-affairs/formation-react/Telephone';
 // Relative imports.
 import CallToActionWidget from 'platform/site-wide/cta-widget';
 import CernerCallToAction from '../../../components/CernerCallToAction';
@@ -325,9 +328,7 @@ const AuthContent = () => (
               </p>
               <p>
                 Or call us at <a href="tel:+18773270022">877-327-0022</a> (TTY:{' '}
-                <a href="tel:+18008778339" aria-label="8 0 0. 8 7 7. 8 3 3 9.">
-                  800-877-8339
-                </a>
+                <Telephone contact={CONTACTS.HELP_TTY} />
                 ). We’re here Monday through Friday, 8:00 a.m. to 8:00 p.m. ET.
               </p>
               <p>

--- a/src/applications/static-pages/health-care-manage-benefits/get-medical-records-page/components/LegacyContent/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/get-medical-records-page/components/LegacyContent/index.js
@@ -1,5 +1,8 @@
 // Node modules.
 import React from 'react';
+import Telephone, {
+  CONTACTS,
+} from '@department-of-veterans-affairs/formation-react/Telephone';
 // Relative imports.
 import CallToActionWidget from 'platform/site-wide/cta-widget';
 
@@ -301,10 +304,7 @@ const LegacyContent = () => (
                 <a aria-label="8 7 7. 3 2 7. 0 0 2 2." href="tel:18773270022">
                   877-327-0022
                 </a>{' '}
-                (TTY:{' '}
-                <a aria-label="8 0 0. 8 7 7. 8 3 3 9." href="tel:18008778339">
-                  800-877-8339
-                </a>
+                (TTY: <Telephone contact={CONTACTS.HELP_TTY} />
                 ). We’re here Monday through Friday, 8:00 a.m. to 8:00 p.m. ET.
               </p>
             </div>

--- a/src/applications/static-pages/health-care-manage-benefits/get-medical-records-page/components/UnauthContent/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/get-medical-records-page/components/UnauthContent/index.js
@@ -1,5 +1,8 @@
 // Node modules.
 import React from 'react';
+import Telephone, {
+  CONTACTS,
+} from '@department-of-veterans-affairs/formation-react/Telephone';
 // Relative imports.
 import CallToActionWidget from 'platform/site-wide/cta-widget';
 
@@ -243,9 +246,7 @@ const UnauthContent = () => (
               </p>
               <p>
                 Or call us at <a href="tel:+18773270022">877-327-0022</a> (TTY:{' '}
-                <a href="tel:+18008778339" aria-label="8 0 0. 8 7 7. 8 3 3 9.">
-                  800-877-8339
-                </a>
+                <Telephone contact={CONTACTS.HELP_TTY} />
                 ). We’re here Monday through Friday, 8:00 a.m. to 8:00 p.m. ET.
               </p>
             </div>

--- a/src/applications/static-pages/health-care-manage-benefits/refill-track-prescriptions-page/components/AuthContent/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/refill-track-prescriptions-page/components/AuthContent/index.js
@@ -1,5 +1,8 @@
 // Node modules.
 import React from 'react';
+import Telephone, {
+  CONTACTS,
+} from '@department-of-veterans-affairs/formation-react/Telephone';
 // Relative imports.
 import CallToActionWidget from 'platform/site-wide/cta-widget';
 import CernerCallToAction from '../../../components/CernerCallToAction';
@@ -355,11 +358,8 @@ export const AuthContent = () => (
               <p>
                 Or contact the My HealtheVet help desk at{' '}
                 <a href="tel:+18773270022">877-327-0022</a> (TTY:{' '}
-                <a href="tel:+18008778339" aria-label="8 0 0. 8 7 7. 8 3 3 9.">
-                  800-877-8339
-                </a>
-                . We&apos;re here Monday through Friday, 7:00 a.m. to 7:00 p.m.
-                CT.
+                <Telephone contact={CONTACTS.HELP_TTY} />. We&apos;re here
+                Monday through Friday, 7:00 a.m. to 7:00 p.m. CT.
               </p>
               <p>
                 You can also{' '}

--- a/src/applications/static-pages/health-care-manage-benefits/refill-track-prescriptions-page/components/LegacyContent/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/refill-track-prescriptions-page/components/LegacyContent/index.js
@@ -1,5 +1,8 @@
 // Node modules.
 import React from 'react';
+import Telephone, {
+  CONTACTS,
+} from '@department-of-veterans-affairs/formation-react/Telephone';
 // Relative imports.
 import CallToActionWidget from 'platform/site-wide/cta-widget';
 
@@ -399,10 +402,7 @@ export const LegacyContent = () => (
                 <a aria-label="8 7 7. 3 2 7. 0 0 2 2." href="tel:18773270022">
                   877-327-0022
                 </a>{' '}
-                (TTY:{' '}
-                <a aria-label="8 0 0. 8 7 7. 8 3 3 9." href="tel:18008778339">
-                  800-877-8339
-                </a>
+                (TTY: <Telephone contact={CONTACTS.HELP_TTY} />
                 ). We’re here Monday through Friday, 7:00 a.m. to 7:00 p.m. CT.
               </p>
             </div>

--- a/src/applications/static-pages/health-care-manage-benefits/refill-track-prescriptions-page/components/UnauthContent/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/refill-track-prescriptions-page/components/UnauthContent/index.js
@@ -1,5 +1,8 @@
 // Node modules.
 import React from 'react';
+import Telephone, {
+  CONTACTS,
+} from '@department-of-veterans-affairs/formation-react/Telephone';
 // Relative imports.
 import CallToActionWidget from 'platform/site-wide/cta-widget';
 
@@ -296,11 +299,8 @@ export const UnauthContent = () => (
               <p>
                 Or contact the My HealtheVet help desk at{' '}
                 <a href="tel:+18773270022">877-327-0022</a> (TTY:{' '}
-                <a href="tel:+18008778339" aria-label="8 0 0. 8 7 7. 8 3 3 9.">
-                  800-877-8339
-                </a>
-                . We&apos;re here Monday through Friday, 7:00 a.m. to 7:00 p.m.
-                CT.
+                <Telephone contact={CONTACTS.HELP_TTY} />. We&apos;re here
+                Monday through Friday, 7:00 a.m. to 7:00 p.m. CT.
               </p>
               <p>
                 You can also{' '}

--- a/src/applications/static-pages/health-care-manage-benefits/schedule-view-va-appointments-page/components/AuthContent/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/schedule-view-va-appointments-page/components/AuthContent/index.js
@@ -1,5 +1,8 @@
 // Node modules.
 import React from 'react';
+import Telephone, {
+  CONTACTS,
+} from '@department-of-veterans-affairs/formation-react/Telephone';
 // Relative imports.
 import CallToActionWidget from 'platform/site-wide/cta-widget';
 import CernerCallToAction from '../../../components/CernerCallToAction';
@@ -317,11 +320,8 @@ export const AuthContent = () => (
               <p>
                 Or contact the My HealtheVet help desk at{' '}
                 <a href="tel:+18773270022">877-327-0022</a> (TTY:{' '}
-                <a href="tel:+18008778339" aria-label="8 0 0. 8 7 7. 8 3 3 9.">
-                  800-877-8339
-                </a>
-                . We&apos;re here Monday through Friday, 7:00 a.m. to 7:00 p.m.
-                CT.
+                <Telephone contact={CONTACTS.HELP_TTY} />. We&apos;re here
+                Monday through Friday, 7:00 a.m. to 7:00 p.m. CT.
               </p>
               <p>
                 You can also{' '}

--- a/src/applications/static-pages/health-care-manage-benefits/schedule-view-va-appointments-page/components/LegacyContent/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/schedule-view-va-appointments-page/components/LegacyContent/index.js
@@ -1,5 +1,8 @@
 // Node modules.
 import React from 'react';
+import Telephone, {
+  CONTACTS,
+} from '@department-of-veterans-affairs/formation-react/Telephone';
 // Relative imports.
 import CallToActionWidget from 'platform/site-wide/cta-widget';
 
@@ -444,10 +447,7 @@ export const LegacyContent = () => (
                 <a aria-label="8 7 7. 3 2 7. 0 0 2 2." href="tel:18773270022">
                   877-327-0022
                 </a>{' '}
-                (TTY:{' '}
-                <a aria-label="8 0 0. 8 7 7. 8 3 3 9." href="tel:18008778339">
-                  800-877-8339
-                </a>
+                (TTY: <Telephone contact={CONTACTS.HELP_TTY} />
                 ). We’re here Monday through Friday, 7:00 a.m. to 7:00 p.m. CT.
               </p>
             </div>

--- a/src/applications/static-pages/health-care-manage-benefits/schedule-view-va-appointments-page/components/UnauthContent/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/schedule-view-va-appointments-page/components/UnauthContent/index.js
@@ -1,5 +1,8 @@
 // Node modules.
 import React from 'react';
+import Telephone, {
+  CONTACTS,
+} from '@department-of-veterans-affairs/formation-react/Telephone';
 // Relative imports.
 import CallToActionWidget from 'platform/site-wide/cta-widget';
 
@@ -329,11 +332,8 @@ export const UnauthContent = () => (
               <p>
                 Or contact the My HealtheVet help desk at{' '}
                 <a href="tel:+18773270022">877-327-0022</a> (TTY:{' '}
-                <a href="tel:+18008778339" aria-label="8 0 0. 8 7 7. 8 3 3 9.">
-                  800-877-8339
-                </a>
-                . We&apos;re here Monday through Friday, 7:00 a.m. to 7:00 p.m.
-                CT.
+                <Telephone contact={CONTACTS.HELP_TTY} />. We&apos;re here
+                Monday through Friday, 7:00 a.m. to 7:00 p.m. CT.
               </p>
               <p>
                 You can also{' '}

--- a/src/applications/static-pages/health-care-manage-benefits/secure-messaging-page/components/AuthContent/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/secure-messaging-page/components/AuthContent/index.js
@@ -1,5 +1,8 @@
 // Node modules.
 import React from 'react';
+import Telephone, {
+  CONTACTS,
+} from '@department-of-veterans-affairs/formation-react/Telephone';
 // Relative imports.
 import CallToActionWidget from 'platform/site-wide/cta-widget';
 import CernerCallToAction from '../../../components/CernerCallToAction';
@@ -303,11 +306,8 @@ export const AuthContent = () => (
               <p>
                 Or contact the My HealtheVet help desk at{' '}
                 <a href="tel:+18773270022">877-327-0022</a> (TTY:{' '}
-                <a href="tel:+18008778339" aria-label="8 0 0. 8 7 7. 8 3 3 9.">
-                  800-877-8339
-                </a>
-                . We&apos;re here Monday through Friday, 7:00 a.m. to 7:00 p.m.
-                CT.
+                <Telephone contact={CONTACTS.HELP_TTY} />. We&apos;re here
+                Monday through Friday, 7:00 a.m. to 7:00 p.m. CT.
               </p>
               <p>
                 You can also{' '}

--- a/src/applications/static-pages/health-care-manage-benefits/secure-messaging-page/components/LegacyContent/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/secure-messaging-page/components/LegacyContent/index.js
@@ -1,5 +1,8 @@
 // Node modules.
 import React from 'react';
+import Telephone, {
+  CONTACTS,
+} from '@department-of-veterans-affairs/formation-react/Telephone';
 // Relative imports.
 import CallToActionWidget from 'platform/site-wide/cta-widget';
 import MoreInfoAboutBenefits from '../../../components/MoreInfoAboutBenefits';
@@ -384,10 +387,7 @@ export const LegacyContent = () => (
                 <a aria-label="8 7 7. 3 2 7. 0 0 2 2." href="tel:18773270022">
                   877-327-0022
                 </a>{' '}
-                (TTY:{' '}
-                <a aria-label="8 0 0. 8 7 7. 8 3 3 9." href="tel:18008778339">
-                  800-877-8339
-                </a>
+                (TTY: <Telephone contact={CONTACTS.HELP_TTY} />
                 ). We’re here Monday through Friday, 7:00 a.m. to 7:00 p.m. CT.
               </p>
             </div>

--- a/src/applications/static-pages/health-care-manage-benefits/secure-messaging-page/components/UnauthContent/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/secure-messaging-page/components/UnauthContent/index.js
@@ -1,5 +1,8 @@
 // Node modules.
 import React from 'react';
+import Telephone, {
+  CONTACTS,
+} from '@department-of-veterans-affairs/formation-react/Telephone';
 // Relative imports.
 import CallToActionWidget from 'platform/site-wide/cta-widget';
 import MoreInfoAboutBenefits from '../../../components/MoreInfoAboutBenefits';
@@ -284,11 +287,8 @@ export const UnauthContent = () => (
               <p>
                 Or contact the My HealtheVet help desk at{' '}
                 <a href="tel:+18773270022">877-327-0022</a> (TTY:{' '}
-                <a href="tel:+18008778339" aria-label="8 0 0. 8 7 7. 8 3 3 9.">
-                  800-877-8339
-                </a>
-                . We&apos;re here Monday through Friday, 7:00 a.m. to 7:00 p.m.
-                CT.
+                <Telephone contact={CONTACTS.HELP_TTY} />. We&apos;re here
+                Monday through Friday, 7:00 a.m. to 7:00 p.m. CT.
               </p>
               <p>
                 You can also{' '}

--- a/src/applications/static-pages/health-care-manage-benefits/view-test-and-lab-results-page/components/AuthContent/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/view-test-and-lab-results-page/components/AuthContent/index.js
@@ -1,5 +1,8 @@
 // Node modules.
 import React from 'react';
+import Telephone, {
+  CONTACTS,
+} from '@department-of-veterans-affairs/formation-react/Telephone';
 // Relative imports.
 import CallToActionWidget from 'platform/site-wide/cta-widget';
 import MoreInfoAboutBenefits from '../../../components/MoreInfoAboutBenefits';
@@ -308,11 +311,8 @@ export const AuthContent = () => (
               <p>
                 Or contact the My HealtheVet help desk at{' '}
                 <a href="tel:+18773270022">877-327-0022</a> (TTY:{' '}
-                <a href="tel:+18008778339" aria-label="8 0 0. 8 7 7. 8 3 3 9.">
-                  800-877-8339
-                </a>
-                . We&apos;re here Monday through Friday, 7:00 a.m. to 7:00 p.m.
-                CT.
+                <Telephone contact={CONTACTS.HELP_TTY} />. We&apos;re here
+                Monday through Friday, 7:00 a.m. to 7:00 p.m. CT.
               </p>
               <p>
                 You can also{' '}

--- a/src/applications/static-pages/health-care-manage-benefits/view-test-and-lab-results-page/components/LegacyContent/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/view-test-and-lab-results-page/components/LegacyContent/index.js
@@ -1,5 +1,8 @@
 // Node modules.
 import React from 'react';
+import Telephone, {
+  CONTACTS,
+} from '@department-of-veterans-affairs/formation-react/Telephone';
 // Relative imports.
 import CallToActionWidget from 'platform/site-wide/cta-widget';
 import MoreInfoAboutBenefits from '../../../components/MoreInfoAboutBenefits';
@@ -348,10 +351,7 @@ export const LegacyContent = () => (
                 <a aria-label="8 7 7. 3 2 7. 0 0 2 2." href="tel:18773270022">
                   877-327-0022
                 </a>{' '}
-                (TTY:{' '}
-                <a aria-label="8 0 0. 8 7 7. 8 3 3 9." href="tel:18008778339">
-                  800-877-8339
-                </a>
+                (TTY: <Telephone contact={CONTACTS.HELP_TTY} />
                 ). We’re here Monday through Friday, 7:00 a.m. to 7:00 p.m. CT.
               </p>
             </div>

--- a/src/applications/static-pages/health-care-manage-benefits/view-test-and-lab-results-page/components/UnauthContent/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/view-test-and-lab-results-page/components/UnauthContent/index.js
@@ -1,5 +1,8 @@
 // Node modules.
 import React from 'react';
+import Telephone, {
+  CONTACTS,
+} from '@department-of-veterans-affairs/formation-react/Telephone';
 // Relative imports.
 import CallToActionWidget from 'platform/site-wide/cta-widget';
 import MoreInfoAboutBenefits from '../../../components/MoreInfoAboutBenefits';
@@ -252,11 +255,8 @@ export const UnauthContent = () => (
               <p>
                 Or contact the My HealtheVet help desk at{' '}
                 <a href="tel:+18773270022">877-327-0022</a> (TTY:{' '}
-                <a href="tel:+18008778339" aria-label="8 0 0. 8 7 7. 8 3 3 9.">
-                  800-877-8339
-                </a>
-                . We&apos;re here Monday through Friday, 7:00 a.m. to 7:00 p.m.
-                CT.
+                <Telephone contact={CONTACTS.HELP_TTY} />. We&apos;re here
+                Monday through Friday, 7:00 a.m. to 7:00 p.m. CT.
               </p>
               <p>
                 You can also{' '}

--- a/src/applications/validate-mhv-account/components/errors/DeactivatedMHVId.jsx
+++ b/src/applications/validate-mhv-account/components/errors/DeactivatedMHVId.jsx
@@ -1,5 +1,8 @@
 import React from 'react';
 import CollapsiblePanel from '@department-of-veterans-affairs/formation-react/CollapsiblePanel';
+import Telephone, {
+  CONTACTS,
+} from '@department-of-veterans-affairs/formation-react/Telephone';
 
 import MessageTemplate from '../MessageTemplate';
 
@@ -29,11 +32,7 @@ const DeactivatedMHVId = () => {
           <p>
             Call us at <a href="tel:877-327-0022">877-327-0022</a>. We’re here
             Monday through Friday, 8:00 a.m. to 8:00 p.m. ET. If you have
-            hearing loss, call TTY:{' '}
-            <a href="tel:8008773399" aria-label="8 0 0. 8 7 7. 3 3 9 9.">
-              800-877-3399
-            </a>
-            .
+            hearing loss, call TTY: <Telephone contact={CONTACTS.HELP_TTY} />.
           </p>
           <p>
             Tell the representative that you tried to sign in to use health

--- a/src/applications/validate-mhv-account/components/errors/MultipleMHVIds.jsx
+++ b/src/applications/validate-mhv-account/components/errors/MultipleMHVIds.jsx
@@ -1,5 +1,8 @@
 import React from 'react';
 import CollapsiblePanel from '@department-of-veterans-affairs/formation-react/CollapsiblePanel';
+import Telephone, {
+  CONTACTS,
+} from '@department-of-veterans-affairs/formation-react/Telephone';
 import MessageTemplate from '../MessageTemplate';
 
 const MultipleMHVIds = () => {
@@ -22,11 +25,7 @@ const MultipleMHVIds = () => {
             Call the My HealtheVet help desk at{' '}
             <a href="tel:877-327-0022">877-327-0022</a>. We’re here Monday
             through Friday, 8:00 a.m. to 8:00 p.m. ET. If you have hearing loss,
-            call TTY:{' '}
-            <a href="tel:8008773399" aria-label="8 0 0. 8 7 7. 3 3 9 9.">
-              800-877-3399
-            </a>
-            .
+            call TTY: <Telephone contact={CONTACTS.HELP_TTY} />.
           </p>
           <p>
             Tell the representative that you tried to sign in to use health

--- a/src/applications/validate-mhv-account/components/errors/NeedsSSNResolution.jsx
+++ b/src/applications/validate-mhv-account/components/errors/NeedsSSNResolution.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import CollapsiblePanel from '@department-of-veterans-affairs/formation-react/CollapsiblePanel';
 import Telephone, {
   CONTACTS,
+  PATTERNS,
 } from '@department-of-veterans-affairs/formation-react/Telephone';
 import MessageTemplate from '../MessageTemplate';
 
@@ -31,7 +32,8 @@ const NeedsSSNResolution = () => {
           <p>
             Please call us at <a href="tel:800-827-1000">800-827-1000</a>. We’re
             here Monday through Friday, 8:00 a.m. to 9:00 p.m. ET. If you have
-            hearing loss, call <Telephone contact={CONTACTS['711']} />.
+            hearin g loss, call g loss, call{' '}
+            <Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />.
           </p>
           <p>
             When the system prompts you to give a reason for your call, say,

--- a/src/applications/validate-mhv-account/components/errors/NeedsSSNResolution.jsx
+++ b/src/applications/validate-mhv-account/components/errors/NeedsSSNResolution.jsx
@@ -1,5 +1,8 @@
 import React from 'react';
 import CollapsiblePanel from '@department-of-veterans-affairs/formation-react/CollapsiblePanel';
+import Telephone, {
+  CONTACTS,
+} from '@department-of-veterans-affairs/formation-react/Telephone';
 import MessageTemplate from '../MessageTemplate';
 
 const NeedsSSNResolution = () => {
@@ -28,11 +31,7 @@ const NeedsSSNResolution = () => {
           <p>
             Please call us at <a href="tel:800-827-1000">800-827-1000</a>. We’re
             here Monday through Friday, 8:00 a.m. to 9:00 p.m. ET. If you have
-            hearing loss, call{' '}
-            <a href="tel:711" aria-label="TTY. 7 1 1.">
-              TTY: 711
-            </a>
-            .
+            hearing loss, call <Telephone contact={CONTACTS['711']} />.
           </p>
           <p>
             When the system prompts you to give a reason for your call, say,

--- a/src/applications/validate-mhv-account/components/errors/NeedsVAPatient.jsx
+++ b/src/applications/validate-mhv-account/components/errors/NeedsVAPatient.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import Telephone, {
   CONTACTS,
+  PATTERNS,
 } from '@department-of-veterans-affairs/formation-react/Telephone';
 import MessageTemplate from '../MessageTemplate';
 
@@ -24,7 +25,8 @@ const NeedsVAPatient = () => {
         <p>
           Call VA311 (<a href="tel:844-698-2311">844-698-2311</a>
           ), and select 3 to reach your nearest VA medical center. If you have
-          hearing loss, call <Telephone contact={CONTACTS['711']} />.
+          hearin g loss, call g loss, call{' '}
+          <Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />.
         </p>
         <p>
           Tell the representative that you tried to sign in to use health tools
@@ -40,7 +42,7 @@ const NeedsVAPatient = () => {
         <p>
           Call <a href="tel:844-698-2311">844-698-2311</a>, and select 3 to
           reach your nearest VA medical center. If you have hearing loss, call
-          <Telephone contact={CONTACTS['711']} />.
+          <Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />.
         </p>
         <p>
           Tell the representative that you’re enrolled in VA health care and

--- a/src/applications/validate-mhv-account/components/errors/NeedsVAPatient.jsx
+++ b/src/applications/validate-mhv-account/components/errors/NeedsVAPatient.jsx
@@ -1,4 +1,7 @@
 import React from 'react';
+import Telephone, {
+  CONTACTS,
+} from '@department-of-veterans-affairs/formation-react/Telephone';
 import MessageTemplate from '../MessageTemplate';
 
 const NeedsVAPatient = () => {
@@ -21,11 +24,7 @@ const NeedsVAPatient = () => {
         <p>
           Call VA311 (<a href="tel:844-698-2311">844-698-2311</a>
           ), and select 3 to reach your nearest VA medical center. If you have
-          hearing loss, call{' '}
-          <a href="tel:711" aria-label="TTY. 7 1 1.">
-            TTY: 711
-          </a>
-          .
+          hearing loss, call <Telephone contact={CONTACTS['711']} />.
         </p>
         <p>
           Tell the representative that you tried to sign in to use health tools
@@ -41,10 +40,7 @@ const NeedsVAPatient = () => {
         <p>
           Call <a href="tel:844-698-2311">844-698-2311</a>, and select 3 to
           reach your nearest VA medical center. If you have hearing loss, call
-          <a href="tel:711" aria-label="TTY. 7 1 1.">
-            TTY: 711
-          </a>
-          .
+          <Telephone contact={CONTACTS['711']} />.
         </p>
         <p>
           Tell the representative that you’re enrolled in VA health care and

--- a/src/applications/validate-mhv-account/components/errors/VerificationFailed.jsx
+++ b/src/applications/validate-mhv-account/components/errors/VerificationFailed.jsx
@@ -1,5 +1,8 @@
 import React from 'react';
 import CollapsiblePanel from '@department-of-veterans-affairs/formation-react/CollapsiblePanel';
+import Telephone, {
+  CONTACTS,
+} from '@department-of-veterans-affairs/formation-react/Telephone';
 import MessageTemplate from '../MessageTemplate';
 
 const VerificationFailed = () => {
@@ -29,11 +32,7 @@ const VerificationFailed = () => {
           <p>
             Please call us at <a href="tel:800-827-1000">800-827-1000</a>. We’re
             here Monday through Friday, 8:00 a.m. to 9:00 p.m. ET. If you have
-            hearing loss, call{' '}
-            <a href="tel:711" aria-label="TTY. 7 1 1.">
-              TTY: 711
-            </a>
-            .
+            hearing loss, call <Telephone contact={CONTACTS['711']} />.
           </p>
           <p>
             When the system prompts you to give a reason for your call, say,

--- a/src/applications/validate-mhv-account/components/errors/VerificationFailed.jsx
+++ b/src/applications/validate-mhv-account/components/errors/VerificationFailed.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import CollapsiblePanel from '@department-of-veterans-affairs/formation-react/CollapsiblePanel';
 import Telephone, {
   CONTACTS,
+  PATTERNS,
 } from '@department-of-veterans-affairs/formation-react/Telephone';
 import MessageTemplate from '../MessageTemplate';
 
@@ -32,7 +33,8 @@ const VerificationFailed = () => {
           <p>
             Please call us at <a href="tel:800-827-1000">800-827-1000</a>. We’re
             here Monday through Friday, 8:00 a.m. to 9:00 p.m. ET. If you have
-            hearing loss, call <Telephone contact={CONTACTS['711']} />.
+            hearin g loss, call g loss, call{' '}
+            <Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />.
           </p>
           <p>
             When the system prompts you to give a reason for your call, say,

--- a/src/applications/validate-mhv-account/containers/CreateMHVAccountFailed.jsx
+++ b/src/applications/validate-mhv-account/containers/CreateMHVAccountFailed.jsx
@@ -2,6 +2,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import CollapsiblePanel from '@department-of-veterans-affairs/formation-react/CollapsiblePanel';
+import Telephone, {
+  CONTACTS,
+} from '@department-of-veterans-affairs/formation-react/Telephone';
 
 import MessageTemplate from '../components/MessageTemplate';
 import { createAndUpgradeMHVAccount } from 'platform/user/profile/actions';
@@ -40,11 +43,7 @@ function CreateMHVAccountFailed(props) {
             Call the My HealtheVet help desk at{' '}
             <a href="tel:877-327-0022">877-327-0022</a>. We’re here Monday
             through Friday, 8:00 a.m. to 8:00 p.m. ET. If you have hearing loss,
-            call TTY:{' '}
-            <a href="tel:8008773399" aria-label="8 0 0. 8 7 7. 3 3 9 9.">
-              800-877-3399
-            </a>
-            .
+            call TTY: <Telephone contact={CONTACTS.HELP_TTY} />.
           </p>
           <p>
             Tell the representative that you tried to sign in to use health

--- a/src/applications/validate-mhv-account/containers/UpgradeAccountFailed.jsx
+++ b/src/applications/validate-mhv-account/containers/UpgradeAccountFailed.jsx
@@ -2,6 +2,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import CollapsiblePanel from '@department-of-veterans-affairs/formation-react/CollapsiblePanel';
+import Telephone, {
+  CONTACTS,
+} from '@department-of-veterans-affairs/formation-react/Telephone';
 
 import MessageTemplate from '../components/MessageTemplate';
 import { upgradeMHVAccount } from 'platform/user/profile/actions';
@@ -37,11 +40,7 @@ function UpgradeMHVAccountFailed(props) {
             Call the My HealtheVet help desk at{' '}
             <a href="tel:877-327-0022">877-327-0022</a>. We’re here Monday
             through Friday, 8:00 a.m. to 8:00 p.m. ET. If you have hearing loss,
-            call TTY:{' '}
-            <a href="tel:8008773399" aria-label="8 0 0. 8 7 7. 3 3 9 9.">
-              800-877-3399
-            </a>
-            .
+            call TTY: <Telephone contact={CONTACTS.HELP_TTY} />.
           </p>
           <p>
             Tell the representative that you tried to sign in to use health

--- a/src/applications/vaos/components/NeedHelp.jsx
+++ b/src/applications/vaos/components/NeedHelp.jsx
@@ -1,5 +1,8 @@
 import React from 'react';
 import recordEvent from 'platform/monitoring/record-event';
+import Telephone, {
+  CONTACTS,
+} from '@department-of-veterans-affairs/formation-react/Telephone';
 
 export default function NeedHelp() {
   return (
@@ -14,19 +17,13 @@ export default function NeedHelp() {
       <p className="vads-u-margin-top--0">
         For help scheduling a VA or Community Care appointment, please call{' '}
         <a href="tel:8774705947">877-470-5947</a> (if you have hearing loss,
-        call{' '}
-        <a href="tel:711" aria-label="TTY. 7 1 1.">
-          TTY: 711
-        </a>
+        call <Telephone contact={CONTACTS['711']} />
         ). We’re here Monday &ndash; Friday, 8:00 a.m. to 8:00 p.m. ET.
       </p>
       <p className="vads-u-margin-top--0">
         For questions about joining a VA Video Connect appointment, please call{' '}
         <a href="tel:8666513180">866-651-3180</a> (if you have hearing loss,
-        call{' '}
-        <a href="tel:711" aria-label="TTY. 7 1 1.">
-          TTY: 711
-        </a>
+        call <Telephone contact={CONTACTS['711']} />
         ). We’re here Monday &ndash; Saturday, 7:00 a.m. to 11:00 p.m. ET.
       </p>
       <p className="vads-u-margin-top--0">

--- a/src/applications/vaos/components/NeedHelp.jsx
+++ b/src/applications/vaos/components/NeedHelp.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import recordEvent from 'platform/monitoring/record-event';
 import Telephone, {
   CONTACTS,
+  PATTERNS,
 } from '@department-of-veterans-affairs/formation-react/Telephone';
 
 export default function NeedHelp() {
@@ -17,13 +18,13 @@ export default function NeedHelp() {
       <p className="vads-u-margin-top--0">
         For help scheduling a VA or Community Care appointment, please call{' '}
         <a href="tel:8774705947">877-470-5947</a> (if you have hearing loss,
-        call <Telephone contact={CONTACTS['711']} />
+        call <Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />
         ). We’re here Monday &ndash; Friday, 8:00 a.m. to 8:00 p.m. ET.
       </p>
       <p className="vads-u-margin-top--0">
         For questions about joining a VA Video Connect appointment, please call{' '}
         <a href="tel:8666513180">866-651-3180</a> (if you have hearing loss,
-        call <Telephone contact={CONTACTS['711']} />
+        call <Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />
         ). We’re here Monday &ndash; Saturday, 7:00 a.m. to 11:00 p.m. ET.
       </p>
       <p className="vads-u-margin-top--0">

--- a/src/applications/vaos/tests/components/NeedHelp.unit.spec.jsx
+++ b/src/applications/vaos/tests/components/NeedHelp.unit.spec.jsx
@@ -12,21 +12,21 @@ describe('VAOS <NeedHelp>', () => {
     expect(tree.hasClass('vads-u-margin-top--9')).be.true;
 
     const links = tree.find('a');
-    expect(links.length).to.equal(5);
+    expect(links.length).to.equal(3);
     expect(links.at(0).props().href).to.equal('tel:8774705947');
     expect(links.at(0).text()).to.equal('877-470-5947');
-    expect(links.at(1).props().href).to.equal('tel:711');
-    expect(links.at(1).text()).to.equal('TTY: 711');
-    expect(links.at(2).props().href).to.equal('tel:8666513180');
-    expect(links.at(2).text()).to.equal('866-651-3180');
-    expect(links.at(3).props().href).to.equal('tel:711');
-    expect(links.at(3).text()).to.equal('TTY: 711');
-    expect(links.at(4).props().href).to.equal(
+    expect(links.at(1).props().href).to.equal('tel:8666513180');
+    expect(links.at(1).text()).to.equal('866-651-3180');
+    expect(links.at(2).props().href).to.equal(
       'https://veteran.apps.va.gov/feedback-web/v1/?appId=85870ADC-CC55-405E-9AC3-976A92BBBBEE',
     );
-    expect(links.at(4).text()).to.equal(
+    expect(links.at(2).text()).to.equal(
       'Leave feedback about this application',
     );
+
+    const telephoneLinks = tree.find('Telephone');
+    expect(telephoneLinks.length).to.equal(2);
+
     tree.unmount();
   });
   it('should have aria labels to hide from screen reader', () => {

--- a/src/applications/verify/containers/VerifyApp.jsx
+++ b/src/applications/verify/containers/VerifyApp.jsx
@@ -4,6 +4,9 @@ import URLSearchParams from 'url-search-params';
 
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 import LoadingIndicator from '@department-of-veterans-affairs/formation-react/LoadingIndicator';
+import Telephone, {
+  CONTACTS,
+} from '@department-of-veterans-affairs/formation-react/Telephone';
 import recordEvent from 'platform/monitoring/record-event';
 
 import { isAuthenticatedWithSSOe } from 'platform/user/authentication/selectors';
@@ -103,12 +106,7 @@ export class VerifyApp extends React.Component {
                   <SubmitSignInForm startSentence>
                     Call the VA.gov Help Desk at{' '}
                     <a href="tel:1-855-574-7286">855-574-7286</a>, TTY:{' '}
-                    <a
-                      href="tel:18008778339"
-                      aria-label="8 0 0. 8 7 7. 8 3 3 9."
-                    >
-                      800-877-8339
-                    </a>
+                    <Telephone contact={CONTACTS.HELP_TTY} />
                     <br />
                     Monday &#8211; Friday, 8:00 a.m. &#8211; 8:00 p.m. ET
                   </SubmitSignInForm>

--- a/src/applications/vre/components/GetFormHelp.jsx
+++ b/src/applications/vre/components/GetFormHelp.jsx
@@ -1,4 +1,7 @@
 import React from 'react';
+import Telephone, {
+  CONTACTS,
+} from '@department-of-veterans-affairs/formation-react/Telephone';
 
 export default function GetFormHelp() {
   return (
@@ -10,13 +13,10 @@ export default function GetFormHelp() {
         </a>
         <br />
         TTY:{' '}
-        <a
+        <Telephone
           className="help-phone-number-link"
-          href="tel:+18008778339"
-          aria-label="8 0 0. 8 7 7. 8 3 3 9."
-        >
-          800-877-8339
-        </a>
+          contact={CONTACTS.HELP_TTY}
+        />
         <br />
         Monday &#8211; Friday, 8:00 a.m. &#8211; 8:00 p.m. ET
       </p>

--- a/src/platform/site-wide/cta-widget/components/messages/DeactivatedMHVIds.jsx
+++ b/src/platform/site-wide/cta-widget/components/messages/DeactivatedMHVIds.jsx
@@ -1,6 +1,9 @@
 import React from 'react';
 import CallToActionAlert from '../CallToActionAlert';
 import AdditionalInfo from '@department-of-veterans-affairs/formation-react/AdditionalInfo';
+import Telephone, {
+  CONTACTS,
+} from '@department-of-veterans-affairs/formation-react/Telephone';
 
 const DeactivatedMHVIds = () => {
   const content = {
@@ -19,11 +22,7 @@ const DeactivatedMHVIds = () => {
           <p>
             Call us at <a href="tel:877-327-0022">877-327-0022</a>. We’re here
             Monday through Friday, 8:00 a.m. to 8:00 p.m. ET. If you have
-            hearing loss, call TTY:{' '}
-            <a href="tel:8008773399" aria-label="8 0 0. 8 7 7. 3 3 9 9.">
-              800-877-3399
-            </a>
-            .
+            hearing loss, call TTY: <Telephone contact={CONTACTS.HELP_TTY} />.
           </p>
           <p>
             Tell the representative that you tried to sign in to use the health

--- a/src/platform/site-wide/cta-widget/components/messages/MultipleIds.jsx
+++ b/src/platform/site-wide/cta-widget/components/messages/MultipleIds.jsx
@@ -1,6 +1,9 @@
 import React from 'react';
 import CallToActionAlert from '../CallToActionAlert';
 import AdditionalInfo from '@department-of-veterans-affairs/formation-react/AdditionalInfo';
+import Telephone, {
+  CONTACTS,
+} from '@department-of-veterans-affairs/formation-react/Telephone';
 
 const MultipleIds = () => {
   const content = {
@@ -15,11 +18,7 @@ const MultipleIds = () => {
           <p>
             Call us at <a href="tel:877-327-0022">877-327-0022</a>. We’re here
             Monday through Friday, 8:00 a.m. to 8:00 p.m. ET. If you have
-            hearing loss, call TTY:{' '}
-            <a href="tel:8008773399" aria-label="8 0 0. 8 7 7. 3 3 9 9.">
-              800-877-3399
-            </a>
-            .
+            hearing loss, call TTY: <Telephone contact={CONTACTS.HELP_TTY} />.
           </p>
           <p>
             Tell the representative that you tried to sign in to use the health

--- a/src/platform/site-wide/cta-widget/components/messages/NeedsSSNResolution.jsx
+++ b/src/platform/site-wide/cta-widget/components/messages/NeedsSSNResolution.jsx
@@ -3,6 +3,7 @@ import CallToActionAlert from './../CallToActionAlert';
 import AdditionalInfo from '@department-of-veterans-affairs/formation-react/AdditionalInfo';
 import Telephone, {
   CONTACTS,
+  PATTERNS,
 } from '@department-of-veterans-affairs/formation-react/Telephone';
 
 const NeedsSSNResolution = () => {
@@ -27,7 +28,8 @@ const NeedsSSNResolution = () => {
           <p>
             Please call us at <a href="tel:800-827-1000">800-827-1000</a>. We’re
             here Monday through Friday, 8:00 a.m. to 9:00 p.m. ET. If you have
-            hearing loss, call <Telephone contact={CONTACTS['711']} />.
+            hearin g loss, call g loss, call{' '}
+            <Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />.
           </p>
           <p>
             When the system prompts you to give a reason for your call, say,

--- a/src/platform/site-wide/cta-widget/components/messages/NeedsSSNResolution.jsx
+++ b/src/platform/site-wide/cta-widget/components/messages/NeedsSSNResolution.jsx
@@ -1,6 +1,9 @@
 import React from 'react';
 import CallToActionAlert from './../CallToActionAlert';
 import AdditionalInfo from '@department-of-veterans-affairs/formation-react/AdditionalInfo';
+import Telephone, {
+  CONTACTS,
+} from '@department-of-veterans-affairs/formation-react/Telephone';
 
 const NeedsSSNResolution = () => {
   const content = {
@@ -24,11 +27,7 @@ const NeedsSSNResolution = () => {
           <p>
             Please call us at <a href="tel:800-827-1000">800-827-1000</a>. We’re
             here Monday through Friday, 8:00 a.m. to 9:00 p.m. ET. If you have
-            hearing loss, call{' '}
-            <a href="tel:711" aria-label="TTY. 7 1 1.">
-              TTY: 711
-            </a>
-            .
+            hearing loss, call <Telephone contact={CONTACTS['711']} />.
           </p>
           <p>
             When the system prompts you to give a reason for your call, say,

--- a/src/platform/site-wide/cta-widget/components/messages/NeedsVAPatient.jsx
+++ b/src/platform/site-wide/cta-widget/components/messages/NeedsVAPatient.jsx
@@ -1,4 +1,7 @@
 import React from 'react';
+import Telephone, {
+  CONTACTS,
+} from '@department-of-veterans-affairs/formation-react/Telephone';
 import CallToActionAlert from '../CallToActionAlert';
 
 const NeedsVAPatient = () => {
@@ -19,11 +22,7 @@ const NeedsVAPatient = () => {
         <p>
           Call VA311 (<a href="tel:844-698-2311">844-698-2311</a>
           ), and select 3 to reach your nearest VA medical center. If you have
-          hearing loss, call{' '}
-          <a href="tel:711" aria-label="TTY. 7 1 1.">
-            TTY: 711
-          </a>
-          .
+          hearing loss, call <Telephone contact={CONTACTS['711']} />.
         </p>
         <p>
           Tell the representative that you tried to sign in to use the health
@@ -39,10 +38,7 @@ const NeedsVAPatient = () => {
         <p>
           Call <a href="tel:844-698-2311">844-698-2311</a>, and select 3 to
           reach your nearest VA medical center. If you have hearing loss, call
-          <a href="tel:711" aria-label="TTY. 7 1 1.">
-            TTY: 711
-          </a>
-          .
+          <Telephone contact={CONTACTS['711']} />.
         </p>
         <p>
           Tell the representative that you’re enrolled in VA health care and

--- a/src/platform/site-wide/cta-widget/components/messages/NeedsVAPatient.jsx
+++ b/src/platform/site-wide/cta-widget/components/messages/NeedsVAPatient.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import Telephone, {
   CONTACTS,
+  PATTERNS,
 } from '@department-of-veterans-affairs/formation-react/Telephone';
 import CallToActionAlert from '../CallToActionAlert';
 
@@ -22,7 +23,8 @@ const NeedsVAPatient = () => {
         <p>
           Call VA311 (<a href="tel:844-698-2311">844-698-2311</a>
           ), and select 3 to reach your nearest VA medical center. If you have
-          hearing loss, call <Telephone contact={CONTACTS['711']} />.
+          hearin g loss, call g loss, call{' '}
+          <Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />.
         </p>
         <p>
           Tell the representative that you tried to sign in to use the health
@@ -38,7 +40,7 @@ const NeedsVAPatient = () => {
         <p>
           Call <a href="tel:844-698-2311">844-698-2311</a>, and select 3 to
           reach your nearest VA medical center. If you have hearing loss, call
-          <Telephone contact={CONTACTS['711']} />.
+          <Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />.
         </p>
         <p>
           Tell the representative that you’re enrolled in VA health care and

--- a/src/platform/site-wide/cta-widget/components/messages/RegisterFailed.jsx
+++ b/src/platform/site-wide/cta-widget/components/messages/RegisterFailed.jsx
@@ -1,7 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import CallToActionAlert from '../CallToActionAlert';
 import AdditionalInfo from '@department-of-veterans-affairs/formation-react/AdditionalInfo';
+import Telephone, {
+  CONTACTS,
+} from '@department-of-veterans-affairs/formation-react/Telephone';
+import CallToActionAlert from '../CallToActionAlert';
 
 const RegisterFailed = ({ createAndUpgradeMHVAccount }) => {
   const content = {
@@ -30,11 +33,7 @@ const RegisterFailed = ({ createAndUpgradeMHVAccount }) => {
           <p>
             Call us at <a href="tel:877-327-0022">877-327-0022</a>. We're here
             Monday through Friday, 8:00 a.m. to 8:00 p.m. ET. If you have
-            hearing loss, call TTY:{' '}
-            <a href="tel:8008773399" aria-label="8 0 0. 8 7 7. 3 3 9 9.">
-              800-877-3399
-            </a>
-            .
+            hearing loss, call TTY: <Telephone contact={CONTACTS.HELP_TTY} />.
           </p>
           <p>
             Tell the representative that you tried to sign in to use the online

--- a/src/platform/site-wide/cta-widget/components/messages/UpgradeFailed.jsx
+++ b/src/platform/site-wide/cta-widget/components/messages/UpgradeFailed.jsx
@@ -1,7 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import CallToActionAlert from '../CallToActionAlert';
 import AdditionalInfo from '@department-of-veterans-affairs/formation-react/AdditionalInfo';
+import Telephone, {
+  CONTACTS,
+} from '@department-of-veterans-affairs/formation-react/Telephone';
+import CallToActionAlert from '../CallToActionAlert';
 
 const UpgradeFailed = ({ upgradeMHVAccount }) => {
   const content = {
@@ -28,11 +31,7 @@ const UpgradeFailed = ({ upgradeMHVAccount }) => {
           <p>
             Call us at <a href="tel:877-327-0022">877-327-0022</a>. We're here
             Monday through Friday, 8:00 a.m. to 8:00 p.m. ET. If you have
-            hearing loss, call TTY:{' '}
-            <a href="tel:8008773399" aria-label="8 0 0. 8 7 7. 3 3 9 9.">
-              800-877-3399
-            </a>
-            .
+            hearing loss, call TTY: <Telephone contact={CONTACTS.HELP_TTY} />.
           </p>
           <p>
             Tell the representative that you tried to sign in to use the online

--- a/src/platform/site-wide/cta-widget/components/messages/mvi/NotFound.jsx
+++ b/src/platform/site-wide/cta-widget/components/messages/mvi/NotFound.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import Telephone, {
   CONTACTS,
+  PATTERNS,
 } from '@department-of-veterans-affairs/formation-react/Telephone';
 import CallToActionAlert from './../../CallToActionAlert';
 
@@ -21,7 +22,8 @@ const NotFound = () => {
         <p>
           Please call us at <a href="tel:800-827-1000">800-827-1000</a>. We’re
           here Monday through Friday, 8:00 a.m. to 9:00 p.m. ET. If you have
-          hearing loss, call <Telephone contact={CONTACTS['711']} />.
+          hearin g loss, call g loss, call{' '}
+          <Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />.
         </p>
         <p>
           When the system prompts you to give a reason for your call, say,

--- a/src/platform/site-wide/cta-widget/components/messages/mvi/NotFound.jsx
+++ b/src/platform/site-wide/cta-widget/components/messages/mvi/NotFound.jsx
@@ -1,4 +1,7 @@
 import React from 'react';
+import Telephone, {
+  CONTACTS,
+} from '@department-of-veterans-affairs/formation-react/Telephone';
 import CallToActionAlert from './../../CallToActionAlert';
 
 const NotFound = () => {
@@ -18,11 +21,7 @@ const NotFound = () => {
         <p>
           Please call us at <a href="tel:800-827-1000">800-827-1000</a>. We’re
           here Monday through Friday, 8:00 a.m. to 9:00 p.m. ET. If you have
-          hearing loss, call{' '}
-          <a href="tel:711" aria-label="TTY. 7 1 1.">
-            TTY: 711
-          </a>
-          .
+          hearing loss, call <Telephone contact={CONTACTS['711']} />.
         </p>
         <p>
           When the system prompts you to give a reason for your call, say,

--- a/src/platform/site-wide/user-nav/components/HelpMenu.jsx
+++ b/src/platform/site-wide/user-nav/components/HelpMenu.jsx
@@ -4,6 +4,9 @@ import React from 'react';
 import DropDownPanel from '@department-of-veterans-affairs/formation-react/DropDownPanel';
 import IconHelp from '@department-of-veterans-affairs/formation-react/IconHelp';
 import recordEvent from 'platform/monitoring/record-event';
+import Telephone, {
+  CONTACTS,
+} from '@department-of-veterans-affairs/formation-react/Telephone';
 
 import isVATeamSiteSubdomain from '../../../utilities/environment/va-subdomain';
 import facilityLocatorManifest from 'applications/facility-locator/manifest.json';
@@ -28,9 +31,7 @@ function HelpMenu({ clickHandler, cssClass, isOpen }) {
         <a href="tel:18446982311">Call VA311: 844-698-2311</a>
       </p>
       <p>
-        <a href="tel:711" aria-label="TTY. 7 1 1.">
-          TTY: 711
-        </a>
+        <Telephone contact={CONTACTS['711']} />
       </p>
     </div>
   );

--- a/src/platform/site-wide/user-nav/components/HelpMenu.jsx
+++ b/src/platform/site-wide/user-nav/components/HelpMenu.jsx
@@ -6,6 +6,7 @@ import IconHelp from '@department-of-veterans-affairs/formation-react/IconHelp';
 import recordEvent from 'platform/monitoring/record-event';
 import Telephone, {
   CONTACTS,
+  PATTERNS,
 } from '@department-of-veterans-affairs/formation-react/Telephone';
 
 import isVATeamSiteSubdomain from '../../../utilities/environment/va-subdomain';
@@ -31,7 +32,7 @@ function HelpMenu({ clickHandler, cssClass, isOpen }) {
         <a href="tel:18446982311">Call VA311: 844-698-2311</a>
       </p>
       <p>
-        <Telephone contact={CONTACTS['711']} />
+        <Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />
       </p>
     </div>
   );

--- a/src/platform/site-wide/va-footer/components/CrisisPanel.jsx
+++ b/src/platform/site-wide/va-footer/components/CrisisPanel.jsx
@@ -1,4 +1,7 @@
 import React from 'react';
+import Telephone, {
+  CONTACTS,
+} from '@department-of-veterans-affairs/formation-react/Telephone';
 
 export default function CrisisPanel() {
   return (
@@ -68,7 +71,10 @@ export default function CrisisPanel() {
                 href="tel:18007994889"
                 aria-label="TTY. 8 0 0. 7 9 9. 4 8 8 9."
               >
-                Call TTY if you have hearing loss <strong>800-799-4889</strong>
+                Call TTY if you have hearing loss{' '}
+                <strong>
+                  <Telephone contact={CONTACTS.SUICIDE_PREVENTION_LIFELINE} />
+                </strong>
               </a>
             </li>
           </ul>

--- a/src/platform/static-data/CallHRC.jsx
+++ b/src/platform/static-data/CallHRC.jsx
@@ -1,15 +1,14 @@
 import React from 'react';
+import Telephone, {
+  CONTACTS,
+} from '@department-of-veterans-affairs/formation-react/Telephone';
 
 export default function CallHRC({ startSentence }) {
   return (
     <span>
       {startSentence ? 'Call' : 'call'} us at{' '}
       <a href="tel:18555747286">855-574-7286</a>.<br />
-      If you have hearing loss, call{' '}
-      <a href="tel:711" aria-label="TTY. 7 1 1.">
-        TTY: 711
-      </a>
-      .
+      If you have hearing loss, call <Telephone contact={CONTACTS['711']} />.
     </span>
   );
 }

--- a/src/platform/static-data/CallHRC.jsx
+++ b/src/platform/static-data/CallHRC.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import Telephone, {
   CONTACTS,
+  PATTERNS,
 } from '@department-of-veterans-affairs/formation-react/Telephone';
 
 export default function CallHRC({ startSentence }) {
@@ -8,7 +9,8 @@ export default function CallHRC({ startSentence }) {
     <span>
       {startSentence ? 'Call' : 'call'} us at{' '}
       <a href="tel:18555747286">855-574-7286</a>.<br />
-      If you have hearing loss, call <Telephone contact={CONTACTS['711']} />.
+      If you have hearin g loss, call{' '}
+      <Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />.
     </span>
   );
 }

--- a/src/platform/static-data/CallNCACenter.jsx
+++ b/src/platform/static-data/CallNCACenter.jsx
@@ -1,14 +1,16 @@
 import React from 'react';
 import Telephone, {
   CONTACTS,
+  PATTERNS,
 } from '@department-of-veterans-affairs/formation-react/Telephone';
 
 export default function CallNCACenter({ startSentence }) {
   return (
     <span>
       {startSentence ? 'Call' : 'call'} the National Cemetery Scheduling Office
-      at <a href="tel:18005351117">800-535-1117</a>.<br /> If you have hearing
-      loss, call <Telephone contact={CONTACTS['711']} />.
+      at <a href="tel:18005351117">800-535-1117</a>.<br /> If you have hearing{' '}
+      loss, call{' '}
+      <Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />.
     </span>
   );
 }

--- a/src/platform/static-data/CallNCACenter.jsx
+++ b/src/platform/static-data/CallNCACenter.jsx
@@ -1,15 +1,14 @@
 import React from 'react';
+import Telephone, {
+  CONTACTS,
+} from '@department-of-veterans-affairs/formation-react/Telephone';
 
 export default function CallNCACenter({ startSentence }) {
   return (
     <span>
       {startSentence ? 'Call' : 'call'} the National Cemetery Scheduling Office
       at <a href="tel:18005351117">800-535-1117</a>.<br /> If you have hearing
-      loss, call{' '}
-      <a href="tel:711" aria-label="TTY. 7 1 1.">
-        TTY: 711
-      </a>
-      .
+      loss, call <Telephone contact={CONTACTS['711']} />.
     </span>
   );
 }

--- a/src/platform/static-data/CallVBACenter.jsx
+++ b/src/platform/static-data/CallVBACenter.jsx
@@ -1,15 +1,14 @@
 import React from 'react';
+import Telephone, {
+  CONTACTS,
+} from '@department-of-veterans-affairs/formation-react/Telephone';
 
 export default function CallVBACenter({ startSentence }) {
   return (
     <span>
       {startSentence ? 'Call' : 'call'} VA Benefits and Services at{' '}
       <a href="tel:18008271000">800-827-1000</a>.<br /> If you have hearing
-      loss, call{' '}
-      <a href="tel:711" aria-label="TTY. 7 1 1.">
-        TTY: 711
-      </a>
-      .
+      loss, call <Telephone contact={CONTACTS['711']} />.
     </span>
   );
 }

--- a/src/platform/static-data/CallVBACenter.jsx
+++ b/src/platform/static-data/CallVBACenter.jsx
@@ -1,14 +1,16 @@
 import React from 'react';
 import Telephone, {
   CONTACTS,
+  PATTERNS,
 } from '@department-of-veterans-affairs/formation-react/Telephone';
 
 export default function CallVBACenter({ startSentence }) {
   return (
     <span>
       {startSentence ? 'Call' : 'call'} VA Benefits and Services at{' '}
-      <a href="tel:18008271000">800-827-1000</a>.<br /> If you have hearing
-      loss, call <Telephone contact={CONTACTS['711']} />.
+      <a href="tel:18008271000">800-827-1000</a>.<br /> If you have hearing{' '}
+      loss, call{' '}
+      <Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />.
     </span>
   );
 }

--- a/src/platform/user/authorization/containers/MHVApp.jsx
+++ b/src/platform/user/authorization/containers/MHVApp.jsx
@@ -6,6 +6,9 @@ import appendQuery from 'append-query';
 
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 import LoadingIndicator from '@department-of-veterans-affairs/formation-react/LoadingIndicator';
+import Telephone, {
+  CONTACTS,
+} from '@department-of-veterans-affairs/formation-react/Telephone';
 import { mhvAccessError } from '../../../static-data/error-messages';
 import backendServices from '../../profile/constants/backendServices';
 import { selectProfile } from '../../selectors';
@@ -71,9 +74,7 @@ const INELIGIBLE_MESSAGES = {
         </p>
         <p>
           Please call the My HealtheVet Help Desk at 877-327-0022 (TTY:
-          <a href="tel:8008773399" aria-label="8 0 0. 8 7 7. 3 3 9 9.">
-            800-877-3399
-          </a>
+          <Telephone contact={CONTACTS.HELP_TTY} />
           ), 7:00 a.m. - 7:00 p.m. CT, and ask for help to activate your
           disabled account.
         </p>
@@ -94,9 +95,7 @@ const INELIGIBLE_MESSAGES = {
         </p>
         <p>
           Please call the My HealtheVet Help Desk at 877-327-0022 (TTY:
-          <a href="tel:8008773399" aria-label="8 0 0. 8 7 7. 3 3 9 9.">
-            800-877-3399
-          </a>
+          <Telephone contact={CONTACTS.HELP_TTY} />
           ), 7:00 a.m. - 7:00 p.m. CT, and ask for help to delete any extra
           accounts in the system.
         </p>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1254,10 +1254,10 @@
     enabled "2.0.x"
     kuler "^2.0.0"
 
-"@department-of-veterans-affairs/formation-react@5.4.5":
-  version "5.4.5"
-  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/formation-react/-/formation-react-5.4.5.tgz#8501cbd115ee4478cacf182b4f31ac5bfdc8f570"
-  integrity sha512-3pvgxUhQ1W9XM1LmVF+UPs8sHC+/99U0ht8MR9IvC3V/npSfGD3wviCd/ypUnx1rCiTK9JBsvd48yxYmLcZOWg==
+"@department-of-veterans-affairs/formation-react@5.4.6":
+  version "5.4.6"
+  resolved "https://registry.yarnpkg.com/@department-of-veterans-affairs/formation-react/-/formation-react-5.4.6.tgz#114615170ab713b9a813f1728fb0815c28538b4b"
+  integrity sha512-Gy1BUZLsC2gza/mKXaFAMHEPZV3XkujpZ8uvBUNxylo8Qc/NH2t2ceokuQYo41JYQiMxvKBBf6OaGKT6Aw4KPw==
   dependencies:
     classnames "^2.2.6"
     lodash "^4.17.15"


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/11418

This PR adds the `<Telephone />` component for all TTY numbers for consistency.

## Testing done
Updated unit tests

## Screenshots
N/A

## Acceptance criteria
- [x] Use `<Telephone />` for all TTY number links.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
