### PR TITLE
update vets-json-schema version to 6.7.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -330,7 +330,7 @@
     "url-search-params-polyfill": "^8.1.0",
     "uswds": "1.6.10",
     "vanilla-lazyload": "^16.1.0",
-    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#91c92dfca26649764745186b4348e1455441925e",
+    "vets-json-schema": "https://github.com/department-of-veterans-affairs/vets-json-schema.git#d89520f3ded7f5e0657cacda602174e426590a5b",
     "whatwg-fetch": "^2.0.3"
   },
   "resolutions": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -17116,9 +17116,9 @@ verror@1.3.6:
   dependencies:
     extsprintf "1.0.2"
 
-"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#91c92dfca26649764745186b4348e1455441925e":
-  version "6.7.3"
-  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#91c92dfca26649764745186b4348e1455441925e"
+"vets-json-schema@https://github.com/department-of-veterans-affairs/vets-json-schema.git#d89520f3ded7f5e0657cacda602174e426590a5b":
+  version "6.7.4"
+  resolved "https://github.com/department-of-veterans-affairs/vets-json-schema.git#d89520f3ded7f5e0657cacda602174e426590a5b"
 
 vinyl-file@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## Description
Schema update
related `vets-json-schema` PR: https://github.com/department-of-veterans-affairs/vets-json-schema/pull/485

## Testing done
![image](https://user-images.githubusercontent.com/2481110/90932278-4d6c5400-e3cc-11ea-8d68-2350572a4de1.png)


## Screenshots
![image](https://user-images.githubusercontent.com/2481110/90931870-85bf6280-e3cb-11ea-855b-42afd2dde6ac.png)


## Acceptance criteria
- [x] `vets-json-schema` version and commit hash updated

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
