### PR TITLE
fix breadcrumb on 686

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -254,7 +254,7 @@
       "includeBreadcrumbs": true,
       "breadcrumbs_override": [
         {
-          "path": "/view-change-dependents/view",
+          "path": "view-change-dependents/view",
           "name": "View or change your dependents"
         },
         {


### PR DESCRIPTION
## Description
This pull request fixes the path for the 686c-674 breadcrumb in registry.json

## Testing done
- local, redirect works as expected. 

## Acceptance criteria
- [x] redirects to expected page

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
