### PR TITLE
[AXE-CORE]  CTA heading levels SHOULD only increase by one

### DIFF
--- a/src/platform/site-wide/cta-widget/components/CallToActionAlert.jsx
+++ b/src/platform/site-wide/cta-widget/components/CallToActionAlert.jsx
@@ -4,6 +4,7 @@ import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
 
 export default function CallToActionAlert({
   heading,
+  headerLevel,
   alertText,
   primaryButtonText,
   primaryButtonHandler,
@@ -16,6 +17,7 @@ export default function CallToActionAlert({
 
   const alertProps = {
     headline: heading,
+    level: headerLevel,
     content: (
       <div>
         {alertText}

--- a/src/platform/site-wide/cta-widget/components/messages/SignIn.jsx
+++ b/src/platform/site-wide/cta-widget/components/messages/SignIn.jsx
@@ -2,9 +2,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import CallToActionAlert from './../CallToActionAlert';
 
-const SignIn = ({ serviceDescription, primaryButtonHandler }) => {
+const SignIn = ({ serviceDescription, primaryButtonHandler, headerLevel }) => {
   const content = {
     heading: `Please sign in to ${serviceDescription}`,
+    headerLevel,
     alertText: (
       <p>
         Try signing in with your <b>DS Logon</b>, <b>My HealtheVet</b>, or{' '}
@@ -23,6 +24,7 @@ const SignIn = ({ serviceDescription, primaryButtonHandler }) => {
 SignIn.propTypes = {
   serviceDescription: PropTypes.string.isRequired,
   primaryButtonHandler: PropTypes.func.isRequired,
+  headerLevel: PropTypes.number,
 };
 
 export default SignIn;

--- a/src/platform/site-wide/cta-widget/index.js
+++ b/src/platform/site-wide/cta-widget/index.js
@@ -112,6 +112,7 @@ export class CallToActionWidget extends React.Component {
         <SignIn
           serviceDescription={this._serviceDescription}
           primaryButtonHandler={this.openLoginModal}
+          headerLevel={this.props.headerLevel}
         />
       );
     }


### PR DESCRIPTION
## Description

When not logged in, the sign in call to action (CTA) width includes an `h3` header inside an alert directly below the form heading (`h1`)

<details><summary>Heading problem found during an HLR spot check</summary>

<!-- leave a blank line above -->
![Screen Shot 2020-09-30 at 11 19 49 AM](https://user-images.githubusercontent.com/136959/94716629-c092af80-0314-11eb-988a-41e016b2b2ea.png)</details>

This PR adds a `headingLevel` property to the following components, which are passed down in this order:

* `CallToActionWidget`
* `SignIn`
* `CallToActionAlert`

The `CallToActionAlert` renders the [`AlertBox` with a `level` property](https://department-of-veterans-affairs.github.io/veteran-facing-services-tools/visual-design/components/alertbox/) which sets the heading level. I named the property in the above components to `headingLevel` to better convey its purpose.

This issue was discovered during a spot check for Form 20-0996 (Higher-Level Review) - https://github.com/department-of-veterans-affairs/va.gov-team/issues/13945

## Testing done

None

## Screenshots

See description

## Acceptance criteria
- [x] Changes allow modifying the alert heading level

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
