### PR TITLE
SSO should redirect the user back to CSS as a last step

### DIFF
--- a/src/platform/utilities/sso/index.js
+++ b/src/platform/utilities/sso/index.js
@@ -48,15 +48,7 @@ export async function checkAutoSession(
     // being logged in is not enough, we also need to make sure that the user
     // has been authenticated with SSOe, otherwise we don't want to perform any
     // auto login/logout operations.
-    if (
-      loginAppUrlRE.test(window.location.pathname) &&
-      ttl > 0 &&
-      profile.verified
-    ) {
-      // the user is in the login app, but already logged in with SSOe
-      // and verified, redirect them back to their return url
-      window.location = standaloneRedirect() || window.location.origin;
-    } else if (ttl === 0) {
+    if (ttl === 0) {
       // explicitly check to see if the TTL for the SSOe session is 0, as it
       // could also be undefined if we failed to get a response from the SSOe server,
       // in which case we don't want to logout the user, because we don't know
@@ -68,6 +60,14 @@ export async function checkAutoSession(
       // user logged in. Thus, we should perform an auto login, which will
       // effectively logout the user then log them back in.
       login('custom', 'v1', { authn }, 'sso-automatic-login');
+    } else if (
+      loginAppUrlRE.test(window.location.pathname) &&
+      ttl > 0 &&
+      profile.verified
+    ) {
+      // the user is in the login app, but already logged in with SSOe
+      // and verified, redirect them back to their return url
+      window.location = standaloneRedirect() || window.location.origin;
     }
   } else if (!loggedIn && ttl > 0 && !getLoginAttempted() && authn) {
     // only attempt an auto login if the user is

--- a/src/platform/utilities/tests/sso.unit.spec.js
+++ b/src/platform/utilities/tests/sso.unit.spec.js
@@ -109,6 +109,31 @@ describe('checkAutoSession', () => {
     expect(global.window.location).to.eq('http://localhost');
   });
 
+  it('should re login user before redirect to myvahealth because transactions are different', async () => {
+    sandbox.stub(keepAliveMod, 'keepAlive').returns({
+      sessionAlive: true,
+      ttl: 900,
+      authn: 'dslogon',
+      transactionid: 'X',
+    });
+    global.window.location.origin = 'http://localhost';
+    global.window.location.pathname = '/sign-in/';
+    global.window.location.search = '?application=myvahealth';
+    const profile = { verified: true };
+
+    const auto = sandbox.stub(authUtils, 'login');
+    await checkAutoSession(true, 'Y', profile);
+
+    sinon.assert.calledOnce(auto);
+    sinon.assert.calledWith(
+      auto,
+      'custom',
+      'v1',
+      { authn: 'dslogon' },
+      'sso-automatic-login',
+    );
+  });
+
   it('should auto logout if user has logged in via SSOe and they do not have a SSOe session anymore', async () => {
     sandbox
       .stub(keepAliveMod, 'keepAlive')


### PR DESCRIPTION
When checking for inbound SSO conditions, we should first check to make
sure that user doesn't need to be logged out, or re-logged in (due to a
mismatched transaction id) before attempting to redirect a user back to
CSS

closes https://github.com/department-of-veterans-affairs/va.gov-team/issues/12608
