### PR TITLE
Add an ignore list to the sitemap a11y tests

### DIFF
--- a/src/platform/site-wide/tests/sitemap/sitemap-helpers.js
+++ b/src/platform/site-wide/tests/sitemap/sitemap-helpers.js
@@ -7,6 +7,19 @@ const SITEMAP_URL = `${E2eHelpers.baseUrl}/sitemap.xml`;
 const SITEMAP_LOC_NS = 'http://www.sitemaps.org/schemas/sitemap/0.9';
 const DOMAIN_REGEX = /http[s]?:\/\/(.*?)\//;
 
+const pagesWithRedirects = ['/manage-va-debt/your-debt/'];
+
+const shouldIgnore = url => {
+  const parsedUrl = new URL(url);
+  return (
+    !url.endsWith('auth/login/callback/') &&
+    !url.includes('playbook/') &&
+    !url.includes('pittsburgh-health-care/') &&
+    !/.*opt-out-information-sharing.*/.test(url) &&
+    !pagesWithRedirects.any(redirectUrl => parsedUrl.pathname === redirectUrl)
+  );
+};
+
 function sitemapURLs() {
   return fetch(SITEMAP_URL)
     .then(res => res.text())
@@ -15,10 +28,7 @@ function sitemapURLs() {
       doc
         .find('//xmlns:loc', SITEMAP_LOC_NS)
         .map(n => n.text().replace(DOMAIN_REGEX, `${E2eHelpers.baseUrl}/`))
-        .filter(url => !url.endsWith('auth/login/callback/'))
-        .filter(url => !url.includes('playbook/'))
-        .filter(url => !url.includes('pittsburgh-health-care/'))
-        .filter(url => !/.*opt-out-information-sharing.*/.test(url)),
+        .filter(shouldIgnore),
     )
     .then(urls => {
       const onlyTest508Rules = [

--- a/src/platform/site-wide/tests/sitemap/sitemap-helpers.js
+++ b/src/platform/site-wide/tests/sitemap/sitemap-helpers.js
@@ -16,7 +16,7 @@ const shouldIgnore = url => {
     !url.includes('playbook/') &&
     !url.includes('pittsburgh-health-care/') &&
     !/.*opt-out-information-sharing.*/.test(url) &&
-    !pagesWithRedirects.any(redirectUrl => parsedUrl.pathname === redirectUrl)
+    !pagesWithRedirects.some(redirectUrl => parsedUrl.pathname === redirectUrl)
   );
 };
 


### PR DESCRIPTION
## Description
This PR stemmed from [this Slack thread](https://dsva.slack.com/archives/CBU0KDSB1/p1600969024032800). What we found is that because the Debt Letters application's landing page redirects if the user is not logged in, the sitemap a11y test fails because there is `No scan result found`.

This PR adds an ignore list to the sitemap test.

The application is still covered by browser tests which run the aXe checker.

## Testing done
If this passes CI and all the sitemap a11y tests are run, it's been tested.

## Acceptance criteria
- [ ] The expected sitemap a11y tests are run
- [ ] All sitemap a11y tests pass