### PR TITLE
Focus on H1 when navigating directly to /profile/

### DIFF
--- a/package.json
+++ b/package.json
@@ -314,6 +314,7 @@
     "react-redux": "5.1.1",
     "react-router": "3",
     "react-router-dom": "^5.2.0",
+    "react-router-last-location": "^2.0.1",
     "react-scroll": "1.7.10",
     "react-tabs": "^3.1.1",
     "react-transition-group": "1",

--- a/src/applications/personalization/profile-2/components/Profile2Router.jsx
+++ b/src/applications/personalization/profile-2/components/Profile2Router.jsx
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { BrowserRouter, Route, Switch, Redirect } from 'react-router-dom';
+import { LastLocationProvider } from 'react-router-last-location';
 import LoadingIndicator from '@department-of-veterans-affairs/formation-react/LoadingIndicator';
 
 import DowntimeNotification, {
@@ -125,64 +126,69 @@ class Profile2Router extends Component {
 
     return (
       <BrowserRouter>
-        <Profile2Wrapper
-          routes={routes}
-          isLOA3={this.props.isLOA3}
-          isInMVI={this.props.isInMVI}
-        >
-          <Switch>
-            {/* Redirect users to Account Security to upgrade their account if they need to */}
-            {routes.map(route => {
-              if (
-                (route.requiresLOA3 && !this.props.isLOA3) ||
-                (route.requiresMVI && !this.props.isInMVI)
-              ) {
+        <LastLocationProvider>
+          <Profile2Wrapper
+            routes={routes}
+            isLOA3={this.props.isLOA3}
+            isInMVI={this.props.isInMVI}
+          >
+            <Switch>
+              {/* Redirect users to Account Security to upgrade their account if they need to */}
+              {routes.map(route => {
+                if (
+                  (route.requiresLOA3 && !this.props.isLOA3) ||
+                  (route.requiresMVI && !this.props.isInMVI)
+                ) {
+                  return (
+                    <Redirect
+                      from={route.path}
+                      to={PROFILE_PATHS.ACCOUNT_SECURITY}
+                      key={route.path}
+                    />
+                  );
+                }
+
+                if (
+                  route.path === PROFILE_PATHS.MILITARY_INFORMATION &&
+                  !this.props.shouldShowMilitaryInformation
+                ) {
+                  return (
+                    <Redirect
+                      to={PROFILE_PATHS.PROFILE_ROOT}
+                      key={route.path}
+                    />
+                  );
+                }
+
                 return (
-                  <Redirect
-                    from={route.path}
-                    to={PROFILE_PATHS.ACCOUNT_SECURITY}
+                  <Route
+                    component={route.component}
+                    exact
                     key={route.path}
+                    path={route.path}
                   />
                 );
-              }
+              })}
 
-              if (
-                route.path === PROFILE_PATHS.MILITARY_INFORMATION &&
-                !this.props.shouldShowMilitaryInformation
-              ) {
-                return (
-                  <Redirect to={PROFILE_PATHS.PROFILE_ROOT} key={route.path} />
-                );
-              }
+              <Redirect
+                exact
+                from="/profile#contact-information"
+                to={PROFILE_PATHS.PERSONAL_INFORMATION}
+              />
 
-              return (
-                <Route
-                  component={route.component}
-                  exact
-                  key={route.path}
-                  path={route.path}
-                />
-              );
-            })}
+              <Redirect
+                exact
+                from={PROFILE_PATHS.PROFILE_ROOT}
+                to={PROFILE_PATHS.PERSONAL_INFORMATION}
+              />
 
-            <Redirect
-              exact
-              from="/profile#contact-information"
-              to={PROFILE_PATHS.PERSONAL_INFORMATION}
-            />
-
-            <Redirect
-              exact
-              from={PROFILE_PATHS.PROFILE_ROOT}
-              to={PROFILE_PATHS.PERSONAL_INFORMATION}
-            />
-
-            {/* fallback handling: redirect to root route */}
-            <Route path="*">
-              <Redirect to={PROFILE_PATHS.PROFILE_ROOT} />
-            </Route>
-          </Switch>
-        </Profile2Wrapper>
+              {/* fallback handling: redirect to root route */}
+              <Route path="*">
+                <Redirect to={PROFILE_PATHS.PROFILE_ROOT} />
+              </Route>
+            </Switch>
+          </Profile2Wrapper>
+        </LastLocationProvider>
       </BrowserRouter>
     );
   };

--- a/src/applications/personalization/profile-2/components/ProfileMobileSubNav.jsx
+++ b/src/applications/personalization/profile-2/components/ProfileMobileSubNav.jsx
@@ -9,6 +9,7 @@ import {
   isReverseTab,
   isTab,
 } from 'platform/utilities/accessibility';
+import prefixUtilityClasses from 'platform/utilities/prefix-utility-classes';
 
 import { isLOA3 as isLOA3Selector } from 'platform/user/selectors';
 
@@ -37,6 +38,12 @@ const getElementHeight = el => {
       .reduce((dimension, sum) => sum + dimension, 0)
   );
 };
+
+const menuButtonClasses = prefixUtilityClasses([
+  'font-size--base',
+  'font-family--sans',
+  'display--inline',
+]).join(' ');
 
 const ProfileMobileSubNav = ({
   openMenu,
@@ -185,14 +192,18 @@ const ProfileMobileSubNav = ({
               type="button"
               onClick={openMenu}
             >
-              <strong>Your profile menu</strong>
+              <strong>
+                <h1 className={menuButtonClasses}>Your profile</h1> menu
+              </strong>
               <i className="fa fa-bars" aria-hidden="true" role="img" />
             </button>
           )}
           {isMenuOpen && (
             <>
               <div className="menu-header vads-u-display--flex">
-                <strong className="vads-u-flex--auto">Your profile menu</strong>
+                <strong className="vads-u-flex--auto">
+                  <h1 className={menuButtonClasses}>Your profile</h1> menu
+                </strong>
                 <button
                   ref={closeMenuButton}
                   className="close-menu vads-u-flex--auto"

--- a/src/applications/personalization/profile-2/components/ProfileSubNav.jsx
+++ b/src/applications/personalization/profile-2/components/ProfileSubNav.jsx
@@ -1,10 +1,11 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 
 import { connect } from 'react-redux';
 import { NavLink } from 'react-router-dom';
 
 import { isLOA3 as isLOA3Selector } from 'platform/user/selectors';
+import { focusElement } from 'platform/utilities/ui';
 
 export function ProfileMenuItems({ routes, isLOA3, clickHandler = null }) {
   return (
@@ -33,10 +34,17 @@ export function ProfileMenuItems({ routes, isLOA3, clickHandler = null }) {
 }
 
 const ProfileSubNav = ({ isLOA3, routes }) => {
+  // on first render, set the focus to the h1
+  useEffect(() => {
+    focusElement('#subnav-header');
+  }, []);
+
   return (
     <nav className="va-subnav" aria-label="Secondary">
       <div>
-        <h1 className="vads-u-font-size--h4">Your profile</h1>
+        <h1 id="subnav-header" className="vads-u-font-size--h4">
+          Your profile
+        </h1>
         <ProfileMenuItems routes={routes} isLOA3={isLOA3} />
       </div>
     </nav>

--- a/src/applications/personalization/profile-2/components/personal-information/PersonalInformation.jsx
+++ b/src/applications/personalization/profile-2/components/personal-information/PersonalInformation.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { Prompt } from 'react-router-dom';
+import { useLastLocation } from 'react-router-last-location';
 import { connect } from 'react-redux';
 
 import DowntimeNotification, {
@@ -14,13 +15,26 @@ import { directDepositIsBlocked } from 'applications/personalization/profile360/
 
 import PersonalInformationContent from './PersonalInformationContent';
 
+import { PROFILE_PATHS } from '../../constants';
+
 const PersonalInformation = ({
   showDirectDepositBlockedError,
   hasUnsavedEdits,
 }) => {
-  useEffect(() => {
-    focusElement('[data-focus-target]');
-  }, []);
+  const lastLocation = useLastLocation();
+  useEffect(
+    () => {
+      // Do not manage the focus if the user just came to this route via the
+      // root profile route. If a user got to the Profile via a link to /profile
+      // we want to focus on the "Your Profile" sub-nav H1, not the H2 on this
+      // page
+      if (lastLocation?.pathname === `${PROFILE_PATHS.PROFILE_ROOT}/`) {
+        return;
+      }
+      focusElement('[data-focus-target]');
+    },
+    [lastLocation],
+  );
 
   useEffect(
     () => {

--- a/src/applications/personalization/profile-2/tests/e2e/profile.cypress.spec.js
+++ b/src/applications/personalization/profile-2/tests/e2e/profile.cypress.spec.js
@@ -101,7 +101,6 @@ function checkAllPages(mobile = false) {
     `${Cypress.config().baseUrl}${PROFILE_PATHS.CONNECTED_APPLICATIONS}`,
   );
   // wait for this section's loading spinner to disappear...
-  cy.findByRole('progressbar').should('exist');
   cy.findByRole('progressbar').should('not.exist');
   cy.axeCheck();
   // focus should be on the section's h2

--- a/src/applications/personalization/profile-2/tests/e2e/profile.cypress.spec.js
+++ b/src/applications/personalization/profile-2/tests/e2e/profile.cypress.spec.js
@@ -4,15 +4,22 @@ import mockUser from '../fixtures/users/user-36.json';
 import mockPaymentInfo from '../fixtures/payment-information/direct-deposit-is-set-up.json';
 import mockFeatureToggles from '../fixtures/feature-toggles.json';
 
+function clickSubNavButton(buttonLabel, mobile) {
+  if (mobile) {
+    cy.findByRole('button', { name: /your profile menu/i }).click();
+  }
+  cy.findByRole('link', { name: buttonLabel }).click();
+}
+
 /**
  *
  * @param {boolean} mobile - test on a mobile viewport or not
  *
  * This helper:
- * - loads the Profile, confirms the user is redirected to the correct URL, and
- *   then performs an aXe scan
+ * - loads the Profile, confirms the user is redirected to the correct URL,
+ *   performs an aXe scan, and checks that focus is managed correctly
  * - clicks through each item in the sub-nav, checks that the URL is correct,
- *   and performs an aXe scan
+ *   performs an aXe scan, and checks that focus is managed correctly
  */
 function checkAllPages(mobile = false) {
   cy.visit(PROFILE_PATHS.PROFILE_ROOT);
@@ -38,53 +45,81 @@ function checkAllPages(mobile = false) {
     `${Cypress.config().baseUrl}${PROFILE_PATHS.PERSONAL_INFORMATION}`,
   );
 
+  // focus should be on the sub-nav's h1 when redirected from /profile/
+  cy.focused()
+    .contains(/your profile/i)
+    .and('have.prop', 'tagName')
+    .should('eq', 'H1');
+
   // make the a11y check on the Personal Info section
   cy.injectAxe();
   cy.axeCheck();
 
-  // make the  a11y check on the Military Info section
-  if (mobile) {
-    cy.findByRole('button', { name: /your profile menu/i }).click();
-  }
-  cy.findByRole('link', { name: 'Military information' }).click();
+  // make the a11y and focus management check on the Military Info section
+  clickSubNavButton('Military information', mobile);
   cy.url().should(
     'eq',
     `${Cypress.config().baseUrl}${PROFILE_PATHS.MILITARY_INFORMATION}`,
   );
   cy.axeCheck();
+  // focus should be on the section's h2
+  cy.focused()
+    .contains(/military information/i)
+    .and('have.prop', 'tagName')
+    .should('eq', 'H2');
 
-  // make the a11y check on the Direct Deposit section
-  if (mobile) {
-    cy.findByRole('button', { name: /your profile menu/i }).click();
-  }
-  cy.findByRole('link', { name: 'Direct deposit' }).click();
+  // make the a11y and focus management check on the Direct Deposit section
+  clickSubNavButton('Direct deposit', mobile);
   cy.url().should(
     'eq',
     `${Cypress.config().baseUrl}${PROFILE_PATHS.DIRECT_DEPOSIT}`,
   );
   cy.axeCheck();
+  // focus should be on the section's h2
+  cy.focused()
+    .contains(/direct deposit/i)
+    .and('have.prop', 'tagName')
+    .should('eq', 'H2');
 
-  // make the a11y check on the Account Security section
-  if (mobile) {
-    cy.findByRole('button', { name: /your profile menu/i }).click();
-  }
-  cy.findByRole('link', { name: 'Account security' }).click();
+  // make the a11y and focus management check on the Account Security section
+  clickSubNavButton('Account security', mobile);
   cy.url().should(
     'eq',
     `${Cypress.config().baseUrl}${PROFILE_PATHS.ACCOUNT_SECURITY}`,
   );
   cy.axeCheck();
+  // focus should be on the section's h2
+  cy.focused()
+    .contains(/account security/i)
+    .and('have.prop', 'tagName')
+    .should('eq', 'H2');
 
-  // make the a11y check on the Connected Apps section
-  if (mobile) {
-    cy.findByRole('button', { name: /your profile menu/i }).click();
-  }
-  cy.findByRole('link', { name: 'Connected apps' }).click();
+  // make the a11y and focus management check on the Connected Apps section
+  clickSubNavButton('Connected apps', mobile);
   cy.url().should(
     'eq',
     `${Cypress.config().baseUrl}${PROFILE_PATHS.CONNECTED_APPLICATIONS}`,
   );
+  // wait for this section's loading spinner to disappear...
+  cy.findByRole('progressbar').should('exist');
+  cy.findByRole('progressbar').should('not.exist');
   cy.axeCheck();
+  // focus should be on the section's h2
+  cy.focused()
+    .contains(/connected apps/i)
+    .and('have.prop', 'tagName')
+    .should('eq', 'H2');
+
+  // navigate directly to the Personal and Contact Info section via the sub-nav to confirm focus is managed correctly
+  clickSubNavButton(/Personal and contact info/i, mobile);
+  cy.url().should(
+    'eq',
+    `${Cypress.config().baseUrl}${PROFILE_PATHS.PERSONAL_INFORMATION}`,
+  );
+  cy.focused()
+    .contains(/personal and contact info/i)
+    .and('have.prop', 'tagName')
+    .should('eq', 'H2');
 }
 
 describe('Profile', () => {
@@ -98,11 +133,11 @@ describe('Profile', () => {
     cy.route('GET', '/v0/feature_toggles*', mockFeatureToggles);
     cy.route('GET', '/v0/ppiu/payment_information', mockPaymentInfo);
   });
-  it('should pass an aXe scan on all pages at desktop size', () => {
+  it('should pass an aXe scan and manage focus on all pages at desktop size', () => {
     checkAllPages(false);
   });
 
-  it('should pass an aXe scan on all pages at mobile phone size', () => {
+  it('should pass an aXe scan and manage focus on all pages at mobile phone size', () => {
     checkAllPages(true);
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -13938,6 +13938,11 @@ react-router-dom@^5.2.0:
     tiny-invariant "^1.0.2"
     tiny-warning "^1.0.0"
 
+react-router-last-location@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/react-router-last-location/-/react-router-last-location-2.0.1.tgz#54d625876dd1448594fa1114aa02e7e21db12970"
+  integrity sha512-3FbFIWwUr2qN28vN9DNdFp6RhUH/yif6ILVff1zT+hLdyGmlNPh3GuPhveb7bHQLgB744QW8L0qtWjX58ESuZQ==
+
 react-router@3:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/react-router/-/react-router-3.2.1.tgz#b9a3279962bdfbe684c8bd0482b81ef288f0f244"


### PR DESCRIPTION
## Description
When a Profile section loads, we set the focus on the H2 which is the title for that particular section. This introduces a change to that logic: if a user navigates to the profile via a link to `/profile/`, we focus on the H1, which reads "Your profile," to better match what the user would be expecting.

The only way I could figure to do that was for the Personal Info section to check what the previous route was, and if it was simply `/profile/`, manage the focus differently. But getting the previous route/page is not something natively supported by React Router. There also doesn't seem to be a way to add any additional functionality to a React Router `Redirect` (where I could have set some global state). So I had to add [this dependency](https://www.npmjs.com/package/react-router-last-location) to get that functionality.

This change also adds an H1 to the mobile sub nav: resolves https://github.com/department-of-veterans-affairs/va.gov-team/issues/11888

## Testing done
~Local. Will determine if it's possible to use Cypress to add coverage for this case.~
Expanded on existing Cypress tests to confirm that focus is managed correctly on Profile pages, including the edge case scenario where you navigate directly to the `/profile/` route and focus should be set on the "Your profile" H1 rather than the more specific section title H2.

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs