### PR TITLE
Add feature flag support for all Cerner pages

### DIFF
--- a/src/applications/static-pages/health-care-manage-benefits/get-medical-records-page/components/App/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/get-medical-records-page/components/App/index.js
@@ -9,8 +9,9 @@ import UnauthContent from '../UnauthContent';
 import { isCernerLive } from 'platform/utilities/cerner';
 import { selectIsCernerPatient } from 'platform/user/selectors';
 
-export const App = ({ isCernerPatient }) => {
-  if (!isCernerLive) {
+export const App = ({ isCernerPatient, showNewGetMedicalRecordsPage }) => {
+  // Show legacy content if Cerner isn't live or if we explicitly shouldn't show the page via a feature flag.
+  if (!isCernerLive || showNewGetMedicalRecordsPage === false) {
     return <LegacyContent />;
   }
 
@@ -24,10 +25,13 @@ export const App = ({ isCernerPatient }) => {
 App.propTypes = {
   // From mapStateToProps.
   isCernerPatient: PropTypes.bool,
+  showNewGetMedicalRecordsPage: PropTypes.bool.isRequired,
 };
 
 const mapStateToProps = state => ({
   isCernerPatient: selectIsCernerPatient(state),
+  showNewGetMedicalRecordsPage:
+    state?.featureToggles?.showNewGetMedicalRecordsPage,
 });
 
 export default connect(

--- a/src/applications/static-pages/health-care-manage-benefits/refill-track-prescriptions-page/components/App/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/refill-track-prescriptions-page/components/App/index.js
@@ -9,8 +9,12 @@ import UnauthContent from '../UnauthContent';
 import { isCernerLive } from 'platform/utilities/cerner';
 import { selectIsCernerPatient } from 'platform/user/selectors';
 
-export const App = ({ isCernerPatient }) => {
-  if (!isCernerLive) {
+export const App = ({
+  isCernerPatient,
+  showNewRefillTrackPrescriptionsPage,
+}) => {
+  // Show legacy content if Cerner isn't live or if we explicitly shouldn't show the page via a feature flag.
+  if (!isCernerLive || showNewRefillTrackPrescriptionsPage === false) {
     return <LegacyContent />;
   }
 
@@ -24,10 +28,13 @@ export const App = ({ isCernerPatient }) => {
 App.propTypes = {
   // From mapStateToProps.
   isCernerPatient: PropTypes.bool,
+  showNewRefillTrackPrescriptionsPage: PropTypes.bool.isRequired,
 };
 
 const mapStateToProps = state => ({
   isCernerPatient: selectIsCernerPatient(state),
+  showNewRefillTrackPrescriptionsPage:
+    state?.featureToggles?.showNewRefillTrackPrescriptionsPage,
 });
 
 export default connect(

--- a/src/applications/static-pages/health-care-manage-benefits/schedule-view-va-appointments-page/components/App/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/schedule-view-va-appointments-page/components/App/index.js
@@ -9,8 +9,12 @@ import UnauthContent from '../UnauthContent';
 import { isCernerLive } from 'platform/utilities/cerner';
 import { selectIsCernerPatient } from 'platform/user/selectors';
 
-export const App = ({ isCernerPatient }) => {
-  if (!isCernerLive) {
+export const App = ({
+  isCernerPatient,
+  showNewScheduleViewAppointmentsPage,
+}) => {
+  // Show legacy content if Cerner isn't live or if we explicitly shouldn't show the page via a feature flag.
+  if (!isCernerLive || showNewScheduleViewAppointmentsPage === false) {
     return <LegacyContent />;
   }
 
@@ -24,10 +28,13 @@ export const App = ({ isCernerPatient }) => {
 App.propTypes = {
   // From mapStateToProps.
   isCernerPatient: PropTypes.bool,
+  showNewScheduleViewAppointmentsPage: PropTypes.bool.isRequired,
 };
 
 const mapStateToProps = state => ({
   isCernerPatient: selectIsCernerPatient(state),
+  showNewScheduleViewAppointmentsPage:
+    state?.featureToggles?.showNewScheduleViewAppointmentsPage,
 });
 
 export default connect(

--- a/src/applications/static-pages/health-care-manage-benefits/secure-messaging-page/components/App/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/secure-messaging-page/components/App/index.js
@@ -9,8 +9,9 @@ import UnauthContent from '../UnauthContent';
 import { isCernerLive } from 'platform/utilities/cerner';
 import { selectIsCernerPatient } from 'platform/user/selectors';
 
-export const App = ({ isCernerPatient }) => {
-  if (!isCernerLive) {
+export const App = ({ isCernerPatient, showNewSecureMessagingPage }) => {
+  // Show legacy content if Cerner isn't live or if we explicitly shouldn't show the page via a feature flag.
+  if (!isCernerLive || showNewSecureMessagingPage === false) {
     return <LegacyContent />;
   }
 
@@ -24,10 +25,12 @@ export const App = ({ isCernerPatient }) => {
 App.propTypes = {
   // From mapStateToProps.
   isCernerPatient: PropTypes.bool,
+  showNewSecureMessagingPage: PropTypes.bool.isRequired,
 };
 
 const mapStateToProps = state => ({
   isCernerPatient: selectIsCernerPatient(state),
+  showNewSecureMessagingPage: state?.featureToggles?.showNewSecureMessagingPage,
 });
 
 export default connect(

--- a/src/applications/static-pages/health-care-manage-benefits/view-test-and-lab-results-page/components/App/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/view-test-and-lab-results-page/components/App/index.js
@@ -9,8 +9,9 @@ import UnauthContent from '../UnauthContent';
 import { isCernerLive } from 'platform/utilities/cerner';
 import { selectIsCernerPatient } from 'platform/user/selectors';
 
-export const App = ({ isCernerPatient }) => {
-  if (!isCernerLive) {
+export const App = ({ isCernerPatient, showNewViewTestLabResultsPage }) => {
+  // Show legacy content if Cerner isn't live or if we explicitly shouldn't show the page via a feature flag.
+  if (!isCernerLive || showNewViewTestLabResultsPage === false) {
     return <LegacyContent />;
   }
 
@@ -24,10 +25,13 @@ export const App = ({ isCernerPatient }) => {
 App.propTypes = {
   // From mapStateToProps.
   isCernerPatient: PropTypes.bool,
+  showNewViewTestLabResultsPage: PropTypes.bool.isRequired,
 };
 
 const mapStateToProps = state => ({
   isCernerPatient: selectIsCernerPatient(state),
+  showNewViewTestLabResultsPage:
+    state?.featureToggles?.showNewViewTestLabResultsPage,
 });
 
 export default connect(

--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -47,4 +47,11 @@ export default Object.freeze({
   stemSCOEmail: 'stem_sco_email',
   showHealthcareExperienceQuestionnaire:
     'showHealthcareExperienceQuestionnaire',
+  showNewGetMedicalRecordsPage: 'show_new_get_medical_records_page',
+  showNewRefillTrackPrescriptionsPage:
+    'show_new_refill_track_prescriptions_page',
+  showNewScheduleViewAppointmentsPage:
+    'show_new_schedule_view_appointments_page',
+  showNewSecureMessagingPage: 'show_new_secure_messaging_page',
+  showNewViewTestLabResultsPage: 'show_new_view_test_lab_results_page',
 });


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/11153

This PR adds feature toggling support for the following pages:

https://www.va.gov/health-care/refill-track-prescriptions
https://www.va.gov/health-care/secure-messaging
https://www.va.gov/health-care/schedule-view-va-appointments
https://www.va.gov/health-care/view-test-and-lab-results
https://www.va.gov/health-care/get-medical-records/

## Testing done
N/A

## Screenshots
N/A

## Acceptance criteria
- [x] Add feature toggles for Cerner pages.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
