### PR TITLE
10-10CG Transform Bug Fix

### DIFF
--- a/src/applications/caregivers/definitions/constants.js
+++ b/src/applications/caregivers/definitions/constants.js
@@ -39,7 +39,7 @@ export const secondaryCaregiverFields = {
     email: 'secondaryOneEmail',
     fullName: 'secondaryOneFullName',
     gender: 'secondaryOneGender',
-    hasSecondaryCaregiverTwoView: 'view:hassecondaryCaregiverTwo',
+    hasSecondaryCaregiverTwoView: 'view:hasSecondaryCaregiverTwo',
     primaryPhoneNumber: 'secondaryOnePrimaryPhoneNumber',
     ssn: 'secondaryOneSsnOrTin',
     verifyEmail: 'view:secondaryOneEmail',

--- a/src/applications/caregivers/helpers.js
+++ b/src/applications/caregivers/helpers.js
@@ -33,10 +33,14 @@ const medicalCentersByState = _.mapValues(
 const submitTransform = (formConfig, form) => {
   // checks for optional chapters using ssnOrTin
   const hasSecondaryOne =
-    form.data.secondaryOneSsnOrTin === undefined ? null : 'secondaryOne';
+    form.data['view:hasSecondaryCaregiverOne'] === undefined
+      ? null
+      : 'secondaryOne';
 
   const hasSecondaryTwo =
-    form.data.secondaryTwoSsnOrTin === undefined ? null : 'secondaryTwo';
+    form.data['view:hasSecondaryCaregiverTwo'] === undefined
+      ? null
+      : 'secondaryTwo';
 
   // creates chapter objects by matching chapter prefixes
   const buildChapterSortedObject = (data, dataPrefix) => {


### PR DESCRIPTION
## Description
When submitting a form with secondaryOne and secondaryTwo caregivers they get dropped when submitting.

## Testing done
Manual testing will follow up with a unit test right after this gets merged. Critical bug that needs to be fixed for prod testing ASAP.

## Screenshots
Minimal submission to API

```
{
  "veteran": {
    "plannedClinic": "598",
    "address": {
      "street": "333 9th Ave N, #1",
      "city": "St. Petersburg",
      "state": "FL",
      "postalCode": "33701"
    },
    "primaryPhoneNumber": "7277092806",
    "fullName": {
      "first": "John",
      "last": "DOe"
    },
    "ssnOrTin": "777887777",
    "dateOfBirth": "1990-01-01"
  },
  "primaryCaregiver": {
    "hasHealthInsurance": true,
    "address": {
      "street": "333 9th Ave N, #1",
      "city": "St. Petersburg",
      "state": "FL",
      "postalCode": "33701"
    },
    "primaryPhoneNumber": "7277092806",
    "alternativePhoneNumber": "7277092806",
    "vetRelationship": "Father",
    "fullName": {
      "first": "John",
      "last": "Doe"
    },
    "dateOfBirth": "1990-01-01"
  },
  "secondaryCaregiverOne": {
    "address": {
      "street": "333 9th Ave N, #1",
      "city": "St. Petersburg",
      "state": "FL",
      "postalCode": "33701"
    },
    "primaryPhoneNumber": "7277092806",
    "vetRelationship": "Father",
    "fullName": {
      "first": "John",
      "last": "Doe"
    },
    "dateOfBirth": "1990-01-01"
  },
  "secondaryCaregiverTwo": {
    "address": {
      "street": "333 9th Ave N, #1",
      "city": "St. Petersburg",
      "state": "FL",
      "postalCode": "33701"
    },
    "primaryPhoneNumber": "7277092806",
    "vetRelationship": "Son",
    "fullName": {
      "first": "John",
      "last": "DOe"
    },
    "dateOfBirth": "1990-01-01"
  }
}
```

## Acceptance criteria
- [x] SecondaryOne and SecondaryTwo get submitted to BE

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
