### PR TITLE
bradl3yC - 13550 - Status field is empty

### DIFF
--- a/src/applications/debt-letters/components/DebtLetterCardV2.jsx
+++ b/src/applications/debt-letters/components/DebtLetterCardV2.jsx
@@ -32,7 +32,7 @@ const DebtLetterCardV2 = props => {
       </p>
       <p className="vads-u-margin-y--2 vads-u-font-size--md vads-u-font-family--sans">
         <strong>Status: </strong>
-        {mostRecentHistory.status}
+        {debt.diaryCodeDescription}
       </p>
       <p className="vads-u-margin-y--2 vads-u-font-size--md vads-u-font-family--sans">
         <strong>Next Step: </strong>

--- a/src/applications/debt-letters/components/DebtLettersSummaryV2.jsx
+++ b/src/applications/debt-letters/components/DebtLettersSummaryV2.jsx
@@ -100,12 +100,12 @@ class DebtLettersSummaryV2 extends Component {
           </h1>
           <div className="vads-u-display--block">
             <div className="vads-l-col--12 vads-u-padding-x--2p5 medium-screen:vads-l-col--8">
-              <h2 className="vads-u-font-size--h3 vads-u-margin-top--0 vads-u-margin-bottom--2 vads-u-font-weight--normal vads-u-line-height--6">
+              <p className="va-introtext vads-u-margin-top--0 vads-u-margin-bottom--2">
                 Check the details of VA debt you might have related to your
                 education, disability compensation, or pension benefits. Find
                 out how to pay your debt and what to do if you need financial
                 assistance.
-              </h2>
+              </p>
               {allDebtsFetchFailure && renderAlert()}
               {allDebtsEmpty && renderEmptyAlert()}
               {!allDebtsFetchFailure && (

--- a/src/applications/debt-letters/tests/actions.unit.spec.js
+++ b/src/applications/debt-letters/tests/actions.unit.spec.js
@@ -14,65 +14,73 @@ describe('fetchDebtLetters', () => {
       expect(dispatch.secondCall.args[0].type).to.equal(DEBTS_FETCH_SUCCESS);
       expect(dispatch.secondCall.args[0].debts).to.deep.equal([
         {
-          adamKey: '4',
-          fileNumber: '000000009',
+          fileNumber: 796121200,
           payeeNumber: '00',
           personEntitled: 'STUB_M',
           deductionCode: '44',
           benefitType: 'CH35 EDU',
-          amountOverpaid: 16000.0,
-          amountWithheld: 0.0,
-          originalAr: 13000,
-          currentAr: 10000,
+          diaryCode: '618',
+          diaryCodeDescription:
+            'Account returned from Treasury Cross Servicing. Account is at TOP.  TOP offsets will be applied to account as Federal funds become available.',
+          amountOverpaid: 26000,
+          amountWithheld: 0,
+          originalAr: 100,
+          currentAr: 80,
           debtHistory: [
             {
-              date: '09/18/2012',
-              letterCode: '100',
-              status: 'First Demand Letter - Inactive Benefits',
+              date: '12/19/2014',
+              letterCode: '681',
               description:
-                'First due process letter sent when debtor is not actively receiving any benefits.',
-            },
-            {
-              date: '09/28/2012',
-              letterCode: '117',
-              status: 'Second Demand Letter',
-              description:
-                'Second demand letter where debtor has no active benefits to offset so debtor is informed that debt may be referred to CRA (60 timer), TOP, CAIVRS or Cross Servicing.  CRA is only one with timer.\r\n117A - Second collections letter sent to schools',
-            },
-            {
-              date: '10/17/2012',
-              letterCode: '212',
-              status: 'Bad Address - Locator Request Sent',
-              description:
-                'Originates from mail room Beep File (file of bad addresses to be sent to LexisNexis).  Remains in this status until LexisNexis comes back with updated address information.',
-            },
-            {
-              date: '11/14/2012',
-              letterCode: '117',
-              status: 'Second Demand Letter',
-              description:
-                'Second demand letter where debtor has no active benefits to offset so debtor is informed that debt may be referred to CRA (60 timer), TOP, CAIVRS or Cross Servicing.  CRA is only one with timer.\r\n117A - Second collections letter sent to schools',
-            },
-            {
-              date: '12/11/2012',
-              letterCode: '510',
-              status:
-                'Mailing Status Inactive/Invalid - Forced to TOP/Cross Servicing',
-              description:
-                'Demand letters returned.  Unable to verify address with third party.  Account forced to TOP and/or CS.',
+                'Account returned from Treasury Cross Servicing. Account is at TOP.  TOP offsets will be applied to account as Federal funds become available.',
             },
             {
               date: '04/11/2013',
               letterCode: '080',
-              status: 'Referred To Cross Servicing',
               description: 'Debt referred to Treasury for Cross servicing',
             },
             {
-              date: '12/19/2014',
-              letterCode: '681',
-              status: 'Returned From Cross Servicing - At TOP',
+              date: '12/11/2012',
+              letterCode: '510',
               description:
-                'Account returned from Treasury Cross Servicing. Account is at TOP.  TOP offsets will be applied to account as Federal funds become available.',
+                'Demand letters returned.  Unable to verify address with third party.  Account forced to TOP and/or CS.',
+            },
+            {
+              date: '10/17/2012',
+              letterCode: '212',
+              description: 'Bad Address - Locator Request Sent',
+            },
+            {
+              date: '09/28/2012',
+              letterCode: '117',
+              description: 'Second Demand Letter',
+            },
+            {
+              date: '09/18/2012',
+              letterCode: '100',
+              description:
+                'First Demand Letter - Inactive Benefits - Due Process',
+            },
+          ],
+        },
+        {
+          fileNumber: 796121200,
+          payeeNumber: '00',
+          personEntitled: 'AJOHNS',
+          deductionCode: '71',
+          benefitType: 'CH33 Books, Supplies/MISC EDU',
+          diaryCode: '100',
+          diaryCodeDescription:
+            'First Demand Letter - Inactive Benefits - Due Process',
+          amountOverpaid: 0,
+          amountWithheld: 0,
+          originalAr: 166.67,
+          currentAr: 120.4,
+          debtHistory: [
+            {
+              date: '09/18/2012',
+              letterCode: '100',
+              description:
+                'First Demand Letter - Inactive Benefits - Due Process',
             },
           ],
         },

--- a/src/applications/debt-letters/tests/actions.unit.spec.js
+++ b/src/applications/debt-letters/tests/actions.unit.spec.js
@@ -14,73 +14,65 @@ describe('fetchDebtLetters', () => {
       expect(dispatch.secondCall.args[0].type).to.equal(DEBTS_FETCH_SUCCESS);
       expect(dispatch.secondCall.args[0].debts).to.deep.equal([
         {
-          fileNumber: 796121200,
+          adamKey: '4',
+          fileNumber: '000000009',
           payeeNumber: '00',
           personEntitled: 'STUB_M',
           deductionCode: '44',
           benefitType: 'CH35 EDU',
-          diaryCode: '618',
-          diaryCodeDescription:
-            'Account returned from Treasury Cross Servicing. Account is at TOP.  TOP offsets will be applied to account as Federal funds become available.',
-          amountOverpaid: 26000,
+          amountOverpaid: 16000,
           amountWithheld: 0,
-          originalAr: 100,
-          currentAr: 80,
+          originalAr: 13000,
+          currentAr: 10000,
           debtHistory: [
             {
-              date: '12/19/2014',
-              letterCode: '681',
+              date: '09/18/2012',
+              letterCode: '100',
+              status: 'First Demand Letter - Inactive Benefits',
               description:
-                'Account returned from Treasury Cross Servicing. Account is at TOP.  TOP offsets will be applied to account as Federal funds become available.',
-            },
-            {
-              date: '04/11/2013',
-              letterCode: '080',
-              description: 'Debt referred to Treasury for Cross servicing',
-            },
-            {
-              date: '12/11/2012',
-              letterCode: '510',
-              description:
-                'Demand letters returned.  Unable to verify address with third party.  Account forced to TOP and/or CS.',
-            },
-            {
-              date: '10/17/2012',
-              letterCode: '212',
-              description: 'Bad Address - Locator Request Sent',
+                'First due process letter sent when debtor is not actively receiving any benefits.',
             },
             {
               date: '09/28/2012',
               letterCode: '117',
-              description: 'Second Demand Letter',
+              status: 'Second Demand Letter',
+              description:
+                'Second demand letter where debtor has no active benefits to offset so debtor is informed that debt may be referred to CRA (60 timer), TOP, CAIVRS or Cross Servicing.  CRA is only one with timer.\r\n117A - Second collections letter sent to schools',
             },
             {
-              date: '09/18/2012',
-              letterCode: '100',
+              date: '10/17/2012',
+              letterCode: '212',
+              status: 'Bad Address - Locator Request Sent',
               description:
-                'First Demand Letter - Inactive Benefits - Due Process',
+                'Originates from mail room Beep File (file of bad addresses to be sent to LexisNexis).  Remains in this status until LexisNexis comes back with updated address information.',
             },
-          ],
-        },
-        {
-          fileNumber: 796121200,
-          payeeNumber: '00',
-          personEntitled: 'AJOHNS',
-          deductionCode: '71',
-          benefitType: 'CH33 Books, Supplies/MISC EDU',
-          diaryCode: '100',
-          diaryCodeDescription:
-            'First Demand Letter - Inactive Benefits - Due Process',
-          amountOverpaid: 0,
-          amountWithheld: 0,
-          originalAr: 166.67,
-          currentAr: 120.4,
-          debtHistory: [
             {
-              date: '09/18/2012',
-              letterCode: '100',
+              date: '11/14/2012',
+              letterCode: '117',
+              status: 'Second Demand Letter',
               description:
-                'First Demand Letter - Inactive Benefits - Due Process',
+                'Second demand letter where debtor has no active benefits to offset so debtor is informed that debt may be referred to CRA (60 timer), TOP, CAIVRS or Cross Servicing.  CRA is only one with timer.\r\n117A - Second collections letter sent to schools',
+            },
+            {
+              date: '12/11/2012',
+              letterCode: '510',
+              status:
+                'Mailing Status Inactive/Invalid - Forced to TOP/Cross Servicing',
+              description:
+                'Demand letters returned.  Unable to verify address with third party.  Account forced to TOP and/or CS.',
+            },
+            {
+              date: '04/11/2013',
+              letterCode: '080',
+              status: 'Referred To Cross Servicing',
+              description: 'Debt referred to Treasury for Cross servicing',
+            },
+            {
+              date: '12/19/2014',
+              letterCode: '681',
+              status: 'Returned From Cross Servicing - At TOP',
+              description:
+                'Account returned from Treasury Cross Servicing. Account is at TOP.  TOP offsets will be applied to account as Federal funds become available.',
             },
           ],
         },

--- a/src/applications/debt-letters/tests/actions.unit.spec.js
+++ b/src/applications/debt-letters/tests/actions.unit.spec.js
@@ -14,65 +14,73 @@ describe('fetchDebtLetters', () => {
       expect(dispatch.secondCall.args[0].type).to.equal(DEBTS_FETCH_SUCCESS);
       expect(dispatch.secondCall.args[0].debts).to.deep.equal([
         {
-          adamKey: '4',
-          fileNumber: '000000009',
+          fileNumber: 796121200,
           payeeNumber: '00',
           personEntitled: 'STUB_M',
           deductionCode: '44',
           benefitType: 'CH35 EDU',
-          amountOverpaid: 16000,
+          diaryCode: '618',
+          diaryCodeDescription:
+            'Account returned from Treasury Cross Servicing. Account is at TOP.  TOP offsets will be applied to account as Federal funds become available.',
+          amountOverpaid: 26000,
           amountWithheld: 0,
-          originalAr: 13000,
-          currentAr: 10000,
+          originalAr: 100,
+          currentAr: 80,
           debtHistory: [
             {
-              date: '09/18/2012',
-              letterCode: '100',
-              status: 'First Demand Letter - Inactive Benefits',
+              date: '12/19/2014',
+              letterCode: '681',
               description:
-                'First due process letter sent when debtor is not actively receiving any benefits.',
-            },
-            {
-              date: '09/28/2012',
-              letterCode: '117',
-              status: 'Second Demand Letter',
-              description:
-                'Second demand letter where debtor has no active benefits to offset so debtor is informed that debt may be referred to CRA (60 timer), TOP, CAIVRS or Cross Servicing.  CRA is only one with timer.\r\n117A - Second collections letter sent to schools',
-            },
-            {
-              date: '10/17/2012',
-              letterCode: '212',
-              status: 'Bad Address - Locator Request Sent',
-              description:
-                'Originates from mail room Beep File (file of bad addresses to be sent to LexisNexis).  Remains in this status until LexisNexis comes back with updated address information.',
-            },
-            {
-              date: '11/14/2012',
-              letterCode: '117',
-              status: 'Second Demand Letter',
-              description:
-                'Second demand letter where debtor has no active benefits to offset so debtor is informed that debt may be referred to CRA (60 timer), TOP, CAIVRS or Cross Servicing.  CRA is only one with timer.\r\n117A - Second collections letter sent to schools',
-            },
-            {
-              date: '12/11/2012',
-              letterCode: '510',
-              status:
-                'Mailing Status Inactive/Invalid - Forced to TOP/Cross Servicing',
-              description:
-                'Demand letters returned.  Unable to verify address with third party.  Account forced to TOP and/or CS.',
+                'Account returned from Treasury Cross Servicing. Account is at TOP.  TOP offsets will be applied to account as Federal funds become available.',
             },
             {
               date: '04/11/2013',
               letterCode: '080',
-              status: 'Referred To Cross Servicing',
               description: 'Debt referred to Treasury for Cross servicing',
             },
             {
-              date: '12/19/2014',
-              letterCode: '681',
-              status: 'Returned From Cross Servicing - At TOP',
+              date: '12/11/2012',
+              letterCode: '510',
               description:
-                'Account returned from Treasury Cross Servicing. Account is at TOP.  TOP offsets will be applied to account as Federal funds become available.',
+                'Demand letters returned.  Unable to verify address with third party.  Account forced to TOP and/or CS.',
+            },
+            {
+              date: '10/17/2012',
+              letterCode: '212',
+              description: 'Bad Address - Locator Request Sent',
+            },
+            {
+              date: '09/28/2012',
+              letterCode: '117',
+              description: 'Second Demand Letter',
+            },
+            {
+              date: '09/18/2012',
+              letterCode: '100',
+              description:
+                'First Demand Letter - Inactive Benefits - Due Process',
+            },
+          ],
+        },
+        {
+          fileNumber: 796121200,
+          payeeNumber: '00',
+          personEntitled: 'AJOHNS',
+          deductionCode: '71',
+          benefitType: 'CH33 Books, Supplies/MISC EDU',
+          diaryCode: '100',
+          diaryCodeDescription:
+            'First Demand Letter - Inactive Benefits - Due Process',
+          amountOverpaid: 0,
+          amountWithheld: 0,
+          originalAr: 166.67,
+          currentAr: 120.4,
+          debtHistory: [
+            {
+              date: '09/18/2012',
+              letterCode: '100',
+              description:
+                'First Demand Letter - Inactive Benefits - Due Process',
             },
           ],
         },

--- a/src/applications/debt-letters/tests/e2e/debt-letters.cypress.spec.js
+++ b/src/applications/debt-letters/tests/e2e/debt-letters.cypress.spec.js
@@ -13,7 +13,7 @@ describe('Debt Letters', () => {
   it('displays the current debts section and navigates to debt details', () => {
     cy.findByText(/Current debts/i, { selector: 'a' }).click();
     cy.get('.usa-button')
-      .contains(/Go to debt details/i)
+      .contains('Go to debt details')
       .first()
       .click();
     cy.get('#debtLetterHistory').contains('Debt letter history');

--- a/src/applications/debt-letters/tests/e2e/debt-letters.cypress.spec.js
+++ b/src/applications/debt-letters/tests/e2e/debt-letters.cypress.spec.js
@@ -12,7 +12,10 @@ describe('Debt Letters', () => {
 
   it('displays the current debts section and navigates to debt details', () => {
     cy.findByText(/Current debts/i, { selector: 'a' }).click();
-    cy.findByText(/Go to debt details/i, { selector: 'a' }).click();
+    cy.get('.usa-button')
+      .contains(/Go to debt details/i)
+      .first()
+      .click();
     cy.get('#debtLetterHistory').contains('Debt letter history');
   });
 

--- a/src/applications/debt-letters/utils/mockResponses.js
+++ b/src/applications/debt-letters/utils/mockResponses.js
@@ -164,6 +164,33 @@ const data = {
   ],
 };
 
+const debtLettersVBMS = [
+  {
+    documentId: '{64B0BDC4-D40C-4C54-86E0-104C987B8D8F}',
+    docType: '1213',
+    typeDescription: 'DMC - Second Demand Letter',
+    receivedAt: '2020-05-26',
+  },
+  {
+    documentId: '{70412535-E39E-4202-B24E-2751D9FBC874}',
+    docType: '194',
+    typeDescription: 'DMC - First Demand Letter',
+    receivedAt: '2020-05-27',
+  },
+  {
+    documentId: '{3626D232-98D9-41AB-AA3A-CD2DDF7DA59C}',
+    docType: '194',
+    typeDescription: 'DMC - First Demand Letter',
+    receivedAt: '2020-05-28',
+  },
+  {
+    documentId: '{641D0414-10A9-4246-9AFD-3C0BE2D62B2F}',
+    docType: '1213',
+    typeDescription: 'DMC - Second Demand Letter',
+    receivedAt: '2020-05-29',
+  },
+];
+
 function asyncReturn(returnValue, delay = 300) {
   return new Promise(resolve => {
     setTimeout(() => {

--- a/src/applications/debt-letters/utils/mockResponses.js
+++ b/src/applications/debt-letters/utils/mockResponses.js
@@ -2,170 +2,167 @@ const data = {
   hasDependentDebt: true,
   debts: [
     {
-      adamKey: '1',
-      fileNumber: '000000009',
+      fileNumber: 796121200,
       payeeNumber: '00',
-      personEntitled: 'STUB_M',
-      deductionCode: '21',
-      benefitType: 'Loan Guaranty (Principal + Interest)',
-      amountOverpaid: 0.0,
-      amountWithheld: 0.0,
-      originalAr: 11599,
-      currentAr: 0,
-      debtHistory: [
-        {
-          date: '03/05/2004',
-          letterCode: '914',
-          status: 'Paid In Full',
-          description: 'Account balance cleared via offset, not including TOP.',
-        },
-      ],
-    },
-    {
-      adamKey: '2',
-      fileNumber: '000000009',
-      payeeNumber: '00',
-      personEntitled: 'STUB_M',
+      personEntitled: 'AJHONS',
       deductionCode: '30',
       benefitType: 'Comp & Pen',
-      amountOverpaid: 0.0,
-      amountWithheld: 0.0,
-      originalAr: 13000,
+      diaryCode: '914',
+      diaryCodeDescription: 'Paid in Full',
+      amountOverpaid: 0,
+      amountWithheld: 0,
+      originalAr: 136.24,
       currentAr: 0,
       debtHistory: [
         {
-          date: '12/03/2008',
-          letterCode: '488',
-          status: 'Death Status - Pending Action',
-          description: 'Pending review for reclamation or next action.',
+          date: '02/25/2009',
+          letterCode: '914',
+          description:
+            'Paid In Full - Account balance cleared via offset, not including TOP.',
         },
         {
           date: '02/07/2009',
           letterCode: '905',
-          status: 'Administrative Write Off',
-          description:
-            'Full debt amount cleared by return of funds to DMC from outside entities (reclamations, insurance companies, etc.)',
+          description: 'Administrative Write Off',
         },
         {
-          date: '02/25/2009',
-          letterCode: '914',
-          status: 'Paid In Full',
-          description: 'Account balance cleared via offset, not including TOP.',
+          date: '12/03/2008',
+          letterCode: '487',
+          description: 'Death Case Pending Action',
         },
       ],
     },
     {
-      adamKey: '3',
-      fileNumber: '000000009',
-      payeeNumber: '00',
-      personEntitled: 'STUB_M',
-      deductionCode: '30',
-      benefitType: 'Comp & Pen',
-      amountOverpaid: 0.0,
-      amountWithheld: 0.0,
-      originalAr: 12000,
-      currentAr: 0,
-      debtHistory: [
-        {
-          date: '09/11/1997',
-          letterCode: '914',
-          status: 'Paid In Full',
-          description: 'Account balance cleared via offset, not including TOP.',
-        },
-      ],
-    },
-    {
-      adamKey: '4',
-      fileNumber: '000000009',
+      fileNumber: 796121200,
       payeeNumber: '00',
       personEntitled: 'STUB_M',
       deductionCode: '44',
       benefitType: 'CH35 EDU',
-      amountOverpaid: 16000.0,
-      amountWithheld: 0.0,
-      originalAr: 13000,
-      currentAr: 10000,
+      diaryCode: '618',
+      diaryCodeDescription:
+        'Account returned from Treasury Cross Servicing. Account is at TOP.  TOP offsets will be applied to account as Federal funds become available.',
+      amountOverpaid: 26000,
+      amountWithheld: 0,
+      originalAr: 100,
+      currentAr: 80,
       debtHistory: [
         {
-          date: '09/18/2012',
-          letterCode: '100',
-          status: 'First Demand Letter - Inactive Benefits',
+          date: '12/19/2014',
+          letterCode: '681',
           description:
-            'First due process letter sent when debtor is not actively receiving any benefits.',
-        },
-        {
-          date: '09/28/2012',
-          letterCode: '117',
-          status: 'Second Demand Letter',
-          description:
-            'Second demand letter where debtor has no active benefits to offset so debtor is informed that debt may be referred to CRA (60 timer), TOP, CAIVRS or Cross Servicing.  CRA is only one with timer.\r\n117A - Second collections letter sent to schools',
-        },
-        {
-          date: '10/17/2012',
-          letterCode: '212',
-          status: 'Bad Address - Locator Request Sent',
-          description:
-            'Originates from mail room Beep File (file of bad addresses to be sent to LexisNexis).  Remains in this status until LexisNexis comes back with updated address information.',
-        },
-        {
-          date: '11/14/2012',
-          letterCode: '117',
-          status: 'Second Demand Letter',
-          description:
-            'Second demand letter where debtor has no active benefits to offset so debtor is informed that debt may be referred to CRA (60 timer), TOP, CAIVRS or Cross Servicing.  CRA is only one with timer.\r\n117A - Second collections letter sent to schools',
-        },
-        {
-          date: '12/11/2012',
-          letterCode: '510',
-          status:
-            'Mailing Status Inactive/Invalid - Forced to TOP/Cross Servicing',
-          description:
-            'Demand letters returned.  Unable to verify address with third party.  Account forced to TOP and/or CS.',
+            'Account returned from Treasury Cross Servicing. Account is at TOP.  TOP offsets will be applied to account as Federal funds become available.',
         },
         {
           date: '04/11/2013',
           letterCode: '080',
-          status: 'Referred To Cross Servicing',
           description: 'Debt referred to Treasury for Cross servicing',
         },
         {
-          date: '12/19/2014',
-          letterCode: '681',
-          status: 'Returned From Cross Servicing - At TOP',
+          date: '12/11/2012',
+          letterCode: '510',
           description:
-            'Account returned from Treasury Cross Servicing. Account is at TOP.  TOP offsets will be applied to account as Federal funds become available.',
+            'Demand letters returned.  Unable to verify address with third party.  Account forced to TOP and/or CS.',
+        },
+        {
+          date: '10/17/2012',
+          letterCode: '212',
+          description: 'Bad Address - Locator Request Sent',
+        },
+        {
+          date: '09/28/2012',
+          letterCode: '117',
+          description: 'Second Demand Letter',
+        },
+        {
+          date: '09/18/2012',
+          letterCode: '100',
+          description: 'First Demand Letter - Inactive Benefits - Due Process',
+        },
+      ],
+    },
+    {
+      fileNumber: 796121200,
+      payeeNumber: '00',
+      personEntitled: 'AJOHNS',
+      deductionCode: '71',
+      benefitType: 'CH33 Books, Supplies/MISC EDU',
+      diaryCode: '100',
+      diaryCodeDescription:
+        'First Demand Letter - Inactive Benefits - Due Process',
+      amountOverpaid: 0,
+      amountWithheld: 0,
+      originalAr: 166.67,
+      currentAr: 120.4,
+      debtHistory: [
+        {
+          date: '09/18/2012',
+          letterCode: '100',
+          description: 'First Demand Letter - Inactive Benefits - Due Process',
+        },
+      ],
+    },
+    {
+      fileNumber: 796121200,
+      payeeNumber: '00',
+      personEntitled: 'AJOHNS',
+      deductionCode: '74',
+      benefitType: 'CH33 Student Tuition EDU',
+      diaryCode: '608',
+      diaryCodeDescription: 'Full C&P Benefit Offset Notifi',
+      amountOverpaid: 0,
+      amountWithheld: 475,
+      originalAr: 2210.9,
+      currentAr: 0,
+      debtHistory: [
+        {
+          date: '04/01/2017',
+          letterCode: 608,
+          description: 'Full C&P Benefit Offset Notifi',
+        },
+        {
+          date: '11/18/2015',
+          letterCode: 130,
+          description: 'Debt Increase - Due P',
+        },
+        {
+          date: '04/08/2015',
+          letterCode: 608,
+          description: 'Full C&P Benefit Offset Notifi',
+        },
+        {
+          date: '03/26/2015',
+          letterCode: 100,
+          description: 'First Demand Letter - Inactive Benefits - Due Process',
+        },
+      ],
+    },
+    {
+      fileNumber: 796121200,
+      payeeNumber: '00',
+      personEntitled: 'AJHONS',
+      deductionCode: '72',
+      benefitType: 'CH33 Housing EDU',
+      diaryCode: '608',
+      diaryCodeDescription: 'Full C&P Benefit Offset Notifi',
+      amountOverpaid: 0,
+      amountWithheld: 321.76,
+      originalAr: 321.76,
+      currentAr: 0,
+      debtHistory: [
+        {
+          date: '08/08/2018',
+          letterCode: 608,
+          description: 'Full C&P Benefit Offset Notifi',
+        },
+        {
+          date: '07/19/2018',
+          letterCode: 100,
+          description: 'First Demand Letter - Inactive Benefits - Due Process',
         },
       ],
     },
   ],
 };
-
-const debtLettersVBMS = [
-  {
-    documentId: '{64B0BDC4-D40C-4C54-86E0-104C987B8D8F}',
-    docType: '1213',
-    typeDescription: 'DMC - Second Demand Letter',
-    receivedAt: '2020-05-26',
-  },
-  {
-    documentId: '{70412535-E39E-4202-B24E-2751D9FBC874}',
-    docType: '194',
-    typeDescription: 'DMC - First Demand Letter',
-    receivedAt: '2020-05-27',
-  },
-  {
-    documentId: '{3626D232-98D9-41AB-AA3A-CD2DDF7DA59C}',
-    docType: '194',
-    typeDescription: 'DMC - First Demand Letter',
-    receivedAt: '2020-05-28',
-  },
-  {
-    documentId: '{641D0414-10A9-4246-9AFD-3C0BE2D62B2F}',
-    docType: '1213',
-    typeDescription: 'DMC - Second Demand Letter',
-    receivedAt: '2020-05-29',
-  },
-];
 
 function asyncReturn(returnValue, delay = 300) {
   return new Promise(resolve => {


### PR DESCRIPTION
## Description
With the most recent update to the DMC API, the status field on the debtHistory no longer exists.

## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
