### PR TITLE
Add scrolling to alertboxes direct deposit

### DIFF
--- a/src/applications/personalization/profile-2/components/direct-deposit/DirectDepositContent.jsx
+++ b/src/applications/personalization/profile-2/components/direct-deposit/DirectDepositContent.jsx
@@ -334,6 +334,7 @@ export const DirectDepositContent = ({
               status="success"
               backgroundOnly
               className="vads-u-margin-top--0 vads-u-margin-bottom--2"
+              scrollOnShow
             >
               We’ve saved your direct deposit information.
             </AlertBox>

--- a/src/applications/personalization/profile360/components/PaymentInformationEditModalError.jsx
+++ b/src/applications/personalization/profile360/components/PaymentInformationEditModalError.jsx
@@ -165,6 +165,7 @@ export default function PaymentInformationEditModalError({
       headline={headline}
       isVisible
       className={className}
+      scrollOnShow
     >
       {content}
     </AlertBox>


### PR DESCRIPTION
## Description
Add the `scrollOnShow` property to ensure the user is scrolled to the relevant AlertBoxes in Direct Deposit.

## Testing done
Works locally

## Acceptance criteria
- [x] Scroll to success or error alert in Direct Deposit

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
