### PR TITLE
Sanlouise 12009 remove cancel buttons

### DIFF
--- a/src/applications/personalization/profile-2/tests/components/personal-information/PersonalInformation.delete-address.unit.spec.jsx
+++ b/src/applications/personalization/profile-2/tests/components/personal-information/PersonalInformation.delete-address.unit.spec.jsx
@@ -51,13 +51,11 @@ function deleteAddress(addressName) {
     })
     .click();
   const confirmDeleteButton = view.getByText('Confirm', { selector: 'button' });
-  const cancelDeleteButton = view.getByText('Cancel', { selector: 'button' });
   confirmDeleteButton.click();
 
   return {
     cityInput,
     confirmDeleteButton,
-    cancelDeleteButton,
   };
 }
 
@@ -65,9 +63,7 @@ function deleteAddress(addressName) {
 async function testQuickSuccess(addressName) {
   server.use(...mocks.transactionPending);
 
-  const { cancelDeleteButton, confirmDeleteButton, cityInput } = deleteAddress(
-    addressName,
-  );
+  const { confirmDeleteButton, cityInput } = deleteAddress(addressName);
 
   // Buttons should be disabled while the delete transaction is pending...
   // Waiting 10ms to make this check so that it happens _after_ the initial
@@ -77,7 +73,7 @@ async function testQuickSuccess(addressName) {
   // added to prevent regressing back to that poor experience where users were
   // able to interact with buttons that created duplicate XHRs.
   await wait(10);
-  expect(!!cancelDeleteButton.attributes.disabled).to.be.true;
+  expect(view.queryByText('Cancel', { selector: 'button' })).to.not.exist;
   expect(!!confirmDeleteButton.attributes.disabled).to.be.true;
   expect(confirmDeleteButton)
     .to.have.descendant('i')

--- a/src/applications/personalization/profile-2/tests/components/personal-information/PersonalInformation.delete-email-address.unit.spec.jsx
+++ b/src/applications/personalization/profile-2/tests/components/personal-information/PersonalInformation.delete-email-address.unit.spec.jsx
@@ -80,13 +80,9 @@ describe('Deleting email address', () => {
 
   it('should handle a deletion that succeeds quickly', async () => {
     server.use(...mocks.transactionPending);
-    const {
-      cancelDeleteButton,
-      confirmDeleteButton,
-      emailAddressInput,
-    } = deleteEmailAddress();
+    const { confirmDeleteButton, emailAddressInput } = deleteEmailAddress();
 
-    // Buttons should be disabled while the delete transaction is pending...
+    // Button should be disabled while the delete transaction is pending...
     // Waiting 10ms to make this check so that it happens _after_ the initial
     // delete transaction request is created. We had a UX bug where the buttons
     // were disabled while the initial transaction request was being created but
@@ -94,7 +90,7 @@ describe('Deleting email address', () => {
     // added to prevent regressing back to that poor experience where users were
     // able to interact with buttons that created duplicate XHRs.
     await wait(10);
-    expect(!!cancelDeleteButton.attributes.disabled).to.be.true;
+    expect(view.queryByText('Cancel', { selector: 'button' })).to.not.exist;
     expect(!!confirmDeleteButton.attributes.disabled).to.be.true;
     expect(confirmDeleteButton)
       .to.have.descendant('i')
@@ -169,7 +165,7 @@ describe('Deleting email address', () => {
     // initial transaction but were re-enabled while the transaction was still
     // pending.
     await wait(10);
-    expect(!!cancelDeleteButton.attributes.disabled).to.be.true;
+    expect(view.queryByText('Cancel', { selector: 'button' })).to.not.exist;
     expect(!!confirmDeleteButton.attributes.disabled).to.be.true;
     expect(confirmDeleteButton)
       .to.have.descendant('i')
@@ -185,7 +181,7 @@ describe('Deleting email address', () => {
     );
 
     // the buttons should be enabled again
-    expect(!!cancelDeleteButton.attributes.disabled).to.be.false;
+    expect(cancelDeleteButton).to.be.visible;
     expect(!!confirmDeleteButton.attributes.disabled).to.be.false;
     expect(confirmDeleteButton).to.contain.text('Confirm');
 

--- a/src/applications/personalization/profile-2/tests/components/personal-information/PersonalInformation.delete-telephone.unit.spec.jsx
+++ b/src/applications/personalization/profile-2/tests/components/personal-information/PersonalInformation.delete-telephone.unit.spec.jsx
@@ -51,21 +51,18 @@ function deletePhoneNumber(numberName) {
     })
     .click();
   const confirmDeleteButton = view.getByText('Confirm', { selector: 'button' });
-  const cancelDeleteButton = view.getByText('Cancel', { selector: 'button' });
   confirmDeleteButton.click();
 
-  return { phoneNumberInput, confirmDeleteButton, cancelDeleteButton };
+  return { phoneNumberInput, confirmDeleteButton };
 }
 
 // When the update happens while the Edit View is still active
 async function testQuickSuccess(numberName) {
   server.use(...mocks.transactionPending);
 
-  const {
-    cancelDeleteButton,
-    confirmDeleteButton,
-    phoneNumberInput,
-  } = deletePhoneNumber(numberName);
+  const { confirmDeleteButton, phoneNumberInput } = deletePhoneNumber(
+    numberName,
+  );
 
   // Button should be disabled while the delete transaction is pending...
   // Waiting 10ms to make this check so that it happens _after_ the initial
@@ -75,7 +72,7 @@ async function testQuickSuccess(numberName) {
   // added to prevent regressing back to that poor experience where users were
   // able to interact with buttons that created duplicate XHRs.
   await wait(10);
-  expect(cancelDeleteButton).to.not.be.visible;
+  expect(view.queryByText('Cancel', { selector: 'button' })).to.not.exist;
   expect(!!confirmDeleteButton.attributes.disabled).to.be.true;
   expect(confirmDeleteButton)
     .to.have.descendant('i')

--- a/src/applications/personalization/profile-2/tests/components/personal-information/PersonalInformation.delete-telephone.unit.spec.jsx
+++ b/src/applications/personalization/profile-2/tests/components/personal-information/PersonalInformation.delete-telephone.unit.spec.jsx
@@ -67,15 +67,15 @@ async function testQuickSuccess(numberName) {
     phoneNumberInput,
   } = deletePhoneNumber(numberName);
 
-  // Buttons should be disabled while the delete transaction is pending...
+  // Button should be disabled while the delete transaction is pending...
   // Waiting 10ms to make this check so that it happens _after_ the initial
-  // delete transaction request is created. We had a UX bug where the buttons
-  // were disabled while the initial transaction request was being created but
-  // were enabled again while polling the transaction status. This test was
+  // delete transaction request is created. We had a UX bug where the button
+  // was disabled while the initial transaction request was being created but
+  // was enabled again while polling the transaction status. This test was
   // added to prevent regressing back to that poor experience where users were
   // able to interact with buttons that created duplicate XHRs.
   await wait(10);
-  expect(!!cancelDeleteButton.attributes.disabled).to.be.true;
+  expect(cancelDeleteButton).to.not.be.visible;
   expect(!!confirmDeleteButton.attributes.disabled).to.be.true;
   expect(confirmDeleteButton)
     .to.have.descendant('i')

--- a/src/platform/user/profile/vet360/components/base/VAPEditModalActionButtons.jsx
+++ b/src/platform/user/profile/vet360/components/base/VAPEditModalActionButtons.jsx
@@ -92,14 +92,16 @@ class VAPEditModalActionButtons extends React.Component {
           >
             Confirm
           </LoadingButton>
-          <button
-            type="button"
-            className="usa-button-secondary"
-            onClick={this.cancelDeleteAction}
-            disabled={this.props.isLoading}
-          >
-            Cancel
-          </button>
+
+          {!this.props.isLoading && (
+            <button
+              type="button"
+              className="usa-button-secondary"
+              onClick={this.cancelDeleteAction}
+            >
+              Cancel
+            </button>
+          )}
         </div>
       </div>
     );

--- a/src/platform/user/profile/vet360/components/base/VAPEditView.jsx
+++ b/src/platform/user/profile/vet360/components/base/VAPEditView.jsx
@@ -118,13 +118,16 @@ class VAPEditView extends Component {
           >
             Update
           </LoadingButton>
-          <button
-            type="button"
-            className="usa-button-secondary vads-u-margin-top--0 vads-u-width--auto"
-            onClick={onCancel}
-          >
-            Cancel
-          </button>
+
+          {!isLoading && (
+            <button
+              type="button"
+              className="usa-button-secondary vads-u-margin-top--0 vads-u-width--auto"
+              onClick={onCancel}
+            >
+              Cancel
+            </button>
+          )}
         </div>
       </VAPEditModalActionButtons>
     );

--- a/src/platform/user/profile/vet360/containers/AddressValidationView.jsx
+++ b/src/platform/user/profile/vet360/containers/AddressValidationView.jsx
@@ -216,6 +216,7 @@ class AddressValidationView extends React.Component {
       transaction,
       transactionRequest,
       validationKey,
+      isLoading,
     } = this.props;
 
     const resetDataAndCloseModal = () => {
@@ -271,13 +272,16 @@ class AddressValidationView extends React.Component {
               this.renderAddressOption(address, String(index)),
             )}
           {this.renderPrimaryButton()}
-          <button
-            type="button"
-            className="usa-button-secondary"
-            onClick={resetDataAndCloseModal}
-          >
-            Cancel
-          </button>
+
+          {!isLoading && (
+            <button
+              type="button"
+              className="usa-button-secondary"
+              onClick={resetDataAndCloseModal}
+            >
+              Cancel
+            </button>
+          )}
         </form>
       </>
     );

--- a/src/platform/user/profile/vet360/tests/components/VAPEditView.unit.spec.jsx
+++ b/src/platform/user/profile/vet360/tests/components/VAPEditView.unit.spec.jsx
@@ -107,6 +107,24 @@ describe('<VAPEditView/>', () => {
     it('sets the LoadingButton to isLoading if the transaction is pending', () => {});
   });
 
+  describe('the cancel button', () => {
+    it('is hidden when the transactionRequest is pending', () => {
+      props.transactionRequest = { isPending: true };
+      props.render = actionButtons => actionButtons;
+      component = enzyme.mount(<VAPEditView {...props} />);
+      expect(component.text()).to.not.include('Cancel');
+      component.unmount();
+    });
+
+    it('is visible when the transactionRequest is not pending', () => {
+      props.transactionRequest = { isPending: false };
+      props.render = actionButtons => actionButtons;
+      component = enzyme.mount(<VAPEditView {...props} />);
+      expect(component.text()).to.include('Cancel');
+      component.unmount();
+    });
+  });
+
   describe('Vet360EditModalErrorMessage', () => {
     it("is not shown if there isn't an error", () => {
       component = enzyme.shallow(<VAPEditView {...props} />);

--- a/src/platform/user/profile/vet360/tests/containers/AddressValidationView.unit.spec.jsx
+++ b/src/platform/user/profile/vet360/tests/containers/AddressValidationView.unit.spec.jsx
@@ -132,6 +132,46 @@ describe('<AddressValidationView/>', () => {
     component.unmount();
   });
 
+  it('does not render cancel button while pending transaction', () => {
+    const newFakeStore = {
+      getState: () => ({
+        vet360: {
+          fieldTransactionMap: {
+            mailingAddress: {
+              isPending: true,
+            },
+          },
+          modal: 'addressValidation',
+          addressValidation: {
+            addressFromUser: {
+              addressLine1: '12345 1st Ave',
+              addressLine2: 'bldg 2',
+              addressLine3: 'apt 23',
+              city: 'Tampa',
+              stateCode: 'FL',
+              zipCode: '12346',
+            },
+            isAddressValidationModalVisible: true,
+            addressValidationError: true,
+            suggestedAddresses: [],
+            confirmedSuggestions: [],
+            addressValidationType: 'mailingAddress',
+            userEnteredAddress: {},
+            validationKey: null,
+          },
+        },
+      }),
+      subscribe: () => {},
+      dispatch: () => {},
+    };
+    const component = enzyme.mount(
+      <AddressValidationView store={newFakeStore} />,
+    );
+
+    expect(component.text()).to.not.include('Cancel');
+    component.unmount();
+  });
+
   it('renders multiple suggestion button text', () => {
     const newFakeStore = {
       getState: () => ({


### PR DESCRIPTION
## Description
When making profile updates, when a transaction is pending and the "update" button is showing a spinner, we should also remove the "cancel" button since it will not actually cancel the pending operation.

## Testing done
Works well locally. Updated unit tests.

## Acceptance criteria
- [x] When a transaction is pending and the "update" button is showing a spinner, remove the "cancel" button 

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
