### PR TITLE
Change direct deposit link

### DIFF
--- a/src/platform/site-wide/cta-widget/helpers.js
+++ b/src/platform/site-wide/cta-widget/helpers.js
@@ -158,7 +158,7 @@ export const toolUrl = (appId, authenticatedWithSSOe = false) => {
 
     case widgetTypes.DIRECT_DEPOSIT:
       return {
-        url: '/profile',
+        url: '/profile/direct-deposit',
         redirect: false,
       };
 


### PR DESCRIPTION
## Description
Once signed in, the link from [the direct deposit page](https://staging.va.gov/change-direct-deposit/) should take the user directly to the profile/direct-deposit.

While 2.0. is not yet turned on to 100% of all users, this link will redirect the user to the root profile route in profile 1. The url will not change to `/profile`, however, since Profile 1 is not wrapped with a `router`, we don't do a redirect.

## Testing done
Works locally.

## Acceptance criteria
- [x] Once signed in, the link from [the direct deposit page](https://staging.va.gov/change-direct-deposit/) should take the user directly to the profile/direct-deposit.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
