### PR TITLE
Make lastFacilityName and lastFacilityType optionally required

### DIFF
--- a/src/applications/caregivers/definitions/caregiverUI.js
+++ b/src/applications/caregivers/definitions/caregiverUI.js
@@ -20,6 +20,7 @@ import {
   medicalCenterLabels,
   medicalCentersByState,
   validateSSNIsUnique,
+  facilityNameMaxLength,
 } from 'applications/caregivers/helpers';
 
 const emptyFacilityList = [];
@@ -106,6 +107,13 @@ export default {
       'ui:order': ['name', 'type'],
       name: {
         'ui:required': formData => !!formData.veteranLastTreatmentFacility.type,
+        'ui:validations': [
+          {
+            validator: (errors, fieldData, formData) => {
+              facilityNameMaxLength(errors, formData);
+            },
+          },
+        ],
         'ui:title': (
           <div>
             <h3 className="vads-u-font-size--h4">Recent medical care</h3>

--- a/src/applications/caregivers/definitions/caregiverUI.js
+++ b/src/applications/caregivers/definitions/caregiverUI.js
@@ -103,7 +103,6 @@ export default {
     vetInputLabel: 'Veteran\u2019s',
     previousTreatmentFacilityUI: {
       'ui:title': ' ',
-
       'ui:order': ['name', 'type'],
       name: {
         'ui:required': formData => !!formData.veteranLastTreatmentFacility.type,

--- a/src/applications/caregivers/definitions/caregiverUI.js
+++ b/src/applications/caregivers/definitions/caregiverUI.js
@@ -103,8 +103,10 @@ export default {
     vetInputLabel: 'Veteran\u2019s',
     previousTreatmentFacilityUI: {
       'ui:title': ' ',
+
       'ui:order': ['name', 'type'],
       name: {
+        'ui:required': formData => !!formData.veteranLastTreatmentFacility.type,
         'ui:title': (
           <div>
             <h3 className="vads-u-font-size--h4">Recent medical care</h3>
@@ -120,6 +122,8 @@ export default {
         ),
       },
       type: {
+        'ui:required': formData =>
+          !!formData.veteranLastTreatmentFacility.name?.split(' ').join(''),
         'ui:title': 'Was this a hospital or clinic?',
         'ui:options': {
           labels: {

--- a/src/applications/caregivers/definitions/caregiverUI.js
+++ b/src/applications/caregivers/definitions/caregiverUI.js
@@ -129,8 +129,7 @@ export default {
         ),
       },
       type: {
-        'ui:required': formData =>
-          !!formData.veteranLastTreatmentFacility.name?.split(' ').join(''),
+        'ui:required': formData => !!formData.veteranLastTreatmentFacility.name,
         'ui:title': 'Was this a hospital or clinic?',
         'ui:options': {
           labels: {

--- a/src/applications/caregivers/helpers.js
+++ b/src/applications/caregivers/helpers.js
@@ -164,3 +164,12 @@ export const validateSSNIsUnique = (errors, formData) => {
     );
   }
 };
+
+export const facilityNameMaxLength = (errors, formData) => {
+  const facilityNameLength = formData.veteranLastTreatmentFacility.name.length;
+  if (facilityNameLength > 80) {
+    errors.addError(
+      "You've entered too many characters, please enter 80 characters or less",
+    );
+  }
+};

--- a/src/applications/caregivers/helpers.js
+++ b/src/applications/caregivers/helpers.js
@@ -169,7 +169,7 @@ export const facilityNameMaxLength = (errors, formData) => {
   const facilityNameLength = formData.veteranLastTreatmentFacility.name?.length;
   if (facilityNameLength > 80) {
     errors.addError(
-      "You've entered too many characters, please enter 80 characters or less",
+      "You've entered too many characters, please enter less than 80 characters.",
     );
   }
 };

--- a/src/applications/caregivers/helpers.js
+++ b/src/applications/caregivers/helpers.js
@@ -166,7 +166,7 @@ export const validateSSNIsUnique = (errors, formData) => {
 };
 
 export const facilityNameMaxLength = (errors, formData) => {
-  const facilityNameLength = formData.veteranLastTreatmentFacility.name.length;
+  const facilityNameLength = formData.veteranLastTreatmentFacility.name?.length;
   if (facilityNameLength > 80) {
     errors.addError(
       "You've entered too many characters, please enter 80 characters or less",


### PR DESCRIPTION
## Description
Make lastFacilityName and lastFacilityType optionally required to support `vets-json-schema` nesting these values till we can refactor

[optionally required bug](https://github.com/department-of-veterans-affairs/va.gov-team/issues/14275)
[maxLength bug](https://github.com/department-of-veterans-affairs/va.gov-team/issues/14272)

## Screenshots
![op-rq](https://user-images.githubusercontent.com/23741323/94837506-534d5000-03e2-11eb-8070-d338e1975d38.gif)

![max-facility-name](https://user-images.githubusercontent.com/23741323/94943427-b2c06400-04a5-11eb-89ef-8484b13f190e.gif)




## Acceptance criteria
- [x] Make facilityType optionally required if facilityName present
- [x] Make facilityName optionally required if facilityType present

## Definition of done
- [x] Events are logged appropriately
- [x] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
