### PR TITLE
12186: Update Search Results - "Refine search"

### DIFF
--- a/src/applications/gi/components/search/InstitutionSearchForm.jsx
+++ b/src/applications/gi/components/search/InstitutionSearchForm.jsx
@@ -30,7 +30,7 @@ function InstitutionSearchForm(props) {
     }
   }
 
-  const header = props.gibctFilterEnhancement ? 'Refine Search' : 'Keywords';
+  const header = props.gibctFilterEnhancement ? 'Refine search' : 'Keywords';
   const keywordSearchLabel = props.gibctFilterEnhancement
     ? 'Enter a school, location, or employer name'
     : 'City, school, or employer';


### PR DESCRIPTION
## Description
As someone using the Comparison Tool, I want to be able to filter search results on more specific criteria so that I can more quickly find the institution I am looking for.

[Originating Issue](https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/12186)

## Testing done
Testing passes locally.

## Screenshots
![Screen Shot 2020-08-07 at 12 20 55 PM](https://user-images.githubusercontent.com/48804834/89666496-765af800-d8a8-11ea-9f15-5e6d91632fea.png)

## Acceptance criteria
- [x] 1. On the Search Results page, the left panel has been updated as follows:
a. The "Refine Search" heading is changed to "Refine search"

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
