### PR TITLE
Fix naming in event_listing

### DIFF
--- a/src/site/stages/build/process-cms-exports/schemas/input/node-event_listing.js
+++ b/src/site/stages/build/process-cms-exports/schemas/input/node-event_listing.js
@@ -35,7 +35,7 @@ module.exports = {
     'field_intro_text',
     'field_meta_title',
     'field_office',
-    'reverse_field_list',
+    'reverse_field_listing',
     'status',
   ],
 };

--- a/src/site/stages/build/process-cms-exports/transformers/node-event_listing.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-event_listing.js
@@ -5,9 +5,9 @@ const {
   isPublished,
 } = require('./helpers');
 
-const reverseFields = reverseFieldList => ({
-  entities: reverseFieldList
-    ? reverseFieldList
+const reverseFields = reverseFieldListing => ({
+  entities: reverseFieldListing
+    ? reverseFieldListing
         .filter(
           reverseField =>
             reverseField.entityBundle === 'event' && reverseField.status,
@@ -37,8 +37,8 @@ const transform = entity => ({
   fieldIntroText: getDrupalValue(entity.fieldIntroText),
   fieldMetaTitle: getDrupalValue(entity.fieldMetaTitle),
   fieldOffice: entity.fieldOffice[0],
-  reverseFieldListingNode: reverseFields(entity.reverseFieldList),
-  pastEvents: reverseFields(entity.reverseFieldList),
+  reverseFieldListingNode: reverseFields(entity.reverseFieldListing),
+  pastEvents: reverseFields(entity.reverseFieldListing),
 });
 module.exports = {
   filter: [
@@ -52,7 +52,7 @@ module.exports = {
     'field_intro_text',
     'field_meta_title',
     'field_office',
-    'reverse_field_list',
+    'reverse_field_listing',
   ],
   transform,
 };


### PR DESCRIPTION
## Description
After changes made by the CMS team, we needed to rename `reverse_field_list` to `reverse_field_listing`

## Testing done
Locally

## Screenshots

![Screen Shot 2020-08-13 at 4 31 47 PM](https://user-images.githubusercontent.com/55560129/90285411-da9a3080-de41-11ea-817a-8a470bdac79e.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
