### PR TITLE
[Development] BDD: Update e2e tests

### DIFF
--- a/src/applications/disability-benefits/all-claims/tests/all-claims.cypress.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/all-claims.cypress.spec.js
@@ -1,4 +1,5 @@
 import path from 'path';
+import moment from 'moment';
 
 import testForm from 'platform/testing/e2e/cypress/support/form-tester';
 import { createTestConfig } from 'platform/testing/e2e/cypress/support/form-tester/utilities';
@@ -29,13 +30,38 @@ const testConfig = createTestConfig(
 
     pageHooks: {
       introduction: () => {
+        cy.axeCheck();
         // Hit the start button
         cy.findAllByText(/start/i, { selector: 'button' })
           .first()
           .click();
 
+        cy.axeCheck();
         // Click past the ITF message
         cy.findByText(/continue/i, { selector: 'button' }).click();
+      },
+
+      'review-veteran-details/military-service-history': () => {
+        cy.get('@testData').then(data => {
+          cy.fillPage();
+          if (data['view:isBddData']) {
+            const date = moment()
+              .add(120, 'days')
+              .format('YYYY-M-D')
+              .split('-');
+            cy.get('select[name$="_dateRange_toMonth"]').select(date[1]);
+            cy.get('select[name$="_dateRange_toDay"]').select(date[2]);
+            cy.get('input[name$="_dateRange_toYear"]')
+              .clear()
+              .type(date[0]);
+            cy.get('.additional-info-button[aria-expanded="false"]').click();
+            cy.get('input[name$="_separationLocation"]')
+              .type(data.serviceInformation.separationLocation)
+              .blur();
+          }
+          cy.axeCheck();
+          cy.findByText(/continue/i, { selector: 'button' }).click();
+        });
       },
 
       'disabilities/rated-disabilities': () => {
@@ -45,6 +71,7 @@ const testConfig = createTestConfig(
               cy.get(`input[name="root_ratedDisabilities_${index}"]`).click();
             }
           });
+          cy.axeCheck();
           cy.findByText(/continue/i, { selector: 'button' }).click();
         });
       },
@@ -60,7 +87,7 @@ const testConfig = createTestConfig(
             cy.fillPage();
             cy.findByText(/save/i, { selector: 'button' }).click();
           }
-
+          cy.axeCheck();
           cy.findByText(/continue/i, { selector: 'button' }).click();
         });
       },

--- a/src/applications/disability-benefits/all-claims/tests/automated-tests.puppeteer.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/automated-tests.puppeteer.spec.js
@@ -7,14 +7,10 @@ const getTestDataSets = require('platform/testing/e2e/form-tester/util')
   .getTestDataSets;
 const PageHelpers = require('./disability-benefits-helpers');
 
-const testData = getTestDataSets(join(__dirname, 'data'), {
+const testData = getTestDataSets(join(__dirname, 'fixtures/data'), {
   extension: 'json',
-  ignore: [
-    'minimal-ptsd-form-upload-test.json',
-    'maximal-bdd-test.json',
-    'minimal-bdd-test.json',
-  ],
-  // only: ['minimal-test.json'],
+  // only run minimal since Cypress is doing all the work now
+  only: ['minimal-test.json'],
 });
 
 const testConfig = {

--- a/src/applications/disability-benefits/all-claims/tests/data
+++ b/src/applications/disability-benefits/all-claims/tests/data
@@ -1,1 +1,0 @@
-fixtures/data

--- a/src/applications/disability-benefits/all-claims/tests/fixtures/data/maximal-bdd-test.json
+++ b/src/applications/disability-benefits/all-claims/tests/fixtures/data/maximal-bdd-test.json
@@ -1,5 +1,6 @@
 {
     "data": {
+      "view:isBddData": true,
       "view:claimType": {
         "view:claimingIncrease": true,
         "view:claimingNew": true
@@ -209,10 +210,16 @@
         },
         "servicePeriods": [
           {
-            "serviceBranch": "Air Force Reserve",
+            "serviceBranch": "Air Force",
             "dateRange": {
               "from": "2001-03-21",
               "to": "2014-07-21"
+            }
+          },
+          {
+            "serviceBranch": "Air Force Reserve",
+            "dateRange": {
+              "from": "2014-07-22"
             }
           }
         ],
@@ -292,4 +299,3 @@
       }
     }
   }
-  

--- a/src/applications/disability-benefits/all-claims/tests/fixtures/data/minimal-bdd-test.json
+++ b/src/applications/disability-benefits/all-claims/tests/fixtures/data/minimal-bdd-test.json
@@ -1,5 +1,6 @@
 {
     "data": {
+      "view:isBddData": true,
       "view:claimType": {
         "view:claimingIncrease": true
       },
@@ -35,10 +36,16 @@
         },
         "servicePeriods": [
           {
-            "serviceBranch": "Air Force Reserve",
+            "serviceBranch": "Air Force",
             "dateRange": {
               "from": "2001-03-21",
               "to": "2014-07-21"
+            }
+          },
+          {
+            "serviceBranch": "Air Force Reserve",
+            "dateRange": {
+              "from": "2014-07-22"
             }
           }
         ],
@@ -137,4 +144,3 @@
       }
     }
   }
-  

--- a/src/applications/disability-benefits/all-claims/tests/schema/schema.unit.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/schema/schema.unit.spec.js
@@ -15,6 +15,11 @@ describe('526 all claims schema tests', () => {
       const contents = JSON.parse(
         fs.readFileSync(path.join(dataDirPath, file), 'utf8'),
       );
+      if (file.includes('-bdd-')) {
+        // "to" date is missing & is calculated dynamically in e2e tests
+        contents.data.serviceInformation.servicePeriods[1].dateRange.to =
+          '2020-01-01';
+      }
       const submitData = JSON.parse(
         formConfig.transformForSubmit(formConfig, contents),
       );

--- a/src/applications/disability-benefits/all-claims/tests/schema/schema.unit.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/schema/schema.unit.spec.js
@@ -8,7 +8,7 @@ import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json';
 
 describe('526 all claims schema tests', () => {
   const v = new Validator();
-  const dataDirPath = path.join(__dirname, '../data/');
+  const dataDirPath = path.join(__dirname, '../fixtures/data/');
   const files = fs.readdirSync(dataDirPath);
   files.filter(file => file.endsWith('json')).forEach(file => {
     it(`should validate ${file}`, () => {

--- a/src/applications/disability-benefits/all-claims/tests/submit-transformer.unit.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/submit-transformer.unit.spec.js
@@ -17,7 +17,7 @@ import {
   filterServicePeriods,
 } from '../submit-transformer';
 
-import maximalData from './data/maximal-test.json';
+import maximalData from './fixtures/data/maximal-test.json';
 
 import {
   PTSD_INCIDENT_ITERATION,
@@ -39,7 +39,7 @@ describe('transform', () => {
   ];
 
   // Read all the data files
-  const dataDir = path.join(__dirname, './data/');
+  const dataDir = path.join(__dirname, './fixtures/data/');
   fs.readdirSync(dataDir)
     .filter(fileName => fileName.endsWith('.json'))
     .forEach(fileName => {


### PR DESCRIPTION
## Description

- Updated BDD military history end-to-end test with dynamic discharge dates
- Removed duplicate e2e test data
- Removed old Puppeteer tests

Related ticket: https://github.com/department-of-veterans-affairs/va.gov-team/issues/11895

## Testing done

Cypress e2e tests

## Screenshots

N/A

## Acceptance criteria
- [x] BDD e2e tests passing locally (currently disabled until the form is in production)

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
