### PR TITLE
[DEVELOPMENT|AXE-CORE] Do not show empty review headers

### DIFF
--- a/src/platform/forms-system/src/js/review/ArrayField.jsx
+++ b/src/platform/forms-system/src/js/review/ArrayField.jsx
@@ -189,8 +189,11 @@ class ArrayField extends React.Component {
 
     const uiOptions = uiSchema['ui:options'] || {};
     const fieldName = path[path.length - 1];
+    const schemaTitle = _.get('ui:title', uiSchema);
     const title =
-      _.get('ui:title', uiSchema) || uiOptions.reviewTitle || pageTitle;
+      uiOptions.reviewTitle ||
+      (typeof schemaTitle === 'string' ? schemaTitle.trim() : schemaTitle) ||
+      pageTitle;
 
     // TODO: Make this better; it’s super hacky for now.
     const itemCountLocked = this.isLocked();
@@ -206,7 +209,9 @@ class ArrayField extends React.Component {
       <div className={itemsNeeded ? 'schemaform-review-array-warning' : null}>
         {title && (
           <div className="form-review-panel-page-header-row">
-            <h3 className="form-review-panel-page-header">{title}</h3>
+            <h3 className="form-review-panel-page-header vads-u-font-size--h4">
+              {title}
+            </h3>
             {itemsNeeded && (
               <span className="schemaform-review-array-warning-icon" />
             )}

--- a/src/platform/forms-system/test/js/review/ArrayField.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/review/ArrayField.unit.spec.jsx
@@ -397,7 +397,7 @@ describe('Schemaform review <ArrayField>', () => {
         idSchema={idSchema}
         registry={registry}
         formContext={formContext}
-        pageTitle=""
+        pageTitle="Page Title"
         requiredSchema={requiredSchema}
       />,
     );

--- a/src/platform/forms-system/test/js/review/ArrayField.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/review/ArrayField.unit.spec.jsx
@@ -365,4 +365,87 @@ describe('Schemaform review <ArrayField>', () => {
     expect(instance.state.items).to.eql(newProps.arrayData);
     expect(instance.state.editing).to.eql([]);
   });
+  it('should render reviewTitle first', () => {
+    const idSchema = {};
+    const schema = {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          field: {
+            type: 'string',
+          },
+        },
+      },
+    };
+    const uiSchema = {
+      'ui:title': 'List of things',
+      items: {},
+      'ui:options': {
+        viewField: f => f,
+        reviewTitle: 'My List',
+      },
+    };
+    const arrayData = [];
+    const tree = SkinDeep.shallowRender(
+      <ArrayField
+        pageKey="page1"
+        arrayData={arrayData}
+        path={['thingList']}
+        schema={schema}
+        uiSchema={uiSchema}
+        idSchema={idSchema}
+        registry={registry}
+        formContext={formContext}
+        pageTitle=""
+        requiredSchema={requiredSchema}
+      />,
+    );
+
+    expect(tree.subTree('.form-review-panel-page-header').text()).to.equal(
+      uiSchema['ui:options'].reviewTitle,
+    );
+    expect(tree.everySubTree('SchemaForm')).to.be.empty;
+  });
+  it('should render page title', () => {
+    const idSchema = {};
+    const schema = {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          field: {
+            type: 'string',
+          },
+        },
+      },
+    };
+    const uiSchema = {
+      'ui:title': ' ',
+      items: {},
+      'ui:options': {
+        viewField: f => f,
+      },
+    };
+    const arrayData = [];
+    const tree = SkinDeep.shallowRender(
+      <ArrayField
+        pageKey="page1"
+        arrayData={arrayData}
+        path={['thingList']}
+        schema={schema}
+        uiSchema={uiSchema}
+        idSchema={idSchema}
+        registry={registry}
+        formContext={formContext}
+        pageTitle="Page Title"
+        requiredSchema={requiredSchema}
+      />,
+    );
+
+    expect(tree.subTree('.form-review-panel-page-header').text()).to.equal(
+      'Page Title',
+    );
+    expect(tree.everySubTree('SchemaForm')).to.be.empty;
+  });
 });


### PR DESCRIPTION
## Description

This PR ensures that review headers aren't empty for `ArrayFields` on the review page
- A set `reviewTitle` will now take precedence over the ui schema and page title.
- When no ui schema title is available, or a string that is empty of contains only whitespace, it ignores this entry and falls back to the page title

Previously, the ui schema title would have priority over the review title, and it would not be ignored if it contained whitespace only.

Related: https://github.com/department-of-veterans-affairs/va.gov-team/issues/12672

## Testing done

Added unit test: `reviewTitle` > `uiSchema['ui:title']` > `pageTitle`

## Screenshots

<details><summary>Periods of Confinement header now shows</summary>

<!-- leave a blank line above -->
![Screen Shot 2020-09-02 at 3 04 37 PM](https://user-images.githubusercontent.com/136959/92032512-e76abf80-ed2f-11ea-927b-cba66773e26d.png)</details>

## Acceptance criteria
- [x] Shows review title first, then ui schema title (if non-empty/non-whitespace filled), then page title

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
