### PR TITLE
Add tests for SMS appointment reminder checkbox

### DIFF
--- a/src/applications/personalization/profile-2/msw-mocks.js
+++ b/src/applications/personalization/profile-2/msw-mocks.js
@@ -1184,6 +1184,127 @@ export const deletePhoneNumberSuccess = () => {
   ];
 };
 
+export const toggleSMSNotificationsSuccess = (enrolled = true) => {
+  return [
+    rest.put(`${prefix}/v0/profile/telephones`, (req, res, ctx) => {
+      return res(
+        ctx.json({
+          data: {
+            id: '',
+            type: 'async_transaction_vet360_telephone_transactions',
+            attributes: {
+              transactionId: '61ffa9bd-3290-4e4b-9480-d93fd6236dcf',
+              transactionStatus: 'RECEIVED',
+              type: 'AsyncTransaction::Vet360::TelephoneTransaction',
+              metadata: [],
+            },
+          },
+        }),
+      );
+    }),
+    rest.get(`${prefix}/v0/user`, (req, res, ctx) => {
+      return res(
+        ctx.json({
+          data: {
+            id: '',
+            type: 'users_scaffolds',
+            attributes: {
+              services: [
+                'facilities',
+                'hca',
+                'edu-benefits',
+                'form-save-in-progress',
+                'form-prefill',
+                'mhv-accounts',
+                'evss-claims',
+                'form526',
+                'user-profile',
+                'appeals-status',
+                'id-card',
+                'identity-proofed',
+                'vet360',
+                'evss_common_client',
+                'claim_increase',
+              ],
+              account: { accountUuid: 'c049d895-ecdf-40a4-ac0f-7947a06ea0c2' },
+              profile: {
+                email: 'vets.gov.user+36@gmail.com',
+                firstName: 'WESLEY',
+                middleName: 'WATSON',
+                lastName: 'FORD',
+                birthDate: '1986-05-06',
+                gender: 'M',
+                zip: '21122-6706',
+                lastSignedIn: '2020-07-28T14:57:28.196Z',
+                loa: { current: 3, highest: 3 },
+                multifactor: true,
+                verified: true,
+                signIn: {
+                  serviceName: 'idme',
+                  accountType: 'N/A',
+                  ssoe: true,
+                  transactionid: '/lob0lmUWabZaaWqJ+ydOKkCYvu55jG3IxIJI4qzGic=',
+                },
+                authnContext: 'http://idmanagement.gov/ns/assurance/loa/3',
+              },
+              vaProfile: {
+                status: 'OK',
+                birthDate: '19860506',
+                familyName: 'Ford',
+                gender: 'M',
+                givenNames: ['Wesley', 'Watson'],
+                isCernerPatient: false,
+                facilities: [{ facilityId: '983', isCerner: false }],
+                vaPatient: true,
+                mhvAccountState: 'NONE',
+              },
+              veteranStatus: {
+                status: 'OK',
+                isVeteran: true,
+                servedInMilitary: true,
+              },
+              inProgressForms: [],
+              prefillsAvailable: [],
+              vet360ContactInformation: {
+                email: null,
+                residentialAddress: null,
+                mailingAddress: null,
+                mobilePhone: {
+                  areaCode: '555',
+                  countryCode: '1',
+                  createdAt: '2020-07-25T00:34:24.000Z',
+                  extension: null,
+                  effectiveEndDate: null,
+                  effectiveStartDate: '2020-07-25T00:34:24.000Z',
+                  id: 155102,
+                  isInternational: false,
+                  isTextable: null,
+                  isTextPermitted: enrolled,
+                  isTty: null,
+                  isVoicemailable: null,
+                  phoneNumber: '5555559',
+                  phoneType: 'MOBILE',
+                  sourceDate: '2020-07-25T00:34:24.000Z',
+                  sourceSystemUser: null,
+                  transactionId: '77ad4f31-2d1a-4aaa-a259-7f0cc8fb0357',
+                  updatedAt: '2020-07-25T00:34:24.000Z',
+                  vet360Id: '1273780',
+                },
+                homePhone: null,
+                workPhone: null,
+                temporaryPhone: null,
+                faxNumber: null,
+                textPermission: null,
+              },
+            },
+          },
+          meta: { errors: null },
+        }),
+      );
+    }),
+  ];
+};
+
 export const allProfileEndpointsLoaded = [
   rest.get(`${prefix}/v0/mhv_account`, (req, res, ctx) => {
     return res(ctx.json(mockMHVHasAccepted));

--- a/src/applications/personalization/profile-2/tests/components/personal-information/PersonalInformation.sms-checkbox.unit.spec.jsx
+++ b/src/applications/personalization/profile-2/tests/components/personal-information/PersonalInformation.sms-checkbox.unit.spec.jsx
@@ -92,6 +92,7 @@ describe('When enrolled in health care', () => {
     server.close();
   });
   // Skipping this test for now since it does not handle this case correctly
+  // TODO: department-of-veterans-affairs/va.gov-team#12751
   it.xit(
     'should show an error if it is unable to create the transaction',
     async () => {

--- a/src/applications/personalization/profile-2/tests/components/personal-information/PersonalInformation.sms-checkbox.unit.spec.jsx
+++ b/src/applications/personalization/profile-2/tests/components/personal-information/PersonalInformation.sms-checkbox.unit.spec.jsx
@@ -91,7 +91,26 @@ describe('When enrolled in health care', () => {
   after(() => {
     server.close();
   });
-  it('should show an error if it is unable to create the transaction', () => {});
+  // Skipping this test for now since it does not handle this case correctly
+  it.xit(
+    'should show an error if it is unable to create the transaction',
+    async () => {
+      server.use(...mocks.createTransactionFailure);
+      getCheckbox(view).click();
+
+      expect(
+        await view.findByText(
+          /We’re working on saving your.*text alert preference/i,
+        ),
+      ).to.exist;
+
+      expect(
+        await view.findByText(
+          /We couldn’t save your recent mobile phone number update. Please try again later./i,
+        ),
+      ).to.exist;
+    },
+  );
   it('should show an error if the transaction fails', async () => {
     server.use(...mocks.transactionPending);
     getCheckbox(view).click();

--- a/src/applications/personalization/profile-2/tests/components/personal-information/PersonalInformation.sms-checkbox.unit.spec.jsx
+++ b/src/applications/personalization/profile-2/tests/components/personal-information/PersonalInformation.sms-checkbox.unit.spec.jsx
@@ -1,0 +1,132 @@
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { expect } from 'chai';
+import { setupServer } from 'msw/node';
+
+import { resetFetch } from 'platform/testing/unit/helpers';
+
+import * as mocks from '../../../msw-mocks';
+import PersonalInformation from '../../../components/personal-information/PersonalInformation';
+
+import {
+  createBasicInitialState,
+  renderWithProfileReducers,
+} from '../../unit-test-helpers';
+import { beforeEach } from 'mocha';
+
+const ui = (
+  <MemoryRouter>
+    <PersonalInformation />
+  </MemoryRouter>
+);
+let view;
+let server;
+
+function getCheckbox(_view) {
+  return _view.getByLabelText(
+    /We’ll send VA health care appointment text reminders to this number/i,
+  );
+}
+
+function queryCheckbox(_view) {
+  return _view.queryByLabelText(
+    /We’ll send VA health care appointment text reminders to this number/i,
+  );
+}
+
+describe('When not enrolled in health care', () => {
+  beforeEach(() => {
+    const initialState = createBasicInitialState();
+    view = renderWithProfileReducers(ui, {
+      initialState,
+    });
+  });
+  it('the text messages checkbox should not be shown in view mode', () => {
+    expect(queryCheckbox(view)).to.not.exist;
+  });
+  it('the text messages checkbox should not be shown in edit mode', () => {
+    view.getByRole('button', { name: /edit mobile phone number/i }).click();
+    expect(
+      view.queryByLabelText(
+        /Send me text message \(SMS\) reminders for my VA health care appointments/i,
+      ),
+    ).to.not.exist;
+  });
+});
+
+describe('When enrolled in health care', () => {
+  before(() => {
+    // before we can use msw, we need to make sure that global.fetch has been
+    // restored and is no longer a sinon stub.
+    resetFetch();
+    server = setupServer(...mocks.toggleSMSNotificationsSuccess());
+    server.listen();
+  });
+  beforeEach(() => {
+    window.VetsGov = { pollTimeout: 1 };
+    const initialState = createBasicInitialState();
+    initialState.hcaEnrollmentStatus = {
+      applicationDate: '2006-01-30T00:00:00.000-06:00',
+      enrollmentDate: '2006-03-20T00:00:00.000-06:00',
+      preferredFacility: '626A4 - ALVIN C. YORK VAMC',
+      enrollmentStatus: 'enrolled',
+      enrollmentStatusEffectiveDate: '2018-04-28T18:21:56.000-05:00',
+      dismissedNotificationDate: null,
+      hasServerError: false,
+      isLoadingApplicationStatus: false,
+      isLoadingDismissedNotification: false,
+      isUserInMVI: true,
+      loginRequired: true,
+      noESRRecordFound: false,
+      showHCAReapplyContent: false,
+    };
+    view = renderWithProfileReducers(ui, {
+      initialState,
+    });
+  });
+  afterEach(() => {
+    server.resetHandlers();
+  });
+  after(() => {
+    server.close();
+  });
+  it('a single text messages checkbox should be shown in view mode', () => {
+    expect(getCheckbox(view)).to.exist;
+  });
+  it('should show an error if it is unable to create the transaction', () => {});
+  it('should show an error if the transaction fails', async () => {
+    server.use(...mocks.transactionPending);
+    getCheckbox(view).click();
+
+    expect(
+      await view.findByText(
+        /We’re working on saving your.*text alert preference/i,
+      ),
+    ).to.exist;
+
+    server.use(...mocks.transactionFailed);
+
+    expect(
+      await view.findByText(
+        /We couldn’t save your recent mobile phone number update. Please try again later./i,
+      ),
+    ).to.exist;
+  });
+  it('should should show the updated checkbox state is the transaction succeeds', () => {});
+  it('the text messages checkbox should be shown in mobile phone edit mode', () => {
+    view.getByRole('button', { name: /edit mobile phone number/i }).click();
+    expect(
+      view.getByLabelText(
+        /Send me text message \(SMS\) reminders for my VA health care appointments/i,
+      ),
+    ).to.exist;
+  });
+  it('the text messages checkbox should not be shown in home phone edit mode', () => {
+    view.getByRole('button', { name: /edit home phone number/i }).click();
+    expect(
+      view.queryByLabelText(
+        /Send me text message \(SMS\) reminders for my VA health care appointments/i,
+      ),
+    ).not.to.exist;
+  });
+});

--- a/src/applications/personalization/profile-2/tests/components/personal-information/PersonalInformation.sms-checkbox.unit.spec.jsx
+++ b/src/applications/personalization/profile-2/tests/components/personal-information/PersonalInformation.sms-checkbox.unit.spec.jsx
@@ -92,26 +92,23 @@ describe('When enrolled in health care', () => {
     server.close();
   });
   // Skipping this test for now since it does not handle this case correctly
-  // TODO: department-of-veterans-affairs/va.gov-team#12751
-  it.xit(
-    'should show an error if it is unable to create the transaction',
-    async () => {
-      server.use(...mocks.createTransactionFailure);
-      getCheckbox(view).click();
+  // TODO:
+  it.skip('should show an error if it is unable to create the transaction', async () => {
+    server.use(...mocks.createTransactionFailure);
+    getCheckbox(view).click();
 
-      expect(
-        await view.findByText(
-          /We’re working on saving your.*text alert preference/i,
-        ),
-      ).to.exist;
+    expect(
+      await view.findByText(
+        /We’re working on saving your.*text alert preference/i,
+      ),
+    ).to.exist;
 
-      expect(
-        await view.findByText(
-          /We couldn’t save your recent mobile phone number update. Please try again later./i,
-        ),
-      ).to.exist;
-    },
-  );
+    expect(
+      await view.findByText(
+        /We couldn’t save your recent mobile phone number update. Please try again later./i,
+      ),
+    ).to.exist;
+  });
   it('should show an error if the transaction fails', async () => {
     server.use(...mocks.transactionPending);
     getCheckbox(view).click();


### PR DESCRIPTION
## Description
Adds tests for the checkbox that enables/disables appointment reminders via SMS

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs