### PR TITLE
Update data sent for EC requests

### DIFF
--- a/src/applications/vaos/reducers/expressCare.js
+++ b/src/applications/vaos/reducers/expressCare.js
@@ -185,7 +185,9 @@ export default function expressCareReducer(state = initialState, action) {
         ...state,
         submitStatus: FETCH_STATUS.succeeded,
         successfulRequest: action.responseData,
-        newRequest: {},
+        newRequest: {
+          data: {},
+        },
       };
     case FORM_SUBMIT_FAILED:
       return {

--- a/src/applications/vaos/tests/new-express-care-request/form-submission.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-express-care-request/form-submission.unit.spec.jsx
@@ -180,6 +180,10 @@ describe('VAOS integration: Express Care form submission', () => {
         parentSiteCode: '983',
         name: 'Testing',
       },
+      optionDate1: moment().format('MM/DD/YYYY'),
+      visitType: 'Express Care',
+      purposeOfVisit: 'Express Care Request',
+      bestTimetoCall: ['Morning', 'Afternoon', 'Evening'],
     });
 
     screen = renderInReduxProvider(

--- a/src/applications/vaos/utils/data.js
+++ b/src/applications/vaos/utils/data.js
@@ -133,13 +133,21 @@ export function transformFormToExpressCareRequest(state) {
     email: data.contactInfo.email,
     // defaulted values
     status: 'Submitted',
+    purposeOfVisit: 'Express Care Request',
+    visitType: 'Express Care',
+    optionDate1: moment().format('MM/DD/YYYY'),
+    optionTime1: 'No Time Selected',
+    optionDate2: 'No Date Selected',
+    optionTime2: 'No Time Selected',
+    optionDate3: 'No Date Selected',
+    optionTime3: 'No Time Selected',
     schedulingMethod: 'clerk',
     requestedPhoneCall: false,
     providerId: '0',
     providerOption: '',
     // The bad camel casing here is intentional, to match downstream
     // system
-    bestTimetoCall: [],
+    bestTimetoCall: ['Morning', 'Afternoon', 'Evening'],
   };
 }
 


### PR DESCRIPTION
## Description
This add some missing data to the EC request submission, which is now testable in staging.

## Testing done
Local and unit testing

## Acceptance criteria
- [ ] EC requests go through

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
