### PR TITLE
Also add checkbox to residential address

### DIFF
--- a/src/platform/user/profile/vet360/components/AddressField/address-schemas.js
+++ b/src/platform/user/profile/vet360/components/AddressField/address-schemas.js
@@ -212,30 +212,5 @@ const uiSchema = {
   },
 };
 
-/**
- * Helper that returns the correct form schema object based on which address
- * field is being rendered
- */
-export const getFormSchema = fieldName => {
-  if (fieldName === FIELD_NAMES.MAILING_ADDRESS) {
-    return cloneDeep(formSchema);
-  }
-  const schema = cloneDeep(formSchema);
-  delete schema.properties['view:livesOnMilitaryBase'];
-  delete schema.properties['view:livesOnMilitaryBaseInfo'];
-  return schema;
-};
-
-/**
- * Helper that returns the correct ui schema object based on which address
- * field is being rendered
- */
-export const getUiSchema = fieldName => {
-  if (fieldName === FIELD_NAMES.MAILING_ADDRESS) {
-    return cloneDeep(uiSchema);
-  }
-  const schema = cloneDeep(uiSchema);
-  delete schema['view:livesOnMilitaryBase'];
-  delete schema['view:livesOnMilitaryBaseInfo'];
-  return schema;
-};
+export const getFormSchema = () => cloneDeep(formSchema);
+export const getUiSchema = () => cloneDeep(uiSchema);

--- a/src/platform/user/profile/vet360/components/AddressField/address-schemas.js
+++ b/src/platform/user/profile/vet360/components/AddressField/address-schemas.js
@@ -3,7 +3,7 @@ import React from 'react';
 import ADDRESS_DATA from 'platform/forms/address/data';
 import cloneDeep from 'platform/utilities/data/cloneDeep';
 
-import { ADDRESS_FORM_VALUES, FIELD_NAMES, USA } from 'vet360/constants';
+import { ADDRESS_FORM_VALUES, USA } from 'vet360/constants';
 
 // make an object of just the military state codes and names
 const MILITARY_STATES = Object.entries(ADDRESS_DATA.states).reduce(


### PR DESCRIPTION
## Description
We noticed an inconsistency between addresses. We need to add the 'I live on a United States military base outside of the country.' checkbox to the Home address section of the Personal and contact information section.

## Testing done
Works locally. I do recommend a good amount of testing in staging - there was no knowledge transfer as to why this checkbox was left out initially, so we need to be 100% sure no unexpected side-effects are introduced by this change.

## Screenshots
![image](https://user-images.githubusercontent.com/14869324/91332831-fd094380-e789-11ea-8bd1-2a0d7d31a871.png)

## Acceptance criteria
- [x] Add military checkbox to home address

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
