### PR TITLE
Fix other tools display sans pagination.

### DIFF
--- a/src/applications/facility-locator/sass/facility-locator.scss
+++ b/src/applications/facility-locator/sass/facility-locator.scss
@@ -845,6 +845,7 @@ $facility-locator-color-gray: #ccc;
 #other-tools {
   text-align: center;
   margin: 22px auto;
+  clear: both;
 
   @media(max-width: $small-screen) {
     width: 260px;


### PR DESCRIPTION
https://github.com/department-of-veterans-affairs/va.gov-team/issues/13291

## Description

Layout of other tools message/link is off when pagination is not displayed.

This was because the pagination code from Formation was magically adding a `clear: both` to the pagination controls element.

## Testing done
Mañuel

## Screenshots
![Find_VA_Locations___Veterans_Affairs](https://user-images.githubusercontent.com/80267/92634981-18547280-f2a3-11ea-91e3-ea51ca0b54e1.png)


## Acceptance criteria
- [x] Other tools link looks good whether or not there are pagination controls

## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
