### PR TITLE
Fix hardcoded future date in VAOS test

### DIFF
--- a/src/applications/vaos/tests/components/calendar/CalendarWidget.unit.spec.jsx
+++ b/src/applications/vaos/tests/components/calendar/CalendarWidget.unit.spec.jsx
@@ -84,7 +84,12 @@ describe('VAOS <CalendarWidget>', () => {
 
   it('should still render a calendar if startMonth is beyond 90 day default', () => {
     const tree = shallow(
-      <CalendarWidget monthsToShowAtOnce={2} startMonth="2020-11-20" />,
+      <CalendarWidget
+        monthsToShowAtOnce={2}
+        startMonth={moment()
+          .add(6, 'months')
+          .format('YYYY-MM-DD')}
+      />,
     );
     const cell = tree.find('.vaos-calendar__container');
     expect(cell.length).to.equal(1);


### PR DESCRIPTION
## Description
Fixes test breaking in master

## Testing done
Unit tests


## Acceptance criteria
- [ ] Build passes

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
