### PR TITLE
hide content the scrolls behind and over the top of the mobile menu trigger

### DIFF
--- a/src/applications/personalization/profile-2/components/ProfileMobileSubNav.jsx
+++ b/src/applications/personalization/profile-2/components/ProfileMobileSubNav.jsx
@@ -200,6 +200,7 @@ const ProfileMobileSubNav = ({
   return (
     <div className="mobile-nav">
       <div className={menuClasses}>
+        <div className="menu-background" />
         <div className="menu-wrapper" ref={theMenu}>
           {!isMenuOpen && (
             <button

--- a/src/applications/personalization/profile-2/sass/profile-mobile-subnav.scss
+++ b/src/applications/personalization/profile-2/sass/profile-mobile-subnav.scss
@@ -9,6 +9,13 @@
       width: 100%;
       top: 0;
     }
+
+    .menu-background {
+      position: absolute;
+      background: $color-white;
+      height: units(1.5);
+      width: 100%;
+    }
   }
 
   .menu-wrapper {


### PR DESCRIPTION
## Description
Adds little `div` at the top of the `.mobile-nav .the-menu` to prevent content scrolling behind the menu or the mobile menu trigger button from showing. The GIFs explain it better than my words.

## Testing done
Local

## Screenshots
<details>
  <summary>Before</summary>
  
![before](https://user-images.githubusercontent.com/20728956/94211425-48e10280-fe86-11ea-9231-04bc2d659fd4.gif)

</details>

<details>
  <summary>After</summary>
  
![after](https://user-images.githubusercontent.com/20728956/94211450-58604b80-fe86-11ea-8f01-11b38a27a629.gif)

</details>

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs