### PR TITLE
[Development] Allow dynamic form titles

### DIFF
--- a/src/platform/forms-system/src/js/containers/FormApp.jsx
+++ b/src/platform/forms-system/src/js/containers/FormApp.jsx
@@ -35,6 +35,10 @@ class FormApp extends React.Component {
     const isIntroductionPage = trimmedPathname.endsWith('introduction');
     const isNonFormPage = this.nonFormPages.includes(lastPathComponent);
     const Footer = formConfig.footerContent;
+    const title =
+      typeof formConfig.title === 'function'
+        ? formConfig.title(this.props)
+        : formConfig.title;
 
     let formTitle;
     let formNav;
@@ -43,10 +47,8 @@ class FormApp extends React.Component {
     // 1. we're not on the intro page *or* one of the additionalRoutes
     //    specified in the form config
     // 2. there is a title specified in the form config
-    if (!isIntroductionPage && !isNonFormPage && formConfig.title) {
-      formTitle = (
-        <FormTitle title={formConfig.title} subTitle={formConfig.subTitle} />
-      );
+    if (!isIntroductionPage && !isNonFormPage && title) {
+      formTitle = <FormTitle title={title} subTitle={formConfig.subTitle} />;
     }
 
     // Show nav only if we're not on the intro, form-saved, error, confirmation

--- a/src/platform/forms-system/test/js/containers/FormApp.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/containers/FormApp.unit.spec.jsx
@@ -56,4 +56,36 @@ describe('Schemaform <FormApp>', () => {
     expect(tree.everySubTree('.child')).not.to.be.empty;
     expect(tree.everySubTree('FormNav')).not.to.be.empty;
   });
+  it('should show dynamic title', () => {
+    const titles = ['Main title', 'Alternate title'];
+    const formData = { test: false };
+    const formConfig = {
+      title: props => titles[props.formData.test ? 1 : 0],
+    };
+    const currentLocation = {
+      pathname: '/veteran-information/personal-information',
+      search: '',
+    };
+    const routes = [
+      {
+        pageList: [{ path: currentLocation.pathname }],
+      },
+    ];
+
+    const tree = SkinDeep.shallowRender(
+      <FormApp
+        formConfig={formConfig}
+        formData={formData}
+        routes={routes}
+        currentLocation={currentLocation}
+      >
+        <div className="child" />
+      </FormApp>,
+    );
+
+    expect(tree.everySubTree('FormTitle')[0].props.title).to.equal(titles[0]);
+    formData.test = true;
+    tree.reRender({ formData, currentLocation, formConfig });
+    expect(tree.everySubTree('FormTitle')[0].props.title).to.equal(titles[1]);
+  });
 });


### PR DESCRIPTION
## Description

Form 526 form title can change depending on the flow. It is "File for disability compensation" for both original- and all-claims; but needs to be set as "File for Benefits Delivery at Discharge" for BDD flow.

Related issues
- Ticket: https://github.com/department-of-veterans-affairs/va.gov-team/issues/12767
- Doc update: https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/pull/376

## Testing done

Added FormApp unit test

## Screenshots

N/A

## Acceptance criteria
- [x] Form title can be dynamically updated

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
