### PR TITLE
Add tests for deleting and editing addresses

### DIFF
--- a/src/applications/personalization/profile-2/msw-mocks.js
+++ b/src/applications/personalization/profile-2/msw-mocks.js
@@ -104,7 +104,7 @@ const createTransactionRequestFailedError = {
 };
 
 export const validateAddressFailure = [
-  rest.post(``, (req, res, ctx) => {
+  rest.post(`${prefix}/v0/profile/address_validation`, (req, res, ctx) => {
     return res(ctx.status(500), ctx.json(mock500));
   }),
 ];

--- a/src/applications/personalization/profile-2/msw-mocks.js
+++ b/src/applications/personalization/profile-2/msw-mocks.js
@@ -103,6 +103,12 @@ const createTransactionRequestFailedError = {
   status: '400',
 };
 
+export const validateAddressFailure = [
+  rest.post(``, (req, res, ctx) => {
+    return res(ctx.status(500), ctx.json(mock500));
+  }),
+];
+
 // Response when transaction fails to be created.
 export const createTransactionFailure = [
   rest.post(`${prefix}/v0/profile/*`, (req, res, ctx) => {
@@ -1164,6 +1170,215 @@ export const deletePhoneNumberSuccess = () => {
     }),
   ];
 };
+
+// Sets up the responses needed to mock a successful address update. In
+// particular it mocks the `GET user/` response so that both mailing and
+// residential addresses are updated to make testing a little bit easier
+export const editAddressSuccess = [
+  rest.post(`${prefix}/v0/profile/address_validation`, (req, res, ctx) => {
+    return res(
+      ctx.json({
+        addresses: [
+          {
+            address: {
+              addressLine1: '123 Main St',
+              addressType: 'DOMESTIC',
+              city: 'San Francisco',
+              countryName: 'United States',
+              countryCodeIso3: 'USA',
+              countyCode: '06075',
+              countyName: 'San Francisco',
+              stateCode: 'CA',
+              zipCode: '94105',
+              zipCodeSuffix: '1804',
+            },
+            addressMetaData: {
+              confidenceScore: 100.0,
+              addressType: 'Domestic',
+              deliveryPointValidation: 'CONFIRMED',
+              residentialDeliveryIndicator: 'RESIDENTIAL',
+            },
+          },
+        ],
+        validationKey: 1438191680,
+      }),
+    );
+  }),
+  rest.post(`${prefix}/v0/profile/addresses`, (req, res, ctx) => {
+    return res(
+      ctx.json({
+        data: createTransactionRequestSuccessBody,
+      }),
+    );
+  }),
+  rest.put(`${prefix}/v0/profile/addresses`, (req, res, ctx) => {
+    return res(
+      ctx.json({
+        data: createTransactionRequestSuccessBody,
+      }),
+    );
+  }),
+  // for testing purposes, after saving an address, return a user object
+  // where both the mailing and residential addresses are updated.
+  rest.get(`${prefix}/v0/user`, (req, res, ctx) => {
+    return res(
+      ctx.json({
+        data: {
+          id: '',
+          type: 'users_scaffolds',
+          attributes: {
+            services: [
+              'facilities',
+              'hca',
+              'edu-benefits',
+              'form-save-in-progress',
+              'form-prefill',
+              'mhv-accounts',
+              'evss-claims',
+              'form526',
+              'user-profile',
+              'appeals-status',
+              'id-card',
+              'identity-proofed',
+              'vet360',
+              'evss_common_client',
+              'claim_increase',
+            ],
+            account: { accountUuid: 'c049d895-ecdf-40a4-ac0f-7947a06ea0c2' },
+            profile: {
+              email: 'vets.gov.user+36@gmail.com',
+              firstName: 'WESLEY',
+              middleName: 'WATSON',
+              lastName: 'FORD',
+              birthDate: '1986-05-06',
+              gender: 'M',
+              zip: '21122-6706',
+              lastSignedIn: '2020-07-28T14:57:28.196Z',
+              loa: { current: 3, highest: 3 },
+              multifactor: true,
+              verified: true,
+              signIn: {
+                serviceName: 'idme',
+                accountType: 'N/A',
+                ssoe: true,
+                transactionid: '/lob0lmUWabZaaWqJ+ydOKkCYvu55jG3IxIJI4qzGic=',
+              },
+              authnContext: 'http://idmanagement.gov/ns/assurance/loa/3',
+            },
+            vaProfile: {
+              status: 'OK',
+              birthDate: '19860506',
+              familyName: 'Ford',
+              gender: 'M',
+              givenNames: ['Wesley', 'Watson'],
+              isCernerPatient: false,
+              facilities: [{ facilityId: '983', isCerner: false }],
+              vaPatient: true,
+              mhvAccountState: 'NONE',
+            },
+            veteranStatus: {
+              status: 'OK',
+              isVeteran: true,
+              servedInMilitary: true,
+            },
+            inProgressForms: [],
+            prefillsAvailable: [
+              '21-686C',
+              '40-10007',
+              '22-1990',
+              '22-1990N',
+              '22-1990E',
+              '22-1995',
+              '22-1995S',
+              '22-5490',
+              '22-5495',
+              '22-0993',
+              '22-0994',
+              'FEEDBACK-TOOL',
+              '22-10203',
+              '21-526EZ',
+              '21-526EZ-BDD',
+              '1010ez',
+              '21P-530',
+              '21P-527EZ',
+              '686C-674',
+              '20-0996',
+              'MDOT',
+            ],
+            vet360ContactInformation: {
+              email: null,
+              residentialAddress: {
+                addressLine1: '123 Main St',
+                addressLine2: null,
+                addressLine3: null,
+                addressPou: 'RESIDENCE/CHOICE',
+                addressType: 'DOMESTIC',
+                city: 'San Francisco',
+                countryName: 'United States',
+                countryCodeIso2: 'US',
+                countryCodeIso3: 'USA',
+                countryCodeFips: null,
+                countyCode: '06075',
+                countyName: 'San Francisco',
+                createdAt: '2020-07-25T00:32:10.000Z',
+                effectiveEndDate: null,
+                effectiveStartDate: '2020-07-25T00:32:09.000Z',
+                id: 185731,
+                internationalPostalCode: null,
+                province: null,
+                sourceDate: '2020-07-25T00:32:09.000Z',
+                sourceSystemUser: null,
+                stateCode: 'CA',
+                transactionId: '6bde244e-a92f-421f-a7dc-923fc85f4f5f',
+                updatedAt: '2020-07-25T00:32:10.000Z',
+                validationKey: null,
+                vet360Id: '1273780',
+                zipCode: '94105',
+                zipCodeSuffix: '1804',
+              },
+              mailingAddress: {
+                addressLine1: '123 Main St',
+                addressLine2: null,
+                addressLine3: null,
+                addressPou: 'CORRESPONDENCE',
+                addressType: 'DOMESTIC',
+                city: 'San Francisco',
+                countryName: 'United States',
+                countryCodeIso2: 'US',
+                countryCodeIso3: 'USA',
+                countryCodeFips: null,
+                countyCode: '06075',
+                countyName: 'San Francisco',
+                createdAt: '2020-07-25T00:32:10.000Z',
+                effectiveEndDate: null,
+                effectiveStartDate: '2020-07-25T00:32:09.000Z',
+                id: 185731,
+                internationalPostalCode: null,
+                province: null,
+                sourceDate: '2020-07-25T00:32:09.000Z',
+                sourceSystemUser: null,
+                stateCode: 'CA',
+                transactionId: '6bde244e-a92f-421f-a7dc-923fc85f4f5f',
+                updatedAt: '2020-07-25T00:32:10.000Z',
+                validationKey: null,
+                vet360Id: '1273780',
+                zipCode: '94105',
+                zipCodeSuffix: '1804',
+              },
+              mobilePhone: null,
+              homePhone: null,
+              workPhone: null,
+              temporaryPhone: null,
+              faxNumber: null,
+              textPermission: null,
+            },
+          },
+        },
+        meta: { errors: null },
+      }),
+    );
+  }),
+];
 
 // Sets up the responses needed to mock a successful home address deletion. In
 // particular it mocks the `GET user/` response so that the residential address

--- a/src/applications/personalization/profile-2/msw-mocks.js
+++ b/src/applications/personalization/profile-2/msw-mocks.js
@@ -14,6 +14,11 @@ import mockServiceHistorySuccess from './tests/fixtures/service-history-success.
 import mock401 from './tests/fixtures/401.json';
 import mock500 from './tests/fixtures/500.json';
 
+// The transactionId of a resolved/failed transaction must match the
+// transactionId of the pending transaction or the status of the transaction
+// will never update.
+const transactionId = '61ffa9bd-3290-4e4b-9480-d93fd6236dcf';
+
 export const newPaymentAccount = {
   accountType: 'Savings',
   financialInstitutionName: 'COMERICA BANK',
@@ -81,7 +86,7 @@ const createTransactionRequestSuccessBody = {
   id: '',
   type: 'async_transaction_vet360_email_transactions',
   attributes: {
-    transactionId: '61ffa9bd-3290-4e4b-9480-d93fd6236dcf',
+    transactionId,
     transactionStatus: 'RECEIVED',
     type: 'AsyncTransaction::Vet360::EmailTransaction',
     metadata: [],
@@ -140,7 +145,7 @@ export const transactionPending = [
           id: '',
           type: 'async_transaction_vet360_email_transactions',
           attributes: {
-            transactionId: '61ffa9bd-3290-4e4b-9480-d93fd6236dcf',
+            transactionId,
             transactionStatus: 'RECEIVED',
             type: 'AsyncTransaction::Vet360::EmailTransaction',
             metadata: [],
@@ -162,7 +167,7 @@ export const transactionFailed = [
           id: '',
           type: 'async_transaction_vet360_email_transactions',
           attributes: {
-            transactionId: '61ffa9bd-3290-4e4b-9480-d93fd6236dcf',
+            transactionId,
             transactionStatus: 'COMPLETED_FAILURE',
             type: 'AsyncTransaction::Vet360::EmailTransaction',
             // this metadata is from a failed address update, _not_ a failed
@@ -196,7 +201,7 @@ export const transactionSucceeded = [
           id: '',
           type: 'async_transaction_vet360_email_transactions',
           attributes: {
-            transactionId: '61ffa9bd-3290-4e4b-9480-d93fd6236dcf',
+            transactionId,
             transactionStatus: 'COMPLETED_SUCCESS',
             type: 'AsyncTransaction::Vet360::EmailTransaction',
             metadata: [],
@@ -207,7 +212,7 @@ export const transactionSucceeded = [
   }),
 ];
 
-// Sets up the responses needed to mack a successful email update. In particular
+// Sets up the responses needed to mock a successful email update. In particular
 // it mocks the `GET user/` response so that the updated email address matches
 // the email address that was entered in the Edit Email Address view.
 export const editEmailAddressSuccess = () => {
@@ -325,7 +330,7 @@ export const editEmailAddressSuccess = () => {
                   id: 114818,
                   sourceDate: '2020-07-28T14:57:53.000Z',
                   sourceSystemUser: null,
-                  transactionId: '61ffa9bd-3290-4e4b-9480-d93fd6236dcf',
+                  transactionId,
                   updatedAt: '2020-07-28T14:57:54.000Z',
                   vet360Id: '1273780',
                 },
@@ -463,7 +468,7 @@ export const editEmailAddressSuccess = () => {
   ];
 };
 
-// Sets up the responses needed to mack a successful email deletion. In
+// Sets up the responses needed to mock a successful email deletion. In
 // particular it mocks the `GET user/` response so that the email address no
 // longer exists
 export const deleteEmailAddressSuccess = [
@@ -694,7 +699,7 @@ export const deleteEmailAddressSuccess = [
   }),
 ];
 
-// Sets up the responses needed to mack a successful phone number update. In
+// Sets up the responses needed to mock a successful phone number update. In
 // particular it mocks the `GET user/` response so that _all_ of the phone
 // numbers match the phone number that was entered in the Edit Phone view.
 export const editPhoneNumberSuccess = () => {
@@ -708,16 +713,7 @@ export const editPhoneNumberSuccess = () => {
       newPhoneNumber = req.body.phoneNumber;
       return res(
         ctx.json({
-          data: {
-            id: '',
-            type: 'async_transaction_vet360_telephone_transactions',
-            attributes: {
-              transactionId: '61ffa9bd-3290-4e4b-9480-d93fd6236dcf',
-              transactionStatus: 'RECEIVED',
-              type: 'AsyncTransaction::Vet360::TelephoneTransaction',
-              metadata: [],
-            },
-          },
+          data: createTransactionRequestSuccessBody,
         }),
       );
     }),
@@ -726,16 +722,7 @@ export const editPhoneNumberSuccess = () => {
       newPhoneNumber = req.body.phoneNumber;
       return res(
         ctx.json({
-          data: {
-            id: '',
-            type: 'async_transaction_vet360_telephone_transactions',
-            attributes: {
-              transactionId: '61ffa9bd-3290-4e4b-9480-d93fd6236dcf',
-              transactionStatus: 'RECEIVED',
-              type: 'AsyncTransaction::Vet360::TelephoneTransaction',
-              metadata: [],
-            },
-          },
+          data: createTransactionRequestSuccessBody,
         }),
       );
     }),
@@ -836,7 +823,7 @@ export const editPhoneNumberSuccess = () => {
                   id: 114818,
                   sourceDate: '2020-07-28T14:57:53.000Z',
                   sourceSystemUser: null,
-                  transactionId: '61ffa9bd-3290-4e4b-9480-d93fd6236dcf',
+                  transactionId,
                   updatedAt: '2020-07-28T14:57:54.000Z',
                   vet360Id: '1273780',
                 },
@@ -994,21 +981,15 @@ export const editPhoneNumberSuccess = () => {
   ];
 };
 
+// Sets up the responses needed to mock a successful phone number deletion. Note
+// that, to make our lives easier, it mocks the `GET user/` response so that
+// _all_ phone numbers are deleted.
 export const deletePhoneNumberSuccess = () => {
   return [
     rest.delete(`${prefix}/v0/profile/telephones`, (req, res, ctx) => {
       return res(
         ctx.json({
-          data: {
-            id: '',
-            type: 'async_transaction_vet360_telephone_transactions',
-            attributes: {
-              transactionId: '61ffa9bd-3290-4e4b-9480-d93fd6236dcf',
-              transactionStatus: 'RECEIVED',
-              type: 'AsyncTransaction::Vet360::TelephoneTransaction',
-              metadata: [],
-            },
-          },
+          data: createTransactionRequestSuccessBody,
         }),
       );
     }),
@@ -1106,7 +1087,7 @@ export const deletePhoneNumberSuccess = () => {
                   id: 114818,
                   sourceDate: '2020-07-28T14:57:53.000Z',
                   sourceSystemUser: null,
-                  transactionId: '61ffa9bd-3290-4e4b-9480-d93fd6236dcf',
+                  transactionId,
                   updatedAt: '2020-07-28T14:57:54.000Z',
                   vet360Id: '1273780',
                 },
@@ -1184,21 +1165,215 @@ export const deletePhoneNumberSuccess = () => {
   ];
 };
 
+// Sets up the responses needed to mock a successful home address deletion. In
+// particular it mocks the `GET user/` response so that the residential address
+// is deleted.
+export const deleteResidentialAddressSuccess = [
+  rest.delete(`${prefix}/v0/profile/addresses`, (req, res, ctx) => {
+    return res(
+      ctx.json({
+        data: createTransactionRequestSuccessBody,
+      }),
+    );
+  }),
+  rest.get(`${prefix}/v0/user`, (req, res, ctx) => {
+    return res(
+      ctx.json({
+        data: {
+          id: '',
+          type: 'users_scaffolds',
+          attributes: {
+            services: [
+              'facilities',
+              'hca',
+              'edu-benefits',
+              'form-save-in-progress',
+              'form-prefill',
+              'mhv-accounts',
+              'evss-claims',
+              'form526',
+              'user-profile',
+              'appeals-status',
+              'id-card',
+              'identity-proofed',
+              'vet360',
+              'evss_common_client',
+              'claim_increase',
+            ],
+            account: { accountUuid: 'c049d895-ecdf-40a4-ac0f-7947a06ea0c2' },
+            profile: {
+              email: 'vets.gov.user+36@gmail.com',
+              firstName: 'WESLEY',
+              middleName: 'WATSON',
+              lastName: 'FORD',
+              birthDate: '1986-05-06',
+              gender: 'M',
+              zip: '21122-6706',
+              lastSignedIn: '2020-07-28T14:57:28.196Z',
+              loa: { current: 3, highest: 3 },
+              multifactor: true,
+              verified: true,
+              signIn: {
+                serviceName: 'idme',
+                accountType: 'N/A',
+                ssoe: true,
+                transactionid: '/lob0lmUWabZaaWqJ+ydOKkCYvu55jG3IxIJI4qzGic=',
+              },
+              authnContext: 'http://idmanagement.gov/ns/assurance/loa/3',
+            },
+            vaProfile: {
+              status: 'OK',
+              birthDate: '19860506',
+              familyName: 'Ford',
+              gender: 'M',
+              givenNames: ['Wesley', 'Watson'],
+              isCernerPatient: false,
+              facilities: [{ facilityId: '983', isCerner: false }],
+              vaPatient: true,
+              mhvAccountState: 'NONE',
+            },
+            veteranStatus: {
+              status: 'OK',
+              isVeteran: true,
+              servedInMilitary: true,
+            },
+            inProgressForms: [],
+            prefillsAvailable: [
+              '21-686C',
+              '40-10007',
+              '22-1990',
+              '22-1990N',
+              '22-1990E',
+              '22-1995',
+              '22-1995S',
+              '22-5490',
+              '22-5495',
+              '22-0993',
+              '22-0994',
+              'FEEDBACK-TOOL',
+              '22-10203',
+              '21-526EZ',
+              '21-526EZ-BDD',
+              '1010ez',
+              '21P-530',
+              '21P-527EZ',
+              '686C-674',
+              '20-0996',
+              'MDOT',
+            ],
+            vet360ContactInformation: {
+              email: null,
+              residentialAddress: null,
+              mailingAddress: {
+                addressLine1: '8210 Doby Ln',
+                addressLine2: null,
+                addressLine3: null,
+                addressPou: 'CORRESPONDENCE',
+                addressType: 'DOMESTIC',
+                city: 'Pasadena',
+                countryName: 'United States',
+                countryCodeIso2: 'US',
+                countryCodeIso3: 'USA',
+                countryCodeFips: null,
+                countyCode: '24003',
+                countyName: 'Anne Arundel County',
+                createdAt: '2020-05-30T03:57:20.000Z',
+                effectiveEndDate: null,
+                effectiveStartDate: '2020-07-25T00:31:00.000Z',
+                id: 173917,
+                internationalPostalCode: null,
+                province: null,
+                sourceDate: '2020-07-25T00:31:00.000Z',
+                sourceSystemUser: null,
+                stateCode: 'MD',
+                transactionId: '2ad2aef3-101a-4bc9-b7dc-2e7ce772c215',
+                updatedAt: '2020-07-25T00:31:02.000Z',
+                validationKey: null,
+                vet360Id: '1273780',
+                zipCode: '21122',
+                zipCodeSuffix: '6706',
+              },
+              mobilePhone: {
+                areaCode: '555',
+                countryCode: '1',
+                createdAt: '2020-07-25T00:34:24.000Z',
+                extension: null,
+                effectiveEndDate: null,
+                effectiveStartDate: '2020-07-25T00:34:24.000Z',
+                id: 155102,
+                isInternational: false,
+                isTextable: null,
+                isTextPermitted: null,
+                isTty: null,
+                isVoicemailable: null,
+                phoneNumber: '5555559',
+                phoneType: 'MOBILE',
+                sourceDate: '2020-07-25T00:34:24.000Z',
+                sourceSystemUser: null,
+                transactionId: '77ad4f31-2d1a-4aaa-a259-7f0cc8fb0357',
+                updatedAt: '2020-07-25T00:34:24.000Z',
+                vet360Id: '1273780',
+              },
+              homePhone: {
+                areaCode: '804',
+                countryCode: '1',
+                createdAt: '2020-07-25T00:33:15.000Z',
+                extension: '17747',
+                effectiveEndDate: null,
+                effectiveStartDate: '2020-07-25T00:33:14.000Z',
+                id: 155101,
+                isInternational: false,
+                isTextable: null,
+                isTextPermitted: null,
+                isTty: null,
+                isVoicemailable: null,
+                phoneNumber: '2055544',
+                phoneType: 'HOME',
+                sourceDate: '2020-07-25T00:33:14.000Z',
+                sourceSystemUser: null,
+                transactionId: 'a7299f8e-1646-40f5-988d-61d0480c01dc',
+                updatedAt: '2020-07-25T00:33:15.000Z',
+                vet360Id: '1273780',
+              },
+              workPhone: {
+                areaCode: '214',
+                countryCode: '1',
+                createdAt: '2020-07-25T00:33:51.000Z',
+                extension: null,
+                effectiveEndDate: null,
+                effectiveStartDate: '2020-07-25T00:33:51.000Z',
+                id: 155103,
+                isInternational: false,
+                isTextable: null,
+                isTextPermitted: null,
+                isTty: null,
+                isVoicemailable: null,
+                phoneNumber: '7182112',
+                phoneType: 'WORK',
+                sourceDate: '2020-07-25T00:33:51.000Z',
+                sourceSystemUser: null,
+                transactionId: 'b98371ec-bfd5-4724-89ee-3ea3c48dac81',
+                updatedAt: '2020-07-25T00:33:51.000Z',
+                vet360Id: '1273780',
+              },
+              temporaryPhone: null,
+              faxNumber: null,
+              textPermission: null,
+            },
+          },
+        },
+        meta: { errors: null },
+      }),
+    );
+  }),
+];
+
 export const toggleSMSNotificationsSuccess = (enrolled = true) => {
   return [
     rest.put(`${prefix}/v0/profile/telephones`, (req, res, ctx) => {
       return res(
         ctx.json({
-          data: {
-            id: '',
-            type: 'async_transaction_vet360_telephone_transactions',
-            attributes: {
-              transactionId: '61ffa9bd-3290-4e4b-9480-d93fd6236dcf',
-              transactionStatus: 'RECEIVED',
-              type: 'AsyncTransaction::Vet360::TelephoneTransaction',
-              metadata: [],
-            },
-          },
+          data: createTransactionRequestSuccessBody,
         }),
       );
     }),

--- a/src/applications/personalization/profile-2/tests/components/personal-information/PersonalInformation.update-address.unit.spec.jsx
+++ b/src/applications/personalization/profile-2/tests/components/personal-information/PersonalInformation.update-address.unit.spec.jsx
@@ -257,8 +257,7 @@ describe('Updating', () => {
       it('should handle a transaction that does not succeed until after the edit view exits', async () => {
         await testSlowSuccess(addressName);
       });
-      // TODO: this test does not pass. If the address validation API fails, we exit edit mode when we should actually keep it open. So we should fix the edit address flow to make this pass.
-      it.skip('should show an error and not auto-exit edit mode if the address validation API errors', async () => {
+      it('should show an error and not auto-exit edit mode if the address validation API errors', async () => {
         await testAddressValidation500(addressName);
       });
       it('should show an error and not auto-exit edit mode if the transaction cannot be created', async () => {

--- a/src/applications/personalization/profile-2/tests/components/personal-information/PersonalInformation.update-address.unit.spec.jsx
+++ b/src/applications/personalization/profile-2/tests/components/personal-information/PersonalInformation.update-address.unit.spec.jsx
@@ -1,0 +1,275 @@
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import userEvent from '@testing-library/user-event';
+import { waitForElementToBeRemoved } from '@testing-library/react';
+import { expect } from 'chai';
+import { setupServer } from 'msw/node';
+
+import { resetFetch } from 'platform/testing/unit/helpers';
+import { FIELD_TITLES, FIELD_NAMES } from 'vet360/constants';
+
+import * as mocks from '../../../msw-mocks';
+import PersonalInformation from '../../../components/personal-information/PersonalInformation';
+
+import {
+  createBasicInitialState,
+  renderWithProfileReducers,
+  wait,
+} from '../../unit-test-helpers';
+
+const ui = (
+  <MemoryRouter>
+    <PersonalInformation />
+  </MemoryRouter>
+);
+let view;
+let server;
+
+function getEditButton(addressName) {
+  let editButton = view.queryByText(new RegExp(`add.*${addressName}`, 'i'), {
+    selector: 'button',
+  });
+  if (!editButton) {
+    // Need to use `queryByRole` since the visible label is simply `Edit`, but
+    // the aria-label is more descriptive
+    editButton = view.queryByRole('button', {
+      name: new RegExp(`edit.*${addressName}`, 'i'),
+    });
+  }
+  return editButton;
+}
+
+function updateAddress(addressName) {
+  userEvent.click(getEditButton(addressName));
+
+  const countryDropdown = view.getByLabelText(/country/i);
+  const line1Input = view.getByLabelText(/street address.*required/i);
+  const cityInput = view.getByLabelText(/city.*required/i);
+  const stateDropdown = view.getByLabelText(/state.*required/i);
+  const zipCodeInput = view.getByLabelText(/zip code/i);
+  const submitButton = view.getByText(/update/i, { selector: 'button' });
+
+  // clear the inputs
+  [line1Input, cityInput, zipCodeInput].forEach(input => {
+    userEvent.clear(input);
+  });
+
+  // input the address info
+  userEvent.selectOptions(countryDropdown, [view.getByText('United States')]);
+  userEvent.type(line1Input, '123 main st');
+  userEvent.type(cityInput, 'san francisco');
+  userEvent.selectOptions(stateDropdown, [view.getByText('California')]);
+  userEvent.type(zipCodeInput, '94105');
+
+  userEvent.click(submitButton);
+
+  return { cityInput };
+}
+
+// When the update happens while the Edit View is still active
+async function testQuickSuccess(addressName) {
+  server.use(...mocks.transactionSucceeded);
+
+  const { cityInput } = updateAddress(addressName);
+
+  // wait for the edit mode to exit
+  await waitForElementToBeRemoved(cityInput);
+
+  // confirm that the new address appears
+  expect(view.getAllByText(/123 Main St/i).length).to.equal(2);
+  expect(view.getAllByText(/San Francisco, CA 94105/i).length).to.equal(2);
+
+  // and the edit address button should exist
+  expect(
+    view.getByRole('button', { name: new RegExp(`edit.*${addressName}`, 'i') }),
+  ).to.exist;
+
+  // the add address button should not exist
+  expect(
+    view.queryByText(new RegExp(`add.*${addressName}`, 'i'), {
+      selector: 'button',
+    }),
+  ).not.to.exist;
+}
+
+// When the update happens but not until after the Edit View has exited and the
+// user returned to the read-only view
+async function testSlowSuccess(addressName) {
+  server.use(...mocks.transactionPending);
+
+  const { cityInput } = updateAddress(addressName);
+
+  // wait for the edit mode to exit
+  await waitForElementToBeRemoved(cityInput);
+
+  // check that the "we're working on saving your..." message appears
+  const updatingMessage = await view.findByText(
+    new RegExp(`We’re working on saving your new ${addressName}.`, 'i'),
+  );
+  expect(updatingMessage).to.exist;
+
+  server.use(...mocks.transactionSucceeded);
+
+  await waitForElementToBeRemoved(updatingMessage);
+
+  // confirm that the new address appears
+  expect(view.getAllByText(/123 Main St/i).length).to.equal(2);
+  expect(view.getAllByText(/San Francisco, CA 94105/i).length).to.equal(2);
+
+  // and the edit address button should exist
+  expect(
+    view.getByRole('button', { name: new RegExp(`edit.*${addressName}`, 'i') }),
+  ).to.exist;
+
+  // the add address button should not exist
+  expect(
+    view.queryByText(new RegExp(`add.*${addressName}`, 'i'), {
+      selector: 'button',
+    }),
+  ).not.to.exist;
+}
+
+async function testAddressValidation500(addressName) {
+  server.use(...mocks.validateAddressFailure);
+
+  updateAddress(addressName);
+
+  // expect an error to be shown
+  const alert = await view.findByTestId('edit-error-alert');
+  expect(alert).to.have.descendant('div.usa-alert-error');
+  expect(alert).to.contain.text(
+    `We’re sorry. We couldn’t update your ${addressName.toLowerCase()}. Please try again.`,
+  );
+
+  // make sure that edit mode is not automatically exited
+  await wait(75);
+  expect(view.getByTestId('edit-error-alert')).to.exist;
+  const editButton = getEditButton();
+  expect(editButton).to.not.exist;
+}
+
+// When the initial transaction creation request fails
+async function testTransactionCreationFails(addressName) {
+  server.use(...mocks.createTransactionFailure);
+
+  updateAddress(addressName);
+
+  // expect an error to be shown
+  const alert = await view.findByTestId('edit-error-alert');
+  expect(alert).to.have.descendant('div.usa-alert-error');
+  expect(alert).to.contain.text(
+    `We’re sorry. We couldn’t update your ${addressName.toLowerCase()}. Please try again.`,
+  );
+
+  // make sure that edit mode is not automatically exited
+  await wait(75);
+  expect(view.getByTestId('edit-error-alert')).to.exist;
+  const editButton = getEditButton();
+  expect(editButton).to.not.exist;
+}
+
+// When the update fails while the Edit View is still active
+async function testQuickFailure(addressName) {
+  server.use(...mocks.transactionFailed);
+
+  updateAddress(addressName);
+
+  // expect an error to be shown
+  const alert = await view.findByTestId('edit-error-alert');
+  expect(alert).to.have.descendant('div.usa-alert-error');
+  expect(alert).to.contain.text(
+    `We’re sorry. We couldn’t update your ${addressName.toLowerCase()}. Please try again.`,
+  );
+
+  // make sure that edit mode is not automatically exited
+  await wait(75);
+  expect(view.getByTestId('edit-error-alert')).to.exist;
+  const editButton = getEditButton();
+  expect(editButton).to.not.exist;
+}
+
+// When the update fails but not until after the Edit View has exited and the
+// user returned to the read-only view
+async function testSlowFailure(addressName) {
+  server.use(...mocks.transactionPending);
+
+  const { cityInput } = updateAddress(addressName);
+
+  // wait for the edit mode to exit
+  await waitForElementToBeRemoved(cityInput);
+
+  // check that the "we're working on saving your..." message appears
+  const updatingMessage = await view.findByText(
+    new RegExp(`We’re working on saving your new ${addressName}.`, 'i'),
+  );
+  expect(updatingMessage).to.exist;
+
+  server.use(...mocks.transactionFailed);
+
+  await waitForElementToBeRemoved(updatingMessage);
+
+  // make sure the error message appears
+  expect(
+    view.getByText(
+      /We couldn’t save your recent .* update. Please try again later/i,
+    ),
+  ).to.exist;
+
+  // and the add/edit button should be back
+  expect(getEditButton(addressName)).to.exist;
+}
+
+describe('Updating', () => {
+  before(() => {
+    // before we can use msw, we need to make sure that global.fetch has been
+    // restored and is no longer a sinon stub.
+    resetFetch();
+    server = setupServer(...mocks.editAddressSuccess);
+    server.listen();
+  });
+  beforeEach(() => {
+    window.VetsGov = { pollTimeout: 1 };
+    const initialState = createBasicInitialState();
+
+    view = renderWithProfileReducers(ui, {
+      initialState,
+    });
+  });
+  afterEach(() => {
+    server.resetHandlers();
+  });
+  after(() => {
+    server.close();
+  });
+
+  // the list of address fields that we need to test
+  const addresses = [
+    FIELD_NAMES.MAILING_ADDRESS,
+    FIELD_NAMES.RESIDENTIAL_ADDRESS,
+  ];
+
+  addresses.forEach(address => {
+    const addressName = FIELD_TITLES[address];
+    describe(`${addressName} when the entered address passes address validation`, () => {
+      it('should handle a transaction that succeeds quickly', async () => {
+        await testQuickSuccess(addressName);
+      });
+      it('should handle a transaction that does not succeed until after the edit view exits', async () => {
+        await testSlowSuccess(addressName);
+      });
+      // TODO: this test does not pass. If the address validation API fails, we exit edit mode when we should actually keep it open. So we should fix the edit address flow to make this pass.
+      it.skip('should show an error and not auto-exit edit mode if the address validation API errors', async () => {
+        await testAddressValidation500(addressName);
+      });
+      it('should show an error and not auto-exit edit mode if the transaction cannot be created', async () => {
+        await testTransactionCreationFails(addressName);
+      });
+      it('should show an error and not auto-exit edit mode if the transaction fails quickly', async () => {
+        await testQuickFailure(addressName);
+      });
+      it('should show an error if the transaction fails after the edit view exits', async () => {
+        await testSlowFailure(addressName);
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Description
Sorry, half of this is API mocks.

This adds RTL tests to make sure that happy and sad paths are handled for editing and deleting addresses.

## Testing done
Make sure the app properly handles editing and deleting addresses when the API behaves or misbehaves.

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs