### PR TITLE
entryname CLI argument -> entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,10 @@ To **recompile your application when you make changes**, run:
 yarn watch
 ```
 
-You can also **limit the applications Webpack builds** with `--env.entryname`:
+You can also **limit the applications Webpack builds** with `--env.entry`:
 
 ```sh
-yarn watch --env.entryname static-pages,auth
+yarn watch --env.entry static-pages,auth
 ```
 
 The `entryname` for your application can be found in its `manifest.json` file.


### PR DESCRIPTION
## Description
The CLI argument is [`entry`](https://github.com/department-of-veterans-affairs/vets-website/blob/master/src/site/stages/build/options.js#L27), not `entryname`.