### PR TITLE
Wrap cta in provider

### DIFF
--- a/src/applications/static-pages/view-modify-dependent/686-cta/form686CTA.js
+++ b/src/applications/static-pages/view-modify-dependent/686-cta/form686CTA.js
@@ -1,13 +1,20 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 
+import { Provider } from 'react-redux';
+
 export default function form686CTA(store, widgetType) {
   const root = document.querySelector(`[data-widget-type="${widgetType}"]`);
   if (root) {
     import(/* webpackChunkName: "Form686CTA" */
     './containers/Form686CTA.jsx').then(module => {
       const Form686CTA = module.default;
-      ReactDOM.render(<Form686CTA store={store} />, root);
+      ReactDOM.render(
+        <Provider store={store}>
+          <Form686CTA />
+        </Provider>,
+        root,
+      );
     });
   }
 }


### PR DESCRIPTION
Description

[Original ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/11652)

Follow up pull request to [this one](https://github.com/department-of-veterans-affairs/vets-website/pull/13604#discussion_r461118671) to wrap the widget in a provider. This mitigates the same run time error found in [this pull request](https://github.com/department-of-veterans-affairs/vets-website/pull/13364#discussion_r449170600)

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
