### PR TITLE
Add post auth url to production

### DIFF
--- a/src/applications/auth/containers/AuthApp.jsx
+++ b/src/applications/auth/containers/AuthApp.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import appendQuery from 'append-query';
 
 import * as Sentry from '@sentry/browser';
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
@@ -18,7 +17,6 @@ import {
 } from 'platform/user/profile/utilities';
 import { apiRequest } from 'platform/utilities/api';
 import get from 'platform/utilities/data/get';
-import environment from 'platform/utilities/environment';
 
 const REDIRECT_IGNORE_PATTERN = new RegExp(
   ['/auth/login/callback', '/session-expired'].join('|'),
@@ -137,13 +135,8 @@ export class AuthApp extends React.Component {
     const returnUrl = sessionStorage.getItem(authnSettings.RETURN_URL) || '';
     sessionStorage.removeItem(authnSettings.RETURN_URL);
 
-    const postAuthUrl =
-      returnUrl && !environment.isProduction()
-        ? appendQuery(returnUrl, 'postLogin=true')
-        : returnUrl;
-
     const redirectUrl =
-      (!returnUrl.match(REDIRECT_IGNORE_PATTERN) && postAuthUrl) || '/';
+      (!returnUrl.match(REDIRECT_IGNORE_PATTERN) && returnUrl) || '/';
 
     window.location.replace(redirectUrl);
   };

--- a/src/applications/auth/containers/AuthApp.jsx
+++ b/src/applications/auth/containers/AuthApp.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { connect } from 'react-redux';
+import appendQuery from 'append-query';
 
 import * as Sentry from '@sentry/browser';
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
@@ -135,8 +136,12 @@ export class AuthApp extends React.Component {
     const returnUrl = sessionStorage.getItem(authnSettings.RETURN_URL) || '';
     sessionStorage.removeItem(authnSettings.RETURN_URL);
 
+    const postAuthUrl = returnUrl
+      ? appendQuery(returnUrl, 'postLogin=true')
+      : returnUrl;
+
     const redirectUrl =
-      (!returnUrl.match(REDIRECT_IGNORE_PATTERN) && returnUrl) || '/';
+      (!returnUrl.match(REDIRECT_IGNORE_PATTERN) && postAuthUrl) || '/';
 
     window.location.replace(redirectUrl);
   };

--- a/src/platform/site-wide/user-nav/containers/Main.jsx
+++ b/src/platform/site-wide/user-nav/containers/Main.jsx
@@ -66,11 +66,7 @@ export class Main extends React.Component {
       redirectUrl && !window.location.pathname.includes('verify');
 
     if (shouldRedirect) {
-      window.location.replace(
-        !environment.isProduction()
-          ? appendQuery(redirectUrl, 'postLogin=true')
-          : redirectUrl,
-      );
+      window.location.replace(appendQuery(redirectUrl, 'postLogin=true'));
     }
   }
 

--- a/src/platform/site-wide/user-nav/tests/containers/Main.unit.spec.jsx
+++ b/src/platform/site-wide/user-nav/tests/containers/Main.unit.spec.jsx
@@ -124,9 +124,8 @@ describe('<Main>', () => {
     const wrapper = shallow(<Main {...props} />);
     wrapper.setProps({ currentlyLoggedIn: true });
     expect(global.window.location.replace.calledOnce).to.be.true;
-    // Commented out while testing on staging
-    // expect(global.window.location.replace.calledWith('/account?postLogin=true'))
-    //   .to.be.true;
+    expect(global.window.location.replace.calledWith('/account?postLogin=true'))
+      .to.be.true;
     wrapper.unmount();
   });
 


### PR DESCRIPTION
## Description
Add the post auth url parameter `postLogin=true` to production.

After a user logs in successfully and is redirected back to the page they came from, the url will contain the post auth param.

## Testing done
Tested on staging in https://github.com/department-of-veterans-affairs/vets-website/pull/13558.

## Screenshots


## Acceptance criteria
- [ ] The post authentication url includes the `postLogin=true` parameter.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
