### PR TITLE
Updated URL for chapter 36

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -809,7 +809,7 @@
   {
     "appName": "28-8832-planning-and-guidance",
     "entryName": "28-8832-planning-and-career-guidance",
-    "rootUrl": "/education-and-career-counseling/apply-career-guidance-form-28-8832/",
+    "rootUrl": "/careers-employment/education-and-career-counseling/apply-career-guidance-form-28-8832/",
     "template": {
       "vagovprod": false,
       "layout": "page-react.html"

--- a/src/applications/vre/28-8832/manifest.json
+++ b/src/applications/vre/28-8832/manifest.json
@@ -2,5 +2,5 @@
   "appName": "28-8832-planning-and-guidance",
   "entryFile": "./app-entry.jsx",
   "entryName": "28-8832-planning-and-career-guidance",
-  "rootUrl": "/education-and-career-counseling/apply-career-guidance-form-28-8832"
+  "rootUrl": "/careers-employment/education-and-career-counseling/apply-career-guidance-form-28-8832/"
 }

--- a/src/applications/vre/28-8832/manifest.json
+++ b/src/applications/vre/28-8832/manifest.json
@@ -2,5 +2,5 @@
   "appName": "28-8832-planning-and-guidance",
   "entryFile": "./app-entry.jsx",
   "entryName": "28-8832-planning-and-career-guidance",
-  "rootUrl": "/careers-employment/education-and-career-counseling/apply-career-guidance-form-28-8832/"
+  "rootUrl": "/careers-employment/education-and-career-counseling/apply-career-guidance-form-28-8832"
 }


### PR DESCRIPTION
## Description
[Original Ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/13290)

This PR is to update the URL for the chapter 36 form

The previous URL was `/education-and-career-counseling/apply-career-guidance-form-28-8832`

The new URL is `/careers-employment/education-and-career-counseling/apply-career-guidance-form-28-8832`

## Acceptance criteria
- [x] The url has been updated to the recommendation from IA
