### PR TITLE
Remove 668

### DIFF
--- a/src/platform/utilities/cerner/index.js
+++ b/src/platform/utilities/cerner/index.js
@@ -1,7 +1,7 @@
 // Relative imports.
 import environment from 'platform/utilities/environment';
 
-export const CERNER_FACILITY_IDS = ['668', '757'];
+export const CERNER_FACILITY_IDS = ['757'];
 
 export const getCernerURL = path => {
   const root = environment.isProduction()


### PR DESCRIPTION
## Description
This PR removes the cerner facility ID 668 in prep for August 21's release date.

## Testing done
N/A

## Screenshots
N/A

## Acceptance criteria
- [x] Update Cerner facility IDs

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
