### PR TITLE
[SCREENREADER]: STEM Standalone - Alert boxes MUST NOT have a role="alert" unless they are announcing high priority information #11970

### DIFF
--- a/src/applications/edu-benefits/10203/containers/ConfirmEligibilityView.jsx
+++ b/src/applications/edu-benefits/10203/containers/ConfirmEligibilityView.jsx
@@ -71,7 +71,7 @@ export class ConfirmEligibilityView extends React.Component {
   };
 
   renderChecks = () => (
-    <div>
+    <div role="alert">
       <div className="vads-u-margin-top--neg2p5">
         <h4>Based on your responses, you may not be eligible</h4>
       </div>

--- a/src/applications/edu-benefits/10203/containers/InitialConfirmEligibilityView.jsx
+++ b/src/applications/edu-benefits/10203/containers/InitialConfirmEligibilityView.jsx
@@ -12,7 +12,7 @@ function InitialConfirmEligibilityView(props) {
   return (
     <div>
       <div>
-        <div className="usa-alert usa-alert-warning">
+        <div className="usa-alert usa-alert-warning" role="alert">
           <div className="usa-alert-body">
             <h4 className="usa-alert-heading">
               Based on your response, you may not be eligible


### PR DESCRIPTION
## Description
https://github.com/department-of-veterans-affairs/va.gov-team/issues/11970

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
