### PR TITLE
Add debugging output for eligibility in VAOS

### DIFF
--- a/src/applications/vaos/new-appointment/redux/actions.js
+++ b/src/applications/vaos/new-appointment/redux/actions.js
@@ -55,6 +55,7 @@ import {
 import {
   getEligibilityData,
   recordEligibilityGAEvents,
+  logEligibilityExplanation,
 } from '../../utils/eligibility';
 
 import { recordEligibilityFailure, resetDataLayer } from '../../utils/events';
@@ -339,6 +340,7 @@ export function openFacilityPage(page, uiSchema, schema) {
         );
 
         recordEligibilityGAEvents(eligibilityData, typeOfCareId, siteId);
+        logEligibilityExplanation(eligibilityData, typeOfCareId, locationId);
       }
 
       dispatch({
@@ -448,6 +450,11 @@ export function updateFacilityPageData(page, uiSchema, data) {
         );
 
         recordEligibilityGAEvents(eligibilityData, typeOfCareId, siteId);
+        logEligibilityExplanation(
+          eligibilityData,
+          typeOfCareId,
+          data.vaFacility,
+        );
 
         dispatch({
           type: FORM_ELIGIBILITY_CHECKS_SUCCEEDED,

--- a/src/applications/vaos/utils/eligibility.js
+++ b/src/applications/vaos/utils/eligibility.js
@@ -294,105 +294,110 @@ export function logEligibilityExplanation(
   typeOfCareId,
   locationId,
 ) {
-  if (environment.isProduction()) {
+  if (environment.isProduction() || navigator.userAgent === 'node.js') {
     return;
   }
 
-  /* eslint-disable no-console */
-  console.log('----');
-  console.log(
-    `%cEligibility checks for location ${locationId.replace(
-      'var',
-      '',
-    )} and type of care ${typeOfCareId}`,
-    'font-weight: bold',
-  );
-  const requestMessages = [];
-  const directMessages = [];
-  if (eligibilityData.requestSupported && !eligibilityData.requestFailed) {
-    if (!isUnderRequestLimit(eligibilityData)) {
-      requestMessages.push(
-        'The var-resources request limit service indicated that there are too many outstanding requests',
-      );
-    }
-
-    if (!hasVisitedInPastMonthsRequest(eligibilityData)) {
-      requestMessages.push(
-        `The var-resources visited in past months service indicated that there has not been a recent visit (past ${
-          eligibilityData.requestPastVisit.durationInMonths
-        } months) for this facility and type of care`,
-      );
-    }
-  } else {
-    if (eligibilityData.requestFailed) {
-      requestMessages.push(
-        'There were errors trying to determine eligibility for making requests',
-      );
-    }
-    if (!eligibilityData.requestSupported) {
-      requestMessages.push(
-        'VATS has requests disabled for this facility and type of care',
-      );
-    }
-  }
-
-  if (
-    eligibilityData.directEnabled &&
-    eligibilityData.directSupported &&
-    !eligibilityData.directFailed
-  ) {
-    if (!hasVisitedInPastMonthsDirect(eligibilityData)) {
-      directMessages.push(
-        `The var-resources visited in past months service indicated that there has not been a recent visit (past ${
-          eligibilityData.requestPastVisit.durationInMonths
-        } months)`,
-      );
-    }
-
-    if (!eligibilityData.clinics?.length) {
-      directMessages.push(
-        `The var-resources clinics service did not return any clinics for this facility and type of care`,
-      );
-    } else if (!eligibilityData.hasMatchingClinics) {
-      directMessages.push(
-        `The FE could not find any of the following clinic ids in the past 24 months of appointments: ${eligibilityData.clinics
-          .map(clinic => clinic.id)
-          .join(', ')}`,
-      );
-    }
-  } else if (eligibilityData.directEnabled) {
-    if (eligibilityData.directFailed) {
-      directMessages.push(
-        'There were errors trying to determine eligibility for direct scheduling',
-      );
-    }
-    if (!eligibilityData.directSupported) {
-      directMessages.push(
-        'VATS has direct scheduling disabled for this facility and type of care',
-      );
-    }
-  } else {
-    directMessages.push(
-      'Direct scheduling is disabled by feature toggle in the UI',
+  /* istanbul ignore next */
+  try {
+    /* eslint-disable no-console */
+    console.log('----');
+    console.log(
+      `%cEligibility checks for location ${locationId.replace(
+        'var',
+        '',
+      )} and type of care ${typeOfCareId}`,
+      'font-weight: bold',
     );
-  }
+    const requestMessages = [];
+    const directMessages = [];
+    if (eligibilityData.requestSupported && !eligibilityData.requestFailed) {
+      if (!isUnderRequestLimit(eligibilityData)) {
+        requestMessages.push(
+          'The var-resources request limit service indicated that there are too many outstanding requests',
+        );
+      }
 
-  if (directMessages.length) {
-    console.log('%cUser not eligible for direct scheduling:', 'color: red');
-    directMessages.forEach(message => {
-      console.log(`  ${message}`);
-    });
-  } else {
-    console.log('%cUser passed checks for direct scheduling', 'color: green');
-  }
+      if (!hasVisitedInPastMonthsRequest(eligibilityData)) {
+        requestMessages.push(
+          `The var-resources visited in past months service indicated that there has not been a recent visit (past ${
+            eligibilityData.requestPastVisit.durationInMonths
+          } months) for this facility and type of care`,
+        );
+      }
+    } else {
+      if (eligibilityData.requestFailed) {
+        requestMessages.push(
+          'There were errors trying to determine eligibility for making requests',
+        );
+      }
+      if (!eligibilityData.requestSupported) {
+        requestMessages.push(
+          'VATS has requests disabled for this facility and type of care',
+        );
+      }
+    }
 
-  if (requestMessages.length) {
-    console.log('%cUser not eligible for requests:', 'color: red');
-    requestMessages.forEach(message => {
-      console.log(`  ${message}`);
-    });
-  } else {
-    console.log('%cUser passed checks for requests', 'color: green');
+    if (
+      eligibilityData.directEnabled &&
+      eligibilityData.directSupported &&
+      !eligibilityData.directFailed
+    ) {
+      if (!hasVisitedInPastMonthsDirect(eligibilityData)) {
+        directMessages.push(
+          `The var-resources visited in past months service indicated that there has not been a recent visit (past ${
+            eligibilityData.requestPastVisit.durationInMonths
+          } months)`,
+        );
+      }
+
+      if (!eligibilityData.clinics?.length) {
+        directMessages.push(
+          `The var-resources clinics service did not return any clinics for this facility and type of care`,
+        );
+      } else if (!eligibilityData.hasMatchingClinics) {
+        directMessages.push(
+          `The FE could not find any of the following clinic ids in the past 24 months of appointments: ${eligibilityData.clinics
+            .map(clinic => clinic.id)
+            .join(', ')}`,
+        );
+      }
+    } else if (eligibilityData.directEnabled) {
+      if (eligibilityData.directFailed) {
+        directMessages.push(
+          'There were errors trying to determine eligibility for direct scheduling',
+        );
+      }
+      if (!eligibilityData.directSupported) {
+        directMessages.push(
+          'VATS has direct scheduling disabled for this facility and type of care',
+        );
+      }
+    } else {
+      directMessages.push(
+        'Direct scheduling is disabled by feature toggle in the UI',
+      );
+    }
+
+    if (directMessages.length) {
+      console.log('%cUser not eligible for direct scheduling:', 'color: red');
+      directMessages.forEach(message => {
+        console.log(`  ${message}`);
+      });
+    } else {
+      console.log('%cUser passed checks for direct scheduling', 'color: green');
+    }
+
+    if (requestMessages.length) {
+      console.log('%cUser not eligible for requests:', 'color: red');
+      requestMessages.forEach(message => {
+        console.log(`  ${message}`);
+      });
+    } else {
+      console.log('%cUser passed checks for requests', 'color: green');
+    }
+  } catch (e) {
+    captureError(e);
   }
   /* eslint-enable no-console */
 }

--- a/src/applications/vaos/utils/eligibility.js
+++ b/src/applications/vaos/utils/eligibility.js
@@ -1,3 +1,4 @@
+import environment from 'platform/utilities/environment';
 import { DISABLED_LIMIT_VALUE, PRIMARY_CARE } from '../utils/constants';
 import { captureError } from '../utils/error';
 
@@ -282,4 +283,116 @@ export function recordEligibilityGAEvents(eligibilityData) {
   if (eligibilityData.directEnabled && !eligibilityData.directSupported) {
     recordEligibilityFailure('direct-supported');
   }
+}
+
+/*
+ * This function logs information about eligibility to the console, to help with
+ * testing in non-production environments
+ */
+export function logEligibilityExplanation(
+  eligibilityData,
+  typeOfCareId,
+  locationId,
+) {
+  if (environment.isProduction()) {
+    return;
+  }
+
+  /* eslint-disable no-console */
+  console.log('----');
+  console.log(
+    `%cEligibility checks for location ${locationId.replace(
+      'var',
+      '',
+    )} and type of care ${typeOfCareId}`,
+    'font-weight: bold',
+  );
+  const requestMessages = [];
+  const directMessages = [];
+  if (eligibilityData.requestSupported && !eligibilityData.requestFailed) {
+    if (!isUnderRequestLimit(eligibilityData)) {
+      requestMessages.push(
+        'The var-resources request limit service indicated that there are too many outstanding requests',
+      );
+    }
+
+    if (!hasVisitedInPastMonthsRequest(eligibilityData)) {
+      requestMessages.push(
+        `The var-resources visited in past months service indicated that there has not been a recent visit (past ${
+          eligibilityData.requestPastVisit.durationInMonths
+        } months) for this facility and type of care`,
+      );
+    }
+  } else {
+    if (eligibilityData.requestFailed) {
+      requestMessages.push(
+        'There were errors trying to determine eligibility for making requests',
+      );
+    }
+    if (!eligibilityData.requestSupported) {
+      requestMessages.push(
+        'VATS has requests disabled for this facility and type of care',
+      );
+    }
+  }
+
+  if (
+    eligibilityData.directEnabled &&
+    eligibilityData.directSupported &&
+    !eligibilityData.directFailed
+  ) {
+    if (!hasVisitedInPastMonthsDirect(eligibilityData)) {
+      directMessages.push(
+        `The var-resources visited in past months service indicated that there has not been a recent visit (past ${
+          eligibilityData.requestPastVisit.durationInMonths
+        } months)`,
+      );
+    }
+
+    if (!eligibilityData.clinics?.length) {
+      directMessages.push(
+        `The var-resources clinics service did not return any clinics for this facility and type of care`,
+      );
+    } else if (!eligibilityData.hasMatchingClinics) {
+      directMessages.push(
+        `The FE could not find any of the following clinic ids in the past 24 months of appointments: ${eligibilityData.clinics
+          .map(clinic => clinic.id)
+          .join(', ')}`,
+      );
+    }
+  } else if (eligibilityData.directEnabled) {
+    if (eligibilityData.directFailed) {
+      directMessages.push(
+        'There were errors trying to determine eligibility for direct scheduling',
+      );
+    }
+    if (!eligibilityData.directSupported) {
+      directMessages.push(
+        'VATS has direct scheduling disabled for this facility and type of care',
+      );
+    }
+  } else {
+    directMessages.push(
+      'Direct scheduling is disabled by feature toggle in the UI',
+    );
+  }
+
+  if (directMessages.length) {
+    console.log('%cUser not eligible for direct scheduling:', 'color: red');
+    directMessages.forEach(message => {
+      console.log(`  ${message}`);
+    });
+  } else {
+    console.log('%cUser passed checks for direct scheduling', 'color: green');
+  }
+
+  if (requestMessages.length) {
+    console.log('%cUser not eligible for requests:', 'color: red');
+    requestMessages.forEach(message => {
+      console.log(`  ${message}`);
+    });
+  } else {
+    console.log('%cUser passed checks for requests', 'color: green');
+  }
+  /* eslint-enable no-console */
 }

--- a/src/applications/vaos/utils/eligibility.js
+++ b/src/applications/vaos/utils/eligibility.js
@@ -322,7 +322,7 @@ export function logEligibilityExplanation(
         requestMessages.push(
           `The var-resources visited in past months service indicated that there has not been a recent visit (past ${
             eligibilityData.requestPastVisit.durationInMonths
-          } months) for this facility and type of care`,
+          } months)`,
         );
       }
     } else {
@@ -353,12 +353,12 @@ export function logEligibilityExplanation(
 
       if (!eligibilityData.clinics?.length) {
         directMessages.push(
-          `The var-resources clinics service did not return any clinics for this facility and type of care`,
+          `The var-resources clinics service did not return any clinics`,
         );
       } else if (!eligibilityData.hasMatchingClinics) {
         directMessages.push(
-          `The FE could not find any of the following clinic ids in the past 24 months of appointments: ${eligibilityData.clinics
-            .map(clinic => clinic.id)
+          `The FE could not find any of the clinics returned by var-resources in the past 24 months of appointments: ${eligibilityData.clinics
+            .map(clinic => `${clinic.serviceName} (${clinic.id})`)
             .join(', ')}`,
         );
       }
@@ -375,7 +375,7 @@ export function logEligibilityExplanation(
       }
     } else {
       directMessages.push(
-        'Direct scheduling is disabled by feature toggle in the UI',
+        'The FE has disabled direct scheduling via feature toggle',
       );
     }
 

--- a/src/applications/vaos/utils/eligibility.js
+++ b/src/applications/vaos/utils/eligibility.js
@@ -289,6 +289,7 @@ export function recordEligibilityGAEvents(eligibilityData) {
  * This function logs information about eligibility to the console, to help with
  * testing in non-production environments
  */
+/* istanbul ignore next */
 export function logEligibilityExplanation(
   eligibilityData,
   typeOfCareId,
@@ -298,7 +299,6 @@ export function logEligibilityExplanation(
     return;
   }
 
-  /* istanbul ignore next */
   try {
     /* eslint-disable no-console */
     console.log('----');


### PR DESCRIPTION
## Description
This adds some console output to explain why a user is or isn't eligible for requests or direct scheduling. Should help testers and us debug more quickly.

## Testing done
Local testing

## Screenshots
![Screen Shot 2020-09-09 at 5 25 43 PM](https://user-images.githubusercontent.com/634932/92657323-9d9b4f80-f2c2-11ea-8f4e-cf03b80b6246.png)

## Acceptance criteria
- [ ] Eligibility information is helpful

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
