### PR TITLE
[Static pages] Fix for analytics on COVID FAQ page

### DIFF
--- a/src/applications/static-pages/analytics/addJumpLinkListeners.js
+++ b/src/applications/static-pages/analytics/addJumpLinkListeners.js
@@ -3,11 +3,12 @@ import { isAnchor } from './utilities';
 
 export default function addJumplinkListeners() {
   const selectors = {
-    heading: '[data-template="paragraphs/wysiwyg"] #on-this-page',
+    template: '#table-of-contents',
   };
 
-  const jumplinkHeading = document.querySelector(selectors.heading);
-  const container = jumplinkHeading.parentElement;
+  const container = document.getElementById(selectors.template);
+
+  if (!container) return;
 
   container.addEventListener('click', event => {
     if (!isAnchor(event.target)) {

--- a/src/applications/static-pages/analytics/index.js
+++ b/src/applications/static-pages/analytics/index.js
@@ -1,3 +1,5 @@
+import * as Sentry from '@sentry/browser';
+
 import addJumplinkListeners from './addJumpLinkListeners';
 import addQaSectionListeners from './addQaSectionListeners';
 import addTeaserListeners from './addTeaserListeners';
@@ -29,7 +31,12 @@ function attachAnalytics() {
     addTeaserListeners();
     addButtonLinkListeners();
   } catch (error) {
-    // Catch any error that might occur while trying to attach listeners.
+    Sentry.withScope(scope => {
+      scope.setExtra('error', error);
+      Sentry.captureMessage(
+        'Error attaching event listeners used for analytics',
+      );
+    });
   }
 }
 


### PR DESCRIPTION
## Description
This PR is a fix for some analytics being broken on `/coronavirus-veteran-frequently-asked-questions/`. Previously, the table of contents on the page was typed into a WYSIWYG, and we'd create event listeners based on that DOM to capture analytics. However, that WYSIWYG content was removed in favor of a generate table of contents. This caused a runtime error in our analytics initializer. This PR fixes that by switching to the new DOM shape.

https://github.com/department-of-veterans-affairs/va.gov-team/issues/13707

## Testing done
Confirmed via Chrome plugin that data layer is getting updated

## Screenshots
![image](https://user-images.githubusercontent.com/1915775/93620409-eed4ce80-f9a7-11ea-8a90-7cedc3cb4acd.png)


## Acceptance criteria
- [ ] Analytics are captured again

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
