### PR TITLE
11929 fix clinic page filtering of clinics with past appointment

### DIFF
--- a/src/applications/vaos/reducers/newAppointment.js
+++ b/src/applications/vaos/reducers/newAppointment.js
@@ -69,7 +69,6 @@ import { getTypeOfCare } from '../utils/selectors';
 import {
   getOrganizationBySiteId,
   getIdOfRootOrganization,
-  getRootOrganization,
   getSiteIdFromOrganization,
 } from '../services/organization';
 import { getClinicId } from '../services/healthcare-service/transformers';
@@ -656,7 +655,9 @@ export default function formReducer(state = initialState, action) {
           state.data.vaParent,
         );
 
-        const org = getRootOrganization(state.parentFacilities, rootOrgId);
+        const org = state.parentFacilities.find(
+          parent => parent.id === state.data.vaParent,
+        );
         const siteId = getSiteIdFromOrganization(org);
 
         state.pastAppointments.forEach(appt => {

--- a/src/applications/vaos/reducers/newAppointment.js
+++ b/src/applications/vaos/reducers/newAppointment.js
@@ -69,7 +69,10 @@ import { getTypeOfCare } from '../utils/selectors';
 import {
   getOrganizationBySiteId,
   getIdOfRootOrganization,
+  getRootOrganization,
+  getSiteIdFromOrganization,
 } from '../services/organization';
+import { getClinicId } from '../services/healthcare-service/transformers';
 
 const initialState = {
   pages: {},
@@ -652,12 +655,16 @@ export default function formReducer(state = initialState, action) {
           state.parentFacilities,
           state.data.vaParent,
         );
+
+        const org = getRootOrganization(state.parentFacilities, rootOrgId);
+        const siteId = getSiteIdFromOrganization(org);
+
         state.pastAppointments.forEach(appt => {
           const apptTime = appt.startDate;
           const latestApptTime = pastAppointmentDateMap.get(appt.clinicId);
           if (
             // Remove parse function when converting the past appointment call to FHIR service
-            appt.facilityId === parseFakeFHIRId(rootOrgId) &&
+            appt.facilityId === siteId &&
             (!latestApptTime || latestApptTime > apptTime)
           ) {
             pastAppointmentDateMap.set(appt.clinicId, apptTime);
@@ -666,7 +673,7 @@ export default function formReducer(state = initialState, action) {
 
         clinics = clinics.filter(clinic =>
           // Get clinic portion of id
-          pastAppointmentDateMap.has(clinic.id?.split('_')[1]),
+          pastAppointmentDateMap.has(getClinicId(clinic)),
         );
       }
 

--- a/src/applications/vaos/services/healthcare-service/transformers.js
+++ b/src/applications/vaos/services/healthcare-service/transformers.js
@@ -174,7 +174,7 @@ function getIdentifierToken(clinic, index) {
  * @param {Object} clinic
  * @returns {String} The clinic id or empty string.
  */
-export function getClinicIdentifier(clinic) {
+export function getClinicId(clinic) {
   return getIdentifierToken(clinic, 5);
 }
 

--- a/src/applications/vaos/tests/reducers/newAppointment.unit.spec.js
+++ b/src/applications/vaos/tests/reducers/newAppointment.unit.spec.js
@@ -578,10 +578,22 @@ describe('VAOS reducer: newAppointment', () => {
             {
               id: 'var983_455',
               resourceType: 'HealthcareService',
+              identifier: [
+                {
+                  system: 'http://med.va.gov/fhir/urn',
+                  value: 'urn:va:healthcareservice:983:983:455',
+                },
+              ],
             },
             {
               id: 'var983_456',
               resourceType: 'HealthcareService',
+              identifier: [
+                {
+                  system: 'http://med.va.gov/fhir/urn',
+                  value: 'urn:va:healthcareservice:983:983:456',
+                },
+              ],
             },
           ],
         },
@@ -638,11 +650,23 @@ describe('VAOS reducer: newAppointment', () => {
             {
               id: 'var983_455',
               resourceType: 'HealthcareService',
+              identifier: [
+                {
+                  system: 'http://med.va.gov/fhir/urn',
+                  value: 'urn:va:healthcareservice:983:983:455',
+                },
+              ],
               serviceName: 'Testing',
             },
             {
               id: 'var983_456',
               resourceType: 'HealthcareService',
+              identifier: [
+                {
+                  system: 'http://med.va.gov/fhir/urn',
+                  value: 'urn:va:healthcareservice:983:983:456',
+                },
+              ],
               serviceName: 'Testing real name',
             },
           ],

--- a/src/applications/vaos/utils/data.js
+++ b/src/applications/vaos/utils/data.js
@@ -23,7 +23,7 @@ import { selectVet360ResidentialAddress } from 'platform/user/selectors';
 import { getFacilityIdFromLocation } from '../services/location';
 import {
   findCharacteristic,
-  getClinicIdentifier,
+  getClinicId,
   getSiteCode,
 } from '../services/healthcare-service/transformers';
 
@@ -249,7 +249,7 @@ export function transformFormToAppointment(state) {
     appointmentType: getTypeOfCare(data).name,
     clinic: {
       siteCode: getSiteCode(clinic),
-      clinicId: getClinicIdentifier(clinic),
+      clinicId: getClinicId(clinic),
       clinicName: clinic.serviceName,
       clinicFriendlyLocationName: findCharacteristic(
         clinic,


### PR DESCRIPTION
## Description
We need to update the clinics page reducer code to use the same check for past appointments that the eligibility.js file uses, so that it works with the VSP flag both on and off.

## Testing done
Unit testing

## Screenshots
![Screen Shot 2020-08-05 at 2 47 08 PM](https://user-images.githubusercontent.com/3587066/89457185-949ae980-d72a-11ea-8c5e-87c04fc1cbe7.png)

## Acceptance criteria
- [ ] All unit test should pass

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
