### PR TITLE
Add redirects

### DIFF
--- a/src/applications/proxy-rewrite/redirects/crossDomainRedirects.json
+++ b/src/applications/proxy-rewrite/redirects/crossDomainRedirects.json
@@ -536,22 +536,7 @@
   },
   {
     "domain": "www.benefits.va.gov",
-    "src": "/compensation/resources_comp0118.asp",
-    "dest": "/disability/compensation-rates/veteran-rates/"
-  },
-  {
-    "domain": "www.benefits.va.gov",
-    "src": "/compensation/resources_comp0218.asp",
-    "dest": "/disability/compensation-rates/special-monthly-compensation-rates/"
-  },
-  {
-    "domain": "www.benefits.va.gov",
     "src": "/compensation/sb2019.asp",
-    "dest": "/disability/compensation-rates/birth-defect-rates/"
-  },
-  {
-    "domain": "www.benefits.va.gov",
-    "src": "/compensation/sb2018.asp",
     "dest": "/disability/compensation-rates/birth-defect-rates/"
   },
   {
@@ -1013,5 +998,45 @@
     "domain": "www.benefits.va.gov",
     "src": "/pension/current_protected_pension_rate_tables.asp",
     "dest": "/pension/protected-pension-rates/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/compensation/resources_comp0217.asp",
+    "dest": "/disability/compensation-rates/special-monthly-compensation-rates/past-rates-2018/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/compensation/resources_comp0218.asp",
+    "dest": "/disability/compensation-rates/special-monthly-compensation-rates/past-rates-2019/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/compensation/resources_comp0117.asp",
+    "dest": "/disability/compensation-rates/veteran-rates/past-rates-2018/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/compensation/resources_comp0118.asp",
+    "dest": "/disability/compensation-rates/veteran-rates/past-rates-2019/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/compensation/special_benefit_allowances_2017.asp",
+    "dest": "/disability/compensation-rates/special-benefit-allowance-rates/past-rates-2018/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/compensation/special_benefit_allowances_2018.asp",
+    "dest": "/disability/compensation-rates/special-benefit-allowance-rates/past-rates-2019/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/compensation/sb2017.asp",
+    "dest": "/disability/compensation-rates/birth-defect-rates/past-rates-2018/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/compensation/sb2018.asp",
+    "dest": "/disability/compensation-rates/birth-defect-rates/past-rates-2019/"
   }
 ]

--- a/src/applications/proxy-rewrite/redirects/crossDomainRedirects.json
+++ b/src/applications/proxy-rewrite/redirects/crossDomainRedirects.json
@@ -546,11 +546,6 @@
   },
   {
     "domain": "www.benefits.va.gov",
-    "src": "/compensation/special_benefit_allowances_2018.asp",
-    "dest": "/disability/compensation-rates/special-benefit-allowance-rates/"
-  },
-  {
-    "domain": "www.benefits.va.gov",
     "src": "/gibill/education_programs.asp",
     "dest": "/education/"
   },


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/13024

This PR implements the following redirects:

Current URL  |  Redirect Destination or New URL
---  |  ---
https://www.benefits.va.gov/COMPENSATION/resources_comp0217.asp | https://www.va.gov/disability/compensation-rates/special-monthly-compensation-rates/past-rates-2018/
https://www.benefits.va.gov/COMPENSATION/resources_comp0218.asp | https://www.va.gov/disability/compensation-rates/special-monthly-compensation-rates/past-rates-2019/
https://www.benefits.va.gov/COMPENSATION/resources_comp0117.asp | https://www.va.gov/disability/compensation-rates/veteran-rates/past-rates-2018/
https://www.benefits.va.gov/COMPENSATION/resources_comp0118.asp | https://www.va.gov/disability/compensation-rates/veteran-rates/past-rates-2019/
https://www.benefits.va.gov/compensation/special_Benefit_Allowances_2017.asp | https://www.va.gov/disability/compensation-rates/special-benefit-allowance-rates/past-rates-2018/
https://www.benefits.va.gov/compensation/special_Benefit_Allowances_2018.asp | https://www.va.gov/disability/compensation-rates/special-benefit-allowance-rates/past-rates-2019/
https://www.benefits.va.gov/COMPENSATION/sb2017.asp | https://www.va.gov/disability/compensation-rates/birth-defect-rates/past-rates-2018/
https://www.benefits.va.gov/COMPENSATION/sb2018.asp | https://www.va.gov/disability/compensation-rates/birth-defect-rates/past-rates-2019/

## Testing done
N/A

## Screenshots
N/A

## Acceptance criteria
- [x] Add redirects

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
