### PR TITLE
CST and 526/BDD: Force minimum upload size of 1 byte

### DIFF
--- a/src/applications/claims-status/components/AddFilesForm.jsx
+++ b/src/applications/claims-status/components/AddFilesForm.jsx
@@ -21,6 +21,7 @@ import {
   isValidFile,
   isValidDocument,
   isValidFileSize,
+  isEmptyFileSize,
   isValidFileType,
   FILE_TYPES,
 } from '../utils/validations';
@@ -87,6 +88,11 @@ class AddFilesForm extends React.Component {
       this.setState({
         errorMessage:
           'The file you selected is larger than the 25MB maximum file size and could not be added.',
+      });
+    } else if (isEmptyFileSize(file)) {
+      this.setState({
+        errorMessage:
+          'The file you selected is empty. Files uploaded must be larger than 0B.',
       });
     }
   }

--- a/src/applications/claims-status/utils/validations.js
+++ b/src/applications/claims-status/utils/validations.js
@@ -17,6 +17,10 @@ export function isValidFileSize(file) {
   return file.size < MAX_FILE_SIZE;
 }
 
+export function isEmptyFileSize(file) {
+  return file.size === 0;
+}
+
 export function isValidFileType(file) {
   return FILE_TYPES.some(type => file.name.toLowerCase().endsWith(type));
 }

--- a/src/applications/disability-benefits/all-claims/utils.jsx
+++ b/src/applications/disability-benefits/all-claims/utils.jsx
@@ -616,7 +616,7 @@ export const ancillaryFormUploadUi = (
     addAnotherLabel,
     fileTypes: ['pdf', 'jpg', 'jpeg', 'png', 'gif', 'bmp', 'txt'],
     maxSize: TWENTY_FIVE_MB,
-    minSize: 0,
+    minSize: 1,
     createPayload: file => {
       const payload = new FormData();
       payload.append('supporting_evidence_attachment[file_data]', file);


### PR DESCRIPTION
## Description
This change to force a minimum uploaded file size of 1 byte for CST and 526/BDD is to combat some errors we have be seeing around empty files being uploaded.

## Acceptance criteria
- [ ] Empty files cannot be uploaded to CST and 526/BDD