### PR TITLE
Hide pagination controls on community provider searches

### DIFF
--- a/src/applications/facility-locator/components/PaginationWrapper.jsx
+++ b/src/applications/facility-locator/components/PaginationWrapper.jsx
@@ -3,7 +3,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { LocationType } from '../constants';
 
-class PaginationWrapper extends Component {
+export class PaginationWrapper extends Component {
   shouldComponentUpdate = nextProps =>
     nextProps.results !== this.props.results ||
     nextProps.inProgress !== this.props.inProgress;
@@ -20,7 +20,7 @@ class PaginationWrapper extends Component {
     if (
       shouldRender &&
       currentPage &&
-      totalPages &&
+      totalPages > 1 &&
       results &&
       results.length > 0
     ) {

--- a/src/applications/facility-locator/components/PaginationWrapper.jsx
+++ b/src/applications/facility-locator/components/PaginationWrapper.jsx
@@ -1,0 +1,65 @@
+import Pagination from '@department-of-veterans-affairs/formation-react/Pagination';
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { LocationType } from '../constants';
+
+class PaginationWrapper extends Component {
+  shouldComponentUpdate = nextProps =>
+    nextProps.results !== this.props.results ||
+    nextProps.inProgress !== this.props.inProgress;
+
+  render() {
+    const {
+      shouldRender,
+      handlePageSelect,
+      currentPage,
+      totalPages,
+      results,
+    } = this.props;
+
+    if (
+      shouldRender &&
+      currentPage &&
+      totalPages &&
+      results &&
+      results.length > 0
+    ) {
+      return (
+        <Pagination
+          onPageSelect={handlePageSelect}
+          page={currentPage}
+          pages={totalPages}
+        />
+      );
+    }
+    return null;
+  }
+}
+
+const mapStateToProps = state => {
+  let isCommunityProviderSearch = false;
+
+  if (
+    [LocationType.CC_PROVIDER, LocationType.URGENT_CARE_PHARMACIES].includes(
+      state.searchQuery.facilityType,
+    )
+  ) {
+    isCommunityProviderSearch = true;
+  }
+
+  if (
+    state.searchQuery.facilityType === LocationType.URGENT_CARE &&
+    (!state.searchQuery.serviceType ||
+      ['AllUrgentCare', 'NonVAUrgentCare'].includes(
+        state.searchQuery.serviceType,
+      ))
+  ) {
+    isCommunityProviderSearch = true;
+  }
+
+  return {
+    shouldRender: !isCommunityProviderSearch,
+  };
+};
+
+export default connect(mapStateToProps)(PaginationWrapper);

--- a/src/applications/facility-locator/containers/VAMap.jsx
+++ b/src/applications/facility-locator/containers/VAMap.jsx
@@ -497,7 +497,7 @@ class VAMap extends Component {
               <div className="facility-search-results">
                 <ResultsList
                   updateUrlParams={this.updateUrlParams}
-                  query={this.props.currentQuery}
+                  query={currentQuery}
                 />
               </div>
               <PaginationWrapper
@@ -505,7 +505,7 @@ class VAMap extends Component {
                 currentPage={currentPage}
                 totalPages={totalPages}
                 results={results}
-                inProgress={this.props.currentQuery.inProgress}
+                inProgress={currentQuery.inProgress}
               />
             </TabPanel>
             <TabPanel>

--- a/src/applications/facility-locator/containers/VAMap.jsx
+++ b/src/applications/facility-locator/containers/VAMap.jsx
@@ -26,11 +26,11 @@ import {
   facilitiesPpmsSuppressPharmacies,
   facilitiesPpmsSuppressCommunityCare,
 } from '../utils/selectors';
-import Pagination from '@department-of-veterans-affairs/formation-react/Pagination';
 import mbxGeo from '@mapbox/mapbox-sdk/services/geocoding';
 import { distBetween } from '../utils/facilityDistance';
 import SearchResultsHeader from '../components/SearchResultsHeader';
 import vaDebounce from 'platform/utilities/data/debounce';
+import PaginationWrapper from '../components/PaginationWrapper';
 
 const mbxClient = mbxGeo(mapboxClient);
 
@@ -500,14 +500,13 @@ class VAMap extends Component {
                   query={this.props.currentQuery}
                 />
               </div>
-              {results &&
-                results.length > 0 && (
-                  <Pagination
-                    onPageSelect={this.handlePageSelect}
-                    page={currentPage}
-                    pages={totalPages}
-                  />
-                )}
+              <PaginationWrapper
+                handlePageSelect={this.handlePageSelect}
+                currentPage={currentPage}
+                totalPages={totalPages}
+                results={results}
+                inProgress={this.props.currentQuery.inProgress}
+              />
             </TabPanel>
             <TabPanel>
               <Map
@@ -577,7 +576,6 @@ class VAMap extends Component {
         </div>
         <div
           className="columns search-results-container medium-4 small-12"
-          style={{ maxHeight: '78vh', overflowY: 'auto' }}
           id="searchResultsContainer"
         >
           <div className="facility-search-results">
@@ -594,7 +592,7 @@ class VAMap extends Component {
             zoomSnap={1}
             zoomDelta={1}
             zoom={parseInt(currentQuery.zoomLevel, 10)}
-            style={{ minHeight: '75vh', width: '100%' }}
+            style={{ minHeight: '78vh', width: '100%' }} // TODO - move this into CSS
             scrollWheelZoom={false}
             onMoveEnd={this.handleBoundsChanged}
           >
@@ -612,15 +610,13 @@ class VAMap extends Component {
               )}
           </Map>
         </div>
-        {currentPage &&
-          results &&
-          results.length > 0 && (
-            <Pagination
-              onPageSelect={this.handlePageSelect}
-              page={currentPage}
-              pages={totalPages}
-            />
-          )}
+        <PaginationWrapper
+          handlePageSelect={this.handlePageSelect}
+          currentPage={currentPage}
+          totalPages={totalPages}
+          results={results}
+          inProgress={this.props.currentQuery.inProgress}
+        />
       </div>
     );
   };

--- a/src/applications/facility-locator/containers/VAMap.jsx
+++ b/src/applications/facility-locator/containers/VAMap.jsx
@@ -615,7 +615,7 @@ class VAMap extends Component {
           currentPage={currentPage}
           totalPages={totalPages}
           results={results}
-          inProgress={this.props.currentQuery.inProgress}
+          inProgress={currentQuery.inProgress}
         />
       </div>
     );

--- a/src/applications/facility-locator/sass/facility-locator.scss
+++ b/src/applications/facility-locator/sass/facility-locator.scss
@@ -88,7 +88,7 @@ $facility-locator-color-gray: #ccc;
   }
 
   .desktop-map-container {
-    min-height: 75vh;
+    min-height: 78vh;
     padding-left: 0;
     float: right;
     width: calc(100% - 305px);
@@ -222,6 +222,8 @@ $facility-locator-color-gray: #ccc;
     float: left;
     display: block;
     width: 305px;
+    max-height: 78vh;
+    overflow-y: auto;
   }
 
   .facility-search-results {

--- a/src/applications/facility-locator/tests/components/PaginationWrapper.unit.spec.jsx
+++ b/src/applications/facility-locator/tests/components/PaginationWrapper.unit.spec.jsx
@@ -1,0 +1,124 @@
+import { PaginationWrapper } from '../../components/PaginationWrapper';
+import React from 'react';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+
+const handlePageSelect = () => {};
+
+describe('PaginationWrapper', () => {
+  it('Should render when all required props are provided', () => {
+    const currentPage = 1;
+    const totalPages = 2;
+    const results = [1, 2];
+    const shouldRender = true;
+
+    const wrapper = shallow(
+      <PaginationWrapper
+        handlePageSelect={handlePageSelect}
+        currentPage={currentPage}
+        totalPages={totalPages}
+        results={results}
+        shouldRender={shouldRender}
+      />,
+    );
+
+    expect(wrapper.find('Pagination').length).to.equal(1);
+    wrapper.unmount();
+  });
+
+  it('Should not render if shouldRender is false', () => {
+    const currentPage = 1;
+    const totalPages = 2;
+    const results = [1, 2];
+    const shouldRender = false;
+
+    const wrapper = shallow(
+      <PaginationWrapper
+        handlePageSelect={handlePageSelect}
+        currentPage={currentPage}
+        totalPages={totalPages}
+        results={results}
+        shouldRender={shouldRender}
+      />,
+    );
+
+    expect(wrapper.find('Pagination').length).to.equal(0);
+    wrapper.unmount();
+  });
+
+  it('Should not render if results is empty', () => {
+    const currentPage = 1;
+    const totalPages = 2;
+    const results = [];
+    const shouldRender = true;
+
+    const wrapper = shallow(
+      <PaginationWrapper
+        handlePageSelect={handlePageSelect}
+        currentPage={currentPage}
+        totalPages={totalPages}
+        results={results}
+        shouldRender={shouldRender}
+      />,
+    );
+
+    expect(wrapper.find('Pagination').length).to.equal(0);
+    wrapper.unmount();
+  });
+
+  it('Should not render if results is undefined', () => {
+    const currentPage = 1;
+    const totalPages = 2;
+    const shouldRender = true;
+
+    const wrapper = shallow(
+      <PaginationWrapper
+        handlePageSelect={handlePageSelect}
+        currentPage={currentPage}
+        totalPages={totalPages}
+        shouldRender={shouldRender}
+      />,
+    );
+
+    expect(wrapper.find('Pagination').length).to.equal(0);
+    wrapper.unmount();
+  });
+
+  it('Should not render if totalPages < 2', () => {
+    const currentPage = 1;
+    const totalPages = 1;
+    const results = [1, 2];
+    const shouldRender = true;
+
+    const wrapper = shallow(
+      <PaginationWrapper
+        handlePageSelect={handlePageSelect}
+        currentPage={currentPage}
+        totalPages={totalPages}
+        results={results}
+        shouldRender={shouldRender}
+      />,
+    );
+
+    expect(wrapper.find('Pagination').length).to.equal(0);
+    wrapper.unmount();
+  });
+
+  it('Should not render if currentPage is undefined', () => {
+    const totalPages = 2;
+    const results = [1, 2];
+    const shouldRender = true;
+
+    const wrapper = shallow(
+      <PaginationWrapper
+        handlePageSelect={handlePageSelect}
+        totalPages={totalPages}
+        results={results}
+        shouldRender={shouldRender}
+      />,
+    );
+
+    expect(wrapper.find('Pagination').length).to.equal(0);
+    wrapper.unmount();
+  });
+});

--- a/src/applications/facility-locator/tests/e2e/search.cypress.spec.js
+++ b/src/applications/facility-locator/tests/e2e/search.cypress.spec.js
@@ -37,6 +37,8 @@ describe('Facility search', () => {
     cy.get('.i-pin-card-map').contains('B');
     cy.get('.i-pin-card-map').contains('C');
     cy.get('.i-pin-card-map').contains('D');
+
+    cy.get('.va-pagination').should('exist');
   });
 
   it('should render breadcrumbs ', () => {
@@ -113,6 +115,8 @@ describe('Facility search', () => {
     cy.axeCheck();
 
     cy.get('.facility-result h3').contains('BADEA, LUANA');
+
+    cy.get('.va-pagination').should('not.exist');
   });
 
   it('finds community urgent care', () => {
@@ -134,6 +138,7 @@ describe('Facility search', () => {
     cy.axeCheck();
 
     cy.get('.facility-result h3').contains('Concentra Urgent Care');
+    cy.get('.va-pagination').should('not.exist');
   });
 
   it('finds community urgent care', () => {
@@ -153,6 +158,7 @@ describe('Facility search', () => {
     cy.axeCheck();
 
     cy.get('.facility-result h3').contains('MinuteClinic');
+    cy.get('.va-pagination').should('not.exist');
   });
 
   it('finds community care pharmacies', () => {
@@ -171,6 +177,7 @@ describe('Facility search', () => {
     cy.axeCheck();
 
     cy.get('.facility-result h3').contains('CVS');
+    cy.get('.va-pagination').should('not.exist');
   });
 
   it('should recover search from an error response state - invalid input location', () => {


### PR DESCRIPTION
https://github.com/department-of-veterans-affairs/va.gov-team/issues/12715

## Description
Hide the pagination controls on CCP searches because PPMS does not support pagination.

## Testing done
- Manual, unit, and Cypress

## Screenshots
![Find_VA_Locations___Veterans_Affairs](https://user-images.githubusercontent.com/80267/92143119-cd3de980-ede2-11ea-87da-a2f46731e057.png)

## Acceptance criteria
- [x] Pagination controls are not displayed for Community Provider/Pharmacy/Urgent care searches
- [x] Pagination controls do not re-appear if you do a search for CCP with > 1 page of results (e.g. dentists in new york), then change the Facility Type to "VA".


