### PR TITLE
Updated Va Video Connect appointment cards to be consistent w/ other …

### DIFF
--- a/src/applications/vaos/appointment-list/components/cards/confirmed/ConfirmedAppointmentListItem.jsx
+++ b/src/applications/vaos/appointment-list/components/cards/confirmed/ConfirmedAppointmentListItem.jsx
@@ -91,9 +91,11 @@ export default function ConfirmedAppointmentListItem({
 
   let header;
   let location;
-  let videoSummary;
+  let vvcHeader = '';
+
   if (isAtlas) {
     header = 'VA Video Connect';
+    vvcHeader = ' at an ATLAS location';
     const address =
       appointment.legacyVAR.apiData.vvsAppointments[0].tasInfo.address;
     if (address) {
@@ -101,19 +103,18 @@ export default function ConfirmedAppointmentListItem({
         address.zipCode
       }`;
     }
-    videoSummary = 'Video appointment at an ATLAS location';
   } else if (videoKind === VIDEO_TYPES.clinic) {
     header = 'VA Video Connect';
+    vvcHeader = ' at a VA location';
     location = facility ? formatFacilityAddress(facility) : null;
-    videoSummary = 'Video appointment at a VA location';
   } else if (videoKind === VIDEO_TYPES.gfe) {
     header = 'VA Video Connect';
+    vvcHeader = ' using a VA device';
     location = 'Video conference';
-    videoSummary = 'Video appointment using a VA device';
   } else if (isVideo) {
     header = 'VA Video Connect';
+    vvcHeader = ' at home';
     location = 'Video conference';
-    videoSummary = 'Video appointment at home';
   } else if (isCommunityCare) {
     header = 'Community Care';
     const address = appointment.contained.find(
@@ -138,28 +139,18 @@ export default function ConfirmedAppointmentListItem({
     >
       <div
         id={`card-${index}-type`}
-        className="vaos-form__title vads-u-font-size--sm vads-u-font-weight--normal vads-u-font-family--sans"
+        className="vads-u-font-size--sm vads-u-font-weight--normal vads-u-font-family--sans"
       >
-        {header}
+        <span className="vaos-form__title">{header}</span>
+        <span>{vvcHeader}</span>
       </div>
       <h3 className="vaos-appts__date-time vads-u-font-size--h3 vads-u-margin-x--0">
-        {isVideo && videoSummary}
-        {!isVideo && (
-          <AppointmentDateTime
-            appointmentDate={moment.parseZone(appointment.start)}
-            timezone={appointment.vaos.timeZone}
-            facilityId={getVARFacilityId(appointment)}
-          />
-        )}
-      </h3>
-      {isVideo && (
         <AppointmentDateTime
           appointmentDate={moment.parseZone(appointment.start)}
           timezone={appointment.vaos.timeZone}
           facilityId={getVARFacilityId(appointment)}
-          twoLineFormat
         />
-      )}
+      </h3>
       <AppointmentStatus
         status={appointment.status}
         isPastAppointment={isPastAppointment}
@@ -211,7 +202,7 @@ export default function ConfirmedAppointmentListItem({
               </AdditionalInfoRow>
             )}
             <AddToCalendar
-              summary={isVideo ? videoSummary : header}
+              summary={`${header}${vvcHeader}`}
               description={instructionText}
               location={location}
               duration={appointment.minutesDuration}

--- a/src/applications/vaos/tests/appointment-list/components/AppointmentsPage/index.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/AppointmentsPage/index.unit.spec.jsx
@@ -96,7 +96,7 @@ describe('VAOS integration: appointment list', () => {
 
     expect(dateHeadings).to.deep.equal([
       secondDate.format('dddd, MMMM D, YYYY [at] h:mm a'),
-      'Video appointment at home',
+      thirdDate.format('dddd, MMMM D, YYYY [at] h:mm a'),
       fourthDate.format('dddd, MMMM D, YYYY [at] h:mm a [UTC UTC]'),
       'Primary care appointment',
     ]);

--- a/src/applications/vaos/tests/appointment-list/components/FutureAppointmentsList.video.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/FutureAppointmentsList.video.unit.spec.jsx
@@ -42,7 +42,9 @@ describe('VAOS integration: upcoming video appointments', () => {
       initialState,
     });
 
-    await findByText('Video appointment at home');
+    await findByText(
+      (_, node) => node.textContent === 'VA Video Connect at home',
+    );
 
     expect(queryByText(/You don’t have any appointments/i)).not.to.exist;
     expect(baseElement).to.contain.text('VA Video Connect');
@@ -267,7 +269,9 @@ describe('VAOS integration: upcoming video appointments', () => {
       initialState,
     });
 
-    await screen.findByText(/Video appointment using a VA device/i);
+    await screen.findByText(
+      (_, node) => node.textContent === 'VA Video Connect using a VA device',
+    );
 
     // Should display appointment date
     expect(
@@ -420,7 +424,9 @@ describe('VAOS integration: upcoming video appointments', () => {
       initialState,
     });
 
-    await findByText('Video appointment at home');
+    await findByText(
+      (_, node) => node.textContent === 'VA Video Connect at home',
+    );
 
     expect(queryByText(/You don’t have any appointments/i)).not.to.exist;
     expect(baseElement).to.contain.text('VA Video Connect');
@@ -578,7 +584,9 @@ describe('VAOS integration: upcoming ATLAS video appointments', () => {
       initialState,
     });
 
-    await screen.findByText(/Video appointment at an ATLAS location/i);
+    await screen.findByText(
+      (_, node) => node.textContent === 'VA Video Connect at an ATLAS location',
+    );
 
     // Should display appointment date
     expect(

--- a/src/applications/vaos/tests/appointment-list/components/PastAppointmentsList/index.unit.spec.jsx
+++ b/src/applications/vaos/tests/appointment-list/components/PastAppointmentsList/index.unit.spec.jsx
@@ -289,7 +289,9 @@ describe('VAOS integration: past appointments', () => {
       initialState,
     });
 
-    await findByText('Video appointment at home');
+    await findByText(
+      (_, node) => node.textContent === 'VA Video Connect at home',
+    );
 
     expect(queryByText(/You don’t have any appointments/i)).not.to.exist;
     expect(baseElement).to.contain.text('VA Video Connect');
@@ -360,7 +362,7 @@ describe('VAOS integration: past appointments', () => {
 
     expect(dateHeadings).to.deep.equal([
       firstDate.format('dddd, MMMM D, YYYY [at] h:mm a'),
-      'Video appointment at home',
+      secondDate.format('dddd, MMMM D, YYYY [at] h:mm a'),
       thirdDate.format('dddd, MMMM D, YYYY [at] h:mm a [UTC UTC]'),
     ]);
   });


### PR DESCRIPTION
Updated VVC cards to be consistent w/ other type of appointments

## Description
Prior to this change VVC appointment cards were displaying the appointment summary in place of the standard date/time.  The fix was to update the VVC appointment cards to use the standard UI layout and format that other appointment types use.  The appointment summary was replaced by the date/time and pushed up into the header instead.

## Testing done
Unit tests were updated to reflect this change

## Acceptance criteria
VA VIDEO CONNECT label should now include additional designation based on VVC Kind:
VA VIDEO CONNECT at home (ADHOC - Single & Mobile_Any)
VA VIDEO CONNECT at a VA location (Clinic-based)
VA VIDEO CONNECT using a VA device (Mobile_GFE)
VA VIDEO CONNECT at an ATLAS location
Date/time should move up to main header (following design pattern of all other appointment cards)

## Definition of done
https://app.zenhub.com/workspaces/vft-59c95ae5fda7577a9b3184f8/issues/department-of-veterans-affairs/va.gov-team/14149
