### PR TITLE
[Development] Form 526 Design updates

### DIFF
--- a/src/applications/disability-benefits/all-claims/content/unemployabilityDates.jsx
+++ b/src/applications/disability-benefits/all-claims/content/unemployabilityDates.jsx
@@ -21,7 +21,7 @@ export const dateDescription = (
 );
 
 export const dateFieldsDescription = (
-  <div className="additional-info-title-help">
+  <div className="additional-info-title-help vads-u-margin-top--4">
     <AdditionalInfo
       triggerText="How are these dates different?"
       onClick={helpClicked}

--- a/src/applications/disability-benefits/all-claims/sass/disability-benefits.scss
+++ b/src/applications/disability-benefits/all-claims/sass/disability-benefits.scss
@@ -157,6 +157,12 @@ div.review {
   }
 }
 
+/* Remove bold on New Disability AdditionalInfo link in review #12678 */
+.usa-accordion > ul button.additional-info-button,
+.usa-accordion-bordered > ul button.additional-info-button {
+  font-weight: normal;
+}
+
 @media (min-width: 481px) {
   dl.review,
   div.review {

--- a/src/applications/disability-benefits/all-claims/sass/disability-benefits.scss
+++ b/src/applications/disability-benefits/all-claims/sass/disability-benefits.scss
@@ -49,10 +49,6 @@ ul.original-disability-list {
   }
 }
 
-.progress-box .va-growable button {
-  max-height: 2.3em;
-}
-
 // Bring the text of an element nested in a <label> up to the same line as the check box
 .form-checkbox input[type="checkbox"] + label {
   div {


### PR DESCRIPTION
## Description

- Remove bold from AdditionalInfo dropdown on the review page
- Fix vertical text alignment in secondary buttons
- Add spacing above AdditionalInfo dropdown on unemployability dates page

Related issue: https://github.com/department-of-veterans-affairs/va.gov-team/issues/12678

## Testing done

N/A

## Screenshots

<details><summary>AdditionalInfo before</summary>

<!-- leave a blank line above -->
![](https://camo.githubusercontent.com/75678d6c885af44cbfbc79f743854465bfe296c0/68747470733a2f2f696d616765732e7a656e68756275736572636f6e74656e742e636f6d2f3564386238643433626231373133303030313662663137612f65643164613366332d646639632d343564652d386134632d643434316338636566626162)</details>

<details><summary>AdditionalInfo after</summary>

<!-- leave a blank line above -->
![Screen Shot 2020-08-31 at 3 28 04 PM](https://user-images.githubusercontent.com/136959/91765781-27e70380-eb9f-11ea-991a-e5a24534527b.png)</details>
<details><summary>Button text alignment before</summary>

<!-- leave a blank line above -->
![](https://camo.githubusercontent.com/500649ef1164b651251f66b2f77364f3f9c4d107/68747470733a2f2f696d616765732e7a656e68756275736572636f6e74656e742e636f6d2f3564386238643433626231373133303030313662663137612f39616538386633332d386335612d343134352d626639652d623633653338306561666635)
</details>
<details><summary>Button text alignment after</summary>

<!-- leave a blank line above -->
![Screen Shot 2020-08-31 at 4 03 45 PM](https://user-images.githubusercontent.com/136959/91768784-c37a7300-eba3-11ea-8949-ece0f9980f75.png)</details>

<details><summary>AdditionalInfo spacing before</summary>

<!-- leave a blank line above -->
![](https://camo.githubusercontent.com/3f3f3cd8e304e7149519d28dd7c7f740204f63f7/68747470733a2f2f696d616765732e7a656e68756275736572636f6e74656e742e636f6d2f3564386238643433626231373133303030313662663137612f63623366383431622d363438382d343732362d613165342d653763396538653233346336)
</details>
<details><summary>AdditionalInfo spacing after</summary>

<!-- leave a blank line above -->
![Screen Shot 2020-08-31 at 4 28 13 PM](https://user-images.githubusercontent.com/136959/91770675-333e2d00-eba7-11ea-94b6-f412df30f6ea.png)</details>

## Acceptance criteria
- [x] AdditionalInfo link not bold in review
- [x] Secondary button text has a centered vertical alignment
- [x] Adequate spacing above the AdditionalInfo dropdown

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
