### PR TITLE
bradl3yC - 12811- Update coronavirus empty state copy

### DIFF
--- a/src/applications/debt-letters/components/DebtCardsList.jsx
+++ b/src/applications/debt-letters/components/DebtCardsList.jsx
@@ -55,6 +55,7 @@ const DebtCardsList = ({ debts, isError }) => {
               <a href="tel: 800-827-0648" aria-label="8 0 0. 8 2 7. 0 6 4 8.">
                 800-827-0648
               </a>
+              {'.'}
             </p>
             <div className="vads-u-margin-top--3">
               {reverse(debts).map((debt, index) => (

--- a/src/applications/debt-letters/components/DebtLettersList.jsx
+++ b/src/applications/debt-letters/components/DebtLettersList.jsx
@@ -118,23 +118,22 @@ const DebtLettersList = ({ debtLinks, isVBMSError }) => {
       {!isVBMSError &&
         debtLinks.length < 1 && (
           <div className="vads-u-background-color--gray-lightest vads-u-padding--3 vads-u-margin-top--3">
-            <h4 className="vads-u-font-family--serif vads-u-margin-top--0">
-              Our records show that you don't have any debt letters
-            </h4>
+            <h3 className="vads-u-font-family--serif vads-u-margin-top--0">
+              VA debt collection is on hold due to the coronavirus
+            </h3>
             <p className="vads-u-font-family--sans vads-u-margin-bottom--0">
-              Debt collection has been put on hold due to the COVID-19 pandemic.
-              If you received a debt after March 2020, debt collection letters
-              haven't been mailed to your address. For more information about
-              your debt, call the Debt Management Center at{' '}
-              <a href="tel: 800-827-0648" aria-label="800. 8 2 7. 0648.">
-                800-827-0648
-              </a>
-              {'.'}
+              We’ve taken action to stop collection on newly established Veteran
+              debt and make it easier for Veterans to request extended repayment
+              plans and address other financial needs during this time.
             </p>
             <p className="vads-u-font-family--sans vads-u-margin-bottom--0">
-              For medical copayment debts, visit{' '}
-              <a href="/health-care/pay-copay-bill/">Pay your VA copay bill</a>{' '}
-              to learn about your payment options.
+              You won’t receive any debt collection letters in the mail until
+              after December 31, 2020. For the latest information about managing
+              VA debt, visit our{' '}
+              <a href="http://va.gov/coronavirus-veteran-frequently-asked-questions/">
+                coronavirus FAQs
+              </a>
+              {'.'}
             </p>
           </div>
         )}

--- a/src/applications/debt-letters/const/index.js
+++ b/src/applications/debt-letters/const/index.js
@@ -91,7 +91,8 @@ export const renderAdditionalInfo = deductionCode => {
             decision resulting in this debt, please call the Education office at{' '}
             <a href="tel: 888-442-4551" aria-label="888. 4 4 2. 4551.">
               888-442-4551
-            </a>{' '}
+            </a>
+            {'. '}
             We're here Monday through Friday, 8:00 a.m. to 7:00 p.m. ET.
           </p>
           <p>
@@ -135,7 +136,8 @@ export const renderAdditionalInfo = deductionCode => {
             decision resulting in this debt, please call the Education office at{' '}
             <a href="tel: 888-442-4551" aria-label="888. 4 4 2. 4551.">
               888-442-4551
-            </a>{' '}
+            </a>
+            {'. '}
             We're here Monday through Friday, 8:00 a.m. to 7:00 p.m. ET.
           </p>
           <p>

--- a/src/applications/debt-letters/tests/DebtLettersList.unit.spec.js
+++ b/src/applications/debt-letters/tests/DebtLettersList.unit.spec.js
@@ -93,17 +93,18 @@ describe('DebtLettersList', () => {
     expect(
       wrapper
         .dive()
-        .find('h4')
+        .find('h3')
+        .at(1)
         .text(),
-    ).to.equal("Our records show that you don't have any debt letters");
+    ).to.equal("What if I don't see the letter I'm looking for?");
     expect(
       wrapper
         .dive()
         .find('p')
-        .at(2)
+        .at(1)
         .text(),
     ).to.equal(
-      'If you’ve received a letter about a VA debt, but don’t see the letter listed here call the VA Debt Management Center at 800-827-0648 You can also call the DMC to get information about your resolved debts For VA health care copay debt, please go to our pay your VA copay bill page to learn about your payment options.',
+      'You won’t receive any debt collection letters in the mail until after December 31, 2020. For the latest information about managing VA debt, visit our coronavirus FAQs.',
     );
     wrapper.unmount();
   });


### PR DESCRIPTION
## Description
Update the empty state for the debt letters download links

## Testing done


## Screenshots
![Screen Shot 2020-08-25 at 3 37 09 PM](https://user-images.githubusercontent.com/6165421/91219739-202fe680-e6e9-11ea-87f3-c785a2a7910c.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
