### PR TITLE
Make sure that email label is right above the input for form 2346

### DIFF
--- a/src/applications/disability-benefits/2346/sass/form-2346.scss
+++ b/src/applications/disability-benefits/2346/sass/form-2346.scss
@@ -105,12 +105,6 @@ div.review {
   }
 }
 
-#root_vetEmail-label {
-  font-family: "Bitter";
-  font-size: 17px;
-  font-weight: 700;
-}
-
 @media print {
   .header, .va-nav-breadcrumbs, .schemaform-title, .print-copy, .order-submission-alert, .order-summary-alert, .order-timeframe-section, .order-questions-section, .footer, .help-footer-box {
     display: none;

--- a/src/applications/disability-benefits/2346/schemas/2346UI.js
+++ b/src/applications/disability-benefits/2346/schemas/2346UI.js
@@ -93,8 +93,6 @@ export default {
     },
     emailUI: {
       'ui:title': 'Email address',
-      'ui:description':
-        "We'll send an order confirmation email with a tracking number to this email address.",
       'ui:widget': 'email',
       'ui:errorMessages': {
         pattern: 'Please enter an email address using this format: X@X.com',


### PR DESCRIPTION
## Description

### Closes department-of-veterans-affairs/va-forms-system-core#315

This issue has changed over time. Originally, the form was configured to render an `<h4>` inside of a `<label>`, which is an a11y issue. Additionally, a "label" was actually being rendered inside of a `<p>` tag. This was fixed in https://github.com/department-of-veterans-affairs/vets-website/pull/13951, but it also introduced custom styling.

Since then, the acceptance criteria has changed. This PR satisfies the new acceptance criteria. The description text is no longer between the label and the input.


## Testing done

Manual visual testing

## Screenshots

![image](https://user-images.githubusercontent.com/2008881/92981343-4aee9e80-f44e-11ea-97f4-309534884d59.png)


## Acceptance criteria
- [x] As a user with cognitive considerations, I expect to see a label and input pairing consistently styled as throughout the rest of the site, with the label just above the text/email/search input or to the right of a radio/checkbox input, so that I am clearly able to understand what entry is expected.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
