### PR TITLE
[Development|508] Wrap links in a list

### DIFF
--- a/src/applications/disability-benefits/all-claims/content/fullyDevelopedClaim.jsx
+++ b/src/applications/disability-benefits/all-claims/content/fullyDevelopedClaim.jsx
@@ -11,22 +11,28 @@ export const FDCDescription = (
       uploaded all the supporting documents or additional forms needed to
       support your claim.
     </p>
-    <a
-      href="/disability/how-to-file-claim/evidence-needed/fully-developed-claims/"
-      target="_blank"
-      rel="noopener noreferrer"
-    >
-      Learn more about the FDC program
-    </a>
-    .<br />
-    <a
-      href="/disability/how-to-file-claim/evidence-needed/"
-      target="_blank"
-      rel="noopener noreferrer"
-    >
-      View the evidence requirements for disability claims
-    </a>
-    .
+    <ul>
+      <li>
+        <a
+          href="/disability/how-to-file-claim/evidence-needed/fully-developed-claims/"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Learn more about the FDC program
+        </a>
+        .
+      </li>
+      <li>
+        <a
+          href="/disability/how-to-file-claim/evidence-needed/"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          View the evidence requirements for disability claims
+        </a>
+        .
+      </li>
+    </ul>
   </div>
 );
 


### PR DESCRIPTION
## Description

The two links on the form [526 fully developed claim program page](https://staging.va.gov/disability/file-disability-claim-form-21-526ez/fully-developed-claim) did not have adequate spacing between them per the WCAG 2.2 AA guidelines.

As recommended, this PR, adds each link into a list to maintain adequate spacing

Related: https://github.com/department-of-veterans-affairs/va.gov-team/issues/12671

## Testing done

N/A

## Screenshots

![](https://user-images.githubusercontent.com/136959/93347841-27837500-f7fb-11ea-815d-87d35ccfde50.png)

## Acceptance criteria
- [x] Links on the fully developed claim program page have adequate spacing between them.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
