### PR TITLE
Show "Direct Deposit is blocked" error alert

### DIFF
--- a/src/applications/personalization/profile-2/components/personal-information/PersonalInformation.jsx
+++ b/src/applications/personalization/profile-2/components/personal-information/PersonalInformation.jsx
@@ -10,8 +10,12 @@ import DowntimeNotification, {
 } from 'platform/monitoring/DowntimeNotification';
 import { focusElement } from 'platform/utilities/ui';
 
+import PaymentInformationBlocked from 'applications/personalization/profile360/components/PaymentInformationBlocked';
 import { handleDowntimeForSection } from 'applications/personalization/profile360/components/DowntimeBanner';
-import { directDepositLoadError } from 'applications/personalization/profile360/selectors';
+import {
+  directDepositIsBlocked,
+  directDepositLoadError,
+} from 'applications/personalization/profile360/selectors';
 
 import PersonalInformationContent from './PersonalInformationContent';
 
@@ -26,6 +30,7 @@ const MyAlert = () => (
 );
 
 const PersonalInformation = ({
+  showDirectDepositBlockedError,
   showNotAllDataAvailableError,
   hasUnsavedEdits,
 }) => {
@@ -63,6 +68,7 @@ const PersonalInformation = ({
         render={handleDowntimeForSection('personal and contact')}
         dependencies={[externalServices.mvi, externalServices.vet360]}
       >
+        {showDirectDepositBlockedError && <PaymentInformationBlocked />}
         {showNotAllDataAvailableError && <MyAlert />}
         <PersonalInformationContent />
       </DowntimeNotification>
@@ -71,11 +77,13 @@ const PersonalInformation = ({
 };
 
 PersonalInformation.propTypes = {
+  showDirectDepositBlockedError: PropTypes.bool.isRequired,
   showNotAllDataAvailableError: PropTypes.bool.isRequired,
   hasUnsavedEdits: PropTypes.bool.isRequired,
 };
 
 const mapStateToProps = state => ({
+  showDirectDepositBlockedError: !!directDepositIsBlocked(state),
   showNotAllDataAvailableError: !!directDepositLoadError(state),
   hasUnsavedEdits: state.vet360.hasUnsavedEdits,
 });


### PR DESCRIPTION
## Description
This adds an alert at to the top of the first page of the Profile if the user is explicitly blocked from accessing their Direct Deposit because they are flagged as deceased, incompetent, or having a fiduciary.

## Testing done
Local + expanded the existing Direct Deposit Cypress tests; we already made sure the DD feature was blocked for users who we flagged.

## Screenshots
![image](https://user-images.githubusercontent.com/20728956/89193436-d412db80-d55a-11ea-9967-d7f21debe2fb.png)

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs