### PR TITLE
[Find forms] Update text for blue box pointing to health care app

### DIFF
--- a/src/applications/find-forms/components/FindVaForms.jsx
+++ b/src/applications/find-forms/components/FindVaForms.jsx
@@ -87,7 +87,7 @@ export default () => (
           onClick={onFeaturedContentClick('Apply for VA health care benefits')}
         >
           <span>
-            Read more
+            Apply online
             <span className="vads-u-visibility--screen-reader">
               about applying for VA health care benefits
             </span>


### PR DESCRIPTION
## Description
This PR changes the "read more" link on /find-forms to ready "apply online" for the health care app.

https://github.com/department-of-veterans-affairs/va.gov-team/issues/12535

## Testing done
This is just a plain text update

## Screenshots


## Acceptance criteria
- [ ] Text is updated

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
