### PR TITLE
10203 Accessibility Fix - Removed Unnecessary Alert

### DIFF
--- a/src/applications/edu-benefits/10203/content/activeDuty.jsx
+++ b/src/applications/edu-benefits/10203/content/activeDuty.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
 
 export const housingPaymentInfo = () => (
-  <div className="feature" role="alert">
+  // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
+  <div className="feature" tabIndex="0">
     You can receive the Rogers STEM Scholarship while you’re on active duty, but
     you won’t be eligible for the scholarship's housing allowance.
   </div>

--- a/src/applications/edu-benefits/10203/content/activeDuty.jsx
+++ b/src/applications/edu-benefits/10203/content/activeDuty.jsx
@@ -1,8 +1,7 @@
 import React from 'react';
 
 export const housingPaymentInfo = () => (
-  // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
-  <div className="feature" tabIndex="0">
+  <div className="feature" role="alert">
     You can receive the Rogers STEM Scholarship while you’re on active duty, but
     you won’t be eligible for the scholarship's housing allowance.
   </div>

--- a/src/applications/edu-benefits/10203/content/directDeposit.jsx
+++ b/src/applications/edu-benefits/10203/content/directDeposit.jsx
@@ -25,7 +25,8 @@ const gaBankInfoHelpText = () => {
 };
 
 export const directDepositAlert = () => (
-  <div className="vads-u-padding-top--1p5" role="alert">
+  // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex
+  <div className="vads-u-padding-top--1p5" tabIndex="0">
     <p>
       <b>Note:</b> Any bank account information you enter here will apply to
       your other Veteran benefits, including compensation, pension, and Benefits


### PR DESCRIPTION
## Description
Removed `role` of "alert" from bank info text because an accessibility review flagged it as not time-sensitive or critical.

This required suppressing the `jsx-a11y/no-noninteractive-tabindex` linter rule. This is considered a blocker for the launch of the 10203 form.

[ZenHub Issue](https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/12328)

## Testing done
Tested locally and QA reviewed

## Screenshots
![image](https://user-images.githubusercontent.com/41960449/89916052-20969080-dbc5-11ea-9d3b-1bed5124b186.png)

## Acceptance criteria
- [x] The note about bank account information is not read aloud when Step 5 is first announced by screen readers
- [x] The note about bank account information can receive keyboard focus (has a tabIndex="0" attribute)
- [x] The note has a yellow focus halo. This is a bit of a departure, but feels right in this case because focus will be driven by the user, not by programmatic focus change.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
