### PR TITLE
Ensure axe checks pass on download links (#5473)

### DIFF
--- a/src/site/paragraphs/downloadable_file.drupal.liquid
+++ b/src/site/paragraphs/downloadable_file.drupal.liquid
@@ -25,24 +25,26 @@
 
         {% assign url = entity.fieldMedia.entity.image.url %}
 
-        <a aria-label="Download {{entity.fieldTitle}}" class="file-download-with-icon" target="_blank"
+        <a class="file-download-with-icon" target="_blank"
            href="{{url}}" download="{{url}}">
-            <i class="fas fa-download vads-u-margin--0p5"></i>{{entity.fieldTitle}} ({{url | fileExt | upcase}})
+            <i class="fas fa-download vads-u-margin--0p5" aria-hidden="true" role="img"></i>
+            Download {{entity.fieldTitle}} ({{url | fileExt | upcase}})
         </a>
     {% endif %}
 
     {% if entity.fieldMedia.entity.entityBundle == 'document' %}
         {% assign url = entity.fieldMedia.entity.fieldDocument.entity.url %}
-        <a aria-label="Download {{entity.fieldTitle}}" class="file-download-with-icon" target="_blank"
+        <a class="file-download-with-icon" target="_blank"
            href="{{url}}" download="{{url}}">
-            <i class="fas fa-download vads-u-margin--0p5"></i>{{entity.fieldTitle}} ({{url | fileExt | upcase}})
+            <i class="fas fa-download vads-u-margin--0p5" aria-hidden="true" role="img"></i>
+            Download {{entity.fieldTitle}} ({{url | fileExt | upcase}})
         </a>
     {% endif %}
 
     {% if entity.fieldMedia.entity.entityBundle == 'video' %}
-        <a aria-label="View {{entity.fieldTitle}}" class="video-link" target="_blank"
+        <a class="video-link" target="_blank"
            href="{{entity.fieldMedia.entity.fieldMediaVideoEmbedField}}">
-            <i class="fas fa-play-circle vads-u-margin--0p5"></i>Go to video
+            <i class="fas fa-play-circle vads-u-margin--0p5" aria-hidden="true" role="img"></i>Go to video
         </a>
     {% endif %}
 </div>


### PR DESCRIPTION
Our download links need to contain all of the link text to pass axe checks.

## Acceptance criteria
- [x] Axe checks pass
- [x] Download link text do not contain the word "Download"

## Definition of done
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
