### PR TITLE
Better SMS appt reminder checkbox error handling

### DIFF
--- a/src/applications/personalization/profile-2/tests/components/personal-information/PersonalInformation.sms-checkbox.unit.spec.jsx
+++ b/src/applications/personalization/profile-2/tests/components/personal-information/PersonalInformation.sms-checkbox.unit.spec.jsx
@@ -91,9 +91,7 @@ describe('When enrolled in health care', () => {
   after(() => {
     server.close();
   });
-  // Skipping this test for now since it does not handle this case correctly
-  // TODO:
-  it.skip('should show an error if it is unable to create the transaction', async () => {
+  it('should show an error if it is unable to create the transaction', async () => {
     server.use(...mocks.createTransactionFailure);
     getCheckbox(view).click();
 

--- a/src/applications/personalization/profile-2/tests/components/personal-information/PersonalInformation.sms-checkbox.unit.spec.jsx
+++ b/src/applications/personalization/profile-2/tests/components/personal-information/PersonalInformation.sms-checkbox.unit.spec.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { expect } from 'chai';
 import { setupServer } from 'msw/node';
-import { waitForElementToBeRemoved } from '@testing-library/dom';
 
 import { resetFetch } from 'platform/testing/unit/helpers';
 
@@ -23,16 +22,16 @@ const ui = (
 let view;
 let server;
 
+const savingMessageRegex = /We’re working on saving your.*text alert preference/i;
+
+const smsCheckboxLabelRegex = /We’ll send VA health care appointment text reminders to this number/i;
+
 function getCheckbox(_view) {
-  return _view.getByLabelText(
-    /We’ll send VA health care appointment text reminders to this number/i,
-  );
+  return _view.getByLabelText(smsCheckboxLabelRegex);
 }
 
 function queryCheckbox(_view) {
-  return _view.queryByLabelText(
-    /We’ll send VA health care appointment text reminders to this number/i,
-  );
+  return _view.queryByLabelText(smsCheckboxLabelRegex);
 }
 
 describe('When not enrolled in health care', () => {
@@ -95,11 +94,7 @@ describe('When enrolled in health care', () => {
     server.use(...mocks.createTransactionFailure);
     getCheckbox(view).click();
 
-    expect(
-      await view.findByText(
-        /We’re working on saving your.*text alert preference/i,
-      ),
-    ).to.exist;
+    expect(await view.findByText(savingMessageRegex)).to.exist;
 
     expect(
       await view.findByText(
@@ -111,11 +106,7 @@ describe('When enrolled in health care', () => {
     server.use(...mocks.transactionPending);
     getCheckbox(view).click();
 
-    expect(
-      await view.findByText(
-        /We’re working on saving your.*text alert preference/i,
-      ),
-    ).to.exist;
+    expect(await view.findByText(savingMessageRegex)).to.exist;
 
     server.use(...mocks.transactionFailed);
 
@@ -129,15 +120,13 @@ describe('When enrolled in health care', () => {
     server.use(...mocks.transactionPending);
     getCheckbox(view).click();
 
-    const savingMessage = await view.findByText(
-      /We’re working on saving your.*text alert preference/i,
-    );
+    const savingMessage = await view.findByText(savingMessageRegex);
 
     expect(savingMessage).to.exist;
 
     server.use(...mocks.transactionSucceeded);
 
-    await waitForElementToBeRemoved(savingMessage);
+    await view.findByLabelText(smsCheckboxLabelRegex);
 
     expect(getCheckbox(view)).to.have.attr('checked');
   });

--- a/src/applications/personalization/profile-2/tests/helpers.unit.spec.js
+++ b/src/applications/personalization/profile-2/tests/helpers.unit.spec.js
@@ -90,8 +90,7 @@ describe('transformServiceHistoryEntryIntoTableRow', () => {
       expect(titleDfn.props().className).to.equal('sr-only');
     });
     it('should have the correct text', () => {
-      expect(value.text().includes('January 31, 2000 – December 25, 2010')).to
-        .be.true;
+      expect(value.text()).to.contain('January 31, 2000 – December 25, 2010');
     });
   });
 });

--- a/src/platform/user/profile/vet360/components/base/Vet360Transaction.jsx
+++ b/src/platform/user/profile/vet360/components/base/Vet360Transaction.jsx
@@ -22,7 +22,10 @@ function Vet360Transaction(props) {
   } = props;
 
   const method = transactionRequest?.method || 'PUT';
-  const hasError = isFailedTransaction(transaction);
+  const updateInProgress =
+    isPendingTransaction(transaction) || transactionRequest?.isPending;
+  const hasError =
+    isFailedTransaction(transaction) || transactionRequest?.isFailed;
   const classes = classNames('vet360-profile-field-content', {
     'usa-input-error': hasError,
   });
@@ -30,7 +33,7 @@ function Vet360Transaction(props) {
   return (
     <div className={classes}>
       {hasError && <Vet360TransactionInlineErrorMessage {...props} />}
-      {isPendingTransaction(transaction) ? (
+      {updateInProgress ? (
         <div id={id}>
           <Vet360TransactionPending
             title={title}

--- a/src/platform/user/profile/vet360/components/base/Vet360Transaction.jsx
+++ b/src/platform/user/profile/vet360/components/base/Vet360Transaction.jsx
@@ -22,8 +22,9 @@ function Vet360Transaction(props) {
   } = props;
 
   const method = transactionRequest?.method || 'PUT';
-  const updateInProgress =
-    isPendingTransaction(transaction) || transactionRequest?.isPending;
+  const transactionRequestPending = transactionRequest?.isPending;
+  const transactionPending = isPendingTransaction(transaction);
+  const transactionResolved = !transactionRequestPending && !transactionPending;
   const hasError =
     isFailedTransaction(transaction) || transactionRequest?.isFailed;
   const classes = classNames('vet360-profile-field-content', {
@@ -33,7 +34,21 @@ function Vet360Transaction(props) {
   return (
     <div className={classes}>
       {hasError && <Vet360TransactionInlineErrorMessage {...props} />}
-      {updateInProgress ? (
+      {transactionRequestPending && (
+        <div id={id}>
+          <Vet360TransactionPending
+            title={title}
+            refreshTransaction={() => {}}
+            method={method}
+          >
+            {/* if this field's modal is open, pass in the children to prevent
+               the `Vet360TransactionPending` component from rendering the
+               "we're saving your info..." message */}
+            {isModalOpen && children}
+          </Vet360TransactionPending>
+        </div>
+      )}
+      {transactionPending && (
         <div id={id}>
           <Vet360TransactionPending
             title={title}
@@ -46,9 +61,8 @@ function Vet360Transaction(props) {
             {isModalOpen && children}
           </Vet360TransactionPending>
         </div>
-      ) : (
-        children
       )}
+      {transactionResolved && children}
     </div>
   );
 }


### PR DESCRIPTION
## Description
This change adds properly handles a situation where a transaction cannot be created when a user clicks on the "appoints by SMS" checkbox. Previously a failure to create the transaction would fail silently and also give the impression that the change they requested had succeeded.

## Testing done
Enabled an existing test that had been disabled.
All other existing tests continue to pass.

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs