### PR TITLE
bradl3yC - bugfix - debt letters - Have right rail only block on small screen

### DIFF
--- a/src/applications/debt-letters/components/DebtLettersSummary.jsx
+++ b/src/applications/debt-letters/components/DebtLettersSummary.jsx
@@ -94,7 +94,7 @@ const DebtLettersSummary = ({ isError, isVBMSError, debts, debtLinks }) => {
         <h1 className="vads-u-padding-x--2p5 vads-u-margin-bottom--2">
           Current VA debt
         </h1>
-        <div className="large-screen:vads-u-display--flex vads-u-flex-direction--row vads-u-display--block">
+        <div className="medium-screen:vads-u-display--flex vads-u-flex-direction--row vads-u-display--block">
           <CallToActionWidget appId="debt-letters">
             <div className="vads-l-col--12 vads-u-padding-x--2p5 medium-screen:vads-l-col--8">
               <h2


### PR DESCRIPTION
## Description
Currently we're using display block for anything under the large-screen break point, this needs to be adjusted to small-screen only

## Testing done


## Screenshots

### Before:
![Screen Shot 2020-08-21 at 1 26 08 PM](https://user-images.githubusercontent.com/6165421/90918327-7384fa80-e3b2-11ea-8487-8f782452dd72.png)


### After:
![Screen Shot 2020-08-21 at 1 25 37 PM](https://user-images.githubusercontent.com/6165421/90918341-7a137200-e3b2-11ea-8e06-430ee38c7d9e.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
