### PR TITLE
Fix alert icons for screenreader

### DIFF
--- a/src/applications/facility-locator/components/search-results-items/common/LocationOperationStatus.jsx
+++ b/src/applications/facility-locator/components/search-results-items/common/LocationOperationStatus.jsx
@@ -31,8 +31,10 @@ const LocationOperationStatus = ({ operatingStatus }) => {
     >
       <i
         aria-hidden="true"
+        role="img"
         className={`fa fa-exclamation-${iconType} vads-u-margin-top--1 icon-base`}
       />
+      <span className="sr-only">Alert: </span>
       <div className="usa-alert-body">{infoMsg}</div>
     </div>
   );

--- a/src/applications/facility-locator/tests/components/VaFacilityResult.unit.spec.jsx
+++ b/src/applications/facility-locator/tests/components/VaFacilityResult.unit.spec.jsx
@@ -3,7 +3,8 @@ import { expect } from 'chai';
 import { shallow } from 'enzyme';
 import VaFacilityResult from '../../components/search-results-items/VaFacilityResult';
 import testData from '../../constants/mock-facility-data-v1.json';
-import { LocationType } from '../../constants';
+import { LocationType, OperatingStatus } from '../../constants';
+import LocationOperationStatus from '../../components/search-results-items/common/LocationOperationStatus';
 
 describe('VaFacilityResult', () => {
   it('Should render VaFacilityResult, facility type health', () => {
@@ -75,6 +76,16 @@ describe('VaFacilityResult', () => {
       'https://va.gov/alexandria',
     );
     expect(wrapper.find('LocationOperationStatus').length).to.equal(0);
+    wrapper.unmount();
+  });
+
+  it('Should render LocationOperationStatus with LIMITED status', () => {
+    const wrapper = shallow(
+      <LocationOperationStatus operatingStatus={OperatingStatus.LIMITED} />,
+    );
+    expect(wrapper.find('span').hasClass('sr-only')).to.equal(true);
+    expect(wrapper.find('i').prop('aria-hidden')).to.equal('true');
+    expect(wrapper.find('i').prop('role')).to.equal('img');
     wrapper.unmount();
   });
 });


### PR DESCRIPTION
## Description
Issue: https://github.com/department-of-veterans-affairs/va.gov-team/issues/8344

## Testing done

## Acceptance criteria
- [x] As a screen reader user, I want to understand the content of information, particularly as it relates to facility operating alerts.

## Definition of done

- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs
