### PR TITLE
Minimize the output for files that fail to download

### DIFF
--- a/src/site/stages/build/plugins/download-drupal-assets.js
+++ b/src/site/stages/build/plugins/download-drupal-assets.js
@@ -2,6 +2,7 @@
 require('isomorphic-fetch');
 const path = require('path');
 const fs = require('fs-extra');
+const chalk = require('chalk');
 
 const { logDrupal: log } = require('../drupal/utilities-drupal');
 const getDrupalClient = require('../drupal/api');
@@ -41,7 +42,12 @@ async function downloadFile(
     // For now, not going to fail the build for a missing asset
     // Should get caught by the broken link checker, though
     downloadResults.errorCount++;
-    log(`Image download failed: ${response.statusText}: ${asset.src}`);
+    if (global.verbose) {
+      log(`Image download failed: ${response.statusText}: ${asset.src}`);
+    } else {
+      process.stdout.write(chalk.red('.'));
+      if (!assetsToDownload.length) process.stdout.write('\n');
+    }
   }
 
   const currentDownloadCount =


### PR DESCRIPTION
## Description
Just like it says on the tin. If there's a download error of some sort, this
will just output a red dot to indicate the error.

## Screenshots
**Not verbose**
![image](https://user-images.githubusercontent.com/12970166/91207242-4cce0900-e6bd-11ea-9f0e-9370a4ba07ff.png)

**Verbose**
![image](https://user-images.githubusercontent.com/12970166/91207379-830b8880-e6bd-11ea-9796-8663e9d4676d.png)
