### PR TITLE
Prevents user from logging out via cancelled /user requests

### DIFF
--- a/src/platform/user/profile/actions/index.js
+++ b/src/platform/user/profile/actions/index.js
@@ -47,10 +47,10 @@ export function initializeProfile() {
       dispatch(updateLoggedInStatus(true));
     } catch (error) {
       /* If the fetch fails due to the browser cancelling the request due to a navigation event short circuit it to prevent terminating session */
-      if (error instanceof TypeError && error.message === 'Failed to fetch') {
-        // eslint-disable-next-line no-useless-return
-        return;
-      } else {
+      if (
+        !(error instanceof TypeError) &&
+        error.message !== 'Failed to fetch'
+      ) {
         dispatch(updateLoggedInStatus(false));
         teardownProfileSession();
       }

--- a/src/platform/user/profile/actions/index.js
+++ b/src/platform/user/profile/actions/index.js
@@ -46,15 +46,10 @@ export function initializeProfile() {
       await dispatch(refreshProfile());
       dispatch(updateLoggedInStatus(true));
     } catch (error) {
-      /* If the fetch fails the first time, try again to ensure the profile should actually be torn down */
+      /* If the fetch fails due to the browser cancelling the request due to a navigation event short circuit it to prevent terminating session */
       if (error instanceof TypeError && error.message === 'Failed to fetch') {
-        try {
-          await dispatch(refreshProfile());
-          dispatch(updateLoggedInStatus(true));
-        } catch (e) {
-          dispatch(updateLoggedInStatus(false));
-          teardownProfileSession();
-        }
+        // eslint-disable-next-line no-useless-return
+        return;
       } else {
         dispatch(updateLoggedInStatus(false));
         teardownProfileSession();

--- a/src/platform/user/profile/actions/index.js
+++ b/src/platform/user/profile/actions/index.js
@@ -46,8 +46,19 @@ export function initializeProfile() {
       await dispatch(refreshProfile());
       dispatch(updateLoggedInStatus(true));
     } catch (error) {
-      dispatch(updateLoggedInStatus(false));
-      teardownProfileSession();
+      /* If the fetch fails the first time, try again to ensure the profile should actually be torn down */
+      if (error instanceof TypeError && error.message === 'Failed to fetch') {
+        try {
+          await dispatch(refreshProfile());
+          dispatch(updateLoggedInStatus(true));
+        } catch (e) {
+          dispatch(updateLoggedInStatus(false));
+          teardownProfileSession();
+        }
+      } else {
+        dispatch(updateLoggedInStatus(false));
+        teardownProfileSession();
+      }
     }
   };
 }


### PR DESCRIPTION
## Description
**Issue**: [https://github.com/department-of-veterans-affairs/va.gov-team/issues/13720](https://github.com/department-of-veterans-affairs/va.gov-team/issues/13720)

This PR adds more logic to the catch statement in the `initializeProfile` action.  The `catch` statement has a conditional statement to check if the error is both a TypeError & has a Failed to Fetch message.  - - When `truthy` an additional `GET /user` request is made to ensure we are actually receiving a logged out response from the endpoint.
- When `falsy` the profile sessions is torn down.
## Testing done
Manual / Visual testing

## Screenshots


## Acceptance criteria
- [X] User is not logged out because of the `GET user/` endpoint was cancelled
- [X] Other `GET user/` call failures should log out users as normal

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
