### PR TITLE
Fix signature box not un-signing on unMount 

### DIFF
--- a/src/applications/caregivers/components/PreSubmitInfo/SignatureCheckbox.jsx
+++ b/src/applications/caregivers/components/PreSubmitInfo/SignatureCheckbox.jsx
@@ -62,7 +62,7 @@ const SignatureCheckbox = ({
 };
 
 SignatureCheckbox.propTypes = {
-  children: PropTypes.any,
+  children: PropTypes.object,
   fullName: PropTypes.object.isRequired,
   isRequired: PropTypes.bool,
   label: PropTypes.string.isRequired,

--- a/src/applications/caregivers/components/PreSubmitInfo/SignatureCheckbox.jsx
+++ b/src/applications/caregivers/components/PreSubmitInfo/SignatureCheckbox.jsx
@@ -11,20 +11,21 @@ const SignatureCheckbox = ({
   label,
   setSignature,
   showError,
-  signatures,
 }) => {
   const [isSigned, setIsSigned] = useState(false);
   const [isChecked, setIsChecked] = useState(false);
   const [hasError, setError] = useState(null);
   const isSignatureComplete = isSigned && isChecked;
+  const createInputContent = inputLabel => `Enter ${inputLabel} full name`;
 
   useEffect(
     () => {
-      setSignature({ ...signatures, [label]: isSignatureComplete });
+      setSignature(prevState => {
+        return { ...prevState, [label]: isSignatureComplete };
+      });
     },
 
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [isSignatureComplete, fullName.first, fullName.last],
+    [isSignatureComplete, label, setSignature],
   );
 
   useEffect(
@@ -45,7 +46,7 @@ const SignatureCheckbox = ({
 
       <SignatureInput
         setIsSigned={setIsSigned}
-        label={label}
+        label={createInputContent(label)}
         fullName={fullName}
         required={isRequired}
         showError={showError}
@@ -62,7 +63,7 @@ const SignatureCheckbox = ({
 };
 
 SignatureCheckbox.propTypes = {
-  children: PropTypes.object,
+  children: PropTypes.any,
   fullName: PropTypes.object.isRequired,
   isRequired: PropTypes.bool,
   label: PropTypes.string.isRequired,

--- a/src/applications/caregivers/components/PreSubmitInfo/index.jsx
+++ b/src/applications/caregivers/components/PreSubmitInfo/index.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { cloneDeep } from 'lodash';
 
 import SignatureCheckbox from './SignatureCheckbox';
 
@@ -7,13 +8,12 @@ const PreSubmitCheckboxGroup = ({ onSectionComplete, formData, showError }) => {
   const primaryLabel = `Primary Family Caregiver applicant\u2019s`;
   const secondaryOneLabel = `Secondary Family Caregiver applicant\u2019s`;
   const secondaryTwoLabel = `Secondary Family Caregiver (2) applicant\u2019s`;
-  const createInputContent = label => `Enter ${label} full name`;
   const hasSecondaryOne = formData['view:hasSecondaryCaregiverOne'];
   const hasSecondaryTwo = formData['view:hasSecondaryCaregiverTwo'];
 
   const [signatures, setSignatures] = useState({
-    [createInputContent(veteranLabel)]: false,
-    [createInputContent(primaryLabel)]: false,
+    [veteranLabel]: false,
+    [primaryLabel]: false,
   });
 
   const unSignedLength = Object.values(signatures).filter(
@@ -24,9 +24,7 @@ const PreSubmitCheckboxGroup = ({ onSectionComplete, formData, showError }) => {
   // if goes to another page (unmount), set AGREED (onSectionComplete) to false
   useEffect(
     () => {
-      if (!unSignedLength) onSectionComplete(true);
-
-      if (unSignedLength) onSectionComplete(false);
+      onSectionComplete(!unSignedLength);
 
       return () => {
         onSectionComplete(false);
@@ -35,6 +33,28 @@ const PreSubmitCheckboxGroup = ({ onSectionComplete, formData, showError }) => {
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [unSignedLength],
+  );
+
+  useEffect(
+    () => {
+      if (!hasSecondaryOne) {
+        setSignatures(prevState => {
+          const newState = cloneDeep(prevState);
+          delete newState[secondaryOneLabel];
+          return newState;
+        });
+      }
+
+      if (!hasSecondaryTwo) {
+        setSignatures(prevState => {
+          const newState = cloneDeep(prevState);
+          delete newState[secondaryTwoLabel];
+          return newState;
+        });
+      }
+    },
+
+    [hasSecondaryOne, hasSecondaryTwo, secondaryOneLabel, secondaryTwoLabel],
   );
 
   const PrivacyPolicy = () => (
@@ -104,7 +124,7 @@ const PreSubmitCheckboxGroup = ({ onSectionComplete, formData, showError }) => {
 
       <SignatureCheckbox
         fullName={formData.veteranFullName}
-        label={createInputContent(veteranLabel)}
+        label={veteranLabel}
         signatures={signatures}
         setSignature={setSignatures}
         isRequired
@@ -123,7 +143,7 @@ const PreSubmitCheckboxGroup = ({ onSectionComplete, formData, showError }) => {
 
       <SignatureCheckbox
         fullName={formData.primaryFullName}
-        label={createInputContent(primaryLabel)}
+        label={primaryLabel}
         signatures={signatures}
         setSignature={setSignatures}
         isRequired
@@ -168,7 +188,7 @@ const PreSubmitCheckboxGroup = ({ onSectionComplete, formData, showError }) => {
       {hasSecondaryOne && (
         <SignatureCheckbox
           fullName={formData.secondaryOneFullName}
-          label={createInputContent(secondaryOneLabel)}
+          label={secondaryOneLabel}
           signatures={signatures}
           setSignature={setSignatures}
           isRequired
@@ -181,7 +201,7 @@ const PreSubmitCheckboxGroup = ({ onSectionComplete, formData, showError }) => {
       {hasSecondaryTwo && (
         <SignatureCheckbox
           fullName={formData.secondaryTwoFullName}
-          label={createInputContent(secondaryTwoLabel)}
+          label={secondaryTwoLabel}
           signatures={signatures}
           setSignature={setSignatures}
           isRequired

--- a/src/applications/caregivers/components/PreSubmitInfo/index.jsx
+++ b/src/applications/caregivers/components/PreSubmitInfo/index.jsx
@@ -3,56 +3,38 @@ import React, { useEffect, useState } from 'react';
 import SignatureCheckbox from './SignatureCheckbox';
 
 const PreSubmitCheckboxGroup = ({ onSectionComplete, formData, showError }) => {
-  const veteranLabel = `Enter Veteran\u2019s full name`;
-  const primaryLabel = `Enter Primary Family Caregiver applicant\u2019s full name`;
-  const secondaryOneLabel = `Enter Secondary Family Caregiver applicant\u2019s full name`;
-  const secondaryTwoLabel = `Enter Secondary Family Caregiver applicant\u2019s (2) full name`;
+  const veteranLabel = `Veteran\u2019s`;
+  const primaryLabel = `Primary Family Caregiver applicant\u2019s`;
+  const secondaryOneLabel = `Secondary Family Caregiver applicant\u2019s`;
+  const secondaryTwoLabel = `Secondary Family Caregiver (2) applicant\u2019s`;
+  const createInputContent = label => `Enter ${label} full name`;
+  const hasSecondaryOne = formData['view:hasSecondaryCaregiverOne'];
+  const hasSecondaryTwo = formData['view:hasSecondaryCaregiverTwo'];
 
-  const [signatures, setSignature] = useState({
-    [veteranLabel]: false,
-    [primaryLabel]: false,
+  const [signatures, setSignatures] = useState({
+    [createInputContent(veteranLabel)]: false,
+    [createInputContent(primaryLabel)]: false,
   });
 
-  const [secondaryCaregivers, setSecondaryCaregivers] = useState({
-    [secondaryOneLabel]: false,
-    [secondaryTwoLabel]: false,
-  });
   const unSignedLength = Object.values(signatures).filter(
     obj => Boolean(obj) === false,
   ).length;
 
+  // when there is no unsigned signatures set AGREED (onSectionComplete) to true
+  // if goes to another page (unmount), set AGREED (onSectionComplete) to false
   useEffect(
     () => {
-      if (!unSignedLength) {
-        onSectionComplete(true);
-      }
+      if (!unSignedLength) onSectionComplete(true);
 
-      if (unSignedLength) {
+      if (unSignedLength) onSectionComplete(false);
+
+      return () => {
         onSectionComplete(false);
-      }
-
-      const hasSecondaryOne =
-        formData?.secondaryOneFullName?.first &&
-        formData?.secondaryOneFullName?.last;
-
-      const hasSecondaryTwo =
-        formData?.secondaryTwoFullName?.first &&
-        formData?.secondaryTwoFullName?.last;
-
-      setSecondaryCaregivers({
-        hasSecondaryOne,
-        hasSecondaryTwo,
-      });
+      };
     },
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [
-      formData.secondaryOneFullName.first,
-      formData.secondaryOneFullName.last,
-      formData.secondaryTwoFullName.first,
-      formData.secondaryTwoFullName.last,
-      unSignedLength,
-    ],
+    [unSignedLength],
   );
 
   const PrivacyPolicy = () => (
@@ -122,9 +104,9 @@ const PreSubmitCheckboxGroup = ({ onSectionComplete, formData, showError }) => {
 
       <SignatureCheckbox
         fullName={formData.veteranFullName}
-        label={veteranLabel}
+        label={createInputContent(veteranLabel)}
         signatures={signatures}
-        setSignature={setSignature}
+        setSignature={setSignatures}
         isRequired
         showError={showError}
       >
@@ -141,9 +123,9 @@ const PreSubmitCheckboxGroup = ({ onSectionComplete, formData, showError }) => {
 
       <SignatureCheckbox
         fullName={formData.primaryFullName}
-        label={primaryLabel}
+        label={createInputContent(primaryLabel)}
         signatures={signatures}
-        setSignature={setSignature}
+        setSignature={setSignatures}
         isRequired
         showError={showError}
       >
@@ -183,29 +165,29 @@ const PreSubmitCheckboxGroup = ({ onSectionComplete, formData, showError }) => {
         <PrivacyPolicy />
       </SignatureCheckbox>
 
-      {secondaryCaregivers.hasSecondaryOne && (
+      {hasSecondaryOne && (
         <SignatureCheckbox
           fullName={formData.secondaryOneFullName}
-          label={secondaryOneLabel}
+          label={createInputContent(secondaryOneLabel)}
           signatures={signatures}
-          setSignature={setSignature}
+          setSignature={setSignatures}
           isRequired
           showError={showError}
         >
-          <SecondaryCaregiverCopy label="Secondary Family Caregiver applicant&apos;s" />
+          <SecondaryCaregiverCopy label={secondaryOneLabel} />
         </SignatureCheckbox>
       )}
 
-      {secondaryCaregivers.hasSecondaryTwo && (
+      {hasSecondaryTwo && (
         <SignatureCheckbox
           fullName={formData.secondaryTwoFullName}
-          label={secondaryTwoLabel}
+          label={createInputContent(secondaryTwoLabel)}
           signatures={signatures}
-          setSignature={setSignature}
+          setSignature={setSignatures}
           isRequired
           showError={showError}
         >
-          <SecondaryCaregiverCopy label="Secondary Family Caregiver (2) applicant&apos;s" />
+          <SecondaryCaregiverCopy label={secondaryTwoLabel} />
         </SignatureCheckbox>
       )}
 

--- a/src/applications/caregivers/definitions/caregiverUI.js
+++ b/src/applications/caregivers/definitions/caregiverUI.js
@@ -97,9 +97,6 @@ export default {
       'ui:title': ' ',
       'ui:description': AdditionalCaregiverInfo(),
       'ui:widget': 'yesNo',
-      'ui:options': {
-        hideOnReview: true,
-      },
     },
   },
   vetUI: {

--- a/src/applications/caregivers/helpers.js
+++ b/src/applications/caregivers/helpers.js
@@ -1,4 +1,4 @@
-import _ from 'lodash/fp';
+import { mapValues } from 'lodash/fp';
 import caregiverFacilities from 'vets-json-schema/dist/caregiverProgramFacilities.json';
 import { transformForSubmit } from 'platform/forms-system/src/js/helpers';
 import {
@@ -24,7 +24,7 @@ const medicalCenterLabels = Object.keys(caregiverFacilities).reduce(
 );
 
 // Turns the facility list for each state into an array of strings
-const medicalCentersByState = _.mapValues(
+const medicalCentersByState = mapValues(
   val => val.map(center => center.code),
   caregiverFacilities,
 );


### PR DESCRIPTION
## Description
When the user navigate backwards after signing the 1010CG the signature box should un-signing this way if the data changes the form has to be re-agreed to if the parties change.

## Screenshots


## Acceptance criteria
- [x] When I click the "Submit" button while there invalid (or no) signatures, nothing happens. All signatures must still be valid before the click button responses to a click.

- [x] If I remove a secondary caregiver from my application, I should not see a signature field on the review page for that caregiver.



## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
