### PR TITLE
Excludes 0873 from forms unit test

### DIFF
--- a/src/platform/forms/tests/forms.unit.spec.js
+++ b/src/platform/forms/tests/forms.unit.spec.js
@@ -82,6 +82,7 @@ const excludedForms = new Set([
   '22-10203',
   'caregiverProgramFacilities',
   'COVID-VACCINE-TRIAL',
+  '0873',
 ]);
 
 describe('form:', () => {


### PR DESCRIPTION


## Description
Issue: [department-of-veterans-affairs/orchid#17]

We are adding a new form json schema for the new IRIS Ask a Question form ([PR here](https://github.com/department-of-veterans-affairs/vets-json-schema/pull/472)). Adding it to the exclusion list to prevent `vets-website` tests from breaking.

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
