### PR TITLE
[CTA] Fix tool URL for managing debt

### DIFF
--- a/src/platform/site-wide/cta-widget/helpers.js
+++ b/src/platform/site-wide/cta-widget/helpers.js
@@ -183,7 +183,7 @@ export const toolUrl = (appId, authenticatedWithSSOe = false) => {
 
     case widgetTypes.MANAGE_VA_DEBT:
       return {
-        url: '/manage-va-debt/debt-letters',
+        url: '/manage-va-debt/your-debt',
         redirect: false,
       };
 


### PR DESCRIPTION
## Description
https://dsva.slack.com/archives/C52CL1PKQ/p1597431403068100

This PR updates the URL of the debt management tool referenced in the CTA widget to be `/manage-va-debt/your-debt`.

## Testing done


## Screenshots
N/A

## Acceptance criteria
- [ ] URL is correct

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
