### PR TITLE
bradl3yC - 11989 - add covid relief messaging

### DIFF
--- a/src/applications/debt-letters/components/DebtLettersSummary.jsx
+++ b/src/applications/debt-letters/components/DebtLettersSummary.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import Breadcrumbs from '@department-of-veterans-affairs/formation-react/Breadcrumbs';
+import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import HowDoIPay from './HowDoIPay';
@@ -58,6 +59,25 @@ const DebtLettersSummary = ({ isError, isVBMSError, debts, debtLinks }) => {
     </div>
   );
 
+
+  const bannerContent = (
+    <>
+      <p>
+        VA is extending debt relief to those impacted by COVID-19 to the end of
+        2020. This includes suspension of debt collection or extending repayment
+        terms on preexisting VA debts
+      </p>
+      <p>
+        If you are impacted by COVID-19 and need temporary financial relief for
+        a VA debt, please contact DMC at{' '}
+        <a href="tel: 800-827-0648" aria-label="800. 8 2 7. 0648.">
+          800-827-0648
+        </a>{' '}
+        to request assistance
+      </p>
+    </>
+  );
+
   const allDebtsFetchFailure = isVBMSError && isError;
   const allDebtsEmpty =
     !allDebtsFetchFailure && debts.length === 0 && debtLinks.length === 0;
@@ -74,7 +94,7 @@ const DebtLettersSummary = ({ isError, isVBMSError, debts, debtLinks }) => {
         </h1>
         <div className="vads-u-display--flex vads-u-flex-direction--row">
           <div className="vads-l-col--12 vads-u-padding-x--2p5 medium-screen:vads-l-col--8">
-            <h2 className="vads-u-font-size--h3 vads-u-font-weight--normal vads-u-margin-top--0 vads-u-margin-bottom--3">
+            <h2 className="vads-u-font-size--h3 vads-u-font-weight--normal vads-u-margin-top--0 vads-u-margin-bottom--2">
               Download your debt letters, learn your payment options, or find
               out how to get help with your VA debts.
             </h2>
@@ -87,6 +107,19 @@ const DebtLettersSummary = ({ isError, isVBMSError, debts, debtLinks }) => {
                   <DebtLettersList />
                 </>
               )}
+            {!allDebtsFetchFailure && (
+              <>
+                <AlertBox
+                  className="vads-u-margin-bottom--2"
+                  headline="Certain debt collection is suspended to the end of 2020"
+                  content={bannerContent}
+                  status="info"
+                  isVisible
+                />
+                <DebtCardsList />
+                <DebtLettersList />
+              </>
+            )}
           </div>
           <div className="vads-u-display--flex vads-u-flex-direction--column vads-l-col--12 vads-u-padding-x--2p5 medium-screen:vads-l-col--4">
             <HowDoIPay />

--- a/src/applications/debt-letters/components/DebtLettersSummary.jsx
+++ b/src/applications/debt-letters/components/DebtLettersSummary.jsx
@@ -59,7 +59,6 @@ const DebtLettersSummary = ({ isError, isVBMSError, debts, debtLinks }) => {
     </div>
   );
 
-
   const bannerContent = (
     <>
       <p>
@@ -103,23 +102,17 @@ const DebtLettersSummary = ({ isError, isVBMSError, debts, debtLinks }) => {
             {!allDebtsFetchFailure &&
               !allDebtsEmpty && (
                 <>
+                  <AlertBox
+                    className="vads-u-margin-bottom--2"
+                    headline="Certain debt collection is suspended to the end of 2020"
+                    content={bannerContent}
+                    status="info"
+                    isVisible
+                  />
                   <DebtCardsList />
                   <DebtLettersList />
                 </>
               )}
-            {!allDebtsFetchFailure && (
-              <>
-                <AlertBox
-                  className="vads-u-margin-bottom--2"
-                  headline="Certain debt collection is suspended to the end of 2020"
-                  content={bannerContent}
-                  status="info"
-                  isVisible
-                />
-                <DebtCardsList />
-                <DebtLettersList />
-              </>
-            )}
           </div>
           <div className="vads-u-display--flex vads-u-flex-direction--column vads-l-col--12 vads-u-padding-x--2p5 medium-screen:vads-l-col--4">
             <HowDoIPay />


### PR DESCRIPTION
## Description
All debt letters have been suspended until the end of 2020 - as a user I want to see this information displayed on the debts page.

## Testing done


## Screenshots
![Screen Shot 2020-08-06 at 9 41 22 AM](https://user-images.githubusercontent.com/6165421/89539772-2d347680-d7ca-11ea-8dfd-d4219fb5f678.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
