### PR TITLE
change 10203 form url and breadcrumb urls

### DIFF
--- a/src/applications/edu-benefits/10203/manifest.json
+++ b/src/applications/edu-benefits/10203/manifest.json
@@ -2,5 +2,5 @@
   "appName": "22-10203 Education benefits form",
   "entryFile": "./edu-benefits-entry.jsx",
   "entryName": "10203-edu-benefits",
-  "rootUrl": "/education/apply-for-education-benefits/application/10203"
+  "rootUrl": "/education/other-va-education-benefits/stem-scholarship/apply-for-scholarship-form-22-10203"
 }

--- a/src/applications/edu-benefits/10203/tests/01-all-fields.e2e.spec.js
+++ b/src/applications/edu-benefits/10203/tests/01-all-fields.e2e.spec.js
@@ -11,7 +11,8 @@ module.exports = E2eHelpers.createE2eTest(client => {
   // Ensure introduction page renders.
   client
     .openUrl(
-      `${E2eHelpers.baseUrl}/education/other-va-education-benefits/stem-scholarship/apply-for-scholarship-form-22-10203`,
+      `${E2eHelpers.baseUrl}
+      /education/other-va-education-benefits/stem-scholarship/apply-for-scholarship-form-22-10203`,
     )
     .waitForElementVisible('body', Timeouts.normal)
     .waitForElementVisible('.schemaform-start-button', Timeouts.slow)

--- a/src/applications/edu-benefits/10203/tests/01-all-fields.e2e.spec.js
+++ b/src/applications/edu-benefits/10203/tests/01-all-fields.e2e.spec.js
@@ -11,9 +11,7 @@ module.exports = E2eHelpers.createE2eTest(client => {
   // Ensure introduction page renders.
   client
     .openUrl(
-      `${
-        E2eHelpers.baseUrl
-      }/education/apply-for-education-benefits/application/10203`,
+      `${E2eHelpers.baseUrl}/education/other-va-education-benefits/stem-scholarship/apply-for-scholarship-form-22-10203`,
     )
     .waitForElementVisible('body', Timeouts.normal)
     .waitForElementVisible('.schemaform-start-button', Timeouts.slow)

--- a/src/applications/edu-benefits/components/EducationWizard.jsx
+++ b/src/applications/edu-benefits/components/EducationWizard.jsx
@@ -40,10 +40,6 @@ export class EducationWizard extends React.Component {
         url = `/education/apply-for-education-benefits/application/${form}`;
         break;
     }
-    // const url =
-    //   form === '0994'
-    //     ? `/education/about-gi-bill-benefits/how-to-use-benefits/vettec-high-tech-program/apply-for-vettec-form-22-0994`
-    //     : `/education/apply-for-education-benefits/application/${form}`;
 
     return (
       <a
@@ -262,27 +258,28 @@ export class EducationWizard extends React.Component {
                 }
               />
             )}
-            {serviceBenefitBasedOn === 'own' && nationalCallToService === 'no' && (
-              <ErrorableRadioButtons
-                additionalFieldsetClass="wizard-fieldset"
-                name="vetTecBenefit"
-                id="vetTecBenefit"
-                options={[
-                  { label: 'Yes', value: 'yes' },
-                  { label: 'No', value: 'no' },
-                ]}
-                onValueChange={({ value }) =>
-                  this.answerQuestion('vetTecBenefit', value)
-                }
-                value={{ value: vetTecBenefit }}
-                label={
-                  <span>
-                    Are you applying for Veteran Employment Through Technology
-                    Education Courses (VET TEC)?
-                  </span>
-                }
-              />
-            )}
+            {serviceBenefitBasedOn === 'own' &&
+              nationalCallToService === 'no' && (
+                <ErrorableRadioButtons
+                  additionalFieldsetClass="wizard-fieldset"
+                  name="vetTecBenefit"
+                  id="vetTecBenefit"
+                  options={[
+                    { label: 'Yes', value: 'yes' },
+                    { label: 'No', value: 'no' },
+                  ]}
+                  onValueChange={({ value }) =>
+                    this.answerQuestion('vetTecBenefit', value)
+                  }
+                  value={{ value: vetTecBenefit }}
+                  label={
+                    <span>
+                      Are you applying for Veteran Employment Through Technology
+                      Education Courses (VET TEC)?
+                    </span>
+                  }
+                />
+              )}
             {serviceBenefitBasedOn === 'other' && (
               <ErrorableRadioButtons
                 additionalFieldsetClass="wizard-fieldset"
@@ -335,30 +332,33 @@ export class EducationWizard extends React.Component {
                   </div>
                 </div>
               )}
-            {newBenefit === 'yes' && nationalCallToService === 'yes' && (
-              <div>
-                <div className="usa-alert usa-alert-warning">
-                  <div className="usa-alert-body">
-                    <h4 className="usa-alert-heading wizard-alert-heading">
-                      Are you sure?
-                    </h4>
-                    <p>Are all of the following things true of your service?</p>
-                    <ul>
-                      <li>
-                        Enlisted under the National Call to Service program,{' '}
-                        <strong>and</strong>
-                      </li>
-                      <li>
-                        Entered service between 10/01/03 and 12/31/07,{' '}
-                        <strong>and</strong>
-                      </li>
-                      <li>Chose education benefits</li>
-                    </ul>
+            {newBenefit === 'yes' &&
+              nationalCallToService === 'yes' && (
+                <div>
+                  <div className="usa-alert usa-alert-warning">
+                    <div className="usa-alert-body">
+                      <h4 className="usa-alert-heading wizard-alert-heading">
+                        Are you sure?
+                      </h4>
+                      <p>
+                        Are all of the following things true of your service?
+                      </p>
+                      <ul>
+                        <li>
+                          Enlisted under the National Call to Service program,{' '}
+                          <strong>and</strong>
+                        </li>
+                        <li>
+                          Entered service between 10/01/03 and 12/31/07,{' '}
+                          <strong>and</strong>
+                        </li>
+                        <li>Chose education benefits</li>
+                      </ul>
+                    </div>
                   </div>
+                  {this.getButton('1990N')}
                 </div>
-                {this.getButton('1990N')}
-              </div>
-            )}
+              )}
             {newBenefit === 'extend' && (
               <div className="wizard-edith-nourse-content">
                 <br />

--- a/src/applications/edu-benefits/components/EducationWizard.jsx
+++ b/src/applications/edu-benefits/components/EducationWizard.jsx
@@ -28,10 +28,22 @@ export class EducationWizard extends React.Component {
   }
 
   getButton(form) {
-    const url =
-      form === '0994'
-        ? `/education/about-gi-bill-benefits/how-to-use-benefits/vettec-high-tech-program/apply-for-vettec-form-22-0994`
-        : `/education/apply-for-education-benefits/application/${form}`;
+    let url = '';
+    switch (form) {
+      case '0994':
+        url = `/education/about-gi-bill-benefits/how-to-use-benefits/vettec-high-tech-program/apply-for-vettec-form-22-0994`;
+        break;
+      case '10203':
+        url = `/education/other-va-education-benefits/stem-scholarship/apply-for-scholarship-form-22-10203`;
+        break;
+      default:
+        url = `/education/apply-for-education-benefits/application/${form}`;
+        break;
+    }
+    // const url =
+    //   form === '0994'
+    //     ? `/education/about-gi-bill-benefits/how-to-use-benefits/vettec-high-tech-program/apply-for-vettec-form-22-0994`
+    //     : `/education/apply-for-education-benefits/application/${form}`;
 
     return (
       <a
@@ -250,28 +262,27 @@ export class EducationWizard extends React.Component {
                 }
               />
             )}
-            {serviceBenefitBasedOn === 'own' &&
-              nationalCallToService === 'no' && (
-                <ErrorableRadioButtons
-                  additionalFieldsetClass="wizard-fieldset"
-                  name="vetTecBenefit"
-                  id="vetTecBenefit"
-                  options={[
-                    { label: 'Yes', value: 'yes' },
-                    { label: 'No', value: 'no' },
-                  ]}
-                  onValueChange={({ value }) =>
-                    this.answerQuestion('vetTecBenefit', value)
-                  }
-                  value={{ value: vetTecBenefit }}
-                  label={
-                    <span>
-                      Are you applying for Veteran Employment Through Technology
-                      Education Courses (VET TEC)?
-                    </span>
-                  }
-                />
-              )}
+            {serviceBenefitBasedOn === 'own' && nationalCallToService === 'no' && (
+              <ErrorableRadioButtons
+                additionalFieldsetClass="wizard-fieldset"
+                name="vetTecBenefit"
+                id="vetTecBenefit"
+                options={[
+                  { label: 'Yes', value: 'yes' },
+                  { label: 'No', value: 'no' },
+                ]}
+                onValueChange={({ value }) =>
+                  this.answerQuestion('vetTecBenefit', value)
+                }
+                value={{ value: vetTecBenefit }}
+                label={
+                  <span>
+                    Are you applying for Veteran Employment Through Technology
+                    Education Courses (VET TEC)?
+                  </span>
+                }
+              />
+            )}
             {serviceBenefitBasedOn === 'other' && (
               <ErrorableRadioButtons
                 additionalFieldsetClass="wizard-fieldset"
@@ -324,33 +335,30 @@ export class EducationWizard extends React.Component {
                   </div>
                 </div>
               )}
-            {newBenefit === 'yes' &&
-              nationalCallToService === 'yes' && (
-                <div>
-                  <div className="usa-alert usa-alert-warning">
-                    <div className="usa-alert-body">
-                      <h4 className="usa-alert-heading wizard-alert-heading">
-                        Are you sure?
-                      </h4>
-                      <p>
-                        Are all of the following things true of your service?
-                      </p>
-                      <ul>
-                        <li>
-                          Enlisted under the National Call to Service program,{' '}
-                          <strong>and</strong>
-                        </li>
-                        <li>
-                          Entered service between 10/01/03 and 12/31/07,{' '}
-                          <strong>and</strong>
-                        </li>
-                        <li>Chose education benefits</li>
-                      </ul>
-                    </div>
+            {newBenefit === 'yes' && nationalCallToService === 'yes' && (
+              <div>
+                <div className="usa-alert usa-alert-warning">
+                  <div className="usa-alert-body">
+                    <h4 className="usa-alert-heading wizard-alert-heading">
+                      Are you sure?
+                    </h4>
+                    <p>Are all of the following things true of your service?</p>
+                    <ul>
+                      <li>
+                        Enlisted under the National Call to Service program,{' '}
+                        <strong>and</strong>
+                      </li>
+                      <li>
+                        Entered service between 10/01/03 and 12/31/07,{' '}
+                        <strong>and</strong>
+                      </li>
+                      <li>Chose education benefits</li>
+                    </ul>
                   </div>
-                  {this.getButton('1990N')}
                 </div>
-              )}
+                {this.getButton('1990N')}
+              </div>
+            )}
             {newBenefit === 'extend' && (
               <div className="wizard-edith-nourse-content">
                 <br />

--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -518,7 +518,7 @@
           "path": "education/other-va-education-benefits/"
         },
         {
-          "name": "Apply for education benefits",
+          "name": "Apply for the Rogers STEM Scholarship",
           "path": "education/other-va-education-benefits/stem-scholarship/apply-for-scholarship-form-22-10203"
         }
       ]

--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -515,7 +515,7 @@
         },
         {
           "name": "How to apply",
-          "path": "education/other-va-education-benefits/"
+          "path": "education/how-to-apply/"
         },
         {
           "name": "Apply for the Rogers STEM Scholarship",

--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -498,7 +498,7 @@
   {
     "appName": "22-10203 Education benefits form",
     "entryName": "10203-edu-benefits",
-    "rootUrl": "/education/apply-for-education-benefits/application/10203",
+    "rootUrl": "/education/other-va-education-benefits/stem-scholarship/apply-for-scholarship-form-22-10203",
     "template": {
       "vagovprod": false,
       "title": "Apply for the Rogers STEM Scholarship",
@@ -515,11 +515,11 @@
         },
         {
           "name": "How to apply",
-          "path": "education/how-to-apply/"
+          "path": "education/other-va-education-benefits/"
         },
         {
           "name": "Apply for education benefits",
-          "path": "education/apply-for-education-benefits/application/10203"
+          "path": "education/other-va-education-benefits/stem-scholarship/apply-for-scholarship-form-22-10203"
         }
       ]
     }


### PR DESCRIPTION
## Description
https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/12156

## Testing done
Dev tested

## Screenshots
![image](https://user-images.githubusercontent.com/48804654/89916724-f72a3480-dbc5-11ea-8d7a-88c5a9697e99.png)


## Acceptance criteria
- [x] Both the "mobile" and "desktop" breadcrumb for the 10203 form are: **Home > Education and training  > How to apply > Apply for the Rogers STEM Scholarship**
- [x] The breadcrumb pieces are links (when applicable) / displayed on the following pages:
    a. Home page: https://staging.va.gov/
    b. Education and training page: https://staging.va.gov/education/
    c. How to apply page: https://staging.va.gov/education/other-va-education-benefits/
    d. Apply for the Rogers STEM Scholarship page: https://staging.va.gov/education/other-va-education-benefits/stem-scholarship/apply-for-scholarship-form-22-10203
- [x] The form url is: https://staging.va.gov/education/other-va-education-benefits/stem-scholarship/apply-for-scholarship-form-22-10203

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
