### PR TITLE
bradl3yC - 11815 - Add check for error in response if response is 200

### DIFF
--- a/src/applications/debt-letters/actions/index.js
+++ b/src/applications/debt-letters/actions/index.js
@@ -55,6 +55,10 @@ export const fetchDebtLetters = () => async dispatch => {
       ? await apiRequest(`${environment.API_URL}/v0/debts`, options)
       : await debtLettersSuccess();
 
+    if (Object.keys(response).includes('error')) {
+      return dispatch(fetchDebtLettersFailure());
+    }
+
     return dispatch(fetchDebtLettersSuccess(response));
   } catch (error) {
     return dispatch(fetchDebtLettersFailure());


### PR DESCRIPTION
## Description
Add handling for edge case with DMC API where they would return a 200 response with the following payload
```
{error: 'invalid client'}
```
https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/11815
## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
