### PR TITLE
Refactored form tester page hooks to support post-hooks

### DIFF
--- a/src/applications/disability-benefits/2346/tests/MDOT.cypress.spec.js
+++ b/src/applications/disability-benefits/2346/tests/MDOT.cypress.spec.js
@@ -23,10 +23,12 @@ const testConfig = createTestConfig(
     },
 
     pageHooks: {
-      introduction: () => {
-        cy.findAllByText(/order/i, { selector: 'button' })
-          .first()
-          .click();
+      introduction: ({ afterHook }) => {
+        afterHook(() => {
+          cy.findAllByText(/order/i, { selector: 'button' })
+            .first()
+            .click();
+        });
       },
       address: () => {
         cy.get('@testKey').then(testKey => {
@@ -41,7 +43,6 @@ const testConfig = createTestConfig(
             cy.findByLabelText(/International Postal Code/i).type('T7N');
             cy.findByText(/Save temporary address/i).click();
             cy.findByLabelText(/Re-enter email address/i).type('vet@vet.com');
-            cy.findByText(/Continue/i).click();
           } else {
             cy.findByText('Edit permanent address', {
               selector: 'button',
@@ -51,7 +52,6 @@ const testConfig = createTestConfig(
             cy.findByLabelText(/International Postal Code/i).type('T7N');
             cy.findByText(/Save permanent address/i).click();
             cy.findByLabelText(/Re-enter email address/i).type('vet@vet.com');
-            cy.findByText(/Continue/i).click();
           }
         });
       },
@@ -67,7 +67,6 @@ const testConfig = createTestConfig(
             cy.get('#3').click();
             cy.get('#5').click();
           }
-          cy.findByText(/Continue/i, { selector: 'button' }).click();
         });
       },
     },

--- a/src/applications/disability-benefits/996/tests/hlr.cypress.spec.js
+++ b/src/applications/disability-benefits/996/tests/hlr.cypress.spec.js
@@ -19,11 +19,13 @@ const testConfig = createTestConfig(
     },
 
     pageHooks: {
-      introduction: () => {
-        // Hit the start button
-        cy.findAllByText(/start/i, { selector: 'button' })
-          .first()
-          .click();
+      introduction: ({ afterHook }) => {
+        afterHook(() => {
+          // Hit the start button
+          cy.findAllByText(/start/i, { selector: 'button' })
+            .first()
+            .click();
+        });
       },
     },
 

--- a/src/applications/disability-benefits/all-claims/tests/all-claims.cypress.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/all-claims.cypress.spec.js
@@ -29,14 +29,16 @@ const testConfig = createTestConfig(
     },
 
     pageHooks: {
-      introduction: () => {
-        cy.axeCheck();
-        // Hit the start button
-        cy.findAllByText(/start/i, { selector: 'button' })
-          .first()
-          .click();
+      introduction: ({ afterHook }) => {
+        afterHook(() => {
+          // Hit the start button
+          cy.findAllByText(/start/i, { selector: 'button' })
+            .first()
+            .click();
+        });
+      },
 
-        cy.axeCheck();
+      'veteran-information': () => {
         // Click past the ITF message
         cy.findByText(/continue/i, { selector: 'button' }).click();
       },
@@ -54,13 +56,10 @@ const testConfig = createTestConfig(
             cy.get('input[name$="_dateRange_toYear"]')
               .clear()
               .type(date[0]);
-            cy.get('.additional-info-button[aria-expanded="false"]').click();
             cy.get('input[name$="_separationLocation"]')
               .type(data.serviceInformation.separationLocation)
               .blur();
           }
-          cy.axeCheck();
-          cy.findByText(/continue/i, { selector: 'button' }).click();
         });
       },
 
@@ -71,8 +70,6 @@ const testConfig = createTestConfig(
               cy.get(`input[name="root_ratedDisabilities_${index}"]`).click();
             }
           });
-          cy.axeCheck();
-          cy.findByText(/continue/i, { selector: 'button' }).click();
         });
       },
 
@@ -87,8 +84,6 @@ const testConfig = createTestConfig(
             cy.fillPage();
             cy.findByText(/save/i, { selector: 'button' }).click();
           }
-          cy.axeCheck();
-          cy.findByText(/continue/i, { selector: 'button' }).click();
         });
       },
     },

--- a/src/applications/disability-benefits/all-claims/tests/all-claims.cypress.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/all-claims.cypress.spec.js
@@ -15,9 +15,9 @@ const testConfig = createTestConfig(
     dataSets: [
       'full-781-781a-8940-test.json',
       'maximal-test',
-      // 'maximal-bdd-test',
+      'maximal-bdd-test',
       'minimal-test',
-      // 'minimal-bdd-test',
+      'minimal-bdd-test',
       'newOnly-test',
       'secondary-new-test.json',
       'upload-781-781a-8940-test.json',
@@ -147,6 +147,8 @@ const testConfig = createTestConfig(
         });
       });
     },
+
+    skip: ['maximal-bdd-test', 'minimal-bdd-test'],
   },
   manifest,
   formConfig,

--- a/src/applications/hca/tests/hca.cypress.spec.js
+++ b/src/applications/hca/tests/hca.cypress.spec.js
@@ -13,10 +13,12 @@ const testConfig = createTestConfig(
     fixtures: { data: path.join(__dirname, 'schema') },
 
     pageHooks: {
-      introduction: () => {
-        cy.findAllByText(/start.+without signing in/i, { selector: 'button' })
-          .first()
-          .click();
+      introduction: ({ afterHook }) => {
+        afterHook(() => {
+          cy.findAllByText(/start.+without signing in/i, { selector: 'button' })
+            .first()
+            .click();
+        });
       },
 
       'id-form': () => {
@@ -34,8 +36,6 @@ const testConfig = createTestConfig(
           cy.findByLabelText(/social security/i).type(
             data.veteranSocialSecurityNumber,
           );
-
-          cy.findAllByText(/continue/i, { selector: 'button' }).click();
         });
       },
     },

--- a/src/platform/testing/e2e/cypress/support/form-tester/README.md
+++ b/src/platform/testing/e2e/cypress/support/form-tester/README.md
@@ -273,11 +273,11 @@ pageHooks: {
 },
 ```
 
-The functions all have access to a context object as a first argument, which currently provides two things:
+The functions **all have access to a context object as a first argument**, which currently provides two things:
 
 1. `pathname`: a convenient reference to the full pathname that got matched for this page hook.
 
-2. `afterHook`, a helper function that takes a function and invokes it at the end of the page processing.
+2. `afterHook`: a helper function that takes a function and uses it to **override the usual end-of-page behavior**.
 
    Typically, the standard flow for processing a page follows these steps:
 
@@ -287,19 +287,18 @@ The functions all have access to a context object as a first argument, which cur
    4. Expand any accordions and run the end-of-page aXe check.
    5. Run the post hook.
 
-   The default "post hook" for a page is to just click the 'Continue' button to proceed to the next page.
-   - For the review page, the post hook checks the privacy agreement box if there is one and then submits the form.
-   - If the page follows the default "post hook" behavior, this helper is not needed at all.
+   The default "post hook" for a page is to just click the 'Continue' button to proceed to the next page. For the review page, the post hook checks the privacy agreement box if there is one and then submits the form.
 
-   The function passed to `afterHook` will override what is normally run for that post hook in step 5.
 
-   It can be considered an override that does the job of **moving from the current page to the next**.
+   The function passed to `afterHook` will override what is normally run for that post hook in step 5. It can be considered an override that does the job of **moving from the current page to the next**. If the page follows the default post hook behavior, this helper is not needed at all.
 
-   The **most common use** would be to pass a function that simply clicks the appropriate button to proceed to the next page.
-   - Note that the second aXe check is still guaranteed to run before this override.
+   The **most common usage for the after hook** would be to pass a function that simply clicks the appropriate button to proceed to the next page.
    - This is useful if the that button does not match the standard button in the default post hook (e.g., the text doesn't say 'Continue').
-   - This is essentially mandatory for the introduction page, where the flow to start a form can vary between forms.
+   - This is practically **mandatory for the introduction page**, where the flow to start a form can vary between forms.
+   - Note that the second aXe check is still guaranteed to run before this override.
 
+   ##### Examples for using the after hook
+   
    ```js
    pageHooks: {
     introduction: ({ afterHook }) => {
@@ -311,7 +310,7 @@ The functions all have access to a context object as a first argument, which cur
     },
 
     'some-other-page': ({ afterHook, pathname }) => {
-      // Do whatever you need in the "main body" of the hook,
+      // Do whatever you need to in the "main body" of the hook,
       // which replaces the default autofilling behavior.
       cy.log(`Look, I'm on ${pathname}!`);
 
@@ -323,6 +322,8 @@ The functions all have access to a context object as a first argument, which cur
     },
    },
    ```
+
+##### Common usage for page hooks
 
 There are various use cases for the `pageHooks` setting, but a couple of common ones are:
 

--- a/src/platform/testing/e2e/cypress/support/form-tester/README.md
+++ b/src/platform/testing/e2e/cypress/support/form-tester/README.md
@@ -273,18 +273,60 @@ pageHooks: {
 },
 ```
 
-There are various use cases for this setting, but a couple of common ones are:
+The functions all have access to a context object as a first argument, which currently provides two things:
 
-1. Special or non-standard pages in the form, like the introduction, where the automatic form filling doesn't work or apply. Virtually every form will have an introduction page, which will require a page hook to proceed.
+1. `pathname`: a convenient reference to the full pathname that got matched for this page hook.
+
+2. `afterHook`, a helper function that takes a function and invokes it at the end of the page processing.
+
+   Typically, the standard flow for processing a page follows these steps:
+
+   1. Run an initial axe check.
+   2. Run the page hook if the page has one.
+   3. Autofill if no hook ran and if the page is not review or confirmation.
+   4. Expand any accordions and run the end-of-page aXe check.
+   5. Run the post hook.
+
+   The default "post hook" for a page is to just click the 'Continue' button to proceed to the next page.
+   - For the review page, the post hook checks the privacy agreement box if there is one and then submits the form.
+   - If the page follows the default "post hook" behavior, this helper is not needed at all.
+
+   The function passed to `afterHook` will override what is normally run for that post hook in step 5.
+
+   It can be considered an override that does the job of **moving from the current page to the next**.
+
+   The **most common use** would be to pass a function that simply clicks the appropriate button to proceed to the next page.
+   - Note that the second aXe check is still guaranteed to run before this override.
+   - This is useful if the that button does not match the standard button in the default post hook (e.g., the text doesn't say 'Continue').
+   - This is essentially mandatory for the introduction page, where the flow to start a form can vary between forms.
+
    ```js
    pageHooks: {
-     introduction: () => {
-       cy.findAllByText(/get started/i)
-         .first()
-         .click();
-     },
+    introduction: ({ afterHook }) => {
+      afterHook(() => {
+        cy.findByText(/begin/i, { selector: 'button' })
+          .first()
+          .click();
+      });
+    },
+
+    'some-other-page': ({ afterHook, pathname }) => {
+      // Do whatever you need in the "main body" of the hook,
+      // which replaces the default autofilling behavior.
+      cy.log(`Look, I'm on ${pathname}!`);
+
+      afterHook(() => {
+        cy.findByText(/next/i, { selector: 'button' })
+          .first()
+          .click();
+      });
+    },
    },
    ```
+
+There are various use cases for the `pageHooks` setting, but a couple of common ones are:
+
+1. Special or non-standard pages in the form, like the introduction, where the automatic form filling doesn't work or apply. Virtually every form will have an introduction page, which will require a page hook to proceed. See the `afterHooks` section above for an example.
 
 2. "Prepping" a page, as in performing any necessary interactions to get the page in the desired state, before invoking the usual automatic filling.
 
@@ -295,7 +337,7 @@ There are various use cases for this setting, but a couple of common ones are:
      '/some-form-app-url/some-page': () => {
        cy.get('.expand-button').click();
        cy.fillPage();
-       cy.findAllByTest(/continue/i)
+       cy.findAllByText(/continue/i)
          .first()
          .click();
      },

--- a/src/platform/testing/e2e/cypress/support/form-tester/README.md
+++ b/src/platform/testing/e2e/cypress/support/form-tester/README.md
@@ -338,9 +338,6 @@ There are various use cases for the `pageHooks` setting, but a couple of common 
      '/some-form-app-url/some-page': () => {
        cy.get('.expand-button').click();
        cy.fillPage();
-       cy.findAllByText(/continue/i)
-         .first()
-         .click();
      },
    },
    ```

--- a/src/platform/testing/e2e/cypress/support/form-tester/index.js
+++ b/src/platform/testing/e2e/cypress/support/form-tester/index.js
@@ -442,6 +442,8 @@ Cypress.Commands.add('fillPage', () => {
 
       fillAvailableFields();
     });
+
+  Cypress.log();
 });
 
 /**

--- a/src/platform/testing/e2e/cypress/support/form-tester/index.js
+++ b/src/platform/testing/e2e/cypress/support/form-tester/index.js
@@ -126,62 +126,46 @@ const addNewArrayItem = $form => {
 };
 
 /**
- * Run the page hook if the page has one, optionally automatically fill the page
- * if no hook ran, expand any accordions, and run an aXe check. Finally, if the
- * page was automatically filled, also automatically continue to the next page.
+ * Performs the following actions on a page:
+ * 1. Run an initial axe check.
+ * 2. Run the page hook if the page has one.
+ * 3. Autofill if no hook ran and if the page is not review or confirmation.
+ * 4. Expand any accordions and run the end-of-page aXe check.
+ * 5. Run the post hook.
  *
  * @param {string} pathname - The pathname of the page to run the page hook on.
- * @param {boolean} [autofill] - If true, and if no page hook ran, automatically
- *     fill the page. If false, don't fill the page, even if no page hook ran.
  */
-const performPageActions = (pathname, autofill = true) => {
-  cy.execHook(pathname).then(hookExecuted => {
-    if (!hookExecuted && autofill) cy.fillPage();
+const performPageActions = pathname => {
+  cy.axeCheck();
+
+  cy.execHook(pathname).then(({ hookExecuted, postHook }) => {
+    const shouldAutofill = !pathname.match(
+      /\/(introduction|confirmation|review-and-submit)$/,
+    );
+
+    if (!hookExecuted && shouldAutofill) cy.fillPage();
 
     cy.expandAccordions();
     cy.axeCheck();
 
-    if (!hookExecuted && autofill) {
-      cy.findByText(/continue/i, { selector: 'button' }).click(FORCE_OPTION);
-    }
+    const postHookPromise = new Promise(resolve => {
+      postHook();
+      resolve();
+    });
+
+    cy.wrap(postHookPromise, NO_LOG_OPTION);
   });
 };
 
 /**
  * Top level loop that invokes all of the processing for a form page and
- * proceeds to the next page. When it gets to the end, it submits the form.
+ * asserts that it proceeds to the next page until it gets to the confirmation.
  */
 const processPage = () => {
-  // Run aXe check before doing anything on the page.
-  cy.axeCheck();
-
   cy.location('pathname', NO_LOG_OPTION).then(pathname => {
-    if (pathname.endsWith('review-and-submit')) {
-      performPageActions(pathname, false);
+    performPageActions(pathname);
 
-      // Check the privacy agreement box if it exists.
-      cy.get(APP_SELECTOR, NO_LOG_OPTION).then($form => {
-        const privacyAgreement = $form.find('input[name^="privacyAgreement"]');
-        if (privacyAgreement.length) {
-          cy.wrap(privacyAgreement)
-            .first()
-            .check(FORCE_OPTION);
-        }
-      });
-
-      cy.findByText(/submit/i, { selector: 'button' }).click(FORCE_OPTION);
-
-      // The form should end up at the confirmation page after submitting.
-      // Increased timeout for this step; there can sometimes be a longer delay
-      // between clicking submit and loading the confirmation page, which would
-      // cause the pathname assertion to time out and fail.
-      cy.location('pathname', { timeout: 8000 }).then(endPathname => {
-        expect(endPathname).to.match(/confirmation$/);
-        cy.axeCheck();
-        performPageActions(endPathname, false);
-      });
-    } else {
-      performPageActions(pathname);
+    if (!pathname.endsWith('/confirmation')) {
       cy.location('pathname', NO_LOG_OPTION)
         .should(newPathname => {
           if (pathname === newPathname) {
@@ -194,6 +178,39 @@ const processPage = () => {
 };
 
 /**
+ * Provides the default post hook to run for the given pathname.
+ * @param {string} pathname - The pathname for the current URL.
+ * @returns {function} The post hook to be invoked after all other page actions.
+ */
+const defaultPostHook = pathname => {
+  // On review pages, check the privacy agreement box if it exists and submit.
+  if (pathname.endsWith('/review-and-submit')) {
+    return () => {
+      cy.get(APP_SELECTOR, NO_LOG_OPTION).then($form => {
+        const privacyAgreement = $form.find('input[name^="privacyAgreement"]');
+        if (privacyAgreement.length) {
+          cy.wrap(privacyAgreement)
+            .first()
+            .check(FORCE_OPTION);
+        }
+      });
+
+      cy.findByText(/submit/i, { selector: 'button' }).click(FORCE_OPTION);
+    };
+  }
+
+  // No-op on introduction and confirmation pages.
+  if (pathname.match(/\/(introduction|confirmation)$/)) {
+    return () => {};
+  }
+
+  // Everything else should click on the 'Continue' button.
+  return () => {
+    cy.findByText(/continue/i, { selector: 'button' }).click(FORCE_OPTION);
+  };
+};
+
+/**
  * Runs the page hook if there is one for the current page.
  * @param {string} pathname - The pathname for the current URL.
  * @returns {boolean} Resolves true if a hook ran and false otherwise.
@@ -201,15 +218,33 @@ const processPage = () => {
 Cypress.Commands.add('execHook', pathname => {
   cy.get('@pageHooks', NO_LOG_OPTION).then(pageHooks => {
     const hook = pageHooks?.[pathname];
-    if (!hook) return cy.wrap(false, NO_LOG_OPTION);
+    let hookExecuted = false;
+    let postHook = defaultPostHook(pathname);
+
+    if (!hook) return cy.wrap({ hookExecuted, postHook }, NO_LOG_OPTION);
 
     if (typeof hook !== 'function') {
       throw new Error(`Page hook for ${pathname} is not a function`);
     }
 
+    // Give the page hook the option to set a custom post hook.
+    const overridePostHook = fn => {
+      if (typeof fn !== 'function') {
+        throw new Error(`Post hook for ${pathname} is not a function`);
+      }
+      postHook = fn;
+    };
+
+    // Context object that's available all page hooks as the first argument.
+    const context = {
+      afterHook: overridePostHook,
+      pathname,
+    };
+
     const hookPromise = new Promise(resolve => {
-      hook();
-      resolve(true);
+      hook(context);
+      hookExecuted = true;
+      resolve({ hookExecuted, postHook });
     });
 
     return cy.wrap(hookPromise, NO_LOG_OPTION);

--- a/src/platform/testing/e2e/cypress/support/form-tester/index.js
+++ b/src/platform/testing/e2e/cypress/support/form-tester/index.js
@@ -306,9 +306,7 @@ Cypress.Commands.add('enterData', field => {
         .type(field.data, { ...FORCE_OPTION, ...NO_DELAY_OPTION })
         .then(element => {
           // Get the autocomplete menu out of the way.
-          if (element.attr('role') === 'combobox') {
-            cy.wrap(element).type('{downarrow}{enter}');
-          }
+          if (element.attr('role') === 'combobox') element.blur();
         });
       break;
     }


### PR DESCRIPTION
## Description
### Background
Previously, page hooks would cause the secondary aXe check on pages to run at the wrong time.

Since page hooks needed to explicitly click the "Continue" button to move to the next page, and that secondary aXe check was set to automatically run after page hooks, the check would incorrectly run on the next page.

### Solution
This refactor fixes that bug, but also reduces the amount of boilerplate needed in page hooks and allows for a way to override the default behavior.
- The aXe checks will still automatically run, but the "Continue" button will also automatically be clicked, so that should no longer be included in page hooks.
- To override that automatic click, there willl now be a context object provided as the first argument to page hooks. It contains an `afterHook` helper function that takes a function and runs that instead of the default behavior of clicking "Continue".
- Docs have been updated (with examples) to explain how to use the override.

## Testing done
Tests are still passing. Observed the Cypress test runner log to verify that aXe checks are happening in the right place.

## Acceptance criteria
- [ ] The form tester should run an aXe check at the beginning and end of processing a form page.
- [ ] The form tester should provide helpful default behavior for processing a form page and also a mechanism to override the defaults.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
