### PR TITLE
[Development|508] Focus on alert header on confirmation page

### DIFF
--- a/src/applications/disability-benefits/all-claims/containers/ConfirmationPage.jsx
+++ b/src/applications/disability-benefits/all-claims/containers/ConfirmationPage.jsx
@@ -27,7 +27,7 @@ export default class ConfirmationPage extends React.Component {
   }
 
   componentDidMount() {
-    focusElement('.confirmation-page-title');
+    focusElement('.usa-alert-body > h3');
     scrollToTop();
   }
 

--- a/src/applications/disability-benefits/all-claims/content/confirmation-page.jsx
+++ b/src/applications/disability-benefits/all-claims/content/confirmation-page.jsx
@@ -18,7 +18,7 @@ const template = (props, title, content, submissionMessage, messageType) => {
   const { first, last, middle, suffix } = fullName;
 
   const renderableContent =
-    typeof content === 'string' ? <p>{content}</p> : content;
+    typeof content === 'string' && content !== '' ? <p>{content}</p> : content;
 
   const alertBox = (
     <AlertBox


### PR DESCRIPTION
## Description

Once a user arrives on the confirmation page, focus must be set to the status message so a screenreader can let the user know the content has changed, and the status of the submission.

Related: https://github.com/department-of-veterans-affairs/va.gov-team/issues/12691

## Testing done

Local unit tests

## Screenshots

<details><summary>Focus on successful header</summary>

<!-- leave a blank line above -->
![Screen Shot 2020-09-16 at 10 05 42 AM](https://user-images.githubusercontent.com/136959/93365559-8e128e00-f80f-11ea-83b5-6a163a6a1b62.png)</details>

<details><summary>Focus on error header</summary>

<!-- leave a blank line above -->
![Screen Shot 2020-09-16 at 10 09 09 AM](https://user-images.githubusercontent.com/136959/93365631-a8e50280-f80f-11ea-8e06-33283333399b.png)</details>

## Acceptance criteria
- [x] Focus is placed on the alert header once the confirmation page is visible

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
