### PR TITLE
update vets-json-schema version

### DIFF
--- a/package.json
+++ b/package.json
@@ -327,7 +327,7 @@
     "url-search-params-polyfill": "^8.1.0",
     "uswds": "1.6.10",
     "vanilla-lazyload": "^16.1.0",
-    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#abff81fc0a078e81a51a8a33d042cf234a14f187",
+    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#4a427785ff46c452cc7cb0c1eb89860fd0796ee0",
     "whatwg-fetch": "^2.0.3"
   },
   "resolutions": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -17075,9 +17075,9 @@ verror@1.3.6:
   dependencies:
     extsprintf "1.0.2"
 
-"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#abff81fc0a078e81a51a8a33d042cf234a14f187":
-  version "6.5.1"
-  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#abff81fc0a078e81a51a8a33d042cf234a14f187"
+"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#4a427785ff46c452cc7cb0c1eb89860fd0796ee0":
+  version "6.6.0"
+  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#4a427785ff46c452cc7cb0c1eb89860fd0796ee0"
 
 vinyl-file@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## Description
Update vets-json-schema version 
related to vets-json-schema PR: https://github.com/department-of-veterans-affairs/vets-json-schema/pull/467

## Testing done
Ran local VAFS application with schema from vets-json-schema

## Screenshots


## Acceptance criteria
- [ ] package.json is updated with url to latest vets-json-schema commit
- [ ] yarn.lock is updated with url to latest vets-json-schema commit

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
