### PR TITLE
Add fieldAlert support for each step in step_by_step

### DIFF
--- a/src/site/layouts/step_by_step.drupal.liquid
+++ b/src/site/layouts/step_by_step.drupal.liquid
@@ -42,7 +42,24 @@
             {% assign count = 1 %}
             {% for fieldStep in fieldSteps.entity.fieldStep %}
               <li class="process-step list-{{ count | numToWord }}">
-                {{ fieldStep.entity.fieldWysiwyg.processed }}<br />
+                <!-- Step wysiyg -->
+                {{ fieldStep.entity.fieldWysiwyg.processed }}
+                <br />
+
+                <!-- Step alert -->
+                {% if fieldAlert.length %}
+                  {% for alert in fieldAlert %}
+                    {% if alert.entity != empty %}
+                      {% include "src/site/blocks/alert.drupal.liquid" with alert = alert.entity %}
+                    {% endif %}
+                  {% endfor %}
+                {% else %}
+                  {% if fieldAlert.entity != empty %}
+                    {% include "src/site/blocks/alert.drupal.liquid" with alert = fieldAlert.entity %}
+                  {% endif %}
+                {% endif %}
+
+                <!-- Step image -->
                 <img alt="{{ fieldStep.entity.fieldMedia.entity.thumbnail.alt }}"
                   src="{{ fieldStep.entity.fieldMedia.entity.thumbnail.url }}" />
               </li>

--- a/src/site/stages/build/drupal/graphql/nodeStepByStep.graphql.js
+++ b/src/site/stages/build/drupal/graphql/nodeStepByStep.graphql.js
@@ -30,6 +30,11 @@ fragment nodeStepByStep on NodeStepByStep {
               fieldWysiwyg {
                 processed
               }
+              fieldAlert {
+                entity {
+                  ... alertParagraph
+                }
+              }
               fieldMedia {
                 entity {
                   ... on Media {


### PR DESCRIPTION
## Description
**Issue:** https://github.com/department-of-veterans-affairs/va.gov-team/issues/13135

This PR adds `fieldAlert` support for each step in the `step_by_step` template. There's an issue at the moment where Drupal is sending the client an empty object for each `fieldAlert`, however, so we won't be able to visually confirm this implementation until it's fixed 😭 

## Testing done
N/A

## Screenshots
![localhost_3001_preview_nodeId=6899](https://user-images.githubusercontent.com/12773166/94834599-cbf5e180-03cd-11eb-92f9-81f6a6538b46.png)


## Acceptance criteria
- [x] Add `fieldAlert` to each step in `step_by_step`

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
