### PR TITLE
526: New Disability Follow Up Additional Info

### DIFF
--- a/src/applications/disability-benefits/all-claims/content/newDisabilityFollowUp.jsx
+++ b/src/applications/disability-benefits/all-claims/content/newDisabilityFollowUp.jsx
@@ -1,50 +1,7 @@
 import React from 'react';
-import Modal from '@department-of-veterans-affairs/formation-react/Modal';
+import AdditionalInfo from '@department-of-veterans-affairs/formation-react/AdditionalInfo';
 import { capitalizeEachWord } from '../utils';
 import { NULL_CONDITION_STRING } from '../constants';
-
-export class CauseTitle extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = { modalVisible: false };
-  }
-
-  openModal = () => this.setState({ modalVisible: true });
-
-  closeModal = () => this.setState({ modalVisible: false });
-
-  render() {
-    return (
-      <div>
-        What caused this{' '}
-        <button
-          type="button"
-          className="va-button-link"
-          onClick={this.openModal}
-        >
-          service-connected
-        </button>{' '}
-        disability?
-        <Modal
-          title="Service-connected disability"
-          onClose={this.closeModal}
-          visible={this.state.modalVisible}
-          id="service-connected-modal"
-        >
-          <p>
-            To be eligible for service-connected disability benefits, you’ll
-            need to show that your disability was caused by an event, injury, or
-            disease during your military service. You’ll need to show your
-            condition is linked to your service by submitting evidence, such as
-            medical reports or lay statements, with your claim. We may ask you
-            to have a claim exam if you don’t submit evidence or if we need more
-            information to decide your claim.
-          </p>
-        </Modal>
-      </div>
-    );
-  }
-}
 
 export const disabilityNameTitle = ({ formData }) => (
   <legend className="schemaform-block-title schemaform-title-underline">
@@ -52,4 +9,17 @@ export const disabilityNameTitle = ({ formData }) => (
       ? capitalizeEachWord(formData.condition)
       : NULL_CONDITION_STRING}
   </legend>
+);
+
+export const ServiceConnectedDisabilityDescription = () => (
+  <AdditionalInfo triggerText="What does service-connected disability mean?">
+    <p>
+      To be eligible for service-connected disability benefits, you’ll need to
+      show that your disability was caused by an event, injury, or disease
+      during your military service. You’ll need to show your condition is linked
+      to your service by submitting evidence, such as medical reports or lay
+      statements, with your claim. We may ask you to have a claim exam if you
+      don’t submit evidence or if we need more information to decide your claim.
+    </p>
+  </AdditionalInfo>
 );

--- a/src/applications/disability-benefits/all-claims/pages/newDisabilityFollowUp.js
+++ b/src/applications/disability-benefits/all-claims/pages/newDisabilityFollowUp.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import { createSelector } from 'reselect';
 
 import { capitalizeEachWord } from '../utils';
@@ -6,8 +5,8 @@ import disabilityLabels from '../content/disabilityLabels';
 
 import fullSchema from 'vets-json-schema/dist/21-526EZ-ALLCLAIMS-schema.json';
 import {
-  CauseTitle,
   disabilityNameTitle,
+  ServiceConnectedDisabilityDescription,
 } from '../content/newDisabilityFollowUp';
 
 import { validateLength } from 'platform/forms/validations';
@@ -62,7 +61,7 @@ export const uiSchema = {
     items: {
       'ui:title': disabilityNameTitle,
       cause: {
-        'ui:title': <CauseTitle />,
+        'ui:title': 'What caused this service-connected disability?',
         'ui:widget': 'radio',
         'ui:options': {
           labels: {
@@ -184,6 +183,9 @@ export const uiSchema = {
           'ui:validations': [validateLength(25)],
         },
       },
+      'view:serviceConnectedDisability': {
+        'ui:description': ServiceConnectedDisabilityDescription,
+      },
     },
   },
 };
@@ -220,6 +222,10 @@ export const schema = {
               vaMistreatmentLocation,
               vaMistreatmentDate,
             },
+          },
+          'view:serviceConnectedDisability': {
+            type: 'object',
+            properties: {},
           },
         },
       },


### PR DESCRIPTION
## Description
This modifies the existing new disability follow up step in 526 to use the additional info component instead of the modal component.

## Screenshots
![newdis](https://user-images.githubusercontent.com/53942725/92249610-5d8a3600-ee98-11ea-8114-f5328560a359.PNG)


## Acceptance criteria
- [ ] New disability follow up uses the additional info component