### PR TITLE
gibct School Ratings feature flag added to front end

### DIFF
--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -33,6 +33,7 @@ export default Object.freeze({
   gibctSearchEnhancements: 'gibctSearchEnhancements',
   gibctFilterEnhancement: 'gibctFilterEnhancement',
   gibctBenefitFilterEnhancement: 'gibctBenefitFilterEnhancement',
+  gibctSchoolRatings: 'gibctSchoolRatings',
   form996HigherLevelReview: 'form996HigherLevelReview',
   debtLettersShowLetters: 'debtLettersShowLetters',
   debtLettersShowLettersV2: 'debtLettersShowLettersV2',


### PR DESCRIPTION
## Description
As a developer, I need to create a feature flag for the school ratings UI functionality so that it is not displayed in production as development is completed.
https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/13359

backend PR: https://github.com/department-of-veterans-affairs/vets-api/pull/4900
## Testing done
local testing

## Screenshots


## Acceptance criteria
- [x] The Feature Flag gibct_school_ratings is available to be used for the ratings enhancements.
- [x] The Feature Flag description is: "Show/Hide the school ratings section of the Comparison Tool School Profile Page"

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
