### PR TITLE
bradl3yC - Correct download links for debt letters

### DIFF
--- a/src/applications/debt-letters/components/DebtLettersList.jsx
+++ b/src/applications/debt-letters/components/DebtLettersList.jsx
@@ -33,8 +33,7 @@ const DebtLettersList = ({ debtLinks, isVBMSError }) => {
     </div>
   );
 
-  const handleDownloadClick = (event, type, date) => {
-    event.preventDefault();
+  const handleDownloadClick = (type, date) => {
     return recordEvent({
       event: 'bam-debt-letter-download',
       'letter-type': type,
@@ -78,9 +77,10 @@ const DebtLettersList = ({ debtLinks, isVBMSError }) => {
                     </td>
                     <td className="vads-u-border--0">
                       <a
+                        target="_blank"
+                        rel="noopener noreferrer"
                         onClick={event =>
                           handleDownloadClick(
-                            event,
                             debtLetter.typeDescription,
                             moment(debtLetter.receivedAt).format('MMM D, YYYY'),
                           )
@@ -105,7 +105,7 @@ const DebtLettersList = ({ debtLinks, isVBMSError }) => {
                         </span>{' '}
                         letter{' '}
                         <span className="sr-only">
-                          `dated $
+                          dated{' '}
                           {moment(debtLetter.receivedAt).format('MMM D, YYYY')}`
                         </span>{' '}
                         <dfn>


### PR DESCRIPTION
## Description
Currently the download links in staging are not working because of a preventDefault invocation

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
