### PR TITLE
[CTA widget] Implement Change Address

### DIFF
--- a/src/platform/site-wide/cta-widget/components/messages/ChangeAddress.jsx
+++ b/src/platform/site-wide/cta-widget/components/messages/ChangeAddress.jsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { selectShowProfile2 } from 'applications/personalization/profile-2/selectors';
+
+import CallToActionAlert from '../CallToActionAlert';
+
+function goToOriginalProfile() {
+  window.location = '/profile';
+}
+
+const ChangeAddress = ({
+  serviceDescription,
+  primaryButtonHandler,
+  featureToggles,
+}) => {
+  const showProfile2 = selectShowProfile2({ featureToggles });
+
+  const content = {
+    heading: `Go to your VA.gov profile to ${serviceDescription}`,
+    alertText: (
+      <p>
+        You’ll find your mailing and home address in your profile’s{' '}
+        <strong>Personal and contact information</strong> section.
+      </p>
+    ),
+    primaryButtonText: 'Go to your VA.gov profile',
+    primaryButtonHandler: showProfile2
+      ? primaryButtonHandler
+      : goToOriginalProfile,
+    status: 'continue',
+  };
+
+  return <CallToActionAlert {...content} />;
+};
+
+ChangeAddress.propTypes = {
+  serviceDescription: PropTypes.string.isRequired,
+  primaryButtonHandler: PropTypes.func.isRequired,
+};
+
+export default ChangeAddress;

--- a/src/platform/site-wide/cta-widget/components/messages/ChangeAddress.jsx
+++ b/src/platform/site-wide/cta-widget/components/messages/ChangeAddress.jsx
@@ -5,7 +5,7 @@ import { selectShowProfile2 } from 'applications/personalization/profile-2/selec
 import CallToActionAlert from '../CallToActionAlert';
 
 function goToOriginalProfile() {
-  window.location = '/profile';
+  window.location = '/profile/';
 }
 
 const ChangeAddress = ({

--- a/src/platform/site-wide/cta-widget/components/messages/ChangeAddress.jsx
+++ b/src/platform/site-wide/cta-widget/components/messages/ChangeAddress.jsx
@@ -36,6 +36,7 @@ const ChangeAddress = ({
 ChangeAddress.propTypes = {
   serviceDescription: PropTypes.string.isRequired,
   primaryButtonHandler: PropTypes.func.isRequired,
+  featureToggles: PropTypes.object.isRequired,
 };
 
 export default ChangeAddress;

--- a/src/platform/site-wide/cta-widget/components/messages/DirectDeposit.jsx
+++ b/src/platform/site-wide/cta-widget/components/messages/DirectDeposit.jsx
@@ -11,7 +11,7 @@ const DirectDeposit = ({ serviceDescription, primaryButtonHandler }) => {
         type.
       </p>
     ),
-    primaryButtonText: 'Go to your profile',
+    primaryButtonText: 'Go to your VA.gov profile',
     primaryButtonHandler,
     status: 'continue',
   };

--- a/src/platform/site-wide/cta-widget/components/messages/SignIn.jsx
+++ b/src/platform/site-wide/cta-widget/components/messages/SignIn.jsx
@@ -9,7 +9,7 @@ const SignIn = ({ serviceDescription, primaryButtonHandler }) => {
       <p>
         Try signing in with your <b>DS Logon</b>, <b>My HealtheVet</b>, or{' '}
         <b>ID.me</b> account. If you don’t have any of those accounts, you can
-        create one.
+        create one now.
       </p>
     ),
     primaryButtonText: 'Sign in or create an account',

--- a/src/platform/site-wide/cta-widget/components/messages/Verify.jsx
+++ b/src/platform/site-wide/cta-widget/components/messages/Verify.jsx
@@ -6,15 +6,21 @@ const Verify = ({ serviceDescription, primaryButtonHandler }) => {
   const content = {
     heading: `Please verify your identity to ${serviceDescription}`,
     alertText: (
-      <p>
-        We take your privacy seriously, and we’re committed to protecting your
-        information. You’ll need to verify your identity before we can give you
-        access to your personal health information.
-      </p>
+      <>
+        <p>
+          We need to make sure you’re you — and not someone pretending to be you
+          — before we can give you access to your personal and health-related
+          information. This helps us keep your information safe and prevent
+          fraud and identity theft.
+        </p>
+        <p>
+          <strong>This one-time process takes about 5 to 10 minutes.</strong>
+        </p>
+      </>
     ),
     primaryButtonText: 'Verify your identity',
     primaryButtonHandler,
-    status: 'continue',
+    status: 'warning',
   };
 
   return <CallToActionAlert {...content} />;

--- a/src/platform/site-wide/cta-widget/helpers.js
+++ b/src/platform/site-wide/cta-widget/helpers.js
@@ -27,6 +27,8 @@ export const widgetTypes = {
   VIEW_APPOINTMENTS: 'view-appointments',
   VIEW_DEPENDENTS: 'view-dependents',
   ADD_REMOVE_DEPENDENTS: 'add-remove-dependents',
+  CHANGE_ADDRESS: 'change-address',
+  CHANGE_ADDRESS_PROFILE_2: 'change-address',
 };
 
 const HEALTH_TOOLS = [
@@ -192,6 +194,18 @@ export const toolUrl = (appId, authenticatedWithSSOe = false) => {
         redirect: false,
       };
 
+    case widgetTypes.CHANGE_ADDRESS:
+      return {
+        url: '/profile/',
+        redirect: false,
+      };
+
+    case widgetTypes.CHANGE_ADDRESS_PROFILE_2:
+      return {
+        url: '/profile/personal-information',
+        redirect: false,
+      };
+
     default:
       return {};
   }
@@ -292,6 +306,10 @@ export const serviceDescription = appId => {
 
     case widgetTypes.ADD_REMOVE_DEPENDENTS:
       return 'add or remove dependents';
+
+    case widgetTypes.CHANGE_ADDRESS:
+    case widgetTypes.CHANGE_ADDRESS_PROFILE_2:
+      return 'change your address';
 
     default:
       return 'use this service';

--- a/src/platform/site-wide/cta-widget/helpers.js
+++ b/src/platform/site-wide/cta-widget/helpers.js
@@ -28,7 +28,6 @@ export const widgetTypes = {
   VIEW_DEPENDENTS: 'view-dependents',
   ADD_REMOVE_DEPENDENTS: 'add-remove-dependents',
   CHANGE_ADDRESS: 'change-address',
-  CHANGE_ADDRESS_PROFILE_2: 'change-address',
 };
 
 const HEALTH_TOOLS = [
@@ -196,12 +195,6 @@ export const toolUrl = (appId, authenticatedWithSSOe = false) => {
 
     case widgetTypes.CHANGE_ADDRESS:
       return {
-        url: '/profile/',
-        redirect: false,
-      };
-
-    case widgetTypes.CHANGE_ADDRESS_PROFILE_2:
-      return {
         url: '/profile/personal-information',
         redirect: false,
       };
@@ -308,7 +301,6 @@ export const serviceDescription = appId => {
       return 'add or remove dependents';
 
     case widgetTypes.CHANGE_ADDRESS:
-    case widgetTypes.CHANGE_ADDRESS_PROFILE_2:
       return 'change your address';
 
     default:

--- a/src/platform/site-wide/cta-widget/index.js
+++ b/src/platform/site-wide/cta-widget/index.js
@@ -38,6 +38,7 @@ import Verify from './components/messages/Verify';
 import OpenMyHealtheVet from './components/messages/OpenMyHealtheVet';
 import MFA from './components/messages/MFA';
 import DirectDeposit from './components/messages/DirectDeposit';
+import ChangeAddress from './components/messages/ChangeAddress';
 import NotAuthorized from './components/messages/mvi/NotAuthorized';
 import NotFound from './components/messages/mvi/NotFound';
 import NeedsSSNResolution from './components/messages/NeedsSSNResolution';
@@ -162,6 +163,16 @@ export class CallToActionWidget extends React.Component {
               event: 'nav-user-profile-cta',
             })
           }
+        />
+      );
+    }
+
+    if (this.props.appId === widgetTypes.CHANGE_ADDRESS) {
+      return (
+        <ChangeAddress
+          featureToggles={this.props.featureToggles}
+          serviceDescription={this._serviceDescription}
+          primaryButtonHandler={this.goToTool}
         />
       );
     }


### PR DESCRIPTION
## Description
- Implements the Change Address widget, including the routing based on the Flipper toggle
- Updates the text for the Verify state (site-wide)
- Updates the text for the Sign-In state (site-wide; just adds the word "now" at the end)

Ticket - https://github.com/department-of-veterans-affairs/va.gov-team/issues/10853

## Testing done
Tested locally by setting up a widget from a Markdown file, running the API, then -

1. observing the content in unauthenticated state
1. observing the content in authenticated state w/Flipper feature toggled

## Screenshots

### Verify your identity
![image](https://user-images.githubusercontent.com/1915775/89837450-fa2a1400-db36-11ea-8794-5d7d2f10946a.png)

### Unauth
![image](https://user-images.githubusercontent.com/1915775/89836600-22187800-db35-11ea-95b5-f11fead12db4.png)

### Auth
With the flipper feature on, the button leads to `/profile/personal-information`. When off, it leads to `/profile/`.

![image](https://user-images.githubusercontent.com/1915775/89836700-53914380-db35-11ea-8a6c-8ac6010b7e91.png)

## Acceptance criteria
- [ ] CTA widget for Change Address is ready for Drupal integration

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
