### PR TITLE
remove 50 char limit label for Gender Custom entry

### DIFF
--- a/src/applications/coronavirus-research/pages/covidResearchUISchema.js
+++ b/src/applications/coronavirus-research/pages/covidResearchUISchema.js
@@ -461,7 +461,7 @@ export const uiSchema = {
     },
   },
   GENDER_SELF_IDENTIFY_DETAILS: {
-    'ui:title': 'Provide your preferred description (50 characters or less)',
+    'ui:title': 'Provide your preferred description',
     'ui:options': {
       expandUnder: 'GENDER',
       expandUnderCondition: formData =>


### PR DESCRIPTION
## Description
Remove label for custom gender entry 50 character limit

## Testing done
unit tests

## Screenshots


## Acceptance criteria
- [x] label is updated

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
