### PR TITLE
standalone sign-in redirects on all app urls

### DIFF
--- a/src/applications/login/tests/utilities.paths.spec.js
+++ b/src/applications/login/tests/utilities.paths.spec.js
@@ -1,0 +1,17 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import { loginAppUrlRE } from 'applications/login/utilities/paths';
+
+describe('loginAppUrlRE', () => {
+  it('should resolve to a login app url', () => {
+    expect(loginAppUrlRE.test('/sign-in')).to.be.true;
+    expect(loginAppUrlRE.test('/sign-in/')).to.be.true;
+    expect(loginAppUrlRE.test('/sign-in/verify')).to.be.true;
+    expect(loginAppUrlRE.test('/sign-in/verify/')).to.be.true;
+  });
+  it('should not resolve to a login app url', () => {
+    expect(loginAppUrlRE.test('/sign-in-faq')).to.be.false;
+    expect(loginAppUrlRE.test('/sign-in-faq/')).to.be.false;
+  });
+});

--- a/src/applications/login/utilities/paths.js
+++ b/src/applications/login/utilities/paths.js
@@ -1,0 +1,4 @@
+// NOTE: the login app typically has URLs that being with 'sign-in',
+// however there is at least one CMS page, 'sign-in-faq', that we don't
+// want to resolve with the login app
+export const loginAppUrlRE = new RegExp('^/sign-in(/.*)?$');

--- a/src/platform/user/authentication/utilities.js
+++ b/src/platform/user/authentication/utilities.js
@@ -7,6 +7,8 @@ import environment from '../../utilities/environment';
 import { eauthEnvironmentPrefixes } from '../../utilities/sso/constants';
 import { setLoginAttempted } from 'platform/utilities/sso/loginAttempted';
 
+import { loginAppUrlRE } from 'applications/login/utilities/paths';
+
 export const authnSettings = {
   RETURN_URL: 'authReturnUrl',
 };
@@ -85,10 +87,9 @@ export function standaloneRedirect() {
 function redirect(redirectUrl, clickedEvent) {
   // Keep track of the URL to return to after auth operation.
   // If the user is coming via the standalone sign-in, redirect to the home page.
-  const returnUrl =
-    window.location.pathname === '/sign-in/'
-      ? standaloneRedirect() || window.location.origin
-      : window.location;
+  const returnUrl = loginAppUrlRE.test(window.location.pathname)
+    ? standaloneRedirect() || window.location.origin
+    : window.location;
   sessionStorage.setItem(authnSettings.RETURN_URL, returnUrl);
   recordEvent({ event: clickedEvent });
 

--- a/src/platform/utilities/sso/index.js
+++ b/src/platform/utilities/sso/index.js
@@ -2,6 +2,7 @@ import moment from 'moment';
 import environment from 'platform/utilities/environment';
 import localStorage from '../storage/localStorage';
 import { hasSession, hasSessionSSO } from '../../user/profile/utilities';
+import { loginAppUrlRE } from 'applications/login/utilities/paths';
 
 import {
   standaloneRedirect,
@@ -45,11 +46,11 @@ export async function checkAutoSession(
 
   if (loggedIn && ssoeTransactionId) {
     if (
-      window.location.pathname === '/sign-in/' &&
+      loginAppUrlRE.test(window.location.pathname) &&
       ttl > 0 &&
       profile.verified
     ) {
-      // the user is on the standalone signin page, but already logged in with SSOe
+      // the user is in the login app, but already logged in with SSOe
       // redirect them back to their return url
       window.location = standaloneRedirect() || window.location.origin;
     } else if (


### PR DESCRIPTION
Updating our authentication utilities to use a RegEx for checking when a user is on a page within the login application.  Previously using a string match didn't account for subroutes or missing trailing `/`.

closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/12174
