### PR TITLE
10203 breadcrumbs

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -514,8 +514,12 @@
           "path": "education/"
         },
         {
-          "name": "How to apply",
-          "path": "education/how-to-apply/"
+          "name": "Other VA education benefits",
+          "path": "education/other-va-education-benefits/"
+        },
+        {
+          "name": "Edith Nourse Rogers STEM Scholarship",
+          "path": "education/other-va-education-benefits/edith-nourse-stem-scholarship/"
         },
         {
           "name": "Apply for the Rogers STEM Scholarship",

--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -519,7 +519,7 @@
         },
         {
           "name": "Edith Nourse Rogers STEM Scholarship",
-          "path": "education/other-va-education-benefits/edith-nourse-stem-scholarship/"
+          "path": "education/other-va-education-benefits/stem-scholarship/"
         },
         {
           "name": "Apply for the Rogers STEM Scholarship",


### PR DESCRIPTION
## Description
Updated 10203 breadcrumbs

## Testing done
Tested locally and QA reviewed

## Screenshots
![image](https://user-images.githubusercontent.com/41960449/93240582-4aa61a00-f752-11ea-92bb-655c69260fc8.png)


## Acceptance criteria
- [x] The breadcrumb for the 10203 form is: Home > Education and training > Other VA education benefits > Edith Nourse Rogers STEM Scholarship > Apply for the Rogers STEM Scholarship
  - a. Home link: https://[environment].va.gov/
  - b. Education and training link: https://[environment].va.gov/education/
  - c. Other VA education benefits link: https://[environment].va.gov/education/other-va-education-benefits/
  - d. Edith Nourse STEM Scholarship link: https://[environment].va.gov/education/other-va-education-benefits/stem-scholarship/
  - e. Apply for the Rogers STEM Scholarship: Read only and displayed when the user is on this page: https://[environment].va.gov/education/other-va-education-benefits/stem-scholarship/apply-for-scholarship-form-22-10203/introduction
- [x] For mobile, the breadcrumb only shows the previous page so users can click back up the hierarchy - this should be standard functionality. So while on the application the breadcrumb would show "< Edith Nourse STEM Scholarship". Clicking back one by one would walk the user back up, so the progression would be:
- < Edith Nourse STEM Scholarship
- < Other VA education benefits
- < Education and training
- < Home

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
