### PR TITLE
Fix mhv signInService naming

### DIFF
--- a/src/applications/personalization/profile-2/components/EmailAddressNotification.jsx
+++ b/src/applications/personalization/profile-2/components/EmailAddressNotification.jsx
@@ -15,7 +15,7 @@ const EmailAddressNotification = ({ signInServiceName }) => {
     buttonText = 'DS Logon';
   }
 
-  if (signInServiceName === 'mhv') {
+  if (signInServiceName === 'mhv' || signInServiceName === 'myhealthevet') {
     link = 'https://www.myhealth.va.gov';
     buttonText = 'My HealtheVet';
   }

--- a/src/applications/personalization/profile-2/components/personal-information/EmailInformationSection.jsx
+++ b/src/applications/personalization/profile-2/components/personal-information/EmailInformationSection.jsx
@@ -23,7 +23,7 @@ const EmailInformationSection = ({ className, signInServiceName }) => {
     buttonText = 'DS Logon';
   }
 
-  if (signInServiceName === 'mhv') {
+  if (signInServiceName === 'mhv' || signInServiceName === 'myhealthevet') {
     link = 'https://www.myhealth.va.gov';
     buttonText = 'My HealtheVet';
   }

--- a/src/applications/personalization/profile-2/tests/components/EmailAddressNotification.unit.spec.jsx
+++ b/src/applications/personalization/profile-2/tests/components/EmailAddressNotification.unit.spec.jsx
@@ -54,4 +54,20 @@ describe('EmailAddressNotification', () => {
     });
     wrapper.unmount();
   });
+
+  describe('when `signInServiceName` is `myhealthevet`', () => {
+    const wrapper = shallow(
+      <EmailAddressNotification signInServiceName="myhealthevet" />,
+    );
+
+    const anchor = wrapper.find('a');
+
+    it('should render the correct button text', () => {
+      expect(anchor.text().includes('My HealtheVet')).to.be.true;
+    });
+    it('should render the correct link url', () => {
+      expect(anchor.props().href).to.equal('https://www.myhealth.va.gov');
+    });
+    wrapper.unmount();
+  });
 });


### PR DESCRIPTION
## Description
During UAT we discovered we were just looking for `mhv` and not `myhealthevet` for the `signInServiceName`.

## Acceptance criteria
- [x] Also check for `myhealthevet` as the `signInServiceName`

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
