### PR TITLE
Added contract tests for search.

### DIFF
--- a/src/applications/search/actions/index.js
+++ b/src/applications/search/actions/index.js
@@ -14,7 +14,7 @@ export function fetchSearchResults(query, page) {
       queryString = queryString.concat(`&page=${page}`);
     }
 
-    apiRequest(queryString)
+    return apiRequest(queryString)
       .then(response =>
         dispatch({
           type: FETCH_SEARCH_RESULTS_SUCCESS,

--- a/src/applications/search/tests/search.pact.spec.js
+++ b/src/applications/search/tests/search.pact.spec.js
@@ -1,0 +1,132 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { Matchers } from '@pact-foundation/pact';
+
+import contractTest from 'platform/testing/contract';
+
+import {
+  FETCH_SEARCH_RESULTS,
+  FETCH_SEARCH_RESULTS_SUCCESS,
+  fetchSearchResults,
+} from '../actions';
+
+const { eachLike, like, string, term } = Matchers;
+
+contractTest('Search', 'VA.gov API', mockApi => {
+  describe('GET /search', () => {
+    context('with at least one result', () => {
+      it('responds with success', async () => {
+        await mockApi().addInteraction({
+          state: 'at least one matching result exists',
+          uponReceiving: 'a search query',
+          withRequest: {
+            method: 'GET',
+            path: '/v0/search',
+            query: { query: 'benefits' },
+            headers: {
+              'X-Key-Inflection': 'camel',
+            },
+          },
+          willRespondWith: {
+            status: 200,
+            headers: {
+              'Content-Type': term({
+                matcher: '^application/json',
+                generate: 'application/json',
+              }),
+            },
+            body: {
+              data: {
+                type: 'search_results_responses',
+                attributes: {
+                  body: {
+                    query: string('benefits'),
+                    web: {
+                      results: eachLike({
+                        title: 'string',
+                        url: 'url',
+                        snippet: 'a short paragraph blurb',
+                      }),
+                    },
+                  },
+                },
+              },
+              meta: {
+                pagination: like({
+                  currentPage: 1,
+                  perPage: 10,
+                  totalPages: 1,
+                  totalEntries: 1,
+                }),
+              },
+            },
+          },
+        });
+
+        const dispatch = sinon.spy();
+        await fetchSearchResults('benefits')(dispatch);
+
+        const [firstAction] = dispatch.firstCall.args;
+        expect(firstAction.type).to.eq(FETCH_SEARCH_RESULTS);
+
+        const [secondAction] = dispatch.secondCall.args;
+        expect(secondAction.type).to.eq(FETCH_SEARCH_RESULTS_SUCCESS);
+        expect(secondAction.results.web.results).to.have.lengthOf.at.least(1);
+
+        secondAction.results.web.results.forEach(result =>
+          expect(Object.keys(result)).to.include('title', 'url', 'snippet'),
+        );
+      });
+    });
+
+    // context('with no results', () => {
+    //   it('responds with success', async () => {
+    //     await mockApi.addInteraction({
+    //       state: 'no matching results exist',
+    //       uponReceiving: 'a search query',
+    //       withRequest: {
+    //         method: 'GET',
+    //         path: '/v0/search',
+    //         query: { query: 'benefits' },
+    //         headers: {
+    //           'X-Key-Inflection': 'camel',
+    //         },
+    //       },
+    //       willRespondWith: {
+    //         status: 200,
+    //         body: {
+    //           data: {
+    //             type: 'search_results_responses',
+    //             attributes: {
+    //               body: {
+    //                 query: string('benefits'),
+    //                 web: {
+    //                   results: [],
+    //                 },
+    //               },
+    //             },
+    //           },
+    //           meta: {
+    //             pagination: like({
+    //               currentPage: 1,
+    //               perPage: 10,
+    //               totalPages: 1,
+    //               totalEntries: 1,
+    //             }),
+    //           },
+    //         },
+    //       },
+    //     });
+    //
+    //     const dispatch = sinon.spy();
+    //     await fetchSearchResults('abcdef')(dispatch);
+    //     const [firstAction] = dispatch.firstCall.args;
+    //     expect(firstAction.type).to.eq(FETCH_SEARCH_RESULTS);
+    //
+    //     const [secondAction] = dispatch.secondCall.args;
+    //     expect(secondAction.type).to.eq(FETCH_SEARCH_RESULTS_SUCCESS);
+    //     expect(secondAction.results.web.results).to.have.lengthOf(0);
+    //   });
+    // });
+  });
+});


### PR DESCRIPTION
## Description
This adds a basic contract test (for the search app) to the suite of Pact tests.

This allows vets-api's CI pipeline to run its verification job against pacts tagged as master, meaning they're on vets-website's main branch. That verification fails if there are no pacts with that tag, so adding test will automatically create that tag.

This also serves as a basic example of using Pact to write contract tests.

## Testing done
Contract tests pass locally and in CI.

## Acceptance criteria
- [ ] Contract tests should pass.
- [ ] vets-api should verify against pacts on the master branch.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
