### PR TITLE
[Templates] Add condition for "form last updated" field

### DIFF
--- a/src/site/filters/liquid.js
+++ b/src/site/filters/liquid.js
@@ -463,4 +463,7 @@ module.exports = function registerFilters() {
 
   // find out if date is in the past
   liquid.filters.isPastDate = contentDate => moment().diff(contentDate, 'days');
+
+  liquid.filters.isLaterThan = (timestamp1, timestamp2) =>
+    moment(timestamp1, 'YYYY-MM-DD').isAfter(moment(timestamp2, 'YYYY-MM-DD'));
 };

--- a/src/site/filters/liquid.unit.spec.js
+++ b/src/site/filters/liquid.unit.spec.js
@@ -1,0 +1,16 @@
+import liquid from 'tinyliquid';
+import { expect } from 'chai';
+
+import registerFilters from './liquid';
+
+registerFilters();
+
+describe('isLaterThan', () => {
+  it('returns true when the left arg is a timestamp later than the right arg', () => {
+    expect(liquid.filters.isLaterThan('2020-01-11', '2016-07-10')).to.be.true;
+  });
+
+  it('returns false when the left arg is a timestamp before the right arg', () => {
+    expect(liquid.filters.isLaterThan('2016-12-11', '2017-01-12')).to.be.false;
+  });
+});

--- a/src/site/layouts/va_form.drupal.liquid
+++ b/src/site/layouts/va_form.drupal.liquid
@@ -50,13 +50,18 @@
             </dd>
           </div>
 
-          {% if fieldVaFormRevisionDate %}
+          {% if fieldVaFormRevisionDate or fieldVaFormIssueDate %}
             <div>
               <dt class="vads-u-font-weight--bold vads-u-display--inline">
                 Form last updated:
               </dt>
               <dd class="vads-u-display--inline">
-                {{ fieldVaFormRevisionDate.value | humanizeDate }}
+                {% assign revisionDateIsLatestUpdate = fieldVaFormRevisionDate.value | isLaterThan: fieldVaFormIssueDate.value %}
+                {% if revisionDateIsLatestUpdate %}
+                  {{ fieldVaFormRevisionDate.value | humanizeDate }}
+                {% else %}
+                  {{ fieldVaFormIssueDate.value | humanizeDate }}
+                {% endif %}
               </dd>
             </div>
           {% endif %}


### PR DESCRIPTION
## Description


Issue - https://github.com/department-of-veterans-affairs/va.gov-team/issues/14024

## Testing done
Tested against a page where "issue date" is the latest date and against a page where "revision date" is the latest date

## Screenshots

### Example where "issue date" is latest date
http://localhost:3001/preview?nodeId=5748
![image](https://user-images.githubusercontent.com/1915775/94617836-4280cb00-0278-11eb-8b23-0b1533360cbd.png)

### Example where "revision date" is latest date
http://localhost:3001/preview?nodeId=5776
![image](https://user-images.githubusercontent.com/1915775/94617902-5a584f00-0278-11eb-9eb0-462f2c71d90b.png)


## Acceptance criteria
- [ ] "form last updated" shows the latest date between revision date and issue date

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
