### PR TITLE
11307: Correction of 508 defect

### DIFF
--- a/src/applications/gi/components/profile/EstimateYourBenefitsForm.jsx
+++ b/src/applications/gi/components/profile/EstimateYourBenefitsForm.jsx
@@ -311,13 +311,6 @@ class EstimateYourBenefitsForm extends React.Component {
     this.handleAccordionFocus();
   };
 
-  handleEYBSkipLinkOnClick = () => {
-    scroller.scrollTo('estimated-benefits', getScrollOptions());
-    setTimeout(() => {
-      focusElement('#estimated-benefits');
-    }, 50);
-  };
-
   /**
    * Renders a learn more label with common props for this component being set
    * @param text
@@ -1044,14 +1037,13 @@ class EstimateYourBenefitsForm extends React.Component {
   renderEYBSkipLink = () => {
     return (
       <div className="vads-u-padding-bottom--2p5">
-        <button
-          type="button"
+        <a
           className="va-button-link learn-more-button eyb-skip-link"
           aria-label="Skip to your estimated benefits"
-          onClick={this.handleEYBSkipLinkOnClick}
+          href="#estimated-benefits"
         >
           Skip to your estimated benefits
-        </button>
+        </a>
       </div>
     );
   };

--- a/src/applications/gi/components/vet-tec/VetTecEstimateYourBenefitsForm.jsx
+++ b/src/applications/gi/components/vet-tec/VetTecEstimateYourBenefitsForm.jsx
@@ -221,14 +221,13 @@ class VetTecEstimateYourBenefitsForm extends React.Component {
           Update benefits
         </button>
         <div className="vads-u-padding-bottom--2p5">
-          <button
-            type="button"
+          <a
             className="va-button-link learn-more-button eyb-skip-link"
             aria-label="Skip to your estimated benefits"
             onClick={this.handleEYBSkipLinkOnClick}
           >
             Skip to your estimated benefits
-          </button>
+          </a>
         </div>
       </div>
     );

--- a/src/applications/gi/components/vet-tec/VetTecEstimateYourBenefitsForm.jsx
+++ b/src/applications/gi/components/vet-tec/VetTecEstimateYourBenefitsForm.jsx
@@ -221,13 +221,14 @@ class VetTecEstimateYourBenefitsForm extends React.Component {
           Update benefits
         </button>
         <div className="vads-u-padding-bottom--2p5">
-          <a
+          <button
+            type="button"
             className="va-button-link learn-more-button eyb-skip-link"
             aria-label="Skip to your estimated benefits"
             onClick={this.handleEYBSkipLinkOnClick}
           >
             Skip to your estimated benefits
-          </a>
+          </button>
         </div>
       </div>
     );


### PR DESCRIPTION
## Description
The skip to your estimated benefits functionality is not working in IE11. I believe this has to do with the skip being a button instead of an in-page link. Screen shot and code snippet attached below.

[Originating Issue](https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/11307)

## Testing done
Behavior is not present in IE11

## Screenshots
N/A

## Acceptance criteria
- [x] Correction of 508 defect

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
