### PR TITLE
Add redirects

### DIFF
--- a/src/applications/proxy-rewrite/redirects/crossDomainRedirects.json
+++ b/src/applications/proxy-rewrite/redirects/crossDomainRedirects.json
@@ -1038,5 +1038,50 @@
     "domain": "www.benefits.va.gov",
     "src": "/gibill/fgib/stem.asp",
     "dest": "/education/other-va-education-benefits/stem-scholarship/"
+  },
+  {
+    "domain": "www.benefits.va.gov",
+    "src": "/compensation/agentorange-c123.asp",
+    "dest": "/disability/eligibility/hazardous-materials-exposure/agent-orange/"
+  },
+  {
+    "domain": "www.vets.gov",
+    "src": "/disability-benefits/conditions/exposure-to-hazardous-materials/agent-orange/diseases/",
+    "dest": "/disability/eligibility/hazardous-materials-exposure/agent-orange/"
+  },
+  {
+    "domain": "www.vets.gov",
+    "src": "/disability-benefits/conditions/exposure-to-hazardous-materials/agent-orange/non-hodgkins/",
+    "dest": "/disability/eligibility/hazardous-materials-exposure/agent-orange/"
+  },
+  {
+    "domain": "www.vets.gov",
+    "src": "/disability-benefits/conditions/exposure-to-hazardous-materials/agent-orange/c-123/",
+    "dest": "/disability/eligibility/hazardous-materials-exposure/agent-orange/"
+  },
+  {
+    "domain": "www.vets.gov",
+    "src": "/disability-benefits/conditions/exposure-to-hazardous-materials/agent-orange/navy-coast-guard/",
+    "dest": "/disability/eligibility/hazardous-materials-exposure/agent-orange/"
+  },
+  {
+    "domain": "www.vets.gov",
+    "src": "/disability-benefits/conditions/exposure-to-hazardous-materials/agent-orange/water-vietnam/",
+    "dest": "/disability/eligibility/hazardous-materials-exposure/agent-orange/"
+  },
+  {
+    "domain": "www.vets.gov",
+    "src": "/disability-benefits/conditions/exposure-to-hazardous-materials/agent-orange/service-inside/",
+    "dest": "/disability/eligibility/hazardous-materials-exposure/agent-orange/"
+  },
+  {
+    "domain": "www.vets.gov",
+    "src": "/disability-benefits/conditions/exposure-to-hazardous-materials/agent-orange/test-storage/",
+    "dest": "/disability/eligibility/hazardous-materials-exposure/agent-orange/"
+  },
+  {
+    "domain": "www.vets.gov",
+    "src": "/disability-benefits/conditions/exposure-to-hazardous-materials/agent-orange/thailand-military-bases/",
+    "dest": "/disability/eligibility/hazardous-materials-exposure/agent-orange/"
   }
 ]

--- a/src/applications/proxy-rewrite/redirects/crossDomainRedirects.json
+++ b/src/applications/proxy-rewrite/redirects/crossDomainRedirects.json
@@ -1043,45 +1043,5 @@
     "domain": "www.benefits.va.gov",
     "src": "/compensation/agentorange-c123.asp",
     "dest": "/disability/eligibility/hazardous-materials-exposure/agent-orange/"
-  },
-  {
-    "domain": "www.vets.gov",
-    "src": "/disability-benefits/conditions/exposure-to-hazardous-materials/agent-orange/diseases/",
-    "dest": "/disability/eligibility/hazardous-materials-exposure/agent-orange/"
-  },
-  {
-    "domain": "www.vets.gov",
-    "src": "/disability-benefits/conditions/exposure-to-hazardous-materials/agent-orange/non-hodgkins/",
-    "dest": "/disability/eligibility/hazardous-materials-exposure/agent-orange/"
-  },
-  {
-    "domain": "www.vets.gov",
-    "src": "/disability-benefits/conditions/exposure-to-hazardous-materials/agent-orange/c-123/",
-    "dest": "/disability/eligibility/hazardous-materials-exposure/agent-orange/"
-  },
-  {
-    "domain": "www.vets.gov",
-    "src": "/disability-benefits/conditions/exposure-to-hazardous-materials/agent-orange/navy-coast-guard/",
-    "dest": "/disability/eligibility/hazardous-materials-exposure/agent-orange/"
-  },
-  {
-    "domain": "www.vets.gov",
-    "src": "/disability-benefits/conditions/exposure-to-hazardous-materials/agent-orange/water-vietnam/",
-    "dest": "/disability/eligibility/hazardous-materials-exposure/agent-orange/"
-  },
-  {
-    "domain": "www.vets.gov",
-    "src": "/disability-benefits/conditions/exposure-to-hazardous-materials/agent-orange/service-inside/",
-    "dest": "/disability/eligibility/hazardous-materials-exposure/agent-orange/"
-  },
-  {
-    "domain": "www.vets.gov",
-    "src": "/disability-benefits/conditions/exposure-to-hazardous-materials/agent-orange/test-storage/",
-    "dest": "/disability/eligibility/hazardous-materials-exposure/agent-orange/"
-  },
-  {
-    "domain": "www.vets.gov",
-    "src": "/disability-benefits/conditions/exposure-to-hazardous-materials/agent-orange/thailand-military-bases/",
-    "dest": "/disability/eligibility/hazardous-materials-exposure/agent-orange/"
   }
 ]

--- a/src/applications/proxy-rewrite/redirects/crossDomainRedirects.json
+++ b/src/applications/proxy-rewrite/redirects/crossDomainRedirects.json
@@ -116,11 +116,6 @@
   },
   {
     "domain": "www.benefits.va.gov",
-    "src": "/compensation/agentorange-c123.asp",
-    "dest": "/disability/eligibility/hazardous-materials-exposure/agent-orange/c-123-aircraft/"
-  },
-  {
-    "domain": "www.benefits.va.gov",
     "src": "/compensation/claims-postservice-exposures-asbestos.asp",
     "dest": "/disability/eligibility/hazardous-materials-exposure/asbestos/"
   },


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/10768

This PR implements the following redirects:

| Source URL | Destination URL |
| ---------- | --------------- |
| www.benefits.va.gov/compensation/agentorange-c123.asp | www.va.gov/disability/eligibility/hazardous-materials-exposure/agent-orange/ |

This PR does **NOT** implement the remaining redirects, you can find these in [this PR](https://github.com/department-of-veterans-affairs/devops/pull/7672).

| Source URL | Destination URL |
| ---------- | --------------- |
| www.vets.gov/disability-benefits/conditions/exposure-to-hazardous-materials/agent-orange/diseases/ | www.va.gov/disability/eligibility/hazardous-materials-exposure/agent-orange/ |
| www.vets.gov/disability-benefits/conditions/exposure-to-hazardous-materials/agent-orange/non-hodgkins/ | www.va.gov/disability/eligibility/hazardous-materials-exposure/agent-orange/ |
| www.vets.gov/disability-benefits/conditions/exposure-to-hazardous-materials/agent-orange/c-123/ | www.va.gov/disability/eligibility/hazardous-materials-exposure/agent-orange/ |
| www.vets.gov/disability-benefits/conditions/exposure-to-hazardous-materials/agent-orange/navy-coast-guard/ | www.va.gov/disability/eligibility/hazardous-materials-exposure/agent-orange/ |
| www.vets.gov/disability-benefits/conditions/exposure-to-hazardous-materials/agent-orange/water-vietnam/ | www.va.gov/disability/eligibility/hazardous-materials-exposure/agent-orange/ |
| www.vets.gov/disability-benefits/conditions/exposure-to-hazardous-materials/agent-orange/service-inside/ | www.va.gov/disability/eligibility/hazardous-materials-exposure/agent-orange/ |
| www.vets.gov/disability-benefits/conditions/exposure-to-hazardous-materials/agent-orange/test-storage/ | www.va.gov/disability/eligibility/hazardous-materials-exposure/agent-orange/ |
| www.vets.gov/disability-benefits/conditions/exposure-to-hazardous-materials/agent-orange/thailand-military-bases/ | www.va.gov/disability/eligibility/hazardous-materials-exposure/agent-orange/ |
| www.va.gov/disability/eligibility/hazardous-materials-exposure/agent-orange/registry-health-exam/ | https://www.publichealth.va.gov/exposures/agentorange/benefits/registry-exam.asp |
| www.vets.gov/disability-benefits/conditions/exposure-to-hazardous-materials/agent-orange/registry-health-exam/ | https://www.publichealth.va.gov/exposures/agentorange/benefits/registry-exam.asp |
| www.va.gov/disability/eligibility/hazardous-materials-exposure/agent-orange/related-diseases/ | http://www.va.gov/disability/eligibility/hazardous-materials-exposure/agent-orange/ |
| www.va.gov/disability/eligibility/hazardous-materials-exposure/agent-orange/c-123-aircraft/ | http://www.va.gov/disability/eligibility/hazardous-materials-exposure/agent-orange/ |
| www.va.gov/disability/eligibility/hazardous-materials-exposure/agent-orange/navy-coast-guard-ships-vietnam/ | http://www.va.gov/disability/eligibility/hazardous-materials-exposure/agent-orange/ |
| www.va.gov/disability/eligibility/hazardous-materials-exposure/agent-orange/service-in-vietnam-korea/ | http://www.va.gov/disability/eligibility/hazardous-materials-exposure/agent-orange/ |
| www.va.gov/disability/eligibility/hazardous-materials-exposure/agent-orange/testing-storage-areas/ | http://www.va.gov/disability/eligibility/hazardous-materials-exposure/agent-orange/ |
| www.va.gov/disability/eligibility/hazardous-materials-exposure/agent-orange/thailand-military-bases/ | http://www.va.gov/disability/eligibility/hazardous-materials-exposure/agent-orange/ |


## Testing done
N/A

## Screenshots
N/A

## Acceptance criteria
- [x] Add redirects

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
