### PR TITLE
Add service type to FL search results subhead

### DIFF
--- a/src/applications/facility-locator/actions/index.js
+++ b/src/applications/facility-locator/actions/index.js
@@ -149,7 +149,7 @@ export const searchWithBounds = ({
   const needsAddress = [
     LocationType.CC_PROVIDER,
     LocationType.ALL,
-    LocationType.URGENT_CARE_FARMACIES,
+    LocationType.URGENT_CARE_PHARMACIES,
     LocationType.URGENT_CARE,
   ];
   return dispatch => {
@@ -293,7 +293,7 @@ export const getProviderSpecialties = () => async dispatch => {
       return [];
     }
     // Great Success!
-    dispatch({ type: FETCH_SPECIALTIES_DONE });
+    dispatch({ type: FETCH_SPECIALTIES_DONE, data });
     return data;
   } catch (error) {
     dispatch({ type: FETCH_SPECIALTIES_FAILED, error });

--- a/src/applications/facility-locator/components/SearchResultsHeader.jsx
+++ b/src/applications/facility-locator/components/SearchResultsHeader.jsx
@@ -1,18 +1,38 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { facilityTypes } from '../config';
+import { facilityTypes, urgentCareServices, healthServices } from '../config';
+import { LocationType } from '../constants';
+import { connect } from 'react-redux';
 
 const SearchResultsHeader = ({
   results,
   facilityType,
+  serviceType,
   context,
   inProgress,
+  specialtyMap,
 }) => {
   if (inProgress || !results.length) {
     return <div style={{ height: '38px' }} />;
   }
 
-  const location = context.replace(', United States', '');
+  const location = context ? context.replace(', United States', '') : null;
+
+  const formatServiceType = rawServiceType => {
+    if (facilityType === LocationType.URGENT_CARE) {
+      return urgentCareServices[rawServiceType];
+    }
+
+    if (facilityType === LocationType.HEALTH) {
+      return healthServices[rawServiceType];
+    }
+
+    if (facilityType === LocationType.CC_PROVIDER) {
+      return specialtyMap[rawServiceType];
+    }
+
+    return rawServiceType;
+  };
 
   return (
     <h2
@@ -23,9 +43,21 @@ const SearchResultsHeader = ({
     >
       Results for &quot;
       <b>{facilityTypes[facilityType]}</b>
-      &quot; near&nbsp; &quot;
-      <b>{location}</b>
       &quot;
+      {serviceType && (
+        <>
+          ,&nbsp;&quot;
+          <b>{formatServiceType(serviceType)}</b>
+          &quot;
+        </>
+      )}
+      {location && (
+        <>
+          &nbsp;near &quot;
+          <b>{location}</b>
+          &quot;
+        </>
+      )}
     </h2>
   );
 };
@@ -33,7 +65,9 @@ const SearchResultsHeader = ({
 SearchResultsHeader.propTypes = {
   results: PropTypes.array,
   facilityType: PropTypes.string,
+  serviceType: PropTypes.string,
   context: PropTypes.string,
+  specialtyMap: PropTypes.object,
 };
 
 // Only re-render if results or inProgress props have changed
@@ -44,4 +78,11 @@ const areEqual = (prevProps, nextProps) => {
   );
 };
 
-export default React.memo(SearchResultsHeader, areEqual);
+const mapStateToProps = state => ({
+  specialtyMap: state.searchQuery.specialties,
+});
+
+export default React.memo(
+  connect(mapStateToProps)(SearchResultsHeader),
+  areEqual,
+);

--- a/src/applications/facility-locator/components/SearchResultsHeader.jsx
+++ b/src/applications/facility-locator/components/SearchResultsHeader.jsx
@@ -4,7 +4,7 @@ import { facilityTypes, urgentCareServices, healthServices } from '../config';
 import { LocationType } from '../constants';
 import { connect } from 'react-redux';
 
-const SearchResultsHeader = ({
+export const SearchResultsHeader = ({
   results,
   facilityType,
   serviceType,

--- a/src/applications/facility-locator/config.js
+++ b/src/applications/facility-locator/config.js
@@ -83,7 +83,7 @@ export const resolveParamsWithUrl = (
 export const facilityTypes = {
   [FacilityType.VA_HEALTH_FACILITY]: 'VA health',
   [FacilityType.URGENT_CARE]: 'Urgent care',
-  [FacilityType.URGENT_CARE_FARMACIES]:
+  [FacilityType.URGENT_CARE_PHARMACIES]:
     'Urgent care pharmacies (in VA’s network)',
   [FacilityType.VA_CEMETARY]: 'VA cemeteries',
   [FacilityType.VA_BENEFITS_FACILITY]: 'Benefits',
@@ -162,7 +162,7 @@ export const facilityTypesOptions = {
   [LocationType.HEALTH]: 'VA health',
   [LocationType.URGENT_CARE]: 'Urgent care',
   [LocationType.CC_PROVIDER]: 'Community providers (in VA’s network)',
-  [LocationType.URGENT_CARE_FARMACIES]:
+  [LocationType.URGENT_CARE_PHARMACIES]:
     'Urgent care pharmacies (in VA’s network)',
   [LocationType.BENEFITS]: 'VA benefits',
   [LocationType.CEMETARY]: 'VA cemeteries',

--- a/src/applications/facility-locator/constants/index.js
+++ b/src/applications/facility-locator/constants/index.js
@@ -11,7 +11,7 @@ export const LocationType = {
   CEMETARY: 'cemetery',
   VET_CENTER: 'vet_center',
   URGENT_CARE: 'urgent_care',
-  URGENT_CARE_FARMACIES: 'pharmacy',
+  URGENT_CARE_PHARMACIES: 'pharmacy',
 };
 
 /**
@@ -23,7 +23,7 @@ export const FacilityType = {
   VA_BENEFITS_FACILITY: 'va_benefits_facility',
   VET_CENTER: 'vet_center',
   URGENT_CARE: 'urgent_care',
-  URGENT_CARE_FARMACIES: 'pharmacy',
+  URGENT_CARE_PHARMACIES: 'pharmacy',
 };
 
 /**
@@ -37,7 +37,7 @@ export const PinNames = {
   [FacilityType.VET_CENTER]: 'vet-centers',
   [FacilityType.URGENT_CARE]: 'health',
   [LocationType.CC_PROVIDER]: 'cc-provider',
-  [LocationType.URGENT_CARE_FARMACIES]: 'cc-provider',
+  [LocationType.URGENT_CARE_PHARMACIES]: 'cc-provider',
 };
 
 /**

--- a/src/applications/facility-locator/containers/VAMap.jsx
+++ b/src/applications/facility-locator/containers/VAMap.jsx
@@ -522,10 +522,11 @@ class VAMap extends Component {
     return mapMarkers;
   };
 
-  renderResultsHeader = (results, facilityType, queryContext) => (
+  renderResultsHeader = (results, facilityType, serviceType, queryContext) => (
     <SearchResultsHeader
       results={results}
       facilityType={facilityType}
+      serviceType={serviceType}
       context={queryContext}
       inProgress={this.props.currentQuery.inProgress}
     />
@@ -543,6 +544,7 @@ class VAMap extends Component {
     } = this.props;
     const facilityLocatorMarkers = this.renderMapMarkers();
     const facilityType = currentQuery.facilityType;
+    const serviceType = currentQuery.serviceType;
     const queryContext = currentQuery.context;
 
     return (
@@ -557,7 +559,12 @@ class VAMap extends Component {
           />
           <div>{showDialogUrgCare(currentQuery)}</div>
           <div ref={this.searchResultTitle}>
-            {this.renderResultsHeader(results, facilityType, queryContext)}
+            {this.renderResultsHeader(
+              results,
+              facilityType,
+              serviceType,
+              queryContext,
+            )}
           </div>
           <Tabs onSelect={this.centerMap}>
             <TabList>
@@ -631,6 +638,7 @@ class VAMap extends Component {
       pagination: { currentPage, totalPages },
     } = this.props;
     const facilityType = currentQuery.facilityType;
+    const serviceType = currentQuery.serviceType;
     const queryContext = currentQuery.context;
 
     const coords = this.props.currentQuery.position;
@@ -649,7 +657,12 @@ class VAMap extends Component {
         </div>
         <div>{showDialogUrgCare(currentQuery)}</div>
         <div ref={this.searchResultTitle}>
-          {this.renderResultsHeader(results, facilityType, queryContext)}
+          {this.renderResultsHeader(
+            results,
+            facilityType,
+            serviceType,
+            queryContext,
+          )}
         </div>
         <div className="row">
           <div

--- a/src/applications/facility-locator/reducers/searchQuery.js
+++ b/src/applications/facility-locator/reducers/searchQuery.js
@@ -61,6 +61,12 @@ export const SearchQueryReducer = (state = INITIAL_STATE, action) => {
         ...state,
         error: false,
         fetchSvcsInProgress: false,
+        specialties: action.data
+          ? action.data.reduce((acc, cur) => {
+              acc[cur.specialtyCode] = cur.name;
+              return acc;
+            }, {})
+          : null,
       };
     case FETCH_SPECIALTIES_FAILED:
       return {

--- a/src/applications/facility-locator/tests/components/search-results/SearchResultsHeader.unit.spec.jsx
+++ b/src/applications/facility-locator/tests/components/search-results/SearchResultsHeader.unit.spec.jsx
@@ -1,26 +1,38 @@
 import React from 'react';
 import { expect } from 'chai';
-import { shallow } from 'enzyme';
+import { mount } from 'enzyme';
 import SearchResultsHeader from '../../../components/SearchResultsHeader';
 import { FacilityType } from '../../../constants';
+import { Provider } from 'react-redux';
 
-describe('SearchResultsHeader', () => {
+// TODO: fix the error being thrown by these tests!
+describe.skip('SearchResultsHeader', () => {
+  const defaultStore = {
+    searchQuery: {
+      specialties: [{ foo: 'bar' }],
+    },
+  };
+
   it('should not render header if results are empty', () => {
-    const wrapper = shallow(<SearchResultsHeader results={[]} />);
+    const wrapper = mount(
+      <Provider store={defaultStore}>
+        <SearchResultsHeader results={[]} />
+      </Provider>,
+    );
 
     expect(wrapper.find('h2').length).to.equal(0);
     wrapper.unmount();
   });
 
-  it('should not render header if inProgress is true', () => {
-    const wrapper = shallow(<SearchResultsHeader results={[{}]} inProgress />);
+  it.skip('should not render header if inProgress is true', () => {
+    const wrapper = mount(<SearchResultsHeader results={[{}]} inProgress />);
 
     expect(wrapper.find('h2').length).to.equal(0);
     wrapper.unmount();
   });
 
-  it('should render header if results exist', () => {
-    const wrapper = shallow(
+  it.skip('should render header if results exist', () => {
+    const wrapper = mount(
       <SearchResultsHeader
         results={[{}]}
         facilityType={FacilityType.VA_HEALTH_FACILITY}

--- a/src/applications/facility-locator/tests/components/search-results/SearchResultsHeader.unit.spec.jsx
+++ b/src/applications/facility-locator/tests/components/search-results/SearchResultsHeader.unit.spec.jsx
@@ -1,12 +1,10 @@
 import React from 'react';
 import { expect } from 'chai';
-import { mount } from 'enzyme';
-import SearchResultsHeader from '../../../components/SearchResultsHeader';
-import { FacilityType } from '../../../constants';
-import { Provider } from 'react-redux';
+import { shallow } from 'enzyme';
+import { SearchResultsHeader } from '../../../components/SearchResultsHeader';
+import { LocationType } from '../../../constants';
 
-// TODO: fix the error being thrown by these tests!
-describe.skip('SearchResultsHeader', () => {
+describe('SearchResultsHeader', () => {
   const defaultStore = {
     searchQuery: {
       specialties: [{ foo: 'bar' }],
@@ -14,34 +12,79 @@ describe.skip('SearchResultsHeader', () => {
   };
 
   it('should not render header if results are empty', () => {
-    const wrapper = mount(
-      <Provider store={defaultStore}>
-        <SearchResultsHeader results={[]} />
-      </Provider>,
-    );
+    const wrapper = shallow(<SearchResultsHeader results={[]} />);
 
     expect(wrapper.find('h2').length).to.equal(0);
     wrapper.unmount();
   });
 
-  it.skip('should not render header if inProgress is true', () => {
-    const wrapper = mount(<SearchResultsHeader results={[{}]} inProgress />);
+  it('should not render header if inProgress is true', () => {
+    const wrapper = shallow(<SearchResultsHeader results={[{}]} inProgress />);
 
     expect(wrapper.find('h2').length).to.equal(0);
     wrapper.unmount();
   });
 
-  it.skip('should render header if results exist', () => {
-    const wrapper = mount(
+  it('should render header if results exist', () => {
+    const wrapper = shallow(
       <SearchResultsHeader
         results={[{}]}
-        facilityType={FacilityType.VA_HEALTH_FACILITY}
+        facilityType={LocationType.HEALTH}
         context={'new york'}
       />,
     );
 
     expect(wrapper.find('h2').text()).to.match(
-      /Results for "VA health" near\s+"new york"/,
+      /Results for "VA health"\s+near\s+"new york"/,
+    );
+    wrapper.unmount();
+  });
+
+  it('should render header with LocationType.HEALTH', () => {
+    const wrapper = shallow(
+      <SearchResultsHeader
+        results={[{}]}
+        facilityType={LocationType.HEALTH}
+        serviceType="PrimaryCare"
+        context="new york"
+      />,
+    );
+
+    expect(wrapper.find('h2').text()).to.match(
+      /Results for "VA health",\s+"Primary care"\s+near\s+"new york"/,
+    );
+    wrapper.unmount();
+  });
+
+  it('should render header with LocationType.URGENT_CARE', () => {
+    const wrapper = shallow(
+      <SearchResultsHeader
+        results={[{}]}
+        facilityType={LocationType.URGENT_CARE}
+        serviceType="NonVAUrgentCare"
+        context="new york"
+      />,
+    );
+
+    expect(wrapper.find('h2').text()).to.match(
+      /Results for "Urgent care",\s+"Community urgent care providers \(in VA’s network\)"\s+near\s+"new york"/,
+    );
+    wrapper.unmount();
+  });
+
+  it('should render header with LocationType.CC_PROVIDER', () => {
+    const wrapper = shallow(
+      <SearchResultsHeader
+        results={[{}]}
+        facilityType={LocationType.CC_PROVIDER}
+        serviceType="foo"
+        context="new york"
+        specialtyMap={{ foo: 'test' }}
+      />,
+    );
+
+    expect(wrapper.find('h2').text()).to.match(
+      /Results for "Community providers \(in VA’s network\)",\s+"test"\s+near\s+"new york"/,
     );
     wrapper.unmount();
   });

--- a/src/applications/facility-locator/tests/e2e/search.cypress.spec.js
+++ b/src/applications/facility-locator/tests/e2e/search.cypress.spec.js
@@ -27,8 +27,11 @@ describe('Facility search', () => {
 
     cy.get('#street-city-state-zip').type('Austin, TX');
     cy.get('#facility-type-dropdown').select('VA health');
+    cy.get('#service-type-dropdown').select('Primary care');
     cy.get('#facility-search').click();
-    cy.get('#facility-search-results').should('exist');
+    cy.get('#facility-search-results').contains(
+      'Results for "VA health", "Primary care" near "Austin, Texas"',
+    );
     cy.get('.facility-result a').should('exist');
   });
 

--- a/src/applications/facility-locator/tests/reducers/searchQuery.unit.spec.js
+++ b/src/applications/facility-locator/tests/reducers/searchQuery.unit.spec.js
@@ -114,10 +114,12 @@ describe('search query reducer', () => {
   it('should handle provider services fetched', () => {
     const state = SearchQueryReducer(INITIAL_STATE, {
       type: FETCH_SPECIALTIES_DONE,
+      data: [{ specialtyCode: 'foo', name: 'bar' }],
     });
 
     expect(state.error).to.eql(false);
     expect(state.fetchSvcsInProgress).to.eql(false);
+    expect(state.specialties).to.eql({ foo: 'bar' });
   });
 
   it('should handle failed fetching provider services', () => {

--- a/src/applications/facility-locator/utils/helpers.js
+++ b/src/applications/facility-locator/utils/helpers.js
@@ -229,7 +229,7 @@ export const showDialogUrgCare = currentQuery => {
   if (
     (currentQuery.facilityType === LocationType.URGENT_CARE &&
       currentQuery.serviceType === 'NonVAUrgentCare') ||
-    currentQuery.facilityType === LocationType.URGENT_CARE_FARMACIES
+    currentQuery.facilityType === LocationType.URGENT_CARE_PHARMACIES
   ) {
     return <UrgentCareAlert />;
   }

--- a/src/applications/facility-locator/utils/mapHelpers.js
+++ b/src/applications/facility-locator/utils/mapHelpers.js
@@ -54,13 +54,22 @@ export const reverseGeocode = async (lon, lat, types) => {
     .reverseGeocode({ query: [lon, lat], types })
     .send()
     .catch();
-  const {
-    features: {
-      0: { place_name: placeName },
-    },
-  } = response.body;
 
-  return placeName;
+  if (
+    response.body &&
+    response.body.features &&
+    response.body.features.length > 0
+  ) {
+    const {
+      features: {
+        0: { place_name: placeName },
+      },
+    } = response.body;
+
+    return placeName;
+  }
+
+  return null;
 };
 
 /**


### PR DESCRIPTION
https://github.com/department-of-veterans-affairs/va.gov-team/issues/11877

## Description
Add service type to FL search results subhead

## Screenshots
<img width="1040" alt="89692731-7f64bd00-d8da-11ea-9900-73094c19dfe2" src="https://user-images.githubusercontent.com/80267/89838562-8806fe80-db39-11ea-8dba-0f6cb718be82.png">

## Acceptance criteria
- [x] Selected service type appears in search results subhead

## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
