### PR TITLE
update vets-json-schema to 6.7.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -328,7 +328,7 @@
     "url-search-params-polyfill": "^8.1.0",
     "uswds": "1.6.10",
     "vanilla-lazyload": "^16.1.0",
-    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#ab5a7181ec2dabe32fc1ec3c8da6ed3c8c5f3f9f",
+    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#680f7d0b66c38667f13dd0573b9860779c438d87",
     "whatwg-fetch": "^2.0.3"
   },
   "resolutions": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -17111,9 +17111,9 @@ verror@1.3.6:
   dependencies:
     extsprintf "1.0.2"
 
-"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#ab5a7181ec2dabe32fc1ec3c8da6ed3c8c5f3f9f":
-  version "6.6.2"
-  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#ab5a7181ec2dabe32fc1ec3c8da6ed3c8c5f3f9f"
+"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#680f7d0b66c38667f13dd0573b9860779c438d87":
+  version "6.7.1"
+  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#680f7d0b66c38667f13dd0573b9860779c438d87"
 
 vinyl-file@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## Description
Update reference to `vets-json-schema`

https://github.com/department-of-veterans-affairs/vets-json-schema/pull/476

## Testing done
Confirmed version and hash in package.json is correct. 

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
