### PR TITLE
[Development] Fix 526 incorrect VBA office hours

### DIFF
--- a/src/applications/disability-benefits/all-claims/content/confirmation-page.jsx
+++ b/src/applications/disability-benefits/all-claims/content/confirmation-page.jsx
@@ -121,7 +121,7 @@ const template = (props, title, content, submissionMessage, messageType) => {
           for your disability claim to show up there. If you don’t see your
           disability claim online after 24 hours, please call Veterans Benefits
           Assistance at <Telephone contact={CONTACTS.VA_BENEFITS} />, Monday
-          through Friday, 8:30 a.m. to 4:30 p.m. ET.
+          through Friday, 8:00 a.m. to 9:00 p.m. ET.
         </p>
         <p>
           <a href="/track-claims">Check the status of your claim</a>
@@ -161,7 +161,7 @@ export const retryableErrorContent = props =>
         </strong>{' '}
         please call Veterans Benefits Assistance at{' '}
         <Telephone contact={CONTACTS.VA_BENEFITS} />, Monday through Friday,
-        8:30 a.m. to 4:30 p.m. ET and provide this reference number{' '}
+        8:00 a.m. to 9:00 p.m. ET and provide this reference number{' '}
         {props.jobId}.
       </p>
     </div>,
@@ -188,7 +188,7 @@ export const submitErrorContent = props =>
         <li>
           Please call Veterans Benefits Assistance at{' '}
           <Telephone contact={CONTACTS.VA_BENEFITS} />, Monday through Friday,
-          8:30 a.m. to 4:30 p.m. ET and provide this reference number{' '}
+          8:00 a.m. to 9:00 p.m. ET and provide this reference number{' '}
           {props.submissionId}, <strong>or</strong>
         </li>
         <li>

--- a/src/applications/disability-benefits/all-claims/content/fullyDevelopedClaim.jsx
+++ b/src/applications/disability-benefits/all-claims/content/fullyDevelopedClaim.jsx
@@ -60,8 +60,8 @@ export const noFDCWarning = (
           </li>
           <li>
             Call Veterans Benefits Assistance at{' '}
-            <Telephone contact={CONTACTS.VA_BENEFITS} />, Monday – Friday, 8:30
-            a.m. – 4:30 p.m. ET.
+            <Telephone contact={CONTACTS.VA_BENEFITS} />, Monday through Friday,
+            8:00 a.m. to 9:00 p.m. ET.
           </li>
           <li>
             Save your application and return to it later when you have your

--- a/src/applications/disability-benefits/all-claims/content/itfWrapper.jsx
+++ b/src/applications/disability-benefits/all-claims/content/itfWrapper.jsx
@@ -62,7 +62,7 @@ export const itfError = (
         something went wrong on our end. For help creating an Intent to File a
         Claim for Compensation, please call Veterans Benefits Assistance at{' '}
         <Telephone contact={CONTACTS.VA_BENEFITS} />, Monday through Friday,
-        8:00 a.m. to 9:00 a.m. ET. Or, you can fill out VA Form 21-0966 and
+        8:00 a.m. to 9:00 p.m. ET. Or, you can fill out VA Form 21-0966 and
         submit it to:
       </p>
       {claimsIntakeAddress}

--- a/src/applications/disability-benefits/all-claims/content/pastEmploymentFormDownload.jsx
+++ b/src/applications/disability-benefits/all-claims/content/pastEmploymentFormDownload.jsx
@@ -26,7 +26,8 @@ export const download4192Notice = (
     <p>Or fax them toll-free: 844-531-7818</p>
     <p>
       If they need help completing this form, they can call Veterans Benefits
-      Assistance at <Telephone contact={CONTACTS.VA_BENEFITS} />.
+      Assistance at <Telephone contact={CONTACTS.VA_BENEFITS} />, Monday through
+      Friday, 8:00 a.m. to 9:00 p.m. ET.
     </p>
   </div>
 );


### PR DESCRIPTION
## Description

Veteran Benefits Assistance office hours that are included in form 526 are inconsistent, or missing. This PR sets the office hours for the VBA line (800-827-1000) to `Monday through Friday, 8:00 a.m. to 9:00 p.m. ET`

## Testing done

N/A - content only updates

## Screenshots

N/A

## Acceptance criteria
- [x] Add & updated form 526 VBA office hour times

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
