### PR TITLE
Stop auto-exiting edit mode when a transaction fails

### DIFF
--- a/src/applications/personalization/profile-2/tests/components/personal-information/PersonalInformation.delete-email-address.unit.spec.jsx
+++ b/src/applications/personalization/profile-2/tests/components/personal-information/PersonalInformation.delete-email-address.unit.spec.jsx
@@ -11,6 +11,7 @@ import PersonalInformation from '../../../components/personal-information/Person
 
 import {
   createBasicInitialState,
+  elementNotRemoved,
   renderWithProfileReducers,
 } from '../../unit-test-helpers';
 
@@ -119,7 +120,7 @@ describe('Deleting email address', () => {
     expect(view.getByText(/add.*email address/i, { selector: 'button' })).to
       .exist;
   });
-  it('should show an error if the transaction cannot be created', async () => {
+  it('should show an error and not exit edit mode if the transaction cannot be created', async () => {
     server.use(...mocks.createTransactionFailure);
 
     deleteEmailAddress();
@@ -130,8 +131,13 @@ describe('Deleting email address', () => {
     expect(alert).to.contain.text(
       'We’re sorry. We couldn’t update your email address. Please try again.',
     );
+
+    // make sure that edit mode is not exited
+    await elementNotRemoved(alert, { timeout: 75 });
+    const editButton = getEditButton();
+    expect(editButton).to.not.exist;
   });
-  it('should show an error if the deletion fails quickly', async () => {
+  it('should show an error and not auto-exit edit mode if the deletion fails quickly', async () => {
     server.use(...mocks.transactionFailed);
 
     deleteEmailAddress();
@@ -142,6 +148,11 @@ describe('Deleting email address', () => {
     expect(alert).to.contain.text(
       'We’re sorry. We couldn’t update your email address. Please try again.',
     );
+
+    // make sure that edit mode is not exited
+    await elementNotRemoved(alert, { timeout: 75 });
+    const editButton = getEditButton();
+    expect(editButton).to.not.exist;
   });
   it('should show an error if the deletion fails after the edit view exits', async () => {
     server.use(...mocks.transactionPending);

--- a/src/applications/personalization/profile-2/tests/components/personal-information/PersonalInformation.edit-email-address.unit.spec.jsx
+++ b/src/applications/personalization/profile-2/tests/components/personal-information/PersonalInformation.edit-email-address.unit.spec.jsx
@@ -12,6 +12,7 @@ import PersonalInformation from '../../../components/personal-information/Person
 
 import {
   createBasicInitialState,
+  elementNotRemoved,
   renderWithProfileReducers,
 } from '../../unit-test-helpers';
 import { beforeEach } from 'mocha';
@@ -114,11 +115,15 @@ async function testTransactionCreationFails() {
   editEmailAddress();
 
   // expect an error to be shown
-  expect(
-    await view.findByText(
-      'We’re sorry. We couldn’t update your email address. Please try again.',
-    ),
-  ).to.exist;
+  const errorText = await view.findByText(
+    'We’re sorry. We couldn’t update your email address. Please try again.',
+  );
+  expect(errorText).to.exist;
+
+  // make sure that edit mode is not exited
+  await elementNotRemoved(errorText, { timeout: 75 });
+  const editButton = getEditButton();
+  expect(editButton).to.not.exist;
 }
 
 // When the update fails while the Edit View is still active
@@ -128,11 +133,15 @@ async function testQuickFailure() {
   editEmailAddress();
 
   // expect an error to be shown
-  expect(
-    await view.findByText(
-      'We’re sorry. We couldn’t update your email address. Please try again.',
-    ),
-  ).to.exist;
+  const errorText = await view.findByText(
+    'We’re sorry. We couldn’t update your email address. Please try again.',
+  );
+  expect(errorText).to.exist;
+
+  // make sure that edit mode is not exited
+  await elementNotRemoved(errorText, { timeout: 75 });
+  const editButton = getEditButton();
+  expect(editButton).to.not.exist;
 }
 
 // When the update fails but not until after the Edit View has exited and the
@@ -202,10 +211,10 @@ describe('Editing email address', () => {
     it('should handle a transaction that does not succeed until after the edit view exits', async () => {
       await testSlowSuccess();
     });
-    it('should show an error if the transaction cannot be created', async () => {
+    it('should show an error and not auto-exit edit mode if the transaction cannot be created', async () => {
       await testTransactionCreationFails();
     });
-    it('should show an error if the transaction fails quickly', async () => {
+    it('should show an error and not auto-exit edit mode if the transaction fails quickly', async () => {
       await testQuickFailure();
     });
     it('should show an error if the transaction fails after the edit view exits', async () => {
@@ -228,10 +237,10 @@ describe('Editing email address', () => {
     it('should handle a transaction that does not succeed until after the edit view exits', async () => {
       await testSlowSuccess();
     });
-    it('should show an error if the transaction cannot be created', async () => {
+    it('should show an error and not auto-exit edit mode if the transaction cannot be created', async () => {
       await testTransactionCreationFails();
     });
-    it('should show an error if the transaction fails quickly', async () => {
+    it('should show an error and not auto-exit edit mode if the transaction fails quickly', async () => {
       await testQuickFailure();
     });
     it('should show an error if the transaction fails after the edit view exits', async () => {

--- a/src/applications/personalization/profile-2/tests/components/personal-information/PersonalInformation.edit-telephone.unit.spec.jsx
+++ b/src/applications/personalization/profile-2/tests/components/personal-information/PersonalInformation.edit-telephone.unit.spec.jsx
@@ -13,6 +13,7 @@ import PersonalInformation from '../../../components/personal-information/Person
 
 import {
   createBasicInitialState,
+  elementNotRemoved,
   renderWithProfileReducers,
 } from '../../unit-test-helpers';
 import { beforeEach } from 'mocha';
@@ -137,6 +138,11 @@ async function testTransactionCreationFails(numberName) {
   // TODO: would be nice to be able to check the contents against a RegExp
   expect(alert).to.contain.text('We’re sorry. We couldn’t update your');
   expect(alert).to.contain.text('Please try again.');
+
+  // make sure that edit mode is not exited
+  await elementNotRemoved(alert, { timeout: 75 });
+  const editButton = getEditButton();
+  expect(editButton).to.not.exist;
 }
 
 // When the update fails while the Edit View is still active
@@ -151,6 +157,11 @@ async function testQuickFailure(numberName) {
   // TODO: would be nice to be able to check the contents against a RegExp
   expect(alert).to.contain.text('We’re sorry. We couldn’t update your');
   expect(alert).to.contain.text('Please try again.');
+
+  // make sure that edit mode is not exited
+  await elementNotRemoved(alert, { timeout: 75 });
+  const editButton = getEditButton();
+  expect(editButton).to.not.exist;
 }
 
 // When the update fails but not until after the Edit View has exited and the
@@ -224,10 +235,10 @@ describe('Editing', () => {
       it('should handle a transaction that does not succeed until after the edit view exits', async () => {
         await testSlowSuccess(numberName);
       });
-      it('should show an error if the transaction cannot be created', async () => {
+      it('should show an error and not auto-exit edit mode if the transaction cannot be created', async () => {
         await testTransactionCreationFails(numberName);
       });
-      it('should show an error if the transaction fails quickly', async () => {
+      it('should show an error and not auto-exit edit mode if the transaction fails quickly', async () => {
         await testQuickFailure(numberName);
       });
       it('should show an error if the transaction fails after the edit view exits', async () => {

--- a/src/applications/personalization/profile-2/tests/unit-test-helpers.js
+++ b/src/applications/personalization/profile-2/tests/unit-test-helpers.js
@@ -1,8 +1,36 @@
+import { waitForElementToBeRemoved } from '@testing-library/react';
+
 import { renderInReduxProvider } from 'platform/testing/unit/react-testing-library-helpers';
 
 import profile from 'applications/personalization/profile360/reducers';
 import connectedApps from 'applications/personalization/profile-2/components/connected-apps/reducers/connectedApps';
 import profileUi from '../reducers';
+
+// TODO: move this to platform/testing/unit/react-testing-library-helpers
+/**
+ * Returns a Promise that rejects if the element is removed from the DOM and
+ * resolves if the element is not removed. Uses DOM Testing Library's
+ * `waitForElementToBeRemoved()`.
+ *
+ * @param {} el - element that should remain in the DOM
+ * @param {} waitForOptions - options to pass to the `waitForElementToBeRemoved`
+ * call
+ */
+export async function elementNotRemoved(el, waitForOptions = {}) {
+  // Creating the Error here, outside of the Promise, gives a better stack
+  // trace, but still not as good as the stack trace you get from a Testing
+  // Library `waitFor` error
+  const err = new Error(`Element was removed but it should not have been`);
+  return new Promise((resolve, reject) => {
+    waitForElementToBeRemoved(el, waitForOptions)
+      .then(() => {
+        reject(err);
+      })
+      .catch(() => {
+        resolve();
+      });
+  });
+}
 
 /**
  * A custom React Testing Library render function that allows for easy rendering

--- a/src/platform/user/profile/vet360/components/base/VAPEditView.jsx
+++ b/src/platform/user/profile/vet360/components/base/VAPEditView.jsx
@@ -52,6 +52,13 @@ class VAPEditView extends Component {
         window.VetsGov.pollTimeout || 1000,
       );
     }
+    // if the transaction is no longer pending, stop refreshing it
+    if (
+      isPendingTransaction(prevProps.transaction) &&
+      !isPendingTransaction(this.props.transaction)
+    ) {
+      window.clearInterval(this.interval);
+    }
   }
 
   componentWillUnmount() {

--- a/src/platform/user/profile/vet360/containers/VAPProfileField.jsx
+++ b/src/platform/user/profile/vet360/containers/VAPProfileField.jsx
@@ -10,7 +10,10 @@ import prefixUtilityClasses from 'platform/utilities/prefix-utility-classes';
 
 import * as VET360 from '../constants';
 
-import { isPendingTransaction } from '../util/transactions';
+import {
+  isFailedTransaction,
+  isPendingTransaction,
+} from '../util/transactions';
 
 import {
   createTransaction,
@@ -99,6 +102,11 @@ class VAPProfileField extends React.Component {
         // your..." message while Redux is processing everything.
         window.VetsGov.pollTimeout ? 50 : 5000,
       );
+    }
+
+    // Do not auto-exit edit view if the transaction failed
+    if (this.transactionJustFailed(prevProps, this.props)) {
+      clearTimeout(this.closeModalTimeoutID);
     }
 
     if (this.justClosedModal(prevProps, this.props)) {
@@ -196,6 +204,15 @@ class VAPProfileField extends React.Component {
     return (
       (prevProps.showEditView && !props.showEditView) ||
       (prevProps.showValidationView && !props.showValidationView)
+    );
+  }
+
+  transactionJustFailed(prevProps, props) {
+    const previousTransaction = prevProps.transaction;
+    const currentTransaction = props.transaction;
+    return (
+      !isFailedTransaction(previousTransaction) &&
+      isFailedTransaction(currentTransaction)
     );
   }
 
@@ -418,7 +435,7 @@ export const mapStateToProps = (state, ownProps) => {
     data,
     fieldName,
     field: selectEditedFormField(state, fieldName),
-    showEditView: selectCurrentlyOpenEditModal(state) === fieldName,
+    showEditView: activeEditView === fieldName,
     showValidationView: !!showValidationView,
     isEmpty,
     transaction,


### PR DESCRIPTION
## Description
Previously when an attempt to update contact info failed quickly, we would show an error (good!) but then after 5s automatically exit edit mode (bad!). With this fix we keep edit mode active if the transaction fails, giving the user a chance to try saving their changes again.

## Testing done
Local + unit tests. Added tests to make sure edit mode does _not_ auto-exit if the transaction cannot be created (this was already working) or if the transaction fails while in edit mode.

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs