### PR TITLE
[Development] Dynamically update 526 content for BDD flow

### DIFF
--- a/src/applications/disability-benefits/all-claims/components/ITFBanner.jsx
+++ b/src/applications/disability-benefits/all-claims/components/ITFBanner.jsx
@@ -55,13 +55,19 @@ export default class ITFBanner extends React.Component {
     }
 
     return (
-      <div className="usa-grid vads-u-margin-bottom--2">
-        {message}
-        {this.props.status !== 'error' && (
-          <button className="usa-button-primary" onClick={this.dismissMessage}>
-            Continue
-          </button>
-        )}
+      <div className="row">
+        <div className="usa-width-two-thirds medium-8 columns vads-u-margin-bottom--2">
+          <h1>{this.props.title}</h1>
+          {message}
+          {this.props.status !== 'error' && (
+            <button
+              className="usa-button-primary"
+              onClick={this.dismissMessage}
+            >
+              Continue
+            </button>
+          )}
+        </div>
       </div>
     );
   }
@@ -69,6 +75,7 @@ export default class ITFBanner extends React.Component {
 
 ITFBanner.propTypes = {
   status: PropTypes.oneOf(['error', 'itf-found', 'itf-created']).isRequired,
+  title: PropTypes.string,
   previousITF: PropTypes.object,
   currentExpDate: PropTypes.string,
   previousExpDate: PropTypes.string,

--- a/src/applications/disability-benefits/all-claims/components/IntroductionPage.jsx
+++ b/src/applications/disability-benefits/all-claims/components/IntroductionPage.jsx
@@ -14,7 +14,7 @@ import { selectAvailableServices } from 'platform/user/selectors';
 import { itfNotice } from '../content/introductionPage';
 import { originalClaimsFeature } from '../config/selectors';
 import fileOriginalClaimPage from '../../wizard/pages/file-original-claim';
-import { getPageTitle, getStartText } from '../utils';
+import { isBDD, getPageTitle, getStartText } from '../utils';
 
 class IntroductionPage extends React.Component {
   componentDidMount() {
@@ -30,9 +30,9 @@ class IntroductionPage extends React.Component {
       : true; // services.includes('form526'); // <- "form526" service should
     // be required to proceed; not changing this now in case it breaks something
 
-    // no formData to pass in at this point
-    const pageTitle = getPageTitle();
-    const startText = getStartText();
+    const isBDDForm = this.props.isBDDForm;
+    const pageTitle = getPageTitle(isBDDForm);
+    const startText = getStartText(isBDDForm);
 
     // Remove this once we original claims feature toggle is set to 100%
     if (!allowContinue) {
@@ -201,6 +201,7 @@ const mapStateToProps = state => ({
   formId: state.form.formId,
   user: state.user,
   allowOriginalClaim: originalClaimsFeature(state),
+  isBDDForm: isBDD(state?.form?.data),
 });
 
 IntroductionPage.propTypes = {
@@ -213,6 +214,7 @@ IntroductionPage.propTypes = {
   }).isRequired,
   user: PropTypes.shape({}),
   allowOriginalClaim: PropTypes.bool,
+  isBDDForm: PropTypes.bool,
 };
 
 export default connect(mapStateToProps)(IntroductionPage);

--- a/src/applications/disability-benefits/all-claims/components/IntroductionPage.jsx
+++ b/src/applications/disability-benefits/all-claims/components/IntroductionPage.jsx
@@ -15,6 +15,7 @@ import { itfNotice } from '../content/introductionPage';
 import { originalClaimsFeature } from '../config/selectors';
 import fileOriginalClaimPage from '../../wizard/pages/file-original-claim';
 import { isBDD, getPageTitle, getStartText } from '../utils';
+import { BDD_INFO_URL } from '../constants';
 
 class IntroductionPage extends React.Component {
   componentDidMount() {
@@ -43,13 +44,37 @@ class IntroductionPage extends React.Component {
         </div>
       );
     }
+    const subwayTitle = `Follow the steps below to file ${
+      isBDDForm
+        ? 'a BDD claim.'
+        : 'a claim for a new or secondary condition or for increased disability compensation.'
+    }`;
+
     return (
       <div className="schemaform-intro">
         <FormTitle title={pageTitle} />
-        <p>
-          Equal to VA Form 21-526EZ (Application for Disability Compensation and
-          Related Compensation Benefits).
-        </p>
+        {isBDDForm ? (
+          <>
+            <h2 className="vads-u-font-size--h4">
+              Benefits Delivery at Discharge (BDD)
+            </h2>
+            <p>
+              Service members who have an illness or injury that was caused
+              &mdash;or made worse&mdash;by their active duty service, can file
+              for disability benefits 180 to 90 days before they leave the
+              military through the Benefits Delivery at Discharge (BDD) program.
+            </p>
+            <a href={BDD_INFO_URL}>
+              Learn more about Benefits Delivery at Discharge (BDD)
+            </a>
+            <p />
+          </>
+        ) : (
+          <p>
+            Equal to VA Form 21-526EZ (Application for Disability Compensation
+            and Related Compensation Benefits).
+          </p>
+        )}
         <SaveInProgressIntro
           hideUnauthedStartLink
           prefillEnabled={this.props.route.formConfig.prefillEnabled}
@@ -60,25 +85,18 @@ class IntroductionPage extends React.Component {
           downtime={this.props.route.formConfig.downtime}
         />
         {itfNotice}
-        <h2 className="vads-u-font-size--h4">
-          Follow the steps below to file a claim for a new or secondary
-          condition or for increased disability compensation.
-        </h2>
+        <h2 className="vads-u-font-size--h4">{subwayTitle}</h2>
         <div className="process schemaform-process">
           <ol>
             <li className="process-step list-one">
-              <div>
-                <h3 className="vads-u-font-size--h5">Prepare</h3>
-              </div>
-              <div>
-                <h4 className="vads-u-font-size--h6">
-                  When you file a disability claim, you’ll have a chance to
-                  provide evidence to support your claim. Evidence could
-                  include:
-                </h4>
-              </div>
+              <h3 className="vads-u-font-size--h4">Prepare</h3>
+              <h4 className="vads-u-font-size--h6">
+                When you file a disability claim, you’ll have a chance to
+                provide evidence to support your claim. Evidence could include:
+              </h4>
               <ul>
                 <li>
+                  {isBDDForm ? 'Service treatment records, ' : ''}
                   VA medical records and hospital records that relate to your
                   claimed condition or that show your rated disability has
                   gotten worse
@@ -94,21 +112,35 @@ class IntroductionPage extends React.Component {
                   your disability happened or how it got worse
                 </li>
               </ul>
-              <p>
-                In some cases, you may need to turn in one or more additional
-                forms to support your disability claim. For example, you’ll need
-                to fill out another form if you’re claiming a dependent or
-                applying for aid and attendance benefits.
-                <br />
-                <a href="/disability/how-to-file-claim/supplemental-forms/">
-                  Learn what additional forms you may need to file with your
-                  disability claim
-                </a>
-                .
-              </p>
-              <p>
-                <strong>What if I need help with my application?</strong>
-              </p>
+              {isBDDForm ? (
+                <div className="usa-alert usa-alert-info background-color-only vads-u-margin-bottom--4">
+                  <strong className="usa-alert-body">
+                    Please be aware that you will need to be available for 45
+                    days after you file in order to complete VA exams during
+                    this period.
+                  </strong>
+                </div>
+              ) : (
+                <>
+                  <p>
+                    In some cases, you may need to turn in one or more
+                    additional forms to support your disability claim. For
+                    example, you’ll need to fill out another form if you’re
+                    claiming a dependent or applying for aid and attendance
+                    benefits.
+                  </p>
+                  <p>
+                    <a href="/disability/how-to-file-claim/supplemental-forms/">
+                      Learn what additional forms you may need to file with your
+                      disability claim
+                    </a>
+                    .
+                  </p>
+                </>
+              )}
+              <h4 className="vads-u-font-size--h6">
+                What if I need help with my application?
+              </h4>
               <p>
                 If you need help filing a disability claim, you can contact a VA
                 regional office and ask to speak to a counselor. To find the
@@ -125,42 +157,59 @@ class IntroductionPage extends React.Component {
                 </a>
                 .
               </p>
-              <div>
-                <div className="usa-alert usa-alert-info">
-                  <div className="usa-alert-body">
-                    <p>
-                      <strong>Disability ratings</strong>
-                    </p>
-                    <p>
-                      For each disability we assign a rating from 0% to 100%. We
-                      base this rating on the evidence you turn in with your
-                      claim. In some cases we may also ask you to have an exam
-                      to help us rate your disability.
-                    </p>
-                    <p>
-                      Before filing a claim for increase, you might want to
-                      check to see if you’re already receiving the maximum
-                      disability rating for your condition.
-                    </p>
+              {!isBDDForm && (
+                <div>
+                  <div className="usa-alert usa-alert-info">
+                    <div className="usa-alert-body">
+                      <h4 className="vads-u-font-size--h6">
+                        Disability ratings
+                      </h4>
+                      <p>
+                        For each disability we assign a rating from 0% to 100%.
+                        We base this rating on the evidence you turn in with
+                        your claim. In some cases we may also ask you to have an
+                        exam to help us rate your disability.
+                      </p>
+                      <p>
+                        Before filing a claim for increase, you might want to
+                        check to see if you’re already receiving the maximum
+                        disability rating for your condition.
+                      </p>
+                    </div>
                   </div>
+                  <br />
                 </div>
-                <br />
-              </div>
+              )}
             </li>
             <li className="process-step list-two">
-              <div>
-                <h3 className="vads-u-font-size--h5">Apply</h3>
-              </div>
-              <p>
-                Complete this disability compensation benefits form. After
-                submitting the form, you’ll get a confirmation message. You can
-                print this for your records.
-              </p>
+              <h3 className="vads-u-font-size--h4">Apply</h3>
+              {isBDDForm ? (
+                <>
+                  <h4 className="vads-u-font-size--h6">
+                    Complete the Benefits Delivery at Discharge form. These are
+                    the steps you can expect:
+                  </h4>
+                  <ul>
+                    <li>Provide your Service Member information</li>
+                    <li>Provide your military history</li>
+                    <li>
+                      Describe the conditions you are submitting (a) claim(s)
+                      for
+                    </li>
+                  </ul>
+                  After submitting the form, you’ll get a confirmation message.
+                  You can print this for your records.
+                </>
+              ) : (
+                <p>
+                  Complete this disability compensation benefits form. After
+                  submitting the form, you’ll get a confirmation message. You
+                  can print this for your records.
+                </p>
+              )}
             </li>
             <li className="process-step list-three">
-              <div>
-                <h3 className="vads-u-font-size--h5">VA Review</h3>
-              </div>
+              <h3 className="vads-u-font-size--h4">VA Review</h3>
               <p>
                 We process applications in the order we receive them. The amount
                 of time it takes to process your claim depends on how many
@@ -169,9 +218,7 @@ class IntroductionPage extends React.Component {
               </p>
             </li>
             <li className="process-step list-four">
-              <div>
-                <h3 className="vads-u-font-size--h5">Decision</h3>
-              </div>
+              <h3 className="vads-u-font-size--h4">Decision</h3>
               <p>
                 Once we’ve processed your claim, you’ll get a notice in the mail
                 with our decision.

--- a/src/applications/disability-benefits/all-claims/components/IntroductionPage.jsx
+++ b/src/applications/disability-benefits/all-claims/components/IntroductionPage.jsx
@@ -14,6 +14,7 @@ import { selectAvailableServices } from 'platform/user/selectors';
 import { itfNotice } from '../content/introductionPage';
 import { originalClaimsFeature } from '../config/selectors';
 import fileOriginalClaimPage from '../../wizard/pages/file-original-claim';
+import { getPageTitle, getStartText } from '../utils';
 
 class IntroductionPage extends React.Component {
   componentDidMount() {
@@ -29,18 +30,22 @@ class IntroductionPage extends React.Component {
       : true; // services.includes('form526'); // <- "form526" service should
     // be required to proceed; not changing this now in case it breaks something
 
+    // no formData to pass in at this point
+    const pageTitle = getPageTitle();
+    const startText = getStartText();
+
     // Remove this once we original claims feature toggle is set to 100%
     if (!allowContinue) {
       return (
         <div className="schemaform-intro">
-          <FormTitle title="File for disability compensation" />
+          <FormTitle title={pageTitle} />
           <fileOriginalClaimPage.component props={this.props} />
         </div>
       );
     }
     return (
       <div className="schemaform-intro">
-        <FormTitle title="File for disability compensation" />
+        <FormTitle title={pageTitle} />
         <p>
           Equal to VA Form 21-526EZ (Application for Disability Compensation and
           Related Compensation Benefits).
@@ -50,7 +55,7 @@ class IntroductionPage extends React.Component {
           prefillEnabled={this.props.route.formConfig.prefillEnabled}
           formId={this.props.formId}
           pageList={this.props.route.pageList}
-          startText="Start the Disability Compensation Application"
+          startText={startText}
           retentionPeriod="1 year"
           downtime={this.props.route.formConfig.downtime}
         />
@@ -180,7 +185,7 @@ class IntroductionPage extends React.Component {
           prefillEnabled={this.props.route.formConfig.prefillEnabled}
           formId={this.props.formId}
           pageList={this.props.route.pageList}
-          startText="Start the Disability Compensation Application"
+          startText={startText}
           downtime={this.props.route.formConfig.downtime}
         />
         {itfNotice}

--- a/src/applications/disability-benefits/all-claims/config/form.js
+++ b/src/applications/disability-benefits/all-claims/config/form.js
@@ -39,6 +39,7 @@ import {
   DISABILITY_SHARED_CONFIG,
   isBDD,
   showSeparationLocation,
+  getPageTitle,
 } from '../utils';
 
 import captureEvents from '../analytics-functions';
@@ -157,7 +158,7 @@ const formConfig = {
   defaultDefinitions: {
     ...fullSchema.definitions,
   },
-  title: 'File for disability compensation',
+  title: ({ formData }) => getPageTitle(formData),
   subTitle: 'Form 21-526EZ',
   preSubmitInfo,
   chapters: {

--- a/src/applications/disability-benefits/all-claims/constants.js
+++ b/src/applications/disability-benefits/all-claims/constants.js
@@ -264,7 +264,7 @@ export const DATE_FORMAT = 'LL';
 // sessionStorage key used to show the wizard has or hasn't been completed
 export const WIZARD_STATUS = 'wizardStatus';
 // sessionStorage key used to determine if the form title should be set to BDD
-export const WIZARD_STATUS_BDD = 'wizardStatusBdd';
+export const FORM_STATUS_BDD = 'formStatusBdd';
 
 // sessionStorage key used for the user entered separation date in the wizard
 // used by the first page of the form to populate the form data

--- a/src/applications/disability-benefits/all-claims/constants.js
+++ b/src/applications/disability-benefits/all-claims/constants.js
@@ -2,6 +2,16 @@ import { pciuStates as PCIU_STATES } from 'vets-json-schema/dist/constants.json'
 
 import disabilityLabels from './content/disabilityLabels';
 
+export const PAGE_TITLES = {
+  ALL: 'File for disability compensation',
+  BDD: 'File for Benefits Disability at Discharge',
+};
+
+export const START_TEXT = {
+  ALL: 'Start the Disability Compensation Application',
+  BDD: 'Start the Benefits Disability at Discharge Application',
+};
+
 export const itfStatuses = {
   active: 'active',
   expired: 'expired',
@@ -253,6 +263,8 @@ export const DATE_FORMAT = 'LL';
 
 // sessionStorage key used to show the wizard has or hasn't been completed
 export const WIZARD_STATUS = 'wizardStatus';
+// sessionStorage key used to determine if the form title should be set to BDD
+export const WIZARD_STATUS_BDD = 'wizardStatusBdd';
 
 // sessionStorage key used for the user entered separation date in the wizard
 // used by the first page of the form to populate the form data

--- a/src/applications/disability-benefits/all-claims/containers/AddPerson.jsx
+++ b/src/applications/disability-benefits/all-claims/containers/AddPerson.jsx
@@ -16,8 +16,9 @@ import {
 const message =
   'We’re doing some additional work to enable you to file a claim...';
 
-const loading = (
+const loading = title => (
   <div className="vads-u-margin--3">
+    <h1>{title}</h1>
     <LoadingIndicator message={message} />
   </div>
 );
@@ -28,9 +29,9 @@ export const AddPerson = props => {
       props.addPerson();
       return null;
     case MVI_ADD_INITIATED:
-      return loading;
+      return loading(props.title);
     case MVI_ADD_FAILED:
-      return <MissingServices />;
+      return <MissingServices title={props.title} />;
     case MVI_ADD_SUCCEEDED:
       // remove 'add-person' user.profile.services here?
       return null;
@@ -41,6 +42,7 @@ export const AddPerson = props => {
 
 AddPerson.propTypes = {
   addPerson: PropTypes.func.isRequired,
+  title: PropTypes.string,
 };
 
 const mapDispatchToProps = {

--- a/src/applications/disability-benefits/all-claims/containers/ITFWrapper.jsx
+++ b/src/applications/disability-benefits/all-claims/containers/ITFWrapper.jsx
@@ -70,7 +70,7 @@ export class ITFWrapper extends React.Component {
   }
 
   render() {
-    const { itf } = this.props;
+    const { itf, title } = this.props;
 
     if (this.shouldBlockITF(this.props.location.pathname)) {
       return this.props.children;
@@ -78,13 +78,16 @@ export class ITFWrapper extends React.Component {
       // If we get here, componentDidMount or componentWillRecieveProps called
       // fetchITF; While we're waiting, show the loading indicator...
       return (
-        <div className="vads-u-margin-bottom--4">
-          <LoadingIndicator message="Please wait while we check to see if you have an existing Intent to File." />
+        <div className="row">
+          <div className="usa-width-two-thirds medium-8 columns vads-u-margin-bottom--4">
+            <h1>{title}</h1>
+            <LoadingIndicator message="Please wait while we check to see if you have an existing Intent to File." />
+          </div>
         </div>
       );
     } else if (itf.fetchCallState === requestStates.failed) {
       // We'll get here after the fetchITF promise is fulfilled
-      return <ITFBanner status="error" />;
+      return <ITFBanner title={title} status="error" />;
     } else if (itf?.currentITF?.status === itfStatuses.active) {
       const status =
         itf.creationCallState === 'succeeded' ? 'itf-created' : 'itf-found';
@@ -96,6 +99,7 @@ export class ITFWrapper extends React.Component {
         // success message
         return (
           <ITFBanner
+            title={title}
             status={status}
             previousITF={itf.previousITF}
             currentExpDate={currentExpDate}
@@ -108,7 +112,11 @@ export class ITFWrapper extends React.Component {
 
       // Else we fetched an active ITF
       return (
-        <ITFBanner status={status} currentExpDate={currentExpDate}>
+        <ITFBanner
+          title={title}
+          status={status}
+          currentExpDate={currentExpDate}
+        >
           {this.props.children}
         </ITFBanner>
       );
@@ -116,15 +124,18 @@ export class ITFWrapper extends React.Component {
       // componentWillRecieveProps called createITF if there was no active ITF
       // found; While we're waiting (again), show the loading indicator...again
       return (
-        <div className="vads-u-margin-bottom--4">
-          <LoadingIndicator message="Submitting a new Intent to File..." />
+        <div className="row">
+          <div className="usa-width-two-thirds medium-8 columns vads-u-margin-bottom--4">
+            <h1>{title}</h1>
+            <LoadingIndicator message="Submitting a new Intent to File..." />
+          </div>
         </div>
       );
     }
 
     // We'll get here after the createITF promise is fulfilled and we have no
     // active ITF because of a failed creation call
-    return <ITFBanner status="error" />;
+    return <ITFBanner title={title} status="error" />;
   }
 }
 

--- a/src/applications/disability-benefits/all-claims/containers/MissingServices.jsx
+++ b/src/applications/disability-benefits/all-claims/containers/MissingServices.jsx
@@ -16,16 +16,16 @@ const Alert = ({ content }) => (
   </div>
 );
 
-export const MissingServices = () => {
-  const title = getPageTitle().toLowerCase();
+export const MissingServices = ({ title }) => {
+  const titleLowerCase = title?.toLowerCase();
   const content = (
     <>
       <h2 className="vads-u-display--inline-block vads-u-font-size--h3 vads-u-margin-top--0">
         We need some information for your application
       </h2>
       <p>
-        We need more information from you before you can {title}. Please call
-        Veterans Benefits Assistance at{' '}
+        We need more information from you before you can {titleLowerCase}.
+        Please call Veterans Benefits Assistance at{' '}
         <Telephone contact={CONTACTS.VA_BENEFITS} /> (TTY:{' '}
         <Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />
         ), Monday through Friday, 8:00 a.m. to 9:00 p.m. ET to update your
@@ -33,11 +33,16 @@ export const MissingServices = () => {
       </p>
     </>
   );
-  return <Alert content={content} />;
+  return (
+    <>
+      <h1>{title}</h1>
+      <Alert content={content} />
+    </>
+  );
 };
 
-export const MissingId = () => {
-  const title = getPageTitle().toLowerCase();
+export const MissingId = ({ title }) => {
+  const titleLowerCase = title?.toLowerCase() || '';
   const content = (
     <>
       <h2 className="vads-u-display--inline-block vads-u-font-size--h3 vads-u-margin-top--0">
@@ -45,8 +50,8 @@ export const MissingId = () => {
       </h2>
       <p>
         We don’t have all of your ID information for your account. We need this
-        information before you can {title}. To update your account, please call
-        Veterans Benefits Assistance at{' '}
+        information before you can {titleLowerCase}. To update your account,
+        please call Veterans Benefits Assistance at{' '}
         <Telephone contact={CONTACTS.VA_BENEFITS} /> (TTY:
         <Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />
         ). We’re here Monday through Friday, 8:00 a.m. to 9:00 p.m. ET.
@@ -64,5 +69,10 @@ export const MissingId = () => {
       </p>
     </>
   );
-  return <Alert content={content} />;
+  return (
+    <>
+      <h1>{title}</h1>
+      <Alert content={content} />
+    </>
+  );
 };

--- a/src/applications/disability-benefits/all-claims/containers/MissingServices.jsx
+++ b/src/applications/disability-benefits/all-claims/containers/MissingServices.jsx
@@ -5,24 +5,27 @@ import Telephone, {
   PATTERNS,
 } from '@department-of-veterans-affairs/formation-react/Telephone';
 
+import { getPageTitle } from '../utils';
+
 const Alert = ({ content }) => (
   <div className="vads-l-grid-container vads-u-padding-bottom--5">
     <div className="usa-content">
-      <h1>File for Disability Compensation</h1>
+      <h1>{getPageTitle()}</h1>
       <AlertBox isVisible content={content} status="error" />
     </div>
   </div>
 );
 
 export const MissingServices = () => {
+  const title = getPageTitle().toLowerCase();
   const content = (
     <>
       <h2 className="vads-u-display--inline-block vads-u-font-size--h3 vads-u-margin-top--0">
         We need some information for your application
       </h2>
       <p>
-        We need more information from you before you can file for disability
-        compensation. Please call Veterans Benefits Assistance at{' '}
+        We need more information from you before you can {title}. Please call
+        Veterans Benefits Assistance at{' '}
         <Telephone contact={CONTACTS.VA_BENEFITS} /> (TTY:{' '}
         <Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />
         ), Monday through Friday, 8:00 a.m. to 9:00 p.m. ET to update your
@@ -34,6 +37,7 @@ export const MissingServices = () => {
 };
 
 export const MissingId = () => {
+  const title = getPageTitle().toLowerCase();
   const content = (
     <>
       <h2 className="vads-u-display--inline-block vads-u-font-size--h3 vads-u-margin-top--0">
@@ -41,8 +45,8 @@ export const MissingId = () => {
       </h2>
       <p>
         We don’t have all of your ID information for your account. We need this
-        information before you can file for disability compensation. To update
-        your account, please call Veterans Benefits Assistance at{' '}
+        information before you can {title}. To update your account, please call
+        Veterans Benefits Assistance at{' '}
         <Telephone contact={CONTACTS.VA_BENEFITS} /> (TTY:
         <Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />
         ). We’re here Monday through Friday, 8:00 a.m. to 9:00 p.m. ET.

--- a/src/applications/disability-benefits/all-claims/containers/WizardContainer.jsx
+++ b/src/applications/disability-benefits/all-claims/containers/WizardContainer.jsx
@@ -8,11 +8,12 @@ import Wizard, {
 
 import pages from '../../wizard/pages';
 import formConfig from '../config/form';
+import { getPageTitle } from '../utils';
 
 const WizardContainer = ({ setWizardStatus }) => (
   <div className="row">
     <div className="usa-width-two-thirds medium-8 columns">
-      <h1>File for disability compensation</h1>
+      <h1>{getPageTitle()}</h1>
       <p>
         Equal to VA Form 21-526EZ (Application for Disability Compensation and
         Related Compensation Benefits).

--- a/src/applications/disability-benefits/all-claims/content/introductionPage.jsx
+++ b/src/applications/disability-benefits/all-claims/content/introductionPage.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 export const itfNotice = (
-  <p>
+  <p className="vads-u-margin-top--0">
     By clicking the button to start the disability application, you’ll declare
     your intent to file. This will reserve a potential effective date for when
     you could start getting benefits. You have 1 year from the day you submit

--- a/src/applications/disability-benefits/all-claims/tests/containers/IntroductionPage.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/containers/IntroductionPage.unit.spec.jsx
@@ -1,10 +1,20 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import { expect } from 'chai';
+import moment from 'moment';
+
+import { sessionStorageSetup } from 'platform/testing/utilities';
+
 import { IntroductionPage } from '../../components/IntroductionPage';
 import formConfig from '../../config/form';
+import {
+  PAGE_TITLES,
+  START_TEXT,
+  SAVED_SEPARATION_DATE,
+} from '../../constants';
 
 describe('<IntroductionPage/>', () => {
+  sessionStorageSetup();
   const { formId, prefillEnabled } = formConfig;
   const defaultProps = {
     formId,
@@ -21,6 +31,10 @@ describe('<IntroductionPage/>', () => {
       },
     },
   };
+
+  afterEach(() => {
+    sessionStorage.removeItem(SAVED_SEPARATION_DATE);
+  });
 
   const originalClaimsProps = allow => ({
     ...defaultProps,
@@ -41,15 +55,45 @@ describe('<IntroductionPage/>', () => {
 
   it('should render a form title', () => {
     const wrapper = shallow(<IntroductionPage {...defaultProps} />);
-    expect(wrapper.find('FormTitle').length).to.equal(1);
+    const title = wrapper.find('FormTitle');
+    expect(title.length).to.equal(1);
+    expect(title.props().title).to.equal(PAGE_TITLES.ALL);
+    wrapper.unmount();
+  });
+
+  it('should render a BDD form title', () => {
+    sessionStorage.setItem(
+      SAVED_SEPARATION_DATE,
+      moment()
+        .add(90, 'days')
+        .format('YYYY-MM-DD'),
+    );
+    const wrapper = shallow(<IntroductionPage {...defaultProps} />);
+    const title = wrapper.find('FormTitle');
+    expect(title.length).to.equal(1);
+    expect(title.props().title).to.equal(PAGE_TITLES.BDD);
     wrapper.unmount();
   });
 
   it('should render 2 SiP intros', () => {
     const wrapper = shallow(<IntroductionPage {...defaultProps} />);
-    expect(
-      wrapper.find('withRouter(Connect(SaveInProgressIntro))').length,
-    ).to.equal(2);
+    const sipIntro = wrapper.find('withRouter(Connect(SaveInProgressIntro))');
+    expect(sipIntro.length).to.equal(2);
+    expect(sipIntro.first().props().startText).to.equal(START_TEXT.ALL);
+    wrapper.unmount();
+  });
+
+  it('should render BDD SiP intros', () => {
+    sessionStorage.setItem(
+      SAVED_SEPARATION_DATE,
+      moment()
+        .add(90, 'days')
+        .format('YYYY-MM-DD'),
+    );
+    const wrapper = shallow(<IntroductionPage {...defaultProps} />);
+    const sipIntro = wrapper.find('withRouter(Connect(SaveInProgressIntro))');
+    expect(sipIntro.length).to.equal(2);
+    expect(sipIntro.first().props().startText).to.equal(START_TEXT.BDD);
     wrapper.unmount();
   });
 

--- a/src/applications/disability-benefits/all-claims/tests/utils.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/utils.unit.spec.jsx
@@ -3,6 +3,8 @@ import { expect } from 'chai';
 import { shallow } from 'enzyme';
 import moment from 'moment';
 
+import { sessionStorageSetup } from 'platform/testing/utilities';
+import { SAVED_SEPARATION_DATE } from '../../all-claims/constants';
 import {
   makeSchemaForNewDisabilities,
   makeSchemaForRatedDisabilities,
@@ -938,6 +940,7 @@ describe('526 v2 depends functions', () => {
     ratedDisabilities: [{}, {}],
     'view:claimType': {},
   };
+
   describe('newOnly', () => {
     it('should return true if only new conditions are claimed', () => {
       expect(newConditionsOnly(newOnlyData)).to.be.true;
@@ -967,9 +970,9 @@ describe('526 v2 depends functions', () => {
 
   describe('format date & date range', () => {
     it('should format dates with full month names', () => {
-      expect(formatDate(true)).to.be.null;
-      expect(formatDate('foobar')).to.be.null;
-      expect(formatDate('2020-02-31')).to.be.null;
+      expect(formatDate(true)).to.equal('Unknown');
+      expect(formatDate('foobar')).to.equal('Unknown');
+      expect(formatDate('2020-02-31')).to.equal('Unknown');
       expect(formatDate('2020-01-31')).to.equal('January 31, 2020');
       expect(formatDate('2020-04-05')).to.equal('April 5, 2020');
       expect(formatDate('2020-05-05')).to.equal('May 5, 2020');
@@ -992,6 +995,13 @@ describe('526 v2 depends functions', () => {
   });
 
   describe('isBDD', () => {
+    before(() => {
+      sessionStorageSetup();
+    });
+    afterEach(() => {
+      sessionStorage.removeItem(SAVED_SEPARATION_DATE);
+    });
+
     it('should return true if the most recent service period has a separation date 90 to 180 days from today', () => {
       expect(isBDD(isBDDTrueData)).to.be.true;
     });
@@ -999,6 +1009,24 @@ describe('526 v2 depends functions', () => {
       expect(isBDD(isBDDLessThan90Data)).to.be.false;
     });
     it('should return false if no service period is provided with a separation date', () => {
+      expect(isBDD(null)).to.be.false;
+    });
+    it('should return true if a valid date is added to session storage from the wizard', () => {
+      sessionStorage.setItem(
+        SAVED_SEPARATION_DATE,
+        moment()
+          .add(90, 'days')
+          .format('YYYY-MM-DD'),
+      );
+      expect(isBDD(null)).to.be.true;
+    });
+    it('should return false for invalid dates in session storage from the wizard', () => {
+      sessionStorage.setItem(
+        SAVED_SEPARATION_DATE,
+        moment()
+          .add(200, 'days')
+          .format('YYYY-MM-DD'),
+      );
       expect(isBDD(null)).to.be.false;
     });
   });

--- a/src/applications/disability-benefits/all-claims/utils.jsx
+++ b/src/applications/disability-benefits/all-claims/utils.jsx
@@ -842,6 +842,8 @@ export const isBDD = formData => {
   const servicePeriods = formData?.serviceInformation?.servicePeriods;
   // separation date entered in the wizard
   const separationDate = window.sessionStorage.getItem(SAVED_SEPARATION_DATE);
+  // this flag helps maintain the correct form title within a session
+  window.sessionStorage.removeItem(WIZARD_STATUS_BDD);
 
   if ((!servicePeriods || !Array.isArray(servicePeriods)) && !separationDate) {
     return false;
@@ -858,14 +860,19 @@ export const isBDD = formData => {
     return false;
   }
 
-  return (
+  const result =
     mostRecentDate.isAfter(moment().add(89, 'days')) &&
-    !mostRecentDate.isAfter(moment().add(180, 'days'))
-  );
+    !mostRecentDate.isAfter(moment().add(180, 'days'));
+  if (result) {
+    // this flag helps maintain the correct form title within a session
+    window.sessionStorage.setItem(WIZARD_STATUS_BDD, 'true');
+  }
+  return result;
 };
 
 export const getPageTitle = formData => {
   const showBDDTitle =
+    formData === true ||
     isBDD(formData) ||
     window.sessionStorage.getItem(WIZARD_STATUS_BDD) === 'true';
   return PAGE_TITLES[showBDDTitle ? 'BDD' : 'ALL'];

--- a/src/applications/disability-benefits/all-claims/utils.jsx
+++ b/src/applications/disability-benefits/all-claims/utils.jsx
@@ -879,9 +879,11 @@ export const getPageTitle = formData => {
 };
 
 // Intro page doesn't have formData
-export const getStartText = () => {
+export const getStartText = isBDDForm => {
   const showBDDText =
-    isBDD() || window.sessionStorage.getItem(FORM_STATUS_BDD) === 'true';
+    isBDDForm ||
+    isBDD() ||
+    window.sessionStorage.getItem(FORM_STATUS_BDD) === 'true';
   return START_TEXT[showBDDText ? 'BDD' : 'ALL'];
 };
 

--- a/src/applications/disability-benefits/all-claims/utils.jsx
+++ b/src/applications/disability-benefits/all-claims/utils.jsx
@@ -74,7 +74,7 @@ export const srSubstitute = (srIgnored, substitutionText) => (
 
 export const formatDate = (date, format = DATE_FORMAT) => {
   const m = moment(date);
-  return m.isValid() ? m.format(format) : null;
+  return date && m.isValid() ? m.format(format) : 'Unknown';
 };
 
 export const formatDateRange = (dateRange = {}, format = DATE_FORMAT) =>
@@ -83,7 +83,7 @@ export const formatDateRange = (dateRange = {}, format = DATE_FORMAT) =>
         dateRange.to,
         format,
       )}`
-    : null;
+    : 'Unknown';
 
 // moment().isSameOrBefore() => true; so expirationDate can't be undefined
 export const isNotExpired = (expirationDate = '') =>

--- a/src/applications/disability-benefits/all-claims/utils.jsx
+++ b/src/applications/disability-benefits/all-claims/utils.jsx
@@ -40,6 +40,10 @@ import {
   itfStatuses,
   NULL_CONDITION_STRING,
   DATE_FORMAT,
+  SAVED_SEPARATION_DATE,
+  PAGE_TITLES,
+  START_TEXT,
+  WIZARD_STATUS_BDD,
 } from './constants';
 
 /**
@@ -836,15 +840,19 @@ export const DISABILITY_SHARED_CONFIG = {
 
 export const isBDD = formData => {
   const servicePeriods = formData?.serviceInformation?.servicePeriods;
+  // separation date entered in the wizard
+  const separationDate = window.sessionStorage.getItem(SAVED_SEPARATION_DATE);
 
-  if (!servicePeriods || !Array.isArray(servicePeriods)) {
+  if ((!servicePeriods || !Array.isArray(servicePeriods)) && !separationDate) {
     return false;
   }
 
-  const mostRecentDate = servicePeriods
-    .filter(({ dateRange }) => dateRange?.to)
-    .map(({ dateRange }) => moment(dateRange.to))
-    .sort((dateA, dateB) => dateB - dateA)[0];
+  const mostRecentDate = separationDate
+    ? moment(separationDate)
+    : servicePeriods
+        .filter(({ dateRange }) => dateRange?.to)
+        .map(({ dateRange }) => moment(dateRange.to))
+        .sort((dateA, dateB) => dateB - dateA)[0];
 
   if (!mostRecentDate) {
     return false;
@@ -854,6 +862,20 @@ export const isBDD = formData => {
     mostRecentDate.isAfter(moment().add(89, 'days')) &&
     !mostRecentDate.isAfter(moment().add(180, 'days'))
   );
+};
+
+export const getPageTitle = formData => {
+  const showBDDTitle =
+    isBDD(formData) ||
+    window.sessionStorage.getItem(WIZARD_STATUS_BDD) === 'true';
+  return PAGE_TITLES[showBDDTitle ? 'BDD' : 'ALL'];
+};
+
+// Intro page doesn't have formData
+export const getStartText = () => {
+  const showBDDText =
+    isBDD() || window.sessionStorage.getItem(WIZARD_STATUS_BDD) === 'true';
+  return START_TEXT[showBDDText ? 'BDD' : 'ALL'];
 };
 
 export const showSeparationLocation = formData => {

--- a/src/applications/disability-benefits/all-claims/utils.jsx
+++ b/src/applications/disability-benefits/all-claims/utils.jsx
@@ -43,7 +43,7 @@ import {
   SAVED_SEPARATION_DATE,
   PAGE_TITLES,
   START_TEXT,
-  WIZARD_STATUS_BDD,
+  FORM_STATUS_BDD,
 } from './constants';
 
 /**
@@ -843,7 +843,7 @@ export const isBDD = formData => {
   // separation date entered in the wizard
   const separationDate = window.sessionStorage.getItem(SAVED_SEPARATION_DATE);
   // this flag helps maintain the correct form title within a session
-  window.sessionStorage.removeItem(WIZARD_STATUS_BDD);
+  window.sessionStorage.removeItem(FORM_STATUS_BDD);
 
   if ((!servicePeriods || !Array.isArray(servicePeriods)) && !separationDate) {
     return false;
@@ -865,7 +865,7 @@ export const isBDD = formData => {
     !mostRecentDate.isAfter(moment().add(180, 'days'));
   if (result) {
     // this flag helps maintain the correct form title within a session
-    window.sessionStorage.setItem(WIZARD_STATUS_BDD, 'true');
+    window.sessionStorage.setItem(FORM_STATUS_BDD, 'true');
   }
   return result;
 };
@@ -874,14 +874,14 @@ export const getPageTitle = formData => {
   const showBDDTitle =
     formData === true ||
     isBDD(formData) ||
-    window.sessionStorage.getItem(WIZARD_STATUS_BDD) === 'true';
+    window.sessionStorage.getItem(FORM_STATUS_BDD) === 'true';
   return PAGE_TITLES[showBDDTitle ? 'BDD' : 'ALL'];
 };
 
 // Intro page doesn't have formData
 export const getStartText = () => {
   const showBDDText =
-    isBDD() || window.sessionStorage.getItem(WIZARD_STATUS_BDD) === 'true';
+    isBDD() || window.sessionStorage.getItem(FORM_STATUS_BDD) === 'true';
   return START_TEXT[showBDDText ? 'BDD' : 'ALL'];
 };
 

--- a/src/applications/disability-benefits/wizard/WizardLink.jsx
+++ b/src/applications/disability-benefits/wizard/WizardLink.jsx
@@ -14,13 +14,10 @@ const WizardLink = ({ showWizard, module }) => {
   const { Wizard, pages } = module.default;
   return showWizard ? (
     <a href={manifest.rootUrl} className="usa-button-primary va-button-primary">
-      Let&apos;s get started{' '}
-      <img
-        src="/img/arrow-right-white.svg"
-        aria-hidden="true"
-        alt=""
-        style={{ height: '13px', verticalAlign: 'baseline' }}
-      />
+      Let&apos;s get started
+      <span role="img" aria-hidden="true" className="button-icon">
+        &nbsp;»
+      </span>
     </a>
   ) : (
     <Wizard pages={pages} expander buttonText="Let's get started" />

--- a/src/applications/disability-benefits/wizard/pages/bdd.jsx
+++ b/src/applications/disability-benefits/wizard/pages/bdd.jsx
@@ -5,7 +5,7 @@ import { pageNames } from './pageList';
 
 import unableToFileBDDProduction from './unable-to-file-bdd-production';
 import {
-  WIZARD_STATUS_BDD,
+  FORM_STATUS_BDD,
   SAVED_SEPARATION_DATE,
 } from '../../all-claims/constants';
 
@@ -14,10 +14,10 @@ const saveDischargeDate = date => {
     const formattedDate = moment(date).format('YYYY-MM-DD');
     window.sessionStorage.setItem(SAVED_SEPARATION_DATE, formattedDate);
     // this flag helps maintain the correct form title within a session
-    window.sessionStorage.setItem(WIZARD_STATUS_BDD, 'true');
+    window.sessionStorage.setItem(FORM_STATUS_BDD, 'true');
   } else {
     window.sessionStorage.removeItem(SAVED_SEPARATION_DATE);
-    window.sessionStorage.removeItem(WIZARD_STATUS_BDD);
+    window.sessionStorage.removeItem(FORM_STATUS_BDD);
   }
 };
 

--- a/src/applications/disability-benefits/wizard/pages/bdd.jsx
+++ b/src/applications/disability-benefits/wizard/pages/bdd.jsx
@@ -4,14 +4,20 @@ import ErrorableDate from '@department-of-veterans-affairs/formation-react/Error
 import { pageNames } from './pageList';
 
 import unableToFileBDDProduction from './unable-to-file-bdd-production';
-import { SAVED_SEPARATION_DATE } from '../../all-claims/constants';
+import {
+  WIZARD_STATUS_BDD,
+  SAVED_SEPARATION_DATE,
+} from '../../all-claims/constants';
 
 const saveDischargeDate = date => {
   if (date) {
     const formattedDate = moment(date).format('YYYY-MM-DD');
     window.sessionStorage.setItem(SAVED_SEPARATION_DATE, formattedDate);
+    // this flag helps maintain the correct form title within a session
+    window.sessionStorage.setItem(WIZARD_STATUS_BDD, 'true');
   } else {
     window.sessionStorage.removeItem(SAVED_SEPARATION_DATE);
+    window.sessionStorage.removeItem(WIZARD_STATUS_BDD);
   }
 };
 

--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -282,18 +282,7 @@
       "title": "File for disability benefits",
       "layout": "page-react.html",
       "description": "Learn how to apply online for disability compensation.",
-      "hideFromSidebar": true,
-      "includeBreadcrumbs": true,
-      "breadcrumbs_override": [
-        {
-          "name": "Disability Benefits",
-          "path": "disability/"
-        },
-        {
-          "name": "File for Disability Compensation",
-          "path": "disability/file-disability-claim-form-21-526ez"
-        }
-      ]
+      "hideFromSidebar": true
     }
   },
   {

--- a/src/platform/forms/tests/forms.unit.spec.js
+++ b/src/platform/forms/tests/forms.unit.spec.js
@@ -22,6 +22,8 @@ import { VA_FORM_IDS } from 'platform/forms/constants';
 
 import schemas from 'vets-json-schema/dist/schemas';
 
+import { sessionStorageSetup } from 'platform/testing/utilities';
+
 // Maps schema id to config id
 const mappedIds = [
   '10-10EZ',
@@ -86,6 +88,7 @@ const excludedForms = new Set([
 ]);
 
 describe('form:', () => {
+  sessionStorageSetup();
   it('should check all forms', () => {
     const includedSchemaIds = Object.keys(schemas).filter(
       formId => !excludedForms.has(formId),
@@ -158,7 +161,11 @@ describe('form:', () => {
       });
 
       it('should have title', () => {
-        expect(form.title).to.be.a('string');
+        const title =
+          typeof form.title === 'function'
+            ? form.title({ formData: {} })
+            : form.title;
+        expect(title).to.be.a('string');
       });
 
       if (form.subTitle) {


### PR DESCRIPTION
## Description

When a user has entered the Benefits Delivery at Discharge (BDD) flow in form 526, the intro page content, document title (browser tab name), breadcrumb, and page title all need to update.

To accomplish this, the internal `isBDD` is checked and dynamically updates the:
- Introduction page content
- Form title on the introduction page
- Form start button text on the introduction page
- Global form config title
- Added custom breadcrumbs to match the form title to the intro page wrapper (Form526EZApp)
- All titles are auto-updated on the military history page to match the flow.

Additionally, `h1`s were added to intermediate and error pages. The content of which matches the form title for all-claims or BDD.

Related tickets:
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/11188
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/12767
- https://github.com/department-of-veterans-affairs/vets-website/pull/13998

## Testing done

Added unit tests

## Screenshots

<details><summary>All/Original claims intro page view</summary>

<!-- leave a blank line above -->
![form-21-526ez_introduction](https://user-images.githubusercontent.com/136959/91607009-cf163180-e938-11ea-8cae-61fbda150734.png)</details>

<details><summary>BDD intro page view</summary>

<!-- leave a blank line above -->
![form-21-526ez_BDD_introduction](https://user-images.githubusercontent.com/136959/91607082-ea813c80-e938-11ea-904f-a8e601e9fb84.png)</details>

## Acceptance criteria
- [x] Form 526 introduction page shows appropriate all-claims or BDD content
- [x] Document title, breadcrumb and page title all match the current flow throughout the form

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
