### PR TITLE
Added props to SearchResult

### DIFF
--- a/src/applications/gi/containers/SearchPage.jsx
+++ b/src/applications/gi/containers/SearchPage.jsx
@@ -212,6 +212,10 @@ export class SearchPage extends React.Component {
                 yr={result.yr}
                 poe={result.poe}
                 eightKeys={result.eightKeys}
+                womenonly={result.womenonly}
+                menonly={result.menonly}
+                relaffil={result.relaffil}
+                hbcu={result.hbcu}
               />
             ))}
           </div>


### PR DESCRIPTION
## Description
The search result "cards" for institutions should have labels as implemented in #11306. The tags are currently not displaying for search results.

https://github.com/department-of-veterans-affairs/va.gov-team/issues/13208

## Testing done
local testing

## Screenshots

![Screen Shot 2020-09-03 at 1 17 45 PM](https://user-images.githubusercontent.com/50601724/92146603-f614ad80-ede7-11ea-82bd-a8191e97b54d.png)

## Acceptance criteria
- [x] Fix scorecard tag issue

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
