### PR TITLE
Removed step that filters out view fields

### DIFF
--- a/src/applications/disability-benefits/686c-674/config/utilities.js
+++ b/src/applications/disability-benefits/686c-674/config/utilities.js
@@ -3,7 +3,6 @@ import _ from 'platform/utilities/data';
 import { validateWhiteSpace } from 'platform/forms/validations';
 import {
   filterInactivePageData,
-  filterViewFields,
   getActivePages,
   getInactivePages,
   stringifyFormReplacer,
@@ -58,7 +57,6 @@ const customFormReplacer = (key, value) => {
       return _.omit('file', value);
     }
   }
-
   // Clean up empty objects in arrays
   if (Array.isArray(value)) {
     const newValues = value.filter(v => !!stringifyFormReplacer(key, v));
@@ -110,6 +108,6 @@ export function customTransformForSubmit(formConfig, form) {
     activePages,
     form,
   );
-  const withoutViewFields = filterViewFields(withoutInactivePages);
-  return JSON.stringify(withoutViewFields, customFormReplacer) || '{}';
+
+  return JSON.stringify(withoutInactivePages, customFormReplacer) || '{}';
 }


### PR DESCRIPTION
## Description
[Original Ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/12557)

We needed to slightly change the data structure as it was getting sent to the back end, this meant removing the step that strips out the view fields. This was so that the reportDivorce data would no longer get stripped out of the payload to the BE.

## Testing done
All existing unit tests still pass

## Acceptance criteria
- [x] The wizard options for the 686 are getting sent to the back end wrapped in an object named for the view field
- [x] PRs have been submitted for review

