### PR TITLE
Adjusted location UI and fixed bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -327,7 +327,7 @@
     "url-search-params-polyfill": "^8.1.0",
     "uswds": "1.6.10",
     "vanilla-lazyload": "^16.1.0",
-    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#86f6211def250399a2f3e16eedfd7b4e8c7b02be",
+    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#4b3cb9634bbdf7be8d79fd30e389c04e06de5bc6",
     "whatwg-fetch": "^2.0.3"
   },
   "resolutions": {

--- a/package.json
+++ b/package.json
@@ -327,7 +327,7 @@
     "url-search-params-polyfill": "^8.1.0",
     "uswds": "1.6.10",
     "vanilla-lazyload": "^16.1.0",
-    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#4b3cb9634bbdf7be8d79fd30e389c04e06de5bc6",
+    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#abff81fc0a078e81a51a8a33d042cf234a14f187",
     "whatwg-fetch": "^2.0.3"
   },
   "resolutions": {

--- a/src/applications/disability-benefits/686c-674/config/helpers.js
+++ b/src/applications/disability-benefits/686c-674/config/helpers.js
@@ -87,10 +87,10 @@ export const isInsideListLoopReturn = (
     country: {
       'ui:title': 'Country',
       'ui:required': (formData, index) =>
-        `formData?.${chapter}?.${index}?.${outerField}?.isOutsideUS`,
+        formData?.[chapter]?.[`${index}`]?.[outerField]?.isOutsideUS,
       'ui:options': {
         hideIf: (formData, index) => {
-          if (!formData[chapter][`${index}`][outerField]?.isOutsideUS) {
+          if (!formData?.[chapter]?.[`${index}`]?.[outerField]?.isOutsideUS) {
             return true;
           }
           return false;
@@ -100,10 +100,10 @@ export const isInsideListLoopReturn = (
     state: {
       'ui:title': 'State',
       'ui:required': (formData, index) =>
-        !`formData?.${chapter}?.${index}?.${outerField}?.isOutsideUS`,
+        !formData?.[chapter]?.[`${index}`]?.[outerField]?.isOutsideUS,
       'ui:options': {
         hideIf: (formData, index) => {
-          if (formData[chapter][`${index}`][outerField]?.isOutsideUS) {
+          if (formData?.[chapter]?.[`${index}`]?.[outerField]?.isOutsideUS) {
             return true;
           }
           return false;

--- a/src/applications/disability-benefits/686c-674/config/helpers.js
+++ b/src/applications/disability-benefits/686c-674/config/helpers.js
@@ -87,7 +87,7 @@ export const isInsideListLoopReturn = (
     country: {
       'ui:title': 'Country',
       'ui:required': (formData, index) =>
-        formData[chapter][`${index}`][outerField]?.isOutsideUS,
+        `formData?.${chapter}?.${index}?.${outerField}?.isOutsideUS`,
       'ui:options': {
         hideIf: (formData, index) => {
           if (!formData[chapter][`${index}`][outerField]?.isOutsideUS) {
@@ -100,7 +100,7 @@ export const isInsideListLoopReturn = (
     state: {
       'ui:title': 'State',
       'ui:required': (formData, index) =>
-        !formData[chapter][`${index}`][outerField]?.isOutsideUS,
+        !`formData?.${chapter}?.${index}?.${outerField}?.isOutsideUS`,
       'ui:options': {
         hideIf: (formData, index) => {
           if (formData[chapter][`${index}`][outerField]?.isOutsideUS) {
@@ -130,10 +130,10 @@ export const isOutsideListLoopReturn = (
     },
     country: {
       'ui:title': 'Country',
-      'ui:required': formData => formData[chapter][outerField]?.isOutsideUS,
+      'ui:required': formData => formData?.[chapter]?.[outerField]?.isOutsideUS,
       'ui:options': {
         hideIf: formData => {
-          if (!formData[chapter][outerField].isOutsideUS) {
+          if (!formData?.[chapter]?.[outerField]?.isOutsideUS) {
             return true;
           }
           return false;
@@ -142,10 +142,11 @@ export const isOutsideListLoopReturn = (
     },
     state: {
       'ui:title': 'State',
-      'ui:required': formData => !formData[chapter][outerField]?.isOutsideUS,
+      'ui:required': formData =>
+        !formData?.[chapter]?.[outerField]?.isOutsideUS,
       'ui:options': {
         hideIf: formData => {
-          if (formData[chapter][outerField].isOutsideUS) {
+          if (formData?.[chapter]?.[outerField]?.isOutsideUS) {
             return true;
           }
           return false;
@@ -153,7 +154,7 @@ export const isOutsideListLoopReturn = (
       },
     },
     city: {
-      'ui:required': formData => isChapterFieldRequired(formData, 'addSpouse'),
+      'ui:required': formData => isChapterFieldRequired(formData, formChapter),
       'ui:title': 'City',
     },
   };

--- a/src/applications/disability-benefits/686c-674/tests/config/currentMarriageInformation.unit.spec.jsx
+++ b/src/applications/disability-benefits/686c-674/tests/config/currentMarriageInformation.unit.spec.jsx
@@ -7,6 +7,7 @@ import {
   DefinitionTester,
   fillData,
   selectRadio,
+  selectCheckbox,
 } from 'platform/testing/unit/schemaform-utils.jsx';
 
 import formConfig from '../../config/form';
@@ -81,6 +82,42 @@ describe('686 current marriage information', () => {
       form,
       'input#root_currentMarriageInformation_location_city',
       'Los Angeles',
+    );
+    selectRadio(form, 'root_currentMarriageInformation_type', 'CEREMONIAL');
+    form.find('form').simulate('submit');
+    expect(form.find('.usa-input-error').length).to.equal(0);
+    expect(onSubmit.called).to.be.true;
+    form.unmount();
+  });
+
+  it('should submit with a marriage location outside of the US', () => {
+    const onSubmit = sinon.spy();
+    const form = mount(
+      <DefinitionTester
+        schema={schema}
+        uiSchema={uiSchema}
+        definitions={formConfig.defaultDefinitions}
+        data={formData}
+        onSubmit={onSubmit}
+      />,
+    );
+    changeDropdown(form, 'select#root_currentMarriageInformation_dateMonth', 1);
+    changeDropdown(form, 'select#root_currentMarriageInformation_dateDay', 1);
+    fillData(form, 'input#root_currentMarriageInformation_dateYear', '2010');
+    selectCheckbox(
+      form,
+      'root_currentMarriageInformation_location_isOutsideUS',
+      true,
+    );
+    changeDropdown(
+      form,
+      'select#root_currentMarriageInformation_location_country',
+      'AFG',
+    );
+    fillData(
+      form,
+      'input#root_currentMarriageInformation_location_city',
+      'Some Place',
     );
     selectRadio(form, 'root_currentMarriageInformation_type', 'CEREMONIAL');
     form.find('form').simulate('submit');

--- a/src/applications/disability-benefits/686c-674/tests/config/reportDeathAdditionalInformation.unit.spec.jsx
+++ b/src/applications/disability-benefits/686c-674/tests/config/reportDeathAdditionalInformation.unit.spec.jsx
@@ -6,6 +6,7 @@ import { mount } from 'enzyme';
 import {
   DefinitionTester,
   fillData,
+  selectCheckbox,
 } from 'platform/testing/unit/schemaform-utils.jsx';
 import { changeDropdown } from '../helpers/index';
 import formConfig from '../../config/form';
@@ -83,6 +84,33 @@ describe('686 report dependent death additional information', () => {
     fillData(form, 'input#root_dateYear', '2000');
     changeDropdown(form, 'select#root_dateMonth', 1);
     changeDropdown(form, 'select#root_location_state', 'CA');
+    fillData(form, 'input#root_location_city', 'Someplace');
+
+    form.find('form').simulate('submit');
+    expect(form.find('.usa-input-error').length).to.equal(0);
+    expect(onSubmit.called).to.be.true;
+    form.unmount();
+  });
+
+  it('should submit a form with a location of death outside US', () => {
+    const onSubmit = sinon.spy();
+    const form = mount(
+      <DefinitionTester
+        schema={schema}
+        definitions={formConfig.defaultDefinitions}
+        uiSchema={uiSchema}
+        onSubmit={onSubmit}
+        data={formData}
+        pagePerItemIndex={0}
+        arrayPath={arrayPath}
+      />,
+    );
+    changeDropdown(form, 'select#root_dateMonth', 1);
+    changeDropdown(form, 'select#root_dateDay', 1);
+    fillData(form, 'input#root_dateYear', '2000');
+    changeDropdown(form, 'select#root_dateMonth', 1);
+    selectCheckbox(form, 'root_location_isOutsideUS', true);
+    changeDropdown(form, 'select#root_location_country', 'AFG');
     fillData(form, 'input#root_location_city', 'Someplace');
 
     form.find('form').simulate('submit');

--- a/src/applications/disability-benefits/686c-674/tests/config/reportDivorce.unit.spec.jsx
+++ b/src/applications/disability-benefits/686c-674/tests/config/reportDivorce.unit.spec.jsx
@@ -8,6 +8,7 @@ import {
   DefinitionTester,
   fillData,
   selectRadio,
+  selectCheckbox,
 } from 'platform/testing/unit/schemaform-utils.jsx';
 import formConfig from '../../config/form';
 
@@ -148,6 +149,43 @@ describe('686 report a divorce', () => {
     fillData(form, 'input#root_reportDivorce_dateYear', '2010');
     // location
     changeDropdown(form, 'select#root_reportDivorce_location_state', 'CA');
+    fillData(form, 'input#root_reportDivorce_location_city', 'somewhere');
+    // is void
+    selectRadio(form, 'root_reportDivorce_reasonMarriageEnded', 'Other');
+    fillData(form, 'input#root_reportDivorce_explanationOfOther', 'Other');
+    form.find('form').simulate('submit');
+    expect(form.find('.usa-input-error').length).to.equal(0);
+    expect(onSubmit.called).to.be.true;
+    form.unmount();
+  });
+
+  it('should submit a form with a location outside the US', () => {
+    const onSubmit = sinon.spy();
+    const form = mount(
+      <DefinitionTester
+        schema={schema}
+        uiSchema={uiSchema}
+        definitions={formConfig.defaultDefinitions}
+        onSubmit={onSubmit}
+        data={formData}
+      />,
+    );
+    // spouse name
+    fillData(form, 'input#root_reportDivorce_fullName_first', 'John');
+    fillData(form, 'input#root_reportDivorce_fullName_last', 'Doe');
+    // date of divorce
+    const monthDropdown = form.find('select#root_reportDivorce_dateMonth');
+    const dayDropdown = form.find('select#root_reportDivorce_dateDay');
+    monthDropdown.simulate('change', {
+      target: { value: '1' },
+    });
+    dayDropdown.simulate('change', {
+      target: { value: '1' },
+    });
+    fillData(form, 'input#root_reportDivorce_dateYear', '2010');
+    // location
+    selectCheckbox(form, 'root_reportDivorce_location_isOutsideUS', true);
+    changeDropdown(form, 'select#root_reportDivorce_location_country', 'AFG');
     fillData(form, 'input#root_reportDivorce_location_city', 'somewhere');
     // is void
     selectRadio(form, 'root_reportDivorce_reasonMarriageEnded', 'Other');

--- a/src/applications/disability-benefits/686c-674/tests/config/reportDivorce.unit.spec.jsx
+++ b/src/applications/disability-benefits/686c-674/tests/config/reportDivorce.unit.spec.jsx
@@ -54,7 +54,7 @@ describe('686 report a divorce', () => {
       />,
     );
     form.find('form').simulate('submit');
-    expect(form.find('.usa-input-error').length).to.equal(5);
+    expect(form.find('.usa-input-error').length).to.equal(6);
     expect(onSubmit.called).to.be.false;
     form.unmount();
   });

--- a/src/applications/disability-benefits/686c-674/tests/config/spouseMarriageHistoryDetails.unit.spec.jsx
+++ b/src/applications/disability-benefits/686c-674/tests/config/spouseMarriageHistoryDetails.unit.spec.jsx
@@ -7,6 +7,7 @@ import {
   DefinitionTester,
   fillData,
   selectRadio,
+  selectCheckbox,
 } from 'platform/testing/unit/schemaform-utils.jsx';
 
 import formConfig from '../../config/form';
@@ -135,6 +136,48 @@ describe('686 spouse marriage history details', () => {
     fillData(form, 'input#root_endDateYear', '2011');
     // Marriage end location
     changeDropdown(form, 'select#root_endLocation_state', 'CA');
+    fillData(form, 'input#root_endLocation_city', 'Not here');
+    form.find('form').simulate('submit');
+    expect(form.find('.usa-input-error').length).to.equal(0);
+    expect(onSubmit.called).to.be.true;
+    form.unmount();
+  });
+
+  it('should submit with a marriage start and end location outside the US', () => {
+    const onSubmit = sinon.spy();
+    const form = mount(
+      <DefinitionTester
+        pagePerItemIndex={0}
+        schema={schema}
+        uiSchema={uiSchema}
+        data={formData}
+        arrayPath={arrayPath}
+        definitions={formConfig.defaultDefinitions}
+        onSubmit={onSubmit}
+      />,
+    );
+    // Date marriage start
+    changeDropdown(form, 'select#root_startDateMonth', 1);
+    changeDropdown(form, 'select#root_startDateDay', 1);
+    fillData(form, 'input#root_startDateYear', '2010');
+    // Marriage start location
+    selectCheckbox(form, 'root_startLocation_isOutsideUS', true);
+    changeDropdown(form, 'select#root_startLocation_country', 'AFG');
+    fillData(form, 'input#root_startLocation_city', 'Outhere');
+    // Reason marriage ended
+    selectRadio(form, 'root_reasonMarriageEnded', 'Other');
+    fillData(
+      form,
+      'input#root_reasonMarriageEndedOther',
+      'This is an explanation',
+    );
+    // Date marriage ended
+    changeDropdown(form, 'select#root_endDateMonth', 1);
+    changeDropdown(form, 'select#root_endDateDay', 1);
+    fillData(form, 'input#root_endDateYear', '2011');
+    // Marriage end location
+    selectCheckbox(form, 'root_endLocation_isOutsideUS', true);
+    changeDropdown(form, 'select#root_endLocation_country', 'AFG');
     fillData(form, 'input#root_endLocation_city', 'Not here');
     form.find('form').simulate('submit');
     expect(form.find('.usa-input-error').length).to.equal(0);

--- a/src/applications/disability-benefits/686c-674/tests/config/veteranMarriageHistoryDetails.unit.spec.jsx
+++ b/src/applications/disability-benefits/686c-674/tests/config/veteranMarriageHistoryDetails.unit.spec.jsx
@@ -44,7 +44,7 @@ describe('686 veteran marriage history details', () => {
         definitions={formConfig.defaultDefinitions}
       />,
     );
-    expect(form.find('input').length).to.equal(11);
+    expect(form.find('input').length).to.equal(9);
     form.unmount();
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -17075,9 +17075,9 @@ verror@1.3.6:
   dependencies:
     extsprintf "1.0.2"
 
-"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#4b3cb9634bbdf7be8d79fd30e389c04e06de5bc6":
-  version "6.5.0"
-  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#4b3cb9634bbdf7be8d79fd30e389c04e06de5bc6"
+"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#abff81fc0a078e81a51a8a33d042cf234a14f187":
+  version "6.5.1"
+  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#abff81fc0a078e81a51a8a33d042cf234a14f187"
 
 vinyl-file@^2.0.0:
   version "2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -17075,9 +17075,9 @@ verror@1.3.6:
   dependencies:
     extsprintf "1.0.2"
 
-"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#86f6211def250399a2f3e16eedfd7b4e8c7b02be":
-  version "6.4.1"
-  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#86f6211def250399a2f3e16eedfd7b4e8c7b02be"
+"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#4b3cb9634bbdf7be8d79fd30e389c04e06de5bc6":
+  version "6.5.0"
+  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#4b3cb9634bbdf7be8d79fd30e389c04e06de5bc6"
 
 vinyl-file@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## Description
[Original Ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/11831)

When we built the new location UI we built it with a plain text field for the country in order to save time. The standard across VA.gov is to use a country drop down so we need to swap out the text field in the location UI for a country drop down. This PR adjusts the commit hash to the correct one for the location UI changes in vets-json-schema and ads unit tests for the changes in vets-website.

This PR also fixes a bug we found with these steps to produce - 
1. Select a workflow on the options page, can be a short one like child marriage
2. Fill out the form
3. Submit,
4. Navigate back to the options page and try to select another workflow. The console will throw an error

this error was fixed by adding optional chaining in the location UI helpers

## Testing done
added new Unit tests and all existing Unit tests still pass


## Screenshots
![Screen Shot 2020-07-30 at 12 00 21 PM](https://user-images.githubusercontent.com/1899695/88963138-4a15fa80-d25c-11ea-8a53-60681c2114a5.png)


## Acceptance criteria
- [ ] vets-json-schema has been updated so that the genericLocation schema uses a country drop down
- [x] The location UI has been updated so that it uses a country drop down
- [x] Backend has been notified of this completion

