### PR TITLE
add pr, vi questions and add exposure question

### DIFF
--- a/src/applications/coronavirus-screener/config/questions.jsx
+++ b/src/applications/coronavirus-screener/config/questions.jsx
@@ -52,7 +52,7 @@ export const questions = [
   {
     id: 'exposure',
     text:
-      'In the past 14 days, have you had close contact with someone who you know was diagnosed with COVID-19?',
+      'In the past 14 days, have you had close contact with someone who you know was diagnosed with COVID-19 or was waiting for COVID-19 test results?',
     dependsOn: {
       id: 'isStaff',
       value: 'no',
@@ -61,7 +61,7 @@ export const questions = [
   {
     id: 'exposure-staff',
     text:
-      "Have you had contact with someone diagnosed with COVID-19 that you haven't already reported to VA occupational health?",
+      "Have you had contact with someone you know was diagnosed with COVID-19 or was waiting for COVID-19 test results that you haven't already reported to VA occupational health?",
     dependsOn: {
       id: 'isStaff',
       value: 'yes',
@@ -99,6 +99,42 @@ export const questions = [
       'In the past 14 days, have you traveled outside of New York and its surrounding states?',
     customId: ['526', '528', '620', '630', '632'],
   },
+  {
+    id: 'travel-self-pr',
+    text:
+      'Have you traveled out of Puerto Rico within the last 14 days?',
+    customId: ['672'],
+  },
+  {
+    id: 'travel-other-pr',
+    text:
+      'Have you had contact with someone who has traveled out of Puerto Rico within the last 14 days?',
+    customId: ['672'],
+  },
+  {
+    id: 'travel-self-stvi',
+    text:
+      'Have you traveled out of St. Thomas within the last 14 days?',
+    customId: ['672GB'],
+  },
+  {
+    id: 'travel-other-stvi',
+    text:
+      'Have you had contact with someone who has traveled out of St. Thomas within the last 14 days?',
+    customId: ['672GB'],
+  },
+  {
+    id: 'travel-self-scvi',
+    text:
+      'Have you traveled out of St. Croix within the last 14 days?',
+    customId: ['672GA'],
+  },
+  {
+    id: 'travel-other-scvi',
+    text:
+      'Have you had contact with someone who has traveled out of St. Croix within the last 14 days?',
+    customId: ['672GA'],
+  }
 ];
 
 export const defaultOptions = [

--- a/src/applications/coronavirus-screener/config/questions.jsx
+++ b/src/applications/coronavirus-screener/config/questions.jsx
@@ -47,7 +47,8 @@ export const questions = [
   },
   {
     id: 'congestion',
-    text: 'Do you currently have a runny nose or nasal congestion?',
+    text:
+      "Do you currently have a runny nose or congestion that's new and not related to allergies?",
   },
   {
     id: 'exposure',

--- a/src/applications/coronavirus-screener/config/questions.jsx
+++ b/src/applications/coronavirus-screener/config/questions.jsx
@@ -101,8 +101,7 @@ export const questions = [
   },
   {
     id: 'travel-self-pr',
-    text:
-      'Have you traveled out of Puerto Rico within the last 14 days?',
+    text: 'Have you traveled out of Puerto Rico within the last 14 days?',
     customId: ['672'],
   },
   {
@@ -113,8 +112,7 @@ export const questions = [
   },
   {
     id: 'travel-self-stvi',
-    text:
-      'Have you traveled out of St. Thomas within the last 14 days?',
+    text: 'Have you traveled out of St. Thomas within the last 14 days?',
     customId: ['672GB'],
   },
   {
@@ -125,8 +123,7 @@ export const questions = [
   },
   {
     id: 'travel-self-scvi',
-    text:
-      'Have you traveled out of St. Croix within the last 14 days?',
+    text: 'Have you traveled out of St. Croix within the last 14 days?',
     customId: ['672GA'],
   },
   {
@@ -134,7 +131,7 @@ export const questions = [
     text:
       'Have you had contact with someone who has traveled out of St. Croix within the last 14 days?',
     customId: ['672GA'],
-  }
+  },
 ];
 
 export const defaultOptions = [

--- a/src/applications/coronavirus-screener/config/questions.jsx
+++ b/src/applications/coronavirus-screener/config/questions.jsx
@@ -102,35 +102,35 @@ export const questions = [
   },
   {
     id: 'travel-self-pr',
-    text: 'Have you traveled out of Puerto Rico within the last 14 days?',
+    text: 'Have you traveled outside of Puerto Rico within the last 14 days?',
     customId: ['672'],
   },
   {
     id: 'travel-other-pr',
     text:
-      'Have you had contact with someone who has traveled out of Puerto Rico within the last 14 days?',
+      'Have you had contact with someone who has traveled outside of Puerto Rico within the last 14 days?',
     customId: ['672'],
   },
   {
     id: 'travel-self-stvi',
-    text: 'Have you traveled out of St. Thomas within the last 14 days?',
+    text: 'Have you traveled outside of St. Thomas within the last 14 days?',
     customId: ['672GB'],
   },
   {
     id: 'travel-other-stvi',
     text:
-      'Have you had contact with someone who has traveled out of St. Thomas within the last 14 days?',
+      'Have you had contact with someone who has traveled outside of St. Thomas within the last 14 days?',
     customId: ['672GB'],
   },
   {
     id: 'travel-self-scvi',
-    text: 'Have you traveled out of St. Croix within the last 14 days?',
+    text: 'Have you traveled outside of St. Croix within the last 14 days?',
     customId: ['672GA'],
   },
   {
     id: 'travel-other-scvi',
     text:
-      'Have you had contact with someone who has traveled out of St. Croix within the last 14 days?',
+      'Have you had contact with someone who has traveled outside of St. Croix within the last 14 days?',
     customId: ['672GA'],
   },
 ];


### PR DESCRIPTION
## Description
- Adds travel questions for PR and USVI.
- Adds exposure to someone waiting for test results modifier.

## Testing done

## Screenshots

## Acceptance criteria
-

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
