### PR TITLE
Fix circular structure with fieldVaFormRelatedForms

### DIFF
--- a/src/site/stages/build/process-cms-exports/transformers/node-va_form.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-va_form.js
@@ -20,7 +20,14 @@ const transform = entity => ({
   fieldVaFormName: getDrupalValue(entity.fieldVaFormName),
   fieldVaFormNumber: getDrupalValue(entity.fieldVaFormNumber),
   fieldVaFormNumPages: getDrupalValue(entity.fieldVaFormNumPages),
-  fieldVaFormRelatedForms: entity.fieldVaFormRelatedForms,
+  fieldVaFormRelatedForms: entity.fieldVaFormRelatedForms.map(n => ({
+    entity: {
+      fieldVaFormName: n.fieldVaFormName,
+      fieldVaFormNumber: n.fieldVaFormNumber,
+      fieldVaFormUsage: n.fieldVaFormUsage,
+      fieldVaFormUrl: n.fieldVaFormUrl,
+    },
+  })),
   fieldVaFormRevisionDate: getDrupalValue(entity.fieldVaFormRevisionDate),
   fieldVaFormTitle: getDrupalValue(entity.fieldVaFormTitle),
   fieldVaFormToolIntro: getDrupalValue(entity.fieldVaFormToolIntro),


### PR DESCRIPTION
## Description
When running the cms export build we are getting the following error:

```
TypeError: Converting circular structure to JSON
    --> starting at object with constructor 'Object'
    |     property 'fieldVaFormRelatedForms' -> object with constructor 'Array'
    |     index 0 -> object with constructor 'Object'
    |     property 'field_va_form_related_forms' -> object with constructor 'Array'
    --- index 0 closes the circle
    at JSON.stringify (<anonymous>)
```

This PR fixes that circular issue.

## Testing done
Locally

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
