### PR TITLE
Adjusted total paid to you style in Estimate Your Benefits

### DIFF
--- a/src/applications/gi/components/profile/EstimatedBenefits.jsx
+++ b/src/applications/gi/components/profile/EstimatedBenefits.jsx
@@ -182,6 +182,7 @@ export const EstimatedBenefits = ({ profile, outputs, calculator }) => (
           value={outputs.totalPaidToYou.value}
           bold
           visible={outputs.totalPaidToYou.visible}
+          header
         />
       </div>
     </div>


### PR DESCRIPTION
## Description
Our tuition and housing cost lists are marked up with divs and headings right now. I think it would be beneficial to make them into headings and heading-labeled lists for screen reader context. 

https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/1277

## Testing done
Local testing

## Screenshots

<img width="560" alt="Screen Shot 2020-09-09 at 3 22 27 PM" src="https://user-images.githubusercontent.com/50601724/92643804-5e640300-f2b0-11ea-80d5-6cf25eaf108f.png">

## Acceptance criteria
- [x] Total paid to user changed to match other labels

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
