### PR TITLE
Empty the export dir, not the whole cache

### DIFF
--- a/src/site/stages/build/drupal/api.js
+++ b/src/site/stages/build/drupal/api.js
@@ -141,7 +141,7 @@ function getDrupalClient(buildOptions, clientOptionsArg) {
         );
         await new Promise(resolve => {
           const parentPath = path.join(buildOptions['cms-export-dir'], '..');
-          fs.emptyDirSync(parentPath);
+          fs.emptyDirSync(path.resolve(buildOptions['cms-export-dir']));
           // This untars to parentDir/cms-export-content/ because the tarball
           // contains a single directory named cms-export-content.
           response.body.pipe(tar.extract(parentPath));


### PR DESCRIPTION
## Description
My previous caching fix cleared out the whole cache for the build type, not the
CMS export directory like I intended. This meant the feature flags were lost.

## Testing done
1. Check that the feature flags aren't there
1. Run the build with `--use-cms-export --pull-drupal`
1. Check that the feature flags are there
