### PR TITLE
[Development] Show prefill banking if user doesn't add new info

### DIFF
--- a/src/applications/disability-benefits/all-claims/components/PaymentViewObjectField.jsx
+++ b/src/applications/disability-benefits/all-claims/components/PaymentViewObjectField.jsx
@@ -1,0 +1,42 @@
+import React from 'react';
+
+export const paymentRows = {
+  bankAccountType: 'Account type',
+  bankAccountNumber: 'Account number',
+  bankRoutingNumber: 'Routing number',
+  bankName: 'Bank name',
+};
+
+const PaymentViewObjectField = (props = {}) => {
+  const { renderedProperties, defaultEditButton, title, formData } = props;
+  if (!renderedProperties) {
+    return null;
+  }
+
+  // Save-in-progress banking info contained in 'view:originalBankAccount'
+  // User entered (new) banking info in 'view:bankAccount'
+  const buildRow = name => (
+    <div className="review-row">
+      <dt>{paymentRows[name]}</dt>
+      <dd>
+        {formData['view:bankAccount'][name] ||
+          formData['view:originalBankAccount']?.[`view:${name}`] ||
+          ''}
+      </dd>
+    </div>
+  );
+
+  return (
+    <>
+      <div className="form-review-panel-page-header-row">
+        <h3 className="form-review-panel-page-header vads-u-font-size--h5">
+          {title}
+        </h3>
+        {defaultEditButton()}
+      </div>
+      <dl className="review">{Object.keys(paymentRows).map(buildRow)}</dl>
+    </>
+  );
+};
+
+export default PaymentViewObjectField;

--- a/src/applications/disability-benefits/all-claims/pages/paymentInformation.js
+++ b/src/applications/disability-benefits/all-claims/pages/paymentInformation.js
@@ -3,6 +3,7 @@ import ReviewCardField from 'platform/forms-system/src/js/components/ReviewCardF
 
 import { bankFieldsHaveInput } from '../utils';
 import PaymentView from '../components/PaymentView';
+import PaymentViewObjectField from '../components/PaymentViewObjectField';
 import { paymentInformationTitle } from '../content/paymentInformation';
 
 const {
@@ -13,6 +14,7 @@ const {
 } = fullSchema.properties;
 
 export const uiSchema = {
+  'ui:objectViewField': PaymentViewObjectField,
   'view:bankAccount': {
     'ui:title': paymentInformationTitle,
     'ui:field': ReviewCardField,

--- a/src/applications/disability-benefits/all-claims/tests/components/PaymentViewObjectField.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/components/PaymentViewObjectField.unit.spec.jsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { expect } from 'chai';
+import { shallow } from 'enzyme';
+import sinon from 'sinon';
+
+import PaymentViewObjectField, {
+  paymentRows,
+} from '../../components/PaymentViewObjectField';
+
+const getProps = ({ onEdit, newValues = '12345', origValues = '9876' }) => {
+  const props = {
+    renderedProperties: <div />,
+    defaultEditButton: () => <button onClick={onEdit}>Edit</button>,
+    title: 'Faboo',
+  };
+  props.formData = Object.keys(paymentRows).reduce(
+    (acc, key) => {
+      acc['view:bankAccount'][key] = newValues;
+      acc['view:originalBankAccount'][`view:${key}`] = origValues;
+      return acc;
+    },
+    { 'view:bankAccount': {}, 'view:originalBankAccount': {} },
+  );
+  return props;
+};
+
+describe('PaymentViewObjectField', () => {
+  it('should not render', () => {
+    const tree = shallow(<PaymentViewObjectField />);
+    expect(tree).to.be.empty;
+    tree.unmount();
+  });
+  it('should render with empty fields', () => {
+    const onEdit = sinon.spy();
+    const props = getProps({ onEdit, newValues: '', origValues: '' });
+    const tree = shallow(<PaymentViewObjectField {...props} />);
+    const list = tree.find('dd');
+    expect(list).to.have.lengthOf(4);
+    list.forEach(entry => expect(entry).to.be.empty);
+    tree.unmount();
+  });
+  it('should render with newly entered values', () => {
+    const onEdit = sinon.spy();
+    const props = getProps({ onEdit });
+    const tree = shallow(<PaymentViewObjectField {...props} />);
+    const list = tree.find('dd');
+    expect(list).to.have.lengthOf(4);
+    list.forEach(entry => expect(entry.text()).to.equal('12345'));
+    tree.unmount();
+  });
+  it('should render with original values', () => {
+    const onEdit = sinon.spy();
+    const props = getProps({ onEdit, newValues: '' });
+    const tree = shallow(<PaymentViewObjectField {...props} />);
+    const list = tree.find('dd');
+    expect(list).to.have.lengthOf(4);
+    list.forEach(entry => expect(entry.text()).to.equal('9876'));
+    tree.unmount();
+  });
+});


### PR DESCRIPTION
## Description

On form 526's review & submit page, the banking information is saved in a separate form data field than the newly entered banking info. If the user did not enter any new data, the content on the review and submit page would be empty.

This fix required a newly added `ui:objectViewField` setting added to the `uiSchema` (see https://github.com/department-of-veterans-affairs/vets-website/pull/14091), to enable this update to work properly.

<details><summary>Existing (prefilled) banking info</summary>

<!-- leave a blank line above -->
![Screen Shot 2020-09-18 at 5 19 20 PM](https://user-images.githubusercontent.com/136959/93650103-3cb2fc00-f9d3-11ea-9ed0-9425407a98d5.png)</details>

<details><summary>Newly entered banking info</summary>

<!-- leave a blank line above -->
![Screen Shot 2020-09-18 at 5 18 59 PM](https://user-images.githubusercontent.com/136959/93650079-23aa4b00-f9d3-11ea-97ea-ed812b8d0c1f.png)</details>

**Note** The existing (prefill) banking info will _always_ be masked out with asterisks (`*`); this is what is provided by the API.

Related:
- https://github.com/department-of-veterans-affairs/va.gov-team/issues/2345
- https://github.com/department-of-veterans-affairs/vets-website/pull/14091

## Testing done

Added new unit tests

## Screenshots

See description

## Acceptance criteria
- [x] Banking info shows either the original (existing) or newly entered banking info
- [x] This switch is dynamic, meaning it can be edited on the review & submit page and show the expected info

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
