### PR TITLE
Extract UI labels in Ask a Question form

### DIFF
--- a/src/applications/ask-a-question/config/pages/contactInformationPage.js
+++ b/src/applications/ask-a-question/config/pages/contactInformationPage.js
@@ -5,12 +5,12 @@ import emailUI from 'platform/forms-system/src/js/definitions/email';
 import { confirmationEmailUI } from '../../../caregivers/definitions/caregiverUI';
 
 import { veteranStatusUI } from './veteranStatusUI';
-import pageDescription from '../../content/PageDescription';
 import fullSchema from '../../0873-schema.json';
 import * as address from '../../contactInformation/address/address';
 import {
   contactInformationPageDescription,
   preferredContactMethodTitle,
+  phoneTitle,
 } from '../../content/labels';
 
 const { email, phone } = fullSchema.definitions;
@@ -46,7 +46,7 @@ const contactInformationPage = {
     [formFields.phoneNumber]: set(
       'ui:required',
       (formData, _index) => formData.preferredContactMethod === 'phone',
-      phoneUI('Daytime Phone'),
+      phoneUI(phoneTitle),
     ),
     [formFields.email]: set(
       'ui:required',

--- a/src/applications/ask-a-question/config/pages/contactInformationPage.js
+++ b/src/applications/ask-a-question/config/pages/contactInformationPage.js
@@ -5,9 +5,13 @@ import emailUI from 'platform/forms-system/src/js/definitions/email';
 import { confirmationEmailUI } from '../../../caregivers/definitions/caregiverUI';
 
 import { veteranStatusUI } from './veteranStatusUI';
-import fullSchema from '../../0873-schema.json';
 import pageDescription from '../../content/PageDescription';
+import fullSchema from '../../0873-schema.json';
 import * as address from '../../contactInformation/address/address';
+import {
+  contactInformationPageDescription,
+  preferredContactMethodTitle,
+} from '../../content/labels';
 
 const { email, phone } = fullSchema.definitions;
 
@@ -29,7 +33,7 @@ const formFields = {
 
 const contactInformationPage = {
   uiSchema: {
-    'ui:description': pageDescription('Your contact info'),
+    'ui:description': contactInformationPageDescription,
     [formFields.fullName]: fullNameUI,
     [formFields.address]: address.uiSchema(
       '',
@@ -51,7 +55,7 @@ const contactInformationPage = {
     ),
     [formFields.verifyEmail]: confirmationEmailUI('', formFields.email),
     [formFields.preferredContactMethod]: {
-      'ui:title': 'How should we get in touch with you?',
+      'ui:title': preferredContactMethodTitle,
       'ui:widget': 'radio',
     },
     [formFields.veteranStatus]: veteranStatusUI,

--- a/src/applications/ask-a-question/config/pages/inquiryPage.js
+++ b/src/applications/ask-a-question/config/pages/inquiryPage.js
@@ -2,8 +2,15 @@ import { uiSchema as autoSuggestUiSchema } from 'platform/forms-system/src/js/de
 import { validateWhiteSpace } from 'platform/forms/validations';
 
 import fullSchema from '../../0873-schema.json';
-import pageDescription from '../../content/PageDescription';
 import reviewField from '../../content/inquiryPage';
+import {
+  inquiryPageDescription,
+  inquiryTypeTitle,
+  queryTitle,
+  topicDescription,
+  topicErrorMessage,
+  topicTitle,
+} from '../../content/labels';
 
 const { topic, inquiryType, query } = fullSchema.properties;
 
@@ -22,30 +29,25 @@ const getOptions = allOptions => {
 };
 
 const topicUiSchema = {
-  ...autoSuggestUiSchema(
-    'Which topic best describes your question or message?',
-    getOptions(topic.enum),
-    {
-      'ui:options': { queryForResults: true, freeInput: true },
-      'ui:errorMessages': {
-        pattern: 'Please enter a valid topic.',
-      },
+  ...autoSuggestUiSchema(topicTitle, getOptions(topic.enum), {
+    'ui:options': { queryForResults: true, freeInput: true },
+    'ui:errorMessages': {
+      pattern: topicErrorMessage,
     },
-  ),
-  'ui:description':
-    'Please start typing below. If you do not find a match, type space to see all possible categories',
+  }),
+  'ui:description': topicDescription,
   'ui:reviewField': reviewField,
 };
 
 const inquiryPage = {
   uiSchema: {
-    'ui:description': pageDescription('Your message'),
+    'ui:description': inquiryPageDescription,
     [formFields.inquiryType]: {
-      'ui:title': "Tell us the reason you're contacting us",
+      'ui:title': inquiryTypeTitle,
     },
     [formFields.topic]: topicUiSchema,
     [formFields.query]: {
-      'ui:title': 'Please enter your question or message below',
+      'ui:title': queryTitle,
       'ui:widget': 'textarea',
       'ui:validations': [validateWhiteSpace],
     },

--- a/src/applications/ask-a-question/config/pages/veteranStatusUI.js
+++ b/src/applications/ask-a-question/config/pages/veteranStatusUI.js
@@ -1,5 +1,13 @@
 import currentOrPastDateUI from 'platform/forms-system/src/js/definitions/currentOrPastDate';
-import sectionHeader from '../../content/SectionHeader';
+import {
+  branchOfServiceTitle,
+  dateOfDeathTitle,
+  isDeceasedTitle,
+  isDependentTitle,
+  relationshipToVeteranTitle,
+  veteranStatusSectionDescription,
+  veteranStatusTitle,
+} from '../../content/labels';
 
 const formFields = {
   veteranStatus: 'veteranStatus',
@@ -21,12 +29,12 @@ const hideDateOfDeath = selectedVeteranStatus =>
   selectedVeteranStatus === 'vet' || selectedVeteranStatus === 'general';
 
 export const veteranStatusUI = {
-  'ui:description': sectionHeader('Veteran Service Information'),
+  'ui:description': veteranStatusSectionDescription,
   [formFields.veteranStatus]: {
-    'ui:title': 'My message is about benefits/services',
+    'ui:title': veteranStatusTitle,
   },
   [formFields.isDependent]: {
-    'ui:title': 'Are you the dependent?',
+    'ui:title': isDependentTitle,
     'ui:widget': 'yesNo',
     'ui:required': formData =>
       formData.veteranStatus.veteranStatus === 'dependent',
@@ -36,7 +44,7 @@ export const veteranStatusUI = {
     },
   },
   [formFields.relationshipToVeteran]: {
-    'ui:title': 'Your relationship to the Veteran',
+    'ui:title': relationshipToVeteranTitle,
     'ui:required': formData =>
       requireVetRelationship(formData.veteranStatus.veteranStatus),
     'ui:options': {
@@ -45,7 +53,7 @@ export const veteranStatusUI = {
     },
   },
   [formFields.veteranIsDeceased]: {
-    'ui:title': 'Is the Veteran deceased?',
+    'ui:title': isDeceasedTitle,
     'ui:widget': 'yesNo',
     'ui:required': formData =>
       requireVetRelationship(formData.veteranStatus.veteranStatus),
@@ -55,7 +63,7 @@ export const veteranStatusUI = {
     },
   },
   [formFields.dateOfDeath]: {
-    ...currentOrPastDateUI('Date of Death if known'),
+    ...currentOrPastDateUI(dateOfDeathTitle),
     ...{
       'ui:options': {
         expandUnder: 'veteranStatus',
@@ -69,7 +77,7 @@ export const veteranStatusUI = {
     },
   },
   [formFields.branchOfService]: {
-    'ui:title': 'Branch of service',
+    'ui:title': branchOfServiceTitle,
     'ui:required': formData =>
       requireServiceInfo(formData.veteranStatus.veteranStatus),
     'ui:options': {

--- a/src/applications/ask-a-question/contactInformation/address/address.js
+++ b/src/applications/ask-a-question/contactInformation/address/address.js
@@ -8,6 +8,25 @@ import {
   isValidCanPostalCode,
 } from 'platform/forms/address';
 
+import {
+  canadaStateTitle,
+  cityErrorMessage,
+  cityTitle,
+  countryTitle,
+  postalCodeErrorMessage,
+  postalCodeTitle,
+  stateErrorMessage,
+  stateOrProvinceErrorMessage,
+  stateOrProvinceMissingErrorMessage,
+  stateTitle,
+  streetErrorMessage,
+  streetThreeTitle,
+  streetTwoTitle,
+  zipCodePatternErrorMessage,
+  zipCodeRequiredErrorMessage,
+  zipCodeTitle,
+} from '../../content/labels';
+
 function validatePostalCodes(errors, address) {
   let isValidPostalCode = true;
 
@@ -23,7 +42,7 @@ function validatePostalCodes(errors, address) {
 
   // Add error message for postal code if it is invalid
   if (address.postalCode && !isValidPostalCode) {
-    errors.postalCode.addError('Please provide a valid postal code');
+    errors.postalCode.addError(postalCodeErrorMessage);
   }
 }
 
@@ -67,7 +86,7 @@ function validateAddress(errors, address, formData, currentSchema) {
     address.state === undefined &&
     currentSchema.required.length
   ) {
-    errors.state.addError('Please select a state or province');
+    errors.state.addError(stateOrProvinceErrorMessage);
   }
 
   const hasAddressInfo =
@@ -78,9 +97,7 @@ function validateAddress(errors, address, formData, currentSchema) {
     typeof address.postalCode !== 'undefined';
 
   if (hasAddressInfo && typeof address.state === 'undefined') {
-    errors.state.addError(
-      'Please enter a state or province, or remove other address information.',
-    );
+    errors.state.addError(stateOrProvinceMissingErrorMessage);
   }
 
   validatePostalCodes(errors, address);
@@ -134,12 +151,12 @@ export function schema(
         enumNames: countryNames,
       },
       state: {
-        title: 'State',
+        title: stateTitle,
         type: 'string',
         maxLength: 51,
       },
       postalCode: {
-        title: 'Postal code',
+        title: postalCodeTitle,
         type: 'string',
         maxLength: 10,
       },
@@ -241,40 +258,40 @@ export function uiSchema(
       // Canada has a different title than others, so set that when necessary
       if (
         country === 'CAN' &&
-        addressSchema.properties.state.title !== 'Province'
+        addressSchema.properties.state.title !== canadaStateTitle
       ) {
         schemaUpdate.properties = _.set(
           'state.title',
-          'Province',
+          canadaStateTitle,
           schemaUpdate.properties,
         );
       } else if (
         country !== 'CAN' &&
-        addressSchema.properties.state.title !== 'State'
+        addressSchema.properties.state.title !== stateTitle
       ) {
         schemaUpdate.properties = _.set(
           'state.title',
-          'State',
+          stateTitle,
           schemaUpdate.properties,
         );
       }
 
       if (
         country === 'USA' &&
-        addressSchema.properties.postalCode.title !== 'Zip code'
+        addressSchema.properties.postalCode.title !== zipCodeTitle
       ) {
         schemaUpdate.properties = _.set(
           'postalCode.title',
-          'Zip code',
+          zipCodeTitle,
           schemaUpdate.properties,
         );
       } else if (
         country !== 'USA' &&
-        addressSchema.properties.postalCode.title !== 'Postal code'
+        addressSchema.properties.postalCode.title !== postalCodeTitle
       ) {
         schemaUpdate.properties = _.set(
           'postalCode.title',
-          'Postal code',
+          postalCodeTitle,
           schemaUpdate.properties,
         );
       }
@@ -346,29 +363,29 @@ export function uiSchema(
     },
     'ui:order': fieldOrder,
     country: {
-      'ui:title': 'Country',
+      'ui:title': countryTitle,
     },
     street: {
       'ui:title': 'Street',
       'ui:errorMessages': {
-        required: 'Please enter a street address',
+        required: streetErrorMessage,
       },
     },
     street2: {
-      'ui:title': 'Line 2',
+      'ui:title': streetTwoTitle,
     },
     street3: {
-      'ui:title': 'Line 3',
+      'ui:title': streetThreeTitle,
     },
     city: {
-      'ui:title': 'City',
+      'ui:title': cityTitle,
       'ui:errorMessages': {
-        required: 'Please enter a city',
+        required: cityErrorMessage,
       },
     },
     state: {
       'ui:errorMessages': {
-        required: 'Please enter a state',
+        required: stateErrorMessage,
       },
     },
     postalCode: {
@@ -376,8 +393,8 @@ export function uiSchema(
         widgetClassNames: 'usa-input-medium',
       },
       'ui:errorMessages': {
-        required: 'Please enter a zip code',
-        pattern: 'Please enter a valid 5- or 9-digit zip code (dashes allowed)',
+        required: zipCodeRequiredErrorMessage,
+        pattern: zipCodePatternErrorMessage,
       },
     },
   };

--- a/src/applications/ask-a-question/content/labels.js
+++ b/src/applications/ask-a-question/content/labels.js
@@ -1,21 +1,49 @@
 import PageDescription from './PageDescription';
 import SectionHeader from './SectionHeader';
 
+/* --------------- Inquiry --------------- */
+
 export const inquiryPageDescription = PageDescription('Your message');
 export const topicTitle =
   'Which topic best describes your question or message?';
-export const topicErrorMessage = 'Please enter a valid topic.';
 export const topicDescription =
   'Please start typing below. If you do not find a match, type space to see all possible categories';
+export const topicErrorMessage = 'Please enter a valid topic.';
 export const inquiryTypeTitle = "Tell us the reason you're contacting us";
 export const queryTitle = 'Please enter your question or message below';
+
+/* --------------- Contact Information --------------- */
 
 export const contactInformationPageDescription = PageDescription(
   'Your contact info',
 );
 export const preferredContactMethodTitle =
   'How should we get in touch with you?';
+export const phoneTitle = 'Daytime Phone';
 
+/* Address fields */
+export const countryTitle = 'Country';
+export const stateTitle = 'State';
+export const canadaStateTitle = 'Province';
+export const streetTwoTitle = 'Line 2';
+export const streetThreeTitle = 'Line 3';
+export const cityTitle = 'City';
+export const postalCodeTitle = 'Postal code';
+export const zipCodeTitle = 'Zip code';
+
+/* Address error messages */
+export const stateOrProvinceMissingErrorMessage =
+  'Please enter a state or province, or remove other address information.';
+export const stateOrProvinceErrorMessage = 'Please select a state or province';
+export const stateErrorMessage = 'Please enter a state';
+export const streetErrorMessage = 'Please enter a street address';
+export const cityErrorMessage = 'Please enter a city';
+export const postalCodeErrorMessage = 'Please provide a valid postal code';
+export const zipCodeRequiredErrorMessage = 'Please enter a zip code';
+export const zipCodePatternErrorMessage =
+  'Please enter a valid 5- or 9-digit zip code (dashes allowed)';
+
+/* Veteran Status Information */
 export const veteranStatusSectionDescription = SectionHeader(
   'Veteran Service Information',
 );

--- a/src/applications/ask-a-question/content/labels.js
+++ b/src/applications/ask-a-question/content/labels.js
@@ -1,0 +1,27 @@
+import PageDescription from './PageDescription';
+import SectionHeader from './SectionHeader';
+
+export const inquiryPageDescription = PageDescription('Your message');
+export const topicTitle =
+  'Which topic best describes your question or message?';
+export const topicErrorMessage = 'Please enter a valid topic.';
+export const topicDescription =
+  'Please start typing below. If you do not find a match, type space to see all possible categories';
+export const inquiryTypeTitle = "Tell us the reason you're contacting us";
+export const queryTitle = 'Please enter your question or message below';
+
+export const contactInformationPageDescription = PageDescription(
+  'Your contact info',
+);
+export const preferredContactMethodTitle =
+  'How should we get in touch with you?';
+
+export const veteranStatusSectionDescription = SectionHeader(
+  'Veteran Service Information',
+);
+export const veteranStatusTitle = 'My message is about benefits/services';
+export const isDependentTitle = 'Are you the dependent?';
+export const relationshipToVeteranTitle = 'Your relationship to the Veteran';
+export const isDeceasedTitle = 'Is the Veteran deceased?';
+export const dateOfDeathTitle = 'Date of Death if known';
+export const branchOfServiceTitle = 'Branch of service';


### PR DESCRIPTION
## Description
[department-of-veterans-affairs/orchid#106]
Strings are now stored in `content/labels.js`

Note: will merge after pulling in changes from [this open PR](https://github.com/department-of-veterans-affairs/vets-website/pull/14351) and extracting those phone and address strings as well.

## Testing done
Manual testing that UI remains unchanged

## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
