### PR TITLE
Add fieldLeadership field to node-health_care_region_page

### DIFF
--- a/src/site/stages/build/process-cms-exports/schemas/input/node-health_care_region_page.js
+++ b/src/site/stages/build/process-cms-exports/schemas/input/node-health_care_region_page.js
@@ -21,6 +21,7 @@ module.exports = {
         required: ['uri', 'title', 'options'],
       },
     },
+    field_leadership: { $ref: 'EntityReferenceArray' },
   },
   required: [
     'title',
@@ -30,5 +31,6 @@ module.exports = {
     // Turns out this sometimes just isn't there
     // 'field_link_facility_emerg_list',
     'field_nickname_for_this_facility',
+    'field_leadership',
   ],
 };

--- a/src/site/stages/build/process-cms-exports/schemas/input/node-person_profile.js
+++ b/src/site/stages/build/process-cms-exports/schemas/input/node-person_profile.js
@@ -21,6 +21,11 @@ module.exports = {
     },
     field_phone_number: { $ref: 'GenericNestedString' },
     field_suffix: { $ref: 'GenericNestedString' },
+    // Used for reverse fields
+    field_intro_text: { $ref: 'GenericNestedString' },
+    field_photo_allow_hires_download: { $ref: 'GenericNestedBoolean' },
+    moderation_state: { $ref: 'GenericNestedString' },
+    changed: { $ref: 'GenericNestedString' },
   },
   required: [
     'path',
@@ -33,5 +38,9 @@ module.exports = {
     'field_office',
     'field_phone_number',
     'field_suffix',
+    'field_intro_text',
+    'field_photo_allow_hires_download',
+    'changed',
+    'moderation_state',
   ],
 };

--- a/src/site/stages/build/process-cms-exports/schemas/output/node-health_care_region_page.js
+++ b/src/site/stages/build/process-cms-exports/schemas/output/node-health_care_region_page.js
@@ -1,3 +1,6 @@
+const { usePartialSchema } = require('../../transformers/helpers');
+const personProfileSchema = require('./node-person_profile');
+
 module.exports = {
   type: 'object',
   properties: {
@@ -27,12 +30,36 @@ module.exports = {
         },
         fieldPressReleaseBlurb: { $ref: 'ProcessedString' },
         entityMetaTags: { $ref: 'MetaTags' },
+        fieldLeadership: {
+          type: 'array',
+          items: {
+            /* eslint-disable react-hooks/rules-of-hooks */
+            entity: usePartialSchema(personProfileSchema, [
+              'entityPublished',
+              'title',
+              'fieldNameFirst',
+              'fieldLastName',
+              'fieldSuffix',
+              'fieldEmailAddress',
+              'fieldPhoneNumber',
+              'fieldDescription',
+              'fieldOffice',
+              'fieldIntroText',
+              'fieldPhotoAllowHiresDownload',
+              'fieldMedia',
+              'fieldBody',
+              'changed',
+              'entityUrl',
+            ]),
+          },
+        },
       },
       required: [
         'title',
         'fieldNicknameForThisFacility',
         'fieldLinkFacilityEmergList',
         'fieldPressReleaseBlurb',
+        'fieldLeadership',
       ],
     },
   },

--- a/src/site/stages/build/process-cms-exports/schemas/output/node-person_profile.js
+++ b/src/site/stages/build/process-cms-exports/schemas/output/node-person_profile.js
@@ -30,6 +30,10 @@ module.exports = {
     },
     fieldPhoneNumber: { type: ['string', 'null'] },
     fieldSuffix: { type: ['string', 'null'] },
+    entityPublished: { type: 'boolean' },
+    fieldIntroText: { type: ['string', 'null'] },
+    fieldPhotoAllowHiresDownload: { type: 'boolean' },
+    changed: { type: 'number' },
   },
   required: [
     'title',
@@ -42,5 +46,9 @@ module.exports = {
     'fieldOffice',
     'fieldPhoneNumber',
     'fieldSuffix',
+    'entityPublished',
+    'fieldIntroText',
+    'fieldPhotoAllowHiresDownload',
+    'changed',
   ],
 };

--- a/src/site/stages/build/process-cms-exports/transformers/node-health_care_region_page.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-health_care_region_page.js
@@ -14,6 +14,7 @@ const transform = ({
   fieldRelatedLinks,
   fieldPressReleaseBlurb,
   fieldLinkFacilityEmergList,
+  fieldLeadership,
 }) => ({
   entity: {
     entityType: 'node',
@@ -36,6 +37,32 @@ const transform = ({
       processed: getWysiwygString(getDrupalValue(fieldPressReleaseBlurb)),
     },
     entityMetatags: createMetaTagArray(metaTags),
+    fieldLeadership: fieldLeadership.length
+      ? fieldLeadership.map(n => ({
+          entity: {
+            entityPublished: n.entityPublished,
+            title: n.title,
+            fieldNameFirst: n.fieldNameFirst,
+            fieldLastName: n.fieldLastName,
+            fieldSuffix: n.fieldSuffix,
+            fieldEmailAddress: n.fieldEmailAddress,
+            fieldPhoneNumber: n.fieldPhoneNumber,
+            fieldDescription: n.fieldDescription,
+            fieldOffice: {
+              entity: {
+                entityLabel: 'VA Pittsburgh health care',
+                entityType: 'node',
+              },
+            },
+            fieldIntroText: n.fieldIntroText,
+            fieldPhotoAllowHiresDownload: n.fieldPhotoAllowHiresDownload,
+            fieldMedia: n.fieldMedia,
+            fieldBody: n.fieldBody,
+            changed: n.changed,
+            entityUrl: n.entityUrl,
+          },
+        }))
+      : [],
   },
 });
 module.exports = {
@@ -48,6 +75,7 @@ module.exports = {
     'field_related_links',
     'field_press_release_blurb',
     'metatag',
+    'field_leadership',
   ],
   transform,
 };

--- a/src/site/stages/build/process-cms-exports/transformers/node-person_profile.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-person_profile.js
@@ -1,6 +1,6 @@
 const { getDrupalValue, isPublished, utcToEpochTime } = require('./helpers');
 
-const transform = entity => ({
+const transform = (entity, { ancestors }) => ({
   entityType: 'node',
   entityBundle: 'person_profile',
   title: `${getDrupalValue(entity.fieldNameFirst)} ${getDrupalValue(
@@ -13,14 +13,18 @@ const transform = entity => ({
   fieldLastName: getDrupalValue(entity.fieldLastName),
   fieldMedia: entity.fieldMedia.length > 0 ? entity.fieldMedia[0] : null,
   fieldNameFirst: getDrupalValue(entity.fieldNameFirst),
-  fieldOffice: entity.fieldOffice[0]
-    ? {
-        entity: {
-          entityLabel: entity.fieldOffice[0].entity.entityLabel,
-          entityType: entity.fieldOffice[0].entity.entityType,
-        },
-      }
-    : null,
+  // Check if fieldOffice is an ancestor of this entity
+  // If so, ignore it, because we'll ignore it in parent transformer
+  fieldOffice:
+    entity.fieldOffice[0] &&
+    !ancestors.find(r => r.entity.uuid === entity.fieldOffice[0].uuid)
+      ? {
+          entity: {
+            entityLabel: entity.fieldOffice[0].entity.entityLabel,
+            entityType: entity.fieldOffice[0].entity.entityType,
+          },
+        }
+      : null,
   fieldPhoneNumber: getDrupalValue(entity.fieldPhoneNumber),
   fieldSuffix: getDrupalValue(entity.fieldSuffix),
   // Used for reverse fields in other transformers

--- a/src/site/stages/build/process-cms-exports/transformers/node-person_profile.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-person_profile.js
@@ -13,8 +13,9 @@ const transform = (entity, { ancestors }) => ({
   fieldLastName: getDrupalValue(entity.fieldLastName),
   fieldMedia: entity.fieldMedia.length > 0 ? entity.fieldMedia[0] : null,
   fieldNameFirst: getDrupalValue(entity.fieldNameFirst),
-  // Check if fieldOffice is an ancestor of this entity
-  // If so, ignore it, because we'll ignore it in parent transformer
+  // If entity.fieldOffice[0] is an ancestor of this entity ignore it
+  // entity.fieldOffice[0] would be untransformed, causing errors
+  // so we need it transformed here, which will happen in the parent transformer
   fieldOffice:
     entity.fieldOffice[0] &&
     !ancestors.find(r => r.entity.uuid === entity.fieldOffice[0].uuid)

--- a/src/site/stages/build/process-cms-exports/transformers/node-person_profile.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-person_profile.js
@@ -1,4 +1,4 @@
-const { getDrupalValue } = require('./helpers');
+const { getDrupalValue, isPublished, utcToEpochTime } = require('./helpers');
 
 const transform = entity => ({
   entityType: 'node',
@@ -6,6 +6,7 @@ const transform = entity => ({
   title: `${getDrupalValue(entity.fieldNameFirst)} ${getDrupalValue(
     entity.fieldLastName,
   )}`,
+  entityPublished: isPublished(getDrupalValue(entity.moderationState)),
   fieldBody: getDrupalValue(entity.fieldBody),
   fieldDescription: getDrupalValue(entity.fieldDescription),
   fieldEmailAddress: getDrupalValue(entity.fieldEmailAddress),
@@ -22,6 +23,12 @@ const transform = entity => ({
     : null,
   fieldPhoneNumber: getDrupalValue(entity.fieldPhoneNumber),
   fieldSuffix: getDrupalValue(entity.fieldSuffix),
+  // Used for reverse fields in other transformers
+  fieldIntroText: getDrupalValue(entity.fieldIntroText),
+  fieldPhotoAllowHiresDownload: getDrupalValue(
+    entity.fieldPhotoAllowHiresDownload,
+  ),
+  changed: utcToEpochTime(getDrupalValue(entity.changed)),
 });
 module.exports = {
   filter: [
@@ -35,6 +42,10 @@ module.exports = {
     'field_office',
     'field_phone_number',
     'field_suffix',
+    'field_intro_text',
+    'field_photo_allow_hires_download',
+    'changed',
+    'moderation_state',
   ],
   transform,
 };


### PR DESCRIPTION
## Description
Add the `fieldLeadership` field to `node-health_care_region_page`. This was causing an error when using the cms export to build content.

Changes were made to the `node-person_profile` transformer. Specifically adding a condition to the `fieldOffice` field that checks if `fieldOffice` is an ancestor of itself(`node-person_profile`). This was causing a circular reference error because `fieldOffice` can be of type `node-health_care_region_page`, and `node-health_care_region_page` can be a parent of `node-person_profile`.

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
