### PR TITLE
CI improvements and cleanup for Cypress tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -187,6 +187,7 @@ jobs:
       - run:
           name: Build apps
           command: yarn build:webpack --env.buildtype vagovprod --env.scaffold
+          no_output_timeout: 15m
       - persist_to_workspace:
           root: ~/
           paths:
@@ -213,7 +214,6 @@ jobs:
       - run:
           name: Run Cypress Tests
           command: yarn cy:test:circle
-          no_output_timeout: 20m
       - store_test_results:
           path: ./test-results
       - store_artifacts:

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -68,19 +68,16 @@ node('vetsgov-general-purpose') {
     dir("vets-website") {
       try {
         parallel (
-          e2e: {
+          'nightwatch-e2e': {
             sh "export IMAGE_TAG=${commonStages.IMAGE_TAG} && docker-compose -p e2e up -d && docker-compose -p e2e run --rm --entrypoint=npm -e BABEL_ENV=test -e BUILDTYPE=vagovprod vets-website --no-color run nightwatch:docker"
-            try {
-              sh "docker-compose -p e2e run --rm --entrypoint npm -e BABEL_ENV=test -e BUILDTYPE=vagovprod vets-website --no-color run test:puppeteer:docker"
-            } catch (error) {
-              commonStages.puppeteerNotification()
-              throw error
-            }
-            sh "export IMAGE_TAG=${commonStages.IMAGE_TAG} && docker-compose -p e2e up -d && docker-compose -p e2e run --rm --entrypoint=npm -e BABEL_ENV=test -e BUILDTYPE=vagovprod vets-website --no-color run cy:test:docker"
           },
 
-          accessibility: {
+          'nightwatch-accessibility': {
             sh "export IMAGE_TAG=${commonStages.IMAGE_TAG} && docker-compose -p accessibility up -d && docker-compose -p accessibility run --rm --entrypoint=npm -e BABEL_ENV=test -e BUILDTYPE=vagovprod vets-website --no-color run nightwatch:docker -- --env=accessibility"
+          }
+
+          cypress: {
+            sh "export IMAGE_TAG=${commonStages.IMAGE_TAG} && docker-compose -p e2e up -d && docker-compose -p e2e run --rm --entrypoint=npm -e BABEL_ENV=test -e BUILDTYPE=vagovprod vets-website --no-color run cy:test:docker"
           }
         )
       } catch (error) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -69,7 +69,7 @@ node('vetsgov-general-purpose') {
       try {
         parallel (
           'nightwatch-e2e': {
-            sh "export IMAGE_TAG=${commonStages.IMAGE_TAG} && docker-compose -p e2e up -d && docker-compose -p e2e run --rm --entrypoint=npm -e BABEL_ENV=test -e BUILDTYPE=vagovprod vets-website --no-color run nightwatch:docker"
+            sh "export IMAGE_TAG=${commonStages.IMAGE_TAG} && docker-compose -p nightwatch up -d && docker-compose -p nightwatch run --rm --entrypoint=npm -e BABEL_ENV=test -e BUILDTYPE=vagovprod vets-website --no-color run nightwatch:docker"
           },
 
           'nightwatch-accessibility': {
@@ -77,15 +77,16 @@ node('vetsgov-general-purpose') {
           }
 
           cypress: {
-            sh "export IMAGE_TAG=${commonStages.IMAGE_TAG} && docker-compose -p e2e up -d && docker-compose -p e2e run --rm --entrypoint=npm -e BABEL_ENV=test -e BUILDTYPE=vagovprod vets-website --no-color run cy:test:docker"
+            sh "export IMAGE_TAG=${commonStages.IMAGE_TAG} && docker-compose -p cypress up -d && docker-compose -p cypress run --rm --entrypoint=npm -e BABEL_ENV=test -e BUILDTYPE=vagovprod vets-website --no-color run cy:test:docker"
           }
         )
       } catch (error) {
         commonStages.slackNotify()
         throw error
       } finally {
-        sh "docker-compose -p e2e down --remove-orphans"
+        sh "docker-compose -p nightwatch down --remove-orphans"
         sh "docker-compose -p accessibility down --remove-orphans"
+        sh "docker-compose -p cypress down --remove-orphans"
         step([$class: 'JUnitResultArchiver', testResults: 'logs/nightwatch/**/*.xml'])
       }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -77,7 +77,7 @@ node('vetsgov-general-purpose') {
           }
 
           cypress: {
-            sh "export IMAGE_TAG=${commonStages.IMAGE_TAG} && docker-compose -p cypress up -d && docker-compose -p cypress run --rm --entrypoint=npm -e BABEL_ENV=test -e BUILDTYPE=vagovprod vets-website --no-color run cy:test:docker"
+            sh "export IMAGE_TAG=${commonStages.IMAGE_TAG} && docker-compose -p cypress up -d && docker-compose -p cypress run --rm --entrypoint=npm -e CI=true vets-website --no-color run cy:test:docker"
           }
         )
       } catch (error) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -74,7 +74,7 @@ node('vetsgov-general-purpose') {
 
           'nightwatch-accessibility': {
             sh "export IMAGE_TAG=${commonStages.IMAGE_TAG} && docker-compose -p accessibility up -d && docker-compose -p accessibility run --rm --entrypoint=npm -e BABEL_ENV=test -e BUILDTYPE=vagovprod vets-website --no-color run nightwatch:docker -- --env=accessibility"
-          }
+          },
 
           cypress: {
             sh "export IMAGE_TAG=${commonStages.IMAGE_TAG} && docker-compose -p cypress up -d && docker-compose -p cypress run --rm --entrypoint=npm -e CI=true vets-website --no-color run cy:test:docker"

--- a/jenkins/common.groovy
+++ b/jenkins/common.groovy
@@ -87,13 +87,6 @@ def slackNotify() {
   }
 }
 
-def puppeteerNotification() {
-  message = "`${env.BRANCH_NAME}` failed the puppeteer tests. |${env.RUN_DISPLAY_URL}".stripMargin()
-  slackSend message: message,
-    color: 'danger',
-    failOnError: true
-}
-
 def slackIntegrationNotify() {
   message = "(Testing): integration tests failed. |${env.RUN_DISPLAY_URL}".stripMargin()
   slackSend message: message,

--- a/script/run-cypress-tests-circle.sh
+++ b/script/run-cypress-tests-circle.sh
@@ -4,10 +4,12 @@ if [ "$(find src -name '*.cypress.spec.js' | wc -l)" -eq 0 ]; then
   echo "No Cypress tests found."
   exit 0
 else
+  # Flag to indicate to tests that they are running in a CI environment.
+  export CYPRESS_CI=$CI
+
   # Use mocha-junit-reporter and save results in './test-results'.
   reporterArgs="--reporter cypress-multi-reporters --reporter-options \"configFile=config/cypress-reporters.json\""
 
   # Start the web server & run Cypress tests.
-  # Wait for http://localhost:3001/generated/style.css to finish bundling so Cypress doesn't start too soon.
   yarn start-server-and-test "node src/platform/testing/e2e/test-server.js --buildtype=vagovprod --port=3001 > /dev/null 2>&1" :3001 "yarn cy:run $reporterArgs"
 fi

--- a/script/run-cypress-tests-docker.sh
+++ b/script/run-cypress-tests-docker.sh
@@ -3,6 +3,6 @@ if [ "$(find src -name '*.cypress.spec.js' | wc -l)" -eq 0 ]; then
   exit 0
 else
   export CYPRESS_BASE_URL=http://vets-website:3001
-  export CYPRESS_BUILDTYPE=$BUILDTYPE
+  export CYPRESS_CI=$CI
   yarn cy:run
 fi

--- a/script/run-cypress-tests-docker.sh
+++ b/script/run-cypress-tests-docker.sh
@@ -2,5 +2,7 @@ if [ "$(find src -name '*.cypress.spec.js' | wc -l)" -eq 0 ]; then
   echo "No Cypress tests found."
   exit 0
 else
-  CYPRESS_BASE_URL=http://vets-website:3001 yarn cy:run
+  export CYPRESS_BASE_URL=http://vets-website:3001
+  export CYPRESS_BUILDTYPE=$BUILDTYPE
+  yarn cy:run
 fi

--- a/src/platform/testing/e2e/cypress/support/form-tester/README.md
+++ b/src/platform/testing/e2e/cypress/support/form-tester/README.md
@@ -391,6 +391,12 @@ skip: ['a-test', 'c-test'],
 skip: true,
 ```
 
+It can be useful to skip tests only in CI so you can continue running them locally. The environment variable `CI` should be present in CI environments.
+
+```js
+skip: Cypress.env('CI'),
+```
+
 ## Aliases
 
 The following aliases are available to `pageHooks` and `setupPerTest`.
@@ -528,10 +534,12 @@ const testConfig = createTestConfig(
     pageHooks: {
       // Due to automatic path resolution, this URL expands to:
       // '/some-form-app-url/introduction'. Either format can be used.
-      introduction: () => {
-        cy.findAllByText(/start/i, { selector: 'button' })
-          .first()
-          .click();
+      introduction: ({ afterHook }) => {
+        afterHook(() => {
+          cy.findAllByText(/start/i, { selector: 'button' })
+            .first()
+            .click();
+        });
       },
 
       'sub-page/do-stuff-before-filling': () => {
@@ -542,11 +550,6 @@ const testConfig = createTestConfig(
 
         // Fill out the rest of the page like normal.
         cy.fillPage();
-
-        // Don't forget to click continue!
-        cy.findAllByText(/continue/i, { selector: 'button' })
-          .first()
-          .click();
       },
 
       // Use files synced to fixtures, either individually or from folders.


### PR DESCRIPTION
## Description
- Run Cypress and Nightwatch tests in parallel in Jenkins.
    - Removed the Puppeteer tests and the related Slack notification.
    - Builds take about 10 minutes less time now.
- Added CI flag to Cypress so tests can be skipped in CI environments.
- Extended timeout on build step for Circle.
    - This is in response to recent builds occasionally running over 10 minutes without output.
- Removed unnecessary extended timeout for Cypress tests in Circle.
- Fixed some form tester documentation.

## Testing done
Tests pass in CI. Verified that skipping tests based on the `'CI'` environment variable works.

## Acceptance criteria
- [ ] E2E tests should continue to pass.
- [ ] Cypress tests should have access to the `'CI'` environment variable.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
