### PR TITLE
Add the entityId to .entity for use in the templates

### DIFF
--- a/src/site/stages/build/process-cms-exports/index.js
+++ b/src/site/stages/build/process-cms-exports/index.js
@@ -135,11 +135,19 @@ const addCommonProperties = (transformedEntity, originalEntity) => {
     transformedEntity.entityBundle || entityBundle;
   transformedEntity.entityUrl =
     transformedEntity.entityUrl || originalEntity.entityUrl;
-  transformedEntity.entityId = (originalEntity.nid ||
+  const entityId = (originalEntity.nid ||
     originalEntity.tid ||
     originalEntity.id ||
     originalEntity.mid ||
     originalEntity.fid)[0].value.toString();
+
+  // Always assign the entityId to the root object
+  transformedEntity.entityId = entityId;
+  // But also assign it to the .entity if available. The Liquid templates
+  // typically pass the .entity property when including template partials.
+  if (transformedEntity.entity) {
+    transformedEntity.entity.entityId = entityId;
+  }
   /* eslint-enable no-param-reassign */
 };
 


### PR DESCRIPTION
## Description
Previously, the `entityId` was only added to the root object, not the `.entity`,
but the `.entity` is what's typically passed to the template includes.

## Testing done
Ran the CMS export build and compared the HTML to the GraphQL. The `entityId`s
were added to the HTML output.
