### PR TITLE
Add household question for Bronx VAMC screener

### DIFF
--- a/src/applications/coronavirus-screener/config/questions.jsx
+++ b/src/applications/coronavirus-screener/config/questions.jsx
@@ -35,6 +35,12 @@ export const questions = [
     ),
   },
   {
+    id: 'household-exposure-526',
+    text:
+      "Has anyone who lives with you had any of the above symptoms that aren't clearly caused by another condition?",
+    customId: ['526'],
+  },
+  {
     id: 'congestion',
     text: 'Do you currently have a runny nose or nasal congestion?',
   },


### PR DESCRIPTION
## Description

Adds household exposure question for the Bronx VAMC per their request.

## Testing done

Local testing

## Screenshots
n/a

## Acceptance criteria
- [x] User viewing the covid screener at /covid19screen/526 is asked the household exposure question
- [x] User viewing the covid screener at any other route is not asked the household exposure question

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
