### PR TITLE
Add script for validating the two content builds

### DIFF
--- a/script/utils.js
+++ b/script/utils.js
@@ -1,4 +1,4 @@
-const { spawn } = require('child_process');
+const { spawn, spawnSync } = require('child_process');
 
 const runCommand = (cmd, forcedExitCode = null) => {
   const child = spawn(cmd, [], { shell: true, stdio: 'inherit' });
@@ -7,6 +7,12 @@ const runCommand = (cmd, forcedExitCode = null) => {
   });
 };
 
+const runCommandSync = (cmd, forcedExitCode = null) => {
+  const child = spawnSync(cmd, [], { shell: true, stdio: 'inherit' });
+  return child.status;
+};
+
 module.exports = {
   runCommand,
+  runCommandSync,
 };

--- a/script/validate-content-builds.js
+++ b/script/validate-content-builds.js
@@ -1,0 +1,11 @@
+const { runCommandSync } = require('./utils');
+
+runCommandSync('npm run build:content --pull-drupal');
+
+// Copy the drupal cache into the content-build repo
+runCommandSync('cp -r .cache ../content-build/.cache');
+
+runCommandSync('cd ../content-build && npm run build:content');
+
+const exitCode = runCommandSync('npm run build:compare');
+process.exit(exitCode);

--- a/script/validate-content-builds.js
+++ b/script/validate-content-builds.js
@@ -1,11 +1,14 @@
 const { runCommandSync } = require('./utils');
 
+// Run the vets-website content build
 runCommandSync('npm run build:content --pull-drupal');
 
 // Copy the drupal cache into the content-build repo
 runCommandSync('cp -r .cache ../content-build/.cache');
 
+// Run the standalone content build using the same cache
 runCommandSync('cd ../content-build && npm run build:content');
 
+// Compare the build outputs to see if they match
 const exitCode = runCommandSync('npm run build:compare');
 process.exit(exitCode);


### PR DESCRIPTION
## Description

This is a script that _right now_ assumes that the [`content-build`](https://github.com/department-of-veterans-affairs/content-build) repo is a sibling to `vets-website`. It also assumes that you're connected to the SOCKS proxy in order to get the latest content from the CMS.

To compare the two builds, run:

```bash
node script/validate-content-builds.js
```

Since the builds are using the same content, if they don't match then this means that the `content-build` repo is missing a commit from `vets-website` that changes something related to the content build (i.e. a template, or one of the metalsmith pipeline steps).

## Testing done

Local testing

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
