### PR TITLE
bradl3yC - 12422 - DL table layout span nesting

### DIFF
--- a/src/applications/debt-letters/components/DebtLettersList.jsx
+++ b/src/applications/debt-letters/components/DebtLettersList.jsx
@@ -99,15 +99,10 @@ const DebtLettersList = ({ debtLinks, isVBMSError }) => {
                           role="img"
                           className="fas fa-download vads-u-padding-right--1"
                         />
-                        Download
+                        <span aria-hidden="true">Download letter </span>
                         <span className="sr-only">
-                          {debtLetter.typeDescription}
-                        </span>{' '}
-                        letter{' '}
-                        <span className="sr-only">
-                          dated{' '}
-                          {moment(debtLetter.receivedAt).format('MMM D, YYYY')}`
-                        </span>{' '}
+                          Download Second Demand Letter dated May 29, 2020
+                        </span>
                         <dfn>
                           <abbr title="Portable Document Format">(PDF)</abbr>
                         </dfn>

--- a/src/applications/debt-letters/components/DebtLettersList.jsx
+++ b/src/applications/debt-letters/components/DebtLettersList.jsx
@@ -101,7 +101,8 @@ const DebtLettersList = ({ debtLinks, isVBMSError }) => {
                         />
                         <span aria-hidden="true">Download letter </span>
                         <span className="sr-only">
-                          Download Second Demand Letter dated May 29, 2020
+                          Download Second Demand Letter dated{' '}
+                          {moment(debtLetter.receivedAt).format('MMM D, YYYY')}
                         </span>
                         <dfn>
                           <abbr title="Portable Document Format">(PDF)</abbr>


### PR DESCRIPTION
## Description
Attempted fix for intermittent bug in table layout that is forcing `download` and `letter` to be joined with no space.

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
