### PR TITLE
Fix padding for event section vamc

### DIFF
--- a/src/site/layouts/event_listing.drupal.liquid
+++ b/src/site/layouts/event_listing.drupal.liquid
@@ -3,7 +3,7 @@
 {% include "src/site/includes/preview-edit.drupal.liquid" %}
 {% include "src/site/includes/breadcrumbs.drupal.liquid" with hideHomeBreadcrumb = true %}
 
-<div class="interior" id="content">
+<div class="interior vads-u-padding-bottom--3" id="content">
   <main class="va-l-detail-page va-facility-page">
     <div class="usa-grid usa-grid-full">
       {% if entityUrl.breadcrumb.1.text == "Outreach and events" %}


### PR DESCRIPTION
## Description
issue:  https://github.com/department-of-veterans-affairs/va.gov-team/issues/11873

## Testing done


## Screenshots

<img width="1313" alt="Screen Shot 2020-09-08 at 11 42 25 AM" src="https://user-images.githubusercontent.com/100468/92504531-6d6f8600-f1c8-11ea-8d70-a8c6c5ad842e.png">



## Acceptance criteria
- [x] https://github.com/department-of-veterans-affairs/va.gov-team/issues/11873#issuecomment-678461593

## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
