### PR TITLE
Updated VETTEC search results length tag

### DIFF
--- a/src/applications/gi/components/vet-tec/VetTecProgramSearchResult.jsx
+++ b/src/applications/gi/components/vet-tec/VetTecProgramSearchResult.jsx
@@ -124,7 +124,9 @@ function VetTecProgramSearchResult(props) {
               {isPresent(lengthInHours) && (
                 <div className="info-flag">{displayHours}</div>
               )}
-              <Link to={linkTo}>View details ›</Link>
+              <div className="vads-u-margin-top--1">
+                <Link to={linkTo}>View details ›</Link>
+              </div>
             </div>
           </div>
         </div>

--- a/src/applications/gi/components/vet-tec/VetTecProgramSearchResult.jsx
+++ b/src/applications/gi/components/vet-tec/VetTecProgramSearchResult.jsx
@@ -120,7 +120,7 @@ function VetTecProgramSearchResult(props) {
             </div>
           </div>
           <div className="row vads-u-padding-top--1p5">
-            <div className="view-details columns vads-u-display--inline-block">
+            <div className="tag-margin view-details columns vads-u-display--inline-block">
               {isPresent(lengthInHours) && (
                 <div className="info-flag">{displayHours}</div>
               )}

--- a/src/applications/gi/components/vet-tec/VetTecProgramSearchResult.jsx
+++ b/src/applications/gi/components/vet-tec/VetTecProgramSearchResult.jsx
@@ -120,7 +120,7 @@ function VetTecProgramSearchResult(props) {
             </div>
           </div>
           <div className="row vads-u-padding-top--1p5">
-            <div className="tag-margin view-details columns vads-u-display--inline-block">
+            <div className="view-details columns vads-u-display--inline-block">
               {isPresent(lengthInHours) && (
                 <div className="info-flag">{displayHours}</div>
               )}

--- a/src/applications/gi/sass/partials/_gi-search-page.scss
+++ b/src/applications/gi/sass/partials/_gi-search-page.scss
@@ -150,8 +150,11 @@
       margin-right: 1em;
       margin-top: -1.75em;
     }
-
-  
+    @media (max-width: 640px) {
+      .info-flag {
+        margin-top: -1em;
+      }
+    }
 
     .caution-flag {
       color: $color-gray-dark;

--- a/src/applications/gi/sass/partials/_gi-search-page.scss
+++ b/src/applications/gi/sass/partials/_gi-search-page.scss
@@ -142,9 +142,8 @@
     }
 
     .info-flag {
-      color: $color-gray-dark;
-      background-color: $color-gray-lighter;
-      border-radius: 3px 3px 3px 3px;
+      color: #323a45;
+      background-color: $color-white;
       font-size: 0.9em;
       font-weight: bold;
       display: inline-block;

--- a/src/applications/gi/sass/partials/_gi-search-page.scss
+++ b/src/applications/gi/sass/partials/_gi-search-page.scss
@@ -148,11 +148,10 @@
       display: inline-block;
       padding: 0.1em 0.5em;
       margin-right: 1em;
-    }
-
-    .tag-margin{
       margin-top: -1.75em;
     }
+
+  
 
     .caution-flag {
       color: $color-gray-dark;

--- a/src/applications/gi/sass/partials/_gi-search-page.scss
+++ b/src/applications/gi/sass/partials/_gi-search-page.scss
@@ -145,10 +145,13 @@
       color: #323a45;
       background-color: $color-white;
       font-size: 0.9em;
-      font-weight: bold;
       display: inline-block;
       padding: 0.1em 0.5em;
       margin-right: 1em;
+    }
+
+    .tag-margin{
+      margin-top: -28px;
     }
 
     .caution-flag {

--- a/src/applications/gi/sass/partials/_gi-search-page.scss
+++ b/src/applications/gi/sass/partials/_gi-search-page.scss
@@ -151,7 +151,7 @@
     }
 
     .tag-margin{
-      margin-top: -28px;
+      margin-top: -1.75em;
     }
 
     .caution-flag {


### PR DESCRIPTION
## Description
As a team member supporting the Comparison Tool, I want the look and feel of tags on the institution "cards" to be consistent in order to increase intuitiveness and ease of use by individuals searching for and viewing institutions.## Testing done

https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/11730
## Screenshots
![Screen Shot 2020-08-04 at 1 12 25 PM](https://user-images.githubusercontent.com/50601724/89324064-a8741c00-d654-11ea-9f72-2827a5dc0cb4.png)


## Acceptance criteria
- [x] The program length label on the institution "cards" on the VET TEC search results page have been updated to reflect the style defined in SA1.
- [x] The following colors are utilized for the tags:
a. Text: 323A45
b. Background: FFFFFF

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
