### PR TITLE
[Development] Update "New condition" review design

### DIFF
--- a/src/applications/disability-benefits/all-claims/components/ConditionReviewField.jsx
+++ b/src/applications/disability-benefits/all-claims/components/ConditionReviewField.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-const ObjectViewField = props => {
+const ConditionReviewField = props => {
   const { renderedProperties, defaultEditButton } = props;
   if (!renderedProperties) {
     return null;
@@ -15,4 +15,4 @@ const ObjectViewField = props => {
   );
 };
 
-export default ObjectViewField;
+export default ConditionReviewField;

--- a/src/applications/disability-benefits/all-claims/components/ObjectViewField.jsx
+++ b/src/applications/disability-benefits/all-claims/components/ObjectViewField.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+const ObjectViewField = props => {
+  const { renderedProperties, editButton } = props;
+  if (!renderedProperties) {
+    return null;
+  }
+  return (
+    <dl className="vads-u-width--full">
+      <div className="review-row vads-u-display--flex vads-u-justify-content--space-between vads-u-align-items--center">
+        <dt className="capitalize-first-letter">{renderedProperties}</dt>
+        <dd>{editButton}</dd>
+      </div>
+    </dl>
+  );
+};
+
+export default ObjectViewField;

--- a/src/applications/disability-benefits/all-claims/components/ObjectViewField.jsx
+++ b/src/applications/disability-benefits/all-claims/components/ObjectViewField.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 const ObjectViewField = props => {
-  const { renderedProperties, editButton } = props;
+  const { renderedProperties, defaultEditButton } = props;
   if (!renderedProperties) {
     return null;
   }
@@ -9,7 +9,7 @@ const ObjectViewField = props => {
     <dl className="vads-u-width--full">
       <div className="review-row vads-u-display--flex vads-u-justify-content--space-between vads-u-align-items--center">
         <dt className="capitalize-first-letter">{renderedProperties}</dt>
-        <dd>{editButton}</dd>
+        <dd>{defaultEditButton()}</dd>
       </div>
     </dl>
   );

--- a/src/applications/disability-benefits/all-claims/pages/addDisabilities.js
+++ b/src/applications/disability-benefits/all-claims/pages/addDisabilities.js
@@ -11,7 +11,7 @@ import {
 } from '../content/addDisabilities';
 import NewDisability from '../components/NewDisability';
 import ArrayField from '../components/ArrayField';
-import ObjectViewField from '../components/ObjectViewField';
+import ConditionReviewField from '../components/ConditionReviewField';
 import { validateDisabilityName, requireDisability } from '../validations';
 import {
   newConditionsOnly,
@@ -81,7 +81,7 @@ export const uiSchema = {
       'view:descriptionInfo': {
         'ui:description': descriptionInfo,
       },
-      'ui:objectViewField': ObjectViewField,
+      'ui:objectViewField': ConditionReviewField,
       'ui:options': {
         ariaLabelForEditButtonOnReview: 'Edit New condition',
       },

--- a/src/applications/disability-benefits/all-claims/pages/addDisabilities.js
+++ b/src/applications/disability-benefits/all-claims/pages/addDisabilities.js
@@ -11,6 +11,7 @@ import {
 } from '../content/addDisabilities';
 import NewDisability from '../components/NewDisability';
 import ArrayField from '../components/ArrayField';
+import ObjectViewField from '../components/ObjectViewField';
 import { validateDisabilityName, requireDisability } from '../validations';
 import {
   newConditionsOnly,
@@ -48,6 +49,7 @@ export const uiSchema = {
             })),
           ),
         {
+          'ui:reviewField': ({ children }) => children,
           'ui:options': {
             debounceRate: 200,
             freeInput: true,
@@ -79,6 +81,7 @@ export const uiSchema = {
       'view:descriptionInfo': {
         'ui:description': descriptionInfo,
       },
+      'ui:objectViewField': ObjectViewField,
       'ui:options': {
         ariaLabelForEditButtonOnReview: 'Edit New condition',
       },

--- a/src/applications/disability-benefits/all-claims/pages/addDisabilities.js
+++ b/src/applications/disability-benefits/all-claims/pages/addDisabilities.js
@@ -11,7 +11,7 @@ import {
 } from '../content/addDisabilities';
 import NewDisability from '../components/NewDisability';
 import ArrayField from '../components/ArrayField';
-import ConditionReviewField from '../components/ConditionReviewField';
+// import ConditionReviewField from '../components/ConditionReviewField';
 import { validateDisabilityName, requireDisability } from '../validations';
 import {
   newConditionsOnly,
@@ -49,7 +49,7 @@ export const uiSchema = {
             })),
           ),
         {
-          'ui:reviewField': ({ children }) => children,
+          // 'ui:reviewField': ({ children }) => children,
           'ui:options': {
             debounceRate: 200,
             freeInput: true,
@@ -81,7 +81,9 @@ export const uiSchema = {
       'view:descriptionInfo': {
         'ui:description': descriptionInfo,
       },
-      'ui:objectViewField': ConditionReviewField,
+      // custom review & submit layout - see https://github.com/department-of-veterans-affairs/vets-website/pull/14091
+      // disabled until design changes have been approved
+      // 'ui:objectViewField': ConditionReviewField,
       'ui:options': {
         ariaLabelForEditButtonOnReview: 'Edit New condition',
       },

--- a/src/applications/disability-benefits/all-claims/sass/disability-benefits.scss
+++ b/src/applications/disability-benefits/all-claims/sass/disability-benefits.scss
@@ -153,15 +153,14 @@ div.review {
   }
 }
 
-<<<<<<< HEAD
 /* Remove bold on New Disability AdditionalInfo link in review #12678 */
 .usa-accordion > ul button.additional-info-button,
 .usa-accordion-bordered > ul button.additional-info-button {
   font-weight: normal;
-=======
+}
+
 .capitalize-first-letter::first-letter {
   text-transform: capitalize;
->>>>>>> Update new condition rending on review page
 }
 
 @media (min-width: 481px) {

--- a/src/applications/disability-benefits/all-claims/sass/disability-benefits.scss
+++ b/src/applications/disability-benefits/all-claims/sass/disability-benefits.scss
@@ -153,10 +153,15 @@ div.review {
   }
 }
 
+<<<<<<< HEAD
 /* Remove bold on New Disability AdditionalInfo link in review #12678 */
 .usa-accordion > ul button.additional-info-button,
 .usa-accordion-bordered > ul button.additional-info-button {
   font-weight: normal;
+=======
+.capitalize-first-letter::first-letter {
+  text-transform: capitalize;
+>>>>>>> Update new condition rending on review page
 }
 
 @media (min-width: 481px) {

--- a/src/platform/forms-system/src/js/review/ObjectField.jsx
+++ b/src/platform/forms-system/src/js/review/ObjectField.jsx
@@ -155,14 +155,18 @@ class ObjectField extends React.Component {
       const Tag = divWrapper ? 'div' : 'dl';
       const objectViewField = uiSchema?.['ui:objectViewField'];
 
-      const editButton = (
+      const defaultEditButton = ({
+        label = editLabel,
+        onEdit = formContext.onEdit,
+        text = 'Edit',
+      } = {}) => (
         <button
           type="button"
           className="edit-btn primary-outline"
-          aria-label={editLabel}
-          onClick={() => formContext.onEdit()}
+          aria-label={label}
+          onClick={onEdit}
         >
-          Edit
+          {text}
         </button>
       );
 
@@ -171,7 +175,7 @@ class ObjectField extends React.Component {
           ...this.props,
           renderedProperties,
           title,
-          editButton,
+          defaultEditButton,
         })
       ) : (
         <>
@@ -183,7 +187,7 @@ class ObjectField extends React.Component {
                     {title}
                   </h3>
                 )}
-              {editButton}
+              {defaultEditButton()}
             </div>
           )}
           <Tag className="review">{renderedProperties}</Tag>

--- a/src/platform/forms-system/src/js/review/ObjectField.jsx
+++ b/src/platform/forms-system/src/js/review/ObjectField.jsx
@@ -168,7 +168,7 @@ class ObjectField extends React.Component {
 
       return typeof objectViewField === 'function' ? (
         objectViewField({
-          props: this.props,
+          ...this.props,
           renderedProperties,
           title,
           editButton,

--- a/src/platform/forms-system/src/js/review/ObjectField.jsx
+++ b/src/platform/forms-system/src/js/review/ObjectField.jsx
@@ -153,8 +153,27 @@ class ObjectField extends React.Component {
         `Edit ${title}`;
 
       const Tag = divWrapper ? 'div' : 'dl';
+      const objectViewField = uiSchema?.['ui:objectViewField'];
 
-      return (
+      const editButton = (
+        <button
+          type="button"
+          className="edit-btn primary-outline"
+          aria-label={editLabel}
+          onClick={() => formContext.onEdit()}
+        >
+          Edit
+        </button>
+      );
+
+      return typeof objectViewField === 'function' ? (
+        objectViewField({
+          props: this.props,
+          renderedProperties,
+          title,
+          editButton,
+        })
+      ) : (
         <>
           {!formContext.hideHeaderRow && (
             <div className="form-review-panel-page-header-row">
@@ -164,14 +183,7 @@ class ObjectField extends React.Component {
                     {title}
                   </h3>
                 )}
-              <button
-                type="button"
-                className="edit-btn primary-outline"
-                aria-label={editLabel}
-                onClick={() => formContext.onEdit()}
-              >
-                Edit
-              </button>
+              {editButton}
             </div>
           )}
           <Tag className="review">{renderedProperties}</Tag>

--- a/src/platform/forms-system/test/js/review/ObjectField.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/review/ObjectField.unit.spec.jsx
@@ -596,7 +596,7 @@ describe('Schemaform review: ObjectField', () => {
     );
     expect(tree.subTree('SchemaField')).not.to.be.empty;
     expect(tree.subTree('.test-title').text()).to.equal('Blah');
-    expect(tree.subTree('.test-edit')).to.exist;
+    expect(tree.subTree('.test-edit')).to.not.be.empty;
     expect(tree.subTree('.test-props').subTree('SchemaField')).not.to.be.empty;
   });
 });

--- a/src/platform/forms-system/test/js/review/ObjectField.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/review/ObjectField.unit.spec.jsx
@@ -562,6 +562,7 @@ describe('Schemaform review: ObjectField', () => {
   it('should render custom ObjectViewField', () => {
     const onChange = sinon.spy();
     const onBlur = sinon.spy();
+    const onClick = sinon.spy();
     const schema = {
       properties: {
         testz: {
@@ -570,10 +571,20 @@ describe('Schemaform review: ObjectField', () => {
       },
     };
     const uiSchema = {
-      'ui:objectViewField': ({ title, editButton, renderedProperties }) => (
+      'ui:objectViewField': ({
+        title,
+        defaultEditButton,
+        renderedProperties,
+      }) => (
         <div>
           <h3 className="test-title">{title}</h3>
-          <div className="test-edit">{editButton}</div>
+          <div className="test-edit">
+            {defaultEditButton({
+              label: 'fooz',
+              onEdit: onClick,
+              text: 'barz',
+            })}
+          </div>
           <div className="test-props">{renderedProperties}</div>
         </div>
       ),
@@ -594,9 +605,15 @@ describe('Schemaform review: ObjectField', () => {
         onBlur={onBlur}
       />,
     );
+    expect(tree.subTree('.test-props').subTree('SchemaField')).not.to.be.empty;
     expect(tree.subTree('SchemaField')).not.to.be.empty;
     expect(tree.subTree('.test-title').text()).to.equal('Blah');
     expect(tree.subTree('.test-edit')).to.not.be.empty;
-    expect(tree.subTree('.test-props').subTree('SchemaField')).not.to.be.empty;
+
+    const edit = tree.subTree('.test-edit').props.children.props;
+    expect(edit['aria-label']).to.equal('fooz');
+    expect(edit.children).to.equal('barz');
+    edit.onClick();
+    expect(onClick.called).to.be.true;
   });
 });

--- a/src/platform/forms-system/test/js/review/ObjectField.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/review/ObjectField.unit.spec.jsx
@@ -559,4 +559,44 @@ describe('Schemaform review: ObjectField', () => {
     expect(review.type).to.equal('dl');
     expect(review.props.className).to.equal('review');
   });
+  it('should render custom ObjectViewField', () => {
+    const onChange = sinon.spy();
+    const onBlur = sinon.spy();
+    const schema = {
+      properties: {
+        testz: {
+          type: 'string',
+        },
+      },
+    };
+    const uiSchema = {
+      'ui:objectViewField': ({ title, editButton, renderedProperties }) => (
+        <div>
+          <h3 className="test-title">{title}</h3>
+          <div className="test-edit">{editButton}</div>
+          <div className="test-props">{renderedProperties}</div>
+        </div>
+      ),
+      testz: {},
+    };
+    const formData = {
+      testz: { foo: 'testzz' },
+    };
+    const tree = SkinDeep.shallowRender(
+      <ObjectField
+        schema={schema}
+        uiSchema={uiSchema}
+        formData={formData}
+        formContext={{ pageTitle: 'Blah' }}
+        idSchema={{ $id: 'root' }}
+        requiredSchema={{}}
+        onChange={onChange}
+        onBlur={onBlur}
+      />,
+    );
+    expect(tree.subTree('SchemaField')).not.to.be.empty;
+    expect(tree.subTree('.test-title').text()).to.equal('Blah');
+    expect(tree.subTree('.test-edit')).to.exist;
+    expect(tree.subTree('.test-props').subTree('SchemaField')).not.to.be.empty;
+  });
 });


### PR DESCRIPTION
## Description

Updated "New condition" review card design. To accomplish this, a new review `ObjectField` setting was added.

Related:
- Design: https://github.com/department-of-veterans-affairs/va.gov-team/issues/12678
- Slack: https://dsva.slack.com/archives/C5AGLBNRK/p1598984849010700
- Documentation: https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/pull/386

## Testing done

- Unit test added for `ui:objectViewField` setting
- Ran axe-coconut to check a11y compliance

## Screenshots

<details><summary>Before</summary>

<!-- leave a blank line above -->
![Screen Shot 2020-09-01 at 12 44 00 PM](https://user-images.githubusercontent.com/136959/92006932-effccf00-ed0a-11ea-8835-fead97fa66ce.png)</details>

<details><summary>After</summary>

<!-- leave a blank line above -->
![Screen Shot 2020-09-01 at 1 35 34 PM](https://user-images.githubusercontent.com/136959/92007027-086ce980-ed0b-11ea-9a52-ffa42a88036b.png)</details>

## Acceptance criteria
- [x] New conditions don't show unnecessary text
- [x] Edit button is aligned with new condition text

## Definition of done
- [ ] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
