### PR TITLE
Update CODEOWNERS for ask-a-question

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -61,6 +61,6 @@ src/applications/coronavirus-research @department-of-veterans-affairs/va-cto-hea
 src/applications/coronavirus-screener @department-of-veterans-affairs/va-cto-health-products
 
 # Other
-src/applications/ask-a-question @department-of-veterans-affairs/thoughtworks
+src/applications/ask-a-question @department-of-veterans-affairs/orchid
 src/applications/coronavirus-chatbot @department-of-veterans-affairs/chatbot-admin
 src/applications/vaos @department-of-veterans-affairs/vfs-vaos


### PR DESCRIPTION
## Description
Updating ask-a-question codeowner to be the newly created `orchid` team.

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
