### PR TITLE
Update the reverse fields for node-story_listing

### DIFF
--- a/src/site/stages/build/process-cms-exports/schemas/input/node-event_listing.js
+++ b/src/site/stages/build/process-cms-exports/schemas/input/node-event_listing.js
@@ -21,7 +21,7 @@ module.exports = {
       maxItems: 1,
       items: { $ref: 'EntityReference' },
     },
-    reverse_field_list: { $ref: 'EntityReferenceArray' },
+    reverse_field_listing: { $ref: 'EntityReferenceArray' },
     status: { $ref: 'GenericNestedBoolean' },
   },
   required: [

--- a/src/site/stages/build/process-cms-exports/schemas/input/node-story_listing.js
+++ b/src/site/stages/build/process-cms-exports/schemas/input/node-story_listing.js
@@ -22,7 +22,7 @@ module.exports = {
       maxItems: 1,
       items: { $ref: 'EntityReference' },
     },
-    reverse_field_list: { $ref: 'EntityReferenceArray' },
+    reverse_field_listing: { $ref: 'EntityReferenceArray' },
     status: { $ref: 'GenericNestedBoolean' },
   },
   required: [
@@ -38,5 +38,6 @@ module.exports = {
     'field_meta_title',
     'field_office',
     'status',
+    'reverse_field_listing',
   ],
 };

--- a/src/site/stages/build/process-cms-exports/transformers/node-story_listing.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-story_listing.js
@@ -19,8 +19,8 @@ const transform = entity => ({
   fieldMetaTitle: getDrupalValue(entity.fieldMetaTitle),
   fieldOffice: entity.fieldOffice[0],
   reverseFieldListingNode: {
-    entities: entity.reverseFieldList
-      ? entity.reverseFieldList
+    entities: entity.reverseFieldListing
+      ? entity.reverseFieldListing
           .filter(
             reverseField =>
               reverseField.entityBundle === 'news_story' &&
@@ -59,7 +59,7 @@ module.exports = {
     'field_intro_text',
     'field_meta_title',
     'field_office',
-    'reverse_field_list',
+    'reverse_field_listing',
     'status',
   ],
   transform,


### PR DESCRIPTION
## Description
Update reverse field for `node-story_listing`.

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
