### PR TITLE
[Development] Fix 526 wizard links

### DIFF
--- a/src/applications/disability-benefits/wizard/pages/file-bdd.jsx
+++ b/src/applications/disability-benefits/wizard/pages/file-bdd.jsx
@@ -65,20 +65,20 @@ function alertContent(getPageStateFromPageName, setWizardStatus) {
       </p>
       {/* Remove link to introduction page once show526Wizard flipper is at
       100% */}
-      {typeof setWizardStatus === 'function' ? (
-        <button
-          onClick={() => setWizardStatus(WIZARD_STATUS_COMPLETE)}
-          className="usa-button-primary va-button-primary"
-        >
-          File a Benefits Delivery at Discharge claim
-        </button>
-      ) : (
+      {window.location.pathname.includes('how-to-file-claim') ? (
         <a
           href={`${DISABILITY_526_V2_ROOT_URL}/introduction`}
           className="usa-button-primary va-button-primary"
         >
           File a Benefits Delivery at Discharge claim
         </a>
+      ) : (
+        <button
+          onClick={() => setWizardStatus(WIZARD_STATUS_COMPLETE)}
+          className="usa-button-primary va-button-primary"
+        >
+          File a Benefits Delivery at Discharge claim
+        </button>
       )}
     </>
   );

--- a/src/applications/disability-benefits/wizard/pages/file-claim-early.jsx
+++ b/src/applications/disability-benefits/wizard/pages/file-claim-early.jsx
@@ -7,20 +7,20 @@ const FileClaimPage = ({ setWizardStatus }) => (
   <div>
     <p>
       {/* Remove link to introduction page once show526Wizard flipper is at 100% */}
-      {typeof setWizardStatus === 'function' ? (
-        <button
-          onClick={() => setWizardStatus(WIZARD_STATUS_COMPLETE)}
-          className="usa-button-primary va-button-primary"
-        >
-          File a disability compensation claim
-        </button>
-      ) : (
+      {window.location.pathname.includes('how-to-file-claim') ? (
         <a
           href={`${DISABILITY_526_V2_ROOT_URL}/introduction`}
           className="usa-button-primary va-button-primary"
         >
           File a disability compensation claim
         </a>
+      ) : (
+        <button
+          onClick={() => setWizardStatus(WIZARD_STATUS_COMPLETE)}
+          className="usa-button-primary va-button-primary"
+        >
+          File a disability compensation claim
+        </button>
       )}
     </p>
   </div>

--- a/src/applications/disability-benefits/wizard/pages/file-claim.jsx
+++ b/src/applications/disability-benefits/wizard/pages/file-claim.jsx
@@ -8,20 +8,20 @@ import { pageNames } from './pageList';
  */
 const FileClaimPage = ({ setWizardStatus }) => (
   <p>
-    {typeof setWizardStatus === 'function' ? (
-      <button
-        onClick={() => setWizardStatus(WIZARD_STATUS_COMPLETE)}
-        className="usa-button-primary va-button-primary"
-      >
-        File a disability compensation claim
-      </button>
-    ) : (
+    {window.location.pathname.includes('how-to-file-claim') ? (
       <a
         href={`${DISABILITY_526_V2_ROOT_URL}/introduction`}
         className="usa-button-primary va-button-primary"
       >
         File a disability compensation claim
       </a>
+    ) : (
+      <button
+        onClick={() => setWizardStatus(WIZARD_STATUS_COMPLETE)}
+        className="usa-button-primary va-button-primary"
+      >
+        File a disability compensation claim
+      </button>
     )}
   </p>
 );


### PR DESCRIPTION
## Description

The 526 wizard isn't showing the links when it should be showing the buttons on the how-to page.

Related to: https://github.com/department-of-veterans-affairs/va.gov-team/issues/11188

## Testing done

N/A

## Screenshots

N/A

## Acceptance criteria
- [ ] Links to 526 intro page are shown on the how-to page

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
