### PR TITLE
Add status and fix entityPublished in person_profile

### DIFF
--- a/src/site/stages/build/process-cms-exports/schemas/input/node-person_profile.js
+++ b/src/site/stages/build/process-cms-exports/schemas/input/node-person_profile.js
@@ -26,6 +26,7 @@ module.exports = {
     field_photo_allow_hires_download: { $ref: 'GenericNestedBoolean' },
     moderation_state: { $ref: 'GenericNestedString' },
     changed: { $ref: 'GenericNestedString' },
+    status: { $ref: 'GenericNestedBoolean' },
   },
   required: [
     'path',
@@ -42,5 +43,6 @@ module.exports = {
     'field_photo_allow_hires_download',
     'changed',
     'moderation_state',
+    'status',
   ],
 };

--- a/src/site/stages/build/process-cms-exports/schemas/output/node-person_profile.js
+++ b/src/site/stages/build/process-cms-exports/schemas/output/node-person_profile.js
@@ -34,6 +34,7 @@ module.exports = {
     fieldIntroText: { type: ['string', 'null'] },
     fieldPhotoAllowHiresDownload: { type: 'boolean' },
     changed: { type: 'number' },
+    status: { type: 'boolean' },
   },
   required: [
     'title',
@@ -50,5 +51,6 @@ module.exports = {
     'fieldIntroText',
     'fieldPhotoAllowHiresDownload',
     'changed',
+    'status',
   ],
 };

--- a/src/site/stages/build/process-cms-exports/transformers/node-person_profile.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-person_profile.js
@@ -6,7 +6,7 @@ const transform = (entity, { ancestors }) => ({
   title: `${getDrupalValue(entity.fieldNameFirst)} ${getDrupalValue(
     entity.fieldLastName,
   )}`,
-  entityPublished: isPublished(getDrupalValue(entity.moderationState)),
+  entityPublished: isPublished(getDrupalValue(entity.status)),
   fieldBody: getDrupalValue(entity.fieldBody),
   fieldDescription: getDrupalValue(entity.fieldDescription),
   fieldEmailAddress: getDrupalValue(entity.fieldEmailAddress),
@@ -34,6 +34,7 @@ const transform = (entity, { ancestors }) => ({
     entity.fieldPhotoAllowHiresDownload,
   ),
   changed: utcToEpochTime(getDrupalValue(entity.changed)),
+  status: getDrupalValue(entity.status),
 });
 module.exports = {
   filter: [
@@ -51,6 +52,7 @@ module.exports = {
     'field_photo_allow_hires_download',
     'changed',
     'moderation_state',
+    'status',
   ],
   transform,
 };


### PR DESCRIPTION
## Description
This PR will fix the `entityPublished` published field to use `status` instead of `moderationState`

## Testing done
Locally

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
