### PR TITLE
Convert Profile from float grid to flexbox grid

### DIFF
--- a/src/applications/personalization/profile-2/components/Profile2Wrapper.jsx
+++ b/src/applications/personalization/profile-2/components/Profile2Wrapper.jsx
@@ -86,16 +86,16 @@ const Profile2Wrapper = ({
         <ProfileMobileSubNav routes={routes} />
       </div>
 
-      <div className="usa-grid usa-grid-full">
-        <div className="usa-width-one-fourth">
-          <div className="vads-u-display--none medium-screen:vads-u-display--block">
+      <div className="vads-l-grid-container vads-u-padding-x--0">
+        <div className="vads-l-row">
+          <div className="vads-u-display--none medium-screen:vads-u-display--block vads-l-col--3 vads-u-padding-left--2">
             <ProfileSubNav routes={routes} />
           </div>
-        </div>
-        <div className="usa-width-two-thirds vads-u-padding-bottom--4 vads-u-padding-x--1 medium-screen:vads-u-padding--0 medium-screen:vads-u-padding-bottom--6">
-          {showNotAllDataAvailableError && <NotAllDataAvailableError />}
-          {/* children will be passed in from React Router one level up */}
-          {children}
+          <div className="vads-l-col--12 vads-u-padding-bottom--4 vads-u-padding-x--1 medium-screen:vads-l-col--9 medium-screen:vads-u-padding-x--2 medium-screen:vads-u-padding-bottom--6 small-desktop-screen:vads-l-col--8">
+            {showNotAllDataAvailableError && <NotAllDataAvailableError />}
+            {/* children will be passed in from React Router one level up */}
+            {children}
+          </div>
         </div>
       </div>
     </>

--- a/src/applications/personalization/profile-2/components/ProfileHeader.jsx
+++ b/src/applications/personalization/profile-2/components/ProfileHeader.jsx
@@ -37,7 +37,7 @@ const ProfileHeader = ({
     'width--full',
   ]);
   const innerWrapperClassesMedium = prefixUtilityClasses(
-    ['flex-direction--row'],
+    ['flex-direction--row', 'padding-left--2'],
     'medium',
   );
 


### PR DESCRIPTION
## Description
- Makes the main content (right column) a little wider on screen sizes from medium to small desktop. Eliminates the single column of unused white-space to the right of the main content area that used to exist.
- Adds left padding to the sub-nav and profile header so those elements no longer touch the edge of the browser window on medium screen sizes.

## Testing done
Local

## Screenshots
<details>
  <summary>New header</summary>

<img width="769" alt="new-header" src="https://user-images.githubusercontent.com/20728956/90162862-21a4fa80-dd4a-11ea-99f3-570ec4e9a2ad.png">

Note that the service badge now has some left padding but still left-aligns with the sub-nav below it.
  
</details>

<details>
  <summary>Smallest "medium" screen - editing</summary>
  
![image](https://user-images.githubusercontent.com/20728956/90162942-40a38c80-dd4a-11ea-8c6e-45babad19255.png)

Note that there is no longer an excess amount of margin/padding to the right of the main content area.

</details>

<details>
  <summary>Smallest "medium" screen - validation</summary>
  
![image](https://user-images.githubusercontent.com/20728956/90162982-531dc600-dd4a-11ea-9cd7-8175f19b2221.png)

</details>

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs