### PR TITLE
added stem text feature flag

### DIFF
--- a/src/platform/utilities/feature-toggles/featureFlagNames.js
+++ b/src/platform/utilities/feature-toggles/featureFlagNames.js
@@ -48,6 +48,7 @@ export default Object.freeze({
   showEduBenefits1990EWizard: 'show_edu_benefits_1990e_wizard',
   showEduBenefits1990Wizard: 'show_edu_benefits_1990_wizard',
   stemSCOEmail: 'stem_sco_email',
+  stemTextMessageQuestion: 'stem_text_message_question',
   showHealthcareExperienceQuestionnaire:
     'showHealthcareExperienceQuestionnaire',
   showNewGetMedicalRecordsPage: 'show_new_get_medical_records_page',


### PR DESCRIPTION
## Description
As a developer, I need a way to toggle when the new text message option question is displayed within the 10203 form, so that it can be delivered when EDU is ready to accept the data.
https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/13826


backend pr: https://github.com/department-of-veterans-affairs/vets-api/pull/4981
## Testing done

local testing
## Screenshots


## Acceptance criteria
- [x] The Feature Flag stem_text_message_question is available to be used for the text message enhancements.
- [x] The Feature Flag description is: "Add text message opt-in question to 10203 Personal Information chapter and layout changes"
- [x] The text message feature flag is created and available in all environments.

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
