### PR TITLE
[Development] Include `inProgressFormId` with Sentry error

### DIFF
--- a/src/platform/forms-system/src/js/review/SubmitController.jsx
+++ b/src/platform/forms-system/src/js/review/SubmitController.jsx
@@ -44,7 +44,13 @@ class SubmitController extends Component {
   };
 
   handleSubmit = () => {
-    const { form, formConfig, pageList, trackingPrefix } = this.props;
+    const {
+      form,
+      formConfig,
+      pageList,
+      trackingPrefix,
+      inProgressFormId,
+    } = this.props;
 
     // If a pre-submit agreement is required, make sure it was accepted
     const preSubmit = this.getPreSubmit(formConfig);
@@ -64,6 +70,7 @@ class SubmitController extends Component {
       Sentry.withScope(scope => {
         scope.setExtra('errors', errors);
         scope.setExtra('prefix', trackingPrefix);
+        scope.setExtra('inProgressFormId', inProgressFormId);
         Sentry.captureMessage('Validation issue not displayed');
       });
       this.props.setSubmission('status', 'validationError');
@@ -99,6 +106,7 @@ function mapStateToProps(state, ownProps) {
   const trackingPrefix = formConfig.trackingPrefix;
   const submission = form.submission;
   const showPreSubmitError = submission.hasAttemptedSubmit;
+  const inProgressFormId = form.loadedData?.metadata?.inProgressFormId;
 
   return {
     form,
@@ -110,6 +118,7 @@ function mapStateToProps(state, ownProps) {
     submission,
     showPreSubmitError,
     trackingPrefix,
+    inProgressFormId,
   };
 }
 


### PR DESCRIPTION
## Description

When a user submits a form, but encounters a validation issue before the form is submitted, the errors are sent submitted as part of a Sentry error, but sometimes the errors are out of context. The save-in-progress (SiP) ID for the user was recently included in the metadata so it could be passed along in the Sentry error.

Related:
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/13689
- https://github.com/department-of-veterans-affairs/vets-api/pull/4925
- http://sentry.vfs.va.gov/vets-gov/website-production/issues/12188/

## Testing done

- Local unit tests (unchanged)
- I did attempt to add a test using Sentry's testkit, but was not successful.

## Screenshots

N/A

## Acceptance criteria
- [x] `inProgressFormId` is included along with the Sentry error for invalid form submission attempts

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
