### PR TITLE
Add reverse fields to node-health_care_region_page

### DIFF
--- a/src/site/stages/build/process-cms-exports/schemas/input/node-health_care_region_page.js
+++ b/src/site/stages/build/process-cms-exports/schemas/input/node-health_care_region_page.js
@@ -22,6 +22,7 @@ module.exports = {
       },
     },
     field_leadership: { $ref: 'EntityReferenceArray' },
+    reverse_field_region_page: { $ref: 'EntityReferenceArray' },
   },
   required: [
     'title',
@@ -32,5 +33,6 @@ module.exports = {
     // 'field_link_facility_emerg_list',
     'field_nickname_for_this_facility',
     'field_leadership',
+    'reverse_field_region_page',
   ],
 };

--- a/src/site/stages/build/process-cms-exports/schemas/input/node-health_care_region_page.js
+++ b/src/site/stages/build/process-cms-exports/schemas/input/node-health_care_region_page.js
@@ -23,6 +23,7 @@ module.exports = {
     },
     field_leadership: { $ref: 'EntityReferenceArray' },
     reverse_field_region_page: { $ref: 'EntityReferenceArray' },
+    reverse_field_office: { $ref: 'EntityReferenceArray' },
   },
   required: [
     'title',
@@ -34,5 +35,6 @@ module.exports = {
     'field_nickname_for_this_facility',
     'field_leadership',
     'reverse_field_region_page',
+    'reverse_field_office',
   ],
 };

--- a/src/site/stages/build/process-cms-exports/schemas/output/node-health_care_region_page.js
+++ b/src/site/stages/build/process-cms-exports/schemas/output/node-health_care_region_page.js
@@ -207,6 +207,24 @@ module.exports = {
             },
           },
         },
+        newsStoryTeasersFeatured: {
+          type: 'object',
+          properties: {
+            entities: {
+              type: 'array',
+              maxItems: 1000,
+              items: {
+                entity: usePartialSchema(newsStorySchema, [
+                  'title',
+                  'fieldFeatured',
+                  'fieldIntroText',
+                  'fieldMedia',
+                  'entityUrl',
+                ]),
+              },
+            },
+          },
+        },
       },
       required: [
         'title',
@@ -223,6 +241,7 @@ module.exports = {
         'mainFacilities',
         'otherFacilities',
         'eventTeasersFeatured',
+        'newsStoryTeasersFeatured',
       ],
     },
   },

--- a/src/site/stages/build/process-cms-exports/schemas/output/node-health_care_region_page.js
+++ b/src/site/stages/build/process-cms-exports/schemas/output/node-health_care_region_page.js
@@ -5,6 +5,35 @@ const newsStorySchema = require('./node-news_story');
 const eventSchema = require('./node-event');
 const pressRelease = require('./node-press_release');
 
+const facilitiesSchema = {
+  type: 'object',
+  properties: {
+    entities: {
+      type: 'array',
+      items: {
+        /* eslint-disable react-hooks/rules-of-hooks */
+        entity: usePartialSchema(healthCareLocalFacilitySchema, [
+          'entityUrl',
+          'entityBundle',
+          'title',
+          'changed',
+          'fieldOperatingStatusFacility',
+          'fieldFacilityLocatorApiId',
+          'fieldNicknameForThisFacility',
+          'fieldIntroText',
+          'fieldLocationServices',
+          'fieldAddress',
+          'fieldPhoneNumber',
+          'fieldMentalHealthPhone',
+          'fieldFacilityHours',
+          'fieldMainLocation',
+          'fieldMedia',
+        ]),
+      },
+    },
+  },
+};
+
 module.exports = {
   type: 'object',
   properties: {
@@ -161,33 +190,8 @@ module.exports = {
             },
           },
         },
-        mainFacilities: {
-          type: 'object',
-          properties: {
-            entities: {
-              type: 'array',
-              items: {
-                entity: usePartialSchema(healthCareLocalFacilitySchema, [
-                  'entityUrl',
-                  'entityBundle',
-                  'title',
-                  'changed',
-                  'fieldOperatingStatusFacility',
-                  'fieldFacilityLocatorApiId',
-                  'fieldNicknameForThisFacility',
-                  'fieldIntroText',
-                  'fieldLocationServices',
-                  'fieldAddress',
-                  'fieldPhoneNumber',
-                  'fieldMentalHealthPhone',
-                  'fieldFacilityHours',
-                  'fieldMainLocation',
-                  'fieldMedia',
-                ]),
-              },
-            },
-          },
-        },
+        mainFacilities: facilitiesSchema,
+        otherFacilities: facilitiesSchema,
       },
       required: [
         'title',
@@ -202,6 +206,7 @@ module.exports = {
         'allEventTeasers',
         'allPressReleaseTeasers',
         'mainFacilities',
+        'otherFacilities',
       ],
     },
   },

--- a/src/site/stages/build/process-cms-exports/schemas/output/node-health_care_region_page.js
+++ b/src/site/stages/build/process-cms-exports/schemas/output/node-health_care_region_page.js
@@ -2,6 +2,7 @@ const { usePartialSchema } = require('../../transformers/helpers');
 const personProfileSchema = require('./node-person_profile');
 const healthCareLocalFacilitySchema = require('./node-health_care_local_facility');
 const newsStorySchema = require('./node-news_story');
+const eventSchema = require('./node-event');
 
 module.exports = {
   type: 'object',
@@ -105,6 +106,25 @@ module.exports = {
             },
           },
         },
+        eventTeasers: {
+          type: 'object',
+          properties: {
+            entities: {
+              type: 'array',
+              maxItems: 2,
+              items: {
+                entity: usePartialSchema(eventSchema, [
+                  'title',
+                  'fieldDate',
+                  'fieldDescription',
+                  'fieldLocationHumanreadable',
+                  'fieldFacilityLocation',
+                  'entityUrl',
+                ]),
+              },
+            },
+          },
+        },
       },
       required: [
         'title',
@@ -115,6 +135,7 @@ module.exports = {
         'reverseFieldRegionPageNode',
         'newsStoryTeasers',
         'allNewsStoryTeasers',
+        'eventTeasers',
       ],
     },
   },

--- a/src/site/stages/build/process-cms-exports/schemas/output/node-health_care_region_page.js
+++ b/src/site/stages/build/process-cms-exports/schemas/output/node-health_care_region_page.js
@@ -1,6 +1,7 @@
 const { usePartialSchema } = require('../../transformers/helpers');
 const personProfileSchema = require('./node-person_profile');
 const healthCareLocalFacilitySchema = require('./node-health_care_local_facility');
+const newsStorySchema = require('./node-news_story');
 
 module.exports = {
   type: 'object',
@@ -68,6 +69,24 @@ module.exports = {
             },
           },
         },
+        newsStoryTeasers: {
+          type: 'object',
+          properties: {
+            entities: {
+              type: 'array',
+              maxItems: 2,
+              items: {
+                entity: usePartialSchema(newsStorySchema, [
+                  'title',
+                  'fieldFeatured',
+                  'fieldIntroText',
+                  'fieldMedia',
+                  'entityUrl',
+                ]),
+              },
+            },
+          },
+        },
       },
       required: [
         'title',
@@ -76,6 +95,7 @@ module.exports = {
         'fieldPressReleaseBlurb',
         'fieldLeadership',
         'reverseFieldRegionPageNode',
+        'newsStoryTeasers',
       ],
     },
   },

--- a/src/site/stages/build/process-cms-exports/schemas/output/node-health_care_region_page.js
+++ b/src/site/stages/build/process-cms-exports/schemas/output/node-health_care_region_page.js
@@ -222,6 +222,7 @@ module.exports = {
         'allPressReleaseTeasers',
         'mainFacilities',
         'otherFacilities',
+        'eventTeasersFeatured',
       ],
     },
   },

--- a/src/site/stages/build/process-cms-exports/schemas/output/node-health_care_region_page.js
+++ b/src/site/stages/build/process-cms-exports/schemas/output/node-health_care_region_page.js
@@ -87,6 +87,24 @@ module.exports = {
             },
           },
         },
+        allNewsStoryTeasers: {
+          type: 'object',
+          properties: {
+            entities: {
+              type: 'array',
+              maxItems: 500,
+              items: {
+                entity: usePartialSchema(newsStorySchema, [
+                  'title',
+                  'fieldFeatured',
+                  'fieldIntroText',
+                  'fieldMedia',
+                  'entityUrl',
+                ]),
+              },
+            },
+          },
+        },
       },
       required: [
         'title',
@@ -96,6 +114,7 @@ module.exports = {
         'fieldLeadership',
         'reverseFieldRegionPageNode',
         'newsStoryTeasers',
+        'allNewsStoryTeasers',
       ],
     },
   },

--- a/src/site/stages/build/process-cms-exports/schemas/output/node-health_care_region_page.js
+++ b/src/site/stages/build/process-cms-exports/schemas/output/node-health_care_region_page.js
@@ -4,7 +4,6 @@ const healthCareLocalFacilitySchema = require('./node-health_care_local_facility
 const newsStorySchema = require('./node-news_story');
 const eventSchema = require('./node-event');
 const pressRelease = require('./node-press_release');
-const eventListingSchema = require('./node-event_listing');
 
 const facilitiesSchema = {
   type: 'object',
@@ -34,6 +33,26 @@ const facilitiesSchema = {
     },
   },
 };
+
+const eventTeasersSchema = max => ({
+  type: 'object',
+  properties: {
+    entities: {
+      type: 'array',
+      maxItems: max,
+      items: {
+        entity: usePartialSchema(eventSchema, [
+          'title',
+          'fieldDate',
+          'fieldDescription',
+          'fieldLocationHumanreadable',
+          'fieldFacilityLocation',
+          'entityUrl',
+        ]),
+      },
+    },
+  },
+});
 
 module.exports = {
   type: 'object',
@@ -137,44 +156,8 @@ module.exports = {
             },
           },
         },
-        eventTeasers: {
-          type: 'object',
-          properties: {
-            entities: {
-              type: 'array',
-              maxItems: 2,
-              items: {
-                entity: usePartialSchema(eventSchema, [
-                  'title',
-                  'fieldDate',
-                  'fieldDescription',
-                  'fieldLocationHumanreadable',
-                  'fieldFacilityLocation',
-                  'entityUrl',
-                ]),
-              },
-            },
-          },
-        },
-        allEventTeasers: {
-          type: 'object',
-          properties: {
-            entities: {
-              type: 'array',
-              maxItems: 500,
-              items: {
-                entity: usePartialSchema(eventSchema, [
-                  'title',
-                  'fieldDate',
-                  'fieldDescription',
-                  'fieldLocationHumanreadable',
-                  'fieldFacilityLocation',
-                  'entityUrl',
-                ]),
-              },
-            },
-          },
-        },
+        eventTeasers: eventTeasersSchema(2),
+        allEventTeasers: eventTeasersSchema(500),
         allPressReleaseTeasers: {
           type: 'object',
           properties: {
@@ -193,20 +176,8 @@ module.exports = {
         },
         mainFacilities: facilitiesSchema,
         otherFacilities: facilitiesSchema,
-        eventTeasersFeatured: {
-          type: 'object',
-          properties: {
-            entities: {
-              type: 'array',
-              maxItems: 1000,
-              items: {
-                entity: usePartialSchema(eventListingSchema, [
-                  'reverseFieldListingNode',
-                ]),
-              },
-            },
-          },
-        },
+        eventTeasersAll: eventTeasersSchema(1000),
+        eventTeasersFeatured: eventTeasersSchema(1000),
         newsStoryTeasersFeatured: {
           type: 'object',
           properties: {
@@ -240,6 +211,7 @@ module.exports = {
         'allPressReleaseTeasers',
         'mainFacilities',
         'otherFacilities',
+        'eventTeasersAll',
         'eventTeasersFeatured',
         'newsStoryTeasersFeatured',
       ],

--- a/src/site/stages/build/process-cms-exports/schemas/output/node-health_care_region_page.js
+++ b/src/site/stages/build/process-cms-exports/schemas/output/node-health_care_region_page.js
@@ -54,6 +54,25 @@ const eventTeasersSchema = max => ({
   },
 });
 
+const newsTeasersSchema = max => ({
+  type: 'object',
+  properties: {
+    entities: {
+      type: 'array',
+      maxItems: max,
+      items: {
+        entity: usePartialSchema(newsStorySchema, [
+          'title',
+          'fieldFeatured',
+          'fieldIntroText',
+          'fieldMedia',
+          'entityUrl',
+        ]),
+      },
+    },
+  },
+});
+
 module.exports = {
   type: 'object',
   properties: {
@@ -120,42 +139,8 @@ module.exports = {
             },
           },
         },
-        newsStoryTeasers: {
-          type: 'object',
-          properties: {
-            entities: {
-              type: 'array',
-              maxItems: 2,
-              items: {
-                entity: usePartialSchema(newsStorySchema, [
-                  'title',
-                  'fieldFeatured',
-                  'fieldIntroText',
-                  'fieldMedia',
-                  'entityUrl',
-                ]),
-              },
-            },
-          },
-        },
-        allNewsStoryTeasers: {
-          type: 'object',
-          properties: {
-            entities: {
-              type: 'array',
-              maxItems: 500,
-              items: {
-                entity: usePartialSchema(newsStorySchema, [
-                  'title',
-                  'fieldFeatured',
-                  'fieldIntroText',
-                  'fieldMedia',
-                  'entityUrl',
-                ]),
-              },
-            },
-          },
-        },
+        newsStoryTeasers: newsTeasersSchema(2),
+        allNewsStoryTeasers: newsTeasersSchema(500),
         eventTeasers: eventTeasersSchema(2),
         allEventTeasers: eventTeasersSchema(500),
         allPressReleaseTeasers: {
@@ -178,24 +163,7 @@ module.exports = {
         otherFacilities: facilitiesSchema,
         eventTeasersAll: eventTeasersSchema(1000),
         eventTeasersFeatured: eventTeasersSchema(1000),
-        newsStoryTeasersFeatured: {
-          type: 'object',
-          properties: {
-            entities: {
-              type: 'array',
-              maxItems: 1000,
-              items: {
-                entity: usePartialSchema(newsStorySchema, [
-                  'title',
-                  'fieldFeatured',
-                  'fieldIntroText',
-                  'fieldMedia',
-                  'entityUrl',
-                ]),
-              },
-            },
-          },
-        },
+        newsStoryTeasersFeatured: newsTeasersSchema(1000),
       },
       required: [
         'title',

--- a/src/site/stages/build/process-cms-exports/schemas/output/node-health_care_region_page.js
+++ b/src/site/stages/build/process-cms-exports/schemas/output/node-health_care_region_page.js
@@ -3,6 +3,7 @@ const personProfileSchema = require('./node-person_profile');
 const healthCareLocalFacilitySchema = require('./node-health_care_local_facility');
 const newsStorySchema = require('./node-news_story');
 const eventSchema = require('./node-event');
+const pressRelease = require('./node-press_release');
 
 module.exports = {
   type: 'object',
@@ -144,6 +145,22 @@ module.exports = {
             },
           },
         },
+        allPressReleaseTeasers: {
+          type: 'object',
+          properties: {
+            entities: {
+              type: 'array',
+              maxItems: 100,
+              items: {
+                entity: usePartialSchema(pressRelease, [
+                  'title',
+                  'fieldReleaseDate',
+                  'entityUrl',
+                ]),
+              },
+            },
+          },
+        },
       },
       required: [
         'title',
@@ -156,6 +173,7 @@ module.exports = {
         'allNewsStoryTeasers',
         'eventTeasers',
         'allEventTeasers',
+        'allPressReleaseTeasers',
       ],
     },
   },

--- a/src/site/stages/build/process-cms-exports/schemas/output/node-health_care_region_page.js
+++ b/src/site/stages/build/process-cms-exports/schemas/output/node-health_care_region_page.js
@@ -4,6 +4,7 @@ const healthCareLocalFacilitySchema = require('./node-health_care_local_facility
 const newsStorySchema = require('./node-news_story');
 const eventSchema = require('./node-event');
 const pressRelease = require('./node-press_release');
+const eventListingSchema = require('./node-event_listing');
 
 const facilitiesSchema = {
   type: 'object',
@@ -192,6 +193,20 @@ module.exports = {
         },
         mainFacilities: facilitiesSchema,
         otherFacilities: facilitiesSchema,
+        eventTeasersFeatured: {
+          type: 'object',
+          properties: {
+            entities: {
+              type: 'array',
+              maxItems: 1000,
+              items: {
+                entity: usePartialSchema(eventListingSchema, [
+                  'reverseFieldListingNode',
+                ]),
+              },
+            },
+          },
+        },
       },
       required: [
         'title',

--- a/src/site/stages/build/process-cms-exports/schemas/output/node-health_care_region_page.js
+++ b/src/site/stages/build/process-cms-exports/schemas/output/node-health_care_region_page.js
@@ -161,6 +161,33 @@ module.exports = {
             },
           },
         },
+        mainFacilities: {
+          type: 'object',
+          properties: {
+            entities: {
+              type: 'array',
+              items: {
+                entity: usePartialSchema(healthCareLocalFacilitySchema, [
+                  'entityUrl',
+                  'entityBundle',
+                  'title',
+                  'changed',
+                  'fieldOperatingStatusFacility',
+                  'fieldFacilityLocatorApiId',
+                  'fieldNicknameForThisFacility',
+                  'fieldIntroText',
+                  'fieldLocationServices',
+                  'fieldAddress',
+                  'fieldPhoneNumber',
+                  'fieldMentalHealthPhone',
+                  'fieldFacilityHours',
+                  'fieldMainLocation',
+                  'fieldMedia',
+                ]),
+              },
+            },
+          },
+        },
       },
       required: [
         'title',
@@ -174,6 +201,7 @@ module.exports = {
         'eventTeasers',
         'allEventTeasers',
         'allPressReleaseTeasers',
+        'mainFacilities',
       ],
     },
   },

--- a/src/site/stages/build/process-cms-exports/schemas/output/node-health_care_region_page.js
+++ b/src/site/stages/build/process-cms-exports/schemas/output/node-health_care_region_page.js
@@ -1,5 +1,6 @@
 const { usePartialSchema } = require('../../transformers/helpers');
 const personProfileSchema = require('./node-person_profile');
+const healthCareLocalFacilitySchema = require('./node-health_care_local_facility');
 
 module.exports = {
   type: 'object',
@@ -53,6 +54,20 @@ module.exports = {
             ]),
           },
         },
+        reverseFieldRegionPageNode: {
+          type: 'object',
+          properties: {
+            entities: {
+              type: 'array',
+              items: {
+                entity: usePartialSchema(healthCareLocalFacilitySchema, [
+                  'title',
+                  'fieldOperatingStatusFacility',
+                ]),
+              },
+            },
+          },
+        },
       },
       required: [
         'title',
@@ -60,6 +75,7 @@ module.exports = {
         'fieldLinkFacilityEmergList',
         'fieldPressReleaseBlurb',
         'fieldLeadership',
+        'reverseFieldRegionPageNode',
       ],
     },
   },

--- a/src/site/stages/build/process-cms-exports/schemas/output/node-health_care_region_page.js
+++ b/src/site/stages/build/process-cms-exports/schemas/output/node-health_care_region_page.js
@@ -125,6 +125,25 @@ module.exports = {
             },
           },
         },
+        allEventTeasers: {
+          type: 'object',
+          properties: {
+            entities: {
+              type: 'array',
+              maxItems: 500,
+              items: {
+                entity: usePartialSchema(eventSchema, [
+                  'title',
+                  'fieldDate',
+                  'fieldDescription',
+                  'fieldLocationHumanreadable',
+                  'fieldFacilityLocation',
+                  'entityUrl',
+                ]),
+              },
+            },
+          },
+        },
       },
       required: [
         'title',
@@ -136,6 +155,7 @@ module.exports = {
         'newsStoryTeasers',
         'allNewsStoryTeasers',
         'eventTeasers',
+        'allEventTeasers',
       ],
     },
   },

--- a/src/site/stages/build/process-cms-exports/schemas/output/node-story_listing.js
+++ b/src/site/stages/build/process-cms-exports/schemas/output/node-story_listing.js
@@ -27,6 +27,7 @@ module.exports = {
               'title',
               'fieldFeatured',
               'entityUrl',
+              'entityPublished',
               'promote',
               'created',
               'fieldAuthor',

--- a/src/site/stages/build/process-cms-exports/transformers/node-event_listing.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-event_listing.js
@@ -24,7 +24,7 @@ const reverseFields = reverseFieldListing => ({
     : [],
 });
 
-const transform = entity => ({
+const transform = (entity, { ancestors }) => ({
   entityType: 'node',
   entityBundle: 'event_listing',
   title: getDrupalValue(entity.title),
@@ -36,7 +36,11 @@ const transform = entity => ({
   fieldDescription: getDrupalValue(entity.fieldDescription),
   fieldIntroText: getDrupalValue(entity.fieldIntroText),
   fieldMetaTitle: getDrupalValue(entity.fieldMetaTitle),
-  fieldOffice: entity.fieldOffice[0],
+  fieldOffice:
+    entity.fieldOffice[0] &&
+    !ancestors.find(r => r.entity.uuid === entity.fieldOffice[0].uuid)
+      ? entity.fieldOffice[0]
+      : null,
   reverseFieldListingNode: reverseFields(entity.reverseFieldListing),
   pastEvents: reverseFields(entity.reverseFieldListing),
 });

--- a/src/site/stages/build/process-cms-exports/transformers/node-health_care_local_facility.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-health_care_local_facility.js
@@ -15,7 +15,7 @@ const getSocialMediaObject = ({ uri, title }) =>
       }
     : null;
 
-const transform = entity => ({
+const transform = (entity, { ancestors }) => ({
   entityType: 'node',
   entityBundle: 'health_care_local_facility',
   title: getDrupalValue(entity.title),
@@ -54,7 +54,11 @@ const transform = entity => ({
     entity.fieldOperatingStatusMoreInfo,
   ),
   fieldPhoneNumber: getDrupalValue(entity.fieldPhoneNumber),
-  fieldRegionPage: entity.fieldRegionPage[0] || null,
+  fieldRegionPage:
+    entity.fieldRegionPage[0] &&
+    !ancestors.find(r => r.entity.uuid === entity.fieldRegionPage[0].uuid)
+      ? entity.fieldRegionPage[0]
+      : null,
   fieldTwitter: getSocialMediaObject(entity.fieldTwitter),
 });
 

--- a/src/site/stages/build/process-cms-exports/transformers/node-health_care_region_detail_page.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-health_care_region_detail_page.js
@@ -5,7 +5,7 @@ const {
   createMetaTagArray,
 } = require('./helpers');
 
-const transform = entity => ({
+const transform = (entity, { ancestors }) => ({
   entityType: 'node',
   entityBundle: 'health_care_region_detail_page',
   title: getDrupalValue(entity.title),
@@ -16,7 +16,11 @@ const transform = entity => ({
   fieldContentBlock: entity.fieldContentBlock,
   fieldFeaturedContent: entity.fieldFeaturedContent,
   fieldIntroText: getDrupalValue(entity.fieldIntroText),
-  fieldOffice: entity.fieldOffice[0] || null,
+  fieldOffice:
+    entity.fieldOffice[0] &&
+    !ancestors.find(r => r.entity.uuid === entity.fieldOffice[0].uuid)
+      ? entity.fieldOffice[0]
+      : null,
   fieldRelatedLinks: entity.fieldRelatedLinks[0] || null,
   fieldTableOfContentsBoolean: getDrupalValue(
     entity.fieldTableOfContentsBoolean,

--- a/src/site/stages/build/process-cms-exports/transformers/node-health_care_region_page.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-health_care_region_page.js
@@ -239,6 +239,31 @@ const transform = ({
             }))
         : [],
     },
+    eventTeasersFeatured: {
+      entities: reverseFieldOffice
+        ? reverseFieldOffice
+            .filter(
+              reverseField => reverseField.entityBundle === 'event_listing',
+            )
+            .slice(0, 1000)
+            .map(r => ({
+              reverseFieldListingNode: {
+                entities: r.reverseFieldListingNode.entities
+                  .slice(0, 1000)
+                  .filter(
+                    reverseField =>
+                      reverseField.entityBundle === 'event' &&
+                      reverseField.entityPublished &&
+                      reverseField.fieldFeatured &&
+                      moment(reverseField.fieldDate.value).isAfter(
+                        moment(),
+                        'day',
+                      ),
+                  ),
+              },
+            }))
+        : [],
+    },
   },
 });
 module.exports = {

--- a/src/site/stages/build/process-cms-exports/transformers/node-health_care_region_page.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-health_care_region_page.js
@@ -77,6 +77,26 @@ const transform = ({
             }))
         : [],
     },
+    newsStoryTeasers: {
+      entities: reverseFieldRegionPage
+        ? reverseFieldRegionPage
+            .filter(
+              reverseField =>
+                reverseField.entityBundle === 'news_story' &&
+                reverseField.entityPublished &&
+                reverseField.fieldFeatured,
+            )
+            .sort((a, b) => b.created - a.created)
+            .slice(0, 2)
+            .map(r => ({
+              title: r.title,
+              fieldFeatured: r.fieldFeatured,
+              fieldIntroText: r.fieldIntroText,
+              fieldMedia: r.fieldMedia,
+              entityUrl: r.entityUrl,
+            }))
+        : [],
+    },
   },
 });
 module.exports = {

--- a/src/site/stages/build/process-cms-exports/transformers/node-health_care_region_page.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-health_care_region_page.js
@@ -239,6 +239,38 @@ const transform = ({
             }))
         : [],
     },
+    eventTeasersAll: {
+      entities: reverseFieldOffice
+        ? reverseFieldOffice
+            .filter(
+              reverseField => reverseField.entityBundle === 'event_listing',
+            )
+            .slice(0, 1000)
+            .map(r => ({
+              reverseFieldListingNode: {
+                entities: r.reverseFieldListingNode.entities
+                  .filter(
+                    reverseField =>
+                      reverseField.entityBundle === 'event' &&
+                      reverseField.entityPublished &&
+                      moment(reverseField.fieldDate.value).isAfter(
+                        moment(),
+                        'day',
+                      ),
+                  )
+                  .slice(0, 1000)
+                  .map(e => ({
+                    title: e.title,
+                    fieldDate: e.fieldDate,
+                    fieldDescription: e.fieldDescription,
+                    fieldLocationHumanreadable: e.fieldLocationHumanreadable,
+                    fieldFacilityLocation: e.fieldFacilityLocation,
+                    entityUrl: e.entityUrl,
+                  })),
+              },
+            }))
+        : [],
+    },
     eventTeasersFeatured: {
       entities: reverseFieldOffice
         ? reverseFieldOffice

--- a/src/site/stages/build/process-cms-exports/transformers/node-health_care_region_page.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-health_care_region_page.js
@@ -16,6 +16,7 @@ const transform = ({
   fieldLinkFacilityEmergList,
   fieldLeadership,
   reverseFieldRegionPage,
+  reverseFieldOffice,
 }) => ({
   entity: {
     entityType: 'node',
@@ -78,8 +79,8 @@ const transform = ({
         : [],
     },
     newsStoryTeasers: {
-      entities: reverseFieldRegionPage
-        ? reverseFieldRegionPage
+      entities: reverseFieldOffice
+        ? reverseFieldOffice
             .filter(
               reverseField =>
                 reverseField.entityBundle === 'news_story' &&
@@ -98,8 +99,8 @@ const transform = ({
         : [],
     },
     allNewsStoryTeasers: {
-      entities: reverseFieldRegionPage
-        ? reverseFieldRegionPage
+      entities: reverseFieldOffice
+        ? reverseFieldOffice
             .filter(
               reverseField =>
                 reverseField.entityBundle === 'news_story' &&
@@ -130,6 +131,7 @@ module.exports = {
     'metatag',
     'field_leadership',
     'reverse_field_region_page',
+    'reverse_field_office',
   ],
   transform,
 };

--- a/src/site/stages/build/process-cms-exports/transformers/node-health_care_region_page.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-health_care_region_page.js
@@ -208,6 +208,37 @@ const transform = ({
             }))
         : [],
     },
+    otherFacilities: {
+      entities: reverseFieldRegionPage
+        ? reverseFieldRegionPage
+            .filter(
+              reverseField =>
+                !reverseField.fieldMainLocation && reverseField.entityPublished,
+            )
+            .sort(
+              (a, b) =>
+                a.fieldNicknameForThisFacility - b.fieldNicknameForThisFacility,
+            )
+            .map(r => ({
+              entityUrl: r.entityUrl,
+              entityBundle: r.entityBundle,
+              title: r.title,
+              entityId: r.entityId,
+              changed: r.changed,
+              fieldOperatingStatusFacility: r.fieldOperatingStatusFacility,
+              fieldFacilityLocatorApiId: r.fieldFacilityLocatorApiId,
+              fieldNicknameForThisFacility: r.fieldNicknameForThisFacility,
+              fieldIntroText: r.fieldIntroText,
+              fieldLocationServices: r.fieldLocationServices,
+              fieldAddress: r.fieldAddress,
+              fieldPhoneNumber: r.fieldPhoneNumber,
+              fieldMentalHealthPhone: r.fieldMentalHealthPhone,
+              fieldFacilityHours: r.fieldFacilityHours,
+              fieldMainLocation: r.fieldMainLocation,
+              fieldMedia: r.fieldMedia,
+            }))
+        : [],
+    },
   },
 });
 module.exports = {

--- a/src/site/stages/build/process-cms-exports/transformers/node-health_care_region_page.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-health_care_region_page.js
@@ -264,6 +264,34 @@ const transform = ({
             }))
         : [],
     },
+    newsStoryTeasersFeatured: {
+      entities: reverseFieldOffice
+        ? reverseFieldOffice
+            .filter(
+              reverseField => reverseField.entityBundle === 'story_listing',
+            )
+            .slice(0, 1000)
+            .map(r => ({
+              reverseFieldListingNode: {
+                entities: r.reverseFieldListingNode.entities
+                  .filter(
+                    reverseField =>
+                      reverseField.entityBundle === 'news_story' &&
+                      reverseField.entityPublished &&
+                      reverseField.fieldFeatured,
+                  )
+                  .slice(0, 1000)
+                  .map(e => ({
+                    title: e.title,
+                    fieldFeatured: e.fieldFeatured,
+                    fieldIntroText: e.fieldIntroText,
+                    fieldMedia: e.fieldMedia,
+                    entityUrl: e.entityUrl,
+                  })),
+              },
+            }))
+        : [],
+    },
   },
 });
 module.exports = {

--- a/src/site/stages/build/process-cms-exports/transformers/node-health_care_region_page.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-health_care_region_page.js
@@ -177,6 +177,37 @@ const transform = ({
             }))
         : [],
     },
+    mainFacilities: {
+      entities: reverseFieldRegionPage
+        ? reverseFieldRegionPage
+            .filter(
+              reverseField =>
+                reverseField.fieldMainLocation && reverseField.entityPublished,
+            )
+            .sort(
+              (a, b) =>
+                a.fieldNicknameForThisFacility - b.fieldNicknameForThisFacility,
+            )
+            .map(r => ({
+              entityUrl: r.entityUrl,
+              entityBundle: r.entityBundle,
+              title: r.title,
+              entityId: r.entityId,
+              changed: r.changed,
+              fieldOperatingStatusFacility: r.fieldOperatingStatusFacility,
+              fieldFacilityLocatorApiId: r.fieldFacilityLocatorApiId,
+              fieldNicknameForThisFacility: r.fieldNicknameForThisFacility,
+              fieldIntroText: r.fieldIntroText,
+              fieldLocationServices: r.fieldLocationServices,
+              fieldAddress: r.fieldAddress,
+              fieldPhoneNumber: r.fieldPhoneNumber,
+              fieldMentalHealthPhone: r.fieldMentalHealthPhone,
+              fieldFacilityHours: r.fieldFacilityHours,
+              fieldMainLocation: r.fieldMainLocation,
+              fieldMedia: r.fieldMedia,
+            }))
+        : [],
+    },
   },
 });
 module.exports = {

--- a/src/site/stages/build/process-cms-exports/transformers/node-health_care_region_page.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-health_care_region_page.js
@@ -248,25 +248,28 @@ const transform = ({
             .slice(0, 1000)
             .map(r => ({
               reverseFieldListingNode: {
-                entities: r.reverseFieldListingNode.entities
-                  .filter(
-                    reverseField =>
-                      reverseField.entityBundle === 'event' &&
-                      reverseField.entityPublished &&
-                      moment(reverseField.fieldDate.value).isAfter(
-                        moment(),
-                        'day',
-                      ),
-                  )
-                  .slice(0, 1000)
-                  .map(e => ({
-                    title: e.title,
-                    fieldDate: e.fieldDate,
-                    fieldDescription: e.fieldDescription,
-                    fieldLocationHumanreadable: e.fieldLocationHumanreadable,
-                    fieldFacilityLocation: e.fieldFacilityLocation,
-                    entityUrl: e.entityUrl,
-                  })),
+                entities: r.reverseFieldListingNode
+                  ? r.reverseFieldListingNode.entities
+                      .filter(
+                        reverseField =>
+                          reverseField.entityBundle === 'event' &&
+                          reverseField.entityPublished &&
+                          moment(reverseField.fieldDate.value).isAfter(
+                            moment(),
+                            'day',
+                          ),
+                      )
+                      .slice(0, 1000)
+                      .map(e => ({
+                        title: e.title,
+                        fieldDate: e.fieldDate,
+                        fieldDescription: e.fieldDescription,
+                        fieldLocationHumanreadable:
+                          e.fieldLocationHumanreadable,
+                        fieldFacilityLocation: e.fieldFacilityLocation,
+                        entityUrl: e.entityUrl,
+                      }))
+                  : [],
               },
             }))
         : [],
@@ -280,26 +283,29 @@ const transform = ({
             .slice(0, 1000)
             .map(r => ({
               reverseFieldListingNode: {
-                entities: r.reverseFieldListingNode.entities
-                  .slice(0, 1000)
-                  .filter(
-                    reverseField =>
-                      reverseField.entityBundle === 'event' &&
-                      reverseField.entityPublished &&
-                      reverseField.fieldFeatured &&
-                      moment(reverseField.fieldDate.value).isAfter(
-                        moment(),
-                        'day',
-                      ),
-                  )
-                  .map(e => ({
-                    title: e.title,
-                    fieldDate: e.fieldDate,
-                    fieldDescription: e.fieldDescription,
-                    fieldLocationHumanreadable: e.fieldLocationHumanreadable,
-                    fieldFacilityLocation: e.fieldFacilityLocation,
-                    entityUrl: e.entityUrl,
-                  })),
+                entities: r.reverseFieldListingNode
+                  ? r.reverseFieldListingNode.entities
+                      .slice(0, 1000)
+                      .filter(
+                        reverseField =>
+                          reverseField.entityBundle === 'event' &&
+                          reverseField.entityPublished &&
+                          reverseField.fieldFeatured &&
+                          moment(reverseField.fieldDate.value).isAfter(
+                            moment(),
+                            'day',
+                          ),
+                      )
+                      .map(e => ({
+                        title: e.title,
+                        fieldDate: e.fieldDate,
+                        fieldDescription: e.fieldDescription,
+                        fieldLocationHumanreadable:
+                          e.fieldLocationHumanreadable,
+                        fieldFacilityLocation: e.fieldFacilityLocation,
+                        entityUrl: e.entityUrl,
+                      }))
+                  : [],
               },
             }))
         : [],
@@ -313,21 +319,23 @@ const transform = ({
             .slice(0, 1000)
             .map(r => ({
               reverseFieldListingNode: {
-                entities: r.reverseFieldListingNode.entities
-                  .filter(
-                    reverseField =>
-                      reverseField.entityBundle === 'news_story' &&
-                      reverseField.entityPublished &&
-                      reverseField.fieldFeatured,
-                  )
-                  .slice(0, 1000)
-                  .map(e => ({
-                    title: e.title,
-                    fieldFeatured: e.fieldFeatured,
-                    fieldIntroText: e.fieldIntroText,
-                    fieldMedia: e.fieldMedia,
-                    entityUrl: e.entityUrl,
-                  })),
+                entities: r.reverseFieldListingNode
+                  ? r.reverseFieldListingNode.entities
+                      .filter(
+                        reverseField =>
+                          reverseField.entityBundle === 'news_story' &&
+                          reverseField.entityPublished &&
+                          reverseField.fieldFeatured,
+                      )
+                      .slice(0, 1000)
+                      .map(e => ({
+                        title: e.title,
+                        fieldFeatured: e.fieldFeatured,
+                        fieldIntroText: e.fieldIntroText,
+                        fieldMedia: e.fieldMedia,
+                        entityUrl: e.entityUrl,
+                      }))
+                  : [],
               },
             }))
         : [],

--- a/src/site/stages/build/process-cms-exports/transformers/node-health_care_region_page.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-health_care_region_page.js
@@ -15,6 +15,7 @@ const transform = ({
   fieldPressReleaseBlurb,
   fieldLinkFacilityEmergList,
   fieldLeadership,
+  reverseFieldRegionPage,
 }) => ({
   entity: {
     entityType: 'node',
@@ -63,6 +64,19 @@ const transform = ({
           },
         }))
       : [],
+    reverseFieldRegionPageNode: {
+      entities: reverseFieldRegionPage
+        ? reverseFieldRegionPage
+            .filter(
+              reverseField =>
+                reverseField.entityBundle === 'health_care_local_facility',
+            )
+            .map(r => ({
+              title: r.title,
+              fieldOperatingStatusFacility: r.fieldOperatingStatusFacility,
+            }))
+        : [],
+    },
   },
 });
 module.exports = {
@@ -76,6 +90,7 @@ module.exports = {
     'field_press_release_blurb',
     'metatag',
     'field_leadership',
+    'reverse_field_region_page',
   ],
   transform,
 };

--- a/src/site/stages/build/process-cms-exports/transformers/node-health_care_region_page.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-health_care_region_page.js
@@ -97,6 +97,25 @@ const transform = ({
             }))
         : [],
     },
+    allNewsStoryTeasers: {
+      entities: reverseFieldRegionPage
+        ? reverseFieldRegionPage
+            .filter(
+              reverseField =>
+                reverseField.entityBundle === 'news_story' &&
+                reverseField.entityPublished,
+            )
+            .sort((a, b) => b.created - a.created)
+            .slice(0, 500)
+            .map(r => ({
+              title: r.title,
+              fieldFeatured: r.fieldFeatured,
+              fieldIntroText: r.fieldIntroText,
+              fieldMedia: r.fieldMedia,
+              entityUrl: r.entityUrl,
+            }))
+        : [],
+    },
   },
 });
 module.exports = {

--- a/src/site/stages/build/process-cms-exports/transformers/node-health_care_region_page.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-health_care_region_page.js
@@ -160,6 +160,23 @@ const transform = ({
             }))
         : [],
     },
+    allPressReleaseTeasers: {
+      entities: reverseFieldOffice
+        ? reverseFieldOffice
+            .filter(
+              reverseField =>
+                reverseField.entityBundle === 'press_release' &&
+                reverseField.entityPublished,
+            )
+            .sort((a, b) => b.fieldReleaseDate.value - a.fieldReleaseDate.value)
+            .slice(0, 100)
+            .map(r => ({
+              title: r.title,
+              fieldReleaseDate: r.fieldReleaseDate,
+              entityUrl: r.entityUrl,
+            }))
+        : [],
+    },
   },
 });
 module.exports = {

--- a/src/site/stages/build/process-cms-exports/transformers/node-health_care_region_page.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-health_care_region_page.js
@@ -141,6 +141,25 @@ const transform = ({
             }))
         : [],
     },
+    allEventTeasers: {
+      entities: reverseFieldOffice
+        ? reverseFieldOffice
+            .filter(
+              reverseField =>
+                reverseField.entityBundle === 'event' &&
+                reverseField.entityPublished,
+            )
+            .sort((a, b) => a.fieldDate.value - b.fieldDate.value)
+            .slice(0, 500)
+            .map(r => ({
+              title: r.title,
+              fieldFeatured: r.fieldFeatured,
+              fieldIntroText: r.fieldIntroText,
+              fieldMedia: r.fieldMedia,
+              entityUrl: r.entityUrl,
+            }))
+        : [],
+    },
   },
 });
 module.exports = {

--- a/src/site/stages/build/process-cms-exports/transformers/node-health_care_region_page.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-health_care_region_page.js
@@ -1,3 +1,4 @@
+const moment = require('moment');
 const {
   getDrupalValue,
   getWysiwygString,
@@ -113,6 +114,29 @@ const transform = ({
               fieldFeatured: r.fieldFeatured,
               fieldIntroText: r.fieldIntroText,
               fieldMedia: r.fieldMedia,
+              entityUrl: r.entityUrl,
+            }))
+        : [],
+    },
+    eventTeasers: {
+      entities: reverseFieldOffice
+        ? reverseFieldOffice
+            .filter(
+              reverseField =>
+                reverseField.entityBundle === 'event' &&
+                reverseField.entityPublished &&
+                reverseField.fieldFeatured &&
+                moment(reverseField.fieldDate.value).isAfter(moment(), 'day'),
+            )
+            .sort((a, b) => a.fieldDate.value - b.fieldDate.value)
+            .slice(0, 2)
+            .map(r => ({
+              title: r.title,
+              uid: r.uid,
+              fieldDate: r.fieldDate,
+              fieldDescription: r.fieldDescription,
+              fieldLocationHumanreadable: r.fieldLocationHumanreadable,
+              fieldFacilityLocation: r.fieldFacilityLocation,
               entityUrl: r.entityUrl,
             }))
         : [],

--- a/src/site/stages/build/process-cms-exports/transformers/node-health_care_region_page.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-health_care_region_page.js
@@ -259,7 +259,15 @@ const transform = ({
                         moment(),
                         'day',
                       ),
-                  ),
+                  )
+                  .map(e => ({
+                    title: e.title,
+                    fieldDate: e.fieldDate,
+                    fieldDescription: e.fieldDescription,
+                    fieldLocationHumanreadable: e.fieldLocationHumanreadable,
+                    fieldFacilityLocation: e.fieldFacilityLocation,
+                    entityUrl: e.entityUrl,
+                  })),
               },
             }))
         : [],

--- a/src/site/stages/build/process-cms-exports/transformers/node-health_services_listing.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-health_services_listing.js
@@ -4,7 +4,7 @@ const {
   utcToEpochTime,
 } = require('./helpers');
 
-const transform = entity => ({
+const transform = (entity, { ancestors }) => ({
   entityType: 'node',
   entityBundle: 'health_services_listing',
   title: getDrupalValue(entity.title),
@@ -24,7 +24,11 @@ const transform = entity => ({
   fieldFeaturedContentHealthser: entity.fieldFeaturedContentHealthser,
   fieldIntroText: getDrupalValue(entity.fieldIntroText),
   fieldMetaTitle: getDrupalValue(entity.fieldMetaTitle),
-  fieldOffice: entity.fieldOffice[0],
+  fieldOffice:
+    entity.fieldOffice[0] &&
+    !ancestors.find(r => r.entity.uuid === entity.fieldOffice[0].uuid)
+      ? entity.fieldOffice[0]
+      : null,
 });
 
 module.exports = {

--- a/src/site/stages/build/process-cms-exports/transformers/node-leadership_listing.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-leadership_listing.js
@@ -4,7 +4,7 @@ const {
   utcToEpochTime,
 } = require('./helpers');
 
-const transform = entity => ({
+const transform = (entity, { ancestors }) => ({
   entityType: 'node',
   entityBundle: 'leadership_listing',
   title: getDrupalValue(entity.title),
@@ -16,7 +16,11 @@ const transform = entity => ({
   fieldIntroText: getDrupalValue(entity.fieldIntroText),
   fieldLeadership: entity.fieldLeadership[0],
   fieldMetaTitle: getDrupalValue(entity.fieldMetaTitle),
-  fieldOffice: entity.fieldOffice[0],
+  fieldOffice:
+    entity.fieldOffice[0] &&
+    !ancestors.find(r => r.entity.uuid === entity.fieldOffice[0].uuid)
+      ? entity.fieldOffice[0]
+      : null,
 });
 
 module.exports = {

--- a/src/site/stages/build/process-cms-exports/transformers/node-locations_listing.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-locations_listing.js
@@ -4,7 +4,7 @@ const {
   utcToEpochTime,
 } = require('./helpers');
 
-const transform = entity => ({
+const transform = (entity, { ancestors }) => ({
   entityType: 'node',
   entityBundle: 'locations_listing',
   title: getDrupalValue(entity.title),
@@ -22,7 +22,11 @@ const transform = entity => ({
   fieldDescription: getDrupalValue(entity.fieldDescription),
   fieldIntroText: getDrupalValue(entity.fieldIntroText),
   fieldMetaTitle: getDrupalValue(entity.fieldMetaTitle),
-  fieldOffice: entity.fieldOffice[0],
+  fieldOffice:
+    entity.fieldOffice[0] &&
+    !ancestors.find(r => r.entity.uuid === entity.fieldOffice[0].uuid)
+      ? entity.fieldOffice[0]
+      : null,
 });
 
 module.exports = {

--- a/src/site/stages/build/process-cms-exports/transformers/node-news_story.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-news_story.js
@@ -6,7 +6,7 @@ const {
   getWysiwygString,
 } = require('./helpers');
 
-const transform = entity => ({
+const transform = (entity, { ancestors }) => ({
   entityType: 'node',
   entityBundle: 'news_story',
   title: getDrupalValue(entity.title),
@@ -23,7 +23,12 @@ const transform = entity => ({
   fieldImageCaption: getDrupalValue(entity.fieldImageCaption),
   fieldIntroText: getDrupalValue(entity.fieldIntroText),
   fieldMedia: entity.fieldMedia[0] || null,
-  fieldOffice: (entity.fieldOffice && entity.fieldOffice[0]) || null,
+  fieldOffice:
+    entity.fieldOffice &&
+    entity.fieldOffice[0] &&
+    !ancestors.find(r => r.entity.uuid === entity.fieldOffice[0].uuid)
+      ? entity.fieldOffice[0]
+      : null,
   // Needed for filtering reverse fields in other transformers
   status: getDrupalValue(entity.status),
   fieldFeatured: getDrupalValue(entity.fieldFeatured),

--- a/src/site/stages/build/process-cms-exports/transformers/node-press_releases_listing.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-press_releases_listing.js
@@ -5,7 +5,7 @@ const {
   isPublished,
 } = require('./helpers');
 
-const transform = entity => ({
+const transform = (entity, { ancestors }) => ({
   entityType: 'node',
   entityBundle: 'press_releases_listing',
   title: getDrupalValue(entity.title),
@@ -16,7 +16,11 @@ const transform = entity => ({
   fieldDescription: getDrupalValue(entity.fieldDescription),
   fieldIntroText: getDrupalValue(entity.fieldIntroText),
   fieldMetaTitle: getDrupalValue(entity.fieldMetaTitle),
-  fieldOffice: entity.fieldOffice[0],
+  fieldOffice:
+    entity.fieldOffice[0] &&
+    !ancestors.find(r => r.entity.uuid === entity.fieldOffice[0].uuid)
+      ? entity.fieldOffice[0]
+      : null,
   fieldPressReleaseBlurb: getDrupalValue(entity.fieldPressReleaseBlurb),
   reverseFieldListingNode: {
     entities: entity.reverseFieldListing

--- a/src/site/stages/build/process-cms-exports/transformers/node-story_listing.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-story_listing.js
@@ -5,7 +5,7 @@ const {
   isPublished,
 } = require('./helpers');
 
-const transform = entity => ({
+const transform = (entity, { ancestors }) => ({
   entityType: 'node',
   entityBundle: 'story_listing',
   title: getDrupalValue(entity.title),
@@ -17,20 +17,26 @@ const transform = entity => ({
   fieldDescription: getDrupalValue(entity.fieldDescription),
   fieldIntroText: getDrupalValue(entity.fieldIntroText),
   fieldMetaTitle: getDrupalValue(entity.fieldMetaTitle),
-  fieldOffice: entity.fieldOffice[0],
+  fieldOffice:
+    entity.fieldOffice[0] &&
+    !ancestors.find(r => r.entity.uuid === entity.fieldOffice[0].uuid)
+      ? entity.fieldOffice[0]
+      : null,
   reverseFieldListingNode: {
     entities: entity.reverseFieldListing
       ? entity.reverseFieldListing
           .filter(
             reverseField =>
               reverseField.entityBundle === 'news_story' &&
-              reverseField.isPublished,
+              reverseField.entityPublished,
           )
           .map(reverseField => ({
             entityId: reverseField.entityId,
             title: reverseField.title,
             fieldFeatured: reverseField.fieldFeatured,
             entityUrl: reverseField.entityUrl,
+            entityPublished: reverseField.entityPublished,
+            entityBundle: reverseField.entityBundle,
             // Ignoring for now since some uids are missing from the export
             // uid: reverseField.uid,
             promote: reverseField.promote,

--- a/src/site/stages/build/process-cms-exports/transformers/node-vamc_operating_status_and_alerts.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-vamc_operating_status_and_alerts.js
@@ -4,7 +4,7 @@ const {
   createMetaTagArray,
 } = require('./helpers');
 
-const transform = entity => ({
+const transform = (entity, { ancestors }) => ({
   entityType: 'node',
   entityBundle: 'vamc_operating_status_and_alerts',
   title: getDrupalValue(entity.title),
@@ -30,7 +30,11 @@ const transform = entity => ({
     },
   })),
   fieldLinks: entity.fieldLinks,
-  fieldOffice: entity.fieldOffice[0] || null,
+  fieldOffice:
+    entity.fieldOffice[0] &&
+    !ancestors.find(r => r.entity.uuid === entity.fieldOffice[0].uuid)
+      ? entity.fieldOffice[0]
+      : null,
   fieldOperatingStatusEmergInf: {
     value: getDrupalValue(entity.fieldOperatingStatusEmergInf),
   },


### PR DESCRIPTION
## Description
Add the remaining reverse fields to `node-health_care_region_page`.

## Testing done
Used:
```schell
node script/cms/test-bundle-transformers.js --bundle "node-health_care_region_page" --entity node.2bddb1a7-6fb1-4503-838d-9c2fcb51c46a.json
```

to test an entity with reverse fields.

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
