### PR TITLE
Add tests for editing the four phone number fields

### DIFF
--- a/src/applications/personalization/profile-2/msw-mocks.js
+++ b/src/applications/personalization/profile-2/msw-mocks.js
@@ -61,7 +61,9 @@ export const updateDirectDepositFailure = [
   }),
 ];
 
-// response when successfully creating a transaction request
+// Response when successfully creating a transaction request. This body mentions
+// `email` in a couple of places but for testing purposes I'm reusing this body
+// for _all_ transaction creation requests.
 const createTransactionRequestSuccessBody = {
   id: '',
   type: 'async_transaction_vet360_email_transactions',
@@ -73,6 +75,9 @@ const createTransactionRequestSuccessBody = {
   },
 };
 
+// Error object when transaction fails to be created. This mentions `email` in a
+// couple of places but for testing purposes I'm reusing this body for _all_
+// transaction creation requests.
 const createTransactionRequestFailedError = {
   title: 'Check Email Domain',
   code: 'VET360_EMAIL304',
@@ -80,7 +85,7 @@ const createTransactionRequestFailedError = {
   status: '400',
 };
 
-// When creating a transaction request fails
+// Response when transaction fails to be created.
 export const createTransactionFailure = [
   rest.post(`${prefix}/v0/profile/*`, (req, res, ctx) => {
     return res(
@@ -111,7 +116,9 @@ export const createTransactionFailure = [
   }),
 ];
 
-// When a transaction has not resolved or failed
+// When a transaction has not resolved or failed. This mentions `email` in a
+// couple of places but for testing purposes I'm reusing this body for _all_
+// transaction.
 export const transactionPending = [
   rest.get(`${prefix}/v0/profile/status/:id`, (req, res, ctx) => {
     return res(
@@ -131,7 +138,9 @@ export const transactionPending = [
   }),
 ];
 
-// When the transaction fails to resolve
+// When the transaction fails to resolve. This mentions `email` and `address`
+// but for testing purposes I'm reusing body for _all_ transactions since the
+// metadata does not matter for the cases we are testing.
 export const transactionFailed = [
   rest.get(`${prefix}/v0/profile/status/:id`, (req, res, ctx) => {
     return res(
@@ -163,7 +172,9 @@ export const transactionFailed = [
   }),
 ];
 
-// When the transaction resolves
+// When the transaction resolves. This mentions `email` but for testing purposes
+// I'm reusing this for _all_ transactions since the metadata does not matter
+// for the cases we are testing.
 export const transactionSucceeded = [
   rest.get(`${prefix}/v0/profile/status/:id`, (req, res, ctx) => {
     return res(
@@ -183,6 +194,9 @@ export const transactionSucceeded = [
   }),
 ];
 
+// Sets up the responses needed to mack a successful email update. In particular
+// it mocks the `GET user/` response so that the updated email address matches
+// the email address that was entered in the Edit Email Address view.
 export const editEmailAddressSuccess = () => {
   // store the email address that's passed in via the POST or PUT call so we can
   // return it with the GET user/ response
@@ -436,6 +450,9 @@ export const editEmailAddressSuccess = () => {
   ];
 };
 
+// Sets up the responses needed to mack a successful email deletion. In
+// particular it mocks the `GET user/` response so that the email address no
+// longer exists
 export const deleteEmailAddressSuccess = [
   rest.delete(`${prefix}/v0/profile/*`, (req, res, ctx) => {
     return res(
@@ -664,6 +681,9 @@ export const deleteEmailAddressSuccess = [
   }),
 ];
 
+// Sets up the responses needed to mack a successful phone number update. In
+// particular it mocks the `GET user/` response so that _all_ of the phone
+// numbers match the phone number that was entered in the Edit Phone view.
 export const editPhoneNumberSuccess = () => {
   // store the phone number that's passed in via the POST or PUT call so we can
   // return it with the GET user/ response

--- a/src/applications/personalization/profile-2/msw-mocks.js
+++ b/src/applications/personalization/profile-2/msw-mocks.js
@@ -454,7 +454,7 @@ export const editEmailAddressSuccess = () => {
 // particular it mocks the `GET user/` response so that the email address no
 // longer exists
 export const deleteEmailAddressSuccess = [
-  rest.delete(`${prefix}/v0/profile/*`, (req, res, ctx) => {
+  rest.delete(`${prefix}/v0/profile/email_addresses`, (req, res, ctx) => {
     return res(
       ctx.json({
         data: createTransactionRequestSuccessBody,

--- a/src/applications/personalization/profile-2/msw-mocks.js
+++ b/src/applications/personalization/profile-2/msw-mocks.js
@@ -61,68 +61,58 @@ export const updateDirectDepositFailure = [
   }),
 ];
 
-// When the initial request to add an email address fails
-export const addEmailAddressCreateTransactionFailure = [
-  rest.post(`${prefix}/v0/profile/email_addresses`, (req, res, ctx) => {
+// response when successfully creating a transaction request
+const createTransactionRequestSuccessBody = {
+  id: '',
+  type: 'async_transaction_vet360_email_transactions',
+  attributes: {
+    transactionId: '61ffa9bd-3290-4e4b-9480-d93fd6236dcf',
+    transactionStatus: 'RECEIVED',
+    type: 'AsyncTransaction::Vet360::EmailTransaction',
+    metadata: [],
+  },
+};
+
+const createTransactionRequestFailedError = {
+  title: 'Check Email Domain',
+  code: 'VET360_EMAIL304',
+  detail: 'AlphaNumeric ToplevelDomainName must be <= 63 Characters.',
+  status: '400',
+};
+
+// When creating a transaction request fails
+export const createTransactionFailure = [
+  rest.post(`${prefix}/v0/profile/*`, (req, res, ctx) => {
     return res(
       ctx.status(400),
       ctx.json({
         // response pulled from vets-api config/locales/exceptions.en.yml
-        errors: [
-          {
-            title: 'Check Email Domain',
-            code: 'VET360_EMAIL304',
-            detail: 'AlphaNumeric ToplevelDomainName must be <= 63 Characters.',
-            status: '400',
-          },
-        ],
+        errors: [createTransactionRequestFailedError],
+      }),
+    );
+  }),
+  rest.put(`${prefix}/v0/profile/*`, (req, res, ctx) => {
+    return res(
+      ctx.status(400),
+      ctx.json({
+        // response pulled from vets-api config/locales/exceptions.en.yml
+        errors: [createTransactionRequestFailedError],
+      }),
+    );
+  }),
+  rest.delete(`${prefix}/v0/profile/*`, (req, res, ctx) => {
+    return res(
+      ctx.status(400),
+      ctx.json({
+        // response pulled from vets-api config/locales/exceptions.en.yml
+        errors: [createTransactionRequestFailedError],
       }),
     );
   }),
 ];
 
-// When the initial request to update an email address fails
-export const updateEmailAddressCreateTransactionFailure = [
-  rest.put(`${prefix}/v0/profile/email_addresses`, (req, res, ctx) => {
-    return res(
-      ctx.status(400),
-      ctx.json({
-        // response pulled from vets-api config/locales/exceptions.en.yml
-        errors: [
-          {
-            title: 'Check Email Domain',
-            code: 'VET360_EMAIL304',
-            detail: 'AlphaNumeric ToplevelDomainName must be <= 63 Characters.',
-            status: '400',
-          },
-        ],
-      }),
-    );
-  }),
-];
-
-// When the initial request to delete an email address fails
-export const deleteEmailAddressCreateTransactionFailure = [
-  rest.delete(`${prefix}/v0/profile/email_addresses`, (req, res, ctx) => {
-    return res(
-      ctx.status(400),
-      ctx.json({
-        // response pulled from vets-api config/locales/exceptions.en.yml
-        errors: [
-          {
-            title: 'Check Email Domain',
-            code: 'VET360_EMAIL304',
-            detail: 'AlphaNumeric ToplevelDomainName must be <= 63 Characters.',
-            status: '400',
-          },
-        ],
-      }),
-    );
-  }),
-];
-
-// When the transaction has not resolved or failed
-export const editEmailAddressTransactionPending = [
+// When a transaction has not resolved or failed
+export const transactionPending = [
   rest.get(`${prefix}/v0/profile/status/:id`, (req, res, ctx) => {
     return res(
       ctx.json({
@@ -142,7 +132,7 @@ export const editEmailAddressTransactionPending = [
 ];
 
 // When the transaction fails to resolve
-export const editEmailAddressTransactionFailure = [
+export const transactionFailed = [
   rest.get(`${prefix}/v0/profile/status/:id`, (req, res, ctx) => {
     return res(
       ctx.json({
@@ -174,7 +164,7 @@ export const editEmailAddressTransactionFailure = [
 ];
 
 // When the transaction resolves
-export const editEmailAddressTransactionSuccess = [
+export const transactionSucceeded = [
   rest.get(`${prefix}/v0/profile/status/:id`, (req, res, ctx) => {
     return res(
       ctx.json({
@@ -194,24 +184,15 @@ export const editEmailAddressTransactionSuccess = [
 ];
 
 export const editEmailAddressSuccess = () => {
-  // store the email address that's passed in via the POST call so we can return
-  // it with the GET user/ response
+  // store the email address that's passed in via the POST or PUT call so we can
+  // return it with the GET user/ response
   let newEmailAddress;
   return [
     rest.post(`${prefix}/v0/profile/email_addresses`, (req, res, ctx) => {
       newEmailAddress = req.body.emailAddress;
       return res(
         ctx.json({
-          data: {
-            id: '',
-            type: 'async_transaction_vet360_email_transactions',
-            attributes: {
-              transactionId: '61ffa9bd-3290-4e4b-9480-d93fd6236dcf',
-              transactionStatus: 'RECEIVED',
-              type: 'AsyncTransaction::Vet360::EmailTransaction',
-              metadata: [],
-            },
-          },
+          data: createTransactionRequestSuccessBody,
         }),
       );
     }),
@@ -219,16 +200,7 @@ export const editEmailAddressSuccess = () => {
       newEmailAddress = req.body.emailAddress;
       return res(
         ctx.json({
-          data: {
-            id: '',
-            type: 'async_transaction_vet360_email_transactions',
-            attributes: {
-              transactionId: '61ffa9bd-3290-4e4b-9480-d93fd6236dcf',
-              transactionStatus: 'RECEIVED',
-              type: 'AsyncTransaction::Vet360::EmailTransaction',
-              metadata: [],
-            },
-          },
+          data: createTransactionRequestSuccessBody,
         }),
       );
     }),
@@ -465,19 +437,10 @@ export const editEmailAddressSuccess = () => {
 };
 
 export const deleteEmailAddressSuccess = [
-  rest.delete(`${prefix}/v0/profile/email_addresses`, (req, res, ctx) => {
+  rest.delete(`${prefix}/v0/profile/*`, (req, res, ctx) => {
     return res(
       ctx.json({
-        data: {
-          id: '',
-          type: 'async_transaction_vet360_email_transactions',
-          attributes: {
-            transactionId: '61ffa9bd-3290-4e4b-9480-d93fd6236dcf',
-            transactionStatus: 'RECEIVED',
-            type: 'AsyncTransaction::Vet360::EmailTransaction',
-            metadata: [],
-          },
-        },
+        data: createTransactionRequestSuccessBody,
       }),
     );
   }),
@@ -700,3 +663,300 @@ export const deleteEmailAddressSuccess = [
     );
   }),
 ];
+
+export const editPhoneNumberSuccess = () => {
+  // store the phone number that's passed in via the POST or PUT call so we can
+  // return it with the GET user/ response
+  let newAreaCode;
+  let newPhoneNumber;
+  return [
+    rest.post(`${prefix}/v0/profile/telephones`, (req, res, ctx) => {
+      newAreaCode = req.body.areaCode;
+      newPhoneNumber = req.body.phoneNumber;
+      return res(
+        ctx.json({
+          data: {
+            id: '',
+            type: 'async_transaction_vet360_telephone_transactions',
+            attributes: {
+              transactionId: '61ffa9bd-3290-4e4b-9480-d93fd6236dcf',
+              transactionStatus: 'RECEIVED',
+              type: 'AsyncTransaction::Vet360::TelephoneTransaction',
+              metadata: [],
+            },
+          },
+        }),
+      );
+    }),
+    rest.put(`${prefix}/v0/profile/telephones`, (req, res, ctx) => {
+      newAreaCode = req.body.areaCode;
+      newPhoneNumber = req.body.phoneNumber;
+      return res(
+        ctx.json({
+          data: {
+            id: '',
+            type: 'async_transaction_vet360_telephone_transactions',
+            attributes: {
+              transactionId: '61ffa9bd-3290-4e4b-9480-d93fd6236dcf',
+              transactionStatus: 'RECEIVED',
+              type: 'AsyncTransaction::Vet360::TelephoneTransaction',
+              metadata: [],
+            },
+          },
+        }),
+      );
+    }),
+    // for testing purposes, after saving a phone number, return a user object
+    // where that phone number is saved for _all_ numbers: home, work, mobile
+    // and fax
+    rest.get(`${prefix}/v0/user`, (req, res, ctx) => {
+      return res(
+        ctx.json({
+          data: {
+            id: '',
+            type: 'users_scaffolds',
+            attributes: {
+              services: [
+                'facilities',
+                'hca',
+                'edu-benefits',
+                'form-save-in-progress',
+                'form-prefill',
+                'mhv-accounts',
+                'evss-claims',
+                'form526',
+                'user-profile',
+                'appeals-status',
+                'id-card',
+                'identity-proofed',
+                'vet360',
+                'evss_common_client',
+                'claim_increase',
+              ],
+              account: { accountUuid: 'c049d895-ecdf-40a4-ac0f-7947a06ea0c2' },
+              profile: {
+                email: 'vets.gov.user+36@gmail.com',
+                firstName: 'WESLEY',
+                middleName: 'WATSON',
+                lastName: 'FORD',
+                birthDate: '1986-05-06',
+                gender: 'M',
+                zip: '21122-6706',
+                lastSignedIn: '2020-07-28T14:57:28.196Z',
+                loa: { current: 3, highest: 3 },
+                multifactor: true,
+                verified: true,
+                signIn: {
+                  serviceName: 'idme',
+                  accountType: 'N/A',
+                  ssoe: true,
+                  transactionid: '/lob0lmUWabZaaWqJ+ydOKkCYvu55jG3IxIJI4qzGic=',
+                },
+                authnContext: 'http://idmanagement.gov/ns/assurance/loa/3',
+              },
+              vaProfile: {
+                status: 'OK',
+                birthDate: '19860506',
+                familyName: 'Ford',
+                gender: 'M',
+                givenNames: ['Wesley', 'Watson'],
+                isCernerPatient: false,
+                facilities: [{ facilityId: '983', isCerner: false }],
+                vaPatient: true,
+                mhvAccountState: 'NONE',
+              },
+              veteranStatus: {
+                status: 'OK',
+                isVeteran: true,
+                servedInMilitary: true,
+              },
+              inProgressForms: [],
+              prefillsAvailable: [
+                '21-686C',
+                '40-10007',
+                '22-1990',
+                '22-1990N',
+                '22-1990E',
+                '22-1995',
+                '22-1995S',
+                '22-5490',
+                '22-5495',
+                '22-0993',
+                '22-0994',
+                'FEEDBACK-TOOL',
+                '22-10203',
+                '21-526EZ',
+                '21-526EZ-BDD',
+                '1010ez',
+                '21P-530',
+                '21P-527EZ',
+                '686C-674',
+                '20-0996',
+                'MDOT',
+              ],
+              vet360ContactInformation: {
+                email: {
+                  createdAt: '2020-07-28T14:57:54.000Z',
+                  emailAddress: newPhoneNumber,
+                  effectiveEndDate: null,
+                  effectiveStartDate: '2020-07-28T14:57:53.000Z',
+                  id: 114818,
+                  sourceDate: '2020-07-28T14:57:53.000Z',
+                  sourceSystemUser: null,
+                  transactionId: '61ffa9bd-3290-4e4b-9480-d93fd6236dcf',
+                  updatedAt: '2020-07-28T14:57:54.000Z',
+                  vet360Id: '1273780',
+                },
+                residentialAddress: {
+                  addressLine1: '34 Blanchard Rd',
+                  addressLine2: null,
+                  addressLine3: null,
+                  addressPou: 'RESIDENCE/CHOICE',
+                  addressType: 'DOMESTIC',
+                  city: 'Shirley Mills',
+                  countryName: 'United States',
+                  countryCodeIso2: 'US',
+                  countryCodeIso3: 'USA',
+                  countryCodeFips: null,
+                  countyCode: '23021',
+                  countyName: 'Piscataquis County',
+                  createdAt: '2020-07-25T00:32:10.000Z',
+                  effectiveEndDate: null,
+                  effectiveStartDate: '2020-07-25T00:32:09.000Z',
+                  id: 185731,
+                  internationalPostalCode: null,
+                  province: null,
+                  sourceDate: '2020-07-25T00:32:09.000Z',
+                  sourceSystemUser: null,
+                  stateCode: 'ME',
+                  transactionId: '6bde244e-a92f-421f-a7dc-923fc85f4f5f',
+                  updatedAt: '2020-07-25T00:32:10.000Z',
+                  validationKey: null,
+                  vet360Id: '1273780',
+                  zipCode: '04485',
+                  zipCodeSuffix: '4413',
+                },
+                mailingAddress: {
+                  addressLine1: '8210 Doby Ln',
+                  addressLine2: null,
+                  addressLine3: null,
+                  addressPou: 'CORRESPONDENCE',
+                  addressType: 'DOMESTIC',
+                  city: 'Pasadena',
+                  countryName: 'United States',
+                  countryCodeIso2: 'US',
+                  countryCodeIso3: 'USA',
+                  countryCodeFips: null,
+                  countyCode: '24003',
+                  countyName: 'Anne Arundel County',
+                  createdAt: '2020-05-30T03:57:20.000Z',
+                  effectiveEndDate: null,
+                  effectiveStartDate: '2020-07-25T00:31:00.000Z',
+                  id: 173917,
+                  internationalPostalCode: null,
+                  province: null,
+                  sourceDate: '2020-07-25T00:31:00.000Z',
+                  sourceSystemUser: null,
+                  stateCode: 'MD',
+                  transactionId: '2ad2aef3-101a-4bc9-b7dc-2e7ce772c215',
+                  updatedAt: '2020-07-25T00:31:02.000Z',
+                  validationKey: null,
+                  vet360Id: '1273780',
+                  zipCode: '21122',
+                  zipCodeSuffix: '6706',
+                },
+                mobilePhone: {
+                  areaCode: newAreaCode,
+                  countryCode: '1',
+                  createdAt: '2020-07-25T00:34:24.000Z',
+                  extension: null,
+                  effectiveEndDate: null,
+                  effectiveStartDate: '2020-07-25T00:34:24.000Z',
+                  id: 155102,
+                  isInternational: false,
+                  isTextable: null,
+                  isTextPermitted: null,
+                  isTty: null,
+                  isVoicemailable: null,
+                  phoneNumber: newPhoneNumber,
+                  phoneType: 'MOBILE',
+                  sourceDate: '2020-07-25T00:34:24.000Z',
+                  sourceSystemUser: null,
+                  transactionId: '77ad4f31-2d1a-4aaa-a259-7f0cc8fb0357',
+                  updatedAt: '2020-07-25T00:34:24.000Z',
+                  vet360Id: '1273780',
+                },
+                homePhone: {
+                  areaCode: newAreaCode,
+                  countryCode: '1',
+                  createdAt: '2020-07-25T00:33:15.000Z',
+                  extension: null,
+                  effectiveEndDate: null,
+                  effectiveStartDate: '2020-07-25T00:33:14.000Z',
+                  id: 155101,
+                  isInternational: false,
+                  isTextable: null,
+                  isTextPermitted: null,
+                  isTty: null,
+                  isVoicemailable: null,
+                  phoneNumber: newPhoneNumber,
+                  phoneType: 'HOME',
+                  sourceDate: '2020-07-25T00:33:14.000Z',
+                  sourceSystemUser: null,
+                  transactionId: 'a7299f8e-1646-40f5-988d-61d0480c01dc',
+                  updatedAt: '2020-07-25T00:33:15.000Z',
+                  vet360Id: '1273780',
+                },
+                workPhone: {
+                  areaCode: newAreaCode,
+                  countryCode: '1',
+                  createdAt: '2020-07-25T00:33:51.000Z',
+                  extension: null,
+                  effectiveEndDate: null,
+                  effectiveStartDate: '2020-07-25T00:33:51.000Z',
+                  id: 155103,
+                  isInternational: false,
+                  isTextable: null,
+                  isTextPermitted: null,
+                  isTty: null,
+                  isVoicemailable: null,
+                  phoneNumber: newPhoneNumber,
+                  phoneType: 'WORK',
+                  sourceDate: '2020-07-25T00:33:51.000Z',
+                  sourceSystemUser: null,
+                  transactionId: 'b98371ec-bfd5-4724-89ee-3ea3c48dac81',
+                  updatedAt: '2020-07-25T00:33:51.000Z',
+                  vet360Id: '1273780',
+                },
+                temporaryPhone: null,
+                faxNumber: {
+                  areaCode: newAreaCode,
+                  countryCode: '1',
+                  createdAt: '2020-07-31T20:54:34.000Z',
+                  extension: null,
+                  effectiveEndDate: null,
+                  effectiveStartDate: '2020-07-31T20:54:33.000Z',
+                  id: 156326,
+                  isInternational: false,
+                  isTextable: null,
+                  isTextPermitted: null,
+                  isTty: null,
+                  isVoicemailable: null,
+                  phoneNumber: newPhoneNumber,
+                  phoneType: 'FAX',
+                  sourceDate: '2020-07-31T20:54:33.000Z',
+                  sourceSystemUser: null,
+                  transactionId: '96a806c2-0af8-4e5a-b8b2-30c44f3a4759',
+                  updatedAt: '2020-07-31T20:54:34.000Z',
+                  vet360Id: '1273780',
+                },
+                textPermission: null,
+              },
+            },
+          },
+          meta: { errors: null },
+        }),
+      );
+    }),
+  ];
+};

--- a/src/applications/personalization/profile-2/tests/components/personal-information/PersonalInformation.delete-email-address.unit.spec.jsx
+++ b/src/applications/personalization/profile-2/tests/components/personal-information/PersonalInformation.delete-email-address.unit.spec.jsx
@@ -76,7 +76,7 @@ describe('Deleting email address', () => {
   });
 
   it('should handle a deletion that succeeds quickly', async () => {
-    server.use(...mocks.editEmailAddressTransactionSuccess);
+    server.use(...mocks.transactionSucceeded);
 
     const { emailAddressInput } = deleteEmailAddress();
 
@@ -93,7 +93,7 @@ describe('Deleting email address', () => {
       .exist;
   });
   it('should handle a deletion that does not succeed until after the edit view exits', async () => {
-    server.use(...mocks.editEmailAddressTransactionPending);
+    server.use(...mocks.transactionPending);
 
     const { emailAddressInput } = deleteEmailAddress();
 
@@ -106,7 +106,7 @@ describe('Deleting email address', () => {
     );
     expect(deletingMessage).to.exist;
 
-    server.use(...mocks.editEmailAddressTransactionSuccess);
+    server.use(...mocks.transactionSucceeded);
 
     await waitForElementToBeRemoved(deletingMessage);
 
@@ -120,7 +120,7 @@ describe('Deleting email address', () => {
       .exist;
   });
   it('should show an error if the transaction cannot be created', async () => {
-    server.use(...mocks.deleteEmailAddressCreateTransactionFailure);
+    server.use(...mocks.createTransactionFailure);
 
     deleteEmailAddress();
 
@@ -132,7 +132,7 @@ describe('Deleting email address', () => {
     );
   });
   it('should show an error if the deletion fails quickly', async () => {
-    server.use(...mocks.editEmailAddressTransactionFailure);
+    server.use(...mocks.transactionFailed);
 
     deleteEmailAddress();
 
@@ -144,7 +144,7 @@ describe('Deleting email address', () => {
     );
   });
   it('should show an error if the deletion fails after the edit view exits', async () => {
-    server.use(...mocks.editEmailAddressTransactionPending);
+    server.use(...mocks.transactionPending);
 
     const { emailAddressInput } = deleteEmailAddress();
 
@@ -157,7 +157,7 @@ describe('Deleting email address', () => {
     );
     expect(deletingMessage).to.exist;
 
-    server.use(...mocks.editEmailAddressTransactionFailure);
+    server.use(...mocks.transactionFailed);
 
     await waitForElementToBeRemoved(deletingMessage);
 

--- a/src/applications/personalization/profile-2/tests/components/personal-information/PersonalInformation.edit-email-address.unit.spec.jsx
+++ b/src/applications/personalization/profile-2/tests/components/personal-information/PersonalInformation.edit-email-address.unit.spec.jsx
@@ -58,7 +58,7 @@ function editEmailAddress() {
 
 // When the update happens while the Edit View is still active
 async function testQuickSuccess() {
-  server.use(...mocks.editEmailAddressTransactionSuccess);
+  server.use(...mocks.transactionSucceeded);
 
   const { emailAddressInput } = editEmailAddress();
 
@@ -77,7 +77,7 @@ async function testQuickSuccess() {
 // When the update happens but not until after the Edit View has exited and the
 // user returned to the read-only view
 async function testSlowSuccess() {
-  server.use(...mocks.editEmailAddressTransactionPending);
+  server.use(...mocks.transactionPending);
 
   const { emailAddressInput } = editEmailAddress();
 
@@ -90,7 +90,7 @@ async function testSlowSuccess() {
   );
   expect(savingMessage).to.exist;
 
-  server.use(...mocks.editEmailAddressTransactionSuccess);
+  server.use(...mocks.transactionSucceeded);
 
   await waitForElementToBeRemoved(savingMessage);
 
@@ -109,10 +109,7 @@ async function testSlowSuccess() {
 
 // When the initial transaction creation request fails
 async function testTransactionCreationFails() {
-  server.use(
-    ...mocks.updateEmailAddressCreateTransactionFailure,
-    ...mocks.addEmailAddressCreateTransactionFailure,
-  );
+  server.use(...mocks.createTransactionFailure);
 
   editEmailAddress();
 
@@ -126,7 +123,7 @@ async function testTransactionCreationFails() {
 
 // When the update fails while the Edit View is still active
 async function testQuickFailure() {
-  server.use(...mocks.editEmailAddressTransactionFailure);
+  server.use(...mocks.transactionFailed);
 
   editEmailAddress();
 
@@ -141,7 +138,7 @@ async function testQuickFailure() {
 // When the update fails but not until after the Edit View has exited and the
 // user returned to the read-only view
 async function testSlowFailure() {
-  server.use(...mocks.editEmailAddressTransactionPending);
+  server.use(...mocks.transactionPending);
 
   const { emailAddressInput } = editEmailAddress();
 
@@ -154,7 +151,7 @@ async function testSlowFailure() {
   );
   expect(savingMessage).to.exist;
 
-  server.use(...mocks.editEmailAddressTransactionFailure);
+  server.use(...mocks.transactionFailed);
 
   await waitForElementToBeRemoved(savingMessage);
 
@@ -167,7 +164,7 @@ async function testSlowFailure() {
 
   // and the new email address should not exist in the DOM
   expect(view.queryByText(newEmailAddress)).not.to.exist;
-  // and the add email button should be back
+  // and the add/edit email button should be back
   expect(getEditButton()).to.exist;
 }
 

--- a/src/applications/personalization/profile-2/tests/components/personal-information/PersonalInformation.edit-telephone.unit.spec.jsx
+++ b/src/applications/personalization/profile-2/tests/components/personal-information/PersonalInformation.edit-telephone.unit.spec.jsx
@@ -1,0 +1,238 @@
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { waitForElementToBeRemoved } from '@testing-library/react';
+import user from '@testing-library/user-event';
+import { expect } from 'chai';
+import { setupServer } from 'msw/node';
+
+import { resetFetch } from 'platform/testing/unit/helpers';
+import { FIELD_TITLES, FIELD_NAMES } from 'vet360/constants';
+
+import * as mocks from '../../../msw-mocks';
+import PersonalInformation from '../../../components/personal-information/PersonalInformation';
+
+import {
+  createBasicInitialState,
+  renderWithProfileReducers,
+} from '../../unit-test-helpers';
+import { beforeEach } from 'mocha';
+
+const newAreaCode = '415';
+const newPhoneNumber = '555-0055';
+const ui = (
+  <MemoryRouter>
+    <PersonalInformation />
+  </MemoryRouter>
+);
+let view;
+let server;
+
+function getEditButton(numberName) {
+  let editButton = view.queryByText(new RegExp(`add.*${numberName}`, 'i'), {
+    selector: 'button',
+  });
+  if (!editButton) {
+    // Need to use `queryByRole` since the visible label is simply `Edit`, but
+    // the aria-label is more descriptive
+    editButton = view.queryByRole('button', {
+      name: new RegExp(`edit.*${numberName}`, 'i'),
+    });
+  }
+  return editButton;
+}
+
+// helper function that enters the `Edit phone number` view, enters a number,
+// and clicks the `Update` button.
+function editPhoneNumber(numberName) {
+  const editButton = getEditButton(numberName);
+  editButton.click();
+
+  const phoneNumberInput = view.getByLabelText(/Number/);
+  const extensionInput = view.getByLabelText(/Extension/);
+  expect(phoneNumberInput).to.exist;
+
+  // enter a new email address in the form
+  user.clear(phoneNumberInput);
+  user.type(phoneNumberInput, `${newAreaCode} ${newPhoneNumber}`);
+  user.clear(extensionInput);
+
+  // save
+  view.getByText('Update', { selector: 'button' }).click();
+
+  return { phoneNumberInput };
+}
+
+// When the update happens while the Edit View is still active
+async function testQuickSuccess(numberName) {
+  server.use(...mocks.transactionSucceeded);
+
+  const { phoneNumberInput } = editPhoneNumber(numberName);
+
+  // wait for the edit mode to exit
+  await waitForElementToBeRemoved(phoneNumberInput);
+
+  // the 'edit' button should exist
+  expect(
+    view.getByRole('button', { name: new RegExp(`edit.*${numberName}`, 'i') }),
+  ).to.exist;
+  // and the new number should exist in the DOM
+  // TODO: make better assertions for this?
+  expect(view.getAllByText(newAreaCode, { exact: false }).length).to.eql(4);
+  expect(view.getAllByText(newPhoneNumber, { exact: false }).length).to.eql(4);
+  // and the 'add' button should be gone
+  expect(
+    view.queryByText(new RegExp(`new.*${numberName}`, 'i'), {
+      selector: 'button',
+    }),
+  ).not.to.exist;
+}
+
+// When the update happens but not until after the Edit View has exited and the
+// user returned to the read-only view
+async function testSlowSuccess(numberName) {
+  server.use(...mocks.transactionPending);
+
+  const { phoneNumberInput } = editPhoneNumber(numberName);
+
+  // wait for the edit mode to exit
+  await waitForElementToBeRemoved(phoneNumberInput);
+
+  // check that the "we're saving your..." message appears
+  const savingMessage = await view.findByText(
+    /We’re working on saving your new.*/i,
+  );
+  expect(savingMessage).to.exist;
+
+  server.use(...mocks.transactionSucceeded);
+
+  await waitForElementToBeRemoved(savingMessage);
+
+  // the edit email button should exist
+  expect(
+    view.getByRole('button', {
+      name: new RegExp(`edit.*${numberName}`, 'i'),
+    }),
+  ).to.exist;
+  // and the updated phone numbers should be in the DOM
+  // TODO: make better assertions for this?
+  expect(view.getAllByText(newAreaCode, { exact: false }).length).to.eql(4);
+  expect(view.getAllByText(newPhoneNumber, { exact: false }).length).to.eql(4);
+  // and the 'add' button should be gone
+  expect(
+    view.queryByText(new RegExp(`new.*${numberName}`, 'i'), {
+      selector: 'button',
+    }),
+  ).not.to.exist;
+}
+
+// When the initial transaction creation request fails
+async function testTransactionCreationFails(numberName) {
+  server.use(...mocks.createTransactionFailure);
+
+  editPhoneNumber(numberName);
+
+  // expect an error to be shown
+  const alert = await view.findByTestId('edit-error-alert');
+  expect(alert).to.have.descendant('div.usa-alert-error');
+  // TODO: would be nice to be able to check the contents against a RegExp
+  expect(alert).to.contain.text('We’re sorry. We couldn’t update your');
+  expect(alert).to.contain.text('Please try again.');
+}
+
+// When the update fails while the Edit View is still active
+async function testQuickFailure(numberName) {
+  server.use(...mocks.transactionFailed);
+
+  editPhoneNumber(numberName);
+
+  // expect an error to be shown
+  const alert = await view.findByTestId('edit-error-alert');
+  expect(alert).to.have.descendant('div.usa-alert-error');
+  // TODO: would be nice to be able to check the contents against a RegExp
+  expect(alert).to.contain.text('We’re sorry. We couldn’t update your');
+  expect(alert).to.contain.text('Please try again.');
+}
+
+// When the update fails but not until after the Edit View has exited and the
+// user returned to the read-only view
+async function testSlowFailure(numberName) {
+  server.use(...mocks.transactionPending);
+
+  const { phoneNumberInput } = editPhoneNumber(numberName);
+
+  // wait for the edit mode to exit
+  await waitForElementToBeRemoved(phoneNumberInput);
+
+  // check that the "we're saving your..." message appears
+  const savingMessage = await view.findByText(
+    /We’re working on saving your new.*/i,
+  );
+  expect(savingMessage).to.exist;
+
+  server.use(...mocks.transactionFailed);
+
+  await waitForElementToBeRemoved(savingMessage);
+
+  // make sure the error message appears
+  expect(
+    view.getByText(
+      /We couldn’t save your recent .* number update. Please try again later/i,
+    ),
+  ).to.exist;
+
+  // and the add/edit button should be back
+  expect(getEditButton(numberName)).to.exist;
+}
+
+describe('Editing', () => {
+  before(() => {
+    // before we can use msw, we need to make sure that global.fetch has been
+    // restored and is no longer a sinon stub.
+    resetFetch();
+    server = setupServer(...mocks.editPhoneNumberSuccess());
+    server.listen();
+  });
+  beforeEach(() => {
+    window.VetsGov = { pollTimeout: 1 };
+    const initialState = createBasicInitialState();
+
+    view = renderWithProfileReducers(ui, {
+      initialState,
+    });
+  });
+  afterEach(() => {
+    server.resetHandlers();
+  });
+  after(() => {
+    server.close();
+  });
+
+  // the list of number fields that we need to test
+  const numbers = [
+    FIELD_NAMES.HOME_PHONE,
+    FIELD_NAMES.MOBILE_PHONE,
+    FIELD_NAMES.WORK_PHONE,
+    FIELD_NAMES.FAX_NUMBER,
+  ];
+
+  numbers.forEach(number => {
+    const numberName = FIELD_TITLES[number];
+    describe(numberName, () => {
+      it('should handle a transaction that succeeds quickly', async () => {
+        await testQuickSuccess(numberName);
+      });
+      it('should handle a transaction that does not succeed until after the edit view exits', async () => {
+        await testSlowSuccess(numberName);
+      });
+      it('should show an error if the transaction cannot be created', async () => {
+        await testTransactionCreationFails(numberName);
+      });
+      it('should show an error if the transaction fails quickly', async () => {
+        await testQuickFailure(numberName);
+      });
+      it('should show an error if the transaction fails after the edit view exits', async () => {
+        await testSlowFailure(numberName);
+      });
+    });
+  });
+});

--- a/src/applications/vaos/tests/list/appointment-list.unit.spec.jsx
+++ b/src/applications/vaos/tests/list/appointment-list.unit.spec.jsx
@@ -224,8 +224,8 @@ describe('VAOS integration: appointment list', () => {
             expressTimes: {
               start: '00:00',
               end: '23:59',
-              timezone: 'MDT',
-              offsetUtc: '-06:00',
+              timezone: 'UTC',
+              offsetUtc: '+00:00',
             },
           },
         },
@@ -278,7 +278,7 @@ describe('VAOS integration: appointment list', () => {
 
   it('should not show express care action when outside of express care window', async () => {
     mockAppointmentInfo({});
-    const now = moment().utcOffset('-06:00');
+    const now = moment.utc();
     mockParentSites(['983'], [parentSite983]);
     mockSupportedFacilities({
       siteId: 983,
@@ -296,8 +296,8 @@ describe('VAOS integration: appointment list', () => {
                 .clone()
                 .subtract(2, 'minutes')
                 .format('HH:mm'),
-              timezone: 'MDT',
-              offsetUtc: '-06:00',
+              timezone: 'UTC',
+              offsetUtc: '+00:00',
             },
           },
         },
@@ -378,8 +378,8 @@ describe('VAOS integration: appointment list', () => {
             expressTimes: {
               start: '00:00',
               end: '23:59',
-              timezone: 'MDT',
-              offsetUtc: '-06:00',
+              timezone: 'UTC',
+              offsetUtc: '+00:00',
             },
           },
         },


### PR DESCRIPTION
## Description
- refactors some existing mocks (mostly renaming) to make them suitable for tests beyond "edit email address" tests
- add tests for adding/editing phone numbers
- [ ] need to add tests for deleting phone numbers

## Testing done
This is all tests :)

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs