### PR TITLE
[Form Details] Add ability to publish a page

### DIFF
--- a/src/site/stages/build/drupal/graphql/GetAllPages.graphql.js
+++ b/src/site/stages/build/drupal/graphql/GetAllPages.graphql.js
@@ -8,6 +8,7 @@ const pressReleasePage = require('./pressReleasePage.graphql');
 const vamcOperatingStatusAndAlerts = require('./vamcOperatingStatusAndAlerts.graphql');
 const fragments = require('./fragments.graphql');
 const newsStoryPage = require('./newStoryPage.graphql');
+const vaFormPage = require('./vaFormPage.graphql');
 const sidebarQuery = require('./navigation-fragments/sidebar.nav.graphql');
 const alertsQuery = require('./alerts.graphql');
 const bannerAlertsQuery = require('./bannerAlerts.graphql');
@@ -62,6 +63,7 @@ const buildQuery = ({ useTomeSync }) => {
   ${eventPage}
   ${officePage}
   ${bioPage}
+  ${vaFormPage}
   ${benefitListingPage}
   ${eventListingPage}
   ${storyListingPage}
@@ -100,6 +102,7 @@ const buildQuery = ({ useTomeSync }) => {
         ... pressReleasesListingPage
         ... healthServicesListingPage
         ... locationListingPage
+        ... vaFormPage
       }
     }`;
 


### PR DESCRIPTION
## Description
The PR adds the `va_form` page-type into the `GetAllPages` GraphQL query, so that form detail pages can be published. Right now, they can only be previewed.

https://github.com/department-of-veterans-affairs/va.gov-team/issues/10819

## Testing done
N/A

## Screenshots
N/A

## Acceptance criteria
- [ ] Form detail pages can be published

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
