### PR TITLE
Sanlouise update copy staging review

### DIFF
--- a/src/applications/personalization/profile-2/components/EmailAddressNotification.jsx
+++ b/src/applications/personalization/profile-2/components/EmailAddressNotification.jsx
@@ -23,13 +23,13 @@ const EmailAddressNotification = ({ signInServiceName }) => {
   return (
     <>
       <p className="vads-u-margin--0">
-        To view or update your sign in email, go to the website where you manage
+        To view or update your sign-in email, go to the website where you manage
         your account information. Any email updates you make there will
         automatically update on VA.gov.
       </p>
       <p className="vads-u-margin-bottom--0">
         <a href={link} target="_blank" rel="noopener noreferrer">
-          Update sign in email address on {buttonText}
+          Update sign-in email address on {buttonText}
         </a>
       </p>
     </>

--- a/src/applications/personalization/profile-2/components/MilitaryInformation.jsx
+++ b/src/applications/personalization/profile-2/components/MilitaryInformation.jsx
@@ -127,16 +127,8 @@ const MilitaryInformationContent = ({ militaryInformation }) => {
             work with you to update your information in DEERS.
           </p>
           <p>
-            To reach the DMDC, call{' '}
-            <a
-              href="tel:1-800-538-9552"
-              aria-label="800. 5 3 8. 9 5 5 2."
-              title="Dial the telephone number 800-538-9552"
-              className="no-wrap"
-            >
-              800-538-9552
-            </a>
-            , Monday through Friday (except federal holidays), 8:00 a.m. to 8:00
+            To reach the DMDC, call <Telephone contact={CONTACTS.DS_LOGON} />,
+            Monday through Friday (except federal holidays), 8:00 a.m. to 8:00
             p.m. ET. If you have hearing loss, call TTY:{' '}
             <Telephone contact={CONTACTS.DS_LOGON_TTY} />.
           </p>

--- a/src/applications/personalization/profile-2/components/MilitaryInformation.jsx
+++ b/src/applications/personalization/profile-2/components/MilitaryInformation.jsx
@@ -134,7 +134,7 @@ const MilitaryInformationContent = ({ militaryInformation }) => {
               title="Dial the telephone number 800-538-9552"
               className="no-wrap"
             >
-              1-800-538-9552
+              800-538-9552
             </a>
             , Monday through Friday (except federal holidays), 8:00 a.m. to 8:00
             p.m. ET. If you have hearing loss, call TTY:{' '}

--- a/src/applications/personalization/profile-2/components/connected-apps/AdditionalInfoSections.jsx
+++ b/src/applications/personalization/profile-2/components/connected-apps/AdditionalInfoSections.jsx
@@ -69,8 +69,8 @@ export const AdditionalInfoSections = ({ activeApps }) => {
               it will ask you to sign in.
             </li>
             <li className="vads-u-padding-left--1">
-              Sign in with your preferred VA.gov account: <strong>DS Logon</strong>, <strong>My
-              HealtheVet</strong>, or <strong>ID.me</strong>.
+              Sign in with your preferred VA.gov account:{' '}
+              <strong>DS Logon</strong>, <strong>My HealtheVet</strong>, or <strong>ID.me</strong>.
             </li>
             <li className="vads-u-padding-left--1">
               Review the information the app is asking to access.
@@ -108,7 +108,8 @@ export const AdditionalInfoSections = ({ activeApps }) => {
               </li>
               <li className="vads-u-padding-left--1">
                 <strong>If your information isn’t accurate:</strong> Call VA311
-                at <Telephone contact={CONTACTS.VA_311} />. If you have hearing loss, call{' '}
+                at <Telephone contact={CONTACTS.VA_311} />. If you have hearing
+                loss, call{' '}
                 <Telephone
                   contact={CONTACTS['711']}
                   pattern={PATTERNS['911']}

--- a/src/applications/personalization/profile-2/components/connected-apps/AdditionalInfoSections.jsx
+++ b/src/applications/personalization/profile-2/components/connected-apps/AdditionalInfoSections.jsx
@@ -69,8 +69,8 @@ export const AdditionalInfoSections = ({ activeApps }) => {
               it will ask you to sign in.
             </li>
             <li className="vads-u-padding-left--1">
-              Sign in with your preferred VA.gov account: DS Logon, My
-              HealtheVet, or ID.me.
+              Sign in with your preferred VA.gov account: <strong>DS Logon</strong>, <strong>My
+              HealtheVet</strong>, or <strong>ID.me</strong>.
             </li>
             <li className="vads-u-padding-left--1">
               Review the information the app is asking to access.
@@ -108,7 +108,7 @@ export const AdditionalInfoSections = ({ activeApps }) => {
               </li>
               <li className="vads-u-padding-left--1">
                 <strong>If your information isn’t accurate:</strong> Call VA311
-                at <Telephone contact={CONTACTS.VA_311} />. If you have hearing{' '}
+                at <Telephone contact={CONTACTS.VA_311} />. If you have hearing loss, call{' '}
                 <Telephone
                   contact={CONTACTS['711']}
                   pattern={PATTERNS['911']}
@@ -123,7 +123,7 @@ export const AdditionalInfoSections = ({ activeApps }) => {
               </li>
               <li className="vads-u-padding-left--1">
                 <strong>If you’re getting an “unreadable data” message:</strong>{' '}
-                This means the This means the connected app has access to your
+                This means the connected app has access to your
                 information, but isn’t using it in its interface. It’s nothing
                 to worry about. If you have questions about this, send feedback
                 directly to the app.

--- a/src/applications/personalization/profile-2/components/connected-apps/AdditionalInfoSections.jsx
+++ b/src/applications/personalization/profile-2/components/connected-apps/AdditionalInfoSections.jsx
@@ -70,7 +70,8 @@ export const AdditionalInfoSections = ({ activeApps }) => {
             </li>
             <li className="vads-u-padding-left--1">
               Sign in with your preferred VA.gov account:{' '}
-              <strong>DS Logon</strong>, <strong>My HealtheVet</strong>, or <strong>ID.me</strong>.
+              <strong>DS Logon</strong>, <strong>My HealtheVet</strong>, or{' '}
+              <strong>ID.me</strong>.
             </li>
             <li className="vads-u-padding-left--1">
               Review the information the app is asking to access.
@@ -124,10 +125,10 @@ export const AdditionalInfoSections = ({ activeApps }) => {
               </li>
               <li className="vads-u-padding-left--1">
                 <strong>If you’re getting an “unreadable data” message:</strong>{' '}
-                This means the connected app has access to your
-                information, but isn’t using it in its interface. It’s nothing
-                to worry about. If you have questions about this, send feedback
-                directly to the app.
+                This means the connected app has access to your information, but
+                isn’t using it in its interface. It’s nothing to worry about. If
+                you have questions about this, send feedback directly to the
+                app.
               </li>
             </ul>
           </AdditionalInfo>

--- a/src/applications/personalization/profile-2/components/personal-information/EmailInformationSection.jsx
+++ b/src/applications/personalization/profile-2/components/personal-information/EmailInformationSection.jsx
@@ -42,11 +42,11 @@ const EmailInformationSection = ({ className, signInServiceName }) => {
                 </p>
                 <p>
                   Your contact email may be different than the email you use to
-                  sign in. To view or update your sign in email, go to the
+                  sign in. To view or update your sign-in email, go to the
                   website where you manage your account information.
                 </p>
                 <a href={link} target="_blank" rel="noopener noreferrer">
-                  Update sign in email address on {buttonText}
+                  Update sign-in email address on {buttonText}
                 </a>
               </>
             ),


### PR DESCRIPTION
## Description
[This ticket here](https://github.com/department-of-veterans-affairs/va.gov-team/issues/11972) captures the VSP content feedback on Profile 2.0 in staging.

Many of the items on this list in the ticket above have already been addressed, but this ticket will fix the outstanding issues (listed below):

## Testing done
Looks good locally.

## Acceptance criteria
**Personal and contact information screens**

- [x] Sign-in email . this should have a hyphen in the below content:
To view or update your sign in email, go to the website where you manage your account information.
Update sign in email address on ID.me

- [x] Please remove the 1- in DMDC phone number, per style guide
To reach the DMDC, call ~1-~800-538-9552

NOTE: I only found this DMDC phone number in the military info section, not in personal and contact info.

**Account Security**
- [x] Sign-in email This should have a hyphen in the below content:
To view or update your sign in email, go to the website where you manage your account information.
Update sign in email address on ID.me

**Connected Apps**
- [x]  Under “How do I connect a third-party app to my profile?”
Bold the names of the accounts: DS Logon, My HealtheVet, or ID.me.
- [x] Under this link: “What should I do if my records are wrong or out of date in a connected app?”
This sentence is missing content: If your information isn’t accurate: Call VA311 at 844-698-2311. If you have hearing 711. Or visit a VA health facility near you and ask a staff member for help. Please update sentence to: If you have hearing loss, call 711
- [x] Under “If you’re getting an “unreadable data” message” :
Please fix typo here: his means the This means the connected app has access to your information, but isn’t using it in its interface. It’s nothing to worry about. If you have questions about this, send feedback directly to the app.
Remove “his means the” as the beginning of the sentence.




## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
