### PR TITLE
Remove isCernerLive and fully depend on feature toggles

### DIFF
--- a/src/applications/static-pages/health-care-manage-benefits/get-medical-records-page/components/App/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/get-medical-records-page/components/App/index.js
@@ -6,12 +6,10 @@ import { connect } from 'react-redux';
 import AuthContent from '../AuthContent';
 import LegacyContent from '../LegacyContent';
 import UnauthContent from '../UnauthContent';
-import { isCernerLive } from 'platform/utilities/cerner';
 import { selectIsCernerPatient } from 'platform/user/selectors';
 
 export const App = ({ isCernerPatient, showNewGetMedicalRecordsPage }) => {
-  // Show legacy content if Cerner isn't live or if we explicitly shouldn't show the page via a feature flag.
-  if (!isCernerLive || showNewGetMedicalRecordsPage === false) {
+  if (!showNewGetMedicalRecordsPage) {
     return <LegacyContent />;
   }
 

--- a/src/applications/static-pages/health-care-manage-benefits/get-medical-records-page/components/App/index.unit.spec.js
+++ b/src/applications/static-pages/health-care-manage-benefits/get-medical-records-page/components/App/index.unit.spec.js
@@ -9,14 +9,18 @@ import { App } from './index';
 
 describe('Get Medical Records Page <App>', () => {
   it('renders what we expect when not a Cerner patient', () => {
-    const wrapper = shallow(<App isCernerPatient={false} />);
+    const wrapper = shallow(
+      <App showNewGetMedicalRecordsPage isCernerPatient={false} />,
+    );
     expect(wrapper.find(UnauthContent)).to.have.lengthOf(1);
     expect(wrapper.find(AuthContent)).to.have.lengthOf(0);
     wrapper.unmount();
   });
 
   it('renders what we expect when a Cerner patient', () => {
-    const wrapper = shallow(<App isCernerPatient />);
+    const wrapper = shallow(
+      <App showNewGetMedicalRecordsPage isCernerPatient />,
+    );
     expect(wrapper.find(UnauthContent)).to.have.lengthOf(0);
     expect(wrapper.find(AuthContent)).to.have.lengthOf(1);
     wrapper.unmount();

--- a/src/applications/static-pages/health-care-manage-benefits/refill-track-prescriptions-page/components/App/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/refill-track-prescriptions-page/components/App/index.js
@@ -6,15 +6,13 @@ import { connect } from 'react-redux';
 import AuthContent from '../AuthContent';
 import LegacyContent from '../LegacyContent';
 import UnauthContent from '../UnauthContent';
-import { isCernerLive } from 'platform/utilities/cerner';
 import { selectIsCernerPatient } from 'platform/user/selectors';
 
 export const App = ({
   isCernerPatient,
   showNewRefillTrackPrescriptionsPage,
 }) => {
-  // Show legacy content if Cerner isn't live or if we explicitly shouldn't show the page via a feature flag.
-  if (!isCernerLive || showNewRefillTrackPrescriptionsPage === false) {
+  if (!showNewRefillTrackPrescriptionsPage) {
     return <LegacyContent />;
   }
 

--- a/src/applications/static-pages/health-care-manage-benefits/refill-track-prescriptions-page/components/App/index.unit.spec.js
+++ b/src/applications/static-pages/health-care-manage-benefits/refill-track-prescriptions-page/components/App/index.unit.spec.js
@@ -9,14 +9,18 @@ import { App } from './index';
 
 describe('Get Medical Records Page <App>', () => {
   it('renders what we expect when not a Cerner patient', () => {
-    const wrapper = shallow(<App isCernerPatient={false} />);
+    const wrapper = shallow(
+      <App showNewRefillTrackPrescriptionsPage isCernerPatient={false} />,
+    );
     expect(wrapper.find(UnauthContent)).to.have.lengthOf(1);
     expect(wrapper.find(AuthContent)).to.have.lengthOf(0);
     wrapper.unmount();
   });
 
   it('renders what we expect when a Cerner patient', () => {
-    const wrapper = shallow(<App isCernerPatient />);
+    const wrapper = shallow(
+      <App showNewRefillTrackPrescriptionsPage isCernerPatient />,
+    );
     expect(wrapper.find(UnauthContent)).to.have.lengthOf(0);
     expect(wrapper.find(AuthContent)).to.have.lengthOf(1);
     wrapper.unmount();

--- a/src/applications/static-pages/health-care-manage-benefits/schedule-view-va-appointments-page/components/App/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/schedule-view-va-appointments-page/components/App/index.js
@@ -6,15 +6,13 @@ import { connect } from 'react-redux';
 import AuthContent from '../AuthContent';
 import LegacyContent from '../LegacyContent';
 import UnauthContent from '../UnauthContent';
-import { isCernerLive } from 'platform/utilities/cerner';
 import { selectIsCernerPatient } from 'platform/user/selectors';
 
 export const App = ({
   isCernerPatient,
   showNewScheduleViewAppointmentsPage,
 }) => {
-  // Show legacy content if Cerner isn't live or if we explicitly shouldn't show the page via a feature flag.
-  if (!isCernerLive || showNewScheduleViewAppointmentsPage === false) {
+  if (!showNewScheduleViewAppointmentsPage) {
     return <LegacyContent />;
   }
 

--- a/src/applications/static-pages/health-care-manage-benefits/schedule-view-va-appointments-page/components/App/index.unit.spec.js
+++ b/src/applications/static-pages/health-care-manage-benefits/schedule-view-va-appointments-page/components/App/index.unit.spec.js
@@ -9,14 +9,18 @@ import { App } from './index';
 
 describe('Get Medical Records Page <App>', () => {
   it('renders what we expect when not a Cerner patient', () => {
-    const wrapper = shallow(<App isCernerPatient={false} />);
+    const wrapper = shallow(
+      <App showNewScheduleViewAppointmentsPage isCernerPatient={false} />,
+    );
     expect(wrapper.find(UnauthContent)).to.have.lengthOf(1);
     expect(wrapper.find(AuthContent)).to.have.lengthOf(0);
     wrapper.unmount();
   });
 
   it('renders what we expect when a Cerner patient', () => {
-    const wrapper = shallow(<App isCernerPatient />);
+    const wrapper = shallow(
+      <App showNewScheduleViewAppointmentsPage isCernerPatient />,
+    );
     expect(wrapper.find(UnauthContent)).to.have.lengthOf(0);
     expect(wrapper.find(AuthContent)).to.have.lengthOf(1);
     wrapper.unmount();

--- a/src/applications/static-pages/health-care-manage-benefits/secure-messaging-page/components/App/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/secure-messaging-page/components/App/index.js
@@ -6,12 +6,10 @@ import { connect } from 'react-redux';
 import AuthContent from '../AuthContent';
 import LegacyContent from '../LegacyContent';
 import UnauthContent from '../UnauthContent';
-import { isCernerLive } from 'platform/utilities/cerner';
 import { selectIsCernerPatient } from 'platform/user/selectors';
 
 export const App = ({ isCernerPatient, showNewSecureMessagingPage }) => {
-  // Show legacy content if Cerner isn't live or if we explicitly shouldn't show the page via a feature flag.
-  if (!isCernerLive || showNewSecureMessagingPage === false) {
+  if (!showNewSecureMessagingPage) {
     return <LegacyContent />;
   }
 

--- a/src/applications/static-pages/health-care-manage-benefits/secure-messaging-page/components/App/index.unit.spec.js
+++ b/src/applications/static-pages/health-care-manage-benefits/secure-messaging-page/components/App/index.unit.spec.js
@@ -9,14 +9,16 @@ import { App } from './index';
 
 describe('Get Medical Records Page <App>', () => {
   it('renders what we expect when not a Cerner patient', () => {
-    const wrapper = shallow(<App isCernerPatient={false} />);
+    const wrapper = shallow(
+      <App showNewSecureMessagingPage isCernerPatient={false} />,
+    );
     expect(wrapper.find(UnauthContent)).to.have.lengthOf(1);
     expect(wrapper.find(AuthContent)).to.have.lengthOf(0);
     wrapper.unmount();
   });
 
   it('renders what we expect when a Cerner patient', () => {
-    const wrapper = shallow(<App isCernerPatient />);
+    const wrapper = shallow(<App showNewSecureMessagingPage isCernerPatient />);
     expect(wrapper.find(UnauthContent)).to.have.lengthOf(0);
     expect(wrapper.find(AuthContent)).to.have.lengthOf(1);
     wrapper.unmount();

--- a/src/applications/static-pages/health-care-manage-benefits/view-test-and-lab-results-page/components/App/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/view-test-and-lab-results-page/components/App/index.js
@@ -6,12 +6,10 @@ import { connect } from 'react-redux';
 import AuthContent from '../AuthContent';
 import LegacyContent from '../LegacyContent';
 import UnauthContent from '../UnauthContent';
-import { isCernerLive } from 'platform/utilities/cerner';
 import { selectIsCernerPatient } from 'platform/user/selectors';
 
 export const App = ({ isCernerPatient, showNewViewTestLabResultsPage }) => {
-  // Show legacy content if Cerner isn't live or if we explicitly shouldn't show the page via a feature flag.
-  if (!isCernerLive || showNewViewTestLabResultsPage === false) {
+  if (!showNewViewTestLabResultsPage) {
     return <LegacyContent />;
   }
 

--- a/src/applications/static-pages/health-care-manage-benefits/view-test-and-lab-results-page/components/App/index.unit.spec.js
+++ b/src/applications/static-pages/health-care-manage-benefits/view-test-and-lab-results-page/components/App/index.unit.spec.js
@@ -9,14 +9,18 @@ import { App } from './index';
 
 describe('Get Medical Records Page <App>', () => {
   it('renders what we expect when not a Cerner patient', () => {
-    const wrapper = shallow(<App isCernerPatient={false} />);
+    const wrapper = shallow(
+      <App showNewViewTestLabResultsPage isCernerPatient={false} />,
+    );
     expect(wrapper.find(UnauthContent)).to.have.lengthOf(1);
     expect(wrapper.find(AuthContent)).to.have.lengthOf(0);
     wrapper.unmount();
   });
 
   it('renders what we expect when a Cerner patient', () => {
-    const wrapper = shallow(<App isCernerPatient />);
+    const wrapper = shallow(
+      <App showNewViewTestLabResultsPage isCernerPatient />,
+    );
     expect(wrapper.find(UnauthContent)).to.have.lengthOf(0);
     expect(wrapper.find(AuthContent)).to.have.lengthOf(1);
     wrapper.unmount();


### PR DESCRIPTION
## Description
This PR removes `isCernerLive` and resorts to fully depending on the feature toggle values.

## Testing done
Updated unit tests

## Screenshots
N/A

## Acceptance criteria
- [x] Remove `isCernerLive` dependency.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
