### PR TITLE
Removed chevron from 10203 exit button

### DIFF
--- a/src/applications/edu-benefits/10203/containers/ConfirmEligibilityView.jsx
+++ b/src/applications/edu-benefits/10203/containers/ConfirmEligibilityView.jsx
@@ -177,7 +177,9 @@ export class ConfirmEligibilityView extends React.Component {
           <div>
             <div className="vads-u-margin-top--neg2">
               <a
-                className={'usa-button-primary wizard-button va-button-primary'}
+                className={
+                  'usa-button-primary wizard-button-10203 va-button-primary'
+                }
                 href="/education/about-gi-bill-benefits/"
                 target="self"
               >

--- a/src/applications/edu-benefits/10203/containers/ConfirmEligibilityView.jsx
+++ b/src/applications/edu-benefits/10203/containers/ConfirmEligibilityView.jsx
@@ -177,9 +177,7 @@ export class ConfirmEligibilityView extends React.Component {
           <div>
             <div className="vads-u-margin-top--neg2">
               <a
-                className={
-                  'usa-button-primary wizard-button-10203 va-button-primary'
-                }
+                className={'usa-button-primary va-button-primary'}
                 href="/education/about-gi-bill-benefits/"
                 target="self"
               >

--- a/src/applications/edu-benefits/10203/containers/InitialConfirmEligibilityView.jsx
+++ b/src/applications/edu-benefits/10203/containers/InitialConfirmEligibilityView.jsx
@@ -29,7 +29,7 @@ function InitialConfirmEligibilityView(props) {
       <br />
       <div>
         <a
-          className={'usa-button-primary wizard-button va-button-primary'}
+          className={'usa-button-primary wizard-button-10203 va-button-primary'}
           href="/education/"
           target="_self"
         >

--- a/src/applications/edu-benefits/10203/containers/InitialConfirmEligibilityView.jsx
+++ b/src/applications/edu-benefits/10203/containers/InitialConfirmEligibilityView.jsx
@@ -29,7 +29,7 @@ function InitialConfirmEligibilityView(props) {
       <br />
       <div>
         <a
-          className={'usa-button-primary wizard-button-10203 va-button-primary'}
+          className={'usa-button-primary va-button-primary'}
           href="/education/"
           target="_self"
         >

--- a/src/applications/static-pages/sass/modules/_m-education-wizard.scss
+++ b/src/applications/static-pages/sass/modules/_m-education-wizard.scss
@@ -18,24 +18,6 @@
     background-image: url("/img/arrow-up-white.svg");
   }
 }
-.wizard-button-10203 {
-  &::after {
-    background-image: url("/img/arrow-down-white.svg");
-    background-position: right bottom;
-    background-repeat: no-repeat;
-    background-size: 0.6em auto;
-    content: ""; // Add content for accessibility purposes?
-    display: inline-block;
-    height: 1em;
-    margin-left: 0.5em;
-    margin-right: -0.3em;
-    text-indent: -9999em;
-    width: 1em;
-  }
-  &[aria-expanded="true"]::after {
-    background-image: url("/img/arrow-up-white.svg");
-  }
-}
 
 // Handles the height transition
 .wizard-content {

--- a/src/applications/static-pages/sass/modules/_m-education-wizard.scss
+++ b/src/applications/static-pages/sass/modules/_m-education-wizard.scss
@@ -18,6 +18,24 @@
     background-image: url("/img/arrow-up-white.svg");
   }
 }
+.wizard-button-10203 {
+  &::after {
+    background-image: url("/img/arrow-down-white.svg");
+    background-position: right bottom;
+    background-repeat: no-repeat;
+    background-size: 0.6em auto;
+    content: ""; // Add content for accessibility purposes?
+    display: inline-block;
+    height: 1em;
+    margin-left: 0.5em;
+    margin-right: -0.3em;
+    text-indent: -9999em;
+    width: 1em;
+  }
+  &[aria-expanded="true"]::after {
+    background-image: url("/img/arrow-up-white.svg");
+  }
+}
 
 // Handles the height transition
 .wizard-content {


### PR DESCRIPTION
## Description
Exit application buttons have down chevron on both benefit eligibility summary page (Ch2) and STEM scholarship summary page (Ch3)

https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/12200

## Testing done
local

## Screenshots
![Screen Shot 2020-08-07 at 2 31 34 PM](https://user-images.githubusercontent.com/50601724/89677058-b7f49e80-d8ba-11ea-9e46-7337e315e259.png)
![Screen Shot 2020-08-07 at 2 31 28 PM](https://user-images.githubusercontent.com/50601724/89677065-b9be6200-d8ba-11ea-80d0-b35d9c161b89.png)


## Acceptance criteria
- [x] Remove Chevrons

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
