### PR TITLE
Fixed publish pacts script with proper value for pactFilesOrDirs.

### DIFF
--- a/script/publish-pacts.js
+++ b/script/publish-pacts.js
@@ -9,11 +9,11 @@ const fs = require('fs');
 const path = require('path');
 const pact = require('@pact-foundation/pact-node');
 
-const pactFilesOrDirs = path.resolve(__dirname, '../pacts');
+const pactsFolder = path.resolve(__dirname, '../pacts');
 
 try {
-  const pacts = fs.readdirSync(pactFilesOrDirs);
-  if (!pacts.length) throw new Error('No pacts found.');
+  const pactFiles = fs.readdirSync(pactsFolder);
+  if (!pactFiles.length) throw new Error('No pacts found.');
 } catch (e) {
   console.warn(e.message);
   console.log('Skipping pact publishing.');
@@ -32,7 +32,7 @@ const opts = {
   pactBroker: process.env.PACT_BROKER_URL,
   pactBrokerUsername: process.env.PACT_BROKER_BASIC_AUTH_USERNAME,
   pactBrokerPassword: process.env.PACT_BROKER_BASIC_AUTH_PASSWORD,
-  pactFilesOrDirs,
+  pactFilesOrDirs: [pactsFolder],
   consumerVersion,
   tags: [branchName],
 };


### PR DESCRIPTION
## Description
Feature branches with Pact tests were failing with this error during the publishing step:

```
TypeError: Must provide the pactFilesOrDirs argument with an array
```

This fix corrects the expected value for the `pactFilesOrDirs` [publishing option](https://github.com/pact-foundation/pact-js#pact-publishing-options) to address that error.

This bug only affected branches that had tests, since the script would early exit if no pacts were generated.

## Testing done
Verified locally that the script doesn't fail with the same error (still fails auth without credentials, but that occurs after evaluating the options).
Tested in a separate branch with multiple pact tests to verify that publishing works in CI.

## Acceptance criteria
- [ ] Pacts should be able to get published to the broker in CI.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
