### PR TITLE
bradl3yC - 12378 - add additional information content to debt cards

### DIFF
--- a/src/applications/debt-letters/components/DebtLetterCard.jsx
+++ b/src/applications/debt-letters/components/DebtLetterCard.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import last from 'lodash/last';
 import moment from 'moment';
 import AdditionalInfo from '@department-of-veterans-affairs/formation-react/AdditionalInfo';
-import { deductionCodes } from '../const';
+import { deductionCodes, renderAdditionalInfo } from '../const';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 
@@ -28,10 +28,7 @@ const DebtLetterCard = ({ debt }) => {
         {debt.currentAr && formatter.format(parseFloat(debt.currentAr))}
       </p>
       <AdditionalInfo triggerText="Why might I have this debt?">
-        Lorem ipsum dolor sit amet, consectetur adipisicing elit. Animi aperiam
-        culpa debitis deleniti earum explicabo fuga fugit libero magnam
-        molestiae non, omnis porro qui, quod voluptatibus. Natus perspiciatis
-        quibusdam recusandae?
+        {renderAdditionalInfo(debt.deductionCode)}
       </AdditionalInfo>
     </div>
   );

--- a/src/applications/debt-letters/const/index.js
+++ b/src/applications/debt-letters/const/index.js
@@ -1,3 +1,5 @@
+import React from 'react';
+
 export const deductionCodes = Object.freeze({
   '30': 'Compensation & pension debt',
   '41': 'Chapter 34 education debt',
@@ -7,3 +9,127 @@ export const deductionCodes = Object.freeze({
   '74': 'Post 9/11 GI Bill debt for tuition',
   '75': 'Post 9/11 GI Bill debt for tuition (school liable)',
 });
+
+export const renderAdditionalInfo = deductionCode => {
+  switch (deductionCode) {
+    case '30':
+      return (
+        <>
+          <p>
+            The compensation and pension offices sent you a letter explaining
+            why you have this debt. Some common reasons for this type of debt
+            are:
+          </p>
+          <ul>
+            <li>
+              A change in your spouse's or dependent's status wasn't submitted
+              or processed before we made a payment to you, or
+            </li>
+            <li>There was an adjustment to your drill pay, or</li>
+            <li>Your eligibility for a benefit might have changed, or</li>
+            <li>We made a duplicate or incorrect payment to you</li>
+          </ul>
+          <p>
+            If you want more information about the reason for this debt or the
+            decision resulting in this debt, please call the VA office for your
+            benefit type:
+          </p>
+          <p>
+            <strong>Disability compensation:</strong>
+            <a href="tel: 800-827-1000" aria-label="800. 8 2 7. 1000.">
+              800-827-1000
+            </a>
+            {', '}
+            Monday through Friday, 8:00 a.m to 8:00 p.m. ET
+          </p>
+          <p>
+            <strong>Veterans Pension:</strong>
+            <a href="tel: 877-294-6380" aria-label="877. 2 9 4. 6380.">
+              877-294-6380
+            </a>
+            {', '}
+            Monday through Friday, 8:00 a.m to 4:30 p.m. ET
+          </p>
+          <p>
+            If you want more information about debt overpayment and available
+            options, please call the Debt Management Center at{' '}
+            <a href="tel: 800-827-0648" aria-label="800. 8 2 7. 0648.">
+              800-827-0648
+            </a>
+          </p>
+        </>
+      );
+    case '41':
+    case '44':
+      return (
+        <>
+          <p>
+            The Education office sent you a letter explaining why you have this
+            debt. Some common reasons for this type of debt are:
+          </p>
+          <ul>
+            <li>You m ade a change in course enrollment, or</li>
+            <li>You withdrew from a higher-education institution, or</li>
+            <li>Your eligibility for a benefit might have changed, or</li>
+            <li>We made a duplicate or incorrect payment to you</li>
+          </ul>
+          <p>
+            If you want more information about the reason for this debt or the
+            decision resulting in this debt, please call the Education office at{' '}
+            <a href="tel: 888-442-4551" aria-label="888. 4 4 2. 4551.">
+              888-442-4551
+            </a>{' '}
+            We're here Monday through Friday, 8:00 a.m. to 7:00 p.m. ET.
+          </p>
+          <p>
+            If you want more information about debt overpayment and available
+            options, please call the Debt Management Center at{' '}
+            <a href="tel: 800-827-0648" aria-label="800. 8 2 7. 0648.">
+              800-827-0648
+            </a>
+          </p>
+        </>
+      );
+    case '71':
+    case '72':
+    case '74':
+    case '75':
+      return (
+        <>
+          <p>
+            The Education office sent you a letter explaining why you have this
+            debt. Some common reasons for this type of debt are:
+          </p>
+          <ul>
+            <li>You m ade a change in course enrollment, or</li>
+            <li>You withdrew from a higher-education institution, or</li>
+            <li>Your eligibility for a benefit might have changed, or</li>
+            <li>We made a duplicate or incorrect payment to you</li>
+          </ul>
+          <p>
+            <strong>**Note:**</strong>
+            For Post-9/11 GI Bill debts, please make separate payments for
+            tuition, housing, and books and supplies. When there is a change in
+            this benefit's use, we'll collect the three debts separately.
+          </p>
+          <p>
+            If you want more information about the reason for this debt or the
+            decision resulting in this debt, please call the Education office at{' '}
+            <a href="tel: 888-442-4551" aria-label="888. 4 4 2. 4551.">
+              888-442-4551
+            </a>{' '}
+            We're here Monday through Friday, 8:00 a.m. to 7:00 p.m. ET.
+          </p>
+          <p>
+            If you want more information about debt overpayment and available
+            options, please call the Debt Management Center at{' '}
+            <a href="tel: 800-827-0648" aria-label="800. 8 2 7. 0648.">
+              800-827-0648
+            </a>
+          </p>
+        </>
+      );
+    default:
+      return null;
+  }
+};

--- a/src/applications/debt-letters/const/index.js
+++ b/src/applications/debt-letters/const/index.js
@@ -35,7 +35,7 @@ export const renderAdditionalInfo = deductionCode => {
             benefit type:
           </p>
           <p>
-            <strong>Disability compensation:</strong>
+            <strong>Disability compensation:</strong>{' '}
             <a href="tel: 800-827-1000" aria-label="800. 8 2 7. 1000.">
               800-827-1000
             </a>
@@ -43,7 +43,7 @@ export const renderAdditionalInfo = deductionCode => {
             Monday through Friday, 8:00 a.m to 8:00 p.m. ET
           </p>
           <p>
-            <strong>Veterans Pension:</strong>
+            <strong>Veterans Pension:</strong>{' '}
             <a href="tel: 877-294-6380" aria-label="877. 2 9 4. 6380.">
               877-294-6380
             </a>
@@ -68,7 +68,7 @@ export const renderAdditionalInfo = deductionCode => {
             debt. Some common reasons for this type of debt are:
           </p>
           <ul>
-            <li>You m ade a change in course enrollment, or</li>
+            <li>You made a change in course enrollment, or</li>
             <li>You withdrew from a higher-education institution, or</li>
             <li>Your eligibility for a benefit might have changed, or</li>
             <li>We made a duplicate or incorrect payment to you</li>
@@ -101,7 +101,7 @@ export const renderAdditionalInfo = deductionCode => {
             debt. Some common reasons for this type of debt are:
           </p>
           <ul>
-            <li>You m ade a change in course enrollment, or</li>
+            <li>You made a change in course enrollment, or</li>
             <li>You withdrew from a higher-education institution, or</li>
             <li>Your eligibility for a benefit might have changed, or</li>
             <li>We made a duplicate or incorrect payment to you</li>


### PR DESCRIPTION
## Description
This PR addresses the content changes for the additional info component as requested in the linked ticket.

## Testing done


## Screenshots
![Screen Shot 2020-08-14 at 11 47 31 AM](https://user-images.githubusercontent.com/6165421/90268278-c6940600-de24-11ea-9126-9ae3c7ee38b3.png)



## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
