### PR TITLE
12129 automate content build comparison script

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -319,3 +319,15 @@ workflows:
   additional-linting:
     jobs:
       - additional-linting
+
+  # https://circleci.com/docs/2.0/workflows/#nightly-example
+  nightly:
+    triggers:
+      - schedule:
+          cron: '0 4 * * *'
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - validate-content-builds

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -265,6 +265,23 @@ jobs:
       - store_artifacts:
           path: ./cypress/screenshots
 
+  validate-content-builds:
+    docker:
+      - image: circleci/node:10.15.3
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - yarn-packages-{{ checksum "yarn.lock" }}
+      - run:
+          command: yarn install --frozen-lockfile
+      - save_cache:
+          key: yarn-packages-{{ checksum "yarn.lock" }}
+          paths:
+            - ~/.cache/yarn
+      - run: git clone https://github.com/department-of-veterans-affairs/content-build
+      - run: yarn validate-content-builds
+
 workflows:
   version: 2
   flag-for-manual-review:

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "test:integration:nightwatch": "nightwatch -c config/nightwatch.js --tag integration",
     "test:integration:nightwatch:docker": "docker-compose -p e2e up -d && docker-compose -p e2e run --user=node --rm --entrypoint=npm -e BABEL_ENV=test -e BUILDTYPE=vagovprod -e WEB_HOST=staging.va.gov -e WEB_PORT=80 vets-website --no-color run nightwatch:docker -- --tag integration && docker-compose -p e2e stop",
     "update:schema": "./script/update-json-schema.sh",
+    "validate-content-builds": "node script/validate-content-builds.js",
     "watch": "node ./script/watch.js",
     "watch:content": "node --max-old-space-size=4096 script/build-content.js --watch",
     "watch:css-sourcemaps": "node --max-old-space-size=8192 script/build-content.js --watch --local-css-sourcemaps",


### PR DESCRIPTION
## GitHub Issue: https://github.com/department-of-veterans-affairs/va.gov-team/issues/12129

## Description

This PR adds a `validate-content-builds` npm script, a `validate-content-builds` job in CircleCI, and a `nightly` scheduled CircleCI workflow to run the `validate-content-builds` job. 

Currently, the `validate-content-builds` script doesn't pass, and there is a [ticket](https://app.zenhub.com/workspace/o/department-of-veterans-affairs/va.gov-team/issues/13604) to figure out why and fix it. 

Also, there is an [ongoing task to copy the latest relevant changes from `vets-website` to `content-build`](https://app.zenhub.com/workspace/o/department-of-veterans-affairs/va.gov-team/issues/13606).

## Acceptance criteria
- [ ] The automated `validate-content-builds` script passes when the repos are in sync
- [ ] The automated `validate-content-builds` script fails when the repos are not in sync

## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
