### PR TITLE
Create function to set image's url and dimensions based on image style

### DIFF
--- a/src/site/stages/build/process-cms-exports/transformers/helpers.js
+++ b/src/site/stages/build/process-cms-exports/transformers/helpers.js
@@ -84,7 +84,7 @@ function getDrupalValue(arr) {
  */
 function getImageCrop(obj, imageStyle = null) {
   if (imageStyle !== null) {
-    const imageObj = obj;
+    const imageObj = Object.assign({}, obj);
     const image = mediaImageStyles.find(({ style }) => style === imageStyle);
     const url = `/img/styles/${image.machine}/${
       imageObj.image.derivative.url

--- a/src/site/stages/build/process-cms-exports/transformers/helpers.js
+++ b/src/site/stages/build/process-cms-exports/transformers/helpers.js
@@ -86,14 +86,17 @@ function getImageCrop(obj, imageStyle = null) {
   if (imageStyle !== null) {
     const imageObj = Object.assign({}, obj);
     const image = mediaImageStyles.find(({ style }) => style === imageStyle);
-    const url = `/img/styles/${image.machine}/${
-      imageObj.image.derivative.url
-    }`.replace('public:/', 'public');
-    imageObj.image.url = url;
-    imageObj.image.derivative.url = url;
-    imageObj.image.derivative.width = image.width;
-    imageObj.image.derivative.height = image.height;
-    return imageObj;
+    // If imageStyle is not found, it will return the raw obj
+    if (image) {
+      const url = `/img/styles/${image.machine}/${
+        imageObj.image.derivative.url
+      }`.replace('public:/', 'public');
+      imageObj.image.url = url;
+      imageObj.image.derivative.url = url;
+      imageObj.image.derivative.width = image.width;
+      imageObj.image.derivative.height = image.height;
+      return imageObj;
+    }
   }
   return obj;
 }

--- a/src/site/stages/build/process-cms-exports/transformers/helpers.js
+++ b/src/site/stages/build/process-cms-exports/transformers/helpers.js
@@ -4,6 +4,45 @@ const { sortBy, unescape, pick, omit } = require('lodash');
 const moment = require('moment-timezone');
 const { readEntity } = require('../helpers');
 
+const mediaImageStyles = [
+  {
+    style: '_1_1_SQUARE_MEDIUM_THUMBNAIL',
+    machine: '1_1_square_medium_thumbnail',
+    width: 240,
+    height: 240,
+  },
+  {
+    style: '_21MEDIUMTHUMBNAIL',
+    machine: '2_1_medium_thumbnail',
+    width: 480,
+    height: 240,
+  },
+  {
+    style: '_23MEDIUMTHUMBNAIL',
+    machine: '2_3_medium_thumbnail',
+    width: 320,
+    height: 480,
+  },
+  {
+    style: '_32MEDIUMTHUMBNAIL',
+    machine: '3_2_medium_thumbnail',
+    width: 480,
+    height: 320,
+  },
+  {
+    style: '_72MEDIUMTHUMBNAIL',
+    machine: '7_2_medium_thumbnail',
+    width: 1050,
+    height: 300,
+  },
+  {
+    style: 'LARGE',
+    machine: 'large',
+    width: 480,
+    height: 480,
+  },
+];
+
 /**
  * Takes a string with escaped unicode code points and replaces them
  * with the unicode characters. E.g. '\u2014' -> '—'
@@ -38,6 +77,28 @@ function getDrupalValue(arr) {
 }
 
 /**
+ * A very specific helper function that expects to receive an
+ * object and an imageStyle string
+ * @param {object}
+ * @return {object}
+ */
+function getImageCrop(obj, imageStyle = null) {
+  if (imageStyle !== null) {
+    const imageObj = obj;
+    const image = mediaImageStyles.find(({ style }) => style === imageStyle);
+    const url = `/img/styles/${image.machine}/${
+      imageObj.image.derivative.url
+    }`.replace('public:/', 'public');
+    imageObj.image.url = url;
+    imageObj.image.derivative.url = url;
+    imageObj.image.derivative.width = image.width;
+    imageObj.image.derivative.height = image.height;
+    return imageObj;
+  }
+  return obj;
+}
+
+/**
  * This is currently a dummy function, but we may
  * need it in the future to convert weird uris like
  * `entity:node/27` to something resembling a
@@ -55,6 +116,7 @@ function uriToUrl(uri) {
 
 module.exports = {
   getDrupalValue,
+  getImageCrop,
   unescapeUnicode,
   uriToUrl,
 

--- a/src/site/stages/build/process-cms-exports/transformers/helpers.js
+++ b/src/site/stages/build/process-cms-exports/transformers/helpers.js
@@ -87,16 +87,21 @@ function getImageCrop(obj, imageStyle = null) {
     const imageObj = Object.assign({}, obj);
     const image = mediaImageStyles.find(({ style }) => style === imageStyle);
     // If imageStyle is not found, it will return the raw obj
-    if (image) {
-      const url = `/img/styles/${image.machine}/${
-        imageObj.image.derivative.url
-      }`.replace('public:/', 'public');
-      imageObj.image.url = url;
-      imageObj.image.derivative.url = url;
-      imageObj.image.derivative.width = image.width;
-      imageObj.image.derivative.height = image.height;
-      return imageObj;
+    if (!image) {
+      throw new Error(
+        `${imageStyle} imageStyle was not found. mediaImageStyles available are ${mediaImageStyles
+          .map(s => s.style)
+          .join(', ')}.`,
+      );
     }
+    const url = `/img/styles/${image.machine}/${
+      imageObj.image.derivative.url
+    }`.replace('public:/', 'public');
+    imageObj.image.url = url;
+    imageObj.image.derivative.url = url;
+    imageObj.image.derivative.width = image.width;
+    imageObj.image.derivative.height = image.height;
+    return imageObj;
   }
   return obj;
 }

--- a/src/site/stages/build/process-cms-exports/transformers/node-news_story.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-news_story.js
@@ -4,6 +4,7 @@ const {
   isPublished,
   utcToEpochTime,
   getWysiwygString,
+  getImageCrop,
 } = require('./helpers');
 
 const transform = (entity, { ancestors }) => ({
@@ -24,7 +25,7 @@ const transform = (entity, { ancestors }) => ({
   fieldIntroText: getDrupalValue(entity.fieldIntroText),
   fieldMedia:
     entity.fieldMedia && entity.fieldMedia.length
-      ? { entity: entity.fieldMedia[0] }
+      ? getImageCrop(entity.fieldMedia[0], '_21MEDIUMTHUMBNAIL')
       : null,
   fieldOffice:
     entity.fieldOffice &&


### PR DESCRIPTION
## Description
Mismatched img width and height attributes. The GraphQL output seems to be using the thumbnail dimensions while the CMS export seems to be using the full dimensions.

This PR will fix that.

Dimensions list was taken from [here](https://github.com/department-of-veterans-affairs/va.gov-team/issues/13215#issuecomment-690681276)

## Testing done
Locally

## Screenshots

### Before
![Screen Shot 2020-09-14 at 10 51 15 AM](https://user-images.githubusercontent.com/55560129/93106232-06494a00-f67e-11ea-87d7-8b66f94fed4c.png)

### After
![Screen Shot 2020-09-14 at 10 50 18 AM](https://user-images.githubusercontent.com/55560129/93106254-0b0dfe00-f67e-11ea-8cc5-e0c9f69a7f50.png)

### Error catching
![Screen Shot 2020-09-14 at 2 11 36 PM](https://user-images.githubusercontent.com/55560129/93122401-65b25480-f694-11ea-85f5-ea2db31f9693.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
