### PR TITLE
10203 Review Page Margin Fix

### DIFF
--- a/src/applications/edu-benefits/sass/edu-benefits.scss
+++ b/src/applications/edu-benefits/sass/edu-benefits.scss
@@ -168,3 +168,9 @@
     display: none;
   }
 }
+
+div[data-chapter="benefitSelection"]{
+  .form-review-panel-page {
+    margin-bottom:0px;
+  }
+}


### PR DESCRIPTION
## Description
Removed bottom margin from the 1st page of the `benefitSelection` chapter.  The following page is never displayed, so this margin is not needed.

[ZenHub Issue](https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/12214)

## Testing done
Tested locally and QA reviewed.

## Screenshots
![image](https://user-images.githubusercontent.com/41960449/89823616-c8f21980-db1f-11ea-888b-ee9a48b12d6b.png)

## Acceptance criteria
- [x] Margin is displayed correctly

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
