### PR TITLE
Add feature flag for new VAOS facility page

### DIFF
--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -20,6 +20,7 @@ export default Object.freeze({
   vaOnlineSchedulingVSPRequestNew: 'vaOnlineSchedulingVspRequestNew',
   vaOnlineSchedulingExpressCare: 'vaOnlineSchedulingExpressCare',
   vaOnlineSchedulingExpressCareNew: 'vaOnlineSchedulingExpressCareNew',
+  vaOnlineSchedulingFlatFacilityPage: 'vaOnlineSchedulingFlatFacilityPage',
   vaGlobalDowntimeNotification: 'vaGlobalDowntimeNotification',
   ssoe: 'ssoe',
   ssoeInbound: 'ssoeInbound',


### PR DESCRIPTION
## Description
Add a new flag for the flat facility page in VAOS.

Backend PR: https://github.com/department-of-veterans-affairs/vets-api/pull/4853

## Acceptance criteria
- [ ] Flag name is correct

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
