### PR TITLE
Properly disable buttons during delete operations

### DIFF
--- a/src/applications/personalization/profile-2/tests/components/personal-information/PersonalInformation.delete-email-address.unit.spec.jsx
+++ b/src/applications/personalization/profile-2/tests/components/personal-information/PersonalInformation.delete-email-address.unit.spec.jsx
@@ -13,6 +13,7 @@ import {
   createBasicInitialState,
   elementNotRemoved,
   renderWithProfileReducers,
+  waitAndCheck,
 } from '../../unit-test-helpers';
 
 let emailAddress;
@@ -24,22 +25,6 @@ const ui = (
 );
 let view;
 let server;
-
-// returns a Promise that resolves if the cb does not throw an error when it's
-// run after the given timeout. The Promise is rejected if the cb throws an
-// error when it runs.
-function waitAndCheck(cb, timeout) {
-  return new Promise((resolve, reject) => {
-    setTimeout(() => {
-      try {
-        cb();
-        resolve();
-      } catch (e) {
-        reject(e);
-      }
-    }, timeout);
-  });
-}
 
 function getEditButton() {
   let editButton = view.queryByText(/add.*email address/i, {

--- a/src/applications/personalization/profile-2/tests/components/personal-information/PersonalInformation.delete-email-address.unit.spec.jsx
+++ b/src/applications/personalization/profile-2/tests/components/personal-information/PersonalInformation.delete-email-address.unit.spec.jsx
@@ -13,7 +13,7 @@ import {
   createBasicInitialState,
   elementNotRemoved,
   renderWithProfileReducers,
-  waitAndCheck,
+  wait,
 } from '../../unit-test-helpers';
 
 let emailAddress;
@@ -94,13 +94,12 @@ describe('Deleting email address', () => {
     // were enabled again while polling the transaction status. This test was
     // added to prevent regression back to that poor experience where users were
     // able to interact with buttons that created duplicate XHRs.
-    await waitAndCheck(() => {
-      expect(!!cancelDeleteButton.attributes.disabled).to.be.true;
-      expect(!!confirmDeleteButton.attributes.disabled).to.be.true;
-      expect(confirmDeleteButton)
-        .to.have.descendant('i')
-        .and.have.class('fa-spinner');
-    }, 10);
+    await wait(10);
+    expect(!!cancelDeleteButton.attributes.disabled).to.be.true;
+    expect(!!confirmDeleteButton.attributes.disabled).to.be.true;
+    expect(confirmDeleteButton)
+      .to.have.descendant('i')
+      .and.have.class('fa-spinner');
 
     server.use(...mocks.transactionSucceeded);
 
@@ -165,13 +164,16 @@ describe('Deleting email address', () => {
 
     const { cancelDeleteButton, confirmDeleteButton } = deleteEmailAddress();
 
-    await waitAndCheck(() => {
-      expect(!!cancelDeleteButton.attributes.disabled).to.be.true;
-      expect(!!confirmDeleteButton.attributes.disabled).to.be.true;
-      expect(confirmDeleteButton)
-        .to.have.descendant('i')
-        .and.have.class('fa-spinner');
-    }, 10);
+    // Wait for the transaction to be created before checking the state of the
+    // buttons. In the past the buttons worked correctly while making the
+    // initial transaction but were re-enabled while the transaction was still
+    // pending.
+    await wait(10);
+    expect(!!cancelDeleteButton.attributes.disabled).to.be.true;
+    expect(!!confirmDeleteButton.attributes.disabled).to.be.true;
+    expect(confirmDeleteButton)
+      .to.have.descendant('i')
+      .and.have.class('fa-spinner');
 
     server.use(...mocks.transactionFailed);
 

--- a/src/applications/personalization/profile-2/tests/unit-test-helpers.js
+++ b/src/applications/personalization/profile-2/tests/unit-test-helpers.js
@@ -6,19 +6,9 @@ import profile from 'applications/personalization/profile360/reducers';
 import connectedApps from 'applications/personalization/profile-2/components/connected-apps/reducers/connectedApps';
 import profileUi from '../reducers';
 
-// returns a Promise that resolves if the cb does not throw an error when it's
-// run after the given timeout. The Promise is rejected if the cb throws an
-// error when it runs.
-export function waitAndCheck(cb, timeout) {
-  return new Promise((resolve, reject) => {
-    setTimeout(() => {
-      try {
-        cb();
-        resolve();
-      } catch (e) {
-        reject(e);
-      }
-    }, timeout);
+export function wait(timeout) {
+  return new Promise(resolve => {
+    setTimeout(resolve, timeout);
   });
 }
 

--- a/src/applications/personalization/profile-2/tests/unit-test-helpers.js
+++ b/src/applications/personalization/profile-2/tests/unit-test-helpers.js
@@ -6,6 +6,22 @@ import profile from 'applications/personalization/profile360/reducers';
 import connectedApps from 'applications/personalization/profile-2/components/connected-apps/reducers/connectedApps';
 import profileUi from '../reducers';
 
+// returns a Promise that resolves if the cb does not throw an error when it's
+// run after the given timeout. The Promise is rejected if the cb throws an
+// error when it runs.
+export function waitAndCheck(cb, timeout) {
+  return new Promise((resolve, reject) => {
+    setTimeout(() => {
+      try {
+        cb();
+        resolve();
+      } catch (e) {
+        reject(e);
+      }
+    }, timeout);
+  });
+}
+
 // TODO: move this to platform/testing/unit/react-testing-library-helpers
 /**
  * Returns a Promise that rejects if the element is removed from the DOM and

--- a/src/platform/user/profile/vet360/components/base/VAPEditView.jsx
+++ b/src/platform/user/profile/vet360/components/base/VAPEditView.jsx
@@ -107,7 +107,7 @@ class VAPEditView extends Component {
         onDelete={onDelete}
         title={title}
         analyticsSectionName={analyticsSectionName}
-        transactionRequest={transactionRequest}
+        isLoading={isLoading}
         deleteEnabled={!isEmpty && !deleteDisabled}
       >
         <LoadingButton data-action="save-edit" isLoading={isLoading}>

--- a/src/platform/user/profile/vet360/components/base/Vet360EditModalActionButtons.jsx
+++ b/src/platform/user/profile/vet360/components/base/Vet360EditModalActionButtons.jsx
@@ -88,7 +88,7 @@ class Vet360EditModalActionButtons extends React.Component {
         </p>
         <div>
           <LoadingButton
-            isLoading={this.props.transactionRequest?.isPending}
+            isLoading={this.props.isLoading}
             onClick={this.confirmDeleteAction}
           >
             Confirm
@@ -97,6 +97,7 @@ class Vet360EditModalActionButtons extends React.Component {
             type="button"
             className="usa-button-secondary"
             onClick={this.cancelDeleteAction}
+            disabled={this.props.isLoading}
           >
             Cancel
           </button>
@@ -133,7 +134,7 @@ Vet360EditModalActionButtons.propTypes = {
   title: PropTypes.string.isRequired,
   onDelete: PropTypes.func.isRequired,
   onCancel: PropTypes.func.isRequired,
-  transactionRequest: PropTypes.object,
+  isLoading: PropTypes.bool,
 };
 
 Vet360EditModalActionButtons.defaultProps = {


### PR DESCRIPTION
## Description
- Stop re-enabling the "confirm" button after the delete transaction is created but before it has succeeded or failed.
- Also disables the "cancel" button while a deletion is in progress.

## Testing done
Local + new unit tests to confirm the buttons behave correctly when deleting an email address.

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs