### PR TITLE
[Templates] Exclude va_form nodes from sitemap

### DIFF
--- a/src/site/stages/build/drupal/page.js
+++ b/src/site/stages/build/drupal/page.js
@@ -6,7 +6,7 @@ const set = require('lodash/fp/set');
 // Creates the file object to add to the file list using the page and layout
 function createFileObj(page, layout) {
   // Exclude some types from sitemap.
-  const privateTypes = ['outreach_asset', 'support_service'];
+  const privateTypes = ['outreach_asset', 'support_service', 'va_form'];
   let privStatus = false;
   if (privateTypes.indexOf(page.entityBundle) > -1) {
     privStatus = true;


### PR DESCRIPTION
## Description
We're launching form detail pages (`va_form` as a Drupal node) behind basic auth to start, so we are also excluding these pages from the sitemap xml file.

This PR, along with the devops PR https://github.com/department-of-veterans-affairs/devops/pull/7535, will be reverted once we are ready to go live.

https://github.com/department-of-veterans-affairs/va.gov-team/issues/13125

## Testing done
Cannot easily test because no form detail pages are published

## Screenshots
N/A

## Acceptance criteria
- [ ] Form detail pages are hidden from sitemap

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
