### PR TITLE
fix bug with ethnicity labels on review screen

### DIFF
--- a/src/applications/coronavirus-research/containers/CustomReviewField.jsx
+++ b/src/applications/coronavirus-research/containers/CustomReviewField.jsx
@@ -22,7 +22,7 @@ export default function CustomReviewField({ children, uiSchema }) {
     case whichSelectQuestions('GENDER'):
       selectQuestionTitle = 'Gender';
       break;
-    case whichSelectQuestions('RACE_ETHNICITY_ORIGIN'):
+    case whichSelectQuestions('RACE_ETHNICITY'):
       selectQuestionTitle = 'Race, ethnicity, and origin';
       break;
     default:


### PR DESCRIPTION
## Description
Labels were not showing for Race, Ethnicity and Origin on review screen 

## Testing done
manual and unit tests

## Screenshots
![image](https://user-images.githubusercontent.com/2481110/94583664-b35dbe00-024b-11eb-91ae-e676e2e19dde.png)


## Acceptance criteria
- [x] Labels show

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
