### PR TITLE
Added window.Mocha flag.

### DIFF
--- a/src/platform/testing/unit/mocha-setup.js
+++ b/src/platform/testing/unit/mocha-setup.js
@@ -102,6 +102,8 @@ export default function setupJSDom() {
     },
   };
 
+  window.Mocha = true;
+
   copyProps(window, global);
 
   // The following properties provided by JSDom are read-only by default.


### PR DESCRIPTION
## Description
Includes a `window.Mocha` flag to enable control over certain app behaviors in unit tests.

This can be used similarly to Cypress's `window.Cypress` flag.

## Testing done
Flag has been used in other PRs.

#14212 uses `window.Mocha` to override the mock API.

## Acceptance criteria
- [ ] There should be a flag that can be used to indicate when code is executed in the context of a unit test.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
