### PR TITLE
Improvements to stability and consistency of Cypress tests

### DIFF
--- a/src/platform/testing/e2e/cypress/support/commands/login.js
+++ b/src/platform/testing/e2e/cypress/support/commands/login.js
@@ -66,6 +66,7 @@ const mockUser = {
 
 /**
  * Simulates a logged in session.
+ * @param {Object} [userData] - Custom response stub for the user endpoint.
  */
 Cypress.Commands.add('login', (userData = mockUser) => {
   window.localStorage.setItem('hasSession', true);

--- a/src/platform/testing/e2e/cypress/support/form-tester/README.md
+++ b/src/platform/testing/e2e/cypress/support/form-tester/README.md
@@ -318,13 +318,13 @@ Function that performs setup before each test in the suite. Can be thought of as
 
 Cypress aliases and routes should get created here instead of `setup`, since those are reset before each test.
 
-Before `setupPerTest` runs, the form tester will have automatically started `cy.server()` and stubbed the `GET /v0/maintenance_windows` request to return `[]`.
+Before `setupPerTest` runs, the shared Cypress setup will have automatically started `cy.server()` and stubbed the `GET /v0/maintenance_windows` and `GET /v0/feature_toggles` requests to return empty arrays.
 
-Default stubs (like the maintenance windows request) can be overriden simply by setting up another `cy.route` on the same endpoint.
+Default stubs (like the maintenance windows and feature toggles requests) can be overriden by setting up another `cy.route` on the same endpoint.
 
 This is also generally the place to set anything in `localStorage` and `sessionStorage` before the test runs.
 
-Authenticated sessions are typically set up here as well with `cy.login()`. This is a custom command that sets the `hasSession` flag in `localStorage` and stubs the `GET v0/user` endpoint.
+Authenticated sessions are typically set up here as well with `cy.login()`. This is a custom command that sets the `hasSession` flag in `localStorage` and stubs the `GET /v0/user` endpoint.
 
 If your test requires a specific `localStorage` or `sessionStorage` state or authenticated session at a later point in the test, as in the middle instead of the beginning, you may set those in a page hook, but you **may need to reload the page (`cy.reload()`) to see the effects**.
 

--- a/src/platform/testing/e2e/cypress/support/form-tester/index.js
+++ b/src/platform/testing/e2e/cypress/support/form-tester/index.js
@@ -172,7 +172,10 @@ const processPage = () => {
       cy.findByText(/submit/i, { selector: 'button' }).click(FORCE_OPTION);
 
       // The form should end up at the confirmation page after submitting.
-      cy.location('pathname').then(endPathname => {
+      // Increased timeout for this step; there can sometimes be a longer delay
+      // between clicking submit and loading the confirmation page, which would
+      // cause the pathname assertion to time out and fail.
+      cy.location('pathname', { timeout: 8000 }).then(endPathname => {
         expect(endPathname).to.match(/confirmation$/);
         cy.axeCheck();
         performPageActions(endPathname, false);

--- a/src/platform/testing/e2e/cypress/support/form-tester/index.js
+++ b/src/platform/testing/e2e/cypress/support/form-tester/index.js
@@ -482,10 +482,6 @@ const testForm = testConfig => {
 
       cy.wrap(arrayPages).as('arrayPages');
 
-      // Save a couple of seconds by definitively responding with
-      // no maintenance windows instead of letting the request time out.
-      cy.server().route('GET', '/v0/maintenance_windows', []);
-
       // Resolve relative page hook paths as relative to the form's root URL.
       const resolvedPageHooks = Object.entries(pageHooks).reduce(
         (hooks, [path, hook]) => ({

--- a/src/platform/testing/e2e/cypress/support/index.js
+++ b/src/platform/testing/e2e/cypress/support/index.js
@@ -30,3 +30,20 @@ Cypress.Commands.overwrite('type', (originalFn, element, text, options) => {
 
   return originalFn(element, text, options);
 });
+
+// Default responses for common endpoints called by most apps.
+// Stubbing these will save a few seconds of loading time in tests.
+beforeEach(() => {
+  cy.server();
+
+  cy.route('GET', '/v0/feature_toggles?*', {
+    data: {
+      type: 'feature_toggles',
+      features: [],
+    },
+  });
+
+  cy.route('GET', '/v0/maintenance_windows', {
+    data: [],
+  });
+});


### PR DESCRIPTION
## Description
- Added default stubbed responses.
    - With these, tests don't have to duplicate stubs of maintenance windows and feature toggles explicitly.
    - These stubs were usually necessary to avoid timing out on assertions before the app even fully loaded.
- Increased timeout on form tester submission to address the rare flaky test that takes slightly too long to process the submission.
    - This would happen around 5% of the time (estimated).
    - Test failures would actually appear to be on the confirmation page but immediately after failing the assertion that the test hasn't landed on that page.
- Updated documentation.

## Testing done
Automated tests.

## Acceptance criteria
- [ ] Cypress tests should automatically include default stubbed responses to prevent timing out when loading apps.
- [ ] Cypress form tests should not time out during submission.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
