### PR TITLE
[Development] Move 526 wizard to intro page

### DIFF
--- a/src/applications/disability-benefits/all-claims/components/ArrayField.jsx
+++ b/src/applications/disability-benefits/all-claims/components/ArrayField.jsx
@@ -40,7 +40,11 @@ export default class ArrayField extends React.Component {
      * manage and doesn’t need to persist from page to page
      */
     this.state = {
-      editing: props.formData ? props.formData.map(() => false) : [true],
+      // force edit mode for valid BDD separation date; empty serviceBranch,
+      // but includes valid "to" entry
+      editing: props.formData
+        ? props.formData.map(data => data?.serviceBranch === '')
+        : [true],
     };
   }
 

--- a/src/applications/disability-benefits/all-claims/components/UpdateMilitaryHistory.jsx
+++ b/src/applications/disability-benefits/all-claims/components/UpdateMilitaryHistory.jsx
@@ -4,7 +4,7 @@ import { setData } from 'platform/forms-system/src/js/actions';
 
 import { SAVED_SEPARATION_DATE } from '../constants';
 
-const addServicePeriod = (formData, separationDate, setFormData) => {
+export const addServicePeriod = (formData, separationDate, setFormData) => {
   const data = formData;
   if (!data.serviceInformation) {
     data.serviceInformation = { servicePeriods: [] };
@@ -27,8 +27,10 @@ const addServicePeriod = (formData, separationDate, setFormData) => {
 };
 
 // Originally added to the military history page, but the setData function would
-// not update until after render of the array field.
-export const UpdateMilitaryHistory = ({ form, setFormData }) => {
+// not update until after render of the array field. This component returns null
+// because it's added as a component to the veteran info page in the 'ui:title',
+// but there is no title to render
+export const UpdateMilitaryHistory = ({ form = {}, setFormData }) => {
   // Get date from Wizard if user entered a valid BDD separation date
   const separationDate = window.sessionStorage.getItem(SAVED_SEPARATION_DATE);
   useEffect(() => {

--- a/src/applications/disability-benefits/all-claims/components/UpdateMilitaryHistory.jsx
+++ b/src/applications/disability-benefits/all-claims/components/UpdateMilitaryHistory.jsx
@@ -1,0 +1,50 @@
+import { useEffect } from 'react';
+import { connect } from 'react-redux';
+import { setData } from 'platform/forms-system/src/js/actions';
+
+import { SAVED_SEPARATION_DATE } from '../constants';
+
+const addServicePeriod = (formData, separationDate, setFormData) => {
+  const data = formData;
+  if (!data.serviceInformation) {
+    data.serviceInformation = { servicePeriods: [] };
+  }
+  if (!data.serviceInformation.servicePeriods) {
+    data.serviceInformation.servicePeriods = [];
+  }
+  if (
+    !data.serviceInformation.servicePeriods.find(
+      entry => entry.dateRange?.to === separationDate,
+    )
+  ) {
+    data.serviceInformation.servicePeriods.push({
+      serviceBranch: '',
+      dateRange: { from: '', to: separationDate },
+    });
+    window.sessionStorage.removeItem(SAVED_SEPARATION_DATE);
+    setFormData(data);
+  }
+};
+
+// Originally added to the military history page, but the setData function would
+// not update until after render of the array field.
+export const UpdateMilitaryHistory = ({ form, setFormData }) => {
+  // Get date from Wizard if user entered a valid BDD separation date
+  const separationDate = window.sessionStorage.getItem(SAVED_SEPARATION_DATE);
+  useEffect(() => {
+    if (form.data && separationDate) {
+      addServicePeriod(form.data, separationDate, setFormData);
+    }
+  });
+  return null;
+};
+
+const mapStateToProps = state => state;
+const mapDispatchToProps = {
+  setFormData: setData,
+};
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(UpdateMilitaryHistory);

--- a/src/applications/disability-benefits/all-claims/components/ValidatedServicePeriodView.jsx
+++ b/src/applications/disability-benefits/all-claims/components/ValidatedServicePeriodView.jsx
@@ -3,7 +3,7 @@ import { formatDateRange } from '../utils';
 
 export default function ValidatedServicePeriodView({ formData }) {
   return (
-    <div>
+    <div className="vads-u-flex--fill">
       <strong>{formData.serviceBranch}</strong>
       <p>{formatDateRange(formData.dateRange)}</p>
     </div>

--- a/src/applications/disability-benefits/all-claims/config/form.js
+++ b/src/applications/disability-benefits/all-claims/config/form.js
@@ -46,7 +46,6 @@ import prefillTransformer from '../prefill-transformer';
 
 import { transform } from '../submit-transformer';
 
-import { veteranInfoDescription } from '../content/veteranDetails';
 import { disabilitiesOrientation } from '../content/disabilitiesOrientation';
 import { supportingEvidenceOrientation } from '../content/supportingEvidenceOrientation';
 import { supportingEvidenceOrientationBDD } from '../content/supportingEvidenceOrientationBDD';
@@ -101,6 +100,7 @@ import {
   uploadPtsdDocuments,
   vaEmployee,
   vaMedicalRecords,
+  veteranInfo,
   workBehaviorChanges,
 } from '../pages';
 
@@ -165,8 +165,8 @@ const formConfig = {
         veteranInformation: {
           title: 'Veteran information',
           path: 'veteran-information',
-          uiSchema: { 'ui:description': veteranInfoDescription },
-          schema: { type: 'object', properties: {} },
+          uiSchema: veteranInfo.uiSchema,
+          schema: veteranInfo.schema,
         },
         alternateNames: {
           title: 'Service under another name',

--- a/src/applications/disability-benefits/all-claims/constants.js
+++ b/src/applications/disability-benefits/all-claims/constants.js
@@ -250,3 +250,11 @@ export const NULL_CONDITION_STRING = 'Unknown Condition';
 
 // Moment date format
 export const DATE_FORMAT = 'LL';
+
+export const WIZARD_STATUS = 'wizardStatus';
+
+export const EBEN_526_PATH =
+  'https://www.ebenefits.va.gov/ebenefits/about/feature?feature=disability-compensation';
+
+export const BDD_INFO_URL =
+  '/disability/how-to-file-claim/when-to-file/pre-discharge-claim/';

--- a/src/applications/disability-benefits/all-claims/constants.js
+++ b/src/applications/disability-benefits/all-claims/constants.js
@@ -252,6 +252,7 @@ export const NULL_CONDITION_STRING = 'Unknown Condition';
 export const DATE_FORMAT = 'LL';
 
 export const WIZARD_STATUS = 'wizardStatus';
+export const SAVED_SEPARATION_DATE = 'savedSeparationDate';
 
 export const EBEN_526_PATH =
   'https://www.ebenefits.va.gov/ebenefits/about/feature?feature=disability-compensation';

--- a/src/applications/disability-benefits/all-claims/constants.js
+++ b/src/applications/disability-benefits/all-claims/constants.js
@@ -251,7 +251,11 @@ export const NULL_CONDITION_STRING = 'Unknown Condition';
 // Moment date format
 export const DATE_FORMAT = 'LL';
 
+// sessionStorage key used to show the wizard has or hasn't been completed
 export const WIZARD_STATUS = 'wizardStatus';
+
+// sessionStorage key used for the user entered separation date in the wizard
+// used by the first page of the form to populate the form data
 export const SAVED_SEPARATION_DATE = 'savedSeparationDate';
 
 export const EBEN_526_PATH =

--- a/src/applications/disability-benefits/all-claims/containers/WizardContainer.jsx
+++ b/src/applications/disability-benefits/all-claims/containers/WizardContainer.jsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import FormFooter from 'platform/forms/components/FormFooter';
+import Wizard, {
+  WIZARD_STATUS_COMPLETE,
+} from 'applications/static-pages/wizard';
+
+import pages from '../../wizard/pages';
+import formConfig from '../config/form';
+
+const WizardContainer = ({ setWizardStatus }) => (
+  <div className="row">
+    <div className="usa-width-two-thirds medium-8 columns">
+      <h1>File for disability compensation</h1>
+      <p>
+        Equal to VA Form 21-526EZ (Application for Disability Compensation and
+        Related Compensation Benefits).
+      </p>
+      <div className="wizard-container">
+        <h2>Find out if this is the right form</h2>
+        <p>
+          Answer a few questions to confirm that this is the correct application
+          21-526EZ or another application form to apply for the VA benefits you
+          need.
+        </p>
+        <Wizard
+          pages={pages}
+          expander={false}
+          setWizardStatus={setWizardStatus}
+        />
+        <h2>Already know this is the right form?</h2>
+        <p>
+          If you know VA Form 21-526EZ is correct, or if you were directd to
+          complete this application, you can go straight to the application
+          withouut answering the questions above.
+        </p>
+        <button
+          type="button"
+          className="va-button-link vads-u-display--inline-block vads-u-margin-bottom--3 skip-wizard-link"
+          onClick={e => {
+            e.preventDefault();
+            setWizardStatus(WIZARD_STATUS_COMPLETE);
+          }}
+        >
+          If you know VA Form 21-526EZ is right, apply now
+        </button>
+      </div>
+      <FormFooter formConfig={formConfig} />
+    </div>
+  </div>
+);
+
+WizardContainer.propTypes = {
+  completed: PropTypes.func,
+};
+
+export default WizardContainer;

--- a/src/applications/disability-benefits/all-claims/containers/WizardContainer.jsx
+++ b/src/applications/disability-benefits/all-claims/containers/WizardContainer.jsx
@@ -20,9 +20,12 @@ const WizardContainer = ({ setWizardStatus }) => (
       <div className="wizard-container">
         <h2>Find out if this is the right form</h2>
         <p>
-          Answer a few questions to confirm that this is the correct application
-          21-526EZ or another application form to apply for the VA benefits you
-          need.
+          This application is for veterans and service members to seek
+          disability compensation for an illness or injury that was caused
+          by&mdash;or got worse because of&mdash;your active military service.
+          Compensation may include financial support and other benefits like
+          health care. To see if this is the right form for you, please answer a
+          few questions.
         </p>
         <Wizard
           pages={pages}
@@ -33,7 +36,7 @@ const WizardContainer = ({ setWizardStatus }) => (
         <p>
           If you know VA Form 21-526EZ is correct, or if you were directd to
           complete this application, you can go straight to the application
-          withouut answering the questions above.
+          without answering the questions above.
         </p>
         <button
           type="button"

--- a/src/applications/disability-benefits/all-claims/containers/WizardContainer.jsx
+++ b/src/applications/disability-benefits/all-claims/containers/WizardContainer.jsx
@@ -55,7 +55,7 @@ const WizardContainer = ({ setWizardStatus }) => (
 );
 
 WizardContainer.propTypes = {
-  completed: PropTypes.func,
+  setWizardStatus: PropTypes.func,
 };
 
 export default WizardContainer;

--- a/src/applications/disability-benefits/all-claims/pages/index.js
+++ b/src/applications/disability-benefits/all-claims/pages/index.js
@@ -93,6 +93,7 @@ import * as uploadUnemployabilitySupportingDocumentsChoice from './uploadUnemplo
 import * as uploadUnemployabilitySupportingDocuments from './uploadUnemployabilitySupportingDocuments';
 import * as vaEmployee from './vaEmployee';
 import * as vaMedicalRecords from './vaMedicalRecords';
+import * as veteranInfo from './veteranInfo';
 import * as workBehaviorChanges from './workBehaviorChanges';
 
 export {
@@ -191,5 +192,6 @@ export {
   uploadUnemployabilitySupportingDocumentsChoice,
   vaEmployee,
   vaMedicalRecords,
+  veteranInfo,
   workBehaviorChanges,
 };

--- a/src/applications/disability-benefits/all-claims/pages/militaryHistory.js
+++ b/src/applications/disability-benefits/all-claims/pages/militaryHistory.js
@@ -6,6 +6,8 @@ import * as autosuggest from 'platform/forms-system/src/js/definitions/autosugge
 
 import ValidatedServicePeriodView from '../components/ValidatedServicePeriodView';
 import { showSeparationLocation } from '../utils';
+
+import ArrayField from '../components/ArrayField';
 import {
   SeparationLocationTitle,
   SeparationLocationDescription,
@@ -62,6 +64,7 @@ export const uiSchema = {
       'ui:title': 'Military service history',
       'ui:description':
         'Please add or update your military service history details below.',
+      'ui:field': ArrayField,
       'ui:options': {
         itemName: 'Service Period',
         viewField: ValidatedServicePeriodView,

--- a/src/applications/disability-benefits/all-claims/pages/veteranInfo.js
+++ b/src/applications/disability-benefits/all-claims/pages/veteranInfo.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import { veteranInfoDescription } from '../content/veteranDetails';
+import UpdateMilitaryHistory from '../components/UpdateMilitaryHistory';
+
+export const uiSchema = {
+  // update separation date from wizard (BDD)
+  'ui:title': <UpdateMilitaryHistory />,
+  'ui:description': veteranInfoDescription,
+};
+
+export const schema = {
+  type: 'object',
+  properties: {},
+};

--- a/src/applications/disability-benefits/all-claims/sass/disability-benefits.scss
+++ b/src/applications/disability-benefits/all-claims/sass/disability-benefits.scss
@@ -23,6 +23,14 @@ ul.original-disability-list {
   }
 }
 
+.wizard-content-inner .fieldset-input:first-child {
+  margin-top: 0;
+}
+
+.row .usa-date-of-birth.row {
+  margin: unset;
+}
+
 .process-step:last-child {
   padding-bottom: 0;
 }

--- a/src/applications/disability-benefits/all-claims/tests/components/UpdateMilitaryHistory.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/components/UpdateMilitaryHistory.unit.spec.jsx
@@ -66,6 +66,10 @@ describe('UpdateMilitaryHistory', () => {
     form.data.serviceInformation.servicePeriods = servicePeriods();
   });
 
+  after(() => {
+    useEffect.restore();
+  });
+
   it('should get called', () => {
     setUp('', () => {
       expect(form.data.serviceInformation.servicePeriods).to.deep.equal(

--- a/src/applications/disability-benefits/all-claims/tests/components/UpdateMilitaryHistory.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/components/UpdateMilitaryHistory.unit.spec.jsx
@@ -26,7 +26,7 @@ describe('UpdateMilitaryHistory', () => {
     },
   };
 
-  function setUp(separationDate, test) {
+  function setUp({ separationDate = '', callback }) {
     const setFormData = data => {
       form.data = data;
     };
@@ -45,7 +45,7 @@ describe('UpdateMilitaryHistory', () => {
     wrapper = mount(
       <UpdateMilitaryHistory form={form} setFormData={setFormData} />,
     );
-    test();
+    callback();
   }
 
   afterEach(() => {
@@ -56,24 +56,30 @@ describe('UpdateMilitaryHistory', () => {
   });
 
   it('should get called', () => {
-    setUp('', () => {
-      expect(form.data.serviceInformation.servicePeriods).to.deep.equal(
-        servicePeriods(),
-      );
+    setUp({
+      separationDate: '', // don't add separation date to sessionStorage
+      callback: () => {
+        expect(form.data.serviceInformation.servicePeriods).to.deep.equal(
+          servicePeriods(),
+        );
+      },
     });
   });
   it('should update the form data', () => {
-    setUp('2021-01-30', () => {
-      expect(form.data.serviceInformation.servicePeriods).to.deep.equal([
-        ...servicePeriods(),
-        {
-          serviceBranch: '',
-          dateRange: {
-            from: '',
-            to: '2021-01-30',
+    setUp({
+      separationDate: '2021-01-30',
+      callback: () => {
+        expect(form.data.serviceInformation.servicePeriods).to.deep.equal([
+          ...servicePeriods(),
+          {
+            serviceBranch: '',
+            dateRange: {
+              from: '',
+              to: '2021-01-30',
+            },
           },
-        },
-      ]);
+        ]);
+      },
     });
   });
 });

--- a/src/applications/disability-benefits/all-claims/tests/components/UpdateMilitaryHistory.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/components/UpdateMilitaryHistory.unit.spec.jsx
@@ -1,13 +1,9 @@
 import React from 'react';
 import { expect } from 'chai';
-import { shallow } from 'enzyme';
-import sinon from 'sinon';
+import { mount } from 'enzyme';
 
 import { SAVED_SEPARATION_DATE } from '../../constants';
-import {
-  UpdateMilitaryHistory,
-  addServicePeriod,
-} from '../../components/UpdateMilitaryHistory';
+import { UpdateMilitaryHistory } from '../../components/UpdateMilitaryHistory';
 
 describe('UpdateMilitaryHistory', () => {
   let wrapper;
@@ -30,8 +26,6 @@ describe('UpdateMilitaryHistory', () => {
     },
   };
 
-  const useEffect = sinon.stub(React, 'useEffect');
-
   function setUp(separationDate, test) {
     const setFormData = data => {
       form.data = data;
@@ -48,15 +42,10 @@ describe('UpdateMilitaryHistory', () => {
     if (separationDate) {
       window.sessionStorage.setItem(SAVED_SEPARATION_DATE, separationDate);
     }
-    useEffect.onCall(0).callsFake(() => {
-      // duplicate code from useEffect in UpdateMilitaryHistory
-      if (form.data && separationDate) {
-        addServicePeriod(form.data, separationDate, setFormData);
-      }
-    });
-    wrapper = shallow(<UpdateMilitaryHistory form={form} />);
+    wrapper = mount(
+      <UpdateMilitaryHistory form={form} setFormData={setFormData} />,
+    );
     test();
-    useEffect.resetHistory();
   }
 
   afterEach(() => {
@@ -64,10 +53,6 @@ describe('UpdateMilitaryHistory', () => {
     storage = {};
     wrapper.unmount();
     form.data.serviceInformation.servicePeriods = servicePeriods();
-  });
-
-  after(() => {
-    useEffect.restore();
   });
 
   it('should get called', () => {

--- a/src/applications/disability-benefits/all-claims/tests/components/UpdateMilitaryHistory.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/components/UpdateMilitaryHistory.unit.spec.jsx
@@ -1,0 +1,90 @@
+import React from 'react';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+import sinon from 'sinon';
+
+import { SAVED_SEPARATION_DATE } from '../../constants';
+import {
+  UpdateMilitaryHistory,
+  addServicePeriod,
+} from '../../components/UpdateMilitaryHistory';
+
+describe('UpdateMilitaryHistory', () => {
+  let wrapper;
+  let oldSessionStorage;
+  let storage = {};
+  const servicePeriods = () => [
+    {
+      serviceBranch: 'Army',
+      dateRange: {
+        from: '2015-12-31',
+        to: '2020-12-31',
+      },
+    },
+  ];
+  const form = {
+    data: {
+      serviceInformation: {
+        servicePeriods: servicePeriods(),
+      },
+    },
+  };
+
+  const useEffect = sinon.stub(React, 'useEffect');
+
+  function setUp(separationDate, test) {
+    const setFormData = data => {
+      form.data = data;
+    };
+    oldSessionStorage = window.sessionStorage;
+    delete window.sessionStorage;
+    window.sessionStorage = {
+      getItem: key => storage[key] || null,
+      setItem: (key, value) => {
+        storage[key] = value;
+      },
+      removeItem: key => delete storage[key],
+    };
+    if (separationDate) {
+      window.sessionStorage.setItem(SAVED_SEPARATION_DATE, separationDate);
+    }
+    useEffect.onCall(0).callsFake(() => {
+      // duplicate code from useEffect in UpdateMilitaryHistory
+      if (form.data && separationDate) {
+        addServicePeriod(form.data, separationDate, setFormData);
+      }
+    });
+    wrapper = shallow(<UpdateMilitaryHistory form={form} />);
+    test();
+    useEffect.resetHistory();
+  }
+
+  afterEach(() => {
+    window.sessionStorage = oldSessionStorage;
+    storage = {};
+    wrapper.unmount();
+    form.data.serviceInformation.servicePeriods = servicePeriods();
+  });
+
+  it('should get called', () => {
+    setUp('', () => {
+      expect(form.data.serviceInformation.servicePeriods).to.deep.equal(
+        servicePeriods(),
+      );
+    });
+  });
+  it('should update the form data', () => {
+    setUp('2021-01-30', () => {
+      expect(form.data.serviceInformation.servicePeriods).to.deep.equal([
+        ...servicePeriods(),
+        {
+          serviceBranch: '',
+          dateRange: {
+            from: '',
+            to: '2021-01-30',
+          },
+        },
+      ]);
+    });
+  });
+});

--- a/src/applications/disability-benefits/all-claims/tests/containers/WizardContainer.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/containers/WizardContainer.unit.spec.jsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+
+import WizardContainer from '../../containers/WizardContainer';
+import { WIZARD_STATUS_COMPLETE } from 'applications/static-pages/wizard';
+
+describe('Wizard Container', () => {
+  global.status = '';
+  const props = {
+    setWizardStatus: value => {
+      global.status = value;
+    },
+  };
+
+  it('should render', () => {
+    const tree = shallow(<WizardContainer {...props} />);
+    expect(tree.find('.wizard-container')).to.have.lengthOf(1);
+    expect(tree.find('FormFooter')).to.have.lengthOf(1);
+    tree.unmount();
+  });
+  it('should update wizard status on bypass click', () => {
+    global.status = '';
+    const tree = shallow(<WizardContainer {...props} />);
+    tree.find('.va-button-link').simulate('click', {
+      preventDefault: () => {},
+    });
+    expect(tree.find('.wizard-container')).to.have.lengthOf(1);
+    expect(global.status).to.equal(WIZARD_STATUS_COMPLETE);
+    tree.unmount();
+  });
+});

--- a/src/applications/disability-benefits/all-claims/tests/pages/contactInformation.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/pages/contactInformation.unit.spec.jsx
@@ -11,7 +11,7 @@ import formConfig from '../../config/form.js';
 import {
   STATE_VALUES,
   MILITARY_STATE_VALUES,
-} from '../../../all-claims/constants';
+} from 'applications/disability-benefits/all-claims/constants';
 
 // const NEXT_YEAR = moment()
 //   .add(1, 'year')

--- a/src/applications/disability-benefits/all-claims/tests/prefill-transformer.unit.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/prefill-transformer.unit.spec.js
@@ -7,7 +7,7 @@ import prefillTransformer, {
 import {
   SERVICE_CONNECTION_TYPES,
   disabilityActionTypes,
-} from '../../all-claims/constants';
+} from 'applications/disability-benefits/all-claims/constants';
 
 describe('526v2 prefill transformer', () => {
   const noTransformData = {

--- a/src/applications/disability-benefits/all-claims/tests/utils.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/utils.unit.spec.jsx
@@ -33,6 +33,7 @@ import {
   formatDate,
   formatDateRange,
   isBDD,
+  show526Wizard,
 } from '../utils.jsx';
 
 describe('526 helpers', () => {
@@ -999,6 +1000,17 @@ describe('526 v2 depends functions', () => {
     });
     it('should return false if no service period is provided with a separation date', () => {
       expect(isBDD(null)).to.be.false;
+    });
+  });
+
+  describe('showWizard', () => {
+    it('should get wizard feature flag value of true', () => {
+      expect(show526Wizard({ featureToggles: { show526Wizard: true } })).to.be
+        .true;
+    });
+    it('should get wizard feature flag value of false', () => {
+      expect(show526Wizard({ featureToggles: { show526Wizard: false } })).to.be
+        .false;
     });
   });
 });

--- a/src/applications/disability-benefits/all-claims/utils.jsx
+++ b/src/applications/disability-benefits/all-claims/utils.jsx
@@ -20,6 +20,7 @@ import {
 } from './validations';
 import ReviewCardField from 'platform/forms-system/src/js/components/ReviewCardField';
 import AddressViewField from 'platform/forms-system/src/js/components/AddressViewField';
+import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
 
 import {
   DATA_PATHS,
@@ -876,3 +877,5 @@ export const showSeparationLocation = formData => {
     !mostRecentDate.isAfter(moment().add(180, 'days'))
   );
 };
+
+export const show526Wizard = state => toggleValues(state).show526Wizard;

--- a/src/applications/disability-benefits/constants.js
+++ b/src/applications/disability-benefits/constants.js
@@ -1,5 +1,0 @@
-export const EBEN_526_PATH =
-  'https://www.ebenefits.va.gov/ebenefits/about/feature?feature=disability-compensation';
-
-export const BDD_INFO_URL =
-  '/disability/how-to-file-claim/when-to-file/pre-discharge-claim/';

--- a/src/applications/disability-benefits/wizard/WizardLink.jsx
+++ b/src/applications/disability-benefits/wizard/WizardLink.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { connect } from 'react-redux';
+
+import manifest from '../all-claims/manifest.json';
+import { show526Wizard } from '../all-claims/utils';
+
+/*
+ * Showing the wizard on the Intro page, so when set, this shows the link
+ * on the hub page; this file & the `createWizard` files won't be neccessary
+ * once we get the flipper to 100% and the Drupal page includes a direct link to
+ * the introduction page
+ */
+const WizardLink = ({ showWizard, module }) => {
+  const { Wizard, pages } = module.default;
+  return showWizard ? (
+    <a href={manifest.rootUrl} className="usa-button-primary va-button-primary">
+      Let&apos;s get started{' '}
+      <img
+        src="/img/arrow-right-white.svg"
+        aria-hidden="true"
+        alt=""
+        style={{ height: '13px', verticalAlign: 'baseline' }}
+      />
+    </a>
+  ) : (
+    <Wizard pages={pages} expander buttonText="Let's get started" />
+  );
+};
+
+const mapStateToProps = state => ({
+  showWizard: show526Wizard(state),
+});
+
+export default connect(mapStateToProps)(WizardLink);

--- a/src/applications/disability-benefits/wizard/WizardLink.jsx
+++ b/src/applications/disability-benefits/wizard/WizardLink.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { connect } from 'react-redux';
 
-import manifest from '../all-claims/manifest.json';
-import { show526Wizard } from '../all-claims/utils';
+import manifest from 'applications/disability-benefits/all-claims/manifest.json';
+import { show526Wizard } from 'applications/disability-benefits/all-claims/utils';
 
 /*
  * Showing the wizard on the Intro page, so when set, this shows the link

--- a/src/applications/disability-benefits/wizard/createWizard.jsx
+++ b/src/applications/disability-benefits/wizard/createWizard.jsx
@@ -2,68 +2,53 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
 import { VA_FORM_IDS } from 'platform/forms/constants';
-import environment from 'platform/utilities/environment';
+import { connectFeatureToggle } from 'platform/utilities/feature-toggles';
 
-import manifest from '../all-claims/manifest.json';
+import WizardLink from './WizardLink';
 
 const disabilityForms = new Set([VA_FORM_IDS.FORM_21_526EZ]);
 
+// This file & the `WizardLink` files won't be neccessary once we get the
+// flipper to 100% and the Drupal page includes a direct link to the
+// introduction page
 export default function createDisabilityIncreaseApplicationStatus(
   store,
   widgetType,
 ) {
   const root = document.querySelector(`[data-widget-type="${widgetType}"]`);
-  if (root) {
-    if (environment.isProduction()) {
-      import(/* webpackChunkName: "disability-application-status" */
-      './wizard-entry').then(module => {
-        const { ApplicationStatus, Wizard, pages } = module.default;
-        ReactDOM.render(
-          <Provider store={store}>
-            <ApplicationStatus
-              formIds={disabilityForms}
-              formType="disability compensation"
-              showApplyButton={
-                root.getAttribute('data-hide-apply-button') === null
-              }
-              stayAfterDelete
-              applyRender={() => (
-                <div itemScope itemType="http://schema.org/Question">
-                  <h2 itemProp="name">Can I file my claim online?</h2>
-                  <div
-                    itemProp="acceptedAnswer"
-                    itemScope
-                    itemType="http://schema.org/Answer"
-                  >
-                    <div itemProp="text">
-                      <p>
-                        It depends on your situation. Answer a few questions,
-                        and we&apos;ll guide you to the right place.
-                      </p>
-                      <Wizard
-                        pages={pages}
-                        expander
-                        buttonText="Let's get started"
-                      />
-                    </div>
-                  </div>
+  import(/* webpackChunkName: "disability-application-status" */
+  './wizard-entry').then(module => {
+    const { ApplicationStatus } = module.default;
+    connectFeatureToggle(store.dispatch);
+
+    ReactDOM.render(
+      <Provider store={store}>
+        <ApplicationStatus
+          formIds={disabilityForms}
+          formType="disability compensation"
+          showApplyButton={root.getAttribute('data-hide-apply-button') === null}
+          stayAfterDelete
+          applyRender={() => (
+            <div itemScope itemType="http://schema.org/Question">
+              <h2 itemProp="name">Can I file my claim online?</h2>
+              <div
+                itemProp="acceptedAnswer"
+                itemScope
+                itemType="http://schema.org/Answer"
+              >
+                <div itemProp="text">
+                  <p>
+                    It depends on your situation. Answer a few questions, and
+                    we&apos;ll guide you to the right place.
+                  </p>
+                  <WizardLink module={module} />
                 </div>
-              )}
-            />
-          </Provider>,
-          root,
-        );
-      });
-    } else {
-      ReactDOM.render(
-        <a
-          href={manifest.rootUrl}
-          className="usa-button-primary va-button-primary"
-        >
-          File a disability compensation claim
-        </a>,
-        root,
-      );
-    }
-  }
+              </div>
+            </div>
+          )}
+        />
+      </Provider>,
+      root,
+    );
+  });
 }

--- a/src/applications/disability-benefits/wizard/createWizard.jsx
+++ b/src/applications/disability-benefits/wizard/createWizard.jsx
@@ -2,6 +2,9 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
 import { VA_FORM_IDS } from 'platform/forms/constants';
+import environment from 'platform/utilities/environment';
+
+import manifest from '../all-claims/manifest.json';
 
 const disabilityForms = new Set([VA_FORM_IDS.FORM_21_526EZ]);
 
@@ -11,44 +14,56 @@ export default function createDisabilityIncreaseApplicationStatus(
 ) {
   const root = document.querySelector(`[data-widget-type="${widgetType}"]`);
   if (root) {
-    import(/* webpackChunkName: "disability-application-status" */
-    './wizard-entry').then(module => {
-      const { ApplicationStatus, Wizard, pages } = module.default;
-      ReactDOM.render(
-        <Provider store={store}>
-          <ApplicationStatus
-            formIds={disabilityForms}
-            formType="disability compensation"
-            showApplyButton={
-              root.getAttribute('data-hide-apply-button') === null
-            }
-            stayAfterDelete
-            applyRender={() => (
-              <div itemScope itemType="http://schema.org/Question">
-                <h2 itemProp="name">Can I file my claim online?</h2>
-                <div
-                  itemProp="acceptedAnswer"
-                  itemScope
-                  itemType="http://schema.org/Answer"
-                >
-                  <div itemProp="text">
-                    <p>
-                      It depends on your situation. Answer a few questions, and
-                      we&apos;ll guide you to the right place.
-                    </p>
-                    <Wizard
-                      pages={pages}
-                      expander
-                      buttonText="Let's get started"
-                    />
+    if (environment.isProduction()) {
+      import(/* webpackChunkName: "disability-application-status" */
+      './wizard-entry').then(module => {
+        const { ApplicationStatus, Wizard, pages } = module.default;
+        ReactDOM.render(
+          <Provider store={store}>
+            <ApplicationStatus
+              formIds={disabilityForms}
+              formType="disability compensation"
+              showApplyButton={
+                root.getAttribute('data-hide-apply-button') === null
+              }
+              stayAfterDelete
+              applyRender={() => (
+                <div itemScope itemType="http://schema.org/Question">
+                  <h2 itemProp="name">Can I file my claim online?</h2>
+                  <div
+                    itemProp="acceptedAnswer"
+                    itemScope
+                    itemType="http://schema.org/Answer"
+                  >
+                    <div itemProp="text">
+                      <p>
+                        It depends on your situation. Answer a few questions,
+                        and we&apos;ll guide you to the right place.
+                      </p>
+                      <Wizard
+                        pages={pages}
+                        expander
+                        buttonText="Let's get started"
+                      />
+                    </div>
                   </div>
                 </div>
-              </div>
-            )}
-          />
-        </Provider>,
+              )}
+            />
+          </Provider>,
+          root,
+        );
+      });
+    } else {
+      ReactDOM.render(
+        <a
+          href={manifest.rootUrl}
+          className="usa-button-primary va-button-primary"
+        >
+          File a disability compensation claim
+        </a>,
         root,
       );
-    });
+    }
   }
 }

--- a/src/applications/disability-benefits/wizard/pages/bdd.jsx
+++ b/src/applications/disability-benefits/wizard/pages/bdd.jsx
@@ -4,6 +4,16 @@ import ErrorableDate from '@department-of-veterans-affairs/formation-react/Error
 import { pageNames } from './pageList';
 
 import unableToFileBDDProduction from './unable-to-file-bdd-production';
+import { SAVED_SEPARATION_DATE } from '../../all-claims/constants';
+
+const saveDischargeDate = date => {
+  if (date) {
+    const formattedDate = moment(date).format('YYYY-MM-DD');
+    window.sessionStorage.setItem(SAVED_SEPARATION_DATE, formattedDate);
+  } else {
+    window.sessionStorage.removeItem(SAVED_SEPARATION_DATE);
+  }
+};
 
 // Figure out which page to go to based on the date entered
 const findNextPage = state => {
@@ -18,10 +28,13 @@ const findNextPage = state => {
     dateDischarge.diff(dateToday, 'days') + 1;
 
   if (differenceBetweenDatesInDays < 90) {
+    saveDischargeDate(dateDischarge);
     return pageNames.fileClaimEarly;
   } else if (differenceBetweenDatesInDays <= 180) {
+    saveDischargeDate(dateDischarge);
     return pageNames.fileBDD;
   }
+  saveDischargeDate();
   return pageNames.unableToFileBDD;
 };
 
@@ -55,13 +68,15 @@ const BDDPage = ({ setPageState, state = defaultState, allowBDD }) => {
     return <unableToFileBDDProduction.component />;
   }
 
-  const onChange = pageState =>
+  const onChange = pageState => {
+    saveDischargeDate();
     setPageState(
       pageState,
       isDateComplete(pageState) && isDateInFuture(pageState)
         ? findNextPage(pageState)
         : undefined,
     );
+  };
 
   return (
     <ErrorableDate

--- a/src/applications/disability-benefits/wizard/pages/file-bdd.jsx
+++ b/src/applications/disability-benefits/wizard/pages/file-bdd.jsx
@@ -2,10 +2,13 @@ import React from 'react';
 import moment from 'moment';
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 import { pageNames } from './pageList';
-import { BDD_INFO_URL } from '../../constants';
-import { DISABILITY_526_V2_ROOT_URL } from 'applications/disability-benefits/all-claims/constants';
+import {
+  BDD_INFO_URL,
+  DISABILITY_526_V2_ROOT_URL,
+} from 'applications/disability-benefits/all-claims/constants';
+import { WIZARD_STATUS_COMPLETE } from 'applications/static-pages/wizard';
 
-function alertContent(getPageStateFromPageName) {
+function alertContent(getPageStateFromPageName, setWizardStatus) {
   const stateBDD = getPageStateFromPageName('bdd');
 
   const dateDischarge = moment({
@@ -60,21 +63,32 @@ function alertContent(getPageStateFromPageName) {
           Learn more about the Benefits Delivery at Discharge (BDD) program
         </a>
       </p>
-      <a
-        href={`${DISABILITY_526_V2_ROOT_URL}/introduction`}
-        className="usa-button-primary va-button-primary"
-      >
-        File a Benefits Delivery at Discharge claim
-      </a>
+      {/* Remove link to introduction page once show526Wizard flipper is at
+      100% */}
+      {typeof setWizardStatus === 'function' ? (
+        <button
+          onClick={() => setWizardStatus(WIZARD_STATUS_COMPLETE)}
+          className="usa-button-primary va-button-primary"
+        >
+          File a Benefits Delivery at Discharge claim
+        </button>
+      ) : (
+        <a
+          href={`${DISABILITY_526_V2_ROOT_URL}/introduction`}
+          className="usa-button-primary va-button-primary"
+        >
+          File a Benefits Delivery at Discharge claim
+        </a>
+      )}
     </>
   );
 }
 
-const FileBDDClaim = ({ getPageStateFromPageName }) => (
+const FileBDDClaim = ({ getPageStateFromPageName, setWizardStatus }) => (
   <AlertBox
     status="info"
-    headline="You're eligible to file a BDD claim"
-    content={alertContent(getPageStateFromPageName)}
+    headline="You’re eligible to file a BDD claim"
+    content={alertContent(getPageStateFromPageName, setWizardStatus)}
   />
 );
 

--- a/src/applications/disability-benefits/wizard/pages/file-claim-early.jsx
+++ b/src/applications/disability-benefits/wizard/pages/file-claim-early.jsx
@@ -1,16 +1,27 @@
 import React from 'react';
 import { DISABILITY_526_V2_ROOT_URL } from 'applications/disability-benefits/all-claims/constants';
+import { WIZARD_STATUS_COMPLETE } from 'applications/static-pages/wizard';
 import { pageNames } from './pageList';
 
-const FileClaimPage = () => (
+const FileClaimPage = ({ setWizardStatus }) => (
   <div>
     <p>
-      <a
-        href={`${DISABILITY_526_V2_ROOT_URL}/introduction`}
-        className="usa-button-primary va-button-primary"
-      >
-        File a disability compensation claim
-      </a>
+      {/* Remove link to introduction page once show526Wizard flipper is at 100% */}
+      {typeof setWizardStatus === 'function' ? (
+        <button
+          onClick={() => setWizardStatus(WIZARD_STATUS_COMPLETE)}
+          className="usa-button-primary va-button-primary"
+        >
+          File a disability compensation claim
+        </button>
+      ) : (
+        <a
+          href={`${DISABILITY_526_V2_ROOT_URL}/introduction`}
+          className="usa-button-primary va-button-primary"
+        >
+          File a disability compensation claim
+        </a>
+      )}
     </p>
   </div>
 );

--- a/src/applications/disability-benefits/wizard/pages/file-claim.jsx
+++ b/src/applications/disability-benefits/wizard/pages/file-claim.jsx
@@ -1,18 +1,29 @@
 import React from 'react';
 import { DISABILITY_526_V2_ROOT_URL } from 'applications/disability-benefits/all-claims/constants';
+import { WIZARD_STATUS_COMPLETE } from 'applications/static-pages/wizard';
 import { pageNames } from './pageList';
 
-const FileClaimPage = () => (
-  <div>
-    <p>
+/**
+ * Remove link to introduction page once show526Wizard flipper is at 100%
+ */
+const FileClaimPage = ({ setWizardStatus }) => (
+  <p>
+    {typeof setWizardStatus === 'function' ? (
+      <button
+        onClick={() => setWizardStatus(WIZARD_STATUS_COMPLETE)}
+        className="usa-button-primary va-button-primary"
+      >
+        File a disability compensation claim
+      </button>
+    ) : (
       <a
         href={`${DISABILITY_526_V2_ROOT_URL}/introduction`}
         className="usa-button-primary va-button-primary"
       >
         File a disability compensation claim
       </a>
-    </p>
-  </div>
+    )}
+  </p>
 );
 
 export default {

--- a/src/applications/disability-benefits/wizard/pages/unable-to-file-bdd-production.jsx
+++ b/src/applications/disability-benefits/wizard/pages/unable-to-file-bdd-production.jsx
@@ -28,7 +28,7 @@ function alertContent(isLoggedIn) {
       </p>
       <p>
         <strong>If your separation date is before {ninetyDays},</strong> you
-        can't file a BDD claim, but you can still begin the process of filing
+        can’t file a BDD claim, but you can still begin the process of filing
         your claim on eBenefits.
       </p>
       <a

--- a/src/applications/disability-benefits/wizard/pages/unable-to-file-bdd-production.jsx
+++ b/src/applications/disability-benefits/wizard/pages/unable-to-file-bdd-production.jsx
@@ -5,7 +5,10 @@ import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 import { pageNames } from './pageList';
 import { isLoggedIn as isLoggedInSelector } from 'platform/user/selectors';
 import recordEvent from 'platform/monitoring/record-event';
-import { EBEN_526_PATH, BDD_INFO_URL } from '../../all-claims/constants';
+import {
+  EBEN_526_PATH,
+  BDD_INFO_URL,
+} from 'applications/disability-benefits/all-claims/constants';
 
 const dateFormat = 'MMMM DD, YYYY';
 const ninetyDays = moment()

--- a/src/applications/disability-benefits/wizard/pages/unable-to-file-bdd-production.jsx
+++ b/src/applications/disability-benefits/wizard/pages/unable-to-file-bdd-production.jsx
@@ -5,7 +5,7 @@ import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 import { pageNames } from './pageList';
 import { isLoggedIn as isLoggedInSelector } from 'platform/user/selectors';
 import recordEvent from 'platform/monitoring/record-event';
-import { EBEN_526_PATH, BDD_INFO_URL } from '../../constants';
+import { EBEN_526_PATH, BDD_INFO_URL } from '../../all-claims/constants';
 
 const dateFormat = 'MMMM DD, YYYY';
 const ninetyDays = moment()

--- a/src/applications/disability-benefits/wizard/pages/unable-to-file-bdd.jsx
+++ b/src/applications/disability-benefits/wizard/pages/unable-to-file-bdd.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import moment from 'moment';
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 import { pageNames } from './pageList';
-import { BDD_INFO_URL } from '../../constants';
+import { BDD_INFO_URL } from '../../all-claims/constants';
 
 function alertContent(getPageStateFromPageName) {
   const stateBDD = getPageStateFromPageName('bdd');

--- a/src/applications/disability-benefits/wizard/pages/unable-to-file-bdd.jsx
+++ b/src/applications/disability-benefits/wizard/pages/unable-to-file-bdd.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import moment from 'moment';
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 import { pageNames } from './pageList';
-import { BDD_INFO_URL } from '../../all-claims/constants';
+import { BDD_INFO_URL } from 'applications/disability-benefits/all-claims/constants';
 
 function alertContent(getPageStateFromPageName) {
   const stateBDD = getPageStateFromPageName('bdd');

--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -53,4 +53,5 @@ export default Object.freeze({
     'show_new_schedule_view_appointments_page',
   showNewSecureMessagingPage: 'show_new_secure_messaging_page',
   showNewViewTestLabResultsPage: 'show_new_view_test_lab_results_page',
+  show526Wizard: 'show526Wizard',
 });


### PR DESCRIPTION
## Description

This PR accomplishes:

- Adds `show526Wizard` feature flag
- Wizard injected into the Drupal hub page will show a direct link to the introduction page when the feature flag is set
  <details><summary>Screenshot of hub page link</summary>

  <!-- leave a blank line above -->
  ![Screen Shot 2020-08-20 at 5 53 35 PM](https://user-images.githubusercontent.com/136959/90833677-251e2000-e30e-11ea-8d26-e4b3802c7192.png)</details>
- The form wrapper (around the introduction page) will show the expanded wizard (step 1) and a link to skip and jump directly to the intro page content
  <details><summary>Screenshot of the intro page showing the wizard</summary>

  <!-- leave a blank line above -->
  ![Screen Shot 2020-08-20 at 5 52 57 PM](https://user-images.githubusercontent.com/136959/90833798-60205380-e30e-11ea-8f4d-c75f22e7e9af.png)</details>
- Updated 3 internal wizard page links to show a button when the feature flag is set, that reveals the intro page content instead of reloading the page
  <details><summary>Screenshot of eiligible BDD alert</summary>

  <!-- leave a blank line above -->
  ![Screen Shot 2020-08-20 at 5 57 25 PM](https://user-images.githubusercontent.com/136959/90833935-ad042a00-e30e-11ea-8664-80241567e6f7.png)</details>
- Updates the Military History page with a new service period entry that includes the separation date entered in the wizard
  <details><summary>Screenshot of prefilled separation date</summary>

  <!-- leave a blank line above -->
  ![Screen Shot 2020-08-20 at 6 03 36 PM](https://user-images.githubusercontent.com/136959/90834280-8266a100-e30f-11ea-9c7e-9a38310cfbd1.png)</details>
 - Updated Array field to automatically put the partially filled-in service period card into edit mode

Related:
- Flow design: https://app.mural.co/t/vsa8243/m/vsa8243/1585244567898/2167d6cafb30ce4a81e2ea8a082a6a832293e11c
- No hi-fi design for this, but copied layout from https://preview.uxpin.com/e291c4ac8956d804d774160cdb82ecb724044689#/pages/130773489/simulate/no-panels
- Move wizard to intro page: https://github.com/department-of-veterans-affairs/va.gov-team/issues/10966
- Prefill separation date: https://github.com/department-of-veterans-affairs/va.gov-team/issues/10842

## Testing done

- Added new unit tests
- Verified e2e tests not effected

## Screenshots

See above

## Acceptance criteria
- [x] Wizard is replaced on hub page with a link, per feature flag
- [x] Wizard now appears on introduction page, per feature flag
- [x] Separation date prefill works
- [x] Accessibility checks passing on updated pages

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
