### PR TITLE
[a11y] Fix iOS VoiceOver bug

### DIFF
--- a/src/platform/forms-system/src/js/components/FormNav.jsx
+++ b/src/platform/forms-system/src/js/components/FormNav.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import _ from 'lodash/fp'; // eslint-disable-line no-restricted-imports
 
 import SegmentedProgressBar from './SegmentedProgressBar';
@@ -14,6 +14,8 @@ import { REVIEW_APP_DEFAULT_MESSAGE } from '../constants';
 
 export default function FormNav(props) {
   const { formConfig, currentPath, formData } = props;
+
+  const [showHeader, setShowHeader] = useState(true);
 
   // This is converting the config into a list of pages with chapter keys,
   // finding the current page, then getting the chapter name using the key
@@ -52,6 +54,19 @@ export default function FormNav(props) {
 
   const stepText = `Step ${current} of ${chapters.length}: ${chapterName}`;
 
+  // The goal with this is to quickly "remove" the header from the DOM, and
+  // immediately re-renderthe componet with the header included. This should
+  // ensure that VoiceOver on iOS will pick up on the new <h2>
+  useEffect(
+    () => {
+      if (current > 1) {
+        setShowHeader(false);
+      }
+      setShowHeader(true);
+    },
+    [current],
+  );
+
   return (
     <div>
       <SegmentedProgressBar total={chapters.length} current={current} />
@@ -63,7 +78,7 @@ export default function FormNav(props) {
           aria-valuemax={chapters.length}
           className="nav-header nav-header-schemaform"
         >
-          <h2 className="vads-u-font-size--h4">{stepText}</h2>
+          {showHeader && <h2 className="vads-u-font-size--h4">{stepText}</h2>}
         </div>
       </div>
     </div>

--- a/src/platform/forms-system/src/js/components/FormNav.jsx
+++ b/src/platform/forms-system/src/js/components/FormNav.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import _ from 'lodash/fp'; // eslint-disable-line no-restricted-imports
-import shallowEqual from 'recompose/shallowEqual';
 
 import SegmentedProgressBar from './SegmentedProgressBar';
 
@@ -13,69 +12,63 @@ import {
 import PropTypes from 'prop-types';
 import { REVIEW_APP_DEFAULT_MESSAGE } from '../constants';
 
-const FormNav = React.memo(
-  props => {
-    const { formConfig, currentPath, formData } = props;
+export default function FormNav(props) {
+  const { formConfig, currentPath, formData } = props;
 
-    // This is converting the config into a list of pages with chapter keys,
-    // finding the current page, then getting the chapter name using the key
-    const formPages = createFormPageList(formConfig);
-    const pageList = createPageList(formConfig, formPages);
+  // This is converting the config into a list of pages with chapter keys,
+  // finding the current page, then getting the chapter name using the key
+  const formPages = createFormPageList(formConfig);
+  const pageList = createPageList(formConfig, formPages);
 
-    const eligiblePageList = getActiveExpandedPages(pageList, formData);
+  const eligiblePageList = getActiveExpandedPages(pageList, formData);
 
-    const chapters = _.uniq(
-      eligiblePageList.map(p => p.chapterKey).filter(key => !!key),
+  const chapters = _.uniq(
+    eligiblePageList.map(p => p.chapterKey).filter(key => !!key),
+  );
+
+  let page = eligiblePageList.filter(p => p.path === currentPath)[0];
+  // If the page isn’t active, it won’t be in the eligiblePageList
+  // This is a fallback to still find the chapter name if you open the page directly
+  // (the chapter index will probably be wrong, but this isn’t a scenario that happens in normal use)
+  if (!page) {
+    page = formPages.find(
+      p => `${formConfig.urlPrefix}${p.path}` === currentPath,
     );
+  }
 
-    let page = eligiblePageList.filter(p => p.path === currentPath)[0];
-    // If the page isn’t active, it won’t be in the eligiblePageList
-    // This is a fallback to still find the chapter name if you open the page directly
-    // (the chapter index will probably be wrong, but this isn’t a scenario that happens in normal use)
-    if (!page) {
-      page = formPages.find(
-        p => `${formConfig.urlPrefix}${p.path}` === currentPath,
-      );
+  let current;
+  let chapterName;
+  if (page) {
+    current = chapters.indexOf(page.chapterKey) + 1;
+    // The review page is always part of our forms, but isn’t listed in chapter list
+    chapterName =
+      page.chapterKey === 'review'
+        ? formConfig?.customText?.reviewPageTitle || REVIEW_APP_DEFAULT_MESSAGE
+        : formConfig.chapters[page.chapterKey].title;
+    if (typeof chapterName === 'function') {
+      chapterName = chapterName();
     }
+  }
 
-    let current;
-    let chapterName;
-    if (page) {
-      current = chapters.indexOf(page.chapterKey) + 1;
-      // The review page is always part of our forms, but isn’t listed in chapter list
-      chapterName =
-        page.chapterKey === 'review'
-          ? formConfig?.customText?.reviewPageTitle ||
-            REVIEW_APP_DEFAULT_MESSAGE
-          : formConfig.chapters[page.chapterKey].title;
-      if (typeof chapterName === 'function') {
-        chapterName = chapterName();
-      }
-    }
+  const stepText = `Step ${current} of ${chapters.length}: ${chapterName}`;
 
-    const stepText = `Step ${current} of ${chapters.length}: ${chapterName}`;
-
-    return (
-      <div>
-        <SegmentedProgressBar total={chapters.length} current={current} />
-        <div className="schemaform-chapter-progress">
-          <div
-            aria-valuenow={current}
-            aria-valuemin="1"
-            aria-valuetext={stepText}
-            aria-valuemax={chapters.length}
-            className="nav-header nav-header-schemaform"
-          >
-            <h2 className="vads-u-font-size--h4">{stepText}</h2>
-          </div>
+  return (
+    <div>
+      <SegmentedProgressBar total={chapters.length} current={current} />
+      <div className="schemaform-chapter-progress">
+        <div
+          aria-valuenow={current}
+          aria-valuemin="1"
+          aria-valuetext={stepText}
+          aria-valuemax={chapters.length}
+          className="nav-header nav-header-schemaform"
+        >
+          <h2 className="vads-u-font-size--h4">{stepText}</h2>
         </div>
       </div>
-    );
-  },
-  (prevProps, nextProps) => !shallowEqual(prevProps, nextProps),
-);
-
-export default FormNav;
+    </div>
+  );
+}
 
 FormNav.defaultProps = {
   formConfig: {

--- a/src/platform/forms-system/src/js/components/FormNav.jsx
+++ b/src/platform/forms-system/src/js/components/FormNav.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useReducer } from 'react';
 import _ from 'lodash/fp'; // eslint-disable-line no-restricted-imports
 
 import SegmentedProgressBar from './SegmentedProgressBar';
@@ -15,7 +15,7 @@ import { REVIEW_APP_DEFAULT_MESSAGE } from '../constants';
 export default function FormNav(props) {
   const { formConfig, currentPath, formData } = props;
 
-  const [showHeader, setShowHeader] = useState(true);
+  const [, forceUpdate] = useReducer(x => x + 1);
 
   // This is converting the config into a list of pages with chapter keys,
   // finding the current page, then getting the chapter name using the key
@@ -55,14 +55,14 @@ export default function FormNav(props) {
   const stepText = `Step ${current} of ${chapters.length}: ${chapterName}`;
 
   // The goal with this is to quickly "remove" the header from the DOM, and
-  // immediately re-renderthe componet with the header included. This should
+  // immediately re-render the component with the header included. This should
   // ensure that VoiceOver on iOS will pick up on the new <h2>
   useEffect(
     () => {
       if (current > 1) {
-        setShowHeader(false);
+        document.querySelector('#nav-form-header').remove();
+        forceUpdate();
       }
-      setShowHeader(true);
     },
     [current],
   );
@@ -78,7 +78,9 @@ export default function FormNav(props) {
           aria-valuemax={chapters.length}
           className="nav-header nav-header-schemaform"
         >
-          {showHeader && <h2 className="vads-u-font-size--h4">{stepText}</h2>}
+          <h2 id="nav-form-header" className="vads-u-font-size--h4">
+            {stepText}
+          </h2>
         </div>
       </div>
     </div>

--- a/src/platform/forms-system/src/js/components/FormNav.jsx
+++ b/src/platform/forms-system/src/js/components/FormNav.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useReducer } from 'react';
+import React, { useEffect, useState } from 'react';
 import _ from 'lodash/fp'; // eslint-disable-line no-restricted-imports
 
 import SegmentedProgressBar from './SegmentedProgressBar';
@@ -15,7 +15,7 @@ import { REVIEW_APP_DEFAULT_MESSAGE } from '../constants';
 export default function FormNav(props) {
   const { formConfig, currentPath, formData } = props;
 
-  const [, forceUpdate] = useReducer(x => x + 1, 0);
+  const [index, setIndex] = useState(0);
 
   // This is converting the config into a list of pages with chapter keys,
   // finding the current page, then getting the chapter name using the key
@@ -53,18 +53,23 @@ export default function FormNav(props) {
   }
 
   const stepText = `Step ${current} of ${chapters.length}: ${chapterName}`;
+  const onNewChapter = Math.abs(current - index) === 1;
+
+  // console.log(current, index);
+  // console.log('New Chapter:', onNewChapter);
 
   // The goal with this is to quickly "remove" the header from the DOM, and
   // immediately re-render the component with the header included. This should
   // ensure that VoiceOver on iOS will pick up on the new <h2>
   useEffect(
     () => {
-      if (current > 1) {
-        document.querySelector('#nav-form-header').remove();
-        forceUpdate();
+      if (current > index + 1) {
+        setIndex(index + 1);
+      } else if (current === index) {
+        setIndex(index - 1);
       }
     },
-    [current],
+    [current, index],
   );
 
   return (
@@ -78,9 +83,15 @@ export default function FormNav(props) {
           aria-valuemax={chapters.length}
           className="nav-header nav-header-schemaform"
         >
-          <h2 id="nav-form-header" className="vads-u-font-size--h4">
-            {stepText}
-          </h2>
+          {onNewChapter && (
+            <h2 id="nav-form-header" className="vads-u-font-size--h4">
+              {stepText}
+            </h2>
+          )}
+
+          {!onNewChapter && (
+            <div className="vads-u-font-size--h4">Loading...</div>
+          )}
         </div>
       </div>
     </div>

--- a/src/platform/forms-system/src/js/components/FormNav.jsx
+++ b/src/platform/forms-system/src/js/components/FormNav.jsx
@@ -9,6 +9,8 @@ import {
   getActiveExpandedPages,
 } from '../helpers';
 
+import { focusElement } from '../utilities/ui';
+
 import PropTypes from 'prop-types';
 import { REVIEW_APP_DEFAULT_MESSAGE } from '../constants';
 
@@ -55,9 +57,6 @@ export default function FormNav(props) {
   const stepText = `Step ${current} of ${chapters.length}: ${chapterName}`;
   const onNewChapter = Math.abs(current - index) === 1;
 
-  // console.log(current, index);
-  // console.log('New Chapter:', onNewChapter);
-
   // The goal with this is to quickly "remove" the header from the DOM, and
   // immediately re-render the component with the header included. This should
   // ensure that VoiceOver on iOS will pick up on the new <h2>
@@ -68,6 +67,10 @@ export default function FormNav(props) {
       } else if (current === index) {
         setIndex(index - 1);
       }
+
+      return () => {
+        focusElement('.nav-header > h2');
+      };
     },
     [current, index],
   );

--- a/src/platform/forms-system/src/js/components/FormNav.jsx
+++ b/src/platform/forms-system/src/js/components/FormNav.jsx
@@ -15,7 +15,7 @@ import { REVIEW_APP_DEFAULT_MESSAGE } from '../constants';
 export default function FormNav(props) {
   const { formConfig, currentPath, formData } = props;
 
-  const [, forceUpdate] = useReducer(x => x + 1);
+  const [, forceUpdate] = useReducer(x => x + 1, 0);
 
   // This is converting the config into a list of pages with chapter keys,
   // finding the current page, then getting the chapter name using the key

--- a/src/platform/forms-system/src/js/components/FormNav.jsx
+++ b/src/platform/forms-system/src/js/components/FormNav.jsx
@@ -90,7 +90,7 @@ export default function FormNav(props) {
           )}
 
           {!onNewChapter && (
-            <div className="vads-u-font-size--h4">Loading...</div>
+            <div className="vads-u-font-size--h4">{stepText}</div>
           )}
         </div>
       </div>

--- a/src/platform/forms-system/src/js/components/FormNav.jsx
+++ b/src/platform/forms-system/src/js/components/FormNav.jsx
@@ -13,13 +13,9 @@ import {
 import PropTypes from 'prop-types';
 import { REVIEW_APP_DEFAULT_MESSAGE } from '../constants';
 
-export default class FormNav extends React.Component {
-  // The formConfig transforming is a little heavy, so skip it if we can
-  shouldComponentUpdate(newProps) {
-    return !shallowEqual(this.props, newProps);
-  }
-  render() {
-    const { formConfig, currentPath, formData } = this.props;
+const FormNav = React.memo(
+  props => {
+    const { formConfig, currentPath, formData } = props;
 
     // This is converting the config into a list of pages with chapter keys,
     // finding the current page, then getting the chapter name using the key
@@ -75,8 +71,11 @@ export default class FormNav extends React.Component {
         </div>
       </div>
     );
-  }
-}
+  },
+  (prevProps, nextProps) => !shallowEqual(prevProps, nextProps),
+);
+
+export default FormNav;
 
 FormNav.defaultProps = {
   formConfig: {

--- a/src/platform/forms-system/src/js/components/FormNav.jsx
+++ b/src/platform/forms-system/src/js/components/FormNav.jsx
@@ -55,7 +55,7 @@ export default function FormNav(props) {
   }
 
   const stepText = `Step ${current} of ${chapters.length}: ${chapterName}`;
-  const onNewChapter = Math.abs(current - index) === 1;
+  const showHeader = Math.abs(current - index) === 1;
 
   // The goal with this is to quickly "remove" the header from the DOM, and
   // immediately re-render the component with the header included. This should
@@ -86,13 +86,13 @@ export default function FormNav(props) {
           aria-valuemax={chapters.length}
           className="nav-header nav-header-schemaform"
         >
-          {onNewChapter && (
+          {showHeader && (
             <h2 id="nav-form-header" className="vads-u-font-size--h4">
               {stepText}
             </h2>
           )}
 
-          {!onNewChapter && (
+          {!showHeader && (
             <div className="vads-u-font-size--h4">{stepText}</div>
           )}
         </div>

--- a/src/platform/forms-system/test/js/components/FormNav.unit.spec.jsx
+++ b/src/platform/forms-system/test/js/components/FormNav.unit.spec.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { expect } from 'chai';
-import SkinDeep from 'skin-deep';
+import { render } from '@testing-library/react';
 
 import FormNav from '../../../src/js/components/FormNav';
 
@@ -57,21 +57,20 @@ describe('Schemaform FormNav', () => {
   it('should render current chapter data', () => {
     const currentPath = 'testing';
     const formConfigDefaultData = getDefaultData();
-    const tree = SkinDeep.shallowRender(
+    const tree = render(
       <FormNav formConfig={formConfigDefaultData} currentPath={currentPath} />,
     );
 
-    expect(tree.subTree('SegmentedProgressBar').props.total).to.equal(4);
-    expect(tree.subTree('SegmentedProgressBar').props.current).to.equal(1);
-    expect(tree.subTree('.nav-header').text()).to.equal('Step 1 of 4: Testing');
+    expect(tree.getByText('Step 1 of 4: Testing')).to.not.be.null;
   });
   it('should display a custom review page title', () => {
     const formConfigReviewData = getReviewData();
     const currentPath = 'review-and-submit';
 
-    const tree = SkinDeep.shallowRender(
+    const tree = render(
       <FormNav formConfig={formConfigReviewData} currentPath={currentPath} />,
     );
-    expect(tree.text()).to.include('Custom Review Page Title');
+    expect(tree.getByText('Custom Review Page Title', { exact: false })).to.not
+      .be.null;
   });
 });


### PR DESCRIPTION
## Description

This is to fix the iOS VoiceOver issue that @1Copenut found after investigating the fix (https://github.com/department-of-veterans-affairs/vets-website/pull/14049) for https://github.com/department-of-veterans-affairs/va.gov-team/issues/12323

I converted the `<FormNav>` component from class-based to functional, because I knew that the solution would involve intercepting things at one of the `UNSAFE_*` lifecycle methods, and I didn't want to implement anything new using that approach. Instead, I use a hook to change state anytime we go to a new chapter, and this state change causes the re-render which fixes the issue.

**Note**: I've structured the branches to try to keep the diffs limited to the respective issue.  This PR was based off of and will merge into `12323-env-flag-removal`, which makes the original fix for 12323 live in production. The changes in this PR have been scoped to the related iOS VoiceOver issue.

## Testing done

Manual local testing in browser to make sure that the `<h2>` is not rendered initially, but a re-render happens immediately which includes it. Trevor tested this using VoiceOver on iOS to make sure the issue was fixed.

This kind of thing doesn't lend itself well to automated testing.


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
