### PR TITLE
Add error conditions for EC submission

### DIFF
--- a/src/applications/vaos/containers/ExpressCareFormPage.jsx
+++ b/src/applications/vaos/containers/ExpressCareFormPage.jsx
@@ -1,13 +1,15 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
-import { FETCH_STATUS } from '../utils/constants';
+import { FETCH_STATUS, EXPRESS_CARE_ERROR_REASON } from '../utils/constants';
 import FormButtons from '../components/FormButtons';
 
 import * as actions from '../actions/expressCare';
 
 function ExpressCareFormPage({
   submitStatus,
+  submitErrorReason,
+  localWindowString,
   submitExpressCareRequest,
   router,
   routeToPreviousAppointmentPage,
@@ -26,17 +28,34 @@ function ExpressCareFormPage({
         onSubmit={() => submitExpressCareRequest(router)}
       />
       {submitStatus === FETCH_STATUS.failed && (
-        <AlertBox
-          status="error"
-          headline="Your request didn’t go through"
-          content={
-            <p>
-              Something went wrong when we tried to submit your request and
-              you’ll need to start over. We suggest you wait a day to try again
-              or you can call your medical center to help with your request.
-            </p>
-          }
-        />
+        <>
+          {submitErrorReason === EXPRESS_CARE_ERROR_REASON.error && (
+            <AlertBox
+              status="error"
+              headline="Your request didn’t go through"
+              content={
+                <p>
+                  Something went wrong when we tried to submit your request and
+                  you’ll need to start over. We suggest you wait a day to try
+                  again or you can call your medical center to help with your
+                  request.
+                </p>
+              }
+            />
+          )}
+          {submitErrorReason === EXPRESS_CARE_ERROR_REASON.noActiveFacility && (
+            <AlertBox
+              status="error"
+              headline="Express Care isn’t available right now"
+              content={
+                <p>
+                  Express Care is only available {localWindowString} today. To
+                  use Express Care, check back during the time shown above.
+                </p>
+              }
+            />
+          )}
+        </>
       )}
     </div>
   );
@@ -48,9 +67,7 @@ const mapDispatchToProps = {
 };
 
 function mapStateToProps(state) {
-  return {
-    submitStatus: state.expressCare.submitStatus,
-  };
+  return state.expressCare;
 }
 
 export default connect(

--- a/src/applications/vaos/reducers/expressCare.js
+++ b/src/applications/vaos/reducers/expressCare.js
@@ -28,6 +28,7 @@ const initialState = {
   maxEnd: null,
   data: {},
   submitStatus: FETCH_STATUS.notStarted,
+  submitErrorReason: null,
   successfulRequest: null,
 };
 
@@ -151,6 +152,7 @@ export default function expressCareReducer(state = initialState, action) {
       return {
         ...state,
         submitStatus: FETCH_STATUS.failed,
+        submitErrorReason: action.errorReason,
       };
     default:
       return state;

--- a/src/applications/vaos/utils/constants.js
+++ b/src/applications/vaos/utils/constants.js
@@ -351,3 +351,8 @@ export const FREE_BUSY_TYPES = {
 };
 
 export const UNABLE_TO_REACH_VETERAN_DETCODE = 'DETCODE23';
+
+export const EXPRESS_CARE_ERROR_REASON = {
+  error: 'error',
+  noActiveFacility: 'noActiveFacility',
+};

--- a/src/applications/vaos/utils/selectors.js
+++ b/src/applications/vaos/utils/selectors.js
@@ -461,6 +461,10 @@ export function selectActiveExpressCareFacility(state, nowUTCMoment) {
     nowUTCMoment.isBetween(ecWindow.utcStart, ecWindow.utcEnd),
   );
 
+  if (!activeWindow) {
+    return null;
+  }
+
   return {
     name: activeWindow.authoritativeName,
     facilityId: activeWindow.id,


### PR DESCRIPTION
## Description
This updates the error handling for EC submissions, to show messages for both generic errors and the case where an EC window closes while a user is filling out the form.

## Testing done
Local and unit testing

## Screenshots
Message when EC window is closed:
![Screen Shot 2020-07-29 at 11 06 22 AM](https://user-images.githubusercontent.com/634932/88820885-e9b98700-d18f-11ea-924d-74f88c7aae9f.png)

Message for a generic error:
![Screen Shot 2020-07-29 at 11 05 22 AM](https://user-images.githubusercontent.com/634932/88820886-ea521d80-d18f-11ea-8d8b-d9104190bd86.png)

## Acceptance criteria
- [ ] Errors are displayed properly

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
