### PR TITLE
Update Review Page to handle CC reason

### DIFF
--- a/src/applications/vaos/components/review/CommunityCareSection.jsx
+++ b/src/applications/vaos/components/review/CommunityCareSection.jsx
@@ -13,7 +13,6 @@ export default function CommunityCareSection(props) {
         data={props.data}
         vaCityState={props.vaCityState}
       />
-      <hr aria-hidden="true" className="vads-u-margin-y--2" />
       <ReasonForAppointmentSection data={props.data} />
       <hr aria-hidden="true" className="vads-u-margin-y--2" />
       <ContactDetailSection data={props.data} />

--- a/src/applications/vaos/components/review/ReasonForAppointmentSection.jsx
+++ b/src/applications/vaos/components/review/ReasonForAppointmentSection.jsx
@@ -3,21 +3,25 @@ import { Link } from 'react-router';
 import newAppointmentFlow from '../../newAppointmentFlow';
 import { PURPOSE_TEXT } from '../../utils/constants';
 
-export default function ReasonForAppointmentSection(props) {
+export default function ReasonForAppointmentSection({ data }) {
+  const { reasonForAppointment, reasonAdditionalInfo } = data;
+
+  if (!reasonForAppointment && !reasonAdditionalInfo) {
+    return null;
+  }
+
   return (
     <>
+      <hr aria-hidden="true" className="vads-u-margin-y--2" />
       <div className="vads-l-grid-container vads-u-padding--0">
         <div className="vads-l-row vads-u-justify-content--space-between">
           <div className="vads-u-flex--1 vads-u-padding-right--1">
             <h3 className="vaos-appts__block-label">
-              {
-                PURPOSE_TEXT.find(
-                  purpose => purpose.id === props.data.reasonForAppointment,
-                )?.short
-              }
+              {PURPOSE_TEXT.find(purpose => purpose.id === reasonForAppointment)
+                ?.short || 'Additional details'}
             </h3>
             <span className="vaos-u-word-break--break-word">
-              {props.data.reasonAdditionalInfo}
+              {reasonAdditionalInfo}
             </span>
           </div>
           <div>

--- a/src/applications/vaos/components/review/ReviewDirectScheduleInfo.jsx
+++ b/src/applications/vaos/components/review/ReviewDirectScheduleInfo.jsx
@@ -28,7 +28,6 @@ export default function ReviewDirectScheduleInfo({
       {facility.name}
       <br />
       {facility.address?.city}, {facility.address?.state}
-      <hr aria-hidden="true" className="vads-u-margin-y--2" />
       <ReasonForAppointmentSection data={data} />
       <hr aria-hidden="true" className="vads-u-margin-y--2" />
       <ContactDetailSection data={data} />

--- a/src/applications/vaos/components/review/VAAppointmentSection.jsx
+++ b/src/applications/vaos/components/review/VAAppointmentSection.jsx
@@ -13,7 +13,6 @@ export default function VAAppointmentSection({ data, facility }) {
       <hr aria-hidden="true" className="vads-u-margin-y--2" />
       <h3 className="vaos-appts__block-label">{facility.name}</h3>
       {facility.address?.city}, {facility.address?.state}
-      <hr aria-hidden="true" className="vads-u-margin-y--2" />
       <ReasonForAppointmentSection data={data} />
       <hr aria-hidden="true" className="vads-u-margin-y--2" />
       <div className="vads-l-grid-container vads-u-padding--0">

--- a/src/applications/vaos/reducers/newAppointment.js
+++ b/src/applications/vaos/reducers/newAppointment.js
@@ -591,6 +591,8 @@ export default function formReducer(state = initialState, action) {
           additionalInfoTitle,
           reasonSchema,
         );
+      } else {
+        delete formData.reasonForAppointment;
       }
 
       const { data, schema } = setupFormData(

--- a/src/applications/vaos/tests/components/ReasonForAppointmentSection.unit.spec.jsx
+++ b/src/applications/vaos/tests/components/ReasonForAppointmentSection.unit.spec.jsx
@@ -11,31 +11,52 @@ const data = {
 };
 
 describe('VAOS <ReasonForAppointmentSection>', () => {
-  let tree;
+  describe('VA direct and requests', () => {
+    let tree;
 
-  beforeEach(() => {
-    tree = shallow(<ReasonForAppointmentSection data={data} />);
+    beforeEach(() => {
+      tree = shallow(<ReasonForAppointmentSection data={data} />);
+    });
+
+    afterEach(() => {
+      tree.unmount();
+    });
+
+    it('should render heading', () => {
+      expect(tree.find('h3').text()).to.equal('Follow-up/Routine');
+    });
+
+    it('should render reason for appointment section additional information', () => {
+      expect(tree.find('span').text()).to.equal('additional information');
+    });
+
+    it('should have aria labels for edit purpose of appointment', () => {
+      expect(
+        tree.find(Link).find('[aria-label="Edit purpose of appointment"]'),
+      ).to.have.lengthOf(1);
+    });
+
+    it('contain class that breaks long comments', () => {
+      expect(tree.find('.vaos-u-word-break--break-word').exists()).to.be.true;
+    });
   });
 
-  afterEach(() => {
-    tree.unmount();
-  });
+  describe('community care', () => {
+    it('should return null if no reasonForAppointent and no reasonAdditionalInfo', () => {
+      const tree = shallow(
+        <ReasonForAppointmentSection
+          data={{ reasonAdditionalInfo: 'additional information' }}
+        />,
+      );
+      expect(tree.find('h3').text()).to.equal('Additional details');
+      expect(tree.find('span').text()).to.equal('additional information');
+      tree.unmount();
+    });
 
-  it('should render heading', () => {
-    expect(tree.find('h3').text()).to.equal('Follow-up/Routine');
-  });
-
-  it('should render reason for appointment section additional information', () => {
-    expect(tree.find('span').text()).to.equal('additional information');
-  });
-
-  it('should have aria labels for edit purpose of appointment', () => {
-    expect(
-      tree.find(Link).find('[aria-label="Edit purpose of appointment"]'),
-    ).to.have.lengthOf(1);
-  });
-
-  it('contain class that breaks long comments', () => {
-    expect(tree.find('.vaos-u-word-break--break-word').exists()).to.be.true;
+    it('should return null if no reasonForAppointent and no reasonAdditionalInfo', () => {
+      const tree = shallow(<ReasonForAppointmentSection data={{}} />);
+      expect(tree.isEmptyRender()).to.equal(true);
+      tree.unmount();
+    });
   });
 });

--- a/src/applications/vaos/tests/reducers/newAppointment.unit.spec.js
+++ b/src/applications/vaos/tests/reducers/newAppointment.unit.spec.js
@@ -776,6 +776,35 @@ describe('VAOS reducer: newAppointment', () => {
     });
   });
 
+  it('should unset reasonForAppointment if CC appointment', () => {
+    const state = {
+      ...defaultState,
+      data: {
+        ...defaultState.data,
+        reasonForAppointment: 'other',
+        facilityType: FACILITY_TYPES.COMMUNITY_CARE,
+      },
+    };
+
+    const action = {
+      type: FORM_REASON_FOR_APPOINTMENT_PAGE_OPENED,
+      page: 'reasonForAppointment',
+      schema: {
+        type: 'object',
+        properties: {
+          reasonAdditionalInfo: {
+            type: 'string',
+          },
+        },
+      },
+      uiSchema: {},
+    };
+
+    const newState = newAppointmentReducer(state, action);
+
+    expect(newState.data.reasonForAppointment).to.equal(undefined);
+  });
+
   it('page open should set max characters', async () => {
     const currentState = {
       ...defaultState,


### PR DESCRIPTION
## Description
The review page was displaying a blank section with an extra `<hr>` if the user left the additional details blank for CC appointments.  This PR hides the section completely if they do not enter additional details, and provides a more accurate section header if they do.

## Testing done
Local and unit

## Screenshots
<img width="680" alt="Screen Shot 2020-07-31 at 1 22 48 PM" src="https://user-images.githubusercontent.com/786704/89074358-1e187900-d331-11ea-846d-ac97638d66b3.png">
<img width="680" alt="Screen Shot 2020-07-31 at 1 23 03 PM" src="https://user-images.githubusercontent.com/786704/89074371-21ac0000-d331-11ea-9997-eb3c1ee6d92c.png">


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
