### PR TITLE
relogin if the SSOe transaction ids are different

### DIFF
--- a/src/platform/utilities/sso/index.js
+++ b/src/platform/utilities/sso/index.js
@@ -53,10 +53,7 @@ export async function checkAutoSession(
       // the user is in the login app, but already logged in with SSOe
       // redirect them back to their return url
       window.location = standaloneRedirect() || window.location.origin;
-    } else if (
-      ttl === 0 ||
-      (transactionid && transactionid !== ssoeTransactionId)
-    ) {
+    } else if (ttl === 0) {
       // having a user session is not enough, we also need to make sure when
       // the user authenticated they used SSOe, otherwise we can't auto logout
       // explicitly check to see if the TTL for the SSOe session is 0, as it
@@ -67,6 +64,8 @@ export async function checkAutoSession(
       // have a different user logged in. Thus, we should auto log out the user,
       // and immediately log them back in to make sure the users match.
       logout('v1', 'sso-automatic-logout', { 'auto-logout': 'true' });
+    } else if (transactionid && transactionid !== ssoeTransactionId) {
+      login('custom', 'v1', { authn }, 'sso-automatic-login');
     }
   } else if (!loggedIn && ttl > 0 && !getLoginAttempted() && authn) {
     // only attempt an auto login if the user is

--- a/src/platform/utilities/tests/sso.unit.spec.js
+++ b/src/platform/utilities/tests/sso.unit.spec.js
@@ -134,17 +134,24 @@ describe('checkAutoSession', () => {
     sinon.assert.notCalled(auto);
   });
 
-  it('should auto logout if user is logged in and they have a mismatched SSOe session', async () => {
+  it('should auto login if user is logged in and they have a mismatched SSOe session', async () => {
     sandbox.stub(keepAliveMod, 'keepAlive').returns({
       sessionAlive: true,
       ttl: 900,
       authn: 'dslogon',
       transactionid: 'X',
     });
-    const auto = sandbox.stub(authUtils, 'logout');
+    const auto = sandbox.stub(authUtils, 'login');
     await checkAutoSession(true, 'Y');
 
     sinon.assert.calledOnce(auto);
+    sinon.assert.calledWith(
+      auto,
+      'custom',
+      'v1',
+      { authn: 'dslogon' },
+      'sso-automatic-login',
+    );
   });
 
   it('should not auto logout if user is logged in and they have a matched SSOe session', async () => {


### PR DESCRIPTION
if the keepalive endpoint returns a transaction id that is different
from the one currently assigned to the user, auto relogin the user.
this will effectively logout the current user then log them back in to
make sure their va.gov and SSOe user sessions are synced

closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/11640
