### PR TITLE
Use fieldTitle on aria-labels for Download links

### DIFF
--- a/src/site/paragraphs/downloadable_file.drupal.liquid
+++ b/src/site/paragraphs/downloadable_file.drupal.liquid
@@ -25,7 +25,7 @@
 
         {% assign url = entity.fieldMedia.entity.image.url %}
 
-        <a aria-label="Download {{entity.fieldMedia.entity.image.alt}}" class="file-download-with-icon" target="_blank"
+        <a aria-label="Download {{entity.fieldTitle}}" class="file-download-with-icon" target="_blank"
            href="{{url}}" download="{{url}}">
             <i class="fas fa-download vads-u-margin--0p5"></i>{{entity.fieldTitle}} ({{url | fileExt | upcase}})
         </a>
@@ -33,7 +33,7 @@
 
     {% if entity.fieldMedia.entity.entityBundle == 'document' %}
         {% assign url = entity.fieldMedia.entity.fieldDocument.entity.url %}
-        <a aria-label="Download {{entity.fieldMedia.entity.fieldDocument.filename}}" class="file-download-with-icon" target="_blank"
+        <a aria-label="Download {{entity.fieldTitle}}" class="file-download-with-icon" target="_blank"
            href="{{url}}" download="{{url}}">
             <i class="fas fa-download vads-u-margin--0p5"></i>{{entity.fieldTitle}} ({{url | fileExt | upcase}})
         </a>


### PR DESCRIPTION
https://github.com/department-of-veterans-affairs/va.gov-team/issues/5473

## Description
The `aria-label` attributes on download links were missing the document title.

## Acceptance criteria
- [x] The `aria-label` attributes on download links contain the "link title"

## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
