### PR TITLE
Add required prop to confirmation email UI

### DIFF
--- a/src/applications/caregivers/definitions/caregiverUI.js
+++ b/src/applications/caregivers/definitions/caregiverUI.js
@@ -61,31 +61,6 @@ export default {
       },
     }),
     emailUI: label => email(`${label}  email address`),
-    confirmationEmailUI: label => ({
-      'ui:title': `${label}  re-enter email address`,
-      'ui:widget': 'email',
-      'ui:errorMessages': {
-        pattern: 'Please enter an email address using this format: X@X.com',
-        required: 'Please enter an email address',
-      },
-      'ui:options': {
-        widgetClassNames: 'va-input-large',
-        inputType: 'email',
-      },
-      'ui:validations': [
-        {
-          validator: (errors, fieldData, formData, dataConstant) => {
-            const emailMatcher = () => formData[dataConstant] === fieldData;
-            const doesEmailMatch = emailMatcher();
-            if (!doesEmailMatch) {
-              errors.addError(
-                'This email does not match your previously entered email',
-              );
-            }
-          },
-        },
-      ],
-    }),
     genderUI: label => ({
       'ui:title': `${label}  sex`,
       'ui:widget': 'radio',
@@ -260,6 +235,7 @@ export const confirmationEmailUI = (label, dataConstant) => ({
     widgetClassNames: 'va-input-large',
     inputType: 'email',
   },
+  'ui:required': formData => !!formData[dataConstant],
   'ui:validations': [
     {
       validator: (errors, fieldData, formData) => {


### PR DESCRIPTION
## Description
This PR fixes a bug where the email confirmation would validate the email with the previous one but was not conditionally required. So you could enter nothing in the confirmation field and still continue.

## Screenshots
![Screen Shot 2020-08-21 at 9 28 05 AM](https://user-images.githubusercontent.com/23741323/90896198-39efc780-e391-11ea-8436-31d9dabf281c.png)
![Screen Shot 2020-08-21 at 9 28 00 AM](https://user-images.githubusercontent.com/23741323/90896201-3a885e00-e391-11ea-923b-9bd8c251a02e.png)


## Acceptance criteria
- [x] The confirmation email validates previous email
- [x] If first email is present make confirmation email required

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
