### PR TITLE
Update GA for connected apps

### DIFF
--- a/src/applications/personalization/profile-2/components/connected-apps/actions/index.js
+++ b/src/applications/personalization/profile-2/components/connected-apps/actions/index.js
@@ -22,6 +22,7 @@ const grantsUrl = '/profile/connected_applications';
 
 export function loadConnectedApps() {
   return async dispatch => {
+    recordEvent({ event: 'profile-get-connected-apps-started' });
     dispatch({ type: LOADING_CONNECTED_APPS });
 
     // Locally we cannot call the endpoint

--- a/src/applications/personalization/profile-2/components/connected-apps/actions/index.js
+++ b/src/applications/personalization/profile-2/components/connected-apps/actions/index.js
@@ -40,13 +40,15 @@ export function loadConnectedApps() {
         const hasConnectedApps = data && deletedApps?.length !== data?.length;
 
         recordEvent({
+          event: 'profile-get-connected-apps-retrieved',
           'user-has-connected-apps': hasConnectedApps,
         });
         dispatch({ type: FINISHED_LOADING_CONNECTED_APPS, data });
       })
-      .catch(({ errors }) =>
-        dispatch({ type: ERROR_LOADING_CONNECTED_APPS, errors }),
-      );
+      .catch(({ errors }) => {
+        recordEvent({ event: 'profile-get-connected-apps-failure' });
+        dispatch({ type: ERROR_LOADING_CONNECTED_APPS, errors });
+      });
   };
 }
 


### PR DESCRIPTION
## Description
In terms of GA, we need to mirror the Direct Deposit call in connected apps, like so:

```
{
  'event': 'profile-get-connected-apps-retrieved',
  'user-has-connected-apps': true|false
}
```
And we also need to record connected apps API failures, like so:

`'event': 'profile-get-connected-apps-failure'`

And upon starting the fetch:

`'event': 'profile-get-connected-apps-started'`

## Acceptance criteria
- [x] Add GA events

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
