### PR TITLE
Remove blocked routes from sub nav when user is not in MPI

### DIFF
--- a/src/applications/personalization/profile-2/components/Profile2Wrapper.jsx
+++ b/src/applications/personalization/profile-2/components/Profile2Wrapper.jsx
@@ -83,13 +83,17 @@ const Profile2Wrapper = ({
       {isEmpty(hero.errors) && <ProfileHeader />}
 
       <div className="medium-screen:vads-u-display--none">
-        <ProfileMobileSubNav routes={routes} />
+        <ProfileMobileSubNav
+          routes={routes}
+          isLOA3={isLOA3}
+          isInMVI={isInMVI}
+        />
       </div>
 
       <div className="vads-l-grid-container vads-u-padding-x--0">
         <div className="vads-l-row">
           <div className="vads-u-display--none medium-screen:vads-u-display--block vads-l-col--3 vads-u-padding-left--2">
-            <ProfileSubNav routes={routes} />
+            <ProfileSubNav routes={routes} isLOA3={isLOA3} isInMVI={isInMVI} />
           </div>
           <div className="vads-l-col--12 vads-u-padding-bottom--4 vads-u-padding-x--1 medium-screen:vads-l-col--9 medium-screen:vads-u-padding-x--2 medium-screen:vads-u-padding-bottom--6 small-desktop-screen:vads-l-col--8">
             {showNotAllDataAvailableError && <NotAllDataAvailableError />}

--- a/src/applications/personalization/profile-2/components/ProfileMobileSubNav.jsx
+++ b/src/applications/personalization/profile-2/components/ProfileMobileSubNav.jsx
@@ -12,7 +12,7 @@ import {
 import prefixUtilityClasses from 'platform/utilities/prefix-utility-classes';
 import { focusElement } from 'platform/utilities/ui';
 
-import { ProfileMenuItems } from './ProfileSubNav';
+import ProfileSubNavItems from './ProfileSubNavItems';
 
 import {
   closeSideNav as closeSideNavAction,
@@ -236,7 +236,7 @@ const ProfileMobileSubNav = ({
                   <i className="fa fa-times" aria-hidden="true" role="img" />
                 </button>
               </div>
-              <ProfileMenuItems
+              <ProfileSubNavItems
                 isLOA3={isLOA3}
                 isInMVI={isInMVI}
                 routes={routes}

--- a/src/applications/personalization/profile-2/components/ProfileMobileSubNav.jsx
+++ b/src/applications/personalization/profile-2/components/ProfileMobileSubNav.jsx
@@ -12,8 +12,6 @@ import {
 import prefixUtilityClasses from 'platform/utilities/prefix-utility-classes';
 import { focusElement } from 'platform/utilities/ui';
 
-import { isLOA3 as isLOA3Selector } from 'platform/user/selectors';
-
 import { ProfileMenuItems } from './ProfileSubNav';
 
 import {
@@ -55,6 +53,7 @@ const ProfileMobileSubNav = ({
   closeMenu,
   isTriggerButtonFocused,
   isLOA3,
+  isInMVI,
   isMenuPinned,
   isMenuOpen,
   pinMenu,
@@ -239,6 +238,7 @@ const ProfileMobileSubNav = ({
               </div>
               <ProfileMenuItems
                 isLOA3={isLOA3}
+                isInMVI={isInMVI}
                 routes={routes}
                 clickHandler={() => {
                   closeMenu();
@@ -262,6 +262,7 @@ ProfileMobileSubNav.propTypes = {
   closeMenu: PropTypes.func.isRequired,
   isTriggerButtonFocused: PropTypes.bool.isRequired,
   isLOA3: PropTypes.bool.isRequired,
+  isInMVI: PropTypes.bool.isRequired,
   isMenuPinned: PropTypes.bool.isRequired,
   openMenu: PropTypes.func.isRequired,
   pinMenu: PropTypes.func.isRequired,
@@ -270,7 +271,6 @@ ProfileMobileSubNav.propTypes = {
 
 const mapStateToProps = state => ({
   isTriggerButtonFocused: selectFocusTriggerButton(state),
-  isLOA3: isLOA3Selector(state),
   isMenuPinned: selectIsMenuTriggerPinned(state),
   isMenuOpen: selectIsSideNavOpen(state),
 });

--- a/src/applications/personalization/profile-2/components/ProfileSubNav.jsx
+++ b/src/applications/personalization/profile-2/components/ProfileSubNav.jsx
@@ -1,44 +1,9 @@
 import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 
-import { NavLink } from 'react-router-dom';
-
 import { focusElement } from 'platform/utilities/ui';
 
-export function ProfileMenuItems({
-  routes,
-  isLOA3,
-  isInMVI,
-  clickHandler = null,
-}) {
-  return (
-    <ul>
-      {routes.map(route => {
-        // Do not render route if it is not isLOA3
-        if (route.requiresLOA3 && !isLOA3) {
-          return null;
-        }
-
-        if (route.requiresMVI && !isInMVI) {
-          return null;
-        }
-
-        return (
-          <li key={route.path}>
-            <NavLink
-              activeClassName="is-active"
-              exact
-              to={route.path}
-              onClick={clickHandler}
-            >
-              {route.name}
-            </NavLink>
-          </li>
-        );
-      })}
-    </ul>
-  );
-}
+import ProfileSubNavItems from './ProfileSubNavItems';
 
 const ProfileSubNav = ({ isInMVI, isLOA3, routes }) => {
   // on first render, set the focus to the h1
@@ -52,7 +17,7 @@ const ProfileSubNav = ({ isInMVI, isLOA3, routes }) => {
         <h1 id="subnav-header" className="vads-u-font-size--h4">
           Your profile
         </h1>
-        <ProfileMenuItems routes={routes} isLOA3={isLOA3} isInMVI={isInMVI} />
+        <ProfileSubNavItems routes={routes} isLOA3={isLOA3} isInMVI={isInMVI} />
       </div>
     </nav>
   );

--- a/src/applications/personalization/profile-2/components/ProfileSubNav.jsx
+++ b/src/applications/personalization/profile-2/components/ProfileSubNav.jsx
@@ -1,18 +1,25 @@
 import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 
-import { connect } from 'react-redux';
 import { NavLink } from 'react-router-dom';
 
-import { isLOA3 as isLOA3Selector } from 'platform/user/selectors';
 import { focusElement } from 'platform/utilities/ui';
 
-export function ProfileMenuItems({ routes, isLOA3, clickHandler = null }) {
+export function ProfileMenuItems({
+  routes,
+  isLOA3,
+  isInMVI,
+  clickHandler = null,
+}) {
   return (
     <ul>
       {routes.map(route => {
         // Do not render route if it is not isLOA3
         if (route.requiresLOA3 && !isLOA3) {
+          return null;
+        }
+
+        if (route.requiresMVI && !isInMVI) {
           return null;
         }
 
@@ -33,7 +40,7 @@ export function ProfileMenuItems({ routes, isLOA3, clickHandler = null }) {
   );
 }
 
-const ProfileSubNav = ({ isLOA3, routes }) => {
+const ProfileSubNav = ({ isInMVI, isLOA3, routes }) => {
   // on first render, set the focus to the h1
   useEffect(() => {
     focusElement('#subnav-header');
@@ -45,13 +52,14 @@ const ProfileSubNav = ({ isLOA3, routes }) => {
         <h1 id="subnav-header" className="vads-u-font-size--h4">
           Your profile
         </h1>
-        <ProfileMenuItems routes={routes} isLOA3={isLOA3} />
+        <ProfileMenuItems routes={routes} isLOA3={isLOA3} isInMVI={isInMVI} />
       </div>
     </nav>
   );
 };
 
 ProfileSubNav.propTypes = {
+  isInMVI: PropTypes.bool.isRequired,
   isLOA3: PropTypes.bool.isRequired,
   routes: PropTypes.arrayOf(
     PropTypes.shape({
@@ -61,10 +69,4 @@ ProfileSubNav.propTypes = {
   ).isRequired,
 };
 
-const mapStateToProps = state => ({
-  isLOA3: isLOA3Selector(state),
-});
-
-export { ProfileSubNav };
-
-export default connect(mapStateToProps)(ProfileSubNav);
+export default ProfileSubNav;

--- a/src/applications/personalization/profile-2/components/ProfileSubNavItems.jsx
+++ b/src/applications/personalization/profile-2/components/ProfileSubNavItems.jsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { NavLink } from 'react-router-dom';
+
+function ProfileSubNavItems({ routes, isLOA3, isInMVI, clickHandler = null }) {
+  // Filter out the routes the user cannot access due to not being in MVI/MPI or
+  // not having a high enough LOA
+  const filteredRoutes = routes.filter(route => {
+    let eligibleRoute = true;
+
+    if (route.requiresLOA3 && !isLOA3) {
+      eligibleRoute = false;
+    }
+
+    if (route.requiresMVI && !isInMVI) {
+      eligibleRoute = false;
+    }
+
+    return eligibleRoute;
+  });
+  return (
+    <ul>
+      {filteredRoutes.map(route => {
+        return (
+          <li key={route.path}>
+            <NavLink
+              activeClassName="is-active"
+              exact
+              to={route.path}
+              onClick={clickHandler}
+            >
+              {route.name}
+            </NavLink>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+
+ProfileSubNavItems.propTypes = {
+  isInMVI: PropTypes.bool.isRequired,
+  isLOA3: PropTypes.bool.isRequired,
+  routes: PropTypes.arrayOf(
+    PropTypes.shape({
+      path: PropTypes.string.isRequired,
+      name: PropTypes.string.isRequired,
+    }),
+  ).isRequired,
+  // Optional handler to fire when a nav item is clicked
+  clickHandler: PropTypes.func,
+};
+
+export default ProfileSubNavItems;

--- a/src/applications/personalization/profile-2/tests/e2e/profile.mpi-error.cypress.spec.js
+++ b/src/applications/personalization/profile-2/tests/e2e/profile.mpi-error.cypress.spec.js
@@ -1,0 +1,69 @@
+import { PROFILE_PATHS } from '../../constants';
+
+import mockMPIErrorUser from '../fixtures/users/user-mpi-error.json';
+import mockFeatureToggles from '../fixtures/feature-toggles.json';
+
+describe('When user is LOA3 with 2FA turned on but we cannot connect to MPI', () => {
+  beforeEach(() => {
+    window.localStorage.setItem(
+      'DISMISSED_ANNOUNCEMENTS',
+      JSON.stringify(['single-sign-on-intro']),
+    );
+    cy.login(mockMPIErrorUser);
+    // login() calls cy.server() so we can now mock routes
+    cy.route('GET', '/v0/feature_toggles*', mockFeatureToggles);
+  });
+  it('should only have access to the Account Security section at desktop size', () => {
+    cy.visit(PROFILE_PATHS.PROFILE_ROOT);
+
+    // should show a loading indicator
+    cy.findByRole('progressbar').should('exist');
+    cy.findByText(/loading your information/i).should('exist');
+
+    // and then the loading indicator should be removed
+    cy.findByRole('progressbar').should('not.exist');
+    cy.findByText(/loading your information/i).should('not.exist');
+
+    // should redirect to profile/account-security on load
+    cy.url().should(
+      'eq',
+      `${Cypress.config().baseUrl}${PROFILE_PATHS.ACCOUNT_SECURITY}`,
+    );
+
+    // Should show an error alert about not being able to connect to MPI
+    // TODO: We might show a different error message in this particular case since in this case we can't connect to MPI.
+    cy.findByText(/We can’t match your information with our Veteran records/i)
+      .should('exist')
+      .closest('.usa-alert-warning')
+      .should('exist');
+
+    // Check that the sub nav does not contain anything other than the Account
+    // Security section
+    cy.findByRole('link', { name: /personal.*info/i }).should('not.exist');
+    cy.findByRole('link', { name: /military info/i }).should('not.exist');
+    cy.findByRole('link', { name: /direct deposit/i }).should('not.exist');
+    cy.findByRole('link', { name: /connected app/i }).should('not.exist');
+
+    // There should be an Account Security item in the sub nav.
+    // NOTE: There are two link elements that contain `account security` so look
+    // for the link specifically in the secondary nav
+    cy.findByRole('navigation', { name: /secondary/i }).within(() => {
+      cy.findByRole('link', { name: /account security/i }).should('exist');
+    });
+
+    // Going directly to any other should redirect to the
+    // account security section
+    [
+      PROFILE_PATHS.CONNECTED_APPLICATIONS,
+      PROFILE_PATHS.DIRECT_DEPOSIT,
+      PROFILE_PATHS.MILITARY_INFORMATION,
+      PROFILE_PATHS.PERSONAL_INFORMATION,
+    ].forEach(path => {
+      cy.visit(path);
+      cy.url().should(
+        'eq',
+        `${Cypress.config().baseUrl}${PROFILE_PATHS.ACCOUNT_SECURITY}`,
+      );
+    });
+  });
+});

--- a/src/applications/personalization/profile-2/tests/e2e/profile.mpi-error.cypress.spec.js
+++ b/src/applications/personalization/profile-2/tests/e2e/profile.mpi-error.cypress.spec.js
@@ -3,6 +3,74 @@ import { PROFILE_PATHS } from '../../constants';
 import mockMPIErrorUser from '../fixtures/users/user-mpi-error.json';
 import mockFeatureToggles from '../fixtures/feature-toggles.json';
 
+/**
+ *
+ * @param {boolean} mobile - test on a mobile viewport or not
+ */
+function test(mobile = false) {
+  cy.visit(PROFILE_PATHS.PROFILE_ROOT);
+  if (mobile) {
+    cy.viewport('iphone-4');
+  }
+
+  // should show a loading indicator
+  cy.findByRole('progressbar').should('exist');
+  cy.findByText(/loading your information/i).should('exist');
+
+  // and then the loading indicator should be removed
+  cy.findByRole('progressbar').should('not.exist');
+  cy.findByText(/loading your information/i).should('not.exist');
+
+  // should redirect to profile/account-security on load
+  cy.url().should(
+    'eq',
+    `${Cypress.config().baseUrl}${PROFILE_PATHS.ACCOUNT_SECURITY}`,
+  );
+
+  // Should show an error alert about not being able to connect to MPI
+  // TODO: We might show a different error message in this particular case since in this case we can't connect to MPI.
+  cy.findByText(/We can’t match your information with our Veteran records/i)
+    .should('exist')
+    .closest('.usa-alert-warning')
+    .should('exist');
+
+  // Check that the sub nav does not contain anything other than the Account
+  // Security section
+  if (mobile) {
+    cy.findByRole('button', { name: /your profile menu/i }).click();
+  }
+  cy.findByRole('link', { name: /personal.*info/i }).should('not.exist');
+  cy.findByRole('link', { name: /military info/i }).should('not.exist');
+  cy.findByRole('link', { name: /direct deposit/i }).should('not.exist');
+  cy.findByRole('link', { name: /connected app/i }).should('not.exist');
+
+  // There should be an Account Security item in the sub nav.
+  // NOTE: There are two link elements that contain `account security` so look
+  // for the link specifically in the secondary nav
+  if (mobile) {
+    cy.findByRole('link', { name: /account security/i }).should('exist');
+  } else {
+    cy.findByRole('navigation', { name: /secondary/i }).within(() => {
+      cy.findByRole('link', { name: /account security/i }).should('exist');
+    });
+  }
+
+  // Going directly to any other should redirect to the
+  // account security section
+  [
+    PROFILE_PATHS.CONNECTED_APPLICATIONS,
+    PROFILE_PATHS.DIRECT_DEPOSIT,
+    PROFILE_PATHS.MILITARY_INFORMATION,
+    PROFILE_PATHS.PERSONAL_INFORMATION,
+  ].forEach(path => {
+    cy.visit(path);
+    cy.url().should(
+      'eq',
+      `${Cypress.config().baseUrl}${PROFILE_PATHS.ACCOUNT_SECURITY}`,
+    );
+  });
+}
+
 describe('When user is LOA3 with 2FA turned on but we cannot connect to MPI', () => {
   beforeEach(() => {
     window.localStorage.setItem(
@@ -14,56 +82,9 @@ describe('When user is LOA3 with 2FA turned on but we cannot connect to MPI', ()
     cy.route('GET', '/v0/feature_toggles*', mockFeatureToggles);
   });
   it('should only have access to the Account Security section at desktop size', () => {
-    cy.visit(PROFILE_PATHS.PROFILE_ROOT);
-
-    // should show a loading indicator
-    cy.findByRole('progressbar').should('exist');
-    cy.findByText(/loading your information/i).should('exist');
-
-    // and then the loading indicator should be removed
-    cy.findByRole('progressbar').should('not.exist');
-    cy.findByText(/loading your information/i).should('not.exist');
-
-    // should redirect to profile/account-security on load
-    cy.url().should(
-      'eq',
-      `${Cypress.config().baseUrl}${PROFILE_PATHS.ACCOUNT_SECURITY}`,
-    );
-
-    // Should show an error alert about not being able to connect to MPI
-    // TODO: We might show a different error message in this particular case since in this case we can't connect to MPI.
-    cy.findByText(/We can’t match your information with our Veteran records/i)
-      .should('exist')
-      .closest('.usa-alert-warning')
-      .should('exist');
-
-    // Check that the sub nav does not contain anything other than the Account
-    // Security section
-    cy.findByRole('link', { name: /personal.*info/i }).should('not.exist');
-    cy.findByRole('link', { name: /military info/i }).should('not.exist');
-    cy.findByRole('link', { name: /direct deposit/i }).should('not.exist');
-    cy.findByRole('link', { name: /connected app/i }).should('not.exist');
-
-    // There should be an Account Security item in the sub nav.
-    // NOTE: There are two link elements that contain `account security` so look
-    // for the link specifically in the secondary nav
-    cy.findByRole('navigation', { name: /secondary/i }).within(() => {
-      cy.findByRole('link', { name: /account security/i }).should('exist');
-    });
-
-    // Going directly to any other should redirect to the
-    // account security section
-    [
-      PROFILE_PATHS.CONNECTED_APPLICATIONS,
-      PROFILE_PATHS.DIRECT_DEPOSIT,
-      PROFILE_PATHS.MILITARY_INFORMATION,
-      PROFILE_PATHS.PERSONAL_INFORMATION,
-    ].forEach(path => {
-      cy.visit(path);
-      cy.url().should(
-        'eq',
-        `${Cypress.config().baseUrl}${PROFILE_PATHS.ACCOUNT_SECURITY}`,
-      );
-    });
+    test();
+  });
+  it('should only have access to the Account Security section at mobile size', () => {
+    test(true);
   });
 });

--- a/src/applications/personalization/profile-2/tests/fixtures/users/user-mpi-error.json
+++ b/src/applications/personalization/profile-2/tests/fixtures/users/user-mpi-error.json
@@ -1,0 +1,93 @@
+{
+  "data": {
+    "id": "",
+    "type": "users_scaffolds",
+    "attributes": {
+      "services": [
+        "facilities",
+        "hca",
+        "edu-benefits",
+        "form-save-in-progress",
+        "form-prefill",
+        "user-profile",
+        "appeals-status",
+        "identity-proofed",
+        "evss_common_client",
+        "claim_increase"
+      ],
+      "account": { "accountUuid": "c049d895-ecdf-40a4-ac0f-7947a06ea0c2" },
+      "profile": {
+        "email": "vets.gov.user+36@gmail.com",
+        "firstName": "WESLEY",
+        "middleName": "Watson",
+        "lastName": "FORD",
+        "birthDate": "1986-05-06",
+        "gender": "M",
+        "zip": "22182",
+        "lastSignedIn": "2020-08-21T22:13:08.801Z",
+        "loa": { "current": 3, "highest": 3 },
+        "multifactor": true,
+        "verified": true,
+        "signIn": { "serviceName": "idme", "accountType": "N/A" },
+        "authnContext": "http://idmanagement.gov/ns/assurance/loa/3/vets"
+      },
+      "vaProfile": null,
+      "veteranStatus": null,
+      "inProgressForms": [
+        {
+          "form": "22-10203",
+          "metadata": {
+            "version": 1,
+            "returnUrl": "/benefits/stem-eligibility",
+            "savedAt": 1597089200404,
+            "expiresAt": 1602273198,
+            "lastUpdated": 1597089198
+          },
+          "lastUpdated": 1597089198
+        }
+      ],
+      "prefillsAvailable": [
+        "21-686C",
+        "40-10007",
+        "22-1990",
+        "22-1990N",
+        "22-1990E",
+        "22-1995",
+        "22-1995S",
+        "22-5490",
+        "22-5495",
+        "22-0993",
+        "22-0994",
+        "FEEDBACK-TOOL",
+        "22-10203",
+        "21-526EZ",
+        "21-526EZ-BDD",
+        "1010ez",
+        "21P-530",
+        "21P-527EZ",
+        "686C-674",
+        "20-0996",
+        "MDOT"
+      ],
+      "vet360ContactInformation": {}
+    }
+  },
+  "meta": {
+    "errors": [
+      {
+        "externalService": "MVI",
+        "startTime": "2020-08-21T22:17:28Z",
+        "endTime": null,
+        "description": "MVI_504, 504, Gateway timeout, Did not receive a timely response from an upstream server",
+        "status": 504
+      },
+      {
+        "externalService": "EMIS",
+        "startTime": "2020-08-21T22:17:28Z",
+        "endTime": null,
+        "description": "EMISRedis::VeteranStatus::NotAuthorized, NOT_AUTHORIZED",
+        "status": 401
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Description
Users who are not in MPI are blocked from most sections of the Profile. Although we were blocking them from accessing those routes at the React Router level, we were still showing the user the corresponding items in the sub nav. This change removes those sub nav items.

## Testing done
Added Cypress tests that mock the `GET user/` call to match what we saw in staging that revealed this bug.

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs