### PR TITLE
use session for ssoe transaction

### DIFF
--- a/src/platform/site-wide/ebenefits/tests/selectors.unit.spec.js
+++ b/src/platform/site-wide/ebenefits/tests/selectors.unit.spec.js
@@ -11,7 +11,7 @@ describe('ebenefits selectors', () => {
         },
         user: {
           profile: {
-            signIn: {},
+            session: {},
           },
         },
       };
@@ -30,7 +30,7 @@ describe('ebenefits selectors', () => {
     });
     it('renders true when user is logged in and feature flags are on', () => {
       expect(selectors.shouldUseProxyUrl(state)).to.equal(false);
-      state.user.profile.signIn.ssoe = true;
+      state.user.profile.session.ssoe = true;
       state.featureToggles.ssoeEbenefitsLinks = true;
       expect(selectors.shouldUseProxyUrl(state)).to.equal(true);
     });

--- a/src/platform/site-wide/ebenefits/tests/selectors.unit.spec.js
+++ b/src/platform/site-wide/ebenefits/tests/selectors.unit.spec.js
@@ -23,7 +23,7 @@ describe('ebenefits selectors', () => {
       expect(selectors.shouldUseProxyUrl(state)).to.equal(false);
     });
     it('renders false when feature flags are off', () => {
-      state.user.profile.signIn.ssoe = true;
+      state.user.profile.session.ssoe = true;
       expect(selectors.shouldUseProxyUrl(state)).to.equal(false);
       state.featureToggles.ssoeEbenefitsLinks = false;
       expect(selectors.shouldUseProxyUrl(state)).to.equal(false);

--- a/src/platform/user/authentication/selectors.js
+++ b/src/platform/user/authentication/selectors.js
@@ -1,5 +1,5 @@
 import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
-import { selectUser, selectProfile } from 'platform/user/selectors';
+import { selectProfile } from 'platform/user/selectors';
 import FEATURE_FLAG_NAMES from 'platform/utilities/feature-toggles/featureFlagNames';
 
 export const ssoe = state => toggleValues(state)[FEATURE_FLAG_NAMES.ssoe];
@@ -17,7 +17,7 @@ export const signInServiceName = state =>
   selectProfile(state).signIn?.serviceName;
 
 export const isAuthenticatedWithSSOe = state =>
-  selectUser(state)?.session?.ssoe;
+  selectProfile(state)?.session?.ssoe;
 
 export const ssoeTransactionId = state =>
-  selectUser(state)?.session?.transactionid;
+  selectProfile(state)?.session?.transactionid;

--- a/src/platform/user/authentication/selectors.js
+++ b/src/platform/user/authentication/selectors.js
@@ -1,5 +1,5 @@
 import { toggleValues } from 'platform/site-wide/feature-toggles/selectors';
-import { selectProfile } from 'platform/user/selectors';
+import { selectUser, selectProfile } from 'platform/user/selectors';
 import FEATURE_FLAG_NAMES from 'platform/utilities/feature-toggles/featureFlagNames';
 
 export const ssoe = state => toggleValues(state)[FEATURE_FLAG_NAMES.ssoe];
@@ -17,7 +17,7 @@ export const signInServiceName = state =>
   selectProfile(state).signIn?.serviceName;
 
 export const isAuthenticatedWithSSOe = state =>
-  selectProfile(state).signIn?.ssoe;
+  selectUser(state)?.session?.ssoe;
 
 export const ssoeTransactionId = state =>
-  selectProfile(state).signIn?.transactionid;
+  selectUser(state)?.session?.transactionid;

--- a/src/platform/user/profile/reducers/index.js
+++ b/src/platform/user/profile/reducers/index.js
@@ -47,6 +47,7 @@ const initialState = {
   prefillsAvailable: [],
   loading: true,
   services: [],
+  session: {},
 };
 
 const updateMhvAccountState = (state, mhvAccount) =>

--- a/src/platform/user/profile/utilities/index.js
+++ b/src/platform/user/profile/utilities/index.js
@@ -60,6 +60,7 @@ export function mapRawUserDataToState(json) {
         vaProfile,
         vet360ContactInformation,
         veteranStatus,
+        session,
       },
     },
     meta,
@@ -86,6 +87,7 @@ export function mapRawUserDataToState(json) {
     vet360: isVet360Configured()
       ? vet360ContactInformation
       : mockContactInformation,
+    session,
   };
 
   if (meta && veteranStatus === null) {

--- a/src/platform/user/tests/authentication/selectors.unit.spec.js
+++ b/src/platform/user/tests/authentication/selectors.unit.spec.js
@@ -10,9 +10,9 @@ describe('authentication selectors', () => {
             signIn: {
               ssoe: false,
             },
-          },
-          session: {
-            ssoe: true,
+            session: {
+              ssoe: true,
+            },
           },
         },
       };
@@ -22,7 +22,9 @@ describe('authentication selectors', () => {
     it('returns undefined when the ssoe flag is not present', () => {
       const state = {
         user: {
-          session: {},
+          profile: {
+            session: {},
+          },
         },
       };
       expect(selectors.isAuthenticatedWithSSOe(state)).to.be.undefined;
@@ -37,9 +39,9 @@ describe('authentication selectors', () => {
             signIn: {
               transactionid: 'X',
             },
-          },
-          session: {
-            transactionid: 'Y',
+            session: {
+              transactionid: 'Y',
+            },
           },
         },
       };
@@ -50,7 +52,9 @@ describe('authentication selectors', () => {
       const state = {
         user: {
           session: {
-            ssoe: false,
+            profile: {
+              ssoe: false,
+            },
           },
         },
       };

--- a/src/platform/user/tests/authentication/selectors.unit.spec.js
+++ b/src/platform/user/tests/authentication/selectors.unit.spec.js
@@ -3,13 +3,16 @@ import * as selectors from '../../authentication/selectors';
 
 describe('authentication selectors', () => {
   describe('isAuthenticatedWithSSOe', () => {
-    it('pulls out state.profile.signin.ssoe', () => {
+    it('pulls out state.session.ssoe', () => {
       const state = {
         user: {
           profile: {
             signIn: {
-              ssoe: true,
+              ssoe: false,
             },
+          },
+          session: {
+            ssoe: true,
           },
         },
       };
@@ -19,9 +22,7 @@ describe('authentication selectors', () => {
     it('returns undefined when the ssoe flag is not present', () => {
       const state = {
         user: {
-          profile: {
-            signIn: {},
-          },
+          session: {},
         },
       };
       expect(selectors.isAuthenticatedWithSSOe(state)).to.be.undefined;
@@ -29,7 +30,7 @@ describe('authentication selectors', () => {
   });
 
   describe('ssoeTransactionId', () => {
-    it('pulls out state.profile.signin.transactionid', () => {
+    it('pulls out state.session.transactionid', () => {
       const state = {
         user: {
           profile: {
@@ -37,16 +38,19 @@ describe('authentication selectors', () => {
               transactionid: 'X',
             },
           },
+          session: {
+            transactionid: 'Y',
+          },
         },
       };
 
-      expect(selectors.ssoeTransactionId(state)).to.eq('X');
+      expect(selectors.ssoeTransactionId(state)).to.eq('Y');
     });
     it('returns undefined when the transactionid is not present', () => {
       const state = {
         user: {
-          profile: {
-            signIn: {},
+          session: {
+            ssoe: false,
           },
         },
       };


### PR DESCRIPTION
Updating the user profile to pull the SSOe transactionid out of the "session" attribute from `/v0/user`.

refs https://github.com/department-of-veterans-affairs/va.gov-team/issues/13726
