### PR TITLE
[Development/QA] Align editable card edit button

### DIFF
--- a/src/platform/forms-system/src/js/fields/ArrayField.jsx
+++ b/src/platform/forms-system/src/js/fields/ArrayField.jsx
@@ -336,13 +336,15 @@ export default class ArrayField extends React.Component {
             }
             return (
               <div key={index} className="va-growable-background editable-row">
-                <div className="row small-collapse">
-                  <ViewField
-                    formData={item}
-                    onEdit={() => this.handleEdit(index)}
-                  />
+                <div className="row small-collapse vads-u-display--flex vads-u-align-items--center">
+                  <div className="vads-u-flex--fill">
+                    <ViewField
+                      formData={item}
+                      onEdit={() => this.handleEdit(index)}
+                    />
+                  </div>
                   <button
-                    className="usa-button-secondary edit-button"
+                    className="usa-button-secondary edit vads-u-flex--auto"
                     onClick={() => this.handleEdit(index)}
                     aria-label={`Edit ${title}`}
                   >


### PR DESCRIPTION
## Description

The edit button is not aligned in editable array card. This PR adds some flex styling to fix the alignment.

<details><summary>Before fix</summary>

<!-- leave a blank line above -->
![](https://user-images.githubusercontent.com/587583/90717788-3eb75d00-e265-11ea-822a-ba7c6fa633c4.png)</details>

<details><summary>After fix</summary>

<!-- leave a blank line above -->
![Screen Shot 2020-08-21 at 2 57 13 PM](https://user-images.githubusercontent.com/136959/90929966-59054e00-e3bf-11ea-9757-0270deb56ac7.png)</details>

Related issue: https://github.com/department-of-veterans-affairs/va.gov-team/issues/12656

## Testing done

None

## Screenshots

See above

## Acceptance criteria
- [x] Button is vertically aligned

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
