### PR TITLE
11843: 10203 form not showing under "Your Applications"

### DIFF
--- a/src/applications/personalization/dashboard/helpers.jsx
+++ b/src/applications/personalization/dashboard/helpers.jsx
@@ -19,6 +19,7 @@ import edu5490Manifest from 'applications/edu-benefits/5490/manifest.json';
 import edu5495Manifest from 'applications/edu-benefits/5495/manifest.json';
 import edu0993Manifest from 'applications/edu-benefits/0993/manifest.json';
 import edu0994Manifest from 'applications/edu-benefits/0994/manifest.json';
+import edu10203Manifest from 'applications/edu-benefits/10203/manifest.json';
 import preneedManifest from 'applications/pre-need/manifest.json';
 import pensionManifest from 'applications/pensions/manifest.json';
 import { DISABILITY_526_V2_ROOT_URL } from 'applications/disability-benefits/all-claims/constants';
@@ -37,6 +38,7 @@ import edu5490Config from 'applications/edu-benefits/5490/config/form.js';
 import edu5495Config from 'applications/edu-benefits/5495/config/form.js';
 import edu0993Config from 'applications/edu-benefits/0993/config/form.js';
 import edu0994Config from 'applications/edu-benefits/0994/config/form.js';
+import edu10203Config from 'applications/edu-benefits/10203/config/form.js';
 import preneedConfig from 'applications/pre-need/config/form.jsx';
 import pensionConfig from 'applications/pensions/config/form.js';
 import disability526Config from 'applications/disability-benefits/all-claims/config/form.js';
@@ -57,6 +59,7 @@ export const formConfigs = {
   [VA_FORM_IDS.FORM_22_1995]: edu1995Config,
   [VA_FORM_IDS.FORM_22_5490]: edu5490Config,
   [VA_FORM_IDS.FORM_22_5495]: edu5495Config,
+  [VA_FORM_IDS.FORM_22_10203]: edu10203Config,
   [VA_FORM_IDS.FORM_40_10007]: preneedConfig,
   [VA_FORM_IDS.FEEDBACK_TOOL]: feedbackConfig,
   [VA_FORM_IDS.FORM_20_0996]: hlrConfig,
@@ -133,6 +136,7 @@ export const formLinks = {
   [VA_FORM_IDS.FORM_22_1995]: `${edu1995Manifest.rootUrl}/`,
   [VA_FORM_IDS.FORM_22_5490]: `${edu5490Manifest.rootUrl}/`,
   [VA_FORM_IDS.FORM_22_5495]: `${edu5495Manifest.rootUrl}/`,
+  [VA_FORM_IDS.FORM_22_10203]: `${edu10203Manifest.rootUrl}/`,
   [VA_FORM_IDS.FORM_40_10007]: `${preneedManifest.rootUrl}/`,
   [VA_FORM_IDS.FEEDBACK_TOOL]: `${feedbackManifest.rootUrl}/`,
   [VA_FORM_IDS.FORM_21_686C]: `${dependentStatusManifest.rootUrl}/`,
@@ -153,6 +157,7 @@ export const trackingPrefixes = {
   [VA_FORM_IDS.FORM_22_1995]: 'edu-1995-',
   [VA_FORM_IDS.FORM_22_5490]: 'edu-5490-',
   [VA_FORM_IDS.FORM_22_5495]: 'edu-5495-',
+  [VA_FORM_IDS.FORM_22_10203]: 'edu-10203-',
   [VA_FORM_IDS.FORM_40_10007]: 'preneed-',
   [VA_FORM_IDS.FEEDBACK_TOOL]: 'gi_bill_feedback',
   [VA_FORM_IDS.FORM_21_686C]: '686-',
@@ -174,6 +179,7 @@ export const sipEnabledForms = new Set([
   VA_FORM_IDS.FORM_22_1995,
   VA_FORM_IDS.FORM_22_5490,
   VA_FORM_IDS.FORM_22_5495,
+  VA_FORM_IDS.FORM_22_10203,
   VA_FORM_IDS.FORM_40_10007,
   VA_FORM_IDS.FEEDBACK_TOOL,
   VA_FORM_IDS.FORM_20_0996,


### PR DESCRIPTION
## Description
10203 form was not showing under the Your Applications section of the "My Va" page.

[Originating Issue](https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/11843)

## Testing done
Testing passes locally. 

Note: code must be modified in order for these changes to be tested locally.

`    if (!shouldRenderContent) return null;` in the file
`vets-website/src/applications/personalization/dashboard/containers/YourApplications.jsx`

 Must be removed or commented out for Your Applications to be displayed.

## Screenshots
![Screen Shot 2020-08-07 at 11 14 31 AM](https://user-images.githubusercontent.com/48804834/89660954-119b9f80-d8a0-11ea-8b83-acfe3e636a3d.png)


## Acceptance criteria
- [x] 10203 Application is displayed 

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
