### PR TITLE
526/BDD: Show Separation Location for 1-180 Days in Future

### DIFF
--- a/src/applications/disability-benefits/all-claims/pages/militaryHistory.js
+++ b/src/applications/disability-benefits/all-claims/pages/militaryHistory.js
@@ -5,7 +5,7 @@ import AutosuggestField from 'platform/forms-system/src/js/fields/AutosuggestFie
 import * as autosuggest from 'platform/forms-system/src/js/definitions/autosuggest';
 
 import ValidatedServicePeriodView from '../components/ValidatedServicePeriodView';
-import { isBDD } from '../utils';
+import { isBDD, showSeparationLocation } from '../utils';
 import {
   SeparationLocationTitle,
   SeparationLocationDescription,
@@ -81,17 +81,17 @@ export const uiSchema = {
       'ui:title': SeparationLocationTitle,
       'ui:description': SeparationLocationDescription,
       'ui:options': {
-        hideIf: formData => !isBDD(formData),
+        hideIf: formData => !showSeparationLocation(formData),
       },
     },
     // Not using autosuggest.uiSchema; validations not set?
     separationLocation: {
       'ui:title': 'Enter a location',
       'ui:field': AutosuggestField,
-      'ui:required': formData => isBDD(formData),
+      'ui:required': formData => showSeparationLocation(formData),
       'ui:validations': [checkSeparationLocation],
       'ui:options': {
-        hideIf: formData => !isBDD(formData),
+        hideIf: formData => !showSeparationLocation(formData),
         showFieldLabel: 'label',
         maxOptions: 20,
         getOptions: () =>

--- a/src/applications/disability-benefits/all-claims/utils.jsx
+++ b/src/applications/disability-benefits/all-claims/utils.jsx
@@ -855,3 +855,25 @@ export const isBDD = formData => {
     !mostRecentDate.isAfter(moment().add(180, 'days'))
   );
 };
+
+export const showSeparationLocation = formData => {
+  const servicePeriods = formData?.serviceInformation?.servicePeriods;
+
+  if (!servicePeriods || !Array.isArray(servicePeriods)) {
+    return false;
+  }
+
+  const mostRecentDate = servicePeriods
+    .filter(({ dateRange }) => dateRange?.to)
+    .map(({ dateRange }) => moment(dateRange.to))
+    .sort((dateA, dateB) => dateB - dateA)[0];
+
+  if (!mostRecentDate) {
+    return false;
+  }
+
+  return (
+    mostRecentDate.isAfter(moment()) &&
+    !mostRecentDate.isAfter(moment().add(180, 'days'))
+  );
+};


### PR DESCRIPTION
## Description
This PR changes the logic for separation location for it to be required for separation dates that are 1-180 days in the future.

## Acceptance criteria
- [ ] Separation location is required for separation dates that are 1-180 days in the future