### PR TITLE
Add bl dependency resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -339,6 +339,7 @@
     "**/js-yaml": "^3.13.1",
     "**/jpeg-js": "^0.4.0",
     "**/dot-prop": "^5.1.1",
-    "cypress": "^4.8.0"
+    "cypress": "^4.8.0",
+    "tar-fs/tar-stream/bl": "^4.0.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3161,10 +3161,10 @@ bl@^1.0.0:
     readable-stream "^2.3.5"
     safe-buffer "^5.1.1"
 
-bl@^4.0.1:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/bl/-/bl-4.0.2.tgz#52b71e9088515d0606d9dd9cc7aa48dc1f98e73a"
-  integrity sha512-j4OH8f6Qg2bGuWfRiltT2HYGx0e1QcBTrK9KAHNMwMZdQnDZFk0ZSYIpADjYCB3U12nicC5tVJwSIhwOWjb4RQ==
+bl@^4.0.1, bl@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/bl/-/bl-4.0.3.tgz#12d6287adc29080e22a705e5764b2a9522cdc489"
+  integrity sha512-fs4G6/Hu4/EE+F75J8DuN/0IpQqNjAdC7aEQv7Qt8MHGUH7Ckv2MwTEEeN9QehD0pfIDkMI1bkHYkKy7xHyKIg==
   dependencies:
     buffer "^5.5.0"
     inherits "^2.0.4"


### PR DESCRIPTION
## Description
Adds a dependency resolution rule to upgrade `bl` to 4.0.3.

According to the [CVE](https://github.com/advisories/GHSA-pp7h-53gx-mx7r), the package is patched at version 4.0.3.

Before adding the resolution, `yarn why bl` returned:
```
=> Found "bl@4.0.2"
info Reasons this module exists
   - "tar-fs#tar-stream" depends on it
   - Hoisted from "tar-fs#tar-stream#bl"
[ snip ]
=> Found "decompress-tar#bl@1.2.2"
info Reasons this module exists
   - "decompress#decompress-tar#tar-stream" depends on it
   - Hoisted from "decompress#decompress-tar#tar-stream#bl"
[ snip ]
```

In both cases, the `bl` package is a dependency of `tar-stream`. Upgrading from `4.0.2` to `4.0.3` seems pretty safe, but from `1.2.2` to `4.0.3` warranted some digging.

### Uses of `decompress`
The `vets-website` dependency `decompress` is at the root of the `bl@1.2.2` dependency, so I investigated where that came from.
```
❯ rg decompress src/
src/site/stages/build/plugins/download-assets.js
8:const decompress = require('decompress');
92:  await decompress(localPath, assetsPath);
```
Fortunately, it's only used one time in one module. In this case, it's used to download pre-built Webpack assets during the content build for content-only deployments.

## Testing done
To ensure I didn't break anything with the `download-asset` Metalsmith plugin, I ran the content build specifying an asset source so `decompress` would be called.

**Trace**
1. The Metalsmith script [adds the `download-asset` plugin to the pipeline](https://github.com/department-of-veterans-affairs/vets-website/blob/update-bl-cv/src/site/stages/build/index.js#L232) if the `asset-source` build option is not equal to `local`
1. The `downloadAssets` function will call `downloadFromArchive` during the pipeline execution if the `asset-source` build option is not equal to `deployed`
    - According to [this comment](https://github.com/department-of-veterans-affairs/vets-website/blob/update-bl-cv/src/site/constants/assetSources.js#L6), any other option for `asset-source` is expected to be a git hash
1. The `downloadFromArchive` function [calls `decompress`](https://github.com/department-of-veterans-affairs/vets-website/blob/update-bl-cv/src/site/stages/build/plugins/download-assets.js#L92)

I then found a [recent content build](http://jenkins.vfs.va.gov/job/builds/job/vets-website-content-vagovprod/503/console) and copied the git hash and ran the following command:
```
NODE_ENV=production yarn build:content --buildtype vagovprod --pull-drupal --asset-source f6f02d862ed9b000cbb32c21259d3e27d90f2860
```

The webpack assets downloaded successfully from the S3 bucket. I verified that they were decompressed with `ls build/vagovprod/generated`.

## Acceptance criteria
- [x] Vulnerable versions of `bl` are removed from the dependency tree
- [x] Nothing breaks