### PR TITLE
Remove the content cache first

### DIFF
--- a/src/site/stages/build/drupal/api.js
+++ b/src/site/stages/build/drupal/api.js
@@ -141,7 +141,7 @@ function getDrupalClient(buildOptions, clientOptionsArg) {
         );
         await new Promise(resolve => {
           const parentPath = path.join(buildOptions['cms-export-dir'], '..');
-          fs.ensureDirSync(parentPath);
+          fs.emptyDirSync(parentPath);
           // This untars to parentDir/cms-export-content/ because the tarball
           // contains a single directory named cms-export-content.
           response.body.pipe(tar.extract(parentPath));


### PR DESCRIPTION
## Description
I discovered that my old cache had extra `node-documentation_page` files that it
shouldn't have. This is because it had vestiges of old caches.

This change empties the CMS export content cache directory before saving the new files.

## Testing done
1) `touch .cache/localhost/cms-export-content/extra-file`
2) `yarn build:content --pull-drupal --use-cms-export`
3) `ls .cache/localhost/cms-export-content/extra-file`
    - "No such file or directory"
