### PR TITLE
Default fieldTimeout to 0

### DIFF
--- a/src/site/stages/build/process-cms-exports/transformers/paragraph-react_widget.js
+++ b/src/site/stages/build/process-cms-exports/transformers/paragraph-react_widget.js
@@ -14,7 +14,7 @@ const transform = entity => ({
       ? omit(['format'], entity.fieldErrorMessage[0])
       : null,
     fieldLoadingMessage: getDrupalValue(entity.fieldLoadingMessage),
-    fieldTimeout: getDrupalValue(entity.fieldTimeout),
+    fieldTimeout: getDrupalValue(entity.fieldTimeout) || 0,
     fieldWidgetType: getDrupalValue(entity.fieldWidgetType),
   },
 });


### PR DESCRIPTION
## Description
Previously, this was failing validation when the `fieldTimeout` wasn't specified
in Drupal.
