### PR TITLE
Switch from complex `elementNotRemoved` helper to a simple `wait` helper

### DIFF
--- a/src/applications/personalization/profile-2/tests/components/personal-information/PersonalInformation.delete-email-address.unit.spec.jsx
+++ b/src/applications/personalization/profile-2/tests/components/personal-information/PersonalInformation.delete-email-address.unit.spec.jsx
@@ -11,7 +11,6 @@ import PersonalInformation from '../../../components/personal-information/Person
 
 import {
   createBasicInitialState,
-  elementNotRemoved,
   renderWithProfileReducers,
   wait,
 } from '../../unit-test-helpers';
@@ -92,7 +91,7 @@ describe('Deleting email address', () => {
     // delete transaction request is created. We had a UX bug where the buttons
     // were disabled while the initial transaction request was being created but
     // were enabled again while polling the transaction status. This test was
-    // added to prevent regression back to that poor experience where users were
+    // added to prevent regressing back to that poor experience where users were
     // able to interact with buttons that created duplicate XHRs.
     await wait(10);
     expect(!!cancelDeleteButton.attributes.disabled).to.be.true;
@@ -154,8 +153,9 @@ describe('Deleting email address', () => {
       'We’re sorry. We couldn’t update your email address. Please try again.',
     );
 
-    // make sure that edit mode is not exited
-    await elementNotRemoved(alert, { timeout: 75 });
+    // make sure that edit mode is not automatically exited
+    await wait(75);
+    expect(view.getByTestId('edit-error-alert')).to.exist;
     const editButton = getEditButton();
     expect(editButton).to.not.exist;
   });
@@ -189,8 +189,9 @@ describe('Deleting email address', () => {
     expect(!!confirmDeleteButton.attributes.disabled).to.be.false;
     expect(confirmDeleteButton).to.contain.text('Confirm');
 
-    // make sure that edit mode is not exited
-    await elementNotRemoved(alert, { timeout: 75 });
+    // make sure that edit mode is not automatically exited
+    await wait(75);
+    expect(view.getByTestId('edit-error-alert')).to.exist;
     const editButton = getEditButton();
     expect(editButton).to.not.exist;
   });

--- a/src/applications/personalization/profile-2/tests/components/personal-information/PersonalInformation.edit-email-address.unit.spec.jsx
+++ b/src/applications/personalization/profile-2/tests/components/personal-information/PersonalInformation.edit-email-address.unit.spec.jsx
@@ -12,11 +12,13 @@ import PersonalInformation from '../../../components/personal-information/Person
 
 import {
   createBasicInitialState,
-  elementNotRemoved,
   renderWithProfileReducers,
+  wait,
 } from '../../unit-test-helpers';
 import { beforeEach } from 'mocha';
 
+const errorText =
+  'We’re sorry. We couldn’t update your email address. Please try again.';
 const newEmailAddress = 'new-address@domain.com';
 const ui = (
   <MemoryRouter>
@@ -115,13 +117,12 @@ async function testTransactionCreationFails() {
   editEmailAddress();
 
   // expect an error to be shown
-  const errorText = await view.findByText(
-    'We’re sorry. We couldn’t update your email address. Please try again.',
-  );
-  expect(errorText).to.exist;
+  const error = await view.findByText(errorText);
+  expect(error).to.exist;
 
-  // make sure that edit mode is not exited
-  await elementNotRemoved(errorText, { timeout: 75 });
+  // make sure that edit mode is not automatically exited
+  await wait(75);
+  expect(view.getByText(errorText)).to.exist;
   const editButton = getEditButton();
   expect(editButton).to.not.exist;
 }
@@ -133,13 +134,12 @@ async function testQuickFailure() {
   editEmailAddress();
 
   // expect an error to be shown
-  const errorText = await view.findByText(
-    'We’re sorry. We couldn’t update your email address. Please try again.',
-  );
-  expect(errorText).to.exist;
+  const error = await view.findByText(errorText);
+  expect(error).to.exist;
 
-  // make sure that edit mode is not exited
-  await elementNotRemoved(errorText, { timeout: 75 });
+  // make sure that edit mode is not automatically exited
+  await wait(75);
+  expect(view.getByText(errorText)).to.exist;
   const editButton = getEditButton();
   expect(editButton).to.not.exist;
 }

--- a/src/applications/personalization/profile-2/tests/components/personal-information/PersonalInformation.edit-telephone.unit.spec.jsx
+++ b/src/applications/personalization/profile-2/tests/components/personal-information/PersonalInformation.edit-telephone.unit.spec.jsx
@@ -13,8 +13,8 @@ import PersonalInformation from '../../../components/personal-information/Person
 
 import {
   createBasicInitialState,
-  elementNotRemoved,
   renderWithProfileReducers,
+  wait,
 } from '../../unit-test-helpers';
 import { beforeEach } from 'mocha';
 
@@ -139,8 +139,9 @@ async function testTransactionCreationFails(numberName) {
   expect(alert).to.contain.text('We’re sorry. We couldn’t update your');
   expect(alert).to.contain.text('Please try again.');
 
-  // make sure that edit mode is not exited
-  await elementNotRemoved(alert, { timeout: 75 });
+  // make sure that edit mode is not automatically exited
+  await wait(75);
+  expect(view.getByTestId('edit-error-alert')).to.exist;
   const editButton = getEditButton();
   expect(editButton).to.not.exist;
 }
@@ -158,8 +159,9 @@ async function testQuickFailure(numberName) {
   expect(alert).to.contain.text('We’re sorry. We couldn’t update your');
   expect(alert).to.contain.text('Please try again.');
 
-  // make sure that edit mode is not exited
-  await elementNotRemoved(alert, { timeout: 75 });
+  // make sure that edit mode is not automatically exited
+  await wait(75);
+  expect(view.getByTestId('edit-error-alert')).to.exist;
   const editButton = getEditButton();
   expect(editButton).to.not.exist;
 }

--- a/src/applications/personalization/profile-2/tests/unit-test-helpers.js
+++ b/src/applications/personalization/profile-2/tests/unit-test-helpers.js
@@ -1,5 +1,3 @@
-import { waitForElementToBeRemoved } from '@testing-library/react';
-
 import { renderInReduxProvider } from 'platform/testing/unit/react-testing-library-helpers';
 
 import profile from 'applications/personalization/profile360/reducers';
@@ -9,32 +7,6 @@ import profileUi from '../reducers';
 export function wait(timeout) {
   return new Promise(resolve => {
     setTimeout(resolve, timeout);
-  });
-}
-
-// TODO: move this to platform/testing/unit/react-testing-library-helpers
-/**
- * Returns a Promise that rejects if the element is removed from the DOM and
- * resolves if the element is not removed. Uses DOM Testing Library's
- * `waitForElementToBeRemoved()`.
- *
- * @param {} el - element that should remain in the DOM
- * @param {} waitForOptions - options to pass to the `waitForElementToBeRemoved`
- * call
- */
-export async function elementNotRemoved(el, waitForOptions = {}) {
-  // Creating the Error here, outside of the Promise, gives a better stack
-  // trace, but still not as good as the stack trace you get from a Testing
-  // Library `waitFor` error
-  const err = new Error(`Element was removed but it should not have been`);
-  return new Promise((resolve, reject) => {
-    waitForElementToBeRemoved(el, waitForOptions)
-      .then(() => {
-        reject(err);
-      })
-      .catch(() => {
-        resolve();
-      });
   });
 }
 


### PR DESCRIPTION
## Description
Using a custom `elementNotRemoved` function that leveraged Testing Library's `waitForElementToBeRemoved` async helper was... not fully thought out. Although it works, all I really needed to do was wait longer than the timeout used to auto-exit edit view during long-running save operations.

This PR switches to using a simple `await wait()` in the unit tests.

## Testing done

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs