### PR TITLE
[a11y] Fix nav-header text and focus

### DIFF
--- a/src/platform/forms-system/src/js/components/FormNav.jsx
+++ b/src/platform/forms-system/src/js/components/FormNav.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import _ from 'lodash/fp'; // eslint-disable-line no-restricted-imports
 import shallowEqual from 'recompose/shallowEqual';
-import environment from 'platform/utilities/environment';
 
 import SegmentedProgressBar from './SegmentedProgressBar';
 
@@ -71,17 +70,9 @@ export default class FormNav extends React.Component {
             aria-valuemax={chapters.length}
             className="nav-header nav-header-schemaform"
           >
-            {environment.isDev() ? (
-              <h2 className="vads-u-font-size--h4">
-                {`${current} of ${chapters.length} ${chapterName}`}
-              </h2>
-            ) : (
-              <h2 className="vads-u-font-size--h4">
-                <span className="form-process-step current">{current}</span>{' '}
-                <span className="form-process-total">of {chapters.length}</span>{' '}
-                {chapterName}
-              </h2>
-            )}
+            <h2 className="vads-u-font-size--h4">
+              {`${current} of ${chapters.length} ${chapterName}`}
+            </h2>
           </div>
         </div>
       </div>

--- a/src/platform/forms-system/src/js/components/FormNav.jsx
+++ b/src/platform/forms-system/src/js/components/FormNav.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import _ from 'lodash/fp'; // eslint-disable-line no-restricted-imports
 import shallowEqual from 'recompose/shallowEqual';
+import environment from 'platform/utilities/environment';
 
 import SegmentedProgressBar from './SegmentedProgressBar';
 
@@ -70,9 +71,17 @@ export default class FormNav extends React.Component {
             aria-valuemax={chapters.length}
             className="nav-header nav-header-schemaform"
           >
-            <h2 className="vads-u-font-size--h4">
-              {`Step ${current} of ${chapters.length}: ${chapterName}`}
-            </h2>
+            {!environment.isProduction() ? (
+              <h2 className="vads-u-font-size--h4">
+                {`Step ${current} of ${chapters.length}: ${chapterName}`}
+              </h2>
+            ) : (
+              <h2 className="vads-u-font-size--h4">
+                <span className="form-process-step current">{current}</span>{' '}
+                <span className="form-process-total">of {chapters.length}</span>{' '}
+                {chapterName}
+              </h2>
+            )}
           </div>
         </div>
       </div>

--- a/src/platform/forms-system/src/js/components/FormNav.jsx
+++ b/src/platform/forms-system/src/js/components/FormNav.jsx
@@ -71,7 +71,7 @@ export default class FormNav extends React.Component {
             className="nav-header nav-header-schemaform"
           >
             <h2 className="vads-u-font-size--h4">
-              {`${current} of ${chapters.length} ${chapterName}`}
+              {`Step ${current} of ${chapters.length}: ${chapterName}`}
             </h2>
           </div>
         </div>

--- a/src/platform/forms-system/src/js/containers/FormPage.jsx
+++ b/src/platform/forms-system/src/js/containers/FormPage.jsx
@@ -6,6 +6,8 @@ import Scroll from 'react-scroll';
 import _ from 'lodash/fp'; // eslint-disable-line no-restricted-imports
 import classNames from 'classnames';
 
+import environment from 'platform/utilities/environment';
+
 import ProgressButton from '../components/ProgressButton';
 import SchemaForm from '../components/SchemaForm';
 import { setData, uploadFile } from '../actions';
@@ -13,7 +15,10 @@ import { getNextPagePath, getPreviousPagePath } from '../routing';
 import { focusElement } from '../utilities/ui';
 
 function focusForm() {
-  focusElement('.nav-header > h2');
+  const selector = environment.isProduction()
+    ? '.nav-header'
+    : '.nav-header > h2';
+  focusElement(selector);
 }
 
 const scroller = Scroll.scroller;

--- a/src/platform/forms-system/src/js/containers/FormPage.jsx
+++ b/src/platform/forms-system/src/js/containers/FormPage.jsx
@@ -13,7 +13,7 @@ import { getNextPagePath, getPreviousPagePath } from '../routing';
 import { focusElement } from '../utilities/ui';
 
 function focusForm() {
-  focusElement('.nav-header');
+  focusElement('.nav-header > h2');
 }
 
 const scroller = Scroll.scroller;

--- a/src/platform/forms-system/test/js/components/FormNav.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/components/FormNav.unit.spec.jsx
@@ -63,7 +63,7 @@ describe('Schemaform FormNav', () => {
 
     expect(tree.subTree('SegmentedProgressBar').props.total).to.equal(4);
     expect(tree.subTree('SegmentedProgressBar').props.current).to.equal(1);
-    expect(tree.subTree('.nav-header').text()).to.equal('1 of 4 Testing');
+    expect(tree.subTree('.nav-header').text()).to.equal('Step 1 of 4: Testing');
   });
   it('should display a custom review page title', () => {
     const formConfigReviewData = getReviewData();


### PR DESCRIPTION
## Description

Related to https://github.com/department-of-veterans-affairs/va.gov-team/issues/12323

This changes the nav-header on forms to remove the `<span>` tags and associated styling and replace them with a simpler copy that sighted users and screen reader users will understand. Additionally, focus is directed to this simplified `<h2>` instead of its parent.

## Testing done

Unit testing

## Screenshots

![image](https://user-images.githubusercontent.com/2008881/91344884-69d50b80-e793-11ea-8c5c-eaa190c08657.png)



## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
