### PR TITLE
[Find Forms] Add some Sentry logging

### DIFF
--- a/src/applications/find-forms/api/index.js
+++ b/src/applications/find-forms/api/index.js
@@ -1,4 +1,5 @@
 // Dependencies.
+import * as Sentry from '@sentry/browser';
 import appendQuery from 'append-query';
 import sortBy from 'lodash/sortBy';
 import { apiRequest } from 'platform/utilities/api';
@@ -27,6 +28,21 @@ export const fetchFormsApi = async (query, options = {}) => {
   const onlyValidForms = forms?.filter(
     form => form.attributes?.validPDF || form.attributes?.validPdf,
   );
+
+  const potentialServerIssue =
+    (query === '' || query === '10-10ez') && onlyValidForms.length === 0;
+
+  if (potentialServerIssue) {
+    // A query-less search should always include hundreds of results, and a
+    // search for "10-10ez" should always yield helath care form 10-10EZ.
+    // If there are no results, this is likely an indicator of an unexpected server response.
+
+    Sentry.withScope(scope => {
+      scope.setExtra('query', query);
+      scope.setExtra('forms', forms);
+      Sentry.captureMessage(`Find Forms - unexpected empty results`);
+    });
+  }
 
   return sortBy(onlyValidForms, 'id');
 };


### PR DESCRIPTION
## Description
Find Forms receives data form an API with each item containing a "validPdf" property. Results that contain this value as false are filtered out of the result set because they do not have a downloadable PDF. About a month ago, we ran into an issue where this value was always missing (falsy) so no results were ever rendered. We only noticed it when we did a query for `health care` and didn't receive any results.

As a basic form of monitoring, we are adding some Sentry messages. If the user executes a query-less search, which should result in _all_ forms rendering, but instead receives no results, then we capture the error. We do the same if the user searched for 10-10ez but received nothing.

https://github.com/department-of-veterans-affairs/va.gov-team/issues/10708

## Testing done
Ran some queries on `/find-forms/` locally to make sure I didn't break it

## Screenshots
N/A

## Acceptance criteria
- [ ] Some basic monitoring in place to spot strange behavior

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
