### PR TITLE
Update FAQ dropdown spacing

### DIFF
--- a/src/applications/personalization/profile-2/components/personal-information/GenderAndDOBSection.jsx
+++ b/src/applications/personalization/profile-2/components/personal-information/GenderAndDOBSection.jsx
@@ -30,20 +30,20 @@ const GenderAndDOBSection = ({ gender, dob, className }) => (
     />
 
     <AdditionalInfo triggerText="How do I update my personal information?">
-      <h4 className="vads-u-font-size--h5 vads-u-margin--0">
+      <h4 className="vads-u-font-size--h5 vads-u-margin-top--3">
         If you’re enrolled in the VA health care program
       </h4>
-      <p className="vads-u-margin--0">
+      <p className="vads-u-margin-y--1">
         Please contact your nearest VA medical center to update your personal
         information.
       </p>
       <a href="https://va.gov/find-locations/?facilityType=health">
         Find your nearest VA medical center{' '}
       </a>
-      <h4 className="vads-u-font-size--h5 vads-u-margin-bottom--0">
+      <h4 className="vads-u-font-size--h5 vads-u-margin-top--3 vads-u-margin-bottom--1">
         If you receive VA benefits, but aren’t enrolled in VA health care
       </h4>
-      <p className="vads-u-margin--0">
+      <p className="vads-u-margin-y--1">
         Please contact your nearest VA regional office to update your personal
         information
       </p>


### PR DESCRIPTION
## Description
Update spacing in FAQ 'How do I update my personal information' in Personal and Contact Information.

Checked with Tressa to make sure the spacing looks good now.

## Testing done
Looks good locally.

## Screenshots
![image](https://user-images.githubusercontent.com/14869324/89557393-f95c4f80-d7cf-11ea-931a-da335b2f42f4.png)
![image](https://user-images.githubusercontent.com/14869324/89557410-ffeac700-d7cf-11ea-9873-f03f0ce23598.png)


## Acceptance criteria
- [x] Update spacing in FAQ 'How do I update my personal information' in Personal and Contact Information.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
