### PR TITLE
[Cerner] Fix for isCerner in CTA widget

### DIFF
--- a/src/applications/static-pages/health-care-manage-benefits/components/CernerCallToAction/index.js
+++ b/src/applications/static-pages/health-care-manage-benefits/components/CernerCallToAction/index.js
@@ -13,6 +13,8 @@ import {
   appointmentsToolLink,
 } from 'platform/utilities/cerner';
 
+import { selectPatientFacilities } from 'platform/user/selectors';
+
 export class CernerCallToAction extends Component {
   static propTypes = {
     linksHeaderText: PropTypes.string.isRequired,
@@ -45,9 +47,7 @@ export class CernerCallToAction extends Component {
     }
 
     // Derive the cerner facilities.
-    const cernerFacilities = facilities.filter(facility =>
-      CERNER_FACILITY_IDS.includes(facility?.facilityId),
-    );
+    const cernerFacilities = facilities.filter(facility => facility.isCerner);
 
     // Escape early if there are no cerner facilities.
     if (isEmpty(cernerFacilities)) {
@@ -189,7 +189,7 @@ export class CernerCallToAction extends Component {
 }
 
 const mapStateToProps = state => ({
-  facilities: state?.user?.profile?.facilities,
+  facilities: selectPatientFacilities(state),
 });
 
 export default connect(


### PR DESCRIPTION
## Description
A fixes so that the Cerner CTA widget is driven off of the derived `isCerner` property rather than purely the frontend lookup table, now that the `isCerner` is coming through as true for 668 but false for 767 (but should be true).

## Testing done
Unfortunately there are no local users that meet the criteria here, but user 241 will be used in staging.

## Screenshots

This issue results in an infinite spinner
![image](https://user-images.githubusercontent.com/1915775/90903434-eb93f600-e39b-11ea-8a68-9350e5610d30.png)


## Acceptance criteria
- [ ] Issue resolved

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
