### PR TITLE
1990n wizard rename feature value

### DIFF
--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -40,7 +40,7 @@ export default Object.freeze({
   form526BDD: 'form526BenefitsDeliveryAtDischarge',
   showEduBenefits5495Wizard: 'showEduBenefits5495Wizard',
   showEduBenefits1995Wizard: 'showEduBenefits1995Wizard',
-  showEduBenefits1990NWizard: 'showEduBenefits1990NWizard',
+  showEduBenefits1990NWizard: 'show_edu_benefits_1990n_wizard',
   showEduBenefits0994Wizard: 'showEduBenefits0994Wizard',
   showEduBenefits5490Wizard: 'showEduBenefits5490Wizard',
   showEduBenefits1990Wizard: 'showEduBenefits1990Wizard',


### PR DESCRIPTION
## Description
Due to inflection translation issues, this flag's value has to be renamed.


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
