### PR TITLE
Show VAOS tabs after requests load, rather than after requests and appointments

### DIFF
--- a/src/applications/vaos/actions/appointments.js
+++ b/src/applications/vaos/actions/appointments.js
@@ -1,27 +1,15 @@
 import moment from 'moment';
 import * as Sentry from '@sentry/browser';
-import {
-  FETCH_STATUS,
-  GA_PREFIX,
-  APPOINTMENT_TYPES,
-  EXPRESS_CARE,
-} from '../utils/constants';
+import { FETCH_STATUS, GA_PREFIX, APPOINTMENT_TYPES } from '../utils/constants';
 import recordEvent from 'platform/monitoring/record-event';
 import { resetDataLayer } from '../utils/events';
 
 import {
   getCancelReasons,
-  getFacilitiesBySystemAndTypeOfCare,
   getRequestMessages,
   updateAppointment,
   updateRequest,
 } from '../api';
-
-import {
-  getOrganizations,
-  getRootOrganization,
-  getSiteIdFromOrganization,
-} from '../services/organization';
 
 import { getLocations } from '../services/location';
 
@@ -35,12 +23,14 @@ import {
   isVideoAppointment,
 } from '../services/appointment';
 
-import { selectSystemIds, vaosVSPAppointmentNew } from '../utils/selectors';
-
 import { captureError, getErrorCodes } from '../utils/error';
 import { STARTED_NEW_APPOINTMENT_FLOW } from './sitewide';
 
 export const FETCH_FUTURE_APPOINTMENTS = 'vaos/FETCH_FUTURE_APPOINTMENTS';
+export const FETCH_PENDING_APPOINTMENTS_FAILED =
+  'vaos/FETCH_PENDING_APPOINTMENTS_FAILED';
+export const FETCH_PENDING_APPOINTMENTS_SUCCEEDED =
+  'vaos/FETCH_PENDING_APPOINTMENTS_SUCCEEDED';
 export const FETCH_FUTURE_APPOINTMENTS_FAILED =
   'vaos/FETCH_FUTURE_APPOINTMENTS_FAILED';
 export const FETCH_FUTURE_APPOINTMENTS_SUCCEEDED =
@@ -137,53 +127,65 @@ async function getAdditionalFacilityInfo(futureAppointments) {
 
 export function fetchFutureAppointments() {
   return async (dispatch, getState) => {
-    if (getState().appointments.futureStatus === FETCH_STATUS.notStarted) {
+    dispatch({
+      type: FETCH_FUTURE_APPOINTMENTS,
+    });
+
+    try {
+      const data = await Promise.all([
+        getBookedAppointments({
+          startDate: moment().format('YYYY-MM-DD'),
+          endDate: moment()
+            .add(13, 'months')
+            .format('YYYY-MM-DD'),
+        }),
+        getAppointmentRequests({
+          startDate: moment()
+            .subtract(30, 'days')
+            .format('YYYY-MM-DD'),
+          endDate: moment().format('YYYY-MM-DD'),
+        })
+          .then(requests => {
+            dispatch({
+              type: FETCH_PENDING_APPOINTMENTS_SUCCEEDED,
+              data: requests,
+            });
+            return requests;
+          })
+          .catch(resp => {
+            dispatch({
+              type: FETCH_PENDING_APPOINTMENTS_FAILED,
+            });
+
+            return Promise.reject(resp);
+          }),
+      ]);
+
       dispatch({
-        type: FETCH_FUTURE_APPOINTMENTS,
+        type: FETCH_FUTURE_APPOINTMENTS_SUCCEEDED,
+        data: data[0],
       });
 
       try {
-        const data = await Promise.all([
-          getBookedAppointments({
-            startDate: moment().format('YYYY-MM-DD'),
-            endDate: moment()
-              .add(13, 'months')
-              .format('YYYY-MM-DD'),
-          }),
-          getAppointmentRequests({
-            startDate: moment()
-              .subtract(30, 'days')
-              .format('YYYY-MM-DD'),
-            endDate: moment().format('YYYY-MM-DD'),
-          }),
-        ]);
+        const facilityData = await getAdditionalFacilityInfo(
+          [].concat(...data),
+        );
 
-        dispatch({
-          type: FETCH_FUTURE_APPOINTMENTS_SUCCEEDED,
-          data,
-        });
-
-        try {
-          const facilityData = await getAdditionalFacilityInfo(
-            getState().appointments.future,
-          );
-
-          if (facilityData) {
-            dispatch({
-              type: FETCH_FACILITY_LIST_DATA_SUCCEEDED,
-              facilityData,
-            });
-          }
-        } catch (error) {
-          captureError(error);
+        if (facilityData) {
+          dispatch({
+            type: FETCH_FACILITY_LIST_DATA_SUCCEEDED,
+            facilityData,
+          });
         }
       } catch (error) {
         captureError(error);
-        dispatch({
-          type: FETCH_FUTURE_APPOINTMENTS_FAILED,
-          error,
-        });
       }
+    } catch (error) {
+      captureError(error);
+      dispatch({
+        type: FETCH_FUTURE_APPOINTMENTS_FAILED,
+        error,
+      });
     }
   };
 }

--- a/src/applications/vaos/actions/appointments.js
+++ b/src/applications/vaos/actions/appointments.js
@@ -126,7 +126,7 @@ async function getAdditionalFacilityInfo(futureAppointments) {
 }
 
 export function fetchFutureAppointments() {
-  return async (dispatch, getState) => {
+  return async dispatch => {
     dispatch({
       type: FETCH_FUTURE_APPOINTMENTS,
     });

--- a/src/applications/vaos/api/index.js
+++ b/src/applications/vaos/api/index.js
@@ -36,7 +36,7 @@ export function getConfirmedAppointments(type, startDate, endDate) {
           import('./confirmed_va.json').then(module => {
             resolve(module.default ? module.default : module);
           });
-        }, 500),
+        }, 15000),
       );
     } else {
       promise = new Promise(resolve =>

--- a/src/applications/vaos/components/ExpressCareList.jsx
+++ b/src/applications/vaos/components/ExpressCareList.jsx
@@ -96,7 +96,7 @@ ExpressCareList.propTypes = {
 function mapStateToProps(state) {
   return {
     expressCareRequests: selectExpressCareRequests(state),
-    status: state.appointments.futureStatus,
+    status: state.appointments.pendingStatus,
     showCancelButton: vaosCancel(state),
     showScheduleButton: vaosRequests(state),
     isCernerOnlyPatient: selectIsCernerOnlyPatient(state),

--- a/src/applications/vaos/components/FutureAppointmentsList.jsx
+++ b/src/applications/vaos/components/FutureAppointmentsList.jsx
@@ -18,7 +18,7 @@ import {
   vaosPastAppts,
   selectFutureAppointments,
   selectExpressCare,
-  vaosExpressCare,
+  selectFutureStatus,
 } from '../utils/selectors';
 import { selectIsCernerOnlyPatient } from 'platform/user/selectors';
 import { FETCH_STATUS, GA_PREFIX, APPOINTMENT_TYPES } from '../utils/constants';
@@ -55,7 +55,7 @@ export class FutureAppointmentsList extends React.Component {
     if (futureStatus === FETCH_STATUS.loading) {
       content = (
         <div className="vads-u-margin-y--8">
-          <LoadingIndicator message="Loading your appointments..." />
+          <LoadingIndicator message="Loading your upcoming appointments..." />
         </div>
       );
     } else if (futureStatus === FETCH_STATUS.succeeded && future?.length > 0) {
@@ -192,7 +192,7 @@ function mapStateToProps(state) {
   return {
     requestMessages: state.appointments.requestMessages,
     facilityData: state.appointments.facilityData,
-    futureStatus: state.appointments.futureStatus,
+    futureStatus: selectFutureStatus(state),
     future: selectFutureAppointments(state),
     isCernerOnlyPatient: selectIsCernerOnlyPatient(state),
     showCancelButton: vaosCancel(state),

--- a/src/applications/vaos/containers/AppointmentsPage.jsx
+++ b/src/applications/vaos/containers/AppointmentsPage.jsx
@@ -24,6 +24,7 @@ import {
   vaosExpressCare,
   isWelcomeModalDismissed,
   selectExpressCare,
+  selectFutureStatus,
 } from '../utils/selectors';
 import { selectIsCernerOnlyPatient } from 'platform/user/selectors';
 import { GA_PREFIX, FETCH_STATUS } from '../utils/constants';
@@ -76,7 +77,7 @@ export class AppointmentsPage extends Component {
     const {
       cancelInfo,
       children,
-      futureStatus,
+      pendingStatus,
       showScheduleButton,
       showCommunityCare,
       expressCare,
@@ -85,9 +86,9 @@ export class AppointmentsPage extends Component {
       showPastAppointments,
     } = this.props;
     const isLoading =
-      futureStatus === FETCH_STATUS.loading ||
+      pendingStatus === FETCH_STATUS.loading ||
       expressCare.windowsStatus === FETCH_STATUS.loading ||
-      futureStatus === FETCH_STATUS.notStarted ||
+      pendingStatus === FETCH_STATUS.notStarted ||
       expressCare.windowsStatus === FETCH_STATUS.notStarted;
 
     return (
@@ -156,7 +157,8 @@ AppointmentsPage.propTypes = {
 
 function mapStateToProps(state) {
   return {
-    futureStatus: state.appointments.futureStatus,
+    pendingStatus: state.appointments.pendingStatus,
+    futureStatus: selectFutureStatus(state),
     cancelInfo: getCancelInfo(state),
     showPastAppointments: vaosPastAppts(state),
     showScheduleButton: vaosRequests(state),

--- a/src/applications/vaos/reducers/appointments.js
+++ b/src/applications/vaos/reducers/appointments.js
@@ -5,6 +5,9 @@ import {
   FETCH_FUTURE_APPOINTMENTS,
   FETCH_FUTURE_APPOINTMENTS_SUCCEEDED,
   FETCH_FUTURE_APPOINTMENTS_FAILED,
+  FETCH_PENDING_APPOINTMENTS,
+  FETCH_PENDING_APPOINTMENTS_SUCCEEDED,
+  FETCH_PENDING_APPOINTMENTS_FAILED,
   FETCH_PAST_APPOINTMENTS,
   FETCH_PAST_APPOINTMENTS_SUCCEEDED,
   FETCH_PAST_APPOINTMENTS_FAILED,
@@ -30,8 +33,10 @@ import {
 } from '../utils/constants';
 
 const initialState = {
-  future: null,
-  futureStatus: FETCH_STATUS.notStarted,
+  pending: null,
+  pendingStatus: FETCH_STATUS.notStarted,
+  confirmed: null,
+  confirmedStatus: FETCH_STATUS.notStarted,
   past: null,
   pastStatus: FETCH_STATUS.notStarted,
   pastSelectedIndex: 0,
@@ -41,14 +46,6 @@ const initialState = {
   facilityData: {},
   requestMessages: {},
   systemClinicToFacilityMap: {},
-  expressCare: {
-    windowsStatus: FETCH_STATUS.notStarted,
-    hasWindow: false,
-    allowRequests: false,
-    localWindowString: null,
-    minStart: null,
-    maxEnd: null,
-  },
 };
 
 export default function appointmentsReducer(state = initialState, action) {
@@ -56,22 +53,34 @@ export default function appointmentsReducer(state = initialState, action) {
     case FETCH_FUTURE_APPOINTMENTS:
       return {
         ...state,
-        futureStatus: FETCH_STATUS.loading,
+        pendingStatus: FETCH_STATUS.loading,
+        confirmedStatus: FETCH_STATUS.loading,
       };
     case FETCH_FUTURE_APPOINTMENTS_SUCCEEDED: {
-      const [bookedAppointments, requests] = action.data;
-
       return {
         ...state,
-        future: [...bookedAppointments, ...requests],
-        futureStatus: FETCH_STATUS.succeeded,
+        confirmed: action.data,
+        confirmedStatus: FETCH_STATUS.succeeded,
       };
     }
     case FETCH_FUTURE_APPOINTMENTS_FAILED:
       return {
         ...state,
-        futureStatus: FETCH_STATUS.failed,
-        future: null,
+        confirmedStatus: FETCH_STATUS.failed,
+        confirmed: null,
+      };
+    case FETCH_PENDING_APPOINTMENTS_SUCCEEDED: {
+      return {
+        ...state,
+        pending: action.data,
+        pendingStatus: FETCH_STATUS.succeeded,
+      };
+    }
+    case FETCH_PENDING_APPOINTMENTS_FAILED:
+      return {
+        ...state,
+        pendingStatus: FETCH_STATUS.failed,
+        pending: null,
       };
     case FETCH_PAST_APPOINTMENTS:
       return {
@@ -140,36 +149,38 @@ export default function appointmentsReducer(state = initialState, action) {
         cancelAppointmentStatus: FETCH_STATUS.loading,
       };
     case CANCEL_APPOINTMENT_CONFIRMED_SUCCEEDED: {
-      const future = state.future.map(appt => {
+      const confirmed = state.confirmed.map(appt => {
         if (appt !== state.appointmentToCancel) {
           return appt;
         }
 
-        let newAppt = appt;
-
-        if (
-          state.appointmentToCancel.vaos?.appointmentType ===
-          APPOINTMENT_TYPES.vaAppointment
-        ) {
-          newAppt = set(
-            'legacyVAR.apiData.vdsAppointments[0].currentStatus',
-            'CANCELLED BY PATIENT',
-            newAppt,
-          );
-          newAppt.description = 'CANCELLED BY PATIENT';
-        } else {
-          newAppt = {
-            ...newAppt,
-            apiData: action.apiData,
-          };
-        }
+        const newAppt = set(
+          'legacyVAR.apiData.vdsAppointments[0].currentStatus',
+          'CANCELLED BY PATIENT',
+          appt,
+        );
+        newAppt.description = 'CANCELLED BY PATIENT';
 
         return { ...newAppt, status: APPOINTMENT_STATUS.cancelled };
       });
+      const pending = state.pending.map(appt => {
+        if (appt !== state.appointmentToCancel) {
+          return appt;
+        }
+
+        const newAppt = {
+          ...appt,
+          apiData: action.apiData,
+        };
+
+        return { ...newAppt, status: APPOINTMENT_STATUS.cancelled };
+      });
+
       return {
         ...state,
         showCancelModal: true,
-        future,
+        confirmed,
+        pending,
         cancelAppointmentStatus: FETCH_STATUS.succeeded,
         cancelAppointmentStatusVaos400: false,
       };
@@ -189,11 +200,18 @@ export default function appointmentsReducer(state = initialState, action) {
         cancelAppointmentStatus: FETCH_STATUS.notStarted,
       };
     case EXPRESS_CARE_FORM_SUBMIT_SUCCEEDED:
+      return {
+        ...state,
+        pending: null,
+        pendingStatus: FETCH_STATUS.notStarted,
+      };
     case FORM_SUBMIT_SUCCEEDED:
       return {
         ...state,
-        future: null,
-        futureStatus: FETCH_STATUS.notStarted,
+        pending: null,
+        pendingStatus: FETCH_STATUS.notStarted,
+        confirmed: null,
+        confirmedStatus: FETCH_STATUS.notStarted,
       };
     default:
       return state;

--- a/src/applications/vaos/reducers/appointments.js
+++ b/src/applications/vaos/reducers/appointments.js
@@ -5,7 +5,6 @@ import {
   FETCH_FUTURE_APPOINTMENTS,
   FETCH_FUTURE_APPOINTMENTS_SUCCEEDED,
   FETCH_FUTURE_APPOINTMENTS_FAILED,
-  FETCH_PENDING_APPOINTMENTS,
   FETCH_PENDING_APPOINTMENTS_SUCCEEDED,
   FETCH_PENDING_APPOINTMENTS_FAILED,
   FETCH_PAST_APPOINTMENTS,
@@ -26,11 +25,7 @@ import {
 } from '../actions/sitewide';
 
 import { sortMessages } from '../services/appointment';
-import {
-  FETCH_STATUS,
-  APPOINTMENT_TYPES,
-  APPOINTMENT_STATUS,
-} from '../utils/constants';
+import { FETCH_STATUS, APPOINTMENT_STATUS } from '../utils/constants';
 
 const initialState = {
   pending: null,
@@ -149,7 +144,7 @@ export default function appointmentsReducer(state = initialState, action) {
         cancelAppointmentStatus: FETCH_STATUS.loading,
       };
     case CANCEL_APPOINTMENT_CONFIRMED_SUCCEEDED: {
-      const confirmed = state.confirmed.map(appt => {
+      const confirmed = state.confirmed?.map(appt => {
         if (appt !== state.appointmentToCancel) {
           return appt;
         }
@@ -163,7 +158,7 @@ export default function appointmentsReducer(state = initialState, action) {
 
         return { ...newAppt, status: APPOINTMENT_STATUS.cancelled };
       });
-      const pending = state.pending.map(appt => {
+      const pending = state.pending?.map(appt => {
         if (appt !== state.appointmentToCancel) {
           return appt;
         }

--- a/src/applications/vaos/tests/actions/appointments.unit.spec.js
+++ b/src/applications/vaos/tests/actions/appointments.unit.spec.js
@@ -19,6 +19,8 @@ import {
   FETCH_FUTURE_APPOINTMENTS,
   FETCH_FUTURE_APPOINTMENTS_SUCCEEDED,
   FETCH_FUTURE_APPOINTMENTS_FAILED,
+  FETCH_PENDING_APPOINTMENTS_SUCCEEDED,
+  FETCH_PENDING_APPOINTMENTS_FAILED,
   FETCH_PAST_APPOINTMENTS,
   FETCH_PAST_APPOINTMENTS_SUCCEEDED,
   FETCH_PAST_APPOINTMENTS_FAILED,
@@ -36,11 +38,9 @@ import {
 import { APPOINTMENT_TYPES, APPOINTMENT_STATUS } from '../../utils/constants';
 import { STARTED_NEW_APPOINTMENT_FLOW } from '../../actions/sitewide';
 
-import parentFacilities from '../../api/facilities.json';
 import facilityData from '../../api/facility_data.json';
-import facilityExpressCareData from '../../api/facilities_983_express_care.json';
-import clinicData from '../../api/clinics.json';
 import cancelReasons from '../../api/cancel_reasons.json';
+import { getVAAppointmentMock } from '../mocks/v0';
 
 describe('VAOS actions: appointments', () => {
   beforeEach(() => {
@@ -55,24 +55,26 @@ describe('VAOS actions: appointments', () => {
     const data = {
       data: [],
     };
+    const appt = getVAAppointmentMock();
+    appt.attributes.sta6aid = '442';
     setFetchJSONResponse(global.fetch, data);
+    setFetchJSONResponse(global.fetch.onCall(2), {
+      data: [appt],
+    });
     setFetchJSONResponse(global.fetch.onCall(4), facilityData);
     const thunk = fetchFutureAppointments();
     const dispatchSpy = sinon.spy();
-    const getState = () => ({
-      appointments: {
-        futureStatus: 'notStarted',
-        future: [{ facilityId: '442' }],
-      },
-    });
-    await thunk(dispatchSpy, getState);
+    await thunk(dispatchSpy);
     expect(dispatchSpy.firstCall.args[0].type).to.eql(
       FETCH_FUTURE_APPOINTMENTS,
     );
     expect(dispatchSpy.secondCall.args[0].type).to.eql(
-      FETCH_FUTURE_APPOINTMENTS_SUCCEEDED,
+      FETCH_PENDING_APPOINTMENTS_SUCCEEDED,
     );
     expect(dispatchSpy.thirdCall.args[0].type).to.eql(
+      FETCH_FUTURE_APPOINTMENTS_SUCCEEDED,
+    );
+    expect(dispatchSpy.lastCall.args[0].type).to.eql(
       FETCH_FACILITY_LIST_DATA_SUCCEEDED,
     );
     expect(global.fetch.lastCall.args[0]).to.contain('ids=vha_442');
@@ -80,22 +82,19 @@ describe('VAOS actions: appointments', () => {
 
   it('should dispatch fail action when fetching future appointments', async () => {
     const data = {
-      data: [],
+      errors: [],
     };
     setFetchJSONFailure(global.fetch, data);
     const thunk = fetchFutureAppointments();
     const dispatchSpy = sinon.spy();
-    const getState = () => ({
-      appointments: {
-        futureStatus: 'notStarted',
-        future: [{ facilityId: '442' }],
-      },
-    });
-    await thunk(dispatchSpy, getState);
+    await thunk(dispatchSpy);
     expect(dispatchSpy.firstCall.args[0].type).to.eql(
       FETCH_FUTURE_APPOINTMENTS,
     );
     expect(dispatchSpy.secondCall.args[0].type).to.eql(
+      FETCH_PENDING_APPOINTMENTS_FAILED,
+    );
+    expect(dispatchSpy.thirdCall.args[0].type).to.eql(
       FETCH_FUTURE_APPOINTMENTS_FAILED,
     );
   });
@@ -146,137 +145,14 @@ describe('VAOS actions: appointments', () => {
     );
   });
 
-  it('should fetch location data', async () => {
+  it('should not send fail action if location details fetch fails', async () => {
     const data = {
       data: [],
     };
     setFetchJSONResponse(global.fetch, data);
-    setFetchJSONResponse(global.fetch.onCall(3), facilityData);
-    const thunk = fetchFutureAppointments();
-    const dispatchSpy = sinon.spy();
-    const getState = () => ({
-      appointments: {
-        futureStatus: 'notStarted',
-        future: [
-          {
-            participant: [
-              {
-                actor: {
-                  reference: 'HealthcareService/var983_455',
-                  display: 'CHY OPT VAR1',
-                },
-              },
-              {
-                actor: {
-                  reference: 'Location/var983',
-                },
-              },
-            ],
-            vaos: { appointmentType: APPOINTMENT_TYPES.vaAppointment },
-          },
-          {
-            participant: [
-              {
-                actor: {
-                  reference: 'HealthcareService/var983_455',
-                  display: 'CHY OPT VAR1',
-                },
-              },
-              {
-                actor: {
-                  reference: 'Location/var983GC',
-                },
-              },
-            ],
-            vaos: { appointmentType: APPOINTMENT_TYPES.vaAppointment },
-          },
-        ],
-      },
+    setFetchJSONResponse(global.fetch.onCall(2), {
+      data: [getVAAppointmentMock()],
     });
-    await thunk(dispatchSpy, getState);
-    expect(dispatchSpy.firstCall.args[0].type).to.eql(
-      FETCH_FUTURE_APPOINTMENTS,
-    );
-    expect(dispatchSpy.secondCall.args[0].type).to.eql(
-      FETCH_FUTURE_APPOINTMENTS_SUCCEEDED,
-    );
-    expect(dispatchSpy.thirdCall.args[0].type).to.eql(
-      FETCH_FACILITY_LIST_DATA_SUCCEEDED,
-    );
-
-    expect(global.fetch.getCall(3).args[0]).to.contain('ids=vha_442');
-  });
-
-  it('should abort fetching clinics if more than 3 systems', async () => {
-    const data = {
-      data: [],
-    };
-    setFetchJSONResponse(global.fetch, data);
-    const thunk = fetchFutureAppointments();
-    const dispatchSpy = sinon.spy();
-    const getState = () => ({
-      appointments: {
-        futureStatus: 'notStarted',
-        future: [
-          {
-            participant: [
-              {
-                actor: {
-                  reference: 'HealthcareService/var983_455',
-                  display: 'CHY OPT VAR1',
-                },
-              },
-            ],
-          },
-          {
-            participant: [
-              {
-                actor: {
-                  reference: 'HealthcareService/var984_455',
-                  display: 'CHY OPT VAR1',
-                },
-              },
-            ],
-          },
-          {
-            participant: [
-              {
-                actor: {
-                  reference: 'HealthcareService/var985_455',
-                  display: 'CHY OPT VAR1',
-                },
-              },
-            ],
-          },
-          {
-            participant: [
-              {
-                actor: {
-                  reference: 'HealthcareService/var986_455',
-                  display: 'CHY OPT VAR1',
-                },
-              },
-            ],
-          },
-        ],
-      },
-    });
-    await thunk(dispatchSpy, getState);
-    expect(dispatchSpy.firstCall.args[0].type).to.eql(
-      FETCH_FUTURE_APPOINTMENTS,
-    );
-    expect(dispatchSpy.secondCall.args[0].type).to.eql(
-      FETCH_FUTURE_APPOINTMENTS_SUCCEEDED,
-    );
-    expect(dispatchSpy.callCount).to.equal(2);
-    expect(global.fetch.callCount).to.equal(3);
-  });
-
-  it('should not send fail action if clinic institution mapping fails', async () => {
-    const data = {
-      data: [],
-    };
-    setFetchJSONResponse(global.fetch, data);
     setFetchJSONFailure(global.fetch.onCall(3), {});
     const thunk = fetchFutureAppointments();
     const dispatchSpy = sinon.spy();
@@ -291,9 +167,12 @@ describe('VAOS actions: appointments', () => {
       FETCH_FUTURE_APPOINTMENTS,
     );
     expect(dispatchSpy.secondCall.args[0].type).to.eql(
+      FETCH_PENDING_APPOINTMENTS_SUCCEEDED,
+    );
+    expect(dispatchSpy.thirdCall.args[0].type).to.eql(
       FETCH_FUTURE_APPOINTMENTS_SUCCEEDED,
     );
-    expect(dispatchSpy.callCount).to.equal(2);
+    expect(dispatchSpy.callCount).to.equal(3);
     expect(global.fetch.callCount).to.equal(4);
   });
 

--- a/src/applications/vaos/tests/actions/appointments.unit.spec.js
+++ b/src/applications/vaos/tests/actions/appointments.unit.spec.js
@@ -156,13 +156,7 @@ describe('VAOS actions: appointments', () => {
     setFetchJSONFailure(global.fetch.onCall(3), {});
     const thunk = fetchFutureAppointments();
     const dispatchSpy = sinon.spy();
-    const getState = () => ({
-      appointments: {
-        futureStatus: 'notStarted',
-        future: [{ facilityId: '983', clinicId: '455' }],
-      },
-    });
-    await thunk(dispatchSpy, getState);
+    await thunk(dispatchSpy);
     expect(dispatchSpy.firstCall.args[0].type).to.eql(
       FETCH_FUTURE_APPOINTMENTS,
     );

--- a/src/applications/vaos/tests/actions/expressCare.unit.spec.js
+++ b/src/applications/vaos/tests/actions/expressCare.unit.spec.js
@@ -39,10 +39,6 @@ describe('VAOS Express Care actions', () => {
   it('should fetch express care windows', async () => {
     const getState = () => ({
       user: userState,
-      appointments: {
-        futureStatus: 'notStarted',
-        future: [{ facilityId: '442' }],
-      },
     });
     const today = moment();
     const requestCriteria = getExpressCareRequestCriteriaMock('983', [

--- a/src/applications/vaos/tests/list/express-care.unit.spec.jsx
+++ b/src/applications/vaos/tests/list/express-care.unit.spec.jsx
@@ -147,6 +147,7 @@ describe('VAOS integration: express care requests', () => {
         additionalInformation: 'Need help ASAP',
       };
       appointment.id = '1234';
+      // We want the EC tab to display even if there's an error fetching appointments
       mockAppointmentInfo({ requests: [appointment], vaError: true });
 
       const { baseElement, findByText, getByText } = renderFromRoutes({

--- a/src/applications/vaos/tests/list/express-care.unit.spec.jsx
+++ b/src/applications/vaos/tests/list/express-care.unit.spec.jsx
@@ -147,7 +147,7 @@ describe('VAOS integration: express care requests', () => {
         additionalInformation: 'Need help ASAP',
       };
       appointment.id = '1234';
-      mockAppointmentInfo({ requests: [appointment] });
+      mockAppointmentInfo({ requests: [appointment], vaError: true });
 
       const { baseElement, findByText, getByText } = renderFromRoutes({
         initialState,

--- a/src/applications/vaos/tests/mocks/helpers.js
+++ b/src/applications/vaos/tests/mocks/helpers.js
@@ -1,21 +1,35 @@
 import moment from 'moment';
 import environment from 'platform/utilities/environment';
-import { mockFetch, setFetchJSONResponse } from 'platform/testing/unit/helpers';
+import {
+  mockFetch,
+  setFetchJSONResponse,
+  setFetchJSONFailure,
+} from 'platform/testing/unit/helpers';
 import { getVAAppointmentMock } from '../mocks/v0';
 
-export function mockAppointmentInfo({ va = [], cc = [], requests = [] }) {
+export function mockAppointmentInfo({
+  va = [],
+  vaError = false,
+  cc = [],
+  requests = [],
+}) {
   mockFetch();
-  setFetchJSONResponse(
-    global.fetch.withArgs(
-      `${environment.API_URL}/vaos/v0/appointments?start_date=${moment()
-        .startOf('day')
-        .toISOString()}&end_date=${moment()
-        .add(13, 'months')
-        .startOf('day')
-        .toISOString()}&type=va`,
-    ),
-    { data: va },
-  );
+
+  const vaUrl = `${
+    environment.API_URL
+  }/vaos/v0/appointments?start_date=${moment()
+    .startOf('day')
+    .toISOString()}&end_date=${moment()
+    .add(13, 'months')
+    .startOf('day')
+    .toISOString()}&type=va`;
+
+  if (vaError) {
+    setFetchJSONFailure(global.fetch.withArgs(vaUrl), { errors: [] });
+  } else {
+    setFetchJSONResponse(global.fetch.withArgs(vaUrl), { data: va });
+  }
+
   setFetchJSONResponse(
     global.fetch.withArgs(
       `${environment.API_URL}/vaos/v0/appointments?start_date=${moment().format(


### PR DESCRIPTION
## Description
This updates our code to store requests and appointments separately in Redux, so that we can display parts of the UI when requests have finished, instead of waiting for appointments.

Note: This still always kicks off a request for appointments when the list page loads. It seems tricky, but possible, to only kick off a request for appointments on the upcoming tab, but I figured that the majority of people coming to VAOS will end up looking at that tab during their session, so it wouldn't necessarily save the user anything.

## Testing done
Local and unit testing

## Acceptance criteria
- [ ] Tabs show after appt requests load

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
