### PR TITLE
[SEMANTIC MARKUP] Wrap wizard in a form element

### DIFF
--- a/src/applications/static-pages/tests/wizard/edu-benefits/index.unit.spec.jsx
+++ b/src/applications/static-pages/tests/wizard/edu-benefits/index.unit.spec.jsx
@@ -31,6 +31,12 @@ describe('the Education Benefits Wizard', () => {
     sessionStorage.clear();
   });
 
+  it('should render the wizard wrapped in a form element', () => {
+    const wrapper = shallow(<Wizard {...defaultProps} />);
+    expect(wrapper.exists('form')).to.equal(true);
+    wrapper.unmount();
+  });
+
   it('should render the wizard start button if the expander prop is true', () => {
     const wrapper = shallow(<Wizard {...defaultProps} />);
     expect(wrapper.exists('.wizard-button')).to.equal(true);

--- a/src/applications/static-pages/wizard/index.js
+++ b/src/applications/static-pages/wizard/index.js
@@ -93,7 +93,7 @@ export class Wizard extends React.Component {
       },
     );
     return (
-      <div>
+      <form onSubmit={e => e.preventDefault()}>
         {expander && (
           <button
             aria-expanded={this.state.expanded ? 'true' : 'false'}
@@ -128,7 +128,7 @@ export class Wizard extends React.Component {
             </div>
           </div>
         )}
-      </div>
+      </form>
     );
   }
 }


### PR DESCRIPTION
## Description

Wizards must be wrapped in a `<form>` element to maintain best-practices & semantic markup.

Related:
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/12545
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/9497#issuecomment-634194820

## Testing done

Local unit tests

## Screenshots

N/A

## Acceptance criteria
- [x] Wizard elements are wrapped in a `<form>`

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
