### PR TITLE
Treat 404 Record not Found as a non-error

### DIFF
--- a/src/applications/personalization/profile-2/components/connected-apps/ConnectedApps.jsx
+++ b/src/applications/personalization/profile-2/components/connected-apps/ConnectedApps.jsx
@@ -44,14 +44,15 @@ export class ConnectedApps extends Component {
 
     const allAppsDeleted = deletedApps?.length === apps?.length;
     // We treat this 404 'Record not found' error as an empty apps array
-    const firstError = errors?.[0];
-    const recordNotFound =
-      firstError?.title === 'Record not found' && firstError?.status === '404';
+    const checkRecordNotFound = error =>
+      error?.title === 'Record not found' && error?.status === '404';
+    const recordNotFound = errors?.some(checkRecordNotFound);
     const showHasNoConnectedApps =
       !apps || (allAppsDeleted && !loading) || recordNotFound;
     const showHasConnectedApps = apps && !allAppsDeleted;
     // Check if any of the active apps have errors
     const disconnectErrorApps = activeApps.filter(app => !isEmpty(app.errors));
+    const showHasServerError = !isEmpty(errors) && !recordNotFound;
 
     return (
       <div className="va-connected-apps">
@@ -87,15 +88,14 @@ export class ConnectedApps extends Component {
           </>
         )}
 
-        {!isEmpty(errors) &&
-          !recordNotFound && (
-            <AlertBox
-              className="vads-u-margin-bottom--2"
-              headline="We couldn’t retrieve your connected apps"
-              status="warning"
-              content="We’re sorry. Something went wrong on our end and we couldn’t access your connected apps. Please try again later."
-            />
-          )}
+        {showHasServerError && (
+          <AlertBox
+            className="vads-u-margin-bottom--2"
+            headline="We couldn’t retrieve your connected apps"
+            status="warning"
+            content="We’re sorry. Something went wrong on our end and we couldn’t access your connected apps. Please try again later."
+          />
+        )}
 
         {deletedApps.map(app => (
           <AppDeletedAlert

--- a/src/applications/personalization/profile-2/components/connected-apps/ConnectedApps.jsx
+++ b/src/applications/personalization/profile-2/components/connected-apps/ConnectedApps.jsx
@@ -43,7 +43,12 @@ export class ConnectedApps extends Component {
     const activeApps = apps ? apps.filter(app => !app.deleted) : [];
 
     const allAppsDeleted = deletedApps?.length === apps?.length;
-    const showHasNoConnectedApps = !apps || (allAppsDeleted && !loading);
+    // We treat this 404 'Record not found' error as an empty apps array
+    const firstError = errors?.[0];
+    const recordNotFound =
+      firstError?.title === 'Record not found' && firstError?.status === '404';
+    const showHasNoConnectedApps =
+      !apps || (allAppsDeleted && !loading) || recordNotFound;
     const showHasConnectedApps = apps && !allAppsDeleted;
     // Check if any of the active apps have errors
     const disconnectErrorApps = activeApps.filter(app => !isEmpty(app.errors));
@@ -82,14 +87,15 @@ export class ConnectedApps extends Component {
           </>
         )}
 
-        {!isEmpty(errors) && (
-          <AlertBox
-            className="vads-u-margin-bottom--2"
-            headline="We couldn’t retrieve your connected apps"
-            status="warning"
-            content="We’re sorry. Something went wrong on our end and we couldn’t access your connected apps. Please try again later."
-          />
-        )}
+        {!isEmpty(errors) &&
+          !recordNotFound && (
+            <AlertBox
+              className="vads-u-margin-bottom--2"
+              headline="We couldn’t retrieve your connected apps"
+              status="warning"
+              content="We’re sorry. Something went wrong on our end and we couldn’t access your connected apps. Please try again later."
+            />
+          )}
 
         {deletedApps.map(app => (
           <AppDeletedAlert

--- a/src/applications/personalization/profile-2/tests/components/connected-apps/ConnectedApps.unit.spec.jsx
+++ b/src/applications/personalization/profile-2/tests/components/connected-apps/ConnectedApps.unit.spec.jsx
@@ -61,8 +61,7 @@ describe('<ConnectedApps>', () => {
       errors: [
         {
           title: 'Record not found',
-          detail:
-            'The record identified by ba09187e35df4853a24e8397f5ac86e8 could not be found',
+          detail: 'The record identified by 0000 could not be found',
           code: '404',
           status: '404',
         },

--- a/src/applications/personalization/profile-2/tests/components/connected-apps/ConnectedApps.unit.spec.jsx
+++ b/src/applications/personalization/profile-2/tests/components/connected-apps/ConnectedApps.unit.spec.jsx
@@ -60,6 +60,12 @@ describe('<ConnectedApps>', () => {
     const defaultProps = {
       errors: [
         {
+          title: 'Some server error',
+          detail: 'Some server error',
+          code: '404',
+          status: '404',
+        },
+        {
           title: 'Record not found',
           detail: 'The record identified by 0000 could not be found',
           code: '404',

--- a/src/applications/personalization/profile-2/tests/components/connected-apps/ConnectedApps.unit.spec.jsx
+++ b/src/applications/personalization/profile-2/tests/components/connected-apps/ConnectedApps.unit.spec.jsx
@@ -56,6 +56,39 @@ describe('<ConnectedApps>', () => {
     wrapper.unmount();
   });
 
+  it('renders correctly when Record not found error is thrown', () => {
+    const defaultProps = {
+      errors: [
+        {
+          title: 'Record not found',
+          detail:
+            'The record identified by ba09187e35df4853a24e8397f5ac86e8 could not be found',
+          code: '404',
+          status: '404',
+        },
+      ],
+      loadConnectedApps: () => {},
+      deleteConnectedApp: () => {},
+      dismissDeletedAppAlert: () => {},
+    };
+
+    const wrapper = shallow(<ConnectedApps {...defaultProps} />);
+
+    const text = wrapper.text();
+    expect(text).to.include('Connected apps');
+    expect(text).to.include(
+      'Connected apps are third-party (non-VA) applications or websites that can share certain information from your VA.gov profile, with your permission. For example, you can connect information from your VA health record to an app that helps you track your health.',
+    );
+    expect(text).to.not.include('Loading your connected apps...');
+    expect(text).to.include(
+      'We offer this feature for your convenience. It’s always your choice whether to connect, or stay connected, to a third-party app',
+    );
+    expect(text).to.include('Third-party apps you can connect to your profile');
+    expect(text).to.include('Have more questions about connected apps?');
+
+    wrapper.unmount();
+  });
+
   it('renders correctly when loading', () => {
     const defaultProps = {
       apps: [{ deleted: true }, { deleted: true }],


### PR DESCRIPTION
## Description
During UAT, we found out that most users who had no connected apps were getting a response back from the connected_apps endpoint similar to this one: `{"errors":[{"title":"Record not found","detail":"The record identified by ba09187e35df4853a24e8397f5ac86e8 could not be found","code":"404","status":"404"}]}`. After talking with some developers on the connected apps team, we decided that this error should not be treated like other errors - instead the UI should be the same as if we got an empty array back.

## Testing done
This 404 only occurs in prod, so it's a bit difficult to test this implementation.

Works locally by updating the `mockConnectedApps` array in `src/applications/personalization/profile360/util/connected-apps.js` to the error response above, and then update the `connectedApps` reducer to populate `errors` instead of `apps` in `FINISHED_LOADING_CONNECTED_APPS`. 

## Screenshots
![image](https://user-images.githubusercontent.com/14869324/93374137-85bc5200-f813-11ea-85f3-f3de0fb60a7a.png)

## Acceptance criteria
- [x] Make sure to not show the error Alert when the error above occurs. Instead, we should treat such a response the same as en empty data array.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
