### PR TITLE
Fix sideNav for multiple transformers

### DIFF
--- a/src/site/stages/build/process-cms-exports/schemas/output/node-person_profile.js
+++ b/src/site/stages/build/process-cms-exports/schemas/output/node-person_profile.js
@@ -22,6 +22,7 @@ module.exports = {
           properties: {
             entityLabel: { type: 'string' },
             entityType: { type: 'string' },
+            entityUrl: { $ref: 'EntityUrl' },
           },
           required: ['entityLabel', 'entityType'],
         },

--- a/src/site/stages/build/process-cms-exports/transformers/node-event_listing.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-event_listing.js
@@ -36,16 +36,17 @@ const transform = (entity, { ancestors }) => ({
   fieldDescription: getDrupalValue(entity.fieldDescription),
   fieldIntroText: getDrupalValue(entity.fieldIntroText),
   fieldMetaTitle: getDrupalValue(entity.fieldMetaTitle),
-  /* eslint-disable no-nested-ternary */
   fieldOffice: entity.fieldOffice[0]
-    ? !ancestors.find(r => r.entity.uuid === entity.fieldOffice[0].uuid)
-      ? { entity: entity.fieldOffice[0] }
-      : {
-          entity: {
-            entityLabel: getDrupalValue(entity.fieldOffice[0].title),
-            entityType: entity.fieldOffice[0].entityType,
-          },
-        }
+    ? {
+        entity: !ancestors.find(
+          r => r.entity.uuid === entity.fieldOffice[0].uuid,
+        )
+          ? entity.fieldOffice[0]
+          : {
+              entityLabel: getDrupalValue(entity.fieldOffice[0].title),
+              entityType: entity.fieldOffice[0].entityType,
+            },
+      }
     : null,
   reverseFieldListingNode: reverseFields(entity.reverseFieldListing),
   pastEvents: reverseFields(entity.reverseFieldListing),

--- a/src/site/stages/build/process-cms-exports/transformers/node-event_listing.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-event_listing.js
@@ -36,13 +36,17 @@ const transform = (entity, { ancestors }) => ({
   fieldDescription: getDrupalValue(entity.fieldDescription),
   fieldIntroText: getDrupalValue(entity.fieldIntroText),
   fieldMetaTitle: getDrupalValue(entity.fieldMetaTitle),
-  fieldOffice:
-    entity.fieldOffice[0] &&
-    !ancestors.find(r => r.entity.uuid === entity.fieldOffice[0].uuid)
-      ? {
-          entity: entity.fieldOffice[0],
+  /* eslint-disable no-nested-ternary */
+  fieldOffice: entity.fieldOffice[0]
+    ? !ancestors.find(r => r.entity.uuid === entity.fieldOffice[0].uuid)
+      ? { entity: entity.fieldOffice[0] }
+      : {
+          entity: {
+            entityLabel: getDrupalValue(entity.fieldOffice[0].title),
+            entityType: entity.fieldOffice[0].entityType,
+          },
         }
-      : null,
+    : null,
   reverseFieldListingNode: reverseFields(entity.reverseFieldListing),
   pastEvents: reverseFields(entity.reverseFieldListing),
 });

--- a/src/site/stages/build/process-cms-exports/transformers/node-health_care_local_facility.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-health_care_local_facility.js
@@ -57,15 +57,14 @@ const transform = (entity, { ancestors }) => ({
     entity.fieldOperatingStatusMoreInfo,
   ),
   fieldPhoneNumber: getDrupalValue(entity.fieldPhoneNumber),
-  /* eslint-disable no-nested-ternary */
   fieldRegionPage: entity.fieldRegionPage[0]
-    ? !ancestors.find(r => r.entity.uuid === entity.fieldRegionPage[0].uuid)
-      ? { entity: entity.fieldRegionPage[0] }
-      : {
-          entity: {
-            title: getDrupalValue(entity.fieldRegionPage[0].title),
-          },
-        }
+    ? {
+        entity: !ancestors.find(
+          r => r.entity.uuid === entity.fieldRegionPage[0].uuid,
+        )
+          ? entity.fieldRegionPage[0]
+          : { title: getDrupalValue(entity.fieldRegionPage[0].title) },
+      }
     : null,
   fieldTwitter: getSocialMediaObject(entity.fieldTwitter),
 });

--- a/src/site/stages/build/process-cms-exports/transformers/node-health_care_local_facility.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-health_care_local_facility.js
@@ -57,11 +57,16 @@ const transform = (entity, { ancestors }) => ({
     entity.fieldOperatingStatusMoreInfo,
   ),
   fieldPhoneNumber: getDrupalValue(entity.fieldPhoneNumber),
-  fieldRegionPage:
-    entity.fieldRegionPage[0] &&
-    !ancestors.find(r => r.entity.uuid === entity.fieldRegionPage[0].uuid)
+  /* eslint-disable no-nested-ternary */
+  fieldRegionPage: entity.fieldRegionPage[0]
+    ? !ancestors.find(r => r.entity.uuid === entity.fieldRegionPage[0].uuid)
       ? { entity: entity.fieldRegionPage[0] }
-      : null,
+      : {
+          entity: {
+            title: getDrupalValue(entity.fieldRegionPage[0].title),
+          },
+        }
+    : null,
   fieldTwitter: getSocialMediaObject(entity.fieldTwitter),
 });
 

--- a/src/site/stages/build/process-cms-exports/transformers/node-health_care_region_detail_page.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-health_care_region_detail_page.js
@@ -16,16 +16,17 @@ const transform = (entity, { ancestors }) => ({
   fieldContentBlock: entity.fieldContentBlock,
   fieldFeaturedContent: entity.fieldFeaturedContent,
   fieldIntroText: getDrupalValue(entity.fieldIntroText),
-  /* eslint-disable no-nested-ternary */
   fieldOffice: entity.fieldOffice[0]
-    ? !ancestors.find(r => r.entity.uuid === entity.fieldOffice[0].uuid)
-      ? { entity: entity.fieldOffice[0] }
-      : {
-          entity: {
-            entityLabel: getDrupalValue(entity.fieldOffice[0].title),
-            entityType: entity.fieldOffice[0].entityType,
-          },
-        }
+    ? {
+        entity: !ancestors.find(
+          r => r.entity.uuid === entity.fieldOffice[0].uuid,
+        )
+          ? entity.fieldOffice[0]
+          : {
+              entityLabel: getDrupalValue(entity.fieldOffice[0].title),
+              entityType: entity.fieldOffice[0].entityType,
+            },
+      }
     : null,
   fieldRelatedLinks: entity.fieldRelatedLinks[0] || null,
   fieldTableOfContentsBoolean: getDrupalValue(

--- a/src/site/stages/build/process-cms-exports/transformers/node-health_care_region_detail_page.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-health_care_region_detail_page.js
@@ -16,11 +16,17 @@ const transform = (entity, { ancestors }) => ({
   fieldContentBlock: entity.fieldContentBlock,
   fieldFeaturedContent: entity.fieldFeaturedContent,
   fieldIntroText: getDrupalValue(entity.fieldIntroText),
-  fieldOffice:
-    entity.fieldOffice[0] &&
-    !ancestors.find(r => r.entity.uuid === entity.fieldOffice[0].uuid)
+  /* eslint-disable no-nested-ternary */
+  fieldOffice: entity.fieldOffice[0]
+    ? !ancestors.find(r => r.entity.uuid === entity.fieldOffice[0].uuid)
       ? { entity: entity.fieldOffice[0] }
-      : null,
+      : {
+          entity: {
+            entityLabel: getDrupalValue(entity.fieldOffice[0].title),
+            entityType: entity.fieldOffice[0].entityType,
+          },
+        }
+    : null,
   fieldRelatedLinks: entity.fieldRelatedLinks[0] || null,
   fieldTableOfContentsBoolean: getDrupalValue(
     entity.fieldTableOfContentsBoolean,

--- a/src/site/stages/build/process-cms-exports/transformers/node-leadership_listing.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-leadership_listing.js
@@ -16,16 +16,17 @@ const transform = (entity, { ancestors }) => ({
   fieldIntroText: getDrupalValue(entity.fieldIntroText),
   fieldLeadership: entity.fieldLeadership[0],
   fieldMetaTitle: getDrupalValue(entity.fieldMetaTitle),
-  /* eslint-disable no-nested-ternary */
   fieldOffice: entity.fieldOffice[0]
-    ? !ancestors.find(r => r.entity.uuid === entity.fieldOffice[0].uuid)
-      ? { entity: entity.fieldOffice[0] }
-      : {
-          entity: {
-            entityLabel: getDrupalValue(entity.fieldOffice[0].title),
-            entityType: entity.fieldOffice[0].entityType,
-          },
-        }
+    ? {
+        entity: !ancestors.find(
+          r => r.entity.uuid === entity.fieldOffice[0].uuid,
+        )
+          ? entity.fieldOffice[0]
+          : {
+              entityLabel: getDrupalValue(entity.fieldOffice[0].title),
+              entityType: entity.fieldOffice[0].entityType,
+            },
+      }
     : null,
 });
 

--- a/src/site/stages/build/process-cms-exports/transformers/node-leadership_listing.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-leadership_listing.js
@@ -16,11 +16,17 @@ const transform = (entity, { ancestors }) => ({
   fieldIntroText: getDrupalValue(entity.fieldIntroText),
   fieldLeadership: entity.fieldLeadership[0],
   fieldMetaTitle: getDrupalValue(entity.fieldMetaTitle),
-  fieldOffice:
-    entity.fieldOffice[0] &&
-    !ancestors.find(r => r.entity.uuid === entity.fieldOffice[0].uuid)
+  /* eslint-disable no-nested-ternary */
+  fieldOffice: entity.fieldOffice[0]
+    ? !ancestors.find(r => r.entity.uuid === entity.fieldOffice[0].uuid)
       ? { entity: entity.fieldOffice[0] }
-      : null,
+      : {
+          entity: {
+            entityLabel: getDrupalValue(entity.fieldOffice[0].title),
+            entityType: entity.fieldOffice[0].entityType,
+          },
+        }
+    : null,
 });
 
 module.exports = {

--- a/src/site/stages/build/process-cms-exports/transformers/node-person_profile.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-person_profile.js
@@ -22,20 +22,18 @@ const transform = (entity, { ancestors }) => ({
       ? { entity: entity.fieldMedia[0] }
       : null,
   fieldNameFirst: getDrupalValue(entity.fieldNameFirst),
-  // If entity.fieldOffice[0] is an ancestor of this entity ignore it
-  // entity.fieldOffice[0] would be untransformed, causing errors
-  // so we need it transformed here, which will happen in the parent transformer
-  /* eslint-disable no-nested-ternary */
   fieldOffice: entity.fieldOffice[0]
-    ? !ancestors.find(r => r.entity.uuid === entity.fieldOffice[0].uuid)
-      ? { entity: entity.fieldOffice[0] }
-      : {
-          entity: {
-            entityLabel: getDrupalValue(entity.fieldOffice[0].title),
-            entityType: entity.fieldOffice[0].entityType,
-            entityUrl: entity.fieldOffice[0].entityUrl,
-          },
-        }
+    ? {
+        entity: !ancestors.find(
+          r => r.entity.uuid === entity.fieldOffice[0].uuid,
+        )
+          ? entity.fieldOffice[0]
+          : {
+              entityLabel: getDrupalValue(entity.fieldOffice[0].title),
+              entityType: entity.fieldOffice[0].entityType,
+              entityUrl: entity.fieldOffice[0].entityUrl,
+            },
+      }
     : null,
   fieldPhoneNumber: getDrupalValue(entity.fieldPhoneNumber),
   fieldSuffix: getDrupalValue(entity.fieldSuffix),

--- a/src/site/stages/build/process-cms-exports/transformers/node-person_profile.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-person_profile.js
@@ -27,25 +27,16 @@ const transform = (entity, { ancestors }) => ({
   // so we need it transformed here, which will happen in the parent transformer
   /* eslint-disable no-nested-ternary */
   fieldOffice: entity.fieldOffice[0]
-    ? ancestors.find(r => r.entity.uuid === entity.fieldOffice[0].uuid) &&
-      entity.fieldOffice[0].entityBundle === 'health_care_region_page'
-      ? {
+    ? !ancestors.find(r => r.entity.uuid === entity.fieldOffice[0].uuid)
+      ? { entity: entity.fieldOffice[0] }
+      : {
           entity: {
-            entityLabel: 'VA Pittsburgh health care',
-            entityType: 'node',
-            entityBundle: 'health_care_region_page',
+            entityLabel: getDrupalValue(entity.fieldOffice[0].title),
+            entityType: entity.fieldOffice[0].entityType,
+            entityUrl: entity.fieldOffice[0].entityUrl,
           },
         }
-      : null
     : null,
-  // !ancestors.find(r => r.entity.uuid === entity.fieldOffice[0].uuid)
-  //   ? {
-  //       entity: {
-  //         entityLabel: entity.fieldOffice[0].entityLabel,
-  //         entityType: entity.fieldOffice[0].entityType,
-  //       },
-  //     }
-  //   : null,
   fieldPhoneNumber: getDrupalValue(entity.fieldPhoneNumber),
   fieldSuffix: getDrupalValue(entity.fieldSuffix),
   // Used for reverse fields in other transformers

--- a/src/site/stages/build/process-cms-exports/transformers/node-person_profile.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-person_profile.js
@@ -25,16 +25,27 @@ const transform = (entity, { ancestors }) => ({
   // If entity.fieldOffice[0] is an ancestor of this entity ignore it
   // entity.fieldOffice[0] would be untransformed, causing errors
   // so we need it transformed here, which will happen in the parent transformer
-  fieldOffice:
-    entity.fieldOffice[0] &&
-    !ancestors.find(r => r.entity.uuid === entity.fieldOffice[0].uuid)
+  /* eslint-disable no-nested-ternary */
+  fieldOffice: entity.fieldOffice[0]
+    ? ancestors.find(r => r.entity.uuid === entity.fieldOffice[0].uuid) &&
+      entity.fieldOffice[0].entityBundle === 'health_care_region_page'
       ? {
           entity: {
-            entityLabel: entity.fieldOffice[0].entityLabel,
-            entityType: entity.fieldOffice[0].entityType,
+            entityLabel: 'VA Pittsburgh health care',
+            entityType: 'node',
+            entityBundle: 'health_care_region_page',
           },
         }
-      : null,
+      : null
+    : null,
+  // !ancestors.find(r => r.entity.uuid === entity.fieldOffice[0].uuid)
+  //   ? {
+  //       entity: {
+  //         entityLabel: entity.fieldOffice[0].entityLabel,
+  //         entityType: entity.fieldOffice[0].entityType,
+  //       },
+  //     }
+  //   : null,
   fieldPhoneNumber: getDrupalValue(entity.fieldPhoneNumber),
   fieldSuffix: getDrupalValue(entity.fieldSuffix),
   // Used for reverse fields in other transformers

--- a/src/site/stages/build/process-cms-exports/transformers/node-press_releases_listing.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-press_releases_listing.js
@@ -16,16 +16,17 @@ const transform = (entity, { ancestors }) => ({
   fieldDescription: getDrupalValue(entity.fieldDescription),
   fieldIntroText: getDrupalValue(entity.fieldIntroText),
   fieldMetaTitle: getDrupalValue(entity.fieldMetaTitle),
-  /* eslint-disable no-nested-ternary */
   fieldOffice: entity.fieldOffice[0]
-    ? !ancestors.find(r => r.entity.uuid === entity.fieldOffice[0].uuid)
-      ? { entity: entity.fieldOffice[0] }
-      : {
-          entity: {
-            entityLabel: getDrupalValue(entity.fieldOffice[0].title),
-            entityType: entity.fieldOffice[0].entityType,
-          },
-        }
+    ? {
+        entity: !ancestors.find(
+          r => r.entity.uuid === entity.fieldOffice[0].uuid,
+        )
+          ? entity.fieldOffice[0]
+          : {
+              entityLabel: getDrupalValue(entity.fieldOffice[0].title),
+              entityType: entity.fieldOffice[0].entityType,
+            },
+      }
     : null,
   fieldPressReleaseBlurb: getDrupalValue(entity.fieldPressReleaseBlurb),
   reverseFieldListingNode: {

--- a/src/site/stages/build/process-cms-exports/transformers/node-press_releases_listing.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-press_releases_listing.js
@@ -16,11 +16,17 @@ const transform = (entity, { ancestors }) => ({
   fieldDescription: getDrupalValue(entity.fieldDescription),
   fieldIntroText: getDrupalValue(entity.fieldIntroText),
   fieldMetaTitle: getDrupalValue(entity.fieldMetaTitle),
-  fieldOffice:
-    entity.fieldOffice[0] &&
-    !ancestors.find(r => r.entity.uuid === entity.fieldOffice[0].uuid)
+  /* eslint-disable no-nested-ternary */
+  fieldOffice: entity.fieldOffice[0]
+    ? !ancestors.find(r => r.entity.uuid === entity.fieldOffice[0].uuid)
       ? { entity: entity.fieldOffice[0] }
-      : null,
+      : {
+          entity: {
+            entityLabel: getDrupalValue(entity.fieldOffice[0].title),
+            entityType: entity.fieldOffice[0].entityType,
+          },
+        }
+    : null,
   fieldPressReleaseBlurb: getDrupalValue(entity.fieldPressReleaseBlurb),
   reverseFieldListingNode: {
     entities: entity.reverseFieldListing

--- a/src/site/stages/build/process-cms-exports/transformers/node-story_listing.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-story_listing.js
@@ -17,16 +17,17 @@ const transform = (entity, { ancestors }) => ({
   fieldDescription: getDrupalValue(entity.fieldDescription),
   fieldIntroText: getDrupalValue(entity.fieldIntroText),
   fieldMetaTitle: getDrupalValue(entity.fieldMetaTitle),
-  /* eslint-disable no-nested-ternary */
   fieldOffice: entity.fieldOffice[0]
-    ? !ancestors.find(r => r.entity.uuid === entity.fieldOffice[0].uuid)
-      ? { entity: entity.fieldOffice[0] }
-      : {
-          entity: {
-            entityLabel: getDrupalValue(entity.fieldOffice[0].title),
-            entityType: entity.fieldOffice[0].entityType,
-          },
-        }
+    ? {
+        entity: !ancestors.find(
+          r => r.entity.uuid === entity.fieldOffice[0].uuid,
+        )
+          ? entity.fieldOffice[0]
+          : {
+              entityLabel: getDrupalValue(entity.fieldOffice[0].title),
+              entityType: entity.fieldOffice[0].entityType,
+            },
+      }
     : null,
   reverseFieldListingNode: {
     entities: entity.reverseFieldListing

--- a/src/site/stages/build/process-cms-exports/transformers/node-story_listing.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-story_listing.js
@@ -17,11 +17,17 @@ const transform = (entity, { ancestors }) => ({
   fieldDescription: getDrupalValue(entity.fieldDescription),
   fieldIntroText: getDrupalValue(entity.fieldIntroText),
   fieldMetaTitle: getDrupalValue(entity.fieldMetaTitle),
-  fieldOffice:
-    entity.fieldOffice[0] &&
-    !ancestors.find(r => r.entity.uuid === entity.fieldOffice[0].uuid)
+  /* eslint-disable no-nested-ternary */
+  fieldOffice: entity.fieldOffice[0]
+    ? !ancestors.find(r => r.entity.uuid === entity.fieldOffice[0].uuid)
       ? { entity: entity.fieldOffice[0] }
-      : null,
+      : {
+          entity: {
+            entityLabel: getDrupalValue(entity.fieldOffice[0].title),
+            entityType: entity.fieldOffice[0].entityType,
+          },
+        }
+    : null,
   reverseFieldListingNode: {
     entities: entity.reverseFieldListing
       ? entity.reverseFieldListing

--- a/src/site/stages/build/process-cms-exports/transformers/node-vamc_operating_status_and_alerts.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-vamc_operating_status_and_alerts.js
@@ -30,16 +30,17 @@ const transform = (entity, { ancestors }) => ({
     },
   })),
   fieldLinks: entity.fieldLinks,
-  /* eslint-disable no-nested-ternary */
   fieldOffice: entity.fieldOffice[0]
-    ? !ancestors.find(r => r.entity.uuid === entity.fieldOffice[0].uuid)
-      ? { entity: entity.fieldOffice[0] }
-      : {
-          entity: {
-            entityLabel: getDrupalValue(entity.fieldOffice[0].title),
-            entityType: entity.fieldOffice[0].entityType,
-          },
-        }
+    ? {
+        entity: !ancestors.find(
+          r => r.entity.uuid === entity.fieldOffice[0].uuid,
+        )
+          ? entity.fieldOffice[0]
+          : {
+              entityLabel: getDrupalValue(entity.fieldOffice[0].title),
+              entityType: entity.fieldOffice[0].entityType,
+            },
+      }
     : null,
   fieldOperatingStatusEmergInf: {
     value: getDrupalValue(entity.fieldOperatingStatusEmergInf),

--- a/src/site/stages/build/process-cms-exports/transformers/node-vamc_operating_status_and_alerts.js
+++ b/src/site/stages/build/process-cms-exports/transformers/node-vamc_operating_status_and_alerts.js
@@ -30,11 +30,17 @@ const transform = (entity, { ancestors }) => ({
     },
   })),
   fieldLinks: entity.fieldLinks,
-  fieldOffice:
-    entity.fieldOffice[0] &&
-    !ancestors.find(r => r.entity.uuid === entity.fieldOffice[0].uuid)
+  /* eslint-disable no-nested-ternary */
+  fieldOffice: entity.fieldOffice[0]
+    ? !ancestors.find(r => r.entity.uuid === entity.fieldOffice[0].uuid)
       ? { entity: entity.fieldOffice[0] }
-      : null,
+      : {
+          entity: {
+            entityLabel: getDrupalValue(entity.fieldOffice[0].title),
+            entityType: entity.fieldOffice[0].entityType,
+          },
+        }
+    : null,
   fieldOperatingStatusEmergInf: {
     value: getDrupalValue(entity.fieldOperatingStatusEmergInf),
   },


### PR DESCRIPTION
## Description
The window.sideNav is missing in the CMS build for the following node types:

- event_listing
- full_width_banner_alert
- health_care_local_facility
- health_care_region_detail_page
- leadership_listing
- person_profile
- press_releases_listing
- story_listing
- vamc_operating_status_and_alerts

The problem was missing data expected in the liquid templates when there was a revolving entity

## Testing done
Locally by comparing the HTML builds

## Screenshots
![SideNav](https://user-images.githubusercontent.com/55560129/94604897-4f94be80-0266-11eb-91e7-568bc14de0ad.png)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
