### PR TITLE
Fix usePartialSchema assertion

### DIFF
--- a/src/site/stages/build/process-cms-exports/transformers/helpers.js
+++ b/src/site/stages/build/process-cms-exports/transformers/helpers.js
@@ -183,7 +183,8 @@ module.exports = {
   usePartialSchema(schema, properties) {
     // Some sanity checking before we start
     assert(
-      schema.type === 'object',
+      schema.type === 'object' ||
+        (Array.isArray(schema.type) && schema.type.includes('object')),
       `Expected object schema. Found ${schema.type}`,
     );
     assert(


### PR DESCRIPTION
## Description
Previously, if we had a schema with `type: ['object']`, it would throw an
assertion error, even though that's valid JSON schema. This fixes that.
