### PR TITLE
Add downtime notification to 686c-674 and view dependents

### DIFF
--- a/src/applications/disability-benefits/686c-674/config/form.js
+++ b/src/applications/disability-benefits/686c-674/config/form.js
@@ -1,12 +1,13 @@
 import fullSchema from 'vets-json-schema/dist/686C-674-schema.json';
 import environment from 'platform/utilities/environment';
+import FormFooter from 'platform/forms/components/FormFooter';
+import { externalServices } from 'platform/monitoring/DowntimeNotification';
 import { VA_FORM_IDS } from 'platform/forms/constants';
 import { TASK_KEYS, MARRIAGE_TYPES } from './constants';
 import { isChapterFieldRequired } from './helpers';
 import { customTransformForSubmit } from './utilities';
 import IntroductionPage from '../containers/IntroductionPage';
 import ConfirmationPage from '../containers/ConfirmationPage';
-import FormFooter from 'platform/forms/components/FormFooter';
 import CustomPreSubmitInfo from '../components/CustomPreSubmitInfo';
 import GetFormHelp from '../components/GetFormHelp.jsx';
 
@@ -72,6 +73,9 @@ const formConfig = {
   prefillEnabled: true,
   footerContent: FormFooter,
   getHelp: GetFormHelp,
+  downtime: {
+    dependencies: [externalServices.bgs],
+  },
   savedFormMessages: {
     notFound: 'Please start over to apply for declare or remove a dependent.',
     noAuth:

--- a/src/applications/disability-benefits/686c-674/containers/IntroductionPage.jsx
+++ b/src/applications/disability-benefits/686c-674/containers/IntroductionPage.jsx
@@ -95,6 +95,7 @@ class IntroductionPage extends React.Component {
           verifiedPrefillAlert={VerifiedAlert}
           prefillEnabled={this.props.route.formConfig.prefillEnabled}
           messages={this.props.route.formConfig.savedFormMessages}
+          downtime={this.props.route.formConfig.downtime}
           pageList={this.props.route.pageList}
           startText="Add or remove a dependent"
         />
@@ -111,6 +112,7 @@ class IntroductionPage extends React.Component {
             verifiedPrefillAlert={VerifiedAlert}
             prefillEnabled={this.props.route.formConfig.prefillEnabled}
             messages={this.props.route.formConfig.savedFormMessages}
+            downtime={this.props.route.formConfig.downtime}
             pageList={this.props.route.pageList}
             startText="Add or remove a dependent"
           />

--- a/src/applications/personalization/view-dependents/containers/ViewDependentsApp.jsx
+++ b/src/applications/personalization/view-dependents/containers/ViewDependentsApp.jsx
@@ -1,8 +1,13 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { fetchAllDependents } from '../actions/index';
+import Breadcrumbs from '@department-of-veterans-affairs/formation-react/Breadcrumbs';
 import backendServices from 'platform/user/profile/constants/backendServices';
+import DowntimeNotification, {
+  externalServices,
+} from 'platform/monitoring/DowntimeNotification';
 import RequiredLoginView from 'platform/user/authorization/components/RequiredLoginView';
+import { breadcrumbLinks } from '../layouts/helpers';
+import { fetchAllDependents } from '../actions/index';
 import ViewDependentsLayout from '../layouts/ViewDependentsLayout';
 
 class ViewDependentsApp extends Component {
@@ -12,17 +17,27 @@ class ViewDependentsApp extends Component {
 
   render() {
     return (
-      <RequiredLoginView
-        serviceRequired={backendServices.USER_PROFILE}
-        user={this.props.user}
-      >
-        <ViewDependentsLayout
-          loading={this.props.loading}
-          error={this.props.error}
-          onAwardDependents={this.props.onAwardDependents}
-          notOnAwardDependents={this.props.notOnAwardDependents}
-        />
-      </RequiredLoginView>
+      <div className="vads-l-grid-container vads-u-padding--2">
+        <div>
+          <Breadcrumbs>{breadcrumbLinks}</Breadcrumbs>
+        </div>
+        <DowntimeNotification
+          appTitle="view dependents tool"
+          dependencies={[externalServices.bgs]}
+        >
+          <RequiredLoginView
+            serviceRequired={backendServices.USER_PROFILE}
+            user={this.props.user}
+          >
+            <ViewDependentsLayout
+              loading={this.props.loading}
+              error={this.props.error}
+              onAwardDependents={this.props.onAwardDependents}
+              notOnAwardDependents={this.props.notOnAwardDependents}
+            />
+          </RequiredLoginView>
+        </DowntimeNotification>
+      </div>
     );
   }
 }

--- a/src/applications/personalization/view-dependents/layouts/ViewDependentsLayout.jsx
+++ b/src/applications/personalization/view-dependents/layouts/ViewDependentsLayout.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import Breadcrumbs from '@department-of-veterans-affairs/formation-react/Breadcrumbs';
 import ViewDependentsLists from './ViewDependentsLists';
 import ViewDependentsSidebar from '../components/ViewDependentsSidebar/ViewDependentsSidebar';
 import ViewDependentsHeader from '../components/ViewDependentsHeader/ViewDependentsHeader';
@@ -11,7 +10,7 @@ import {
 } from '../components/ViewDependentsSidebar/ViewDependentsSidebarBlockStates/ViewDependentSidebarBlockStates';
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 import { isServerError, isClientError } from '../util';
-import { errorFragment, infoFragment, breadcrumbLinks } from './helpers';
+import { errorFragment, infoFragment } from './helpers';
 
 function ViewDependentsLayout(props) {
   let mainContent;
@@ -36,40 +35,31 @@ function ViewDependentsLayout(props) {
   }
 
   const layout = (
-    <div className="vads-l-grid-container vads-u-padding--2">
-      <div className="vads-l-row">
-        <div className="vads-l-col--12 medium-screen:vads-l-col--8">
-          <ViewDependentsHeader />
-          {mainContent}
-        </div>
-        <div className="vads-l-col--12 medium-screen:vads-l-col--4">
-          <ViewDependentsSidebar>
-            <ViewDependentsSidebarBlock
-              heading={firstSidebarBlock.heading}
-              content={firstSidebarBlock.content}
-            />
-            <ViewDependentsSidebarBlock
-              heading={secondSidebarBlock.heading}
-              content={secondSidebarBlock.content}
-            />
-            <ViewDependentsSidebarBlock
-              heading={thirdSidebarBlock.heading}
-              content={thirdSidebarBlock.content}
-            />
-          </ViewDependentsSidebar>
-        </div>
+    <div className="vads-l-row">
+      <div className="vads-l-col--12 medium-screen:vads-l-col--8">
+        <ViewDependentsHeader />
+        {mainContent}
+      </div>
+      <div className="vads-l-col--12 medium-screen:vads-l-col--4">
+        <ViewDependentsSidebar>
+          <ViewDependentsSidebarBlock
+            heading={firstSidebarBlock.heading}
+            content={firstSidebarBlock.content}
+          />
+          <ViewDependentsSidebarBlock
+            heading={secondSidebarBlock.heading}
+            content={secondSidebarBlock.content}
+          />
+          <ViewDependentsSidebarBlock
+            heading={thirdSidebarBlock.heading}
+            content={thirdSidebarBlock.content}
+          />
+        </ViewDependentsSidebar>
       </div>
     </div>
   );
 
-  return (
-    <div>
-      <div className="medium-screen:vads-u-padding-left--1p5 large-screen:vads-u-padding-left--6">
-        <Breadcrumbs>{breadcrumbLinks}</Breadcrumbs>
-      </div>
-      {layout}
-    </div>
-  );
+  return <div>{layout}</div>;
 }
 
 export default ViewDependentsLayout;

--- a/src/applications/personalization/view-dependents/layouts/helpers.jsx
+++ b/src/applications/personalization/view-dependents/layouts/helpers.jsx
@@ -24,7 +24,9 @@ export const errorFragment = (
 
 export const infoFragment = (
   <>
-    <h2>We don't have dependents information on file for you</h2>
+    <h2 className="vads-u-margin-top--1">
+      We don't have dependents information on file for you
+    </h2>
     <p>
       We can't find any dependents added to your disability award. If you are
       eligible for VA disability compensation and you have a VA combined rating

--- a/src/applications/personalization/view-dependents/sass/view-dependents.scss
+++ b/src/applications/personalization/view-dependents/sass/view-dependents.scss
@@ -1,0 +1,3 @@
+.usa-alert-info::before {
+    content: none;
+}

--- a/src/platform/monitoring/DowntimeNotification/config/externalServices.js
+++ b/src/platform/monitoring/DowntimeNotification/config/externalServices.js
@@ -1,10 +1,12 @@
 /**
  * A list of services that correspond to those which we have downtime information as provided by the API.
- * API - see services under maintenance_windows - https://github.com/department-of-veterans-affairs/devops/blob/master/ansible/deployment/config/vets-api/prod-settings.local.yml.j2#L217
+ * API - see services under maintenance_windows - https://github.com/department-of-veterans-affairs/devops/blob/master/ansible/deployment/config/vets-api/prod-settings.local.yml.j2#L284
  */
 export default {
   appeals: 'appeals',
   arcgis: 'arcgis',
+  // Benefits Gateway Services
+  bgs: 'bgs',
   dslogon: 'dslogon',
   emis: 'emis',
   // Enrollment System (HCA submissions)


### PR DESCRIPTION
## Description
This pull request adds BGS to the list of external services available for maintenance windows. [This pull request](https://github.com/department-of-veterans-affairs/devops/pull/7411/files) recently added the pager duty identifier for BGS to `settings.local.yml`. 

## Testing done
- local, mocked downtime by modifying the downtime notification reducer and was able to observe maintenance alert for required services

## Screenshots
<details><summary>Maintenance Alerts for 686c-674 and view-dependents</summary>

<img width="738" alt="Screen Shot 2020-08-21 at 9 45 55 AM" src="https://user-images.githubusercontent.com/15097156/90903178-91933080-e39b-11ea-85d9-47e025c183c2.png">
<img width="1073" alt="Screen Shot 2020-08-21 at 10 48 00 AM" src="https://user-images.githubusercontent.com/15097156/90903344-cf905480-e39b-11ea-8028-be00d9bbea39.png">

</details>

## Acceptance criteria
- [x] Maintenance windows render properly

## Definition of done
- [ ] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
