### PR TITLE
Only run output schema validation on root entities

### DIFF
--- a/src/site/stages/build/process-cms-exports/index.js
+++ b/src/site/stages/build/process-cms-exports/index.js
@@ -262,7 +262,10 @@ const entityAssemblerFactory = contentDir => {
     // Mutates transformedEntity
     addCommonProperties(transformedEntity, entity);
 
-    validateOutput(entity, transformedEntity);
+    // Only run output schema validation on root entities
+    if (ancestors.length === 0) {
+      validateOutput(entity, transformedEntity);
+    }
 
     return transformedEntity;
   };


### PR DESCRIPTION
## Description
These changes improve the need to validate the output schema of every entity

## Testing done
Locally

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
