### PR TITLE
bradl3yC - debt letters - Filter out paid off debts

### DIFF
--- a/src/applications/debt-letters/actions/index.js
+++ b/src/applications/debt-letters/actions/index.js
@@ -61,9 +61,11 @@ export const fetchDebtLetters = () => async dispatch => {
     }
 
     const approvedDeductionCodes = Object.keys(deductionCodes);
-    const filteredResponse = response.filter(res =>
-      approvedDeductionCodes.includes(res.deductionCode),
-    );
+    // remove any debts that do not have approved deductionCodes or
+    // that have a current amount owed of 0
+    const filteredResponse = response
+      .filter(res => approvedDeductionCodes.includes(res.deductionCode))
+      .filter(debt => debt.currentAr > 0);
     return dispatch(fetchDebtLettersSuccess(filteredResponse));
   } catch (error) {
     return dispatch(fetchDebtLettersFailure());

--- a/src/applications/debt-letters/tests/actions.unit.spec.js
+++ b/src/applications/debt-letters/tests/actions.unit.spec.js
@@ -14,61 +14,6 @@ describe('fetchDebtLetters', () => {
       expect(dispatch.secondCall.args[0].type).to.equal(DEBTS_FETCH_SUCCESS);
       expect(dispatch.secondCall.args[0].debts).to.deep.equal([
         {
-          adamKey: '2',
-          fileNumber: '000000009',
-          payeeNumber: '00',
-          personEntitled: 'STUB_M',
-          deductionCode: '30',
-          benefitType: 'Comp & Pen',
-          amountOverpaid: 0.0,
-          amountWithheld: 0.0,
-          originalAr: 13000,
-          currentAr: 0,
-          debtHistory: [
-            {
-              date: '12/03/2008',
-              letterCode: '488',
-              status: 'Death Status - Pending Action',
-              description: 'Pending review for reclamation or next action.',
-            },
-            {
-              date: '02/07/2009',
-              letterCode: '905',
-              status: 'Administrative Write Off',
-              description:
-                'Full debt amount cleared by return of funds to DMC from outside entities (reclamations, insurance companies, etc.)',
-            },
-            {
-              date: '02/25/2009',
-              letterCode: '914',
-              status: 'Paid In Full',
-              description:
-                'Account balance cleared via offset, not including TOP.',
-            },
-          ],
-        },
-        {
-          adamKey: '3',
-          fileNumber: '000000009',
-          payeeNumber: '00',
-          personEntitled: 'STUB_M',
-          deductionCode: '30',
-          benefitType: 'Comp & Pen',
-          amountOverpaid: 0.0,
-          amountWithheld: 0.0,
-          originalAr: 12000,
-          currentAr: 0,
-          debtHistory: [
-            {
-              date: '09/11/1997',
-              letterCode: '914',
-              status: 'Paid In Full',
-              description:
-                'Account balance cleared via offset, not including TOP.',
-            },
-          ],
-        },
-        {
           adamKey: '4',
           fileNumber: '000000009',
           payeeNumber: '00',


### PR DESCRIPTION
## Description
As a user I do not want to see debts that have been resolved, currently.  I only wish to see debts that are active and have an outstanding balance.

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
