### PR TITLE
11265 test 686 widget

### DIFF
--- a/src/applications/static-pages/view-modify-dependent/686-cta/containers/Form686CTA.jsx
+++ b/src/applications/static-pages/view-modify-dependent/686-cta/containers/Form686CTA.jsx
@@ -2,13 +2,13 @@ import React from 'react';
 import { connect } from 'react-redux';
 import LoadingIndicator from '@department-of-veterans-affairs/formation-react/LoadingIndicator';
 
+import CallToActionWidget from 'platform/site-wide/cta-widget';
 import EbenefitsLink from 'platform/site-wide/ebenefits/containers/EbenefitsLink';
-import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
 import FEATURE_FLAG_NAMES from 'platform/utilities/feature-toggles/featureFlagNames';
-import { CallToActionWidget } from 'platform/site-wide/cta-widget';
+import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
 
 const Form686CTA = props => {
-  let content = <></>;
+  let content;
   if (props.showContent === undefined) {
     content = <LoadingIndicator message="Loading..." />;
   } else if (props.showContent === false) {

--- a/src/platform/site-wide/cta-widget/helpers.js
+++ b/src/platform/site-wide/cta-widget/helpers.js
@@ -186,7 +186,7 @@ export const toolUrl = (appId, authenticatedWithSSOe = false) => {
         redirect: false,
       };
 
-    case widgetTypes.ADD_MODIFY_DEPENDENTS:
+    case widgetTypes.ADD_REMOVE_DEPENDENTS:
       return {
         url: form686FormUrl,
         redirect: false,
@@ -290,7 +290,7 @@ export const serviceDescription = appId => {
     case widgetTypes.MANAGE_VA_DEBT:
       return 'manage your VA debt';
 
-    case widgetTypes.FORM_686_CTA:
+    case widgetTypes.ADD_REMOVE_DEPENDENTS:
       return 'add or remove dependents';
 
     default:


### PR DESCRIPTION
## Description
Follow up pull request to fix the import for CallToActionWidget. This allows the Form686CTA to render properly to the page. 

## Testing done
- local

## Screenshots
- User is whitelisted in flipper:
<img width="781" alt="Screen Shot 2020-07-31 at 12 22 10 PM" src="https://user-images.githubusercontent.com/15097156/89055948-3f756700-d329-11ea-899b-9924a7156158.png">

- User is not whitelisted in flipper:
<img width="766" alt="Screen Shot 2020-07-31 at 12 22 57 PM" src="https://user-images.githubusercontent.com/15097156/89055976-48fecf00-d329-11ea-8d34-9becdb0b17ca.png">


## Acceptance criteria
- [ ] expected behaviour is observed on page.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
