### PR TITLE
Update markup to use dl, dd, dt tags

### DIFF
--- a/src/applications/yellow-ribbon/components/SearchResult/index.jsx
+++ b/src/applications/yellow-ribbon/components/SearchResult/index.jsx
@@ -117,70 +117,70 @@ export const deriveDivisionProfessionalSchool = (school = {}) => {
 export const SearchResult = ({ school }) => (
   <li className="usa-unstyled-list vads-l-col vads-u-margin-bottom--2 vads-u-padding-x--2 vads-u-padding-y--2 vads-u-background-color--gray-light-alt">
     {/* School Name */}
-    <p
-      className="vads-u-font-size--h3 vads-u-font-weight--bold vads-u-font-family--serif vads-u-margin--0"
-      data-e2e-id="result-title"
-    >
-      <span className="sr-only">School name</span>
-      {deriveNameLabel(school)}
-    </p>
+    <dl className="vads-u-margin--0">
+      <dt className="sr-only">School name:</dt>
+      <dd
+        className="vads-u-font-size--h3 vads-u-font-weight--bold vads-u-font-family--serif vads-u-margin--0"
+        data-e2e-id="result-title"
+      >
+        {deriveNameLabel(school)}
+      </dd>
 
-    {/* School Location */}
-    <p className="vads-u-margin-bottom--1 vads-u-margin-top--0">
-      <span className="sr-only">School location</span>
-      {deriveLocationLabel(school)}
-    </p>
+      {/* School Location */}
+      <dt className="sr-only">School location</dt>
+      <dd className="vads-u-margin-bottom--1 vads-u-margin-top--0">
+        {deriveLocationLabel(school)}
+      </dd>
+    </dl>
 
     <div className="vads-l-row vads-u-margin-top--2">
       <div className="vads-l-col--12 vads-u-display--flex vads-u-flex-direction--column vads-u-justify-content--space-between medium-screen:vads-l-col--6">
         {/* Max Contribution Amount */}
         <div className="vads-u-col">
-          <p className="vads-u-font-weight--bold vads-u-font-family--sans vads-u-font-size--h5 vads-u-margin--0">
-            Maximum Yellow Ribbon funding amount
-            <br />
-            (per student, per year)
-            <span className="sr-only">:</span>
-          </p>
-          <p className="vads-u-margin--0">{deriveMaxAmountLabel(school)}</p>
+          <dl className="vads-u-margin--0">
+            <dt className="vads-u-font-weight--bold vads-u-font-family--sans vads-u-font-size--h5 vads-u-margin--0">
+              Maximum Yellow Ribbon funding amount
+              <br />
+              (per student, per year)
+              <dfn className="sr-only">:</dfn>
+            </dt>
+            <dd>{deriveMaxAmountLabel(school)}</dd>
+          </dl>
         </div>
 
         {/* Student Count */}
-        <p className="vads-u-font-weight--bold vads-u-font-family--sans vads-u-font-size--h5 vads-u-margin-top--2 vads-u-margin-bottom--0">
-          Funding available for
-          <span className="sr-only">:</span>
-        </p>
-        <p className="vads-u-margin-top--0 vads-u-margin-bottom--0">
-          {deriveEligibleStudentsLabel(school)}
-        </p>
+        <dl className="vads-u-margin--0">
+          <dt className="vads-u-font-weight--bold vads-u-font-family--sans vads-u-font-size--h5 vads-u-margin-top--2 vads-u-margin-bottom--0">
+            Funding available for
+            <dfn className="sr-only">:</dfn>
+          </dt>
+          <dd>{deriveEligibleStudentsLabel(school)}</dd>
 
-        {/* School Website */}
-        <p className="vads-u-font-weight--bold vads-u-font-family--sans vads-u-font-size--h5 vads-u-margin-top--2 vads-u-margin-bottom--0">
-          School website
-          <span className="sr-only">:</span>
-        </p>
-        <p className="vads-u-margin-top--0 vads-u-margin-bottom--0">
-          {deriveInstURLLabel(school)}
-        </p>
+          {/* School Website */}
+          <dt className="vads-u-font-weight--bold vads-u-font-family--sans vads-u-font-size--h5 vads-u-margin-top--2 vads-u-margin-bottom--0">
+            School website
+            <dfn className="sr-only">:</dfn>
+          </dt>
+          <dd>{deriveInstURLLabel(school)}</dd>
+        </dl>
       </div>
 
       <div className="vads-l-col--12 medium-screen:vads-l-col--6 medium-screen:vads-u-padding-left--2">
-        {/* Degree Level */}
-        <p className="vads-u-font-weight--bold vads-u-margin-top--2 vads-u-margin-bottom--0 vads-u-font-family--sans vads-u-font-size--h5 medium-screen:vads-u-margin--0">
-          Degree type
-          <span className="sr-only">:</span>
-        </p>
-        <p className="vads-u-margin-top--0 vads-u-margin-bottom--0 medium-screen:vads-u-margin--0">
-          {deriveDegreeLevel(school)}
-        </p>
+        <dl className="vads-u-margin--0">
+          {/* Degree Level */}
+          <dt className="vads-u-font-weight--bold vads-u-margin-top--2 vads-u-margin-bottom--0 vads-u-font-family--sans vads-u-font-size--h5 medium-screen:vads-u-margin--0">
+            Degree type
+            <dfn className="sr-only">:</dfn>
+          </dt>
+          <dd>{deriveDegreeLevel(school)}</dd>
 
-        {/* Division Professional School */}
-        <p className="school-program vads-u-font-weight--bold vads-u-margin-top--2 vads-u-margin-bottom--0 vads-u-font-family--sans vads-u-font-size--h5 medium-screen:vads-u-margin-bottom--0">
-          School or program
-          <span className="sr-only">:</span>
-        </p>
-        <p className="vads-u-margin-top--0 vads-u-margin-bottom--0 medium-screen:vads-u-margin--0">
-          {deriveDivisionProfessionalSchool(school)}
-        </p>
+          {/* Division Professional School */}
+          <dt className="school-program vads-u-font-weight--bold vads-u-margin-top--2 vads-u-margin-bottom--0 vads-u-font-family--sans vads-u-font-size--h5 medium-screen:vads-u-margin-bottom--0">
+            School or program
+            <dfn className="sr-only">:</dfn>
+          </dt>
+          <dd>{deriveDivisionProfessionalSchool(school)}</dd>
+        </dl>
       </div>
     </div>
   </li>


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/8791

This PR fixes the markup on each search result for YR to read semantically using `dl`, `dt`, and `dd` tags.

This PR was implemented based on [this helpful resource](https://dequeuniversity.com/rules/axe/3.5/definition-list?application=AxeChrome) from Axe.

## Testing done
N/A

## Screenshots

<img width="1680" alt="desktop" src="https://user-images.githubusercontent.com/12773166/91869171-cd978280-ec32-11ea-9a4b-e6da687c837e.png">

<img width="386" alt="mobile" src="https://user-images.githubusercontent.com/12773166/91869187-d0927300-ec32-11ea-8ed2-04189f43e193.png">

<img width="1680" alt="no-axe-errors" src="https://user-images.githubusercontent.com/12773166/91869192-d12b0980-ec32-11ea-8630-c16e68941810.png">

## Acceptance criteria
- [x] Update markup on YR to read semantically using the best potential fix suggested by Jen S.

![image](https://user-images.githubusercontent.com/12773166/91869049-a5a81f00-ec32-11ea-8e83-9b0456d561b1.png)

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
