### PR TITLE
[Static pages] Add a widget for Find Forms PDF validation

### DIFF
--- a/src/applications/find-forms/tests/widgets/createInvalidPdfAlert.unit.spec.js
+++ b/src/applications/find-forms/tests/widgets/createInvalidPdfAlert.unit.spec.js
@@ -14,17 +14,18 @@ describe('createInvalidPdfAlert', () => {
   beforeEach(() => {
     mockFetch();
     setFetchResponse(global.fetch.onFirstCall(), {
-      data: [{
-        id: '10-10EZ',
-        type: 'va_form',
-        attributes: { validPdf: true }
-      },
-      {
-        id: 'VA0927b',
-        type: 'va_form',
-        attributes: { validPdf: false }
-      },
-    ],
+      data: [
+        {
+          id: '10-10EZ',
+          type: 'va_form',
+          attributes: { validPdf: true },
+        },
+        {
+          id: 'VA0927b',
+          type: 'va_form',
+          attributes: { validPdf: false },
+        },
+      ],
     });
   });
 
@@ -37,13 +38,13 @@ describe('createInvalidPdfAlert', () => {
       click: sinon.stub(),
       href: 'https://www.va.gov/vaforms/medical/pdf/10-10EZ-fillable.pdf',
       dataset: {
-        formNumber: 'VA0927b'
+        formNumber: 'VA0927b',
       },
       remove: sinon.stub(),
       parentNode: {
         insertBefore: sinon.stub(),
-      }
-    }
+      },
+    };
 
     const event = {
       target: link,
@@ -68,10 +69,10 @@ describe('createInvalidPdfAlert', () => {
       removeEventListener: sinon.stub(),
       href: 'https://www.va.gov/vaforms/medical/pdf/10-10EZ-fillable.pdf',
       dataset: {
-        formNumber: '10-10EZ'
+        formNumber: '10-10EZ',
       },
-      remove: sinon.stub()
-    }
+      remove: sinon.stub(),
+    };
 
     const event = {
       target: link,

--- a/src/applications/find-forms/tests/widgets/createInvalidPdfAlert.unit.spec.js
+++ b/src/applications/find-forms/tests/widgets/createInvalidPdfAlert.unit.spec.js
@@ -1,0 +1,87 @@
+import sinon from 'sinon';
+import { expect } from 'chai';
+
+import {
+  mockFetch,
+  setFetchJSONResponse as setFetchResponse,
+  resetFetch,
+} from 'platform/testing/unit/helpers';
+
+import { onDownloadLinkClick } from '../../widgets/createInvalidPdfAlert';
+import { escapeRegExp } from 'lodash';
+
+describe('createInvalidPdfAlert', () => {
+  beforeEach(() => {
+    mockFetch();
+    setFetchResponse(global.fetch.onFirstCall(), {
+      data: [{
+        id: '10-10EZ',
+        type: 'va_form',
+        attributes: { validPdf: true }
+      },
+      {
+        id: 'VA0927b',
+        type: 'va_form',
+        attributes: { validPdf: false }
+      },
+    ],
+    });
+  });
+
+  afterEach(() => {
+    resetFetch();
+  });
+
+  it('shows an alert banner for invalid forms', async () => {
+    const link = {
+      click: sinon.stub(),
+      href: 'https://www.va.gov/vaforms/medical/pdf/10-10EZ-fillable.pdf',
+      dataset: {
+        formNumber: 'VA0927b'
+      },
+      remove: sinon.stub(),
+      parentNode: {
+        insertBefore: sinon.stub(),
+      }
+    }
+
+    const event = {
+      target: link,
+      preventDefault: sinon.stub(),
+    };
+
+    await onDownloadLinkClick(event);
+
+    expect(link.click.called).to.be.false;
+    expect(link.parentNode.insertBefore.called).to.be.true;
+
+    const alertBox = link.parentNode.insertBefore.firstCall.args[0];
+
+    expect(alertBox).to.be.instanceOf(HTMLDivElement);
+    expect(alertBox.innerHTML).to.include('We’re sorry');
+    expect(link.remove.called).to.be.true;
+  });
+
+  it('shows an alert banner for invalid forms', async () => {
+    const link = {
+      click: sinon.stub(),
+      removeEventListener: sinon.stub(),
+      href: 'https://www.va.gov/vaforms/medical/pdf/10-10EZ-fillable.pdf',
+      dataset: {
+        formNumber: '10-10EZ'
+      },
+      remove: sinon.stub()
+    }
+
+    const event = {
+      target: link,
+      preventDefault: sinon.stub(),
+    };
+
+    await onDownloadLinkClick(event);
+
+    expect(link.remove.called).to.be.false;
+    expect(link.removeEventListener.called).to.be.true;
+    expect(link.click.called).to.be.true;
+  });
+});

--- a/src/applications/find-forms/widgets/createDownloadValidator.js
+++ b/src/applications/find-forms/widgets/createDownloadValidator.js
@@ -1,48 +1,75 @@
 // Dependencies.
 import React from 'react';
 import ReactDOM from 'react-dom';
+import * as Sentry from '@sentry/browser';
+
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 
 import { fetchFormsApi } from '../api';
 
-const InvalidPdfMessage = () => (
-  <AlertBox
-    status="error"
-    headline="This form link isn’t working"
-    content={
-      <>
-        We’re sorry, but the form you’re trying to download appears to have an
-        invalid link. Please{' '}
-        <a href="mailto:VaFormsManagers@va.gov">email the forms managers</a> for
-        help with this form.
-      </>
-    }
-  />
-);
+class InvalidPdfMessage extends React.Component {
+  state = {
+    isVisible: false,
+  };
 
-export default (store, widgetType) => {
-  // Derive the element to render our widget.
-  const root = document.querySelector(`[data-widget-type="${widgetType}"]`);
-  const formName = root.dataset.formName;
+  componentDidMount() {
+    const { formName, downloadLinkSelector } = this.props;
+    const pdfLink = document.querySelector(downloadLinkSelector);
+    const pdfFileUrl = pdfLink.href;
 
-  // Escape early if no element was found.
-  if (!root) {
-    return;
+    pdfLink.addEventListener('click', async event => {
+      event.preventDefault();
+
+      const forms = await fetchFormsApi(formName);
+      const form = forms.find(f => f.attributes.formName === formName);
+
+      if (!form?.attributes.validPdf) {
+        Sentry.withScope(scope => {
+          scope.setExtra('form API response', form);
+          scope.setExtra('form number (aka form name)', formName);
+          scope.setExtra('pdf link', pdfFileUrl);
+          Sentry.captureMessage(
+            `Find Forms - Form Detail - invalid PDF accessed`,
+          );
+        });
+
+        pdfLink.remove();
+        this.setState({ isVisible: true });
+      } else {
+        window.open(pdfFileUrl);
+      }
+    });
   }
 
-  const pdfLink = document.querySelector(root.dataset.pdfLink);
+  render() {
+    return (
+      <AlertBox
+        isVisible={this.state.isVisible}
+        status="error"
+        headline="This form link isn’t working"
+        content={
+          <>
+            We’re sorry, but the form you’re trying to download appears to have
+            an invalid link. Please{' '}
+            <a href="mailto:VaFormsManagers@va.gov">email the forms managers</a>{' '}
+            for help with this form.
+          </>
+        }
+      />
+    );
+  }
+}
 
-  pdfLink.addEventListener('click', async event => {
-    event.preventDefault();
+export default (store, widgetType) => {
+  const roots = document.querySelectorAll(`[data-widget-type="${widgetType}"]`);
 
-    const forms = await fetchFormsApi(formName);
-    const form = forms.find(f => f.attributes.formName === formName);
-
-    if (!form?.attributes.validPdf) {
-      pdfLink.remove();
-      ReactDOM.render(<InvalidPdfMessage />, root);
-    } else {
-      window.open(pdfLink.href);
-    }
-  });
+  for (const root of [...roots]) {
+    ReactDOM.render(
+      <InvalidPdfMessage
+        formName={root.dataset.formName}
+        downloadLinkSelector={root.dataset.pdfLink}
+      />,
+      root,
+    );
+  }
 };

--- a/src/applications/find-forms/widgets/createDownloadValidator.js
+++ b/src/applications/find-forms/widgets/createDownloadValidator.js
@@ -20,10 +20,22 @@ class InvalidPdfMessage extends React.Component {
     pdfLink.addEventListener('click', async event => {
       event.preventDefault();
 
-      const forms = await fetchFormsApi(formName);
-      const form = forms.find(f => f.attributes.formName === formName);
+      // Default to true in case we encounter an error
+      // determining validity through the API.
+      let formPdfIsValid = true;
+      let form = null;
 
-      if (!form?.attributes.validPdf) {
+      try {
+        const forms = await fetchFormsApi(formName);
+        form = forms.find(f => f.attributes.formName === formName);
+        formPdfIsValid = form?.attributes.validPdf;
+      } catch (err) {
+        // Todo
+      }
+
+      if (formPdfIsValid) {
+        window.open(pdfFileUrl);
+      } else {
         Sentry.withScope(scope => {
           scope.setExtra('form API response', form);
           scope.setExtra('form number (aka form name)', formName);
@@ -35,8 +47,6 @@ class InvalidPdfMessage extends React.Component {
 
         pdfLink.remove();
         this.setState({ isVisible: true });
-      } else {
-        window.open(pdfFileUrl);
       }
     });
   }

--- a/src/applications/find-forms/widgets/createDownloadValidator.js
+++ b/src/applications/find-forms/widgets/createDownloadValidator.js
@@ -1,0 +1,48 @@
+// Dependencies.
+import React from 'react';
+import ReactDOM from 'react-dom';
+import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
+
+import { fetchFormsApi } from '../api';
+
+const InvalidPdfMessage = () => (
+  <AlertBox
+    status="error"
+    headline="This form link isn’t working"
+    content={
+      <>
+        We’re sorry, but the form you’re trying to download appears to have an
+        invalid link. Please{' '}
+        <a href="mailto:VaFormsManagers@va.gov">email the forms managers</a> for
+        help with this form.
+      </>
+    }
+  />
+);
+
+export default (store, widgetType) => {
+  // Derive the element to render our widget.
+  const root = document.querySelector(`[data-widget-type="${widgetType}"]`);
+  const formName = root.dataset.formName;
+
+  // Escape early if no element was found.
+  if (!root) {
+    return;
+  }
+
+  const pdfLink = document.querySelector(root.dataset.pdfLink);
+
+  pdfLink.addEventListener('click', async event => {
+    event.preventDefault();
+
+    const forms = await fetchFormsApi(formName);
+    const form = forms.find(f => f.attributes.formName === formName);
+
+    if (!form?.attributes.validPdf) {
+      pdfLink.remove();
+      ReactDOM.render(<InvalidPdfMessage />, root);
+    } else {
+      window.open(pdfLink.href);
+    }
+  });
+};

--- a/src/applications/find-forms/widgets/createInvalidPdfAlert.js
+++ b/src/applications/find-forms/widgets/createInvalidPdfAlert.js
@@ -41,7 +41,7 @@ class InvalidPdf extends React.Component {
           scope.setExtra('form number (aka form name)', formName);
           scope.setExtra('pdf link', pdfFileUrl);
           Sentry.captureMessage(
-            `Find Forms - Form Detail - invalid PDF accessed`,
+            'Find Forms - Form Detail - invalid PDF accessed',
           );
         });
 

--- a/src/applications/find-forms/widgets/createInvalidPdfAlert.js
+++ b/src/applications/find-forms/widgets/createInvalidPdfAlert.js
@@ -23,7 +23,7 @@ const InvalidFormDownload = () => (
   />
 );
 
-async function onDownloadLinkClick(event) {
+export async function onDownloadLinkClick(event) {
   event.preventDefault();
 
   const link = event.target;
@@ -37,14 +37,14 @@ async function onDownloadLinkClick(event) {
 
   try {
     const forms = await fetchFormsApi(formNumber);
-    form = forms.find(f => f.attributes.formName === formNumber);
+    form = forms.find(f => f.id === formNumber);
     formPdfIsValid = form?.attributes.validPdf;
   } catch (err) {
     // Todo
   }
 
   if (formPdfIsValid) {
-    link.removeEventListener('click');
+    link.removeEventListener('click', onDownloadLinkClick);
     link.click();
   } else {
     Sentry.withScope(scope => {

--- a/src/applications/find-forms/widgets/createInvalidPdfAlert.js
+++ b/src/applications/find-forms/widgets/createInvalidPdfAlert.js
@@ -7,7 +7,7 @@ import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 
 import { fetchFormsApi } from '../api';
 
-class InvalidPdfMessage extends React.Component {
+class InvalidPdf extends React.Component {
   state = {
     isVisible: false,
   };
@@ -75,7 +75,7 @@ export default (store, widgetType) => {
 
   for (const root of [...roots]) {
     ReactDOM.render(
-      <InvalidPdfMessage
+      <InvalidPdf
         formName={root.dataset.formName}
         downloadLinkSelector={root.dataset.pdfLink}
       />,

--- a/src/applications/static-pages/static-pages-entry.js
+++ b/src/applications/static-pages/static-pages-entry.js
@@ -24,6 +24,7 @@ import createOptOutApplicationStatus from '../edu-benefits/components/createOptO
 import createFindVaForms, {
   findVaFormsWidgetReducer,
 } from '../find-forms/createFindVaForms';
+import createFindVaFormsDownloadValidator from '../find-forms/widgets/createDownloadValidator';
 import createHigherLevelReviewApplicationStatus from 'applications/disability-benefits/996/components/createHLRApplicationStatus';
 import createPost911GiBillStatusWidget, {
   post911GIBillStatusReducer,
@@ -135,6 +136,10 @@ createScoEventsWidget();
 createScoAnnouncementsWidget();
 
 createFindVaForms(store, widgetTypes.FIND_VA_FORMS);
+createFindVaFormsDownloadValidator(
+  store,
+  widgetTypes.FIND_VA_FORMS_DOWNLOAD_VALIDATOR,
+);
 createPost911GiBillStatusWidget(
   store,
   widgetTypes.POST_911_GI_BILL_STATUS_WIDGET,

--- a/src/applications/static-pages/static-pages-entry.js
+++ b/src/applications/static-pages/static-pages-entry.js
@@ -24,7 +24,7 @@ import createOptOutApplicationStatus from '../edu-benefits/components/createOptO
 import createFindVaForms, {
   findVaFormsWidgetReducer,
 } from '../find-forms/createFindVaForms';
-import createFindVaFormsDownloadValidator from '../find-forms/widgets/createDownloadValidator';
+import createFindVaFormsInvalidPdfAlert from '../find-forms/widgets/createInvalidPdfAlert';
 import createHigherLevelReviewApplicationStatus from 'applications/disability-benefits/996/components/createHLRApplicationStatus';
 import createPost911GiBillStatusWidget, {
   post911GIBillStatusReducer,
@@ -136,9 +136,9 @@ createScoEventsWidget();
 createScoAnnouncementsWidget();
 
 createFindVaForms(store, widgetTypes.FIND_VA_FORMS);
-createFindVaFormsDownloadValidator(
+createFindVaFormsInvalidPdfAlert(
   store,
-  widgetTypes.FIND_VA_FORMS_DOWNLOAD_VALIDATOR,
+  widgetTypes.FIND_VA_FORMS_INVALID_PDF_ALERT,
 );
 createPost911GiBillStatusWidget(
   store,

--- a/src/applications/static-pages/widgetTypes.js
+++ b/src/applications/static-pages/widgetTypes.js
@@ -8,6 +8,7 @@ export default {
   DISABILITY_APP_STATUS: 'disability-app-status',
   DISABILITY_RATING_CALCULATOR: 'disability-rating-calculator',
   FIND_VA_FORMS: 'find-va-forms',
+  FIND_VA_FORMS_DOWNLOAD_VALIDATOR: 'find-va-forms-download-validator',
   HIGHER_LEVEL_REVIEW_APP_STATUS: 'higher-level-review-status',
   HOMEPAGE_BANNER: 'homepage-banner',
   POST_911_GI_BILL_STATUS_WIDGET: 'post-9-11-gi-bill-status',

--- a/src/applications/static-pages/widgetTypes.js
+++ b/src/applications/static-pages/widgetTypes.js
@@ -8,7 +8,7 @@ export default {
   DISABILITY_APP_STATUS: 'disability-app-status',
   DISABILITY_RATING_CALCULATOR: 'disability-rating-calculator',
   FIND_VA_FORMS: 'find-va-forms',
-  FIND_VA_FORMS_DOWNLOAD_VALIDATOR: 'find-va-forms-download-validator',
+  FIND_VA_FORMS_INVALID_PDF_ALERT: 'find-va-forms-invalid-pdf-alert',
   HIGHER_LEVEL_REVIEW_APP_STATUS: 'higher-level-review-status',
   HOMEPAGE_BANNER: 'homepage-banner',
   POST_911_GI_BILL_STATUS_WIDGET: 'post-9-11-gi-bill-status',

--- a/src/site/layouts/va_form.drupal.liquid
+++ b/src/site/layouts/va_form.drupal.liquid
@@ -68,9 +68,22 @@
           {{ fieldVaFormUsage.processed }}
 
           <h3>Downloadable PDF</h3>
-          <a href="{{ fieldVaFormUrl.uri }}" download>Download VA Form {{ fieldVaFormNumber }} (PDF)</a>
+          <a
+            href="{{ fieldVaFormUrl.uri }}"
+            download
+            data-widget-type="find-va-forms-invalid-pdf-alert"
+            data-form-number="{{ fieldVaFormNumber }}">
+            Download VA Form {{ fieldVaFormNumber }} (PDF)
+          </a>
         {% else %}
-          <a class="vads-u-margin-top--4" href="{{ fieldVaFormUrl.uri }}" download>Download VA Form {{ fieldVaFormNumber }} (PDF)</a>
+          <a
+            class="vads-u-margin-top--4"
+            href="{{ fieldVaFormUrl.uri }}"
+            download
+            data-widget-type="find-va-forms-invalid-pdf-alert"
+            data-form-number="{{ fieldVaFormNumber }}">
+            Download VA Form {{ fieldVaFormNumber }} (PDF)
+          </a>
         {% endif %}
 
         {% if fieldVaFormToolUrl %}
@@ -96,7 +109,12 @@
                   </hgroup>
 
                   {{ vaForm.entity.fieldVaFormUsage.processed }}
-                  <a href="{{ vaForm.entity.fieldVaFormUrl.uri }}" download>
+
+                  <a
+                    href="{{ vaForm.entity.fieldVaFormUrl.uri }}"
+                    download
+                    data-widget-type="find-va-forms-invalid-pdf-alert"
+                    data-form-number="{{ vaForm.entity.fieldVaFormNumber }}">
                     Download VA Form {{ vaForm.entity.fieldVaFormNumber }} (PDF)
                   </a>
                 </li>

--- a/src/site/layouts/va_form.drupal.liquid
+++ b/src/site/layouts/va_form.drupal.liquid
@@ -70,6 +70,7 @@
           <h3>Downloadable PDF</h3>
           <a
             href="{{ fieldVaFormUrl.uri }}"
+            target="_blank"
             download
             data-widget-type="find-va-forms-invalid-pdf-alert"
             data-form-number="{{ fieldVaFormNumber }}">
@@ -79,6 +80,7 @@
           <a
             class="vads-u-margin-top--4"
             href="{{ fieldVaFormUrl.uri }}"
+            target="_blank"
             download
             data-widget-type="find-va-forms-invalid-pdf-alert"
             data-form-number="{{ fieldVaFormNumber }}">
@@ -112,6 +114,7 @@
 
                   <a
                     href="{{ vaForm.entity.fieldVaFormUrl.uri }}"
+                    target="_blank"
                     download
                     data-widget-type="find-va-forms-invalid-pdf-alert"
                     data-form-number="{{ vaForm.entity.fieldVaFormNumber }}">


### PR DESCRIPTION
## Description
On the upcoming form detail pages, we want to confirm a PDF's link is valid when the link is clicked before initiating the download, so that we can provide feedback to the user that they can get in touch with the form admins if the link isn't working.

https://github.com/department-of-veterans-affairs/va.gov-team/issues/12181

## Testing done

In vagov-content I created a dummy page, `/form-detail-dummy/` with this html to serve as a static version of the template output -

```
### Invalid form download
<a
  href="https://www.va.gov/vaforms/medical/pdf/10-10EZ-fillable.pdf"
  download
  data-widget-type="find-va-forms-invalid-pdf-alert"
  data-form-number="VA0927b">Download VA Form VA0927b (PDF)</a>

### Valid form download
<a
  href="https://www.va.gov/vaforms/medical/pdf/10-10EZ-fillable.pdf"
  download
  data-widget-type="find-va-forms-invalid-pdf-alert"
  data-form-number="10-10EZ">Download VA Form 10-10ez (PDF)</a>

```

![image](https://user-images.githubusercontent.com/1915775/91052302-45d8c500-e5ef-11ea-85ba-4b102cb077f0.png)

## Screenshots

### Invalid link (after click)
There is a couple second delay before this message shows -

![image](https://user-images.githubusercontent.com/1915775/91052340-512bf080-e5ef-11ea-8594-853f896a9d21.png)

### Valid link click
Downloads to the tray


## Acceptance criteria
- [ ] Messaging shows for invalid links

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
