### PR TITLE
22-10203: add chapter 2 confirm eligibility page

### DIFF
--- a/src/applications/edu-benefits/10203/config/chapters.js
+++ b/src/applications/edu-benefits/10203/config/chapters.js
@@ -1,16 +1,17 @@
 import fullSchema10203 from 'vets-json-schema/dist/22-10203-schema.json';
 import createApplicantInformationPage from 'platform/forms/pages/applicantInformation';
 
-import { displayConfirmEligibility } from '../helpers';
+import { displayConfirmEligibility, isChapter33 } from '../helpers';
 
 import {
   activeDuty,
   applicantInformation,
   benefitSelection,
-  directDeposit,
-  personalInformation,
-  stemEligibility,
   confirmEligibility,
+  directDeposit,
+  initialConfirmEligibility,
+  stemEligibility,
+  personalInformation,
   programDetails,
 } from '../pages';
 
@@ -37,6 +38,14 @@ export const chapters = {
         uiSchema: benefitSelection.uiSchema,
         schema: benefitSelection.schema,
       },
+      initialConfirmEligibility: {
+        title: '',
+        path: 'benefits/initial-confirm-eligibility',
+        depends: form => !isChapter33(form),
+        pageClass: 'vads-u-max-width--100 vads-u-vads-u-width--full',
+        uiSchema: initialConfirmEligibility.uiSchema,
+        schema: initialConfirmEligibility.schema,
+      },
     },
   },
   programDetails: {
@@ -51,7 +60,7 @@ export const chapters = {
       confirmEligibility: {
         title: '',
         path: 'benefits/confirm-eligibility',
-        depends: form => displayConfirmEligibility(form),
+        depends: displayConfirmEligibility,
         pageClass: 'vads-u-max-width--100 vads-u-vads-u-width--full',
         uiSchema: confirmEligibility.uiSchema,
         schema: confirmEligibility.schema,

--- a/src/applications/edu-benefits/10203/containers/InitialConfirmEligibilityView.jsx
+++ b/src/applications/edu-benefits/10203/containers/InitialConfirmEligibilityView.jsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { connect } from 'react-redux';
+
+function InitialConfirmEligibilityView(props) {
+  if (props.onReviewPage) {
+    return null;
+  }
+  return (
+    <div>
+      <div>
+        <div className="usa-alert usa-alert-warning">
+          <div className="usa-alert-body">
+            <h4 className="usa-alert-heading">
+              Based on your response, you may not be eligible for the Rogers
+              STEM Scholarship
+            </h4>
+            <div className="usa-alert-text">
+              <p>
+                <strong>
+                  You must be a Post-9/11 GI Bill or Fry Scholarship beneficiary
+                  to qualify for the scholarship.
+                </strong>{' '}
+                Please consider that ineligible applications delay the
+                processing of benefits for eligible applicants.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+      <br />
+      <div>
+        <a
+          className={'usa-button-primary wizard-button va-button-primary'}
+          href="/education/"
+          target="_self"
+          rel="noopener noreferrer"
+        >
+          Exit application
+        </a>
+      </div>
+      <br />
+      <span>
+        If you'd still like to apply, you can continue with your application.
+      </span>
+    </div>
+  );
+}
+
+const mapStateToProps = (state, props) => {
+  return {
+    onReviewPage: props?.formContext?.onReviewPage,
+  };
+};
+
+const mapDispatchToProps = {};
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(InitialConfirmEligibilityView);

--- a/src/applications/edu-benefits/10203/containers/InitialConfirmEligibilityView.jsx
+++ b/src/applications/edu-benefits/10203/containers/InitialConfirmEligibilityView.jsx
@@ -11,8 +11,7 @@ function InitialConfirmEligibilityView(props) {
         <div className="usa-alert usa-alert-warning">
           <div className="usa-alert-body">
             <h4 className="usa-alert-heading">
-              Based on your response, you may not be eligible for the Rogers
-              STEM Scholarship
+              Based on your response, you may not be eligible
             </h4>
             <div className="usa-alert-text">
               <p>
@@ -33,7 +32,6 @@ function InitialConfirmEligibilityView(props) {
           className={'usa-button-primary wizard-button va-button-primary'}
           href="/education/"
           target="_self"
-          rel="noopener noreferrer"
         >
           Exit application
         </a>
@@ -46,15 +44,8 @@ function InitialConfirmEligibilityView(props) {
   );
 }
 
-const mapStateToProps = (state, props) => {
-  return {
-    onReviewPage: props?.formContext?.onReviewPage,
-  };
-};
+const mapStateToProps = (state, props) => ({
+  onReviewPage: props?.formContext?.onReviewPage,
+});
 
-const mapDispatchToProps = {};
-
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps,
-)(InitialConfirmEligibilityView);
+export default connect(mapStateToProps)(InitialConfirmEligibilityView);

--- a/src/applications/edu-benefits/10203/pages/index.js
+++ b/src/applications/edu-benefits/10203/pages/index.js
@@ -3,6 +3,7 @@ import * as applicantInformation from './applicantInformation';
 import * as benefitSelection from './benefitSelection';
 import * as confirmEligibility from './confirmEligibility';
 import * as directDeposit from './directDeposit';
+import * as initialConfirmEligibility from './initialConfirmEligibility';
 import * as personalInformation from './personalInformation';
 import * as programDetails from './programDetails';
 import * as stemEligibility from './stemEligibility';
@@ -11,9 +12,10 @@ export {
   activeDuty,
   applicantInformation,
   benefitSelection,
-  directDeposit,
-  personalInformation,
-  stemEligibility,
   confirmEligibility,
+  directDeposit,
+  initialConfirmEligibility,
+  personalInformation,
   programDetails,
+  stemEligibility,
 };

--- a/src/applications/edu-benefits/10203/pages/initialConfirmEligibility.js
+++ b/src/applications/edu-benefits/10203/pages/initialConfirmEligibility.js
@@ -1,0 +1,17 @@
+import InitialConfirmEligibilityView from '../containers/InitialConfirmEligibilityView';
+
+export const uiSchema = {
+  'view:initialConfirmEligibility': {
+    'ui:field': InitialConfirmEligibilityView,
+  },
+};
+
+export const schema = {
+  type: 'object',
+  properties: {
+    'view:initialConfirmEligibility': {
+      type: 'object',
+      properties: {},
+    },
+  },
+};

--- a/src/applications/edu-benefits/10203/tests/containers/InitialConfirmEligibilityView.unit.spec.jsx
+++ b/src/applications/edu-benefits/10203/tests/containers/InitialConfirmEligibilityView.unit.spec.jsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { expect } from 'chai';
+
+import InitialConfirmEligibilityView from '../../containers/InitialConfirmEligibilityView';
+import createCommonStore from 'platform/startup/store';
+import { Provider } from 'react-redux';
+
+const createStore = (data = {}) =>
+  createCommonStore({
+    form: () => ({
+      data: {
+        'view:benefit': { chapter33: true },
+        isEnrolledStem: true,
+        isPursuingTeachingCert: false,
+        benefitLeft: 'none',
+        ...data,
+      },
+    }),
+  });
+const defaultStore = createStore();
+const defaultProps = {
+  ...defaultStore.getState(),
+  formData: {},
+  errorSchema: {
+    'view:confirmEligibility': {
+      __errors: [],
+    },
+  },
+};
+
+describe('<InitialConfirmEligibilityView>', () => {
+  it('should render', () => {
+    const tree = mount(
+      <Provider store={defaultStore}>
+        <InitialConfirmEligibilityView {...defaultProps} />
+      </Provider>,
+    );
+    expect(tree).to.not.be.undefined;
+    tree.unmount();
+  });
+});


### PR DESCRIPTION
## Description
Added an additional "confirm eligibility" page to chapter 2 of the 22-10203 form.

[ZenHub Issue 11456](https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/11456)

## Testing done
Tested locally and QA reviewed

## Screenshots
![image](https://user-images.githubusercontent.com/41960449/88663637-e946c080-d0a9-11ea-88eb-1d47c59aaca2.png)

## Acceptance criteria
- [x] On Chapter 2, Page 1:
  - a. If the user does not select a Chapter 33 benefit, the user is routed to Chapter 2, page 2 (benefit eligibility summary)
  - b. If the user selects a Chapter 33 benefit, the applicant is routed to Chapter 3, page 1 (program details)

- [x] On Chapter 2, Page 2:
  - a. Yellow warning alert has been added and the content and layout matches the behavior outlined in SA1. 
  - b. A green "Exit application" button appears below the grey warning box and the button is linked to https://www.va.gov/education/, which opens in the same window.
  - c. Below the "Exit application" button, the following text appears: If you’d still like to apply, you can continue with your application.
  - d. The standard form system "back" and "continue" buttons are included at the bottom of the page.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
