### PR TITLE
Fix the content watch

### DIFF
--- a/src/site/stages/build/console.js
+++ b/src/site/stages/build/console.js
@@ -1,0 +1,38 @@
+/* eslint-disable no-console */
+
+let alreadyOverloaded = false;
+let consoleDirty = false;
+
+/**
+ * Replace the process.stdout.write and process.stderr.out with a simple wrapper
+ * which toggles consoleDirty to true. This is because we only need to write the
+ * full logStepEnd if there's any output after the logStepStart.
+ */
+function overloadConsoleWrites() {
+  if (!alreadyOverloaded) {
+    alreadyOverloaded = true;
+    console.log('overloading terminal writes');
+    process.stdout.__write = process.stdout.write;
+    process.stdout.write = function _write(...params) {
+      consoleDirty = true;
+      process.stdout.__write(...params);
+    };
+    process.stderr.__write = process.stderr.write;
+    process.stderr.write = function _write(...params) {
+      consoleDirty = true;
+      process.stderr.__write(...params);
+    };
+  }
+}
+
+const isConsoleDirty = () => consoleDirty;
+
+function cleanConsole() {
+  consoleDirty = false;
+}
+
+module.exports = {
+  overloadConsoleWrites,
+  isConsoleDirty,
+  cleanConsole,
+};


### PR DESCRIPTION
## Description
When we run the content watch, Silversmith is called multiple times. This is a problem because the process.stdout.write and process.stderr.write overloads were causing an endless loop.

I cleaned this up by moving the logic to its own module and checking to see if we've already overloaded the global process functions.
