### PR TITLE
FL search results data layer

### DIFF
--- a/src/applications/facility-locator/components/ResultsList.jsx
+++ b/src/applications/facility-locator/components/ResultsList.jsx
@@ -54,14 +54,21 @@ class ResultsList extends Component {
    * @returns [] list of results
    */
   renderResultItems(query, results) {
-    return results.map(r => {
+    return results.map((r, index) => {
       let item;
       switch (query.facilityType) {
         case 'health':
         case 'cemetery':
         case 'benefits':
         case 'vet_center':
-          item = <VaFacilityResult location={r} query={query} key={r.id} />;
+          item = (
+            <VaFacilityResult
+              location={r}
+              query={query}
+              key={r.id}
+              index={index}
+            />
+          );
           break;
         case 'provider':
           // Support non va urgent care search through ccp option
@@ -80,7 +87,14 @@ class ResultsList extends Component {
           if (r.type === LocationType.CC_PROVIDER) {
             item = <UrgentCareResult provider={r} query={query} key={r.id} />;
           } else {
-            item = <VaFacilityResult location={r} query={query} key={r.id} />;
+            item = (
+              <VaFacilityResult
+                location={r}
+                query={query}
+                key={r.id}
+                index={index}
+              />
+            );
           }
           break;
         default:
@@ -98,6 +112,7 @@ class ResultsList extends Component {
       searchString,
       results,
       error,
+      pagination: { currentPage },
       currentQuery,
       query,
     } = this.props;
@@ -173,6 +188,7 @@ class ResultsList extends Component {
           distance,
           resultItem: true,
           searchString,
+          currentPage,
         };
       })
       .sort((resultA, resultB) => resultA.distance - resultB.distance)

--- a/src/applications/facility-locator/components/search-results-items/VaFacilityResult.jsx
+++ b/src/applications/facility-locator/components/search-results-items/VaFacilityResult.jsx
@@ -2,14 +2,14 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import LocationPhoneLink from './common/LocationPhoneLink';
 import LocationDirectionsLink from './common/LocationDirectionsLink';
-import { isVADomain } from '../../utils/helpers';
+import { isVADomain, recordResultEvents } from '../../utils/helpers';
 import { Link } from 'react-router';
 import { OperatingStatus } from '../../constants';
 import LocationAddress from './common/LocationAddress';
 import LocationOperationStatus from './common/LocationOperationStatus';
 import LocationDistance from './common/LocationDistance';
 
-const VaFacilityResult = ({ location, query }) => {
+const VaFacilityResult = ({ location, query, index }) => {
   const { name, website, operatingStatus } = location.attributes;
   return (
     <div className="facility-result" id={location.id} key={location.id}>
@@ -18,7 +18,11 @@ const VaFacilityResult = ({ location, query }) => {
           distance={location.distance}
           markerText={location.markerText}
         />
-        <span>
+        <span
+          onClick={() => {
+            recordResultEvents(location, index);
+          }}
+        >
           {isVADomain(website) ? (
             <h3 id="facility-name" className="vads-u-font-size--h5 no-marg-top">
               <a href={website}>{name}</a>
@@ -48,6 +52,7 @@ const VaFacilityResult = ({ location, query }) => {
 VaFacilityResult.propTypes = {
   location: PropTypes.object,
   query: PropTypes.object,
+  index: PropTypes.number,
 };
 
 export default VaFacilityResult;

--- a/src/applications/facility-locator/containers/FacilityDetail.jsx
+++ b/src/applications/facility-locator/containers/FacilityDetail.jsx
@@ -162,7 +162,7 @@ class FacilityDetail extends Component {
     }
 
     return (
-      <div className="row facility-detail all-details">
+      <div className="row facility-detail all-details" id="facility-detail-id">
         <div className="usa-width-two-thirds medium-8 columns">
           <div>
             {this.renderFacilityInfo()}

--- a/src/applications/facility-locator/tests/e2e/gaEvents.cypress.spec.js
+++ b/src/applications/facility-locator/tests/e2e/gaEvents.cypress.spec.js
@@ -1,4 +1,5 @@
 import path from 'path';
+import { assertDataLayerEvent, assertDataLayerItem } from './utils';
 
 describe('Google Analytics FL Events', () => {
   before(() => {
@@ -19,12 +20,8 @@ describe('Google Analytics FL Events', () => {
       cy.axeCheck();
 
       cy.get('#map-id', { timeout: 10000 }).should(() => {
-        assert.isObject(
-          win.dataLayer.find(d => d.event && d.event === 'fl-search'),
-        );
-        assert.isObject(
-          win.dataLayer.find(d => d.event && d.event === 'fl-search-results'),
-        );
+        assertDataLayerEvent(win, 'fl-search');
+        assertDataLayerEvent(win, 'fl-search-results');
       });
 
       cy.get('#marker-id')
@@ -32,28 +29,22 @@ describe('Google Analytics FL Events', () => {
         .click()
         .as('markerClick')
         .then(() => {
-          assert.isObject(
-            win.dataLayer.find(d => d.event && d.event === 'fl-map-pin-click'),
-          );
-          assert.isObject(win.dataLayer.find(d => d['fl-facility-type']));
-          assert.isObject(
-            win.dataLayer.find(d => d['fl-facility-classification']),
-          );
-          assert.isObject(win.dataLayer.find(d => d['fl-facility-name']));
+          assertDataLayerEvent(win, 'fl-map-pin-click');
+          [
+            'fl-facility-type',
+            'fl-facility-classification',
+            'fl-facility-name',
+          ].forEach(a => assertDataLayerItem(win, a));
         });
 
       cy.get('.leaflet-control-zoom-in').click();
       cy.get('#map-id', { timeout: 10000 }).should(() => {
-        assert.isObject(
-          win.dataLayer.find(d => d.event && d.event === 'fl-map-zoom-in'),
-        );
+        assertDataLayerEvent(win, 'fl-map-zoom-in');
       });
 
       cy.get('.leaflet-control-zoom-out').click();
       cy.get('#map-id', { timeout: 10000 }).should(() => {
-        assert.isObject(
-          win.dataLayer.find(d => d.event && d.event === 'fl-map-zoom-out'),
-        );
+        assertDataLayerEvent(win, 'fl-map-zoom-out');
       });
 
       cy.get('#map-id').dragMapFromCenter({
@@ -61,7 +52,7 @@ describe('Google Analytics FL Events', () => {
         yMoveFactor: 1 / 3,
       });
       cy.get('#map-id', { timeout: 10000 }).should(() => {
-        assert.isObject(win.dataLayer.find(d => d['fl-map-miles-moved']));
+        assertDataLayerItem(win, 'fl-map-miles-moved');
       });
 
       cy.findByText(/austin va clinic/i, { selector: 'a' })
@@ -69,17 +60,15 @@ describe('Google Analytics FL Events', () => {
         .click();
 
       cy.get('#facility-detail-id', { timeout: 10000 }).should(() => {
-        assert.isObject(
-          win.dataLayer.find(d => d.event && d.event === 'fl-results-click'),
-        );
-        assert.isObject(win.dataLayer.find(d => d['fl-facility-name']));
-        assert.isObject(win.dataLayer.find(d => d['fl-facility-type']));
-        assert.isObject(
-          win.dataLayer.find(d => d['fl-facility-classification']),
-        );
-        assert.isObject(win.dataLayer.find(d => d['fl-facility-id']));
-        assert.isObject(win.dataLayer.find(d => d['fl-result-page-number']));
-        assert.isObject(win.dataLayer.find(d => d['fl-result-position']));
+        assertDataLayerEvent(win, 'fl-results-click');
+        [
+          'fl-facility-name',
+          'fl-facility-type',
+          'fl-facility-classification',
+          'fl-facility-id',
+          'fl-result-page-number',
+          'fl-result-position',
+        ].forEach(a => assertDataLayerItem(win, a));
       });
     });
   });

--- a/src/applications/facility-locator/tests/e2e/gaEvents.cypress.spec.js
+++ b/src/applications/facility-locator/tests/e2e/gaEvents.cypress.spec.js
@@ -63,6 +63,24 @@ describe('Google Analytics FL Events', () => {
       cy.get('#map-id', { timeout: 10000 }).should(() => {
         assert.isObject(win.dataLayer.find(d => d['fl-map-miles-moved']));
       });
+
+      cy.findByText(/austin va clinic/i, { selector: 'a' })
+        .first()
+        .click();
+
+      cy.get('#facility-detail-id', { timeout: 10000 }).should(() => {
+        assert.isObject(
+          win.dataLayer.find(d => d.event && d.event === 'fl-results-click'),
+        );
+        assert.isObject(win.dataLayer.find(d => d['fl-facility-name']));
+        assert.isObject(win.dataLayer.find(d => d['fl-facility-type']));
+        assert.isObject(
+          win.dataLayer.find(d => d['fl-facility-classification']),
+        );
+        assert.isObject(win.dataLayer.find(d => d['fl-facility-id']));
+        assert.isObject(win.dataLayer.find(d => d['fl-result-page-number']));
+        assert.isObject(win.dataLayer.find(d => d['fl-result-position']));
+      });
     });
   });
 });

--- a/src/applications/facility-locator/tests/e2e/utils.js
+++ b/src/applications/facility-locator/tests/e2e/utils.js
@@ -1,0 +1,7 @@
+export const assertDataLayerEvent = (win, eventName) => {
+  assert.isObject(win.dataLayer.find(d => d.event && d.event === eventName));
+};
+
+export const assertDataLayerItem = (win, item) => {
+  assert.isObject(win.dataLayer.find(d => d[item]));
+};

--- a/src/applications/facility-locator/utils/helpers.jsx
+++ b/src/applications/facility-locator/utils/helpers.jsx
@@ -286,3 +286,21 @@ export const recordZoomPanEvents = (e, searchCoords, currentZoomLevel) => {
     }
   }
 };
+
+/**
+ * Helper fn to record search results data layer
+ */
+export const recordResultEvents = (location, index) => {
+  const { classification, name, facilityType, id } = location.attributes;
+  const currentPage = location.currentPage;
+  recordEvent({ event: 'fl-results-click' });
+
+  if (classification && name && facilityType && id && index && currentPage) {
+    recordEvent({ 'fl-facility-type': facilityType });
+    recordEvent({ 'fl-facility-classification': classification });
+    recordEvent({ 'fl-facility-name': name });
+    recordEvent({ 'fl-facility-id': id });
+    recordEvent({ 'fl-result-page-number': currentPage });
+    recordEvent({ 'fl-result-position': index });
+  }
+};

--- a/src/applications/facility-locator/utils/helpers.jsx
+++ b/src/applications/facility-locator/utils/helpers.jsx
@@ -294,13 +294,13 @@ export const recordResultEvents = (location, index) => {
   const { classification, name, facilityType, id } = location.attributes;
   const currentPage = location.currentPage;
   recordEvent({ event: 'fl-results-click' });
+  recordEvent({ 'fl-result-page-number': currentPage });
+  recordEvent({ 'fl-result-position': index + 1 });
 
-  if (classification && name && facilityType && id && index && currentPage) {
+  if (classification && name && facilityType && id) {
     recordEvent({ 'fl-facility-type': facilityType });
     recordEvent({ 'fl-facility-classification': classification });
     recordEvent({ 'fl-facility-name': name });
     recordEvent({ 'fl-facility-id': id });
-    recordEvent({ 'fl-result-page-number': currentPage });
-    recordEvent({ 'fl-result-position': index });
   }
 };


### PR DESCRIPTION
## Description
Issue: https://github.com/department-of-veterans-affairs/va.gov-team/issues/12138

## Testing done


## Acceptance criteria
-  [x]  `'event': 'fl-results-click'` | consistently this value | Event push on ANY search result click
 - [x] `'fl-facility-name'` | `'Charlotte Hall VA Clinic'` | Store the name of the facility 
 - [x] `'fl-facility-type'` | `'VA Health'` | Store the type of facility 
 - [x] `'fl-facility-id'` | `'vha_688GD'` | Store the facility ID 
 - [x] `'fl-facility-classification'` | `'Primary Care CBOC'` | Store classification of facility
 - [x] `'fl-result-page-number'` | `4 //if on the 4th result page` | Store the result page number user is currently on (pagination number)
 - [x] `'fl-result-position'` | `5 //if the 5th result on the page` | Store the search result position in the list 

## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
