### PR TITLE
Add nodeSupportResourcesDetailPage template (about template)

### DIFF
--- a/src/site/layouts/support_resources_detail_page.drupal.liquid
+++ b/src/site/layouts/support_resources_detail_page.drupal.liquid
@@ -1,0 +1,80 @@
+{% include "src/site/includes/header.html" with drupalTags = true %}
+{% include "src/site/includes/alerts.drupal.liquid" %}
+{% include "src/site/includes/preview-edit.drupal.liquid" %}
+{% include "src/site/includes/breadcrumbs.drupal.liquid" %}
+
+{% assign listchecklistItemIndex = 0 %}
+
+<div id="content" class="interior">
+  <main class="va-l-detail-page">
+    <div class="usa-grid usa-grid-full">
+      <div class="usa-width-three-fourths">
+        <!-- Draft status -->
+        {% if !entityPublished %}
+          <div class="usa-alert usa-alert-info">
+            <div class="usa-alert-body">
+              <p class="usa-alert-text">You are viewing a draft.</p>
+            </div>
+          </div>
+        {% endif %}
+
+        <article class="usa-content">
+          <!-- Title -->
+          <h1>{{ title }}</h1>
+
+          <!-- Intro -->
+          <div class="va-introtext">{{ fieldIntroTextLimitedHtml.processed }}</div>
+
+          <!-- Alert -->
+          {% if fieldAlertSingle %}
+            {% include "src/site/paragraphs/alert_single.drupal.liquid" with entity = fieldAlertSingle.entity %}
+          {% endif %}
+
+          <!-- Buttons -->
+          <div class="vads-u-margin-y--3">
+            {% for fieldButton in fieldButtons %}
+              {% include "src/site/paragraphs/button.drupal.liquid" with entity = fieldButton.entity %}
+            {% endfor %}
+          </div>
+
+          <!-- TOC -->
+          {% if fieldTableOfContentsBoolean %}
+            <section id="table-of-contents">
+              <h2 class="vads-u-margin-bottom--2 vads-u-font-size--lg">On this page</h2>
+              <ul class="usa-unstyled-list"></ul>
+            </section>
+          {% endif %}
+
+          <!-- Repeated buttons -->
+          {% if fieldButtonsRepeat %}
+            <div class="vads-u-margin-y--3">
+              {% for fieldButton in fieldButtons %}
+                {% include "src/site/paragraphs/button.drupal.liquid" with entity = fieldButton.entity %}
+              {% endfor %}
+            </div>
+          {% endif %}
+        </article>
+
+        <!-- Related Links -->
+        {% if fieldRelatedLinks != empty %}
+          <div class="row">
+            <div class="usa-content columns">
+              <aside class="va-nav-linkslist va-nav-linkslist--related">
+                {% include 'src/site/paragraphs/list_of_link_teasers.drupal.liquid' with entity = fieldRelatedLinks.entity %}
+              </aside>
+            </div>
+          </div>
+        {% endif %}
+
+        <!-- Last Updated -->
+        <div class="last-updated usa-content">
+          Last updated: <time
+            datetime="{{ changed | dateFromUnix: 'YYYY-MM-DD'}}">{{ changed | humanizeTimestamp }}</time>
+        </div>
+      </div>
+    </div>
+  </main>
+</div>
+
+{% include "src/site/includes/footer.html" %}
+{% include "src/site/includes/debug.drupal.liquid" %}

--- a/src/site/stages/build/drupal/graphql/GetAllPages.graphql.js
+++ b/src/site/stages/build/drupal/graphql/GetAllPages.graphql.js
@@ -32,6 +32,7 @@ const qaPage = require('./nodeQa.graphql');
 const sidebarQuery = require('./navigation-fragments/sidebar.nav.graphql');
 const stepByStepPage = require('./nodeStepByStep.graphql');
 const storyListingPage = require('./storyListingPage.graphql');
+const supportResourcesDetailPage = require('./nodeSupportResourcesDetailPage.graphql');
 const vaFormPage = require('./vaFormPage.graphql');
 const vamcOperatingStatusAndAlerts = require('./vamcOperatingStatusAndAlerts.graphql');
 
@@ -83,6 +84,7 @@ const buildQuery = ({ useTomeSync }) => {
   ${mediaListImages}
   ${checklistPage}
   ${mediaListVideos}
+  ${supportResourcesDetailPage}
 `;
 
   const todayQueryVar = useTomeSync ? '' : '$today: String!,';
@@ -121,6 +123,7 @@ const buildQuery = ({ useTomeSync }) => {
         ... nodeMediaListImages
         ... nodeChecklist
         ... nodeMediaListVideos
+        ... nodeSupportResourcesDetailPage
       }
     }`;
 

--- a/src/site/stages/build/drupal/graphql/GetLatestPageById.graphql.js
+++ b/src/site/stages/build/drupal/graphql/GetLatestPageById.graphql.js
@@ -15,11 +15,12 @@ const healthCareRegionDetailPage = require('./healthCareRegionDetailPage.graphql
 const icsFileQuery = require('./file-fragments/ics.file.graphql');
 const menuLinksQuery = require('./navigation-fragments/menuLinks.nav.graphql');
 const newsStoryPage = require('./newStoryPage.graphql');
-const nodeMediaListImages = require('./nodeMediaListImages.graphql');
 const nodeChecklist = require('./nodeChecklist.graphql');
+const nodeMediaListImages = require('./nodeMediaListImages.graphql');
 const nodeMediaListVideos = require('./nodeMediaListVideos.graphql');
 const nodeQa = require('./nodeQa.graphql');
 const nodeStepByStep = require('./nodeStepByStep.graphql');
+const nodeSupportResourcesDetailPage = require('./nodeSupportResourcesDetailPage.graphql');
 const pressReleasePage = require('./pressReleasePage.graphql');
 const sidebarQuery = require('./navigation-fragments/sidebar.nav.graphql');
 const vaFormPage = require('./vaFormPage.graphql');
@@ -58,6 +59,7 @@ module.exports = `
   ${nodeMediaListImages}
   ${nodeChecklist}
   ${nodeMediaListVideos}
+  ${nodeSupportResourcesDetailPage}
 
   query GetLatestPageById($id: String!, $today: String!, $onlyPublishedContent: Boolean!) {
     nodes: nodeQuery(revisions: LATEST, filter: {
@@ -83,6 +85,7 @@ module.exports = `
         ... nodeMediaListImages
         ... nodeChecklist
         ... nodeMediaListVideos
+        ... nodeSupportResourcesDetailPage
       }
     }
     ${icsFileQuery}

--- a/src/site/stages/build/drupal/graphql/nodeSupportResourcesDetailPage.graphql.js
+++ b/src/site/stages/build/drupal/graphql/nodeSupportResourcesDetailPage.graphql.js
@@ -1,0 +1,77 @@
+const entityElementsFromPages = require('./entityElementsForPages.graphql');
+
+const fragment = `
+fragment nodeSupportResourcesDetailPage on NodeSupportResourcesDetailPage {
+  ${entityElementsFromPages}
+  entityBundle
+  changed
+  title
+
+  fieldContentBlock {
+    entity {
+      entityType
+      entityBundle
+      ... wysiwyg
+      ... collapsiblePanel
+      ... process
+      ... qaSection
+      ... qa
+      ... listOfLinkTeasers
+      ... reactWidget
+      ... spanishSummary
+      ... alertParagraph
+      ... table
+      ... downloadableFile
+      ... embeddedImage
+      ... numberCallout
+    }
+  }
+  fieldTableOfContentsBoolean
+  fieldIntroTextLimitedHtml {
+    processed
+  }
+  fieldAlertSingle {
+    entity {
+      ... alertSingle
+    }
+  }
+  fieldButtons {
+    entity {
+      ... button
+    }
+  }
+  fieldButtonsRepeat
+  fieldSteps {
+    entity {
+      ... on ParagraphStepByStep {
+        fieldStep {
+          entity {
+            ... on ParagraphStep {
+              fieldWysiwyg {
+                processed
+              }
+              fieldMedia {
+                entity {
+                  ... on Media {
+                    thumbnail {
+                      alt
+                      url
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  fieldRelatedLinks {
+    entity {
+      ... listOfLinkTeasers
+    }
+  }
+}
+`;
+
+module.exports = fragment;


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/13963

This PR implements the about template. **THIS PR IS A DRAFT AND JUST ADDS BOILERPLATE FOR NOW**.

This is the node ID we can use to test it with: https://prod.cms.va.gov/node/7910

## Testing done
N/A

## Screenshots
N/A

## Acceptance criteria
- [ ] Implement the about template (`support_resources_detail_page`)

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
