### PR TITLE
Add pact tests for facility search

### DIFF
--- a/src/applications/facility-locator/actions/index.js
+++ b/src/applications/facility-locator/actions/index.js
@@ -42,9 +42,8 @@ export const clearSearchResults = () => ({
  * @param {Object} location The actual location object if we already have it.
  *                 (This is a kinda hacky way to do a force update of the Redux
  *                  store to set the currently `selectedResult` but ¯\_(ツ)_/¯)
- * @param {number} api version number
  */
-export const fetchVAFacility = (id, location = null, apiVersion) => {
+export const fetchVAFacility = (id, location = null) => {
   if (location) {
     return {
       type: FETCH_LOCATION_DETAIL,
@@ -61,7 +60,7 @@ export const fetchVAFacility = (id, location = null, apiVersion) => {
     });
 
     try {
-      const data = await LocatorApi.fetchVAFacility(id, apiVersion);
+      const data = await LocatorApi.fetchVAFacility(id);
       dispatch({ type: FETCH_LOCATION_DETAIL, payload: data.data });
     } catch (error) {
       dispatch({ type: SEARCH_FAILED, error });
@@ -102,14 +101,13 @@ export const fetchProviderDetail = id => async dispatch => {
  * @param {Function} dispatch Redux's dispatch method
  * @param {number} api version number
  */
-const fetchLocations = async (
+export const fetchLocations = async (
   address = null,
   bounds,
   locationType,
   serviceType,
   page,
   dispatch,
-  apiVersion,
 ) => {
   try {
     const data = await LocatorApi.searchWithBounds(
@@ -118,7 +116,6 @@ const fetchLocations = async (
       locationType,
       serviceType,
       page,
-      apiVersion,
     );
     // Record event as soon as API return results
     if (data.errors) {
@@ -143,7 +140,6 @@ export const searchWithBounds = ({
   facilityType,
   serviceType,
   page = 1,
-  apiVersion,
 }) => {
   const needsAddress = [
     LocationType.CC_PROVIDER,
@@ -178,19 +174,10 @@ export const searchWithBounds = ({
           serviceType,
           page,
           dispatch,
-          apiVersion,
         );
       });
     } else {
-      fetchLocations(
-        null,
-        bounds,
-        facilityType,
-        serviceType,
-        page,
-        dispatch,
-        apiVersion,
-      );
+      fetchLocations(null, bounds, facilityType, serviceType, page, dispatch);
     }
   };
 };

--- a/src/applications/facility-locator/api/index.js
+++ b/src/applications/facility-locator/api/index.js
@@ -6,11 +6,15 @@ import environment from 'platform/utilities/environment';
 // export default LiveApi;
 
 const getAPI = () => {
-  return !window.Mocha &&
-    (environment.isLocalhost() || window.Cypress) &&
-    !environment.API_URL.includes('review.vetsgov')
-    ? MockApi
-    : LiveApi;
+  const isUnitTest = window.Mocha;
+  const isReviewEnvironment = environment.API_URL.includes('review.vetsgov');
+  const isLocal = environment.isLocalhost();
+  const isCypress = window.Cypress;
+
+  if (isUnitTest || isReviewEnvironment) return LiveApi;
+  if (isLocal || isCypress) return MockApi;
+
+  return LiveApi;
 };
 
 export default getAPI();

--- a/src/applications/facility-locator/api/index.js
+++ b/src/applications/facility-locator/api/index.js
@@ -4,7 +4,13 @@ import environment from 'platform/utilities/environment';
 
 // To use vets-api data locally, replace the following with this:
 // export default LiveApi;
-export default ((environment.isLocalhost() || window.Cypress) &&
-!environment.API_URL.includes('review.vetsgov')
-  ? MockApi
-  : LiveApi);
+
+const getAPI = () => {
+  return !window.Mocha &&
+    (environment.isLocalhost() || window.Cypress) &&
+    !environment.API_URL.includes('review.vetsgov')
+    ? MockApi
+    : LiveApi;
+};
+
+export default getAPI();

--- a/src/applications/facility-locator/containers/VAMap.jsx
+++ b/src/applications/facility-locator/containers/VAMap.jsx
@@ -136,7 +136,6 @@ class VAMap extends Component {
         facilityType: newQuery.facilityType,
         serviceType: newQuery.serviceType,
         page: resultsPage,
-        apiVersion: this.props.useAPIv1 ? 1 : 0,
       });
     }
 
@@ -339,7 +338,6 @@ class VAMap extends Component {
       facilityType: currentQuery.facilityType,
       serviceType: currentQuery.serviceType,
       page,
-      apiVersion: this.props.useAPIv1 ? 1 : 0,
     });
     setFocus(this.searchResultTitle.current);
   };

--- a/src/applications/facility-locator/tests/contract/search.pact.spec.js
+++ b/src/applications/facility-locator/tests/contract/search.pact.spec.js
@@ -1,0 +1,323 @@
+import contractTest from 'platform/testing/contract';
+
+import {
+  fetchLocations,
+  fetchVAFacility,
+  getProviderSpecialties,
+} from '../../actions';
+import {
+  decimal,
+  eachLike,
+  integer,
+  string,
+} from '@pact-foundation/pact/dsl/matchers';
+import sinon from 'sinon';
+import LocatorApi from '../../api/LocatorApi';
+
+const bounds = ['-112.54', '32.53', '-111.04', '34.03'];
+const address = 'South Gilbert Road, Chandler, Arizona 85286, United States';
+
+const ccpInteraction = {
+  state: 'ccp data exists',
+  uponReceiving: 'a request for ccp data',
+  withRequest: {
+    method: 'GET',
+    path: '/v1/facilities/ccp',
+    headers: {
+      'X-Key-Inflection': 'camel',
+    },
+    query: {
+      address,
+      'bbox[]': bounds,
+      type: 'pharmacy',
+      page: '1',
+      // eslint-disable-next-line camelcase
+      per_page: '10',
+      trim: 'true',
+    },
+  },
+  willRespondWith: {
+    status: 200,
+    body: {
+      data: eachLike({
+        id: string('1972660348'),
+        type: 'provider',
+        attributes: {
+          address: {
+            street: string('2750 E GERMANN RD'),
+            city: string('CHANDLER'),
+            state: string('AZ'),
+            zip: string('85249'),
+          },
+          caresitePhone: string('4808122942'),
+          lat: decimal(33.281291),
+          long: decimal(-111.793486),
+          name: string('WAL-MART'),
+        },
+      }),
+    },
+  },
+};
+
+const mashupUrgentCareInteraction = {
+  state: 'mashup urgent care data exists',
+  uponReceiving: 'a request for mashup urgent care data',
+  withRequest: {
+    method: 'GET',
+    path: '/v1/facilities/va_ccp/urgent_care',
+    headers: {
+      'X-Key-Inflection': 'camel',
+    },
+    query: {
+      address,
+      'bbox[]': bounds,
+      page: '1',
+      // eslint-disable-next-line camelcase
+      per_page: '20',
+    },
+  },
+  willRespondWith: {
+    status: 200,
+    body: {
+      data: eachLike({
+        id: string('1972660348'),
+        type: 'provider',
+        attributes: {
+          address: {
+            street: string('2750 E GERMANN RD'),
+            city: string('CHANDLER'),
+            state: string('AZ'),
+            zip: string('85249'),
+          },
+          caresitePhone: string('4808122942'),
+          lat: decimal(33.281291),
+          long: decimal(-111.793486),
+          name: string('WAL-MART'),
+        },
+      }),
+    },
+  },
+};
+
+const vaInteraction = {
+  state: 'va data exists',
+  uponReceiving: 'a request for va data',
+  withRequest: {
+    method: 'GET',
+    path: '/v1/facilities/va',
+    headers: {
+      'X-Key-Inflection': 'camel',
+    },
+    query: {
+      'bbox[]': bounds,
+      type: 'health',
+      'services[]': 'PrimaryCare',
+      page: '1',
+      // eslint-disable-next-line camelcase
+      per_page: '20',
+    },
+  },
+  willRespondWith: {
+    status: 200,
+    body: {
+      data: eachLike({
+        id: string('1972660348'),
+        type: 'facility',
+        attributes: {
+          address: {
+            street: string('2750 E GERMANN RD'),
+            city: string('CHANDLER'),
+            state: string('AZ'),
+            zip: string('85249'),
+          },
+          phone: {
+            main: string('919-286-0411'),
+            mentalHealthClinic: string('919-286-0411'),
+          },
+          lat: decimal(33.281291),
+          long: decimal(-111.793486),
+          name: string('WAL-MART'),
+        },
+      }),
+      links: {
+        first: string(
+          'https://dev-api.va.gov/v1/facilities/va?bbox%5B%5D=-79.43&bbox%5B%5D=35.03&bbox%5B%5D=-77.93&bbox%5B%5D=36.53&page=1&per_page=20&services%5B%5D=PrimaryCare&type=health',
+        ),
+        last: string(
+          'https://dev-api.va.gov/v1/facilities/va?bbox%5B%5D=-79.43&bbox%5B%5D=35.03&bbox%5B%5D=-77.93&bbox%5B%5D=36.53&page=1&per_page=20&services%5B%5D=PrimaryCare&type=health',
+        ),
+        next: null,
+        prev: null,
+        self: string(
+          'https://staging-api.va.gov/v1/facilities/va?bbox%5B%5D=-79.43&bbox%5B%5D=35.03&bbox%5B%5D=-77.93&bbox%5B%5D=36.53&page=1&per_page=20&services%5B%5D=PrimaryCare&type=health',
+        ),
+      },
+      meta: {
+        pagination: {
+          currentPage: integer(1),
+          prevPage: null,
+          nextPage: null,
+          totalPages: integer(1),
+        },
+      },
+    },
+  },
+};
+
+const vaDetailInteraction = {
+  state: 'va facility data exists',
+  uponReceiving: 'a request for va facility data',
+  withRequest: {
+    method: 'GET',
+    path: '/v1/facilities/va/vha_123ABC',
+    headers: {
+      'X-Key-Inflection': 'camel',
+    },
+  },
+  willRespondWith: {
+    status: 200,
+    body: {
+      data: eachLike({
+        id: 'vha_123ABC',
+        type: 'facility',
+        attributes: {
+          address: {
+            street: string('2750 E GERMANN RD'),
+            city: string('CHANDLER'),
+            state: string('AZ'),
+            zip: string('85249'),
+          },
+          facilityType: 'va_health_facility',
+          feedback: {
+            health: {
+              primaryCareRoutine: decimal(0.8500000238418579),
+              primaryCareUrgent: decimal(0.8299999833106995),
+              specialtyCareRoutine: decimal(0.8199999928474426),
+              specialtyCareUrgent: decimal(0.6600000262260437),
+            },
+            effectiveDate: null,
+          },
+          hours: {
+            monday: string('24/7'),
+            tuesday: string('24/7'),
+            wednesday: string('24/7'),
+            thursday: string('24/7'),
+            friday: string('24/7'),
+            saturday: string('24/7'),
+            sunday: string('24/7'),
+          },
+          lat: decimal(33.281291),
+          long: decimal(-111.793486),
+          name: string('WAL-MART'),
+          operatingStatus: { code: string('NORMAL') },
+          phone: {
+            fax: string('919-286-6825'),
+            main: string('919-286-0411'),
+            mentalHealthClinic: string('919-286-0411 x 5418'),
+            pharmacy: string('888-878-6890'),
+          },
+          services: {
+            health: eachLike(string('Audiology')),
+            lastUpdated: string('2020-09-28'),
+            other: eachLike(string('Poetry Therapy')),
+          },
+          website: string('https://www.durham.va.gov/locations/directions.asp'),
+        },
+      }),
+    },
+  },
+};
+
+const ccpSpecialtiesInteraction = {
+  state: 'ccp specialties data exists',
+  uponReceiving: 'a request for ccp specialties data',
+  withRequest: {
+    method: 'GET',
+    path: '/v1/facilities/ccp/specialties',
+    headers: {
+      'X-Key-Inflection': 'camel',
+    },
+  },
+  willRespondWith: {
+    status: 200,
+    body: {
+      data: eachLike({
+        id: string('400VATAICX'),
+        attributes: {
+          classification: string(
+            'Complementary and Integrative Healthcare Services CIHS',
+          ),
+          name: string(
+            'Complementary and Integrative Healthcare Services CIHS - TaiChi ',
+          ),
+          specialtyCode: string('400VATAICX'),
+          specialtyDescription: string(
+            'Description: Tai Chi They involves certain postures and gentle movements with mental focus, breathing, and relaxation. The movements can be adapted or practiced while walking, standing, or sitting. Delivered by a certified Tai Chi instructor',
+          ),
+        },
+      }),
+    },
+  },
+};
+
+const dispatch = sinon.stub();
+
+contractTest('Facility Locator', 'VA.gov API', mockApi => {
+  describe('GET /v1/facilities/ccp', () => {
+    context('facilities: ccp data exists', () => {
+      it('responds appropriately', async () => {
+        await mockApi().addInteraction(ccpInteraction);
+        await fetchLocations(address, bounds, 'pharmacy', null, 1, dispatch);
+      });
+    });
+  });
+
+  describe('GET /v1/facilities/ccp/specialties', () => {
+    context('facilities: ccp specialties data exists', () => {
+      it('responds appropriately', async () => {
+        await mockApi().addInteraction(ccpSpecialtiesInteraction);
+        await getProviderSpecialties()(dispatch);
+      });
+    });
+  });
+
+  describe('GET /v1/facilities/va', () => {
+    context('facilities: va data exists', () => {
+      it('responds appropriately', async () => {
+        await mockApi().addInteraction(vaInteraction);
+        await fetchLocations(
+          null,
+          bounds,
+          'health',
+          'PrimaryCare',
+          1,
+          dispatch,
+        );
+      });
+    });
+  });
+
+  describe('GET /v1/facilities/va/:id', () => {
+    context('facilities: va facility data exists', () => {
+      it('responds appropriately', async () => {
+        await mockApi().addInteraction(vaDetailInteraction);
+        await fetchVAFacility('vha_123ABC')(dispatch);
+      });
+    });
+  });
+
+  describe('GET /v1/facilities/va_ccp/urgent_care', () => {
+    context('facilities: mashup urgent_care data exists', () => {
+      it('responds appropriately', async () => {
+        await mockApi().addInteraction(mashupUrgentCareInteraction);
+        await LocatorApi.searchWithBounds(
+          address,
+          bounds,
+          'urgent_care',
+          null,
+          1,
+        );
+      });
+    });
+  });
+});

--- a/src/applications/facility-locator/tests/contract/search.pact.spec.js
+++ b/src/applications/facility-locator/tests/contract/search.pact.spec.js
@@ -165,7 +165,7 @@ const vaInteraction = {
 };
 
 const vaDetailInteraction = {
-  state: 'va facility data exists',
+  state: 'va data exists',
   uponReceiving: 'a request for va facility data',
   withRequest: {
     method: 'GET',
@@ -298,7 +298,7 @@ contractTest('Facility Locator', 'VA.gov API', mockApi => {
   });
 
   describe('GET /v1/facilities/va/:id', () => {
-    context('facilities: va facility data exists', () => {
+    context('facilities: va data exists', () => {
       it('responds appropriately', async () => {
         await mockApi().addInteraction(vaDetailInteraction);
         await fetchVAFacility('vha_123ABC')(dispatch);


### PR DESCRIPTION
## Description
Added pact tests for facility locator.

Also, removed a few vestiges of the v0 -> v1 cutover.

## Acceptance criteria
- [x] All facility locator API calls are covered by passing pact tests.

## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
