### PR TITLE
Fix logic for pointer-events on active children

### DIFF
--- a/src/platform/site-wide/sass/modules/_m-side-nav.scss
+++ b/src/platform/site-wide/sass/modules/_m-side-nav.scss
@@ -149,10 +149,6 @@ $side-nav-color-dark: #323a45;
       background-repeat: no-repeat;
     }
 
-    .active {
-      pointer-events: none;
-    }
-
     a.selected {
       color: $side-nav-color-dark !important;
       background: linear-gradient($side-nav-color-dark, $side-nav-color-dark) 100% top / 100% 1px,
@@ -239,26 +235,9 @@ $side-nav-color-dark: #323a45;
           display: none;
         }
         border-bottom: thin solid $side-nav-color-dark;
-        &.active {
-          pointer-events: none;
-          .va-sidenav-level-3,
-          .va-sidenav-level-4,
-          .va-sidenav-level-5 {
-            pointer-events: all;
-          }
-        }
         &.hasChildren {
           padding-bottom: 20px;
           margin-bottom: 20px;
-        }
-      }
-      .va-sidenav-level-3,
-      .va-sidenav-level-4,
-      .va-sidenav-level-5,
-      .va-sidenav-level-6 {
-        &.isSelected,
-        &.active {
-          pointer-events: none;
         }
       }
     }

--- a/src/platform/site-wide/side-nav/components/NavItemRow.js
+++ b/src/platform/site-wide/side-nav/components/NavItemRow.js
@@ -45,6 +45,14 @@ const NavItemRow = ({ depth, item, trackEvents }) => {
     trackEvents(id);
   };
 
+  const pointerEventsStyle = _href =>
+    window.location.pathname.substring(
+      0,
+      window.location.pathname.length - 1,
+    ) === _href
+      ? 'none'
+      : 'all';
+
   // Render the row not as a link when there are child nav items.
   if (hasChildren) {
     return (
@@ -61,7 +69,10 @@ const NavItemRow = ({ depth, item, trackEvents }) => {
         href={href}
         onClick={handleClick}
         rel="noopener noreferrer"
-        style={{ paddingLeft: indentation }}
+        style={{
+          paddingLeft: indentation,
+          pointerEvents: pointerEventsStyle(href),
+        }}
       >
         {/* Label text */}
         <span
@@ -86,7 +97,10 @@ const NavItemRow = ({ depth, item, trackEvents }) => {
       href={href}
       onClick={handleClick}
       rel="noopener noreferrer"
-      style={{ paddingLeft: indentation }}
+      style={{
+        paddingLeft: indentation,
+        pointerEvents: pointerEventsStyle(href),
+      }}
     >
       {/* Label text */}
       <span

--- a/src/platform/site-wide/side-nav/tests/components/NavItemRow.unit.spec.js
+++ b/src/platform/site-wide/side-nav/tests/components/NavItemRow.unit.spec.js
@@ -65,4 +65,50 @@ describe('<NavItemRow>', () => {
     expect(wrapper.exists('a')).to.equal(true);
     wrapper.unmount();
   });
+
+  it('renders pointerEvents none for current page', () => {
+    window.location = { pathname: '/pittsburgh-health-care/' };
+
+    const itemWithoutChildren = {
+      description: 'Some description',
+      expanded: true,
+      hasChildren: false,
+      href: '/pittsburgh-health-care',
+      id: uniqueId('sidenav_'),
+      isSelected: true,
+      label: 'Location',
+      order: 0,
+      parentID: uniqueId('sidenav_'),
+    };
+
+    const wrapper = shallow(
+      <NavItemRow {...defaultProps(itemWithoutChildren)} />,
+    );
+
+    expect(wrapper.find('a').prop('style').pointerEvents).to.equal('none');
+    wrapper.unmount();
+  });
+
+  it('renders pointerEvents all for non-current page', () => {
+    window.location = { pathname: '/pittsburgh-health-care/' };
+
+    const itemWithoutChildren = {
+      description: 'Some description',
+      expanded: true,
+      hasChildren: false,
+      href: '/pittsburgh-health-care/foo',
+      id: uniqueId('sidenav_'),
+      isSelected: true,
+      label: 'Location',
+      order: 0,
+      parentID: uniqueId('sidenav_'),
+    };
+
+    const wrapper = shallow(
+      <NavItemRow {...defaultProps(itemWithoutChildren)} />,
+    );
+
+    expect(wrapper.find('a').prop('style').pointerEvents).to.equal('all');
+    wrapper.unmount();
+  });
 });


### PR DESCRIPTION
The logic in the CSS for rendering pointer-events:none to disable links on the currently-selected page was very complex and broken. We were cascading "pointer-events:none" down to all children of the active node.

I moved the logic into JS, wrote a unit test to cover it, and removed it from CSS.

https://github.com/department-of-veterans-affairs/va.gov-team/issues/13621


## Acceptance criteria
- [x] Can navigate to children of active nodes

## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
