### PR TITLE
Fix styling

### DIFF
--- a/src/platform/user/profile/vet360/components/base/VAPEditModalActionButtons.jsx
+++ b/src/platform/user/profile/vet360/components/base/VAPEditModalActionButtons.jsx
@@ -120,7 +120,7 @@ class VAPEditModalActionButtons extends React.Component {
     }
 
     return (
-      <div className="vads-u-display--flex vads-u-flex-wrap--wrap">
+      <div className="vads-u-display--flex vads-u-flex-wrap--wrap vads-u-flex-direction--column">
         {this.props.children}
         {this.renderDeleteAction()}
       </div>

--- a/src/platform/user/profile/vet360/components/base/VAPEditView.jsx
+++ b/src/platform/user/profile/vet360/components/base/VAPEditView.jsx
@@ -110,7 +110,7 @@ class VAPEditView extends Component {
         isLoading={isLoading}
         deleteEnabled={!isEmpty && !deleteDisabled}
       >
-        <div className="vads-u-display--flex">
+        <div>
           <LoadingButton
             data-action="save-edit"
             isLoading={isLoading}

--- a/src/platform/user/profile/vet360/components/base/VAPEditView.jsx
+++ b/src/platform/user/profile/vet360/components/base/VAPEditView.jsx
@@ -120,7 +120,7 @@ class VAPEditView extends Component {
           </LoadingButton>
           <button
             type="button"
-            className="usa-button-secondary medium-screen:vads-u-margin-left--1 vads-u-margin-top--0 vads-u-width--auto"
+            className="usa-button-secondary vads-u-margin-top--0 vads-u-width--auto"
             onClick={onCancel}
           >
             Cancel

--- a/src/platform/user/profile/vet360/components/base/VAPEditView.jsx
+++ b/src/platform/user/profile/vet360/components/base/VAPEditView.jsx
@@ -110,20 +110,22 @@ class VAPEditView extends Component {
         isLoading={isLoading}
         deleteEnabled={!isEmpty && !deleteDisabled}
       >
-        <LoadingButton
-          data-action="save-edit"
-          isLoading={isLoading}
-          className="vads-u-width--auto vads-u-margin-top--0"
-        >
-          Update
-        </LoadingButton>
-        <button
-          type="button"
-          className="usa-button-secondary medium-screen:vads-u-margin-left--2 vads-u-margin-top--0 vads-u-width--auto"
-          onClick={onCancel}
-        >
-          Cancel
-        </button>
+        <div className="vads-u-display--flex">
+          <LoadingButton
+            data-action="save-edit"
+            isLoading={isLoading}
+            className="vads-u-width--auto vads-u-margin-top--0"
+          >
+            Update
+          </LoadingButton>
+          <button
+            type="button"
+            className="usa-button-secondary medium-screen:vads-u-margin-left--1 vads-u-margin-top--0 vads-u-width--auto"
+            onClick={onCancel}
+          >
+            Cancel
+          </button>
+        </div>
       </VAPEditModalActionButtons>
     );
 


### PR DESCRIPTION
## Description
In some rare scenarios, the 'Remove' action did not wrap to the next line. Also, the margin between the Cancel and Confirm buttons is too wide.

## Testing done
Looks good locally.

## Screenshots
![image](https://user-images.githubusercontent.com/14869324/91455993-fd641600-e83f-11ea-985e-85714a7b5a1b.png)
![image](https://user-images.githubusercontent.com/14869324/91456381-6cda0580-e840-11ea-995e-09f6498125f5.png)


## Acceptance criteria
 - [x] Ensure the Remove action wraps to the next line
 - [x] Remove left margin on the cancel button

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
