### PR TITLE
Sanlouise 12037 update faq links

### DIFF
--- a/src/applications/personalization/profile-2/components/AccountSecurityContent.jsx
+++ b/src/applications/personalization/profile-2/components/AccountSecurityContent.jsx
@@ -92,7 +92,7 @@ export const AccountSecurityContent = ({
             })
           }
         >
-          Go to VA.gov FAQs
+          Go to FAQs about signing in to VA.gov
         </a>
       </AlertBox>
     </>

--- a/src/applications/personalization/profile-2/components/connected-apps/ConnectedApps.jsx
+++ b/src/applications/personalization/profile-2/components/connected-apps/ConnectedApps.jsx
@@ -150,7 +150,7 @@ export class ConnectedApps extends Component {
                   'profile-section': 'vets-faqs',
                 })
               }
-              href="/sign-in-faq/"
+              href="/sign-in-faq/#connecting-third-party-(non-VA"
             >
               Go to FAQs about signing in to VA.gov
             </a>

--- a/src/applications/personalization/profile-2/components/connected-apps/ConnectedApps.jsx
+++ b/src/applications/personalization/profile-2/components/connected-apps/ConnectedApps.jsx
@@ -141,7 +141,6 @@ export class ConnectedApps extends Component {
             Have more questions about connected apps?
           </h3>
           <p>
-            Visit our{' '}
             <a
               className="vads-u-color--primary-alt-darkest"
               onClick={() =>
@@ -153,9 +152,8 @@ export class ConnectedApps extends Component {
               }
               href="/sign-in-faq/"
             >
-              frequently asked questions
+              Go to FAQs about signing in to VA.gov
             </a>
-            .
           </p>
         </div>
       </div>

--- a/src/applications/personalization/profile-2/tests/components/AccountSecurityContent.unit.spec.jsx
+++ b/src/applications/personalization/profile-2/tests/components/AccountSecurityContent.unit.spec.jsx
@@ -123,7 +123,9 @@ describe('AccountSecurityContent', () => {
     expect(alertBox.prop('backgroundOnly')).to.be.true;
     expect(alertBoxText.text()).to.contain('Get answers');
     expect(alertBoxLink.prop('href')).to.equal('/sign-in-faq/');
-    expect(alertBoxLink.text()).to.equal('Go to FAQs about signing in to VA.gov');
+    expect(alertBoxLink.text()).to.equal(
+      'Go to FAQs about signing in to VA.gov',
+    );
     wrapper.unmount();
   });
 });

--- a/src/applications/personalization/profile-2/tests/components/AccountSecurityContent.unit.spec.jsx
+++ b/src/applications/personalization/profile-2/tests/components/AccountSecurityContent.unit.spec.jsx
@@ -123,7 +123,7 @@ describe('AccountSecurityContent', () => {
     expect(alertBox.prop('backgroundOnly')).to.be.true;
     expect(alertBoxText.text()).to.contain('Get answers');
     expect(alertBoxLink.prop('href')).to.equal('/sign-in-faq/');
-    expect(alertBoxLink.text()).to.equal('Go to VA.gov FAQs');
+    expect(alertBoxLink.text()).to.equal('Go to FAQs about signing in to VA.gov');
     wrapper.unmount();
   });
 });


### PR DESCRIPTION
## Description
[TICKET](https://github.com/department-of-veterans-affairs/va.gov-team/issues/12037)

For context:
`There is a link to /sign-in-faqs on the account security and connected apps pages, but the links are labeled very differently and sort of seem to refer to very broad "va.gov faqs". I recommend working with Peggy on this to label these faqs consistently, potentially link to an anchor on the page for specific faqs, and ensure they they are represented as faqs specific to authentication and not just general faqs.`

Updated copy requirements found in [this ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/11972)

## Acceptance criteria
- [x] Update copy FAQ links
- [x] Update anchor link Connected Apps FAQ

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
