### PR TITLE
Fix forced logout on account/ redirect

### DIFF
--- a/src/applications/personalization/account/containers/AccountApp.jsx
+++ b/src/applications/personalization/account/containers/AccountApp.jsx
@@ -14,44 +14,47 @@ import { fetchMHVAccount } from 'platform/user/profile/actions';
 
 import { selectShowProfile2 } from 'applications/personalization/profile-2/selectors';
 
-function AccountApp(props) {
-  useEffect(
-    () => {
-      if (props.redirect) {
-        window.location.replace('/profile/account-security');
-      }
-    },
-    [props.redirect],
-  );
+function Redirect() {
+  useEffect(() => {
+    window.location.replace('/profile/account-security');
+  }, []);
 
+  return null;
+}
+
+function AccountApp(props) {
   return (
     <div>
       <RequiredLoginView
         serviceRequired={backendServices.USER_PROFILE}
         user={props.user}
       >
-        <DowntimeNotification
-          appTitle="user account page"
-          dependencies={[externalServices.mvi, externalServices.emis]}
-        >
-          <div className="row user-profile-row">
-            <div className="usa-width-two-thirds medium-8 small-12 columns">
-              <h1>Your VA.gov account settings</h1>
-              <div className="va-introtext">
-                <p>
-                  Below, you’ll find your current settings for signing in to{' '}
-                  VA.gov. Find out how to update your settings as needed to
-                  access more site tools or add extra security to your account.
-                </p>
+        {props.redirect && <Redirect />}
+        {!props.redirect && (
+          <DowntimeNotification
+            appTitle="user account page"
+            dependencies={[externalServices.mvi, externalServices.emis]}
+          >
+            <div className="row user-profile-row">
+              <div className="usa-width-two-thirds medium-8 small-12 columns">
+                <h1>Your VA.gov account settings</h1>
+                <div className="va-introtext">
+                  <p>
+                    Below, you’ll find your current settings for signing in to{' '}
+                    VA.gov. Find out how to update your settings as needed to
+                    access more site tools or add extra security to your
+                    account.
+                  </p>
+                </div>
+                <AccountMain
+                  login={props.login}
+                  profile={props.profile}
+                  fetchMHVAccount={props.fetchMHVAccount}
+                />
               </div>
-              <AccountMain
-                login={props.login}
-                profile={props.profile}
-                fetchMHVAccount={props.fetchMHVAccount}
-              />
             </div>
-          </div>
-        </DowntimeNotification>
+          </DowntimeNotification>
+        )}
       </RequiredLoginView>
     </div>
   );

--- a/src/applications/personalization/account/tests/containers/AccountApp.redirect.unit.spec.jsx
+++ b/src/applications/personalization/account/tests/containers/AccountApp.redirect.unit.spec.jsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import sinon from 'sinon';
+import thunk from 'redux-thunk';
 import { mount } from 'enzyme';
 import { expect } from 'chai';
 import { Provider } from 'react-redux';
-import { combineReducers, createStore } from 'redux';
+import { applyMiddleware, combineReducers, createStore } from 'redux';
 
 import { commonReducer } from 'platform/startup/store';
 import localStorage from 'platform/utilities/storage/localStorage';
@@ -24,13 +25,24 @@ describe('<AccountApp>', () => {
           },
           multifactor: true,
           loading: false,
+          mhvAccount: {
+            loading: false,
+          },
+          services: ['user-profile'],
+        },
+        login: {
+          currentlyLoggedIn: true,
         },
       },
       featureToggles: {
         'profile_show_profile_2.0': featureFlag,
       },
     };
-    const store = createStore(combineReducers(commonReducer), initialState);
+    const store = createStore(
+      combineReducers(commonReducer),
+      initialState,
+      applyMiddleware(thunk),
+    );
     wrapper = mount(
       <Provider store={store}>
         <AccountApp />


### PR DESCRIPTION
## Description
The issue seemed to be that the URL redirect on component mount would cancel the `GET user/` call that was in flight. That would throw an error resulting in the user's session getting wiped out. This fixes it by waiting for the `GET user/` call to resolve before triggering the redirect. Takes a little longer but it gets the job done. I think. This whole "redirect from the front end" approach will be removed when Profile 2.0 is live to 100% of users and we can implement a proper backend redirect.

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs