### PR TITLE
Add CC eligibility mocks

### DIFF
--- a/src/applications/vaos/tests/mocks/helpers.js
+++ b/src/applications/vaos/tests/mocks/helpers.js
@@ -161,6 +161,28 @@ export function mockParentSites(ids, data) {
   );
 }
 
+export function mockSupportedCCSites(ids, data) {
+  setFetchJSONResponse(
+    global.fetch.withArgs(
+      `${environment.API_URL}/vaos/v0/community_care/supported_sites?${ids
+        .map(id => `site_codes[]=${id}`)
+        .join('&')}`,
+    ),
+    { data },
+  );
+}
+
+export function mockCCEligibility(typeOfCare, data) {
+  setFetchJSONResponse(
+    global.fetch.withArgs(
+      `${environment.API_URL}/vaos/v0/community_care/eligibility/${typeOfCare}`,
+    ),
+    {
+      data,
+    },
+  );
+}
+
 export function mockSupportedFacilities({
   siteId,
   parentId,

--- a/src/applications/vaos/tests/mocks/v0.js
+++ b/src/applications/vaos/tests/mocks/v0.js
@@ -290,3 +290,26 @@ export function getExpressCareRequestCriteriaMock(id, schedulingDays) {
     },
   ];
 }
+
+export function getCCEligibilityMock(typeOfCare, eligible = true) {
+  return {
+    id: typeOfCare,
+    type: 'cc_eligibility',
+    attributes: { eligible },
+  };
+}
+
+export function getSupportedSiteMock(
+  id,
+  name = 'Cheyenne',
+  timezone = 'US/Mountain',
+) {
+  return {
+    id,
+    type: 'object_type',
+    attributes: {
+      name,
+      timezone,
+    },
+  };
+}


### PR DESCRIPTION
## Description
The type of care page performs CC eligibility checks in order to determine whether to show the user the Type of Facility page or not.  Without these checks, `typeOfFacility` is automatically set to VA.  These mock helpers can be used when we want to test the CC flow.

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
