### PR TITLE
Focus H2 when Connected Apps loads

### DIFF
--- a/src/applications/personalization/profile-2/components/connected-apps/ConnectedApps.jsx
+++ b/src/applications/personalization/profile-2/components/connected-apps/ConnectedApps.jsx
@@ -10,6 +10,7 @@ import {
   loadConnectedApps,
 } from 'applications/personalization/profile-2/components/connected-apps/actions';
 import recordEvent from 'platform/monitoring/record-event';
+import { focusElement } from 'platform/utilities/ui';
 import { AdditionalInfoSections } from './AdditionalInfoSections';
 import { AppDeletedAlert } from './AppDeletedAlert';
 import availableConnectedApps from './availableConnectedApps';
@@ -17,7 +18,14 @@ import { ConnectedApp } from './ConnectedApp';
 
 export class ConnectedApps extends Component {
   componentDidMount() {
+    focusElement('[data-focus-target]');
     this.props.loadConnectedApps();
+  }
+
+  componentDidUpdate(prevProps) {
+    if (prevProps.loading && !this.props.loading) {
+      focusElement('[data-focus-target]');
+    }
   }
 
   confirmDelete = appId => {


### PR DESCRIPTION
## Description
This PR focuses on the Connected Apps H2 when the section mounts and restores focus back to the H2 from the loading spinner after the connected apps data has finished loading.

## Testing done
Local

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs