### PR TITLE
Fix 508 violations due to duplicate IDs (13998)

### DIFF
--- a/src/applications/facility-locator/components/markers/FacilityMarker.jsx
+++ b/src/applications/facility-locator/components/markers/FacilityMarker.jsx
@@ -5,9 +5,7 @@ import React from 'react';
 function FacilityMarker({ position, onClick, markerText }) {
   return (
     <DivMarker position={position} onClick={onClick}>
-      <span className="i-pin-card-map" id="marker-id">
-        {markerText}
-      </span>
+      <span className="i-pin-card-map">{markerText}</span>
     </DivMarker>
   );
 }

--- a/src/applications/facility-locator/components/search-results-items/CCProviderResult.jsx
+++ b/src/applications/facility-locator/components/search-results-items/CCProviderResult.jsx
@@ -18,9 +18,7 @@ const CCProviderResult = ({ provider, query }) => {
         />
         <span>
           <ProviderServiceDescription provider={provider} query={query} />
-          <h3 id="provider-name" className="vads-u-font-size--h5 no-marg-top">
-            {name}
-          </h3>
+          <h3 className="vads-u-font-size--h5 no-marg-top">{name}</h3>
           {provider.attributes.orgName && (
             <h6>{provider.attributes.orgName}</h6>
           )}

--- a/src/applications/facility-locator/components/search-results-items/PharmacyResult.jsx
+++ b/src/applications/facility-locator/components/search-results-items/PharmacyResult.jsx
@@ -15,9 +15,7 @@ const PharmacyResult = ({ provider, query }) => {
           markerText={provider.markerText}
         />
         <span>
-          <h3 id="provider-name" className="vads-u-font-size--h5 no-marg-top">
-            {name}
-          </h3>
+          <h3 className="vads-u-font-size--h5 no-marg-top">{name}</h3>
           {provider.attributes.orgName && (
             <h6>{provider.attributes.orgName}</h6>
           )}

--- a/src/applications/facility-locator/components/search-results-items/UrgentCareResult.jsx
+++ b/src/applications/facility-locator/components/search-results-items/UrgentCareResult.jsx
@@ -19,9 +19,7 @@ const UrgentCareResult = ({ provider, query }) => {
           markerText={provider.markerText}
         />
         <span>
-          <h3 id="provider-name" className="vads-u-font-size--h5 no-marg-top">
-            {name}
-          </h3>
+          <h3 className="vads-u-font-size--h5 no-marg-top">{name}</h3>
           {provider.attributes.orgName && (
             <h6>{provider.attributes.orgName}</h6>
           )}

--- a/src/applications/facility-locator/components/search-results-items/VaFacilityResult.jsx
+++ b/src/applications/facility-locator/components/search-results-items/VaFacilityResult.jsx
@@ -24,11 +24,11 @@ const VaFacilityResult = ({ location, query, index }) => {
           }}
         >
           {isVADomain(website) ? (
-            <h3 id="facility-name" className="vads-u-font-size--h5 no-marg-top">
+            <h3 className="vads-u-font-size--h5 no-marg-top">
               <a href={website}>{name}</a>
             </h3>
           ) : (
-            <h3 id="facility-name" className="vads-u-font-size--h5 no-marg-top">
+            <h3 className="vads-u-font-size--h5 no-marg-top">
               <Link to={`facility/${location.id}`}>{name}</Link>
             </h3>
           )}

--- a/src/applications/facility-locator/tests/components/CCProviderResult.unit.spec.jsx
+++ b/src/applications/facility-locator/tests/components/CCProviderResult.unit.spec.jsx
@@ -17,8 +17,8 @@ describe('CCProviderResult', () => {
     expect(wrapper.find('LocationAddress').length).to.equal(1);
     expect(wrapper.find('LocationDirectionsLink').length).to.equal(1);
     expect(wrapper.find('LocationPhoneLink').length).to.equal(1);
-    expect(wrapper.find('#provider-name').text()).to.equal('BADEA, LUANA');
-    expect(wrapper.find('#provider-name a').length).to.equal(0);
+    expect(wrapper.find('.facility-result h3').text()).to.equal('BADEA, LUANA');
+    expect(wrapper.find('.facility-result a').length).to.equal(0);
     expect(wrapper.find('LocationOperationStatus').length).to.equal(0);
 
     wrapper.unmount();

--- a/src/applications/facility-locator/tests/components/PharmacyResult.unit.spec.jsx
+++ b/src/applications/facility-locator/tests/components/PharmacyResult.unit.spec.jsx
@@ -16,8 +16,8 @@ describe('PharmacyResult', () => {
     expect(wrapper.find('LocationAddress').length).to.equal(1);
     expect(wrapper.find('LocationDirectionsLink').length).to.equal(1);
     expect(wrapper.find('LocationPhoneLink').length).to.equal(1);
-    expect(wrapper.find('#provider-name').text()).to.equal('CVS');
-    expect(wrapper.find('#provider-name a').length).to.equal(0);
+    expect(wrapper.find('.facility-result h3').text()).to.equal('CVS');
+    expect(wrapper.find('.facility-result a').length).to.equal(0);
     expect(wrapper.find('LocationOperationStatus').length).to.equal(0);
     wrapper.unmount();
   });

--- a/src/applications/facility-locator/tests/components/UrgentCareResult.unit.spec.jsx
+++ b/src/applications/facility-locator/tests/components/UrgentCareResult.unit.spec.jsx
@@ -17,10 +17,10 @@ describe('UrgentCareResult', () => {
     expect(wrapper.find('LocationAddress').length).to.equal(1);
     expect(wrapper.find('LocationDirectionsLink').length).to.equal(1);
     expect(wrapper.find('LocationPhoneLink').length).to.equal(1);
-    expect(wrapper.find('#provider-name').text()).to.equal(
+    expect(wrapper.find('.facility-result h3').text()).to.equal(
       'FastMed Urgent Care',
     );
-    expect(wrapper.find('#provider-name a').length).to.equal(0);
+    expect(wrapper.find('.facility-result h3 a').length).to.equal(0);
     expect(wrapper.find('LocationOperationStatus').length).to.equal(0);
 
     wrapper.unmount();
@@ -38,10 +38,10 @@ describe('UrgentCareResult', () => {
     expect(wrapper.find('LocationAddress').length).to.equal(1);
     expect(wrapper.find('LocationDirectionsLink').length).to.equal(1);
     expect(wrapper.find('LocationPhoneLink').length).to.equal(1);
-    expect(wrapper.find('#provider-name').text()).to.equal(
+    expect(wrapper.find('.facility-result h3').text()).to.equal(
       "Overton Brooks Veterans' Administration Medical Center",
     );
-    expect(wrapper.find('#provider-name a').length).to.equal(0);
+    expect(wrapper.find('.facility-result h3 a').length).to.equal(0);
     expect(wrapper.find('LocationOperationStatus').length).to.equal(0);
 
     wrapper.unmount();

--- a/src/applications/facility-locator/tests/components/VaFacilityResult.unit.spec.jsx
+++ b/src/applications/facility-locator/tests/components/VaFacilityResult.unit.spec.jsx
@@ -17,7 +17,7 @@ describe('VaFacilityResult', () => {
     expect(wrapper.find('LocationAddress').length).to.equal(1);
     expect(wrapper.find('LocationDirectionsLink').length).to.equal(1);
     expect(wrapper.find('LocationPhoneLink').length).to.equal(1);
-    expect(wrapper.find('#facility-name Link').html()).to.equal(
+    expect(wrapper.find('.facility-result Link').html()).to.equal(
       '<a>Austin VA Clinic</a>',
     );
     expect(wrapper.find('LocationOperationStatus').length).to.equal(0);
@@ -35,7 +35,7 @@ describe('VaFacilityResult', () => {
     expect(wrapper.find('LocationAddress').length).to.equal(1);
     expect(wrapper.find('LocationDirectionsLink').length).to.equal(1);
     expect(wrapper.find('LocationPhoneLink').length).to.equal(1);
-    expect(wrapper.find('#facility-name Link').html()).to.equal(
+    expect(wrapper.find('.facility-result h3 Link').html()).to.equal(
       '<a>VetSuccess on Campus at Los Angeles City College</a>',
     );
     expect(wrapper.find('LocationOperationStatus').length).to.equal(0);
@@ -53,7 +53,7 @@ describe('VaFacilityResult', () => {
     expect(wrapper.find('LocationAddress').length).to.equal(1);
     expect(wrapper.find('LocationDirectionsLink').length).to.equal(1);
     expect(wrapper.find('LocationPhoneLink').length).to.equal(1);
-    expect(wrapper.find('#facility-name Link').html()).to.equal(
+    expect(wrapper.find('.facility-result h3 Link').html()).to.equal(
       '<a>Washington State Veterans Cemetery Medical Lake</a>',
     );
     expect(wrapper.find('LocationOperationStatus').length).to.equal(1);
@@ -71,7 +71,7 @@ describe('VaFacilityResult', () => {
     expect(wrapper.find('LocationAddress').length).to.equal(1);
     expect(wrapper.find('LocationDirectionsLink').length).to.equal(1);
     expect(wrapper.find('LocationPhoneLink').length).to.equal(1);
-    expect(wrapper.find('#facility-name a').props().href).to.equal(
+    expect(wrapper.find('.facility-result a').props().href).to.equal(
       'https://va.gov/alexandria',
     );
     expect(wrapper.find('LocationOperationStatus').length).to.equal(0);

--- a/src/applications/facility-locator/tests/e2e/gaEvents.cypress.spec.js
+++ b/src/applications/facility-locator/tests/e2e/gaEvents.cypress.spec.js
@@ -21,14 +21,14 @@ describe('Google Analytics FL Events', () => {
       cy.get('#facility-type-dropdown').select('VA health');
       cy.get('#facility-search').click();
       cy.injectAxe();
-      cy.axeCheck('main', { _13647Exception: true });
+      cy.axeCheck();
 
       cy.get('#map-id', { timeout: 10000 }).should(() => {
         assertDataLayerEvent(win, 'fl-search');
         assertDataLayerEvent(win, 'fl-search-results');
       });
 
-      cy.get('#marker-id')
+      cy.get('.i-pin-card-map')
         .first()
         .click()
         .as('markerClick')

--- a/src/applications/facility-locator/tests/e2e/mobile.cypress.spec.js
+++ b/src/applications/facility-locator/tests/e2e/mobile.cypress.spec.js
@@ -1,7 +1,7 @@
 import path from 'path';
 
-Cypress.Commands.add('checkSearch', ({ _13647Exception = false }) => {
-  cy.axeCheck('main', { _13647Exception });
+Cypress.Commands.add('checkSearch', () => {
+  cy.axeCheck();
 
   // Search
   cy.get('#street-city-state-zip').type('Austin, TX');
@@ -47,19 +47,19 @@ describe('Mobile', () => {
 
     // iPhone X
     cy.viewport(400, 812);
-    cy.checkSearch({ _13647Exception: true });
+    cy.checkSearch();
 
     // iPhone 6/7/8 plus
     cy.viewport(414, 736);
-    cy.checkSearch({ _13647Exception: true });
+    cy.checkSearch();
 
     // Pixel 2
     cy.viewport(411, 731);
-    cy.checkSearch({ _13647Exception: true });
+    cy.checkSearch();
 
     // Galaxy S5/Moto
     cy.viewport(360, 640);
-    cy.checkSearch({ _13647Exception: true });
+    cy.checkSearch();
   });
 
   it('should render the appropriate elements at each breakpoint', () => {

--- a/src/applications/facility-locator/tests/e2e/search.cypress.spec.js
+++ b/src/applications/facility-locator/tests/e2e/search.cypress.spec.js
@@ -80,7 +80,7 @@ describe('Facility search', () => {
     cy.get('#facility-search').click();
 
     cy.injectAxe();
-    cy.axeCheck('main', { _13647Exception: true });
+    cy.axeCheck();
 
     cy.get('.facility-result a').should('exist');
     cy.route(
@@ -93,7 +93,7 @@ describe('Facility search', () => {
       .first()
       .click();
 
-    cy.axeCheck('main', { _13647Exception: true });
+    cy.axeCheck();
 
     cy.get('.all-details').should('exist');
 
@@ -169,7 +169,7 @@ describe('Facility search', () => {
     cy.get('#other-tools').should('exist');
 
     cy.injectAxe();
-    cy.axeCheck('main', { _13647Exception: true });
+    cy.axeCheck();
 
     cy.get('.facility-result h3').contains('Concentra Urgent Care');
     cy.get('.va-pagination').should('not.exist');
@@ -190,7 +190,7 @@ describe('Facility search', () => {
     cy.get('#other-tools').should('exist');
 
     cy.injectAxe();
-    cy.axeCheck('main', { _13647Exception: true });
+    cy.axeCheck();
 
     cy.get('.facility-result h3').contains('MinuteClinic');
     cy.get('.va-pagination').should('not.exist');
@@ -231,7 +231,7 @@ describe('Facility search', () => {
     cy.get('.facility-search-results').contains(
       /Something’s not quite right. Please enter a valid or different location and try your search again./gi,
     );
-    cy.axeCheck('main', { _13647Exception: true });
+    cy.axeCheck();
 
     // Valid location search
     cy.route('GET', '/geocoding/**/*', 'fx:constants/mock-geocoding-data').as(
@@ -245,7 +245,7 @@ describe('Facility search', () => {
       'Results for "VA health", "Primary care" near "Austin, Texas"',
     );
     cy.get('.facility-result a').should('exist');
-    cy.axeCheck('main', { _13647Exception: true });
+    cy.axeCheck();
   });
 
   it('finds va benefits facility in Los Angeles and views its page', () => {
@@ -264,7 +264,7 @@ describe('Facility search', () => {
     );
     cy.get('#other-tools').should('exist');
 
-    cy.axeCheck('main', { _13647Exception: true });
+    cy.axeCheck();
 
     cy.get('.facility-result a').contains('Los Angeles Ambulatory Care Center');
     cy.findByText(/Los Angeles Ambulatory Care Center/i, { selector: 'a' })
@@ -280,10 +280,10 @@ describe('Facility search', () => {
     cy.get('#hours-op h3').contains('Hours of operation');
     cy.get('#other-tools').should('not.exist');
 
-    cy.axeCheck('main', { _13647Exception: true });
+    cy.axeCheck();
   });
 
-  it.skip('renders static map images on detail page', () => {
+  it('renders static map images on detail page', () => {
     // from https://stackoverflow.com/questions/51246606/test-loading-of-image-in-cypress
     cy.visit('/find-locations/facility/vha_688GA');
     cy.get('[alt="Static map"]')


### PR DESCRIPTION
VSP made the axe checks more strict, and this revealed some 508 violations in the facility locator (duplicate ID's in the HTML).

This PR fixes the violations and makes the needed changes to make the tests pass.

I've also un-skipped the test for static map images, which now seems to be working (yay!).

## Acceptance criteria
- [x] All tests pass, no regressions

## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)