### PR TITLE
9860 experimental design change

### DIFF
--- a/src/applications/disability-benefits/2346/sass/form-2346.scss
+++ b/src/applications/disability-benefits/2346/sass/form-2346.scss
@@ -105,12 +105,6 @@ div.review {
   }
 }
 
-#root_vetEmail-label {
-  font-family: "Bitter";
-  font-size: 17px;
-  font-weight: 700;
-}
-
 @media print {
   .header, .va-nav-breadcrumbs, .schemaform-title, .print-copy, .order-submission-alert, .order-summary-alert, .order-timeframe-section, .order-questions-section, .footer, .help-footer-box {
     display: none;

--- a/src/applications/disability-benefits/2346/schemas/2346UI.js
+++ b/src/applications/disability-benefits/2346/schemas/2346UI.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import { isValidEmail } from 'platform/forms/validations';
 import fullSchema from 'vets-json-schema/dist/MDOT-schema.json';
 import AddressViewField from '../components/AddressViewField';
@@ -8,6 +9,18 @@ import { schemaFields } from '../constants';
 import { addressUISchema } from './address-schema';
 
 const { permanentAddressField, temporaryAddressField } = schemaFields;
+
+const EmailForOrderConfirmation = () => {
+  return (
+    <>
+      <h4>Email for Order Confirmation</h4>
+      <p>
+        We'll send an order confirmation email with a tracking number to this
+        email address.
+      </p>
+    </>
+  );
+};
 
 export default {
   'ui:title': fullSchema.title,
@@ -92,9 +105,8 @@ export default {
       },
     },
     emailUI: {
+      'ui:header': EmailForOrderConfirmation,
       'ui:title': 'Email address',
-      'ui:description':
-        "We'll send an order confirmation email with a tracking number to this email address.",
       'ui:widget': 'email',
       'ui:errorMessages': {
         pattern: 'Please enter an email address using this format: X@X.com',

--- a/src/platform/forms-system/src/js/components/FieldTemplate.jsx
+++ b/src/platform/forms-system/src/js/components/FieldTemplate.jsx
@@ -94,6 +94,9 @@ export default function FieldTemplate(props) {
     </label>
   );
 
+  const HeaderComponent =
+    typeof uiSchema['ui:header'] === 'function' ? uiSchema['ui:header'] : null;
+
   // Don't render hidden or empty labels - prevents duplicate IDs on review &
   // submit page
   const showLabel =
@@ -102,6 +105,7 @@ export default function FieldTemplate(props) {
 
   const content = (
     <>
+      {HeaderComponent && <HeaderComponent />}
       {showLabel && labelElement}
       {textDescription && <p>{textDescription}</p>}
       {DescriptionField && (


### PR DESCRIPTION
## Description

This is a design change to the forms library to help close department-of-veterans-affairs/va-forms-system-core#315

This PR allows an optional `'ui:header'` property (which is a React component) to be rendered above the `label` in our `<FieldTemplate>`. It is important for this `<h4>` and `<p>` tag to not come between the label and the input, but currently the forms library doesn't support that kind of design.



## Testing done

manual


## Screenshots

![image](https://user-images.githubusercontent.com/2008881/93147034-3bb55e00-f6a5-11ea-8412-7ff6158a1f7b.png)


## Acceptance criteria
- [ ] As a user, I want a label to be presented directly next to the associated input consistently throughout a form, so I may easily understand and complete the form.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
