### PR TITLE
Update styling/autoscroll for botframework 4.10.0

### DIFF
--- a/src/applications/coronavirus-chatbot/sass/coronavirus-chatbot.scss
+++ b/src/applications/coronavirus-chatbot/sass/coronavirus-chatbot.scss
@@ -84,9 +84,13 @@ button.ac-pushButton:hover {
   color: $color-base;
 }
 
-/* side vertical container with avatar in it */
-.webchat__stackedLayout__avatar {
+/* padding around avatar */
+.webchat__stacked-layout__avatar-gutter {
   margin: 7px 8px 0 !important;
+}
+
+.webchat__bubble__nub-pad {
+  display: none;
 }
 
 /* horizontal container with chat bubbles */
@@ -117,7 +121,7 @@ div.ac-container.ac-adaptiveCard {
 
 /* additional padding around answer chat bubbles
 (3px + webchat__row 5px + css-1qyo5rb 8px = 16px from design specs) */
-.webchat__stackedLayout--fromUser {
+.webchat__stacked-layout--from-user {
   padding: 3px 0 !important;
 }
 
@@ -152,6 +156,11 @@ div.ac-container.ac-adaptiveCard {
 /* Connecting... text before chatbot shows */
 .webchat__connectivityStatus.css-nd6pw {
   align-items: flex-start;
+}
+
+/* remove scrollbar from main transcript container */
+.webchat__basic-transcript__scrollable {
+  overflow: visible !important;
 }
 
 .css-1t62idy {

--- a/src/applications/coronavirus-chatbot/tests/01-buttons.e2e.spec.js
+++ b/src/applications/coronavirus-chatbot/tests/01-buttons.e2e.spec.js
@@ -1,7 +1,7 @@
 const E2eHelpers = require('platform/testing/e2e/helpers');
 const Timeouts = require('platform/testing/e2e/timeouts');
 
-const vaAvatarMatcher = 'div#webchat div.webchat__imageAvatar__image';
+const vaAvatarMatcher = 'div#webchat div.webchat__initialsAvatar';
 const webchatBubbleContent = 'div.webchat__bubble__content';
 const covid19PreventionButton =
   "div#webchat button[aria-label='COVID-19 prevention']";

--- a/src/applications/coronavirus-chatbot/utils.js
+++ b/src/applications/coronavirus-chatbot/utils.js
@@ -26,7 +26,7 @@ const disableCheckboxes = () => {
 
 const scrollToNewMessage = () => {
   const messages = [
-    ...document.getElementsByClassName('webchat__stackedLayout--fromUser'),
+    ...document.getElementsByClassName('webchat__stacked-layout--from-user'),
   ];
   const lastMessageFromUser = messages[messages.length - 1];
   lastMessageFromUser.scrollIntoView({ behavior: 'smooth' });


### PR DESCRIPTION
**NOTE** Must be merged along with [sibling PR](https://github.com/department-of-veterans-affairs/vagov-content/pull/708) in `vagov-content` that updates the version.

## Description
[department-of-veterans-affairs/covid19-chatbot#324] 

Updating `botframework-webchat` v4.9.2 to v4.10.0, there are some changes that break our chatbot styling and autoscroll. This PR fixes those changes to maintain the current style and functionality when we upgrade. Essentially, some class names and HTML elements were changed by botframework, so they've been updated to the new names in our stylesheet, utils, and UI test.

There is now only an avatar next to the first chat bubble in a group (spoken by the same user), where previously there was an avatar next to every chat bubble.

## Testing done


## Screenshots
![Screen Shot 2020-08-21 at 13 10 01](https://user-images.githubusercontent.com/19177102/90917826-a24ea100-e3b1-11ea-846b-f06b9ebe704a.png)


## Acceptance criteria
- [ ] chat window expands to fit new content, no scrollbar
- [ ] avatar padding is what it used to be
- [ ] autoscroll behavior is what it used to be
- [ ] happy path UI test passes locally

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
