### PR TITLE
fixes from a failed merge involving GIBCT feature flags

### DIFF
--- a/src/applications/gi/components/search/InstitutionSearchForm.jsx
+++ b/src/applications/gi/components/search/InstitutionSearchForm.jsx
@@ -65,7 +65,6 @@ function InstitutionSearchForm(props) {
             showHeader
             handleInputFocus={handleInstitutionSearchInputFocus}
             gibctBenefitFilterEnhancement={props.gibctBenefitFilterEnhancement}
-            gibctFilterEnhancement={props.gibctFilterEnhancement}
           />
           <OnlineClassesFilter
             onlineClasses={props.eligibility.onlineClasses}

--- a/src/applications/gi/tests/components/search/InstitutionSearchForm.unit.spec.jsx
+++ b/src/applications/gi/tests/components/search/InstitutionSearchForm.unit.spec.jsx
@@ -62,7 +62,6 @@ describe('<InstitutionSearchForm>', () => {
         autocomplete={autocomplete}
         eligibility={eligibility}
         filters
-        gibctCh33BenefitRateUpdate
         showModal={() => {}}
         hideModal={() => {}}
         clearAutocompleteSuggestions={() => {}}

--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -31,6 +31,7 @@ export default Object.freeze({
   gibctEybBottomSheet: 'gibctEybBottomSheet',
   gibctSearchEnhancements: 'gibctSearchEnhancements',
   gibctCh33BenefitRateUpdate: 'gibctCh33BenefitRateUpdate',
+  gibctFilterEnhancement: 'gibctFilterEnhancement',
   gibctBenefitFilterEnhancement: 'gibctBenefitFilterEnhancement',
   form996HigherLevelReview: 'form996HigherLevelReview',
   debtLettersShowLetters: 'debtLettersShowLetters',

--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -30,7 +30,6 @@ export default Object.freeze({
   allowOnline1010cgSubmissions: 'allow_online_10_10cg_submissions',
   gibctEybBottomSheet: 'gibctEybBottomSheet',
   gibctSearchEnhancements: 'gibctSearchEnhancements',
-  gibctCh33BenefitRateUpdate: 'gibctCh33BenefitRateUpdate',
   gibctFilterEnhancement: 'gibctFilterEnhancement',
   gibctBenefitFilterEnhancement: 'gibctBenefitFilterEnhancement',
   form996HigherLevelReview: 'form996HigherLevelReview',


### PR DESCRIPTION
## Description
https://github.com/department-of-veterans-affairs/va.gov-team/issues/13208

A bad merge caused college labels to be removed from the GIBCT search results page. These changes removes bad code and adds back in the feature flag for the labels.

## Testing done
Dev tested. 

## Screenshots
![image](https://user-images.githubusercontent.com/48804654/92272796-3e9b9c00-eeb8-11ea-9569-5d7498fd3341.png)


## Acceptance criteria
- [ ] 

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
