### PR TITLE
12038 686 location payload bug

### DIFF
--- a/src/applications/disability-benefits/686c-674/config/chapters/report-add-a-spouse/current-spouse-marriage-history-details/currentSpouseMarriageHistoryDetails.js
+++ b/src/applications/disability-benefits/686c-674/config/chapters/report-add-a-spouse/current-spouse-marriage-history-details/currentSpouseMarriageHistoryDetails.js
@@ -1,7 +1,6 @@
 import currentOrPastDateUI from 'platform/forms-system/src/js/definitions/currentOrPastDate';
 import { addSpouse } from '../../../utilities';
 import { SpouseTitle } from '../../../../components/ArrayPageItemSpouseTitle';
-import { stateTitle, cityTitle } from '../../../helpers';
 import { locationUISchema } from '../../../location-schema';
 
 import { get } from 'lodash';

--- a/src/applications/disability-benefits/686c-674/config/chapters/report-add-a-spouse/veteran-marriage-history-details/veteranMarriageHistoryDetails.js
+++ b/src/applications/disability-benefits/686c-674/config/chapters/report-add-a-spouse/veteran-marriage-history-details/veteranMarriageHistoryDetails.js
@@ -1,6 +1,7 @@
 import currentOrPastDateUI from 'platform/forms-system/src/js/definitions/currentOrPastDate';
 import { addSpouse } from '../../../utilities';
 import { SpouseTitle } from '../../../../components/ArrayPageItemSpouseTitle';
+import { locationUISchema } from '../../../location-schema';
 
 export const schema = addSpouse.properties.veteranMarriageHistoryDetails;
 
@@ -14,17 +15,13 @@ export const uiSchema = {
           'ui:required': formData => formData.veteranWasMarriedBefore,
         },
       },
-      startLocation: {
-        'ui:title': 'Place of marriage to former spouse',
-        state: {
-          'ui:required': formData => formData.veteranWasMarriedBefore,
-          'ui:title': 'State (or country if outside the U.S.)',
-        },
-        city: {
-          'ui:required': formData => formData.veteranWasMarriedBefore,
-          'ui:title': 'City or county',
-        },
-      },
+      startLocation: locationUISchema(
+        'veteranMarriageHistory',
+        'startLocation',
+        true,
+        'Place of marriage to former spouse',
+        'addSpouse',
+      ),
       reasonMarriageEnded: {
         'ui:required': formData => formData.veteranWasMarriedBefore,
         'ui:title': 'Reason marriage ended',
@@ -53,17 +50,13 @@ export const uiSchema = {
           'ui:required': formData => formData.veteranWasMarriedBefore,
         },
       },
-      endLocation: {
-        'ui:title': 'Place marriage with former spouse ended',
-        state: {
-          'ui:required': formData => formData.veteranWasMarriedBefore,
-          'ui:title': 'State (or country if outside the U.S.)',
-        },
-        city: {
-          'ui:required': formData => formData.veteranWasMarriedBefore,
-          'ui:title': 'City or county',
-        },
-      },
+      endLocation: locationUISchema(
+        'veteranMarriageHistory',
+        'endLocation',
+        true,
+        'Place marriage with former spouse ended',
+        'addSpouse',
+      ),
     },
   },
 };

--- a/src/applications/disability-benefits/686c-674/config/helpers.js
+++ b/src/applications/disability-benefits/686c-674/config/helpers.js
@@ -61,18 +61,6 @@ export const ServerErrorAlert = (
   </>
 );
 
-export const stateTitle = (
-  <>
-    State (<strong>or</strong> Country if outside the U.S.)
-  </>
-);
-
-export const cityTitle = (
-  <>
-    City <strong>or</strong> county
-  </>
-);
-
 export const isInsideListLoopReturn = (
   chapter,
   outerField,
@@ -126,7 +114,7 @@ export const isOutsideListLoopReturn = (
   return {
     'ui:title': 'Where were you married?',
     isOutsideUS: {
-      'ui:title': 'This occurred outsite the US',
+      'ui:title': 'This occurred outside the US',
     },
     country: {
       'ui:title': 'Country',

--- a/src/applications/disability-benefits/686c-674/config/helpers.js
+++ b/src/applications/disability-benefits/686c-674/config/helpers.js
@@ -112,7 +112,7 @@ export const isOutsideListLoopReturn = (
   formChapter,
 ) => {
   return {
-    'ui:title': 'Where were you married?',
+    'ui:title': uiTitle,
     isOutsideUS: {
       'ui:title': 'This occurred outside the US',
     },

--- a/src/applications/disability-benefits/686c-674/config/utilities.js
+++ b/src/applications/disability-benefits/686c-674/config/utilities.js
@@ -1,4 +1,5 @@
 import fullSchema from 'vets-json-schema/dist/686C-674-schema.json';
+import _ from 'platform/utilities/data';
 import { validateWhiteSpace } from 'platform/forms/validations';
 import {
   filterInactivePageData,
@@ -32,6 +33,41 @@ const validateName = (errors, pageData) => {
   validateWhiteSpace(errors.last, last);
 };
 
+/**
+ * Mostly copied from the platform provided stringifyFormReplacer, with the removal of the address check. We don't need it here for our location use.
+ */
+const customFormReplacer = (key, value) => {
+  // clean up empty objects, which we have no reason to send
+  if (typeof value === 'object') {
+    const fields = Object.keys(value);
+    if (
+      fields.length === 0 ||
+      fields.every(field => value[field] === undefined)
+    ) {
+      return undefined;
+    }
+
+    // autosuggest widgets save value and label info, but we should just return the value
+    if (value.widget === 'autosuggest') {
+      return value.id;
+    }
+
+    // Exclude file data
+    if (value.confirmationCode && value.file) {
+      return _.omit('file', value);
+    }
+  }
+
+  // Clean up empty objects in arrays
+  if (Array.isArray(value)) {
+    const newValues = value.filter(v => !!stringifyFormReplacer(key, v));
+    // If every item in the array is cleared, remove the whole array
+    return newValues.length > 0 ? newValues : undefined;
+  }
+
+  return value;
+};
+
 const {
   optionSelection,
   veteranInformation,
@@ -61,11 +97,7 @@ export {
   isClientError,
 };
 
-export function customTransformForSubmit(
-  formConfig,
-  form,
-  replacer = stringifyFormReplacer,
-) {
+export function customTransformForSubmit(formConfig, form) {
   const expandedPages = expandArrayPages(
     createFormPageList(formConfig),
     form.data,
@@ -77,5 +109,5 @@ export function customTransformForSubmit(
     activePages,
     form,
   );
-  return JSON.stringify(withoutInactivePages, replacer) || '{}';
+  return JSON.stringify(withoutInactivePages, customFormReplacer) || '{}';
 }

--- a/src/applications/disability-benefits/686c-674/tests/e2e/686-spouse-child-divorce-death-test-data.json
+++ b/src/applications/disability-benefits/686c-674/tests/e2e/686-spouse-child-divorce-death-test-data.json
@@ -1,0 +1,103 @@
+{
+  "deaths": [
+    {
+      "date": "2013-05-06",
+      "location": {
+        "isOutsideUS": true,
+        "country": "ATG",
+        "city": "antigua city"
+      },
+      "fullName": { "first": "adam", "last": "adamson" },
+      "dependentType": "DEPENDENT_PARENT"
+    }
+  ],
+  "childrenToAdd": [
+    {
+      "doesChildLiveWithYou": true,
+      "placeOfBirth": {
+        "isOutsideUS": true,
+        "country": "GRD",
+        "city": "grenada city"
+      },
+      "childStatus": { "biological": true },
+      "previouslyMarried": "No",
+      "fullName": { "first": "jones", "last": "junior" },
+      "ssn": "123211234",
+      "birthDate": "2015-04-12"
+    }
+  ],
+  "veteranWasMarriedBefore": true,
+  "veteranMarriageHistory": [
+    {
+      "startDate": "2003-04-05",
+      "startLocation": {
+        "isOutsideUS": true,
+        "country": "CUB",
+        "city": "Cuba"
+      },
+      "reasonMarriageEnded": "Divorce",
+      "endDate": "2006-04-16",
+      "endLocation": {
+        "isOutsideUS": true,
+        "country": "LUX",
+        "city": "lichtenstein"
+      },
+      "fullName": { "first": "jill", "last": "jillson" }
+    }
+  ],
+  "spouseWasMarriedBefore": true,
+  "spouseMarriageHistory": [
+    {
+      "startDate": "2005-08-11",
+      "startLocation": {
+        "isOutsideUS": true,
+        "country": "ARG",
+        "city": "buenos ares"
+      },
+      "reasonMarriageEnded": "Divorce",
+      "endDate": "2007-08-18",
+      "endLocation": { "isOutsideUS": false, "state": "HI", "city": "city" },
+      "fullName": { "first": "john", "last": "johnson" }
+    }
+  ],
+  "doesLiveWithSpouse": { "spouseDoesLiveWithVeteran": true },
+  "currentMarriageInformation": {
+    "date": "2009-08-10",
+    "location": {
+      "isOutsideUS": true,
+      "country": "AIA",
+      "city": "anguilla city"
+    },
+    "type": "CEREMONIAL"
+  },
+  "spouseInformation": {
+    "fullName": { "first": "jane", "last": "doe" },
+    "ssn": "123211234",
+    "birthDate": "1999-04-05",
+    "isVeteran": false
+  },
+  "veteranContactInformation": {
+    "veteranAddress": {
+      "view:livesOnMilitaryBase": true,
+      "countryName": "USA",
+      "addressLine1": "123 at hom dr",
+      "city": "FPO",
+      "stateCode": "AA",
+      "zipCode": "12321"
+    },
+    "phoneNumber": "4445551212",
+    "emailAddress": "test2@test1.net"
+  },
+  "view:selectable686Options": {
+    "addSpouse": true,
+    "addChild": true,
+    "reportDivorce": true,
+    "reportDeath": true
+  },
+  "veteranInformation": {
+    "fullName": { "first": "Greg", "middle": "A", "last": "Anderson" },
+    "ssn": "796121200",
+    "birthDate": "1933-04-05"
+  },
+  "privacyAgreementAccepted": true
+}


### PR DESCRIPTION
## Description
This pull request fixes a bug where non-US locations were stripping out the country field from the payload. This phenomenon occurred because the default `stringifyFormReplacer` provided by `platform/` has a check for country, which our location schema didn't need, but failed anyway. The solution was to use a custom form replacer instead, which removes the country check used in the default replacer. 

## Testing done
- local
- checked all workflows to verify payload was including country field

## Screenshots
<details><summary>Payload showing location/country</summary>

```JSON
{
  "deaths": [
    {
      "date": "2013-05-06",
      "location": {
        "isOutsideUS": true,
        "country": "ATG",
        "city": "antigua city"
      },
      "fullName": { "first": "adam", "last": "adamson" },
      "dependentType": "DEPENDENT_PARENT"
    }
  ],
  "childrenToAdd": [
    {
      "doesChildLiveWithYou": true,
      "placeOfBirth": {
        "isOutsideUS": true,
        "country": "GRD",
        "city": "grenada city"
      },
      "childStatus": { "biological": true },
      "previouslyMarried": "No",
      "fullName": { "first": "jones", "last": "junior" },
      "ssn": "123211234",
      "birthDate": "2015-04-12"
    }
  ],
  "veteranWasMarriedBefore": true,
  "veteranMarriageHistory": [
    {
      "startDate": "2003-04-05",
      "startLocation": {
        "isOutsideUS": true,
        "country": "CUB",
        "city": "Cuba"
      },
      "reasonMarriageEnded": "Divorce",
      "endDate": "2006-04-16",
      "endLocation": {
        "isOutsideUS": true,
        "country": "LUX",
        "city": "lichtenstein"
      },
      "fullName": { "first": "jill", "last": "jillson" }
    }
  ],
  "spouseWasMarriedBefore": true,
  "spouseMarriageHistory": [
    {
      "startDate": "2005-08-11",
      "startLocation": {
        "isOutsideUS": true,
        "country": "ARG",
        "city": "buenos ares"
      },
      "reasonMarriageEnded": "Divorce",
      "endDate": "2007-08-18",
      "endLocation": { "isOutsideUS": false, "state": "HI", "city": "city" },
      "fullName": { "first": "john", "last": "johnson" }
    }
  ],
  "doesLiveWithSpouse": { "spouseDoesLiveWithVeteran": true },
  "currentMarriageInformation": {
    "date": "2009-08-10",
    "location": {
      "isOutsideUS": true,
      "country": "AIA",
      "city": "anguilla city"
    },
    "type": "CEREMONIAL"
  },
  "spouseInformation": {
    "fullName": { "first": "jane", "last": "doe" },
    "ssn": "123211234",
    "birthDate": "1999-04-05",
    "isVeteran": false
  },
  "veteranContactInformation": {
    "veteranAddress": {
      "view:livesOnMilitaryBase": true,
      "countryName": "USA",
      "addressLine1": "123 at hom dr",
      "city": "FPO",
      "stateCode": "AA",
      "zipCode": "12321"
    },
    "phoneNumber": "4445551212",
    "emailAddress": "test2@test1.net"
  },
  "view:selectable686Options": {
    "addSpouse": true,
    "addChild": true,
    "reportDivorce": true,
    "reportDeath": true
  },
  "veteranInformation": {
    "fullName": { "first": "Greg", "middle": "A", "last": "Anderson" },
    "ssn": "796121200",
    "birthDate": "1933-04-05"
  },
  "privacyAgreementAccepted": true
}
```
</details>
<details><summary>Fixed location UI</summary>

<img width="574" alt="Screen Shot 2020-08-05 at 9 31 29 AM" src="https://user-images.githubusercontent.com/15097156/89422267-19720d00-d703-11ea-97f6-9bbea27641d2.png">
</details>

## Acceptance criteria
- [x] all unit tests pass
- [x] location is properly included in payload

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
