### PR TITLE
Updated in progress message to display correct message

### DIFF
--- a/src/applications/edu-benefits/10203/content/SaveInProgressIntro.jsx
+++ b/src/applications/edu-benefits/10203/content/SaveInProgressIntro.jsx
@@ -68,7 +68,7 @@ class SaveInProgressIntro extends React.Component {
                 </div>
                 <div className="saved-form-metadata-container">
                   <span className="saved-form-item-metadata">
-                    Your {formDescriptions[formId]} is in progress.
+                    Your Rogers STEM Scholarship application is in progress.
                   </span>
                   <br />
                   <span className="saved-form-item-metadata">

--- a/src/applications/edu-benefits/10203/content/SaveInProgressIntro.jsx
+++ b/src/applications/edu-benefits/10203/content/SaveInProgressIntro.jsx
@@ -68,7 +68,7 @@ class SaveInProgressIntro extends React.Component {
                 </div>
                 <div className="saved-form-metadata-container">
                   <span className="saved-form-item-metadata">
-                    Your Rogers STEM Scholarship application is in progress.
+                    Your {formDescriptions[formId]} is in progress.
                   </span>
                   <br />
                   <span className="saved-form-item-metadata">

--- a/src/applications/personalization/dashboard/helpers.jsx
+++ b/src/applications/personalization/dashboard/helpers.jsx
@@ -76,6 +76,7 @@ export const formBenefits = {
   [VA_FORM_IDS.FORM_22_1995]: 'education benefits',
   [VA_FORM_IDS.FORM_22_5490]: 'education benefits',
   [VA_FORM_IDS.FORM_22_5495]: 'education benefits',
+  [VA_FORM_IDS.FORM_22_10203]: 'Rogers STEM Scholarship',
   [VA_FORM_IDS.FORM_40_10007]:
     'pre-need determination of eligibility in a VA national cemetery',
   [VA_FORM_IDS.FEEDBACK_TOOL]: 'feedback',


### PR DESCRIPTION
## Description
"Rogers STEM Scholarship" is missing from "Your is in progress." It should say "Your Rogers STEM Scholarship application is in progress."
https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/11844
## Testing done
local testing

## Screenshots
![Screen Shot 2020-08-05 at 8 11 04 AM](https://user-images.githubusercontent.com/50601724/89412180-9fd32280-d6f4-11ea-815d-c80d2c11c587.png)



## Acceptance criteria
- [x] Your Rogers STEM Scholarship application is in progress. is displayed

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
