### PR TITLE
Add distance between helper function for geo coordinates

### DIFF
--- a/src/applications/facility-locator/utils/facilityDistance.js
+++ b/src/applications/facility-locator/utils/facilityDistance.js
@@ -3,7 +3,7 @@ function toRadians(value) {
 }
 
 export function distBetween(lat1, lng1, lat2, lng2) {
-  const R = 3959; // Earth's radius in miles
+  const R = 3959; // radius in miles
   const dLat = toRadians(lat2 - lat1);
   const dLon = toRadians(lng2 - lng1);
 

--- a/src/applications/facility-locator/utils/facilityDistance.js
+++ b/src/applications/facility-locator/utils/facilityDistance.js
@@ -3,7 +3,7 @@ function toRadians(value) {
 }
 
 export function distBetween(lat1, lng1, lat2, lng2) {
-  const R = 3959; // radius in miles
+  const R = 3959; // Earth's radius in miles
   const dLat = toRadians(lat2 - lat1);
   const dLon = toRadians(lng2 - lng1);
 

--- a/src/applications/vaos/utils/address.js
+++ b/src/applications/vaos/utils/address.js
@@ -158,7 +158,7 @@ function toRadians(value) {
 }
 
 export function distanceBetween(lat1, lng1, lat2, lng2) {
-  const R = 3959; // radius in miles
+  const R = 3959; // Earth's radius in miles
   const dLat = toRadians(lat2 - lat1);
   const dLon = toRadians(lng2 - lng1);
 

--- a/src/applications/vaos/utils/address.js
+++ b/src/applications/vaos/utils/address.js
@@ -152,3 +152,23 @@ export function uiSchema(label = '') {
     },
   };
 }
+
+function toRadians(value) {
+  return (value * Math.PI) / 180;
+}
+
+export function distanceBetween(lat1, lng1, lat2, lng2) {
+  const R = 3959; // radius in miles
+  const dLat = toRadians(lat2 - lat1);
+  const dLon = toRadians(lng2 - lng1);
+
+  const a =
+    Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+    Math.sin(dLon / 2) *
+      Math.sin(dLon / 2) *
+      Math.cos(toRadians(lat1)) *
+      Math.cos(toRadians(lat2));
+  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+
+  return (R * c).toFixed(1);
+}


### PR DESCRIPTION
## Description
This is simply a copy of the `distBetween()` function used in Facility Locator (`src/applications/facility-locator/utils/facilityDistance.js`) which calculates the distance in miles between 2 sets of coordinates.  I've re-confirmed the formula with a bit of research.


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
