### PR TITLE
Update no results messaging

### DIFF
--- a/src/applications/yellow-ribbon/containers/SearchResults/index.jsx
+++ b/src/applications/yellow-ribbon/containers/SearchResults/index.jsx
@@ -135,12 +135,20 @@ export class SearchResults extends Component {
     // Show no results found message.
     if (!results.length) {
       return (
-        <h2
-          className="va-introtext va-u-outline--none vads-u-font-size--lg vads-u-margin-top--1p5 vads-u-font-weight--normal"
-          data-display-results-header
-        >
-          No results found.
-        </h2>
+        <>
+          <h2
+            className="va-introtext va-u-outline--none vads-u-font-size--lg vads-u-margin-top--1p5 vads-u-font-weight--normal"
+            data-display-results-header
+          >
+            No schools found for your search criteria.
+          </h2>
+          <p>To find participating schools:</p>
+          <ul>
+            <li>Double-check your spelling.</li>
+            <li>Try fewer search terms.</li>
+            <li>Try more general search terms.</li>
+          </ul>
+        </>
       );
     }
 

--- a/src/applications/yellow-ribbon/containers/SearchResults/index.unit.spec.jsx
+++ b/src/applications/yellow-ribbon/containers/SearchResults/index.unit.spec.jsx
@@ -36,7 +36,7 @@ describe('Yellow Ribbon container <SearchResults>', () => {
   it('renders no results', () => {
     const tree = shallow(<SearchResults results={[]} />);
 
-    expect(tree.html()).to.include('No results');
+    expect(tree.html()).to.include('No schools found');
 
     tree.unmount();
   });


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/10244

**Design Spec:** https://vsateams.invisionapp.com/share/Z6XPA1BE4AB#/screens/421619606_Screen_Shot_2020-06-15_At_1-08-08_PM

This PR updates the YR no results messaging.

## Testing done
N/A

## Screenshots
![localhost_3001_education_yellow-ribbon-participating-schools__name=asdf](https://user-images.githubusercontent.com/12773166/89554727-784f8900-d7cc-11ea-8b5c-f49fc844b0e7.png)


## Acceptance criteria
- [x] Update copy for no results.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
