### PR TITLE
Revert "VAVFS-10002: Remove legacy mobile nav button."

### DIFF
--- a/src/platform/site-wide/sass/modules/_m-layers.scss
+++ b/src/platform/site-wide/sass/modules/_m-layers.scss
@@ -34,3 +34,6 @@
     z-index: $middle-layer;
   }
 }
+.va-btn-sidebarnav-trigger {
+  z-index: $top-layer + 1;
+}

--- a/src/site/components/navigation-sidebar-trigger.html
+++ b/src/site/components/navigation-sidebar-trigger.html
@@ -1,0 +1,46 @@
+{% comment %}
+
+=====================
+Navigation side bar trigger
+=====================
+
+Used to open or close the side bar navigation bar on mobile screens. Must be
+used in a template with navigation-sidebar.html
+
+{% endcomment %}
+{% if buildtype == 'vagovprod' %}
+  <button type="button" class="va-btn-sidebarnav-trigger vads-u-width--full"
+    aria-controls="va-detailpage-sidebar">
+    <span>
+      <b>More in this section</b>
+      {% include "src/site/assets/img/arrow-right-white.svg" %}
+    </span>
+  </button>
+
+
+  <script type="text/javascript">
+    var mobileMediaQuery = window.matchMedia('(max-width: 767px)');
+    var element = document.getElementsByClassName("va-btn-sidebarnav-trigger")[0];
+    var offset;
+
+    if (mobileMediaQuery.matches) {
+      offset = element.offsetTop;
+    }
+
+    window.addEventListener("resize", function () {
+      if (mobileMediaQuery.matches) {
+        offset = element.offsetTop;
+      }
+    }, false);
+
+    window.addEventListener("scroll", function () {
+      if (mobileMediaQuery.matches) {
+        if (offset < window.pageYOffset) {
+          element.classList.add("fixed-trigger");
+        } else {
+          element.classList.remove("fixed-trigger");
+        }
+      }
+    }, false);
+  </script>
+{% endif %}

--- a/src/site/includes/detail-page.html
+++ b/src/site/includes/detail-page.html
@@ -10,6 +10,9 @@
 {% endcomment %}
 
 <main class="va-l-detail-page">
+  {% if hidesidenav == empty %}
+    {% include "src/site/components/navigation-sidebar-trigger.html" with menuId = "va-detailpage-sidebar" %}
+  {% endif %}
   <div class="vads-l-grid-container large-screen:vads-u-padding-x--0">
     <div class="vads-l-row vads-u-margin-x--neg2p5">
       {% if hidesidenav == empty %}

--- a/src/site/layouts/bios_page.drupal.liquid
+++ b/src/site/layouts/bios_page.drupal.liquid
@@ -44,6 +44,7 @@
             {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with sidebarData = facilitySidebar %}
 
             <div class="usa-width-three-fourths">
+                {% include "src/site/components/navigation-sidebar-trigger.html" with menuId = "va-detailpage-sidebar" %}
                 <article class="usa-content">
                     <h1 class="vads-u-margin-bottom--3">Our leadership team</h1>
                     {% for bio in pagedItems %}

--- a/src/site/layouts/event.drupal.liquid
+++ b/src/site/layouts/event.drupal.liquid
@@ -120,6 +120,7 @@ Ultimately, we will allow check to use user timezone.
 
         {% comment %} Content {% endcomment %}
         <div class="usa-width-three-fourths">
+          {% include "src/site/components/navigation-sidebar-trigger.html" with menuId = "va-detailpage-sidebar" %}
           {% if !entityPublished %}
             <div class="usa-alert usa-alert-info">
               <div class="usa-alert-body">
@@ -260,6 +261,7 @@ Ultimately, we will allow check to use user timezone.
     {% endcomment %}
     {% else %}
       <div class="usa-grid usa-grid-full">
+        {% include "src/site/components/navigation-sidebar-trigger.html" with menuId = "va-detailpage-sidebar" %}
         {% if !entityPublished %}
           <div class="usa-alert usa-alert-info">
             <div class="usa-alert-body">

--- a/src/site/layouts/event_listing.drupal.liquid
+++ b/src/site/layouts/event_listing.drupal.liquid
@@ -12,6 +12,7 @@
         {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with sidebarData = facilitySidebar%}
       {% endif %}
       <div class="usa-width-three-fourths">
+        {% include "src/site/components/navigation-sidebar-trigger.html" with menuId = "va-detailpage-sidebar" %}
 
         <article aria-labelledby="article-heading" class="vads-l-grid-container--full" role="region">
           <div class="vads-l-grid-container--full">

--- a/src/site/layouts/events_page.drupal.liquid
+++ b/src/site/layouts/events_page.drupal.liquid
@@ -52,6 +52,7 @@ Example data:
     <div class="usa-grid usa-grid-full">
       {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with sidebarData = facilitySidebar %}
       <div class="usa-width-three-fourths">
+        {% include "src/site/components/navigation-sidebar-trigger.html" with menuId = "va-detailpage-sidebar" %}
         <article class="usa-content">
           <h1>Events</h1>
           <div class="va-introtext vads-u-margin-bottom--6">

--- a/src/site/layouts/health_care_facility_status.drupal.liquid
+++ b/src/site/layouts/health_care_facility_status.drupal.liquid
@@ -7,6 +7,7 @@
         <div class="usa-grid usa-grid-full">
             {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with sidebarData = facilitySidebar %}
             <div class="usa-width-three-fourths">
+                {% include "src/site/components/navigation-sidebar-trigger.html" with menuId = "va-detailpage-sidebar" %}
 
                 <article class="usa-content">
                     <h1 class="vads-u-margin-bottom--2">Operating status</h1>

--- a/src/site/layouts/health_care_local_facility.drupal.liquid
+++ b/src/site/layouts/health_care_local_facility.drupal.liquid
@@ -217,6 +217,7 @@ more.\r\n",
     <div class="usa-grid usa-grid-full">
       {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with sidebarData = facilitySidebar %}
       <div class="usa-width-three-fourths">
+        {% include "src/site/components/navigation-sidebar-trigger.html" with menuId = "va-detailpage-sidebar" %}
         {% if !entityPublished %}
         <div class="usa-alert usa-alert-info">
           <div class="usa-alert-body">

--- a/src/site/layouts/health_care_region_detail_page.drupal.liquid
+++ b/src/site/layouts/health_care_region_detail_page.drupal.liquid
@@ -79,6 +79,7 @@
           {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with sidebarData = facilitySidebar %}
         {% endif %}
         <div class="usa-width-three-fourths">
+        {% include "src/site/components/navigation-sidebar-trigger.html" with menuId = "va-detailpage-sidebar" %}
           <article aria-labelledby="article-heading" role="region" class="usa-content">
             <h1 id="article-heading">{{ title }}</h1>
             <div class="va-introtext">

--- a/src/site/layouts/health_care_region_health_services_page.drupal.liquid
+++ b/src/site/layouts/health_care_region_health_services_page.drupal.liquid
@@ -7,6 +7,7 @@
     <div class="usa-grid usa-grid-full">
         {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with sidebarData = facilitySidebar %}
         <div class="usa-width-three-fourths">
+            {% include "src/site/components/navigation-sidebar-trigger.html" with menuId = "va-detailpage-sidebar" %}
             <article class="usa-content">
                 <h1 class="vads-u-margin-bottom--1 medium-screen:vads-u-margin-bottom--2">Health services</h1>
                 <div class="va-introtext">{{ fieldClinicalHealthServi.processed }}</div>

--- a/src/site/layouts/health_care_region_locations_page.drupal.liquid
+++ b/src/site/layouts/health_care_region_locations_page.drupal.liquid
@@ -7,6 +7,7 @@
     <div class="usa-grid usa-grid-full">
       {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with sidebarData = facilitySidebar %}
       <div class="usa-width-three-fourths">
+        {% include "src/site/components/navigation-sidebar-trigger.html" with menuId = "va-detailpage-sidebar" %}
 
         <article class="usa-content">
           <h1 class="vads-u-margin-bottom--2">Locations</h1>

--- a/src/site/layouts/health_care_region_page.drupal.liquid
+++ b/src/site/layouts/health_care_region_page.drupal.liquid
@@ -129,6 +129,7 @@ Example data:
     <div class="usa-grid usa-grid-full">
       {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with sidebarData = facilitySidebar %}
       <div class="usa-width-three-fourths">
+        {% include "src/site/components/navigation-sidebar-trigger.html" with menuId = "va-detailpage-sidebar" %}
         {% if !entityPublished %}
         <div class="usa-alert usa-alert-info">
           <div class="usa-alert-body">

--- a/src/site/layouts/health_services_listing.drupal.liquid
+++ b/src/site/layouts/health_services_listing.drupal.liquid
@@ -7,6 +7,7 @@
     <div class="usa-grid usa-grid-full">
       {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with sidebarData = facilitySidebar %}
       <div class="usa-width-three-fourths">
+        {% include "src/site/components/navigation-sidebar-trigger.html" with menuId = "va-detailpage-sidebar" %}
         <article class="usa-content">
           <h1 class="vads-u-margin-bottom--1 medium-screen:vads-u-margin-bottom--2">
             {{title}}</h1>

--- a/src/site/layouts/leadership_listing.drupal.liquid
+++ b/src/site/layouts/leadership_listing.drupal.liquid
@@ -45,6 +45,7 @@ Example data:
             {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with sidebarData = facilitySidebar %}
 
             <div class="usa-width-three-fourths">
+                {% include "src/site/components/navigation-sidebar-trigger.html" with menuId = "va-detailpage-sidebar" %}
                 <article class="usa-content">
                     <h1 class="vads-u-margin-bottom--3">{{ title }}</h1>
                         {% if fieldIntroText %}

--- a/src/site/layouts/locations_listing.drupal.liquid
+++ b/src/site/layouts/locations_listing.drupal.liquid
@@ -7,6 +7,7 @@
         <div class="usa-grid usa-grid-full">
             {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with sidebarData = facilitySidebar %}
             <div class="usa-width-three-fourths">
+                {% include "src/site/components/navigation-sidebar-trigger.html" with menuId = "va-detailpage-sidebar" %}
 
                 <article class="usa-content">
                     <h1 class="vads-u-margin-bottom--2">{{title}}</h1>

--- a/src/site/layouts/news_stories_page.drupal.liquid
+++ b/src/site/layouts/news_stories_page.drupal.liquid
@@ -55,6 +55,7 @@ Example data:
     <div class="usa-grid usa-grid-full">
       {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with sidebarData = facilitySidebar %}
       <div class="usa-width-three-fourths">
+       {% include "src/site/components/navigation-sidebar-trigger.html" with menuId = "va-detailpage-sidebar" %}
         <article class="usa-content">
             <h1 id="article-heading">{{ title }}</h1>
             <div class="vads-l-grid-container--full">

--- a/src/site/layouts/news_story.drupal.liquid
+++ b/src/site/layouts/news_story.drupal.liquid
@@ -70,6 +70,7 @@ Example data:
 
                 {% comment %} Content {% endcomment %}
                 <div class="usa-width-three-fourths">
+                    {% include "src/site/components/navigation-sidebar-trigger.html" with menuId = "va-detailpage-sidebar" %}
                     {% if !entityPublished %}
                         <div class="usa-alert usa-alert-info" >
                             <div class="usa-alert-body">
@@ -109,6 +110,7 @@ Example data:
         {% comment %} On non-prod environments, do not show the SideNav. {% endcomment %}
         {% else %}
             <div class="usa-grid usa-grid-full">
+                {% include "src/site/components/navigation-sidebar-trigger.html" with menuId = "va-detailpage-sidebar" %}
                 {% if !entityPublished %}
                     <div class="usa-alert usa-alert-info" >
                         <div class="usa-alert-body">

--- a/src/site/layouts/office.drupal.liquid
+++ b/src/site/layouts/office.drupal.liquid
@@ -9,6 +9,7 @@
     <div class="usa-grid usa-grid-full">
       {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with sidebarData = outreachSidebar %}
       <div class="usa-width-three-fourths">
+        {% include "src/site/components/navigation-sidebar-trigger.html" with menuId = "va-detailpage-sidebar" %}
         {% if !entityPublished %}
         <div class="usa-alert usa-alert-info">
           <div class="usa-alert-body">

--- a/src/site/layouts/page.drupal.liquid
+++ b/src/site/layouts/page.drupal.liquid
@@ -13,6 +13,10 @@
 
       <div class="usa-width-three-fourths">
 
+        {% if sidebar.links != empty %}
+          {% include "src/site/components/navigation-sidebar-trigger.html" with menuId = "va-detailpage-sidebar" %}
+        {% endif %}
+
         {% if !entityPublished %}
           <div class="usa-alert usa-alert-info" >
             <div class="usa-alert-body">

--- a/src/site/layouts/person_profile.drupal.liquid
+++ b/src/site/layouts/person_profile.drupal.liquid
@@ -47,6 +47,7 @@
                 {% include 'src/site/navigation/facility_no_drupal_page_sidebar_nav.drupal.liquid' with entityUrl = entityUrl, sidebarData = sidebarData %}
             {%  endif %}
             <div class="usa-width-three-fourths">
+                {% include "src/site/components/navigation-sidebar-trigger.html" with menuId = "va-detailpage-sidebar" %}
                 {% if !entityPublished %}
                     <div class="usa-alert usa-alert-info" >
                         <div class="usa-alert-body">

--- a/src/site/layouts/press_release.drupal.liquid
+++ b/src/site/layouts/press_release.drupal.liquid
@@ -106,6 +106,7 @@
 
                 {% comment %} Content {% endcomment %}
                 <div class="usa-width-three-fourths">
+                    {% include "src/site/components/navigation-sidebar-trigger.html" with menuId = "va-detailpage-sidebar" %}
                     <article class="usa-content">
                         <section class="vads-u-margin-bottom--5">
                             <h1 class="vads-u-margin-bottom--2p5">{{ title }}</h1>
@@ -176,6 +177,7 @@
         {% comment %} On non-prod environments, do not show the SideNav. {% endcomment %}
         {% else %}
             <div class="usa-grid usa-grid-full">
+                {% include "src/site/components/navigation-sidebar-trigger.html" with menuId = "va-detailpage-sidebar" %}
                 <article class="usa-content">
                     <section class="vads-u-margin-bottom--5">
                         <h1 class="vads-u-margin-bottom--2p5">{{ title }}</h1>

--- a/src/site/layouts/press_releases_listing.drupal.liquid
+++ b/src/site/layouts/press_releases_listing.drupal.liquid
@@ -58,6 +58,7 @@ larger space in the Fayette Plaza at 627 Pittsburgh Road, Suite 2, Uniontown,
       {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with sidebarData = facilitySidebar %}
 
       <div class="usa-width-three-fourths">
+        {% include "src/site/components/navigation-sidebar-trigger.html" with menuId = "va-detailpage-sidebar" %}
         <article class="usa-content">
           <h1 id="article-heading">{{ title }}</h1>
           <div class="vads-l-grid-container--full">

--- a/src/site/layouts/press_releases_page.drupal.liquid
+++ b/src/site/layouts/press_releases_page.drupal.liquid
@@ -52,6 +52,7 @@ Example data:
       {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with sidebarData = facilitySidebar %}
 
       <div class="usa-width-three-fourths">
+       {% include "src/site/components/navigation-sidebar-trigger.html" with menuId = "va-detailpage-sidebar" %}
         <article class="usa-content">
           <h1 class="vads-u-margin-bottom--5">News releases</h1>
           {% for pr in pagedItems %}

--- a/src/site/layouts/publication_listing.drupal.liquid
+++ b/src/site/layouts/publication_listing.drupal.liquid
@@ -9,6 +9,7 @@
     <div class="usa-grid usa-grid-full">
       {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with sidebarData = outreachSidebar %}
       <div class="usa-width-three-fourths">
+        {% include "src/site/components/navigation-sidebar-trigger.html" with menuId = "va-detailpage-sidebar" %}
         {% if !entityPublished %}
         <div class="usa-alert usa-alert-info">
           <div class="usa-alert-body">

--- a/src/site/layouts/story_listing.drupal.liquid
+++ b/src/site/layouts/story_listing.drupal.liquid
@@ -55,6 +55,7 @@ Example data:
     <div class="usa-grid usa-grid-full">
       {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with sidebarData = facilitySidebar %}
       <div class="usa-width-three-fourths">
+       {% include "src/site/components/navigation-sidebar-trigger.html" with menuId = "va-detailpage-sidebar" %}
         <article class="usa-content">
             <h1 id="article-heading">{{ title }}</h1>
             <div class="vads-l-grid-container--full">

--- a/src/site/layouts/vamc_operating_status_and_alerts.drupal.liquid
+++ b/src/site/layouts/vamc_operating_status_and_alerts.drupal.liquid
@@ -12,6 +12,7 @@
         <div class="usa-grid usa-grid-full">
             {% include 'src/site/navigation/facility_sidebar_nav.drupal.liquid' with sidebarData = facilitySidebar %}
             <div class="usa-width-three-fourths">
+                {% include "src/site/components/navigation-sidebar-trigger.html" with menuId = "va-detailpage-sidebar" %}
 
                 <article class="usa-content">
                     <h1 class="vads-u-margin-bottom--2">Operating status</h1>


### PR DESCRIPTION
Reverts department-of-veterans-affairs/vets-website#13157

The pull request above removed the trigger button for the sidebar on mobile devices for _all_ pages, whereas it should have removed it for only the Pittsburgh Health Care section of the website. This is a bug, meaning that the side nav is not accessible at all on mobile devices from the benefit pages.