### PR TITLE
updated link

### DIFF
--- a/src/applications/edu-benefits/10203/containers/ConfirmEligibilityView.jsx
+++ b/src/applications/edu-benefits/10203/containers/ConfirmEligibilityView.jsx
@@ -162,8 +162,7 @@ export class ConfirmEligibilityView extends React.Component {
           <div className="vads-u-margin-top--neg2">
             <a
               className={'usa-button-primary va-button-primary'}
-              href="/education/about-gi-bill-benefits/"
-              target="self"
+              href="/education/"
               onClick={captureEvents.exitApplication()}
             >
               Exit application


### PR DESCRIPTION
## Description
STEM: Exit application button going to wrong link
https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/12795

## Testing done

local testing
## Screenshots
![link](https://user-images.githubusercontent.com/50601724/91205143-1602ed80-e6d3-11ea-8aea-659eef0ca210.gif)


## Acceptance criteria
- [x] link is updated and opened in same tab

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
