### PR TITLE
[508|Development] Add H1 to 526 intermediate pages

### DIFF
--- a/src/applications/disability-benefits/all-claims/components/ITFBanner.jsx
+++ b/src/applications/disability-benefits/all-claims/components/ITFBanner.jsx
@@ -20,7 +20,7 @@ export default class ITFBanner extends React.Component {
 
   render() {
     if (this.state.messageDismissed) {
-      return <>{this.props.children}</>;
+      return this.props.children;
     }
 
     let message;
@@ -55,8 +55,8 @@ export default class ITFBanner extends React.Component {
     }
 
     return (
-      <div className="row">
-        <div className="usa-width-two-thirds medium-8 columns vads-u-margin-bottom--2">
+      <div className="vads-l-grid-container vads-u-padding-left--0 vads-u-padding-bottom--5">
+        <div className="usa-content">
           <h1>{this.props.title}</h1>
           {message}
           {this.props.status !== 'error' && (

--- a/src/applications/disability-benefits/all-claims/containers/AddPerson.jsx
+++ b/src/applications/disability-benefits/all-claims/containers/AddPerson.jsx
@@ -17,9 +17,11 @@ const message =
   'We’re doing some additional work to enable you to file a claim...';
 
 const loading = title => (
-  <div className="vads-u-margin--3">
-    <h1>{title}</h1>
-    <LoadingIndicator message={message} />
+  <div className="vads-l-grid-container vads-u-padding-left--0 vads-u-padding-bottom--5">
+    <div className="usa-content">
+      <h1>{title}</h1>
+      <LoadingIndicator message={message} />
+    </div>
   </div>
 );
 

--- a/src/applications/disability-benefits/all-claims/containers/ITFWrapper.jsx
+++ b/src/applications/disability-benefits/all-claims/containers/ITFWrapper.jsx
@@ -69,6 +69,15 @@ export class ITFWrapper extends React.Component {
     );
   }
 
+  showLoading = (title, message) => (
+    <div className="vads-l-grid-container vads-u-padding-left--0 vads-u-padding-bottom--5">
+      <div className="usa-content">
+        <h1>{title}</h1>
+        <LoadingIndicator message={message} />
+      </div>
+    </div>
+  );
+
   render() {
     const { itf, title } = this.props;
 
@@ -77,13 +86,9 @@ export class ITFWrapper extends React.Component {
     } else if (fetchWaitingStates.includes(itf.fetchCallState)) {
       // If we get here, componentDidMount or componentWillRecieveProps called
       // fetchITF; While we're waiting, show the loading indicator...
-      return (
-        <div className="row">
-          <div className="usa-width-two-thirds medium-8 columns vads-u-margin-bottom--4">
-            <h1>{title}</h1>
-            <LoadingIndicator message="Please wait while we check to see if you have an existing Intent to File." />
-          </div>
-        </div>
+      return this.showLoading(
+        title,
+        'Please wait while we check to see if you have an existing Intent to File.',
       );
     } else if (itf.fetchCallState === requestStates.failed) {
       // We'll get here after the fetchITF promise is fulfilled
@@ -123,14 +128,7 @@ export class ITFWrapper extends React.Component {
     } else if (fetchWaitingStates.includes(itf.creationCallState)) {
       // componentWillRecieveProps called createITF if there was no active ITF
       // found; While we're waiting (again), show the loading indicator...again
-      return (
-        <div className="row">
-          <div className="usa-width-two-thirds medium-8 columns vads-u-margin-bottom--4">
-            <h1>{title}</h1>
-            <LoadingIndicator message="Submitting a new Intent to File..." />
-          </div>
-        </div>
-      );
+      return this.showLoading(title, 'Submitting a new Intent to File...');
     }
 
     // We'll get here after the createITF promise is fulfilled and we have no

--- a/src/applications/disability-benefits/all-claims/containers/MissingServices.jsx
+++ b/src/applications/disability-benefits/all-claims/containers/MissingServices.jsx
@@ -8,7 +8,7 @@ import Telephone, {
 import { getPageTitle } from '../utils';
 
 const Alert = ({ content }) => (
-  <div className="vads-l-grid-container vads-u-padding-bottom--5">
+  <div className="vads-l-grid-container vads-u-padding-left--0 vads-u-padding-bottom--5">
     <div className="usa-content">
       <h1>{getPageTitle()}</h1>
       <AlertBox isVisible content={content} status="error" />
@@ -33,12 +33,7 @@ export const MissingServices = ({ title }) => {
       </p>
     </>
   );
-  return (
-    <>
-      <h1>{title}</h1>
-      <Alert content={content} />
-    </>
-  );
+  return <Alert content={content} />;
 };
 
 export const MissingId = ({ title }) => {

--- a/src/applications/disability-benefits/all-claims/tests/containers/Form526EZApp.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/containers/Form526EZApp.unit.spec.jsx
@@ -82,7 +82,9 @@ describe('Form 526EZ Entry Page', () => {
           user={initialState.user}
           showWizard={initialState.showWizard}
         >
-          <main>{fakeSipsIntro(initialState.user)}</main>
+          <main>
+            <h1>{fakeSipsIntro(initialState.user)}</h1>
+          </main>
         </Form526Entry>
       </Provider>,
     );
@@ -94,6 +96,7 @@ describe('Form 526EZ Entry Page', () => {
     const tree = testPage({
       currentlyLoggedIn: false,
     });
+    expect(tree.find('h1')).to.have.lengthOf(1);
     expect(tree.find('RoutedSavableApp')).to.have.lengthOf(1);
     expect(tree.find('main').text()).to.contain('Log in');
     tree.unmount();
@@ -108,6 +111,7 @@ describe('Form 526EZ Entry Page', () => {
       services: [],
     });
     expect(tree.find('main')).to.have.lengthOf(0);
+    expect(tree.find('h1')).to.have.lengthOf(1);
     expect(tree.find('AlertBox')).to.have.lengthOf(1);
     expect(tree.find('AlertBox').text()).to.contain('BIRLS ID');
     tree.unmount();
@@ -123,6 +127,7 @@ describe('Form 526EZ Entry Page', () => {
       services: [idRequired[0]],
     });
     expect(tree.find('main')).to.have.lengthOf(0);
+    expect(tree.find('h1')).to.have.lengthOf(1);
     expect(tree.find('AlertBox')).to.have.lengthOf(1);
     expect(tree.find('AlertBox').text()).to.contain('need some information');
     tree.unmount();
@@ -136,6 +141,7 @@ describe('Form 526EZ Entry Page', () => {
       verified: true,
       services: serviceRequired,
     });
+    expect(tree.find('h1')).to.have.lengthOf(1);
     expect(tree.find('main').text()).to.contain('Start the form');
     tree.unmount();
   });
@@ -150,6 +156,7 @@ describe('Form 526EZ Entry Page', () => {
       services: serviceRequired,
     });
     localStorage.removeItem('hasSession');
+    expect(tree.find('h1')).to.have.lengthOf(1);
     expect(tree.find('main').text()).to.contain('Need to be verified');
 
     tree.unmount();
@@ -166,6 +173,7 @@ describe('Form 526EZ Entry Page', () => {
       mvi: MVI_ADD_INITIATED,
     });
     localStorage.removeItem('hasSession');
+    expect(tree.find('h1')).to.have.lengthOf(1);
     expect(tree.find('main')).to.have.lengthOf(0);
     expect(tree.find('LoadingIndicator')).to.have.lengthOf(1);
     expect(tree.find('LoadingIndicator').text()).to.contain('additional work');
@@ -184,6 +192,7 @@ describe('Form 526EZ Entry Page', () => {
       mvi: MVI_ADD_SUCCEEDED,
     });
     localStorage.removeItem('hasSession');
+    expect(tree.find('h1')).to.have.lengthOf(1);
     expect(tree.find('main').text()).to.contain('Start the form');
     tree.unmount();
   });
@@ -197,6 +206,7 @@ describe('Form 526EZ Entry Page', () => {
       services: ['add-person'],
       mvi: MVI_ADD_FAILED,
     });
+    expect(tree.find('h1')).to.have.lengthOf(1);
     expect(tree.find('main')).to.have.lengthOf(0);
     expect(tree.find('AlertBox')).to.have.lengthOf(1);
     expect(tree.find('AlertBox p').text()).to.contain(
@@ -211,6 +221,7 @@ describe('Form 526EZ Entry Page', () => {
     const tree = testPage({
       currentlyLoggedIn: false,
     });
+    expect(tree.find('h1')).to.have.lengthOf(1);
     expect(tree.find('WizardContainer')).to.have.lengthOf(1);
     tree.unmount();
   });
@@ -221,6 +232,7 @@ describe('Form 526EZ Entry Page', () => {
       currentlyLoggedIn: false,
     });
     localStorage.removeItem('hasSession');
+    expect(tree.find('h1')).to.have.lengthOf(1);
     expect(tree.find('WizardContainer')).to.have.lengthOf(1);
     tree.unmount();
   });
@@ -230,6 +242,7 @@ describe('Form 526EZ Entry Page', () => {
       currentlyLoggedIn: false,
       show526Wizard: false,
     });
+    expect(tree.find('h1')).to.have.lengthOf(1);
     expect(tree.find('WizardContainer')).to.have.lengthOf(0);
     tree.unmount();
   });

--- a/src/applications/disability-benefits/all-claims/tests/containers/ITFWrapper.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/containers/ITFWrapper.unit.spec.jsx
@@ -196,6 +196,7 @@ describe('526 ITFWrapper', () => {
       </ITFWrapper>,
     );
     const banner = tree.find('ITFBanner');
+    expect(tree.dive().find('h1')).to.have.lengthOf(1);
     expect(banner.length).to.equal(1);
     expect(banner.props().status).to.equal('error');
     tree.unmount();
@@ -224,6 +225,7 @@ describe('526 ITFWrapper', () => {
     expect(banner.length).to.equal(1);
     expect(bannerProps.status).to.equal('itf-found');
     expect(bannerProps.currentExpDate).to.equal(expirationDate);
+    expect(tree.find('h1')).to.have.lengthOf(1);
     tree.unmount();
   });
 

--- a/src/applications/disability-benefits/all-claims/tests/containers/WizardContainer.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/containers/WizardContainer.unit.spec.jsx
@@ -15,6 +15,7 @@ describe('Wizard Container', () => {
 
   it('should render', () => {
     const tree = shallow(<WizardContainer {...props} />);
+    expect(tree.find('h1')).to.have.lengthOf(1);
     expect(tree.find('.wizard-container')).to.have.lengthOf(1);
     expect(tree.find('FormFooter')).to.have.lengthOf(1);
     tree.unmount();


### PR DESCRIPTION
## Description

Form 526's intermediate pages, intent-to-file and ID error pages, do not include an `H1` with the form title. Adding the `H1`s was previously implemented in [PR 14052](https://github.com/department-of-veterans-affairs/vets-website/pull/14052), but causes some duplication of `H1`s. This PR fixes the problem and adds unit tests.

Note: These changes do not include showing an `H1` while the loading indicator of the save-in-progress (`RoutedSavableApp`) component is visible. That will require code changes in the platform folder.

Related: https://github.com/department-of-veterans-affairs/va.gov-team/issues/12666

## Testing done

Added unit tests to check for `H1`s

## Screenshots

<details><summary>Intent to File H1</summary>

<!-- leave a blank line above -->
![Screen Shot 2020-09-09 at 5 12 00 PM](https://user-images.githubusercontent.com/136959/92770904-071d6b80-f360-11ea-987e-70f84b10ef76.png)

![Screen Shot 2020-09-09 at 5 05 00 PM](https://user-images.githubusercontent.com/136959/92770984-1ef4ef80-f360-11ea-85c0-d5c53dfff1bf.png)</details>

<details><summary>ID Error H1</summary>

<!-- leave a blank line above -->
![Screen Shot 2020-09-10 at 12 32 00 PM](https://user-images.githubusercontent.com/136959/92773031-d9392680-f361-11ea-8205-4044cb69b939.png)</details>

## Acceptance criteria
- [x] H1s with the appropriate form flow included on every page

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
