### PR TITLE
Reduce the content build verbosity

### DIFF
--- a/jenkins/common.groovy
+++ b/jenkins/common.groovy
@@ -194,7 +194,7 @@ def build(String ref, dockerContainer, String assetSource, String envName, Boole
     dockerContainer.inside(DOCKER_ARGS) {
       def buildLogPath = "/application/${envName}-build.log"
 
-      sh "cd /application && jenkins/build.sh --envName ${envName} --assetSource ${assetSource} --drupalAddress ${drupalAddress} ${drupalMode} --buildLog ${buildLogPath}"
+      sh "cd /application && jenkins/build.sh --envName ${envName} --assetSource ${assetSource} --drupalAddress ${drupalAddress} ${drupalMode} --buildLog ${buildLogPath} --verbose"
 
       if (envName == 'vagovprod') {
 	checkForBrokenLinks(buildLogPath, envName, contentOnlyBuild)

--- a/src/site/stages/build/drupal/metalsmith-drupal.js
+++ b/src/site/stages/build/drupal/metalsmith-drupal.js
@@ -238,7 +238,9 @@ async function loadCachedDrupalFiles(buildOptions, files) {
         path.join(buildOptions.cacheDirectory, 'drupal/downloads'),
         file,
       );
-      log(`Loaded Drupal asset from cache: ${relativePath}`);
+      if (global.verbose) {
+        log(`Loaded Drupal asset from cache: ${relativePath}`);
+      }
       files[relativePath] = {
         path: relativePath,
         isDrupalAsset: true,

--- a/src/site/stages/build/index.js
+++ b/src/site/stages/build/index.js
@@ -273,7 +273,9 @@ function build(BUILD_OPTIONS) {
     if (BUILD_OPTIONS.watch) {
       console.log('Metalsmith build finished!');
     } else {
-      smith.printSummary();
+      if (global.verbose) {
+        smith.printSummary();
+      }
       console.log('Build finished!');
     }
   });

--- a/src/site/stages/build/options.js
+++ b/src/site/stages/build/options.js
@@ -55,6 +55,7 @@ const COMMAND_LINE_OPTIONS_DEFINITIONS = [
   { name: 'local-css-sourcemaps', type: Boolean, defaultValue: false },
   { name: 'accessibility', type: Boolean, defaultValue: false },
   { name: 'lint-plain-language', type: Boolean, defaultValue: false },
+  { name: 'verbose', alias: 'v', type: Boolean, defaultValue: false },
   { name: 'unexpected', type: String, multile: true, defaultOption: true },
 ];
 
@@ -224,6 +225,10 @@ async function getOptions(commandLineOptions) {
   applyEnvironmentOverrides(options);
   deriveHostUrl(options);
   await setUpFeatureFlags(options);
+
+  // Setting verbosity for the whole content build process as global so we don't
+  // have to pass the buildOptions around for just that.
+  global.verbose = options.verbose;
 
   return options;
 }

--- a/src/site/stages/build/options.js
+++ b/src/site/stages/build/options.js
@@ -208,7 +208,9 @@ async function setUpFeatureFlags(options) {
       : {};
   }
 
-  logDrupal(`Drupal feature flags:\n${JSON.stringify(rawFlags, null, 2)}`);
+  if (global.verbose) {
+    logDrupal(`Drupal feature flags:\n${JSON.stringify(rawFlags, null, 2)}`);
+  }
 
   // eslint-disable-next-line react-hooks/rules-of-hooks
   const proxiedFlags = useFlags(rawFlags);

--- a/src/site/stages/build/plugins/add-drupal-prefix.js
+++ b/src/site/stages/build/plugins/add-drupal-prefix.js
@@ -68,10 +68,14 @@ function addDrupalPrefix(buildOptions) {
     const applyPrefix = PREFIXED_ENVIRONMENTS.has(buildOptions.buildtype);
 
     if (!applyPrefix) {
-      log('Drupal-generated pages set to overwrite vagov-content.');
+      if (global.verbose) {
+        log('Drupal-generated pages set to overwrite vagov-content.');
+      }
       overwriteConflictingVagovContentFiles(files);
     } else {
-      log('Applying "/drupal" prefix to the URLs of Drupal-generated pages.');
+      if (global.verbose) {
+        log('Applying "/drupal" prefix to the URLs of Drupal-generated pages.');
+      }
       applyPrefixToFiles(files);
     }
 

--- a/src/site/stages/build/plugins/create-drupal-debug.js
+++ b/src/site/stages/build/plugins/create-drupal-debug.js
@@ -39,7 +39,9 @@ function createDrupalDebugPage(buildOptions) {
   }
 
   return (files, smith, done) => {
-    log('Drupal debug page written to /drupal/debug.');
+    if (global.verbose) {
+      log('Drupal debug page written to /drupal/debug.');
+    }
 
     const { drupalError } = buildOptions;
     const drupalDebugPage = drupalError

--- a/src/site/stages/build/plugins/create-react-pages.js
+++ b/src/site/stages/build/plugins/create-react-pages.js
@@ -9,9 +9,11 @@ function createReactPages() {
       const filePath = path.join(trimmedUrl, 'index.html');
 
       if (!files[filePath]) {
-        console.log(
-          `Generating HTML template for application ${appName} at ${rootUrl}`,
-        );
+        if (global.verbose) {
+          console.log(
+            `Generating HTML template for application ${appName} at ${rootUrl}`,
+          );
+        }
         files[filePath] = {
           title: appName,
           entryname: entryName,

--- a/src/site/stages/build/plugins/download-drupal-assets.js
+++ b/src/site/stages/build/plugins/download-drupal-assets.js
@@ -31,7 +31,12 @@ async function downloadFile(
 
     downloadResults.downloadCount++;
 
-    log(`Finished downloading ${asset.src}`);
+    if (global.verbose) {
+      log(`Finished downloading ${asset.src}`);
+    } else {
+      process.stdout.write('.');
+      if (!assetsToDownload.length) process.stdout.write('\n');
+    }
   } else {
     // For now, not going to fail the build for a missing asset
     // Should get caught by the broken link checker, though

--- a/src/site/stages/build/plugins/update-robots.js
+++ b/src/site/stages/build/plugins/update-robots.js
@@ -4,8 +4,10 @@ const ENVIRONMENTS = require('../../../constants/environments');
 function updateRobots(buildOptions) {
   // Use the default robots.txt file on production.
   if (buildOptions.buildtype === ENVIRONMENTS.VAGOVPROD) {
-    // eslint-disable-next-line no-console
-    console.log('Using the production robots.txt');
+    if (global.verbose) {
+      // eslint-disable-next-line no-console
+      console.log('Using the production robots.txt');
+    }
     return () => {};
   }
 
@@ -16,8 +18,10 @@ function updateRobots(buildOptions) {
     // Update the robots.txt contents to disallow crawlers.
     robots.contents = new Buffer('User-agent: *\nDisallow: /\n');
 
-    // eslint-disable-next-line no-console
-    console.log('Using the non-production robots.txt');
+    if (global.verbose) {
+      // eslint-disable-next-line no-console
+      console.log('Using the non-production robots.txt');
+    }
   };
 }
 

--- a/src/site/stages/build/process-cms-exports/index.js
+++ b/src/site/stages/build/process-cms-exports/index.js
@@ -31,8 +31,10 @@ const findCircularReference = (entity, ancestors) => {
   if (a) {
     // This logging is to help debug if AJV fails on an unexpected circular
     // reference
-    console.log(`I'm my own grandpa! (${toId(entity)})`);
-    console.log(`  Parents:\n    ${ancestorIds.join('\n    ')}`);
+    if (global.verbose) {
+      console.log(`I'm my own grandpa! (${toId(entity)})`);
+      console.log(`  Parents:\n    ${ancestorIds.join('\n    ')}`);
+    }
 
     // NOTE: If we find a circular reference, it needs to be addressed in the
     // transformer and accounted for in the transformed schema.

--- a/src/site/stages/build/silversmith.js
+++ b/src/site/stages/build/silversmith.js
@@ -29,7 +29,9 @@ module.exports = () => {
   let consoleDirty = false;
   let lastLogLineLength = 0;
 
-  // Spy on stdout & stderr to see if we need to write the full logStepEnd line
+  // We only need to write the full logStepEnd if there's any output after the
+  // logStepStart. This sets up spies to see if there has been any output since
+  // the logStepStart.
   process.stdout.__write = process.stdout.write;
   process.stdout.write = function _write(...params) {
     consoleDirty = true;

--- a/src/site/stages/build/silversmith.js
+++ b/src/site/stages/build/silversmith.js
@@ -68,7 +68,9 @@ module.exports = () => {
         smith.stepStats[step].timeElapsed = timeElapsed;
 
         logStepEnd(step, description, timeElapsed);
-        logMemoryUsage(heapUsedStart, heapUsedEnd);
+        if (global.verbose) {
+          logMemoryUsage(heapUsedStart, heapUsedEnd);
+        }
       });
   };
 

--- a/src/site/stages/build/silversmith.js
+++ b/src/site/stages/build/silversmith.js
@@ -57,17 +57,17 @@ module.exports = () => {
     else color = chalk.red;
     const coloredTime = color(`[${timeElapsed}ms]`);
 
-    if (consoleDirty || !process.stdout.isTTY) {
-      // Output to a new line
-      console.log(
-        chalk.cyan(`Step ${step + 1} end ${coloredTime}: ${description}`),
-      );
-    } else {
+    if (process.stdout.isTTY && !global.verbose && !consoleDirty) {
       // Just append the logStepStart line with the time elapsed
       process.stdout.cursorTo(lastLogLineLength, process.stdout.rows - 2);
       process.stdout.write(`${coloredTime}`);
       // If we added another cursorTo(0, process.stdout.rows), it creates
       // a blank line between the two logStepStart lines
+    } else {
+      // Output to a new line
+      console.log(
+        chalk.cyan(`Step ${step + 1} end ${coloredTime}: ${description}`),
+      );
     }
   };
 

--- a/src/site/stages/build/silversmith.js
+++ b/src/site/stages/build/silversmith.js
@@ -42,8 +42,7 @@ module.exports = () => {
   };
 
   const logStepStart = (step, description) => {
-    const logLine = `\nStep ${step + 1} of ${stepCount +
-      1} start: ${description}`;
+    const logLine = `\nStep ${step + 1} of ${stepCount} start: ${description}`;
     console.log(chalk.cyan(logLine));
     lastLogLineLength = logLine.length % process.stdout.columns;
     consoleDirty = false;
@@ -63,6 +62,10 @@ module.exports = () => {
       process.stdout.write(`${coloredTime}`);
       // If we added another cursorTo(0, process.stdout.rows), it creates
       // a blank line between the two logStepStart lines
+      if (step + 1 === stepCount) {
+        // Last step; clean it up with a newline
+        process.stdout.write('\n');
+      }
     } else {
       // Output to a new line
       console.log(

--- a/src/site/stages/build/silversmith.js
+++ b/src/site/stages/build/silversmith.js
@@ -6,9 +6,6 @@ const AsciiTable = require('ascii-table');
 
 const formatMemory = m => Math.round((m / 1024 / 1024) * 100) / 100;
 
-const logStepStart = (step, description) =>
-  console.log(chalk.cyan(`\nStep ${step + 1} start: ${description}`));
-
 const logStepEnd = (step, description, timeElapsed) => {
   // Color the time
   let color;
@@ -41,10 +38,17 @@ module.exports = () => {
   const smith = Metalsmith(__dirname);
 
   smith.stepStats = [];
+  let stepCount = 0;
+
+  const logStepStart = (step, description) =>
+    console.log(
+      chalk.cyan(
+        `\nStep ${step + 1} of ${stepCount + 1} start: ${description}`,
+      ),
+    );
 
   // Override the normal use function to log additional information
   smith._use = smith.use;
-  let stepCount = 0;
   smith.use = function use(plugin, description = 'Unknown Plugin') {
     const step = stepCount++;
     smith.stepStats[step] = { description };


### PR DESCRIPTION
## Description
This PR cleans up the output of the content build, greatly reducing the amount
of noise. All the old information can be seen by passing the `--verbose` or `-v`
flag to the build command.

## Testing done
Manual testing

## Screenshots
Steps with no console logs take up only one line, while steps with console logs wrap the output in the familiar "start" and "end" lines.
![image](https://user-images.githubusercontent.com/12970166/90811613-c2ab2c80-e2d9-11ea-841a-10804e2f4dc2.png)
![image](https://user-images.githubusercontent.com/12970166/90811734-f71ee880-e2d9-11ea-8d47-5ff2fabd2fea.png)
![image](https://user-images.githubusercontent.com/12970166/90811749-fdad6000-e2d9-11ea-9b01-5ed6306a9b81.png)
