### PR TITLE
Add "TTY: " in front of 711 <Telephone /> numbers

### DIFF
--- a/src/applications/caregivers/components/NeedHelpFooter/index.jsx
+++ b/src/applications/caregivers/components/NeedHelpFooter/index.jsx
@@ -50,7 +50,7 @@ const NeedHelpFooter = props => {
           />
           .<br />
           <span>
-            If you have hearing loss, call{' '}
+            If you have hearing loss, call TTY:{' '}
             <Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />.
           </span>
         </p>

--- a/src/applications/disability-benefits/2346/components/FooterInfo.jsx
+++ b/src/applications/disability-benefits/2346/components/FooterInfo.jsx
@@ -8,7 +8,7 @@ const FooterInfo = () => (
   <section className="need-help-footer row vads-u-padding-x--1p5">
     For benefit-related questions, or if the form isn’t working right, please
     call VA Benefits and Services at <a href="tel:800-827-1000">800-827-1000</a>
-    . If you have hearing loss, call{' '}
+    . If you have hearing loss, call TTY:{' '}
     <Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />.
   </section>
 );

--- a/src/applications/disability-benefits/686c-674/components/GetFormHelp.jsx
+++ b/src/applications/disability-benefits/686c-674/components/GetFormHelp.jsx
@@ -13,7 +13,7 @@ const GetFormHelp = () => (
     </a>
     .<br />
     <br />
-    If you have hearing loss, call{' '}
+    If you have hearing loss, call TTY:{' '}
     <Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />.
   </p>
 );

--- a/src/applications/disability-benefits/686c-674/config/helpers.js
+++ b/src/applications/disability-benefits/686c-674/config/helpers.js
@@ -55,7 +55,7 @@ export const ServerErrorAlert = (
       <a href="tel:8446982311" aria-label="8 4 4. 6 9 8. 2 3 1 1.">
         844-698-2311
       </a>{' '}
-      (<Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />
+      (TTY: <Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />
       ). We’re here Monday through Friday, 8:00 a.m. to 8:00 p.m. ET.
     </p>
   </>

--- a/src/applications/disability-benefits/996/components/GetFormHelp.jsx
+++ b/src/applications/disability-benefits/996/components/GetFormHelp.jsx
@@ -17,7 +17,7 @@ const GetFormHelp = () => (
     </a>
     .<br />
     <br />
-    If you have hearing loss, call{' '}
+    If you have hearing loss, call TTY:{' '}
     <Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />.
   </p>
 );

--- a/src/applications/disability-benefits/all-claims/containers/MissingServices.jsx
+++ b/src/applications/disability-benefits/all-claims/containers/MissingServices.jsx
@@ -23,7 +23,7 @@ export const MissingServices = () => {
       <p>
         We need more information from you before you can file for disability
         compensation. Please call Veterans Benefits Assistance at{' '}
-        <Telephone contact={CONTACTS.VA_BENEFITS} /> (
+        <Telephone contact={CONTACTS.VA_BENEFITS} /> (TTY:{' '}
         <Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />
         ), Monday through Friday, 8:00 a.m. to 9:00 p.m. ET to update your
         account.
@@ -43,7 +43,7 @@ export const MissingId = ({ children }) => {
         We don’t have all of your ID information for your account. We need this
         information before you can file for disability compensation. To update
         your account, please call Veterans Benefits Assistance at{' '}
-        <Telephone contact={CONTACTS.VA_BENEFITS} /> (
+        <Telephone contact={CONTACTS.VA_BENEFITS} /> (TTY:
         <Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />
         ). We’re here Monday through Friday, 8:00 a.m. to 9:00 p.m. ET.
       </p>

--- a/src/applications/facility-locator/components/VABenefitsCall.jsx
+++ b/src/applications/facility-locator/components/VABenefitsCall.jsx
@@ -16,7 +16,7 @@ export default function VABenefitsCall() {
         <strong>To get help with benefits</strong>, call{' '}
         <Telephone contact={CONTACTS.VA_BENEFITS} /> toll-free. We’re here
         Monday through Friday, 8:00 a.m. to 9:00 p.m. ET. If you have hearing{' '}
-        loss, call{' '}
+        loss, call TTY:{' '}
         <Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />.
       </p>
       <p className="p1">

--- a/src/applications/personalization/profile-2/components/direct-deposit/FraudVictimAlert.jsx
+++ b/src/applications/personalization/profile-2/components/direct-deposit/FraudVictimAlert.jsx
@@ -20,7 +20,7 @@ const FraudVictimAlert = () => (
     >
       800-827-1000
     </a>{' '}
-    (<Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />
+    (TTY: <Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />
     ). We’re here Monday through Friday, 8:00 a.m. to 9:00 p.m. ET.
   </AlertBox>
 );

--- a/src/applications/personalization/profile360/components/PaymentInformationBlocked.jsx
+++ b/src/applications/personalization/profile360/components/PaymentInformationBlocked.jsx
@@ -27,7 +27,7 @@ export default function PaymentInformationBlocked() {
         >
           855-574-7286
         </a>{' '}
-        (<Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />
+        (TTY: <Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />
         ). We’re here Monday &#8211; Friday, 8 a.m. &#8211; 8 p.m. ET.
       </p>
     </AlertBox>

--- a/src/applications/personalization/profile360/components/PaymentInformationEditModalError.jsx
+++ b/src/applications/personalization/profile360/components/PaymentInformationEditModalError.jsx
@@ -29,7 +29,7 @@ function FlaggedAccount() {
         <span className="no-wrap">
           <a href="tel:1-800-827-1000">800-827-1000</a>
         </span>{' '}
-        (<Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />
+        (TTY: <Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />
         ). We’re here Monday through Friday, 8:00 a.m. to 9:00 p.m. ET.
       </p>
     </>
@@ -46,7 +46,7 @@ function FlaggedRoutingNumber() {
         <span className="no-wrap">
           <a href="tel:1-800-827-1000">800-827-1000</a>
         </span>{' '}
-        (<Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />
+        (TTY: <Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />
         ). We’re here Monday through Friday, 8:00 a.m. to 9:00 p.m. ET.
       </p>
       <p>

--- a/src/applications/personalization/profile360/containers/PaymentInformation.jsx
+++ b/src/applications/personalization/profile360/containers/PaymentInformation.jsx
@@ -228,7 +228,8 @@ class PaymentInformation extends React.Component {
               <a href="tel:1-800-827-1000" className="no-wrap">
                 800-827-1000
               </a>{' '}
-              (<Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />
+              (TTY:{' '}
+              <Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />
               ). We’re here Monday through Friday, 8:00 a.m. to 9:00 p.m. ET.
             </p>
           )}

--- a/src/applications/personalization/profile360/tests/components/PaymentInformationEditModalError.unit.spec.jsx
+++ b/src/applications/personalization/profile360/tests/components/PaymentInformationEditModalError.unit.spec.jsx
@@ -277,7 +277,7 @@ describe('<PaymentInformationEditModalError />', () => {
       />,
     );
     expect(wrapper.html()).to.contain(
-      'We’re sorry. The bank routing number you entered requires additional verification before we can save your information. To use this bank routing number, you’ll need to call us at <span class="no-wrap"><a href="tel:1-800-827-1000">800-827-1000</a></span> (<a class="no-wrap " href="tel:+1711" aria-label="TTY: 7 1 1.">711</a>). We’re here Monday through Friday, 8:00 a.m. to 9:00 p.m. ET.',
+      'We’re sorry. The bank routing number you entered requires additional verification before we can save your information. To use this bank routing number, you’ll need to call us at <span class="no-wrap"><a href="tel:1-800-827-1000">800-827-1000</a></span> (TTY: <a class="no-wrap " href="tel:+1711" aria-label="TTY: 7 1 1.">711</a>). We’re here Monday through Friday, 8:00 a.m. to 9:00 p.m. ET.',
     );
     wrapper.unmount();
   });

--- a/src/applications/personalization/rated-disabilities/components/RatedDisabilityList.jsx
+++ b/src/applications/personalization/rated-disabilities/components/RatedDisabilityList.jsx
@@ -45,7 +45,8 @@ class RatedDisabilityList extends React.Component {
             >
               844-698-2311
             </a>{' '}
-            (<Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />
+            (TTY:{' '}
+            <Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />
             ). We’re here Monday-Friday, 8:00 a.m.-8:00 p.m. ET.
           </p>
         </>

--- a/src/applications/personalization/rated-disabilities/components/TotalRatingStates.jsx
+++ b/src/applications/personalization/rated-disabilities/components/TotalRatingStates.jsx
@@ -25,7 +25,7 @@ export const errorMessage = () => {
         >
           844-698-2311
         </a>{' '}
-        (<Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />
+        (TTY: <Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />
         ). We’re here Monday-Friday, 8:00 a.m.-8:00 p.m. ET.
       </p>
     </>

--- a/src/applications/personalization/view-dependents/layouts/helpers.jsx
+++ b/src/applications/personalization/view-dependents/layouts/helpers.jsx
@@ -16,7 +16,7 @@ export const errorFragment = (
       <a aria-label="8 4 4. 6 9 8. 2 3 1 1." href="tel:8446982311">
         844-698-2311
       </a>{' '}
-      (<Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />
+      (TTY: <Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />
       ). We're here Monday-Friday, 8:00a.m.-8:00p.m. ET.
     </p>
   </>

--- a/src/applications/static-pages/health-care-manage-benefits/schedule-view-va-appointments-page/components/AuthContent/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/schedule-view-va-appointments-page/components/AuthContent/index.js
@@ -182,8 +182,8 @@ export const AuthContent = () => (
       <a href="tel: 18774705947" aria-label="8 7 7. 4 7 0. 5 9 4 7.">
         877-470-5947
       </a>{' '}
-      (<Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} /> />).
-      We’re here Monday through Friday, 8:00 a.m. to 8:00 p.m. ET.
+      (TTY: <Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />{' '}
+      />). We’re here Monday through Friday, 8:00 a.m. to 8:00 p.m. ET.
     </p>
     <p>
       <strong>
@@ -193,8 +193,8 @@ export const AuthContent = () => (
       <a href="tel: 18666513180" aria-label="8 6 6. 6 5 1. 3 1 8 0.">
         866-651-3180
       </a>{' '}
-      (<Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} /> />).
-      We’re here Monday through Saturday, 7:00 a.m. to 11:00 p.m. ET.
+      (TTY: <Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />{' '}
+      />). We’re here Monday through Saturday, 7:00 a.m. to 11:00 p.m. ET.
     </p>
     <h3>For My VA Health questions</h3>
     <p>

--- a/src/applications/validate-mhv-account/components/errors/NeedsSSNResolution.jsx
+++ b/src/applications/validate-mhv-account/components/errors/NeedsSSNResolution.jsx
@@ -32,7 +32,7 @@ const NeedsSSNResolution = () => {
           <p>
             Please call us at <a href="tel:800-827-1000">800-827-1000</a>. We’re
             here Monday through Friday, 8:00 a.m. to 9:00 p.m. ET. If you have
-            hearing loss, call{' '}
+            hearing loss, call TTY:{' '}
             <Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />.
           </p>
           <p>

--- a/src/applications/validate-mhv-account/components/errors/NeedsVAPatient.jsx
+++ b/src/applications/validate-mhv-account/components/errors/NeedsVAPatient.jsx
@@ -25,7 +25,7 @@ const NeedsVAPatient = () => {
         <p>
           Call VA311 (<a href="tel:844-698-2311">844-698-2311</a>
           ), and select 3 to reach your nearest VA medical center. If you have
-          hearing loss, call{' '}
+          hearing loss, call TTY:{' '}
           <Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />.
         </p>
         <p>
@@ -42,7 +42,8 @@ const NeedsVAPatient = () => {
         <p>
           Call <a href="tel:844-698-2311">844-698-2311</a>, and select 3 to
           reach your nearest VA medical center. If you have hearing loss, call
-          <Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />.
+          TTY: <Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />
+          .
         </p>
         <p>
           Tell the representative that you’re enrolled in VA health care and

--- a/src/applications/validate-mhv-account/components/errors/VerificationFailed.jsx
+++ b/src/applications/validate-mhv-account/components/errors/VerificationFailed.jsx
@@ -33,7 +33,7 @@ const VerificationFailed = () => {
           <p>
             Please call us at <a href="tel:800-827-1000">800-827-1000</a>. We’re
             here Monday through Friday, 8:00 a.m. to 9:00 p.m. ET. If you have
-            hearing loss, call{' '}
+            hearing loss, call TTY:{' '}
             <Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />.
           </p>
           <p>

--- a/src/applications/vaos/components/NeedHelp.jsx
+++ b/src/applications/vaos/components/NeedHelp.jsx
@@ -18,13 +18,15 @@ export default function NeedHelp() {
       <p className="vads-u-margin-top--0">
         For help scheduling a VA or Community Care appointment, please call{' '}
         <a href="tel:8774705947">877-470-5947</a> (if you have hearing loss,
-        call <Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />
+        call TTY:{' '}
+        <Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />
         ). We’re here Monday &ndash; Friday, 8:00 a.m. to 8:00 p.m. ET.
       </p>
       <p className="vads-u-margin-top--0">
         For questions about joining a VA Video Connect appointment, please call{' '}
         <a href="tel:8666513180">866-651-3180</a> (if you have hearing loss,
-        call <Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />
+        call TTY:{' '}
+        <Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />
         ). We’re here Monday &ndash; Saturday, 7:00 a.m. to 11:00 p.m. ET.
       </p>
       <p className="vads-u-margin-top--0">

--- a/src/platform/site-wide/cta-widget/components/messages/NeedsSSNResolution.jsx
+++ b/src/platform/site-wide/cta-widget/components/messages/NeedsSSNResolution.jsx
@@ -28,7 +28,7 @@ const NeedsSSNResolution = () => {
           <p>
             Please call us at <a href="tel:800-827-1000">800-827-1000</a>. We’re
             here Monday through Friday, 8:00 a.m. to 9:00 p.m. ET. If you have
-            hearing loss, call{' '}
+            hearing loss, call TTY:{' '}
             <Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />.
           </p>
           <p>

--- a/src/platform/site-wide/cta-widget/components/messages/NeedsVAPatient.jsx
+++ b/src/platform/site-wide/cta-widget/components/messages/NeedsVAPatient.jsx
@@ -23,7 +23,7 @@ const NeedsVAPatient = () => {
         <p>
           Call VA311 (<a href="tel:844-698-2311">844-698-2311</a>
           ), and select 3 to reach your nearest VA medical center. If you have
-          hearing loss, call{' '}
+          hearing loss, call TTY:{' '}
           <Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />.
         </p>
         <p>
@@ -40,7 +40,8 @@ const NeedsVAPatient = () => {
         <p>
           Call <a href="tel:844-698-2311">844-698-2311</a>, and select 3 to
           reach your nearest VA medical center. If you have hearing loss, call
-          <Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />.
+          TTY: <Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />
+          .
         </p>
         <p>
           Tell the representative that you’re enrolled in VA health care and

--- a/src/platform/site-wide/cta-widget/components/messages/mvi/NotFound.jsx
+++ b/src/platform/site-wide/cta-widget/components/messages/mvi/NotFound.jsx
@@ -22,7 +22,7 @@ const NotFound = () => {
         <p>
           Please call us at <a href="tel:800-827-1000">800-827-1000</a>. We’re
           here Monday through Friday, 8:00 a.m. to 9:00 p.m. ET. If you have
-          hearing loss, call{' '}
+          hearing loss, call TTY:{' '}
           <Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />.
         </p>
         <p>

--- a/src/platform/site-wide/user-nav/components/HelpMenu.jsx
+++ b/src/platform/site-wide/user-nav/components/HelpMenu.jsx
@@ -32,7 +32,7 @@ function HelpMenu({ clickHandler, cssClass, isOpen }) {
         <a href="tel:18446982311">Call VA311: 844-698-2311</a>
       </p>
       <p>
-        <Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />
+        TTY: <Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />
       </p>
     </div>
   );

--- a/src/platform/static-data/CallHRC.jsx
+++ b/src/platform/static-data/CallHRC.jsx
@@ -9,7 +9,7 @@ export default function CallHRC({ startSentence }) {
     <span>
       {startSentence ? 'Call' : 'call'} us at{' '}
       <a href="tel:18555747286">855-574-7286</a>.<br />
-      If you have hearing loss, call{' '}
+      If you have hearing loss, call TTY:{' '}
       <Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />.
     </span>
   );

--- a/src/platform/static-data/CallNCACenter.jsx
+++ b/src/platform/static-data/CallNCACenter.jsx
@@ -9,7 +9,7 @@ export default function CallNCACenter({ startSentence }) {
     <span>
       {startSentence ? 'Call' : 'call'} the National Cemetery Scheduling Office
       at <a href="tel:18005351117">800-535-1117</a>.<br /> If you have hearing{' '}
-      loss, call{' '}
+      loss, call TTY:{' '}
       <Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />.
     </span>
   );

--- a/src/platform/static-data/CallVBACenter.jsx
+++ b/src/platform/static-data/CallVBACenter.jsx
@@ -9,7 +9,7 @@ export default function CallVBACenter({ startSentence }) {
     <span>
       {startSentence ? 'Call' : 'call'} VA Benefits and Services at{' '}
       <a href="tel:18008271000">800-827-1000</a>.<br /> If you have hearing{' '}
-      loss, call{' '}
+      loss, call TTY:{' '}
       <Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />.
     </span>
   );


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/12125

This PR adds `TTY: ` prefixed to 711 `<Telephone />` component numbers. I had mistakenly removed it because I thought the `<Telephone />` component would render it visually [due to this line](https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/blob/master/packages/formation-react/src/components/Telephone/Telephone.jsx#L37), but I actually just read that wrong lol

## Testing done
N/A

## Screenshots
N/A

## Acceptance criteria
- [x] Add back `TTY: ` for 711 numbers.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
