### PR TITLE
Clear old slot data when loading calendar page

### DIFF
--- a/src/applications/vaos/actions/newAppointment.js
+++ b/src/applications/vaos/actions/newAppointment.js
@@ -525,7 +525,6 @@ export function getAppointmentSlots(startDate, endDate, forceFetch = false) {
     const state = getState();
     const rootOrgId = getRootIdForChosenFacility(state);
     const newAppointment = getNewAppointment(state);
-    const availableSlots = newAppointment.availableSlots || [];
     const { data } = newAppointment;
 
     const startDateMonth = moment(startDate).format('YYYY-MM');
@@ -534,6 +533,7 @@ export function getAppointmentSlots(startDate, endDate, forceFetch = false) {
     let fetchedAppointmentSlotMonths = [];
     let fetchedStartMonth = false;
     let fetchedEndMonth = false;
+    let availableSlots = [];
 
     if (!forceFetch) {
       fetchedAppointmentSlotMonths = [
@@ -542,6 +542,7 @@ export function getAppointmentSlots(startDate, endDate, forceFetch = false) {
 
       fetchedStartMonth = fetchedAppointmentSlotMonths.includes(startDateMonth);
       fetchedEndMonth = fetchedAppointmentSlotMonths.includes(endDateMonth);
+      availableSlots = newAppointment.availableSlots || [];
     }
 
     if (!fetchedStartMonth || !fetchedEndMonth) {

--- a/src/applications/vaos/api/index.js
+++ b/src/applications/vaos/api/index.js
@@ -293,7 +293,7 @@ export function getRequestLimits(facilityId, typeOfCareId) {
 export function getAvailableClinics(facilityId, typeOfCareId, systemId) {
   let promise;
   if (USE_MOCK_DATA) {
-    if (facilityId === '983A6') {
+    if (facilityId === '983') {
       promise = import('./clinicList983.json').then(
         module => (module.default ? module.default : module),
       );


### PR DESCRIPTION
## Description
Previous attempt at fixing this didn't actually clear the old slot data, just reset the months.

## Testing done
Local and unit testing

## Acceptance criteria
- [ ] Slots are correct

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
