### PR TITLE
make it clearer when we don't know a Vet's service branch

### DIFF
--- a/src/applications/personalization/profile-2/helpers.js
+++ b/src/applications/personalization/profile-2/helpers.js
@@ -13,7 +13,7 @@ import { USA_MILITARY_BRANCHES } from './constants';
  *
  */
 export const getServiceBranchDisplayName = serviceBranch => {
-  if (!serviceBranch) return 'Unknown';
+  if (!serviceBranch) return 'Unknown branch of service';
   if (Object.values(USA_MILITARY_BRANCHES).includes(serviceBranch)) {
     return `United States ${serviceBranch}`;
   }

--- a/src/applications/personalization/profile-2/helpers.js
+++ b/src/applications/personalization/profile-2/helpers.js
@@ -13,6 +13,7 @@ import { USA_MILITARY_BRANCHES } from './constants';
  *
  */
 export const getServiceBranchDisplayName = serviceBranch => {
+  if (!serviceBranch) return 'Unknown';
   if (Object.values(USA_MILITARY_BRANCHES).includes(serviceBranch)) {
     return `United States ${serviceBranch}`;
   }

--- a/src/applications/personalization/profile-2/tests/components/MilitaryInformation.unit.spec.jsx
+++ b/src/applications/personalization/profile-2/tests/components/MilitaryInformation.unit.spec.jsx
@@ -83,11 +83,11 @@ describe('MilitaryInformation', () => {
       const entries = view.queryAllByRole('listitem');
 
       expect(entries.length).to.equal(2);
-      expect(entries[0]).to.contain.text('Unknown');
+      expect(entries[0]).to.contain.text('Unknown branch of service');
       expect(entries[0]).to.contain.text('Dates of service: April 12, 2009');
       expect(entries[0]).to.contain.text('April 11, 2013');
 
-      expect(entries[1]).to.contain.text('Unknown');
+      expect(entries[1]).to.contain.text('Unknown branch of service');
       expect(entries[1]).to.contain.text('Dates of service: April 12, 2005');
       expect(entries[1]).to.contain.text('April 11, 2009');
     });

--- a/src/applications/personalization/profile-2/tests/components/MilitaryInformation.unit.spec.jsx
+++ b/src/applications/personalization/profile-2/tests/components/MilitaryInformation.unit.spec.jsx
@@ -72,6 +72,26 @@ describe('MilitaryInformation', () => {
       expect(entries[1]).to.contain.text('April 11, 2009');
     });
   });
+  describe('when military branch is not set', () => {
+    it('should show "Unknown" for the service branch if it is missing', () => {
+      initialState = createBasicInitialState();
+      initialState.vaProfile.militaryInformation.serviceHistory.serviceHistory[0].branchOfService = null;
+      initialState.vaProfile.militaryInformation.serviceHistory.serviceHistory[1].branchOfService = undefined;
+      view = renderWithProfileReducers(<MilitaryInformation />, {
+        initialState,
+      });
+      const entries = view.queryAllByRole('listitem');
+
+      expect(entries.length).to.equal(2);
+      expect(entries[0]).to.contain.text('Unknown');
+      expect(entries[0]).to.contain.text('Dates of service: April 12, 2009');
+      expect(entries[0]).to.contain.text('April 11, 2013');
+
+      expect(entries[1]).to.contain.text('Unknown');
+      expect(entries[1]).to.contain.text('Dates of service: April 12, 2005');
+      expect(entries[1]).to.contain.text('April 11, 2009');
+    });
+  });
   describe('when a service history date cannot be parsed', () => {
     it('should report that the date is invalid', () => {
       initialState = createBasicInitialState();


### PR DESCRIPTION
## Description
Show `Unknown` instead of an empty string if a service branch is blank/missing/null

## Testing done
Local + new tests

## Screenshots
<img width="933" alt="Screen Shot 2020-09-24 at 8 04 42 AM" src="https://user-images.githubusercontent.com/20728956/94171371-0b5c8500-fe46-11ea-873c-111e9379f295.png">

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs