### PR TITLE
Time the transformations

### DIFF
--- a/src/site/stages/build/drupal/api.js
+++ b/src/site/stages/build/drupal/api.js
@@ -195,9 +195,12 @@ function getDrupalClient(buildOptions, clientOptionsArg) {
       );
       const assembleEntityTree = entityTreeFactory(contentDir);
 
+      const timerStart = process.hrtime.bigint();
       const transformedEntities = entities.map(entity =>
         assembleEntityTree(entity),
       );
+      const timeElapsed = (process.hrtime.bigint() - timerStart) / 1000000n;
+
       say(
         `${chalk.green(
           global.readEntityCacheHits,
@@ -207,6 +210,11 @@ function getDrupalClient(buildOptions, clientOptionsArg) {
         `${chalk.green(
           global.transformerCacheHits,
         )} cache hits while performing entity transformations`,
+      );
+      say(
+        `Total time to transform ${chalk.blue(
+          transformedEntities.length,
+        )} nodes: ${chalk.green(timeElapsed)}ms`,
       );
       return transformedEntities;
     },


### PR DESCRIPTION
## Description
Like it says on the tin, this PR does one thing: It times how long the
transformations take on the CMS export.

## Screenshots
![image](https://user-images.githubusercontent.com/12970166/91095952-0c658100-e612-11ea-849c-e00eb643b9d2.png)
