### PR TITLE
vagovprod flag set to true

### DIFF
--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -127,7 +127,7 @@
     "rootUrl": "/view-change-dependents/view",
     "template": {
       "layout": "page-react.html",
-      "vagovprod": false
+      "vagovprod": true
     }
   },
   {

--- a/src/applications/registry.json
+++ b/src/applications/registry.json
@@ -127,7 +127,7 @@
     "rootUrl": "/view-change-dependents/view",
     "template": {
       "layout": "page-react.html",
-      "vagovprod": true
+      "vagovprod": false
     }
   },
   {
@@ -263,10 +263,6 @@
       "vagovprod": true,
       "includeBreadcrumbs": true,
       "breadcrumbs_override": [
-        {
-          "path": "view-change-dependents/view",
-          "name": "View or change your dependents"
-        },
         {
           "path": "view-change-dependents/add-remove-form-686c/",
           "name": "Add or remove dependents form 21-686c"


### PR DESCRIPTION
## Description
~This pull request builds view-dependents for production, as it is part of the complete 686c workflow needed for UAT.~

Edit: This pull request removes the breadcrumb override from the 686c registry entry to fix the broken link issue in the production build. 

## Testing done


## Screenshots


## Acceptance criteria
- [x] breadcrumb override removed. 

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
