### PR TITLE
Fix the content watch

### DIFF
--- a/src/site/stages/build/options.js
+++ b/src/site/stages/build/options.js
@@ -8,9 +8,11 @@ const ENVIRONMENTS = require('../../constants/environments');
 const HOSTNAMES = require('../../constants/hostnames');
 const assetSources = require('../../constants/assetSources');
 
+const projectRoot = path.resolve(__dirname, '../../../../');
+
 const defaultBuildtype = ENVIRONMENTS.LOCALHOST;
 const defaultHost = HOSTNAMES[defaultBuildtype];
-const defaultContentDir = '../../../../../vagov-content/pages';
+const defaultContentDir = path.join(projectRoot, '../vagov-content/pages');
 
 const getDrupalClient = require('./drupal/api');
 const { shouldPullDrupal } = require('./drupal/metalsmith-drupal');
@@ -76,7 +78,6 @@ function applyDefaultOptions(options) {
   const contentPagesRoot = options['content-directory'];
   const contentRoot = path.join(contentPagesRoot, '../');
 
-  const projectRoot = path.resolve(__dirname, '../../../../');
   const siteRoot = path.join(__dirname, '../../');
   const includes = path.join(siteRoot, 'includes');
   const components = path.join(siteRoot, 'components');


### PR DESCRIPTION
## Description
Previously, editing a markdown file didn't trigger the content build during a
`yarn watch:static`. Using an absolute path for the content directory seems to
do the trick, though.

## Testing done
1. `yarn watch:static`
1. Edit a markdown file in `vagov-content`
1. Watch the `watch` task re-run the `metalsmith` task

## Screenshots
![image](https://user-images.githubusercontent.com/12970166/90063850-cff36600-dc9e-11ea-8413-53c890f8e916.png)

