### PR TITLE
Filter item schemas with itemFilter

### DIFF
--- a/src/platform/forms-system/src/js/validation.js
+++ b/src/platform/forms-system/src/js/validation.js
@@ -263,16 +263,24 @@ export function isValidForm(form, pageList) {
             formData,
           );
           // Remove the excluded array itemSchemas
-          // NOTE: This will only work when arrayPath isn't a nested path.
+          //
+          // NOTE: This will only work when `arrayPath` isn't a nested path.
           // This is consistent with other uses of arrayPath throughout the
           // library.
-          schema.properties[arrayPath] = _.set(
-            'items',
-            schema.properties[arrayPath].items.filter(
-              (item, index) => itemsToKeep[index],
-            ),
-            formData,
-          );
+          if (Array.isArray(schema.properties[arrayPath].items)) {
+            // `items` may be an array if the individual item schemas can be
+            // different, or a single object to describe every item. We only
+            // want to filter the schemas if they can be different. This ensures
+            // the data still matches its corresponding schema if we filtered
+            // out some data with `itemFilter`.
+            schema.properties[arrayPath] = _.set(
+              'items',
+              schema.properties[arrayPath].items.filter(
+                (item, index) => itemsToKeep[index],
+              ),
+              formData,
+            );
+          }
         } else {
           formData = _.unset(arrayPath, formData);
         }

--- a/src/platform/forms-system/src/js/validation.js
+++ b/src/platform/forms-system/src/js/validation.js
@@ -255,9 +255,22 @@ export function isValidForm(form, pageList) {
       if (showPagePerItem) {
         const arrayData = formData[arrayPath];
         if (arrayData) {
+          const itemsToKeep = arrayData.map(itemFilter || (() => true));
+          // Remove the excluded array data
           formData = _.set(
             arrayPath,
-            itemFilter ? arrayData.filter(itemFilter) : arrayData,
+            arrayData.filter((item, index) => itemsToKeep[index]),
+            formData,
+          );
+          // Remove the excluded array itemSchemas
+          // NOTE: This will only work when arrayPath isn't a nested path.
+          // This is consistent with other uses of arrayPath throughout the
+          // library.
+          schema.properties[arrayPath] = _.set(
+            'items',
+            schema.properties[arrayPath].items.filter(
+              (item, index) => itemsToKeep[index],
+            ),
             formData,
           );
         } else {

--- a/src/platform/forms-system/test/js/validation.unit.spec.js
+++ b/src/platform/forms-system/test/js/validation.unit.spec.js
@@ -573,66 +573,14 @@ describe('Schemaform validations', () => {
         data: {
           privacyAgreementAccepted: true,
           newDisabilities: [
-            {
-              condition: 'PTSD',
-              'view:descriptionInfo': {},
-            },
-            {
-              cause: 'NEW',
-              primaryDescription: 'while in service...',
-              'view:serviceConnectedDisability': {},
-              condition: 'TBI',
-              'view:descriptionInfo': {},
-            },
-            {
-              cause: 'SECONDARY',
-              'view:secondaryFollowUp': {
-                causedByDisability:
-                  'Intervertebral Disc Degeneration, Lumbosacral Region',
-                causedByDisabilityDescription: 'while in service...',
-              },
-              'view:serviceConnectedDisability': {},
-              condition: 'Cervicalgia',
-              'view:descriptionInfo': {},
-            },
+            { condition: 'PTSD' },
+            { cause: 'NEW', primaryDescription: 'while in service...' },
+            { cause: 'SECONDARY' },
           ],
         },
         pages: {
           newDisabilityFollowUp: {
-            uiSchema: {
-              'ui:title': 'Disability details',
-              newDisabilities: {
-                items: {
-                  cause: {
-                    'ui:title':
-                      'What caused this service-connected disability?',
-                    'ui:widget': 'radio',
-                    'ui:options': {
-                      labels: {
-                        NEW:
-                          'My disability was caused by an injury or exposure during my military service.',
-                        SECONDARY:
-                          'My disability was caused by another service-connected disability I already have. (For example, I have a limp that caused lower-back problems.)',
-                        WORSENED:
-                          'My disability or condition existed before I served in the military, but it got worse because of my military service.',
-                        VA:
-                          'My disability was caused by an injury or event that happened when I was receiving VA care.',
-                      },
-                    },
-                  },
-                  primaryDescription: {
-                    'ui:title':
-                      'Please briefly describe the injury or exposure that caused your condition. For example, I operated loud machinery while in the service, and this caused me to lose my hearing. (400 characters maximum)',
-                    'ui:widget': 'textarea',
-                    'ui:options': {
-                      expandUnder: 'cause',
-                      expandUnderCondition: 'NEW',
-                    },
-                    'ui:validations': [null],
-                  },
-                },
-              },
-            },
+            uiSchema: {},
             schema: {
               type: 'object',
               properties: {
@@ -643,41 +591,24 @@ describe('Schemaform validations', () => {
                       type: 'object',
                       required: ['cause'],
                       properties: {
-                        cause: {
-                          type: 'string',
-                          enum: ['NEW', 'SECONDARY', 'WORSENED', 'VA'],
-                        },
-                        primaryDescription: {
-                          type: 'string',
-                          'ui:collapsed': true,
-                        },
+                        cause: { type: 'string' },
+                        primaryDescription: { type: 'string' },
                       },
                     },
                     {
                       type: 'object',
                       required: ['cause', 'primaryDescription'],
                       properties: {
-                        cause: {
-                          type: 'string',
-                          enum: ['NEW', 'SECONDARY', 'WORSENED', 'VA'],
-                        },
-                        primaryDescription: {
-                          type: 'string',
-                        },
+                        cause: { type: 'string' },
+                        primaryDescription: { type: 'string' },
                       },
                     },
                     {
                       type: 'object',
                       required: ['cause'],
                       properties: {
-                        cause: {
-                          type: 'string',
-                          enum: ['NEW', 'SECONDARY', 'WORSENED', 'VA'],
-                        },
-                        primaryDescription: {
-                          type: 'string',
-                          'ui:collapsed': true,
-                        },
+                        cause: { type: 'string' },
+                        primaryDescription: { type: 'string' },
                       },
                     },
                   ],
@@ -685,13 +616,8 @@ describe('Schemaform validations', () => {
                     type: 'object',
                     required: ['cause'],
                     properties: {
-                      cause: {
-                        type: 'string',
-                        enum: ['NEW', 'SECONDARY', 'WORSENED', 'VA'],
-                      },
-                      primaryDescription: {
-                        type: 'string',
-                      },
+                      cause: { type: 'string' },
+                      primaryDescription: { type: 'string' },
                     },
                   },
                 },
@@ -709,39 +635,7 @@ describe('Schemaform validations', () => {
           showPagePerItem: true,
           itemFilter: item => item.condition !== 'PTSD',
           arrayPath: 'newDisabilities',
-          uiSchema: {
-            'ui:title': 'Disability details',
-            newDisabilities: {
-              items: {
-                cause: {
-                  'ui:title': 'What caused this service-connected disability?',
-                  'ui:widget': 'radio',
-                  'ui:options': {
-                    labels: {
-                      NEW:
-                        'My disability was caused by an injury or exposure during my military service.',
-                      SECONDARY:
-                        'My disability was caused by another service-connected disability I already have. (For example, I have a limp that caused lower-back problems.)',
-                      WORSENED:
-                        'My disability or condition existed before I served in the military, but it got worse because of my military service.',
-                      VA:
-                        'My disability was caused by an injury or event that happened when I was receiving VA care.',
-                    },
-                  },
-                },
-                primaryDescription: {
-                  'ui:title':
-                    'Please briefly describe the injury or exposure that caused your condition. For example, I operated loud machinery while in the service, and this caused me to lose my hearing. (400 characters maximum)',
-                  'ui:widget': 'textarea',
-                  'ui:options': {
-                    expandUnder: 'cause',
-                    expandUnderCondition: 'NEW',
-                  },
-                  'ui:validations': [null],
-                },
-              },
-            },
-          },
+          uiSchema: {},
           schema: {
             type: 'object',
             properties: {

--- a/src/platform/forms-system/test/js/validation.unit.spec.js
+++ b/src/platform/forms-system/test/js/validation.unit.spec.js
@@ -626,6 +626,7 @@ describe('Schemaform validations', () => {
             editMode: [false, false, false],
             showPagePerItem: true,
             arrayPath: 'newDisabilities',
+            itemFilter: item => item.condition !== 'PTSD',
           },
         },
       };
@@ -633,7 +634,6 @@ describe('Schemaform validations', () => {
         {
           path: '/new-disabilities/follow-up/:index',
           showPagePerItem: true,
-          itemFilter: item => item.condition !== 'PTSD',
           arrayPath: 'newDisabilities',
           uiSchema: {},
           schema: {

--- a/src/platform/forms-system/test/js/validation.unit.spec.js
+++ b/src/platform/forms-system/test/js/validation.unit.spec.js
@@ -587,30 +587,12 @@ describe('Schemaform validations', () => {
                 newDisabilities: {
                   type: 'array',
                   items: [
-                    {
-                      type: 'object',
-                      required: ['condition'],
-                      properties: {
-                        cause: { type: 'string' },
-                        primaryDescription: { type: 'string' },
-                      },
-                    },
+                    { type: 'object', required: ['condition'] },
                     {
                       type: 'object',
                       required: ['cause', 'primaryDescription'],
-                      properties: {
-                        cause: { type: 'string' },
-                        primaryDescription: { type: 'string' },
-                      },
                     },
-                    {
-                      type: 'object',
-                      required: ['cause'],
-                      properties: {
-                        cause: { type: 'string' },
-                        primaryDescription: { type: 'string' },
-                      },
-                    },
+                    { type: 'object', required: ['cause'] },
                   ],
                   additionalItems: {
                     type: 'object',

--- a/src/platform/forms-system/test/js/validation.unit.spec.js
+++ b/src/platform/forms-system/test/js/validation.unit.spec.js
@@ -589,7 +589,7 @@ describe('Schemaform validations', () => {
                   items: [
                     {
                       type: 'object',
-                      required: ['cause'],
+                      required: ['condition'],
                       properties: {
                         cause: { type: 'string' },
                         primaryDescription: { type: 'string' },

--- a/src/platform/forms-system/test/js/validation.unit.spec.js
+++ b/src/platform/forms-system/test/js/validation.unit.spec.js
@@ -565,6 +565,212 @@ describe('Schemaform validations', () => {
       expect(isValidForm(form, pageList).isValid).to.be.true;
       expect(pageList[1].depends.calledWith(form.data)).to.be.true;
     });
+    it('should match array itemSchema entries with formData array items', () => {
+      // The array items have different required fields, but some items are
+      // filtered out for the page. This test ensures that the corresponding
+      // schemas are also removed because they may be different.
+      const form = {
+        data: {
+          privacyAgreementAccepted: true,
+          newDisabilities: [
+            {
+              condition: 'PTSD',
+              'view:descriptionInfo': {},
+            },
+            {
+              cause: 'NEW',
+              primaryDescription: 'while in service...',
+              'view:serviceConnectedDisability': {},
+              condition: 'TBI',
+              'view:descriptionInfo': {},
+            },
+            {
+              cause: 'SECONDARY',
+              'view:secondaryFollowUp': {
+                causedByDisability:
+                  'Intervertebral Disc Degeneration, Lumbosacral Region',
+                causedByDisabilityDescription: 'while in service...',
+              },
+              'view:serviceConnectedDisability': {},
+              condition: 'Cervicalgia',
+              'view:descriptionInfo': {},
+            },
+          ],
+        },
+        pages: {
+          newDisabilityFollowUp: {
+            uiSchema: {
+              'ui:title': 'Disability details',
+              newDisabilities: {
+                items: {
+                  cause: {
+                    'ui:title':
+                      'What caused this service-connected disability?',
+                    'ui:widget': 'radio',
+                    'ui:options': {
+                      labels: {
+                        NEW:
+                          'My disability was caused by an injury or exposure during my military service.',
+                        SECONDARY:
+                          'My disability was caused by another service-connected disability I already have. (For example, I have a limp that caused lower-back problems.)',
+                        WORSENED:
+                          'My disability or condition existed before I served in the military, but it got worse because of my military service.',
+                        VA:
+                          'My disability was caused by an injury or event that happened when I was receiving VA care.',
+                      },
+                    },
+                  },
+                  primaryDescription: {
+                    'ui:title':
+                      'Please briefly describe the injury or exposure that caused your condition. For example, I operated loud machinery while in the service, and this caused me to lose my hearing. (400 characters maximum)',
+                    'ui:widget': 'textarea',
+                    'ui:options': {
+                      expandUnder: 'cause',
+                      expandUnderCondition: 'NEW',
+                    },
+                    'ui:validations': [null],
+                  },
+                },
+              },
+            },
+            schema: {
+              type: 'object',
+              properties: {
+                newDisabilities: {
+                  type: 'array',
+                  items: [
+                    {
+                      type: 'object',
+                      required: ['cause'],
+                      properties: {
+                        cause: {
+                          type: 'string',
+                          enum: ['NEW', 'SECONDARY', 'WORSENED', 'VA'],
+                        },
+                        primaryDescription: {
+                          type: 'string',
+                          'ui:collapsed': true,
+                        },
+                      },
+                    },
+                    {
+                      type: 'object',
+                      required: ['cause', 'primaryDescription'],
+                      properties: {
+                        cause: {
+                          type: 'string',
+                          enum: ['NEW', 'SECONDARY', 'WORSENED', 'VA'],
+                        },
+                        primaryDescription: {
+                          type: 'string',
+                        },
+                      },
+                    },
+                    {
+                      type: 'object',
+                      required: ['cause'],
+                      properties: {
+                        cause: {
+                          type: 'string',
+                          enum: ['NEW', 'SECONDARY', 'WORSENED', 'VA'],
+                        },
+                        primaryDescription: {
+                          type: 'string',
+                          'ui:collapsed': true,
+                        },
+                      },
+                    },
+                  ],
+                  additionalItems: {
+                    type: 'object',
+                    required: ['cause'],
+                    properties: {
+                      cause: {
+                        type: 'string',
+                        enum: ['NEW', 'SECONDARY', 'WORSENED', 'VA'],
+                      },
+                      primaryDescription: {
+                        type: 'string',
+                      },
+                    },
+                  },
+                },
+              },
+            },
+            editMode: [false, false, false],
+            showPagePerItem: true,
+            arrayPath: 'newDisabilities',
+          },
+        },
+      };
+      const pageList = [
+        {
+          path: '/new-disabilities/follow-up/:index',
+          showPagePerItem: true,
+          itemFilter: item => item.condition !== 'PTSD',
+          arrayPath: 'newDisabilities',
+          uiSchema: {
+            'ui:title': 'Disability details',
+            newDisabilities: {
+              items: {
+                cause: {
+                  'ui:title': 'What caused this service-connected disability?',
+                  'ui:widget': 'radio',
+                  'ui:options': {
+                    labels: {
+                      NEW:
+                        'My disability was caused by an injury or exposure during my military service.',
+                      SECONDARY:
+                        'My disability was caused by another service-connected disability I already have. (For example, I have a limp that caused lower-back problems.)',
+                      WORSENED:
+                        'My disability or condition existed before I served in the military, but it got worse because of my military service.',
+                      VA:
+                        'My disability was caused by an injury or event that happened when I was receiving VA care.',
+                    },
+                  },
+                },
+                primaryDescription: {
+                  'ui:title':
+                    'Please briefly describe the injury or exposure that caused your condition. For example, I operated loud machinery while in the service, and this caused me to lose my hearing. (400 characters maximum)',
+                  'ui:widget': 'textarea',
+                  'ui:options': {
+                    expandUnder: 'cause',
+                    expandUnderCondition: 'NEW',
+                  },
+                  'ui:validations': [null],
+                },
+              },
+            },
+          },
+          schema: {
+            type: 'object',
+            properties: {
+              newDisabilities: {
+                type: 'array',
+                items: {
+                  type: 'object',
+                  required: ['cause'],
+                  properties: {
+                    cause: {
+                      type: 'string',
+                      enum: ['NEW', 'SECONDARY', 'WORSENED', 'VA'],
+                    },
+                    primaryDescription: {
+                      type: 'string',
+                    },
+                  },
+                },
+              },
+            },
+          },
+          chapterTitle: 'Disabilities',
+          chapterKey: 'disabilities',
+          pageKey: 'newDisabilityFollowUp',
+        },
+      ];
+
+      expect(isValidForm(form, pageList).isValid).to.be.true;
+    });
   });
   describe('validateMonthYear', () => {
     it('should validate month and year', () => {


### PR DESCRIPTION
## Description
Items in an array may have different schemas. In `isValidForm`, we filter out array data for a page, given its `itemFilter`. Prior to this change, we did _not_ filter out the corresponding schemas.

This fixes that.

## Testing done
I wrote a unit test, modeling the data and schema after the bug we found. Before
making any changes, the test failed. After this fix, the test passes.

Test-driven development for the win!

## Screenshots
N/A

## Acceptance criteria
- [x] All tests pass
- [x] The item schemas match the data they correspond to in `isValidForm`
