### PR TITLE
add optional chaining

### DIFF
--- a/src/applications/disability-benefits/686c-674/config/chapters/674/student-address-marriage-tuition/studentAddressMarriageTuition.js
+++ b/src/applications/disability-benefits/686c-674/config/chapters/674/student-address-marriage-tuition/studentAddressMarriageTuition.js
@@ -44,7 +44,7 @@ export const uiSchema = {
       ...currentOrPastDateUI('Date of marriage'),
       ...{
         'ui:required': formData =>
-          formData.studentAddressMarriageTuition.wasMarried,
+          formData?.studentAddressMarriageTuition?.wasMarried,
         'ui:options': {
           expandUnder: 'wasMarried',
           expandUnderCondition: true,
@@ -60,7 +60,7 @@ export const uiSchema = {
     },
     agencyName: {
       'ui:required': formData =>
-        formData.studentAddressMarriageTuition.tuitionIsPaidByGovAgency,
+        formData?.studentAddressMarriageTuition?.tuitionIsPaidByGovAgency,
       'ui:title': 'Agency name',
       'ui:options': {
         expandUnder: 'tuitionIsPaidByGovAgency',
@@ -75,7 +75,7 @@ export const uiSchema = {
       ...currentOrPastDateUI('Date payments began'),
       ...{
         'ui:required': formData =>
-          formData.studentAddressMarriageTuition.tuitionIsPaidByGovAgency,
+          formData?.studentAddressMarriageTuition?.tuitionIsPaidByGovAgency,
         'ui:options': {
           expandUnder: 'tuitionIsPaidByGovAgency',
           expandUnderCondition: true,


### PR DESCRIPTION
## Description
- Previously, a few `ui:required` checks were trying to access undefined data, which would throw a reference error and break the form. This pull request adds optional chaining to safely handle undefined on those properties. 

## Testing done
- local

## Acceptance criteria
- [x] optional chaining has been added

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
