### PR TITLE
526/BDD: Update Supported File Upload Types and Minimum Size for TXT

### DIFF
--- a/src/applications/disability-benefits/all-claims/content/fileUploadDescriptions.jsx
+++ b/src/applications/disability-benefits/all-claims/content/fileUploadDescriptions.jsx
@@ -4,14 +4,17 @@ export const UploadDescription = ({ uploadTitle }) => (
   <div>
     {uploadTitle && <h3 className="vads-u-font-size--h5">{uploadTitle}</h3>}
     <p>
-      You can upload your document in a .pdf, .jpeg, or .png file format. You’ll
-      first need to scan a copy of your document onto your computer or mobile
-      phone. You can then upload the document from there.
+      You can upload your document in a .pdf, .jpg, .jpeg, .png, .gif, .bmp, or
+      .txt file format. You’ll first need to scan a copy of your document onto
+      your computer or mobile phone. You can then upload the document from
+      there.
       <br />
       Guidelines for uploading a file:
     </p>
     <ul>
-      <li>File types you can upload: .pdf, .jpeg, or .png</li>
+      <li>
+        File types you can upload: .pdf, .jpg, .jpeg, .png, .gif, .bmp, or .txt
+      </li>
       <li>Maximum file size: 25MB</li>
     </ul>
     <p>

--- a/src/applications/disability-benefits/all-claims/content/fileUploadDescriptions.jsx
+++ b/src/applications/disability-benefits/all-claims/content/fileUploadDescriptions.jsx
@@ -4,16 +4,17 @@ export const UploadDescription = ({ uploadTitle }) => (
   <div>
     {uploadTitle && <h3 className="vads-u-font-size--h5">{uploadTitle}</h3>}
     <p>
-      You can upload your document in a .pdf, .jpg, .jpeg, .png, .gif, .bmp, or
-      .txt file format. You’ll first need to scan a copy of your document onto
-      your computer or mobile phone. You can then upload the document from
-      there.
+      You can upload your document in a .pdf (unlocked), .jpg, .jpeg, .png,
+      .gif, .bmp, or .txt file format. You’ll first need to scan a copy of your
+      document onto your computer or mobile phone. You can then upload the
+      document from there.
       <br />
       Guidelines for uploading a file:
     </p>
     <ul>
       <li>
-        File types you can upload: .pdf, .jpg, .jpeg, .png, .gif, .bmp, or .txt
+        File types you can upload: .pdf (unlocked), .jpg, .jpeg, .png, .gif,
+        .bmp, or .txt
       </li>
       <li>Maximum file size: 25MB</li>
     </ul>

--- a/src/applications/disability-benefits/all-claims/utils.jsx
+++ b/src/applications/disability-benefits/all-claims/utils.jsx
@@ -616,6 +616,7 @@ export const ancillaryFormUploadUi = (
     addAnotherLabel,
     fileTypes: ['pdf', 'jpg', 'jpeg', 'png', 'gif', 'bmp', 'txt'],
     maxSize: TWENTY_FIVE_MB,
+    minSize: 0,
     createPayload: file => {
       const payload = new FormData();
       payload.append('supporting_evidence_attachment[file_data]', file);


### PR DESCRIPTION
## Description
This updates the language for the supported file upload types for the 526 and BDD form flows. Also changed is the minimum file size restriction in those forms to be 0 bytes to properly support .txt files.

## Screenshots
![bdd](https://user-images.githubusercontent.com/53942725/93485511-23c22200-f8d1-11ea-95d0-7664f6b43b5a.PNG)

## Acceptance criteria
- [ ] 526/BDD properly show supported file types
- [ ] 526/BDD support TXT files by removing the minimum file size restriction