### PR TITLE
[Development] Fix BDD upload medical records header

### DIFF
--- a/src/applications/disability-benefits/all-claims/content/privateMedicalRecords.jsx
+++ b/src/applications/disability-benefits/all-claims/content/privateMedicalRecords.jsx
@@ -127,7 +127,7 @@ export const patientAcknowledgmentText = (
       </p>
       <p>
         Note: For additional information regarding VA Form 21-4142, refer to the
-        following website:
+        following website:{' '}
         <a
           href="https://www.benefits.va.gov/privateproviders/"
           target="_blank"

--- a/src/applications/disability-benefits/all-claims/pages/privateMedicalRecords.js
+++ b/src/applications/disability-benefits/all-claims/pages/privateMedicalRecords.js
@@ -11,7 +11,7 @@ import { DATA_PATHS } from '../constants';
 const { privateMedicalRecordAttachments } = fullSchema.properties;
 
 const fileUploadUi = ancillaryFormUploadUi(
-  'to your private medical records',
+  'Upload your private medical records',
   ' ',
   {
     attachmentId: '',

--- a/src/applications/disability-benefits/all-claims/sass/disability-benefits.scss
+++ b/src/applications/disability-benefits/all-claims/sass/disability-benefits.scss
@@ -90,6 +90,17 @@ ul.original-disability-list {
   }
 }
 
+// Supporting evidence legend (matches h4 style)
+#root_privateMedicalRecordAttachments-label {
+  font-family: "Bitter", "Georgia", "Cambria", "Times New Roman", "Times", serif;
+  font-size: 1.7rem;
+  font-weight: 700;
+
+  .schemaform-required-span {
+    display: none;
+  }
+}
+
 // removes gap when using multiple widget-outlines
 .widget-outline-group {
   &:last-child {


### PR DESCRIPTION
## Description

The header (actually a `legend`) no longer matches the design

- "to your private..." should be "Upload your private..."
- The legend should appear as an `h4` header
- "Required" label should be hidden

<details><summary>Current view</summary>

<!-- leave a blank line above -->
![Screen Shot 2020-08-04 at 2 50 52 PM](https://user-images.githubusercontent.com/136959/89342458-710f6a80-d668-11ea-98a9-8a7156bcc4df.png)</details>

<details><summary>Changes in this PR</summary>

<!-- leave a blank line above -->
![Screen Shot 2020-08-04 at 3 41 11 PM](https://user-images.githubusercontent.com/136959/89342824-f5fa8400-d668-11ea-9b27-a0871fbcc866.png)</details>

Related links:
- Page with problem: https://staging.va.gov/disability/file-disability-claim-form-21-526ez/supporting-evidence/private-medical-records
- Ticket: https://github.com/department-of-veterans-affairs/va.gov-team/issues/11895
- Design: https://vsateams.invisionapp.com/share/8GXOG91ZWNJ#/screens/421409443

## Testing done

Local unit tests

## Screenshots

See description

## Acceptance criteria
- [x] Second legend matches `h4` styling
- [x] Hide "Required" label

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
