### PR TITLE
Past appts not showing

### DIFF
--- a/src/applications/vaos/services/appointment/index.js
+++ b/src/applications/vaos/services/appointment/index.js
@@ -30,7 +30,11 @@ export async function getBookedAppointments({ startDate, endDate }) {
         moment(startDate).toISOString(),
         moment(endDate).toISOString(),
       ),
-      getConfirmedAppointments('cc', startDate, endDate),
+      getConfirmedAppointments(
+        'cc',
+        moment(startDate).toISOString(),
+        moment(endDate).toISOString(),
+      ),
     ]);
 
     return transformConfirmedAppointments([

--- a/src/applications/vaos/tests/mocks/helpers.js
+++ b/src/applications/vaos/tests/mocks/helpers.js
@@ -18,14 +18,17 @@ export function mockAppointmentInfo({
 }) {
   mockFetch();
 
-  const vaUrl = `${
+  const baseUrl = `${
     environment.API_URL
   }/vaos/v0/appointments?start_date=${moment()
     .startOf('day')
     .toISOString()}&end_date=${moment()
     .add(13, 'months')
     .startOf('day')
-    .toISOString()}&type=va`;
+    .toISOString()}`;
+
+  const vaUrl = `${baseUrl}&type=va`;
+  const ccUrl = `${baseUrl}&type=cc`;
 
   if (vaError) {
     setFetchJSONFailure(global.fetch.withArgs(vaUrl), { errors: [] });
@@ -33,16 +36,8 @@ export function mockAppointmentInfo({
     setFetchJSONResponse(global.fetch.withArgs(vaUrl), { data: va });
   }
 
-  setFetchJSONResponse(
-    global.fetch.withArgs(
-      `${environment.API_URL}/vaos/v0/appointments?start_date=${moment().format(
-        'YYYY-MM-DD',
-      )}&end_date=${moment()
-        .add(13, 'months')
-        .format('YYYY-MM-DD')}&type=cc`,
-    ),
-    { data: cc },
-  );
+  setFetchJSONResponse(global.fetch.withArgs(ccUrl), { data: cc });
+
   setFetchJSONResponse(
     global.fetch.withArgs(
       `${environment.API_URL}/vaos/v0/appointment_requests?start_date=${moment()
@@ -55,27 +50,20 @@ export function mockAppointmentInfo({
 
 export function mockPastAppointmentInfo({ va = [], cc = [] }) {
   mockFetch();
-  const vaUrl = `${
+  const baseUrl = `${
     environment.API_URL
   }/vaos/v0/appointments?start_date=${moment()
     .startOf('day')
     .add(-3, 'months')
     .toISOString()}&end_date=${moment()
-    .startOf('day')
-    .toISOString()}&type=va`;
+    .set('milliseconds', 0)
+    .toISOString()}`;
+
+  const vaUrl = `${baseUrl}&type=va`;
+  const ccUrl = `${baseUrl}&type=cc`;
 
   setFetchJSONResponse(global.fetch.withArgs(vaUrl), { data: va });
-  setFetchJSONResponse(
-    global.fetch.withArgs(
-      `${environment.API_URL}/vaos/v0/appointments?start_date=${moment()
-        .add(-3, 'months')
-        .startOf('day')
-        .format()}&end_date=${moment()
-        .startOf('day')
-        .format()}&type=cc`,
-    ),
-    { data: cc },
-  );
+  setFetchJSONResponse(global.fetch.withArgs(ccUrl), { data: cc });
 }
 
 export function mockPastAppointmentInfoOption1({ va = [], cc = [] }) {

--- a/src/applications/vaos/tests/services/appointment/index.unit.spec.js
+++ b/src/applications/vaos/tests/services/appointment/index.unit.spec.js
@@ -55,7 +55,9 @@ describe('VAOS Appointment service', () => {
         ).toISOString()}&end_date=${moment(endDate).toISOString()}&type=va`,
       );
       expect(global.fetch.secondCall.args[0]).to.contain(
-        '/vaos/v0/appointments?start_date=2020-05-01&end_date=2020-06-30&type=cc',
+        `/vaos/v0/appointments?start_date=${moment(
+          startDate,
+        ).toISOString()}&end_date=${moment(endDate).toISOString()}&type=cc`,
       );
       expect(data[0].status).to.equal('booked');
     });
@@ -84,7 +86,9 @@ describe('VAOS Appointment service', () => {
         ).toISOString()}&end_date=${moment(endDate).toISOString()}&type=va`,
       );
       expect(global.fetch.secondCall.args[0]).to.contain(
-        '/vaos/v0/appointments?start_date=2020-05-01&end_date=2020-06-30&type=cc',
+        `/vaos/v0/appointments?start_date=${moment(
+          startDate,
+        ).toISOString()}&end_date=${moment(endDate).toISOString()}&type=cc`,
       );
       expect(error?.resourceType).to.equal('OperationOutcome');
     });

--- a/src/applications/vaos/utils/appointment.js
+++ b/src/applications/vaos/utils/appointment.js
@@ -36,10 +36,8 @@ export function getAppointmentTimezoneDescription(timezone, facilityId) {
 }
 
 export function getPastAppointmentDateRangeOptions(today = moment()) {
-  const startOfToday = today
-    .clone()
-    .startOf('day');
-    
+  const startOfToday = today.clone().startOf('day');
+
   // Past 3 months
   const options = [
     {

--- a/src/applications/vaos/utils/appointment.js
+++ b/src/applications/vaos/utils/appointment.js
@@ -36,7 +36,10 @@ export function getAppointmentTimezoneDescription(timezone, facilityId) {
 }
 
 export function getPastAppointmentDateRangeOptions(today = moment()) {
-  const startOfToday = today.startOf('day');
+  const startOfToday = today
+    .clone()
+    .startOf('day');
+    
   // Past 3 months
   const options = [
     {


### PR DESCRIPTION
## Description
https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/12260

Past appointments for the current day were not being displayed because end-date was set to the start of day resulting in appointments for that day being filtered out.  The solution was to fix the end-date by cloning the `moment` object, this resulted in an accurate setting of end-date that included the time at which the call was made (instead of it being set to start of day).

## Testing done
Unit tests were updated to reflect this change
