### PR TITLE
Darken pass result section on screener

### DIFF
--- a/src/applications/coronavirus-screener/sass/coronavirus-screener.scss
+++ b/src/applications/coronavirus-screener/sass/coronavirus-screener.scss
@@ -2,15 +2,24 @@
 
 .covid-screener {
   *:not(.fas) {
-    font-family: Source Sans Pro,Helvetica Neue,Helvetica,Roboto,Arial,sans-serif;
+    font-family: Source Sans Pro, Helvetica Neue, Helvetica, Roboto, Arial,
+      sans-serif;
   }
   .covid-screener-date {
     margin: 2em 0 2em 0;
-    h2,h3,h4 { margin: 0; }
-    h4 { font-size: 150%; }
+    h2,
+    h3,
+    h4 {
+      margin: 0;
+    }
+    h4 {
+      font-size: 150%;
+    }
   }
   .covid-screener-results {
-    h3 { font-size: 300%; }
+    h3 {
+      font-size: 300%;
+    }
     background-color: $color-primary-alt-lightest;
     p {
       font-weight: bold !important;
@@ -19,8 +28,10 @@
     color: $color-primary-darkest;
   }
   .covid-screener-results-pass {
-    i {font-size: 10em;}
-    background-color: $color-primary;
+    i {
+      font-size: 10em;
+    }
+    background-color: $color-primary-darkest;
     color: $color-white;
   }
 }


### PR DESCRIPTION
## Description
Darken pass result section for COVID-19 screening tool to increase contrast with white text.

See https://github.com/department-of-veterans-affairs/va.gov-team/issues/11922.

Also some automatic CSS linting.

## Testing done

Local.

## Screenshots

### Old

<img width="350" alt="Screen Shot 2020-08-09 at 9 56 01 AM" src="https://user-images.githubusercontent.com/7645362/89734546-b4802500-da2a-11ea-87a5-873e4b50da98.png">

### New

<img width="340" alt="Screen Shot 2020-08-09 at 10 38 45 AM" src="https://user-images.githubusercontent.com/7645362/89734841-94516580-da2c-11ea-9a61-def0e62a6541.png">



## Acceptance criteria
- [x] Background of result section in "Pass" state appears darker. 

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs

