### PR TITLE
Remove try again later message from all 400 errors

### DIFF
--- a/src/applications/vaos/appointment-list/redux/actions.js
+++ b/src/applications/vaos/appointment-list/redux/actions.js
@@ -25,7 +25,7 @@ import {
   isVideoAppointment,
 } from '../../services/appointment';
 
-import { captureError, getErrorCodes } from '../../utils/error';
+import { captureError, has400LevelError } from '../../utils/error';
 import { STARTED_NEW_APPOINTMENT_FLOW } from '../../redux/sitewide';
 
 export const FETCH_FUTURE_APPOINTMENTS = 'vaos/FETCH_FUTURE_APPOINTMENTS';
@@ -387,7 +387,7 @@ export function confirmCancelAppointment() {
       });
       resetDataLayer();
     } catch (e) {
-      const isVaos400Error = getErrorCodes(e).includes('VAOS_400');
+      const isVaos400Error = has400LevelError(e);
       if (isVaos400Error) {
         Sentry.withScope(scope => {
           scope.setExtra('error', e);

--- a/src/applications/vaos/new-appointment/components/ReviewPage/index.jsx
+++ b/src/applications/vaos/new-appointment/components/ReviewPage/index.jsx
@@ -84,27 +84,22 @@ export class ReviewPage extends React.Component {
         {submitStatus === FETCH_STATUS.failed && (
           <AlertBox
             status="error"
-            headline={
-              submitStatusVaos400
-                ? 'We’re sorry. We can’t schedule your appointment'
-                : `We’re sorry. Your ${
-                    isDirectSchedule ? 'appointment' : 'request'
-                  } didn’t go through`
-            }
+            headline="We couldn’t schedule this appointment"
             content={
               <>
                 {submitStatusVaos400 ? (
                   <p>
-                    You can’t schedule your appointment on the VA appointments
-                    tool. Please contact your local VA medical center to
-                    schedule this appointment:
+                    We’re sorry. Something went wrong when we tried to submit
+                    your {isDirectSchedule ? 'appointment' : 'request'}. You’ll
+                    need to call your local VA medical center to schedule this
+                    appointment.
                   </p>
                 ) : (
                   <p>
-                    Something went wrong when we tried to submit your{' '}
-                    {isDirectSchedule ? 'appointment' : 'request'} and you’ll
-                    need to start over. We suggest you wait a day to try again
-                    or you can call your medical center to help with your{' '}
+                    We’re sorry. Something went wrong when we tried to submit
+                    your {isDirectSchedule ? 'appointment' : 'request'} and
+                    you’ll need to start over. We suggest you wait a day to try
+                    again or you can call your medical center to help with your{' '}
                     {isDirectSchedule ? 'appointment' : 'request'}.
                   </p>
                 )}

--- a/src/applications/vaos/new-appointment/redux/actions.js
+++ b/src/applications/vaos/new-appointment/redux/actions.js
@@ -60,7 +60,11 @@ import {
 
 import { recordEligibilityFailure, resetDataLayer } from '../../utils/events';
 
-import { captureError, getErrorCodes } from '../../utils/error';
+import {
+  captureError,
+  getErrorCodes,
+  has400LevelError,
+} from '../../utils/error';
 
 import {
   STARTED_NEW_APPOINTMENT_FLOW,
@@ -791,7 +795,7 @@ export function submitAppointmentOrRequest(history) {
         captureError(error, true);
         dispatch({
           type: FORM_SUBMIT_FAILED,
-          isVaos400Error: getErrorCodes(error).includes('VAOS_400'),
+          isVaos400Error: has400LevelError(error),
         });
 
         // Remove parse function when converting this call to FHIR service

--- a/src/applications/vaos/tests/new-appointment/components/ReviewPage/index.unit.spec.jsx
+++ b/src/applications/vaos/tests/new-appointment/components/ReviewPage/index.unit.spec.jsx
@@ -100,11 +100,13 @@ describe('VAOS <ReviewPage>', () => {
         .find('FacilityAddress')
         .exists(),
     ).to.be.true;
-    expect(alertBox.dive().text()).contain('Something went wrong');
+    expect(alertBox.dive().text()).contain(
+      'We suggest you wait a day to try again or you can call your medical center',
+    );
     tree.unmount();
   });
 
-  it('should render submit error with facility', () => {
+  it('should render 400 error with facility', () => {
     const flowType = FLOW_TYPES.REQUEST;
     const data = {};
 
@@ -128,7 +130,7 @@ describe('VAOS <ReviewPage>', () => {
         .exists(),
     ).to.be.true;
     expect(alertBox.dive().text()).contain(
-      'You can’t schedule your appointment on the VA appointments tool.',
+      'You’ll need to call your local VA medical center',
     );
     tree.unmount();
   });

--- a/src/applications/vaos/utils/error.js
+++ b/src/applications/vaos/utils/error.js
@@ -41,3 +41,7 @@ export function captureError(
 export function getErrorCodes(error) {
   return error?.errors?.map(e => e.code) || [];
 }
+
+export function has400LevelError(error) {
+  return getErrorCodes(error).some(code => code.startsWith('VAOS_4'));
+}


### PR DESCRIPTION
## Description
We have some error scenarios when submitting appointments where backend configuration means that the user won't be able to schedule, but we can't tell them beforehand. It's misleading to tell these users to try again, since it's a configuration issue, not a bug.

These issues seems to all come in as 400 level errors. We already show a different message for 400 errors, so I've tweaked that message to match the new design and expand it to all 4xx errors.

## Testing done
Local testing

## Screenshots
![Screen Shot 2020-09-29 at 11 30 35 AM](https://user-images.githubusercontent.com/634932/94579836-39c3d100-0247-11eb-99e9-a20f0a12af5b.png)

## Acceptance criteria
- [ ] Correct error message is displayed

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
