### PR TITLE
Send SIGINT to child process

### DIFF
--- a/script/utils.js
+++ b/script/utils.js
@@ -5,6 +5,11 @@ const runCommand = (cmd, forcedExitCode = null) => {
   child.on('exit', code => {
     process.exit(forcedExitCode === null ? code : forcedExitCode);
   });
+
+  // When we ^C out of the parent Node script, also interrupt the child
+  process.on('SIGINT', () => {
+    child.kill('SIGINT');
+  });
 };
 
 module.exports = {


### PR DESCRIPTION
## Description
Previously, ^C-ing out of a `yarn watch` wouldn't stop the child process. This fixes that.

## Testing done
Tested locally.
