### PR TITLE
Fix logic for Profile focus management

### DIFF
--- a/src/applications/personalization/profile-2/components/personal-information/PersonalInformation.jsx
+++ b/src/applications/personalization/profile-2/components/personal-information/PersonalInformation.jsx
@@ -28,7 +28,7 @@ const PersonalInformation = ({
       // root profile route. If a user got to the Profile via a link to /profile
       // or /profile/ we want to focus on the "Your Profile" sub-nav H1, not the
       // H2 on this page
-      const pathRegExp = new RegExp(`${PROFILE_PATHS.PROFILE_ROOT}/?`);
+      const pathRegExp = new RegExp(`${PROFILE_PATHS.PROFILE_ROOT}/?$`);
       if (lastLocation?.pathname.match(new RegExp(pathRegExp))) {
         return;
       }

--- a/src/applications/personalization/profile-2/components/personal-information/PersonalInformation.jsx
+++ b/src/applications/personalization/profile-2/components/personal-information/PersonalInformation.jsx
@@ -26,9 +26,10 @@ const PersonalInformation = ({
     () => {
       // Do not manage the focus if the user just came to this route via the
       // root profile route. If a user got to the Profile via a link to /profile
-      // we want to focus on the "Your Profile" sub-nav H1, not the H2 on this
-      // page
-      if (lastLocation?.pathname === `${PROFILE_PATHS.PROFILE_ROOT}/`) {
+      // or /profile/ we want to focus on the "Your Profile" sub-nav H1, not the
+      // H2 on this page
+      const pathRegExp = new RegExp(`${PROFILE_PATHS.PROFILE_ROOT}/?`);
+      if (lastLocation?.pathname.match(new RegExp(pathRegExp))) {
         return;
       }
       focusElement('[data-focus-target]');


### PR DESCRIPTION
## Description
My original attempt didn't always work on staging like it does locally because of some web server behavior that does not exist locally. Locally, when you go to `/profile` the URL is immediately updated to `/profile/`, but that does not happen on staging. This change expands the logic to check for either `/profile` or `/profile/`.

## Testing done
Local + existing tests

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs