### PR TITLE
new type for auto logout

### DIFF
--- a/src/platform/user/authentication/utilities.js
+++ b/src/platform/user/authentication/utilities.js
@@ -121,10 +121,11 @@ export function verify(version = 'v0') {
 export function logout(
   version = 'v0',
   clickedEvent = 'logout-link-clicked',
+  policy = 'slo',
   queryParams = {},
 ) {
   clearSentryLoginType();
-  return redirect(sessionTypeUrl('slo', version, queryParams), clickedEvent);
+  return redirect(sessionTypeUrl(policy, version, queryParams), clickedEvent);
 }
 
 export function signup(version = 'v0') {

--- a/src/platform/user/tests/authentication/utilities.unit.spec.js
+++ b/src/platform/user/tests/authentication/utilities.unit.spec.js
@@ -91,6 +91,11 @@ describe('authentication URL helpers', () => {
     expect(global.window.dataLayer[0].event).to.eq('custom-event');
   });
 
+  it('should redirect for logout with explicit logout policy', () => {
+    logout('v1', '', 'logout');
+    expect(global.window.location).to.include('/v1/sessions/logout/new');
+  });
+
   it('should redirect for MFA', () => {
     mfa();
     expect(global.window.location).to.include('/sessions/mfa/new');

--- a/src/platform/utilities/sso/index.js
+++ b/src/platform/utilities/sso/index.js
@@ -65,7 +65,7 @@ export async function checkAutoSession(
       // with the existing transaction id. If they don't match, it means we might
       // have a different user logged in. Thus, we should auto log out the user,
       // and immediately log them back in to make sure the users match.
-      logout('v1', 'sso-automatic-logout', { 'auto-logout': 'true' });
+      logout('v1', 'sso-automatic-logout', 'logout');
     }
   } else if (!loggedIn && ttl > 0 && !getLoginAttempted() && authn) {
     // only attempt an auto login if the user is

--- a/src/platform/utilities/tests/sso.unit.spec.js
+++ b/src/platform/utilities/tests/sso.unit.spec.js
@@ -118,9 +118,7 @@ describe('checkAutoSession', () => {
     await checkAutoSession(true, 'X');
 
     sinon.assert.calledOnce(auto);
-    sinon.assert.calledWith(auto, 'v1', 'sso-automatic-logout', {
-      'auto-logout': 'true',
-    });
+    sinon.assert.calledWith(auto, 'v1', 'sso-automatic-logout', 'logout');
   });
 
   it('should not auto logout if user is logged without SSOe and they do not have a SSOe session', async () => {


### PR DESCRIPTION
use `sessions/logout/new` for auto logout instead of `sessions/slo/new`.

deps on https://github.com/department-of-veterans-affairs/vets-api/pull/4666
closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/11640
