### PR TITLE
Update Letter Types

### DIFF
--- a/src/applications/letters/utils/constants.js
+++ b/src/applications/letters/utils/constants.js
@@ -39,15 +39,18 @@ export const DOWNLOAD_STATUSES = Object.freeze({
   failure: 'failure',
 });
 
+// if you update LETTER_TYPES, update LETTER_TYPES in vets-api lib/evss/letters/letter.rb
 export const LETTER_TYPES = Object.freeze({
   benefitSummary: 'benefit_summary',
+  benefitSummaryDependent: 'benefit_summary_dependent',
+  benefitVerification: 'benefit_verification',
+  certificateOfEligibility: 'certificate_of_eligibility',
+  civilService: 'civil_service',
   commissary: 'commissary',
-  proofOfService: 'proof_of_service',
   medicarePartD: 'medicare_partd',
   minimumEssentialCoverage: 'minimum_essential_coverage',
+  proofOfService: 'proof_of_service',
   serviceVerification: 'service_verification',
-  civilService: 'civil_service',
-  benefitVerification: 'benefit_verification',
 });
 
 // Benefit options returned from vets-api, used in UI


### PR DESCRIPTION
Does:
* Adds missing letter type `benefit_summary_dependent`
* Adds missing letter type `certificate_of_eligibility`
* Alphabetizes list

Notes:
[error example in sentry](http://sentry.vfs.va.gov/vets-gov/platform-api-production/issues/155640/?query=is%3Aunresolved%20invalid%20letter%20type) (see ADDITIONAL DATA / message)

More complete list found at https://github.com/department-of-veterans-affairs/va.gov-team/blob/master/products/veteran-military-records/documents-and-letters/letters-api-docs-fe-notes.md

Related PR https://github.com/department-of-veterans-affairs/vets-api/pull/5014