### PR TITLE
better handling of empty/missing service history dates

### DIFF
--- a/src/applications/personalization/profile-2/helpers.js
+++ b/src/applications/personalization/profile-2/helpers.js
@@ -28,18 +28,29 @@ export const getServiceBranchDisplayName = serviceBranch => {
  * `beginDate`, and `endDate` keys
  * @returns {Object} An object with `title` and `value` keys
  */
-export const transformServiceHistoryEntryIntoTableRow = entry => ({
-  title: (
-    <>
-      <dfn className="sr-only">Service branch: </dfn>
-      {getServiceBranchDisplayName(entry.branchOfService)}
-    </>
-  ),
-  value: (
-    <>
-      <dfn className="sr-only">Dates of service: </dfn>
-      {moment(entry.beginDate).format('LL')} –{' '}
-      {moment(entry.endDate).format('LL')}
-    </>
-  ),
-});
+export const transformServiceHistoryEntryIntoTableRow = entry => {
+  const formattedBeginDate = entry.beginDate
+    ? moment(entry.beginDate).format('LL')
+    : '';
+  const formattedEndDate = entry.endDate
+    ? moment(entry.endDate).format('LL')
+    : '';
+  const dateRange =
+    formattedBeginDate.length || formattedEndDate.length
+      ? `${formattedBeginDate} – ${formattedEndDate}`
+      : '';
+  return {
+    title: (
+      <>
+        <dfn className="sr-only">Service branch: </dfn>
+        {getServiceBranchDisplayName(entry.branchOfService)}
+      </>
+    ),
+    value: (
+      <>
+        <dfn className="sr-only">Dates of service: </dfn>
+        {dateRange}
+      </>
+    ),
+  };
+};

--- a/src/applications/personalization/profile-2/tests/components/MilitaryInformation.unit.spec.jsx
+++ b/src/applications/personalization/profile-2/tests/components/MilitaryInformation.unit.spec.jsx
@@ -67,6 +67,118 @@ describe('MilitaryInformation', () => {
       expect(entries[1]).to.contain.text('April 11, 2009');
     });
   });
+  describe('when a service history date cannot be parsed', () => {
+    it('should report that the date is invalid', () => {
+      initialState = createBasicInitialState();
+      initialState.vaProfile.militaryInformation.serviceHistory.serviceHistory[0].endDate =
+        'not a valid date';
+      view = renderWithProfileReducers(<MilitaryInformation />, {
+        initialState,
+      });
+      const entries = view.queryAllByRole('listitem');
+
+      expect(entries.length).to.equal(2);
+      expect(entries[0]).to.contain.text(
+        'Service branch: United States Air Force',
+      );
+      expect(entries[0]).to.contain.text(
+        'Dates of service: April 12, 2009 – Invalid date',
+      );
+
+      expect(entries[1]).to.contain.text(
+        'Service branch: United States Air Force',
+      );
+      expect(entries[1]).to.contain.text('Dates of service: April 12, 2005');
+      expect(entries[1]).to.contain.text('April 11, 2009');
+    });
+  });
+  describe('when military history is missing a date', () => {
+    it('should not parse a date that is an empty string', () => {
+      initialState = createBasicInitialState();
+      initialState.vaProfile.militaryInformation.serviceHistory.serviceHistory[0].endDate =
+        '';
+      view = renderWithProfileReducers(<MilitaryInformation />, {
+        initialState,
+      });
+      const entries = view.queryAllByRole('listitem');
+
+      expect(entries.length).to.equal(2);
+      expect(entries[0]).to.contain.text(
+        'Service branch: United States Air Force',
+      );
+      expect(entries[0]).to.contain.text('Dates of service: April 12, 2009 – ');
+
+      expect(entries[1]).to.contain.text(
+        'Service branch: United States Air Force',
+      );
+      expect(entries[1]).to.contain.text('Dates of service: April 12, 2005');
+      expect(entries[1]).to.contain.text('April 11, 2009');
+    });
+    it('should not parse a null date', () => {
+      initialState = createBasicInitialState();
+      initialState.vaProfile.militaryInformation.serviceHistory.serviceHistory[0].endDate = null;
+      view = renderWithProfileReducers(<MilitaryInformation />, {
+        initialState,
+      });
+      const entries = view.queryAllByRole('listitem');
+
+      expect(entries.length).to.equal(2);
+      expect(entries[0]).to.contain.text(
+        'Service branch: United States Air Force',
+      );
+      expect(entries[0]).to.contain.text('Dates of service: April 12, 2009 – ');
+
+      expect(entries[1]).to.contain.text(
+        'Service branch: United States Air Force',
+      );
+      expect(entries[1]).to.contain.text('Dates of service: April 12, 2005');
+      expect(entries[1]).to.contain.text('April 11, 2009');
+    });
+    it('should not parse an undefined date', () => {
+      initialState = createBasicInitialState();
+      initialState.vaProfile.militaryInformation.serviceHistory.serviceHistory[0].beginDate = undefined;
+      view = renderWithProfileReducers(<MilitaryInformation />, {
+        initialState,
+      });
+      const entries = view.queryAllByRole('listitem');
+
+      expect(entries.length).to.equal(2);
+      expect(entries[0]).to.contain.text(
+        'Service branch: United States Air Force',
+      );
+      expect(entries[0]).to.contain.text('Dates of service:  – April 11, 2013');
+
+      expect(entries[1]).to.contain.text(
+        'Service branch: United States Air Force',
+      );
+      expect(entries[1]).to.contain.text('Dates of service: April 12, 2005');
+      expect(entries[1]).to.contain.text('April 11, 2009');
+    });
+    it('should not parse a date if it does not exist on the service history entry', () => {
+      initialState = createBasicInitialState();
+      delete initialState.vaProfile.militaryInformation.serviceHistory
+        .serviceHistory[0].beginDate;
+      delete initialState.vaProfile.militaryInformation.serviceHistory
+        .serviceHistory[0].endDate;
+      view = renderWithProfileReducers(<MilitaryInformation />, {
+        initialState,
+      });
+      const entries = view.queryAllByRole('listitem');
+
+      expect(entries.length).to.equal(2);
+      expect(entries[0]).to.contain.text(
+        'Service branch: United States Air Force',
+      );
+      expect(entries[0]).to.contain.text('Dates of service:');
+      expect(entries[0]).to.not.contain.text('Invalid date');
+
+      expect(entries[1]).to.contain.text(
+        'Service branch: United States Air Force',
+      );
+      expect(entries[1]).to.contain.text('Dates of service: April 12, 2005');
+      expect(entries[1]).to.contain.text('April 11, 2009');
+    });
+  });
   describe('when the military history is empty', () => {
     it('should show the correct error', () => {
       initialState = createBasicInitialState();

--- a/src/applications/personalization/profile-2/tests/helpers.unit.spec.js
+++ b/src/applications/personalization/profile-2/tests/helpers.unit.spec.js
@@ -90,8 +90,7 @@ describe('transformServiceHistoryEntryIntoTableRow', () => {
       expect(titleDfn.props().className).to.equal('sr-only');
     });
     it('should have the correct text', () => {
-      expect(value.text().includes('January 31, 2000 – December 25, 2010')).to
-        .be.true;
+      expect(value.text()).to.contain('January 31, 2000 – December 25, 2010');
     });
   });
 });


### PR DESCRIPTION
## Description
Adds handling of undefined/null/empty-strings for service history dates.

## Testing done
Unit

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs