### PR TITLE
[Redirect due 8/13] Redirects in Pension based on legacy rewriting work

### DIFF
--- a/src/applications/proxy-rewrite/redirects/crossDomainRedirects.json
+++ b/src/applications/proxy-rewrite/redirects/crossDomainRedirects.json
@@ -1008,5 +1008,10 @@
     "domain": "www.benefits.va.gov",
     "src": "/gibill/yellow_ribbon/2019/states/wy.asp",
     "dest": "/education/yellow-ribbon-participating-schools/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/pension/current_protected_pension_rate_tables.asp",
+    "dest": "/pension/protected-pension-rates/"
   }
 ]


### PR DESCRIPTION
## Description
This PR implements a redirect from `https://www.benefits.va.gov/pension/current_protected_pension_rate_tables.asp` to `/pension/protected-pension-rates/`.

https://github.com/department-of-veterans-affairs/va.gov-team/issues/2212

## Testing done
Ran `yarn proxy-rewrite:verify-targets` locally to ensure page can be verified.

## Screenshots
n/a

## Acceptance criteria
- [ ] Redirect is out

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
