### PR TITLE
Incorrect system id used for single site users

### DIFF
--- a/src/applications/vaos/actions/newAppointment.js
+++ b/src/applications/vaos/actions/newAppointment.js
@@ -29,7 +29,7 @@ import {
 } from '../api';
 import {
   getOrganizations,
-  getSiteIdFromOrganization,
+  getIdOfRootOrganization,
 } from '../services/organization';
 import { getLocation } from '../services/location';
 import { getSupportedHealthcareServicesAndLocations } from '../services/healthcare-service';
@@ -301,8 +301,8 @@ export function openFacilityPage(page, uiSchema, schema) {
       }
 
       if (parentId) {
-        siteId = getSiteIdFromOrganization(
-          parentFacilities.find(parent => parent.id === parentId),
+        siteId = parseFakeFHIRId(
+          getIdOfRootOrganization(parentFacilities, parentId),
         );
       }
 

--- a/src/applications/vaos/sass/vaos.scss
+++ b/src/applications/vaos/sass/vaos.scss
@@ -106,7 +106,6 @@
 
 .vaos-form__facility-type {
   legend {
-    margin-bottom: 30px;
     max-width: none;
   }
 }

--- a/src/applications/vaos/tests/new-appointment/va-facility-page-single-site.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/va-facility-page-single-site.unit.spec.jsx
@@ -104,7 +104,17 @@ describe('VAOS integration: VA facility page with a single-site user', () => {
   });
 
   it('should show alert when only one facility is supported', async () => {
-    mockParentSites(['983'], [parentSite983]);
+    const parentSite5digit = {
+      id: '983GC',
+      attributes: {
+        ...getParentSiteMock().attributes,
+        institutionCode: '983GC',
+        authoritativeName: 'Some VA facility',
+        rootStationCode: '983',
+        parentStationCode: '983GC',
+      },
+    };
+    mockParentSites(['983'], [parentSite5digit]);
     const facilities = [
       {
         id: '983GC',
@@ -115,14 +125,14 @@ describe('VAOS integration: VA facility page with a single-site user', () => {
           stateAbbrev: 'MT',
           authoritativeName: 'Belgrade VA clinic',
           rootStationCode: '983',
-          parentStationCode: '983',
+          parentStationCode: '983GC',
           requestSupported: true,
         },
       },
     ];
     mockSupportedFacilities({
       siteId: '983',
-      parentId: '983',
+      parentId: '983GC',
       typeOfCareId: '323',
       data: facilities,
     });


### PR DESCRIPTION
## Description
Users with a single parent site weren't getting the correct system id if that parent site was not also a vista site. This was happening for some users registered at 612, which never uses 612 as a parent site.

I also fixed a cosmetic issue on a form page

## Testing done
Local and unit testing


## Acceptance criteria
- [ ] System id correctly populated

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
