### PR TITLE
Log Drupal flag result upon error

### DIFF
--- a/src/site/stages/build/options.js
+++ b/src/site/stages/build/options.js
@@ -187,7 +187,14 @@ async function setUpFeatureFlags(options) {
       `${apiClient.getSiteUri()}/flags_list`,
     );
 
-    rawFlags = (await result.json()).data;
+    const responseBody = await result.text();
+    try {
+      rawFlags = JSON.parse(responseBody).data;
+    } catch (e) {
+      throw new TypeError(
+        `Could not parse Drupal build flags. Response:\n${responseBody}`,
+      );
+    }
 
     // Write them to .cache/{buildtype}/drupal/feature-flags.json
     fs.ensureDirSync(options.cacheDirectory);


### PR DESCRIPTION
## Description
Currently, when we run into an error fetching the feature flags, it just says
that there was an invalid token in the JSON, but we don't get to see what the
JSON _was._ This change logs the response if that response is invalid JSON.
