### PR TITLE
Remove `isCernerLive` in selector

### DIFF
--- a/src/applications/vaos/tests/list/appointment-list.unit.spec.jsx
+++ b/src/applications/vaos/tests/list/appointment-list.unit.spec.jsx
@@ -32,6 +32,8 @@ const initialState = {
     vaOnlineSchedulingCancel: true,
     vaOnlineSchedulingRequests: true,
     vaOnlineSchedulingPast: true,
+    // eslint-disable-next-line camelcase
+    show_new_schedule_view_appointments_page: true,
   },
 };
 

--- a/src/applications/vaos/tests/list/cancel-appointments.unit.spec.jsx
+++ b/src/applications/vaos/tests/list/cancel-appointments.unit.spec.jsx
@@ -509,12 +509,17 @@ describe('VAOS integration appointment cancellation:', () => {
       {
         initialState: {
           ...initialState,
+          featureToggles: {
+            // eslint-disable-next-line camelcase
+            show_new_schedule_view_appointments_page: true,
+          },
           user: {
             profile: {
               facilities: [
                 { facilityId: '983', isCerner: false },
                 { facilityId: '668', isCerner: true },
               ],
+              isCernerPatient: true,
             },
           },
         },

--- a/src/applications/vaos/tests/list/cancel-appointments.unit.spec.jsx
+++ b/src/applications/vaos/tests/list/cancel-appointments.unit.spec.jsx
@@ -32,6 +32,8 @@ import AppointmentsPage from '../../containers/AppointmentsPage';
 const initialState = {
   featureToggles: {
     vaOnlineSchedulingCancel: true,
+    // eslint-disable-next-line camelcase
+    show_new_schedule_view_appointments_page: true,
   },
 };
 
@@ -509,10 +511,6 @@ describe('VAOS integration appointment cancellation:', () => {
       {
         initialState: {
           ...initialState,
-          featureToggles: {
-            // eslint-disable-next-line camelcase
-            show_new_schedule_view_appointments_page: true,
-          },
           user: {
             profile: {
               facilities: [

--- a/src/applications/vaos/tests/new-appointment/va-facility-page-multi-site.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/va-facility-page-multi-site.unit.spec.jsx
@@ -25,6 +25,8 @@ const initialState = {
   featureToggles: {
     vaOnlineSchedulingVSPAppointmentNew: false,
     vaOnlineSchedulingDirect: true,
+    // eslint-disable-next-line camelcase
+    show_new_schedule_view_appointments_page: true,
   },
   user: {
     profile: {

--- a/src/applications/vaos/tests/utils/selectors.unit.spec.js
+++ b/src/applications/vaos/tests/utils/selectors.unit.spec.js
@@ -118,12 +118,17 @@ describe('VAOS selectors', () => {
     });
     it('should return Cerner facilities', () => {
       const state = {
+        featureToggles: {
+          // eslint-disable-next-line camelcase
+          show_new_schedule_view_appointments_page: true,
+        },
         user: {
           profile: {
             facilities: [
               { facilityId: '668', isCerner: true },
               { facilityId: '124', isCerner: false },
             ],
+            isCernerPatient: true,
           },
         },
         newAppointment: {
@@ -423,9 +428,14 @@ describe('VAOS selectors', () => {
   describe('getCancelInfo', () => {
     it('should fetch facility in info', () => {
       const state = {
+        featureToggles: {
+          // eslint-disable-next-line camelcase
+          show_new_schedule_view_appointments_page: true,
+        },
         user: {
           profile: {
             facilities: [{ facilityId: '123', isCerner: true }],
+            isCernerPatient: true,
           },
         },
         appointments: {
@@ -448,9 +458,14 @@ describe('VAOS selectors', () => {
     });
     it('should fetch facility from clinic map', () => {
       const state = {
+        featureToggles: {
+          // eslint-disable-next-line camelcase
+          show_new_schedule_view_appointments_page: true,
+        },
         user: {
           profile: {
             facilities: [{ facilityId: '123', isCerner: true }],
+            isCernerPatient: true,
           },
         },
         appointments: {
@@ -488,9 +503,14 @@ describe('VAOS selectors', () => {
     });
     it('should fetch facility from video appointment', () => {
       const state = {
+        featureToggles: {
+          // eslint-disable-next-line camelcase
+          show_new_schedule_view_appointments_page: true,
+        },
         user: {
           profile: {
             facilities: [{ facilityId: '123', isCerner: true }],
+            isCernerPatient: true,
           },
         },
         appointments: {
@@ -576,22 +596,32 @@ describe('VAOS selectors', () => {
   describe('selectIsCernerOnlyPatient', () => {
     it('should return true if Cerner only', () => {
       const state = {
+        featureToggles: {
+          // eslint-disable-next-line camelcase
+          show_new_schedule_view_appointments_page: true,
+        },
         user: {
           profile: {
             facilities: [{ facilityId: '668', isCerner: true }],
           },
+          isCernerPatient: true,
         },
       };
       expect(selectIsCernerOnlyPatient(state)).to.be.true;
     });
     it('should return false if not Cerner only', () => {
       const state = {
+        featureToggles: {
+          // eslint-disable-next-line camelcase
+          show_new_schedule_view_appointments_page: true,
+        },
         user: {
           profile: {
             facilities: [
               { facilityId: '668', isCerner: true },
               { facilityId: '124', isCerner: false },
             ],
+            isCernerPatient: true,
           },
         },
       };

--- a/src/platform/user/profile/reducers/index.js
+++ b/src/platform/user/profile/reducers/index.js
@@ -29,6 +29,7 @@ const initialState = {
   dob: null,
   gender: null,
   accountType: null,
+  isCernerPatient: false,
   loa: {
     current: null,
     highest: null,

--- a/src/platform/user/profile/utilities/index.js
+++ b/src/platform/user/profile/utilities/index.js
@@ -67,15 +67,16 @@ export function mapRawUserDataToState(json) {
 
   const userState = {
     accountType: loa.current,
-    signIn,
     dob,
     email,
     gender,
+    isCernerPatient: vaProfile?.isCernerPatient,
     loa,
     multifactor,
     prefillsAvailable,
     savedForms,
     services,
+    signIn,
     userFullName: {
       first,
       middle,

--- a/src/platform/user/selectors.js
+++ b/src/platform/user/selectors.js
@@ -24,14 +24,17 @@ export const selectPatientFacilities = state =>
       ];
 
     // Derive if they are a 200CRNR Cerner patient.
-    const isCernerPatient = state?.user?.profile?.isCernerPatient;
+    const isCernerPatient = selectProfile(state)?.isCernerPatient;
+
+    // Derive if we should consider it a Cerner facility.
+    const passesCernerChecks =
+      showNewScheduleViewAppointmentsPage &&
+      (isCerner || (isCernerPatient && hasCernerFacilityID));
 
     return {
       facilityId,
       // This overrides the MPI isCerner flag in favor of the feature toggle.
-      isCerner:
-        showNewScheduleViewAppointmentsPage &&
-        (isCerner || (isCernerPatient && hasCernerFacilityID)),
+      isCerner: passesCernerChecks,
     };
   }) || null;
 export const selectVet360 = state => selectProfile(state).vet360;

--- a/src/platform/user/selectors.js
+++ b/src/platform/user/selectors.js
@@ -1,6 +1,6 @@
 // TODO: perhaps make these selectors fail gracefully if state.user, or any of
 // the properties on the user object are not defined
-import { CERNER_FACILITY_IDS, isCernerLive } from '../utilities/cerner';
+import { CERNER_FACILITY_IDS } from '../utilities/cerner';
 
 export const selectUser = state => state.user;
 export const isLoggedIn = state => selectUser(state).login.currentlyLoggedIn;
@@ -14,10 +14,8 @@ export const selectAvailableServices = state => selectProfile(state)?.services;
 export const selectPatientFacilities = state =>
   selectProfile(state)?.facilities?.map(({ facilityId, isCerner }) => ({
     facilityId,
-    // This overrides the MPI isCerner flag in favor of the list maintained
-    // in vets-website
-    isCerner:
-      isCerner || (isCernerLive && CERNER_FACILITY_IDS.includes(facilityId)),
+    // This overrides the MPI isCerner flag in favor of the list maintained in vets-website.
+    isCerner: isCerner || CERNER_FACILITY_IDS.includes(facilityId),
   })) || null;
 export const selectVet360 = state => selectProfile(state).vet360;
 export const selectVet360EmailAddress = state =>

--- a/src/platform/user/tests/selectors.unit.spec.js
+++ b/src/platform/user/tests/selectors.unit.spec.js
@@ -248,12 +248,17 @@ describe('user selectors', () => {
   describe('selectPatientFacilities', () => {
     it('pulls out the state.profile.facilities array', () => {
       const state = {
+        featureToggles: {
+          // eslint-disable-next-line camelcase
+          show_new_schedule_view_appointments_page: true,
+        },
         user: {
           profile: {
             facilities: [
               { facilityId: '983', isCerner: false },
               { facilityId: '984', isCerner: false },
             ],
+            isCernerPatient: false,
           },
         },
       };
@@ -273,9 +278,14 @@ describe('user selectors', () => {
   describe('selectIsCernerOnlyPatient', () => {
     it('should return true if Cerner only', () => {
       const state = {
+        featureToggles: {
+          // eslint-disable-next-line camelcase
+          show_new_schedule_view_appointments_page: true,
+        },
         user: {
           profile: {
             facilities: [{ facilityId: '123', isCerner: true }],
+            isCernerPatient: true,
           },
         },
       };
@@ -283,12 +293,17 @@ describe('user selectors', () => {
     });
     it('should return false if not Cerner only', () => {
       const state = {
+        featureToggles: {
+          // eslint-disable-next-line camelcase
+          show_new_schedule_view_appointments_page: true,
+        },
         user: {
           profile: {
             facilities: [
               { facilityId: '123', isCerner: true },
               { facilityId: '124', isCerner: false },
             ],
+            isCernerPatient: true,
           },
         },
       };
@@ -298,9 +313,14 @@ describe('user selectors', () => {
   describe('selectIsCernerPatient', () => {
     it('should return true if single cerner response', () => {
       const state = {
+        featureToggles: {
+          // eslint-disable-next-line camelcase
+          show_new_schedule_view_appointments_page: true,
+        },
         user: {
           profile: {
             facilities: [{ facilityId: '123', isCerner: true }],
+            isCernerPatient: true,
           },
         },
       };
@@ -308,12 +328,17 @@ describe('user selectors', () => {
     });
     it('should return true if atleast 1 cerner facility', () => {
       const state = {
+        featureToggles: {
+          // eslint-disable-next-line camelcase
+          show_new_schedule_view_appointments_page: true,
+        },
         user: {
           profile: {
             facilities: [
               { facilityId: '123', isCerner: true },
               { facilityId: '124', isCerner: false },
             ],
+            isCernerPatient: true,
           },
         },
       };
@@ -321,9 +346,14 @@ describe('user selectors', () => {
     });
     it('should return false if no cerner facilities', () => {
       const state = {
+        featureToggles: {
+          // eslint-disable-next-line camelcase
+          show_new_schedule_view_appointments_page: true,
+        },
         user: {
           profile: {
             facilities: [{ facilityId: '124', isCerner: false }],
+            isCernerPatient: false,
           },
         },
       };


### PR DESCRIPTION
## Description
This PR removes the `isCernerLive` logic in the `selectPatientFacilities` selector.

## Testing done
N/A

## Screenshots
N/A

## Acceptance criteria
- [x] Remove `isCernerLive` from `selectPatientFacilities`.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
