### PR TITLE
[Development] Replace claim estimate with COVID message

### DIFF
--- a/src/applications/claims-status/components/ClaimEstimate.jsx
+++ b/src/applications/claims-status/components/ClaimEstimate.jsx
@@ -12,16 +12,17 @@ export default function ClaimEstimate({
   // Hide until estimates are accurate
   if (showCovidMessage) {
     return (
-      <AlertBox status="warning" headline="Completion estimate is unavailable">
+      <AlertBox
+        status="warning"
+        headline="Claim completion dates aren’t available right now"
+      >
         <p>
-          The estimated claim completion date feature has been temporarily
-          removed. Due to the impact COVID-19 has had on the availability and
-          scheduling of required in-person medical disability exams, the
-          estimated completion date is not accurate at this time. VA is
-          coordinating efforts to ensure all exams are scheduled and conducted
-          as soon as it is safe in each area. You can{' '}
+          We can’t provide an estimated date on when your claim will be complete
+          due to the affect that COVID-19 has had on scheduling in-person claim
+          exams. We’re starting to schedule in-person exams again in many
+          locations. To see the status of claim exams in your area, you can{' '}
           <a href="https://benefits.va.gov/compensation/claimexam.asp">
-            review the status of exams in your area
+            review locations where we’re now offering in-person exams
           </a>
           .
         </p>

--- a/src/applications/claims-status/components/ClaimEstimate.jsx
+++ b/src/applications/claims-status/components/ClaimEstimate.jsx
@@ -2,8 +2,33 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import moment from 'moment';
 import { Link } from 'react-router';
+import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 
-export default function ClaimEstimate({ maxDate, id }) {
+export default function ClaimEstimate({
+  maxDate,
+  id,
+  showCovidMessage = true,
+}) {
+  // Hide until estimates are accurate
+  if (showCovidMessage) {
+    return (
+      <AlertBox status="warning" headline="Completion estimate is unavailable">
+        <p>
+          The estimated claim completion date feature has been temporarily
+          removed. Due to the impact COVID-19 has bad on the availability and
+          scheduling of required in-person medical disability exams, the
+          estimated completion date is not accurate at this time. VA is
+          coordinating efforts to ensure all exams are scheduled and conducted
+          as soon as it is safe in each area. You can{' '}
+          <a href="https://benefits.va.gov/compensation/claimexam.asp">
+            review the status of exams in your area
+          </a>
+          .
+        </p>
+      </AlertBox>
+    );
+  }
+
   const estimatedDate = moment(maxDate);
   const today = moment().startOf('day');
 

--- a/src/applications/claims-status/components/ClaimEstimate.jsx
+++ b/src/applications/claims-status/components/ClaimEstimate.jsx
@@ -15,7 +15,7 @@ export default function ClaimEstimate({
       <AlertBox status="warning" headline="Completion estimate is unavailable">
         <p>
           The estimated claim completion date feature has been temporarily
-          removed. Due to the impact COVID-19 has bad on the availability and
+          removed. Due to the impact COVID-19 has had on the availability and
           scheduling of required in-person medical disability exams, the
           estimated completion date is not accurate at this time. VA is
           coordinating efforts to ensure all exams are scheduled and conducted

--- a/src/applications/claims-status/tests/components/ClaimEstimate.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/ClaimEstimate.unit.spec.jsx
@@ -11,7 +11,10 @@ describe('<ClaimEstimate>', () => {
       .startOf('day')
       .add(2, 'days');
     const tree = SkinDeep.shallowRender(
-      <ClaimEstimate maxDate={date.format('YYYY-MM-DD')} />,
+      <ClaimEstimate
+        maxDate={date.format('YYYY-MM-DD')}
+        showCovidMessage={false}
+      />,
     );
     expect(tree.text()).to.contain(
       `Estimated date: ${date.format('MMM D, YYYY')}`,
@@ -25,14 +28,19 @@ describe('<ClaimEstimate>', () => {
       .startOf('day')
       .subtract(2, 'days');
     const tree = SkinDeep.shallowRender(
-      <ClaimEstimate maxDate={date.format('YYYY-MM-DD')} />,
+      <ClaimEstimate
+        maxDate={date.format('YYYY-MM-DD')}
+        showCovidMessage={false}
+      />,
     );
     expect(tree.text()).to.contain(
       'We estimated your claim would be completed by now',
     );
   });
   it('should render no estimate warning', () => {
-    const tree = SkinDeep.shallowRender(<ClaimEstimate maxDate="" />);
+    const tree = SkinDeep.shallowRender(
+      <ClaimEstimate maxDate="" showCovidMessage={false} />,
+    );
     expect(tree.text()).to.contain('Estimate not available');
   });
   it('should render no estimate warning with far away date', () => {
@@ -40,7 +48,10 @@ describe('<ClaimEstimate>', () => {
       .startOf('day')
       .add(5, 'years');
     const tree = SkinDeep.shallowRender(
-      <ClaimEstimate maxDate={date.format('YYYY-MM-DD')} />,
+      <ClaimEstimate
+        maxDate={date.format('YYYY-MM-DD')}
+        showCovidMessage={false}
+      />,
     );
     expect(tree.text()).to.contain('Estimate not available');
   });

--- a/src/applications/claims-status/tests/e2e/01.claim-status-est-current.e2e.spec.js
+++ b/src/applications/claims-status/tests/e2e/01.claim-status-est-current.e2e.spec.js
@@ -35,8 +35,10 @@ module.exports = E2eHelpers.createE2eTest(client => {
   client.assert.urlContains('/your-claims/11/status');
 
   client.expect
-    .element('.claim-completion-desc')
+    // Disabled until COVID-19 message removed
+    // .element('.claim-completion-desc')
     // .text.to.contain('Estimate not available');
+    .element('.usa-alert-text')
     .text.to.contain('COVID-19 has had on the availability');
 
   client.end();

--- a/src/applications/claims-status/tests/e2e/01.claim-status-est-current.e2e.spec.js
+++ b/src/applications/claims-status/tests/e2e/01.claim-status-est-current.e2e.spec.js
@@ -36,7 +36,8 @@ module.exports = E2eHelpers.createE2eTest(client => {
 
   client.expect
     .element('.claim-completion-desc')
-    .text.to.contain('Estimate not available');
+    // .text.to.contain('Estimate not available');
+    .text.to.contain('COVID-19 has had on the availability');
 
   client.end();
 });

--- a/src/applications/claims-status/tests/e2e/01.claim-status-est-current.e2e.spec.js
+++ b/src/applications/claims-status/tests/e2e/01.claim-status-est-current.e2e.spec.js
@@ -39,7 +39,7 @@ module.exports = E2eHelpers.createE2eTest(client => {
     // .element('.claim-completion-desc')
     // .text.to.contain('Estimate not available');
     .element('.usa-alert-text')
-    .text.to.contain('COVID-19 has had on the availability');
+    .text.to.contain('COVID-19 has had on');
 
   client.end();
 });

--- a/src/applications/claims-status/tests/e2e/01.claim-status-est-past.e2e.spec.js
+++ b/src/applications/claims-status/tests/e2e/01.claim-status-est-past.e2e.spec.js
@@ -36,7 +36,9 @@ module.exports = E2eHelpers.createE2eTest(client => {
 
   client.expect
     .element('.claim-completion-desc')
-    .text.to.contain('We estimated your claim would be completed by now');
+    // Disabled unit COVID-19 message removed
+    // .text.to.contain('We estimated your claim would be completed by now');
+    .text.to.contain('COVID-19 has had on the availability');
 
   client.end();
 });

--- a/src/applications/claims-status/tests/e2e/01.claim-status-est-past.e2e.spec.js
+++ b/src/applications/claims-status/tests/e2e/01.claim-status-est-past.e2e.spec.js
@@ -39,7 +39,7 @@ module.exports = E2eHelpers.createE2eTest(client => {
     // .element('.claim-completion-desc')
     // .text.to.contain('We estimated your claim would be completed by now');
     .element('.usa-alert-text')
-    .text.to.contain('COVID-19 has had on the availability');
+    .text.to.contain('COVID-19 has had on');
 
   client.end();
 });

--- a/src/applications/claims-status/tests/e2e/01.claim-status-est-past.e2e.spec.js
+++ b/src/applications/claims-status/tests/e2e/01.claim-status-est-past.e2e.spec.js
@@ -35,9 +35,10 @@ module.exports = E2eHelpers.createE2eTest(client => {
   client.assert.urlContains('/your-claims/11/status');
 
   client.expect
-    .element('.claim-completion-desc')
-    // Disabled unit COVID-19 message removed
+    // Disabled until COVID-19 message removed
+    // .element('.claim-completion-desc')
     // .text.to.contain('We estimated your claim would be completed by now');
+    .element('.usa-alert-text')
     .text.to.contain('COVID-19 has had on the availability');
 
   client.end();

--- a/src/applications/claims-status/tests/e2e/01.claim-status-est.e2e.spec.js
+++ b/src/applications/claims-status/tests/e2e/01.claim-status-est.e2e.spec.js
@@ -39,7 +39,7 @@ module.exports = E2eHelpers.createE2eTest(client => {
     // .element('.claim-completion-desc')
     // .text.to.contain('base this on claims similar to yours');
     .element('.usa-alert-text')
-    .text.to.contain('COVID-19 has had on the availability');
+    .text.to.contain('COVID-19 has had on');
 
   client.end();
 });

--- a/src/applications/claims-status/tests/e2e/01.claim-status-est.e2e.spec.js
+++ b/src/applications/claims-status/tests/e2e/01.claim-status-est.e2e.spec.js
@@ -35,9 +35,10 @@ module.exports = E2eHelpers.createE2eTest(client => {
   client.assert.urlContains('/your-claims/11/status');
 
   client.expect
-    .element('.claim-completion-desc')
     // Disabled unit COVID-19 message removed
+    // .element('.claim-completion-desc')
     // .text.to.contain('base this on claims similar to yours');
+    .element('.usa-alert-text')
     .text.to.contain('COVID-19 has had on the availability');
 
   client.end();

--- a/src/applications/claims-status/tests/e2e/01.claim-status-est.e2e.spec.js
+++ b/src/applications/claims-status/tests/e2e/01.claim-status-est.e2e.spec.js
@@ -36,7 +36,9 @@ module.exports = E2eHelpers.createE2eTest(client => {
 
   client.expect
     .element('.claim-completion-desc')
-    .text.to.contain('base this on claims similar to yours');
+    // Disabled unit COVID-19 message removed
+    // .text.to.contain('base this on claims similar to yours');
+    .text.to.contain('COVID-19 has had on the availability');
 
   client.end();
 });

--- a/src/applications/claims-status/tests/e2e/06-claim-estimation-breadcrumb.e2e.spec.js
+++ b/src/applications/claims-status/tests/e2e/06-claim-estimation-breadcrumb.e2e.spec.js
@@ -20,7 +20,7 @@ module.exports = E2eHelpers.createE2eTest(client => {
     .waitForElementVisible('.claim-title', Timeouts.normal)
     .axeCheck('.main');
 
-  /* Disabled unit COVID-19 message removed
+  /* Disabled until COVID-19 message removed
   const selector = '.claim-estimate-link';
 
   client

--- a/src/applications/claims-status/tests/e2e/06-claim-estimation-breadcrumb.e2e.spec.js
+++ b/src/applications/claims-status/tests/e2e/06-claim-estimation-breadcrumb.e2e.spec.js
@@ -20,6 +20,7 @@ module.exports = E2eHelpers.createE2eTest(client => {
     .waitForElementVisible('.claim-title', Timeouts.normal)
     .axeCheck('.main');
 
+  /* Disabled unit COVID-19 message removed
   const selector = '.claim-estimate-link';
 
   client
@@ -43,6 +44,6 @@ module.exports = E2eHelpers.createE2eTest(client => {
     )
     .to.have.css('pointer-events')
     .which.equal('none');
-
+  */
   client.end();
 });

--- a/src/applications/claims-status/tests/e2e/06.claim-estimation.e2e.spec.js
+++ b/src/applications/claims-status/tests/e2e/06.claim-estimation.e2e.spec.js
@@ -20,7 +20,7 @@ module.exports = E2eHelpers.createE2eTest(client => {
     .waitForElementVisible('.claim-title', Timeouts.normal)
     .axeCheck('.main');
 
-  /* Disabled unit COVID-19 message removed
+  /* Disabled until COVID-19 message removed
   const selector = '.claim-estimate-link';
 
   client

--- a/src/applications/claims-status/tests/e2e/06.claim-estimation.e2e.spec.js
+++ b/src/applications/claims-status/tests/e2e/06.claim-estimation.e2e.spec.js
@@ -20,6 +20,7 @@ module.exports = E2eHelpers.createE2eTest(client => {
     .waitForElementVisible('.claim-title', Timeouts.normal)
     .axeCheck('.main');
 
+  /* Disabled unit COVID-19 message removed
   const selector = '.claim-estimate-link';
 
   client
@@ -32,6 +33,6 @@ module.exports = E2eHelpers.createE2eTest(client => {
   client.expect
     .element('.claims-status-content h1')
     .text.to.equal('How we come up with your estimated decision date');
-
+  */
   client.end();
 });


### PR DESCRIPTION
## Description

Temporarily replace the claim status estimate with a COVID-19 message

![Screen Shot 2020-09-16 at 1 36 03 PM](https://user-images.githubusercontent.com/136959/93378205-b905dd80-f821-11ea-9bfd-3e71725211c3.png)

The link leads to https://benefits.va.gov/compensation/claimexam.asp

<details><summary>Original appearance</summary>

<!-- leave a blank line above -->
<img width="1165" alt="screen_shot_2020-08-24_at_11 53 58_am" src="https://user-images.githubusercontent.com/136959/93378547-3a5d7000-f822-11ea-939f-0484a051c52f.png"></details>

NOTE: I was unable to find a user in my local dev environment to verify that this message is shown

Related: https://github.com/department-of-veterans-affairs/va.gov-team/issues/12480

## Testing done

Unit tests

## Screenshots

See above

## Acceptance criteria
- [x] COVID-19 alert shown in place of claim estimate

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
