### PR TITLE
Show error on Profile when unable to fetch all required data

### DIFF
--- a/src/applications/personalization/profile-2/components/Profile2Wrapper.jsx
+++ b/src/applications/personalization/profile-2/components/Profile2Wrapper.jsx
@@ -2,8 +2,16 @@ import React from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { Link, useLocation } from 'react-router-dom';
+import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 import Breadcrumbs from '@department-of-veterans-affairs/formation-react/Breadcrumbs';
 import { isWideScreen } from 'platform/utilities/accessibility/index';
+
+import {
+  directDepositLoadError,
+  fullNameLoadError,
+  militaryInformationLoadError,
+  personalInformationLoadError,
+} from 'applications/personalization/profile360/selectors';
 
 import ProfileHeader from './ProfileHeader';
 import ProfileSubNav from './ProfileSubNav';
@@ -11,7 +19,29 @@ import ProfileMobileSubNav from './ProfileMobileSubNav';
 import { PROFILE_PATHS } from '../constants';
 import { isEmpty } from 'lodash';
 
-const Profile2Wrapper = ({ children, routes, isLOA3, isInMVI, hero }) => {
+const NotAllDataAvailableError = () => (
+  <div data-testid="not-all-data-available-error">
+    <AlertBox
+      status="warning"
+      headline="We can’t load all of your information"
+      className="vads-u-margin-bottom--4"
+    >
+      <p>
+        We’re sorry. Something went wrong on our end. We can’t display all the
+        information on this page. Please refresh the page or try again later.
+      </p>
+    </AlertBox>
+  </div>
+);
+
+const Profile2Wrapper = ({
+  children,
+  routes,
+  isLOA3,
+  isInMVI,
+  hero,
+  showNotAllDataAvailableError,
+}) => {
   const location = useLocation();
   const createBreadCrumbAttributes = () => {
     const activeLocation = location?.pathname;
@@ -63,6 +93,7 @@ const Profile2Wrapper = ({ children, routes, isLOA3, isInMVI, hero }) => {
           </div>
         </div>
         <div className="usa-width-two-thirds vads-u-padding-bottom--4 vads-u-padding-x--1 medium-screen:vads-u-padding--0 medium-screen:vads-u-padding-bottom--6">
+          {showNotAllDataAvailableError && <NotAllDataAvailableError />}
           {/* children will be passed in from React Router one level up */}
           {children}
         </div>
@@ -73,6 +104,11 @@ const Profile2Wrapper = ({ children, routes, isLOA3, isInMVI, hero }) => {
 
 const mapStateToProps = state => ({
   hero: state.vaProfile?.hero,
+  showNotAllDataAvailableError:
+    !!directDepositLoadError(state) ||
+    !!fullNameLoadError(state) ||
+    !!personalInformationLoadError(state) ||
+    !!militaryInformationLoadError(state),
 });
 
 Profile2Wrapper.propTypes = {
@@ -88,6 +124,7 @@ Profile2Wrapper.propTypes = {
       requiresMVI: PropTypes.bool.isRequired,
     }),
   ).isRequired,
+  showNotAllDataAvailableError: PropTypes.bool.isRequired,
 };
 
 export default connect(mapStateToProps)(Profile2Wrapper);

--- a/src/applications/personalization/profile-2/components/personal-information/PersonalInformation.jsx
+++ b/src/applications/personalization/profile-2/components/personal-information/PersonalInformation.jsx
@@ -3,8 +3,6 @@ import PropTypes from 'prop-types';
 import { Prompt } from 'react-router-dom';
 import { connect } from 'react-redux';
 
-import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
-
 import DowntimeNotification, {
   externalServices,
 } from 'platform/monitoring/DowntimeNotification';
@@ -12,26 +10,12 @@ import { focusElement } from 'platform/utilities/ui';
 
 import PaymentInformationBlocked from 'applications/personalization/profile360/components/PaymentInformationBlocked';
 import { handleDowntimeForSection } from 'applications/personalization/profile360/components/DowntimeBanner';
-import {
-  directDepositIsBlocked,
-  directDepositLoadError,
-} from 'applications/personalization/profile360/selectors';
+import { directDepositIsBlocked } from 'applications/personalization/profile360/selectors';
 
 import PersonalInformationContent from './PersonalInformationContent';
 
-const MyAlert = () => (
-  <AlertBox
-    status="warning"
-    headline="We can’t access your contact information"
-    className="vads-u-margin-bottom--4"
-  >
-    <p>We’re sorry. Something went wrong on our end. Please try again later.</p>
-  </AlertBox>
-);
-
 const PersonalInformation = ({
   showDirectDepositBlockedError,
-  showNotAllDataAvailableError,
   hasUnsavedEdits,
 }) => {
   useEffect(() => {
@@ -69,7 +53,6 @@ const PersonalInformation = ({
         dependencies={[externalServices.mvi, externalServices.vet360]}
       >
         {showDirectDepositBlockedError && <PaymentInformationBlocked />}
-        {showNotAllDataAvailableError && <MyAlert />}
         <PersonalInformationContent />
       </DowntimeNotification>
     </>
@@ -78,13 +61,11 @@ const PersonalInformation = ({
 
 PersonalInformation.propTypes = {
   showDirectDepositBlockedError: PropTypes.bool.isRequired,
-  showNotAllDataAvailableError: PropTypes.bool.isRequired,
   hasUnsavedEdits: PropTypes.bool.isRequired,
 };
 
 const mapStateToProps = state => ({
   showDirectDepositBlockedError: !!directDepositIsBlocked(state),
-  showNotAllDataAvailableError: !!directDepositLoadError(state),
   hasUnsavedEdits: state.vet360.hasUnsavedEdits,
 });
 

--- a/src/applications/personalization/profile-2/msw-mocks.js
+++ b/src/applications/personalization/profile-2/msw-mocks.js
@@ -1,6 +1,21 @@
 import { rest } from 'msw';
 import environment from 'platform/utilities/environment';
 
+import mockPaymentInfoSuccess from './tests/fixtures/payment-information/direct-deposit-is-set-up.json';
+
+import mockMHVHasAccepted from './tests/fixtures/mhv-has-accepted.json';
+
+import mockFullNameSuccess from './tests/fixtures/full-name-success.json';
+
+import mockPersonalInfoSuccess from './tests/fixtures/personal-information-success.json';
+import mockPersonalInfoError from './tests/fixtures/personal-information-502.json';
+
+import mockServiceHistorySuccess from './tests/fixtures/service-history-success.json';
+import mockServiceHistoryError from './tests/fixtures/service-history-502.json';
+
+import mock401 from './tests/fixtures/401.json';
+import mock500 from './tests/fixtures/500.json';
+
 export const newPaymentAccount = {
   accountType: 'Savings',
   financialInstitutionName: 'COMERICA BANK',
@@ -980,3 +995,45 @@ export const editPhoneNumberSuccess = () => {
     }),
   ];
 };
+
+export const allProfileEndpointsLoaded = [
+  rest.get(`${prefix}/v0/mhv_account`, (req, res, ctx) => {
+    return res(ctx.json(mockMHVHasAccepted));
+  }),
+  rest.get(`${prefix}/v0/profile/full_name`, (req, res, ctx) => {
+    return res(ctx.json(mockFullNameSuccess));
+  }),
+  rest.get(`${prefix}/v0/profile/personal_information`, (req, res, ctx) => {
+    return res(ctx.json(mockPersonalInfoSuccess));
+  }),
+  rest.get(`${prefix}/v0/profile/service_history`, (req, res, ctx) => {
+    return res(ctx.json(mockServiceHistorySuccess));
+  }),
+  rest.get(`${prefix}/v0/ppiu/payment_information`, (req, res, ctx) => {
+    return res(ctx.json(mockPaymentInfoSuccess));
+  }),
+];
+
+export const getFullNameFailure = [
+  rest.get(`${prefix}/v0/profile/full_name`, (req, res, ctx) => {
+    return res(ctx.status(401), ctx.json(mock401));
+  }),
+];
+
+export const getPersonalInformationFailure = [
+  rest.get(`${prefix}/v0/profile/personal_information`, (req, res, ctx) => {
+    return res(ctx.status(500), ctx.json(mock500));
+  }),
+];
+
+export const getServiceHistoryFailure = [
+  rest.get(`${prefix}/v0/profile/service_history`, (req, res, ctx) => {
+    return res(ctx.status(500), ctx.json(mock500));
+  }),
+];
+
+export const getPaymentInformationFailure = [
+  rest.get(`${prefix}/v0/ppiu/payment_information`, (req, res, ctx) => {
+    return res(ctx.status(401), ctx.json(mock401));
+  }),
+];

--- a/src/applications/personalization/profile-2/msw-mocks.js
+++ b/src/applications/personalization/profile-2/msw-mocks.js
@@ -1026,9 +1026,15 @@ export const getPersonalInformationFailure = [
   }),
 ];
 
-export const getServiceHistoryFailure = [
+export const getServiceHistory500 = [
   rest.get(`${prefix}/v0/profile/service_history`, (req, res, ctx) => {
     return res(ctx.status(500), ctx.json(mock500));
+  }),
+];
+
+export const getServiceHistory401 = [
+  rest.get(`${prefix}/v0/profile/service_history`, (req, res, ctx) => {
+    return res(ctx.status(401), ctx.json(mock401));
   }),
 ];
 

--- a/src/applications/personalization/profile-2/tests/components/Profile.data-unavailable-error.unit.spec.js
+++ b/src/applications/personalization/profile-2/tests/components/Profile.data-unavailable-error.unit.spec.js
@@ -1,0 +1,153 @@
+import React from 'react';
+
+import sinon from 'sinon';
+import { waitForElementToBeRemoved } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { expect } from 'chai';
+import { setupServer } from 'msw/node';
+
+import { resetFetch } from 'platform/testing/unit/helpers';
+
+import * as mocks from '../../msw-mocks';
+import { renderWithProfileReducers as render } from '../unit-test-helpers';
+
+import Profile2Router from '../../components/Profile2Router';
+import { PROFILE_PATH_NAMES } from '../../constants';
+
+// Returns the Redux state needed by the Profile2Router and its child components
+function createBasicInitialState() {
+  return {
+    scheduledDowntime: {
+      globalDowntime: null,
+      isReady: true,
+      isPending: false,
+      serviceMap: {
+        get() {},
+      },
+      dismissedDowntimeWarnings: [],
+    },
+    user: {
+      login: {
+        currentlyLoggedIn: true,
+        hasCheckedKeepAlive: true,
+      },
+      profile: {
+        loa: {
+          current: 3,
+          highest: 3,
+        },
+        vet360: {},
+        multifactor: true,
+        services: ['evss-claims', 'user-profile', 'vet360'],
+        isVeteran: true,
+        veteranStatus: {
+          isVeteran: true,
+          veteranStatus: {
+            status: 'OK',
+            isVeteran: true,
+            servedInMilitary: true,
+          },
+          servedInMilitary: true,
+        },
+        verified: true,
+        status: 'OK',
+      },
+    },
+  };
+}
+
+/**
+ * Checks that the error alert appears on the main Profile page as well as all
+ * of the provided pages.
+ *
+ * @param {string[]} pageNames - Array of button labels that exist in the
+ * Profile sub-nav
+ */
+async function errorAppearsOnAllPages(
+  pageNames = [
+    PROFILE_PATH_NAMES.MILITARY_INFORMATION,
+    PROFILE_PATH_NAMES.DIRECT_DEPOSIT,
+    PROFILE_PATH_NAMES.ACCOUNT_SECURITY,
+    PROFILE_PATH_NAMES.CONNECTED_APPLICATIONS,
+  ],
+) {
+  const ALERT_ID = 'not-all-data-available-error';
+  const initialState = createBasicInitialState();
+  const view = render(<Profile2Router isLOA3 isInMVI />, {
+    initialState,
+  });
+  const spinner = view.queryByRole('progressbar');
+  await waitForElementToBeRemoved(spinner);
+
+  let alert = await view.findByTestId(ALERT_ID);
+  expect(alert).to.exist;
+  expect(alert).to.contain.html('We can’t load all of your information');
+  expect(alert).to.contain.html(
+    'We’re sorry. Something went wrong on our end. We can’t display all the information on this page. Please refresh the page or try again later.',
+  );
+
+  pageNames.forEach(pageName => {
+    userEvent.click(view.getByRole('link', { name: pageName }));
+    alert = view.getByTestId(ALERT_ID);
+    expect(alert).to.exist;
+  });
+}
+
+describe('Profile "Not all data available" error', () => {
+  let server;
+
+  before(() => {
+    resetFetch();
+    server = setupServer(...mocks.allProfileEndpointsLoaded);
+    server.listen();
+  });
+  afterEach(() => {
+    server.resetHandlers();
+  });
+  after(() => {
+    server.close();
+  });
+  it('should not be shown if we can get data from all required endpoints', async () => {
+    const initialState = createBasicInitialState();
+    const view = render(<Profile2Router isLOA3 isInMVI />, {
+      initialState,
+    });
+    const spinner = view.queryByRole('progressbar');
+    await waitForElementToBeRemoved(spinner);
+    expect(view.queryByTestId('not-all-data-available-error')).not.to.exist;
+  });
+
+  it('should be shown on all pages if there is an error with the `GET full_name` endpoint', async () => {
+    server.use(...mocks.getFullNameFailure);
+
+    await errorAppearsOnAllPages();
+  });
+
+  it('should be shown on all pages if there is an error with the `GET personal_information` endpoint', async () => {
+    server.use(...mocks.getPersonalInformationFailure);
+
+    await errorAppearsOnAllPages();
+  });
+
+  it('should be shown on all pages if there is an error with the `GET service_history` endpoint', async () => {
+    server.use(...mocks.getServiceHistoryFailure);
+
+    // don't check for the error on the military info page since that page is unavailable when the `GET service_history` endpoint fails
+    await errorAppearsOnAllPages([
+      PROFILE_PATH_NAMES.DIRECT_DEPOSIT,
+      PROFILE_PATH_NAMES.ACCOUNT_SECURITY,
+      PROFILE_PATH_NAMES.CONNECTED_APPLICATIONS,
+    ]);
+  });
+
+  it('should be shown on all pages if there is an error with the `GET payment_information` endpoint`', async () => {
+    server.use(...mocks.getPaymentInformationFailure);
+
+    // don't check for the error on the direct deposit page since that page is unavailable when the `GET payment_information` endpoint fails
+    await errorAppearsOnAllPages([
+      PROFILE_PATH_NAMES.MILITARY_INFORMATION,
+      PROFILE_PATH_NAMES.ACCOUNT_SECURITY,
+      PROFILE_PATH_NAMES.CONNECTED_APPLICATIONS,
+    ]);
+  });
+});

--- a/src/applications/personalization/profile-2/tests/e2e/profile.direct-deposit.cypress.spec.js
+++ b/src/applications/personalization/profile-2/tests/e2e/profile.direct-deposit.cypress.spec.js
@@ -50,6 +50,11 @@ describe('Direct Deposit', () => {
 
     // TODO: add test to make sure that GET payment_information is not called?
 
+    // I attempted to do this based on [this
+    // example](https://github.com/cypress-io/cypress-example-recipes/blob/master/examples/stubbing-spying__window-fetch/cypress/integration/spy-on-fetch-spec.js)
+    // but was unable to get even this simple assertion to work:
+    // `cy.window().its('fetch').should('be.called')`
+
     confirmDirectDepositIsBlocked();
     cy.findByRole('alert').should('not.exist');
   });

--- a/src/applications/personalization/profile-2/tests/e2e/profile.direct-deposit.cypress.spec.js
+++ b/src/applications/personalization/profile-2/tests/e2e/profile.direct-deposit.cypress.spec.js
@@ -11,15 +11,19 @@ import mockPaymentInfoDeceased from '../fixtures/payment-information/direct-depo
 import mockPaymentInfoFiduciary from '../fixtures/payment-information/direct-deposit-fiduciary.json';
 
 describe('Direct Deposit', () => {
-  function confirmDDBlockedAlertIsShown() {
-    cy.findByRole('alert')
-      .should('have.class', 'usa-alert-error')
-      .within(() => {
-        cy.findByText(/You can’t update your financial information/i).should(
-          'exist',
-        );
-      });
+  function confirmDDBlockedAlertIsNotShown() {
+    cy.findByText(/You can’t update your financial information/i).should(
+      'not.exist',
+    );
   }
+
+  function confirmDDBlockedAlertIsShown() {
+    cy.findByText(/You can’t update your financial information/i)
+      .should('exist')
+      .closest('.usa-alert-error')
+      .should('exist');
+  }
+
   function confirmDirectDepositIsBlocked() {
     // the DD item should not exist in the sub nav
     cy.findByRole('navigation', { name: /secondary/i }).within(() => {
@@ -36,6 +40,7 @@ describe('Direct Deposit', () => {
       `${Cypress.config().baseUrl}${PROFILE_PATHS.PERSONAL_INFORMATION}`,
     );
   }
+
   beforeEach(() => {
     window.localStorage.setItem(
       'DISMISSED_ANNOUNCEMENTS',
@@ -56,7 +61,7 @@ describe('Direct Deposit', () => {
     // `cy.window().its('fetch').should('be.called')`
 
     confirmDirectDepositIsBlocked();
-    cy.findByRole('alert').should('not.exist');
+    confirmDDBlockedAlertIsNotShown();
   });
   it('should be blocked if the user is not enrolled in Direct Deposit and is not eligible to set up Direct Deposit', () => {
     cy.route('GET', 'v0/user', mockUserInEVSS);
@@ -64,7 +69,7 @@ describe('Direct Deposit', () => {
     cy.visit(PROFILE_PATHS.PROFILE_ROOT);
 
     confirmDirectDepositIsBlocked();
-    cy.findByRole('alert').should('not.exist');
+    confirmDDBlockedAlertIsNotShown();
   });
   it('should be blocked and show an alert if the user is enrolled but flagged as incompetent', () => {
     cy.route('GET', 'v0/user', mockUserInEVSS);
@@ -96,11 +101,7 @@ describe('Direct Deposit', () => {
 
     confirmDirectDepositIsBlocked();
 
-    cy.findByRole('alert')
-      .should('have.class', 'usa-alert-warning')
-      .within(() => {
-        cy.findByText(/we can’t access/i).should('exist');
-        cy.findByText(/something went wrong/i).should('exist');
-      });
+    cy.findByText(/we can’t load all of your information/i).should('exist');
+    cy.findByText(/something went wrong/i).should('exist');
   });
 });

--- a/src/applications/personalization/profile-2/tests/fixtures/401.json
+++ b/src/applications/personalization/profile-2/tests/fixtures/401.json
@@ -1,0 +1,10 @@
+{
+  "errors": [
+    {
+      "title": "Error",
+      "detail": "Error Detail",
+      "code": "SVC_ERR123",
+      "status": "401"
+    }
+  ]
+}

--- a/src/applications/personalization/profile-2/tests/fixtures/500.json
+++ b/src/applications/personalization/profile-2/tests/fixtures/500.json
@@ -1,0 +1,5 @@
+{
+  "status": 500,
+  "error": "Internal Server Error",
+  "exception": {}
+}

--- a/src/applications/personalization/profile-2/tests/fixtures/full-name-success.json
+++ b/src/applications/personalization/profile-2/tests/fixtures/full-name-success.json
@@ -1,0 +1,12 @@
+{
+  "data": {
+    "id": "",
+    "type": "hashes",
+    "attributes": {
+      "first": "Wesley",
+      "middle": "Watson",
+      "last": "Ford",
+      "suffix": null
+    }
+  }
+}

--- a/src/applications/personalization/profile-2/tests/fixtures/mhv-has-accepted.json
+++ b/src/applications/personalization/profile-2/tests/fixtures/mhv-has-accepted.json
@@ -1,0 +1,11 @@
+{
+  "data": {
+    "id": "",
+    "type": "mhv_accounts",
+    "attributes": {
+      "accountLevel": null,
+      "accountState": "no_account",
+      "termsAndConditionsAccepted": true
+    }
+  }
+}

--- a/src/applications/personalization/profile-2/tests/fixtures/personal-information-502.json
+++ b/src/applications/personalization/profile-2/tests/fixtures/personal-information-502.json
@@ -1,0 +1,11 @@
+{
+  "errors": [
+    {
+      "title": "Unexpected response body",
+      "detail": "MVI service responded without a birthday or a gender.",
+      "code": "MVI_BD502",
+      "status": "502",
+      "source": "V0::Profile::PersonalInformationsController"
+    }
+  ]
+}

--- a/src/applications/personalization/profile-2/tests/fixtures/personal-information-success.json
+++ b/src/applications/personalization/profile-2/tests/fixtures/personal-information-success.json
@@ -1,0 +1,7 @@
+{
+  "data": {
+    "id": "",
+    "type": "mvi_models_mvi_profiles",
+    "attributes": { "gender": "M", "birthDate": "1986-05-06" }
+  }
+}

--- a/src/applications/personalization/profile-2/tests/fixtures/service-history-502.json
+++ b/src/applications/personalization/profile-2/tests/fixtures/service-history-502.json
@@ -1,0 +1,11 @@
+{
+  "errors": [
+    {
+      "title": "Unexpected response body",
+      "detail": "EMIS service responded with something other than the expected array of service history hashes.",
+      "code": "EMIS_HIST502",
+      "status": "502",
+      "source": "V0::Profile::ServiceHistoriesController"
+    }
+  ]
+}

--- a/src/applications/personalization/profile-2/tests/fixtures/service-history-success.json
+++ b/src/applications/personalization/profile-2/tests/fixtures/service-history-success.json
@@ -1,0 +1,22 @@
+{
+  "data": {
+    "id": "",
+    "type": "arrays",
+    "attributes": {
+      "serviceHistory": [
+        {
+          "branchOfService": "Air Force",
+          "beginDate": "2009-04-12",
+          "endDate": "2013-04-11",
+          "personnelCategoryTypeCode": "V"
+        },
+        {
+          "branchOfService": "Air Force",
+          "beginDate": "2005-04-12",
+          "endDate": "2009-04-11",
+          "personnelCategoryTypeCode": "A"
+        }
+      ]
+    }
+  }
+}

--- a/src/applications/personalization/profile360/actions/index.js
+++ b/src/applications/personalization/profile360/actions/index.js
@@ -58,9 +58,14 @@ export function fetchMilitaryInformation() {
     const response = await getData('/profile/service_history');
 
     if (response.errors || response.error) {
+      const error = response.error || response.errors;
       dispatch({
         type: FETCH_MILITARY_INFORMATION_FAILED,
-        militaryInformation: { errors: response },
+        militaryInformation: {
+          serviceHistory: {
+            error,
+          },
+        },
       });
       return;
     }

--- a/src/applications/personalization/profile360/actions/index.js
+++ b/src/applications/personalization/profile360/actions/index.js
@@ -3,10 +3,19 @@ import { getData } from '../util';
 export const FETCH_HERO = 'FETCH_HERO';
 export const FETCH_HERO_SUCCESS = 'FETCH_HERO_SUCCESS';
 export const FETCH_HERO_FAILED = 'FETCH_HERO_FAILED';
+
+export const FETCH_PERSONAL_INFORMATION = 'FETCH_PERSONAL_INFORMATION';
 export const FETCH_PERSONAL_INFORMATION_SUCCESS =
   'FETCH_PERSONAL_INFORMATION_SUCCESS';
+export const FETCH_PERSONAL_INFORMATION_FAILED =
+  'FETCH_PERSONAL_INFORMATION_FAILED';
+
+export const FETCH_MILITARY_INFORMATION = 'FETCH_MILITARY_INFORMATION';
 export const FETCH_MILITARY_INFORMATION_SUCCESS =
   'FETCH_MILITARY_INFORMATION_SUCCESS';
+export const FETCH_MILITARY_INFORMATION_FAILED =
+  'FETCH_MILITARY_INFORMATION_FAILED';
+
 export const FETCH_ADDRESS_CONSTANTS_SUCCESS =
   'FETCH_ADDRESS_CONSTANTS_SUCCESS';
 
@@ -26,19 +35,40 @@ export function fetchHero() {
 
 export function fetchPersonalInformation() {
   return async dispatch => {
+    dispatch({ type: FETCH_PERSONAL_INFORMATION });
+    const response = await getData('/profile/personal_information');
+
+    if (response.errors || response.error) {
+      dispatch({
+        type: FETCH_PERSONAL_INFORMATION_FAILED,
+        personalInformation: { errors: response },
+      });
+      return;
+    }
     dispatch({
       type: FETCH_PERSONAL_INFORMATION_SUCCESS,
-      personalInformation: await getData('/profile/personal_information'),
+      personalInformation: response,
     });
   };
 }
 
 export function fetchMilitaryInformation() {
   return async dispatch => {
+    dispatch({ type: FETCH_MILITARY_INFORMATION });
+    const response = await getData('/profile/service_history');
+
+    if (response.errors || response.error) {
+      dispatch({
+        type: FETCH_MILITARY_INFORMATION_FAILED,
+        militaryInformation: { errors: response },
+      });
+      return;
+    }
+
     dispatch({
       type: FETCH_MILITARY_INFORMATION_SUCCESS,
       militaryInformation: {
-        serviceHistory: await getData('/profile/service_history'),
+        serviceHistory: response,
       },
     });
   };

--- a/src/applications/personalization/profile360/reducers/index.js
+++ b/src/applications/personalization/profile360/reducers/index.js
@@ -6,7 +6,9 @@ import {
   FETCH_HERO_SUCCESS,
   FETCH_HERO_FAILED,
   FETCH_PERSONAL_INFORMATION_SUCCESS,
+  FETCH_PERSONAL_INFORMATION_FAILED,
   FETCH_MILITARY_INFORMATION_SUCCESS,
+  FETCH_MILITARY_INFORMATION_FAILED,
 } from '../actions';
 
 import {
@@ -33,15 +35,15 @@ const initialState = {
 function vaProfile(state = initialState, action) {
   switch (action.type) {
     case FETCH_HERO_SUCCESS:
-      return set('hero', action.hero, state);
-
     case FETCH_HERO_FAILED:
       return set('hero', action.hero, state);
 
     case FETCH_PERSONAL_INFORMATION_SUCCESS:
+    case FETCH_PERSONAL_INFORMATION_FAILED:
       return set('personalInformation', action.personalInformation, state);
 
     case FETCH_MILITARY_INFORMATION_SUCCESS:
+    case FETCH_MILITARY_INFORMATION_FAILED:
       return set('militaryInformation', action.militaryInformation, state);
 
     case PAYMENT_INFORMATION_FETCH_SUCCEEDED:

--- a/src/applications/personalization/profile360/selectors.js
+++ b/src/applications/personalization/profile360/selectors.js
@@ -45,5 +45,5 @@ export const personalInformationLoadError = state => {
 };
 
 export const militaryInformationLoadError = state => {
-  return state.vaProfile?.militaryInformation?.errors;
+  return state.vaProfile?.militaryInformation?.serviceHistory?.error;
 };

--- a/src/applications/personalization/profile360/selectors.js
+++ b/src/applications/personalization/profile360/selectors.js
@@ -1,6 +1,3 @@
-import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
-import FEATURE_FLAG_NAMES from 'platform/utilities/feature-toggles/featureFlagNames';
-
 export const directDepositInformation = state =>
   state.vaProfile?.paymentInformation;
 
@@ -37,4 +34,16 @@ export const directDepositIsBlocked = state => {
     !controlInfo.noFiduciaryAssignedIndicator ||
     !controlInfo.notDeceasedIndicator
   );
+};
+
+export const fullNameLoadError = state => {
+  return state.vaProfile?.hero?.errors;
+};
+
+export const personalInformationLoadError = state => {
+  return state.vaProfile?.personalInformation?.errors;
+};
+
+export const militaryInformationLoadError = state => {
+  return state.vaProfile?.militaryInformation?.errors;
 };

--- a/src/applications/personalization/profile360/tests/reducers/index.unit.spec.js
+++ b/src/applications/personalization/profile360/tests/reducers/index.unit.spec.js
@@ -15,7 +15,7 @@ describe('index reducer', () => {
     expect(state.hero).to.eql('heroContent');
   });
 
-  it('should populate with errors when errors are present', () => {
+  it('should populate hero with errors when errors are present', () => {
     const state = vaProfile(undefined, {
       type: 'FETCH_HERO_FAILED',
       hero: {
@@ -33,6 +33,37 @@ describe('index reducer', () => {
     });
 
     expect(state.personalInformation).to.eql('personalInformation');
+  });
+
+  it('should populate personalInformation with errors when errors are present', () => {
+    const state = vaProfile(undefined, {
+      type: 'FETCH_PERSONAL_INFORMATION_FAILED',
+      personalInformation: {
+        errors: ['error'],
+      },
+    });
+
+    expect(state.personalInformation.errors).to.eql(['error']);
+  });
+
+  it('should fetch militaryInformation', () => {
+    const state = vaProfile(undefined, {
+      type: 'FETCH_MILITARY_INFORMATION_SUCCESS',
+      militaryInformation: 'military info',
+    });
+
+    expect(state.militaryInformation).to.eql('military info');
+  });
+
+  it('should populate militaryInformation with errors when errors are present', () => {
+    const state = vaProfile(undefined, {
+      type: 'FETCH_MILITARY_INFORMATION_FAILED',
+      militaryInformation: {
+        errors: ['error'],
+      },
+    });
+
+    expect(state.militaryInformation.errors).to.eql(['error']);
   });
 
   it('fetches paymentInformation', () => {

--- a/src/applications/personalization/profile360/tests/selectors.unit.spec.js
+++ b/src/applications/personalization/profile360/tests/selectors.unit.spec.js
@@ -312,7 +312,9 @@ describe('profile360 selectors', () => {
       const state = {
         vaProfile: {
           militaryInformation: {
-            errors,
+            serviceHistory: {
+              error: errors,
+            },
           },
         },
       };
@@ -323,7 +325,9 @@ describe('profile360 selectors', () => {
     it('should return undefined if there are no errors', () => {
       const state = {
         vaProfile: {
-          militaryInformation: {},
+          militaryInformation: {
+            serviceHistory: {},
+          },
         },
       };
       expect(selectors.militaryInformationLoadError(state)).to.be.undefined;

--- a/src/applications/personalization/profile360/tests/selectors.unit.spec.js
+++ b/src/applications/personalization/profile360/tests/selectors.unit.spec.js
@@ -13,6 +13,8 @@ const getDirectDepositInfoError = {
   ],
 };
 
+const errors = [{ name: 'error1' }, { name: 'error2' }];
+
 describe('profile360 selectors', () => {
   describe('directDepositIsSetUp selector', () => {
     let state;
@@ -246,6 +248,91 @@ describe('profile360 selectors', () => {
     it('should return undefined if vaProfile is not set on the state', () => {
       const state = {};
       expect(selectors.directDepositUiState(state)).to.equal(undefined);
+    });
+  });
+
+  describe('fullNameLoadError', () => {
+    it('should return the error data if it exists', () => {
+      const state = {
+        vaProfile: {
+          hero: {
+            errors,
+          },
+        },
+      };
+      expect(selectors.fullNameLoadError(state)).to.deep.equal(errors);
+    });
+    it('should return undefined if there are no errors', () => {
+      const state = {
+        vaProfile: {
+          hero: {},
+        },
+      };
+      expect(selectors.fullNameLoadError(state)).to.be.undefined;
+    });
+    it('should return undefined if hero info does not exist on the state', () => {
+      let state = {};
+      expect(selectors.fullNameLoadError(state)).to.be.undefined;
+      state = { vaProfile: {} };
+      expect(selectors.fullNameLoadError(state)).to.be.undefined;
+    });
+  });
+
+  describe('personalInformationLoadError', () => {
+    it('should return the error data if it exists', () => {
+      const state = {
+        vaProfile: {
+          personalInformation: {
+            errors,
+          },
+        },
+      };
+      expect(selectors.personalInformationLoadError(state)).to.deep.equal(
+        errors,
+      );
+    });
+    it('should return undefined if there are no errors', () => {
+      const state = {
+        vaProfile: {
+          personalInformation: {},
+        },
+      };
+      expect(selectors.personalInformationLoadError(state)).to.be.undefined;
+    });
+    it('should return undefined if personalInformation info does not exist on the state', () => {
+      let state = {};
+      expect(selectors.personalInformationLoadError(state)).to.be.undefined;
+      state = { vaProfile: {} };
+      expect(selectors.personalInformationLoadError(state)).to.be.undefined;
+    });
+  });
+
+  describe('militaryInformationLoadError', () => {
+    it('should return the error data if it exists', () => {
+      const state = {
+        vaProfile: {
+          militaryInformation: {
+            errors,
+          },
+        },
+      };
+      expect(selectors.militaryInformationLoadError(state)).to.deep.equal(
+        errors,
+      );
+    });
+    it('should return undefined if there are no errors', () => {
+      const state = {
+        vaProfile: {
+          militaryInformation: {},
+        },
+      };
+      expect(selectors.militaryInformationLoadError(state)).to.be.undefined;
+    });
+    it('should return undefined if militaryInformation info does not exist on the state', () => {
+      let state = {};
+      expect(selectors.militaryInformationLoadError(state)).to.be.undefined;
+      state = { vaProfile: {} };
+      expect(selectors.militaryInformationLoadError(state)).to.be.undefined;
     });
   });
 });


### PR DESCRIPTION
## Description
Show a general error on top of all the Profile pages if one of the required endpoints errors out.

## Testing done
Added RTL tests to ensure the error is shown when it should be.

## Screenshots
**Error when full name can't load**
![image](https://user-images.githubusercontent.com/20728956/89570986-cae47180-d7db-11ea-9172-f0551728c078.png)

**When personal info cannot load**
![image](https://user-images.githubusercontent.com/20728956/89571006-cfa92580-d7db-11ea-9a22-009334180edc.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs