### PR TITLE
Have Cypress run axe checks in WCAG 2 rulesets

### DIFF
--- a/src/applications/disability-benefits/all-claims/tests/all-claims.cypress.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/all-claims.cypress.spec.js
@@ -10,6 +10,7 @@ import { mockItf } from './all-claims.cypress.helpers';
 
 const testConfig = createTestConfig(
   {
+    _13647Exception: true,
     dataPrefix: 'data',
 
     dataSets: [

--- a/src/applications/disability-benefits/all-claims/tests/all-claims.cypress.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/all-claims.cypress.spec.js
@@ -14,12 +14,12 @@ const testConfig = createTestConfig(
 
     dataSets: [
       'full-781-781a-8940-test.json',
-      'maximal-test',
+      // 'maximal-test',
       'maximal-bdd-test',
       'minimal-test',
       'minimal-bdd-test',
-      'newOnly-test',
-      'secondary-new-test.json',
+      // 'newOnly-test',
+      // 'secondary-new-test.json',
       'upload-781-781a-8940-test.json',
     ],
 

--- a/src/applications/disability-benefits/all-claims/tests/all-claims.cypress.spec.js
+++ b/src/applications/disability-benefits/all-claims/tests/all-claims.cypress.spec.js
@@ -14,12 +14,12 @@ const testConfig = createTestConfig(
 
     dataSets: [
       'full-781-781a-8940-test.json',
-      // 'maximal-test',
+      'maximal-test',
       'maximal-bdd-test',
       'minimal-test',
       'minimal-bdd-test',
-      // 'newOnly-test',
-      // 'secondary-new-test.json',
+      'newOnly-test',
+      'secondary-new-test.json',
       'upload-781-781a-8940-test.json',
     ],
 

--- a/src/applications/facility-locator/tests/e2e/gaEvents.cypress.spec.js
+++ b/src/applications/facility-locator/tests/e2e/gaEvents.cypress.spec.js
@@ -16,8 +16,8 @@ describe('Google Analytics FL Events', () => {
       cy.get('#street-city-state-zip').type('Austin, TX');
       cy.get('#facility-type-dropdown').select('VA health');
       cy.get('#facility-search').click();
-      // cy.injectAxe();
-      // cy.axeCheck();
+      cy.injectAxe();
+      cy.axeCheck('main', { _13647Exception: true });
 
       cy.get('#map-id', { timeout: 10000 }).should(() => {
         assertDataLayerEvent(win, 'fl-search');

--- a/src/applications/facility-locator/tests/e2e/gaEvents.cypress.spec.js
+++ b/src/applications/facility-locator/tests/e2e/gaEvents.cypress.spec.js
@@ -16,8 +16,8 @@ describe('Google Analytics FL Events', () => {
       cy.get('#street-city-state-zip').type('Austin, TX');
       cy.get('#facility-type-dropdown').select('VA health');
       cy.get('#facility-search').click();
-      cy.injectAxe();
-      cy.axeCheck();
+      // cy.injectAxe();
+      // cy.axeCheck();
 
       cy.get('#map-id', { timeout: 10000 }).should(() => {
         assertDataLayerEvent(win, 'fl-search');

--- a/src/applications/facility-locator/tests/e2e/mobile.cypress.spec.js
+++ b/src/applications/facility-locator/tests/e2e/mobile.cypress.spec.js
@@ -1,7 +1,7 @@
 import path from 'path';
 
-Cypress.Commands.add('checkSearch', () => {
-  cy.axeCheck();
+Cypress.Commands.add('checkSearch', ({ _13647Exception = false }) => {
+  cy.axeCheck('main', { _13647Exception });
 
   // Search
   cy.get('#street-city-state-zip').type('Austin, TX');
@@ -42,19 +42,19 @@ describe('Mobile', () => {
 
     // iPhone X
     cy.viewport(400, 812);
-    cy.checkSearch();
+    cy.checkSearch({ _13647Exception: true });
 
     // iPhone 6/7/8 plus
     cy.viewport(414, 736);
-    cy.checkSearch();
+    cy.checkSearch({ _13647Exception: true });
 
     // Pixel 2
     cy.viewport(411, 731);
-    cy.checkSearch();
+    cy.checkSearch({ _13647Exception: true });
 
     // Galaxy S5/Moto
     cy.viewport(360, 640);
-    cy.checkSearch();
+    cy.checkSearch({ _13647Exception: true });
   });
 
   it('should render the appropriate elements at each breakpoint', () => {

--- a/src/applications/facility-locator/tests/e2e/search.cypress.spec.js
+++ b/src/applications/facility-locator/tests/e2e/search.cypress.spec.js
@@ -80,7 +80,7 @@ describe('Facility search', () => {
     cy.get('#facility-search').click();
 
     cy.injectAxe();
-    cy.axeCheck();
+    cy.axeCheck('main', { _13647Exception: true });
 
     cy.get('.facility-result a').should('exist');
     cy.route(
@@ -93,7 +93,7 @@ describe('Facility search', () => {
       .first()
       .click();
 
-    cy.axeCheck();
+    cy.axeCheck('main', { _13647Exception: true });
 
     cy.get('.all-details').should('exist');
 
@@ -169,7 +169,7 @@ describe('Facility search', () => {
     cy.get('#other-tools').should('exist');
 
     cy.injectAxe();
-    cy.axeCheck();
+    cy.axeCheck('main', { _13647Exception: true });
 
     cy.get('.facility-result h3').contains('Concentra Urgent Care');
     cy.get('.va-pagination').should('not.exist');
@@ -190,7 +190,7 @@ describe('Facility search', () => {
     cy.get('#other-tools').should('exist');
 
     cy.injectAxe();
-    cy.axeCheck();
+    cy.axeCheck('main', { _13647Exception: true });
 
     cy.get('.facility-result h3').contains('MinuteClinic');
     cy.get('.va-pagination').should('not.exist');
@@ -231,7 +231,7 @@ describe('Facility search', () => {
     cy.get('.facility-search-results').contains(
       /Something’s not quite right. Please enter a valid or different location and try your search again./gi,
     );
-    cy.axeCheck();
+    cy.axeCheck('main', { _13647Exception: true });
 
     // Valid location search
     cy.route('GET', '/geocoding/**/*', 'fx:constants/mock-geocoding-data').as(
@@ -245,7 +245,7 @@ describe('Facility search', () => {
       'Results for "VA health", "Primary care" near "Austin, Texas"',
     );
     cy.get('.facility-result a').should('exist');
-    cy.axeCheck();
+    cy.axeCheck('main', { _13647Exception: true });
   });
 
   it('finds va benefits facility in Los Angeles and views its page', () => {
@@ -264,7 +264,7 @@ describe('Facility search', () => {
     );
     cy.get('#other-tools').should('exist');
 
-    cy.axeCheck();
+    cy.axeCheck('main', { _13647Exception: true });
 
     cy.get('.facility-result a').contains('Los Angeles Ambulatory Care Center');
     cy.findByText(/Los Angeles Ambulatory Care Center/i, { selector: 'a' })
@@ -280,7 +280,7 @@ describe('Facility search', () => {
     cy.get('#hours-op h3').contains('Hours of operation');
     cy.get('#other-tools').should('not.exist');
 
-    cy.axeCheck();
+    cy.axeCheck('main', { _13647Exception: true });
   });
 
   it.skip('renders static map images on detail page', () => {

--- a/src/applications/hca/tests/hca.cypress.spec.js
+++ b/src/applications/hca/tests/hca.cypress.spec.js
@@ -8,6 +8,7 @@ import manifest from '../manifest.json';
 
 const testConfig = createTestConfig(
   {
+    _13647Exception: true,
     dataPrefix: 'data',
     dataSets: ['minimal-test', 'maximal-test', 'foreign-address-test'],
     fixtures: { data: path.join(__dirname, 'schema') },

--- a/src/platform/testing/e2e/cypress/support/commands/axeCheck.js
+++ b/src/platform/testing/e2e/cypress/support/commands/axeCheck.js
@@ -32,7 +32,6 @@ Cypress.Commands.add('axeCheck', (context = 'main') => {
   Cypress.log();
 
   const options = {
-    includedImpacts: ['critical'],
     runOnly: {
       type: 'tag',
       values: ['wcag2a', 'wcag2aa'],

--- a/src/platform/testing/e2e/cypress/support/commands/axeCheck.js
+++ b/src/platform/testing/e2e/cypress/support/commands/axeCheck.js
@@ -28,7 +28,7 @@ const processAxeCheckResults = violations => {
  * Checks the current page for aXe violations.
  * @param {string} [context] - Selector for the container element to aXe check.
  */
-Cypress.Commands.add('axeCheck', (context = 'main', tempOptions) => {
+Cypress.Commands.add('axeCheck', (context = 'main', tempOptions = {}) => {
   const { _13647Exception } = tempOptions;
   Cypress.log();
 

--- a/src/platform/testing/e2e/cypress/support/commands/axeCheck.js
+++ b/src/platform/testing/e2e/cypress/support/commands/axeCheck.js
@@ -33,6 +33,10 @@ Cypress.Commands.add('axeCheck', (context = 'main') => {
 
   const options = {
     includedImpacts: ['critical'],
+    runOnly: {
+      type: 'tag',
+      values: ['wcag2a', 'wcag2aa'],
+    },
   };
 
   cy.checkA11y(context, options, processAxeCheckResults);

--- a/src/platform/testing/e2e/cypress/support/commands/axeCheck.js
+++ b/src/platform/testing/e2e/cypress/support/commands/axeCheck.js
@@ -28,22 +28,20 @@ const processAxeCheckResults = violations => {
  * Checks the current page for aXe violations.
  * @param {string} [context] - Selector for the container element to aXe check.
  */
-Cypress.Commands.add(
-  'axeCheck',
-  (context = 'main', { _13647Exception = false }) => {
-    Cypress.log();
+Cypress.Commands.add('axeCheck', (context = 'main', tempOptions) => {
+  const { _13647Exception } = tempOptions;
+  Cypress.log();
 
-    const options = _13647Exception
-      ? {
-          includedImpacts: ['critical'],
-        }
-      : {
-          runOnly: {
-            type: 'tag',
-            values: ['wcag2a', 'wcag2aa'],
-          },
-        };
+  const options = _13647Exception
+    ? {
+        includedImpacts: ['critical'],
+      }
+    : {
+        runOnly: {
+          type: 'tag',
+          values: ['wcag2a', 'wcag2aa'],
+        },
+      };
 
-    cy.checkA11y(context, options, processAxeCheckResults);
-  },
-);
+  cy.checkA11y(context, options, processAxeCheckResults);
+});

--- a/src/platform/testing/e2e/cypress/support/commands/axeCheck.js
+++ b/src/platform/testing/e2e/cypress/support/commands/axeCheck.js
@@ -28,15 +28,22 @@ const processAxeCheckResults = violations => {
  * Checks the current page for aXe violations.
  * @param {string} [context] - Selector for the container element to aXe check.
  */
-Cypress.Commands.add('axeCheck', (context = 'main') => {
-  Cypress.log();
+Cypress.Commands.add(
+  'axeCheck',
+  (context = 'main', { _13647Exception = false }) => {
+    Cypress.log();
 
-  const options = {
-    runOnly: {
-      type: 'tag',
-      values: ['wcag2a', 'wcag2aa'],
-    },
-  };
+    const options = _13647Exception
+      ? {
+          includedImpacts: ['critical'],
+        }
+      : {
+          runOnly: {
+            type: 'tag',
+            values: ['wcag2a', 'wcag2aa'],
+          },
+        };
 
-  cy.checkA11y(context, options, processAxeCheckResults);
-});
+    cy.checkA11y(context, options, processAxeCheckResults);
+  },
+);

--- a/src/platform/testing/e2e/cypress/support/form-tester/index.js
+++ b/src/platform/testing/e2e/cypress/support/form-tester/index.js
@@ -135,8 +135,8 @@ const addNewArrayItem = $form => {
  *
  * @param {string} pathname - The pathname of the page to run the page hook on.
  */
-const performPageActions = pathname => {
-  cy.axeCheck();
+const performPageActions = (pathname, _13647Exception = false) => {
+  cy.axeCheck('main', { _13647Exception });
 
   cy.execHook(pathname).then(({ hookExecuted, postHook }) => {
     const shouldAutofill = !pathname.match(
@@ -146,7 +146,7 @@ const performPageActions = pathname => {
     if (!hookExecuted && shouldAutofill) cy.fillPage();
 
     cy.expandAccordions();
-    cy.axeCheck();
+    cy.axeCheck('main', { _13647Exception });
 
     const postHookPromise = new Promise(resolve => {
       postHook();
@@ -161,9 +161,9 @@ const performPageActions = pathname => {
  * Top level loop that invokes all of the processing for a form page and
  * asserts that it proceeds to the next page until it gets to the confirmation.
  */
-const processPage = () => {
+const processPage = ({ _13647Exception }) => {
   cy.location('pathname', NO_LOG_OPTION).then(pathname => {
-    performPageActions(pathname);
+    performPageActions(pathname, _13647Exception);
 
     if (!pathname.endsWith('/confirmation')) {
       cy.location('pathname', NO_LOG_OPTION)
@@ -172,7 +172,7 @@ const processPage = () => {
             throw new Error(`Expected to navigate away from ${pathname}`);
           }
         })
-        .then(processPage);
+        .then(() => processPage({ _13647Exception }));
     }
   });
 };
@@ -490,6 +490,7 @@ const testForm = testConfig => {
     setup = () => {},
     setupPerTest = () => {},
     skip,
+    _13647Exception = false,
   } = testConfig;
 
   const skippedTests = Array.isArray(skip) && new Set(skip);
@@ -549,7 +550,7 @@ const testForm = testConfig => {
 
           cy.get(LOADING_SELECTOR)
             .should('not.exist')
-            .then(processPage);
+            .then(() => processPage({ _13647Exception }));
         });
       });
 

--- a/src/platform/testing/e2e/cypress/support/form-tester/index.js
+++ b/src/platform/testing/e2e/cypress/support/form-tester/index.js
@@ -135,8 +135,8 @@ const addNewArrayItem = $form => {
  *
  * @param {string} pathname - The pathname of the page to run the page hook on.
  */
-const performPageActions = (pathname, { runAxeCheck }) => {
-  if (runAxeCheck) cy.axeCheck();
+const performPageActions = pathname => {
+  cy.axeCheck();
 
   cy.execHook(pathname).then(({ hookExecuted, postHook }) => {
     const shouldAutofill = !pathname.match(
@@ -146,8 +146,7 @@ const performPageActions = (pathname, { runAxeCheck }) => {
     if (!hookExecuted && shouldAutofill) cy.fillPage();
 
     cy.expandAccordions();
-
-    if (runAxeCheck) cy.axeCheck();
+    cy.axeCheck();
 
     const postHookPromise = new Promise(resolve => {
       postHook();
@@ -162,9 +161,9 @@ const performPageActions = (pathname, { runAxeCheck }) => {
  * Top level loop that invokes all of the processing for a form page and
  * asserts that it proceeds to the next page until it gets to the confirmation.
  */
-const processPage = ({ runAxeCheck = true }) => {
+const processPage = () => {
   cy.location('pathname', NO_LOG_OPTION).then(pathname => {
-    performPageActions(pathname, { runAxeCheck });
+    performPageActions(pathname);
 
     if (!pathname.endsWith('/confirmation')) {
       cy.location('pathname', NO_LOG_OPTION)
@@ -173,7 +172,7 @@ const processPage = ({ runAxeCheck = true }) => {
             throw new Error(`Expected to navigate away from ${pathname}`);
           }
         })
-        .then(() => processPage({ runAxeCheck }));
+        .then(processPage);
     }
   });
 };
@@ -491,7 +490,6 @@ const testForm = testConfig => {
     setup = () => {},
     setupPerTest = () => {},
     skip,
-    runAxeCheck = true,
   } = testConfig;
 
   const skippedTests = Array.isArray(skip) && new Set(skip);
@@ -551,7 +549,7 @@ const testForm = testConfig => {
 
           cy.get(LOADING_SELECTOR)
             .should('not.exist')
-            .then(() => processPage({ runAxeCheck }));
+            .then(processPage);
         });
       });
 


### PR DESCRIPTION
## Description

### Addresses https://github.com/department-of-veterans-affairs/va.gov-team/issues/13647

This adds configuration to the Cypress axe checker so that it will throw errors for `serious`, `minor`, and `trivial` a11y violations, which are included in the WCAG 2 Level A and WCAG 2 Level AA rulesets. Introducing these new rules causes some existing app code to fail the stricter axe checks in Cypress, so this PR also adds a _temporary_ exception which will allow those apps to use the older less-strict checks until they fix the code that causes the violations. Once all apps have fixed the accessibility violations, the code that allows for the exception will be removed.

## Testing done

Cypress tests


## Screenshots

## Acceptance criteria
- [x] Cypress form tests run normally
- [x] Tests break on any violation impact (critical, serious, minor, trivial)
- [ ] Tests do NOT break on best-practice rules
- [ ] Tests do NOT break on experimental rules

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
