### PR TITLE
[Development] Ignore immediate confirmation poll error

### DIFF
--- a/src/applications/disability-benefits/all-claims/components/ConfirmationPoll.jsx
+++ b/src/applications/disability-benefits/all-claims/components/ConfirmationPoll.jsx
@@ -15,6 +15,7 @@ export class ConfirmationPoll extends React.Component {
   static defaultProps = {
     pollRate: 5000,
     delayFailure: 6000, // larger than pollRate
+    longWaitTime: 30000,
   };
 
   constructor(props) {
@@ -69,7 +70,7 @@ export class ConfirmationPoll extends React.Component {
               : this.props.pollRate * 2; // Seems like we don't need to poll as frequently when we get here
 
           // Force a re-render to update the pending message if necessary
-          if (Date.now() - this.startTime >= 30000) {
+          if (Date.now() - this.startTime >= this.props.longWaitTime) {
             this.setState({ longWait: true });
           }
           setTimeout(this.poll, waitTime);

--- a/src/applications/disability-benefits/all-claims/components/ConfirmationPoll.jsx
+++ b/src/applications/disability-benefits/all-claims/components/ConfirmationPoll.jsx
@@ -14,6 +14,7 @@ export class ConfirmationPoll extends React.Component {
   // Using it as a prop for easy testing
   static defaultProps = {
     pollRate: 5000,
+    delayFailure: 6000, // larger than pollRate
   };
 
   constructor(props) {
@@ -80,11 +81,16 @@ export class ConfirmationPoll extends React.Component {
           return;
         }
 
-        this.setState({
-          submissionStatus: submissionStatuses.apiFailure,
-          // NOTE: I don't know that it'll always take this shape.
-          failureCode: get('errors[0].status', response),
-        });
+        if (Date.now() - this.startTime < this.props.delayFailure) {
+          // Page may return 404 immediately
+          setTimeout(this.poll, this.props.pollRate);
+        } else {
+          this.setState({
+            submissionStatus: submissionStatuses.apiFailure,
+            // NOTE: I don't know that it'll always take this shape.
+            failureCode: get('errors[0].status', response),
+          });
+        }
       });
   };
 

--- a/src/applications/disability-benefits/all-claims/tests/components/ConfirmationPoll.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/components/ConfirmationPoll.unit.spec.jsx
@@ -120,6 +120,26 @@ describe('ConfirmationPoll', () => {
     }, 500);
   });
 
+  it('should render long wait alert', done => {
+    mockMultipleApiRequests([
+      pendingResponse,
+      pendingResponse,
+      pendingResponse,
+      successResponse,
+    ]);
+
+    const form = mount(
+      <ConfirmationPoll {...defaultProps} pollRate={10} longWaitTime={20} />,
+    );
+    setTimeout(() => {
+      expect(global.fetch.callCount).to.equal(3);
+      const alert = form.find('LoadingIndicator');
+      expect(alert.text()).to.contain('longer than expected');
+      form.unmount();
+      done();
+    }, 30);
+  });
+
   it('should ignore immediate api failures', done => {
     mockMultipleApiRequests([
       errorResponse,

--- a/src/applications/disability-benefits/all-claims/tests/components/ConfirmationPoll.unit.spec.jsx
+++ b/src/applications/disability-benefits/all-claims/tests/components/ConfirmationPoll.unit.spec.jsx
@@ -49,6 +49,20 @@ const failureResponse = {
   },
 };
 
+const errorResponse = {
+  shouldResolve: true,
+  response: {
+    errors: [
+      {
+        title: 'error',
+        detail: 'some error',
+        code: '401',
+        status: 'some status',
+      },
+    ],
+  },
+};
+
 describe('ConfirmationPoll', () => {
   const defaultProps = {
     jobId: '12345',
@@ -104,6 +118,27 @@ describe('ConfirmationPoll', () => {
       tree.unmount();
       done();
     }, 500);
+  });
+
+  it('should ignore immediate api failures', done => {
+    mockMultipleApiRequests([
+      errorResponse,
+      pendingResponse,
+      pendingResponse,
+      successResponse,
+    ]);
+
+    const form = mount(
+      <ConfirmationPoll {...defaultProps} pollRate={10} delayFailure={20} />,
+    );
+    setTimeout(() => {
+      form.update();
+      expect(global.fetch.callCount).to.equal(4);
+      const confirmationPage = form.find('ConfirmationPage');
+      expect(confirmationPage.length).to.equal(1);
+      form.unmount();
+      done();
+    }, 50);
   });
 
   describe('selectAllDisabilityNames', () => {


### PR DESCRIPTION
## Description

After submitting a 526 form, the confirmation page polls the server to check the job status. Currently, it is checked immediately after submission, before the job starts so the poll receives an error and displays that to the user.

This PR adds a delay set-point before which server errors are ignored and the polling is continued. Errors that occur after the set delay time will still show an error to the user.

For more details, see the analysis Anna provided in https://github.com/department-of-veterans-affairs/va.gov-team/issues/12668

## Testing done

Added unit test

## Screenshots

N/A

## Acceptance criteria
- [x] Immediate error responses are ignored & the polling continues.

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
