### PR TITLE
Accessibility updates for sign-in page and modal

### DIFF
--- a/src/applications/login/components/SignInButtons.jsx
+++ b/src/applications/login/components/SignInButtons.jsx
@@ -20,6 +20,8 @@ export default function SignInButtons({ isDisabled, application, redirect }) {
         onClick={() => loginHandler('dslogon')}
       >
         <img
+          aria-hidden="true"
+          role="presentation"
           alt="DS Logon"
           src={`${vaGovFullDomain}/img/signin/dslogon-icon.svg`}
         />
@@ -31,6 +33,8 @@ export default function SignInButtons({ isDisabled, application, redirect }) {
         onClick={() => loginHandler('mhv')}
       >
         <img
+          aria-hidden="true"
+          role="presentation"
           alt="My HealtheVet"
           src={`${vaGovFullDomain}/img/signin/mhv-icon.svg`}
         />
@@ -42,6 +46,8 @@ export default function SignInButtons({ isDisabled, application, redirect }) {
         onClick={() => loginHandler('idme')}
       >
         <img
+          aria-hidden="true"
+          role="presentation"
           alt="ID.me"
           src={`${vaGovFullDomain}/img/signin/idme-icon-white.svg`}
         />
@@ -49,13 +55,17 @@ export default function SignInButtons({ isDisabled, application, redirect }) {
       </button>
       <span className="sidelines">OR</span>
       <div className="alternate-signin">
-        <h5>Don't have those accounts?</h5>
+        <h2 className="vads-u-font-size--sm vads-u-margin-top--0">
+          Don't have those accounts?
+        </h2>
         <button
           disabled={isDisabled}
           className="idme-create usa-button usa-button-secondary"
           onClick={() => signup('v1')}
         >
           <img
+            aria-hidden="true"
+            role="presentation"
             alt="ID.me"
             src={`${vaGovFullDomain}/img/signin/idme-icon-dark.svg`}
           />

--- a/src/applications/login/components/SignInDescription.jsx
+++ b/src/applications/login/components/SignInDescription.jsx
@@ -5,7 +5,7 @@ export default function SignInDescription() {
     <div className="usa-width-one-half">
       <div className="explanation-content vads-u-padding-left--2p5">
         <div className="vads-u-display--none medium-screen:vads-u-display--block">
-          <h2 className="usa-font-lead">
+          <h2 className="usa-font-lead vads-u-margin-top--0">
             One sign in. A lifetime of benefits and services at your fingertips.
           </h2>
         </div>

--- a/src/applications/login/components/SignInDescription.jsx
+++ b/src/applications/login/components/SignInDescription.jsx
@@ -4,8 +4,10 @@ export default function SignInDescription() {
   return (
     <div className="usa-width-one-half">
       <div className="explanation-content vads-u-padding-left--2p5">
-        <div className="vads-u-display--none medium-screen:vads-u-display--block usa-font-lead">
-          One sign in. A lifetime of benefits and services at your fingertips.
+        <div className="vads-u-display--none medium-screen:vads-u-display--block">
+          <h2 className="usa-font-lead">
+            One sign in. A lifetime of benefits and services at your fingertips.
+          </h2>
         </div>
         <ul>
           <li>Check your disability claim and appeal status</li>
@@ -21,9 +23,10 @@ export default function SignInDescription() {
           Use your existing DS Logon, My HealtheVet, or ID.me account to sign in
           to access and manage your VA benefits and health care.
         </p>
-        <p>
-          <strong>A secure account powered by ID.me</strong>
-          <br />
+        <h3 className="vads-u-font-size--base vads-u-margin-top--2">
+          A secure account powered by ID.me
+        </h3>
+        <p className="vads-u-margin-top--0">
           ID.me is our trusted technology partner in helping to keep your
           personal information safe. They specialize in digital identity
           protection and help us make sure you're you—and not someone pretending

--- a/src/applications/login/containers/SignInApp.jsx
+++ b/src/applications/login/containers/SignInApp.jsx
@@ -83,7 +83,7 @@ class SignInPage extends React.Component {
           </div>
         </div>
         <div className="row medium-screen:vads-u-display--none mobile-explanation">
-          <div className="va-introtext columns small-12">
+          <div className="columns small-12">
             <h2>
               One sign in. A lifetime of benefits and services at your
               fingertips.

--- a/src/applications/login/containers/SignInApp.jsx
+++ b/src/applications/login/containers/SignInApp.jsx
@@ -84,7 +84,7 @@ class SignInPage extends React.Component {
         </div>
         <div className="row medium-screen:vads-u-display--none mobile-explanation">
           <div className="columns small-12">
-            <h2>
+            <h2 className="vads-u-margin-top--0">
               One sign in. A lifetime of benefits and services at your
               fingertips.
             </h2>

--- a/src/applications/login/containers/SignInApp.jsx
+++ b/src/applications/login/containers/SignInApp.jsx
@@ -83,7 +83,7 @@ class SignInPage extends React.Component {
           </div>
         </div>
         <div className="row medium-screen:vads-u-display--none mobile-explanation">
-          <div className="columns small-12">
+          <div className="va-introtext columns small-12">
             <h2>
               One sign in. A lifetime of benefits and services at your
               fingertips.
@@ -99,18 +99,24 @@ class SignInPage extends React.Component {
               <div className="top-banner">
                 <div>
                   <img
+                    aria-hidden="true"
+                    role="presentation"
                     alt="ID.me"
                     src={`${vaGovFullDomain}/img/signin/lock-icon.svg`}
                   />{' '}
                   Secured & powered by{' '}
                   <img
+                    aria-hidden="true"
+                    role="presentation"
                     alt="ID.me"
                     src={`${vaGovFullDomain}/img/signin/idme-icon-dark.svg`}
                   />
                 </div>
               </div>
               <div className="signin-actions">
-                <h5>Sign in with an existing account</h5>
+                <h2 className="vads-u-font-size--sm vads-u-margin-top--0">
+                  Sign in with an existing account
+                </h2>
                 <SignInButtons isDisabled={globalDowntime} />
               </div>
             </div>
@@ -120,7 +126,9 @@ class SignInPage extends React.Component {
         <div className="row">
           <div className="columns small-12">
             <div className="help-info">
-              <h4>Having trouble signing in?</h4>
+              <h2 className="vads-u-font-size--md">
+                Having trouble signing in?
+              </h2>
               <p>
                 <a href="/sign-in-faq/" target="_blank">
                   Get answers to Frequently Asked Questions

--- a/src/platform/user/authentication/components/SignInModal.jsx
+++ b/src/platform/user/authentication/components/SignInModal.jsx
@@ -164,18 +164,24 @@ export class SignInModal extends React.Component {
               <div className="top-banner">
                 <div>
                   <img
+                    aria-hidden="true"
+                    role="presentation"
                     alt="ID.me"
                     src={`${vaGovFullDomain}/img/signin/lock-icon.svg`}
                   />{' '}
                   Secured & powered by{' '}
                   <img
+                    aria-hidden="true"
+                    role="presentation"
                     alt="ID.me"
                     src={`${vaGovFullDomain}/img/signin/idme-icon-dark.svg`}
                   />
                 </div>
               </div>
               <div className="signin-actions">
-                <h5>Sign in with an existing account</h5>
+                <h2 className="vads-u-font-size--sm vads-u-margin-top--0">
+                  Sign in with an existing account
+                </h2>
                 <div>
                   <button
                     disabled={globalDowntime}
@@ -183,6 +189,8 @@ export class SignInModal extends React.Component {
                     onClick={this.loginHandler('dslogon')}
                   >
                     <img
+                      aria-hidden="true"
+                      role="presentation"
                       alt="DS Logon"
                       src={`${vaGovFullDomain}/img/signin/dslogon-icon.svg`}
                     />
@@ -194,6 +202,8 @@ export class SignInModal extends React.Component {
                     onClick={this.loginHandler('mhv')}
                   >
                     <img
+                      aria-hidden="true"
+                      role="presentation"
                       alt="My HealtheVet"
                       src={`${vaGovFullDomain}/img/signin/mhv-icon.svg`}
                     />
@@ -205,6 +215,8 @@ export class SignInModal extends React.Component {
                     onClick={this.loginHandler('idme')}
                   >
                     <img
+                      aria-hidden="true"
+                      role="presentation"
                       alt="ID.me"
                       src={`${vaGovFullDomain}/img/signin/idme-icon-white.svg`}
                     />
@@ -212,13 +224,17 @@ export class SignInModal extends React.Component {
                   </button>
                   <span className="sidelines">OR</span>
                   <div className="alternate-signin">
-                    <h5>Don't have those accounts?</h5>
+                    <h2 className="vads-u-font-size--sm vads-u-margin-top--0">
+                      Don't have those accounts?
+                    </h2>
                     <button
                       disabled={globalDowntime}
                       className="idme-create usa-button usa-button-secondary"
                       onClick={this.signupHandler}
                     >
                       <img
+                        aria-hidden="true"
+                        role="presentation"
                         alt="ID.me"
                         src={`${vaGovFullDomain}/img/signin/idme-icon-dark.svg`}
                       />
@@ -252,9 +268,10 @@ export class SignInModal extends React.Component {
                 </li>
                 <li>...and more</li>
               </ul>
-              <p>
-                <strong>A secure account powered by ID.me</strong>
-                <br />
+              <h3 className="vads-u-font-size--base vads-u-margin-top--2">
+                A secure account powered by ID.me
+              </h3>
+              <p className="vads-u-margin-top--0">
                 ID.me is our trusted technology partner in helping to keep your
                 personal information safe. They specialize in digital identity
                 protection and help us make sure you're you—and not someone
@@ -272,7 +289,9 @@ export class SignInModal extends React.Component {
         <div className="row">
           <div className="columns small-12">
             <div className="help-info">
-              <h4>Having trouble signing in?</h4>
+              <h2 className="vads-u-font-size--md">
+                Having trouble signing in?
+              </h2>
               <p>
                 <a href="/sign-in-faq/" target="_blank">
                   Get answers to Frequently Asked Questions

--- a/src/platform/user/authentication/components/SignInModal.jsx
+++ b/src/platform/user/authentication/components/SignInModal.jsx
@@ -248,9 +248,11 @@ export class SignInModal extends React.Component {
           </div>
           <div className="usa-width-one-half">
             <div className="explanation-content">
-              <div className="vads-u-display--none medium-screen:vads-u-display--block usa-font-lead">
-                One site. A lifetime of benefits and services at your
-                fingertips.
+              <div className="vads-u-display--none medium-screen:vads-u-display--block">
+                <h2 className="usa-font-lead vads-u-margin-top--0">
+                  One site. A lifetime of benefits and services at your
+                  fingertips.
+                </h2>
               </div>
               <p>
                 You spoke. We listened. VA.gov is the direct result of what you


### PR DESCRIPTION
## Description

This adds a11y fixes recommended by @jenstrickland

Close department-of-veterans-affairs/va.gov-team#7767

## Testing done

Visual verification of parity in appearance between the updates and existing pages/components

## Screenshots
Compare https://staging.va.gov/sign-in/ and the sign-in modal with the review instance. Other than negligible differences with "A secure account powered by ID.me" (line height differences not worth changing), appearance should be the same

## Acceptance criteria
- [ ] Pages/Components look the same with the requested a11y fixes

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
