### PR TITLE
Update css mobile sub nav

### DIFF
--- a/src/applications/personalization/profile-2/sass/profile-mobile-subnav.scss
+++ b/src/applications/personalization/profile-2/sass/profile-mobile-subnav.scss
@@ -60,9 +60,8 @@
     ul {
       padding: units(1) 0;
       background-color: $color-white;
-      margin: 0 units(1) units(15);
+      margin: 0 units(1) units(1);
       border-top: 1px solid $color-gray-lighter;
-      border-bottom: 1px solid $color-gray-lighter;
 
       li {
         @include subnav-item;


### PR DESCRIPTION
## Description
Remove the white space and grey bar below 'Connected Apps' in the mobile menu sub nav.

Called with Tressa to make sure the updated design looks as expected.

## Testing done
Looks great locally

## Screenshots
![image](https://user-images.githubusercontent.com/14869324/89549366-7209de80-d7c5-11ea-9862-7835b6585333.png)


## Acceptance criteria
- [x] Remove the white space and grey bar below 'Connected Apps' in the mobile menu sub nav

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
