### PR TITLE
1990 wizard rename feature value

### DIFF
--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -43,6 +43,6 @@ export default Object.freeze({
   showEduBenefits1990NWizard: 'showEduBenefits1990NWizard',
   showEduBenefits0994Wizard: 'showEduBenefits0994Wizard',
   showEduBenefits5490Wizard: 'showEduBenefits5490Wizard',
-  showEduBenefits1990Wizard: 'showEduBenefits1990Wizard',
+  showEduBenefits1990Wizard: 'show_edu_benefits_1990_wizard',
   showEduBenefits1990EWizard: 'showEduBenefits1990EWizard',
 });


### PR DESCRIPTION
## Description
Due to inflection translation issues, this flag's value has to be renamed.

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
