### PR TITLE
Fixed contractTest helper to prevent conflicts between mulltiple tests.

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "test:accessibility": "./script/run-nightwatch.sh --env accessibility",
     "test:accessibility:docker": "docker-compose -p accessibility up -d && docker-compose -p accessibility run --rm --entrypoint=npm -e BABEL_ENV=test -e BUILDTYPE=vagovprod vets-website --no-color run nightwatch:docker -- --env=accessibility && docker-compose -p accessibility stop",
     "test:best-practice": "./script/run-nightwatch.sh --env bestpractice",
-    "test:contract": "./script/run-pact-tests.sh",
+    "test:contract": "BUILDTYPE=localhost npm run test:unit 'src/**/tests/**/*.pact.spec.js'",
     "test:coverage": "npm run test:unit -- --coverage",
     "test:coverage-apps": "npm run test:coverage && node script/app-coverage-report.js",
     "test:puppeteer": "./script/run-puppeteer-tests.sh",

--- a/script/run-pact-tests.sh
+++ b/script/run-pact-tests.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-if [ "$(find src -name '*.pact.spec.js' | wc -l)" -eq 0 ]; then
-  echo "No Pact tests found."
-  exit 0
-else
-  BUILDTYPE=localhost BABEL_ENV=test mocha --opts src/platform/testing/unit/mocha.opts --recursive 'src/**/tests/**/*.pact.spec.js' --timeout 10000
-fi

--- a/src/platform/testing/contract/index.js
+++ b/src/platform/testing/contract/index.js
@@ -7,6 +7,8 @@ import { Pact } from '@pact-foundation/pact';
  * @param {string} consumer - String label for the consumer.
  * @param {string} provider - String label for the provider.
  * @param {function} test - Callback function for a test suite (describe block).
+ *                          Receives one argument: a function that returns the
+ *                          mock provider instance for the test.
  */
 const contractTest = (consumer, provider, test) => {
   describe(consumer, () => {

--- a/src/platform/testing/unit/mocha.opts
+++ b/src/platform/testing/unit/mocha.opts
@@ -8,4 +8,4 @@
 --compilers js:@babel/register,jsx:@babel/register
 --prof
 --reporter progress
---timeout 5000
+--timeout 10000


### PR DESCRIPTION
## Description
Previously, having multiple Pact spec files would fail when running `yarn test:contract` due to the setup of the Pact mock server.

I've tested that the [official example using Mocha](https://github.com/pact-foundation/pact-js/blob/master/examples/mocha/test/get-dogs.spec.js) would also fail if multiple specs were present.

The way that Mocha runs tests causes it to run everything in `describe` blocks, queueing up hooks and `it` blocks to run later. Since the Pact mock server is set up to run on port 3000 in order to accommodate the requests to the API, it would encounter conflicts when starting up that server for each consumer-provider pair.

**Changes:**
- The `mockApi` passed to the callback function in `contractTest` is now a function that returns the actual instance of the `mockApi`. This reference is necessary as the initialization of the mock server has moved to the `before` hook for the test.
- Built in hooks from `contractTest` were given descripive names for better debuggability.

## Testing done
Ran the command with multiple tests.

## Acceptance criteria
- [ ] Multiple Pact tests should be able to run without errors due to conflicts.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
