### PR TITLE
Fix confirmation footer

### DIFF
--- a/src/applications/caregivers/components/NeedHelpFooter/index.jsx
+++ b/src/applications/caregivers/components/NeedHelpFooter/index.jsx
@@ -45,8 +45,13 @@ const NeedHelpFooter = () => {
         />
         .<br />
         <span>
-          If you have hearing loss, call TTY:{' '}
-          <Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />.
+          If you have hearing loss, call TTY:
+          <Telephone
+            className="vads-u-margin-left--0p5"
+            contact={CONTACTS['711']}
+            pattern={PATTERNS['911']}
+          />
+          .
         </span>
       </p>
     </>

--- a/src/applications/caregivers/components/SubmitError/DownloadLink.jsx
+++ b/src/applications/caregivers/components/SubmitError/DownloadLink.jsx
@@ -48,9 +48,9 @@ const DownLoadLink = ({ form }) => {
           className="fas fa-download vads-u-padding-right--1"
         />
         Download your completed application
-        <span className="sr-only">
+        <span className="sr-only vads-u-margin-right--0p5">
           `dated ${moment(Date.now()).format('MMM D, YYYY')}`
-        </span>{' '}
+        </span>
         <dfn>
           <abbr title="Portable Document Format">(PDF)</abbr>
         </dfn>

--- a/src/applications/caregivers/containers/ConfirmationPage.jsx
+++ b/src/applications/caregivers/containers/ConfirmationPage.jsx
@@ -36,7 +36,7 @@ const ConfirmationPage = props => {
       <section>
         <div>
           <h2 className="vads-u-font-size--h4">
-            You’ve successfullly submitted your application.
+            You’ve successful submitted your application.
           </h2>
 
           <p>

--- a/src/applications/caregivers/containers/ConfirmationPage.jsx
+++ b/src/applications/caregivers/containers/ConfirmationPage.jsx
@@ -1,6 +1,9 @@
 import React, { useEffect } from 'react';
 import moment from 'moment';
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
+import Telephone, {
+  CONTACTS,
+} from '@department-of-veterans-affairs/formation-react/Telephone';
 import { connect } from 'react-redux';
 
 import { focusElement } from 'platform/utilities/ui';
@@ -64,7 +67,7 @@ const ConfirmationPage = props => {
   );
 
   return (
-    <section className="caregiver-confirmation">
+    <section className="caregiver-confirmation vads-u-margin-bottom--2p5">
       <AlertBox
         level={2}
         headline="You’ve successfully submitted your application."
@@ -94,6 +97,48 @@ const ConfirmationPage = props => {
         <button className="usa-button button" onClick={() => window.print()}>
           Print this page
         </button>
+      </div>
+
+      <div className="caregiver-footer row vads-u-padding-x--1p5">
+        <div style={{ maxWidth: '600px' }}>
+          <h3>What happens after I apply?</h3>
+
+          <p>
+            If we need you to provide more information or documents, we will
+            contact you.
+          </p>
+
+          <p>
+            A member of the Caregiver Support Program team at the medical center
+            where the Veteran plans to receive care will contact you to discuss
+            the application process and next steps in determining eligibility.
+            If you aren’t eligible for PCAFC you may be eligible for the Program
+            of General Caregiver Support Services (PGCSS).
+          </p>
+
+          <p>
+            If you have questions about your application, what to expect next,
+            or if you are interested in learning more about the supports and
+            services available to support Veterans and caregivers, you may
+            contact the VA Caregiver Support Line at
+            <Telephone
+              contact={CONTACTS.CAREGIVER}
+              className="vads-u-margin-x--0p5"
+            />
+            or visit
+            <a className="vads-u-margin-left--0p5" href="www.va.caregiver.gov">
+              www.va.caregiver.gov
+            </a>
+            .
+          </p>
+
+          <a
+            className="usa-button-primary va-button-primary vads-u-margin-top--1p5 vads-u-margin-bottom--2p5"
+            href="VA.gov"
+          >
+            Go back to VA.gov
+          </a>
+        </div>
       </div>
 
       <PrintDetails />

--- a/src/applications/caregivers/containers/IntroductionPage.jsx
+++ b/src/applications/caregivers/containers/IntroductionPage.jsx
@@ -88,8 +88,12 @@ const IntroductionPage = ({ route, router }) => {
                   to find a coordinator at your nearest VA health care facility
                 </li>
                 <li>
-                  Contact the National Caregiver Support Line at{' '}
-                  <Telephone contact={CONTACTS.CAREGIVER} /> or a
+                  Contact the National Caregiver Support Line at
+                  <Telephone
+                    className="vads-u-margin-x--0p5"
+                    contact={CONTACTS.CAREGIVER}
+                  />
+                  or a
                   <a
                     className="vads-u-margin-x--0p5"
                     href="https://www.va.gov/disability/get-help-filing-claim/"

--- a/src/applications/caregivers/sass/confirmationPrint.scss
+++ b/src/applications/caregivers/sass/confirmationPrint.scss
@@ -2,6 +2,10 @@ h2:focus {
   outline: none;
 }
 
+.additional-info-title {
+  font-weight: normal;
+}
+
 .caregiver-confirmation {
   .print-details {
     display: none;


### PR DESCRIPTION
## Description
When I adopted the VSP footer there was a miscommunication on whether we needed the "ConfirmationFooter" or not. Adding it back with the updated designs

I also removed all `{' '}` in favor of using margins for cleaner code.

Also fixed the bolded `ExpandUnder` on review page

## Screenshots
![image](https://user-images.githubusercontent.com/23741323/90901496-06b13680-e399-11ea-8e19-ee3ca7dc41e7.png)

## Acceptance criteria
- [x] Make the confirmation footer content match [designs](https://vsateams.invisionapp.com/d/main/#/console/19742872/412943896/preview)

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
