### PR TITLE
Show the other tools link only on the search page.

### DIFF
--- a/src/applications/facility-locator/containers/FacilityLocatorApp.jsx
+++ b/src/applications/facility-locator/containers/FacilityLocatorApp.jsx
@@ -60,19 +60,8 @@ class FacilityLocatorApp extends React.Component {
     return crumbs;
   }
 
-  otherToolsLink = () => (
-    <div id="other-tools">
-      Can’t find what you’re looking for?&nbsp;&nbsp;
-      {/* Add a line break for mobile, which uses white-space: pre-line */}
-      {'\n'}
-      <a href="https://www.va.gov/directory/guide/home.asp">
-        Try using our other tools to search.
-      </a>
-    </div>
-  );
-
   render() {
-    const { location, selectedResult, results } = this.props;
+    const { location, selectedResult } = this.props;
 
     return (
       <div>
@@ -87,7 +76,6 @@ class FacilityLocatorApp extends React.Component {
             <div className="facility-locator">{this.props.children}</div>
           </DowntimeNotification>
         </div>
-        {results && results.length > 0 && this.otherToolsLink()}
       </div>
     );
   }

--- a/src/applications/facility-locator/containers/VAMap.jsx
+++ b/src/applications/facility-locator/containers/VAMap.jsx
@@ -621,7 +621,20 @@ class VAMap extends Component {
     );
   };
 
+  otherToolsLink = () => (
+    <div id="other-tools">
+      Can’t find what you’re looking for?&nbsp;&nbsp;
+      {/* Add a line break for mobile, which uses white-space: pre-line */}
+      {'\n'}
+      <a href="https://www.va.gov/directory/guide/home.asp">
+        Try using our other tools to search.
+      </a>
+    </div>
+  );
+
   render() {
+    const results = this.props.results;
+
     const coronavirusUpdate = (
       <>
         Please call first to confirm services or ask about getting help by phone
@@ -635,25 +648,28 @@ class VAMap extends Component {
     );
 
     return (
-      <div>
-        <div className="title-section">
-          <h1>Find VA locations</h1>
-        </div>
+      <>
+        <div>
+          <div className="title-section">
+            <h1>Find VA locations</h1>
+          </div>
 
-        <div className="facility-introtext">
-          <p>
-            Find a VA location or in-network community care provider. For
-            same-day care for minor illnesses or injuries, select Urgent care
-            for facility type.
-          </p>
-          <p>
-            <strong>Coronavirus update:</strong> {coronavirusUpdate}
-          </p>
+          <div className="facility-introtext">
+            <p>
+              Find a VA location or in-network community care provider. For
+              same-day care for minor illnesses or injuries, select Urgent care
+              for facility type.
+            </p>
+            <p>
+              <strong>Coronavirus update:</strong> {coronavirusUpdate}
+            </p>
+          </div>
+          {this.state.isMobile
+            ? this.renderMobileView()
+            : this.renderDesktopView()}
         </div>
-        {this.state.isMobile
-          ? this.renderMobileView()
-          : this.renderDesktopView()}
-      </div>
+        {results && results.length > 0 && this.otherToolsLink()}
+      </>
     );
   }
 }

--- a/src/applications/facility-locator/tests/e2e/search.cypress.spec.js
+++ b/src/applications/facility-locator/tests/e2e/search.cypress.spec.js
@@ -39,6 +39,7 @@ describe('Facility search', () => {
     cy.get('.i-pin-card-map').contains('D');
 
     cy.get('.va-pagination').should('exist');
+    cy.get('#other-tools').should('exist');
   });
 
   it('should render breadcrumbs ', () => {
@@ -94,6 +95,7 @@ describe('Facility search', () => {
     cy.visit('/find-locations?fail=true');
 
     cy.get('#search-results-subheader').should('not.exist');
+    cy.get('#other-tools').should('not.exist');
   });
 
   it('finds community dentists', () => {
@@ -110,6 +112,7 @@ describe('Facility search', () => {
     cy.get('#search-results-subheader').contains(
       'Results for "Community providers (in VA’s network)", "Dentist - Orofacial Pain " near "Austin, Texas"',
     );
+    cy.get('#other-tools').should('exist');
 
     cy.injectAxe();
     cy.axeCheck();
@@ -133,6 +136,7 @@ describe('Facility search', () => {
     cy.get('#search-results-subheader').contains(
       'Results for "Community providers (in VA’s network)", "Clinic/Center - Urgent Care" near "Austin, Texas"',
     );
+    cy.get('#other-tools').should('exist');
 
     cy.injectAxe();
     cy.axeCheck();
@@ -153,6 +157,7 @@ describe('Facility search', () => {
     cy.get('#search-results-subheader').contains(
       'Results for "Urgent care", "Community urgent care providers (in VA’s network)" near "Austin, Texas"',
     );
+    cy.get('#other-tools').should('exist');
 
     cy.injectAxe();
     cy.axeCheck();
@@ -172,6 +177,7 @@ describe('Facility search', () => {
     cy.get('#search-results-subheader').contains(
       'Results for "Community pharmacies (in VA’s network)" near "Austin, Texas"',
     );
+    cy.get('#other-tools').should('exist');
 
     cy.injectAxe();
     cy.axeCheck();
@@ -226,6 +232,7 @@ describe('Facility search', () => {
     cy.get('#search-results-subheader').contains(
       'Results for "VA benefits", "All VA benefit services" near "Los Angeles, California"',
     );
+    cy.get('#other-tools').should('exist');
 
     cy.axeCheck();
 
@@ -241,6 +248,7 @@ describe('Facility search', () => {
     cy.findByText(/Get Directions/i).should('exist');
     cy.get('[alt="Static map"]').should('exist');
     cy.get('#hours-op h3').contains('Hours of operation');
+    cy.get('#other-tools').should('not.exist');
 
     cy.axeCheck();
   });

--- a/src/platform/testing/unit/mocha-setup.js
+++ b/src/platform/testing/unit/mocha-setup.js
@@ -11,6 +11,7 @@ import chaiDOM from 'chai-dom';
 import { JSDOM } from 'jsdom';
 import '../../site-wide/moment-setup';
 import ENVIRONMENTS from 'site/constants/environments';
+import { sessionStorageSetup } from '../utilities';
 
 // import sinon from 'sinon'
 
@@ -125,3 +126,4 @@ export default function setupJSDom() {
 }
 
 setupJSDom();
+sessionStorageSetup();

--- a/src/platform/testing/unit/mocha-setup.js
+++ b/src/platform/testing/unit/mocha-setup.js
@@ -11,7 +11,6 @@ import chaiDOM from 'chai-dom';
 import { JSDOM } from 'jsdom';
 import '../../site-wide/moment-setup';
 import ENVIRONMENTS from 'site/constants/environments';
-import { sessionStorageSetup } from '../utilities';
 
 // import sinon from 'sinon'
 
@@ -126,4 +125,3 @@ export default function setupJSDom() {
 }
 
 setupJSDom();
-sessionStorageSetup();


### PR DESCRIPTION
https://github.com/department-of-veterans-affairs/va.gov-team/issues/13180

## Description - see linked issue

During the recent changes for responsive design, the "other tools" link was added to the detail page by mistake.

## Acceptance criteria
- [x] The "other tools" link only appears on the search page, not on the detail page.
- [x] The "other tools" link appears centered, with appropriate spacing, whether or not pagination controls are shown.
- [x] Automated tests are added to ensure this

## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
