### PR TITLE
Ignore Nova config files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ temp
 # Ignore user's editor/IDE prefs
 .vscode/
 .idea/
+.nova/
 .swp
 .swo
 all-links.csv


### PR DESCRIPTION
## Description
I started playing around with Panic's Nova editor and noticed the project config for that editor is stored in `.nova`

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs