### PR TITLE
[Development] Claim Status Tools: Show EVSS error

### DIFF
--- a/src/applications/claims-status/containers/FilesPage.jsx
+++ b/src/applications/claims-status/containers/FilesPage.jsx
@@ -51,7 +51,7 @@ class FilesPage extends React.Component {
     const { claim, loading, message, synced } = this.props;
 
     let content = null;
-    if (!loading) {
+    if (!loading && claim) {
       const showDecision =
         claim.attributes.phase === FIRST_GATHERING_EVIDENCE_PHASE &&
         !claim.attributes.waiverSubmitted;

--- a/src/applications/claims-status/tests/components/ClaimDetailLayout.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/ClaimDetailLayout.unit.spec.jsx
@@ -22,6 +22,14 @@ describe('<ClaimDetailLayout>', () => {
     );
     expect(tree.everySubTree('ClaimSyncWarning')).not.to.be.empty;
   });
+  it('should render unavailable warning', () => {
+    const claim = null;
+
+    const tree = SkinDeep.shallowRender(
+      <ClaimDetailLayout claim={claim} synced={false} />,
+    );
+    expect(tree.everySubTree('ClaimsUnavailable')).to.have.lengthOf(1);
+  });
   it('should render contention list', () => {
     const claim = {
       attributes: {

--- a/src/applications/claims-status/tests/components/FilesPage.unit.spec.jsx
+++ b/src/applications/claims-status/tests/components/FilesPage.unit.spec.jsx
@@ -18,6 +18,19 @@ describe('<FilesPage>', () => {
     );
     expect(tree.props.message).not.to.be.null;
   });
+  it('should not render children with null claim', () => {
+    const claim = null;
+
+    const tree = SkinDeep.shallowRender(
+      <FilesPage
+        loading
+        message={{ title: 'Test', body: 'Body' }}
+        claim={claim}
+      />,
+    );
+    expect(tree.props.children).to.be.null;
+  });
+
   it('should hide requested files when closed', () => {
     const claim = {
       attributes: {


### PR DESCRIPTION
## Description

When a claim doesn't exist, a JS error prevents rendering content on the screen. This PR ensures that the empty claim doesn't cause an error and allow the "claim status unavailable" message to show

Related: https://github.com/department-of-veterans-affairs/va.gov-team/issues/13377

## Testing done

Added unit tests for testing the claim as `null`; and the layout displays the error alert.

## Screenshots

![Screen Shot 2020-09-24 at 12 28 48 PM](https://user-images.githubusercontent.com/136959/94179065-98f99e00-fe61-11ea-9e89-beace7dc7ba2.png)

## Acceptance criteria
- [x] Error alert is shown instead of an empty page body

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
