### PR TITLE
Add caching to CMS export transformers

### DIFF
--- a/src/site/stages/build/drupal/api.js
+++ b/src/site/stages/build/drupal/api.js
@@ -195,7 +195,15 @@ function getDrupalClient(buildOptions, clientOptionsArg) {
       );
       const assembleEntityTree = entityTreeFactory(contentDir);
 
-      return entities.map(entity => assembleEntityTree(entity));
+      const transformedEntities = entities.map(entity =>
+        assembleEntityTree(entity),
+      );
+      say(
+        `${chalk.green(
+          global.exportCacheHits,
+        )} cache hits while expanding entity references`,
+      );
+      return transformedEntities;
     },
 
     getLatestPageById(nodeId) {

--- a/src/site/stages/build/drupal/api.js
+++ b/src/site/stages/build/drupal/api.js
@@ -200,7 +200,7 @@ function getDrupalClient(buildOptions, clientOptionsArg) {
       );
       say(
         `${chalk.green(
-          global.exportCacheHits,
+          global.readEntityCacheHits,
         )} cache hits while expanding entity references`,
       );
       return transformedEntities;

--- a/src/site/stages/build/drupal/api.js
+++ b/src/site/stages/build/drupal/api.js
@@ -203,6 +203,11 @@ function getDrupalClient(buildOptions, clientOptionsArg) {
           global.readEntityCacheHits,
         )} cache hits while expanding entity references`,
       );
+      say(
+        `${chalk.green(
+          global.transformerCacheHits,
+        )} cache hits while performing entity transformations`,
+      );
       return transformedEntities;
     },
 

--- a/src/site/stages/build/process-cms-exports/helpers.js
+++ b/src/site/stages/build/process-cms-exports/helpers.js
@@ -5,7 +5,7 @@ const get = require('lodash/get');
 const cloneDeep = require('lodash/cloneDeep');
 
 const cachedEntities = new Map();
-global.exportCacheHits = 0;
+global.readEntityCacheHits = 0;
 
 /**
  * The path to the CMS export content.
@@ -136,7 +136,7 @@ module.exports = {
     }
 
     if (cachedEntities.has(filename)) {
-      global.exportCacheHits++;
+      global.readEntityCacheHits++;
       return cloneDeep(cachedEntities.get(filename));
     } else {
       const entity = addCommonProperties(


### PR DESCRIPTION
## Description
This _greatly_ improves performance by caching both `readEntity` results and
`assembleEntityTree` results. What was taking 190+ seconds on my machine
finishes in < 10 seconds again.

Unfortunately, I'm stil running into an error that I'm not sure is a result of
the caching or the broken transformers themselves.

## Testing done
Locally.
