### PR TITLE
Do not validate contact info forms when each field blurs

### DIFF
--- a/src/platform/forms-system/src/js/components/SchemaForm.jsx
+++ b/src/platform/forms-system/src/js/components/SchemaForm.jsx
@@ -179,6 +179,7 @@ class SchemaForm extends React.Component {
       safeRenderCompletion,
       name,
       addNameAttribute,
+      liveValidate,
     } = this.props;
 
     const useReviewMode = reviewMode && !editModeOnReviewPage;
@@ -188,7 +189,7 @@ class SchemaForm extends React.Component {
         safeRenderCompletion={safeRenderCompletion}
         FieldTemplate={useReviewMode ? ReviewFieldTemplate : FieldTemplate}
         formContext={this.state.formContext}
-        liveValidate
+        liveValidate={liveValidate}
         noHtml5Validate
         onError={this.onError}
         onBlur={this.onBlur}
@@ -223,6 +224,7 @@ SchemaForm.propTypes = {
   onChange: PropTypes.func,
   hideTitle: PropTypes.bool,
   addNameAttribute: PropTypes.bool,
+  liveValidate: PropTypes.bool,
 };
 
 SchemaForm.defaultProps = {
@@ -235,6 +237,9 @@ SchemaForm.defaultProps = {
   // re: the implicit role:
   // https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form
   addNameAttribute: false,
+  // When `false` the form is not validated when each field is marked as dirty.
+  // Instead, validation only happens before trying to submit the form.
+  liveValidate: true,
 };
 
 export default SchemaForm;

--- a/src/platform/user/profile/vet360/components/ContactInfoForm.jsx
+++ b/src/platform/user/profile/vet360/components/ContactInfoForm.jsx
@@ -17,6 +17,7 @@ const ContactInfoForm = props => (
     }}
     onSubmit={e => props.onSubmit(e)}
     data={props.formData}
+    liveValidate={false}
   >
     {props.children}
   </SchemaForm>

--- a/src/platform/user/profile/vet360/components/base/VAPEditModalActionButtons.jsx
+++ b/src/platform/user/profile/vet360/components/base/VAPEditModalActionButtons.jsx
@@ -132,7 +132,6 @@ VAPEditModalActionButtons.propTypes = {
   deleteEnabled: PropTypes.bool,
   title: PropTypes.string.isRequired,
   onDelete: PropTypes.func.isRequired,
-  onCancel: PropTypes.func.isRequired,
   isLoading: PropTypes.bool,
 };
 

--- a/src/platform/user/profile/vet360/components/base/VAPEditView.jsx
+++ b/src/platform/user/profile/vet360/components/base/VAPEditView.jsx
@@ -103,7 +103,6 @@ class VAPEditView extends Component {
 
     const actionButtons = (
       <VAPEditModalActionButtons
-        onCancel={onCancel}
         onDelete={onDelete}
         title={title}
         analyticsSectionName={analyticsSectionName}


### PR DESCRIPTION
This allows you to cancel out of a form without being warned of errors

## Description


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs