### PR TITLE
removed content doc error

### DIFF
--- a/src/applications/edu-benefits/10203/containers/IntroductionPage.jsx
+++ b/src/applications/edu-benefits/10203/containers/IntroductionPage.jsx
@@ -106,7 +106,7 @@ export class IntroductionPage extends React.Component {
                     <a href="https://benefits.va.gov/gibill/fgib/stem.asp">
                       Edith Nourse Rogers STEM Scholarship
                     </a>
-                    , you must meet all the requirements below. You:
+                    , you must meet all the requirements below.
                   </p>
                 </div>
                 <ul>


### PR DESCRIPTION
## Description
Fixed extra word in intro page of 10203

https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/10958

## Testing done
local

## Screenshots
<img width="622" alt="Screen Shot 2020-07-30 at 8 01 19 AM" src="https://user-images.githubusercontent.com/50601724/88920500-fa730700-d23a-11ea-9cb8-49de91196eea.png">

## Acceptance criteria
- [x] remove the extra `you:`



## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
