### PR TITLE
12323 outline fix followon

### DIFF
--- a/src/platform/forms/sass/_m-schemaform.scss
+++ b/src/platform/forms/sass/_m-schemaform.scss
@@ -29,7 +29,7 @@ legend {
   font-weight: 700;
   line-height: 1.5;
   margin: 0;
-  padding: 0 0 .5em 0;
+  padding: 0 0 0.5em 0;
 }
 
 // IE
@@ -45,8 +45,8 @@ fieldset {
 @media (max-width: 40.063em) {
   .progress-box {
     border: none;
-    padding-left: 2rem - .9375rem;
-    padding-right: 2rem - .9375rem;
+    padding-left: 2rem - 0.9375rem;
+    padding-right: 2rem - 0.9375rem;
   }
 }
 
@@ -162,8 +162,8 @@ label {
   padding-right: 2rem;
   margin-bottom: 1.5em;
   @media (max-width: 40.063em) {
-    padding-left: 2rem - .9375rem;
-    padding-right: 2rem - .9375rem;
+    padding-left: 2rem - 0.9375rem;
+    padding-right: 2rem - 0.9375rem;
   }
   > h4 {
     padding-bottom: 0 !important;
@@ -212,7 +212,9 @@ label {
 
 .schemaform-block-header {
   margin-bottom: 0.7em;
-  > legend, > h5, > p {
+  > legend,
+  > h5,
+  > p {
     padding-bottom: 0 !important;
     margin-bottom: 0 !important;
   }
@@ -233,7 +235,8 @@ label {
 }
 
 .schemaform-first-field {
-  .schemaform-label, > .usa-input-error {
+  .schemaform-label,
+  > .usa-input-error {
     margin-top: 0;
   }
 }
@@ -510,7 +513,7 @@ legend.schemaform-label.schemaform-file-label {
 }
 
 .saved-success-icon {
-  margin: 0 .5em 0 0;
+  margin: 0 0.5em 0 0;
 }
 
 .usa-alert-no-color {
@@ -574,12 +577,10 @@ legend.schemaform-label.schemaform-file-label {
   background: $color-white;
   border: 1px solid $color-gray;
   // Box shadow only sides and bottom of suggestion list.
-  box-shadow: 3px 3px 3px -3px $color-focus,
-              -3px 3px 3px -3px $color-focus,
-              7px 7px 7px -7px $color-focus,
-              -7px 7px 7px -7px $color-focus;
+  box-shadow: 3px 3px 3px -3px $color-focus, -3px 3px 3px -3px $color-focus,
+    7px 7px 7px -7px $color-focus, -7px 7px 7px -7px $color-focus;
   list-style: none;
-  margin-top: -.5rem;
+  margin-top: -0.5rem;
   max-width: 46rem;
   max-height: 46rem;
   overflow: auto;
@@ -595,12 +596,15 @@ legend.schemaform-label.schemaform-file-label {
   }
 }
 
-.usa-input-error > .schemaform-widget-wrapper > .autosuggest-container > .autosuggest-list {
+.usa-input-error
+  > .schemaform-widget-wrapper
+  > .autosuggest-container
+  > .autosuggest-list {
   width: calc(100% + 1.9rem);
 }
 
 .autosuggest-item {
-  padding: .5rem 1rem;
+  padding: 0.5rem 1rem;
   list-style-type: none;
 
   &-highlighted {
@@ -613,7 +617,7 @@ legend.schemaform-label.schemaform-file-label {
 }
 
 // More correcting of overly broad uswds accordion styles
-.react-autosuggest__input[aria-expanded=false] {
+.react-autosuggest__input[aria-expanded="false"] {
   background-image: inherit !important;
   background-repeat: inherit !important;
   background-size: inherit !important;
@@ -628,7 +632,8 @@ legend.schemaform-label.schemaform-file-label {
   margin-top: 1em;
 }
 
-.usa-accordion, .usa-accordion-bordered {
+.usa-accordion,
+.usa-accordion-bordered {
   > ul {
     button {
       border-radius: $button-border-radius;
@@ -646,7 +651,7 @@ legend.schemaform-label.schemaform-file-label {
 }
 
 // highlighted outlines for accessibility
-[role=button]:focus,
+[role="button"]:focus,
 button:focus,
 input:focus,
 select:focus,
@@ -655,11 +660,11 @@ textarea:focus {
   outline-offset: 2px;
 }
 
-.form-checkbox>input[type=checkbox]+.schemaform-label {
+.form-checkbox > input[type="checkbox"] + .schemaform-label {
   line-height: 2.4rem;
 }
 
-.form-checkbox>input[type=checkbox]+label:before {
+.form-checkbox > input[type="checkbox"] + label:before {
   margin-right: 0.6em;
 }
 

--- a/src/platform/forms/sass/_m-schemaform.scss
+++ b/src/platform/forms/sass/_m-schemaform.scss
@@ -58,7 +58,14 @@ fieldset {
   }
 }
 
-.va-nav-breadcrumbs-list, legend, .nav-header > h4, .nav-header, .usa-input-error, .input-error-date, .usa-alert {
+.va-nav-breadcrumbs-list,
+legend,
+.nav-header > h4,
+.nav-header > h2,
+.nav-header,
+.usa-input-error,
+.input-error-date,
+.usa-alert {
   &:focus {
     outline: none;
   }


### PR DESCRIPTION
## Description

This is a followup to #14024 

This follows the current guidance of not applying the outline from USWDS around focused `<h2>` elements.

## Testing done

:eyes: check

## Screenshots

![image](https://user-images.githubusercontent.com/2008881/91470391-816ecb80-e849-11ea-8610-0fe6e3ddcf85.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
