### PR TITLE
Disable personal info update button when no changes have been made

### DIFF
--- a/src/applications/personalization/profile-2/tests/e2e/profile.personal-and-contact-information-modals.cypress.spec.js
+++ b/src/applications/personalization/profile-2/tests/e2e/profile.personal-and-contact-information-modals.cypress.spec.js
@@ -36,10 +36,16 @@ const checkModals = options => {
     force: true,
   });
 
+  // confirm that the update button is disabled before a change is made
+  cy.findByRole('button', { name: 'Update' }).should('be.disabled');
+
   // Make an edit
   cy.get(`#${editLineId}`)
     .click()
     .type('test');
+
+  // confirm that the update button is enabled
+  cy.findByRole('button', { name: 'Update' }).should('not.be.disabled');
 
   // Click on a different section to edit
   cy.findByRole('button', {

--- a/src/platform/user/profile/vet360/components/base/VAPEditView.jsx
+++ b/src/platform/user/profile/vet360/components/base/VAPEditView.jsx
@@ -85,6 +85,7 @@ class VAPEditView extends Component {
         clearErrors,
         deleteDisabled,
         field,
+        hasUnsavedEdits,
         isEmpty,
         onCancel,
         onDelete,
@@ -115,6 +116,7 @@ class VAPEditView extends Component {
             data-action="save-edit"
             isLoading={isLoading}
             className="vads-u-width--auto vads-u-margin-top--0"
+            disabled={!hasUnsavedEdits}
           >
             Update
           </LoadingButton>


### PR DESCRIPTION
## Description


## Testing done


## Screenshots


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs