### PR TITLE
[Development] Update vets-json-schema

### DIFF
--- a/package.json
+++ b/package.json
@@ -326,7 +326,7 @@
     "url-search-params-polyfill": "^8.1.0",
     "uswds": "1.6.10",
     "vanilla-lazyload": "^16.1.0",
-    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#dfee66d46dcbd9bcc7631c02d25db39eed43b4f0",
+    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#86f6211def250399a2f3e16eedfd7b4e8c7b02be",
     "whatwg-fetch": "^2.0.3"
   },
   "resolutions": {

--- a/src/platform/forms/tests/forms.unit.spec.js
+++ b/src/platform/forms/tests/forms.unit.spec.js
@@ -69,6 +69,7 @@ const configs = [
 
 // These forms do not have formConfig but are found in vets-json-schema/dist/schemas
 const excludedForms = new Set([
+  '21-526EZ', // v1 of form 526
   '21-686C', // Old version of the 21-686C. Present in vets-json-schema, but will be removed in a future pull request.
   '28-1900',
   '28-8832',

--- a/yarn.lock
+++ b/yarn.lock
@@ -9824,9 +9824,10 @@ jest@^23.6.0:
     import-local "^1.0.0"
     jest-cli "^23.6.0"
 
-jpeg-js@0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/jpeg-js/-/jpeg-js-0.2.0.tgz#53e448ec9d263e683266467e9442d2c5a2ef5482"
+jpeg-js@0.2.0, jpeg-js@^0.4.0:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/jpeg-js/-/jpeg-js-0.4.1.tgz#937a3ae911eb6427f151760f8123f04c8bfe6ef7"
+  integrity sha512-jA55yJiB5tCXEddos8JBbvW+IMrqY0y1tjjx9KNVtA+QPmu7ND5j0zkKopClpUTsaETL135uOM2XfcYG4XRjmw==
 
 js-base64@^2.1.8:
   version "2.5.1"
@@ -17057,9 +17058,9 @@ verror@1.3.6:
   dependencies:
     extsprintf "1.0.2"
 
-"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#dfee66d46dcbd9bcc7631c02d25db39eed43b4f0":
-  version "6.3.0"
-  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#dfee66d46dcbd9bcc7631c02d25db39eed43b4f0"
+"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#86f6211def250399a2f3e16eedfd7b4e8c7b02be":
+  version "6.4.1"
+  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#86f6211def250399a2f3e16eedfd7b4e8c7b02be"
 
 vinyl-file@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## Description

`vets-json-schema` was updated to v6.4.1 to fix an issue with form 526

Related tickets:
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/11731
- https://github.com/department-of-veterans-affairs/vets-json-schema/pull/463
- https://github.com/department-of-veterans-affairs/vets-api/pull/4611

## Testing done

Unit tests - added exception for temporary restoration of form 526 v1 (for failing vets-api tests)

## Screenshots

N/A

## Acceptance criteria
- [x] Update `vets-json-schema` version in package.json

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
