### PR TITLE
Sanlouise 12217 hide military info

### DIFF
--- a/src/applications/personalization/profile-2/sass/personal-contact-information.scss
+++ b/src/applications/personalization/profile-2/sass/personal-contact-information.scss
@@ -1,3 +1,5 @@
+// the description of the military address need to be aligned with
+// the text next to the checkbox
 .profile-military-domestic {
   margin-left: 1.7em;
 }

--- a/src/applications/personalization/profile-2/sass/personal-contact-information.scss
+++ b/src/applications/personalization/profile-2/sass/personal-contact-information.scss
@@ -1,0 +1,3 @@
+.profile-military-domestic {
+  margin-left: 1.7em;
+}

--- a/src/applications/personalization/profile-2/sass/profile-2.scss
+++ b/src/applications/personalization/profile-2/sass/profile-2.scss
@@ -13,3 +13,7 @@
 [tabindex="-1"]:focus {
   outline: 0;
 }
+
+.profile-military-domestic {
+  margin-left: 1.7em;
+}

--- a/src/applications/personalization/profile-2/sass/profile-2.scss
+++ b/src/applications/personalization/profile-2/sass/profile-2.scss
@@ -5,6 +5,7 @@
 @import "./profile-subnav";
 @import "./profile-mobile-subnav";
 @import "./connected-apps";
+@import "./personal-contact-information";
 
 .profile-service-badge {
   max-height: 75px;
@@ -12,8 +13,4 @@
 
 [tabindex="-1"]:focus {
   outline: 0;
-}
-
-.profile-military-domestic {
-  margin-left: 1.7em;
 }

--- a/src/applications/personalization/profile-2/tests/e2e/profile.personal-and-contact-mailing-address.cypress.spec.js
+++ b/src/applications/personalization/profile-2/tests/e2e/profile.personal-and-contact-mailing-address.cypress.spec.js
@@ -1,0 +1,60 @@
+import { PROFILE_PATHS } from '../../constants';
+import mockUser from '../fixtures/users/user-36.json';
+import mockFeatureToggles from '../fixtures/feature-toggles.json';
+
+const setup = (mobile = false) => {
+  window.localStorage.setItem(
+    'DISMISSED_ANNOUNCEMENTS',
+    JSON.stringify(['single-sign-on-intro']),
+  );
+
+  if (mobile) {
+    cy.viewport('iphone-4');
+  }
+
+  cy.login(mockUser);
+  cy.route('GET', '/v0/feature_toggles*', mockFeatureToggles);
+  cy.visit(PROFILE_PATHS.PROFILE_ROOT);
+
+  // should show a loading indicator
+  cy.findByRole('progressbar').should('exist');
+  cy.findByText(/loading your information/i).should('exist');
+
+  // and then the loading indicator should be removed
+  cy.findByText(/loading your information/i).should('not.exist');
+  cy.findByRole('progressbar').should('not.exist');
+};
+
+const checkMilitaryAddress = () => {
+  const militaryAddressCountry =
+    'U.S. military bases are considered a domestic address and a part of the United States.'
+
+  // Open edit view
+  cy.findByRole('button', {
+    name: new RegExp(`edit mailing address`, 'i'),
+  }).click({
+    force: true,
+  });
+
+  cy.contains(militaryAddressCountry).should('not.exist');
+
+  cy.findByRole('checkbox', {
+    name: `I live on a United States military base outside of the United States.`,
+  }).click({
+    force: true,
+  });
+
+  cy.contains(militaryAddressCountry).should('exist');
+};
+
+describe('The personal and contact information page', () => {
+  it('should render as expected on Desktop', () => {
+    setup();
+    checkMilitaryAddress();
+  });
+
+  it('should render as expected on Mobile', () => {
+    setup(true);
+    checkMilitaryAddress();
+  });
+});

--- a/src/applications/personalization/profile-2/tests/e2e/profile.personal-and-contact-mailing-address.cypress.spec.js
+++ b/src/applications/personalization/profile-2/tests/e2e/profile.personal-and-contact-mailing-address.cypress.spec.js
@@ -27,7 +27,7 @@ const setup = (mobile = false) => {
 
 const checkMilitaryAddress = () => {
   const militaryAddressCountry =
-    'U.S. military bases are considered a domestic address and a part of the United States.'
+    'U.S. military bases are considered a domestic address and a part of the United States.';
 
   // Open edit view
   cy.findByRole('button', {

--- a/src/platform/user/profile/vet360/components/AddressField/address-schemas.js
+++ b/src/platform/user/profile/vet360/components/AddressField/address-schemas.js
@@ -83,9 +83,10 @@ const uiSchema = {
       'I live on a United States military base outside of the United States.',
   },
   'view:livesOnMilitaryBaseInfo': {
-    'ui:description': 'U.S. military bases are considered a domestic address and a part of the United States.',
+    'ui:description':
+      'U.S. military bases are considered a domestic address and a part of the United States.',
     'ui:options': {
-      hideIf: (formData) => !formData?.['view:livesOnMilitaryBase'],
+      hideIf: formData => !formData?.['view:livesOnMilitaryBase'],
     },
   },
   countryCodeIso3: {

--- a/src/platform/user/profile/vet360/components/AddressField/address-schemas.js
+++ b/src/platform/user/profile/vet360/components/AddressField/address-schemas.js
@@ -1,5 +1,7 @@
 import React from 'react';
+import { connect } from 'react-redux';
 import AdditionalInfo from '@department-of-veterans-affairs/formation-react/AdditionalInfo';
+import { selectEditedFormField } from 'platform/user/profile/vet360/selectors.js';
 
 import ADDRESS_DATA from 'platform/forms/address/data';
 import cloneDeep from 'platform/utilities/data/cloneDeep';
@@ -77,25 +79,33 @@ const formSchema = {
   required: ['countryCodeIso3', 'addressLine1', 'city'],
 };
 
+const Description = (props) => {
+  console.log("This is field", props)
+  if (props.field === true) {
+    return (
+      <span>
+        U.S. military bases are considered a domestic address and a part of the United States.
+      </span>
+    )
+  }
+  return null
+}
+
+const mapStateToProps = (state) => {
+  return {
+    field: state?.vet360?.formFields?.mailingAddress?.value['view:livesOnMilitaryBase'],
+  }
+};
+
+const ConnectedDescription = connect(mapStateToProps)(Description)
+
 const uiSchema = {
   'view:livesOnMilitaryBase': {
     'ui:title':
       'I live on a United States military base outside of the United States.',
   },
   'view:livesOnMilitaryBaseInfo': {
-    'ui:description': () => (
-      <div className="vads-u-padding-x--2p5">
-        <AdditionalInfo
-          status="info"
-          triggerText="Learn more about military base addresses"
-        >
-          <span>
-            The United States is automatically chosen as your country if you
-            live on a military base outside of the country.
-          </span>
-        </AdditionalInfo>
-      </div>
-    ),
+    'ui:description': () => <ConnectedDescription />,
   },
   countryCodeIso3: {
     'ui:title': 'Country',

--- a/src/platform/user/profile/vet360/components/AddressField/address-schemas.js
+++ b/src/platform/user/profile/vet360/components/AddressField/address-schemas.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { connect } from 'react-redux';
 import AdditionalInfo from '@department-of-veterans-affairs/formation-react/AdditionalInfo';
 
 import ADDRESS_DATA from 'platform/forms/address/data';

--- a/src/platform/user/profile/vet360/components/AddressField/address-schemas.js
+++ b/src/platform/user/profile/vet360/components/AddressField/address-schemas.js
@@ -22,15 +22,6 @@ const MILITARY_STATES = Object.entries(ADDRESS_DATA.states).reduce(
 
 const STREET_LINE_MAX_LENGTH = 35;
 
-const militaryAddressCountry = () => {
-  return (
-    <p className="profile-military-domestic">
-      U.S. military bases are considered a domestic address and a part of the
-      United States.
-    </p>
-  );
-};
-
 const formSchema = {
   type: 'object',
   properties: {
@@ -92,7 +83,12 @@ const uiSchema = {
       'I live on a United States military base outside of the United States.',
   },
   'view:livesOnMilitaryBaseInfo': {
-    'ui:description': militaryAddressCountry,
+    'ui:description': () => (
+      <p className="profile-military-domestic">
+        U.S. military bases are considered a domestic address and a part of the
+        United States.
+      </p>
+    ),
     'ui:options': {
       hideIf: formData => !formData?.['view:livesOnMilitaryBase'],
     },

--- a/src/platform/user/profile/vet360/components/AddressField/address-schemas.js
+++ b/src/platform/user/profile/vet360/components/AddressField/address-schemas.js
@@ -26,7 +26,7 @@ const militaryAddressCountry = () => {
   return (
     <p className="profile-military-domestic">
       U.S. military bases are considered a domestic address and a part of the
-        United States.
+      United States.
     </p>
   );
 };
@@ -94,7 +94,7 @@ const uiSchema = {
   'view:livesOnMilitaryBaseInfo': {
     'ui:description': militaryAddressCountry,
     'ui:options': {
-      hideIf: formData => !formData ?.['view:livesOnMilitaryBase'],
+      hideIf: formData => !formData?.['view:livesOnMilitaryBase'],
     },
   },
   countryCodeIso3: {

--- a/src/platform/user/profile/vet360/components/AddressField/address-schemas.js
+++ b/src/platform/user/profile/vet360/components/AddressField/address-schemas.js
@@ -22,6 +22,15 @@ const MILITARY_STATES = Object.entries(ADDRESS_DATA.states).reduce(
 
 const STREET_LINE_MAX_LENGTH = 35;
 
+const militaryAddressCountry = () => {
+  return (
+    <p className="profile-military-domestic">
+      U.S. military bases are considered a domestic address and a part of the
+        United States.
+    </p>
+  );
+};
+
 const formSchema = {
   type: 'object',
   properties: {
@@ -77,14 +86,6 @@ const formSchema = {
   required: ['countryCodeIso3', 'addressLine1', 'city'],
 };
 
-const militaryAddressCountry = () => {
-  return (
-    <p className="profile-military-domestic">
-      U.S. military bases are considered a domestic address and a part of the United States.
-    </p>
-  )
-}
-
 const uiSchema = {
   'view:livesOnMilitaryBase': {
     'ui:title':
@@ -93,7 +94,7 @@ const uiSchema = {
   'view:livesOnMilitaryBaseInfo': {
     'ui:description': militaryAddressCountry,
     'ui:options': {
-      hideIf: formData => !formData?.['view:livesOnMilitaryBase'],
+      hideIf: formData => !formData ?.['view:livesOnMilitaryBase'],
     },
   },
   countryCodeIso3: {

--- a/src/platform/user/profile/vet360/components/AddressField/address-schemas.js
+++ b/src/platform/user/profile/vet360/components/AddressField/address-schemas.js
@@ -79,21 +79,21 @@ const formSchema = {
   required: ['countryCodeIso3', 'addressLine1', 'city'],
 };
 
-const Description = (props) => {
-  console.log("This is field", props)
-  if (props.field === true) {
-    return (
-      <span>
-        U.S. military bases are considered a domestic address and a part of the United States.
-      </span>
-    )
+const Description = ({ isMilitaryAddress }) => {
+  if (!isMilitaryAddress) {
+    return null
   }
-  return null
+
+  return (
+    <span>
+      U.S. military bases are considered a domestic address and a part of the United States.
+    </span>
+  )
 }
 
 const mapStateToProps = (state) => {
   return {
-    field: state?.vet360?.formFields?.mailingAddress?.value['view:livesOnMilitaryBase'],
+    isMilitaryAddress: state?.vet360?.formFields?.mailingAddress?.value['view:livesOnMilitaryBase'],
   }
 };
 

--- a/src/platform/user/profile/vet360/components/AddressField/address-schemas.js
+++ b/src/platform/user/profile/vet360/components/AddressField/address-schemas.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import AdditionalInfo from '@department-of-veterans-affairs/formation-react/AdditionalInfo';
-import { selectEditedFormField } from 'platform/user/profile/vet360/selectors.js';
 
 import ADDRESS_DATA from 'platform/forms/address/data';
 import cloneDeep from 'platform/utilities/data/cloneDeep';
@@ -79,33 +78,16 @@ const formSchema = {
   required: ['countryCodeIso3', 'addressLine1', 'city'],
 };
 
-const Description = ({ isMilitaryAddress }) => {
-  if (!isMilitaryAddress) {
-    return null
-  }
-
-  return (
-    <span>
-      U.S. military bases are considered a domestic address and a part of the United States.
-    </span>
-  )
-}
-
-const mapStateToProps = (state) => {
-  return {
-    isMilitaryAddress: state?.vet360?.formFields?.mailingAddress?.value['view:livesOnMilitaryBase'],
-  }
-};
-
-const ConnectedDescription = connect(mapStateToProps)(Description)
-
 const uiSchema = {
   'view:livesOnMilitaryBase': {
     'ui:title':
       'I live on a United States military base outside of the United States.',
   },
   'view:livesOnMilitaryBaseInfo': {
-    'ui:description': () => <ConnectedDescription />,
+    'ui:description': 'U.S. military bases are considered a domestic address and a part of the United States.',
+    'ui:options': {
+      hideIf: (formData) => !formData?.['view:livesOnMilitaryBase'],
+    },
   },
   countryCodeIso3: {
     'ui:title': 'Country',

--- a/src/platform/user/profile/vet360/components/AddressField/address-schemas.js
+++ b/src/platform/user/profile/vet360/components/AddressField/address-schemas.js
@@ -77,14 +77,21 @@ const formSchema = {
   required: ['countryCodeIso3', 'addressLine1', 'city'],
 };
 
+const militaryAddressCountry = () => {
+  return (
+    <p className="profile-military-domestic">
+      U.S. military bases are considered a domestic address and a part of the United States.
+    </p>
+  )
+}
+
 const uiSchema = {
   'view:livesOnMilitaryBase': {
     'ui:title':
       'I live on a United States military base outside of the United States.',
   },
   'view:livesOnMilitaryBaseInfo': {
-    'ui:description':
-      'U.S. military bases are considered a domestic address and a part of the United States.',
+    'ui:description': militaryAddressCountry,
     'ui:options': {
       hideIf: formData => !formData?.['view:livesOnMilitaryBase'],
     },


### PR DESCRIPTION
## Description
The text should ONLY appear when the military address checkbox is checked. Change the text to U.S. military bases are considered a domestic address and a part of the United States.

Although the original designs places the description below 'Country', I made sure with Tressa that leaving it above 'Country' was acceptable.

## Testing done
Works locally

## Screenshots
![image](https://user-images.githubusercontent.com/14869324/90441718-aec3b880-e096-11ea-96b1-9c9bab810d96.png)

![image](https://user-images.githubusercontent.com/14869324/90442439-e41cd600-e097-11ea-9904-6e221e819e97.png)


## Acceptance criteria
- [x] The text should ONLY appear when the checkbox is checked
- [x] Change the text to U.S. military bases are considered a domestic address and a part of the United States.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
