### PR TITLE
13006 rewrite reason for appointment page tests

### DIFF
--- a/src/applications/vaos/tests/mocks/setup.js
+++ b/src/applications/vaos/tests/mocks/setup.js
@@ -27,6 +27,7 @@ import { mockParentSites, mockSupportedFacilities } from './helpers';
 
 import createRoutesWithStore from '../../routes';
 import TypeOfEyeCarePage from '../../new-appointment/components/TypeOfEyeCarePage';
+import TypeOfFacilityPage from '../../new-appointment/components/TypeOfFacilityPage';
 
 export function createTestStore(initialState) {
   return createStore(
@@ -93,6 +94,24 @@ export function renderFromRoutes({ initialState, store = null, path = '/' }) {
   );
 
   return { ...screen, history };
+}
+
+export async function setTypeOfFacility(store, label) {
+  const history = {
+    push: sinon.spy(),
+  };
+  const { findByLabelText, getByText } = renderWithStoreAndRouter(
+    <TypeOfFacilityPage history={history} />,
+    { store },
+  );
+
+  const radioButton = await findByLabelText(label);
+  fireEvent.click(radioButton);
+  fireEvent.click(getByText(/Continue/));
+  await waitFor(() => expect(history.push.called).to.be.true);
+  await cleanup();
+
+  return history.push.firstCall.args[0];
 }
 
 export async function setTypeOfCare(store, label) {

--- a/src/applications/vaos/tests/new-appointment/components/ReasonForAppointmentPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/ReasonForAppointmentPage.unit.spec.jsx
@@ -10,6 +10,7 @@ import { fireEvent, waitFor } from '@testing-library/dom';
 import ReasonForAppointmentPage from '../../../new-appointment/components/ReasonForAppointmentPage';
 import { Route } from 'react-router-dom';
 import { cleanup } from '@testing-library/react';
+import { startDirectScheduleFlow } from '../../../new-appointment/redux/actions';
 
 const initialState = {
   featureToggles: {
@@ -62,7 +63,11 @@ describe('VAOS integration: reason for appointment page with a single-site user'
       'Tell us the reason for this appointment',
     );
 
-    expect(screen.getByRole('textbox')).to.exist;
+    const textBox = screen.getByRole('textbox');
+    expect(textBox).to.exist;
+    expect(textBox)
+      .to.have.attribute('maxlength')
+      .to.equal('100');
 
     expect(
       screen.getByRole('heading', {
@@ -99,6 +104,31 @@ describe('VAOS integration: reason for appointment page with a single-site user'
 
     expect(await screen.findByRole('alert')).to.contain.text(
       'Please provide a response',
+    );
+  });
+
+  it('should show alternate textbox char length if navigated via direct schedule flow', async () => {
+    const store = createTestStore(initialState);
+    store.dispatch(startDirectScheduleFlow());
+
+    const screen = renderWithStoreAndRouter(<ReasonForAppointmentPage />, {
+      store,
+    });
+
+    fireEvent.click(
+      await screen.findByLabelText(/Routine or follow-up visit/i),
+    );
+
+    const textBox = screen.getByRole('textbox');
+    expect(textBox).to.exist;
+    expect(textBox)
+      .to.have.attribute('maxlength')
+      .to.equal('131');
+
+    expect(
+      screen.getByRole('heading', {
+        name: /If you have an urgent medical need, please:/i,
+      }),
     );
   });
 

--- a/src/applications/vaos/tests/new-appointment/components/ReasonForAppointmentPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/ReasonForAppointmentPage.unit.spec.jsx
@@ -147,35 +147,6 @@ describe('VAOS integration: reason for appointment page with a single-site user'
         '/new-appointment/choose-visit-type',
       ),
     );
-
-    fireEvent.click(
-      await screen.findByLabelText(/I have a new medical issue/i),
-    );
-    await waitFor(() =>
-      expect(screen.history.push.lastCall?.args[0]).to.equal(
-        '/new-appointment/choose-visit-type',
-      ),
-    );
-
-    fireEvent.click(
-      await screen.findByLabelText(
-        /I have a concern or question about my medication/i,
-      ),
-    );
-    await waitFor(() =>
-      expect(screen.history.push.lastCall?.args[0]).to.equal(
-        '/new-appointment/choose-visit-type',
-      ),
-    );
-
-    fireEvent.click(
-      await screen.findByLabelText(/My reason isn’t listed here/i),
-    );
-    await waitFor(() =>
-      expect(screen.history.push.lastCall?.args[0]).to.equal(
-        '/new-appointment/choose-visit-type',
-      ),
-    );
   });
 
   it('should continue to the correct page for Community Care medical request', async () => {
@@ -217,9 +188,6 @@ describe('VAOS integration: reason for appointment page with a single-site user'
     fireEvent.click(
       await screen.findByLabelText(/Routine or follow-up visit/i),
     );
-    const textBox = screen.getByRole('textbox');
-    fireEvent.change(textBox, { target: { value: 'test' } });
-    expect(textBox.value).to.equal('test');
     await cleanup();
 
     screen = renderWithStoreAndRouter(

--- a/src/applications/vaos/tests/new-appointment/components/ReasonForAppointmentPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/ReasonForAppointmentPage.unit.spec.jsx
@@ -1,189 +1,236 @@
 import React from 'react';
 import { expect } from 'chai';
-import sinon from 'sinon';
-import { mount } from 'enzyme';
+import { mockFetch, resetFetch } from 'platform/testing/unit/helpers';
+import {
+  createTestStore,
+  renderWithStoreAndRouter,
+  setTypeOfFacility,
+} from '../../mocks/setup';
+import { fireEvent, waitFor } from '@testing-library/dom';
+import ReasonForAppointmentPage from '../../../new-appointment/components/ReasonForAppointmentPage';
+import { Route } from 'react-router-dom';
+import { cleanup } from '@testing-library/react';
 
-import { selectRadio } from 'platform/testing/unit/schemaform-utils.jsx';
-import { ReasonForAppointmentPage } from '../../../new-appointment/components/ReasonForAppointmentPage';
-import { FACILITY_TYPES } from '../../../utils/constants';
+const initialState = {
+  featureToggles: {
+    vaOnlineSchedulingVSPAppointmentNew: false,
+    vaOnlineSchedulingDirect: true,
+    vaOnlineSchedulingCommunityCare: true,
+  },
+  user: {
+    profile: {
+      facilities: [
+        { facilityId: '983', isCerner: false },
+        { facilityId: '984', isCerner: false },
+      ],
+    },
+  },
+};
 
-describe('VAOS <ReasonForAppointmentPage>', () => {
-  it('should render', () => {
-    const openReasonForAppointment = sinon.spy();
-    const updateReasonForAppointmentData = sinon.spy();
+describe('VAOS integration: reason for appointment page with a single-site user', () => {
+  beforeEach(() => mockFetch());
+  afterEach(() => resetFetch());
 
-    const form = mount(
-      <ReasonForAppointmentPage
-        openReasonForAppointment={openReasonForAppointment}
-        updateReasonForAppointmentData={updateReasonForAppointmentData}
-        data={{}}
-      />,
+  it('should show page for VA medical request', async () => {
+    const store = createTestStore(initialState);
+    const screen = renderWithStoreAndRouter(<ReasonForAppointmentPage />, {
+      store,
+    });
+
+    expect(screen.baseElement).to.contain.text(
+      'Please let us know why you’re making this appointment',
     );
 
-    expect(form.find('input').length).to.equal(4);
-    expect(form.find('textarea').length).to.equal(1);
-    form.unmount();
-  });
-
-  it('should not submit empty form', () => {
-    const openReasonForAppointment = sinon.spy();
-    const history = {
-      push: sinon.spy(),
-    };
-
-    const form = mount(
-      <ReasonForAppointmentPage
-        openReasonForAppointment={openReasonForAppointment}
-        history={history}
-        data={{}}
-      />,
-    );
-
-    form.find('form').simulate('submit');
-
-    expect(form.find('AlertBox').length).to.equal(1);
-
-    expect(form.find('.usa-input-error').length).to.equal(2);
-    expect(history.push.called).to.be.false;
-    form.unmount();
-  });
-
-  it('should call updateReasonForAppointmentData after change', () => {
-    const openReasonForAppointment = sinon.spy();
-    const updateReasonForAppointmentData = sinon.spy();
-    const history = {
-      push: sinon.spy(),
-    };
-
-    const form = mount(
-      <ReasonForAppointmentPage
-        openReasonForAppointment={openReasonForAppointment}
-        updateReasonForAppointmentData={updateReasonForAppointmentData}
-        history={history}
-        data={{}}
-      />,
-    );
-
-    selectRadio(form, 'root_reasonForAppointment', 'routine-follow-up');
+    expect(screen.getAllByRole('radio').length).to.equal(4);
 
     expect(
-      updateReasonForAppointmentData.firstCall.args[2].reasonForAppointment,
-    ).to.equal('routine-follow-up');
-    form.unmount();
+      screen.getByRole('heading', {
+        name: /If you have an urgent medical need, please:/i,
+      }),
+    );
   });
 
-  it('should submit with valid data', () => {
-    const openReasonForAppointment = sinon.spy();
-    const routeToNextAppointmentPage = sinon.spy();
+  it('should show page for Community Care medical request', async () => {
+    const store = createTestStore(initialState);
+    await setTypeOfFacility(store, /Community Care/i);
 
-    const form = mount(
-      <ReasonForAppointmentPage
-        openReasonForAppointment={openReasonForAppointment}
-        routeToNextAppointmentPage={routeToNextAppointmentPage}
-        data={{
-          reasonForAppointment: 'routine-follow-up',
-          reasonAdditionalInfo: 'test',
-        }}
-      />,
+    const screen = renderWithStoreAndRouter(<ReasonForAppointmentPage />, {
+      store,
+    });
+
+    expect(screen.baseElement).to.contain.text(
+      'Tell us the reason for this appointment',
     );
-    form.find('form').simulate('submit');
 
-    expect(form.find('.usa-input-error').length).to.equal(0);
+    expect(screen.getByRole('textbox')).to.exist;
 
-    form.unmount();
+    expect(
+      screen.getByRole('heading', {
+        name: /If you have an urgent medical need, please:/i,
+      }),
+    );
   });
 
-  it('should render alert message', () => {
-    const openReasonForAppointment = sinon.spy();
-    const updateReasonForAppointmentData = sinon.spy();
+  it('should show validation for VA medical request', async () => {
+    const store = createTestStore(initialState);
+    const screen = renderWithStoreAndRouter(<ReasonForAppointmentPage />, {
+      store,
+    });
 
-    const form = mount(
-      <ReasonForAppointmentPage
-        openReasonForAppointment={openReasonForAppointment}
-        updateReasonForAppointmentData={updateReasonForAppointmentData}
-        data={{}}
-      />,
+    fireEvent.click(screen.getByText(/Continue/));
+    expect(await screen.findByRole('alert')).to.contain.text(
+      'Please provide a response',
     );
-    expect(form.text()).to.contain(
-      'If you have an urgent medical need, please',
-    );
-
-    form.unmount();
   });
 
-  it('document title should match h1 text', () => {
-    const openReasonForAppointment = sinon.spy();
-    const updateReasonForAppointmentData = sinon.spy();
-    const pageTitle = 'Choose a reason for your appointment';
+  it('should show error msg when enter all spaces for VA medical request', async () => {
+    const store = createTestStore(initialState);
+    const screen = renderWithStoreAndRouter(<ReasonForAppointmentPage />, {
+      store,
+    });
 
-    const form = mount(
-      <ReasonForAppointmentPage
-        openReasonForAppointment={openReasonForAppointment}
-        updateReasonForAppointmentData={updateReasonForAppointmentData}
-        data={{}}
-      />,
+    fireEvent.click(
+      await screen.findByLabelText(/Routine or follow-up visit/i),
     );
+    const textBox = screen.getByRole('textbox');
+    fireEvent.change(textBox, { target: { value: '   ' } });
+    expect(textBox.value).to.equal('   ');
+    fireEvent.click(screen.getByText(/Continue/));
 
-    expect(form.find('h1').text()).to.equal(pageTitle);
-    expect(document.title).contain(pageTitle);
-
-    form.unmount();
+    expect(await screen.findByRole('alert')).to.contain.text(
+      'Please provide a response',
+    );
   });
 
-  it('should render radio buttons and a textarea', () => {
-    const openReasonForAppointment = sinon.spy();
-    const updateReasonForAppointmentData = sinon.spy();
+  it('should show error msg when enter all spaces for Community Care medical request', async () => {
+    const store = createTestStore(initialState);
+    await setTypeOfFacility(store, /Community Care/i);
 
-    const form = mount(
-      <ReasonForAppointmentPage
-        openReasonForAppointment={openReasonForAppointment}
-        updateReasonForAppointmentData={updateReasonForAppointmentData}
-        data={{}}
-      />,
+    const screen = renderWithStoreAndRouter(<ReasonForAppointmentPage />, {
+      store,
+    });
+
+    expect(screen.baseElement).to.contain.text(
+      'Tell us the reason for this appointment',
     );
 
-    expect(form.find('input[type="radio"]').length).to.equal(4);
-    expect(form.find('textarea').length).to.equal(1);
+    const textBox = screen.getByRole('textbox');
+    fireEvent.change(textBox, { target: { value: '   ' } });
+    expect(textBox.value).to.equal('   ');
+    fireEvent.click(screen.getByText(/Continue/));
 
-    form.unmount();
+    expect(await screen.findByRole('alert')).to.contain.text(
+      'Please provide a response',
+    );
   });
 
-  it('document title should be different if community care', () => {
-    const openReasonForAppointment = sinon.spy();
-    const updateReasonForAppointmentData = sinon.spy();
-    const pageTitle = 'Tell us the reason for this appointment';
-
-    const form = mount(
-      <ReasonForAppointmentPage
-        openReasonForAppointment={openReasonForAppointment}
-        updateReasonForAppointmentData={updateReasonForAppointmentData}
-        data={{ facilityType: FACILITY_TYPES.COMMUNITY_CARE }}
-      />,
+  it('should continue to the correct page based on type choice for VA medical request', async () => {
+    const store = createTestStore(initialState);
+    const screen = renderWithStoreAndRouter(
+      <Route component={ReasonForAppointmentPage} />,
+      {
+        store,
+      },
     );
 
-    expect(form.find('h1').text()).to.equal(pageTitle);
-    expect(document.title).contain(pageTitle);
-    form.unmount();
+    fireEvent.click(
+      await screen.findByLabelText(/Routine or follow-up visit/i),
+    );
+    const textBox = screen.getByRole('textbox');
+    fireEvent.change(textBox, { target: { value: 'test' } });
+    expect(textBox.value).to.equal('test');
+
+    fireEvent.click(screen.getByText(/Continue/));
+
+    await waitFor(() =>
+      expect(screen.history.push.lastCall?.args[0]).to.equal(
+        '/new-appointment/choose-visit-type',
+      ),
+    );
+
+    fireEvent.click(
+      await screen.findByLabelText(/I have a new medical issue/i),
+    );
+    await waitFor(() =>
+      expect(screen.history.push.lastCall?.args[0]).to.equal(
+        '/new-appointment/choose-visit-type',
+      ),
+    );
+
+    fireEvent.click(
+      await screen.findByLabelText(
+        /I have a concern or question about my medication/i,
+      ),
+    );
+    await waitFor(() =>
+      expect(screen.history.push.lastCall?.args[0]).to.equal(
+        '/new-appointment/choose-visit-type',
+      ),
+    );
+
+    fireEvent.click(
+      await screen.findByLabelText(/My reason isn’t listed here/i),
+    );
+    await waitFor(() =>
+      expect(screen.history.push.lastCall?.args[0]).to.equal(
+        '/new-appointment/choose-visit-type',
+      ),
+    );
   });
 
-  it('should show error msg when enter all spaces', () => {
-    const openReasonForAppointment = sinon.spy();
-    const routeToNextAppointmentPage = sinon.spy();
-
-    const form = mount(
-      <ReasonForAppointmentPage
-        openReasonForAppointment={openReasonForAppointment}
-        routeToNextAppointmentPage={routeToNextAppointmentPage}
-        data={{
-          reasonForAppointment: 'routine-follow-up',
-          reasonAdditionalInfo: '   ',
-        }}
-      />,
+  it('should continue to the correct page for Community Care medical request', async () => {
+    const store = createTestStore(initialState);
+    await setTypeOfFacility(store, /Community Care/i);
+    const screen = renderWithStoreAndRouter(
+      <Route component={ReasonForAppointmentPage} />,
+      {
+        store,
+      },
     );
-    form.find('form').simulate('submit');
 
-    expect(form.find('.usa-input-error-message').length).to.equal(1);
+    expect(screen.baseElement).to.contain.text(
+      'Tell us the reason for this appointment',
+    );
 
-    form.unmount();
+    const textBox = screen.getByRole('textbox');
+    fireEvent.change(textBox, { target: { value: 'test' } });
+    expect(textBox.value).to.equal('test');
+
+    fireEvent.click(screen.getByText(/Continue/));
+
+    await waitFor(() =>
+      expect(screen.history.push.lastCall?.args[0]).to.equal(
+        '/new-appointment/contact-info',
+      ),
+    );
+  });
+
+  it('should save reason choice on for VA medical request page change', async () => {
+    const store = createTestStore(initialState);
+    let screen = renderWithStoreAndRouter(
+      <Route component={ReasonForAppointmentPage} />,
+      {
+        store,
+      },
+    );
+
+    fireEvent.click(
+      await screen.findByLabelText(/Routine or follow-up visit/i),
+    );
+    const textBox = screen.getByRole('textbox');
+    fireEvent.change(textBox, { target: { value: 'test' } });
+    expect(textBox.value).to.equal('test');
+    await cleanup();
+
+    screen = renderWithStoreAndRouter(
+      <Route component={ReasonForAppointmentPage} />,
+      {
+        store,
+      },
+    );
+
+    expect(
+      await screen.findByLabelText(/Routine or follow-up visit/i),
+    ).to.have.attribute('checked');
   });
 });

--- a/src/applications/vaos/tests/new-appointment/components/TypeOfFacilityPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/TypeOfFacilityPage.unit.spec.jsx
@@ -6,6 +6,7 @@ import { fireEvent, waitFor } from '@testing-library/dom';
 import TypeOfFacilityPage from '../../../new-appointment/components/TypeOfFacilityPage';
 import { Route } from 'react-router-dom';
 import { cleanup } from '@testing-library/react';
+import { startDirectScheduleFlow } from '../../../new-appointment/redux/actions';
 
 const initialState = {
   featureToggles: {
@@ -24,11 +25,16 @@ const initialState = {
 };
 
 describe('VAOS integration: VA facility page with a single-site user', () => {
-  beforeEach(() => mockFetch());
+  let store;
+
+  beforeEach(() => {
+    mockFetch();
+    store = createTestStore(initialState);
+    store.dispatch(startDirectScheduleFlow());
+  });
   afterEach(() => resetFetch());
 
   it('should show page', async () => {
-    const store = createTestStore(initialState);
     const screen = renderWithStoreAndRouter(<TypeOfFacilityPage />, {
       store,
     });
@@ -41,7 +47,6 @@ describe('VAOS integration: VA facility page with a single-site user', () => {
   });
 
   it('should show validation', async () => {
-    const store = createTestStore(initialState);
     const screen = renderWithStoreAndRouter(<TypeOfFacilityPage />, {
       store,
     });
@@ -53,7 +58,6 @@ describe('VAOS integration: VA facility page with a single-site user', () => {
   });
 
   it('should continue to the correct page based on type choice', async () => {
-    const store = createTestStore(initialState);
     const screen = renderWithStoreAndRouter(
       <Route component={TypeOfFacilityPage} />,
       {
@@ -83,7 +87,6 @@ describe('VAOS integration: VA facility page with a single-site user', () => {
   });
 
   it('should save type of facility choice on page change', async () => {
-    const store = createTestStore(initialState);
     let screen = renderWithStoreAndRouter(
       <Route component={TypeOfFacilityPage} />,
       {

--- a/src/applications/vaos/tests/new-appointment/components/TypeOfFacilityPage.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/TypeOfFacilityPage.unit.spec.jsx
@@ -6,7 +6,6 @@ import { fireEvent, waitFor } from '@testing-library/dom';
 import TypeOfFacilityPage from '../../../new-appointment/components/TypeOfFacilityPage';
 import { Route } from 'react-router-dom';
 import { cleanup } from '@testing-library/react';
-import { startDirectScheduleFlow } from '../../../new-appointment/redux/actions';
 
 const initialState = {
   featureToggles: {
@@ -25,16 +24,11 @@ const initialState = {
 };
 
 describe('VAOS integration: VA facility page with a single-site user', () => {
-  let store;
-
-  beforeEach(() => {
-    mockFetch();
-    store = createTestStore(initialState);
-    store.dispatch(startDirectScheduleFlow());
-  });
+  beforeEach(() => mockFetch());
   afterEach(() => resetFetch());
 
   it('should show page', async () => {
+    const store = createTestStore(initialState);
     const screen = renderWithStoreAndRouter(<TypeOfFacilityPage />, {
       store,
     });
@@ -47,6 +41,7 @@ describe('VAOS integration: VA facility page with a single-site user', () => {
   });
 
   it('should show validation', async () => {
+    const store = createTestStore(initialState);
     const screen = renderWithStoreAndRouter(<TypeOfFacilityPage />, {
       store,
     });
@@ -58,6 +53,7 @@ describe('VAOS integration: VA facility page with a single-site user', () => {
   });
 
   it('should continue to the correct page based on type choice', async () => {
+    const store = createTestStore(initialState);
     const screen = renderWithStoreAndRouter(
       <Route component={TypeOfFacilityPage} />,
       {
@@ -87,6 +83,7 @@ describe('VAOS integration: VA facility page with a single-site user', () => {
   });
 
   it('should save type of facility choice on page change', async () => {
+    const store = createTestStore(initialState);
     let screen = renderWithStoreAndRouter(
       <Route component={TypeOfFacilityPage} />,
       {


### PR DESCRIPTION
## Description
We want to rewrite our Enzyme based tests with tests in RTL that do not test implementation details.

## Testing done
Local and unit

## Screenshots
![image](https://user-images.githubusercontent.com/8315447/94297643-d5e19580-ff32-11ea-918a-d58a1672285f.png)


## Acceptance criteria
- [ ] Test coverage matches
- [ ] RTL Tests fully replace enzyme tests

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
