### PR TITLE
Set email address in preferences update for EC

### DIFF
--- a/src/applications/vaos/actions/expressCare.js
+++ b/src/applications/vaos/actions/expressCare.js
@@ -161,9 +161,9 @@ export function routeToPreviousAppointmentPage(router, current) {
   );
 }
 
-async function buildPreferencesDataAndUpdate(data) {
+async function buildPreferencesDataAndUpdate(email) {
   const preferenceData = await getPreferences();
-  const preferenceBody = createPreferenceBody(preferenceData, data);
+  const preferenceBody = createPreferenceBody(preferenceData, email);
   return updatePreferences(preferenceBody);
 }
 
@@ -226,7 +226,7 @@ export function submitExpressCareRequest(router) {
       const responseData = await submitRequest('va', requestBody);
 
       try {
-        await buildPreferencesDataAndUpdate(formData);
+        await buildPreferencesDataAndUpdate(formData.contactInfo.email);
       } catch (error) {
         // These are ancillary updates, the request went through if the first submit
         // succeeded

--- a/src/applications/vaos/actions/newAppointment.js
+++ b/src/applications/vaos/actions/newAppointment.js
@@ -752,11 +752,11 @@ export function submitAppointmentOrRequest(router) {
         }
 
         try {
-          const requestMessage = newAppointment.data.reasonAdditionalInfo;
+          const requestMessage = data.reasonAdditionalInfo;
           if (requestMessage) {
             await sendRequestMessage(requestData.id, requestMessage);
           }
-          await buildPreferencesDataAndUpdate(newAppointment);
+          await buildPreferencesDataAndUpdate(data.email);
         } catch (error) {
           // These are ancillary updates, the request went through if the first submit
           // succeeded

--- a/src/applications/vaos/actions/newAppointment.js
+++ b/src/applications/vaos/actions/newAppointment.js
@@ -656,12 +656,9 @@ export function updateCCEligibility(isEligible) {
   };
 }
 
-async function buildPreferencesDataAndUpdate(newAppointment) {
+async function buildPreferencesDataAndUpdate(email) {
   const preferenceData = await getPreferences();
-  const preferenceBody = createPreferenceBody(
-    preferenceData,
-    newAppointment.data,
-  );
+  const preferenceBody = createPreferenceBody(preferenceData, email);
   return updatePreferences(preferenceBody);
 }
 
@@ -694,7 +691,7 @@ export function submitAppointmentOrRequest(router) {
         await submitAppointment(appointmentBody);
 
         try {
-          await buildPreferencesDataAndUpdate(newAppointment);
+          await buildPreferencesDataAndUpdate(data.email);
         } catch (error) {
           // These are ancillary updates, the request went through if the first submit
           // succeeded

--- a/src/applications/vaos/tests/mocks/helpers.js
+++ b/src/applications/vaos/tests/mocks/helpers.js
@@ -353,3 +353,21 @@ export function mockRequestEligibilityCriteria(parentSites, data) {
     { data },
   );
 }
+
+export function mockPreferences(emailAddress) {
+  setFetchJSONResponse(
+    global.fetch.withArgs(`${environment.API_URL}/vaos/v0/preferences`),
+    {
+      data: {
+        id: '3071ca1783954ec19170f3c4bdfd0c95',
+        type: 'preferences',
+        attributes: {
+          notificationFrequency: 'Each new message',
+          emailAllowed: true,
+          emailAddress,
+          textMsgAllowed: false,
+        },
+      },
+    },
+  );
+}

--- a/src/applications/vaos/tests/new-express-care-request/form-submission.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-express-care-request/form-submission.unit.spec.jsx
@@ -24,6 +24,7 @@ import {
   mockRequestEligibilityCriteria,
   mockParentSites,
   mockSupportedFacilities,
+  mockPreferences,
 } from '../mocks/helpers';
 import ExpressCareFormPage from '../../containers/ExpressCareFormPage';
 import ExpressCareConfirmationPage from '../../containers/ExpressCareConfirmationPage';
@@ -123,6 +124,7 @@ describe('VAOS integration: Express Care form submission', () => {
       },
     ]);
     mockRequestEligibilityCriteria(['983'], requestCriteria);
+    mockPreferences('old.email@va.gov');
     const store = createTestStore({
       ...initialState,
     });
@@ -177,6 +179,14 @@ describe('VAOS integration: Express Care form submission', () => {
         .find(call => call.args[0].includes('appointment_requests')).args[1]
         .body,
     );
+
+    const preferencesData = JSON.parse(
+      global.fetch
+        .getCalls()
+        .filter(call => call.args[0].includes('preferences'))[1].args[1].body,
+    );
+
+    expect(preferencesData.emailAddress).to.equal(requestData.attributes.email);
 
     expect(responseData).to.deep.include({
       ...requestData.attributes,

--- a/src/applications/vaos/utils/data.js
+++ b/src/applications/vaos/utils/data.js
@@ -281,10 +281,10 @@ export function transformFormToAppointment(state) {
   };
 }
 
-export function createPreferenceBody(preferences, email) {
+export function createPreferenceBody(preferences, emailAddress) {
   return {
     ...preferences,
-    emailAddress: email,
+    emailAddress,
     notificationFrequency: 'Each new message',
     emailAllowed: true,
   };

--- a/src/applications/vaos/utils/data.js
+++ b/src/applications/vaos/utils/data.js
@@ -281,10 +281,10 @@ export function transformFormToAppointment(state) {
   };
 }
 
-export function createPreferenceBody(preferences, data) {
+export function createPreferenceBody(preferences, email) {
   return {
     ...preferences,
-    emailAddress: data.email,
+    emailAddress: email,
     notificationFrequency: 'Each new message',
     emailAllowed: true,
   };


### PR DESCRIPTION
## Description
We're not correctly setting the email address in the preferences call.

## Testing done
Local testing

## Acceptance criteria
- [ ] Email is set and SM doesn't break on every EC request

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
