### PR TITLE
bradl3yC - debt letters - only redirect if in prod

### DIFF
--- a/src/applications/debt-letters/components/DebtLettersWrapper.jsx
+++ b/src/applications/debt-letters/components/DebtLettersWrapper.jsx
@@ -4,6 +4,8 @@ import LoadingIndicator from '@department-of-veterans-affairs/formation-react/Lo
 import { bindActionCreators } from 'redux';
 import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
 import FEATURE_FLAG_NAMES from 'platform/utilities/feature-toggles/featureFlagNames';
+import environment from 'platform/utilities/environment';
+import CallToActionWidget from 'platform/site-wide/cta-widget';
 import PropTypes from 'prop-types';
 import { fetchDebtLetters, fetchDebtLettersVBMS } from '../actions';
 
@@ -24,7 +26,7 @@ class DebtLettersWrapper extends Component {
       isLoggedIn,
     } = this.props;
 
-    if (!isLoggedIn) {
+    if (environment.isProduction() && isLoggedIn === false) {
       return window.location.replace('/manage-va-debt');
     }
 
@@ -40,7 +42,9 @@ class DebtLettersWrapper extends Component {
       <>
         {showDebtLetters ? (
           <div className="vads-l-grid-container large-screen:vads-u-padding-x--0 vads-u-margin-bottom--4 vads-u-margin-top--2 vads-u-font-family--serif">
-            {children}
+            <CallToActionWidget appId="debt-letters">
+              {children}
+            </CallToActionWidget>
           </div>
         ) : (
           <div />


### PR DESCRIPTION
## Description
Currently since the static lander isn't in place that would redirect the user to the tool after login, there is no way for a staging user to make it the debt letters tool for testing

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
