### PR TITLE
1010CG Returning Empty Object to API

### DIFF
--- a/src/applications/caregivers/helpers.js
+++ b/src/applications/caregivers/helpers.js
@@ -32,15 +32,13 @@ const medicalCentersByState = _.mapValues(
 // transforms forData to match fullSchema structure for backend submission
 const submitTransform = (formConfig, form) => {
   // checks for optional chapters using ssnOrTin
-  const hasSecondaryOne =
-    form.data['view:hasSecondaryCaregiverOne'] === undefined
-      ? null
-      : 'secondaryOne';
+  const hasSecondaryOne = form.data['view:hasSecondaryCaregiverOne']
+    ? 'secondaryOne'
+    : null;
 
-  const hasSecondaryTwo =
-    form.data['view:hasSecondaryCaregiverTwo'] === undefined
-      ? null
-      : 'secondaryTwo';
+  const hasSecondaryTwo = form.data['view:hasSecondaryCaregiverTwo']
+    ? 'secondaryTwo'
+    : null;
 
   // creates chapter objects by matching chapter prefixes
   const buildChapterSortedObject = (data, dataPrefix) => {


### PR DESCRIPTION
## Description
When submitting the 1010CG it would return an empty object for an absent party when a user filled out false. Reversed the ternary so we are checking for all falsy values rather than just undefined.


## Acceptance criteria
- [x] When filing out 1010CG and you pass in false for secondary caregivers it should not submit any object to BE

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
