### PR TITLE
Enable 1010CG CTA for flipper

### DIFF
--- a/src/applications/static-pages/caregiver-content-toggle/widget.jsx
+++ b/src/applications/static-pages/caregiver-content-toggle/widget.jsx
@@ -3,13 +3,13 @@ import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
 import FEATURE_FLAG_NAMES from 'platform/utilities/feature-toggles/featureFlagNames';
 import { connect } from 'react-redux';
 
-// import OnState from './On';
+import OnState from './On';
 import OffState from './Off';
 
-function CaregiverContentToggle() {
-  // if (showLinkToOnlineForm) {
-  //   return <OnState />;
-  // }
+function CaregiverContentToggle({ showLinkToOnlineForm }) {
+  if (showLinkToOnlineForm) {
+    return <OnState />;
+  }
 
   return <OffState />;
 }


### PR DESCRIPTION
## Description
Needed to enable 1010CG CTA so feature flip works on content page

## Testing done
Tested locally

## Screenshots
![content-flip-2](https://user-images.githubusercontent.com/23741323/94589733-a5ac3680-0253-11eb-9dc8-0dfa7ab09272.gif)



## Acceptance criteria
- [x] CTA shows up on content page when feature flip is on

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
