### PR TITLE
bradl3yC - 12367 - Display block if on mobile screens

### DIFF
--- a/src/applications/debt-letters/components/DebtLettersSummary.jsx
+++ b/src/applications/debt-letters/components/DebtLettersSummary.jsx
@@ -91,7 +91,7 @@ const DebtLettersSummary = ({ isError, isVBMSError, debts, debtLinks }) => {
         <h1 className="vads-u-padding-x--2p5 vads-u-margin-bottom--2">
           Your VA debt
         </h1>
-        <div className="vads-u-display--flex vads-u-flex-direction--row">
+        <div className="large-screen:vads-u-display--flex vads-u-flex-direction--row vads-u-display--block">
           <div className="vads-l-col--12 vads-u-padding-x--2p5 medium-screen:vads-l-col--8">
             <h2 className="vads-u-font-size--h3 vads-u-font-weight--normal vads-u-margin-top--0 vads-u-margin-bottom--2">
               Download your debt letters, learn your payment options, or find


### PR DESCRIPTION
## Description
The right rail was being obscured by a overflow-x: hidden on the body - we need the right rail content to shift under the main content if on smaller screens

## Testing done


## Screenshots
![Screen Shot 2020-08-11 at 2 58 39 PM](https://user-images.githubusercontent.com/6165421/89938003-d7a20480-dbe3-11ea-9c99-a273209787a8.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
