### PR TITLE
Exclude HLR Schemas

### DIFF
--- a/src/platform/forms/tests/forms.unit.spec.js
+++ b/src/platform/forms/tests/forms.unit.spec.js
@@ -85,6 +85,8 @@ const excludedForms = new Set([
   'caregiverProgramFacilities',
   'COVID-VACCINE-TRIAL',
   '0873',
+  'CREATE_HLR_200_RESPONSE',
+  'CREATE_HLR_422_RESPONSE',
 ]);
 
 describe('form:', () => {


### PR DESCRIPTION
`CREATE_HLR_200_RESPONSE` and `CREATE_HLR_422_RESPONSE` are not form schemas, and, consequently, were causing `forms.unit.spec.js` to fail

**Action:** add them to the excluded forms set

**AC:** tests pass

slack convo:
https://dsva.slack.com/archives/CBU0KDSB1/p1598977853072800?thread_ts=1598977821.072300&cid=CBU0KDSB1
