### PR TITLE
BDD: Add Additional 526 pages to BDD Flow

### DIFF
--- a/src/applications/disability-benefits/all-claims/config/form.js
+++ b/src/applications/disability-benefits/all-claims/config/form.js
@@ -198,7 +198,7 @@ const formConfig = {
         servedInCombatZone: {
           title: 'Combat status',
           path: 'review-veteran-details/combat-status',
-          depends: formData => servedAfter911(formData) && !isBDD(formData),
+          depends: servedAfter911,
           uiSchema: servedInCombatZone.uiSchema,
           schema: servedInCombatZone.schema,
         },
@@ -207,8 +207,7 @@ const formConfig = {
           path:
             'review-veteran-details/military-service-history/reserves-national-guard',
           depends: formData =>
-            hasGuardOrReservePeriod(formData.serviceInformation) &&
-            !isBDD(formData),
+            hasGuardOrReservePeriod(formData.serviceInformation),
           uiSchema: reservesNationalGuardService.uiSchema,
           schema: reservesNationalGuardService.schema,
         },
@@ -650,7 +649,6 @@ const formConfig = {
         vaEmployee: {
           title: 'VA employee',
           path: 'va-employee',
-          depends: formData => !isBDD(formData),
           uiSchema: vaEmployee.uiSchema,
           schema: vaEmployee.schema,
         },

--- a/src/applications/disability-benefits/all-claims/tests/fixtures/data/transformed-data/maximal-bdd-test.json
+++ b/src/applications/disability-benefits/all-claims/tests/fixtures/data/transformed-data/maximal-bdd-test.json
@@ -1,5 +1,6 @@
 {
     "form526": {
+      "isVaEmployee": true,
       "standardClaim": false,
       "bankAccountType": "Checking",
       "bankAccountNumber": "1233",
@@ -9,6 +10,7 @@
         "primaryPhone": "4445551212",
         "emailAddress": "test2@test1.net"
       },
+      "servedInCombatZonePost911": true,
       "mailingAddress": {
         "country": "USA",
         "addressLine1": "123 Main",

--- a/src/applications/disability-benefits/all-claims/tests/fixtures/data/transformed-data/minimal-bdd-test.json
+++ b/src/applications/disability-benefits/all-claims/tests/fixtures/data/transformed-data/minimal-bdd-test.json
@@ -1,9 +1,11 @@
 {
     "form526": {
+      "isVaEmployee": false,
       "phoneAndEmail": {
         "primaryPhone": "4445551212",
         "emailAddress": "test2@test1.net"
       },
+      "servedInCombatZonePost911": false,
       "mailingAddress": {
         "country": "USA",
         "addressLine1": "123 Main",


### PR DESCRIPTION
## Description
This adds a few additionally required pages from the 526 flow to the BDD flow in the all-claims form.

## Acceptance criteria
- [ ] Additional required pages from 526 flow are added to the BDD flow in all-claims