### PR TITLE
CT: Search showing "name" when searching on enter #12570

### DIFF
--- a/src/applications/gi/containers/LandingPage.jsx
+++ b/src/applications/gi/containers/LandingPage.jsx
@@ -1,4 +1,3 @@
-import _ from 'lodash';
 import React from 'react';
 import { connect } from 'react-redux';
 
@@ -63,7 +62,7 @@ export class LandingPage extends React.Component {
       category,
     };
 
-    _.forEach(query, (val, key) => {
+    Object.entries(query).forEach(({ val, key }) => {
       if (typeof val !== 'boolean' && (!val || val === 'ALL')) {
         delete query[key];
       }
@@ -183,7 +182,9 @@ export class LandingPage extends React.Component {
                     this.props.clearAutocompleteSuggestions
                   }
                   onFetchAutocompleteSuggestions={this.autocomplete}
-                  onFilterChange={this.handleFilterChange}
+                  onFilterChange={(field, value) => {
+                    this.handleFilterChange(value);
+                  }}
                   onUpdateAutocompleteSearchTerm={
                     this.props.updateAutocompleteSearchTerm
                   }


### PR DESCRIPTION
## Description
https://github.com/department-of-veterans-affairs/va.gov-team/issues/12570

LandingPage was passing in a function to KeywordSearch with different number of parameters then both SearchPage and VetTecSearchPage and when a special case within search logic was removed on SearchPages it caused this issue

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
