### PR TITLE
Make Profile 2.0 page titles more specific

### DIFF
--- a/.nova/Configuration.json
+++ b/.nova/Configuration.json
@@ -1,0 +1,3 @@
+{
+  "workspace.color" : 9
+}

--- a/src/applications/personalization/profile-2/components/AccountSecurity.jsx
+++ b/src/applications/personalization/profile-2/components/AccountSecurity.jsx
@@ -16,6 +16,7 @@ import AccountSecurityContent from './AccountSecurityContent';
 class AccountSecurity extends Component {
   componentDidMount() {
     focusElement('[data-focus-target]');
+    document.title = `Account Security | Veterans Affairs`;
   }
 
   render() {

--- a/src/applications/personalization/profile-2/components/MilitaryInformation.jsx
+++ b/src/applications/personalization/profile-2/components/MilitaryInformation.jsx
@@ -138,24 +138,30 @@ const MilitaryInformationContent = ({ militaryInformation }) => {
   );
 };
 
-const MilitaryInformation = ({ militaryInformation }) => (
-  <>
-    <h2
-      tabIndex="-1"
-      className="vads-u-margin-y--2 medium-screen:vads-u-margin-bottom--4 medium-screen:vads-u-margin-top--3"
-      data-focus-target
-    >
-      Military information
-    </h2>
-    <DowntimeNotification
-      appTitle="Military Information"
-      render={handleDowntimeForSection('military service')}
-      dependencies={[externalServices.emis]}
-    >
-      <MilitaryInformationContent militaryInformation={militaryInformation} />
-    </DowntimeNotification>
-  </>
-);
+const MilitaryInformation = ({ militaryInformation }) => {
+  useEffect(() => {
+    document.title = `Military Information | Veterans Affairs`;
+  }, []);
+
+  return (
+    <>
+      <h2
+        tabIndex="-1"
+        className="vads-u-margin-y--2 medium-screen:vads-u-margin-bottom--4 medium-screen:vads-u-margin-top--3"
+        data-focus-target
+      >
+        Military information
+      </h2>
+      <DowntimeNotification
+        appTitle="Military Information"
+        render={handleDowntimeForSection('military service')}
+        dependencies={[externalServices.emis]}
+      >
+        <MilitaryInformationContent militaryInformation={militaryInformation} />
+      </DowntimeNotification>
+    </>
+  );
+};
 
 MilitaryInformation.propTypes = {
   militaryInformation: PropTypes.shape({

--- a/src/applications/personalization/profile-2/components/connected-apps/ConnectedApps.jsx
+++ b/src/applications/personalization/profile-2/components/connected-apps/ConnectedApps.jsx
@@ -19,6 +19,7 @@ import { ConnectedApp } from './ConnectedApp';
 export class ConnectedApps extends Component {
   componentDidMount() {
     focusElement('[data-focus-target]');
+    document.title = `Connected Apps | Veterans Affairs`;
     this.props.loadConnectedApps();
   }
 

--- a/src/applications/personalization/profile-2/components/direct-deposit/DirectDeposit.jsx
+++ b/src/applications/personalization/profile-2/components/direct-deposit/DirectDeposit.jsx
@@ -12,6 +12,7 @@ import DirectDepositContent from './DirectDepositContent';
 const DirectDeposit = () => {
   useEffect(() => {
     focusElement('[data-focus-target]');
+    document.title = `Direct Deposit | Veterans Affairs`;
   }, []);
 
   return (

--- a/src/applications/personalization/profile-2/components/personal-information/PersonalInformation.jsx
+++ b/src/applications/personalization/profile-2/components/personal-information/PersonalInformation.jsx
@@ -22,6 +22,10 @@ const PersonalInformation = ({
   hasUnsavedEdits,
 }) => {
   const lastLocation = useLastLocation();
+  useEffect(() => {
+    document.title = `Personal And Contact Information | Veterans Affairs`;
+  }, []);
+
   useEffect(
     () => {
       // Do not manage the focus if the user just came to this route via the

--- a/src/applications/personalization/profile-2/tests/e2e/profile.cypress.spec.js
+++ b/src/applications/personalization/profile-2/tests/e2e/profile.cypress.spec.js
@@ -18,8 +18,11 @@ function clickSubNavButton(buttonLabel, mobile) {
  * This helper:
  * - loads the Profile, confirms the user is redirected to the correct URL,
  *   performs an aXe scan, and checks that focus is managed correctly
- * - clicks through each item in the sub-nav, checks that the URL is correct,
- *   performs an aXe scan, and checks that focus is managed correctly
+ * - clicks through each item in the sub-nav and:
+ *   - checks that the URL is correct
+ *   - checks that the document title is correct
+ *   - performs an aXe scan
+ *   - checks that focus is managed correctly
  */
 function checkAllPages(mobile = false) {
   cy.visit(PROFILE_PATHS.PROFILE_ROOT);
@@ -44,6 +47,10 @@ function checkAllPages(mobile = false) {
     'eq',
     `${Cypress.config().baseUrl}${PROFILE_PATHS.PERSONAL_INFORMATION}`,
   );
+  cy.title().should(
+    'eq',
+    'Personal And Contact Information | Veterans Affairs',
+  );
 
   // focus should be on the sub-nav's h1 when redirected from /profile/
   cy.focused()
@@ -61,6 +68,7 @@ function checkAllPages(mobile = false) {
     'eq',
     `${Cypress.config().baseUrl}${PROFILE_PATHS.MILITARY_INFORMATION}`,
   );
+  cy.title().should('eq', 'Military Information | Veterans Affairs');
   cy.axeCheck();
   // focus should be on the section's h2
   cy.focused()
@@ -74,6 +82,7 @@ function checkAllPages(mobile = false) {
     'eq',
     `${Cypress.config().baseUrl}${PROFILE_PATHS.DIRECT_DEPOSIT}`,
   );
+  cy.title().should('eq', 'Direct Deposit | Veterans Affairs');
   cy.axeCheck();
   // focus should be on the section's h2
   cy.focused()
@@ -87,6 +96,7 @@ function checkAllPages(mobile = false) {
     'eq',
     `${Cypress.config().baseUrl}${PROFILE_PATHS.ACCOUNT_SECURITY}`,
   );
+  cy.title().should('eq', 'Account Security | Veterans Affairs');
   cy.axeCheck();
   // focus should be on the section's h2
   cy.focused()
@@ -100,6 +110,7 @@ function checkAllPages(mobile = false) {
     'eq',
     `${Cypress.config().baseUrl}${PROFILE_PATHS.CONNECTED_APPLICATIONS}`,
   );
+  cy.title().should('eq', 'Connected Apps | Veterans Affairs');
   // wait for this section's loading spinner to disappear...
   cy.findByRole('progressbar').should('not.exist');
   cy.axeCheck();

--- a/src/applications/vaos/tests/new-appointment/components/ConfirmationPage/index.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/ConfirmationPage/index.unit.spec.jsx
@@ -7,9 +7,6 @@ import { ConfirmationPage } from '../../../../new-appointment/components/Confirm
 import { FLOW_TYPES } from '../../../../utils/constants';
 import { renderWithStoreAndRouter } from '../../../mocks/setup';
 
-const start = moment();
-const end = start;
-
 const initialState = {
   featureToggles: {
     vaOnlineSchedulingCancel: true,
@@ -24,6 +21,8 @@ const startNewAppointmentFlow = sinon.spy();
 
 describe('VAOS <ConfirmationPage>', () => {
   it('should render appointment direct schedule view', async () => {
+    const start = moment().tz('America/Denver');
+    const end = start;
     const flowType = FLOW_TYPES.DIRECT;
     const data = {
       typeOfCareId: '323',
@@ -379,6 +378,8 @@ describe('VAOS <ConfirmationPage>', () => {
   });
 
   it('should render appointment list page when "View your appointments" button is clicked', () => {
+    const start = moment().tz('America/Denver');
+    const end = start;
     const flowType = FLOW_TYPES.DIRECT;
     const data = {
       typeOfCareId: '323',


### PR DESCRIPTION
## Description
Update the document title when each Profile component mounts. This is consistent with how other apps dynamically update the page title.

## Testing done
- [ ] update some existing Cypress tests

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs