### PR TITLE
Update EBEN_526_PATH link

### DIFF
--- a/src/applications/disability-benefits/constants.js
+++ b/src/applications/disability-benefits/constants.js
@@ -1,5 +1,5 @@
 export const EBEN_526_PATH =
-  'ebenefits/about/feature?feature=disability-compensation';
+  'https://www.ebenefits.va.gov/ebenefits/about/feature?feature=disability-compensation';
 
 export const BDD_INFO_URL =
   '/disability/how-to-file-claim/when-to-file/pre-discharge-claim/';


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/12704

This PR updates the `EBEN_526_PATH` link to be absolute instead of relative to va.gov.

## Testing done
N/A

## Screenshots
N/A

## Acceptance criteria
- [x] Update ebenefits link.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
