### PR TITLE
Add test results question for HI health system screener

### DIFF
--- a/src/applications/coronavirus-screener/config/questions.jsx
+++ b/src/applications/coronavirus-screener/config/questions.jsx
@@ -9,6 +9,11 @@ export const questions = [
     startQuestion: true,
   },
   {
+    id: 'test-results-hi',
+    text: 'Are you waiting for COVID-19 test results?',
+    customId: ['459', '459GE', '459GF', '459GH'],
+  },
+  {
     id: 'fever',
     text: 'In the past 24 hours, have you had a fever?',
   },


### PR DESCRIPTION
## Description

Adds "Are you waiting for COVID-19 test results?" for HI VAMC and outlying clinics.

## Testing done

Manual.

## Screenshots
<img width="478" alt="Screen Shot 2020-08-26 at 10 10 16 AM" src="https://user-images.githubusercontent.com/7645362/91322143-fe843d00-e784-11ea-8e8a-91f75330bc62.png">
<img width="464" alt="Screen Shot 2020-08-26 at 10 10 27 AM" src="https://user-images.githubusercontent.com/7645362/91322149-004e0080-e785-11ea-9cbd-a69d10338a8c.png">


## Acceptance criteria
- [x] Navigate to /covid19screen/459 or /covid19screen/459GE or /covid19screen/459GF or /covid19screen/459GH
- [x] Click "Yes" to "Are you waiting for COVID-19 test results?" question
- [x] See "More screening needed" result

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
