### PR TITLE
Add `Last updated` to all LC templates

### DIFF
--- a/src/site/layouts/checklist.drupal.liquid
+++ b/src/site/layouts/checklist.drupal.liquid
@@ -9,6 +9,7 @@
   <main class="va-l-detail-page">
     <div class="usa-grid usa-grid-full">
       <div class="usa-width-three-fourths">
+        <!-- Draft status -->
         {% if !entityPublished %}
           <div class="usa-alert usa-alert-info">
             <div class="usa-alert-body">
@@ -22,7 +23,7 @@
           <h1>{{ title }}</h1>
 
           <!-- Intro -->
-          <p>{{ fieldIntroTextLimitedHtml.processed }}</p>
+          <div class="va-introtext">{{ fieldIntroTextLimitedHtml.processed }}</div>
 
           <!-- Alert -->
           {% if fieldAlertSingle %}
@@ -30,9 +31,11 @@
           {% endif %}
 
           <!-- Buttons -->
+          <div class="vads-u-margin-y--3">
           {% for fieldButton in fieldButtons %}
             {% include "src/site/paragraphs/button.drupal.liquid" with entity = fieldButton.entity %}
           {% endfor %}
+        </div>
 
           <!-- Checklist sections -->
           <h2>Checklist</h2>
@@ -49,8 +52,8 @@
               {% assign checklistItemIndex = 0 %}
               {% for checklistItem in checklistSection.entity.fieldChecklistItems %}
 
-              {% assign listchecklistItemIndex = listchecklistItemIndex | plus: 1 %}
-              {% assign checkboxId = "checkbox-" | append: listchecklistItemIndex %}
+                {% assign listchecklistItemIndex = listchecklistItemIndex | plus: 1 %}
+                {% assign checkboxId = "checkbox-" | append: listchecklistItemIndex %}
 
                 <!-- Checklist item -->
                 <li>
@@ -76,20 +79,26 @@
             </div>
           {% endif %}
         </article>
+
+        <!-- Related Links -->
+        {% if fieldRelatedLinks != empty %}
+          <div class="row">
+            <div class="usa-content columns">
+              <aside class="va-nav-linkslist va-nav-linkslist--related">
+                {% include 'src/site/paragraphs/list_of_link_teasers.drupal.liquid' with entity = fieldRelatedLinks.entity %}
+              </aside>
+            </div>
+          </div>
+        {% endif %}
+
+        <!-- Last Updated -->
+        <div class="last-updated usa-content">
+          Last updated: <time
+            datetime="{{ changed | dateFromUnix: 'YYYY-MM-DD'}}">{{ changed | humanizeTimestamp }}</time>
+        </div>
       </div>
     </div>
   </main>
-
-  <!-- Related Links -->
-  {% if fieldRelatedLinks != empty %}
-    <div class="row">
-      <div class="usa-content columns">
-        <aside class="va-nav-linkslist va-nav-linkslist--related">
-          {% include 'src/site/paragraphs/list_of_link_teasers.drupal.liquid' with entity = fieldRelatedLinks.entity %}
-        </aside>
-      </div>
-    </div>
-  {% endif %}
 </div>
 
 {% include "src/site/includes/footer.html" %}

--- a/src/site/layouts/faq_multiple_q_a.drupal.liquid
+++ b/src/site/layouts/faq_multiple_q_a.drupal.liquid
@@ -8,56 +8,56 @@
   <main class="va-l-detail-page">
     <div class="usa-grid usa-grid-full">
       <div class="usa-width-three-fourths">
+        <!-- Draft status -->
         {% if !entityPublished %}
-          <div class="usa-alert usa-alert-info" >
+          <div class="usa-alert usa-alert-info">
             <div class="usa-alert-body">
               <p class="usa-alert-text">You are viewing a draft.</p>
             </div>
           </div>
         {% endif %}
+
         <article class="usa-content">
+          <!-- Title -->
           <h1>{{ title }}</h1>
 
+          <!-- Intro text -->
           <div class="va-introtext">
             {{ fieldIntroTextLimitedHtml.processed }}
           </div>
 
+          <!-- Alert -->
           {% if fieldAlertSingle %}
             {% include "src/site/paragraphs/alert_single.drupal.liquid" with entity = fieldAlertSingle.entity %}
           {% endif %}
 
-          {% if fieldButtonsRepeat %}
-            <div class="vads-u-margin-y--3">
-              {% for fieldButton in fieldButtons  %}
-                {% include "src/site/paragraphs/button.drupal.liquid" with entity = fieldButton.entity %}
-              {% endfor %}
-            </div>
-          {% endif %}
+          <!-- Buttons -->
+          <div class="vads-u-margin-y--3">
+            {% for fieldButton in fieldButtons  %}
+              {% include "src/site/paragraphs/button.drupal.liquid" with entity = fieldButton.entity %}
+            {% endfor %}
+          </div>
 
+          <!-- TOC -->
           {% if fieldTableOfContentsBoolean %}
-          <section id="table-of-contents">
-            <h2 class="vads-u-margin-bottom--2 vads-u-font-size--lg">On this page</h2>
-            <ul class="usa-unstyled-list"></ul>
-          </section>
+            <section id="table-of-contents">
+              <h2 class="vads-u-margin-bottom--2 vads-u-font-size--lg">On this page</h2>
+              <ul class="usa-unstyled-list"></ul>
+            </section>
           {% endif %}
 
+          <!-- QAs -->
           {% for fieldQAGroup in fieldQAGroups %}
             <h2>{{ fieldQAGroup.entity.fieldSectionHeader }}</h2>
             <div class="usa-accordion-bordered">
               <ul class="usa-unstyled-list">
                 {% for fieldQA in fieldQAGroup.entity.fieldQAs %}
                   <li>
-                    <button
-                      type="button"
-                      aria-controls="{{ fieldQA.entity.entityBundle }}-{{ fieldQA.entity.entityId }}"
+                    <button type="button" aria-controls="{{ fieldQA.entity.entityBundle }}-{{ fieldQA.entity.entityId }}"
                       class="usa-accordion-button usa-button-unstyled"
-                      aria-expanded="false"
-                    >{{ fieldQA.entity.title }}</button>
-                    <div
-                       id="{{ fieldQA.entity.entityBundle }}-{{ fieldQA.entity.entityId }}"
-                       class="usa-accordion-content"
-                       aria-hidden="true"
-                      >
+                      aria-expanded="false">{{ fieldQA.entity.title }}</button>
+                    <div id="{{ fieldQA.entity.entityBundle }}-{{ fieldQA.entity.entityId }}" class="usa-accordion-content"
+                      aria-hidden="true">
                       {% for block in fieldQA.entity.fieldAnswer %}
                         {% assign bundleComponent = "src/site/paragraphs/" | append: block.entity.entityBundle %}
                         {% assign bundleComponentWithExtension = bundleComponent | append: ".drupal.liquid" %}
@@ -70,12 +70,32 @@
             </div>
           {% endfor %}
 
-          <div class="vads-u-margin-y--3">
-            {% for fieldButton in fieldButtons  %}
-              {% include "src/site/paragraphs/button.drupal.liquid" with entity = fieldButton.entity %}
-            {% endfor %}
-          </div>
+          <!-- Repeated buttons -->
+          {% if fieldButtonsRepeat %}
+            <div class="vads-u-margin-y--3">
+              {% for fieldButton in fieldButtons  %}
+                {% include "src/site/paragraphs/button.drupal.liquid" with entity = fieldButton.entity %}
+              {% endfor %}
+            </div>
+          {% end %}
         </article>
+
+        <!-- Related Links -->
+        {% if fieldRelatedLinks != empty %}
+          <div class="row">
+            <div class="usa-content columns">
+              <aside class="va-nav-linkslist va-nav-linkslist--related">
+                {% include 'src/site/paragraphs/list_of_link_teasers.drupal.liquid' with entity = fieldRelatedLinks.entity %}
+              </aside>
+            </div>
+          </div>
+        {% endif %}
+
+        <!-- Last Updated -->
+        <div class="last-updated usa-content">
+          Last updated: <time
+            datetime="{{ changed | dateFromUnix: 'YYYY-MM-DD'}}">{{ changed | humanizeTimestamp }}</time>
+        </div>
       </div>
     </div>
   </main>

--- a/src/site/layouts/media_list_images.drupal.liquid
+++ b/src/site/layouts/media_list_images.drupal.liquid
@@ -8,6 +8,7 @@
   <main class="va-l-detail-page">
     <div class="usa-grid usa-grid-full">
       <div class="usa-width-three-fourths">
+        <!-- Draft status -->
         {% if !entityPublished %}
           <div class="usa-alert usa-alert-info">
             <div class="usa-alert-body">
@@ -21,7 +22,7 @@
           <h1>{{ title }}</h1>
 
           <!-- Intro -->
-          <p>{{ fieldIntroTextLimitedHtml.processed }}</p>
+          <div class="va-introtext">{{ fieldIntroTextLimitedHtml.processed }}</div>
 
           <!-- Alert -->
           {% if fieldAlertSingle %}
@@ -29,9 +30,11 @@
           {% endif %}
 
           <!-- Buttons -->
-          {% for fieldButton in fieldButtons %}
-            {% include "src/site/paragraphs/button.drupal.liquid" with entity = fieldButton.entity %}
-          {% endfor %}
+          <div class="vads-u-margin-y--3">
+            {% for fieldButton in fieldButtons %}
+              {% include "src/site/paragraphs/button.drupal.liquid" with entity = fieldButton.entity %}
+            {% endfor %}
+          </div>
 
           <!-- Images List -->
           <ul class="usa-unstyled-list">
@@ -47,11 +50,8 @@
                 <div class="vads-l-grid-container vads-u-padding-x--0 vads-u-margin-y--2">
                   <div class="vads-l-row">
                     <div class="vads-l-col--2">
-                      <img
-                        class="vads-u-border--1px vads-u-border-color--gray-light"
-                        alt="{{ alt }}"
-                        height="{{ mediaImage.entity.image.height }}"
-                        width="{{ mediaImage.entity.image.width }}"
+                      <img class="vads-u-border--1px vads-u-border-color--gray-light" alt="{{ alt }}"
+                        height="{{ mediaImage.entity.image.height }}" width="{{ mediaImage.entity.image.width }}"
                         src="{{ mediaImage.entity.image.url }}" />
                     </div>
                     <div class="vads-l-col--10 vads-u-padding-left--2">
@@ -67,7 +67,7 @@
           </ul>
 
 
-          <!-- Buttons -->
+          <!-- Repeated buttons -->
           {% if fieldButtonsRepeat %}
             <div class="vads-u-margin-y--3">
               {% for fieldButton in fieldButtons %}
@@ -76,20 +76,26 @@
             </div>
           {% endif %}
         </article>
+
+        <!-- Related links -->
+        {% if fieldRelatedLinks != empty %}
+          <div class="row">
+            <div class="usa-content columns">
+              <aside class="va-nav-linkslist va-nav-linkslist--related">
+                {% include 'src/site/paragraphs/list_of_link_teasers.drupal.liquid' with entity = fieldRelatedLinks.entity %}
+              </aside>
+            </div>
+          </div>
+        {% endif %}
+
+        <!-- Last updated -->
+        <div class="last-updated usa-content">
+          Last updated: <time
+            datetime="{{ changed | dateFromUnix: 'YYYY-MM-DD'}}">{{ changed | humanizeTimestamp }}</time>
+        </div>
       </div>
     </div>
   </main>
-
-  <!-- Related Links -->
-  {% if fieldRelatedLinks != empty %}
-    <div class="row">
-      <div class="usa-content columns">
-        <aside class="va-nav-linkslist va-nav-linkslist--related">
-          {% include 'src/site/paragraphs/list_of_link_teasers.drupal.liquid' with entity = fieldRelatedLinks.entity %}
-        </aside>
-      </div>
-    </div>
-  {% endif %}
 </div>
 
 {% include "src/site/includes/footer.html" %}

--- a/src/site/layouts/media_list_videos.drupal.liquid
+++ b/src/site/layouts/media_list_videos.drupal.liquid
@@ -8,6 +8,7 @@
   <main class="va-l-detail-page">
     <div class="usa-grid usa-grid-full">
       <div class="usa-width-three-fourths">
+        <!-- Draft status -->
         {% if !entityPublished %}
           <div class="usa-alert usa-alert-info">
             <div class="usa-alert-body">
@@ -21,7 +22,7 @@
           <h1>{{ title }}</h1>
 
           <!-- Intro -->
-          <p>{{ fieldIntroTextLimitedHtml.processed }}</p>
+          <div class="va-introtext">{{ fieldIntroTextLimitedHtml.processed }}</div>
 
           <!-- Alert -->
           {% if fieldAlertSingle %}
@@ -29,37 +30,32 @@
           {% endif %}
 
           <!-- Buttons -->
-          {% for fieldButton in fieldButtons %}
-            {% include "src/site/paragraphs/button.drupal.liquid" with entity = fieldButton.entity %}
-          {% endfor %}
+          <div class="vads-u-margin-y--3">
+            {% for fieldButton in fieldButtons %}
+              {% include "src/site/paragraphs/button.drupal.liquid" with entity = fieldButton.entity %}
+            {% endfor %}
+          </div>
 
           <!-- Videos List -->
           <h2>{{ fieldMediaListVideos.entity.fieldSectionHeader | default: 'Videos' }}</h2>
-
           <ul class="usa-unstyled-list">
             {% for mediaVideo in fieldMediaListVideos.entity.fieldVideos %}
               <li>
                 <h3>{{ mediaVideo.entity.name }}</h3>
-                <iframe
-                  allowFullScreen
-                  frameBorder="0"
-                  src="{{ mediaVideo.entity.fieldMediaVideoEmbedField }}"
-                  title="{{ mediaVideo.entity.name }}"
-                  width="100%"
-                ></iframe>
+                <iframe allowFullScreen frameBorder="0" src="{{ mediaVideo.entity.fieldMediaVideoEmbedField }}"
+                  title="{{ mediaVideo.entity.name }}" width="100%"></iframe>
                 {% comment %}
-                  @Todo
-                  Awaiting CMS implementation as The duration, date and description are maintained by YouTube.
-                  https://github.com/department-of-veterans-affairs/va.gov-cms/issues/2454
-                  <p>{{ mediaVideo.entity.created | humanizeTimestamp }}</p>
-                  <p>{{ mediaEntity.entity.fieldDescription }}</p>
+                @Todo
+                Awaiting CMS implementation as The duration, date and description are maintained by YouTube.
+                https://github.com/department-of-veterans-affairs/va.gov-cms/issues/2454
+                <p>{{ mediaVideo.entity.created | humanizeTimestamp }}</p>
+                <p>{{ mediaEntity.entity.fieldDescription }}</p>
                 {% endcomment %}
               </li>
             {% endfor %}
           </ul>
 
-
-          <!-- Buttons -->
+          <!-- Repeated buttons -->
           {% if fieldButtonsRepeat %}
             <div class="vads-u-margin-y--3">
               {% for fieldButton in fieldButtons %}
@@ -68,20 +64,26 @@
             </div>
           {% endif %}
         </article>
+
+        <!-- Related links -->
+        {% if fieldRelatedLinks != empty %}
+          <div class="row">
+            <div class="usa-content columns">
+              <aside class="va-nav-linkslist va-nav-linkslist--related">
+                {% include 'src/site/paragraphs/list_of_link_teasers.drupal.liquid' with entity = fieldRelatedLinks.entity %}
+              </aside>
+            </div>
+          </div>
+        {% endif %}
+
+        <!-- Last updated -->
+        <div class="last-updated usa-content">
+          Last updated: <time
+            datetime="{{ changed | dateFromUnix: 'YYYY-MM-DD'}}">{{ changed | humanizeTimestamp }}</time>
+        </div>
       </div>
     </div>
   </main>
-
-  <!-- Related Links -->
-  {% if fieldRelatedLinks != empty %}
-    <div class="row">
-      <div class="usa-content columns">
-        <aside class="va-nav-linkslist va-nav-linkslist--related">
-          {% include 'src/site/paragraphs/list_of_link_teasers.drupal.liquid' with entity = fieldRelatedLinks.entity %}
-        </aside>
-      </div>
-    </div>
-  {% endif %}
 </div>
 
 {% include "src/site/includes/footer.html" %}

--- a/src/site/layouts/q_a.drupal.liquid
+++ b/src/site/layouts/q_a.drupal.liquid
@@ -8,29 +8,55 @@
   <main class="va-l-detail-page">
     <div class="usa-grid usa-grid-full">
       <div class="usa-width-three-fourths">
+        <!-- Draft status -->
         {% if !entityPublished %}
-          <div class="usa-alert usa-alert-info" >
+          <div class="usa-alert usa-alert-info">
             <div class="usa-alert-body">
               <p class="usa-alert-text">You are viewing a draft.</p>
             </div>
           </div>
         {% endif %}
+
         <article class="usa-content">
+          <!-- Title -->
           <h1>{{ title }}</h1>
+
+          <!-- QA -->
           {% for block in fieldAnswer %}
             {% assign bundleComponent = "src/site/paragraphs/" | append: block.entity.entityBundle %}
             {% assign bundleComponentWithExtension = bundleComponent | append: ".drupal.liquid" %}
             {% include {{ bundleComponentWithExtension }} with entity = block.entity %}
           {% endfor %}
 
+          <!-- Alert -->
           {% if fieldAlertSingle %}
             {% include "src/site/paragraphs/alert_single.drupal.liquid" with entity = fieldAlertSingle.entity %}
           {% endif %}
 
-          {% for fieldButton in fieldButtons  %}
-            {% include "src/site/paragraphs/button.drupal.liquid" with entity = fieldButton.entity %}
-          {% endfor %}
+          <!-- Buttons -->
+          <div class="vads-u-margin-y--3">
+            {% for fieldButton in fieldButtons  %}
+              {% include "src/site/paragraphs/button.drupal.liquid" with entity = fieldButton.entity %}
+            {% endfor %}
+          </div>
         </article>
+
+        <!-- Related links -->
+        {% if fieldRelatedLinks != empty %}
+          <div class="row">
+            <div class="usa-content columns">
+              <aside class="va-nav-linkslist va-nav-linkslist--related">
+                {% include 'src/site/paragraphs/list_of_link_teasers.drupal.liquid' with entity = fieldRelatedLinks.entity %}
+              </aside>
+            </div>
+          </div>
+        {% endif %}
+
+        <!-- Last updated -->
+        <div class="last-updated usa-content">
+          Last updated: <time
+            datetime="{{ changed | dateFromUnix: 'YYYY-MM-DD'}}">{{ changed | humanizeTimestamp }}</time>
+        </div>
       </div>
     </div>
   </main>

--- a/src/site/layouts/step_by_step.drupal.liquid
+++ b/src/site/layouts/step_by_step.drupal.liquid
@@ -8,6 +8,7 @@
   <main class="va-l-detail-page">
     <div class="usa-grid usa-grid-full">
       <div class="usa-width-three-fourths">
+        <!-- Draft status -->
         {% if !entityPublished %}
           <div class="usa-alert usa-alert-info">
             <div class="usa-alert-body">
@@ -21,7 +22,7 @@
           <h1>{{ title }}</h1>
 
           <!-- Intro -->
-          <p>{{ fieldIntroTextLimitedHtml.processed }}</p>
+          <div class="va-introtext">{{ fieldIntroTextLimitedHtml.processed }}</div>
 
           <!-- Alert -->
           {% if fieldAlertSingle %}
@@ -29,9 +30,11 @@
           {% endif %}
 
           <!-- Buttons -->
-          {% for fieldButton in fieldButtons  %}
-            {% include "src/site/paragraphs/button.drupal.liquid" with entity = fieldButton.entity %}
-          {% endfor %}
+          <div class="vads-u-margin-y--3">
+            {% for fieldButton in fieldButtons  %}
+              {% include "src/site/paragraphs/button.drupal.liquid" with entity = fieldButton.entity %}
+            {% endfor %}
+          </div>
 
           <!-- Steps -->
           <h2>Step-by-step</h2>
@@ -39,36 +42,43 @@
             {% assign count = 1 %}
             {% for fieldStep in fieldSteps.entity.fieldStep %}
               <li class="process-step list-{{ count | numToWord }}">
-                {{ fieldStep.entity.fieldWysiwyg.processed }}<br/>
-                <img alt="{{ fieldStep.entity.fieldMedia.entity.thumbnail.alt }}" src="{{ fieldStep.entity.fieldMedia.entity.thumbnail.url }}" />
+                {{ fieldStep.entity.fieldWysiwyg.processed }}<br />
+                <img alt="{{ fieldStep.entity.fieldMedia.entity.thumbnail.alt }}"
+                  src="{{ fieldStep.entity.fieldMedia.entity.thumbnail.url }}" />
               </li>
               {% assign count = count | plus: 1 %}
             {% endfor %}
           </ol>
 
-          <!-- Buttons -->
+          <!-- Repeated buttons -->
           {% if fieldButtonsRepeat %}
-            <div class="vads-u-margin-y--3">
-              {% for fieldButton in fieldButtons  %}
-                {% include "src/site/paragraphs/button.drupal.liquid" with entity = fieldButton.entity %}
-              {% endfor %}
-            </div>
+          <div class="vads-u-margin-y--3">
+            {% for fieldButton in fieldButtons  %}
+              {% include "src/site/paragraphs/button.drupal.liquid" with entity = fieldButton.entity %}
+            {% endfor %}
+          </div>
           {% endif %}
         </article>
+
+        <!-- Related links -->
+        {% if fieldRelatedLinks != empty %}
+          <div class="row">
+            <div class="usa-content columns">
+              <aside class="va-nav-linkslist va-nav-linkslist--related">
+                {% include 'src/site/paragraphs/list_of_link_teasers.drupal.liquid' with entity = fieldRelatedLinks.entity %}
+              </aside>
+            </div>
+          </div>
+        {% endif %}
+
+        <!-- Last updated -->
+        <div class="last-updated usa-content">
+          Last updated: <time
+            datetime="{{ changed | dateFromUnix: 'YYYY-MM-DD'}}">{{ changed | humanizeTimestamp }}</time>
+        </div>
       </div>
     </div>
   </main>
-
-  <!-- Related Links -->
-  {% if fieldRelatedLinks != empty %}
-    <div class="row">
-      <div class="usa-content columns">
-        <aside class="va-nav-linkslist va-nav-linkslist--related">
-          {% include 'src/site/paragraphs/list_of_link_teasers.drupal.liquid' with entity = fieldRelatedLinks.entity %}
-        </aside>
-      </div>
-    </div>
-  {% endif %}
 </div>
 
 {% include "src/site/includes/footer.html" %}

--- a/src/site/stages/build/drupal/graphql/faqMultipleQa.graphql.js
+++ b/src/site/stages/build/drupal/graphql/faqMultipleQa.graphql.js
@@ -10,6 +10,8 @@ module.exports = `
 fragment faqMultipleQA on NodeFaqMultipleQA {
   ${entityElementsFromPages}
   entityBundle
+  changed
+
   fieldTableOfContentsBoolean
   fieldIntroTextLimitedHtml {
     processed
@@ -47,6 +49,11 @@ fragment faqMultipleQA on NodeFaqMultipleQA {
   fieldButtons {
     entity {
       ${BUTTON}
+    }
+  }
+  fieldRelatedLinks {
+    entity {
+      ... listOfLinkTeasers
     }
   }
 }

--- a/src/site/stages/build/drupal/graphql/nodeChecklist.graphql.js
+++ b/src/site/stages/build/drupal/graphql/nodeChecklist.graphql.js
@@ -5,6 +5,7 @@ fragment nodeChecklist on NodeChecklist {
   ${entityElementsFromPages}
   entityBundle
 
+  changed
   title
   fieldDescription
   fieldIntroTextLimitedHtml {

--- a/src/site/stages/build/drupal/graphql/nodeMediaListImages.graphql.js
+++ b/src/site/stages/build/drupal/graphql/nodeMediaListImages.graphql.js
@@ -5,6 +5,7 @@ fragment nodeMediaListImages on NodeMediaListImages {
   ${entityElementsFromPages}
   entityBundle
 
+  changed
   title
   fieldDescription
   fieldIntroTextLimitedHtml {

--- a/src/site/stages/build/drupal/graphql/nodeMediaListVideos.graphql.js
+++ b/src/site/stages/build/drupal/graphql/nodeMediaListVideos.graphql.js
@@ -5,6 +5,7 @@ fragment nodeMediaListVideos on NodeMediaListVideos {
   ${entityElementsFromPages}
   entityBundle
 
+  changed
   title
   fieldDescription
   fieldIntroTextLimitedHtml {

--- a/src/site/stages/build/drupal/graphql/nodeQa.graphql.js
+++ b/src/site/stages/build/drupal/graphql/nodeQa.graphql.js
@@ -9,6 +9,8 @@ const fragment = `
 fragment nodeQa on NodeQA {
   ${entityElementsFromPages}
   entityBundle
+
+  changed
   fieldAnswer {
     entity {
       entityType
@@ -25,6 +27,11 @@ fragment nodeQa on NodeQA {
   fieldButtons {
     entity {
       ${BUTTON}
+    }
+  }
+  fieldRelatedLinks {
+    entity {
+      ... listOfLinkTeasers
     }
   }
 }

--- a/src/site/stages/build/drupal/graphql/nodeStepByStep.graphql.js
+++ b/src/site/stages/build/drupal/graphql/nodeStepByStep.graphql.js
@@ -5,6 +5,7 @@ fragment nodeStepByStep on NodeStepByStep {
   ${entityElementsFromPages}
   entityBundle
 
+  changed
   title
   fieldIntroTextLimitedHtml {
     processed


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/14009

This PR adds `Last updated` to all LC templates and generally standardizes all markup across them to support buttons, alerts, intro text, etc.

## Testing done
N/A

## Screenshots
N/A

## Acceptance criteria
- [x] Standardize all LC template markup
- [x] Add `Last updated` field to all LC templates

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
