### PR TITLE
Update vets-json-schema

### DIFF
--- a/package.json
+++ b/package.json
@@ -330,7 +330,7 @@
     "url-search-params-polyfill": "^8.1.0",
     "uswds": "1.6.10",
     "vanilla-lazyload": "^16.1.0",
-    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#2419e49d9b14922d5f2af85ab6b69cb6caef3339",
+    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#91c92dfca26649764745186b4348e1455441925e",
     "whatwg-fetch": "^2.0.3"
   },
   "resolutions": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -17116,9 +17116,9 @@ verror@1.3.6:
   dependencies:
     extsprintf "1.0.2"
 
-"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#2419e49d9b14922d5f2af85ab6b69cb6caef3339":
-  version "6.7.2"
-  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#2419e49d9b14922d5f2af85ab6b69cb6caef3339"
+"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#91c92dfca26649764745186b4348e1455441925e":
+  version "6.7.3"
+  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#91c92dfca26649764745186b4348e1455441925e"
 
 vinyl-file@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## Description
Update vets-json-schema.

Related PR requiring this update: https://github.com/department-of-veterans-affairs/vets-website/pull/13937

[ZenHub Issue](https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/12553)

## Testing done
Tested locally and QA reviewed

## Screenshots
N/A

## Acceptance criteria
- [x] vets-json-schema updated to 6.7.3

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
