### PR TITLE
[Templates] Add analytics into va_form layout

### DIFF
--- a/src/applications/find-forms/widgets/createInvalidPdfAlert.js
+++ b/src/applications/find-forms/widgets/createInvalidPdfAlert.js
@@ -2,26 +2,32 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import * as Sentry from '@sentry/browser';
-
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 
 import { fetchFormsApi } from '../api';
 
-const InvalidFormDownload = () => (
-  <AlertBox
-    isVisible
-    status="error"
-    headline="This form link isn’t working"
-    content={
-      <>
-        We’re sorry, but the form you’re trying to download appears to have an
-        invalid link. Please{' '}
-        <a href="mailto:VaFormsManagers@va.gov">email the forms managers</a> for
-        help with this form.
-      </>
-    }
-  />
-);
+function InvalidFormDownload({ downloadUrl }) {
+  const subject = encodeURIComponent('Bad PDF link');
+  const body = encodeURIComponent(
+    `I tried to download this form but the link doesn't work: ${downloadUrl}`,
+  );
+  const mailto = `mailto:VaFormsManagers@va.gov?subject=${subject}&body=${body}`;
+
+  return (
+    <AlertBox
+      isVisible
+      status="error"
+      headline="This form link isn’t working"
+      content={
+        <>
+          We’re sorry, but the form you’re trying to download appears to have an
+          invalid link. Please <a href={mailto}>email the forms managers</a> for
+          help with this form.
+        </>
+      }
+    />
+  );
+}
 
 export async function onDownloadLinkClick(event) {
   event.preventDefault();
@@ -55,7 +61,7 @@ export async function onDownloadLinkClick(event) {
     });
 
     const div = document.createElement('div');
-    const alertBox = <InvalidFormDownload />;
+    const alertBox = <InvalidFormDownload downloadUrl={downloadUrl} />;
 
     ReactDOM.render(alertBox, div);
     link.parentNode.insertBefore(div, link);

--- a/src/site/layouts/va_form.drupal.liquid
+++ b/src/site/layouts/va_form.drupal.liquid
@@ -102,7 +102,9 @@
         {% if fieldVaFormToolUrl %}
           <h3>Online tool</h3>
           <p>{{ fieldVaFormToolIntro }}</p>
-          <a href="{{ fieldVaFormToolUrl.uri }}" class="usa-button-primary va-button-primary">
+          <a
+            href="{{ fieldVaFormToolUrl.uri }}" class="usa-button-primary va-button-primary"
+            onclick="recordEvent({ event: 'cta-primary-button-click' });">
             Go to the online tool <i role="presentation" aria-hidden="true" class="fa fa-chevron-right vads-u-margin-left--1"> </i>
           </a>
         {% endif %}
@@ -140,10 +142,9 @@
         <section>
           <div class="vads-u-background-color--gray-lightest vads-u-padding--3 vads-u-margin-y--4">
             <h2 class="vads-u-font-size--h3 vads-u-margin-top--0 vads-u-padding-bottom--1 vads-u-border-bottom--1px vads-u-border-color--gray-light">
+              {% assign linkTeasersHeader = 'Helpful links' %}
               {% if fieldVaFormLinkTeasers.length > 0 %}
                 Helpful links related to VA Form {{ fieldVaFormNumber }}
-              {% else %}
-                Helpful links
               {% endif %}
             </h2>
             <ul class="usa-unstyled-list">
@@ -151,7 +152,10 @@
                 {% for vaFormLinkTeaser in fieldVaFormLinkTeasers %}
                   <li>
                     <h3 class="vads-u-font-size--h4 vads-u-margin-bottom--0 vads-u-font-family--sans">
-                      <a class="vads-u-text-decoration--none" href="{{ vaFormLinkTeaser.entity.fieldLink.url.path }}">
+                      <a
+                        class="vads-u-text-decoration--none"
+                        href="{{ vaFormLinkTeaser.entity.fieldLink.url.path }}"
+                        onclick="recordEvent({ event: 'nav-linkslist', 'links-list-header': '{{ vaFormLinkTeaser.entity.fieldLink.title | escape }}', 'links-list-section-header': '{{ linkTeasersHeader | escape }}' })">
                         {{ vaFormLinkTeaser.entity.fieldLink.title }}
                       </a>
                     </h3>
@@ -162,7 +166,10 @@
                 {% comment %} The default related links if custom links aren't defined {% endcomment %}
                 <li>
                   <h3 class="vads-u-font-size--h4 vads-u-margin-bottom--0 vads-u-font-family--sans">
-                    <a class="vads-u-text-decoration--none" href="/change-direct-deposit">
+                    <a
+                      class="vads-u-text-decoration--none"
+                      href="/change-direct-deposit"
+                      onclick="recordEvent({ event: 'nav-linkslist', 'links-list-header': 'Change your direct deposit information', 'links-list-section-header': '{{ linkTeasersHeader | escape }}' })">
                       Change your direct deposit information
                     </a>
                   </h3>
@@ -170,7 +177,10 @@
                 </li>
                 <li>
                   <h3 class="vads-u-font-size--h4 vads-u-margin-bottom--0 vads-u-font-family--sans">
-                    <a class="vads-u-text-decoration--none" href="/change-address">
+                    <a
+                      class="vads-u-text-decoration--none"
+                      href="/change-address"
+                      onclick="recordEvent({ event: 'nav-linkslist', 'links-list-header': 'Change your address', 'links-list-section-header': '{{ linkTeasersHeader | escape }}' })">
                       Change your address
                     </a>
                   </h3>
@@ -178,7 +188,10 @@
                 </li>
                 <li>
                   <h3 class="vads-u-font-size--h4 vads-u-margin-bottom--0 vads-u-font-family--sans">
-                    <a class="vads-u-text-decoration--none" href="/records/get-military-service-records/">
+                    <a
+                      class="vads-u-text-decoration--none"
+                      href="/records/get-military-service-records/"
+                      onclick="recordEvent({ event: 'nav-linkslist', 'links-list-header': 'Request your military records, including DD214', 'links-list-section-header': '{{ linkTeasersHeader | escape }}' })">
                       Request your military records, including DD214
                     </a>
                   </h3>
@@ -186,7 +199,10 @@
                 </li>
                 <li>
                   <h3 class="vads-u-font-size--h4 vads-u-margin-bottom--0 vads-u-font-family--sans">
-                    <a class="vads-u-text-decoration--none" href="/records/">
+                    <a
+                      class="vads-u-text-decoration--none"
+                      href="/records/"
+                      onclick="recordEvent({ event: 'nav-linkslist', 'links-list-header': 'Get your VA records and documents online', 'links-list-section-header': '{{ linkTeasersHeader | escape }}' })">
                       Get your VA records and documents online
                     </a>
                   </h3>


### PR DESCRIPTION
## Description
This PR implements the data layer events into form detail pages. The events are outlined here, https://github.com/department-of-veterans-affairs/va.gov-team/issues/4552#issuecomment-677799170.

https://github.com/department-of-veterans-affairs/va.gov-team/issues/12757

## Testing done
Tested using local preview server and a Chrome extension for checking the datalayer

## Screenshots
Example analytic when clicking a link under Helpful Link

![image](https://user-images.githubusercontent.com/1915775/91489441-d842c800-e87e-11ea-8b5b-952256d9cc31.png)


## Acceptance criteria
- [ ] Events are triggered as expected

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
