### PR TITLE
11238 ga events

### DIFF
--- a/src/applications/vre/28-8832/wizard/pages/ApplyLaterNotification.jsx
+++ b/src/applications/vre/28-8832/wizard/pages/ApplyLaterNotification.jsx
@@ -1,9 +1,14 @@
 import React, { useEffect } from 'react';
+import recordEvent from 'platform/monitoring/record-event';
 import { WIZARD_STATUS, WIZARD_STATUS_COMPLETE } from '../../constants';
 
 const ApplyLaterNotification = () => {
   useEffect(() => {
     sessionStorage.setItem(WIZARD_STATUS, WIZARD_STATUS_COMPLETE);
+    recordEvent({
+      event: `howToWizard-notice-displayed`,
+      'reason-for-notice': 'chose not to apply now',
+    });
   });
 
   return (

--- a/src/applications/vre/28-8832/wizard/pages/BeginFormNow.jsx
+++ b/src/applications/vre/28-8832/wizard/pages/BeginFormNow.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import recordEvent from 'platform/monitoring/record-event';
 import ErrorableRadioButtons from '@department-of-veterans-affairs/formation-react/ErrorableRadioButtons';
 import { pageNames } from './pageList';
 
@@ -13,16 +14,28 @@ const options = [
   },
 ];
 
-const BeginFormNow = ({ setPageState, state = {} }) => (
-  <ErrorableRadioButtons
-    name="begin-form-now"
-    label="Would you like to apply for career planning and guidance benefits now?"
-    options={options}
-    id="begin-form-now"
-    onValueChange={({ value }) => setPageState({ selected: value }, value)}
-    value={{ value: state.selected }}
-  />
-);
+const BeginFormNow = ({ setPageState, state = {} }) => {
+  const handleValueChange = ({ value }) => {
+    recordEvent({
+      event: `howToWizard-formChange`,
+      'form-field-type': 'form-radio-buttons',
+      'form-field-label':
+        'Would you like to apply for career planning and guidance benefits now?',
+      'form-field-value': value,
+    });
+    setPageState({ selected: value }, value);
+  };
+  return (
+    <ErrorableRadioButtons
+      name="begin-form-now"
+      label="Would you like to apply for career planning and guidance benefits now?"
+      options={options}
+      id="begin-form-now"
+      onValueChange={handleValueChange}
+      value={{ value: state.selected }}
+    />
+  );
+};
 
 export default {
   name: 'beginFormNow',

--- a/src/applications/vre/28-8832/wizard/pages/DischargeNotification.jsx
+++ b/src/applications/vre/28-8832/wizard/pages/DischargeNotification.jsx
@@ -1,9 +1,15 @@
 import React, { useEffect } from 'react';
+import recordEvent from 'platform/monitoring/record-event';
 import { WIZARD_STATUS, WIZARD_STATUS_INELIGIBLE } from '../../constants';
 
 const DischargeNotification = () => {
   useEffect(() => {
     sessionStorage.setItem(WIZARD_STATUS, WIZARD_STATUS_INELIGIBLE);
+    recordEvent({
+      event: `howToWizard-notice-displayed`,
+      'reason-for-notice':
+        'ineligibility - outside time period from active duty discharge',
+    });
   });
   return (
     <div className="vads-u-margin-top--2 vads-u-padding--3 vads-u-background-color--primary-alt-lightest">

--- a/src/applications/vre/28-8832/wizard/pages/DischargeStatus.jsx
+++ b/src/applications/vre/28-8832/wizard/pages/DischargeStatus.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import recordEvent from 'platform/monitoring/record-event';
 import ErrorableRadioButtons from '@department-of-veterans-affairs/formation-react/ErrorableRadioButtons';
 import { pageNames } from './pageList';
 
@@ -13,16 +14,29 @@ const options = [
   },
 ];
 
-const DischargeStatus = ({ setPageState, state = {} }) => (
-  <ErrorableRadioButtons
-    name="discharge-status"
-    label="Have you or your sponsor been discharged form active-duty service in the last year, or do you have less than 6 months until discharge?"
-    options={options}
-    id="discharge-status"
-    onValueChange={({ value }) => setPageState({ selected: value }, value)}
-    value={{ value: state.selected }}
-  />
-);
+const DischargeStatus = ({ setPageState, state = {} }) => {
+  const handleValueChange = ({ value }) => {
+    recordEvent({
+      event: `howToWizard-formChange`,
+      'form-field-type': 'form-radio-buttons',
+      'form-field-label':
+        'Have you or your sponsor been discharged form active-duty service in the last year, or do you have less than 6 months until discharge?',
+      'form-field-value': value,
+    });
+    setPageState({ selected: value }, value);
+  };
+
+  return (
+    <ErrorableRadioButtons
+      name="discharge-status"
+      label="Have you or your sponsor been discharged form active-duty service in the last year, or do you have less than 6 months until discharge?"
+      options={options}
+      id="discharge-status"
+      onValueChange={handleValueChange}
+      value={{ value: state.selected }}
+    />
+  );
+};
 
 export default {
   name: 'dischargeStatus',

--- a/src/applications/vre/28-8832/wizard/pages/IneligibleNotice.jsx
+++ b/src/applications/vre/28-8832/wizard/pages/IneligibleNotice.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect } from 'react';
+import recordEvent from 'platform/monitoring/record-event';
 import {
   WIZARD_STATUS,
   WIZARD_STATUS_INELIGIBLE,
@@ -8,6 +9,10 @@ import {
 const IneligibleNotice = () => {
   useEffect(() => {
     sessionStorage.setItem(WIZARD_STATUS, WIZARD_STATUS_INELIGIBLE);
+    recordEvent({
+      event: `howToWizard-notice-displayed`,
+      'reason-for-notice': 'ineligibility - not a service member or veteran',
+    });
   });
   return (
     <div className="vads-u-margin-top--2 vads-u-padding--3 vads-u-background-color--primary-alt-lightest">

--- a/src/applications/vre/28-8832/wizard/pages/Start.jsx
+++ b/src/applications/vre/28-8832/wizard/pages/Start.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import recordEvent from 'platform/monitoring/record-event';
 import ErrorableRadioButtons from '@department-of-veterans-affairs/formation-react/ErrorableRadioButtons';
 import { pageNames } from './pageList';
 
@@ -23,6 +24,12 @@ const options = [
 
 const StartPage = ({ setPageState, state = {} }) => {
   const handleValueChange = ({ value }) => {
+    recordEvent({
+      event: `howToWizard-formChange`,
+      'form-field-type': 'form-radio-buttons',
+      'form-field-label': 'Which of these best describes you?',
+      'form-field-value': value,
+    });
     switch (value) {
       case 'isVeteran':
       case 'isServiceMember':

--- a/src/applications/vre/28-8832/wizard/pages/VREBenefits.jsx
+++ b/src/applications/vre/28-8832/wizard/pages/VREBenefits.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import recordEvent from 'platform/monitoring/record-event';
 import ErrorableRadioButtons from '@department-of-veterans-affairs/formation-react/ErrorableRadioButtons';
 import { pageNames } from './pageList';
 
@@ -13,16 +14,28 @@ const options = [
   },
 ];
 
-const VREBenefits = ({ setPageState, state = {} }) => (
-  <ErrorableRadioButtons
-    name="vre-benefits"
-    label="Are you receiving Chapter 31 Veteran Readiness and Employment (VR&E) benefits?"
-    options={options}
-    id="vre-benefits"
-    onValueChange={({ value }) => setPageState({ selected: value }, value)}
-    value={{ value: state.selected }}
-  />
-);
+const VREBenefits = ({ setPageState, state = {} }) => {
+  const handleValueChange = ({ value }) => {
+    recordEvent({
+      event: `howToWizard-formChange`,
+      'form-field-type': 'form-radio-buttons',
+      'form-field-label':
+        'Are you receiving Chapter 31 Veteran Readiness and Employment (VR&E) benefits?',
+      'form-field-value': value,
+    });
+    setPageState({ selected: value }, value);
+  };
+  return (
+    <ErrorableRadioButtons
+      name="vre-benefits"
+      label="Are you receiving Chapter 31 Veteran Readiness and Employment (VR&E) benefits?"
+      options={options}
+      id="vre-benefits"
+      onValueChange={handleValueChange}
+      value={{ value: state.selected }}
+    />
+  );
+};
 
 export default {
   name: 'VREBenefits',

--- a/src/applications/vre/28-8832/wizard/pages/VRECounselorNotification.jsx
+++ b/src/applications/vre/28-8832/wizard/pages/VRECounselorNotification.jsx
@@ -1,17 +1,26 @@
-import React from 'react';
+import React, { useEffect } from 'react';
+import recordEvent from 'platform/monitoring/record-event';
 import { VRE_COUNSELOR_ROOT_URL } from '../../constants';
 
-const VRECounselorNotification = () => (
-  <div className="vads-u-margin-top--2 vads-u-background-color--primary-alt-lightest vads-u-padding--3">
-    <p className="vads-u-margin-top--0">
-      Please contact your vocational rehabilitation counselor to learn more
-      about how to get career planning and guidance benefits.
-    </p>
-    <a href={VRE_COUNSELOR_ROOT_URL}>
-      Contact a vocational rehabilitation counselor
-    </a>
-  </div>
-);
+const VRECounselorNotification = () => {
+  useEffect(() => {
+    recordEvent({
+      event: `howToWizard-notice-displayed`,
+      'reason-for-notice': 'ineligibility - eligible for chapter 31',
+    });
+  });
+  return (
+    <div className="vads-u-margin-top--2 vads-u-background-color--primary-alt-lightest vads-u-padding--3">
+      <p className="vads-u-margin-top--0">
+        Please contact your vocational rehabilitation counselor to learn more
+        about how to get career planning and guidance benefits.
+      </p>
+      <a href={VRE_COUNSELOR_ROOT_URL}>
+        Contact a vocational rehabilitation counselor
+      </a>
+    </div>
+  );
+};
 
 export default {
   name: 'VRECounselorNotification',

--- a/src/applications/vre/28-8832/wizard/pages/VaEducationBenefits.jsx
+++ b/src/applications/vre/28-8832/wizard/pages/VaEducationBenefits.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import recordEvent from 'platform/monitoring/record-event';
 import ErrorableRadioButtons from '@department-of-veterans-affairs/formation-react/ErrorableRadioButtons';
 import { pageNames } from './pageList';
 
@@ -13,16 +14,28 @@ const options = [
   },
 ];
 
-const EducationBenefits = ({ setPageState, state = {} }) => (
-  <ErrorableRadioButtons
-    name="education-benefits"
-    label="Are you using VA education benefits to go to school?"
-    options={options}
-    id="education-benefits"
-    onValueChange={({ value }) => setPageState({ selected: value }, value)}
-    value={{ value: state.selected }}
-  />
-);
+const EducationBenefits = ({ setPageState, state = {} }) => {
+  const handleValueChange = ({ value }) => {
+    recordEvent({
+      event: `howToWizard-formChange`,
+      'form-field-type': 'form-radio-buttons',
+      'form-field-label':
+        'Are you using VA education benefits to go to school?',
+      'form-field-value': value,
+    });
+    setPageState({ selected: value }, value);
+  };
+  return (
+    <ErrorableRadioButtons
+      name="education-benefits"
+      label="Are you using VA education benefits to go to school?"
+      options={options}
+      id="education-benefits"
+      onValueChange={handleValueChange}
+      value={{ value: state.selected }}
+    />
+  );
+};
 
 export default {
   name: 'VAEducationBenefits',


### PR DESCRIPTION
## Description
[Original Ticket](https://github.com/department-of-veterans-affairs/va.gov-team/issues/11238)

This PR is to add Google Analytics events to the wizard for the chapter 36 form. All events were tested using Dataslayer in Firefox and Google tag assistant in Chrome and are firing correctly.

## Screenshots
Here are screenshots of the custom events we added, the rest of the events come with the platform.

<details><summary>howToWizard-formChange</summary>

![Screen Shot 2020-09-24 at 12 55 30 PM](https://user-images.githubusercontent.com/1899695/94193488-44f0b880-fe65-11ea-89b0-e42da01626b8.png)

![Screen Shot 2020-09-24 at 12 56 01 PM](https://user-images.githubusercontent.com/1899695/94193524-50dc7a80-fe65-11ea-8c81-3edf02196afe.png)

![Screen Shot 2020-09-24 at 12 56 39 PM](https://user-images.githubusercontent.com/1899695/94193613-681b6800-fe65-11ea-8dda-3a2aa9bce5e8.png)

![Screen Shot 2020-09-24 at 12 57 32 PM](https://user-images.githubusercontent.com/1899695/94193712-88e3bd80-fe65-11ea-8b04-2591e2c3d718.png)

![Screen Shot 2020-09-24 at 12 57 58 PM](https://user-images.githubusercontent.com/1899695/94193753-96994300-fe65-11ea-9039-a586e6f95ac1.png)

![Screen Shot 2020-09-24 at 12 58 21 PM](https://user-images.githubusercontent.com/1899695/94193782-a4e75f00-fe65-11ea-85f3-769e2429c59d.png)

![Screen Shot 2020-09-24 at 12 59 00 PM](https://user-images.githubusercontent.com/1899695/94193876-c1839700-fe65-11ea-9a37-bbc86076132e.png)

![Screen Shot 2020-09-24 at 12 59 11 PM](https://user-images.githubusercontent.com/1899695/94193886-c47e8780-fe65-11ea-922b-d278a5b356c5.png)

![Screen Shot 2020-09-24 at 12 59 39 PM](https://user-images.githubusercontent.com/1899695/94193939-d829ee00-fe65-11ea-8e50-42bd0e283098.png)

![Screen Shot 2020-09-24 at 12 59 48 PM](https://user-images.githubusercontent.com/1899695/94193943-db24de80-fe65-11ea-8868-8127821bfaf8.png)

</details>

<details><summary>howToWizard-notice-displayed</summary>

![Screen Shot 2020-09-24 at 1 01 17 PM](https://user-images.githubusercontent.com/1899695/94194319-5be3da80-fe66-11ea-8655-853c96dd2c2a.png)

![Screen Shot 2020-09-24 at 1 05 02 PM](https://user-images.githubusercontent.com/1899695/94194469-95b4e100-fe66-11ea-9550-7d99e99f058b.png)

![Screen Shot 2020-09-24 at 1 02 30 PM](https://user-images.githubusercontent.com/1899695/94194343-669e6f80-fe66-11ea-826e-fb327223a3c0.png)

![Screen Shot 2020-09-24 at 1 02 22 PM](https://user-images.githubusercontent.com/1899695/94194324-5f776180-fe66-11ea-8492-b4a81cef4894.png)

</details>

## Acceptance criteria
- [x] Code/event names provided by the GA/Insights Team has been inserted into our feature for tracking
