### PR TITLE
[Templates] Quick fix for VA Form teaser header

### DIFF
--- a/src/site/layouts/va_form.drupal.liquid
+++ b/src/site/layouts/va_form.drupal.liquid
@@ -144,8 +144,9 @@
             <h2 class="vads-u-font-size--h3 vads-u-margin-top--0 vads-u-padding-bottom--1 vads-u-border-bottom--1px vads-u-border-color--gray-light">
               {% assign linkTeasersHeader = 'Helpful links' %}
               {% if fieldVaFormLinkTeasers.length > 0 %}
-                Helpful links related to VA Form {{ fieldVaFormNumber }}
+                {% assign linkTeasersHeader = 'Helpful links related to VA Form ' | append: fieldVaFormNumber %}
               {% endif %}
+              {{ linkTeasersHeader }}
             </h2>
             <ul class="usa-unstyled-list">
               {% if fieldVaFormLinkTeasers.length > 0 %}


### PR DESCRIPTION
## Description
When I went to https://www.va.gov/find-forms/about-form-10-10ez/ I noticed the related links are missing their heading -

![image](https://user-images.githubusercontent.com/1915775/92513702-b7fbfd00-f1de-11ea-9c22-854b128f814f.png)

This PR fixes that logical error in the template.

## Testing done
Tested against http://localhost:3001/preview?nodeId=5745, the nodeId of the page that shows the error.

## Screenshots
![image](https://user-images.githubusercontent.com/1915775/92513786-db26ac80-f1de-11ea-9d20-b0437b7570bf.png)


## Acceptance criteria
- [ ] Heading isn't empty

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
