### PR TITLE
Fix for facility wait time infinite spinner

### DIFF
--- a/src/applications/static-pages/facilities/FacilityAppointmentWaitTimesWidget.jsx
+++ b/src/applications/static-pages/facilities/FacilityAppointmentWaitTimesWidget.jsx
@@ -17,7 +17,7 @@ export class FacilityAppointmentWaitTimesWidget extends React.Component {
     // find service in waitTimes object as a key
     const time = waitTimes[serviceKey];
     // return waitTimes for service
-    const waitTime = time[established ? 'established' : 'new'];
+    const waitTime = Number(time[established ? 'established' : 'new']);
     return waitTime ? `${waitTime.toFixed(0)} days` : '';
   }
 

--- a/src/applications/static-pages/facilities/actions/index.js
+++ b/src/applications/static-pages/facilities/actions/index.js
@@ -37,7 +37,7 @@ export function fetchFacility(id) {
     dispatch(fetchFacilityStarted());
 
     // eslint-disable-next-line consistent-return
-    return apiRequest(`/facilities/va/${id}`, {}, null, null, 'v1')
+    return apiRequest(`/facilities/va/${id}`, { apiVersion: 'v1' })
       .then(facility => dispatch(fetchFacilitySuccess(facility.data)))
       .catch(() => dispatch(fetchFacilityFailed()));
   };

--- a/src/applications/static-pages/facilities/actions/index.js
+++ b/src/applications/static-pages/facilities/actions/index.js
@@ -37,7 +37,7 @@ export function fetchFacility(id) {
     dispatch(fetchFacilityStarted());
 
     // eslint-disable-next-line consistent-return
-    return apiRequest(`/facilities/va/${id}`)
+    return apiRequest(`/facilities/va/${id}`, {}, null, null, 'v1')
       .then(facility => dispatch(fetchFacilitySuccess(facility.data)))
       .catch(() => dispatch(fetchFacilityFailed()));
   };

--- a/src/applications/static-pages/tests/facilities/actions.unit.spec.js
+++ b/src/applications/static-pages/tests/facilities/actions.unit.spec.js
@@ -70,7 +70,7 @@ describe('Facilities actions', () => {
       thunk(dispatch, getState)
         .then(() => {
           expect(global.fetch.args[0][0]).to.contain(
-            '/v0/facilities/va/vha_646',
+            '/v1/facilities/va/vha_646',
           );
           resetFetch();
           done();

--- a/src/platform/utilities/api/index.js
+++ b/src/platform/utilities/api/index.js
@@ -45,15 +45,9 @@ function isJson(response) {
  * @param {Function} **(DEPRECATED)** success - Callback to execute after successfully resolving
  * the initial fetch request.
  * @param {Function} **(DEPRECATED)** error - Callback to execute if the fetch fails to resolve.
- * @param {string} apiVersion - 'v0' by default. Set to 'v1' if you need it.
  */
-export function apiRequest(
-  resource,
-  optionalSettings = {},
-  success,
-  error,
-  apiVersion = 'v0',
-) {
+export function apiRequest(resource, optionalSettings = {}, success, error) {
+  const apiVersion = (optionalSettings && optionalSettings.apiVersion) || 'v0';
   const baseUrl = `${environment.API_URL}/${apiVersion}`;
   const url = resource[0] === '/' ? [baseUrl, resource].join('') : resource;
   const csrfTokenStored = localStorage.getItem('csrfToken');

--- a/src/platform/utilities/api/index.js
+++ b/src/platform/utilities/api/index.js
@@ -45,9 +45,16 @@ function isJson(response) {
  * @param {Function} **(DEPRECATED)** success - Callback to execute after successfully resolving
  * the initial fetch request.
  * @param {Function} **(DEPRECATED)** error - Callback to execute if the fetch fails to resolve.
+ * @param {string} apiVersion - 'v0' by default. Set to 'v1' if you need it.
  */
-export function apiRequest(resource, optionalSettings = {}, success, error) {
-  const baseUrl = `${environment.API_URL}/v0`;
+export function apiRequest(
+  resource,
+  optionalSettings = {},
+  success,
+  error,
+  apiVersion = 'v0',
+) {
+  const baseUrl = `${environment.API_URL}/${apiVersion}`;
   const url = resource[0] === '/' ? [baseUrl, resource].join('') : resource;
   const csrfTokenStored = localStorage.getItem('csrfToken');
 


### PR DESCRIPTION
https://github.com/department-of-veterans-affairs/va.gov-team/issues/13585

## Description

Facility wait time spinner spins forever due to error from invalid data from the API.

Fix: use v1 API instead of v0, and add a conversion for string to number.

See issue for more details.


## Testing done
- Mañuel

## Acceptance criteria
- [x] Wait times are displayed on facility pages
- [x] No other bugs are introduced

## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
