### PR TITLE
Direct Schedule Flow - 'Earliest date we can schedule' alert showing when it shouldn't #11631

### DIFF
--- a/src/applications/vaos/containers/DateTimeSelectPage.jsx
+++ b/src/applications/vaos/containers/DateTimeSelectPage.jsx
@@ -92,7 +92,7 @@ export class DateTimeSelectPage extends React.Component {
         .startOf('month')
         .format('YYYY-MM-DD'),
       moment(preferredDate)
-        .add(1, 'months')
+        .add(12, 'months')
         .endOf('month')
         .format('YYYY-MM-DD'),
       true,

--- a/src/applications/vaos/tests/components/calendar/CalendarWidget.unit.spec.jsx
+++ b/src/applications/vaos/tests/components/calendar/CalendarWidget.unit.spec.jsx
@@ -82,16 +82,16 @@ describe('VAOS <CalendarWidget>', () => {
     tree.unmount();
   });
 
-  xit('should still render a calendar if startMonth is beyond 90 day default', () => {
+  it('should still render a calendar if startMonth is beyond 90 day default', () => {
     const tree = shallow(
       <CalendarWidget monthsToShowAtOnce={2} startMonth="2020-11-20" />,
     );
     const cell = tree.find('.vaos-calendar__container');
-    expect(cell.length).to.equal(1);
+    expect(cell.length).to.equal(2);
     const navigation = tree.find('CalendarNavigation');
     expect(navigation.length).to.equal(1);
     const weekdayHeaders = tree.find('CalendarWeekdayHeader');
-    expect(weekdayHeaders.length).to.equal(1);
+    expect(weekdayHeaders.length).to.equal(2);
     tree.unmount();
   });
 

--- a/src/applications/vaos/tests/components/calendar/CalendarWidget.unit.spec.jsx
+++ b/src/applications/vaos/tests/components/calendar/CalendarWidget.unit.spec.jsx
@@ -82,7 +82,7 @@ describe('VAOS <CalendarWidget>', () => {
     tree.unmount();
   });
 
-  it('should still render a calendar if startMonth is beyond 90 day default', () => {
+  xit('should still render a calendar if startMonth is beyond 90 day default', () => {
     const tree = shallow(
       <CalendarWidget monthsToShowAtOnce={2} startMonth="2020-11-20" />,
     );

--- a/src/applications/vaos/tests/mocks/helpers.js
+++ b/src/applications/vaos/tests/mocks/helpers.js
@@ -325,7 +325,7 @@ export function mockAppointmentSlotFetch({
           .format('YYYY-MM-DD')}` +
         `&end_date=${preferredDate
           .clone()
-          .add(1, 'month')
+          .add(12, 'month')
           .endOf('month')
           .format('YYYY-MM-DD')}`,
     ),

--- a/src/applications/vaos/tests/new-appointment/select-date-page.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/select-date-page.unit.spec.jsx
@@ -38,7 +38,7 @@ describe('VAOS integration: select date time slot page', () => {
   beforeEach(() => mockFetch());
   afterEach(() => resetFetch());
 
-  it('should fetch new slots after clinic change', async () => {
+  xit('should fetch new slots after clinic change', async () => {
     const clinics = [
       {
         id: '308',

--- a/src/applications/vaos/tests/new-appointment/select-date-page.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/select-date-page.unit.spec.jsx
@@ -38,7 +38,7 @@ describe('VAOS integration: select date time slot page', () => {
   beforeEach(() => mockFetch());
   afterEach(() => resetFetch());
 
-  xit('should fetch new slots after clinic change', async () => {
+  it('should fetch new slots after clinic change', async () => {
     const clinics = [
       {
         id: '308',


### PR DESCRIPTION
## Description
User is seeing 'earliest date we can schedule' alert showing when it shouldn't be.

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
