### PR TITLE
Fix alert conditional rendering

### DIFF
--- a/src/applications/personalization/profile-2/components/MilitaryInformation.jsx
+++ b/src/applications/personalization/profile-2/components/MilitaryInformation.jsx
@@ -31,6 +31,7 @@ const MilitaryInformationContent = ({ militaryInformation, veteranStatus }) => {
   const invalidVeteranStatus =
     !veteranStatus || veteranStatus === 'NOT_AUTHORIZED';
 
+  // When the user is not authorized, militaryInformation.serviceHistory is populated with .error
   if (
     invalidVeteranStatus &&
     !militaryInformation?.serviceHistory?.serviceHistory

--- a/src/applications/personalization/profile-2/components/MilitaryInformation.jsx
+++ b/src/applications/personalization/profile-2/components/MilitaryInformation.jsx
@@ -31,7 +31,10 @@ const MilitaryInformationContent = ({ militaryInformation, veteranStatus }) => {
   const invalidVeteranStatus =
     !veteranStatus || veteranStatus === 'NOT_AUTHORIZED';
 
-  if (invalidVeteranStatus && !militaryInformation) {
+  if (
+    invalidVeteranStatus &&
+    !militaryInformation?.serviceHistory?.serviceHistory
+  ) {
     return (
       <AlertBox
         isVisible


### PR DESCRIPTION
## Description
We were conditionally rendering the new Alert based on an empty `militaryHistory`, but when the user does not have a military history, `militaryHistory` is populated with an error - so the condition was falsey.

## Testing done
Works locally.

## Acceptance criteria
- [x] Make sure the correct Alert is shown when the user is not a veteran

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
