### PR TITLE
Change z-index of mobile subnav

### DIFF
--- a/src/applications/personalization/profile-2/sass/profile-mobile-subnav.scss
+++ b/src/applications/personalization/profile-2/sass/profile-mobile-subnav.scss
@@ -2,7 +2,7 @@
   .the-menu {
     // setting to `relative` so the z-index is actually used
     position: relative;
-    z-index: 1; // the megamenu is at 2 so this must be below that.
+    z-index: $middle-layer; // This needs to sit behind the mega menu's #vetnav which is set to $top-layer on mobile in the _m-layers.scss
 
     &.fixed {
       position: fixed;

--- a/src/applications/personalization/profile-2/sass/profile-mobile-subnav.scss
+++ b/src/applications/personalization/profile-2/sass/profile-mobile-subnav.scss
@@ -2,7 +2,7 @@
   .the-menu {
     // setting to `relative` so the z-index is actually used
     position: relative;
-    z-index: $top-layer;
+    z-index: 1; // the megamenu is at 2 so this must be below that.
 
     &.fixed {
       position: fixed;


### PR DESCRIPTION
## Description
This places the profile's mobile subnav below the Mega Menu where it belongs.

## Testing done
Local

## Screenshots
![menu-layers-fixed](https://user-images.githubusercontent.com/20728956/89969214-b4d71680-dc0a-11ea-81d1-4568bed306a7.gif)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs