### PR TITLE
1010CG noindex for prod testing

### DIFF
--- a/src/applications/caregivers/containers/App.jsx
+++ b/src/applications/caregivers/containers/App.jsx
@@ -22,6 +22,7 @@ const App = ({ loading, isFormAvailable, location, children }) => {
 
   return (
     <RoutedSavableApp formConfig={formConfig} currentLocation={location}>
+      {/* TODO: remove after prod testing */}
       <MetaTags>
         <meta name="robots" content="noindex" />
       </MetaTags>

--- a/src/applications/caregivers/containers/App.jsx
+++ b/src/applications/caregivers/containers/App.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import MetaTags from 'react-meta-tags';
 
 import LoadingIndicator from '@department-of-veterans-affairs/formation-react/LoadingIndicator';
 
@@ -21,6 +22,9 @@ const App = ({ loading, isFormAvailable, location, children }) => {
 
   return (
     <RoutedSavableApp formConfig={formConfig} currentLocation={location}>
+      <MetaTags>
+        <meta name="robots" content="noindex" />
+      </MetaTags>
       {children}
     </RoutedSavableApp>
   );


### PR DESCRIPTION
## Description
We are going to be testing 1010CG in prod behind a password protecting route, for extra precaution adding `noindex` so no one can find this route without explicit directions.


## Acceptance criteria
- [x] Add `noindex` meta tags to 1010CG app

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
