### PR TITLE
13934 chp36 veteran review info

### DIFF
--- a/src/applications/vre/28-8832/components/ReadOnlyUserDescription.js
+++ b/src/applications/vre/28-8832/components/ReadOnlyUserDescription.js
@@ -1,0 +1,50 @@
+import React, { useState, useEffect } from 'react';
+import { connect } from 'react-redux';
+
+const ReadOnlyUserDescription = props => {
+  const [isLoggedIn, setIsLoggedIn] = useState();
+  useEffect(
+    () => {
+      setIsLoggedIn(props.isLoggedIn);
+    },
+    [props],
+  );
+  const display = {
+    'Your first name': props?.profile?.userFullName?.first || '',
+    'Your middle name': props?.profile?.userFullName?.middle || '',
+    'Your last name': props?.profile?.userFullName?.last || '',
+    Suffix: props?.profile?.userFullName?.suffix || '',
+    'Date of birth': props?.profile?.dob || '',
+  };
+
+  return (
+    <>
+      {!isLoggedIn ? null : (
+        <>
+          <div className="form-review-panel-page-header-row">
+            <h3 className="vads-u-font-size--h5 vads-u-margin--0">
+              Claimant Information
+            </h3>
+          </div>
+          <dl className="review vads-u-border-bottom--0">
+            {Object.entries(display).map(([label, value]) => {
+              return value ? (
+                <div key={label} className="review-row">
+                  <dt>{label}</dt>
+                  <dd>{value}</dd>
+                </div>
+              ) : null;
+            })}
+          </dl>
+        </>
+      )}
+    </>
+  );
+};
+
+const mapStateToProps = state => ({
+  profile: state?.user?.profile,
+  isLoggedIn: state?.user?.login?.currentlyLoggedIn,
+});
+
+export default connect(mapStateToProps)(ReadOnlyUserDescription);

--- a/src/applications/vre/28-8832/components/ReadOnlyUserDescription.js
+++ b/src/applications/vre/28-8832/components/ReadOnlyUserDescription.js
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { connect } from 'react-redux';
+import moment from 'moment';
 
 const ReadOnlyUserDescription = props => {
   const [isLoggedIn, setIsLoggedIn] = useState();
@@ -14,7 +15,9 @@ const ReadOnlyUserDescription = props => {
     'Your middle name': props?.profile?.userFullName?.middle || '',
     'Your last name': props?.profile?.userFullName?.last || '',
     Suffix: props?.profile?.userFullName?.suffix || '',
-    'Date of birth': props?.profile?.dob || '',
+    'Date of birth': props?.profile?.dob
+      ? moment(props?.profile?.dob).format('MMMM D, YYYY')
+      : '',
   };
 
   return (

--- a/src/applications/vre/28-8832/config/chapters/claimant-information/staticClaimantComponent.jsx
+++ b/src/applications/vre/28-8832/config/chapters/claimant-information/staticClaimantComponent.jsx
@@ -16,7 +16,7 @@ const ClaimantInformationComponent = ({
   let dateOfBirthFormatted = '-';
   let genderFull = '-';
   if (dob) {
-    dateOfBirthFormatted = moment(dob).format('MMMM Do YYYY');
+    dateOfBirthFormatted = moment(dob).format('MMMM D, YYYY');
   }
   if (gender === 'M') {
     genderFull = 'Male';

--- a/src/applications/vre/28-8832/config/chapters/claimant-information/staticClaimantInformation.js
+++ b/src/applications/vre/28-8832/config/chapters/claimant-information/staticClaimantInformation.js
@@ -5,7 +5,4 @@ export const schema = claimantStaticInformation;
 
 export const uiSchema = {
   'ui:description': ClaimantInformationComponent,
-  'ui:options': {
-    hideOnReview: true,
-  },
 };

--- a/src/applications/vre/28-8832/config/form.js
+++ b/src/applications/vre/28-8832/config/form.js
@@ -3,11 +3,12 @@ import { VA_FORM_IDS } from 'platform/forms/constants';
 import IntroductionPage from '../containers/IntroductionPage';
 import ConfirmationPage from '../containers/ConfirmationPage';
 
-import GetFormHelp from '../components/GetFormHelp';
 import { hasSession } from 'platform/user/profile/utilities';
 
 import { statusSelection } from './chapters/status-selection';
 import { veteranInformation } from './chapters/veteran-information';
+import GetFormHelp from '../components/GetFormHelp';
+import ReadOnlyUserDescription from '../components/ReadOnlyUserDescription';
 import PreSubmitInfo from '../components/PreSubmitInfo';
 
 import {
@@ -38,6 +39,7 @@ const formConfig = {
   chapters: {
     claimantInformation: {
       title: 'Claimant Information',
+      reviewDescription: ReadOnlyUserDescription,
       pages: {
         claimantInformation: {
           depends: () => !hasSession(),


### PR DESCRIPTION
## Description
This pull request adds read-only claimant information to the review page of the Chapter 36 form when a user is filling it out logged in. 

## Testing done
- local

## Screenshots
<img width="517" alt="Screen Shot 2020-09-24 at 2 04 40 PM" src="https://user-images.githubusercontent.com/15097156/94190937-c7d03e00-fe7a-11ea-8318-4c59dba7b151.png">


## Acceptance criteria
- [x] Read only information added to review page

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
