### PR TITLE
Use intro page url for wizard check

### DIFF
--- a/src/applications/disability-benefits/wizard/pages/file-bdd.jsx
+++ b/src/applications/disability-benefits/wizard/pages/file-bdd.jsx
@@ -1,8 +1,6 @@
 import React from 'react';
 import moment from 'moment';
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
-
-import manifest from '../../all-claims/manifest.json';
 import { pageNames } from './pageList';
 import {
   BDD_INFO_URL,
@@ -67,7 +65,7 @@ function alertContent(getPageStateFromPageName, setWizardStatus) {
       </p>
       {/* Remove link to introduction page once show526Wizard flipper is at
       100% */}
-      {window.location.pathname.includes(manifest.rootUrl) ? (
+      {window.location.pathname.includes(DISABILITY_526_V2_ROOT_URL) ? (
         <button
           onClick={() => setWizardStatus(WIZARD_STATUS_COMPLETE)}
           className="usa-button-primary va-button-primary"

--- a/src/applications/disability-benefits/wizard/pages/file-bdd.jsx
+++ b/src/applications/disability-benefits/wizard/pages/file-bdd.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import moment from 'moment';
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
+
+import manifest from '../../all-claims/manifest.json';
 import { pageNames } from './pageList';
 import {
   BDD_INFO_URL,
@@ -65,20 +67,20 @@ function alertContent(getPageStateFromPageName, setWizardStatus) {
       </p>
       {/* Remove link to introduction page once show526Wizard flipper is at
       100% */}
-      {window.location.pathname.includes('how-to-file-claim') ? (
-        <a
-          href={`${DISABILITY_526_V2_ROOT_URL}/introduction`}
-          className="usa-button-primary va-button-primary"
-        >
-          File a Benefits Delivery at Discharge claim
-        </a>
-      ) : (
+      {window.location.pathname.includes(manifest.rootUrl) ? (
         <button
           onClick={() => setWizardStatus(WIZARD_STATUS_COMPLETE)}
           className="usa-button-primary va-button-primary"
         >
           File a Benefits Delivery at Discharge claim
         </button>
+      ) : (
+        <a
+          href={`${DISABILITY_526_V2_ROOT_URL}/introduction`}
+          className="usa-button-primary va-button-primary"
+        >
+          File a Benefits Delivery at Discharge claim
+        </a>
       )}
     </>
   );

--- a/src/applications/disability-benefits/wizard/pages/file-claim-early.jsx
+++ b/src/applications/disability-benefits/wizard/pages/file-claim-early.jsx
@@ -1,14 +1,13 @@
 import React from 'react';
 import { DISABILITY_526_V2_ROOT_URL } from 'applications/disability-benefits/all-claims/constants';
 import { WIZARD_STATUS_COMPLETE } from 'applications/static-pages/wizard';
-import manifest from '../../all-claims/manifest.json';
 import { pageNames } from './pageList';
 
 const FileClaimPage = ({ setWizardStatus }) => (
   <div>
     <p>
       {/* Remove link to introduction page once show526Wizard flipper is at 100% */}
-      {window.location.pathname.includes(manifest.rootUrl) ? (
+      {window.location.pathname.includes(DISABILITY_526_V2_ROOT_URL) ? (
         <button
           onClick={() => setWizardStatus(WIZARD_STATUS_COMPLETE)}
           className="usa-button-primary va-button-primary"

--- a/src/applications/disability-benefits/wizard/pages/file-claim-early.jsx
+++ b/src/applications/disability-benefits/wizard/pages/file-claim-early.jsx
@@ -1,26 +1,27 @@
 import React from 'react';
 import { DISABILITY_526_V2_ROOT_URL } from 'applications/disability-benefits/all-claims/constants';
 import { WIZARD_STATUS_COMPLETE } from 'applications/static-pages/wizard';
+import manifest from '../../all-claims/manifest.json';
 import { pageNames } from './pageList';
 
 const FileClaimPage = ({ setWizardStatus }) => (
   <div>
     <p>
       {/* Remove link to introduction page once show526Wizard flipper is at 100% */}
-      {window.location.pathname.includes('how-to-file-claim') ? (
-        <a
-          href={`${DISABILITY_526_V2_ROOT_URL}/introduction`}
-          className="usa-button-primary va-button-primary"
-        >
-          File a disability compensation claim
-        </a>
-      ) : (
+      {window.location.pathname.includes(manifest.rootUrl) ? (
         <button
           onClick={() => setWizardStatus(WIZARD_STATUS_COMPLETE)}
           className="usa-button-primary va-button-primary"
         >
           File a disability compensation claim
         </button>
+      ) : (
+        <a
+          href={`${DISABILITY_526_V2_ROOT_URL}/introduction`}
+          className="usa-button-primary va-button-primary"
+        >
+          File a disability compensation claim
+        </a>
       )}
     </p>
   </div>

--- a/src/applications/disability-benefits/wizard/pages/file-claim.jsx
+++ b/src/applications/disability-benefits/wizard/pages/file-claim.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { DISABILITY_526_V2_ROOT_URL } from 'applications/disability-benefits/all-claims/constants';
 import { WIZARD_STATUS_COMPLETE } from 'applications/static-pages/wizard';
+import manifest from '../../all-claims/manifest.json';
 import { pageNames } from './pageList';
 
 /**
@@ -8,20 +9,20 @@ import { pageNames } from './pageList';
  */
 const FileClaimPage = ({ setWizardStatus }) => (
   <p>
-    {window.location.pathname.includes('how-to-file-claim') ? (
-      <a
-        href={`${DISABILITY_526_V2_ROOT_URL}/introduction`}
-        className="usa-button-primary va-button-primary"
-      >
-        File a disability compensation claim
-      </a>
-    ) : (
+    {window.location.pathname.includes(manifest.rootUrl) ? (
       <button
         onClick={() => setWizardStatus(WIZARD_STATUS_COMPLETE)}
         className="usa-button-primary va-button-primary"
       >
         File a disability compensation claim
       </button>
+    ) : (
+      <a
+        href={`${DISABILITY_526_V2_ROOT_URL}/introduction`}
+        className="usa-button-primary va-button-primary"
+      >
+        File a disability compensation claim
+      </a>
     )}
   </p>
 );

--- a/src/applications/disability-benefits/wizard/pages/file-claim.jsx
+++ b/src/applications/disability-benefits/wizard/pages/file-claim.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { DISABILITY_526_V2_ROOT_URL } from 'applications/disability-benefits/all-claims/constants';
 import { WIZARD_STATUS_COMPLETE } from 'applications/static-pages/wizard';
-import manifest from '../../all-claims/manifest.json';
 import { pageNames } from './pageList';
 
 /**
@@ -9,7 +8,7 @@ import { pageNames } from './pageList';
  */
 const FileClaimPage = ({ setWizardStatus }) => (
   <p>
-    {window.location.pathname.includes(manifest.rootUrl) ? (
+    {window.location.pathname.includes(DISABILITY_526_V2_ROOT_URL) ? (
       <button
         onClick={() => setWizardStatus(WIZARD_STATUS_COMPLETE)}
         className="usa-button-primary va-button-primary"


### PR DESCRIPTION
## Description

Wizard links to form 526 introduction page from the eligibility page are not working as expected. This PR detects the url of the introduction page to show the correct link (vs button)

## Testing done

N/A

## Screenshots

N/A

## Acceptance criteria
- [ ] Wizard is showing links to the 526 intro page when the feature flag is disabled.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
