### PR TITLE
Fix header img src field

### DIFF
--- a/src/site/stages/build/drupal/menus.js
+++ b/src/site/stages/build/drupal/menus.js
@@ -147,9 +147,17 @@ function makePromo(hostUrl, promo) {
   const img = promo.entity.fieldImage.entity.image;
   const link = promo.entity.fieldPromoLink.entity.fieldLink;
 
+  // Based on the GraphQL query 'header.nav.graphql.js' there needs to be an
+  // adjustment to the image path based on the `style: _32MEDIUMTHUMBNAIL`
+
+  const url = `/img/styles/3_2_medium_thumbnail/${
+    // Verify that the image is not transformed previously
+    img.derivative.url.replace('/img/styles/3_2_medium_thumbnail/', '')
+  }`.replace('public:/', 'public');
+
   return {
     img: {
-      src: convertLinkToAbsolute(hostUrl, img.derivative.url),
+      src: convertLinkToAbsolute(hostUrl, url),
       alt: img.alt || '',
     },
     link: {

--- a/src/site/stages/build/drupal/menus.js
+++ b/src/site/stages/build/drupal/menus.js
@@ -147,17 +147,9 @@ function makePromo(hostUrl, promo) {
   const img = promo.entity.fieldImage.entity.image;
   const link = promo.entity.fieldPromoLink.entity.fieldLink;
 
-  // Based on the GraphQL query 'header.nav.graphql.js' there needs to be an
-  // adjustment to the image path based on the `style: _32MEDIUMTHUMBNAIL`
-
-  const url = `/img/styles/3_2_medium_thumbnail/${
-    // Verify that the image is not transformed previously
-    img.derivative.url.replace('/img/styles/3_2_medium_thumbnail/', '')
-  }`.replace('public:/', 'public');
-
   return {
     img: {
-      src: convertLinkToAbsolute(hostUrl, url),
+      src: convertLinkToAbsolute(hostUrl, img.derivative.url),
       alt: img.alt || '',
     },
     link: {

--- a/src/site/stages/build/process-cms-exports/transformers/block_content-promo.js
+++ b/src/site/stages/build/process-cms-exports/transformers/block_content-promo.js
@@ -1,8 +1,12 @@
+const { getImageCrop } = require('./helpers');
+
 const transform = entity => ({
   entity: {
     entityType: 'block_content',
     entityBundle: 'promo',
-    fieldImage: { entity: entity.fieldImage[0] },
+    fieldImage: {
+      entity: getImageCrop(entity.fieldImage[0], '_32MEDIUMTHUMBNAIL'),
+    },
     fieldPromoLink: entity.fieldPromoLink[0],
   },
 });


### PR DESCRIPTION
## Description
The image's `src` doesn't match the GraphQL build HTML. This is the same in all transformers.

The [header.htm](  <script type="text/javascript">)l template file populates `headerFooterData` which contains the information displayed
```
  <script type="text/javascript">
    window.VetsGov = window.VetsGov || {};
    window.VetsGov.headerFooter = {{ headerFooterData }};
  </script>
```

## Example:
![Screen Shot 2020-09-29 at 3.57.03 PM.png](https://images.zenhubusercontent.com/5d89589c3ac3440001d19c89/dcd03493-54c2-4f69-888a-5b4486092af4)


## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [ ] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [ ] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
