### PR TITLE
Css fix

### DIFF
--- a/src/applications/personalization/profile-2/components/MHVTermsAndConditionsStatus.jsx
+++ b/src/applications/personalization/profile-2/components/MHVTermsAndConditionsStatus.jsx
@@ -10,7 +10,7 @@ const MHVTermsAndConditionsStatus = ({ mhvAccount }) => {
 
   if (mhvAccount.termsAndConditionsAccepted) {
     return (
-      <div className="vads-u-display--flex vads-u-flex-direction--column vads-u-flex--1">
+      <div className="vads-u-display--flex vads-u-flex-direction--column vads-u-width--full">
         <Verified>
           You’ve accepted the terms and conditions for using VA.gov health
           tools.


### PR DESCRIPTION
## Description
Adding `flex: 1` messed up the styling on mobile Safari.

## Testing done
Works well locally, tested both on IE11 on my Desktop as well as in Safari in responsive mode.

## Screenshots
![image](https://user-images.githubusercontent.com/14869324/89443163-25fb6300-d70d-11ea-9216-f6deab12a913.png)


## Acceptance criteria
- [x] Ensure that the Terms and Security section does not overlap in either IE11 or Safari.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
