### PR TITLE
Fix IE11 wrapping bug

### DIFF
--- a/src/applications/personalization/profile-2/components/MHVTermsAndConditionsStatus.jsx
+++ b/src/applications/personalization/profile-2/components/MHVTermsAndConditionsStatus.jsx
@@ -10,7 +10,7 @@ const MHVTermsAndConditionsStatus = ({ mhvAccount }) => {
 
   if (mhvAccount.termsAndConditionsAccepted) {
     return (
-      <div className="vads-u-display--flex vads-u-flex-direction--column">
+      <div className="vads-u-display--flex vads-u-flex-direction--column vads-u-flex--1">
         <Verified>
           You’ve accepted the terms and conditions for using VA.gov health
           tools.


### PR DESCRIPTION
## Description
IE11 needed an explicit flex property so it understood to only grow the size of the div to 100% max. https://stackoverflow.com/questions/35111090/text-in-a-flex-container-doesnt-wrap-in-ie11

## Testing done
Tested functionality on my windows machine.

## Screenshots
![image](https://user-images.githubusercontent.com/14869324/89307014-d3974500-d62d-11ea-83d0-0aecac09c2e7.png)


## Acceptance criteria
- [x] Fix wrapping issue in IE11

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
