### PR TITLE
Treat all international address suggestions as CONFIRMED suggestions

### DIFF
--- a/src/platform/user/profile/utilities/index.js
+++ b/src/platform/user/profile/utilities/index.js
@@ -250,7 +250,8 @@ export const showAddressValidationModal = suggestedAddresses => {
   if (
     suggestedAddresses.length === 1 &&
     addressMetaData.confidenceScore > 90 &&
-    addressMetaData.deliveryPointValidation === CONFIRMED
+    (addressMetaData.deliveryPointValidation === CONFIRMED ||
+      addressMetaData.addressType === 'International')
   ) {
     return false;
   }

--- a/src/platform/user/profile/utilities/index.js
+++ b/src/platform/user/profile/utilities/index.js
@@ -251,7 +251,7 @@ export const showAddressValidationModal = suggestedAddresses => {
     suggestedAddresses.length === 1 &&
     addressMetaData.confidenceScore > 90 &&
     (addressMetaData.deliveryPointValidation === CONFIRMED ||
-      addressMetaData.addressType === 'International')
+      addressMetaData.addressType?.toLowerCase() === 'international')
   ) {
     return false;
   }

--- a/src/platform/user/profile/vet360/actions/transactions.js
+++ b/src/platform/user/profile/vet360/actions/transactions.js
@@ -230,7 +230,8 @@ export const validateAddress = (
       }));
     const confirmedSuggestions = suggestedAddresses.filter(
       suggestion =>
-        suggestion.addressMetaData?.deliveryPointValidation === CONFIRMED,
+        suggestion.addressMetaData?.deliveryPointValidation === CONFIRMED ||
+        suggestion.addressMetaData?.addressType === 'International',
     );
     const payloadWithSuggestedAddress = {
       ...confirmedSuggestions[0],

--- a/src/platform/user/profile/vet360/actions/transactions.js
+++ b/src/platform/user/profile/vet360/actions/transactions.js
@@ -231,7 +231,8 @@ export const validateAddress = (
     const confirmedSuggestions = suggestedAddresses.filter(
       suggestion =>
         suggestion.addressMetaData?.deliveryPointValidation === CONFIRMED ||
-        suggestion.addressMetaData?.addressType === 'International',
+        suggestion.addressMetaData?.addressType?.toLowerCase() ===
+          'international',
     );
     const payloadWithSuggestedAddress = {
       ...confirmedSuggestions[0],

--- a/src/platform/user/profile/vet360/util/local-vet360.js
+++ b/src/platform/user/profile/vet360/util/local-vet360.js
@@ -247,6 +247,68 @@ export default {
       1000,
     );
   },
+  addressValidationSuccessSingleInternational() {
+    return asyncReturn(
+      {
+        addresses: [
+          {
+            address: {
+              addressLine1: 'Great Russell Street',
+              addressType: 'INTERNATIONAL',
+              city: 'London',
+              countryName: 'United Kingdom',
+              countryCodeIso3: 'GBR',
+              internationalPostalCode: 'WC1B 3DG',
+            },
+            addressMetaData: {
+              confidenceScore: 96.0,
+              addressType: 'International',
+            },
+          },
+        ],
+        validationKey: 1520831034,
+      },
+      1000,
+    );
+  },
+  addressValidationSuccessTwoInternational() {
+    return asyncReturn(
+      {
+        addresses: [
+          {
+            address: {
+              addressLine1: '123 Great Russell Street',
+              addressType: 'INTERNATIONAL',
+              city: 'London',
+              countryName: 'United Kingdom',
+              countryCodeIso3: 'GBR',
+              internationalPostalCode: 'WC1B 3DG',
+            },
+            addressMetaData: {
+              confidenceScore: 96.0,
+              addressType: 'International',
+            },
+          },
+          {
+            address: {
+              addressLine1: '456 Great Russell Street',
+              addressType: 'INTERNATIONAL',
+              city: 'London',
+              countryName: 'United Kingdom',
+              countryCodeIso3: 'GBR',
+              internationalPostalCode: 'WC1B 3DG',
+            },
+            addressMetaData: {
+              confidenceScore: 96.0,
+              addressType: 'International',
+            },
+          },
+        ],
+        validationKey: 1520831034,
+      },
+      1000,
+    );
+  },
   addressValidationSuccessTwoConfirmedSuggestions() {
     return asyncReturn(
       {


### PR DESCRIPTION
## Description
Our code was filtering out and not showing any international address suggestions since we assumed all suggestions have the `deliveryPointValidation` prop, but that's only available on domestic addresses.


## Testing done
Local. Added some additional mock responses to use during local testing. Confirmed that when a single intl suggestion comes back, we do not show the validation screen and when more than one intl suggestion comes back, we show them all.

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs