### PR TITLE
adds `noopener noreferrer` to anchor tag

### DIFF
--- a/src/site/includes/common-and-popular.html
+++ b/src/site/includes/common-and-popular.html
@@ -16,12 +16,15 @@
   <div class="small-12 usa-width-one-half medium-6 columns">
     <h3 class="va-h-ruled">Popular on VA.gov</h3>
     <ul class="va-list--plain">
-      <li><a href="/find-locations/">Find nearby VA locations</a></li>
+      <li>
+        <a href="/find-locations/">Find nearby VA locations</a>
+      </li>
       <li>
         <a href="/gi-bill-comparison-tool">View education benefits available by school</a>
       </li>
-      <li><a target="_blank" href="https://www.veteranscrisisline.net/" class="external no-external-icon">Contact the Veterans Crisis Line</a></li>
+      <li>
+        <a target="_blank" href="https://www.veteranscrisisline.net/" rel="noopener noreferrer" class="external no-external-icon">Contact the Veterans Crisis Line</a>
+      </li>
     </ul>
   </div>
 </div>
-


### PR DESCRIPTION
## Description
**Issue:** [department-of-veterans-affairs/va.gov-team#13644](https://github.com/department-of-veterans-affairs/va.gov-team/issues/13644).

This PR adds `noreferrer noopener` to an anchor tag in the `common-and-popular.html` fragment.
## Testing done
N/A

## Screenshots
N/A

## Acceptance criteria
- [X] Add `noopener noreferrer` to anchor tag

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
