### PR TITLE
[Development] Add separation date to empty "to" date range

### DIFF
--- a/src/applications/disability-benefits/all-claims/components/UpdateMilitaryHistory.jsx
+++ b/src/applications/disability-benefits/all-claims/components/UpdateMilitaryHistory.jsx
@@ -5,6 +5,11 @@ import { setData } from 'platform/forms-system/src/js/actions';
 import { SAVED_SEPARATION_DATE } from '../constants';
 
 export const addServicePeriod = (formData, separationDate, setFormData) => {
+  const updateData = newData => {
+    window.sessionStorage.removeItem(SAVED_SEPARATION_DATE);
+    setFormData(newData);
+  };
+
   const data = formData;
   if (!data.serviceInformation) {
     data.serviceInformation = { servicePeriods: [] };
@@ -12,17 +17,25 @@ export const addServicePeriod = (formData, separationDate, setFormData) => {
   if (!data.serviceInformation.servicePeriods) {
     data.serviceInformation.servicePeriods = [];
   }
-  if (
+  const index = data.serviceInformation.servicePeriods.findIndex(entry => {
+    const range = entry.dateRange || {};
+    return range.from && !range.to;
+  });
+  if (index > -1) {
+    // User has "from" date, but no "to" date
+    data.serviceInformation.servicePeriods[index].dateRange.to = separationDate;
+    updateData(data);
+  } else if (
     !data.serviceInformation.servicePeriods.find(
       entry => entry.dateRange?.to === separationDate,
     )
   ) {
+    // If the separation date doesn't already exists, add a new entry
     data.serviceInformation.servicePeriods.push({
       serviceBranch: '',
       dateRange: { from: '', to: separationDate },
     });
-    window.sessionStorage.removeItem(SAVED_SEPARATION_DATE);
-    setFormData(data);
+    updateData(data);
   }
 };
 

--- a/src/applications/disability-benefits/all-claims/tests/components/UpdateMilitaryHistory.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/components/UpdateMilitaryHistory.unit.spec.jsx
@@ -9,24 +9,25 @@ describe('UpdateMilitaryHistory', () => {
   let wrapper;
   let oldSessionStorage;
   let storage = {};
-  const servicePeriods = () => [
+  const servicePeriods = (to = '2020-12-31') => [
     {
       serviceBranch: 'Army',
       dateRange: {
         from: '2015-12-31',
-        to: '2020-12-31',
+        to,
       },
     },
   ];
   const form = {
     data: {
       serviceInformation: {
-        servicePeriods: servicePeriods(),
+        servicePeriods: [],
       },
     },
   };
 
-  function setUp({ separationDate = '', callback }) {
+  function setUp({ separationDate = '', to, callback }) {
+    form.data.serviceInformation.servicePeriods = servicePeriods(to);
     const setFormData = data => {
       form.data = data;
     };
@@ -52,7 +53,7 @@ describe('UpdateMilitaryHistory', () => {
     window.sessionStorage = oldSessionStorage;
     storage = {};
     wrapper.unmount();
-    form.data.serviceInformation.servicePeriods = servicePeriods();
+    form.data.serviceInformation.servicePeriods = [];
   });
 
   it('should get called', () => {
@@ -79,6 +80,33 @@ describe('UpdateMilitaryHistory', () => {
             },
           },
         ]);
+        expect(form.data.serviceInformation.servicePeriods).to.have.lengthOf(2);
+      },
+    });
+  });
+  it('should add separation date to an existing "empty" entry', () => {
+    const separationDate = '2021-01-30';
+    setUp({
+      separationDate,
+      to: '', // Add empty "to" date in prefill
+      callback: () => {
+        expect(form.data.serviceInformation.servicePeriods).to.deep.equal(
+          servicePeriods(separationDate),
+        );
+        expect(form.data.serviceInformation.servicePeriods).to.have.lengthOf(1);
+      },
+    });
+  });
+  it('should not add a duplicate separation date', () => {
+    const separationDate = '2021-01-30';
+    setUp({
+      separationDate,
+      to: separationDate, // Separation date already in prefill
+      callback: () => {
+        expect(form.data.serviceInformation.servicePeriods).to.deep.equal(
+          servicePeriods(separationDate),
+        );
+        expect(form.data.serviceInformation.servicePeriods).to.have.lengthOf(1);
       },
     });
   });


### PR DESCRIPTION
## Description

When a Veteran enters a separation date into the 526 wizard, that date will now fill an existing service period that has an empty end date. Prior to this change, it would _always_ add the separation date into a new service period.

Related: https://github.com/department-of-veterans-affairs/va.gov-team/issues/13631

## Testing done

Updated unit tests

## Screenshots

<details><summary>Separation date (01-17-2021) added to an existing period</summary>

<!-- leave a blank line above -->
![Screen Shot 2020-09-17 at 9 32 17 AM](https://user-images.githubusercontent.com/136959/93485458-b4483480-f8c8-11ea-9bfe-2bcb61762e3e.png)</details>

<details><summary>Separation date (01-17-2021) to a new service period</summary>

<!-- leave a blank line above -->
![Screen Shot 2020-09-17 at 9 36 59 AM](https://user-images.githubusercontent.com/136959/93486063-5f58ee00-f8c9-11ea-9674-9946d6e3f132.png)</details>

## Acceptance criteria
- [x] An empty ending service history date is now filled with the user-entered separation date
- [x] Filled service periods without a matching separation date will cause a new entry to be added 
- [x] All unit tests pass

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
