### PR TITLE
Fix VAOS unload check when using SSOe

### DIFF
--- a/src/applications/vaos/containers/NewAppointmentLayout.jsx
+++ b/src/applications/vaos/containers/NewAppointmentLayout.jsx
@@ -41,10 +41,11 @@ export class NewAppointmentLayout extends React.Component {
 
   onBeforeUnload = e => {
     const expirationDate = localStorage.getItem('sessionExpiration');
+    const expirationDateSSO = localStorage.getItem('sessionExpirationSSO');
 
     // If there's no expiration date, then the session has already expired
     // and keeping a person on the form won't save their data
-    if (expirationDate) {
+    if (expirationDate || expirationDateSSO) {
       e.preventDefault();
       e.returnValue =
         'Are you sure you wish to leave this application? All progress will be lost.';


### PR DESCRIPTION
## Description
The session expiration logic we have for the new appointment flow only checks the old sessionExpiration value, rather than the new one. This checks either of them, which will hopefully prevent some 401 errors we're seeing.

## Testing done
None, basically

## Acceptance criteria
- [ ] Session expiration on a form page redirects correctly

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
