### PR TITLE
Add va facility v2 scaffold and scaffold unit test

### DIFF
--- a/src/applications/vaos/containers/VAFacilityPageV2.jsx
+++ b/src/applications/vaos/containers/VAFacilityPageV2.jsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { scrollAndFocus } from '../utils/scrollAndFocus';
+
+import {
+  openFacilityPage,
+  updateFacilityPageData,
+  routeToNextAppointmentPage,
+  routeToPreviousAppointmentPage,
+} from '../new-appointment/redux/actions';
+import { getFacilityPageInfo } from '../utils/selectors';
+
+const initialSchema = {
+  type: 'object',
+  required: ['vaParent', 'vaFacility'],
+  properties: {
+    vaParent: {
+      type: 'string',
+      enum: [],
+    },
+    vaFacility: {
+      type: 'string',
+      enum: [],
+    },
+  },
+};
+
+const pageKey = 'vaFacility';
+const pageTitle = 'Choose a VA location for your appointment';
+const title = <h1 className="vads-u-font-size--h2">{pageTitle}</h1>;
+
+export class VAFacilityPage extends React.Component {
+  componentDidMount() {
+    this.props.openFacilityPage(pageKey, initialSchema);
+    document.title = `${pageTitle} | Veterans Affairs`;
+    scrollAndFocus();
+  }
+
+  goBack = () => {
+    this.props.routeToPreviousAppointmentPage(this.props.history, pageKey);
+  };
+
+  goForward = () => {
+    this.props.routeToNextAppointmentPage(this.props.history, pageKey);
+  };
+
+  render() {
+    return (
+      <div>
+        {title}
+        Scaffold for VA Facility Page V2.
+      </div>
+    );
+  }
+}
+
+VAFacilityPage.propTypes = {
+  schema: PropTypes.object,
+  data: PropTypes.object.isRequired,
+};
+
+function mapStateToProps(state) {
+  return getFacilityPageInfo(state, pageKey);
+}
+
+const mapDispatchToProps = {
+  openFacilityPage,
+  updateFacilityPageData,
+  routeToNextAppointmentPage,
+  routeToPreviousAppointmentPage,
+};
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps,
+)(VAFacilityPage);

--- a/src/applications/vaos/containers/VAFacilityPageV2.jsx
+++ b/src/applications/vaos/containers/VAFacilityPageV2.jsx
@@ -13,12 +13,8 @@ import { getFacilityPageInfo } from '../utils/selectors';
 
 const initialSchema = {
   type: 'object',
-  required: ['vaParent', 'vaFacility'],
+  required: ['vaFacility'],
   properties: {
-    vaParent: {
-      type: 'string',
-      enum: [],
-    },
     vaFacility: {
       type: 'string',
       enum: [],

--- a/src/applications/vaos/tests/new-appointment/va-facility-page-v2.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/va-facility-page-v2.unit.spec.jsx
@@ -1,0 +1,97 @@
+import React from 'react';
+import { expect } from 'chai';
+
+import { mockFetch, resetFetch } from 'platform/testing/unit/helpers';
+import VAFacilityPage from '../../containers/VAFacilityPage';
+import { getParentSiteMock, getFacilityMock } from '../mocks/v0';
+import {
+  createTestStore,
+  setTypeOfCare,
+  renderWithStoreAndRouter,
+} from '../mocks/setup';
+import {
+  mockEligibilityFetches,
+  mockParentSites,
+  mockSupportedFacilities,
+} from '../mocks/helpers';
+
+const initialState = {
+  featureToggles: {
+    vaOnlineSchedulingVSPAppointmentNew: false,
+    vaOnlineSchedulingDirect: true,
+  },
+  user: {
+    profile: {
+      facilities: [{ facilityId: '983', isCerner: false }],
+    },
+  },
+};
+
+const parentSite983 = {
+  id: '983',
+  attributes: {
+    ...getParentSiteMock().attributes,
+    institutionCode: '983',
+    authoritativeName: 'Some VA facility',
+    rootStationCode: '983',
+    parentStationCode: '983',
+  },
+};
+
+describe('VAOS integration: VA facility page with a single-site user', () => {
+  beforeEach(() => mockFetch());
+  afterEach(() => resetFetch());
+
+  it('should show form with single required facility question', async () => {
+    mockParentSites(['983'], [parentSite983]);
+    const facilities = [
+      {
+        id: '983',
+        attributes: {
+          ...getFacilityMock().attributes,
+          institutionCode: '983',
+          city: 'Bozeman',
+          stateAbbrev: 'MT',
+          authoritativeName: 'Bozeman VA medical center',
+          rootStationCode: '983',
+          parentStationCode: '983',
+          requestSupported: true,
+        },
+      },
+      {
+        id: '983GC',
+        attributes: {
+          ...getFacilityMock().attributes,
+          institutionCode: '983GC',
+          rootStationCode: '983',
+          parentStationCode: '983',
+          requestSupported: true,
+        },
+      },
+    ];
+    mockSupportedFacilities({
+      siteId: '983',
+      parentId: '983',
+      typeOfCareId: '323',
+      data: facilities,
+    });
+    mockEligibilityFetches({
+      siteId: '983',
+      facilityId: '983',
+      typeOfCareId: '323',
+    });
+    const store = createTestStore(initialState);
+    await setTypeOfCare(store, /primary care/i);
+
+    const screen = renderWithStoreAndRouter(<VAFacilityPage />, {
+      store,
+    });
+
+    expect(global.document.title).to.equal(
+      'Choose a VA location for your appointment | Veterans Affairs',
+    );
+    expect(screen.baseElement).to.contain.text(
+      'Choose a VA location for your appointment',
+    );
+  });
+});


### PR DESCRIPTION
## Description
As part of our iteration on the VA Facility selection page, need to create page skeleton.

**NOTE:** Replace line 120 component 
`<Route path={`${match.url}/va-facility`} component={VAFacilityPage} />` with `<Route path={`${match.url}/va-facility`} component={VAFacilityPageV2} />` in order to view the component.

## Testing done
Basic Unit Test

## Screenshots
![image](https://user-images.githubusercontent.com/8315447/92518860-09a88580-f1e7-11ea-90c6-bf894de45854.png)
![image](https://user-images.githubusercontent.com/8315447/92518881-175e0b00-f1e7-11ea-89c4-8a83d027427d.png)

## Acceptance criteria
- [ ] Ensure page is navigated to via workflow

## Definition of done
- [ ] Events are logged appropriately
- [-] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
