### PR TITLE
Move focus to first editable field when "Edit" is clicked

### DIFF
--- a/src/platform/forms-system/src/js/review/ReviewCollapsibleChapter.jsx
+++ b/src/platform/forms-system/src/js/review/ReviewCollapsibleChapter.jsx
@@ -37,7 +37,7 @@ export default class ReviewCollapsibleChapter extends React.Component {
   focusOnPage(key) {
     const name = `${key.replace(/:/g, '\\:')}`;
     // legend & label target array type form elements
-    focusOnChange(name, 'input, select, textarea');
+    focusOnChange(name, 'p, legend, label');
   }
 
   handleEdit(key, editing, index = null) {

--- a/src/platform/forms-system/src/js/review/ReviewCollapsibleChapter.jsx
+++ b/src/platform/forms-system/src/js/review/ReviewCollapsibleChapter.jsx
@@ -4,6 +4,8 @@ import Scroll from 'react-scroll';
 import _ from 'lodash/fp'; // eslint-disable-line no-restricted-imports
 import classNames from 'classnames';
 
+import environment from 'platform/utilities/environment';
+
 import ProgressButton from '../components/ProgressButton';
 import { focusOnChange, focusElement, getScrollOptions } from '../utilities/ui';
 import SchemaForm from '../components/SchemaForm';
@@ -37,7 +39,15 @@ export default class ReviewCollapsibleChapter extends React.Component {
 
   focusOnPage(key) {
     const name = `${key.replace(/:/g, '\\:')}`;
-    focusElement(document.querySelector(`div[data-chapter="${name}"] button`));
+
+    if (environment.isProduction()) {
+      // legend & label target array type form elements
+      focusOnChange(name, 'p, legend, label');
+    } else {
+      focusElement(
+        document.querySelector(`div[data-chapter="${name}"] button`),
+      );
+    }
   }
 
   handleEdit(key, editing, index = null) {
@@ -263,7 +273,9 @@ export default class ReviewCollapsibleChapter extends React.Component {
                 aria-controls={`collapsible-${this.id}`}
                 onClick={this.props.toggleButtonClicked}
               >
-                {`${this.state.editing ? 'Edit' : ''} ${chapterTitle || ''}`}
+                {environment.isProduction()
+                  ? `${chapterTitle || ''}`
+                  : `${this.state.editing ? 'Edit' : ''} ${chapterTitle || ''}`}
               </button>
               {showUnviewedPageWarning && (
                 <span className="schemaform-review-chapter-warning-icon" />

--- a/src/platform/forms-system/src/js/review/ReviewCollapsibleChapter.jsx
+++ b/src/platform/forms-system/src/js/review/ReviewCollapsibleChapter.jsx
@@ -37,7 +37,7 @@ export default class ReviewCollapsibleChapter extends React.Component {
   focusOnPage(key) {
     const name = `${key.replace(/:/g, '\\:')}`;
     // legend & label target array type form elements
-    focusOnChange(name, 'p, legend, label');
+    focusOnChange(name, 'input, select, textarea');
   }
 
   handleEdit(key, editing, index = null) {

--- a/src/platform/forms-system/src/js/review/ReviewCollapsibleChapter.jsx
+++ b/src/platform/forms-system/src/js/review/ReviewCollapsibleChapter.jsx
@@ -41,9 +41,10 @@ export default class ReviewCollapsibleChapter extends React.Component {
   }
 
   handleEdit(key, editing, index = null) {
+    const chapterName = `${key}${index === null ? '' : index}`;
     this.props.onEdit(key, editing, index);
-    this.scrollToPage(`${key}${index === null ? '' : index}`);
-    this.focusOnPage(`${key}${index === null ? '' : index}`);
+    this.scrollToPage(chapterName);
+    this.focusOnPage(chapterName);
   }
 
   handleSubmit = (formData, key, path = null, index = null) => {

--- a/src/platform/forms-system/src/js/review/ReviewCollapsibleChapter.jsx
+++ b/src/platform/forms-system/src/js/review/ReviewCollapsibleChapter.jsx
@@ -5,7 +5,7 @@ import _ from 'lodash/fp'; // eslint-disable-line no-restricted-imports
 import classNames from 'classnames';
 
 import ProgressButton from '../components/ProgressButton';
-import { focusOnChange, getScrollOptions } from '../utilities/ui';
+import { focusOnChange, focusElement, getScrollOptions } from '../utilities/ui';
 import SchemaForm from '../components/SchemaForm';
 import { getArrayFields, getNonArraySchema } from '../helpers';
 import ArrayField from './ArrayField';
@@ -20,6 +20,7 @@ export default class ReviewCollapsibleChapter extends React.Component {
   constructor() {
     super();
     this.handleEdit = this.handleEdit.bind(this);
+    this.state = { editing: false };
   }
   /* eslint-disable-next-line camelcase */
   UNSAFE_componentWillMount() {
@@ -36,11 +37,11 @@ export default class ReviewCollapsibleChapter extends React.Component {
 
   focusOnPage(key) {
     const name = `${key.replace(/:/g, '\\:')}`;
-    // legend & label target array type form elements
-    focusOnChange(name, 'p, legend, label');
+    focusElement(document.querySelector(`div[data-chapter="${name}"] button`));
   }
 
   handleEdit(key, editing, index = null) {
+    this.setState({ editing });
     const chapterName = `${key}${index === null ? '' : index}`;
     this.props.onEdit(key, editing, index);
     this.scrollToPage(chapterName);
@@ -262,7 +263,7 @@ export default class ReviewCollapsibleChapter extends React.Component {
                 aria-controls={`collapsible-${this.id}`}
                 onClick={this.props.toggleButtonClicked}
               >
-                {chapterTitle || ''}
+                {`${this.state.editing ? 'Edit' : ''} ${chapterTitle || ''}`}
               </button>
               {showUnviewedPageWarning && (
                 <span className="schemaform-review-chapter-warning-icon" />

--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -44,5 +44,4 @@ export default Object.freeze({
   showEduBenefits5490Wizard: 'show_edu_benefits_5490_wizard',
   showEduBenefits1990EWizard: 'show_edu_benefits_1990e_wizard',
   showEduBenefits1990Wizard: 'show_edu_benefits_1990_wizard',
-  formsA11yfix4613: 'forms_a11y_fix_4613',
 });

--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -44,4 +44,5 @@ export default Object.freeze({
   showEduBenefits5490Wizard: 'show_edu_benefits_5490_wizard',
   showEduBenefits1990EWizard: 'show_edu_benefits_1990e_wizard',
   showEduBenefits1990Wizard: 'show_edu_benefits_1990_wizard',
+  formsA11yfix4613: 'forms_a11y_fix_4613',
 });


### PR DESCRIPTION
## Description

### Closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/4613

On the review page at the end of a form, when a user opens a collapsed section and clicks "Edit", the chapter header will now be prepended with "Edit" and will also grab focus.


This seems to go against the decisions made in [this PR](https://github.com/department-of-veterans-affairs/vets-website/pull/11847).

## Testing done

Local environment testing to see that it behaves as expected.


## Screenshots



<details>
<summary>A somewhat choppy gif demonstrating the header getting prepended with "Edit" and it grabbing focus</summary>

![a117y-4613](https://user-images.githubusercontent.com/2008881/90060580-cca9ab80-dc99-11ea-90ce-9fcc5b427740.gif)

</details>


## Acceptance criteria
- [x] Focus should move from the hidden edit button to the first focusable elements inside the expanded accordion.
- [ ]  Once focus has moved, there should be a message to indicate that the area is interactive

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
