### PR TITLE
Update 'not in MPI' error

### DIFF
--- a/src/applications/personalization/profile-2/components/MilitaryInformation.jsx
+++ b/src/applications/personalization/profile-2/components/MilitaryInformation.jsx
@@ -23,6 +23,99 @@ import facilityLocator from 'applications/facility-locator/manifest.json';
 import ProfileInfoTable from './ProfileInfoTable';
 import { transformServiceHistoryEntryIntoTableRow } from '../helpers';
 
+// Alert to show when a user does not appear to be a Veteran
+const NotAVeteranAlert = () => {
+  return (
+    <AlertBox
+      isVisible
+      status="warning"
+      headline="We don't seem to have your military records"
+      content={
+        <>
+          <p>
+            We're sorry. We can't match your information to our records. If you
+            think this is an error, please call the VA.gov help desk at{' '}
+            <Telephone contact={CONTACTS.HELP_DESK} /> (TTY:{' '}
+            <Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />
+            ). We’re here Monday–Friday, 8:00 a.m.–8:00 p.m. ET.
+          </p>
+          <p>
+            Or you can learn how to{' '}
+            <a
+              href="https://www.archives.gov/veterans/military-service-records/correct-service-records.html"
+              target="blank"
+              rel="noopener noreferrer"
+            >
+              update or correct your military service history
+            </a>
+            .
+          </p>
+        </>
+      }
+    />
+  );
+};
+
+// Alert to show if `GET service_history` returned a 403
+const NotInDEERSAlert = () => {
+  return (
+    <AlertBox
+      isVisible
+      status="warning"
+      headline="We can’t access your military information"
+      content={
+        <div>
+          <p>
+            We’re sorry. We can’t find your Department of Defense (DoD) ID. We
+            need this to access your military service records. Please call us at{' '}
+            <a
+              href="tel:1-800-827-1000"
+              aria-label="800. 8 2 7. 1000."
+              title="Dial the telephone number 800-827-1000"
+              className="no-wrap"
+            >
+              800-827-1000
+            </a>
+            , or visit your nearest VA regional office and request to be added
+            to the Defense Enrollment Eligibility Reporting System (DEERS).
+          </p>
+          <a href={facilityLocator.rootUrl}>
+            Find your nearest VA regional office
+          </a>
+          .
+          <p>
+            You can also request to be added to DEERS through our online
+            customer help center.
+          </p>
+          <a href="https://iris.custhelp.va.gov/app/answers/detail/a_id/3036/~/not-registered-in-deers%2C-or-received-and-error-message-while-trying-to">
+            Get instructions from our help center
+          </a>
+          .
+        </div>
+      }
+    />
+  );
+};
+
+// Alert to show if `GET service_history` returned an empty service history array
+const NoServiceHistoryAlert = () => {
+  return (
+    <AlertBox
+      isVisible
+      status="warning"
+      headline="We can’t access your military information"
+      content={
+        <p>
+          We’re sorry. We can’t access your military service records. If you
+          think you should be able to view your service information here, please
+          file a request to change or correct your DD214 or other military
+          records.
+        </p>
+      }
+    />
+  );
+};
+
 const MilitaryInformationContent = ({ militaryInformation, veteranStatus }) => {
   useEffect(() => {
     focusElement('[data-focus-target]');
@@ -36,35 +129,7 @@ const MilitaryInformationContent = ({ militaryInformation, veteranStatus }) => {
     invalidVeteranStatus &&
     !militaryInformation?.serviceHistory?.serviceHistory
   ) {
-    return (
-      <AlertBox
-        isVisible
-        status="warning"
-        headline="We don't seem to have your military records"
-        content={
-          <>
-            <p>
-              We're sorry. We can't match your information to our records. If
-              you think this is an error, please call the VA.gov help desk at{' '}
-              <Telephone contact={CONTACTS.HELP_DESK} /> (TTY:{' '}
-              <Telephone contact={CONTACTS['711']} pattern={PATTERNS['911']} />
-              ). We’re here Monday–Friday, 8:00 a.m.–8:00 p.m. ET.
-            </p>
-            <p>
-              Or you can learn how to{' '}
-              <a
-                href="https://www.archives.gov/veterans/military-service-records/correct-service-records.html"
-                target="blank"
-                rel="noopener noreferrer"
-              >
-                update or correct your military service history
-              </a>
-              .
-            </p>
-          </>
-        }
-      />
-    );
+    return <NotAVeteranAlert />;
   }
 
   const {
@@ -73,66 +138,14 @@ const MilitaryInformationContent = ({ militaryInformation, veteranStatus }) => {
 
   if (error) {
     if (some(error.errors, ['code', '403'])) {
-      return (
-        <AlertBox
-          isVisible
-          status="warning"
-          headline="We can’t access your military information"
-          content={
-            <div>
-              <p>
-                We’re sorry. We can’t find your Department of Defense (DoD) ID.
-                We need this to access your military service records. Please
-                call us at{' '}
-                <a
-                  href="tel:1-800-827-1000"
-                  aria-label="800. 8 2 7. 1000."
-                  title="Dial the telephone number 800-827-1000"
-                  className="no-wrap"
-                >
-                  800-827-1000
-                </a>
-                , or visit your nearest VA regional office and request to be
-                added to the Defense Enrollment Eligibility Reporting System
-                (DEERS).
-              </p>
-              <a href={facilityLocator.rootUrl}>
-                Find your nearest VA regional office
-              </a>
-              .
-              <p>
-                You can also request to be added to DEERS through our online
-                customer help center.
-              </p>
-              <a href="https://iris.custhelp.va.gov/app/answers/detail/a_id/3036/~/not-registered-in-deers%2C-or-received-and-error-message-while-trying-to">
-                Get instructions from our help center
-              </a>
-              .
-            </div>
-          }
-        />
-      );
+      return <NotInDEERSAlert />;
     } else {
       return <LoadFail information="military" />;
     }
   }
 
   if (serviceHistory.length === 0) {
-    return (
-      <AlertBox
-        isVisible
-        status="warning"
-        headline="We can’t access your military information"
-        content={
-          <p>
-            We’re sorry. We can’t access your military service records. If you
-            think you should be able to view your service information here,
-            please file a request to change or correct your DD214 or other
-            military records.
-          </p>
-        }
-      />
-    );
+    return <NoServiceHistoryAlert />;
   }
 
   return (

--- a/src/applications/personalization/profile-2/components/NotInMVI.jsx
+++ b/src/applications/personalization/profile-2/components/NotInMVI.jsx
@@ -1,27 +1,30 @@
 import React from 'react';
 import AlertBox from '@department-of-veterans-affairs/formation-react/AlertBox';
-import facilityLocator from 'applications/facility-locator/manifest.json';
+import Telephone, {
+  CONTACTS,
+} from '@department-of-veterans-affairs/formation-react/Telephone';
 
 const NotInMVI = () => {
   const content = (
     <>
       <p>
-        We’re sorry. We can’t give you access to health and benefit tools until
-        we can match your information with our records and verify your identity.
+        We’re sorry. We can’t give you access to your profile or account
+        information until we can match your information and verify your
+        identity.
       </p>
       <p>
-        If you’d like to use these tools on VA.gov, please contact your nearest
-        VA medical center to verify and update your records.
+        If you’d like to access these tools, please contact the VA.gov help desk
+        at <Telephone contact={CONTACTS.VA_311} /> (TTY:{' '}
+        <Telephone contact={CONTACTS['711']} />) to verify and update your
+        records.
       </p>
-
-      <a href={facilityLocator.rootUrl}>Find your nearest VA medical center</a>
     </>
   );
 
   return (
     <div className="vads-u-margin-bottom--3 medium-screen:vads-u-margin-bottom--4">
       <AlertBox
-        headline="We can’t match your information with our Veteran records"
+        headline="We can’t match your information to our Veteran records"
         content={content}
         status="warning"
       />

--- a/src/applications/personalization/profile-2/tests/components/NotInMVI.unit.spec.jsx
+++ b/src/applications/personalization/profile-2/tests/components/NotInMVI.unit.spec.jsx
@@ -14,16 +14,22 @@ describe('NotInMVI', () => {
     expect(
       wrapper
         .text()
-        .includes('We can’t match your information with our Veteran records'),
+        .includes('We can’t match your information to our Veteran records'),
     ).to.be.true;
-    wrapper.unmount();
-  });
-
-  it('should render the correct link', () => {
-    const link = wrapper.find('a');
-    expect(link.text().includes('Find your nearest VA medical center')).to.be
-      .true;
-    expect(link.prop('href')).to.equal('/find-locations');
+    expect(
+      wrapper
+        .text()
+        .includes(
+          'We’re sorry. We can’t give you access to your profile or account information until we can match your information and verify your identity.',
+        ),
+    ).to.be.true;
+    expect(
+      wrapper
+        .text()
+        .includes(
+          'If you’d like to access these tools, please contact the VA.gov help desk at 844-698-2311 (TTY: 711) to verify and update your records.',
+        ),
+    ).to.be.true;
     wrapper.unmount();
   });
 });

--- a/src/applications/personalization/profile-2/tests/e2e/profile.mpi-error.cypress.spec.js
+++ b/src/applications/personalization/profile-2/tests/e2e/profile.mpi-error.cypress.spec.js
@@ -29,7 +29,7 @@ function test(mobile = false) {
 
   // Should show an error alert about not being able to connect to MPI
   // TODO: We might show a different error message in this particular case since in this case we can't connect to MPI.
-  cy.findByText(/We can’t match your information with our Veteran records/i)
+  cy.findByText(/We can’t match your information to our Veteran records/i)
     .should('exist')
     .closest('.usa-alert-warning')
     .should('exist');


### PR DESCRIPTION
## Description
Update the error we show on the Account page when a user is not in MPI

Also refactored the `MilitaryInformation` component to pull out all the different alerts into their own components.

## Testing done
Updated unit tests

## Screenshots
![image](https://user-images.githubusercontent.com/20728956/94939947-b3e29880-0487-11eb-9af5-02d3f18c1c0b.png)

## Acceptance criteria
- [ ]

## Definition of done
- [ ] Events are logged appropriately
- [ ] Documentation has been updated, if applicable
- [x] A link has been provided to the originating GitHub issue (or connected to it via ZenHub)
- [x] No sensitive information (i.e. PII/credentials/internal URLs/etc.) is captured in logging, hardcoded, or specs