### PR TITLE
Add Cypress test to confirm header is not shown

### DIFF
--- a/src/applications/personalization/profile-2/components/ProfileHeader.jsx
+++ b/src/applications/personalization/profile-2/components/ProfileHeader.jsx
@@ -103,7 +103,7 @@ const ProfileHeader = ({
   };
 
   return (
-    <div className={classes.wrapper}>
+    <div className={classes.wrapper} data-testid="profile-header">
       <div className={classes.innerWrapper}>
         <div className={classes.serviceBadge}>
           {showBadgeImage && (

--- a/src/applications/personalization/profile-2/tests/e2e/profile.cypress.spec.js
+++ b/src/applications/personalization/profile-2/tests/e2e/profile.cypress.spec.js
@@ -28,6 +28,10 @@ function checkAllPages(mobile = false) {
   cy.findByRole('progressbar').should('not.exist');
   cy.findByText(/loading your information/i).should('not.exist');
 
+  // since we did not mock the `GET profile/full_name` endpoint, the
+  // ProfileHeader should not be rendered on the page
+  cy.findByTestId('profile-header').should('not.exist');
+
   // visiting /profile should redirect to profile/personal-information
   cy.url().should(
     'eq',

--- a/src/applications/personalization/profile360/actions/index.js
+++ b/src/applications/personalization/profile360/actions/index.js
@@ -16,8 +16,8 @@ export function fetchHero() {
     dispatch({ type: FETCH_HERO });
     const response = await getData('/profile/full_name');
 
-    if (response?.errors) {
-      dispatch({ type: FETCH_HERO_FAILED, hero: { response } });
+    if (response.errors || response.error) {
+      dispatch({ type: FETCH_HERO_FAILED, hero: { errors: response } });
       return;
     }
 

--- a/src/applications/personalization/profile360/actions/index.js
+++ b/src/applications/personalization/profile360/actions/index.js
@@ -1,5 +1,4 @@
 import { getData } from '../util';
-import environment from 'platform/utilities/environment';
 
 export const FETCH_HERO = 'FETCH_HERO';
 export const FETCH_HERO_SUCCESS = 'FETCH_HERO_SUCCESS';


### PR DESCRIPTION
## Description
@sanlouise hope I'm not stepping on your toes too much here! But I wanted to add a simple check to our existing Cypress tests for the Profile. I knew we weren't mocking the `GET full_name` endpoint so figured we could easily add an assertion to make sure that the ProfileHeader is not shown in those tests. Doing so required me to make a small change to how the `fetchHero()` action works. In the case of the Cypress test since the endpoint just fails and returns nothing, we need to check for `error` on the response since that is what the `getData()` helper provides in the case of a server error. Let me know what you think.

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs