### PR TITLE
Remove top margin address validation alert

### DIFF
--- a/src/platform/user/profile/vet360/containers/AddressValidationView.jsx
+++ b/src/platform/user/profile/vet360/containers/AddressValidationView.jsx
@@ -251,7 +251,7 @@ class AddressValidationView extends React.Component {
           </div>
         )}
         <AlertBox
-          className="vads-u-margin-bottom--1"
+          className="vads-u-margin-bottom--1 vads-u-margin-top--0"
           status="warning"
           headline={addressValidationMessage.headline}
           scrollOnShow


### PR DESCRIPTION
## Description
Remove top padding Address Validation AlertBox.

## Testing done
Looks good locally

## Screenshots
![image](https://user-images.githubusercontent.com/14869324/92745810-e9400e80-f33f-11ea-868f-b6999a615f3a.png)

![image](https://user-images.githubusercontent.com/14869324/92745781-e3e2c400-f33f-11ea-8d7d-967a13a527c0.png)


## Acceptance criteria
- [x] Remove top padding Address Validation AlertBox

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
