### PR TITLE
VACMS-2770: Add path based bc logic.

### DIFF
--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -390,9 +390,13 @@ module.exports = function registerFilters() {
     return fieldLink;
   };
 
-  liquid.filters.deriveLastBreadcrumbFromPath = (breadcrumbs, string) => {
+  liquid.filters.deriveLastBreadcrumbFromPath = (
+    breadcrumbs,
+    string,
+    currentPath,
+  ) => {
     const last = {
-      url: { path: breadcrumbs.path, routed: true },
+      url: { path: currentPath, routed: true },
       text: string,
     };
     breadcrumbs.push(last);

--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -390,13 +390,14 @@ module.exports = function registerFilters() {
     return fieldLink;
   };
 
-  liquid.filters.pathBCFormat = (bc, string) => {
-    const last = { url: { path: bc.path, routed: true }, text: string };
-    if (bc.length > 0) {
-      bc.push(last);
-    }
+  liquid.filters.deriveLastBreadcrumbFromPath = (breadcrumbs, string) => {
+    const last = {
+      url: { path: breadcrumbs.path, routed: true },
+      text: string,
+    };
+    breadcrumbs.push(last);
 
-    return bc;
+    return breadcrumbs;
   };
 
   // used to get a base url path of a health care region from entityUrl.path

--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -390,6 +390,15 @@ module.exports = function registerFilters() {
     return fieldLink;
   };
 
+  liquid.filters.pathBCFormat = (bc, string) => {
+    const last = { url: { path: bc.path, routed: true }, text: string };
+    if (bc.length > 0) {
+      bc.push(last);
+    }
+
+    return bc;
+  };
+
   // used to get a base url path of a health care region from entityUrl.path
   liquid.filters.regionBasePath = path => path.split('/')[1];
 

--- a/src/site/includes/breadcrumbs.drupal.liquid
+++ b/src/site/includes/breadcrumbs.drupal.liquid
@@ -1,6 +1,10 @@
 <nav data-template="includes/breadcrumbs" aria-label="Breadcrumb" aria-live="polite" class="va-nav-breadcrumbs" id="va-breadcrumbs">
   <ul class="row va-nav-breadcrumbs-list columns" id="va-breadcrumbs-list">
-    {% for crumb in entityUrl.breadcrumb %}
+    {% assign crumbs = entityUrl.breadcrumb %}
+    {% if pathBreadcrumb = true %}
+    {% assign crumbs = entityUrl.breadcrumb | pathBCFormat: title %}
+    {% endif %}
+    {% for crumb in crumbs %}
       {% if forloop.last == true %}
         <li><a aria-current="page" href="/{{ path }}">{{ crumb.text }}</a></li>
       {% elsif crumb.url.path %}

--- a/src/site/includes/breadcrumbs.drupal.liquid
+++ b/src/site/includes/breadcrumbs.drupal.liquid
@@ -1,8 +1,8 @@
 <nav data-template="includes/breadcrumbs" aria-label="Breadcrumb" aria-live="polite" class="va-nav-breadcrumbs" id="va-breadcrumbs">
   <ul class="row va-nav-breadcrumbs-list columns" id="va-breadcrumbs-list">
     {% assign crumbs = entityUrl.breadcrumb %}
-    {% if pathBreadcrumb = true %}
-    {% assign crumbs = entityUrl.breadcrumb | pathBCFormat: title %}
+    {% if deriveBreadcrumbsFromUrl == true %}
+    {% assign crumbs = entityUrl.breadcrumb | deriveLastBreadcrumbFromPath: title %}
     {% endif %}
     {% for crumb in crumbs %}
       {% if forloop.last == true %}

--- a/src/site/includes/breadcrumbs.drupal.liquid
+++ b/src/site/includes/breadcrumbs.drupal.liquid
@@ -2,7 +2,7 @@
   <ul class="row va-nav-breadcrumbs-list columns" id="va-breadcrumbs-list">
     {% assign crumbs = entityUrl.breadcrumb %}
     {% if deriveBreadcrumbsFromUrl == true %}
-    {% assign crumbs = entityUrl.breadcrumb | deriveLastBreadcrumbFromPath: title %}
+    {% assign crumbs = entityUrl.breadcrumb | deriveLastBreadcrumbFromPath: title, entityUrl.path %}
     {% endif %}
     {% for crumb in crumbs %}
       {% if forloop.last == true %}

--- a/src/site/layouts/va_form.drupal.liquid
+++ b/src/site/layouts/va_form.drupal.liquid
@@ -1,7 +1,7 @@
 {% include "src/site/includes/header.html" with drupalTags = true %}
 {% include "src/site/includes/alerts.drupal.liquid" %}
 {% include "src/site/includes/preview-edit.drupal.liquid" %}
-{% include "src/site/includes/breadcrumbs.drupal.liquid" %}
+{% include "src/site/includes/breadcrumbs.drupal.liquid" with pathBreadcrumb = true %}
 <div id="content" class="interior">
   <main class="va-l-detail-page">
     <div class="usa-grid usa-grid-full">

--- a/src/site/layouts/va_form.drupal.liquid
+++ b/src/site/layouts/va_form.drupal.liquid
@@ -1,7 +1,7 @@
 {% include "src/site/includes/header.html" with drupalTags = true %}
 {% include "src/site/includes/alerts.drupal.liquid" %}
 {% include "src/site/includes/preview-edit.drupal.liquid" %}
-{% include "src/site/includes/breadcrumbs.drupal.liquid" with pathBreadcrumb = true %}
+{% include "src/site/includes/breadcrumbs.drupal.liquid" with deriveBreadcrumbsFromUrl = true %}
 <div id="content" class="interior">
   <main class="va-l-detail-page">
     <div class="usa-grid usa-grid-full">


### PR DESCRIPTION
## Description
See https://github.com/department-of-veterans-affairs/va.gov-cms/issues/2770
We have some content types that need path driven breadcrumbs (content types that are not in the drupal menu system). For now, we are only targeting VA forms to use path driven crumbs.

## Testing done
Visual

## Screenshots
![image](https://user-images.githubusercontent.com/2404547/92643135-4475f080-f2af-11ea-9ae2-cfcf79a7a7e5.png)

## Acceptance criteria
- [ ] Go to `find-forms/about-form-21-22a/` and confirm breadcrumb looks like screenshot.