### PR TITLE
[Development] Remove duplicate 526 title

### DIFF
--- a/src/applications/disability-benefits/all-claims/containers/MissingServices.jsx
+++ b/src/applications/disability-benefits/all-claims/containers/MissingServices.jsx
@@ -69,10 +69,5 @@ export const MissingId = ({ title }) => {
       </p>
     </>
   );
-  return (
-    <>
-      <h1>{title}</h1>
-      <Alert content={content} />
-    </>
-  );
+  return <Alert content={content} />;
 };


### PR DESCRIPTION
## Description

While adding `<h1>`s to 526 error pages, the header was duplicated. This PR removes the improperly styled duplicate.

Related issue: https://github.com/department-of-veterans-affairs/va.gov-team/issues/11188

## Testing done

N/A

## Screenshots

N/A

## Acceptance criteria
- [x] A single `h1` is shown on the page

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
