### PR TITLE
Show service type name in search result subhead for VA benefits

### DIFF
--- a/src/applications/facility-locator/components/SearchResultsHeader.jsx
+++ b/src/applications/facility-locator/components/SearchResultsHeader.jsx
@@ -1,6 +1,11 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { facilityTypes, urgentCareServices, healthServices } from '../config';
+import {
+  facilityTypes,
+  urgentCareServices,
+  healthServices,
+  benefitsServices,
+} from '../config';
 import { LocationType } from '../constants';
 import { connect } from 'react-redux';
 
@@ -29,6 +34,10 @@ export const SearchResultsHeader = ({
 
     if (facilityType === LocationType.CC_PROVIDER) {
       return specialtyMap[rawServiceType];
+    }
+
+    if (facilityType === LocationType.BENEFITS) {
+      return benefitsServices[rawServiceType];
     }
 
     return rawServiceType;

--- a/src/applications/facility-locator/tests/components/search-results/SearchResultsHeader.unit.spec.jsx
+++ b/src/applications/facility-locator/tests/components/search-results/SearchResultsHeader.unit.spec.jsx
@@ -89,5 +89,21 @@ describe('SearchResultsHeader', () => {
     wrapper.unmount();
   });
 
+  it('should render header with LocationType.BENEFITS', () => {
+    const wrapper = shallow(
+      <SearchResultsHeader
+        results={[{}]}
+        facilityType={LocationType.BENEFITS}
+        serviceType="ApplyingForBenefits"
+        context="new york"
+      />,
+    );
+
+    expect(wrapper.find('h2').text()).to.match(
+      /Results for "VA benefits",\s+"Applying for benefits"\s+near\s+"new york"/,
+    );
+    wrapper.unmount();
+  });
+
   // TODO: find a way to unit test the React.memo behavior
 });


### PR DESCRIPTION
https://github.com/department-of-veterans-affairs/va.gov-team/issues/12428

## Acceptance criteria
- [x] Subhead shows service type name, not code, when searching for VA benefits

## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)

