### PR TITLE
Remove text from FL intro

### DIFF
--- a/src/applications/facility-locator/containers/VAMap.jsx
+++ b/src/applications/facility-locator/containers/VAMap.jsx
@@ -748,11 +748,6 @@ class VAMap extends Component {
           <p>
             <strong>Coronavirus update:</strong> {coronavirusUpdate}
           </p>
-          <p>
-            <strong>Need same-day care for a minor illness or injury?</strong>{' '}
-            Select Urgent care under facility type, then select either VA or
-            community providers as the service type.
-          </p>
         </div>
         {isMobile ? this.renderMobileView() : this.renderDesktopView()}
       </div>


### PR DESCRIPTION
https://github.com/department-of-veterans-affairs/va.gov-team/issues/12232

## Description
Remove paragraph of text below the Coronavirus update.

This was an additional requirement [added](https://github.com/department-of-veterans-affairs/va.gov-team/issues/12232#issuecomment-673177624) after the first PR was merged.

## Acceptance criteria
- [x] Text removed

## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
